### PR TITLE
fix cleanup of UI elements

### DIFF
--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -64,6 +64,8 @@ class UIElementRegistry:
 
         registered_python_id = id(self._objects[object_id]())
         if registered_python_id != python_id:
+            # guards against UIElement's destructor racing against
+            # registration of another element when a cell re-runs
             LOGGER.debug(
                 "Python id mismatch when deleting UI element %s", object_id
             )

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -198,6 +198,14 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
             + "</marimo-ui-element>"
         )
 
+    def _dispose(self) -> None:
+        """Handle used by the registry to clean-up this element on removal."""
+        try:
+            ctx = get_context()
+            ctx.function_registry.delete(namespace=self._id)
+        except ContextNotInitializedError:
+            pass
+
     def __del__(self) -> None:
         try:
             ctx = get_context()

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -19,10 +19,8 @@ from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType, build_ui_plugin
 from marimo._plugins.ui._core import ids
-from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
 from marimo._runtime.context import (
     ContextNotInitializedError,
-    RuntimeContext,
     get_context,
 )
 from marimo._runtime.functions import Function
@@ -45,22 +43,6 @@ LOGGER = _loggers.marimo_logger()
 
 class MarimoConvertValueException(Exception):
     pass
-
-
-class UIElementLifeCycleItem(CellLifecycleItem):
-    """Handles to cleanup a UI element."""
-
-    def __init__(self, element_id: str, object_id: int) -> None:
-        self.element_id = element_id
-        self.object_id = object_id
-
-    def create(self, context: RuntimeContext) -> None:
-        del context
-        pass
-
-    def dispose(self, context: RuntimeContext) -> None:
-        context.function_registry.delete(namespace=self.element_id)
-        context.ui_element_registry.delete(self.element_id, self.object_id)
 
 
 @mddoc
@@ -197,12 +179,6 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
                 ctx.function_registry.register(
                     namespace=self._id, function=function
                 )
-
-            # This has to happen in the cell lifecycle, not del, to avoid
-            # races; order in which __del__ is called is not guaranteed
-            ctx.cell_lifecycle_registry.add(
-                UIElementLifeCycleItem(element_id=self._id, object_id=id(self))
-            )
         self._initial_value_frontend = initial_value
         self._value_frontend = initial_value
         self._value = self._initial_value = self._convert_value(initial_value)
@@ -221,6 +197,13 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
             + self._inner_text
             + "</marimo-ui-element>"
         )
+
+    def __del__(self) -> None:
+        try:
+            ctx = get_context()
+            ctx.ui_element_registry.delete(self._id, id(self))
+        except ContextNotInitializedError:
+            pass
 
     @abc.abstractmethod
     def _convert_value(self, value: S) -> T:

--- a/marimo/_runtime/test_ui_element_registration.py
+++ b/marimo/_runtime/test_ui_element_registration.py
@@ -6,7 +6,9 @@ from marimo._runtime.runtime import Kernel
 
 # TODO: colocate test with UIElementRegistry file; requires refactoring
 # pytest's conftests ...
-def test_set_and_get_state(k: Kernel, exec_req: ExecReqProvider) -> None:
+def test_cached_element_still_registered(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
     k.run(
         [
             exec_req.get("import functools"),

--- a/marimo/_runtime/test_ui_element_registration.py
+++ b/marimo/_runtime/test_ui_element_registration.py
@@ -1,4 +1,6 @@
 # Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
 from marimo._runtime.conftest import ExecReqProvider
 from marimo._runtime.context import get_context
 from marimo._runtime.runtime import Kernel
@@ -15,7 +17,7 @@ def test_cached_element_still_registered(
             exec_req.get("import marimo as mo"),
             exec_req.get(
                 """
-                @functools.cache
+                @functools.lru_cache
                 def slider():
                     return mo.ui.slider(1, 10)
                 """

--- a/marimo/_runtime/test_ui_element_registration.py
+++ b/marimo/_runtime/test_ui_element_registration.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Marimo. All rights reserved.
+from marimo._runtime.conftest import ExecReqProvider
+from marimo._runtime.runtime import Kernel
+from marimo._runtime.context import get_context
+
+
+# TODO: colocate test with UIElementRegistry file; requires refactoring
+# pytest's conftests ...
+def test_set_and_get_state(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            exec_req.get("import functools"),
+            exec_req.get("import marimo as mo"),
+            exec_req.get(
+                """
+                @functools.cache
+                def slider():
+                    return mo.ui.slider(1, 10)
+                """
+            ),
+            (construct_slider := exec_req.get("s = slider()")),
+        ]
+    )
+    # Make sure that the slider is registered
+    s = k.globals["s"]
+    assert get_context().ui_element_registry.get_object(s._id) == s
+
+    # Re-run the cell but fetch the same slider, since we're using
+    # functools.cache. Make sure it's still registered!
+    k.run([construct_slider])
+    assert get_context().ui_element_registry.get_object(s._id) == s

--- a/marimo/_runtime/test_ui_element_registration.py
+++ b/marimo/_runtime/test_ui_element_registration.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Marimo. All rights reserved.
 from marimo._runtime.conftest import ExecReqProvider
-from marimo._runtime.runtime import Kernel
 from marimo._runtime.context import get_context
+from marimo._runtime.runtime import Kernel
 
 
 # TODO: colocate test with UIElementRegistry file; requires refactoring


### PR DESCRIPTION
UI elements may be cached across runs, so can't be tied to cell lifecycle. Use __del__ to manage, but add safety check to account for fact that we don't know when del will be called

Fixes #307. An analogous bug exists for virtual files, but the fix is not as apparent.