### PR TITLE
remove python 3.7 from classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Education",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
We require >= 3.8