### PR TITLE
minor change to progress bar style

### DIFF
--- a/frontend/src/plugins/layout/ProgressPlugin.tsx
+++ b/frontend/src/plugins/layout/ProgressPlugin.tsx
@@ -48,10 +48,12 @@ export const ProgressComponent = ({
   progress,
   total,
 }: PropsWithChildren<Data>): JSX.Element => {
+  const alignment =
+    typeof progress === "number" ? "items-start" : "items-center";
   return (
-    <div className="flex flex-col items-center max-w-sm p-6 mx-auto space-y-4">
+    <div className={`flex flex-col ${alignment} max-w-sm p-6 mx-auto`}>
       {title && (
-        <div className="text-2xl font-bold text-foreground/60">
+        <div className="text-lg font-bold text-foreground/60">
           {renderHTML({ html: title })}
         </div>
       )}


### PR DESCRIPTION
<img width="375" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/6f49641b-4b5b-4c98-9099-fdae4973ef25">

- align progress bar text to start instead of center
- make title font size smaller