### PR TITLE
Remote Function Registry + ui.table download function

### DIFF
--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -21,8 +21,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { DataTablePagination } from "./pagination";
+import { DownloadActionProps, DownloadAs } from "./download-actions";
 
-interface DataTableProps<TData, TValue> {
+interface DataTableProps<TData, TValue> extends Partial<DownloadActionProps> {
   columns: Array<ColumnDef<TData, TValue>>;
   data: TData[];
   pagination?: boolean;
@@ -35,6 +36,7 @@ export const DataTable = <TData, TValue>({
   columns,
   data,
   rowSelection,
+  downloadAs,
   pagination = false,
   onRowSelectionChange,
 }: DataTableProps<TData, TValue>) => {
@@ -106,7 +108,10 @@ export const DataTable = <TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      {pagination && <DataTablePagination table={table} />}
+      <div className="flex align-items justify-between">
+        {pagination ? <DataTablePagination table={table} /> : <div />}
+        {downloadAs && <DownloadAs downloadAs={downloadAs} />}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/data-table/download-actions.tsx
+++ b/frontend/src/components/data-table/download-actions.tsx
@@ -8,15 +8,15 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
+import { toast } from "../ui/use-toast";
 
 export interface DownloadActionProps {
-  downloadAs: (format: "csv" | "json" | "xls") => Promise<string>;
+  downloadAs: (req: { format: "csv" | "json" }) => Promise<string>;
 }
 
-const formats = [
+const options = [
   { label: "CSV", format: "csv" },
   { label: "JSON", format: "json" },
-  { label: "Excel", format: "xls" },
 ] as const;
 
 export const DownloadAs: React.FC<DownloadActionProps> = (props) => {
@@ -30,11 +30,24 @@ export const DownloadAs: React.FC<DownloadActionProps> = (props) => {
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild={true}>{button}</DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" className="no-print">
-        {formats.map((format) => (
+        {options.map((option) => (
           <DropdownMenuItem
-            key={format.label}
+            key={option.label}
             onSelect={async () => {
-              const downloadUrl = await props.downloadAs(format.format);
+              const downloadUrl = await props
+                .downloadAs({
+                  format: option.format,
+                })
+                .catch((error) => {
+                  toast({
+                    title: "Failed to download",
+                    description:
+                      "message" in error ? error.message : String(error),
+                  });
+                });
+              if (!downloadUrl) {
+                return;
+              }
               const link = document.createElement("a");
               link.href = downloadUrl;
               link.setAttribute("download", "download");
@@ -43,7 +56,7 @@ export const DownloadAs: React.FC<DownloadActionProps> = (props) => {
               link.remove();
             }}
           >
-            {format.label}
+            {option.label}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>

--- a/frontend/src/components/data-table/download-actions.tsx
+++ b/frontend/src/components/data-table/download-actions.tsx
@@ -1,0 +1,52 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import React from "react";
+import { Button } from "../ui/button";
+import { CaretDownIcon } from "@radix-ui/react-icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+
+export interface DownloadActionProps {
+  downloadAs: (format: "csv" | "json" | "xls") => Promise<string>;
+}
+
+const formats = [
+  { label: "CSV", format: "csv" },
+  { label: "JSON", format: "json" },
+  { label: "Excel", format: "xls" },
+] as const;
+
+export const DownloadAs: React.FC<DownloadActionProps> = (props) => {
+  const button = (
+    <Button size="xs" variant="link">
+      Download <CaretDownIcon className="w-3 h-3 ml-1" />
+    </Button>
+  );
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild={true}>{button}</DropdownMenuTrigger>
+      <DropdownMenuContent side="bottom" className="no-print">
+        {formats.map((format) => (
+          <DropdownMenuItem
+            key={format.label}
+            onSelect={async () => {
+              const downloadUrl = await props.downloadAs(format.format);
+              const link = document.createElement("a");
+              link.href = downloadUrl;
+              link.setAttribute("download", "download");
+              document.body.append(link);
+              link.click();
+              link.remove();
+            }}
+          >
+            {format.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/frontend/src/components/data-table/pagination.tsx
+++ b/frontend/src/components/data-table/pagination.tsx
@@ -56,7 +56,7 @@ export const DataTablePagination = <TData,>({
   };
 
   return (
-    <div className="flex items-center justify-between px-2">
+    <div className="flex flex-1 items-center justify-between px-2">
       <div className="text-sm text-muted-foreground">{renderTotal()}</div>
       <div className="flex items-center space-x-2">
         <Button

--- a/frontend/src/core/codemirror/completion/completer.ts
+++ b/frontend/src/core/codemirror/completion/completer.ts
@@ -1,7 +1,7 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { CompletionContext, CompletionResult } from "@codemirror/autocomplete";
 
-import { Autocompleter } from "./Autocompleter";
+import { AUTOCOMPLETER, Autocompleter } from "./Autocompleter";
 import { Logger } from "../../../utils/Logger";
 import { CellId, HTMLCellId } from "@/core/model/ids";
 import { getCells } from "@/core/state/cells";
@@ -25,9 +25,8 @@ export async function completer(
     return null;
   }
 
-  const result = await Autocompleter.INSTANCE.request({
-    pos: context.pos,
-    query: query,
+  const result = await AUTOCOMPLETER.request({
+    document: query,
     cellId: cellId,
   });
 

--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -7,7 +7,7 @@ import {
   hoverTooltip,
   showTooltip,
 } from "@codemirror/view";
-import { Autocompleter } from "./Autocompleter";
+import { AUTOCOMPLETER, Autocompleter } from "./Autocompleter";
 import { Logger } from "@/utils/Logger";
 import { closeCompletion } from "@codemirror/autocomplete";
 import { StateField, StateEffect } from "@codemirror/state";
@@ -50,9 +50,8 @@ export function hintTooltip() {
           endToken++;
         }
 
-        const result = await Autocompleter.INSTANCE.request({
-          pos: endToken, // Send up to the end of the word, so the results are more accurate
-          query: view.state.doc.slice(0, endToken).toString(), // convert Text to string
+        const result = await AUTOCOMPLETER.request({
+          document: view.state.doc.slice(0, endToken).toString(), // convert Text to string
           cellId: cellId,
         });
 

--- a/frontend/src/core/dom/UIElement.ts
+++ b/frontend/src/core/dom/UIElement.ts
@@ -5,7 +5,7 @@ import { defineCustomElement } from "./defineCustomElement";
 import { MarimoValueInputEventType, marimoValueInputEvent } from "./events";
 import { UI_ELEMENT_REGISTRY } from "./uiregistry";
 
-export const UI_ELEMENT_TAG_NAME = "MARIMO-UI-ELEMENT";
+const UI_ELEMENT_TAG_NAME = "MARIMO-UI-ELEMENT";
 
 /**
  * Lazily initialize the UIElement component.
@@ -181,4 +181,25 @@ export function initializeUIElement() {
   }
 
   defineCustomElement(UI_ELEMENT_TAG_NAME.toLowerCase(), UIElement);
+}
+
+/**
+ * Given a node, check if its parent or itself is a UIElement,
+ * and return its objectId if so.
+ */
+export function getUIElementObjectId(target: HTMLElement): string | null {
+  if (!target) {
+    return null;
+  }
+
+  if (target.nodeName === UI_ELEMENT_TAG_NAME) {
+    return target.getAttribute("object-id");
+  }
+
+  const node = target.parentElement;
+  if (node?.nodeName === UI_ELEMENT_TAG_NAME) {
+    return node.getAttribute("object-id");
+  }
+
+  return null;
 }

--- a/frontend/src/core/functions/FunctionRegistry.ts
+++ b/frontend/src/core/functions/FunctionRegistry.ts
@@ -1,0 +1,16 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+
+import { sendFunctionRequest } from "@/core/network/requests";
+import { FunctionCallResultMessage } from "../kernel/messages";
+import { DeferredRequestRegistry } from "../network/DeferredRequestRegistry";
+import { SendFunctionRequest } from "../network/types";
+
+export const FUNCTIONS_REGISTRY = new DeferredRequestRegistry<
+  Omit<SendFunctionRequest, "id">,
+  FunctionCallResultMessage
+>("function-call-result", async (requestId, req) => {
+  await sendFunctionRequest({
+    id: requestId,
+    ...req,
+  });
+});

--- a/frontend/src/core/functions/FunctionRegistry.ts
+++ b/frontend/src/core/functions/FunctionRegistry.ts
@@ -6,11 +6,11 @@ import { DeferredRequestRegistry } from "../network/DeferredRequestRegistry";
 import { SendFunctionRequest } from "../network/types";
 
 export const FUNCTIONS_REGISTRY = new DeferredRequestRegistry<
-  Omit<SendFunctionRequest, "id">,
+  Omit<SendFunctionRequest, "functionCallId">,
   FunctionCallResultMessage
 >("function-call-result", async (requestId, req) => {
   await sendFunctionRequest({
-    id: requestId,
+    functionCallId: requestId,
     ...req,
   });
 });

--- a/frontend/src/core/kernel/messages.ts
+++ b/frontend/src/core/kernel/messages.ts
@@ -112,6 +112,15 @@ export interface CompletionResultMessage {
 }
 
 /**
+ * Status code, and human readable explanation.
+ */
+export interface HumanReadableStatus {
+  code: "ok" | "error";
+  title?: string;
+  message?: string;
+}
+
+/**
  * Message for function call results
  */
 export interface FunctionCallResultMessage {
@@ -123,8 +132,10 @@ export interface FunctionCallResultMessage {
    * The result of the function call
    */
   return_value: unknown;
-
-  success: boolean;
+  /**
+   * Status code and human readable info.
+   */
+  status: HumanReadableStatus;
 }
 
 /**

--- a/frontend/src/core/kernel/messages.ts
+++ b/frontend/src/core/kernel/messages.ts
@@ -4,6 +4,7 @@ import { LayoutType } from "@/editor/renderers/types";
 import { CellConfig, CellStatus } from "../model/cells";
 import { CellId } from "../model/ids";
 import { VariableName } from "../variables/types";
+import { RequestId } from "../network/DeferredRequestRegistry";
 
 export type OutputChannel =
   | "output"
@@ -102,12 +103,28 @@ export interface CompletionResultMessage {
   /**
    * The ID of the completion request
    */
-  completion_id: string;
+  completion_id: RequestId;
   prefix_length: number;
   /**
    * The options for completion
    */
   options: CompletionOption[];
+}
+
+/**
+ * Message for function call results
+ */
+export interface FunctionCallResultMessage {
+  /**
+   * The ID of the function call
+   */
+  function_call_id: RequestId;
+  /**
+   * The result of the function call
+   */
+  return_value: unknown;
+
+  success: boolean;
 }
 
 /**
@@ -165,6 +182,10 @@ export type OperationMessage =
   | {
       op: "completion-result";
       data: CompletionResultMessage;
+    }
+  | {
+      op: "function-call-result";
+      data: FunctionCallResultMessage;
     }
   | {
       op: "cell-op";

--- a/frontend/src/core/network/DeferredRequestRegistry.ts
+++ b/frontend/src/core/network/DeferredRequestRegistry.ts
@@ -1,0 +1,49 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-redeclare */
+import { Deferred } from "@/utils/Deferred";
+import { generateUUID } from "@/utils/uuid";
+import { TypedString } from "../model/typed";
+
+export type RequestId = TypedString<"RequestId">;
+export const RequestId = {
+  create(): RequestId {
+    return generateUUID() as RequestId;
+  },
+};
+
+/**
+ * Helper class to manage deferred requests.
+ * We send a request via HTTP and then wait for the response from the kernel
+ * via a websocket.
+ */
+export class DeferredRequestRegistry<REQ, RES> {
+  public requests = new Map<RequestId, Deferred<RES>>();
+
+  constructor(
+    public operation: string,
+    private makeRequest: (id: RequestId, req: REQ) => Promise<void>
+  ) {}
+
+  async request(opts: REQ): Promise<RES> {
+    const requestId = RequestId.create();
+    const deferred = new Deferred<RES>();
+
+    this.requests.set(requestId, deferred);
+
+    await this.makeRequest(requestId, opts).catch((error) => {
+      deferred.reject(error);
+      this.requests.delete(requestId);
+    });
+    return deferred.promise;
+  }
+
+  resolve(requestId: RequestId, response: RES) {
+    const entry = this.requests.get(requestId);
+    if (entry === undefined) {
+      return;
+    }
+
+    entry.resolve(response);
+    this.requests.delete(requestId);
+  }
+}

--- a/frontend/src/core/network/__tests__/DeferredRequestRegistry.test.ts
+++ b/frontend/src/core/network/__tests__/DeferredRequestRegistry.test.ts
@@ -1,0 +1,34 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { beforeEach, expect, vi, describe, it } from "vitest";
+import { DeferredRequestRegistry, RequestId } from "../DeferredRequestRegistry";
+
+vi.mock("@/utils/uuid", () => ({
+  generateUUID: vi.fn().mockReturnValue("uuid"),
+}));
+
+describe("DeferredRequestRegistry", () => {
+  const REQUEST_ID = "uuid" as RequestId;
+  let makeRequestMock = vi.fn();
+  let registry: DeferredRequestRegistry<unknown, unknown>;
+
+  beforeEach(() => {
+    makeRequestMock = vi.fn().mockResolvedValue(undefined);
+    registry = new DeferredRequestRegistry("operation", makeRequestMock);
+  });
+
+  it("should create and resolve new request", async () => {
+    const promise = registry.request("requestOptions");
+    expect(makeRequestMock).toHaveBeenCalledWith("uuid", "requestOptions");
+    expect(registry.requests.has(REQUEST_ID)).toBe(true);
+
+    // resolve
+    registry.resolve(REQUEST_ID, "response");
+    await expect(promise).resolves.toBe("response");
+  });
+
+  it("should handle request failure", async () => {
+    makeRequestMock.mockRejectedValue(new Error("request error"));
+    const promise = registry.request("requestOptions");
+    await expect(promise).rejects.toThrow("request error");
+  });
+});

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -131,5 +131,5 @@ export function saveCellConfig(request: SaveCellConfigRequest) {
 }
 
 export function sendFunctionRequest(request: SendFunctionRequest) {
-  return API.post<SendFunctionRequest>("/kernel/function/", request);
+  return API.post<SendFunctionRequest>("/kernel/function_call/", request);
 }

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -16,6 +16,7 @@ import {
   SaveUserConfigRequest,
   SaveAppConfigRequest,
   SaveCellConfigRequest,
+  SendFunctionRequest,
 } from "./types";
 import { invariant } from "@/utils/invariant";
 
@@ -112,15 +113,9 @@ export async function sendDirectoryAutocompleteRequest(prefix: string) {
 }
 
 export async function sendCodeCompletionRequest(
-  id: string,
-  document: string,
-  cellId: CellId
+  request: CodeCompletionRequest
 ) {
-  return API.post<CodeCompletionRequest>("/kernel/code_autocomplete/", {
-    id: id,
-    document: document,
-    cellId: cellId,
-  });
+  return API.post<CodeCompletionRequest>("/kernel/code_autocomplete/", request);
 }
 
 export function saveUserConfig(request: SaveUserConfigRequest) {
@@ -133,4 +128,8 @@ export function saveAppConfig(request: SaveAppConfigRequest) {
 
 export function saveCellConfig(request: SaveCellConfigRequest) {
   return API.post<SaveCellConfigRequest>("/kernel/set_cell_config/", request);
+}
+
+export function sendFunctionRequest(request: SendFunctionRequest) {
+  return API.post<SendFunctionRequest>("/kernel/function/", request);
 }

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -84,8 +84,8 @@ export interface SaveCellConfigRequest {
 }
 
 export interface SendFunctionRequest {
-  id: RequestId;
+  functionCallId: RequestId;
   args: unknown;
   namespace: string;
-  functionId: string;
+  functionName: string;
 }

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -3,6 +3,7 @@ import { AppConfig, UserConfig } from "../config/config";
 import { LayoutType } from "@/editor/renderers/types";
 import { CellId } from "../../core/model/ids";
 import { CellConfig } from "../model/cells";
+import { RequestId } from "./DeferredRequestRegistry";
 
 export interface DeleteRequest {
   cellId: CellId;
@@ -65,7 +66,7 @@ export interface SetComponentValuesRequest {
 }
 
 export interface CodeCompletionRequest {
-  id: string;
+  id: RequestId;
   document: string;
   cellId: CellId;
 }
@@ -80,4 +81,11 @@ export interface SaveAppConfigRequest {
 
 export interface SaveCellConfigRequest {
   configs: Record<CellId, CellConfig>;
+}
+
+export interface SendFunctionRequest {
+  id: RequestId;
+  args: unknown;
+  namespace: string;
+  functionId: string;
 }

--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -6,7 +6,7 @@ import { useWebSocket } from "@/core/websocket/useWebSocket";
 import { logNever } from "@/utils/assertNever";
 import { useCellActions } from "@/core/state/cells";
 import { RuntimeState } from "@/core/RuntimeState";
-import { Autocompleter } from "@/core/codemirror/completion/Autocompleter";
+import { AUTOCOMPLETER } from "@/core/codemirror/completion/Autocompleter";
 import { UI_ELEMENT_REGISTRY } from "@/core/dom/uiregistry";
 import { OperationMessage } from "@/core/kernel/messages";
 import { saveCellConfig, sendInstantiate } from "../network/requests";
@@ -20,6 +20,7 @@ import { deserializeLayout } from "@/editor/renderers/plugins";
 import { useVariablesActions } from "../variables/state";
 import { toast } from "@/components/ui/use-toast";
 import { renderHTML } from "@/plugins/core/RenderHTML";
+import { FUNCTIONS_REGISTRY } from "../functions/FunctionRegistry";
 
 /**
  * WebSocket that connects to the Marimo kernel and handles incoming messages.
@@ -142,7 +143,10 @@ export function useMarimoWebSocket(opts: {
           return;
         }
         case "completion-result":
-          Autocompleter.INSTANCE.resolve(msg.data);
+          AUTOCOMPLETER.resolve(msg.data.completion_id, msg.data);
+          return;
+        case "function-call-result":
+          FUNCTIONS_REGISTRY.resolve(msg.data.function_call_id, msg.data);
           return;
         case "cell-op": {
           /* Register a state transition for a cell.

--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -59,10 +59,8 @@
   white-space: normal;
   display: block;
   list-style-type: disc;
-  margin-block-start: 0;
-  margin-block-end: 0;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 0 0;
+  margin-inline: 0 0;
   padding-inline-start: 40px;
 }
 
@@ -71,10 +69,8 @@
   white-space: normal;
   display: block;
   list-style-type: decimal;
-  margin-block-start: 0;
-  margin-block-end: 0;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 0 0;
+  margin-inline: 0 0;
   padding-inline-start: 40px;
 }
 
@@ -87,10 +83,8 @@
 
 .mo-cm-tooltip blockquote {
   display: contents;
-  margin-block-start: 0;
-  margin-block-end: 0;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 0 0;
+  margin-inline: 0 0;
 }
 
 .mo-cm-tooltip pre {

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -32,10 +32,8 @@
   /* provide by the browser, but removed from 'reset' */
   display: block;
   font-size: 2rem;
-  margin-block-start: 0.67rem;
-  margin-block-end: 0.67rem;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 0.67rem 0.67rem;
+  margin-inline: 0 0;
   text-align: center;
 }
 
@@ -48,40 +46,32 @@
   /* provide by the browser, but removed from 'reset' */
   display: block;
   font-size: 1.5rem;
-  margin-block-start: 0.83rem;
-  margin-block-end: 0.83rem;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 0.83rem 0.83rem;
+  margin-inline: 0 0;
 }
 
 .markdown h3 {
   /* provide by the browser, but removed from 'reset' */
   display: block;
   font-size: 1.17rem;
-  margin-block-start: 1rem;
-  margin-block-end: 1rem;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 1rem 1rem;
+  margin-inline: 0 0;
 }
 
 .markdown p,
 .markdown .paragraph {
   /* provide by the browser, but removed from 'reset' */
   display: block;
-  margin-block-start: 1rem;
-  margin-block-end: 1rem;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 1rem 1rem;
+  margin-inline: 0 0;
 }
 
 .markdown ul {
   /* provide by the browser, but removed from 'reset' */
   display: block;
   list-style-type: disc;
-  margin-block-start: 1rem;
-  margin-block-end: 1rem;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 1rem 1rem;
+  margin-inline: 0 0;
   padding-inline-start: 40px;
 }
 
@@ -89,10 +79,8 @@
   /* provide by the browser, but removed from 'reset' */
   display: block;
   list-style-type: decimal;
-  margin-block-start: 1rem;
-  margin-block-end: 1rem;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-block: 1rem 1rem;
+  margin-inline: 0 0;
   padding-inline-start: 40px;
 }
 

--- a/frontend/src/plugins/core/builder.ts
+++ b/frontend/src/plugins/core/builder.ts
@@ -1,0 +1,50 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { ZodType, ZodTypeDef } from "zod";
+import { IPluginProps, IPlugin } from "../types";
+import { FunctionSchemas, PluginFunctions } from "./rpc";
+
+type Renderer<S, D, F> = (props: IPluginProps<S, D, F>) => JSX.Element;
+// If this simple builder pattern becomes unwieldy, we can switch to a more
+// complex builder pattern with individual classes.
+
+export function createPlugin<S>(tagName: string) {
+  return {
+    /**
+     * Data schema for the plugin.
+     */
+    withData<D>(validator: ZodType<D, ZodTypeDef, unknown>) {
+      return {
+        /**
+         * Functions that the plugin can call.
+         */
+        withFunctions<F extends PluginFunctions>(
+          functions: FunctionSchemas<F>
+        ) {
+          return {
+            /**
+             * Render the plugin.
+             */
+            renderer(renderer: Renderer<S, D, F>): IPlugin<S, D, F> {
+              return {
+                tagName,
+                validator,
+                functions,
+                render: renderer,
+              };
+            },
+          };
+        },
+        /**
+         * Render the plugin.
+         */
+        renderer(renderer: Renderer<S, D, unknown>): IPlugin<S, D, {}> {
+          return {
+            tagName,
+            validator,
+            render: renderer,
+          };
+        },
+      };
+    },
+  };
+}

--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -172,12 +172,11 @@ function PluginSlotInternal<T>(
         invariant(objectId, "Object ID should exist");
         const response = await FUNCTIONS_REGISTRY.request({
           args: input.parse(args[0]),
-          functionId: key,
+          functionName: key,
           namespace: objectId,
         });
         if (response.status.code !== "ok") {
-          // TODO: Propagate status.title/status.message
-          throw new Error(`Failed to call function ${key}`);
+          throw new Error(response.status.message);
         }
         return output.parse(response.return_value);
       };

--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -13,6 +13,7 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -32,6 +33,10 @@ import { renderHTML } from "./RenderHTML";
 import { invariant } from "../../utils/invariant";
 import { Logger } from "../../utils/Logger";
 import { getTheme } from "@/theme/useTheme";
+import { FUNCTIONS_REGISTRY } from "@/core/functions/FunctionRegistry";
+import { getUIElementObjectId } from "@/core/dom/UIElement";
+import { PluginFunctions } from "./rpc";
+import { ZodSchema } from "zod";
 
 export interface PluginSlotHandle {
   /**
@@ -146,6 +151,40 @@ function PluginSlotInternal<T>(
     [setValue, shouldDispatchInput]
   );
 
+  // Create a map of functions that can be called by the plugin
+  const functionMethods = useMemo<PluginFunctions>(() => {
+    if (!plugin.functions) {
+      return {};
+    }
+
+    const methods: PluginFunctions = {};
+    for (const [key, schemas] of Objects.entries(plugin.functions)) {
+      const { input, output } = schemas as {
+        input: ZodSchema<unknown>;
+        output: ZodSchema<unknown>;
+      };
+      methods[key] = async (...args: unknown[]) => {
+        invariant(
+          args.length <= 1,
+          `Plugin functions only supports a single argument. Called ${key}`
+        );
+        const objectId = getUIElementObjectId(hostElement);
+        invariant(objectId, "Object ID should exist");
+        const response = await FUNCTIONS_REGISTRY.request({
+          args: input.parse(args[0]),
+          functionId: key,
+          namespace: objectId,
+        });
+        if (!response.success) {
+          throw new Error(`Failed to call function ${key}`);
+        }
+        return output.parse(response.return_value);
+      };
+    }
+
+    return methods;
+  }, [plugin.functions, hostElement]);
+
   // If we failed to parse the initial value, render an error
   if (!parseResult.success) {
     return renderError(parseResult.error);
@@ -161,6 +200,7 @@ function PluginSlotInternal<T>(
         data: parseResult.data,
         children: childNodes,
         host: hostElement,
+        functions: functionMethods,
       })}
     </div>
   );

--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -175,7 +175,8 @@ function PluginSlotInternal<T>(
           functionId: key,
           namespace: objectId,
         });
-        if (!response.success) {
+        if (response.status.code !== "ok") {
+          // TODO: Propagate status.title/status.message
           throw new Error(`Failed to call function ${key}`);
         }
         return output.parse(response.return_value);

--- a/frontend/src/plugins/core/rpc.ts
+++ b/frontend/src/plugins/core/rpc.ts
@@ -1,0 +1,55 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { ZodType, ZodTypeDef } from "zod";
+
+export type PluginFunction<REQ = any, RES = any> = (args: REQ) => Promise<RES>;
+
+/**
+ * Functions that can be called from the plugin.
+ */
+export type PluginFunctions = Record<string, PluginFunction>;
+
+// Utility types for extracting schemas from functions.
+export type ExtractInputSchema<F extends PluginFunction> = F extends (
+  args: infer REQ
+) => Promise<any>
+  ? ZodType<REQ, ZodTypeDef, unknown>
+  : never;
+export type ExtractOutputSchema<F extends PluginFunction> = F extends (
+  args: any
+) => Promise<infer RES>
+  ? ZodType<RES, ZodTypeDef, unknown>
+  : never;
+
+/**
+ * Schemas for the plugin functions.
+ */
+export type FunctionSchemas<F extends PluginFunctions> = {
+  [K in keyof F]: {
+    /**
+     * Validate the function arguments.
+     */
+    input: ExtractInputSchema<F[K]>;
+    /**
+     * Validate the function output.
+     */
+    output: ExtractOutputSchema<F[K]>;
+  };
+};
+
+/**
+ * RPC builder for plugin functions.
+ */
+export const rpc = {
+  input<I>(inputSchema: ZodType<I, ZodTypeDef, unknown>) {
+    return {
+      output<O>(outputSchema: ZodType<O, ZodTypeDef, unknown>) {
+        return {
+          input: inputSchema,
+          output: outputSchema,
+        };
+      },
+    };
+  },
+};

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -4,12 +4,13 @@ import { z } from "zod";
 // @ts-expect-error - no types
 import { loader as createLoader, read } from "vega-loader";
 
-import { IPlugin, IPluginProps } from "@/plugins/types";
 import { DataTable } from "../../components/data-table/data-table";
 import { generateColumns } from "../../components/data-table/columns";
 import { Labeled } from "./common/labeled";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { Alert, AlertTitle } from "@/components/ui/alert";
+import { rpc } from "../core/rpc";
+import { createPlugin } from "../core/builder";
 
 /**
  * Arguments for a data table
@@ -22,29 +23,38 @@ interface Data<T> {
   data: T[] | string;
   pagination: boolean;
   selection: "single" | "multi" | null;
+  showDownload: boolean;
 }
 
-// Value is selection, but it is not currently exposed to the user
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type Functions = {
+  downloadAs: (type: "csv" | "json" | "xls") => Promise<string>;
+};
+
 type S = Array<string | number>;
 
 const loader = createLoader();
 
-export class DataTablePlugin implements IPlugin<S, Data<unknown>> {
-  tagName = "marimo-table";
-
-  validator = z.object({
-    initialValue: z.array(z.number()),
-    label: z.string().nullable(),
-    data: z.union([z.string(), z.array(z.object({}).passthrough())]),
-    pagination: z.boolean().default(false),
-    selection: z.enum(["single", "multi"]).nullable().default(null),
-  });
-
-  render(props: IPluginProps<S, Data<unknown>>): JSX.Element {
+export const DataTablePlugin = createPlugin<S>("marimo-table")
+  .withData(
+    z.object({
+      initialValue: z.array(z.number()),
+      label: z.string().nullable(),
+      data: z.union([z.string(), z.array(z.object({}).passthrough())]),
+      pagination: z.boolean().default(false),
+      selection: z.enum(["single", "multi"]).nullable().default(null),
+      showDownload: z.boolean().default(false),
+    })
+  )
+  .withFunctions<Functions>({
+    downloadAs: rpc.input(z.enum(["csv", "json", "xls"])).output(z.string()),
+  })
+  .renderer((props) => {
     if (typeof props.data.data === "string") {
       return (
         <LoadingDataTableComponent
           {...props.data}
+          {...props.functions}
           data={props.data.data}
           value={props.value}
           setValue={props.setValue}
@@ -54,15 +64,15 @@ export class DataTablePlugin implements IPlugin<S, Data<unknown>> {
     return (
       <DataTableComponent
         {...props.data}
+        {...props.functions}
         data={props.data.data}
         value={props.value}
         setValue={props.setValue}
       />
     );
-  }
-}
+  });
 
-interface DataTableProps extends Data<unknown> {
+interface DataTableProps extends Data<unknown>, Functions {
   value: S;
   setValue: (value: S) => void;
 }
@@ -101,6 +111,8 @@ const DataTableComponent = ({
   pagination,
   selection,
   value,
+  showDownload,
+  downloadAs,
   setValue,
 }: DataTableProps & {
   data: unknown[];
@@ -119,6 +131,7 @@ const DataTableComponent = ({
         columns={columns}
         pagination={pagination}
         rowSelection={rowSelection}
+        downloadAs={showDownload ? downloadAs : undefined}
         onRowSelectionChange={(updater) => {
           if (selection === "single") {
             const nextValue =

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -28,7 +28,7 @@ interface Data<T> {
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type Functions = {
-  downloadAs: (type: "csv" | "json" | "xls") => Promise<string>;
+  download_as: (req: { format: "csv" | "json" }) => Promise<string>;
 };
 
 type S = Array<string | number>;
@@ -47,7 +47,9 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
     })
   )
   .withFunctions<Functions>({
-    downloadAs: rpc.input(z.enum(["csv", "json", "xls"])).output(z.string()),
+    download_as: rpc
+      .input(z.object({ format: z.enum(["csv", "json"]) }))
+      .output(z.string()),
   })
   .renderer((props) => {
     if (typeof props.data.data === "string") {
@@ -112,7 +114,7 @@ const DataTableComponent = ({
   selection,
   value,
   showDownload,
-  downloadAs,
+  download_as: downloadAs,
   setValue,
 }: DataTableProps & {
   data: unknown[];

--- a/frontend/src/plugins/impl/DictPlugin.tsx
+++ b/frontend/src/plugins/impl/DictPlugin.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from "react";
 import { z } from "zod";
 
-import { UI_ELEMENT_TAG_NAME } from "../../core/dom/UIElement";
+import { getUIElementObjectId } from "../../core/dom/UIElement";
 import {
   marimoValueInputEvent,
   MarimoValueInputEventType,
@@ -55,13 +55,11 @@ const Dict = ({
       if (target === null || !(target instanceof Node)) {
         return;
       }
-      const node = target.parentNode;
-      if (node === null || node.nodeName !== UI_ELEMENT_TAG_NAME) {
-        // If something other than a UI element triggered an event, ignore it
+      const objectId = getUIElementObjectId(target);
+      if (objectId === null) {
         return;
       }
-      const id = (node as Element).getAttribute("object-id") as string;
-      const key = elementIds[id];
+      const key = elementIds[objectId];
       if (key === undefined) {
         // If the UI element firing the event is not in the dict, ignore it
         return;

--- a/frontend/src/plugins/impl/FormPlugin.tsx
+++ b/frontend/src/plugins/impl/FormPlugin.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
-import { UI_ELEMENT_TAG_NAME } from "../../core/dom/UIElement";
+import { getUIElementObjectId } from "../../core/dom/UIElement";
 import {
   marimoValueInputEvent,
   MarimoValueInputEventType,
@@ -123,15 +123,8 @@ const Form = ({ elementId, value, setValue, children, label }: SubmitProps) => {
       if (target === null || !(target instanceof Node)) {
         return;
       }
-      const node = target.parentNode;
-
-      // If something other than a UI element triggered an event, ignore it
-      if (node === null || node.nodeName !== UI_ELEMENT_TAG_NAME) {
-        return;
-      }
-
-      const id = (node as Element).getAttribute("object-id") as string;
-      if (id === elementId) {
+      const objectId = getUIElementObjectId(target);
+      if (objectId === elementId) {
         setInternalValue(e.detail.value);
       }
     };

--- a/frontend/src/plugins/plugins.ts
+++ b/frontend/src/plugins/plugins.ts
@@ -1,7 +1,7 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { initializeUIElement } from "../core/dom/UIElement";
-import { registerReactComponent } from "./core/componentFactory";
+import { registerReactComponent } from "./core/registerReactComponent";
 import { ButtonPlugin } from "./impl/ButtonPlugin";
 import { CheckboxPlugin } from "./impl/CheckboxPlugin";
 import { DatePickerPlugin } from "./impl/DatePickerPlugin";
@@ -35,7 +35,7 @@ import { StatPlugin } from "./layout/StatPlugin";
 const UI_PLUGINS: Array<IPlugin<any, unknown>> = [
   new ButtonPlugin(),
   new CheckboxPlugin(),
-  new DataTablePlugin(),
+  DataTablePlugin,
   new DatePickerPlugin(),
   new DictPlugin(),
   new DropdownPlugin(),

--- a/frontend/src/plugins/stateless-plugin.ts
+++ b/frontend/src/plugins/stateless-plugin.ts
@@ -18,7 +18,8 @@ export interface IStatelessPluginProps<D> {
   children?: React.ReactNode | undefined;
 }
 
-export interface IStatelessPlugin<D> extends Omit<IPlugin<never, D>, "render"> {
+export interface IStatelessPlugin<D>
+  extends Omit<IPlugin<never, D>, "render" | "functions"> {
   /**
    * Render the plugin.
    */

--- a/frontend/src/plugins/types.ts
+++ b/frontend/src/plugins/types.ts
@@ -1,5 +1,6 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { ZodType, ZodTypeDef } from "zod";
+import { PluginFunctions, FunctionSchemas } from "./core/rpc";
 
 /**
  * State setter. Either a value or a function that takes the previous value and
@@ -9,10 +10,8 @@ export type Setter<S> = (value: S | ((prev: S) => S)) => void;
 
 /**
  * Props for a plugin.
- *
- * TODO(akshayka): (Maybe) add children elements for composition
  */
-export interface IPluginProps<S, D> {
+export interface IPluginProps<S, D, F = {}> {
   /**
    * Host element.
    */
@@ -29,6 +28,11 @@ export interface IPluginProps<S, D> {
    * Plugin data.
    */
   data: D;
+
+  /**
+   * Functions that can be called from the plugin.
+   */
+  functions: F;
 
   /**
    * Children elements.
@@ -48,7 +52,11 @@ export type StringifiedPluginData<D> = {
  * @template S - the type of the state
  * @template P - the type of the props
  */
-export interface IPlugin<S, D = Record<string, never>> {
+export interface IPlugin<
+  S,
+  D = Record<string, never>,
+  F extends PluginFunctions = {}
+> {
   /**
    * The html tag name to render the plugin.
    */
@@ -60,7 +68,12 @@ export interface IPlugin<S, D = Record<string, never>> {
   validator: ZodType<D, ZodTypeDef, unknown>;
 
   /**
+   * Functions definitions and validation.
+   */
+  functions?: FunctionSchemas<F>;
+
+  /**
    * Render the plugin.
    */
-  render(props: IPluginProps<S, D>): JSX.Element;
+  render(props: IPluginProps<S, D, F>): JSX.Element;
 }

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -193,6 +193,16 @@ class CellOp(Op):
 
 
 @dataclass
+class FunctionCallResult(Op):
+    """Result of calling a function."""
+
+    function_call_id: str
+    return_value: JSONType
+    # True if the function call succeeded, False if it was aborted
+    success: bool
+
+
+@dataclass
 class RemoveUIElements(Op):
     """Invalidate UI elements for a given cell."""
 

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -196,6 +196,8 @@ class CellOp(Op):
 class FunctionCallResult(Op):
     """Result of calling a function."""
 
+    name: ClassVar[str] = "function-call-result"
+
     function_call_id: str
     return_value: JSONType
     # True if the function call succeeded, False if it was aborted

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -193,6 +193,15 @@ class CellOp(Op):
 
 
 @dataclass
+class HumanReadableStatus(Op):
+    """Human-readable status."""
+
+    code: Literal["ok", "error"]
+    title: str | None = None
+    message: str | None = None
+
+
+@dataclass
 class FunctionCallResult(Op):
     """Result of calling a function."""
 
@@ -200,8 +209,7 @@ class FunctionCallResult(Op):
 
     function_call_id: str
     return_value: JSONType
-    # True if the function call succeeded, False if it was aborted
-    success: bool
+    status: HumanReadableStatus
 
 
 @dataclass

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -96,6 +96,32 @@ def json(data: Union[str, bytes, io.BytesIO, "pd.DataFrame"]) -> VirtualFile:
     return any_data(data, ext="json")  # type: ignore
 
 
+def xls(data: Union[str, bytes, io.BytesIO, "pd.DataFrame"]) -> VirtualFile:
+    """Create a virtual file for XLS data.
+
+    **Args.**
+
+    - data: XLS data in bytes, or string representing a data URL, external URL
+        or a Pandas DataFrame
+
+    **Returns.**
+
+    A `VirtualFile` object.
+    """
+    # Pandas DataFrame
+    if DependencyManager.has_pandas():
+        import pandas as pd
+
+        if isinstance(data, pd.DataFrame):
+            output = io.BytesIO()
+            writer = pd.ExcelWriter(output, engine="xlsxwriter")
+            data.to_excel(writer, index=False)
+            output.seek(0)
+            return any_data(output, ext="xls")
+
+    return any_data(data, ext="xls")  # type: ignore
+
+
 def any_data(data: Union[str, bytes, io.BytesIO], ext: str) -> VirtualFile:
     """Create a virtual file from any data.
 

--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -96,32 +96,6 @@ def json(data: Union[str, bytes, io.BytesIO, "pd.DataFrame"]) -> VirtualFile:
     return any_data(data, ext="json")  # type: ignore
 
 
-def xls(data: Union[str, bytes, io.BytesIO, "pd.DataFrame"]) -> VirtualFile:
-    """Create a virtual file for XLS data.
-
-    **Args.**
-
-    - data: XLS data in bytes, or string representing a data URL, external URL
-        or a Pandas DataFrame
-
-    **Returns.**
-
-    A `VirtualFile` object.
-    """
-    # Pandas DataFrame
-    if DependencyManager.has_pandas():
-        import pandas as pd
-
-        if isinstance(data, pd.DataFrame):
-            output = io.BytesIO()
-            writer = pd.ExcelWriter(output, engine="xlsxwriter")
-            data.to_excel(writer, index=False)
-            output.seek(0)
-            return any_data(output, ext="xls")
-
-    return any_data(data, ext="xls")  # type: ignore
-
-
 def any_data(data: Union[str, bytes, io.BytesIO], ext: str) -> VirtualFile:
     """Create a virtual file from any data.
 

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 import abc
 import copy
 import uuid
-from typing import TYPE_CHECKING, Callable, Generic, Optional, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Generic,
+    Optional,
+    Sequence,
+    TypeVar,
+    cast,
+)
 
 from marimo import _loggers
 from marimo._output.hypertext import Html
@@ -12,6 +20,7 @@ from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType, build_ui_plugin
 from marimo._plugins.ui._core import ids
 from marimo._runtime.context import ContextNotInitializedError, get_context
+from marimo._runtime.functions import Function
 
 if TYPE_CHECKING:
     from marimo._plugins.ui._impl.input import form as form_plugin
@@ -70,6 +79,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         on_change: Optional[Callable[[T], None]],
         args: dict[str, JSONType],
         slotted_html: str = "",
+        functions: tuple[Function, ...] = (),
     ) -> None:
         """Initialize a UIElement
 
@@ -78,9 +88,10 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         component_name: tag name of the custom element
         initial_value: initial value of the element in the frontend
         label: markdown string, label of element
+        on_change: callback, called with element's new value on change
         args: arguments that the element takes
         slotted_html: any html to slot in the custom element
-        on_change: callback, called with element's new value on change
+        functions: any functions to register with the graph
         """
         # arguments stored in signature order for cloning
         self._args = (
@@ -90,6 +101,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
             on_change,
             args,
             slotted_html,
+            functions,
         )
         self._initialized = False
         self._initialize(*self._args)
@@ -103,6 +115,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         on_change: Optional[Callable[[T], None]],
         args: dict[str, JSONType],
         slotted_html: str,
+        functions: tuple[Function, ...] = (),
     ) -> None:
         """Initialize the UIElement
 
@@ -176,6 +189,10 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
             + self._inner_text
             + "</marimo-ui-element>"
         )
+
+        for function in functions:
+            # TODO
+            ...
 
     @abc.abstractmethod
     def _convert_value(self, value: S) -> T:

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -159,7 +159,6 @@ class table(UIElement[List[str], Union[List[object], "pd.DataFrame"]]):
         import pandas as pd
 
         # download selected rows if there are any, otherwise use all rows
-        # TODO: selection does not actually work
         data = self._value if len(self._value) > 0 else self._data
 
         as_dataframe = (

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -164,7 +164,8 @@ class table(UIElement[List[str], Union[List[object], "pd.DataFrame"]]):
         as_dataframe = (
             data
             if isinstance(data, pd.DataFrame)
-            else pd.DataFrame(self._normalized_data)
+            # TODO: fix types to remove type ignore
+            else pd.DataFrame(self._normalized_data)  # type:ignore[arg-type]
         )
 
         ext = args.format
@@ -176,6 +177,7 @@ class table(UIElement[List[str], Union[List[object], "pd.DataFrame"]]):
             raise ValueError("format must be one of 'csv' or 'json'.")
 
 
+# TODO: more narrow return type
 def _normalize_data(data: TableData) -> JSONType:
     # Handle pandas
     if DependencyManager.has_pandas():

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -116,6 +116,7 @@ class table(UIElement[List[str], Union[List[object], "pd.DataFrame"]]):
                 "data": normalized_data,
                 "pagination": pagination,
                 "selection": selection,
+                "show-download": DependencyManager.has_pandas(),
             },
             on_change=on_change,
         )
@@ -135,6 +136,22 @@ class table(UIElement[List[str], Union[List[object], "pd.DataFrame"]]):
             if isinstance(self._data, pd.DataFrame):
                 return self._data.iloc[[int(v) for v in value]]
         return [self._data[int(v)] for v in value]
+
+    def download_as(self, ext: Literal["csv", "json", "xls"]) -> str:
+        if not DependencyManager.has_pandas():
+            raise RuntimeError("Pandas must be installed to download tables.")
+
+        import pandas as pd
+
+        if isinstance(self._data, pd.DataFrame):
+            if ext == "csv":
+                return mo_data.csv(self._data).url
+            elif ext == "json":
+                return mo_data.json(self._data).url
+            elif ext == "xls":
+                return mo_data.xls(self._data).url
+            else:
+                raise ValueError("ext must be one of 'csv' or 'json'.")
 
 
 def _normalize_data(data: TableData) -> JSONType:

--- a/marimo/_runtime/context.py
+++ b/marimo/_runtime/context.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Iterator, Optional
 
 from marimo._plugins.ui._core.ids import IDProvider, NoIDProviderException
 from marimo._runtime.cell_lifecycle_registry import CellLifecycleRegistry
+from marimo._runtime.functions import FunctionRegistry
 
 if TYPE_CHECKING:
     from marimo._ast.cell import CellId_t
@@ -50,6 +51,7 @@ class RuntimeContext:
 
     kernel: Kernel
     ui_element_registry: UIElementRegistry
+    function_registry: FunctionRegistry
     cell_lifecycle_registry: CellLifecycleRegistry
     virtual_file_registry: VirtualFileRegistry
     stream: Stream
@@ -119,6 +121,7 @@ def initialize_context(
         runtime_context = RuntimeContext(
             kernel=kernel,
             ui_element_registry=UIElementRegistry(),
+            function_registry=FunctionRegistry(),
             cell_lifecycle_registry=CellLifecycleRegistry(),
             virtual_file_registry=VirtualFileRegistry(),
             stream=stream,

--- a/marimo/_runtime/functions.py
+++ b/marimo/_runtime/functions.py
@@ -1,11 +1,13 @@
+# Copyright 2023 Marimo. All rights reserved.
 """Functions associated with a graph.
 """
 from __future__ import annotations
 
 import dataclasses
-from typing import Callable, Generic, Type, TypeVar
+from typing import Any, Callable, Generic, Type, TypeVar
 
-from marimo._server.api.model import parse_raw
+from marimo._ast.cell import CellId_t
+from marimo._utils.parse_dataclass import build_dataclass
 
 S = TypeVar("S")
 T = TypeVar("T")
@@ -16,21 +18,62 @@ class Function(Generic[S, T]):
     name: str
     arg_cls: Type[S]
     function: Callable[[S], T]
+    cell_id: CellId_t | None
 
-    def call(self, args: bytes) -> T:
-        return self.function(parse_raw(args, self.arg_cls))
+    def __init__(
+        self,
+        name: str,
+        arg_cls: Type[S],
+        function: Callable[[S], T],
+    ) -> None:
+        from marimo._runtime.context import get_context
+
+        self.name = name
+        self.arg_cls = arg_cls
+        self.function = function
+
+        ctx = get_context()
+        if ctx is not None and ctx.kernel.execution_context is not None:
+            self.cell_id = ctx.kernel.execution_context.cell_id
+        else:
+            self.cell_id = None
+
+    def __call__(self, args: dict[Any, Any]) -> T:
+        return self.function(build_dataclass(args, self.arg_cls))
+
+
+@dataclasses.dataclass
+class FunctionNamespace:
+    namespace: str
+    functions: dict[str, Function[Any, Any]] = dataclasses.field(
+        default_factory=dict
+    )
+
+    def add(self, function: Function[Any, Any]) -> None:
+        self.functions[function.name] = function
+
+    def get(self, name: str) -> Function[Any, Any] | None:
+        if name in self.functions:
+            return self.functions[name]
+        return None
 
 
 class FunctionRegistry:
     def __init__(self) -> None:
-        self.functions = {}
+        self.namespaces: dict[str, FunctionNamespace] = {}
 
-    def register_function(self, function: Function) -> None:
-        self.functions[function.name] = function
+    def register(self, namespace: str, function: Function[Any, Any]) -> None:
+        if namespace not in self.namespaces:
+            self.namespaces[namespace] = FunctionNamespace(namespace=namespace)
+        self.namespaces[namespace].add(function)
 
-    def get_function(self, name: str) -> Function | None:
-        return self.functions[name] if name in self.functions else None
+    def get_function(
+        self, namespace: str, function_name: str
+    ) -> Function[Any, Any] | None:
+        if namespace in self.namespaces:
+            return self.namespaces[namespace].get(function_name)
+        return None
 
-    def remove_function(self, name: str) -> None:
-        if name in self.functions:
-            del self.functions[name]
+    def delete(self, namespace: str) -> None:
+        if namespace in self.namespaces:
+            del self.namespaces[namespace]

--- a/marimo/_runtime/functions.py
+++ b/marimo/_runtime/functions.py
@@ -1,0 +1,36 @@
+"""Functions associated with a graph.
+"""
+from __future__ import annotations
+
+import dataclasses
+from typing import Callable, Generic, Type, TypeVar
+
+from marimo._server.api.model import parse_raw
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+
+@dataclasses.dataclass
+class Function(Generic[S, T]):
+    name: str
+    arg_cls: Type[S]
+    function: Callable[[S], T]
+
+    def call(self, args: bytes) -> T:
+        return self.function(parse_raw(args, self.arg_cls))
+
+
+class FunctionRegistry:
+    def __init__(self) -> None:
+        self.functions = {}
+
+    def register_function(self, function: Function) -> None:
+        self.functions[function.name] = function
+
+    def get_function(self, name: str) -> Function | None:
+        return self.functions[name] if name in self.functions else None
+
+    def remove_function(self, name: str) -> None:
+        if name in self.functions:
+            del self.functions[name]

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -26,6 +26,14 @@ class SetUIElementValueRequest:
 
 
 @dataclass
+class FunctionCallRequest:
+    function_call_id: str
+    namespace: str
+    function_name: str
+    args: dict[str, Any]
+
+
+@dataclass
 class SetCellConfigRequest:
     configs: dict[CellId_t, dict[str, object]]
 
@@ -64,6 +72,7 @@ Request = Union[
     ExecuteMultipleRequest,
     CreationRequest,
     DeleteRequest,
+    FunctionCallRequest,
     SetCellConfigRequest,
     SetUIElementValueRequest,
     StopRequest,

--- a/marimo/_server/api/__init__.py
+++ b/marimo/_server/api/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "DeleteHandler",
     "DirectoryAutocompleteHandler",
     "FormatHandler",
+    "FunctionHandler",
     "InstantiateHandler",
     "InterruptHandler",
     "RenameHandler",
@@ -22,6 +23,7 @@ from marimo._server.api.directory_autocomplete import (
     DirectoryAutocompleteHandler,
 )
 from marimo._server.api.format import FormatHandler
+from marimo._server.api.function_call import FunctionHandler
 from marimo._server.api.instantiate import InstantiateHandler
 from marimo._server.api.interrupt import InterruptHandler
 from marimo._server.api.rename import RenameHandler

--- a/marimo/_server/api/code_complete.py
+++ b/marimo/_server/api/code_complete.py
@@ -8,7 +8,7 @@ import tornado.web
 from marimo._ast.cell import CellId_t
 from marimo._runtime import requests
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
+from marimo._utils.parse_dataclass import parse_raw
 
 
 @dataclass

--- a/marimo/_server/api/delete.py
+++ b/marimo/_server/api/delete.py
@@ -8,7 +8,7 @@ import tornado.web
 from marimo._ast.cell import CellId_t
 from marimo._runtime import requests
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
+from marimo._utils.parse_dataclass import parse_raw
 
 
 @dataclass

--- a/marimo/_server/api/directory_autocomplete.py
+++ b/marimo/_server/api/directory_autocomplete.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import tornado.web
 
-from marimo._server.api.model import parse_raw
+from marimo._utils.parse_dataclass import parse_raw
 
 
 @dataclass

--- a/marimo/_server/api/format.py
+++ b/marimo/_server/api/format.py
@@ -9,7 +9,7 @@ import tornado.web
 from marimo import _loggers
 from marimo._ast import cell
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
+from marimo._utils.parse_dataclass import parse_raw
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_server/api/function_call.py
+++ b/marimo/_server/api/function_call.py
@@ -23,11 +23,8 @@ class FunctionCall:
     args: Dict[str, Any]
 
 
-class RunHandler(tornado.web.RequestHandler):
-    """Run multiple cells (and their descendants).
-
-    Only allowed in edit mode.
-    """
+class FunctionHandler(tornado.web.RequestHandler):
+    """Invoke an RPC"""
 
     def post(self) -> None:
         session = sessions.require_session_from_header(self.request.headers)

--- a/marimo/_server/api/function_call.py
+++ b/marimo/_server/api/function_call.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import tornado.web
+
+from marimo import _loggers
+from marimo._runtime import requests
+from marimo._server import sessions
+from marimo._utils.parse_dataclass import parse_raw
+
+LOGGER = _loggers.marimo_logger()
+
+
+@dataclass
+class FunctionCall:
+    # unique token associated with the function call
+    function_call_id: str
+    namespace: str
+    function_name: str
+    args: Dict[str, Any]
+
+
+class RunHandler(tornado.web.RequestHandler):
+    """Run multiple cells (and their descendants).
+
+    Only allowed in edit mode.
+    """
+
+    def post(self) -> None:
+        session = sessions.require_session_from_header(self.request.headers)
+        args = parse_raw(self.request.body, FunctionCall)
+        request = requests.FunctionCallRequest(
+            function_call_id=args.function_call_id,
+            namespace=args.namespace,
+            function_name=args.function_name,
+            args=args.args,
+        )
+        session.queue.put(request)

--- a/marimo/_server/api/instantiate.py
+++ b/marimo/_server/api/instantiate.py
@@ -9,7 +9,7 @@ import tornado.web
 from marimo._ast.app import App
 from marimo._runtime import requests
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
+from marimo._utils.parse_dataclass import parse_raw
 
 
 @dataclass

--- a/marimo/_server/api/rename.py
+++ b/marimo/_server/api/rename.py
@@ -9,8 +9,8 @@ import tornado.web
 from marimo import _loggers
 from marimo._server import sessions
 from marimo._server.api import status
-from marimo._server.api.model import parse_raw
 from marimo._server.utils import canonicalize_filename
+from marimo._utils.parse_dataclass import parse_raw
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_server/api/run.py
+++ b/marimo/_server/api/run.py
@@ -9,7 +9,7 @@ import tornado.web
 from marimo._ast.cell import CellId_t
 from marimo._runtime import requests
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
+from marimo._utils.parse_dataclass import parse_raw
 
 
 @dataclass

--- a/marimo/_server/api/save.py
+++ b/marimo/_server/api/save.py
@@ -11,10 +11,10 @@ from marimo import _loggers
 from marimo._ast import codegen
 from marimo._ast.cell import CellConfig
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
 from marimo._server.api.status import HTTPStatus
 from marimo._server.layout import LayoutConfig, save_layout_config
 from marimo._server.utils import canonicalize_filename
+from marimo._utils.parse_dataclass import parse_raw
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_server/api/save_app_config.py
+++ b/marimo/_server/api/save_app_config.py
@@ -9,8 +9,8 @@ import tornado.web
 from marimo import _loggers
 from marimo._ast import codegen
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
 from marimo._server.api.status import HTTPStatus
+from marimo._utils.parse_dataclass import parse_raw
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_server/api/save_user_config.py
+++ b/marimo/_server/api/save_user_config.py
@@ -13,8 +13,8 @@ from marimo._config.config import MarimoConfig, configure
 from marimo._config.utils import get_config_path
 from marimo._runtime import requests
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
 from marimo._server.api.status import HTTPStatus
+from marimo._utils.parse_dataclass import parse_raw
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_server/api/set_cell_config.py
+++ b/marimo/_server/api/set_cell_config.py
@@ -9,7 +9,7 @@ import tornado.web
 from marimo._ast.cell import CellId_t
 from marimo._runtime import requests
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
+from marimo._utils.parse_dataclass import parse_raw
 
 
 @dataclass

--- a/marimo/_server/api/set_ui_element_value.py
+++ b/marimo/_server/api/set_ui_element_value.py
@@ -8,7 +8,7 @@ import tornado.web
 
 from marimo._runtime import requests
 from marimo._server import sessions
-from marimo._server.api.model import parse_raw
+from marimo._utils.parse_dataclass import parse_raw
 
 
 @dataclass

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -158,6 +158,10 @@ def construct_app(
                 api.SetUIElementValueHandler,
             ),
             (
+                r"/api/kernel/function_call/",
+                api.FunctionHandler,
+            ),
+            (
                 r"/api/kernel/set_cell_config/",
                 api.SetCellConfigHandler,
             ),

--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -38,12 +38,12 @@ def _build_value(value: Any, cls: Type[T]) -> T:
             }
         )
     elif dataclasses.is_dataclass(cls):
-        return _build_dataclass(value, cls)  # type: ignore[return-value]
+        return build_dataclass(value, cls)  # type: ignore[return-value]
     else:
         return value  # type: ignore[no-any-return]
 
 
-def _build_dataclass(value: dict[Any, Any], cls: Type[T]) -> T:
+def build_dataclass(value: dict[Any, Any], cls: Type[T]) -> T:
     types = get_type_hints(cls)
     transformed = {
         to_snake(k): _build_value(v, types[to_snake(k)])
@@ -70,4 +70,4 @@ def parse_raw(message: bytes, cls: Type[T]) -> T:
     cls: the type to instantiate
     """
     parsed = json.loads(message)
-    return _build_dataclass(parsed, cls)
+    return build_dataclass(parsed, cls)

--- a/marimo/_utils/test_parse_dataclass.py
+++ b/marimo/_utils/test_parse_dataclass.py
@@ -6,8 +6,8 @@ from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Tuple
 
 from marimo._server import api
-from marimo._server.api.model import parse_raw
 from marimo._server.api.set_cell_config import SetCellConfig
+from marimo._utils.parse_dataclass import parse_raw
 
 
 @dataclass


### PR DESCRIPTION
This change adds a function registry for RPCs to the backend, adding the following:
- namespaced registry
- server route for invoking a function; request includes a unique function call ID/token so frontend can match return values to invocations
- websocket op for returning a result or indicating an error status
- functions are not specialized to UI elements, any Python object can register an RPC, including stateless plugins

Additionally, this PR adds a function for `mo.ui.table` for downloading the data as CSV/JSON.

Comments/room for improvement:
- For UI elements, the namespace is the object ID
- This isn't made explicit to the frontend, so the abstraction is a little leaky