### PR TITLE
fix api dataclass types

### DIFF
--- a/marimo/_server/api/format.py
+++ b/marimo/_server/api/format.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Dict
 
 import tornado.web
 
@@ -16,7 +17,7 @@ LOGGER = _loggers.marimo_logger()
 @dataclass
 class Format:
     # map from cell id to code
-    codes: dict[cell.CellId_t, str]
+    codes: Dict[cell.CellId_t, str]
 
 
 class FormatHandler(tornado.web.RequestHandler):

--- a/marimo/_server/api/instantiate.py
+++ b/marimo/_server/api/instantiate.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, List
 
 import tornado.web
 
@@ -15,9 +15,9 @@ from marimo._server.api.model import parse_raw
 @dataclass
 class Instantiate:
     # unique identifiers for UIElements
-    object_ids: list[str]
+    object_ids: List[str]
     # initial value of each UIElement
-    values: list[Any]
+    values: List[Any]
 
 
 class InstantiateHandler(tornado.web.RequestHandler):

--- a/marimo/_server/api/run.py
+++ b/marimo/_server/api/run.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import List
 
 import tornado.web
 
@@ -14,9 +15,9 @@ from marimo._server.api.model import parse_raw
 @dataclass
 class Run:
     # ids of cells to run
-    cell_ids: list[CellId_t]
+    cell_ids: List[CellId_t]
     # code to register/run for each cell
-    codes: list[str]
+    codes: List[str]
 
 
 class RunHandler(tornado.web.RequestHandler):

--- a/marimo/_server/api/save.py
+++ b/marimo/_server/api/save.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import List
 
 import tornado.web
 
@@ -19,9 +20,9 @@ LOGGER = _loggers.marimo_logger()
 @dataclass
 class Save:
     # code for each cell
-    codes: list[str]
+    codes: List[str]
     # name of each cell
-    names: list[str]
+    names: List[str]
     # path to app
     filename: str
 

--- a/marimo/_server/api/save_app_config.py
+++ b/marimo/_server/api/save_app_config.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict
 
 import tornado.web
 
@@ -18,7 +18,7 @@ LOGGER = _loggers.marimo_logger()
 @dataclass
 class SaveAppConfiguration:
     # partial app config
-    config: dict[str, Any]
+    config: Dict[str, Any]
 
 
 class SaveAppConfigurationHandler(tornado.web.RequestHandler):

--- a/marimo/_server/api/set_ui_element_value.py
+++ b/marimo/_server/api/set_ui_element_value.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, List
 
 import tornado.web
 
@@ -14,9 +14,9 @@ from marimo._server.api.model import parse_raw
 @dataclass
 class SetUIElementValue:
     # ids of UI elements whose values we'll set
-    object_ids: list[str]
+    object_ids: List[str]
     # value of each UI element; same length as object_ids
-    values: list[Any]
+    values: List[Any]
 
 
 class SetUIElementValueHandler(tornado.web.RequestHandler):


### PR DESCRIPTION
parse_raw now requires python 3.8 style type hints for py3.8 compatibility