### PR TITLE
fix: remove aggressive padding on mobile

### DIFF
--- a/frontend/src/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
+++ b/frontend/src/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
@@ -14,7 +14,7 @@ export const VerticalLayoutWrapper: React.FC<PropsWithChildren<Props>> = ({
   children,
 }) => {
   return (
-    <div className="px-32">
+    <div className="sm:px-16 md:px-32">
       <div
         className={cn(
           "m-auto pb-12",


### PR DESCRIPTION
previously
![image](https://github.com/marimo-team/marimo/assets/2753772/3c9ef5f7-245b-4c2d-a47d-1190812e348a)

now
![image](https://github.com/marimo-team/marimo/assets/2753772/a9e42c46-3745-44da-8d6c-fbbb907f8e09)
