### PR TITLE
wip: pull out data from html components to avoid json parsing/unparsing and decoding

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,7 +42,7 @@ import { CellId, HTMLCellId } from "./core/model/ids";
 import { CellConfig } from "./core/model/cells";
 import { getFilenameFromDOM } from "./core/dom/htmlUtils";
 import { CellArray } from "./editor/renderers/CellArray";
-import { RuntimeState } from "./core/RuntimeState";
+import { RuntimeState } from "./core/kernel/runtime-state";
 import { CellsRenderer } from "./editor/renderers/cells-renderer";
 import { getSerializedLayout } from "./core/state/layout";
 import { useAtom } from "jotai";

--- a/frontend/src/core/dom/htmlUtils.ts
+++ b/frontend/src/core/dom/htmlUtils.ts
@@ -1,42 +1,23 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { assertExists } from "@/utils/assertExists";
 import { UI_ELEMENT_REGISTRY } from "./uiregistry";
-
-// Random unicode character that is unlikely to be used in the JSON string
-const CHAR = "◐";
+import {
+  DataLocatorId,
+  UIElementDataRegistry,
+} from "../kernel/ui-data-registry";
+import { Objects } from "@/utils/objects";
 
 /**
  * Parse an attribute value as JSON.
  */
 export function parseAttrValue<T>(value: string | undefined): T {
-  try {
-    // This will properly handle NaN, Infinity, and -Infinity
-    // The python json.dumps encoding will serialize to NaN, Infinity, -Infinity which is not valid JSON,
-    // but we don't want to change the python encoding because NaN, Infinity, -Infinity are valuable to know.
-    value = value ?? "";
-    value = value.replaceAll(
-      // This was iterated on with GPT. The confidence lies in the unit tests.
-      /(?<=\s|^|\[|,|:)(NaN|-Infinity|Infinity)(?=(?:[^"'\\]*(\\.|'([^'\\]*\\.)*[^'\\]*'|"([^"\\]*\\.)*[^"\\]*"))*[^"']*$)/g,
-      `"${CHAR}$1${CHAR}"`
-    );
-    return JSON.parse(value, (key, v) => {
-      if (typeof v !== "string") {
-        return v;
-      }
-      if (v === `${CHAR}NaN${CHAR}`) {
-        return Number.NaN;
-      }
-      if (v === `${CHAR}Infinity${CHAR}`) {
-        return Number.POSITIVE_INFINITY;
-      }
-      if (v === `${CHAR}-Infinity${CHAR}`) {
-        return Number.NEGATIVE_INFINITY;
-      }
-      return v;
-    }) as T;
-  } catch {
-    return {} as T;
-  }
+  return UIElementDataRegistry.INSTANCE.getValue(value as DataLocatorId) as T;
+}
+
+export function parseHTMLDataset(element: HTMLElement): unknown {
+  return Objects.mapValues(element.dataset, (value) =>
+    value ? parseAttrValue(value) : value
+  );
 }
 
 /**

--- a/frontend/src/core/dom/uiregistry.ts
+++ b/frontend/src/core/dom/uiregistry.ts
@@ -1,5 +1,6 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { repl } from "../../utils/repl";
+import { CellId } from "../model/ids";
 import {
   ValueType,
   marimoValueUpdateEvent,
@@ -27,8 +28,14 @@ export class UIElementRegistry {
   // maps UIElement objectIds to entries.
   entries: Map<string, UIElementEntry>;
 
-  constructor() {
+  /**
+   * Shared singleton instance.
+   */
+  static readonly INSTANCE = new UIElementRegistry();
+
+  private constructor() {
     this.entries = new Map();
+    repl(this, "UI_ELEMENT_REGISTRY");
   }
 
   has(objectId: string): boolean {
@@ -84,7 +91,7 @@ export class UIElementRegistry {
    *
    * @param cellId - stringified cellId
    */
-  removeElementsByCell(cellId: string) {
+  removeElementsByCell(cellId: CellId) {
     const objectIds = [...this.entries.keys()].filter((objectId) =>
       objectId.startsWith(`${cellId}-`)
     );
@@ -148,5 +155,4 @@ export class UIElementRegistry {
   }
 }
 
-export const UI_ELEMENT_REGISTRY = new UIElementRegistry();
-repl(UI_ELEMENT_REGISTRY, "UI_ELEMENT_REGISTRY");
+export const UI_ELEMENT_REGISTRY = UIElementRegistry.INSTANCE;

--- a/frontend/src/core/kernel/messages.tsx
+++ b/frontend/src/core/kernel/messages.tsx
@@ -33,6 +33,10 @@ export type OutputMessage =
       channel: OutputChannel;
       mimetype: "application/vnd.marimo+error";
       data: MarimoError[];
+      /**
+       * key/values for data that is included in the messages HTML data-* attributes.
+       */
+      data_store: Record<string, unknown> | undefined;
       timestamp: number;
     }
   | {
@@ -51,12 +55,20 @@ export type OutputMessage =
         | "video/mp4"
         | "video/mpeg";
       data: string;
+      /**
+       * key/values for data that is included in the messages HTML data-* attributes.
+       */
+      data_store: Record<string, unknown> | undefined;
       timestamp: number;
     }
   | {
       channel: OutputChannel;
       mimetype: "application/json";
       data: unknown;
+      /**
+       * key/values for data that is included in the messages HTML data-* attributes.
+       */
+      data_store: Record<string, unknown> | undefined;
       timestamp: number;
     };
 

--- a/frontend/src/core/kernel/runtime-state.ts
+++ b/frontend/src/core/kernel/runtime-state.ts
@@ -1,7 +1,10 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { sendComponentValues } from "@/core/network/requests";
-import { marimoValueReadyEvent, MarimoValueReadyEventType } from "./dom/events";
-import { UI_ELEMENT_REGISTRY, UIElementRegistry } from "./dom/uiregistry";
+import {
+  marimoValueReadyEvent,
+  MarimoValueReadyEventType,
+} from "../dom/events";
+import { UI_ELEMENT_REGISTRY, UIElementRegistry } from "../dom/uiregistry";
 
 /**
  * Manager to track running cells.

--- a/frontend/src/core/kernel/ui-data-registry.tsx
+++ b/frontend/src/core/kernel/ui-data-registry.tsx
@@ -1,0 +1,69 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { Logger } from "@/utils/Logger";
+import { CellId } from "../model/ids";
+import { TypedString } from "../model/typed";
+import { Objects } from "@/utils/objects";
+import { repl } from "@/utils/repl";
+
+export type DataLocatorId = TypedString<"DataLocatorId">;
+
+/**
+ * Registry to track UIElement values.
+ */
+export class UIElementDataRegistry {
+  /**
+   * Shared singleton instance.
+   */
+  static readonly INSTANCE = new UIElementDataRegistry();
+
+  private constructor() {
+    repl(this, "UI_ELEMENT_DATA_REGISTRY");
+  }
+
+  // We want fast lookups by DataLocatorId and fast removals by CellId.
+  private data = new Map<DataLocatorId, unknown>();
+  private removeHandlers = new Map<CellId, () => void>();
+
+  /**
+   * Set the datastore for a Cell.
+   */
+  setValue(
+    cellId: CellId,
+    dataStore: Record<DataLocatorId, unknown> | undefined
+  ) {
+    // If there is already a remove handler for this cell, call it to remove
+    // the old values.
+    this.removeHandlers.get(cellId)?.();
+
+    if (!dataStore) {
+      return;
+    }
+
+    for (const [name, value] of Objects.entries(dataStore)) {
+      const dataLocatorId = name as DataLocatorId;
+      this.data.set(dataLocatorId, value);
+    }
+    this.removeHandlers.set(cellId, () => {
+      Objects.keys(dataStore).forEach((dataLocatorId) => {
+        this.data.delete(dataLocatorId);
+      });
+    });
+  }
+
+  /**
+   * Get the value for a DataLocatorId
+   */
+  getValue<T>(dataLocatorId: DataLocatorId): T {
+    if (!this.data.has(dataLocatorId)) {
+      Logger.warn(`No value found for ${dataLocatorId}`);
+    }
+    return this.data.get(dataLocatorId) as T;
+  }
+
+  /**
+   * Remove the value for a UIElement.
+   */
+  removeDataStore(cellId: CellId) {
+    this.removeHandlers.get(cellId)?.();
+  }
+}

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -1,4 +1,5 @@
 /* Copyright 2023 Marimo. All rights reserved. */
+import { UIElementDataRegistry } from "../kernel/ui-data-registry";
 import { CellId } from "../model/ids";
 import { API } from "./api";
 import {
@@ -97,6 +98,7 @@ export function sendRunMultiple(cellIds: CellId[], codes: string[]) {
 }
 
 export function sendDeleteCell(cellId: CellId) {
+  UIElementDataRegistry.INSTANCE.removeDataStore(cellId);
   return API.post<DeleteRequest>("/kernel/delete/", {
     cellId: cellId,
   });

--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -5,7 +5,7 @@ import { connectionAtom } from "../state/connection";
 import { useWebSocket } from "@/core/websocket/useWebSocket";
 import { logNever } from "@/utils/assertNever";
 import { useCellActions } from "@/core/state/cells";
-import { RuntimeState } from "@/core/RuntimeState";
+import { RuntimeState } from "@/core/kernel/runtime-state";
 import { COMPLETION_REQUESTS } from "@/core/codemirror/completion/CompletionRequests";
 import { UI_ELEMENT_REGISTRY } from "@/core/dom/uiregistry";
 import { OperationMessage } from "@/core/kernel/messages";
@@ -20,6 +20,7 @@ import { deserializeLayout } from "@/editor/renderers/plugins";
 import { useVariablesActions } from "../variables/state";
 import { toast } from "@/components/ui/use-toast";
 import { renderHTML } from "@/plugins/core/RenderHTML";
+import { UIElementDataRegistry } from "../kernel/ui-data-registry";
 
 /**
  * WebSocket that connects to the Marimo kernel and handles incoming messages.
@@ -139,6 +140,7 @@ export function useMarimoWebSocket(opts: {
           // if the same cell-id is later reused for another element.
           const { cell_id } = msg.data;
           UI_ELEMENT_REGISTRY.removeElementsByCell(cell_id);
+          UIElementDataRegistry.INSTANCE.removeDataStore(cell_id);
           return;
         }
         case "completion-result":
@@ -153,6 +155,10 @@ export function useMarimoWebSocket(opts: {
            * affects how the cell should be rendered.
            */
           const body = msg.data;
+          UIElementDataRegistry.INSTANCE.setValue(
+            body.cell_id,
+            body.output?.data_store
+          );
           handleCellMessage({ cellId: body.cell_id, message: body });
           return;
         }

--- a/frontend/src/editor/cell/useRunCells.ts
+++ b/frontend/src/editor/cell/useRunCells.ts
@@ -1,5 +1,5 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { RuntimeState } from "@/core/RuntimeState";
+import { RuntimeState } from "@/core/kernel/runtime-state";
 import { CellState } from "@/core/model/cells";
 import { CellId } from "@/core/model/ids";
 import { sendRunMultiple } from "@/core/network/requests";

--- a/frontend/src/editor/renderers/CellArray.tsx
+++ b/frontend/src/editor/renderers/CellArray.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from "react";
 import { sendDeleteCell } from "@/core/network/requests";
 import { Cell } from "editor/Cell";
-import { RuntimeState } from "../../core/RuntimeState";
+import { RuntimeState } from "../../core/kernel/runtime-state";
 import { ConnectionStatus, WebSocketState } from "../../core/websocket/types";
 import { CellsAndHistory, useCellActions } from "../../core/state/cells";
 import { AppConfig, UserConfig } from "../../core/config/config";

--- a/frontend/src/plugins/core/componentFactory.tsx
+++ b/frontend/src/plugins/core/componentFactory.tsx
@@ -24,9 +24,8 @@ import {
   MarimoValueUpdateEventType,
 } from "@/core/dom/events";
 import { defineCustomElement } from "../../core/dom/defineCustomElement";
-import { parseAttrValue, parseInitialValue } from "../../core/dom/htmlUtils";
+import { parseHTMLDataset, parseInitialValue } from "../../core/dom/htmlUtils";
 import { IPlugin } from "../types";
-import { Objects } from "../../utils/objects";
 import { renderError } from "./BadPlugin";
 import { renderHTML } from "./RenderHTML";
 import { invariant } from "../../utils/invariant";
@@ -62,25 +61,13 @@ function PluginSlotInternal<T>(
   const [value, setValue] = useState<T>(getInitialValue());
 
   const [parseResult, setParseResult] = useState(() => {
-    return plugin.validator.safeParse({
-      // For any string values, unescape/parse them
-      ...Objects.mapValues(hostElement.dataset, (value) =>
-        typeof value === "string" ? parseAttrValue(value) : value
-      ),
-    });
+    return plugin.validator.safeParse(parseHTMLDataset(hostElement));
   });
 
   useImperativeHandle(ref, () => ({
     reset: () => {
       setValue(getInitialValue());
-      setParseResult(
-        plugin.validator.safeParse({
-          // For any string values, unescape/parse them
-          ...Objects.mapValues(hostElement.dataset, (value) =>
-            typeof value === "string" ? parseAttrValue(value) : value
-          ),
-        })
-      );
+      setParseResult(plugin.validator.safeParse(parseHTMLDataset(hostElement)));
     },
     setChildren: (children) => {
       setChildNodes(children);
@@ -115,12 +102,7 @@ function PluginSlotInternal<T>(
       );
       if (hasAttributeMutation) {
         setParseResult(
-          plugin.validator.safeParse({
-            // For any string values, unescape/parse them
-            ...Objects.mapValues(hostElement.dataset, (value) =>
-              typeof value === "string" ? parseAttrValue(value) : value
-            ),
-          })
+          plugin.validator.safeParse(parseHTMLDataset(hostElement))
         );
       }
     });

--- a/frontend/src/plugins/impl/CheckboxPlugin.tsx
+++ b/frontend/src/plugins/impl/CheckboxPlugin.tsx
@@ -8,16 +8,16 @@ import { CheckedState } from "@radix-ui/react-checkbox";
 import { Labeled } from "./common/labeled";
 
 export class CheckboxPlugin
-  implements IPlugin<boolean, { label: string | null }>
+  implements IPlugin<boolean, { label?: string | null }>
 {
   tagName = "marimo-checkbox";
 
   validator = z.object({
     initialValue: z.boolean(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
   });
 
-  render(props: IPluginProps<boolean, { label: string | null }>): JSX.Element {
+  render(props: IPluginProps<boolean, { label?: string | null }>): JSX.Element {
     return <CheckboxComponent {...props} />;
   }
 }
@@ -26,7 +26,7 @@ const CheckboxComponent = ({
   value,
   setValue,
   data,
-}: IPluginProps<boolean, { label: string | null }>): JSX.Element => {
+}: IPluginProps<boolean, { label?: string | null }>): JSX.Element => {
   const onClick = (newValue: CheckedState) => {
     // unsupported state
     if (newValue === "indeterminate") {

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -14,7 +14,7 @@ import { Labeled } from "./common/labeled";
  * @param data - the data to display
  */
 interface Data<T> {
-  label: string | null;
+  label?: string | null;
   data: T[];
   pagination: boolean;
   selection: "single" | "multi" | null;
@@ -28,7 +28,7 @@ export class DataTablePlugin implements IPlugin<S, Data<unknown>> {
 
   validator = z.object({
     initialValue: z.array(z.number()),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     data: z.array(z.object({}).passthrough()),
     pagination: z.boolean().default(false),
     selection: z.enum(["single", "multi"]).nullable().default(null),

--- a/frontend/src/plugins/impl/DatePickerPlugin.tsx
+++ b/frontend/src/plugins/impl/DatePickerPlugin.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 type T = string;
 
 interface Data {
-  label: string | null;
+  label?: string | null;
   start: string;
   stop: string;
   step?: string;
@@ -22,7 +22,7 @@ export class DatePickerPlugin implements IPlugin<T, Data> {
 
   validator = z.object({
     initialValue: z.string(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     start: z.string(),
     stop: z.string(),
     step: z.string().optional(),

--- a/frontend/src/plugins/impl/DictPlugin.tsx
+++ b/frontend/src/plugins/impl/DictPlugin.tsx
@@ -13,7 +13,7 @@ import { IPlugin, IPluginProps, Setter } from "../types";
 type T = Record<string, unknown> | null;
 
 interface Data {
-  label: string | null;
+  label?: string | null;
   // mapping from elementId to key
   elementIds: Record<string, string>;
 }
@@ -22,7 +22,7 @@ export class DictPlugin implements IPlugin<T, Data> {
   tagName = "marimo-dict";
 
   validator = z.object({
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     elementIds: z.record(z.string(), z.string()),
   });
 

--- a/frontend/src/plugins/impl/DropdownPlugin.tsx
+++ b/frontend/src/plugins/impl/DropdownPlugin.tsx
@@ -8,7 +8,7 @@ import { Labeled } from "./common/labeled";
 import { cn } from "@/lib/utils";
 
 interface Data {
-  label: string | null;
+  label?: string | null;
   options: string[];
   allowSelectNone: boolean;
   fullWidth: boolean;
@@ -19,7 +19,7 @@ export class DropdownPlugin implements IPlugin<string[], Data> {
 
   validator = z.object({
     initialValue: z.array(z.string()),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     options: z.array(z.string()),
     allowSelectNone: z.boolean(),
     fullWidth: z.boolean().default(false),

--- a/frontend/src/plugins/impl/FileUploadPlugin.tsx
+++ b/frontend/src/plugins/impl/FileUploadPlugin.tsx
@@ -22,7 +22,7 @@ interface Data {
   filetypes: string[];
   multiple: boolean;
   kind: FileUploadType;
-  label: string | null;
+  label?: string | null;
 }
 
 type T = Array<[string, string]>;
@@ -34,7 +34,7 @@ export class FileUploadPlugin implements IPlugin<T, Data> {
     filetypes: z.array(z.string()),
     multiple: z.boolean(),
     kind: z.enum(["button", "area"]),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {

--- a/frontend/src/plugins/impl/FormPlugin.tsx
+++ b/frontend/src/plugins/impl/FormPlugin.tsx
@@ -16,7 +16,7 @@ import { renderHTML } from "../core/RenderHTML";
 type T = unknown;
 
 interface Data {
-  label: string | null;
+  label?: string | null;
   elementId: string;
 }
 
@@ -30,7 +30,7 @@ export class FormPlugin implements IPlugin<T, Data> {
   tagName = "marimo-form";
 
   validator = z.object({
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     elementId: z.string(),
   });
 
@@ -48,7 +48,7 @@ interface SubmitBoxProps<T> {
   currentValue: T;
   newValue: T;
   setValue: Setter<T>;
-  label: string | null;
+  label?: string | null;
 }
 
 const SubmitBox = <T,>({

--- a/frontend/src/plugins/impl/MultiselectPlugin.tsx
+++ b/frontend/src/plugins/impl/MultiselectPlugin.tsx
@@ -8,7 +8,7 @@ import { Labeled } from "./common/labeled";
 import { cn } from "@/lib/utils";
 
 interface Data {
-  label: string | null;
+  label?: string | null;
   options: string[];
   fullWidth: boolean;
 }
@@ -20,7 +20,7 @@ export class MultiselectPlugin implements IPlugin<T, Data> {
 
   validator = z.object({
     initialValue: z.array(z.string()),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     options: z.array(z.string()),
     fullWidth: z.boolean().default(false),
   });

--- a/frontend/src/plugins/impl/NumberPlugin.tsx
+++ b/frontend/src/plugins/impl/NumberPlugin.tsx
@@ -14,7 +14,7 @@ interface Data {
   start: T;
   stop: T;
   step?: T;
-  label: string | null;
+  label?: string | null;
   debounce: boolean;
   fullWidth: boolean;
 }
@@ -24,7 +24,7 @@ export class NumberPlugin implements IPlugin<T, Data> {
 
   validator = z.object({
     initialValue: z.number(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     start: z.number(),
     stop: z.number(),
     step: z.number().optional(),

--- a/frontend/src/plugins/impl/RadioPlugin.tsx
+++ b/frontend/src/plugins/impl/RadioPlugin.tsx
@@ -15,7 +15,7 @@ import { Labeled } from "./common/labeled";
  * @param options - text labels for each radio option
  */
 interface Data {
-  label: string | null;
+  label?: string | null;
   options: string[];
 }
 
@@ -27,7 +27,7 @@ export class RadioPlugin implements IPlugin<S, Data> {
 
   validator = z.object({
     initialValue: z.string().nullable(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     options: z.array(z.string()),
   });
 

--- a/frontend/src/plugins/impl/RefreshPlugin.tsx
+++ b/frontend/src/plugins/impl/RefreshPlugin.tsx
@@ -54,7 +54,7 @@ export class RefreshPlugin implements IPlugin<Value, Data> {
   validator = z.object({
     options: z.array(z.union([zodTimestring, z.number().min(1)])).default([]),
     defaultInterval: z.union([zodTimestring, z.number().min(1)]).optional(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
   });
 
   render(props: IPluginProps<Value, Data>): JSX.Element {

--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -12,7 +12,7 @@ interface Data {
   start: T;
   stop: T;
   step?: T;
-  label: string | null;
+  label?: string | null;
   debounce: boolean;
 }
 
@@ -21,7 +21,7 @@ export class SliderPlugin implements IPlugin<T, Data> {
 
   validator = z.object({
     initialValue: z.number(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     start: z.number(),
     stop: z.number(),
     step: z.number().optional(),

--- a/frontend/src/plugins/impl/SwitchPlugin.tsx
+++ b/frontend/src/plugins/impl/SwitchPlugin.tsx
@@ -7,16 +7,16 @@ import { IPlugin, IPluginProps } from "@/plugins/types";
 import { Labeled } from "./common/labeled";
 
 export class SwitchPlugin
-  implements IPlugin<boolean, { label: string | null }>
+  implements IPlugin<boolean, { label?: string | null }>
 {
   tagName = "marimo-switch";
 
   validator = z.object({
     initialValue: z.boolean(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
   });
 
-  render(props: IPluginProps<boolean, { label: string | null }>): JSX.Element {
+  render(props: IPluginProps<boolean, { label?: string | null }>): JSX.Element {
     return <SwitchComponent {...props} />;
   }
 }
@@ -25,7 +25,7 @@ const SwitchComponent = ({
   value,
   setValue,
   data,
-}: IPluginProps<boolean, { label: string | null }>): JSX.Element => {
+}: IPluginProps<boolean, { label?: string | null }>): JSX.Element => {
   const id = useId();
 
   return (

--- a/frontend/src/plugins/impl/TextAreaPlugin.tsx
+++ b/frontend/src/plugins/impl/TextAreaPlugin.tsx
@@ -10,7 +10,7 @@ type T = string;
 
 interface Data {
   placeholder: string;
-  label: string | null;
+  label?: string | null;
   maxLength?: number;
   minLength?: number;
   disabled?: boolean;
@@ -23,7 +23,7 @@ export class TextAreaPlugin implements IPlugin<T, Data> {
   validator = z.object({
     initialValue: z.string(),
     placeholder: z.string(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     maxLength: z.number().optional(),
     minLength: z.number().optional(),
     disabled: z.boolean().optional(),

--- a/frontend/src/plugins/impl/TextInputPlugin.tsx
+++ b/frontend/src/plugins/impl/TextInputPlugin.tsx
@@ -14,7 +14,7 @@ type InputType = "text" | "password" | "email" | "url";
 
 interface Data {
   placeholder: string;
-  label: string | null;
+  label?: string | null;
   kind: InputType;
   maxLength?: number;
   minLength?: number;
@@ -28,7 +28,7 @@ export class TextInputPlugin implements IPlugin<T, Data> {
   validator = z.object({
     initialValue: z.string(),
     placeholder: z.string(),
-    label: z.string().nullable(),
+    label: z.string().nullish(),
     kind: z.enum(["text", "password", "email", "url"]).default("text"),
     maxLength: z.number().optional(),
     minLength: z.number().optional(),

--- a/marimo/_messaging/cell_output.py
+++ b/marimo/_messaging/cell_output.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Sequence, Union
+from typing import Any, Sequence, Union
 
 from marimo._messaging.errors import Error
 
@@ -18,4 +18,5 @@ class CellOutput:
     channel: str
     mimetype: str
     data: Union[str, Sequence[Error]]
+    data_store: dict[str, Any] = field(default_factory=dict)
     timestamp: float = field(default_factory=lambda: time.time())

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -100,6 +100,7 @@ class CellOp(Op):
         channel: str,
         mimetype: str,
         data: str,
+        data_store: dict[str, Any],
         cell_id: Optional[CellId_t],
         status: Optional[CellStatusType],
     ) -> None:
@@ -114,6 +115,7 @@ class CellOp(Op):
                 channel=channel,
                 mimetype=mimetype,
                 data=data,
+                data_store=data_store,
             ),
             status=status,
         ).broadcast()

--- a/marimo/_plugins/core/test_web_component.py
+++ b/marimo/_plugins/core/test_web_component.py
@@ -7,42 +7,38 @@ from marimo._output.formatting import as_html
 from marimo._output.md import md
 from marimo._plugins.core.web_component import (
     build_ui_plugin,
-    parse_initial_value,
 )
 
 
 def test_args_escaped() -> None:
     initial_value = "'ello&"
-    html = build_ui_plugin(
+    html, data = build_ui_plugin(
         "tag-name", initial_value, label=None, args={"text": "a & b"}
     )
 
     # args should be JSON-encoded and escaped
     match = re.search("data-initial-value='(.*?)'", html)
     assert match is not None
-    assert match.groups()[0] == "&quot;&#x27;ello&amp;&quot;"
+    locator_id = match.groups()[0]
+    assert data[locator_id] == initial_value
 
     match = re.search("data-text='(.*?)'", html)
     assert match is not None
-    assert match.groups()[0] == "&quot;a &amp; b&quot;"
-
-
-def test_initial_value_parse() -> None:
-    initial_value = "'ello"
-    html = build_ui_plugin("tag-name", initial_value, label=None, args={})
-
-    # extracted value should be unescaped
-    assert initial_value == parse_initial_value(html)
+    locator_id = match.groups()[0]
+    assert data[locator_id] == "a & b"
 
 
 def test_label_md_compiled() -> None:
     initial_value = "'ello"
-    html = build_ui_plugin("tag-name", initial_value, label="$x$", args={})
+    html, data = build_ui_plugin(
+        "tag-name", initial_value, label="$x$", args={}
+    )
 
     match = re.search("data-label='(.*?)'", html)
     assert match is not None
     # "md"'s latex extension generates spans with class name arithmatex
-    assert "arithmatex" in match.groups()[0]
+    locator_id = match.groups()[0]
+    assert "arithmatex" in data[locator_id]
 
 
 def test_embed_dollar_sign_in_md() -> None:

--- a/marimo/_plugins/stateless/accordion.py
+++ b/marimo/_plugins/stateless/accordion.py
@@ -6,6 +6,8 @@ from marimo._output.hypertext import Html
 from marimo._output.md import md
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import build_stateless_plugin
+from marimo._runtime.context import get_context
+from marimo._runtime.data_store import UIDataLifecycleItem
 
 
 @mddoc
@@ -40,10 +42,11 @@ def accordion(items: dict[str, object], multiple: bool = False) -> Html:
             for item in items.values()
         ]
     )
-    return Html(
-        build_stateless_plugin(
-            component_name="marimo-accordion",
-            args={"labels": item_labels, "multiple": multiple},
-            slotted_html=item_content,
-        )
+    text, data_store = build_stateless_plugin(
+        component_name="marimo-accordion",
+        args={"labels": item_labels, "multiple": multiple},
+        slotted_html=item_content,
     )
+    # TODO: probably not the right place to set this
+    get_context().cell_lifecycle_registry.add(UIDataLifecycleItem(data_store))
+    return Html(text)

--- a/marimo/_plugins/stateless/callout_output.py
+++ b/marimo/_plugins/stateless/callout_output.py
@@ -7,6 +7,8 @@ from marimo._output.formatting import as_html
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import build_stateless_plugin
+from marimo._runtime.context import get_context
+from marimo._runtime.data_store import UIDataLifecycleItem
 
 
 @mddoc
@@ -25,9 +27,10 @@ def callout(
 
     - An HTML object.
     """
-    return Html(
-        build_stateless_plugin(
-            component_name="marimo-callout-output",
-            args={"html": as_html(value).text, "kind": kind},
-        )
+    text, data_store = build_stateless_plugin(
+        component_name="marimo-callout-output",
+        args={"html": as_html(value).text, "kind": kind},
     )
+    # TODO: probably not the right place to set this
+    get_context().cell_lifecycle_registry.add(UIDataLifecycleItem(data_store))
+    return Html(text)

--- a/marimo/_plugins/stateless/download.py
+++ b/marimo/_plugins/stateless/download.py
@@ -12,6 +12,8 @@ from marimo._plugins.core.media import (
     is_data_empty,
 )
 from marimo._plugins.core.web_component import build_stateless_plugin
+from marimo._runtime.context import get_context
+from marimo._runtime.data_store import UIDataLifecycleItem
 
 
 @mddoc
@@ -66,16 +68,15 @@ def download(
     # the frontend can use to download the file. This will
     # lazily read the file and avoid loading it into memory.
 
-    return Html(
-        build_stateless_plugin(
-            component_name="marimo-download",
-            args={
-                "data": io_to_data_url(
-                    data, fallback_mime_type=resolved_mimetype
-                ),
-                "filename": filename,
-                "disabled": disabled,
-                "label": label,
-            },
-        )
+    text, data_store = build_stateless_plugin(
+        component_name="marimo-download",
+        args={
+            "data": io_to_data_url(data, fallback_mime_type=resolved_mimetype),
+            "filename": filename,
+            "disabled": disabled,
+            "label": label,
+        },
     )
+    # TODO: probably not the right place to set this
+    get_context().cell_lifecycle_registry.add(UIDataLifecycleItem(data_store))
+    return Html(text)

--- a/marimo/_plugins/stateless/json_output.py
+++ b/marimo/_plugins/stateless/json_output.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from marimo._output.hypertext import Html
 from marimo._plugins.core.web_component import JSONType, build_stateless_plugin
+from marimo._runtime.context import get_context
+from marimo._runtime.data_store import UIDataLifecycleItem
 
 
 def json_output(json_data: JSONType, name: Optional[str] = None) -> Html:
@@ -19,11 +21,12 @@ def json_output(json_data: JSONType, name: Optional[str] = None) -> Html:
     --------
     A string of HTML for a JSON output element.
     """
-    return Html(
-        build_stateless_plugin(
-            component_name="marimo-json-output",
-            args={"json-data": json_data, "name": name}
-            if name is not None
-            else {"json-data": json_data},
-        )
+    text, data_store = build_stateless_plugin(
+        component_name="marimo-json-output",
+        args={"json-data": json_data, "name": name}
+        if name is not None
+        else {"json-data": json_data},
     )
+    # TODO: probably not the right place to set this
+    get_context().cell_lifecycle_registry.add(UIDataLifecycleItem(data_store))
+    return Html(text)

--- a/marimo/_plugins/stateless/tabs.py
+++ b/marimo/_plugins/stateless/tabs.py
@@ -6,6 +6,8 @@ from marimo._output.hypertext import Html
 from marimo._output.md import md
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import build_stateless_plugin
+from marimo._runtime.context import get_context
+from marimo._runtime.data_store import UIDataLifecycleItem
 
 
 @mddoc
@@ -50,10 +52,11 @@ def tabs(tabs: dict[str, object]) -> Html:
         ]
     )
     tab_labels = list(md(label).text for label in tabs.keys())
-    return Html(
-        build_stateless_plugin(
-            component_name="marimo-tabs",
-            args={"tabs": tab_labels},
-            slotted_html=tab_items,
-        )
+    text, data_store = build_stateless_plugin(
+        component_name="marimo-tabs",
+        args={"tabs": tab_labels},
+        slotted_html=tab_items,
     )
+    # TODO: probably not the right place to set this
+    get_context().cell_lifecycle_registry.add(UIDataLifecycleItem(data_store))
+    return Html(text)

--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -21,6 +21,8 @@ class UIElementRegistry:
         self._bindings: dict[UIElementId, set[str]] = {}
         # mapping from object id to cell that created it
         self._constructing_cells: dict[UIElementId, CellId_t] = {}
+        # mapping from object id to data
+        self._data_stores: dict[str, dict[str, Any]] = {}
 
     def register(
         self,
@@ -41,6 +43,15 @@ class UIElementRegistry:
         if object_id not in self._bindings:
             self._register_bindings(object_id)
         return self._bindings[object_id]
+
+    def add_data_store(
+        self, store_id: str, data_store: dict[str, Any]
+    ) -> None:
+        self._data_stores[store_id] = data_store
+
+    def remove_data_store(self, store_id: str) -> None:
+        if store_id in self._data_stores:
+            del self._data_stores[store_id]
 
     def _register_bindings(self, object_id: UIElementId) -> None:
         kernel = get_context().kernel
@@ -73,6 +84,8 @@ class UIElementRegistry:
             del self._bindings[object_id]
         if object_id in self._constructing_cells:
             del self._constructing_cells[object_id]
+        if object_id in self._data_stores:
+            del self._data_stores[object_id]
 
     def get_object(self, object_id: UIElementId) -> UIElement[Any, Any]:
         if object_id not in self._objects:

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -12,6 +12,7 @@ from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType, build_ui_plugin
 from marimo._plugins.ui._core import ids
 from marimo._runtime.context import get_context
+from marimo._runtime.data_store import UIDataLifecycleItem
 
 if TYPE_CHECKING:
     from marimo._plugins.ui._impl.input import form as form_plugin
@@ -159,13 +160,16 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         self._value = self._initial_value = self._convert_value(initial_value)
         self._on_change = on_change
 
-        self._inner_text = build_ui_plugin(
+        inner_text, data_store = build_ui_plugin(
             component_name,
             initial_value,
             label,
             args,
             slotted_html,
         )
+        self._inner_text = inner_text
+        self._data_store = data_store
+        ctx.cell_lifecycle_registry.add(UIDataLifecycleItem(data_store))
         self._text = (
             f"<marimo-ui-element object-id='{self._id}' "
             + f"random-id='{self._random_id}'>"

--- a/marimo/_runtime/data_store.py
+++ b/marimo/_runtime/data_store.py
@@ -1,0 +1,37 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+import random
+import string
+import threading
+from typing import TYPE_CHECKING, Any
+
+from marimo import _loggers
+from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
+
+if TYPE_CHECKING:
+    from marimo._runtime.context import RuntimeContext
+
+LOGGER = _loggers.marimo_logger()
+
+
+_ALPHABET = string.ascii_letters + string.digits
+
+
+def random_id() -> str:
+    # adapted from: https://stackoverflow.com/questions/13484726/safe-enough-8-character-short-unique-random-string  # noqa: E501
+    # TODO(akshayka): should callers redraw if they get a collision?
+    tid = str(threading.get_native_id())
+    return tid + "-" + "".join(random.choices(_ALPHABET, k=8))
+
+
+class UIDataLifecycleItem(CellLifecycleItem):
+    def __init__(self, data_store: dict[str, Any]) -> None:
+        self.id = random_id()
+        self.data_store = data_store
+
+    def create(self, context: "RuntimeContext") -> None:
+        context.ui_element_registry.add_data_store(self.id, self.data_store)
+
+    def dispose(self, context: "RuntimeContext") -> None:
+        context.ui_element_registry.remove_data_store(self.id)

--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -17,6 +17,7 @@ def write_internal(cell_id: CellId_t, value: object) -> None:
         channel="output",
         mimetype=output.mimetype,
         data=output.data,
+        data_store={},
         cell_id=cell_id,
         status=None,
     )

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -447,6 +447,7 @@ class Kernel:
                 channel="output",
                 mimetype="text/plain",
                 data="",
+                data_store={},
                 cell_id=cid,
                 status=None,
             )
@@ -612,12 +613,17 @@ class Kernel:
                 if formatted_output.traceback is not None:
                     with self._install_execution_context(cell_id):
                         sys.stderr.write(formatted_output.traceback)
+                data_stores = get_context().ui_element_registry._data_stores
+                flat_data_store = {
+                    k: v for data_store in data_stores.values() for k, v in data_store.items()
+                }
                 CellOp.broadcast_output(
                     channel="output",
                     mimetype=formatted_output.mimetype,
                     data=formatted_output.data,
                     cell_id=cell_id,
                     status=cell.status,
+                    data_store=flat_data_store,
                 )
             elif isinstance(run_result.exception, MarimoInterrupt):
                 LOGGER.debug("Cell %s was interrupted", cell_id)


### PR DESCRIPTION
in order to pass data to stateful and stateless plugin, we `json-stringify` and `html-encode` them into strings to put them into `data-*` attributes. instead this PR creates a "data locator" for each attribute so that it can be looked up in a map that is passed along with the message:
for example
```
data: <marimo-table data-rows="12345" />
data_store: {
  "12345": {...}
}
```

this should improve performance, message size, debuggability, and remove some encoding/decoding hacks

open issues: 
- [ ] i've regressed the Inf, -Inf, NaN issue when python creates JSON for `float('nan'), float('inf')`. but the fix should be less hacky than before
- [ ] accessing context in stateless plugins..feels...wrong. will need a better way to do this
- [ ] we sometimes create more info when the data value was a small string or number, should we special case small values or certain value types? my hunch is no, since they are already small, the extra size is still small