### PR TITLE
Fix: Graceful exit when cell is executing

### DIFF
--- a/marimo/_runtime/cell_runner.py
+++ b/marimo/_runtime/cell_runner.py
@@ -82,7 +82,7 @@ class RunResult:
     # Raw output of cell
     output: Any
     # Exception raised by cell, if any
-    exception: Optional[BaseException]
+    exception: Optional[Exception | MarimoInterrupt | MarimoStopError]
 
     def success(self) -> bool:
         """Whether the cell exected successfully"""
@@ -240,10 +240,11 @@ class Runner:
             run_result = RunResult(output=e.output, exception=e)
             # don't print a traceback, since quitting is the intended
             # behavior (like sys.exit())
-        except BaseException as e:  # noqa: E722
-            # except BaseException to catch everything, including
-            # KeyboardInterrupt: nothing should go uncaught
-            # cancel only the descendants of this cell
+        except Exception as e:
+            # Don't catch BaseExceptions:
+            # - KeyboardInterrupt shouldn't be raised, since marimo
+            #   redirects it to a MarimoInterrupt
+            # - SystemExit should kill the process
             self.cancel(cell_id)
             run_result = RunResult(output=None, exception=e)
             self.print_traceback()


### PR DESCRIPTION
This PR fixes a bug in which the kernel process would not terminate on SIGTERM if it was executing a cell. This left zombie marimo processes on the user's system.

The fix is to no longer catch BaseException's in the cell runner, just regular Exceptions and our special MarimoInterrupt and MarimoStopError exceptions. This means that if a user types sys.exit(), or `raise Keyboard Interrupt` in a cell, it will kill the kernel. The server isn't aware that the kernel dies in these cases (which should be rare), but we can fix that in a future change.