### PR TITLE
improvement: support full-width input UI elements

### DIFF
--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -34,6 +34,7 @@ interface ComboboxCommonProps<TValue> {
   search?: string;
   onSearchChange?: (search: string) => void;
   emptyState?: React.ReactNode;
+  className?: string;
 }
 
 type ComboboxFilterProps =
@@ -67,6 +68,7 @@ export type ComboboxProps<TValue> = ComboboxCommonProps<TValue> &
 export const Combobox = <TValue,>({
   children,
   displayValue,
+  className,
   placeholder = "--",
   value: valueProp,
   defaultValue,
@@ -147,7 +149,10 @@ export const Combobox = <TValue,>({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild={true}>
         <div
-          className="flex h-6 w-fit mb-1 shadow-xsSolid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-smSolid focus:outline-none focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-mdSolid disabled:cursor-not-allowed disabled:opacity-50"
+          className={cn(
+            "flex h-6 w-fit mb-1 shadow-xsSolid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-smSolid focus:outline-none focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-mdSolid disabled:cursor-not-allowed disabled:opacity-50",
+            className
+          )}
           aria-expanded={open}
         >
           {renderValue()} <ChevronDownIcon className="ml-3 w-4 h-4" />
@@ -160,7 +165,7 @@ export const Combobox = <TValue,>({
         <Command filter={filterFn} shouldFilter={shouldFilter}>
           <CommandInput
             placeholder={inputPlaceholder}
-            rootClassName="px-2 h-10"
+            rootClassName={"px-2 h-10"}
             autoFocus={true}
             value={search}
             onValueChange={onSearchChange}

--- a/frontend/src/core/codemirror/extensions.ts
+++ b/frontend/src/core/codemirror/extensions.ts
@@ -88,7 +88,7 @@ export function scrollActiveLineIntoView() {
         const activeLine = activeLines[0] as HTMLElement;
         smartScrollIntoView(activeLine, {
           top: 30,
-          bottom: 90,
+          bottom: 120,
         });
       }
     }

--- a/frontend/src/plugins/impl/ButtonPlugin.tsx
+++ b/frontend/src/plugins/impl/ButtonPlugin.tsx
@@ -5,11 +5,13 @@ import { IPlugin, IPluginProps } from "../types";
 import { Button } from "../../components/ui/button";
 import { renderHTML } from "../core/RenderHTML";
 import { Intent, zodIntent } from "./common/intent";
+import { cn } from "@/lib/utils";
 
 interface Data {
   label: string;
   kind: Intent;
   disabled: boolean;
+  fullWidth: boolean;
 }
 
 export class ButtonPlugin implements IPlugin<number, Data> {
@@ -19,11 +21,12 @@ export class ButtonPlugin implements IPlugin<number, Data> {
     label: z.string(),
     kind: zodIntent,
     disabled: z.boolean().default(false),
+    fullWidth: z.boolean().default(false),
   });
 
   render(props: IPluginProps<number, Data>): JSX.Element {
     const {
-      data: { disabled, kind, label },
+      data: { disabled, kind, label, fullWidth },
     } = props;
     // value counts number of times button was clicked
     return (
@@ -31,6 +34,9 @@ export class ButtonPlugin implements IPlugin<number, Data> {
         variant={kindToButtonVariant(kind)}
         disabled={disabled}
         size="xs"
+        className={cn({
+          "w-full": fullWidth,
+        })}
         onClick={() => {
           if (disabled) {
             return;

--- a/frontend/src/plugins/impl/DatePickerPlugin.tsx
+++ b/frontend/src/plugins/impl/DatePickerPlugin.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { IPlugin, IPluginProps, Setter } from "../types";
 import { Input } from "../../components/ui/input";
 import { Labeled } from "./common/labeled";
+import { cn } from "@/lib/utils";
 
 type T = string;
 
@@ -13,6 +14,7 @@ interface Data {
   start: string;
   stop: string;
   step?: string;
+  fullWidth: boolean;
 }
 
 export class DatePickerPlugin implements IPlugin<T, Data> {
@@ -24,6 +26,7 @@ export class DatePickerPlugin implements IPlugin<T, Data> {
     start: z.string(),
     stop: z.string(),
     step: z.string().optional(),
+    fullWidth: z.boolean().default(false),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -63,10 +66,13 @@ const DatePicker = (props: DatePickerProps): JSX.Element => {
   const id = useId();
 
   return (
-    <Labeled label={props.label} id={id}>
+    <Labeled label={props.label} id={id} fullWidth={props.fullWidth}>
       <Input
         ref={inputRef}
         type="date"
+        className={cn({
+          "w-full": props.fullWidth,
+        })}
         min={props.start}
         max={props.stop}
         value={props.value}

--- a/frontend/src/plugins/impl/DropdownPlugin.tsx
+++ b/frontend/src/plugins/impl/DropdownPlugin.tsx
@@ -5,11 +5,13 @@ import { z } from "zod";
 import { IPlugin, IPluginProps } from "../types";
 import { NativeSelect } from "../../components/ui/native-select";
 import { Labeled } from "./common/labeled";
+import { cn } from "@/lib/utils";
 
 interface Data {
   label: string | null;
   options: string[];
   allowSelectNone: boolean;
+  fullWidth: boolean;
 }
 
 export class DropdownPlugin implements IPlugin<string[], Data> {
@@ -20,6 +22,7 @@ export class DropdownPlugin implements IPlugin<string[], Data> {
     label: z.string().nullable(),
     options: z.array(z.string()),
     allowSelectNone: z.boolean(),
+    fullWidth: z.boolean().default(false),
   });
 
   render(props: IPluginProps<string[], Data>): JSX.Element {
@@ -48,7 +51,7 @@ interface DropdownProps extends Data {
 const EMPTY_VALUE = "--";
 
 const Dropdown = (props: DropdownProps): JSX.Element => {
-  const { label, options, value, setValue, allowSelectNone } = props;
+  const { label, options, value, setValue, allowSelectNone, fullWidth } = props;
 
   const id = useId();
 
@@ -56,7 +59,7 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
   const singleValue = value.length === 0 ? defaultValue : value[0];
 
   return (
-    <Labeled label={label} id={id}>
+    <Labeled label={label} id={id} fullWidth={fullWidth}>
       <NativeSelect
         onChange={(e) => {
           const newValue = e.target.value;
@@ -66,6 +69,9 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
             setValue([newValue]);
           }
         }}
+        className={cn({
+          "w-full": fullWidth,
+        })}
         value={singleValue}
         id={id}
       >

--- a/frontend/src/plugins/impl/MultiselectPlugin.tsx
+++ b/frontend/src/plugins/impl/MultiselectPlugin.tsx
@@ -5,10 +5,12 @@ import { z } from "zod";
 import { IPlugin, IPluginProps, Setter } from "../types";
 import { Combobox, ComboboxItem } from "../../components/ui/combobox";
 import { Labeled } from "./common/labeled";
+import { cn } from "@/lib/utils";
 
 interface Data {
   label: string | null;
   options: string[];
+  fullWidth: boolean;
 }
 
 type T = string[];
@@ -20,6 +22,7 @@ export class MultiselectPlugin implements IPlugin<T, Data> {
     initialValue: z.array(z.string()),
     label: z.string().nullable(),
     options: z.array(z.string()),
+    fullWidth: z.boolean().default(false),
   });
 
   render(props: IPluginProps<string[], Data>): JSX.Element {
@@ -50,11 +53,14 @@ const Multiselect = (props: MultiselectProps): JSX.Element => {
   const id = useId();
 
   return (
-    <Labeled label={props.label} id={id}>
+    <Labeled label={props.label} id={id} fullWidth={props.fullWidth}>
       <Combobox<string>
         displayValue={(option) => option}
         placeholder="Select..."
         multiple={true}
+        className={cn({
+          "w-full": props.fullWidth,
+        })}
         value={props.value}
         onValueChange={(newValues) => props.setValue(newValues || [])}
       >

--- a/frontend/src/plugins/impl/NumberPlugin.tsx
+++ b/frontend/src/plugins/impl/NumberPlugin.tsx
@@ -6,6 +6,7 @@ import { IPlugin, IPluginProps, Setter } from "../types";
 import { Input } from "../../components/ui/input";
 import { Labeled } from "./common/labeled";
 import { useDebounceControlledState } from "@/hooks/useDebounce";
+import { cn } from "@/lib/utils";
 
 type T = number;
 
@@ -15,6 +16,7 @@ interface Data {
   step?: T;
   label: string | null;
   debounce: boolean;
+  fullWidth: boolean;
 }
 
 export class NumberPlugin implements IPlugin<T, Data> {
@@ -27,6 +29,7 @@ export class NumberPlugin implements IPlugin<T, Data> {
     stop: z.number(),
     step: z.number().optional(),
     debounce: z.boolean().default(false),
+    fullWidth: z.boolean().default(false),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -58,9 +61,9 @@ const NumberComponent = (props: NumberComponentProps): JSX.Element => {
   });
 
   return (
-    <Labeled label={props.label} id={id}>
+    <Labeled label={props.label} id={id} fullWidth={props.fullWidth}>
       <Input
-        className="min-w-[3em]"
+        className={cn("min-w-[3em]", props.fullWidth && "w-full")}
         ref={inputRef}
         type="number"
         min={props.start}

--- a/frontend/src/plugins/impl/TextAreaPlugin.tsx
+++ b/frontend/src/plugins/impl/TextAreaPlugin.tsx
@@ -4,6 +4,7 @@ import { IPlugin, IPluginProps, Setter } from "../types";
 
 import { Textarea } from "../../components/ui/textarea";
 import { Labeled } from "./common/labeled";
+import { cn } from "@/lib/utils";
 
 type T = string;
 
@@ -13,6 +14,7 @@ interface Data {
   maxLength?: number;
   minLength?: number;
   disabled?: boolean;
+  fullWidth: boolean;
 }
 
 export class TextAreaPlugin implements IPlugin<T, Data> {
@@ -25,6 +27,7 @@ export class TextAreaPlugin implements IPlugin<T, Data> {
     maxLength: z.number().optional(),
     minLength: z.number().optional(),
     disabled: z.boolean().optional(),
+    fullWidth: z.boolean().default(false),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -51,9 +54,11 @@ const TextAreaComponent = (props: TextAreaComponentProps) => {
   ) : null;
 
   return (
-    <Labeled label={props.label} align="top">
+    <Labeled label={props.label} align="top" fullWidth={props.fullWidth}>
       <Textarea
-        className="font-code"
+        className={cn("font-code", {
+          "w-full": props.fullWidth,
+        })}
         rows={5}
         cols={33}
         maxLength={props.maxLength}

--- a/frontend/src/plugins/impl/TextInputPlugin.tsx
+++ b/frontend/src/plugins/impl/TextInputPlugin.tsx
@@ -72,12 +72,7 @@ const TextComponent = (props: TextComponentProps) => {
   ) : null;
 
   return (
-    <Labeled
-      label={props.label}
-      className={cn({
-        block: props.fullWidth,
-      })}
-    >
+    <Labeled label={props.label} fullWidth={props.fullWidth}>
       <Input
         type={props.kind}
         icon={icon[props.kind]}

--- a/frontend/src/plugins/impl/TextInputPlugin.tsx
+++ b/frontend/src/plugins/impl/TextInputPlugin.tsx
@@ -19,6 +19,7 @@ interface Data {
   maxLength?: number;
   minLength?: number;
   disabled?: boolean;
+  fullWidth: boolean;
 }
 
 export class TextInputPlugin implements IPlugin<T, Data> {
@@ -31,6 +32,7 @@ export class TextInputPlugin implements IPlugin<T, Data> {
     kind: z.enum(["text", "password", "email", "url"]).default("text"),
     maxLength: z.number().optional(),
     minLength: z.number().optional(),
+    fullWidth: z.boolean().default(false),
     disabled: z.boolean().optional(),
   });
 
@@ -70,7 +72,12 @@ const TextComponent = (props: TextComponentProps) => {
   ) : null;
 
   return (
-    <Labeled label={props.label}>
+    <Labeled
+      label={props.label}
+      className={cn({
+        block: props.fullWidth,
+      })}
+    >
       <Input
         type={props.kind}
         icon={icon[props.kind]}
@@ -81,6 +88,7 @@ const TextComponent = (props: TextComponentProps) => {
         disabled={props.disabled}
         className={cn({
           "border-destructive": !isValid,
+          "w-full": props.fullWidth,
         })}
         endAdornment={endAdornment}
         value={props.value}

--- a/frontend/src/plugins/impl/common/labeled.tsx
+++ b/frontend/src/plugins/impl/common/labeled.tsx
@@ -9,6 +9,7 @@ interface Props {
   className?: string;
   labelClassName?: string;
   id?: string;
+  fullWidth?: boolean;
   /**
    * Align the label to the top, left, or right of the component.
    * @default "left"
@@ -25,8 +26,13 @@ export const Labeled: React.FC<PropsWithChildren<Props>> = ({
   align = "left",
   className,
   labelClassName,
+  fullWidth,
   id,
 }) => {
+  // If fullWidth is true, force align to be "top"
+  if (fullWidth) {
+    align = "top";
+  }
   if (!label) {
     // If its a top label, just return the children
     if (align === "top") {
@@ -47,9 +53,10 @@ export const Labeled: React.FC<PropsWithChildren<Props>> = ({
       className={cn(
         "mo-label inline-flex",
         "pt-0 pb-0 pl-0",
-        align === "top" && "flex-col items-start gap-y-3",
+        align === "top" && "flex-col items-start gap-y-2",
         align === "left" && "flex-row items-center gap-x-1.5 pr-2",
         align === "right" && "flex-row-reverse items-center gap-x-1.5 pr-2",
+        fullWidth && "block space-y-2",
         className
       )}
     >

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -328,6 +328,8 @@ class text(UIElement[str, str]):
         defaults to `"text"`
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
+    - `full_width`: whether the input should take up the full width of its
+        container
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
@@ -341,6 +343,7 @@ class text(UIElement[str, str]):
         kind: Literal["text", "password", "email", "url"] = "text",
         max_length: Optional[int] = None,
         disabled: bool = False,
+        full_width: bool = False,
         *,
         label: str = "",
         on_change: Optional[Callable[[str], None]] = None,
@@ -353,6 +356,7 @@ class text(UIElement[str, str]):
                 "placeholder": placeholder,
                 "kind": kind,
                 "max-length": max_length,
+                "full-width": full_width,
                 "disabled": disabled,
             },
             on_change=on_change,

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -57,9 +57,9 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     - `debounce`: whether to debounce (rate-limit) value
         updates from the frontend
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
-    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-number"
@@ -73,8 +73,8 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
         debounce: bool = False,
         *,
         label: str = "",
-        full_width: bool = False,
         on_change: Optional[Callable[[Optional[Numeric]], None]] = None,
+        full_width: bool = False,
     ) -> None:
         value = start if value is None else value
         if stop < start:
@@ -333,9 +333,9 @@ class text(UIElement[str, str]):
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
-    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-text"
@@ -349,8 +349,8 @@ class text(UIElement[str, str]):
         disabled: bool = False,
         *,
         label: str = "",
-        full_width: bool = False,
         on_change: Optional[Callable[[str], None]] = None,
+        full_width: bool = False,
     ) -> None:
         super().__init__(
             component_name=text._name,
@@ -392,9 +392,9 @@ class text_area(UIElement[str, str]):
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
-    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-text-area"
@@ -407,8 +407,8 @@ class text_area(UIElement[str, str]):
         disabled: bool = False,
         *,
         label: str = "",
-        full_width: bool = False,
         on_change: Optional[Callable[[str], None]] = None,
+        full_width: bool = False,
     ) -> None:
         super().__init__(
             component_name=text_area._name,
@@ -456,8 +456,6 @@ class dropdown(UIElement[List[str], Any]):
     - `options`: a dict mapping option name to option value
     - `selected_key`: the selected option's key, or `None` if no selection
 
-    - `full_width`: whether the input should take up the full width of its
-        container
     **Initialization Args.**
 
     - `options`: sequence of text options, or dict mapping option name
@@ -468,6 +466,8 @@ class dropdown(UIElement[List[str], Any]):
                            `value` is `None`
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
+    - `full_width`: whether the input should take up the full width of its
+        container
     """
 
     _name: Final[str] = "marimo-dropdown"
@@ -480,8 +480,8 @@ class dropdown(UIElement[List[str], Any]):
         allow_select_none: Optional[bool] = None,
         *,
         label: str = "",
-        full_width: bool = False,
         on_change: Optional[Callable[[Any], None]] = None,
+        full_width: bool = False,
     ) -> None:
         if not isinstance(options, dict):
             options = {option: option for option in options}
@@ -548,8 +548,6 @@ class multiselect(UIElement[List[str], List[object]]):
     - `value`: the selected values, or `None` if no selection
     - `options`: a dict mapping option name to option value
 
-    - `full_width`: whether the input should take up the full width of its
-        container
     **Initialization Args.**
 
     - `options`: sequence of text options, or dict mapping option name
@@ -557,6 +555,8 @@ class multiselect(UIElement[List[str], List[object]]):
     - `value`: a list of initially selected options
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
+    - `full_width`: whether the input should take up the full width of its
+        container
     """
 
     _name: Final[str] = "marimo-multiselect"
@@ -567,8 +567,8 @@ class multiselect(UIElement[List[str], List[object]]):
         value: Optional[Sequence[str]] = None,
         *,
         label: str = "",
-        full_width: bool = False,
         on_change: Optional[Callable[[List[object]], None]] = None,
+        full_width: bool = False,
     ) -> None:
         if not isinstance(options, dict):
             options = {option: option for option in options}
@@ -732,9 +732,9 @@ class button(UIElement[Any, Any]):
     - `kind`: 'neutral', 'success', 'warn', or 'danger'
     - `disabled`: whether the button is disabled
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
-    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-button"
@@ -747,8 +747,8 @@ class button(UIElement[Any, Any]):
         disabled: bool = False,
         *,
         label: str = "click here",
-        full_width: bool = False,
         on_change: Optional[Callable[[Any], None]] = None,
+        full_width: bool = False,
     ) -> None:
         self._on_click = (lambda _: value) if on_click is None else on_click
         self._initial_value = value
@@ -952,9 +952,9 @@ class date(UIElement[str, dt.date]):
         - else if `None` and `start` is not `None`, defaults to `start`;
         - else if `None` and `stop` is not `None`, defaults to `stop`
     - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
-    - `on_change`: optional callback to run when this element's value changes
     """
 
     _name: Final[str] = "marimo-date-picker"
@@ -968,8 +968,8 @@ class date(UIElement[str, dt.date]):
         value: Optional[dt.date | str] = None,
         *,
         label: str = "",
-        full_width: bool = False,
         on_change: Optional[Callable[[dt.date], None]] = None,
+        full_width: bool = False,
     ) -> None:
         if isinstance(start, str):
             start = self._convert_value(start)

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -57,6 +57,8 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     - `debounce`: whether to debounce (rate-limit) value
         updates from the frontend
     - `label`: text label for the element
+    - `full_width`: whether the input should take up the full width of its
+        container
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -71,6 +73,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
         debounce: bool = False,
         *,
         label: str = "",
+        full_width: bool = False,
         on_change: Optional[Callable[[Optional[Numeric]], None]] = None,
     ) -> None:
         value = start if value is None else value
@@ -100,6 +103,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
                 "stop": stop,
                 "step": step if step is not None else None,
                 "debounce": debounce,
+                "full-width": full_width,
             },
             on_change=on_change,
         )
@@ -328,9 +332,9 @@ class text(UIElement[str, str]):
         defaults to `"text"`
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
+    - `label`: text label for the element
     - `full_width`: whether the input should take up the full width of its
         container
-    - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -343,9 +347,9 @@ class text(UIElement[str, str]):
         kind: Literal["text", "password", "email", "url"] = "text",
         max_length: Optional[int] = None,
         disabled: bool = False,
-        full_width: bool = False,
         *,
         label: str = "",
+        full_width: bool = False,
         on_change: Optional[Callable[[str], None]] = None,
     ) -> None:
         super().__init__(
@@ -388,6 +392,8 @@ class text_area(UIElement[str, str]):
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
     - `label`: text label for the element
+    - `full_width`: whether the input should take up the full width of its
+        container
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -401,6 +407,7 @@ class text_area(UIElement[str, str]):
         disabled: bool = False,
         *,
         label: str = "",
+        full_width: bool = False,
         on_change: Optional[Callable[[str], None]] = None,
     ) -> None:
         super().__init__(
@@ -411,6 +418,7 @@ class text_area(UIElement[str, str]):
                 "placeholder": placeholder,
                 "max-length": max_length,
                 "disabled": disabled,
+                "full-width": full_width,
             },
             on_change=on_change,
         )
@@ -448,6 +456,8 @@ class dropdown(UIElement[List[str], Any]):
     - `options`: a dict mapping option name to option value
     - `selected_key`: the selected option's key, or `None` if no selection
 
+    - `full_width`: whether the input should take up the full width of its
+        container
     **Initialization Args.**
 
     - `options`: sequence of text options, or dict mapping option name
@@ -470,6 +480,7 @@ class dropdown(UIElement[List[str], Any]):
         allow_select_none: Optional[bool] = None,
         *,
         label: str = "",
+        full_width: bool = False,
         on_change: Optional[Callable[[Any], None]] = None,
     ) -> None:
         if not isinstance(options, dict):
@@ -498,6 +509,7 @@ class dropdown(UIElement[List[str], Any]):
             args={
                 "options": list(self.options.keys()),
                 "allow-select-none": allow_select_none,
+                "full-width": full_width,
             },
             on_change=on_change,
         )
@@ -536,6 +548,8 @@ class multiselect(UIElement[List[str], List[object]]):
     - `value`: the selected values, or `None` if no selection
     - `options`: a dict mapping option name to option value
 
+    - `full_width`: whether the input should take up the full width of its
+        container
     **Initialization Args.**
 
     - `options`: sequence of text options, or dict mapping option name
@@ -553,6 +567,7 @@ class multiselect(UIElement[List[str], List[object]]):
         value: Optional[Sequence[str]] = None,
         *,
         label: str = "",
+        full_width: bool = False,
         on_change: Optional[Callable[[List[object]], None]] = None,
     ) -> None:
         if not isinstance(options, dict):
@@ -567,6 +582,7 @@ class multiselect(UIElement[List[str], List[object]]):
             label=label,
             args={
                 "options": list(self.options.keys()),
+                "full-width": full_width,
             },
             on_change=on_change,
         )
@@ -716,6 +732,8 @@ class button(UIElement[Any, Any]):
     - `kind`: 'neutral', 'success', 'warn', or 'danger'
     - `disabled`: whether the button is disabled
     - `label`: text label for the element
+    - `full_width`: whether the input should take up the full width of its
+        container
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -729,6 +747,7 @@ class button(UIElement[Any, Any]):
         disabled: bool = False,
         *,
         label: str = "click here",
+        full_width: bool = False,
         on_change: Optional[Callable[[Any], None]] = None,
     ) -> None:
         self._on_click = (lambda _: value) if on_click is None else on_click
@@ -741,6 +760,7 @@ class button(UIElement[Any, Any]):
             args={
                 "kind": kind,
                 "disabled": disabled,
+                "full-width": full_width,
             },
             on_change=on_change,
         )
@@ -932,6 +952,8 @@ class date(UIElement[str, dt.date]):
         - else if `None` and `start` is not `None`, defaults to `start`;
         - else if `None` and `stop` is not `None`, defaults to `stop`
     - `label`: text label for the element
+    - `full_width`: whether the input should take up the full width of its
+        container
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -946,6 +968,7 @@ class date(UIElement[str, dt.date]):
         value: Optional[dt.date | str] = None,
         *,
         label: str = "",
+        full_width: bool = False,
         on_change: Optional[Callable[[dt.date], None]] = None,
     ) -> None:
         if isinstance(start, str):
@@ -986,6 +1009,7 @@ class date(UIElement[str, dt.date]):
             args={
                 "start": self._start.isoformat(),
                 "stop": self._stop.isoformat(),
+                "full-width": full_width,
             },
             on_change=on_change,
         )

--- a/marimo/_smoke_tests/full_width.py
+++ b/marimo/_smoke_tests/full_width.py
@@ -1,0 +1,73 @@
+import marimo
+
+__generated_with = "0.1.22"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    checkbox = mo.ui.checkbox(label="Full width")
+    checkbox
+    return checkbox,
+
+
+@app.cell
+def __(checkbox, mo):
+    mo.ui.text(label="Text", full_width=checkbox.value)
+    return
+
+
+@app.cell
+def __(checkbox, mo):
+    mo.ui.text_area(label="Text area", full_width=checkbox.value)
+    return
+
+
+@app.cell
+def __(checkbox, mo):
+    mo.ui.number(0, 10, label="Number", full_width=checkbox.value)
+    return
+
+
+@app.cell
+def __(checkbox, mo):
+    mo.ui.dropdown(label="Dropdown", options=["A", "B", "C"], full_width=checkbox.value)
+    return
+
+
+@app.cell
+def __(checkbox, mo):
+    mo.ui.multiselect(label="Multiselect", options=["A", "B", "C"], full_width=checkbox.value)
+    return
+
+
+@app.cell
+def __(checkbox, mo):
+    mo.ui.date(label="Date", full_width=checkbox.value)
+    return
+
+
+@app.cell
+def __(checkbox, mo):
+    mo.ui.button(label="Button", full_width=checkbox.value)
+    return
+
+
+@app.cell
+def __(checkbox, mo):
+    # Is this the behavior we want?
+    mo.hstack([
+        mo.ui.text(label="Input A", full_width=checkbox.value),
+        mo.ui.text(label="Input B", full_width=checkbox.value)
+    ])
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/full_width.py
+++ b/marimo/_smoke_tests/full_width.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.22"

--- a/marimo/_smoke_tests/full_width.py
+++ b/marimo/_smoke_tests/full_width.py
@@ -1,4 +1,3 @@
-# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.22"
@@ -14,7 +13,7 @@ def __():
 @app.cell
 def __(mo):
     checkbox = mo.ui.checkbox(label="Full width")
-    checkbox
+    checkbox.callout()
     return checkbox,
 
 
@@ -64,6 +63,15 @@ def __(checkbox, mo):
 def __(checkbox, mo):
     # Is this the behavior we want?
     mo.hstack([
+        mo.ui.text(label="Input A", full_width=checkbox.value),
+        mo.ui.text(label="Input B", full_width=checkbox.value)
+    ])
+    return
+
+
+@app.cell
+def __(checkbox, mo):
+    mo.vstack([
         mo.ui.text(label="Input A", full_width=checkbox.value),
         mo.ui.text(label="Input B", full_width=checkbox.value)
     ])


### PR DESCRIPTION
Added to these elements
- mo.ui.text,
- mo.ui.text_area
- mo.ui.button
- mo.ui.number
- mo.ui.dropdown
- mo.ui.multiselect
- mo.ui.date

Note in the smoke test, full width does not apply when its parent is flex (e.g. a hstack). There is a fixable solution by making it `flex: 1` and then updating a few components to be `display: contents`. but this can break other elements. easier to show live, but my guess is we can support this later