### PR TITLE
Add black as a dependency for formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "tornado>=6.1,<7",
     # python 3.8 compatibility
     "typing_extensions>=4.4.0",
+    # for cell formatting; if user version is not compatible, no-op
+    "black",
 ]
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
But no upper/lower bound; no-op if user's version incompatible with API we're calling.