### PR TITLE
Update code editor to clear tooltips on 'Escape' key press, adjust code cell active line contrast in dark mode and optimize tooltip height

### DIFF
--- a/frontend/src/core/codemirror/__tests__/__snapshots__/setup.test.ts.snap
+++ b/frontend/src/core/codemirror/__tests__/__snapshots__/setup.test.ts.snap
@@ -54,6 +54,10 @@ exports[`snapshot all duplicate keymaps > default keymaps 2`] = `
     },
     {
       "key": "Escape",
+      "run": "clearTooltips",
+    },
+    {
+      "key": "Escape",
       "run": "simplifySelection",
     },
     {
@@ -155,6 +159,10 @@ exports[`snapshot all duplicate keymaps > vim keymaps 2`] = `
     {
       "key": "Escape",
       "run": "closeCompletion",
+    },
+    {
+      "key": "Escape",
+      "run": "clearTooltips",
     },
     {
       "key": "Escape",

--- a/frontend/src/core/codemirror/__tests__/setup.test.ts
+++ b/frontend/src/core/codemirror/__tests__/setup.test.ts
@@ -88,7 +88,7 @@ describe("snapshot all duplicate keymaps", () => {
     );
     // Total duplicates:
     // if this changes, please make sure to validate they are not conflicting
-    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot('19');
+    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot("19");
     expect(duplicates).toMatchSnapshot();
   });
 
@@ -101,7 +101,7 @@ describe("snapshot all duplicate keymaps", () => {
     );
     // Total duplicates:
     // if this changes, please make sure to validate they are not conflicting
-    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot('18');
+    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot("18");
     expect(duplicates).toMatchSnapshot();
   });
 });

--- a/frontend/src/core/codemirror/__tests__/setup.test.ts
+++ b/frontend/src/core/codemirror/__tests__/setup.test.ts
@@ -88,7 +88,7 @@ describe("snapshot all duplicate keymaps", () => {
     );
     // Total duplicates:
     // if this changes, please make sure to validate they are not conflicting
-    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot("18");
+    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot('19');
     expect(duplicates).toMatchSnapshot();
   });
 
@@ -101,7 +101,7 @@ describe("snapshot all duplicate keymaps", () => {
     );
     // Total duplicates:
     // if this changes, please make sure to validate they are not conflicting
-    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot("17");
+    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot('18');
     expect(duplicates).toMatchSnapshot();
   });
 });

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -226,7 +226,7 @@
 }
 
 .dark .Cell .cm-editor.cm-focused .cm-activeLine {
-  background: hsl(210deg 100% 2% / 75%);
+  background: hsl(210deg 100% 2% / 20%);
 }
 
 .Cell .cm-editor .cm-activeLine {
@@ -346,7 +346,6 @@
 .Cell.needs-run:focus-within .cm-editor {
   box-shadow: none;
   border: 1px solid transparent;
-  border-radius: 0;
 }
 
 .Cell.needs-run .output-area {

--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -1,12 +1,8 @@
-.cm-selectionBackground {
+.light .cm-selectionBackground {
   /* This is the background for selected text when focused,
   but we want to use it when not in focus either because we
   will often lose focus during find/replace or in another editor */
   background-color: #d7d4f0 !important;
-}
-
-.dark .cm-selectionBackground {
-  background-color: #4d4d4d !important;
 }
 
 /* -- Gutters -- */
@@ -30,7 +26,6 @@
 /* -- Tooltips: code completion and type hints -- */
 
 .cm .cm-tooltip {
-  font-family: var(--monospace-font);
   font-size: 0.875rem;
   border: none;
   box-shadow: var(--light-shadow);
@@ -46,7 +41,7 @@
 .cm .cm-tooltip.cm-tooltip-hover,
 .cm .cm-tooltip.mo-cm-tooltip,
 .cm .cm-tooltip.cm-completionInfo {
-  max-height: 800px;
+  max-height: 45vh; /* 45% of viewport height */
   overflow: auto;
 
   /* Respect newlines. */

--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -26,6 +26,7 @@
 /* -- Tooltips: code completion and type hints -- */
 
 .cm .cm-tooltip {
+  font-family: var(--monospace-font);
   font-size: 0.875rem;
   border: none;
   box-shadow: var(--light-shadow);


### PR DESCRIPTION
* clear tooltip on Esc and don't lose focus
* improve dark mode contrast
* make tooltip height responsive, With This One Neat Trick™️ 
