### PR TITLE
Catch/log exception when writing to pipe

### DIFF
--- a/marimo/_runtime/functions.py
+++ b/marimo/_runtime/functions.py
@@ -16,6 +16,7 @@ T = TypeVar("T")
 @dataclasses.dataclass
 class EmptyArgs:
     """Utility type for functions that take no arguments."""
+
     ...
 
 

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -63,6 +63,8 @@ def shutdown(with_error: bool = False) -> None:
         )
         print()
     mgr.shutdown()
+    # TODO(akshayka): This method raises an exception sometimes.
+    # debug, or just wrap in a try/except since we're on our way out anyway ...
     tornado.ioloop.IOLoop.current().stop()
     if with_error:
         sys.exit(1)


### PR DESCRIPTION
- Closing the server when the pipe is being written to raises an exception, crashes the kernel process, and prints a scary message to console
- This change catches the exception, debug logs it, and lets the kernel process exit gracefully