### PR TITLE
Add scatter to smoke test

### DIFF
--- a/marimo/_smoke_tests/charts/1mil_flights.py
+++ b/marimo/_smoke_tests/charts/1mil_flights.py
@@ -1,7 +1,6 @@
-# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
-__generated_with = "0.1.25"
+__generated_with = "0.1.39"
 app = marimo.App(width="full")
 
 
@@ -23,6 +22,21 @@ def __(mo):
     )
     size
     return size,
+
+
+@app.cell
+def __(alt, flights, mo):
+    scatter = mo.ui.altair_chart(
+        alt.Chart(flights).mark_point().encode(x="delay:Q", y="distance:Q")
+    )
+    scatter
+    return scatter,
+
+
+@app.cell
+def __(scatter):
+    scatter.value.head()
+    return
 
 
 @app.cell


### PR DESCRIPTION
-100k is slow with select

@mscolnick included a scatter plot in the charts smoke test. it's not really usable at 100k points right now -- haven't looked into where the slowness is coming from