### PR TITLE
fix: autocomplete regressions

### DIFF
--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -75,7 +75,8 @@ export function hintTooltip() {
     // Clear tooltips on blur
     EditorView.domEventObservers({
       blur: (event, view) => {
-        closeCompletion(view);
+        // Only close tooltip, not view; blur for completion handled by
+        // cell editor, so that completion text is selectable
         clearTooltips(view);
       },
     }),

--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -9,7 +9,6 @@ import {
 } from "@codemirror/view";
 import { AUTOCOMPLETER, Autocompleter } from "./Autocompleter";
 import { Logger } from "@/utils/Logger";
-import { closeCompletion } from "@codemirror/autocomplete";
 import { StateField, StateEffect } from "@codemirror/state";
 
 export function hintTooltip() {

--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -61,10 +61,6 @@ export function hintTooltip() {
           message: result,
           exactName: fullWord,
         });
-        // Close the completion tooltips
-        if (tooltip) {
-          closeCompletion(view);
-        }
         return tooltip ?? null;
       },
       {

--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -55,6 +55,11 @@
   padding: 0.625rem 0.875rem;
 }
 
+/* Hover tooltips get highest priority in display. */
+.cm .cm-tooltip.cm-tooltip-hover {
+  z-index: 1000;
+}
+
 .mo-cm-tooltip ul {
   white-space: normal;
   display: block;

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -233,7 +233,7 @@ def complete(
                             )
                         ],
                     )
-                continue
+                    continue
 
             if not completions:
                 # If there are still no completions, then bail.


### PR DESCRIPTION
- fixes a bug which prevented user from being able to select (eg copy) text in a completion window
  - blur logic for closing completion window already handled by cell component
- fix a bug in which kernel stopped sending "no completions" op
- make tooltips appear above code completion