### PR TITLE
Add styling for blockquotes in markdown CSS

### DIFF
--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -153,6 +153,13 @@
   color: hsl(var(--link-visited));
 }
 
+.markdown blockquote {
+  padding: 0 1rem;
+
+  @apply border-l-4;
+  @apply text-muted-foreground;
+}
+
 .mo-label .markdown p,
 .mo-label-block .markdown p,
 .mo-label .markdown .paragraph,


### PR DESCRIPTION
<img width="946" alt="image" src="https://github.com/marimo-team/marimo/assets/2753772/a50864b8-7159-4083-8d71-bf425bf3da5c">
