### PR TITLE
Stop HTTP Server for MPL Interactive on cleanup

### DIFF
--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -23,7 +23,6 @@ import tornado.netutil
 import tornado.web
 import tornado.websocket
 
-from marimo import _loggers
 from marimo._output.builder import h
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc

--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -35,9 +35,6 @@ from marimo._runtime.context import (
 )
 
 
-LOGGER = _loggers.marimo_logger()
-
-
 class MplApplication(tornado.web.Application):
     # Figure Manager, Any type because matplotlib doesn't have typings
     manager: Any
@@ -199,15 +196,11 @@ class CleanupHandle(CellLifecycleItem):
 
     def create(self, context: RuntimeContext) -> None:
         del context
-        LOGGER.debug("Creating mpl cleanup handle")
         pass
 
     def dispose(self, context: RuntimeContext) -> None:
         del context
-        LOGGER.debug("Disposing mpl cleanup handle")
-        LOGGER.debug("shutdown event: %s", self.shutdown_event)
         if self.shutdown_event is not None:
-            LOGGER.debug("Setting event")
             self.shutdown_event.set()
 
 
@@ -260,11 +253,11 @@ def interactive(figure: "Figure | Axes") -> Html:  # type: ignore[name-defined] 
         http_server = tornado.httpserver.HTTPServer(application)
         http_server.add_sockets(sockets)
         await cleanup_handle.shutdown_event.wait()
-        LOGGER.debug("MPL: Quitting")
+        http_server.stop()
+        await http_server.close_all_connections()
 
     def start_server() -> None:
         asyncio.run(main())
-        LOGGER.debug("MPL: mpl server done")
 
     addr: Optional[str] = None
     port: Optional[int] = None

--- a/marimo/_smoke_tests/third_party/plotly.py
+++ b/marimo/_smoke_tests/third_party/plotly.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.39"

--- a/marimo/_smoke_tests/ws.py
+++ b/marimo/_smoke_tests/ws.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.39"


### PR DESCRIPTION
Stops the HTTP server for mpl.interactive when it's cleaned up.

@mscolnick mpl interactive works fine for me on linux and macOS. This change is just a precaution but it doesn't seem to affect behavior for me. Can you share a repro for the issue you found?