### PR TITLE
Fix virtual files on Windows

### DIFF
--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -149,6 +149,8 @@ class VirtualFileRegistry:
     def remove(self, virtual_file: VirtualFile) -> None:
         key = virtual_file.filename
         if key in self.registry:
+            if sys.platform == "win32":
+                self.registry[key].close()
             # destroy the shared memory
             self.registry[key].unlink()
             del self.registry[key]
@@ -163,6 +165,8 @@ class VirtualFileRegistry:
         try:
             self.shutting_down = True
             for _, shm in self.registry.items():
+                if sys.platform == "win32":
+                    shm.close()
                 shm.unlink()
             self.registry.clear()
         finally:

--- a/marimo/_server/api/virtual_file.py
+++ b/marimo/_server/api/virtual_file.py
@@ -19,6 +19,7 @@ class VirtualFileHandler(tornado.web.RequestHandler):
     """Handler for virtual files."""
 
     def get(self, filename_and_length: str) -> None:
+        LOGGER.debug("Getting virtual file: %s", filename_and_length)
         if filename_and_length == EMPTY_VIRTUAL_FILE.filename:
             self.write(b"")
             return
@@ -33,6 +34,9 @@ class VirtualFileHandler(tornado.web.RequestHandler):
             shm = shared_memory.SharedMemory(name=key)
             buffer_contents = bytes(shm.buf)[: int(byte_length)]
         except FileNotFoundError as err:
+            LOGGER.debug(
+                "Error retrieving shared memory for virtual file: %s", err
+            )
             raise tornado.web.HTTPError(
                 HTTPStatus.NOT_FOUND,
                 reason="File not found",

--- a/marimo/_smoke_tests/third_party/plotly.py
+++ b/marimo/_smoke_tests/third_party/plotly.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.39"

--- a/marimo/_smoke_tests/ws.py
+++ b/marimo/_smoke_tests/ws.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.39"


### PR DESCRIPTION
Can't close `shared_memory` objects on Windows due to a bug in the Windows implementation of `shared_memory` (or an incorrect description in the Python docs).

Makes altair plots, plotly plots work on Windows (for #273)