### PR TITLE
Prevent cells from overlapping notebook controls

### DIFF
--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -166,7 +166,7 @@ const DEFAULT_HOT_KEY = {
 
   // Global Actions
   "global.hideCode": {
-    name: "Show/Hide code",
+    name: "Toggle app view",
     group: "Other",
     key: "Mod-.",
   },

--- a/frontend/src/editor/Controls.tsx
+++ b/frontend/src/editor/Controls.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import {
-  AppWindowIcon,
+  LayoutTemplateIcon,
   SaveIcon,
   EditIcon,
   PlayIcon,
@@ -120,7 +120,7 @@ export const Controls = ({
             {presenting ? (
               <EditIcon strokeWidth={1.5} />
             ) : (
-              <AppWindowIcon strokeWidth={1.5} />
+              <LayoutTemplateIcon strokeWidth={1.5} />
             )}
           </Button>
         </Tooltip>
@@ -212,4 +212,4 @@ const bottomRightControls =
   "absolute bottom-5 right-5 flex items-center space-x-3 no-print pointer-events-auto z-30";
 
 const bottomLeftControls =
-  "absolute bottom-5 left-4 m-0 flex items-center space-x-3 no-print pointer-events-auto z-30";
+  "absolute bottom-5 left-4 m-0 flex flex-col-reverse xl:flex-row gap-2 items-center no-print pointer-events-auto z-30";

--- a/frontend/src/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
+++ b/frontend/src/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
@@ -14,11 +14,11 @@ export const VerticalLayoutWrapper: React.FC<PropsWithChildren<Props>> = ({
   children,
 }) => {
   return (
-    <div className="px-24">
+    <div className="px-32 xl:px-60">
       <div
         className={cn(
           "m-auto pb-12",
-          appConfig.width !== "full" && "max-w-contentWidth",
+          appConfig.width !== "full" && "max-w-contentWidth min-w-[400px]",
           // Hide the cells for a fake loading effect, to avoid flickering
           invisible && "invisible"
         )}


### PR DESCRIPTION
- icons flex vertically when window is small
- otherwise flex horizontally as they used to
- increase padding when flexed horizontally to prevent clipping cells
- change app icon, hotkey description to look more like layout