### PR TITLE
fix: increase pygments min version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # add features to markdown
     "pymdown-extensions>=9.0,<11",
     # syntax highlighting of code in markdown
-    "pygments>=2.3,<3",
+    "pygments>=2.13,<3",
     # for reading, writing configs
     "tomlkit>= 0.12.0",
     # web server


### PR DESCRIPTION
Raise pygments min version. There was a bug in 2.11.2 that broke syntax highlighting. Increase to 2.13, which I've been using locally, to be safe.