### PR TITLE
Detach kernel process from server

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -7,6 +7,7 @@ import dataclasses
 import io
 import itertools
 import multiprocessing as mp
+import os
 import queue
 import signal
 import sys
@@ -948,7 +949,18 @@ def launch_kernel(
     )
 
     if is_edit_mode:
+        # In edit mode, kernel runs in its own process so it's interruptible.
         from marimo._output.formatters.formatters import register_formatters
+
+        try:
+            # Make this process group leader to prevent it from receiving
+            # signals intended for the parent (server) process,
+            # Ctrl+C in particular.
+            os.setsid()
+        except Exception:
+            # Not supported on Windows.
+            # TODO(akshayka): Test/fix on Windows.
+            ...
 
         # kernels are processes in edit mode, and each process needs to
         # install the formatter import hooks

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -254,6 +254,7 @@ class Session:
             self.kernel_task = mp.Process(
                 target=runtime.launch_kernel,
                 args=(self.queue, listener.address, is_edit_mode),
+                daemon=True,
             )
         else:
             # We use threads in run mode to minimize memory consumption;


### PR DESCRIPTION
- Prevent signals intended for server process from interfering with kernel
- Fixes a bug in which Ctrl+C sent to terminal interrupted kernel
- Won't fix Windows ...