### PR TITLE
fix: fix importing nested modules

### DIFF
--- a/marimo/_ast/test_visitor.py
+++ b/marimo/_ast/test_visitor.py
@@ -511,3 +511,39 @@ def test_matchmapping() -> None:
     v.visit(mod)
     assert v.defs == set(["a", "b"])
     assert v.refs == set(["value"])
+
+
+def test_import_nested() -> None:
+    expr = "import a.b.c"
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(expr)
+    v.visit(mod)
+    assert v.defs == set(["a"])
+    assert v.refs == set()
+
+
+def test_import_as() -> None:
+    expr = "import a.b.c as d"
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(expr)
+    v.visit(mod)
+    assert v.defs == set(["d"])
+    assert v.refs == set()
+
+
+def test_import_multiple() -> None:
+    expr = "import a.b.c, d"
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(expr)
+    v.visit(mod)
+    assert v.defs == set(["a", "d"])
+    assert v.refs == set()
+
+
+def test_from_import() -> None:
+    expr = "from a.b.c import d"
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(expr)
+    v.visit(mod)
+    assert v.defs == set(["d"])
+    assert v.refs == set()

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -294,8 +294,10 @@ class ScopedVisitor(ast.NodeVisitor):
     # Import and ImportFrom statements have symbol names in alias nodes
     def visit_alias(self, node: ast.alias) -> None:
         if node.asname is None:
-            node.name = self._if_local_then_mangle(node.name)
-            self._define(node.name)
+            # (1) Don't mangle - user has not control over package name
+            # (2) for "a.b.c", register "a" as the def
+            basename = node.name.split(".")[0]
+            self._define(basename)
         else:
             node.asname = self._if_local_then_mangle(node.asname)
             self._define(node.asname)

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -294,7 +294,7 @@ class ScopedVisitor(ast.NodeVisitor):
     # Import and ImportFrom statements have symbol names in alias nodes
     def visit_alias(self, node: ast.alias) -> None:
         if node.asname is None:
-            # (1) Don't mangle - user has not control over package name
+            # (1) Don't mangle - user has no control over package name
             # (2) for "a.b.c", register "a" as the def
             basename = node.name.split(".")[0]
             self._define(basename)


### PR DESCRIPTION
This fixes a bug in importing nested modules (import a.b.c); previously, a.b.c was being treated as the def, whereas it should just be a (since we don't track attributes). This bug broke an assumption in marimo's loading of an app file.