### PR TITLE
Add logging for WebSocket closure. Try to reconnect on ws error

### DIFF
--- a/frontend/src/utils/Logger.ts
+++ b/frontend/src/utils/Logger.ts
@@ -11,7 +11,9 @@ interface ILogger {
  */
 export const Logger: ILogger = {
   debug: (...args) => {
-    console.debug(...args);
+    if (process.env.NODE_ENV !== "production") {
+      console.debug(...args);
+    }
   },
   log: (...args) => {
     console.log(...args);


### PR DESCRIPTION
This could be an initial network error. Noticing this in the cloud deployments. We can prevent the initial network error, but as an extra layer of defense, we can try to reconnect