### PR TITLE
feat: mo.plain_text

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -28,7 +28,7 @@ and more.
 | {doc}`inputs/index`  | Connect sliders, dropdowns, tables, and more to Python    |
 | {doc}`layouts/index` | Customize outputs with accordions, tabs, stacks, and more |
 | {doc}`plotting`      | Output interactive plots                                  |
-| {doc}`media/index`   | Output media like images, audio, and PDFs                 |
+| {doc}`media/index`   | Output media like images, audio, PDFs, and plain text     |
 | {doc}`html`          | Manipulate HTML objects                                   |
 | {doc}`control_flow`  | Control how cells execute                                 |
 | {doc}`state`         | Make stateful apps with `mo.state`                        |

--- a/docs/api/markdown.md
+++ b/docs/api/markdown.md
@@ -2,7 +2,7 @@
 
 Write markdown with `mo.md`; make your markdown **interactive**, **dynamic**,
 and **visually rich** by interpolating arbitrary Python values and marimo
-elements .
+elements.
 
 ```{eval-rst}
 .. autofunction:: marimo.md

--- a/docs/api/media/index.md
+++ b/docs/api/media/index.md
@@ -9,9 +9,10 @@
   audio
   pdf
   download
+  plain_text
 ```
 
-Use `mo.image`, `mo.audio`, and `mo.pdf` to embed media in your outputs.
+Use these functions to embed media in your outputs.
 
 ```{eval-rst}
 .. autosummary::
@@ -21,4 +22,5 @@ Use `mo.image`, `mo.audio`, and `mo.pdf` to embed media in your outputs.
   marimo.audio
   marimo.pdf
   marimo.download
+  marimo.plain_text
 ```

--- a/docs/api/media/plain_text.md
+++ b/docs/api/media/plain_text.md
@@ -1,0 +1,5 @@
+# Plain text
+
+```{eval-rst}
+.. autofunction:: marimo.plain_text
+```

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "md",
     "mpl",
     "output",
+    "plain_text",
     "pdf",
     "refs",
     "right",
@@ -57,6 +58,7 @@ from marimo._plugins.stateless.download import download
 from marimo._plugins.stateless.flex import hstack, vstack
 from marimo._plugins.stateless.image import image
 from marimo._plugins.stateless.pdf import pdf
+from marimo._plugins.stateless.plain_text import plain_text
 from marimo._plugins.stateless.tabs import tabs
 from marimo._plugins.stateless.tree import tree
 from marimo._runtime import output

--- a/marimo/_output/builder.py
+++ b/marimo/_output/builder.py
@@ -88,7 +88,7 @@ class _HTMLBuilder:
         if not params:
             return f"<pre>{child}</pre>"
         else:
-            return f"<pre {_join_params(params)}>{child}</>"
+            return f"<pre {_join_params(params)}>{child}</pre>"
 
 
 def _join_params(params: List[Tuple[str, str]]) -> str:

--- a/marimo/_output/builder.py
+++ b/marimo/_output/builder.py
@@ -79,6 +79,17 @@ class _HTMLBuilder:
         else:
             return f"<iframe {_join_params(params)} />"
 
+    @staticmethod
+    def pre(child: str, style: Optional[str] = None) -> str:
+        params: List[Tuple[str, str]] = []
+        if style is not None:
+            params.append(("style", style))
+
+        if not params:
+            return f"<pre>{child}</pre>"
+        else:
+            return f"<pre {_join_params(params)}>{child}</>"
+
 
 def _join_params(params: List[Tuple[str, str]]) -> str:
     return " ".join([f"{k}='{v}'" if v != "" else f"{k}" for k, v in params])

--- a/marimo/_output/test_builder.py
+++ b/marimo/_output/test_builder.py
@@ -31,6 +31,11 @@ def test_iframe() -> None:
     )
 
 
+def test_pre() -> None:
+    assert h.pre("Hello") == "<pre>Hello</pre>"
+    assert h.pre("Hello", "color:red") == "<pre style='color:red'>Hello</pre>"
+
+
 def test_join_params() -> None:
     assert (
         _join_params([("style", "color:red"), ("class", "myClass")])

--- a/marimo/_plugins/stateless/plain_text.py
+++ b/marimo/_plugins/stateless/plain_text.py
@@ -1,0 +1,24 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._output.builder import h
+from marimo._output.hypertext import Html
+from marimo._output.rich_help import mddoc
+from marimo._output.utils import create_style
+
+
+@mddoc
+def plain_text(text: str) -> Html:
+    """Text that's fixed-width, with spaces and newlines preserved.
+
+    **Args.**
+
+    - `text`: text to output
+
+    **Returns.**
+
+    An `Html` object representing the text.
+    """
+    styles = create_style({"font-size": f"12px"})
+    img = h.pre(child=text, style=styles)
+    return Html(img)

--- a/marimo/_plugins/stateless/plain_text.py
+++ b/marimo/_plugins/stateless/plain_text.py
@@ -19,6 +19,6 @@ def plain_text(text: str) -> Html:
 
     An `Html` object representing the text.
     """
-    styles = create_style({"font-size": f"12px"})
+    styles = create_style({"font-size": "12px"})
     img = h.pre(child=text, style=styles)
     return Html(img)


### PR DESCRIPTION
Create fixed-width preformatted text with `mo.plain_text`.

Other names considered:
- `mo.monospace` - many of our users won't know what this means
- `mo.pre` - even fewer of our users will know what this means
- `mo.text` - confusing to have `mo.ui.text` and `mo.text`
- `mo.plaintext` - clashes with cryptography