### PR TITLE
App config

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,7 +19,8 @@
     </script>
     <marimo-filename hidden>{{ filename }}</marimo-filename>
     <marimo-mode data-mode={{ mode }} hidden></marimo-mode>
-    <marimo-config data-config='{{ config }}' hidden></marimo-config>
+    <marimo-user-config data-config='{{ user_config }}' hidden></marimo-user-config>
+    <marimo-app-config data-config='{{ app_config }}' hidden></marimo-app-config>
     <title>{{ title }}</title>
   </head>
   <body>

--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -44,10 +44,10 @@ export const AppConfigForm: React.FC = () => {
             <FormItem className="flex flex-row items-center space-x-2 space-y-0">
               <FormControl>
                 <Switch
-                  checked={field.value === "wide"}
+                  checked={field.value === "full"}
                   size="sm"
                   onCheckedChange={(checked) => {
-                    return field.onChange(checked === true ? "wide" : "normal");
+                    return field.onChange(checked === true ? "full" : "normal");
                   }}
                 />
               </FormControl>

--- a/frontend/src/core/config.ts
+++ b/frontend/src/core/config.ts
@@ -20,7 +20,7 @@ export type SaveConfig = UserConfig["save"];
 export type CompletionConfig = UserConfig["completion"];
 
 export const AppConfigSchema = z.object({
-  width: z.enum(["wide", "normal"]).default("normal"),
+  width: z.enum(["full", "normal"]).default("normal"),
 });
 export type AppConfig = z.infer<typeof AppConfigSchema>;
 

--- a/frontend/src/core/config.ts
+++ b/frontend/src/core/config.ts
@@ -26,7 +26,7 @@ export type AppConfig = z.infer<typeof AppConfigSchema>;
 
 export function getAppConfig() {
   try {
-    return AppConfigSchema.parse(JSON.parse(getConfig()));
+    return AppConfigSchema.parse(JSON.parse(getConfig("app")));
   } catch (error) {
     throw new Error(
       `Marimo got an unexpected value in the configuration file: ${error}`
@@ -36,7 +36,7 @@ export function getAppConfig() {
 
 export function getUserConfig() {
   try {
-    return UserConfigSchema.parse(JSON.parse(getConfig()));
+    return UserConfigSchema.parse(JSON.parse(getConfig("user")));
   } catch (error) {
     throw new Error(
       `Marimo got an unexpected value in the configuration file: ${error}`
@@ -44,9 +44,10 @@ export function getUserConfig() {
   }
 }
 
-function getConfig() {
-  const tag = document.querySelector<HTMLElement>("marimo-config");
-  assertExists(tag, "internal-error: marimo-config tag not found");
+function getConfig(kind: "user" | "app") {
+  const tagName = kind === "user" ? "marimo-user-config" : "marimo-app-config";
+  const tag = document.querySelector<HTMLElement>(tagName);
+  assertExists(tag, `internal-error: ${tagName} tag not found`);
 
   const configData = tag.dataset.config;
   assertExists(configData, "internal-error: missing config");

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -352,7 +352,7 @@
 }
 
 .OutputArea {
-  padding: 0.5% 4%;
+  padding: 0.25rem 1.85rem;
   border: 1px solid transparent;
   border-bottom: 1px solid var(--gray-5);
 }

--- a/frontend/src/editor/renderers/CellArray.tsx
+++ b/frontend/src/editor/renderers/CellArray.tsx
@@ -99,8 +99,8 @@ export const CellArray: React.FC<CellArrayProps> = ({
     <div
       className={cn(
         "m-auto pb-12",
-        appConfig.width === "wide" && "px-24",
-        appConfig.width !== "wide" && "max-w-contentWidth",
+        appConfig.width === "full" && "px-24",
+        appConfig.width !== "full" && "max-w-contentWidth",
         // Hide the cells for a fake loading effect, to avoid flickering
         invisible && "invisible"
       )}

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -47,6 +47,8 @@ class _AppConfig:
 
 @dataclass
 class CellData:
+    """A cell together with some metadata"""
+
     cell_id: CellId_t
     # User code comprising the cell
     code: str

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -5,7 +5,8 @@ import builtins
 import itertools
 import textwrap
 from collections.abc import Sequence
-from typing import Any, Optional
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Literal, Optional
 
 from marimo._ast.cell import (
     CellFunction,
@@ -24,6 +25,37 @@ from marimo._output.rich_help import mddoc
 from marimo._runtime.dataflow import DirectedGraph, topological_sort
 
 
+@dataclass
+class _AppConfig:
+    """Program-specific configuration.
+
+    Configuration for frontends or runtimes that is specific to
+    a single marimo program.
+    """
+
+    width: Literal["normal", "full"] = "normal"
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def update(self, updates: dict[str, Any]) -> None:
+        config_dict = asdict(self)
+        for key in updates:
+            if key in config_dict:
+                self.__setattr__(key, updates[key])
+
+
+@dataclass
+class CellData:
+    cell_id: CellId_t
+    # User code comprising the cell
+    code: str
+    # User-provided name for cell (or default)
+    name: str
+    # Callable cell, or None if cell was not parsable
+    cell_function: Optional[CellFunction]
+
+
 @mddoc
 class App:
     """A marimo app.
@@ -34,11 +66,16 @@ class App:
     This class has no public API, but this may change in the future.
     """
 
-    def __init__(self) -> None:
-        # cell is unparsable <=> its value in self._cell_functions is None
-        self._cell_functions: dict[CellId_t, Optional[CellFunction]] = {}
-        self._cell_names: dict[CellId_t, str] = {}
-        self._codes: dict[CellId_t, str] = {}
+    def __init__(self, **kwargs: Any) -> None:
+        # Take `AppConfig` as kwargs for forward/backward compatibility;
+        # unrecognized settings will just be dropped, instead of raising
+        # a TypeError.
+        self._config = _AppConfig()
+        for key in asdict(self._config):
+            if key in kwargs:
+                self._config.__setattr__(key, kwargs.pop("width"))
+
+        self._cell_data: dict[CellId_t, CellData] = {}
         self._registration_order: list[CellId_t] = []
 
         self._cell_id_counter = 0
@@ -57,10 +94,24 @@ class App:
     def cell(self, f: cell_func_t) -> CellFunction:
         cell_function = cell_factory(f)
         cell_id = self._create_cell_id(cell_function)
-        self._cell_functions[cell_id] = cell_function
-        self._cell_names[cell_id] = f.__name__
-        self._codes[cell_id] = cell_function.cell.code
+        self._cell_data[cell_id] = CellData(
+            cell_id=cell_id,
+            code=cell_function.cell.code,
+            name=f.__name__,
+            cell_function=cell_function,
+        )
         return cell_function
+
+    def _names(self) -> Iterable[str]:
+        return (cell_data.name for cell_data in self._cell_data.values())
+
+    def _codes(self) -> Iterable[str]:
+        return (cell_data.code for cell_data in self._cell_data.values())
+
+    def _cell_functions(self) -> Iterable[Optional[CellFunction]]:
+        return (
+            cell_data.cell_function for cell_data in self._cell_data.values()
+        )
 
     def _validate_args(self) -> None:
         """Validate the args of each cell function.
@@ -75,13 +126,11 @@ class App:
         """
         defs = set(
             itertools.chain.from_iterable(
-                f.cell.defs
-                for f in self._cell_functions.values()
-                if f is not None
+                f.cell.defs for f in self._cell_functions() if f is not None
             )
         )
         unshadowed_builtins = set(builtins.__dict__.keys()).difference(defs)
-        for f in self._cell_functions.values():
+        for f in self._cell_functions():
             if f is None:
                 continue
             expected_args = f.cell.refs - unshadowed_builtins
@@ -99,7 +148,7 @@ class App:
 
     def _unparsable_cell(self, code: str, name: Optional[str] = None) -> None:
         cell_id = self._create_cell_id(None)
-        self._cell_names[cell_id] = name if name is not None else "__"
+        name = name if name is not None else "__"
         # - code.split("\n")[1:-1] disregards first and last lines, which are
         #   empty
         # - line[4:] removes leading indent in multiline string
@@ -108,7 +157,9 @@ class App:
         code = "\n".join(
             [line[4:].replace('\\"', '"') for line in code.split("\n")[1:-1]]
         )
-        self._codes[cell_id] = code
+        self._cell_data[cell_id] = CellData(
+            cell_id=cell_id, code=code, name=name, cell_function=None
+        )
         self._unparsable = True
 
     def _maybe_initialize(self) -> None:
@@ -118,13 +169,13 @@ class App:
             # were registered with the app
             self._cell_ids = [
                 # exclude unparseable cells from graph
-                cid
-                for cid, f in self._cell_functions.items()
-                if f is not None
+                cell_data.cell_id
+                for cell_data in self._cell_data.values()
+                if cell_data.cell_function is not None
             ]
             self._graph = DirectedGraph()
             for cell_id in self._cell_ids:
-                cell_function = self._cell_functions[cell_id]
+                cell_function = self._cell_data[cell_id].cell_function
                 assert cell_function is not None
                 self._graph.register_cell(cell_id, cell_function.cell)
             self._defs = self._graph.definitions.keys()
@@ -180,7 +231,8 @@ class App:
         outputs = {
             cid: execute_cell(cell_function.cell, glbls)
             for cid in self._execution_order
-            if (cell_function := self._cell_functions[cid]) is not None
+            if (cell_function := self._cell_data[cid].cell_function)
+            is not None
         }
         # Return
         # - the outputs, sorted in the order that cells were added to the

--- a/marimo/_ast/test_app.py
+++ b/marimo/_ast/test_app.py
@@ -37,12 +37,12 @@ class TestApp:
             z = y + 1
             return y, z
 
-        cell_names = tuple(app._cell_names.values())
+        cell_names = tuple(app._names())
         assert cell_names[0] == "one"
         assert cell_names[1] == "two"
         assert cell_names[2] == "__"
 
-        codes = tuple(app._codes.values())
+        codes = tuple(app._codes())
         assert codes[0] == "x = 0\nx"
         assert codes[1] == "a = x + z\na + 1"
         assert codes[2] == "y = x + 1\nz = y + 1"

--- a/marimo/_ast/test_app.py
+++ b/marimo/_ast/test_app.py
@@ -232,3 +232,18 @@ class TestApp:
             return
 
         app.run()
+
+    @staticmethod
+    def test_app_width_config() -> None:
+        app = App(width="full")
+        assert app._config.width == "full"
+
+    @staticmethod
+    def test_app_width_default() -> None:
+        app = App()
+        assert app._config.width == "normal"
+
+    @staticmethod
+    def test_app_config_extra_args_ignored() -> None:
+        app = App(width="full", fake_config="foo")
+        assert app._config.asdict() == {"width": "full"}

--- a/marimo/_ast/test_codegen.py
+++ b/marimo/_ast/test_codegen.py
@@ -134,11 +134,10 @@ class TestGeneration:
 class TestGetCodes:
     @staticmethod
     def test_get_codes() -> None:
-        codes, names = codegen.get_codes(
-            get_filepath("test_generate_filecontents")
-        )
-        assert names == ["one", "two", "three", "four", "five"]
-        assert codes == [
+        app = codegen.get_app(get_filepath("test_generate_filecontents"))
+        assert app is not None
+        assert list(app._names()) == ["one", "two", "three", "four", "five"]
+        assert list(app._codes()) == [
             "import numpy as np",
             "x = 0\nxx = 1",
             "y = x + 1",
@@ -149,70 +148,68 @@ class TestGetCodes:
     @staticmethod
     def test_get_codes_with_name_error() -> None:
         # name mo is not defined --- make sure this file is still parseable
-        codes, names = codegen.get_codes(
-            get_filepath("test_get_codes_with_name_error")
-        )
-        assert names == ["one"]
-        assert codes == [
+        app = codegen.get_app(get_filepath("test_get_codes_with_name_error"))
+        assert app is not None
+        assert list(app._names()) == ["one"]
+        assert list(app._codes()) == [
             "mo",
         ]
 
     @staticmethod
     def test_get_codes_multiline_fndef() -> None:
-        codes, names = codegen.get_codes(
-            get_filepath("test_get_codes_multiline_fndef")
-        )
-        assert names == ["one"]
-        assert codes == [
+        app = codegen.get_app(get_filepath("test_get_codes_multiline_fndef"))
+        assert app is not None
+        assert list(app._names()) == ["one"]
+        assert list(app._codes()) == [
             "# comment\nx = 0 + a + b + c + d",
         ]
 
     @staticmethod
     def test_get_codes_messy() -> None:
-        codes, names = codegen.get_codes(get_filepath("test_get_codes_messy"))
-        assert names == ["__"]
-        assert codes == [
+        app = codegen.get_app(get_filepath("test_get_codes_messy"))
+        assert app is not None
+        assert list(app._names()) == ["__"]
+        assert list(app._codes()) == [
             "# comment\n# another comment\n\n# yet another comment\n"
             + "x = 0 + a + b + c + d",
         ]
 
     @staticmethod
     def test_get_codes_single_line_fn() -> None:
-        codes, names = codegen.get_codes(
-            get_filepath("test_get_codes_single_line_fn")
-        )
-        assert names == ["one"]
-        assert codes == ["c = a + b; print(c); "]
+        app = codegen.get_app(get_filepath("test_get_codes_single_line_fn"))
+        assert app is not None
+        assert list(app._names()) == ["one"]
+        assert list(app._codes()) == ["c = a + b; print(c); "]
 
     @staticmethod
     def test_get_codes_multiline_string() -> None:
-        codes, names = codegen.get_codes(
-            get_filepath("test_get_codes_multiline_string")
-        )
-        assert names == ["one"]
-        assert codes == ['c = """\n  a, b"""; ']
+        app = codegen.get_app(get_filepath("test_get_codes_multiline_string"))
+        assert app is not None
+        assert list(app._names()) == ["one"]
+        assert list(app._codes()) == ['c = """\n  a, b"""; ']
 
     @staticmethod
     def test_get_codes_comment_after_sig() -> None:
-        codes, names = codegen.get_codes(
-            get_filepath("test_get_codes_comment_after_sig")
-        )
-        assert names == ["one"]
-        assert codes == ['print("hi")']
+        app = codegen.get_app(get_filepath("test_get_codes_comment_after_sig"))
+        assert app is not None
+        assert list(app._names()) == ["one"]
+        assert list(app._codes()) == ['print("hi")']
 
     @staticmethod
     def test_get_codes_empty() -> None:
-        codes, names = codegen.get_codes(get_filepath("test_get_codes_empty"))
-        assert names == ["one", "two"]
-        assert [c.strip() for c in codes] == ["", ""]
+        app = codegen.get_app(get_filepath("test_get_codes_empty"))
+        assert app is not None
+        assert list(app._names()) == ["one", "two"]
+        assert [c.strip() for c in app._codes()] == ["", ""]
 
     @staticmethod
     def test_get_codes_syntax_error() -> None:
-        codes, names = codegen.get_codes(
+        app = codegen.get_app(
             get_filepath("test_generate_filecontents_with_syntax_error")
         )
-        assert names == ["one", "two", "__", "__"]
-        assert codes == [
+        assert app is not None
+        assert list(app._names()) == ["one", "two", "__", "__"]
+        assert list(app._codes()) == [
             "import numpy as np",
             "_ error",
             "'all good'",

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -197,7 +197,7 @@ def edit(
                 )
             # module correctness check - don't start the server
             # if we can't import the module
-            codegen.get_codes(name)
+            codegen.get_app(name)
         else:
             # write empty file
             try:
@@ -265,7 +265,7 @@ def run(port: Optional[int], headless: bool, name: str) -> None:
         raise click.UsageError("Invalid NAME - %s is not a file" % name)
 
     # correctness check - don't start the server if we can't import the module
-    codegen.get_codes(name)
+    codegen.get_app(name)
 
     asyncio.run(
         start_server(

--- a/marimo/_cli/test_ipynb_to_marimo.py
+++ b/marimo/_cli/test_ipynb_to_marimo.py
@@ -20,7 +20,9 @@ def get_codes(ipynb_name: str) -> tuple[Sequence[str], Sequence[str]]:
     with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as f:
         f.write(contents)
         f.seek(0)
-        return codegen.get_codes(f.name)
+        app = codegen.get_app(f.name)
+        assert app is not None
+        return list(app._codes()), list(app._names())
 
 
 def test_markdown() -> None:

--- a/marimo/_server/api/__init__.py
+++ b/marimo/_server/api/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "InterruptHandler",
     "RenameHandler",
     "RunHandler",
+    "SaveAppConfigurationHandler",
     "SaveHandler",
     "SaveUserConfigurationHandler",
     "SetUIElementValueHandler",
@@ -24,5 +25,6 @@ from marimo._server.api.interrupt import InterruptHandler
 from marimo._server.api.rename import RenameHandler
 from marimo._server.api.run import RunHandler
 from marimo._server.api.save import SaveHandler
+from marimo._server.api.save_app_config import SaveAppConfigurationHandler
 from marimo._server.api.save_user_config import SaveUserConfigurationHandler
 from marimo._server.api.set_ui_element_value import SetUIElementValueHandler

--- a/marimo/_server/api/save.py
+++ b/marimo/_server/api/save.py
@@ -47,7 +47,9 @@ class SaveHandler(tornado.web.RequestHandler):
             )
         else:
             # try to save the app under the name `filename`
-            contents = codegen.generate_filecontents(codes, names)
+            contents = codegen.generate_filecontents(
+                codes, names, config=mgr.app_config
+            )
             LOGGER.debug("Saving app to %s", filename)
             try:
                 with open(filename, "w", encoding="utf-8") as f:

--- a/marimo/_server/api/save_app_config.py
+++ b/marimo/_server/api/save_app_config.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import tornado.web
+
+from marimo import _loggers
+from marimo._ast import codegen
+from marimo._server import sessions
+from marimo._server.api.model import parse_raw
+from marimo._server.api.status import HTTPStatus
+
+LOGGER = _loggers.marimo_logger()
+
+
+@dataclass
+class SaveAppConfiguration:
+    # partial app config
+    config: dict[str, Any]
+
+
+class SaveAppConfigurationHandler(tornado.web.RequestHandler):
+    """Save app configuration to session manager."""
+
+    @sessions.requires_edit
+    def post(self) -> None:
+        mgr = sessions.get_manager()
+        args = parse_raw(self.request.body, SaveAppConfiguration)
+        mgr.update_app_config(args.config)
+        # Update the file with the latest app config
+        # TODO(akshayka): Only change the `app = marimo.App` line (at top level
+        # of file), instead of overwriting the whole file.
+        app = mgr.load_app()
+        if app is not None and mgr.filename is not None:
+            codes = list(app._codes())
+            names = list(app._names())
+
+            # Try to save the app under the name `mgr.filename`
+            contents = codegen.generate_filecontents(
+                codes, names, config=mgr.app_config
+            )
+            try:
+                with open(mgr.filename, "w", encoding="utf-8") as f:
+                    f.write(contents)
+            except Exception as e:
+                raise tornado.web.HTTPError(
+                    HTTPStatus.SERVER_ERROR,
+                    reason="Failed to save file: {0}".format(str(e)),
+                ) from e

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -115,13 +115,13 @@ class MainHandler(tornado.web.RequestHandler):
         app_config = (
             mgr.app_config.asdict() if mgr.app_config is not None else {}
         )
-        config = {**user_config, **app_config}
         self.render(
             "index.html",
             title=title,
             filename=mgr.filename if mgr.filename is not None else "",
             mode="read" if mgr.mode == sessions.SessionMode.RUN else "edit",
-            config=json.dumps(config),
+            user_config=json.dumps(user_config),
+            app_config=json.dumps(app_config),
         )
 
 

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -111,12 +111,17 @@ class MainHandler(tornado.web.RequestHandler):
                 "_", " "
             )
         )
+        user_config = get_configuration()
+        app_config = (
+            mgr.app_config.asdict() if mgr.app_config is not None else {}
+        )
+        config = {**user_config, **app_config}
         self.render(
             "index.html",
             title=title,
             filename=mgr.filename if mgr.filename is not None else "",
             mode="read" if mgr.mode == sessions.SessionMode.RUN else "edit",
-            config=json.dumps(get_configuration()),
+            config=json.dumps(config),
         )
 
 
@@ -222,6 +227,10 @@ async def start_server(
             (
                 r"/api/kernel/save_user_config/",
                 api.SaveUserConfigurationHandler,
+            ),
+            (
+                r"/api/kernel/save_app_config/",
+                api.SaveAppConfigurationHandler,
             ),
             (
                 r"/(favicon\.ico)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,14 @@ dev = [
     "mypy~=1.4.1",
     "ruff~=0.0.275",
     # For docs
-    "pypandoc",
-    "autoclasstoc",
-    "sphinx",
-    "sphinx-copybutton",
-    "sphinx-new-tab-link",
+    "pypandoc~=1.11",
+    "autoclasstoc~=1.6.0",
+    # furo raises an error during docs build when sphinx is upgraded
+    "sphinx==7.0.1",
+    "sphinx-copybutton~=0.5.2",
+    "sphinx-new-tab-link~=0.1.1",
     "myst_parser~=2.0.0",
-    "furo"
+    "furo==2023.5.20"
 ]
 
 [project.urls]


### PR DESCRIPTION
This change adds a private API for per-app configuration:

- Configuration is specified via keyword arguments to the App object. This is a private API (for now).
- Edit-mode only handler for saving app config added.

To start we have just one setting, the width of the app (normal or full). For example,

```python
import marimo

app = marimo.App(width="full")
```