### PR TITLE
fix: remove unexpected completed-run messages

### DIFF
--- a/frontend/src/core/RuntimeState.ts
+++ b/frontend/src/core/RuntimeState.ts
@@ -49,7 +49,9 @@ export class RuntimeState {
   }
 
   registerRunEnd(): void {
-    this.runningCount -= 1;
+    // Threshold runningCount to 0 for resiliency. Won't be needed once
+    // we merge UI component updates in Python
+    this.runningCount = Math.max(this.runningCount - 1, 0);
   }
 
   running(): boolean {

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -518,7 +518,6 @@ class Kernel:
                 self.graph, cells_with_stale_state
             )
         LOGGER.debug("Finished run.")
-        write_completed_run()
 
     def _run_cells_internal(self, cell_ids: set[CellId_t]) -> set[CellId_t]:
         """Run cells, send outputs to frontends
@@ -889,7 +888,6 @@ class Kernel:
         if self.graph.cells:
             del request
             LOGGER.debug("App already instantiated.")
-            write_completed_run()
         else:
             self.reset_ui_initializers()
             for (
@@ -976,12 +974,15 @@ def launch_kernel(
         LOGGER.debug("received request %s", request)
         if isinstance(request, CreationRequest):
             kernel.instantiate(request)
+            write_completed_run()
         elif isinstance(request, ExecuteMultipleRequest):
             kernel.run(request.execution_requests)
+            write_completed_run()
         elif isinstance(request, SetCellConfigRequest):
             kernel.set_cell_config(request)
         elif isinstance(request, SetUIElementValueRequest):
             kernel.set_ui_element_value(request)
+            write_completed_run()
         elif isinstance(request, DeleteRequest):
             kernel.delete(request)
         elif isinstance(request, CompletionRequest):

--- a/marimo/_tutorials/intro.py
+++ b/marimo/_tutorials/intro.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.8"


### PR DESCRIPTION
Kernel was sending completed-run when frontend hadn't registered a new run (on delete cell and on set cell config). This sent runningCount < 0 in the frontend, causing UI updates to be sent when they should have been buffered.

This is just a fix to hold us over to when we merge UI updates in the kernel ...