### PR TITLE
feat: add debounce to slider and number input

### DIFF
--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,77 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { useEffect, useState } from "react";
+import useEvent from "react-use-event-hook";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+/**
+ * A hook that allows you to control a state value, but also get a debounced version of that value.
+ */
+export function useDebounceControlledState<T>(opts: {
+  /**
+   * Initial value of the state.
+   */
+  initialValue: T;
+  /**
+   * Callback to run when the state changes.
+   * This will be debounced.
+   */
+  onChange: (value: T) => void;
+  /**
+   * The delay to debounce the state change by.
+   * @default 200
+   */
+  delay?: number;
+  /**
+   * Whether the state is disabled.
+   */
+  disabled?: boolean;
+}) {
+  const { initialValue, onChange, delay, disabled } = opts;
+  const [internalValue, setInternalValue] = useState<T>(initialValue);
+  const debouncedValue = useDebounce(internalValue, delay || 200);
+
+  const onUpdate = useEvent(onChange);
+
+  // If the initialValue changes, update the internal value
+  useEffect(() => {
+    setInternalValue(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
+    onUpdate(debouncedValue);
+  }, [debouncedValue, disabled, onUpdate]);
+
+  // If disabled, just pass through the initialValue and onChange
+  if (disabled) {
+    return {
+      value: internalValue,
+      debouncedValue: internalValue,
+      onChange: onChange,
+    };
+  }
+
+  return {
+    value: internalValue,
+    debouncedValue,
+    onChange: (value: T) => {
+      setInternalValue(value);
+    },
+  };
+}

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -54,6 +54,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     - `stop`: the maximum value of the interval
     - `step`: the number increment
     - `value`: default value
+    - `debounce`: whether to debounce the number picker
     - `label`: text label for the element
     """
 
@@ -65,6 +66,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
         stop: float,
         step: Optional[float] = None,
         value: Optional[float] = None,
+        debounce: bool = False,
         label: str = "",
     ) -> None:
         value = start if value is None else value
@@ -93,6 +95,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
                 "start": start,
                 "stop": stop,
                 "step": step if step is not None else None,
+                "debounce": debounce,
             },
         )
 
@@ -125,6 +128,8 @@ class slider(UIElement[Numeric, Numeric]):
     - `stop`: the maximum value of the interval
     - `step`: the slider increment
     - `value`: default value
+    - `debounce`: whether to debounce the slider to only send
+        the value on mouseup
     - `label`: text label for the element
     """
 
@@ -136,6 +141,7 @@ class slider(UIElement[Numeric, Numeric]):
         stop: float,
         step: Optional[float] = None,
         value: Optional[float] = None,
+        debounce: bool = False,
         label: str = "",
     ) -> None:
         self._dtype = (
@@ -173,6 +179,7 @@ class slider(UIElement[Numeric, Numeric]):
                 "start": start,
                 "stop": stop,
                 "step": step if step is not None else None,
+                "debounce": debounce,
             },
         )
 

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -54,7 +54,8 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     - `stop`: the maximum value of the interval
     - `step`: the number increment
     - `value`: default value
-    - `debounce`: whether to debounce (rate-limit) value updates from the frontend
+    - `debounce`: whether to debounce (rate-limit) value
+        updates from the frontend
     - `label`: text label for the element
     """
 

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -54,7 +54,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     - `stop`: the maximum value of the interval
     - `step`: the number increment
     - `value`: default value
-    - `debounce`: whether to debounce the number picker
+    - `debounce`: whether to debounce (rate-limit) value updates from the frontend
     - `label`: text label for the element
     """
 
@@ -129,7 +129,7 @@ class slider(UIElement[Numeric, Numeric]):
     - `step`: the slider increment
     - `value`: default value
     - `debounce`: whether to debounce the slider to only send
-        the value on mouseup
+        the value on mouse-up or drag-end
     - `label`: text label for the element
     """
 

--- a/marimo/_smoke_tests/buttons.py
+++ b/marimo/_smoke_tests/buttons.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.2"

--- a/marimo/_smoke_tests/debounce.py
+++ b/marimo/_smoke_tests/debounce.py
@@ -1,0 +1,72 @@
+# Copyright 2023 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.1.3"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    slider = mo.ui.slider(1, 10, label="Slider")
+    debounced_slider = mo.ui.slider(1, 10, debounce=True, label="Debounced Slider")
+
+    number = mo.ui.number(1, 10, label="Number")
+    debounced_number = mo.ui.number(1, 10, debounce=True, label="Debounced Number")
+    return debounced_number, debounced_slider, number, slider
+
+
+@app.cell
+def __(debounced_number, debounced_slider, mo, number, slider):
+    mo.md(f"""
+        Controls:
+
+        {slider}
+
+        {debounced_slider}
+
+        {number}
+
+        {debounced_number}
+    """)
+    return
+
+
+@app.cell
+def __(debounced_number, debounced_slider, mo, number, slider):
+    # Values
+    mo.md(f"""    
+        slider: {slider.value}
+
+        debounced slider: {debounced_slider.value}
+
+        number: {number.value}
+
+        debounced number: {debounced_number.value}
+    """)
+    return
+
+
+@app.cell
+def __(debounced_number, debounced_slider, mo, number, slider):
+    mo.md(f"""
+        Controls and Values:
+
+        {slider} -> {slider.value}
+
+        {debounced_slider} -> {debounced_slider.value}
+
+        {number} -> {number.value}
+
+        {debounced_number} -> {debounced_number.value}
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
- smoke test included to easily verify

API
- `debounce` is a true/false instead of a delay. ideally we abstract away too many details and we can always at a `debounce_delay` later.

Impl
- for slider, the debounce isn't a time, but rather on mouse up
- for number, the default is 200ms
- although they are different implementations, they achieve the same thing so i think we should keep the naming (`debounce`) consistent