### PR TITLE
dataframe: load values from backend and distaply in better dropdowns

### DIFF
--- a/frontend/src/components/forms/switchable-multi-select.tsx
+++ b/frontend/src/components/forms/switchable-multi-select.tsx
@@ -38,16 +38,10 @@ export const SwitchableMultiSelect: React.FC<Props> = ({
   const renderInput = () => {
     if (showTextArea) {
       return (
-        <Textarea
-          value={valueAsArray.join(DELIMINATOR)}
+        <TextAreaMultiSelect
+          value={valueAsArray}
           className={textAreaClassName}
-          onChange={(e) => {
-            if (e.target.value === "") {
-              onChange([]);
-              return;
-            }
-            onChange(e.target.value.split(DELIMINATOR));
-          }}
+          onChange={onChange}
           placeholder={
             placeholder ? `${placeholder}: one per line` : "One value per line"
           }
@@ -59,12 +53,13 @@ export const SwitchableMultiSelect: React.FC<Props> = ({
       <Combobox
         placeholder={placeholder}
         displayValue={(option: string) => option}
-        className={comboBoxClassName}
+        className={cn("w-full max-w-[400px]", comboBoxClassName)}
         multiple={true}
         value={valueAsArray}
         onValueChange={onChange}
         keepPopoverOpenOnSelect={true}
         chips={true}
+        chipsClassName="flex-row flex-wrap min-w-[210px]"
       >
         {options.map((option) => (
           <ComboboxItem key={option} value={option}>
@@ -90,5 +85,34 @@ export const SwitchableMultiSelect: React.FC<Props> = ({
         </Toggle>
       </Tooltip>
     </div>
+  );
+};
+
+/**
+ * Treat a textarea as a multi-select,
+ * where each line is a value.
+ */
+export const TextAreaMultiSelect: React.FC<{
+  value: string[];
+  onChange: (value: string[]) => void;
+  className?: string;
+  placeholder?: string;
+}> = (props) => {
+  const { className, value = [], onChange, placeholder } = props;
+  return (
+    <Textarea
+      value={value.join(DELIMINATOR)}
+      className={className}
+      onChange={(e) => {
+        if (e.target.value === "") {
+          onChange([]);
+          return;
+        }
+        onChange(e.target.value.split(DELIMINATOR));
+      }}
+      placeholder={
+        placeholder ? `${placeholder}: one per line` : "One value per line"
+      }
+    />
   );
 };

--- a/frontend/src/components/forms/switchable-multi-select.tsx
+++ b/frontend/src/components/forms/switchable-multi-select.tsx
@@ -33,7 +33,7 @@ export const SwitchableMultiSelect: React.FC<Props> = ({
   comboBoxClassName,
 }) => {
   const [showTextArea, setShowTextArea] = useState(false);
-  const valueAsArray = Array.isArray(value) ? value : [value];
+  const valueAsArray = ensureStringArray(value);
 
   const renderInput = () => {
     if (showTextArea) {
@@ -98,10 +98,11 @@ export const TextAreaMultiSelect: React.FC<{
   className?: string;
   placeholder?: string;
 }> = (props) => {
-  const { className, value = [], onChange, placeholder } = props;
+  const { className, value, onChange, placeholder } = props;
+  const valueAsArray = ensureStringArray(value);
   return (
     <Textarea
-      value={value.join(DELIMINATOR)}
+      value={valueAsArray.join(DELIMINATOR)}
       className={className}
       onChange={(e) => {
         if (e.target.value === "") {
@@ -116,3 +117,16 @@ export const TextAreaMultiSelect: React.FC<{
     />
   );
 };
+
+export function ensureStringArray<T extends string>(
+  value: T | T[] | null | undefined
+): T[] {
+  if (value == null) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return [value].filter((v) => v != null || v !== "");
+}

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -13,7 +13,7 @@ import {
 
 import { cn } from "@/lib/utils";
 import { Label } from "@/components/ui/label";
-import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip } from "@/components/ui/tooltip";
 import { AlertCircleIcon } from "lucide-react";
 
 const Form = FormProvider;
@@ -187,11 +187,9 @@ const FormMessageTooltip = ({ className }: { className: string }) => {
   }
 
   return (
-    <TooltipProvider>
-      <Tooltip content={body}>
-        <AlertCircleIcon className={cn("stroke-[1.8px]", className)} />
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip content={body}>
+      <AlertCircleIcon className={cn("stroke-[1.8px]", className)} />
+    </Tooltip>
   );
 };
 FormMessageTooltip.displayName = "FormMessageTooltip";

--- a/frontend/src/components/ui/native-select.tsx
+++ b/frontend/src/components/ui/native-select.tsx
@@ -6,7 +6,7 @@ import { Events } from "@/utils/events";
 import { cva } from "class-variance-authority";
 
 export const selectStyles = cva(
-  "flex h-6 w-fit mb-1 shadow-xsSolid items-center justify-between rounded-sm border border-input bg-transparent px-2 py-1 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-smSolid focus:outline-none focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-mdSolid disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer",
+  "flex h-6 w-fit mb-1 shadow-xsSolid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-smSolid focus:outline-none focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-mdSolid disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer",
   {
     variants: {},
   }

--- a/frontend/src/components/ui/native-select.tsx
+++ b/frontend/src/components/ui/native-select.tsx
@@ -3,6 +3,14 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 import { Events } from "@/utils/events";
+import { cva } from "class-variance-authority";
+
+export const selectStyles = cva(
+  "flex h-6 w-fit mb-1 shadow-xsSolid items-center justify-between rounded-sm border border-input bg-transparent px-2 py-1 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-smSolid focus:outline-none focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-mdSolid disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer",
+  {
+    variants: {},
+  }
+);
 
 const NativeSelect = React.forwardRef<
   HTMLSelectElement,
@@ -11,10 +19,7 @@ const NativeSelect = React.forwardRef<
   <select
     ref={ref}
     onClick={Events.stopPropagation()}
-    className={cn(
-      "flex h-6 w-fit mb-1 shadow-xsSolid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-smSolid focus:outline-none focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-mdSolid disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer",
-      className
-    )}
+    className={cn(selectStyles({}), className)}
     {...props}
   >
     {children}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -65,7 +65,7 @@ const SelectContent = React.forwardRef<
       position={position}
       {...props}
     >
-      <SelectPrimitive.ScrollUpButton className="flex items-center justify-center h-[20px] bg-white text-muted-foreground cursor-default">
+      <SelectPrimitive.ScrollUpButton className="flex items-center justify-center h-[20px] bg-background text-muted-foreground cursor-default">
         <ChevronUpIcon className="h-4 w-4" />
       </SelectPrimitive.ScrollUpButton>
 
@@ -79,7 +79,7 @@ const SelectContent = React.forwardRef<
         {children}
       </SelectPrimitive.Viewport>
 
-      <SelectPrimitive.ScrollDownButton className="flex items-center justify-center h-[20px] bg-white text-muted-foreground cursor-default">
+      <SelectPrimitive.ScrollDownButton className="flex items-center justify-center h-[20px] bg-background text-muted-foreground cursor-default">
         <ChevronDownIcon className="h-4 w-4 opacity-50" />
       </SelectPrimitive.ScrollDownButton>
     </SelectPrimitive.Content>

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { selectStyles } from "./native-select";
 
 const Select = SelectPrimitive.Root;
 
@@ -25,10 +26,7 @@ const SelectTrigger = React.forwardRef<
 >(({ className, children, onClear, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
-    className={cn(
-      "flex h-7 items-center justify-between rounded-md border border-input shadow-sm bg-transparent px-2 py-1 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-      className
-    )}
+    className={cn(selectStyles({}), "mb-0", className)}
     {...props}
   >
     {children}
@@ -82,7 +80,7 @@ const SelectContent = React.forwardRef<
       </SelectPrimitive.Viewport>
 
       <SelectPrimitive.ScrollDownButton className="flex items-center justify-center h-[20px] bg-white text-muted-foreground cursor-default">
-        <ChevronDownIcon className="h-4 w-4" />
+        <ChevronDownIcon className="h-4 w-4 opacity-50" />
       </SelectPrimitive.ScrollDownButton>
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -23,6 +23,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 /**
  * Arguments for a data table
@@ -78,12 +79,14 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
     ),
   })
   .renderer((props) => (
-    <DataFrameComponent
-      {...props.data}
-      {...props.functions}
-      value={props.value}
-      setValue={props.setValue}
-    />
+    <TooltipProvider>
+      <DataFrameComponent
+        {...props.data}
+        {...props.functions}
+        value={props.value}
+        setValue={props.setValue}
+      />
+    </TooltipProvider>
   ));
 
 interface DataTableProps extends Data, PluginFunctions {

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -126,7 +126,10 @@ export const DataFrameComponent = ({
             Code
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="transform" className="mt-1">
+        <TabsContent
+          value="transform"
+          className="mt-1 border-x border-t rounded-t"
+        >
           <TransformPanel
             initialValue={internalValue}
             columns={columns}
@@ -139,14 +142,17 @@ export const DataFrameComponent = ({
             getColumnValues={get_column_values}
           />
         </TabsContent>
-        <TabsContent value="code" className="mt-1">
+        <TabsContent
+          value="code"
+          className="mt-1 border-x border-t rounded-t overflow-hidden"
+        >
           <CodePanel dataframeName={dataframeName} transforms={value} />
         </TabsContent>
       </Tabs>
       {error && <ErrorBanner error={error} />}
       <LoadingDataTableComponent
         label={null}
-        className="rounded-b border"
+        className="rounded-b border-x border-b"
         data={url || ""}
         pageSize={5}
         pagination={true}

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -42,6 +42,10 @@ type PluginFunctions = {
     url: string;
     row_headers: Array<[string, string[]]>;
   }>;
+  get_column_values: (req: { column: string }) => Promise<{
+    values: unknown[];
+    too_many_values: boolean;
+  }>;
 };
 
 // Value is selection, but it is not currently exposed to the user
@@ -64,6 +68,12 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
       z.object({
         url: z.string(),
         row_headers: z.array(z.tuple([z.string(), z.array(z.any())])),
+      })
+    ),
+    get_column_values: rpc.input(z.object({ column: z.string() })).output(
+      z.object({
+        values: z.array(z.any()),
+        too_many_values: z.boolean(),
       })
     ),
   })
@@ -91,6 +101,7 @@ export const DataFrameComponent = ({
   value,
   setValue,
   get_dataframe,
+  get_column_values,
 }: DataTableProps): JSX.Element => {
   const { data, error } = useAsyncData(
     () => get_dataframe({}),
@@ -125,6 +136,7 @@ export const DataFrameComponent = ({
               setInternalValue(v);
             }}
             onInvalidChange={setInternalValue}
+            getColumnValues={get_column_values}
           />
         </TabsContent>
         <TabsContent value="code" className="mt-1">

--- a/frontend/src/plugins/impl/data-frames/forms/context.ts
+++ b/frontend/src/plugins/impl/data-frames/forms/context.ts
@@ -2,4 +2,12 @@
 import { createContext } from "react";
 import { ColumnDataTypes } from "../types";
 
-export const ColumnContext = createContext<ColumnDataTypes>({});
+export const ColumnInfoContext = createContext<ColumnDataTypes>({});
+
+export const ColumnNameContext = createContext<string>("");
+export const ColumnFetchValuesContext = createContext<
+  (req: { column: string }) => Promise<{
+    values: unknown[];
+    too_many_values: boolean;
+  }>
+>(() => Promise.resolve({ values: [], too_many_values: false }));

--- a/frontend/src/plugins/impl/data-frames/forms/form.tsx
+++ b/frontend/src/plugins/impl/data-frames/forms/form.tsx
@@ -951,13 +951,10 @@ const ColumnValuesFormField = ({
     return fetchValues({ column });
   }, [column]);
 
-  if (loading) {
-    return null;
-  }
-
   const options = data?.values || [];
 
-  if (options.length === 0) {
+  // loaded with no options
+  if (options.length === 0 && !loading) {
     return <StringFormField schema={schema} form={form} path={path} />;
   }
 
@@ -992,11 +989,8 @@ const MultiColumnValuesFormField = ({
 
   const options = data?.values || [];
 
-  if (loading) {
-    return null;
-  }
-
-  if (options.length === 0) {
+  // loaded with no options
+  if (options.length === 0 && !loading) {
     return <MultiStringFormField schema={schema} form={form} path={path} />;
   }
 

--- a/frontend/src/plugins/impl/data-frames/forms/form.tsx
+++ b/frontend/src/plugins/impl/data-frames/forms/form.tsx
@@ -55,6 +55,7 @@ import { Combobox, ComboboxItem } from "@/components/ui/combobox";
 import {
   SwitchableMultiSelect,
   TextAreaMultiSelect,
+  ensureStringArray,
 } from "@/components/forms/switchable-multi-select";
 
 interface Props<T extends FieldValues> {
@@ -507,8 +508,7 @@ const MultiColumnFormField = ({
       control={form.control}
       name={path}
       render={({ field }) => {
-        let values = Array.isArray(field.value) ? field.value : [field.value];
-        values = values.filter(Boolean);
+        const values = ensureStringArray(field.value);
         return (
           <FormItem>
             <FormLabel>{itemLabel}</FormLabel>
@@ -892,10 +892,7 @@ const MultiSelectFormField = ({
       control={form.control}
       name={path}
       render={({ field }) => {
-        let valueAsArray = Array.isArray(field.value)
-          ? field.value
-          : [field.value];
-        valueAsArray = valueAsArray.filter(Boolean);
+        const valueAsArray = ensureStringArray(field.value);
         return (
           <FormItem>
             <FormLabel className="whitespace-pre">{label}</FormLabel>

--- a/frontend/src/plugins/impl/data-frames/forms/form.tsx
+++ b/frontend/src/plugins/impl/data-frames/forms/form.tsx
@@ -845,7 +845,7 @@ const SelectFormField = ({
                     );
                   })}
                   {options.length === 0 && (
-                    <SelectItem disabled={true} value={""}>
+                    <SelectItem disabled={true} value="--">
                       No options
                     </SelectItem>
                   )}
@@ -945,6 +945,9 @@ const ColumnValuesFormField = ({
   form: UseFormReturn<any>;
   path: Path<any>;
 }) => {
+  const { label, description, placeholder } = FieldOptions.parse(
+    schema._def.description
+  );
   const column = useContext(ColumnNameContext);
   const fetchValues = useContext(ColumnFetchValuesContext);
   const { data, loading } = useAsyncData(() => {
@@ -958,12 +961,38 @@ const ColumnValuesFormField = ({
     return <StringFormField schema={schema} form={form} path={path} />;
   }
 
+  const optionsAsStrings = options.map(String);
   return (
-    <SelectFormField
-      schema={schema}
-      form={form}
-      path={path}
-      options={options.map(String)}
+    <FormField
+      control={form.control}
+      name={path}
+      render={({ field }) => {
+        return (
+          <FormItem>
+            <FormLabel className="whitespace-pre">{label}</FormLabel>
+            <FormDescription>{description}</FormDescription>
+            <FormControl>
+              <Combobox
+                className="min-w-[210px]"
+                placeholder={placeholder}
+                multiple={false}
+                displayValue={(option: string) => option}
+                value={
+                  Array.isArray(field.value) ? field.value[0] : field.value
+                }
+                onValueChange={field.onChange}
+              >
+                {optionsAsStrings.map((option) => (
+                  <ComboboxItem key={option} value={option}>
+                    {option}
+                  </ComboboxItem>
+                ))}
+              </Combobox>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        );
+      }}
     />
   );
 };

--- a/frontend/src/plugins/impl/data-frames/forms/form.tsx
+++ b/frontend/src/plugins/impl/data-frames/forms/form.tsx
@@ -767,11 +767,13 @@ const SelectFormField = ({
   form,
   path,
   options,
+  textTransform,
 }: {
   schema: z.ZodEnum<any> | z.ZodString;
   form: UseFormReturn<any>;
   path: Path<any>;
   options: string[];
+  textTransform?: (value: string) => string;
 }) => {
   const { label, description, disabled, special } = FieldOptions.parse(
     schema._def.description
@@ -838,7 +840,7 @@ const SelectFormField = ({
                   {options.map((value: string) => {
                     return (
                       <SelectItem key={value} value={value}>
-                        {Strings.startCase(value)}
+                        {textTransform?.(value) ?? value}
                       </SelectItem>
                     );
                   })}

--- a/frontend/src/plugins/impl/data-frames/forms/options.ts
+++ b/frontend/src/plugins/impl/data-frames/forms/options.ts
@@ -11,7 +11,8 @@ export interface FieldOptions {
     | "column_type"
     | "radio_group"
     | "column_filter"
-    | "text_area_multiline";
+    | "text_area_multiline"
+    | "column_values";
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/frontend/src/plugins/impl/data-frames/panel.tsx
+++ b/frontend/src/plugins/impl/data-frames/panel.tsx
@@ -125,7 +125,7 @@ export const TransformPanel: React.FC<Props> = ({
       <ColumnFetchValuesContext.Provider value={getColumnValues}>
         <form
           onSubmit={(e) => e.preventDefault()}
-          className="flex flex-row max-h-[400px] overflow-hidden bg-white border rounded-t"
+          className="flex flex-row max-h-[400px] overflow-hidden bg-background"
         >
           <Sidebar
             items={form.watch("transforms")}
@@ -213,7 +213,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           );
         })}
       </div>
-      <div className="flex flex-row flex-shrink-0 border-t">
+      <div className="flex flex-row flex-shrink-0">
         <AddTransformDropdown onAdd={onAdd}>
           <Button
             variant="text"

--- a/frontend/src/plugins/impl/data-frames/panel.tsx
+++ b/frontend/src/plugins/impl/data-frames/panel.tsx
@@ -34,7 +34,10 @@ import {
   Trash2Icon,
 } from "lucide-react";
 import { cn } from "../../../lib/utils";
-import { ColumnContext } from "@/plugins/impl/data-frames/forms/context";
+import {
+  ColumnFetchValuesContext,
+  ColumnInfoContext,
+} from "@/plugins/impl/data-frames/forms/context";
 import useEvent from "react-use-event-hook";
 import { ColumnDataTypes } from "./types";
 import { getUpdatedColumnTypes } from "./utils/getUpdatedColumnTypes";
@@ -45,6 +48,10 @@ interface Props {
   initialValue: Transformations;
   onChange: (value: Transformations) => void;
   onInvalidChange: (value: Transformations) => void;
+  getColumnValues: (req: { column: string }) => Promise<{
+    values: unknown[];
+    too_many_values: boolean;
+  }>;
 }
 
 export const TransformPanel: React.FC<Props> = ({
@@ -52,6 +59,7 @@ export const TransformPanel: React.FC<Props> = ({
   columns,
   onChange,
   onInvalidChange,
+  getColumnValues,
 }) => {
   const form = useForm<z.infer<typeof TransformationsSchema>>({
     resolver: zodResolver(TransformationsSchema),
@@ -113,46 +121,48 @@ export const TransformPanel: React.FC<Props> = ({
   };
 
   return (
-    <ColumnContext.Provider value={effectiveColumns}>
-      <form
-        onSubmit={(e) => e.preventDefault()}
-        className="flex flex-row max-h-[400px] overflow-hidden bg-white border rounded-t"
-      >
-        <Sidebar
-          items={form.watch("transforms")}
-          selected={selectedTransform}
-          onSelect={(index) => {
-            setSelectedTransform(index);
-          }}
-          onDelete={(index) => {
-            transformsField.remove(index);
-            const indexBefore = index - 1;
-            setSelectedTransform(Math.max(indexBefore, 0));
-          }}
-          onAdd={handleAddTransform}
-        />
-        <div className="flex flex-col flex-1 p-4 overflow-auto min-h-[200px] border-l">
-          {selectedTransform !== undefined && selectedTransformSchema && (
-            <ZodForm
-              key={`transforms.${selectedTransform}`}
-              form={form}
-              schema={selectedTransformSchema}
-              path={`transforms.${selectedTransform}`}
-            />
-          )}
-          {(selectedTransform === undefined || !selectedTransformSchema) && (
-            <div className="flex flex-col items-center justify-center flex-grow gap-3">
-              <MousePointerSquareDashedIcon className="w-8 h-8  text-muted-foreground" />
-              <AddTransformDropdown onAdd={handleAddTransform}>
-                <Button variant="text" size="xs">
-                  <div className="text-sm">Select a transform to begin</div>
-                </Button>
-              </AddTransformDropdown>
-            </div>
-          )}
-        </div>
-      </form>
-    </ColumnContext.Provider>
+    <ColumnInfoContext.Provider value={effectiveColumns}>
+      <ColumnFetchValuesContext.Provider value={getColumnValues}>
+        <form
+          onSubmit={(e) => e.preventDefault()}
+          className="flex flex-row max-h-[400px] overflow-hidden bg-white border rounded-t"
+        >
+          <Sidebar
+            items={form.watch("transforms")}
+            selected={selectedTransform}
+            onSelect={(index) => {
+              setSelectedTransform(index);
+            }}
+            onDelete={(index) => {
+              transformsField.remove(index);
+              const indexBefore = index - 1;
+              setSelectedTransform(Math.max(indexBefore, 0));
+            }}
+            onAdd={handleAddTransform}
+          />
+          <div className="flex flex-col flex-1 p-4 overflow-auto min-h-[200px] border-l">
+            {selectedTransform !== undefined && selectedTransformSchema && (
+              <ZodForm
+                key={`transforms.${selectedTransform}`}
+                form={form}
+                schema={selectedTransformSchema}
+                path={`transforms.${selectedTransform}`}
+              />
+            )}
+            {(selectedTransform === undefined || !selectedTransformSchema) && (
+              <div className="flex flex-col items-center justify-center flex-grow gap-3">
+                <MousePointerSquareDashedIcon className="w-8 h-8  text-muted-foreground" />
+                <AddTransformDropdown onAdd={handleAddTransform}>
+                  <Button variant="text" size="xs">
+                    <div className="text-sm">Select a transform to begin</div>
+                  </Button>
+                </AddTransformDropdown>
+              </div>
+            )}
+          </div>
+        </form>
+      </ColumnFetchValuesContext.Provider>
+    </ColumnInfoContext.Provider>
   );
 };
 

--- a/frontend/src/plugins/impl/data-frames/python/code-panel.tsx
+++ b/frontend/src/plugins/impl/data-frames/python/code-panel.tsx
@@ -26,7 +26,7 @@ const PythonCode = (props: { code: string }) => {
   return (
     <div className="border-t border-x rounded-t overflow-hidden">
       <CodeMirror
-        minHeight="100px"
+        minHeight="200px"
         height="100%"
         editable={true}
         extensions={[python()]}

--- a/frontend/src/plugins/impl/data-frames/schema.ts
+++ b/frontend/src/plugins/impl/data-frames/schema.ts
@@ -19,7 +19,7 @@ const column_id = z
 const column_id_array = z
   .array(column_id.describe(FieldOptions.of({ special: "column_id" })))
   .min(1, "At least one column is required")
-  .default([""])
+  .default([])
   .describe(FieldOptions.of({ label: "Columns" }));
 
 const ColumnConversionTransformSchema = z
@@ -112,6 +112,7 @@ const AggregateTransformSchema = z
     column_ids: column_id_array,
     aggregations: z
       .array(z.enum(AGGREGATION_FNS))
+      .min(1, "At least one aggregation is required")
       .default(["count"])
       .describe(FieldOptions.of({ label: "Aggregations" })),
   })

--- a/frontend/src/plugins/impl/data-frames/utils/operators.ts
+++ b/frontend/src/plugins/impl/data-frames/utils/operators.ts
@@ -8,6 +8,10 @@ const Schema = {
     .string()
     .min(1)
     .describe(FieldOptions.of({ label: "Value" })),
+  stringValues: z
+    .string()
+    .min(1)
+    .describe(FieldOptions.of({ label: "Value", special: "column_values" })),
   date: z.coerce.date().describe(FieldOptions.of({ label: "Value" })),
   stringArray: z
     .array(z.string())
@@ -49,8 +53,8 @@ export const DATE_OPERATORS = {
 };
 
 export const STRING_OPERATORS = {
-  equals: [Schema.string],
-  does_not_equal: [Schema.string],
+  equals: [Schema.stringValues],
+  does_not_equal: [Schema.stringValues],
   contains: [Schema.string],
   regex: [Schema.string],
   starts_with: [Schema.string],

--- a/frontend/src/plugins/impl/data-frames/utils/operators.ts
+++ b/frontend/src/plugins/impl/data-frames/utils/operators.ts
@@ -8,8 +8,12 @@ const Schema = {
     .string()
     .min(1)
     .describe(FieldOptions.of({ label: "Value" })),
-  stringValues: z
+  stringColumnValues: z
     .string()
+    .min(1)
+    .describe(FieldOptions.of({ label: "Value", special: "column_values" })),
+  stringMultiColumnValues: z
+    .array(z.string())
     .min(1)
     .describe(FieldOptions.of({ label: "Value", special: "column_values" })),
   date: z.coerce.date().describe(FieldOptions.of({ label: "Value" })),
@@ -53,13 +57,13 @@ export const DATE_OPERATORS = {
 };
 
 export const STRING_OPERATORS = {
-  equals: [Schema.stringValues],
-  does_not_equal: [Schema.stringValues],
+  equals: [Schema.stringColumnValues],
+  does_not_equal: [Schema.stringColumnValues],
   contains: [Schema.string],
   regex: [Schema.string],
   starts_with: [Schema.string],
   ends_with: [Schema.string],
-  in: [Schema.stringArray],
+  in: [Schema.stringMultiColumnValues],
 };
 
 export const ALL_OPERATORS = {

--- a/frontend/src/stories/dataframe.stories.tsx
+++ b/frontend/src/stories/dataframe.stories.tsx
@@ -17,6 +17,10 @@ export const DataFrame: StoryObj = {
     const [value, setValue] = useState<Transformations>();
     return (
       <DataFrameComponent
+        get_column_values={async () => ({
+          values: Array.from({ length: 100 }).map((_, i) => `value ${i}`),
+          too_many_values: false,
+        })}
         columns={{
           name: "object",
           age: "int",
@@ -25,7 +29,10 @@ export const DataFrame: StoryObj = {
         }}
         dataframeName={"df"}
         value={value}
-        setValue={setValue}
+        setValue={(v) => {
+          console.log(v);
+          setValue(v);
+        }}
         get_dataframe={() => Promise.reject({})}
       />
     );

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -5,7 +5,6 @@ import inspect
 import sys
 from typing import TYPE_CHECKING, Any, Callable, Dict, Final, List, Optional
 
-
 if TYPE_CHECKING:
     import pandas as pd
 


### PR DESCRIPTION
* add RPC to `mo.ui.dataframe` to load column values. this loads all values instead of at that particular transform or filter. this adds complexity and could be confusing to users.
* refactor the inputs in form.tsx to be more re-usable and use better inputs (selects, multi-select, etc)
* make panels the same height to avoid content shift
* improving some border styling