### PR TITLE
Don't print a traceback on mo.stop()

### DIFF
--- a/marimo/_runtime/cell_runner.py
+++ b/marimo/_runtime/cell_runner.py
@@ -195,7 +195,8 @@ class Runner:
             # cancel only the descendants of this cell
             self.cancel(cell_id)
             run_result = RunResult(output=e.output, exception=e)
-            self.print_traceback()
+            # don't print a traceback, since quitting is the intended
+            # behavior (like sys.exit())
         except Exception as e:  # noqa: E722
             # cancel only the descendants of this cell
             self.cancel(cell_id)

--- a/marimo/_runtime/control_flow.py
+++ b/marimo/_runtime/control_flow.py
@@ -21,10 +21,11 @@ class MarimoStopError(Exception):
 def stop(predicate: bool, output: Optional[object] = None) -> None:
     """Stops execution of a cell when `predicate` is `False`
 
-    When `predicate` is `True`, this function stops execution of the
-    current cell and makes `output` its output. Any descendants of this cell
-    that were previously scheduled to run will not be run, and their defs will
-    be removed from program memory.
+    When `predicate` is `True`, this function raises a `MarimoStopError`. If
+    uncaught, this exception stops execution of the current cell and makes
+    `output` its output. Any descendants of this cell that were previously
+    scheduled to run will not be run, and their defs will be removed from
+    program memory.
 
     **Example:**
 


### PR DESCRIPTION
Analogous to `sys.exit()`.