### PR TITLE
DRY up labels in ui plugins

### DIFF
--- a/frontend/e2e-tests/components.spec.ts
+++ b/frontend/e2e-tests/components.spec.ts
@@ -306,7 +306,7 @@ test("complex - array", async ({ page }) => {
     `
 [3 Items
 0:"hi marimo"
-1:6
+1:5
 2:2020-01-20
 ]
 `.trim()

--- a/frontend/src/plugins/impl/CheckboxPlugin.tsx
+++ b/frontend/src/plugins/impl/CheckboxPlugin.tsx
@@ -37,7 +37,7 @@ const CheckboxComponent = ({
   const id = useId();
 
   return (
-    <Labeled label={data.label} align="right" id={id} labelClassName="text-md">
+    <Labeled label={data.label} align="right" id={id}>
       <Checkbox checked={value} onCheckedChange={onClick} id={id} />
     </Labeled>
   );

--- a/frontend/src/plugins/impl/CheckboxPlugin.tsx
+++ b/frontend/src/plugins/impl/CheckboxPlugin.tsx
@@ -3,11 +3,9 @@ import { useId } from "react";
 import { z } from "zod";
 
 import { IPlugin, IPluginProps } from "../types";
-import * as labelStyles from "./Label.styles";
 import { Checkbox } from "../../components/ui/checkbox";
-import { Label } from "../../components/ui/label";
 import { CheckedState } from "@radix-ui/react-checkbox";
-import { renderHTML } from "../core/RenderHTML";
+import { Labeled } from "./common/labeled";
 
 export class CheckboxPlugin
   implements IPlugin<boolean, { label: string | null }>
@@ -37,17 +35,10 @@ const CheckboxComponent = ({
     setValue(newValue);
   };
   const id = useId();
-  const labelElement =
-    data.label === null ? null : (
-      <Label htmlFor={id} className="text-md">
-        {renderHTML({ html: data.label })}
-      </Label>
-    );
 
   return (
-    <div className={`${labelStyles.labelContainer} align-middle`}>
+    <Labeled label={data.label} align="right" id={id} labelClassName="text-md">
       <Checkbox checked={value} onCheckedChange={onClick} id={id} />
-      {labelElement}
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -1,12 +1,11 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { useId, useMemo } from "react";
+import { useMemo } from "react";
 import { z } from "zod";
 
-import { Label } from "@/components/ui/label";
-import { HtmlOutput } from "@/editor/output/HtmlOutput";
 import { IPlugin, IPluginProps } from "@/plugins/types";
 import { DataTable } from "../../components/data-table/data-table";
 import { generateColumns } from "../../components/data-table/columns";
+import { Labeled } from "./common/labeled";
 
 /**
  * Arguments for a data table
@@ -59,13 +58,6 @@ const DataTableComponent = ({
   value,
   setValue,
 }: DataTableProps): JSX.Element => {
-  const id = useId();
-  const labelElement = label && (
-    <Label htmlFor={id} className="pb-3">
-      <HtmlOutput html={label} inline={true} />
-    </Label>
-  );
-
   const columns = useMemo(
     () => generateColumns(data, selection),
     [data, selection]
@@ -74,8 +66,7 @@ const DataTableComponent = ({
   const rowSelection = Object.fromEntries((value || []).map((v) => [v, true]));
 
   return (
-    <div className="flex flex-col">
-      {labelElement}
+    <Labeled label={label} align="top">
       <DataTable
         data={data}
         columns={columns}
@@ -95,6 +86,6 @@ const DataTableComponent = ({
           }
         }}
       />
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/DatePickerPlugin.tsx
+++ b/frontend/src/plugins/impl/DatePickerPlugin.tsx
@@ -1,12 +1,10 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { useId, useRef } from "react";
-import { Label } from "../../components/ui/label";
 import { z } from "zod";
 
 import { IPlugin, IPluginProps, Setter } from "../types";
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
-import * as labelStyles from "./Label.styles";
 import { Input } from "../../components/ui/input";
+import { Labeled } from "./common/labeled";
 
 type T = string;
 
@@ -63,16 +61,9 @@ const DatePicker = (props: DatePickerProps): JSX.Element => {
   };
 
   const id = useId();
-  const labelElement =
-    props.label === null ? null : (
-      <Label htmlFor={id}>
-        <HtmlOutput html={props.label} inline={true} />
-      </Label>
-    );
 
   return (
-    <div className={labelStyles.labelContainer}>
-      {labelElement}
+    <Labeled label={props.label} id={id}>
       <Input
         ref={inputRef}
         type="date"
@@ -82,6 +73,6 @@ const DatePicker = (props: DatePickerProps): JSX.Element => {
         onInput={handleInput}
         id={id}
       />
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/DropdownPlugin.tsx
+++ b/frontend/src/plugins/impl/DropdownPlugin.tsx
@@ -1,12 +1,10 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { useId } from "react";
-import { Label } from "../../components/ui/label";
 import { z } from "zod";
 
 import { IPlugin, IPluginProps } from "../types";
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
-import * as labelStyles from "./Label.styles";
 import { NativeSelect } from "../../components/ui/native-select";
+import { Labeled } from "./common/labeled";
 
 interface Data {
   label: string | null;
@@ -53,19 +51,12 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
   const { label, options, value, setValue, allowSelectNone } = props;
 
   const id = useId();
-  const labelElement =
-    label === null ? null : (
-      <Label htmlFor={id}>
-        <HtmlOutput html={label} inline={true} />
-      </Label>
-    );
 
   const defaultValue = allowSelectNone ? EMPTY_VALUE : options[0];
   const singleValue = value.length === 0 ? defaultValue : value[0];
 
   return (
-    <div className={labelStyles.labelContainer}>
-      {labelElement}
+    <Labeled label={label} id={id}>
       <NativeSelect
         onChange={(e) => {
           const newValue = e.target.value;
@@ -89,6 +80,6 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
           </option>
         ))}
       </NativeSelect>
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/FileUploadPlugin.tsx
+++ b/frontend/src/plugins/impl/FileUploadPlugin.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 import { IPlugin, IPluginProps, Setter } from "../types";
 import { filesToBase64 } from "../../utils/fileToBase64";
 import { buttonVariants } from "../../components/ui/button";
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
+import { renderHTML } from "../core/RenderHTML";
 
 type FileUploadType = "button" | "area";
 
@@ -141,7 +141,7 @@ export const FileUpload = (props: FileUploadProps): JSX.Element => {
             size: "xs",
           })}
         >
-          <HtmlOutput html={label} inline={true} />
+          {renderHTML({ html: label })}
           <Upload size={16} className="ml-2" />
         </button>
         <input {...getInputProps({})} type="file" />
@@ -177,13 +177,9 @@ export const FileUpload = (props: FileUploadProps): JSX.Element => {
       >
         <input {...getInputProps()} />
         {uploaded ? (
-          <span>
-            To re-upload: <HtmlOutput html={label} inline={true} />
-          </span>
+          <span>To re-upload: {renderHTML({ html: label })}</span>
         ) : (
-          <span className="mt-0">
-            <HtmlOutput html={label} inline={true} />
-          </span>
+          <span className="mt-0">{renderHTML({ html: label })}</span>
         )}
       </div>
 

--- a/frontend/src/plugins/impl/FormPlugin.tsx
+++ b/frontend/src/plugins/impl/FormPlugin.tsx
@@ -7,11 +7,11 @@ import {
   marimoValueInputEvent,
   MarimoValueInputEventType,
 } from "@/core/dom/events";
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
 import { IPlugin, IPluginProps, Setter } from "../types";
 import { Button } from "../../components/ui/button";
 import { UI_ELEMENT_REGISTRY } from "@/core/dom/uiregistry";
 import { cn } from "../../lib/utils";
+import { renderHTML } from "../core/RenderHTML";
 
 type T = unknown;
 
@@ -77,9 +77,7 @@ const SubmitBox = <T,>({
       }}
     >
       {label === null ? null : (
-        <div className="text-center mt-4">
-          <HtmlOutput html={label} inline={true} />
-        </div>
+        <div className="text-center mt-4">{renderHTML({ html: label })}</div>
       )}
       <div className="pl-12 pr-12 pt-4">{children}</div>
       <div className="text-right mt-0.5 font-code p-4">

--- a/frontend/src/plugins/impl/Label.styles.ts
+++ b/frontend/src/plugins/impl/Label.styles.ts
@@ -1,7 +1,0 @@
-/* Copyright 2023 Marimo. All rights reserved. */
-export const label = "font-medium font-prose";
-
-export const labelContainer =
-  "mo-label inline-flex pt-0 pb-0 pl-0 pr-2 items-center space-x-1.5";
-
-export const labelContainerBlock = "mo-label-block block p-0";

--- a/frontend/src/plugins/impl/MultiselectPlugin.tsx
+++ b/frontend/src/plugins/impl/MultiselectPlugin.tsx
@@ -1,12 +1,10 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { useId } from "react";
-import { Label } from "../../components/ui/label";
 import { z } from "zod";
 
 import { IPlugin, IPluginProps, Setter } from "../types";
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
-import * as labelStyles from "./Label.styles";
 import { Combobox, ComboboxItem } from "../../components/ui/combobox";
+import { Labeled } from "./common/labeled";
 
 interface Data {
   label: string | null;
@@ -50,16 +48,9 @@ interface MultiselectProps extends Data {
 
 const Multiselect = (props: MultiselectProps): JSX.Element => {
   const id = useId();
-  const labelElement =
-    props.label === null ? null : (
-      <Label htmlFor={id}>
-        <HtmlOutput html={props.label} inline={true} />
-      </Label>
-    );
 
   return (
-    <div className={labelStyles.labelContainer}>
-      {labelElement}
+    <Labeled label={props.label} id={id}>
       <Combobox<string>
         displayValue={(option) => option}
         placeholder="Select..."
@@ -73,6 +64,6 @@ const Multiselect = (props: MultiselectProps): JSX.Element => {
           </ComboboxItem>
         ))}
       </Combobox>
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/NumberPlugin.tsx
+++ b/frontend/src/plugins/impl/NumberPlugin.tsx
@@ -1,12 +1,10 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { useEffect, useId, useRef } from "react";
-import { Label } from "../../components/ui/label";
 import { z } from "zod";
 
 import { IPlugin, IPluginProps, Setter } from "../types";
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
-import * as labelStyles from "./Label.styles";
 import { Input } from "../../components/ui/input";
+import { Labeled } from "./common/labeled";
 
 type T = number;
 
@@ -69,16 +67,9 @@ const NumberComponent = (props: NumberComponentProps): JSX.Element => {
   }, [inputRef]);
 
   const id = useId();
-  const labelElement =
-    props.label === null ? null : (
-      <Label htmlFor={id}>
-        <HtmlOutput html={props.label} inline={true} />
-      </Label>
-    );
 
   return (
-    <div className={labelStyles.labelContainer}>
-      {labelElement}
+    <Labeled label={props.label} id={id}>
       <Input
         className="min-w-[3em]"
         ref={inputRef}
@@ -90,6 +81,6 @@ const NumberComponent = (props: NumberComponentProps): JSX.Element => {
         onInput={oninput}
         id={id}
       />
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/RadioPlugin.tsx
+++ b/frontend/src/plugins/impl/RadioPlugin.tsx
@@ -5,8 +5,8 @@ import { z } from "zod";
 
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { HtmlOutput } from "@/editor/output/HtmlOutput";
 import { IPlugin, IPluginProps } from "@/plugins/types";
+import { Labeled } from "./common/labeled";
 
 /**
  * Arguments for a radio group
@@ -45,18 +45,9 @@ interface RadioProps extends Data {
 
 const Radio = (props: RadioProps): JSX.Element => {
   const id = useId();
-  const labelElement =
-    props.label === null ? null : (
-      <div className="pb-3">
-        <Label htmlFor={id} className="pb-3">
-          <HtmlOutput html={props.label} inline={true} />
-        </Label>
-      </div>
-    );
 
   return (
-    <div>
-      {labelElement}
+    <Labeled label={props.label} id={id} align="top">
       <RadioGroup
         value={props.value ?? ""}
         onValueChange={props.setValue}
@@ -77,6 +68,6 @@ const Radio = (props: RadioProps): JSX.Element => {
           </div>
         ))}
       </RadioGroup>
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/RefreshPlugin.tsx
+++ b/frontend/src/plugins/impl/RefreshPlugin.tsx
@@ -7,11 +7,9 @@ import { RefreshCwIcon } from "lucide-react";
 import timestring from "timestring";
 import { NativeSelect } from "@/components/ui/native-select";
 import { Button } from "@/components/ui/button";
-import * as labelStyles from "./Label.styles";
 import { useEvent } from "../../hooks/useEvent";
 import { cn } from "@/lib/utils";
-import { Label } from "@/components/ui/label";
-import { HtmlOutput } from "@/editor/output/HtmlOutput";
+import { Labeled } from "./common/labeled";
 
 type Value = string | number | undefined;
 
@@ -112,12 +110,7 @@ const RefreshComponent = ({ setValue, data }: IPluginProps<Value, Data>) => {
   const hasOptions = data.options.length > 0;
 
   return (
-    <div className={labelStyles.labelContainer}>
-      {data.label && (
-        <Label className={labelStyles.label}>
-          <HtmlOutput html={data.label} inline={true} />
-        </Label>
-      )}
+    <Labeled label={data.label}>
       <span className="inline-flex items-center text-secondary-foreground rounded shadow-smSolid">
         <Button
           variant="secondary"
@@ -152,6 +145,6 @@ const RefreshComponent = ({ setValue, data }: IPluginProps<Value, Data>) => {
           ))}
         </NativeSelect>
       </span>
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -1,13 +1,10 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { useCallback, useId } from "react";
-import { Label } from "../../components/ui/label";
 import { z } from "zod";
 
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
 import { IPlugin, IPluginProps, Setter } from "../types";
-import * as labelStyles from "./Label.styles";
 import { Slider } from "../../components/ui/slider";
-import clsx from "clsx";
+import { Labeled } from "./common/labeled";
 
 type T = number;
 
@@ -54,16 +51,9 @@ const SliderComponent = (props: SliderProps): JSX.Element => {
     [setValue]
   );
   const id = useId();
-  const labelElement =
-    props.label === null ? null : (
-      <Label htmlFor={id}>
-        <HtmlOutput html={props.label} inline={true} />
-      </Label>
-    );
 
   return (
-    <div className={clsx(labelStyles.labelContainer, "mb-2")}>
-      {labelElement}
+    <Labeled label={props.label} id={id}>
       <Slider
         className={"relative flex items-center select-none w-36"}
         value={[props.value]}
@@ -73,6 +63,6 @@ const SliderComponent = (props: SliderProps): JSX.Element => {
         onValueChange={onValueChange}
         id={id}
       />
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/SwitchPlugin.tsx
+++ b/frontend/src/plugins/impl/SwitchPlugin.tsx
@@ -3,11 +3,8 @@ import { useId } from "react";
 import { z } from "zod";
 
 import { Switch } from "@/components/ui/switch";
-import { Label } from "@/components/ui/label";
 import { IPlugin, IPluginProps } from "@/plugins/types";
-import * as labelStyles from "@/plugins/impl/Label.styles";
-import { cn } from "@/lib/utils";
-import { renderHTML } from "../core/RenderHTML";
+import { Labeled } from "./common/labeled";
 
 export class SwitchPlugin
   implements IPlugin<boolean, { label: string | null }>
@@ -30,29 +27,20 @@ const SwitchComponent = ({
   data,
 }: IPluginProps<boolean, { label: string | null }>): JSX.Element => {
   const id = useId();
-  const labelElement =
-    data.label === null ? null : (
-      <Label htmlFor={id} className="text-md">
-        {renderHTML({ html: data.label })}
-      </Label>
-    );
 
   return (
-    <div
-      className={cn(
-        labelStyles.labelContainer,
-        "align-middle",
-        "items-start",
-        "gap-x-2"
-      )}
+    <Labeled
+      label={data.label}
+      align="right"
+      id={id}
+      labelClassName="text-md ml-1"
     >
       <Switch
         checked={value}
         onCheckedChange={setValue}
         id={id}
-        className="data-[state=unchecked]:hover:bg-input/80"
+        className="data-[state=unchecked]:hover:bg-input/80 mb-0"
       />
-      {labelElement}
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/SwitchPlugin.tsx
+++ b/frontend/src/plugins/impl/SwitchPlugin.tsx
@@ -29,12 +29,7 @@ const SwitchComponent = ({
   const id = useId();
 
   return (
-    <Labeled
-      label={data.label}
-      align="right"
-      id={id}
-      labelClassName="text-md ml-1"
-    >
+    <Labeled label={data.label} align="right" id={id} labelClassName="ml-1">
       <Switch
         checked={value}
         onCheckedChange={setValue}

--- a/frontend/src/plugins/impl/TextAreaPlugin.tsx
+++ b/frontend/src/plugins/impl/TextAreaPlugin.tsx
@@ -39,7 +39,7 @@ interface TextAreaComponentProps extends Data {
 
 const TextAreaComponent = (props: TextAreaComponentProps) => {
   return (
-    <Labeled label={props.label} align="top" labelClassName="text-md">
+    <Labeled label={props.label} align="top">
       <Textarea
         className="font-code"
         rows={5}

--- a/frontend/src/plugins/impl/TextAreaPlugin.tsx
+++ b/frontend/src/plugins/impl/TextAreaPlugin.tsx
@@ -1,11 +1,9 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { Label } from "../../components/ui/label";
 import { z } from "zod";
 import { IPlugin, IPluginProps, Setter } from "../types";
 
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
-import * as labelStyles from "./Label.styles";
 import { Textarea } from "../../components/ui/textarea";
+import { Labeled } from "./common/labeled";
 
 type T = string;
 
@@ -40,21 +38,10 @@ interface TextAreaComponentProps extends Data {
 }
 
 const TextAreaComponent = (props: TextAreaComponentProps) => {
-  const labelElement =
-    props.label === null ? null : (
-      <Label className="text-md">
-        <HtmlOutput html={props.label} />
-      </Label>
-    );
-
   return (
-    <div className={labelStyles.labelContainerBlock}>
-      {labelElement}
+    <Labeled label={props.label} align="top" labelClassName="text-md">
       <Textarea
-        className="mt-3"
-        style={{
-          fontFamily: "var(--monospace-font)",
-        }}
+        className="font-code"
         rows={5}
         cols={33}
         value={props.value}
@@ -63,6 +50,6 @@ const TextAreaComponent = (props: TextAreaComponentProps) => {
         }
         placeholder={props.placeholder}
       />
-    </div>
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/TextInputPlugin.tsx
+++ b/frontend/src/plugins/impl/TextInputPlugin.tsx
@@ -1,14 +1,12 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { Label } from "../../components/ui/label";
 import { z } from "zod";
 import { IPlugin, IPluginProps, Setter } from "../types";
 
-import { HtmlOutput } from "../../editor/output/HtmlOutput";
-import * as labelStyles from "./Label.styles";
 import { Input } from "../../components/ui/input";
 import { cn } from "../../lib/utils";
 import { AtSignIcon, GlobeIcon, LockIcon } from "lucide-react";
 import { useState } from "react";
+import { Labeled } from "./common/labeled";
 
 type T = string;
 
@@ -49,13 +47,6 @@ interface TextComponentProps extends Data {
 const TextComponent = (props: TextComponentProps) => {
   const [valueOnBlur, setValueOnBlur] = useState(props.value);
 
-  const labelElement =
-    props.label === null ? null : (
-      <Label className={labelStyles.label}>
-        <HtmlOutput html={props.label} inline={true} />
-      </Label>
-    );
-
   const valueToValidate = valueOnBlur == null ? props.value : valueOnBlur;
   const isValid = validate(props.kind, valueToValidate);
 
@@ -67,8 +58,7 @@ const TextComponent = (props: TextComponentProps) => {
   };
 
   return (
-    <div className={labelStyles.labelContainer}>
-      {labelElement}
+    <Labeled label={props.label}>
       <Input
         type={props.kind}
         icon={icon[props.kind]}
@@ -80,7 +70,7 @@ const TextComponent = (props: TextComponentProps) => {
         onInput={(event) => props.setValue(event.currentTarget.value)}
         onBlur={(event) => setValueOnBlur(event.currentTarget.value)}
       />
-    </div>
+    </Labeled>
   );
 };
 

--- a/frontend/src/plugins/impl/common/labeled.tsx
+++ b/frontend/src/plugins/impl/common/labeled.tsx
@@ -1,0 +1,60 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { Label } from "@/components/ui/label";
+import { renderHTML } from "@/plugins/core/RenderHTML";
+import React, { PropsWithChildren } from "react";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  label: string | null | undefined;
+  className?: string;
+  labelClassName?: string;
+  id?: string;
+  /**
+   * Align the label to the top, left, or right of the component.
+   * @default "left"
+   */
+  align?: "top" | "left" | "right";
+}
+
+/**
+ * Label a component.
+ */
+export const Labeled: React.FC<PropsWithChildren<Props>> = ({
+  label,
+  children,
+  align = "left",
+  className,
+  labelClassName,
+  id,
+}) => {
+  if (!label) {
+    // If its a top label, just return the children
+    if (align === "top") {
+      return children;
+    }
+    // Otherwise, return the children in an inline-flex container
+    return <div className={cn("inline-flex", className)}>{children}</div>;
+  }
+
+  const labelElement = (
+    <Label htmlFor={id} className={cn("font-prose", labelClassName)}>
+      {renderHTML({ html: label })}
+    </Label>
+  );
+
+  return (
+    <div
+      className={cn(
+        "mo-label inline-flex",
+        "pt-0 pb-0 pl-0",
+        align === "top" && "flex-col items-start gap-y-3",
+        align === "left" && "flex-row items-center gap-x-1.5 pr-2",
+        align === "right" && "flex-row-reverse items-center gap-x-1.5 pr-2",
+        className
+      )}
+    >
+      {labelElement}
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
There shouldn't be any visual changes. But some components are spaced a bit better (i.e. using gap instead of margins).

I used this snippet to update the `construct_element` cell in  `marimo tutorial ui` to compare:
```
def construct_element(value):
    if value == mo.ui.array:
        return mo.ui.array([mo.ui.text(), mo.ui.slider(1, 10), mo.ui.date()])
    elif value == mo.ui.batch:
        return mo.md(
            """
            - Name: {name}
            - Date: {date}
            """
        ).batch(name=mo.ui.text(label="something"), date=mo.ui.date(label="something"))
    elif value == mo.ui.button:
        return mo.ui.button(
            value=0, label="click me", on_click=lambda value: value + 1
        )
    elif value == mo.ui.checkbox:
        return mo.ui.checkbox(label="check me")
    elif value == mo.ui.date:
        return mo.ui.date(label="something")
    elif value == mo.ui.dictionary:
        return mo.ui.dictionary(
            {
                "slider": mo.ui.slider(1, 10, label="something"),
                "text": mo.ui.text("type something!"),
                "array": mo.ui.array(
                    [
                        mo.ui.button(value=0, on_click=lambda v: v + 1)
                        for _ in range(3)
                    ],
                    label="buttons",
                ),
            }
        )
    elif value == mo.ui.dropdown:
        return mo.ui.dropdown(["a", "b", "c"], label="something")
    elif value == mo.ui.file:
        return [mo.ui.file(kind="button", label="something"), mo.ui.file(kind="area", label="something")]
    elif value == mo.ui.form:
        return mo.ui.text_area(placeholder="...", label="something").form()
    elif value == mo.ui.multiselect:
        return mo.ui.multiselect(["a", "b", "c"], label="something")
    elif value == mo.ui.number:
        return mo.ui.number(start=1, stop=10, step=0.5, label="something")
    elif value == mo.ui.radio:
        return mo.ui.radio(["a", "b", "c"], value="a", label="something")
    elif value == mo.ui.slider:
        return mo.ui.slider(start=1, stop=10, step=0.5, label="something")
    elif value == mo.ui.switch:
        return mo.ui.switch(label="something")
    elif value == mo.ui.table:
        return mo.ui.table(
            data=[
                {"first_name": "Michael", "last_name": "Scott"},
                {"first_name": "Dwight", "last_name": "Schrute"},
            ],
            label="Employees",
        )
    elif value == mo.ui.text:
        return mo.ui.text(label="something")
    elif value == mo.ui.text_area:
        return mo.ui.text_area(label="something")
    return None
```