### PR TITLE
fix ui.array updating logic: check against frontend value

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -69,6 +69,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
     - form: create a submittable form this `UIElement`.
     """
 
+    _value_frontend: S
     _value: T
 
     def __init__(
@@ -175,6 +176,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
                     namespace=self._id, function=function
                 )
         self._initial_value_frontend = initial_value
+        self._value_frontend = initial_value
         self._value = self._initial_value = self._convert_value(initial_value)
         self._on_change = on_change
 
@@ -276,6 +278,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         Calls the on_change handler with the element's new value as a
         side-effect.
         """
+        self._value_frontend = value
         try:
             self._value = self._convert_value(value)
         except MarimoConvertValueException:

--- a/marimo/_plugins/ui/_impl/array.py
+++ b/marimo/_plugins/ui/_impl/array.py
@@ -98,7 +98,7 @@ class array(UIElement[Dict[str, JSONType], Sequence[object]]):
             for k, v in value.items():
                 element = self._elements[int(k)]
                 # only call update if the value has changed
-                if element and element._value != v:
+                if element and element._value_frontend != v:
                     element._update(v)
         return [e._value for e in self._elements]
 


### PR DESCRIPTION
Fixes array updates to check value frontend sent against last value received from frontend (instead of against Python value). Fixes a bug in which `mo.ui.array()` couldn't hold `mo.ui.dataframe` and other complex types.