### PR TITLE
feat: disable cell (runtime implementation)

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -142,9 +142,7 @@ class App:
                 func: CellFuncTypeBound,
             ) -> CellFunction[CellFuncTypeBound]:
                 cell_function = cell_factory(func)
-                cell_function.cell = cell_function.cell.with_config(
-                    CellConfig(disabled=disabled)
-                )
+                cell_function.cell.configure(CellConfig(disabled=disabled))
                 self._register_cell(cell_function)
                 return cell_function
 
@@ -156,9 +154,7 @@ class App:
             # If the decorator was used without parentheses, func will be the
             # decorated function
             cell_function = cell_factory(func)
-            cell_function.cell = cell_function.cell.with_config(
-                CellConfig(disabled=disabled)
-            )
+            cell_function.cell.configure(CellConfig(disabled=disabled))
             self._register_cell(cell_function)
             return cell_function
 

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -139,7 +139,7 @@ def generate_filecontents(
 
     for code, cell_config in zip(codes, cell_configs):
         try:
-            cell = parse_cell(code).with_config(cell_config)
+            cell = parse_cell(code).configure(cell_config)
             defs |= cell.defs
             cell_function_data.append(cell)
         except SyntaxError:

--- a/marimo/_ast/test_codegen.py
+++ b/marimo/_ast/test_codegen.py
@@ -301,7 +301,7 @@ class TestToFunctionDef:
     def test_with_empty_config(self) -> None:
         code = "x = 0"
         cell = parse_cell(code)
-        cell = cell.with_config(CellConfig())
+        cell = cell.configure(CellConfig())
         fndef = codegen.to_functiondef(cell, "foo")
         expected = "\n".join(
             ["@app.cell", "def foo():", "    x = 0", "    return x,"]
@@ -311,7 +311,7 @@ class TestToFunctionDef:
     def test_with_some_config(self) -> None:
         code = "x = 0"
         cell = parse_cell(code)
-        cell = cell.with_config(CellConfig(disabled=True))
+        cell = cell.configure(CellConfig(disabled=True))
         fndef = codegen.to_functiondef(cell, "foo")
         expected = "\n".join(
             [

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, Optional, cast
+from typing import Any, Dict, Optional, cast
 
 from typing_extensions import Literal
 
@@ -87,7 +87,7 @@ class MarimoConfig(TypedDict, total=False):
     completion: CompletionConfig
     save: SaveConfig
     keymap: KeymapConfig
-    experimental: dict[str, Any]
+    experimental: Dict[str, Any]
 
 
 DEFAULT_CONFIG: MarimoConfig = {
@@ -110,7 +110,7 @@ def configure(config: MarimoConfig) -> MarimoConfig:
     _USER_CONFIG = cast(
         MarimoConfig,
         deep_merge(
-            cast(dict[Any, Any], DEFAULT_CONFIG), cast(dict[Any, Any], config)
+            cast(Dict[Any, Any], DEFAULT_CONFIG), cast(Dict[Any, Any], config)
         ),
     )
     return _USER_CONFIG

--- a/marimo/_messaging/message_types.py
+++ b/marimo/_messaging/message_types.py
@@ -16,6 +16,13 @@ from marimo._messaging.completion_option import CompletionOption
 from marimo._plugins.core.web_component import JSONType
 
 
+"""CellStatus
+
+idle: cell has run with latest inputs
+queued: cell is queued to run
+running: cell is running
+stale: cell hasn't run with latest inputs, and can't run (disabled)
+"""
 CellStatus = Literal["idle", "queued", "running", "stale"]
 
 
@@ -23,7 +30,7 @@ CellStatus = Literal["idle", "queued", "running", "stale"]
 #
 # output  - a CellOutput
 # console - a CellOutput (console message to append), or a list of CellOutputs
-# status  - execution status (idle, queued, running)
+# status  - execution status
 #
 # NB: omitting a field means that its value should be unchanged
 #

--- a/marimo/_messaging/message_types.py
+++ b/marimo/_messaging/message_types.py
@@ -16,6 +16,9 @@ from marimo._messaging.completion_option import CompletionOption
 from marimo._plugins.core.web_component import JSONType
 
 
+CellStatus = Literal["idle", "queued", "running", "stale"]
+
+
 # A cell-op's data has three optional fields:
 #
 # output  - a CellOutput
@@ -33,7 +36,7 @@ class CellOp:
     cell_id: CellId_t
     output: Optional[CellOutput] = None
     console: Optional[Union[CellOutput, list[CellOutput]]] = None
-    status: Optional[Literal["idle", "queued", "running"]] = None
+    status: Optional[CellStatus] = None
     timestamp: float = field(default_factory=lambda: time.time())
 
 

--- a/marimo/_messaging/message_types.py
+++ b/marimo/_messaging/message_types.py
@@ -15,7 +15,6 @@ from marimo._messaging.cell_output import CellOutput
 from marimo._messaging.completion_option import CompletionOption
 from marimo._plugins.core.web_component import JSONType
 
-
 """CellStatus
 
 idle: cell has run with latest inputs

--- a/marimo/_messaging/messages.py
+++ b/marimo/_messaging/messages.py
@@ -59,6 +59,13 @@ def write_output(
     )
 
 
+def write_stale(cell_id: CellId_t) -> None:
+    get_context().stream.write(
+        op=CellOp.name,
+        data=serialize(CellOp(cell_id=cell_id, status="stale")),
+    )
+
+
 def write_queued(cell_id: CellId_t) -> None:
     get_context().stream.write(
         op=CellOp.name,

--- a/marimo/_runtime/conftest.py
+++ b/marimo/_runtime/conftest.py
@@ -6,6 +6,7 @@ from typing import Any, Generator
 
 import pytest
 
+from marimo._ast.cell import CellId_t
 from marimo._plugins.ui._core.registry import UIElementRegistry
 from marimo._runtime.context import get_context
 from marimo._runtime.requests import ExecutionRequest
@@ -47,6 +48,9 @@ class ExecReqProvider:
         key = str(self.counter)
         self.counter += 1
         return ExecutionRequest(key, textwrap.dedent(code))
+
+    def get_with_id(self, cell_id: CellId_t, code: str) -> ExecutionRequest:
+        return ExecutionRequest(cell_id, textwrap.dedent(code))
 
 
 # fixture that provides an ExecReqProvider

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -190,6 +190,26 @@ class DirectedGraph:
 
             return children
 
+    def is_disabled(self, cell_id: CellId_t) -> bool:
+        if cell_id not in self.cells:
+            raise ValueError(f"Cell {cell_id} not in graph.")
+        cell = self.cells[cell_id]
+        if cell.config.disabled:
+            return True
+        seen: set[CellId_t] = set()
+        queue = [cell_id]
+        while queue:
+            cid = queue.pop()
+            seen.add(cid)
+            for parent_id in self.parents[cid]:
+                if parent_id in seen:
+                    continue
+                elif self.cells[parent_id].config.disabled:
+                    return True
+                else:
+                    queue.append(parent_id)
+        return False
+
 
 def transitive_closure(
     graph: DirectedGraph, cell_ids: set[CellId_t]

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -461,8 +461,14 @@ class Kernel:
         write_completed_run()
 
     def _run_cells_internal(self, cell_ids: set[CellId_t]) -> set[CellId_t]:
-        """Run cells, send outputs to frontends"""
+        """Run cells, send outputs to frontends
+
+        Returns set of cells that need to be re-run due to state updates.
+        """
         LOGGER.debug("preparing to evaluate cells %s", cell_ids)
+
+        # Status updates: cells transition to queued, except for
+        # cells that are disabled (explicity or implicitly).
         disabled_cells: set[CellId_t] = set()
         for cid in cell_ids:
             if self.graph.is_disabled(cid):
@@ -471,7 +477,6 @@ class Kernel:
             else:
                 write_queued(cell_id=cid)
         cell_ids = cell_ids - disabled_cells
-
         runner = cell_runner.Runner(
             cell_ids=cell_ids,
             graph=self.graph,

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import builtins
 import contextlib
+import dataclasses
 import io
 import itertools
 import multiprocessing as mp
@@ -13,12 +14,11 @@ import threading
 import time
 import traceback
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
 from queue import Empty as QueueEmpty
 from typing import Any, Iterator, Optional
 
 from marimo import _loggers
-from marimo._ast.cell import CellId_t, parse_cell
+from marimo._ast.cell import CellConfig, CellId_t, parse_cell
 from marimo._config.config import configure
 from marimo._messaging.errors import (
     Error,
@@ -116,10 +116,22 @@ def refs() -> tuple[str, ...]:
     return tuple()
 
 
-@dataclass
+@dataclasses.dataclass
 class ExecutionContext:
     cell_id: CellId_t
     setting_element_value: bool
+
+
+@dataclasses.dataclass
+class CellMetadata:
+    """CellMetadata
+
+    Metadata the kernel needs to persist, even when a cell is removed
+    from the graph or when a cell can't be formed from user code due to syntax
+    errors.
+    """
+
+    config: CellConfig = dataclasses.field(default_factory=CellConfig)
 
 
 class Kernel:
@@ -129,6 +141,8 @@ class Kernel:
             "__builtins__": globals()["__builtins__"],
         }
         self.graph = dataflow.DirectedGraph()
+        self.cell_metadata: dict[CellId_t, CellMetadata] = {}
+
         self.execution_context: Optional[ExecutionContext] = None
         # initializers to override construction of ui elements
         self.ui_initializers: dict[str, Any] = {}
@@ -193,11 +207,21 @@ class Kernel:
                 tmpio.seek(0)
                 error = UnknownError(msg=tmpio.read())
 
+        if cell_id in self.cell_metadata and cell is not None:
+            # If we already have a config for this cell id, restore it
+            # This can happen when a cell was previously deactivated (due to a
+            # syntax error or multiple definition error, for example) and then
+            # re-registered
+            cell.configure(self.cell_metadata[cell_id].config)
+        elif cell_id not in self.cell_metadata:
+            self.cell_metadata[cell_id] = CellMetadata()
+
         if cell is not None:
             self.graph.register_cell(cell_id, cell)
             LOGGER.debug("registered cell %s", cell_id)
             LOGGER.debug("parents: %s", self.graph.parents[cell_id])
             LOGGER.debug("children: %s", self.graph.children[cell_id])
+
         return error
 
     def _maybe_register_cell(
@@ -220,7 +244,7 @@ class Kernel:
         if not self.graph.is_cell_cached(cell_id, code):
             if cell_id in self.graph.cells:
                 LOGGER.debug("Deleting cell %s", cell_id)
-                previous_children = self._delete_cell(cell_id)
+                previous_children = self._deactivate_cell(cell_id)
             error = self._try_registering_cell(cell_id, code)
 
         LOGGER.debug(
@@ -264,13 +288,13 @@ class Kernel:
         )
         write_remove_ui_elements(cell_id)
 
-    def _delete_cell(self, cell_id: CellId_t) -> set[CellId_t]:
-        """Delete a cell from the kernel and the graph.
+    def _deactivate_cell(self, cell_id: CellId_t) -> set[CellId_t]:
+        """Deactivate: remove from graph, invalidate state, but keep metadata
 
-        Deletion from the kernel involves removing cell's defs and
-        de-registering its UI Elements.
+        Keeps the cell's config, in case we see the same cell again.
 
-        Deletion from graph is forwarded to graph object.
+        In contrast to deleting a cell, which fully scrubs the cell
+        from the kernel and graph.
         """
         if cell_id not in self.errors:
             self._invalidate_cell_state(cell_id)
@@ -279,9 +303,21 @@ class Kernel:
             # An errored cell can be thought of as a cell that's in the graph
             # but that has no state in the kernel (because it was never run).
             # Its defs may overlap with defs of a non-errored cell, so we MUST
-            # NOT delete/cleanup its defs from the kernel.
+            # NOT delete/cleanup its defs from the kernel (i.e., an errored
+            # cell shouldn't invalidate state of another cell).
             self.graph.delete_cell(cell_id)
             return set()
+
+    def _delete_cell(self, cell_id: CellId_t) -> set[CellId_t]:
+        """Delete a cell from the kernel and the graph.
+
+        Deletion from the kernel involves removing cell's defs and
+        de-registering its UI Elements.
+
+        Deletion from graph is forwarded to graph object.
+        """
+        del self.cell_metadata[cell_id]
+        return self._deactivate_cell(cell_id)
 
     def mutate_graph(
         self,
@@ -292,10 +328,10 @@ class Kernel:
 
         This method adds the cells in `execution_requests` to the kernel's
         graph (deleting old versions of these cells, if any), and removes the
-        cells in `execution_requests` from the kernel's graph.
+        cells in `deletion_requests` from the kernel's graph.
 
         The mutations that this method makes to the graph renders the
-        kernel inconsistent.
+        kernel inconsistent (stale).
 
         This method does not register errors for cells that were previously
         valid and are not descendants of any of the newly registered cells.
@@ -469,16 +505,13 @@ class Kernel:
 
         # Status updates: cells transition to queued, except for
         # cells that are disabled (explicity or implicitly).
-        disabled_cells: set[CellId_t] = set()
         for cid in cell_ids:
             if self.graph.is_disabled(cid):
                 self.graph.cells[cid].set_status(stale=True)
                 write_stale(cell_id=cid)
-                disabled_cells.add(cid)
             else:
                 self.graph.cells[cid].set_status(stale=False)
                 write_queued(cell_id=cid)
-        cell_ids = cell_ids - disabled_cells
         runner = cell_runner.Runner(
             cell_ids=cell_ids,
             graph=self.graph,
@@ -500,11 +533,13 @@ class Kernel:
             cell_id = runner.pop_cell()
             if runner.cancelled(cell_id):
                 continue
+            # State clean-up: don't leak names, UI elements, ...
+            self._invalidate_cell_state(cell_id)
+            if self.graph.cells[cell_id].status.stale:
+                continue
 
             LOGGER.debug("running cell %s", cell_id)
             write_new_run(cell_id)
-            # State clean-up: don't leak names, UI elements, ...
-            self._invalidate_cell_state(cell_id)
 
             with self._install_execution_context(cell_id):
                 run_result = runner.run(cell_id)
@@ -671,6 +706,10 @@ class Kernel:
                 cell.configure(config)
                 if not cell.config.disabled and cell.status.stale:
                     enabled_cells_to_run.add(cell_id)
+            # store the config, regardless of whether we've seen the cell yet
+            self.cell_metadata[cell_id] = CellMetadata(
+                config=CellConfig.from_dict(config)
+            )
         if enabled_cells_to_run:
             self._run_cells(
                 dataflow.transitive_closure(self.graph, enabled_cells_to_run)

--- a/marimo/_runtime/test_runtime.py
+++ b/marimo/_runtime/test_runtime.py
@@ -10,11 +10,13 @@ from marimo._messaging.errors import (
     MultipleDefinitionError,
 )
 from marimo._plugins.ui._core.ids import IDProvider
+from marimo._runtime.conftest import ExecReqProvider
 from marimo._runtime.dataflow import Edge
 from marimo._runtime.requests import (
     CreationRequest,
     DeleteRequest,
     ExecutionRequest,
+    SetCellConfigRequest,
     SetUIElementValueRequest,
 )
 from marimo._runtime.runtime import Kernel
@@ -278,3 +280,234 @@ def test_syntax_error(k: Kernel) -> None:
     assert "0" in k.graph.cells
     assert "1" in k.graph.cells
     assert not k.errors
+
+
+def test_disable_and_reenable_not_stale(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    k.run(
+        [
+            (
+                er_1 := exec_req.get(
+                    """
+                class namespace:
+                    ...
+                ns = namespace()
+                ns.count = 0
+                """
+                )
+            ),
+            (er_2 := exec_req.get("ns.count += 1")),
+        ]
+    )
+    assert k.globals["ns"].count == 1
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+
+    # disable and re-enable cell 2: cell 2 should not re-run because it
+    # shouldn't have passed through stale status
+    # disable cell 2
+    k.set_cell_config(SetCellConfigRequest({er_2.cell_id: {"disabled": True}}))
+    assert k.globals["ns"].count == 1
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+
+    # re-enable cell 2
+    k.set_cell_config(
+        SetCellConfigRequest({er_2.cell_id: {"disabled": False}})
+    )
+    # cell 2 should **not** have re-run
+    assert k.globals["ns"].count == 1
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+
+
+def test_disable_and_reenable_stale(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    k.run(
+        [
+            (
+                er_1 := exec_req.get(
+                    """
+                class namespace:
+                    ...
+                ns = namespace()
+                ns.count = 0
+                """
+                )
+            ),
+            (er_2 := exec_req.get("ns.count += 1")),
+        ]
+    )
+    assert k.globals["ns"].count == 1
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+
+    # disable and re-enable cell 2, making it stale in between;
+    # cell 2 should re-run on enable
+    k.set_cell_config(SetCellConfigRequest({er_2.cell_id: {"disabled": True}}))
+    k.run(
+        [
+            exec_req.get_with_id(
+                er_1.cell_id,
+                """
+                class namespace:
+                    ...
+                ns = namespace()
+                ns.count = 10
+                """,
+            )
+        ]
+    )
+
+    assert k.globals["ns"].count == 10
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert k.graph.cells[er_2.cell_id].status.stale
+
+    # re-enable cell 2
+    k.set_cell_config(
+        SetCellConfigRequest({er_2.cell_id: {"disabled": False}})
+    )
+    # cell 2 should have re-run
+    assert k.globals["ns"].count == 11
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+
+
+def test_disable_and_reenable_tree(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    # x
+    # x --> y
+    # x, y --> z
+    k.run(
+        [
+            (er_1 := exec_req.get("x = 1")),
+            (er_2 := exec_req.get("y = x + 1")),
+            (er_3 := exec_req.get("z = x + y")),
+            (er_4 := exec_req.get("zz = z + 1")),
+            (er_5 := exec_req.get("zzz = x + 1")),
+        ]
+    )
+    assert k.globals["x"] == 1
+    assert k.globals["y"] == 2
+    assert k.globals["z"] == 3
+    assert k.globals["zz"] == 4
+    assert k.globals["zzz"] == 2
+
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+    assert not k.graph.cells[er_3.cell_id].status.stale
+    assert not k.graph.cells[er_4.cell_id].status.stale
+    assert not k.graph.cells[er_5.cell_id].status.stale
+
+    # disable cell 2
+    k.set_cell_config(SetCellConfigRequest({er_2.cell_id: {"disabled": True}}))
+
+    k.run([ExecutionRequest(er_1.cell_id, "x = 2")])
+    assert k.globals["x"] == 2
+    assert k.globals["zzz"] == 3
+
+    # stale cells' state is gone
+    assert "y" not in k.globals
+    assert "z" not in k.globals
+    assert "zz" not in k.globals
+
+    # cell 1 is not disabled
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    # cell 2 stale because disabled and cannot run
+    assert k.graph.cells[er_2.cell_id].status.stale
+    # cell 3 stale because its parent (cell 2) is disabled
+    assert k.graph.cells[er_3.cell_id].status.stale
+    # cell 4 stale because cell 2 (an ancestor) is disabled
+    assert k.graph.cells[er_4.cell_id].status.stale
+    # cell 5 is not disabled
+    assert not k.graph.cells[er_5.cell_id].status.stale
+
+    # enable cell 2: should run stale cells as a side-effect
+    k.set_cell_config(
+        SetCellConfigRequest({er_2.cell_id: {"disabled": False}})
+    )
+    assert k.globals["x"] == 2
+    assert k.globals["zzz"] == 3
+
+    # stale cells **should have** updated
+    assert k.globals["y"] == 3
+    assert k.globals["z"] == 5
+    assert k.globals["zz"] == 6
+
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+    assert not k.graph.cells[er_3.cell_id].status.stale
+    assert not k.graph.cells[er_4.cell_id].status.stale
+    assert not k.graph.cells[er_5.cell_id].status.stale
+
+
+def test_disable_consecutive(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            (er_1 := exec_req.get("x = 1")),
+            (er_2 := exec_req.get("y = x + 1")),
+        ]
+    )
+    assert k.globals["x"] == 1
+    assert k.globals["y"] == 2
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+
+    # disable both cells
+    k.set_cell_config(SetCellConfigRequest({er_1.cell_id: {"disabled": True}}))
+    k.set_cell_config(SetCellConfigRequest({er_2.cell_id: {"disabled": True}}))
+    # update the code of cell 1 -- both cells stale
+    k.run([exec_req.get_with_id(er_1.cell_id, "x = 2")])
+    assert "x" not in k.globals
+    assert "y" not in k.globals
+    assert k.graph.cells[er_1.cell_id].status.stale
+    assert k.graph.cells[er_2.cell_id].status.stale
+
+    # enable cell 1, but 2 still disabled
+    k.set_cell_config(
+        SetCellConfigRequest({er_1.cell_id: {"disabled": False}})
+    )
+    assert k.globals["x"] == 2
+    assert "y" not in k.globals
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert k.graph.cells[er_2.cell_id].status.stale
+
+    # enable cell 2
+    k.set_cell_config(
+        SetCellConfigRequest({er_2.cell_id: {"disabled": False}})
+    )
+    assert k.globals["x"] == 2
+    assert k.globals["y"] == 3
+    assert not k.graph.cells[er_1.cell_id].status.stale
+    assert not k.graph.cells[er_2.cell_id].status.stale
+
+
+def test_disable_syntax_error(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            (er_1 := exec_req.get("x = 1")),
+        ]
+    )
+    assert k.globals["x"] == 1
+
+    # disable cell
+    k.set_cell_config(SetCellConfigRequest({er_1.cell_id: {"disabled": True}}))
+
+    # add a syntax error
+    k.run([exec_req.get_with_id(er_1.cell_id, "x 2")])
+    assert "x" not in k.globals
+
+    # repair syntax, cell should still be disabled
+    k.run([exec_req.get_with_id(er_1.cell_id, "x = 2")])
+    assert "x" not in k.globals
+    assert k.graph.cells[er_1.cell_id].status.stale
+
+    # enable: should run
+    k.set_cell_config(
+        SetCellConfigRequest({er_1.cell_id: {"disabled": False}})
+    )
+    assert k.globals["x"] == 2
+    assert not k.graph.cells[er_1.cell_id].status.stale

--- a/marimo/_utils/deep_merge.py
+++ b/marimo/_utils/deep_merge.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import Any
+
+
+def _merge_key(
+    original: dict[Any, Any], update: dict[Any, Any], key: str
+) -> Any:
+    # Precondition: key is in at least one of original and update
+    if key not in update:
+        # keep keys in original if they aren't in the update
+        return original[key]
+    elif key not in original:
+        # new keys in update get added to original
+        return update[key]
+    elif isinstance(original[key], dict) and isinstance(update[key], dict):
+        # both dicts, so recurse
+        return deep_merge(original[key], update[key])
+    else:
+        # key is present in both original and update, but values are not
+        # both dicts; just take the update value.
+        return update[key]
+
+
+def deep_merge(
+    original: dict[Any, Any], update: dict[Any, Any]
+) -> dict[Any, Any]:
+    """Deep merge of two dicts."""
+    return {
+        key: _merge_key(original, update, key)
+        for key in set(original.keys()).union(set(update.keys()))
+    }


### PR DESCRIPTION
Implements disabled cells in the runtime.

- Marking a cell as disabled means it and the tree rooted at it can't run
- If a disabled cell (or its descendant) is triggered for a run, it is marked as stale
- When re-enabled, if stale, cell runs

Enhances the kernel to keep track of cell metadata separately from the graph. When we remove cells from the graph due to errors, we still want to hang onto their configs.