### PR TITLE
fix: Eliminate race in UI element lifecycle

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -19,7 +19,12 @@ from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType, build_ui_plugin
 from marimo._plugins.ui._core import ids
-from marimo._runtime.context import ContextNotInitializedError, get_context
+from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
+from marimo._runtime.context import (
+    ContextNotInitializedError,
+    RuntimeContext,
+    get_context,
+)
 from marimo._runtime.functions import Function
 
 if TYPE_CHECKING:
@@ -40,6 +45,22 @@ LOGGER = _loggers.marimo_logger()
 
 class MarimoConvertValueException(Exception):
     pass
+
+
+class UIElementLifeCycleItem(CellLifecycleItem):
+    """Handles to cleanup a UI element."""
+
+    def __init__(self, element_id: str, object_id: int) -> None:
+        self.element_id = element_id
+        self.object_id = object_id
+
+    def create(self, context: RuntimeContext) -> None:
+        del context
+        pass
+
+    def dispose(self, context: RuntimeContext) -> None:
+        context.function_registry.delete(namespace=self.element_id)
+        context.ui_element_registry.delete(self.element_id, self.object_id)
 
 
 @mddoc
@@ -171,10 +192,17 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
             except KeyError:
                 # we weren't asked to override the UI element's value
                 pass
+
             for function in functions:
                 ctx.function_registry.register(
                     namespace=self._id, function=function
                 )
+
+            # This has to happen in the cell lifecycle, not del, to avoid
+            # races; order in which __del__ is called is not guaranteed
+            ctx.cell_lifecycle_registry.add(
+                UIElementLifeCycleItem(element_id=self._id, object_id=id(self))
+            )
         self._initial_value_frontend = initial_value
         self._value_frontend = initial_value
         self._value = self._initial_value = self._convert_value(initial_value)
@@ -286,14 +314,6 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
 
         if self._on_change is not None:
             self._on_change(self._value)
-
-    def __del__(self) -> None:
-        try:
-            ctx = get_context()
-            ctx.ui_element_registry.delete(self._id, id(self))
-            ctx.function_registry.delete(namespace=self._id)
-        except ContextNotInitializedError:
-            pass
 
     def _clone(self) -> UIElement[S, T]:
         """Clone a UIElement, returning one with a different id

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -900,7 +900,7 @@ class Kernel:
         error_title, error_message = "", ""
 
         def debug(title: str, message: str) -> None:
-            return LOGGER.debug("%s: %s", title, message)
+            LOGGER.debug("%s: %s", title, message)
 
         if function is None:
             error_title = "Function not found"


### PR DESCRIPTION
This change fixes a race in the UI element lifecycle. Previously we relied on `__del__` to cleanup global state associated with a cell, but we can't rely on when Python will call `__del__`. This change moves the cleanup code to a `CellLifecycleItem`.