### PR TITLE
Shared memory for virtual files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,10 +48,11 @@ jobs:
         run: pnpm run build
 
   test_python:
-    name: Tests on Ubuntu, Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: Tests on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10"]
-
+        exclude:
+          - os: macos-latest
+            python: "3.8"
+          - os: macos-latest
+            python: "3.9"
+          - os: windows-latest
+            python: "3.8"
+          - os: windows-latest
+            python: "3.9"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,13 +56,13 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
         exclude:
           - os: macos-latest
-            python: "3.8"
+            python-version: "3.8"
           - os: macos-latest
-            python: "3.9"
+            python-version: "3.9"
           - os: windows-latest
-            python: "3.8"
+            python-version: "3.8"
           - os: windows-latest
-            python: "3.9"
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -59,9 +59,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # TODO(akshayka): consider adding 3.8, 3.9; macos, windows
+        # TODO(akshayka): consider adding 3.8, 3.9
         python-version: ["3.10"]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/marimo/_ast/test_codegen.py
+++ b/marimo/_ast/test_codegen.py
@@ -333,10 +333,18 @@ def test_recover() -> None:
         ]
     }
     filecontents = json.dumps(cells)
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as f:
+    # keep open for windows compat
+    tempfile_name = ""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False
+    ) as f:
         f.write(filecontents)
         f.seek(0)
-        recovered = codegen.recover(f.name)
+        tempfile_name = f.name
+    try:
+        recovered = codegen.recover(tempfile_name)
+    finally:
+        os.remove(tempfile_name)
 
     codes = [
         "\n".join(['"santa"', "", '"claus"', "", "", ""]),

--- a/marimo/_cli/test_ipynb_to_marimo.py
+++ b/marimo/_cli/test_ipynb_to_marimo.py
@@ -17,12 +17,21 @@ def get_codes(ipynb_name: str) -> tuple[Sequence[str], Sequence[str]]:
         DIR_PATH + f"/../_test_utils/ipynb_data/{ipynb_name}.ipynb.txt"
     )
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as f:
-        f.write(contents)
-        f.seek(0)
+    tempfile_name = ""
+    try:
+        # in windows, can't re-open an open named temporary file, hence
+        # delete=False and manual clean up
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False
+        ) as f:
+            tempfile_name = f.name
+            f.write(contents)
+            f.seek(0)
         app = codegen.get_app(f.name)
         assert app is not None
         return list(app._codes()), list(app._names())
+    finally:
+        os.remove(tempfile_name)
 
 
 def test_markdown() -> None:

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -1,0 +1,48 @@
+# Copyright 2023 Marimo. All rights reserved.
+import io
+import random
+import string
+from typing import Union
+
+from marimo._runtime.context import get_context
+from marimo._runtime.virtual_file import VirtualFile, VirtualFileLifecycleItem
+
+
+def pdf(
+    data: io.IOBase,
+) -> VirtualFile:
+    """Create a virtual file from a PDF.
+
+    **Args.**
+    - data: The data the represents the PDF
+
+    **Returns.**
+    A `VirtualFile` object.
+    """
+    filename = _random_filename("pdf")
+    item = VirtualFileLifecycleItem(filename, "application/pdf", data)
+    get_context().virtual_file_registry.add(item)
+    return item.to_virtual_file()
+
+
+def image(
+    data: io.IOBase,
+    ext: string = "png",
+) -> VirtualFile:
+    """Create a virtual file from an image.
+
+    **Args.**
+    - data: The data the represents the image
+
+    **Returns.**
+    A `VirtualFile` object.
+    """
+    filename = _random_filename(ext)
+    item = VirtualFileLifecycleItem(filename, f"image/{ext}", data)
+    get_context().virtual_file_registry.add(item)
+    return item.to_virtual_file()
+
+
+def _random_filename(ext: string) -> str:
+    basename = "".join(random.choices(string.ascii_letters, k=8))
+    return f"{basename}.{ext}"

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Marimo. All rights reserved.
+import random
 import string
-import uuid
+import threading
 
 from marimo._runtime.context import get_context
 from marimo._runtime.virtual_file import VirtualFile, VirtualFileLifecycleItem
@@ -49,5 +50,8 @@ _ALPHABET = string.ascii_letters + string.digits
 
 
 def _random_filename(ext: str) -> str:
-    basename = str(uuid.uuid4())
+    # adapted from: https://stackoverflow.com/questions/13484726/safe-enough-8-character-short-unique-random-string  # noqa: E501
+    # TODO(akshayka): should callers redraw if they get a collision?
+    tid = str(threading.get_native_id())
+    basename = tid + "-" + "".join(random.choices(_ALPHABET, k=8))
     return f"{basename}.{ext}"

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -30,6 +30,6 @@ def image(data: bytes, ext: str = "png") -> VirtualFile:
 
     A `VirtualFile` object.
     """
-    item = VirtualFileLifecycleItem(ext="pdf", buffer=data)
+    item = VirtualFileLifecycleItem(ext=ext, buffer=data)
     get_context().cell_lifecycle_registry.add(item)
     return item.virtual_file

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Marimo. All rights reserved.
-import random
 import string
+import uuid
 
 from marimo._runtime.context import get_context
 from marimo._runtime.virtual_file import VirtualFile, VirtualFileLifecycleItem
@@ -12,13 +12,15 @@ def pdf(
     """Create a virtual file from a PDF.
 
     **Args.**
-    - data: The data the represents the PDF
+
+    - data: PDF data in bytes
 
     **Returns.**
+
     A `VirtualFile` object.
     """
     filename = _random_filename("pdf")
-    item = VirtualFileLifecycleItem(filename, "application/pdf", data)
+    item = VirtualFileLifecycleItem(filename, data)
     get_context().cell_lifecycle_registry.add(item)
     return item.virtual_file
 
@@ -30,18 +32,22 @@ def image(
     """Create a virtual file from an image.
 
     **Args.**
-    - data: The data the represents the image
+
+    - data: Image data in bytes
 
     **Returns.**
+
     A `VirtualFile` object.
     """
     filename = _random_filename(ext)
-    item = VirtualFileLifecycleItem(filename, f"image/{ext}", data)
+    item = VirtualFileLifecycleItem(filename, data)
     get_context().cell_lifecycle_registry.add(item)
     return item.virtual_file
 
 
+_ALPHABET = string.ascii_letters + string.digits
+
+
 def _random_filename(ext: str) -> str:
-    # TODO use uuid ...
-    basename = "".join(random.choices(string.ascii_letters, k=8))
+    basename = str(uuid.uuid4())
     return f"{basename}.{ext}"

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -42,5 +42,6 @@ def image(
 
 
 def _random_filename(ext: str) -> str:
+    # TODO use uuid ...
     basename = "".join(random.choices(string.ascii_letters, k=8))
     return f"{basename}.{ext}"

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -1,15 +1,13 @@
 # Copyright 2023 Marimo. All rights reserved.
-import io
 import random
 import string
-from typing import Union
 
 from marimo._runtime.context import get_context
 from marimo._runtime.virtual_file import VirtualFile, VirtualFileLifecycleItem
 
 
 def pdf(
-    data: io.IOBase,
+    data: bytes,
 ) -> VirtualFile:
     """Create a virtual file from a PDF.
 
@@ -21,13 +19,13 @@ def pdf(
     """
     filename = _random_filename("pdf")
     item = VirtualFileLifecycleItem(filename, "application/pdf", data)
-    get_context().virtual_file_registry.add(item)
-    return item.to_virtual_file()
+    get_context().cell_lifecycle_registry.add(item)
+    return item.virtual_file
 
 
 def image(
-    data: io.IOBase,
-    ext: string = "png",
+    data: bytes,
+    ext: str = "png",
 ) -> VirtualFile:
     """Create a virtual file from an image.
 
@@ -39,10 +37,10 @@ def image(
     """
     filename = _random_filename(ext)
     item = VirtualFileLifecycleItem(filename, f"image/{ext}", data)
-    get_context().virtual_file_registry.add(item)
-    return item.to_virtual_file()
+    get_context().cell_lifecycle_registry.add(item)
+    return item.virtual_file
 
 
-def _random_filename(ext: string) -> str:
+def _random_filename(ext: str) -> str:
     basename = "".join(random.choices(string.ascii_letters, k=8))
     return f"{basename}.{ext}"

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -1,15 +1,9 @@
 # Copyright 2023 Marimo. All rights reserved.
-import random
-import string
-import threading
-
 from marimo._runtime.context import get_context
 from marimo._runtime.virtual_file import VirtualFile, VirtualFileLifecycleItem
 
 
-def pdf(
-    data: bytes,
-) -> VirtualFile:
+def pdf(data: bytes) -> VirtualFile:
     """Create a virtual file from a PDF.
 
     **Args.**
@@ -20,16 +14,12 @@ def pdf(
 
     A `VirtualFile` object.
     """
-    filename = _random_filename("pdf")
-    item = VirtualFileLifecycleItem(filename, data)
+    item = VirtualFileLifecycleItem(ext="pdf", buffer=data)
     get_context().cell_lifecycle_registry.add(item)
     return item.virtual_file
 
 
-def image(
-    data: bytes,
-    ext: str = "png",
-) -> VirtualFile:
+def image(data: bytes, ext: str = "png") -> VirtualFile:
     """Create a virtual file from an image.
 
     **Args.**
@@ -40,18 +30,6 @@ def image(
 
     A `VirtualFile` object.
     """
-    filename = _random_filename(ext)
-    item = VirtualFileLifecycleItem(filename, data)
+    item = VirtualFileLifecycleItem(ext="pdf", buffer=data)
     get_context().cell_lifecycle_registry.add(item)
     return item.virtual_file
-
-
-_ALPHABET = string.ascii_letters + string.digits
-
-
-def _random_filename(ext: str) -> str:
-    # adapted from: https://stackoverflow.com/questions/13484726/safe-enough-8-character-short-unique-random-string  # noqa: E501
-    # TODO(akshayka): should callers redraw if they get a collision?
-    tid = str(threading.get_native_id())
-    basename = tid + "-" + "".join(random.choices(_ALPHABET, k=8))
-    return f"{basename}.{ext}"

--- a/marimo/_plugins/stateless/pdf.py
+++ b/marimo/_plugins/stateless/pdf.py
@@ -1,10 +1,10 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
-import base64
 import io
 from typing import Any, Optional, Union
 
+import marimo._output.data.data as mo_data
 from marimo._output.builder import h
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
@@ -51,7 +51,7 @@ def pdf(
 
     `Html` object
     """
-    resolved_src = src if isinstance(src, str) else _io_to_data_url(src)
+    resolved_src = src if isinstance(src, str) else mo_data.pdf(src).url
     if initial_page is not None and isinstance(src, str):
         # FitV is "fit to vertical"
         resolved_src += f"#page={initial_page}&view=FitV"
@@ -69,8 +69,3 @@ def pdf(
             style=styles,
         )
     )
-
-
-def _io_to_data_url(readable: io.IOBase) -> str:
-    base64_string = base64.b64encode(readable.read()).decode("utf-8")
-    return f"data:application/pdf;base64,{base64_string}"

--- a/marimo/_plugins/stateless/pdf.py
+++ b/marimo/_plugins/stateless/pdf.py
@@ -51,7 +51,7 @@ def pdf(
 
     `Html` object
     """
-    resolved_src = src if isinstance(src, str) else mo_data.pdf(src).url
+    resolved_src = src if isinstance(src, str) else mo_data.pdf(src.read()).url
     if initial_page is not None and isinstance(src, str):
         # FitV is "fit to vertical"
         resolved_src += f"#page={initial_page}&view=FitV"

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -989,7 +989,7 @@ def launch_kernel(
 
         signal.signal(signal.SIGINT, interrupt_handler)
 
-        if os.name == "nt":
+        if sys.platform == "win32" or sys.platform == "cygwin":
             # windows doesn't handle SIGTERM
             signal.signal(signal.SIGBREAK, sigterm_handler)
         else:

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -952,15 +952,12 @@ def launch_kernel(
         # In edit mode, kernel runs in its own process so it's interruptible.
         from marimo._output.formatters.formatters import register_formatters
 
-        try:
+        # TODO: windows workaround
+        if sys.platform != "win32":
             # Make this process group leader to prevent it from receiving
             # signals intended for the parent (server) process,
             # Ctrl+C in particular.
             os.setsid()
-        except Exception:
-            # Not supported on Windows.
-            # TODO(akshayka): Test/fix on Windows.
-            ...
 
         # kernels are processes in edit mode, and each process needs to
         # install the formatter import hooks

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -979,7 +979,21 @@ def launch_kernel(
                 Interrupted().broadcast()
                 raise MarimoInterrupt
 
+        def sigterm_handler(signum: int, frame: Any) -> None:
+            """Cleans up the kernel ends exit."""
+            del signum
+            del frame
+
+            get_context().virtual_file_registry.shutdown()
+            sys.exit(0)
+
         signal.signal(signal.SIGINT, interrupt_handler)
+
+        if os.name == "nt":
+            # windows doesn't handle SIGTERM
+            signal.signal(signal.SIGBREAK, sigterm_handler)
+        else:
+            signal.signal(signal.SIGTERM, sigterm_handler)
 
     while True:
         try:

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1014,3 +1014,4 @@ def launch_kernel(
             break
         else:
             raise ValueError(f"Unknown request {request}")
+    get_context().virtual_file_registry.shutdown()

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -980,7 +980,7 @@ def launch_kernel(
                 raise MarimoInterrupt
 
         def sigterm_handler(signum: int, frame: Any) -> None:
-            """Cleans up the kernel ends exit."""
+            """Cleans up the kernel ands exit."""
             del signum
             del frame
 

--- a/marimo/_runtime/test_virtual_file.py
+++ b/marimo/_runtime/test_virtual_file.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._runtime.conftest import ExecReqProvider
+from marimo._runtime.context import get_context
+from marimo._runtime.requests import DeleteRequest
+from marimo._runtime.runtime import Kernel
+
+
+def test_virtual_file_creation(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            exec_req.get(
+                """
+                import io
+                import marimo as mo
+                bytestream = io.BytesIO(b"hello world")
+                pdf_plugin = mo.pdf(bytestream)
+                """
+            ),
+        ]
+    )
+    assert len(get_context().virtual_file_registry.registry) == 1
+    for fname, _ in get_context().virtual_file_registry.registry.items():
+        assert fname.endswith(".pdf")
+
+
+def test_virtual_file_deletion(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            er := exec_req.get(
+                """
+                import io
+                import marimo as mo
+                bytestream = io.BytesIO(b"hello world")
+                pdf_plugin = mo.pdf(bytestream)
+                """
+            ),
+        ]
+    )
+    assert len(get_context().virtual_file_registry.registry) == 1
+    for fname, _ in get_context().virtual_file_registry.registry.items():
+        assert fname.endswith(".pdf")
+
+    k.delete(DeleteRequest(er.cell_id))
+    assert not get_context().virtual_file_registry.registry

--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -48,6 +48,9 @@ class VirtualFileRegistry:
         default_factory=dict
     )
 
+    def __del__(self) -> None:
+        self.shutdown()
+
     def _key(self, url: str) -> str:
         return url.replace("/", "_")
 
@@ -78,6 +81,7 @@ class VirtualFileRegistry:
             size=len(buffer),
         )
         shm.buf[:] = buffer
+        shm.close()
         self.registry[key] = shm
 
     def remove(self, url: str) -> None:
@@ -86,3 +90,8 @@ class VirtualFileRegistry:
             # destroy the shared memory
             self.registry[key].unlink()
             del self.registry[key]
+
+    def shutdown(self) -> None:
+        for _, shm in self.registry.items():
+            shm.unlink()
+        self.registry.clear()

--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -80,7 +80,10 @@ class VirtualFileRegistry:
             create=True,
             size=len(buffer),
         )
-        shm.buf[:] = buffer
+        print("buffer: ", buffer)
+        print(len(buffer))
+        print(len(shm.buf))
+        shm.buf[: len(buffer)] = buffer
         shm.close()
         self.registry[key] = shm
 

--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -20,18 +20,16 @@ class VirtualFile:
     filename: str
     buffer: bytes
 
-    def __init__(self, filename: str, mimetype: str, buffer: bytes) -> None:
+    def __init__(self, filename: str, buffer: bytes) -> None:
         self.filename = filename
-        self.mimetype = mimetype
-        self.url = f"/@file/{filename}/{mimetype}"
+        self.url = f"/@file/{filename}"
         self.buffer = buffer
 
 
 class VirtualFileLifecycleItem(CellLifecycleItem):
-    def __init__(self, filename: str, mimetype: str, buffer: bytes) -> None:
+    def __init__(self, filename: str, buffer: bytes) -> None:
         self.filename = filename
-        self.mimetype = mimetype
-        self.virtual_file = VirtualFile(self.filename, mimetype, buffer)
+        self.virtual_file = VirtualFile(self.filename, buffer)
 
     def create(self, context: "RuntimeContext") -> None:
         context.virtual_file_registry.add(self.virtual_file)

--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import dataclasses
 import io
+from multiprocessing import shared_memory
 from typing import TYPE_CHECKING, Callable
 
 from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
@@ -18,33 +19,52 @@ class VirtualFile:
     def __init__(self, filename: str) -> None:
         raise NotImplementedError
 
+    def to_stream(self) -> io.BytesIO:
+        raise NotImplementedError
+
 
 class VirutalFileLifeCycleItem(CellLifecycleItem):
     def __init__(
         self, filename: str, to_stream: Callable[[], io.BytesIO]
     ) -> None:
         self.filename = filename
+        self.virtual_file = VirtualFile(self.filename)
         self.to_stream = to_stream
 
     def create(self, context: "RuntimeContext") -> None:
         context.virtual_file_registry.add(
-            self.filename, self.to_virtual_file()
+            self.virtual_file.url, self.virtual_file
         )
 
     def dispose(self, context: "RuntimeContext") -> None:
-        context.virtual_file_registry.remove(self.filename)
-
-    def to_virtual_file(self) -> VirtualFile:
-        return VirtualFile(self.filename)
+        context.virtual_file_registry.remove(self.virtual_file.url)
 
 
 @dataclasses.dataclass
 class VirtualFileRegistry:
-    registry: dict[str, VirtualFile] = dataclasses.field(default_factory=dict)
+    registry: dict[str, shared_memory.SharedMemory] = dataclasses.field(
+        default_factory=dict
+    )
 
-    def add(self, filename: str, virtual_file: VirtualFile) -> None:
-        self.registry[filename] = virtual_file
+    def add(self, url: str, virtual_file: VirtualFile) -> None:
+        buffer = virtual_file.to_stream().getbuffer()
+        # Immediately writes the contents of the file to an in-memory
+        # buffer; not lazy.
+        #
+        # To retrieve the buffer from another proces, use:
+        #
+        # ```
+        # buffer_contents = bytes(shared_memory.SharedMemory(name=url).buf)
+        # ```
+        shm = shared_memory.SharedMemory(
+            name=url,
+            create=True,
+            size=buffer.nbytes,
+        )
+        shm.buf[:] = buffer
+        self.registry[url] = shm
 
-    def remove(self, filename: str) -> None:
-        if filename in self.registry:
-            del self.registry[filename]
+    def remove(self, url: str) -> None:
+        if url in self.registry:
+            self.registry[url].unlink()
+            del self.registry[url]

--- a/marimo/_server/api/__init__.py
+++ b/marimo/_server/api/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "SaveUserConfigurationHandler",
     "SetCellConfigHandler",
     "SetUIElementValueHandler",
+    "VirtualFileHandler",
 ]
 
 from marimo._server.api.code_complete import CodeCompleteHandler
@@ -30,3 +31,4 @@ from marimo._server.api.save_app_config import SaveAppConfigurationHandler
 from marimo._server.api.save_user_config import SaveUserConfigurationHandler
 from marimo._server.api.set_cell_config import SetCellConfigHandler
 from marimo._server.api.set_ui_element_value import SetUIElementValueHandler
+from marimo._server.api.virtual_file import VirtualFileHandler

--- a/marimo/_server/api/virtual_file.py
+++ b/marimo/_server/api/virtual_file.py
@@ -1,0 +1,52 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import tornado.web
+
+from marimo import _loggers
+from marimo._ast import codegen
+from marimo._server import sessions
+from marimo._server.api.model import parse_raw
+from marimo._server.api.status import HTTPStatus
+
+LOGGER = _loggers.marimo_logger()
+
+
+class VirtualFileHandler(tornado.web.RequestHandler):
+    """Handler for virtual files."""
+
+    @sessions.requires_edit
+    def get(self, filename) -> None:
+        mgr = sessions.get_manager()
+        session_id = self.get_argument("session_id")
+        if session_id is not None:
+            raise tornado.web.HTTPError(
+                HTTPStatus.BAD_REQUEST,
+                reason="Session ID must be provided",
+            )
+        if filename is None:
+            raise tornado.web.HTTPError(
+                HTTPStatus.BAD_REQUEST,
+                reason="Filename must be provided",
+            )
+        session = mgr.get_session(session_id)
+        if session is None:
+            raise tornado.web.HTTPError(
+                HTTPStatus.NOT_FOUND,
+                reason="Session not found",
+            )
+
+        # get virtual file
+        # TODO: get virtual file from session
+        virtual_file = session.get_virtual_file(filename)
+        if virtual_file is None:
+            raise tornado.web.HTTPError(
+                HTTPStatus.NOT_FOUND,
+                reason="File not found",
+            )
+
+        self.set_header("Content-Type", virtual_file.mimetype)
+        self.write(virtual_file.to_stream())

--- a/marimo/_server/api/virtual_file.py
+++ b/marimo/_server/api/virtual_file.py
@@ -1,16 +1,11 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
-from dataclasses import dataclass
 from multiprocessing import shared_memory
-from typing import Any, Dict
 
 import tornado.web
 
 from marimo import _loggers
-from marimo._ast import codegen
-from marimo._server import sessions
-from marimo._server.api.model import parse_raw
 from marimo._server.api.status import HTTPStatus
 
 LOGGER = _loggers.marimo_logger()
@@ -19,37 +14,25 @@ LOGGER = _loggers.marimo_logger()
 class VirtualFileHandler(tornado.web.RequestHandler):
     """Handler for virtual files."""
 
-    @sessions.requires_edit
     def get(self, filename) -> None:
-        mgr = sessions.get_manager()
-        session_id = self.get_argument("session_id")
-        if session_id is not None:
-            raise tornado.web.HTTPError(
-                HTTPStatus.BAD_REQUEST,
-                reason="Session ID must be provided",
-            )
         if filename is None:
             raise tornado.web.HTTPError(
                 HTTPStatus.BAD_REQUEST,
                 reason="Filename must be provided",
             )
-        session = mgr.get_session(session_id)
-        if session is None:
-            raise tornado.web.HTTPError(
-                HTTPStatus.NOT_FOUND,
-                reason="Session not found",
-            )
-
+        key = self.request.path.replace("/", "_")
         try:
-            buffer_contents = bytes(
-                shared_memory.SharedMemory(name=self.request.path).buf
-            )
+            # NB: this can't be collapsed into a one-liner!
+            # for some reason doing it in one line yields a
+            # 'released memoryview ...'
+            shm = shared_memory.SharedMemory(name=key)
+            buffer_contents = bytes(shm.buf)
         except FileNotFoundError:
             raise tornado.web.HTTPError(
                 HTTPStatus.NOT_FOUND,
                 reason="File not found",
             )
-
         # TODO(akshayka): can we encode mime-type in the path?
-        # self.set_header("Content-Type", virtual_file.mimetype)
+        # TODO: hack content-type to test ...
+        self.set_header("Content-Type", "application/pdf")
         self.write(buffer_contents)

--- a/marimo/_server/api/virtual_file.py
+++ b/marimo/_server/api/virtual_file.py
@@ -17,6 +17,7 @@ class VirtualFileHandler(tornado.web.RequestHandler):
 
     def get(self, filename: str) -> None:
         key = filename
+        shm = None
         try:
             # NB: this can't be collapsed into a one-liner!
             # doing it in one line yields a 'released memoryview ...'
@@ -28,6 +29,9 @@ class VirtualFileHandler(tornado.web.RequestHandler):
                 HTTPStatus.NOT_FOUND,
                 reason="File not found",
             ) from err
+        finally:
+            if shm is not None:
+                shm.close()
         mimetype, _ = mimetypes.guess_type(filename)
         if mimetype is not None:
             self.set_header("Content-Type", mimetype)

--- a/marimo/_server/api/virtual_file.py
+++ b/marimo/_server/api/virtual_file.py
@@ -14,25 +14,18 @@ LOGGER = _loggers.marimo_logger()
 class VirtualFileHandler(tornado.web.RequestHandler):
     """Handler for virtual files."""
 
-    def get(self, filename) -> None:
-        if filename is None:
-            raise tornado.web.HTTPError(
-                HTTPStatus.BAD_REQUEST,
-                reason="Filename must be provided",
-            )
-        key = self.request.path.replace("/", "_")
+    def get(self, filename: str, mimetype: str) -> None:
+        key = filename
         try:
             # NB: this can't be collapsed into a one-liner!
-            # for some reason doing it in one line yields a
-            # 'released memoryview ...'
+            # doing it in one line yields a 'released memoryview ...'
+            # because shared_memory has built in ref-tracking + GC
             shm = shared_memory.SharedMemory(name=key)
             buffer_contents = bytes(shm.buf)
-        except FileNotFoundError:
+        except FileNotFoundError as err:
             raise tornado.web.HTTPError(
                 HTTPStatus.NOT_FOUND,
                 reason="File not found",
-            )
-        # TODO(akshayka): can we encode mime-type in the path?
-        # TODO: hack content-type to test ...
-        self.set_header("Content-Type", "application/pdf")
+            ) from err
+        self.set_header("Content-Type", mimetype)
         self.write(buffer_contents)

--- a/marimo/_server/api/virtual_file.py
+++ b/marimo/_server/api/virtual_file.py
@@ -31,4 +31,5 @@ class VirtualFileHandler(tornado.web.RequestHandler):
         mimetype, _ = mimetypes.guess_type(filename)
         if mimetype is not None:
             self.set_header("Content-Type", mimetype)
+        self.set_header("Cache-Control", "max-age=86400")
         self.write(buffer_contents)

--- a/marimo/_server/api/virtual_file.py
+++ b/marimo/_server/api/virtual_file.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
+import mimetypes
 from multiprocessing import shared_memory
 
 import tornado.web
@@ -14,7 +15,7 @@ LOGGER = _loggers.marimo_logger()
 class VirtualFileHandler(tornado.web.RequestHandler):
     """Handler for virtual files."""
 
-    def get(self, filename: str, mimetype: str) -> None:
+    def get(self, filename: str) -> None:
         key = filename
         try:
             # NB: this can't be collapsed into a one-liner!
@@ -27,5 +28,7 @@ class VirtualFileHandler(tornado.web.RequestHandler):
                 HTTPStatus.NOT_FOUND,
                 reason="File not found",
             ) from err
-        self.set_header("Content-Type", mimetype)
+        mimetype, _ = mimetypes.guess_type(filename)
+        if mimetype is not None:
+            self.set_header("Content-Type", mimetype)
         self.write(buffer_contents)

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -198,6 +198,10 @@ def construct_app(
                 api.SaveAppConfigurationHandler,
             ),
             (
+                r"/api/kernel/@file/(.*)",
+                api.VirtualFileHandler,
+            ),
+            (
                 r"/(favicon\.ico)",
                 tornado.web.StaticFileHandler,
                 {"path": root},

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -322,7 +322,8 @@ async def start_server(
                 subprocess.Popen(
                     ["xdg-open", url],
                     # don't forward signals: ctrl-c shouldn't kill the browser
-                    preexec_fn=os.setpgrp,
+                    # TODO: test/workaround on windows
+                    preexec_fn=os.setpgrp if sys.platform != "win32" else None,
                     stdout=devnull,
                     stderr=subprocess.STDOUT,
                 )

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -62,6 +62,7 @@ def shutdown(with_error: bool = False) -> None:
             "\033[32mThanks for using marimo!\033[0m %s" % _utf8("🌊🍃")
         )
         print()
+    # TODO(akshayka): need to close shared memory vfiles ...
     mgr.shutdown()
     tornado.ioloop.IOLoop.current().stop()
     if with_error:
@@ -198,7 +199,7 @@ def construct_app(
                 api.SaveAppConfigurationHandler,
             ),
             (
-                r"/api/kernel/@file/(.*)",
+                r"/@file/(.*)",
                 api.VirtualFileHandler,
             ),
             (

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -319,11 +319,15 @@ async def start_server(
     if not headless:
         if which("xdg-open") is not None:
             with open(os.devnull, "w") as devnull:
+                if sys.platform == "win32" or sys.platform == "cygwin":
+                    preexec_fn = None
+                else:
+                    preexec_fn = os.setpgrp
                 subprocess.Popen(
                     ["xdg-open", url],
                     # don't forward signals: ctrl-c shouldn't kill the browser
                     # TODO: test/workaround on windows
-                    preexec_fn=os.setpgrp if sys.platform != "win32" else None,
+                    preexec_fn=preexec_fn,
                     stdout=devnull,
                     stderr=subprocess.STDOUT,
                 )

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -62,7 +62,6 @@ def shutdown(with_error: bool = False) -> None:
             "\033[32mThanks for using marimo!\033[0m %s" % _utf8("🌊🍃")
         )
         print()
-    # TODO(akshayka): need to close shared memory vfiles ...
     mgr.shutdown()
     tornado.ioloop.IOLoop.current().stop()
     if with_error:

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -198,7 +198,8 @@ def construct_app(
                 api.SaveAppConfigurationHandler,
             ),
             (
-                r"/@file/(.*)",
+                # filename/mimetype
+                r"/@file/(.*?)/(.*)",
                 api.VirtualFileHandler,
             ),
             (

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -198,8 +198,7 @@ def construct_app(
                 api.SaveAppConfigurationHandler,
             ),
             (
-                # filename/mimetype
-                r"/@file/(.*?)/(.*)",
+                r"/@file/(.*)",
                 api.VirtualFileHandler,
             ),
             (

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -331,7 +331,9 @@ class Session:
             # this, because mp.Queue appears to be a function
             self.queue.close()  # type: ignore
             if self.kernel_task.is_alive():
-                if os.name == "nt":
+                if (
+                    sys.platform == "win32" or sys.platform == "cygwin"
+                ) and self.kernel_task.pid is not None:
                     # send a CTRL_BREAK_EVENT to gracefully shutdown
                     # since SIGTERM isn't handled on windows
                     os.kill(self.kernel_task.pid, signal.CTRL_BREAK_EVENT)

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -331,6 +331,7 @@ class Session:
             # this, because mp.Queue appears to be a function
             self.queue.close()  # type: ignore
             if self.kernel_task.is_alive():
+                # TODO: gracefully unlink shm/vfiles
                 self.kernel_task.terminate()
             tornado.ioloop.IOLoop.current().remove_handler(
                 self.read_conn.fileno()

--- a/marimo/_smoke_tests/pdf.py
+++ b/marimo/_smoke_tests/pdf.py
@@ -1,14 +1,15 @@
 # Copyright 2023 Marimo. All rights reserved.
 import marimo
 
-__generated_with = "0.1.4"
+__generated_with = "0.1.21"
 app = marimo.App(width="full")
 
 
 @app.cell
 def __():
     import marimo as mo
-    return mo,
+    import requests
+    return mo, requests
 
 
 @app.cell
@@ -33,6 +34,20 @@ def __(mo, page):
         height="60vh"
     )
     return
+
+
+@app.cell
+def __(mo, page, requests):
+    downloaded = requests.get("https://arxiv.org/pdf/2104.00282.pdf")
+    # This is still performant as it does not pass the full PDF to the frontend,
+    # and instead creates a VirtualFile
+    mo.pdf(
+        src=downloaded.content,
+        initial_page=page.value,
+        width="100%",
+        height="60vh"
+    )
+    return downloaded,
 
 
 if __name__ == "__main__":

--- a/marimo/_smoke_tests/pdf.py
+++ b/marimo/_smoke_tests/pdf.py
@@ -1,6 +1,7 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
-__generated_with = "0.1.21"
+__generated_with = "0.1.18"
 app = marimo.App(width="full")
 
 
@@ -31,7 +32,7 @@ def __(mo, page):
         src="https://arxiv.org/pdf/2104.00282.pdf",
         initial_page=page.value,
         width="100%",
-        height="60vh"
+        height="60vh",
     )
     return
 
@@ -45,10 +46,20 @@ def __(io, mo, page, requests):
         src=io.BytesIO(downloaded.content),
         initial_page=page.value,
         width="100%",
-        height="60vh"
+        height="60vh",
     )
     pdf
     return downloaded, pdf
+
+
+@app.cell
+def __(pdf):
+    pdf
+    import time
+    while True:
+        time.sleep(1)
+        print('hi')
+    return time,
 
 
 @app.cell

--- a/marimo/_smoke_tests/pdf.py
+++ b/marimo/_smoke_tests/pdf.py
@@ -58,11 +58,5 @@ def __(pdf):
     return
 
 
-@app.cell
-def __(pdf):
-    pdf
-    return
-
-
 if __name__ == "__main__":
     app.run()

--- a/marimo/_smoke_tests/pdf.py
+++ b/marimo/_smoke_tests/pdf.py
@@ -1,7 +1,6 @@
-# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
-__generated_with = "0.1.18"
+__generated_with = "0.1.21"
 app = marimo.App(width="full")
 
 
@@ -50,6 +49,12 @@ def __(io, mo, page, requests):
     )
     pdf
     return downloaded, pdf
+
+
+@app.cell
+def __(pdf):
+    pdf
+    return
 
 
 @app.cell

--- a/marimo/_smoke_tests/pdf.py
+++ b/marimo/_smoke_tests/pdf.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.21"

--- a/marimo/_smoke_tests/pdf.py
+++ b/marimo/_smoke_tests/pdf.py
@@ -55,16 +55,6 @@ def __(io, mo, page, requests):
 @app.cell
 def __(pdf):
     pdf
-    import time
-    while True:
-        time.sleep(1)
-        print('hi')
-    return time,
-
-
-@app.cell
-def __(pdf):
-    pdf
     return
 
 

--- a/marimo/_smoke_tests/pdf.py
+++ b/marimo/_smoke_tests/pdf.py
@@ -1,4 +1,3 @@
-# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.21"
@@ -9,7 +8,8 @@ app = marimo.App(width="full")
 def __():
     import marimo as mo
     import requests
-    return mo, requests
+    import io
+    return io, mo, requests
 
 
 @app.cell
@@ -37,17 +37,24 @@ def __(mo, page):
 
 
 @app.cell
-def __(mo, page, requests):
+def __(io, mo, page, requests):
     downloaded = requests.get("https://arxiv.org/pdf/2104.00282.pdf")
     # This is still performant as it does not pass the full PDF to the frontend,
     # and instead creates a VirtualFile
-    mo.pdf(
-        src=downloaded.content,
+    pdf = mo.pdf(
+        src=io.BytesIO(downloaded.content),
         initial_page=page.value,
         width="100%",
         height="60vh"
     )
-    return downloaded,
+    pdf
+    return downloaded, pdf
+
+
+@app.cell
+def __(pdf):
+    pdf
+    return
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ select = [
     "A001",
     # flake8 builtin-argument-shadowing
     "A002",
+    # flake8-unused-arguments
+    "ARG",
     # flake8-bugbear
     "B",
     # future annotations


### PR DESCRIPTION
This change adds "virtual files" — files served by the marimo server, accessed via a route `/@file/{filename}`.
- This enables plugins like `mo.pdf` and `mo.image` to take URLs to virtual files instead of binary data in their HTML attributes
- Care is taken to make virtual filenames unique within kernel thread (by using random filenames) and across kernel threads (by prepending a thread ID)
- The mimetype of the file is inferred from its extension
- We use Python's `shared_memory` module to make the virtual file data accessible to the server (it's registered in the kernel) — this is really only needed in edit mode, in which the kernel is a separate process instead of a thread. In run mode, we could in the future add a simpler path just use (lock-protected) global memory ...
- Virtual files are tied to the cells that create them: they (and their associated shared memory) are destroyed when a cell is re-run, deleted, or otherwise invalidated

Because this change adds OS-specific logic, it also updates our unit tests and CLI tests to run on windows + macOS