### PR TITLE
fix: [windows] refresh shouldn't kill server

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1012,7 +1012,8 @@ def launch_kernel(
         # In edit mode, kernel runs in its own process so it's interruptible.
         from marimo._output.formatters.formatters import register_formatters
 
-        # TODO: windows workaround
+        # TODO: Windows workaround -- find a way to make the process
+        # its group leader
         if sys.platform != "win32":
             # Make this process group leader to prevent it from receiving
             # signals intended for the parent (server) process,
@@ -1083,7 +1084,7 @@ def launch_kernel(
         except Exception as e:
             # triggered on Windows when quit with Ctrl+C
             LOGGER.debug("kernel queue.get() failed %s", e)
-            return
+            break
         LOGGER.debug("received request %s", request)
         if isinstance(request, CreationRequest):
             kernel.instantiate(request)

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -341,20 +341,8 @@ class Session:
             self.queue.cancel_join_thread()  # type: ignore
             self.queue.close()  # type: ignore
             if self.kernel_task.is_alive():
-                if (
-                    sys.platform == "win32" or sys.platform == "cygwin"
-                ) and self.kernel_task.pid is not None:
-                    # send a CTRL_BREAK_EVENT to gracefully shutdown
-                    # since SIGTERM isn't handled on windows
-                    os.kill(self.kernel_task.pid, signal.CTRL_BREAK_EVENT)
-                else:
-                    # TODO(akshayka): Might be able to remove this
-                    # and just rely on the fact that the kernel is a daemon
-                    # process (so will terminate after this process terminates)
-                    #
-                    # Explicitly terminate the process, in case something
-                    # prevents the server process from terminating ...
-                    self.kernel_task.terminate()
+                # Explicitly terminate the process
+                self.kernel_task.terminate()
             tornado.ioloop.IOLoop.current().remove_handler(
                 self.read_conn.fileno()
             )
@@ -521,6 +509,7 @@ class SessionManager:
         self.sessions = {}
 
     def shutdown(self) -> None:
+        LOGGER.debug("Shutting down")
         self.close_all_sessions()
         if self.lsp_process is not None:
             self.lsp_process.terminate()

--- a/marimo/_smoke_tests/charts/1mil_flights.py
+++ b/marimo/_smoke_tests/charts/1mil_flights.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.39"

--- a/marimo/_smoke_tests/forms.py
+++ b/marimo/_smoke_tests/forms.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.39"


### PR DESCRIPTION
This change fixes a bug in which refreshing in edit mode would kill the server. Previously, a CTRL_BREAK event was sent to the kernel process, but this killed the server, since the kernel process is in the same process group as the parent. Instead, this change uses the `Process.terminate()` method to force the process to exit, which uses `TerminateProcess` on Windows.

A better fix would figure out how to put the kernel process in its own process group on Windows; that would let us send the ctrl-break and still do cleanup in the kernel process. This is possible through the subprocess module (creation_flags), but not through the multiprocessing module as far as I can tell. To start a process with subprocess, though, requires starting it as an external program, which is extra (coding) work. In a future change we can move toward that ...