### PR TITLE
Update tooltip styles in codemirror.css and handle docstrings differently based on module in complete.py

### DIFF
--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -54,11 +54,11 @@
 }
 
 .cm .cm-tooltip code {
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 
 .cm .cm-tooltip .external-docs {
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 
 /* Hover tooltips get highest priority in display. */

--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -30,7 +30,6 @@
 /* -- Tooltips: code completion and type hints -- */
 
 .cm .cm-tooltip {
-  font-family: var(--monospace-font);
   font-size: 0.875rem;
   border: none;
   box-shadow: var(--light-shadow);
@@ -50,9 +49,16 @@
   overflow: auto;
 
   /* Respect newlines. */
-  white-space: pre-wrap;
   border-radius: 4px;
   padding: 0.625rem 0.875rem;
+}
+
+.cm .cm-tooltip code {
+  font-size: 13px;
+}
+
+.cm .cm-tooltip .external-docs {
+  font-size: 13px;
 }
 
 /* Hover tooltips get highest priority in display. */

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
+import html
 import queue
 from typing import cast
 
@@ -76,9 +77,14 @@ def _get_docstring(completion: jedi.api.classes.BaseName) -> str:
         ).text
 
     if body:
-        # aggressively treat docstrings as markdown. this does mostly okay for
-        # most docstrings, and makes marimo docstrings much easier to read.
-        body = _md(body, apply_markdown_class=False).text
+        # for marimo docstrings, treat them as markdown
+        # for other modules, treat them as plain text
+        if completion.module_name.startswith("marimo"):
+            body = _md(body, apply_markdown_class=False).text
+        else:
+            # TODO: this would look better parsed as RST
+            # for non-marimo modules
+            body = "<pre class='external-docs'>" + html.escape(body) + "</pre>"
 
     if signature_text and body:
         docstring = signature_text + "\n\n" + body


### PR DESCRIPTION
![Screenshot 2023-10-28 at 1 33 36 PM](https://github.com/marimo-team/marimo/assets/2753772/44622309-fdc3-4f81-9812-23b520265fcf)


![image](https://github.com/marimo-team/marimo/assets/2753772/a4c7089f-5080-4e04-b6fe-66282b5df491)

* change font of tooltip

| With monospace | Without monospace |
|--------|--------|
| ![Screenshot 2023-10-28 at 12 01 27 PM](https://github.com/marimo-team/marimo/assets/2753772/c4ee9dd0-52de-4b24-8d93-747e7a8434c1) | ![Screenshot 2023-10-28 at 12 01 18 PM](https://github.com/marimo-team/marimo/assets/2753772/94cb8426-1654-4896-ad6e-1a7545e9dad6) | 

