### PR TITLE
feat: on_change callback on `UIElement`

### DIFF
--- a/examples/ai/data_labeler.py
+++ b/examples/ai/data_labeler.py
@@ -54,21 +54,8 @@ def __(NUMBER_OF_EXAMPLES, index_state, mo, set_index):
 
 
 @app.cell
-def __(NUMBER_OF_EXAMPLES, index_state, mo, set_index):
-    index_slider = mo.ui.slider(
-        0,
-        NUMBER_OF_EXAMPLES - 1,
-        value=index_state.value,
-        step=1,
-        label="example number",
-        on_change=set_index,
-    )
-    return index_slider,
-
-
-@app.cell
-def __(index, index_slider, mo, next_button, previous_button):
-    mo.hstack([index, previous_button, next_button, index_slider], justify="start")
+def __(index, mo, next_button, previous_button):
+    mo.hstack([index, previous_button, next_button], justify="start")
     return
 
 

--- a/examples/ai/data_labeler.py
+++ b/examples/ai/data_labeler.py
@@ -13,25 +13,13 @@ def __(mo):
 @app.cell
 def __(NUMBER_OF_EXAMPLES, mo):
     def next_index(index: int) -> int:
-        return min(index + 1, NUMBER_OF_EXAMPLES)
+        return min(index + 1, NUMBER_OF_EXAMPLES - 1)
 
     def previous_index(index: int) -> int:
         return max(0, index - 1)
 
-    # TODO hack to prevent on_change from destorying and recreating 
-    # the target element ... otherwise if on_change is slow relative to how
-    # quickly the element is interacted with, element can get recreated with a
-    # stale value, leading to janky behavior where interactions get undone
     get_index, set_index = mo.state(0)
-    get_slider_index, set_slider_index = mo.state(0)
-    return (
-        get_index,
-        get_slider_index,
-        next_index,
-        previous_index,
-        set_index,
-        set_slider_index,
-    )
+    return get_index, next_index, previous_index, set_index
 
 
 @app.cell
@@ -47,33 +35,42 @@ def __(mo, next_index, previous_index, set_index):
 
 
 @app.cell
+def __(set_index):
+    def on_change(v):
+        import time
+        time.sleep(0)
+        set_index(v)
+    return on_change,
+
+
+@app.cell
 def __(mo):
     mo.md(f"**Choose an example to label.**")
     return
 
 
 @app.cell
-def __(NUMBER_OF_EXAMPLES, get_slider_index, mo, set_index):
+def __(NUMBER_OF_EXAMPLES, get_index, mo, on_change):
     index = mo.ui.number(
         0,
-        NUMBER_OF_EXAMPLES,
-        value=get_slider_index(),
+        NUMBER_OF_EXAMPLES - 1,
+        value=get_index(),
         step=1,
         label="example number",
-        on_change=set_index,
+        on_change=on_change,
     )
     return index,
 
 
 @app.cell
-def __(NUMBER_OF_EXAMPLES, get_index, mo, set_slider_index):
+def __(NUMBER_OF_EXAMPLES, get_index, mo, on_change):
     index_slider = mo.ui.slider(
         0,
-        NUMBER_OF_EXAMPLES,
+        NUMBER_OF_EXAMPLES - 1,
         value=get_index(),
         step=1,
         label="example number",
-        on_change=set_slider_index,
+        on_change=on_change,
     )
     return index_slider,
 

--- a/examples/ai/data_labeler.py
+++ b/examples/ai/data_labeler.py
@@ -12,24 +12,24 @@ def __(mo):
 
 @app.cell
 def __(NUMBER_OF_EXAMPLES, mo):
-    def next_index(index: int) -> int:
-        return min(index + 1, NUMBER_OF_EXAMPLES - 1)
-
-    def previous_index(index: int) -> int:
-        return max(0, index - 1)
-
     index_state, set_index = mo.state(0)
-    return index_state, next_index, previous_index, set_index
+
+
+    def increment_index():
+        set_index(min(index_state.value + 1, NUMBER_OF_EXAMPLES - 1))
+
+
+    def decrement_index() -> int:
+        set_index(max(0, index_state.value - 1))
+    return decrement_index, increment_index, index_state, set_index
 
 
 @app.cell
-def __(mo, next_index, previous_index, set_index):
-    next_button = mo.ui.button(
-        label="next", on_change=lambda _: set_index(next_index)
-    )
+def __(decrement_index, increment_index, mo):
+    next_button = mo.ui.button(label="next", on_change=lambda _: increment_index())
 
     previous_button = mo.ui.button(
-        label="previous", on_change=lambda _: set_index(previous_index)
+        label="previous", on_change=lambda _: decrement_index()
     )
     return next_button, previous_button
 

--- a/examples/ai/data_labeler.py
+++ b/examples/ai/data_labeler.py
@@ -18,8 +18,8 @@ def __(NUMBER_OF_EXAMPLES, mo):
     def previous_index(index: int) -> int:
         return max(0, index - 1)
 
-    get_index, set_index = mo.state(0)
-    return get_index, next_index, previous_index, set_index
+    index_state, set_index = mo.state(0)
+    return index_state, next_index, previous_index, set_index
 
 
 @app.cell
@@ -35,42 +35,33 @@ def __(mo, next_index, previous_index, set_index):
 
 
 @app.cell
-def __(set_index):
-    def on_change(v):
-        import time
-        time.sleep(0)
-        set_index(v)
-    return on_change,
-
-
-@app.cell
 def __(mo):
     mo.md(f"**Choose an example to label.**")
     return
 
 
 @app.cell
-def __(NUMBER_OF_EXAMPLES, get_index, mo, on_change):
+def __(NUMBER_OF_EXAMPLES, index_state, mo, set_index):
     index = mo.ui.number(
         0,
         NUMBER_OF_EXAMPLES - 1,
-        value=get_index(),
+        value=index_state.value,
         step=1,
         label="example number",
-        on_change=on_change,
+        on_change=set_index,
     )
     return index,
 
 
 @app.cell
-def __(NUMBER_OF_EXAMPLES, get_index, mo, on_change):
+def __(NUMBER_OF_EXAMPLES, index_state, mo, set_index):
     index_slider = mo.ui.slider(
         0,
         NUMBER_OF_EXAMPLES - 1,
-        value=get_index(),
+        value=index_state.value,
         step=1,
         label="example number",
-        on_change=on_change,
+        on_change=set_index,
     )
     return index_slider,
 

--- a/examples/optimization/signals/modules/dataloaders.py
+++ b/examples/optimization/signals/modules/dataloaders.py
@@ -9,15 +9,11 @@ import pandas as pd
 
 
 def get_c02_data() -> pd.DataFrame:
-    path = "../data/co2_weekly_mlo.csv"
-    if not os.path.isfile(path):
-        path = (
-            "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_weekly_mlo.csv"
-        )
+    path = "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_weekly_mlo.csv"
     df = pd.read_csv(
         path,
-        # column names on row 52, data starts on row 53
-        skiprows=51,
+        # column names on row 35, data starts on row 56
+        skiprows=34,
         index_col=False,
         na_values=[-999.99],
     )

--- a/examples/optimization/signals/modules/problems.py
+++ b/examples/optimization/signals/modules/problems.py
@@ -439,8 +439,8 @@ class Soiling(OSDProblem):
         return "Solar Panel Soiling"
 
     def description(self):
-        reference_decomposition = mo.Html(
-            layout.image("assets/solar_power_soiling_reference.png")
+        reference_decomposition = layout.image(
+            "assets/solar_power_soiling_reference.png"
         )
         return mo.md(
             f"""
@@ -463,7 +463,7 @@ class Soiling(OSDProblem):
             We've created what we think is a good decomposition for this
             data. Here it is:
 
-            {mo.tree([reference_decomposition], label="Reference Decomposition")}
+            {mo.tree([reference_decomposition], label="reference decomposition")}
 
             **Your task:** Create a decomposition that matches our reference
             decomposition.

--- a/examples/task_list.py
+++ b/examples/task_list.py
@@ -53,7 +53,7 @@ def __(add_task_button, clear_tasks_button, mo, task_entry_box):
 
 @app.cell
 def __(mo, task_list):
-    mo.as_html(task_list)
+    mo.as_html(task_list) if task_list.value else mo.md("No tasks! 🎉")
     return
 
 

--- a/examples/task_list.py
+++ b/examples/task_list.py
@@ -1,107 +1,84 @@
 import marimo
 
-__generated_with = "0.1.0"
+__generated_with = "0.1.2"
 app = marimo.App()
 
 
 @app.cell
 def __(mo):
-    mo.md("# Task List")
+    mo.md("# Task List").left()
     return
 
 
 @app.cell
-def __(add_task_button, clear_tasks_button, mo, state, task):
-    # Construct the task list based on the task list state.
-    #
-    # This cell will re-run and reconstruct the task list with updated state 
-    # whenever either of the buttons are clicked, since they include references 
-    # to the button elements.
-    task_list = mo.ui.array(
-        [
-            mo.ui.checkbox(value=v, label=l)
-            for v, l in zip(state.values, state.labels)
-        ],
-        label="tasks",
-    )
-
-    (
-        task,
-        add_task_button,
-        clear_tasks_button,
-        task_list if state.values else mo.md("No tasks! 🎉"),
-    )
-    return task_list,
-
-
-@app.cell
-def __(state, task_list):
-    # This cell runs whenever a task is checked or unchecked, updating the state.
-    #
-    # This makes use of the fact that writing to attributes (non-globals) doesn't
-    # trigger reactive execution.
-    #
-    # In the future we may introduce an API for setting state.
-    state.values[:] = task_list.value
-    return
+def __(dataclass):
+    @dataclass
+    class Task:
+        name: str
+        done: bool = False
+    return Task,
 
 
 @app.cell
 def __(mo):
-    # A text input for entering a task
-    task = mo.ui.text(placeholder="a task ...")
+    tasks, set_tasks = mo.state([])
+    return set_tasks, tasks
 
-    class TaskListState:
-        """
-        This class holds the state of the task list: the tasks (labels),
-        and whether they've been completed (values).
-        """
-        def __init__(self):
-            # The task labels
-            self.labels = []
-            # Whether each label is checked
-            self.values = []
 
-        def add_task(self):
-            if task.value:
-                # Add the current value of the task input to `self.labels`
-                self.labels.append(task.value)
-                # The task starts as incomplete
-                self.values.append(False)
-            return self
+@app.cell
+def __(Task, mo, set_tasks, tasks):
+    task_entry_box = mo.ui.text(placeholder="a task ...")
 
-        def clear_tasks(self):
-            # Remove all completed tasks from state
-            self.labels[:] = [
-                label
-                for i, label in enumerate(self.labels)
-                if not self.values[i]
-            ]
-            self.values[:] = [v for v in self.values if not v]
-            return self
-
-    state = TaskListState()
-
-    # Buttons to add and remove tasks; these buttons mutate state when they
-    # are clicked.
     add_task_button = mo.ui.button(
-        value=state,
-        on_click=lambda state: state.add_task(),
         label="add task",
+        on_change=lambda _: set_tasks(tasks.value + [Task(task_entry_box.value)]),
     )
 
     clear_tasks_button = mo.ui.button(
-        value=state,
-        on_click=lambda state: state.clear_tasks(),
         label="clear completed tasks",
+        on_change=lambda _: set_tasks(
+            [task for task in tasks.value if not task.done]
+        ),
     )
-    return TaskListState, add_task_button, clear_tasks_button, state, task
+    return add_task_button, clear_tasks_button, task_entry_box
+
+
+@app.cell
+def __(add_task_button, clear_tasks_button, mo, task_entry_box):
+    mo.hstack(
+        [task_entry_box, add_task_button, clear_tasks_button], justify="start"
+    )
+    return
+
+
+@app.cell
+def __(mo, task_list):
+    mo.as_html(task_list)
+    return
+
+
+@app.cell
+def __(Task, mo, set_tasks, tasks):
+    task_list = mo.ui.array(
+        [mo.ui.checkbox(value=task.done, label=task.name) for task in tasks.value],
+        label="tasks",
+        on_change=lambda v: set_tasks(
+            [Task(task.name, done=v[i]) for i, task in enumerate(tasks.value)]
+        ),
+    )
+    return task_list,
 
 
 @app.cell
 def __():
     import marimo as mo
     return mo,
+
+
+@app.cell
+def __():
+    from dataclasses import dataclass
+    return dataclass,
 
 
 if __name__ == "__main__":

--- a/frontend/src/core/RuntimeState.ts
+++ b/frontend/src/core/RuntimeState.ts
@@ -59,6 +59,7 @@ export class RuntimeState {
   flushUpdates() {
     if (this.componentsToUpdate.size > 0) {
       this.registerRunStart();
+
       sendComponentValues(
         Array.from(this.componentsToUpdate.values(), (objectId) => ({
           objectId: objectId,

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -63,9 +63,9 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         component_name: str,
         initial_value: S,
         label: Optional[str],
+        on_change: Optional[Callable[[T], None]],
         args: dict[str, JSONType],
         slotted_html: str = "",
-        on_change: Optional[Callable[[T], None]] = None,
     ) -> None:
         """Initialize a UIElement
 
@@ -76,6 +76,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         label: markdown string, label of element
         args: arguments that the element takes
         slotted_html: any html to slot in the custom element
+        on_change: callback, called with element's new value on change
         """
         # arguments stored in signature order for cloning
         self._args = (
@@ -244,6 +245,11 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         return form_plugin(element=self, label=label)
 
     def _update(self, value: S) -> None:
+        """Update value, given a value from the frontend
+
+        Calls the on_change handler with the element's new value as a
+        side-effect.
+        """
         self._value = self._convert_value(value)
         if self._on_change is not None:
             self._on_change(self._value)

--- a/marimo/_plugins/ui/_impl/array.py
+++ b/marimo/_plugins/ui/_impl/array.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any, Dict, Final, Sequence
+from typing import Any, Callable, Dict, Final, Optional, Sequence
 
 from marimo._output.formatters.structures import format_structure
 from marimo._output.rich_help import mddoc
@@ -55,6 +55,7 @@ class array(UIElement[Dict[str, JSONType], Sequence[object]]):
 
     - `elements`: the UI elements to include
     - `label`: a descriptive name for the array
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-dict"
@@ -63,6 +64,7 @@ class array(UIElement[Dict[str, JSONType], Sequence[object]]):
         self,
         elements: Sequence[UIElement[Any, Any]],
         label: str = "",
+        on_change: Optional[Callable[[Sequence[object]], None]] = None,
     ) -> None:
         self._elements = [e._clone() for e in elements]
         self._label = label
@@ -83,6 +85,7 @@ class array(UIElement[Dict[str, JSONType], Sequence[object]]):
                 },
             },
             slotted_html=slotted_html.text,
+            on_change=on_change,
         )
 
     @property

--- a/marimo/_plugins/ui/_impl/batch.py
+++ b/marimo/_plugins/ui/_impl/batch.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any, Dict, Final
+from typing import Any, Callable, Dict, Final, Optional
 
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
@@ -23,6 +23,7 @@ class _batch_base(UIElement[Dict[str, JSONType], Dict[str, object]]):
         html: Html,
         elements: dict[str, UIElement[JSONType, object]],
         label: str = "",
+        on_change: Optional[Callable[[Dict[str, object]], None]] = None,
     ) -> None:
         self._elements = elements
         super().__init__(
@@ -38,6 +39,7 @@ class _batch_base(UIElement[Dict[str, JSONType], Dict[str, object]]):
                 },
             },
             slotted_html=html.text,
+            on_change=on_change,
         )
 
     @property
@@ -96,23 +98,27 @@ class batch(_batch_base):
 
     - `value`: a `dict` of the batched elements' values
     - `elements`: a `dict` of the batched elements (clones of the originals)
+    - `on_change`: optional callback to run when this element's value changes
 
     **Initialization Args.**
 
     - html: a templated `Html` object
     - elements: the UI elements to interpolate into the HTML template
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     def __init__(
         self,
         html: Html,
         elements: dict[str, UIElement[Any, Any]],
+        on_change: Optional[Callable[[Dict[str, object]], None]] = None,
     ) -> None:
         self._html = html
         elements = {key: element._clone() for key, element in elements.items()}
         super().__init__(
             html=Html(self._html.text.format(**elements)),
             elements=elements,
+            on_change=on_change,
         )
 
     def _clone(self) -> batch:

--- a/marimo/_plugins/ui/_impl/dictionary.py
+++ b/marimo/_plugins/ui/_impl/dictionary.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable, Optional
 
 from marimo._output.formatters.structures import format_structure
 from marimo._output.rich_help import mddoc
@@ -55,6 +55,7 @@ class dictionary(_batch_base):
     - `value`: a dict holding the values of the UI elements, keyed by
                their names.
     - `elements`: a dict of the wrapped elements (clones of the originals)
+    - `on_change`: optional callback to run when this element's value changes
 
     **Initialization Args.**
 
@@ -67,6 +68,7 @@ class dictionary(_batch_base):
         self,
         elements: dict[str, UIElement[Any, Any]],
         label: str = "",
+        on_change: Optional[Callable[[dict[str, object]], None]] = None,
     ) -> None:
         # Why we clone the wrapped elements:
         #
@@ -94,7 +96,12 @@ class dictionary(_batch_base):
             json_data=format_structure(elements),
             name="dictionary" if not label else label,
         )
-        super().__init__(html=slotted_html, elements=elements, label=label)
+        super().__init__(
+            html=slotted_html,
+            elements=elements,
+            label=label,
+            on_change=on_change,
+        )
 
     def _clone(self) -> dictionary:
         """Custom clone method so new dict gets copies of UI elements."""

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -66,6 +66,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
         step: Optional[float] = None,
         value: Optional[float] = None,
         label: str = "",
+        on_change=None,
     ) -> None:
         value = start if value is None else value
         if stop < start:
@@ -94,6 +95,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
                 "stop": stop,
                 "step": step if step is not None else None,
             },
+            on_change=on_change,
         )
 
     def _convert_value(self, value: Optional[Numeric]) -> Optional[Numeric]:
@@ -258,6 +260,7 @@ class radio(UIElement[Optional[str], Any]):
         options: Sequence[str] | dict[str, Any],
         value: Optional[str] = None,
         label: str = "",
+        on_change=None,
     ) -> None:
         if not isinstance(options, dict):
             if len(set(options)) != len(options):
@@ -268,6 +271,7 @@ class radio(UIElement[Optional[str], Any]):
             component_name=radio._name,
             initial_value=value,
             label=label,
+            on_change=on_change,
             args={
                 "options": list(options.keys()),
             },
@@ -353,11 +357,13 @@ class text_area(UIElement[str, str]):
         value: str = "",
         placeholder: str = "",
         label: str = "",
+        on_change=None,
     ) -> None:
         super().__init__(
             component_name=text_area._name,
             initial_value=value,
             label=label,
+            on_change=on_change,
             args={
                 "placeholder": placeholder,
             },
@@ -642,6 +648,7 @@ class button(UIElement[Any, Any]):
     def __init__(
         self,
         on_click: Optional[Callable[[Any], Any]] = None,
+        on_change=None,
         value: Optional[Any] = None,
         label: str = "click here",
     ) -> None:
@@ -652,6 +659,7 @@ class button(UIElement[Any, Any]):
             # frontend's value is always a counter
             initial_value=0,
             label=label,
+            on_change=on_change,
             args={},
         )
 

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -139,6 +139,7 @@ class slider(UIElement[Numeric, Numeric]):
         step: Optional[float] = None,
         value: Optional[float] = None,
         label: str = "",
+        on_change=None,
     ) -> None:
         self._dtype = (
             float
@@ -176,6 +177,7 @@ class slider(UIElement[Numeric, Numeric]):
                 "stop": stop,
                 "step": step if step is not None else None,
             },
+            on_change=on_change,
         )
 
     def _convert_value(self, value: Numeric) -> Numeric:

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -55,6 +55,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     - `step`: the number increment
     - `value`: default value
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-number"
@@ -66,7 +67,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
         step: Optional[float] = None,
         value: Optional[float] = None,
         label: str = "",
-        on_change=None,
+        on_change: Optional[Callable[[Optional[Numeric]], None]] = None,
     ) -> None:
         value = start if value is None else value
         if stop < start:
@@ -128,6 +129,7 @@ class slider(UIElement[Numeric, Numeric]):
     - `step`: the slider increment
     - `value`: default value
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-slider"
@@ -139,7 +141,7 @@ class slider(UIElement[Numeric, Numeric]):
         step: Optional[float] = None,
         value: Optional[float] = None,
         label: str = "",
-        on_change=None,
+        on_change: Optional[Callable[[Optional[Numeric]], None]] = None,
     ) -> None:
         self._dtype = (
             float
@@ -203,16 +205,23 @@ class checkbox(UIElement[bool, bool]):
 
     - `value`: default value, True or False
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-checkbox"
 
-    def __init__(self, value: bool = False, label: str = "") -> None:
+    def __init__(
+        self,
+        value: bool = False,
+        label: str = "",
+        on_change: Optional[Callable[[bool], None]] = None,
+    ) -> None:
         super().__init__(
             component_name=checkbox._name,
             initial_value=value,
             label=label,
             args={},
+            on_change=on_change,
         )
 
     def _convert_value(self, value: bool) -> bool:
@@ -253,6 +262,7 @@ class radio(UIElement[Optional[str], Any]):
                  to option value
     - `value`: default option name, if None, starts with nothing checked
     - `label`: optional text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-radio"
@@ -262,7 +272,7 @@ class radio(UIElement[Optional[str], Any]):
         options: Sequence[str] | dict[str, Any],
         value: Optional[str] = None,
         label: str = "",
-        on_change=None,
+        on_change: Optional[Callable[[Any], None]] = None,
     ) -> None:
         if not isinstance(options, dict):
             if len(set(options)) != len(options):
@@ -273,10 +283,10 @@ class radio(UIElement[Optional[str], Any]):
             component_name=radio._name,
             initial_value=value,
             label=label,
-            on_change=on_change,
             args={
                 "options": list(options.keys()),
             },
+            on_change=on_change,
         )
 
     def _convert_value(self, value: Optional[str]) -> Any:
@@ -305,6 +315,7 @@ class text(UIElement[str, str]):
     - `kind`: input kind, one of `"text"`, `"password"`, `"email"`, or `"url"`
         defaults to `"text"`
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-text"
@@ -315,6 +326,7 @@ class text(UIElement[str, str]):
         placeholder: str = "",
         kind: Literal["text", "password", "email", "url"] = "text",
         label: str = "",
+        on_change: Optional[Callable[[str], None]] = None,
     ) -> None:
         super().__init__(
             component_name=text._name,
@@ -324,6 +336,7 @@ class text(UIElement[str, str]):
                 "placeholder": placeholder,
                 "kind": kind,
             },
+            on_change=on_change,
         )
 
     def _convert_value(self, value: str) -> str:
@@ -350,6 +363,7 @@ class text_area(UIElement[str, str]):
     - `value`: initial value of the text area
     - `placeholder`: placeholder text to display when the text area is empty
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-text-area"
@@ -359,16 +373,16 @@ class text_area(UIElement[str, str]):
         value: str = "",
         placeholder: str = "",
         label: str = "",
-        on_change=None,
+        on_change: Optional[Callable[[str], None]] = None,
     ) -> None:
         super().__init__(
             component_name=text_area._name,
             initial_value=value,
             label=label,
-            on_change=on_change,
             args={
                 "placeholder": placeholder,
             },
+            on_change=on_change,
         )
 
     def _convert_value(self, value: str) -> str:
@@ -412,6 +426,7 @@ class dropdown(UIElement[List[str], Any]):
                            `None` value; when `None`, defaults to `True` when
                            `value` is `None`
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-dropdown"
@@ -422,6 +437,7 @@ class dropdown(UIElement[List[str], Any]):
         value: Optional[str] = None,
         allow_select_none: Optional[bool] = None,
         label: str = "",
+        on_change: Optional[Callable[[Any], None]] = None,
     ) -> None:
         if not isinstance(options, dict):
             options = {option: option for option in options}
@@ -450,6 +466,7 @@ class dropdown(UIElement[List[str], Any]):
                 "options": list(self.options.keys()),
                 "allow-select-none": allow_select_none,
             },
+            on_change=on_change,
         )
 
     def _convert_value(self, value: list[str]) -> Any:
@@ -485,6 +502,7 @@ class multiselect(UIElement[List[str], List[object]]):
                  to option value
     - `value`: a list of initially selected options
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-multiselect"
@@ -494,6 +512,7 @@ class multiselect(UIElement[List[str], List[object]]):
         options: Sequence[str] | dict[str, Any],
         value: Optional[Sequence[str]] = None,
         label: str = "",
+        on_change: Optional[Callable[[List[object]], None]] = None,
     ) -> None:
         if not isinstance(options, dict):
             options = {option: option for option in options}
@@ -508,6 +527,7 @@ class multiselect(UIElement[List[str], List[object]]):
             args={
                 "options": list(self.options.keys()),
             },
+            on_change=on_change,
         )
 
     def _convert_value(self, value: list[str]) -> list[object]:
@@ -558,6 +578,7 @@ class table(UIElement[List[str], List[object]]):
     - `selection`: 'single' or 'multi' to enable row selection, or `None` to
         disable
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-table"
@@ -569,6 +590,7 @@ class table(UIElement[List[str], List[object]]):
         pagination: bool = False,
         selection: Optional[Literal["single", "multi"]] = "multi",
         label: str = "",
+        on_change: Optional[Callable[[List[object]], None]] = None,
     ) -> None:
         if not isinstance(data, (list, tuple)):
             raise ValueError("data must be a list or tuple.")
@@ -596,6 +618,7 @@ class table(UIElement[List[str], List[object]]):
                 "pagination": pagination,
                 "selection": selection,
             },
+            on_change=on_change,
         )
 
     @property
@@ -643,6 +666,7 @@ class button(UIElement[Any, Any]):
        value of the button and returns a new value
     - `value`: an initial value for the button
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-button"
@@ -650,9 +674,9 @@ class button(UIElement[Any, Any]):
     def __init__(
         self,
         on_click: Optional[Callable[[Any], Any]] = None,
-        on_change=None,
         value: Optional[Any] = None,
         label: str = "click here",
+        on_change: Optional[Callable[[Any], None]] = None,
     ) -> None:
         self._on_click = (lambda _: value) if on_click is None else on_click
         self._initial_value = value
@@ -661,8 +685,8 @@ class button(UIElement[Any, Any]):
             # frontend's value is always a counter
             initial_value=0,
             label=label,
-            on_change=on_change,
             args={},
+            on_change=on_change,
         )
 
     def _convert_value(self, value: Any) -> Any:
@@ -759,6 +783,7 @@ class file(UIElement[List[Tuple[str, str]], Sequence[FileUploadResults]]):
     - `multiple`: if True, allow the user to upload multiple files
     - `kind`: `"button"` or `"area"`
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-file"
@@ -769,6 +794,9 @@ class file(UIElement[List[Tuple[str, str]], Sequence[FileUploadResults]]):
         multiple: bool = False,
         kind: Literal["button", "area"] = "button",
         label: str = "",
+        on_change: Optional[
+            Callable[[Sequence[FileUploadResults]], None]
+        ] = None,
     ) -> None:
         super().__init__(
             component_name=file._name,
@@ -779,6 +807,7 @@ class file(UIElement[List[Tuple[str, str]], Sequence[FileUploadResults]]):
                 "multiple": multiple,
                 "kind": kind,
             },
+            on_change=on_change,
         )
 
     def _convert_value(
@@ -846,6 +875,7 @@ class date(UIElement[str, dt.date]):
         - else if `None` and `start` is not `None`, defaults to `start`;
         - else if `None` and `stop` is not `None`, defaults to `stop`
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-date-picker"
@@ -858,6 +888,7 @@ class date(UIElement[str, dt.date]):
         stop: Optional[dt.date | str] = None,
         value: Optional[dt.date | str] = None,
         label: str = "",
+        on_change: Optional[Callable[[dt.date], None]] = None,
     ) -> None:
         if isinstance(start, str):
             start = self._convert_value(start)
@@ -898,6 +929,7 @@ class date(UIElement[str, dt.date]):
                 "start": self._start.isoformat(),
                 "stop": self._stop.isoformat(),
             },
+            on_change=on_change,
         )
 
     def _convert_value(self, value: str) -> dt.date:
@@ -962,6 +994,7 @@ class form(UIElement[Optional[JSONTypeBound], Optional[T]]):
 
     - `element`: the element to wrap
     - `label`: text label for the form
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-form"
@@ -970,6 +1003,7 @@ class form(UIElement[Optional[JSONTypeBound], Optional[T]]):
         self,
         element: UIElement[JSONTypeBound, T],
         label: str = "",
+        on_change: Optional[Callable[[Optional[T]], None]] = None,
     ) -> None:
         self.element = element._clone()
         super().__init__(
@@ -978,6 +1012,7 @@ class form(UIElement[Optional[JSONTypeBound], Optional[T]]):
             label=label,
             args={"element-id": self.element._id},
             slotted_html=self.element.text,
+            on_change=on_change,
         )
 
     def _convert_value(self, value: Optional[JSONTypeBound]) -> Optional[T]:

--- a/marimo/_plugins/ui/_impl/switch.py
+++ b/marimo/_plugins/ui/_impl/switch.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Final
+from typing import Callable, Final, Optional
 
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
@@ -26,11 +26,17 @@ class switch(UIElement[bool, bool]):
 
     - `value`: default value, True or False
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-switch"
 
-    def __init__(self, value: bool = False, label: str = "") -> None:
+    def __init__(
+        self,
+        value: bool = False,
+        label: str = "",
+        on_change: Optional[Callable[[bool], None]] = None,
+    ) -> None:
         if not isinstance(value, bool):
             raise ValueError(
                 "Invalid type: `value` must be a bool, but got %s"
@@ -46,6 +52,7 @@ class switch(UIElement[bool, bool]):
             initial_value=value,
             label=label,
             args={},
+            on_change=on_change,
         )
 
     def _convert_value(self, value: bool) -> bool:

--- a/marimo/_plugins/ui/_impl/test_input.py
+++ b/marimo/_plugins/ui/_impl/test_input.py
@@ -143,5 +143,15 @@ def test_button() -> None:
     assert button.value == 2
 
 
+def test_on_change() -> None:
+    state = []
+    button = ui.checkbox(on_change=lambda v: state.append(v))
+    assert not state
+    button._update(False)
+    assert state == [False]
+    button._update(True)
+    assert state == [False, True]
+
+
 # TODO(akshayka): test file
 # TODO(akshayka): test date

--- a/marimo/_smoke_tests/state.py
+++ b/marimo/_smoke_tests/state.py
@@ -1,4 +1,3 @@
-# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.2"
@@ -9,6 +8,12 @@ app = marimo.App()
 def __():
     import marimo as mo
     return mo,
+
+
+@app.cell
+def __():
+    import math
+    return math,
 
 
 @app.cell
@@ -53,8 +58,36 @@ def __(mo, set_state):
 
 
 @app.cell
-def __(state):
-    state.value
+def __(mo):
+    # tie two number components together
+    angle, set_angle = mo.state(0)
+    return angle, set_angle
+
+
+@app.cell
+def __(angle, mo, set_angle):
+    degrees = mo.ui.number(
+        0, 360, step=1, value=angle.value, on_change=set_angle, label="degrees"
+    )
+    return degrees,
+
+
+@app.cell
+def __(angle, math, mo, set_angle):
+    radians = mo.ui.number(
+        0,
+        2*math.pi,
+        step=0.01,
+        value=angle.value * math.pi / 180,
+        on_change=lambda v: set_angle(v * 180 / math.pi),
+        label="radians"
+    )
+    return radians,
+
+
+@app.cell
+def __(degrees, radians):
+    degrees, radians
     return
 
 

--- a/marimo/_smoke_tests/state.py
+++ b/marimo/_smoke_tests/state.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.2"


### PR DESCRIPTION
Adds an optional argument to the `UIElement` class:

```python
on_change: Optional[Callable[[T], None]]
```

where `T` is the type of the element's value.

When not `None`, this function is called right after a `UIElement`'s value is updated with the new value of the element provided as its argument.

Motivation: Lets users colocate side-effecting code, including calling a `State` instance's setter, with the element's construction. This makes code more readable and less error-prone (the alternative is to put side effects in a separate standalone cell that refs the element). It's also needed to support tying two or more elements.
