### PR TITLE
feat: dependency graph

### DIFF
--- a/frontend/e2e-tests/layout-grid.spec.ts
+++ b/frontend/e2e-tests/layout-grid.spec.ts
@@ -14,7 +14,7 @@ test("can run Grid layout", async ({ page }) => {
   await expect(page.getByText("Grid Layout")).toBeVisible();
 
   // Type in search box
-  await page.getByRole("textbox").first().fill("hello");
+  await page.getByRole("textbox").last().fill("hello");
 
   // Verify dependent output updated
   await expect(page.getByText("Searching hello")).toBeVisible();
@@ -46,7 +46,7 @@ test("can edit Grid layout", async ({ page }) => {
   await expect(bb1.x).toBeGreaterThan(bb2.x);
 
   // Can still use interactive elements
-  await page.getByRole("textbox").first().fill("hello");
+  await page.getByRole("textbox").last().fill("hello");
   await expect(page.getByText("Searching hello")).toBeVisible();
 
   // Can toggle to Vertical layout

--- a/frontend/e2e-tests/layout-grid.spec.ts
+++ b/frontend/e2e-tests/layout-grid.spec.ts
@@ -14,7 +14,7 @@ test("can run Grid layout", async ({ page }) => {
   await expect(page.getByText("Grid Layout")).toBeVisible();
 
   // Type in search box
-  await page.getByRole("textbox").fill("hello");
+  await page.getByRole("textbox").first().fill("hello");
 
   // Verify dependent output updated
   await expect(page.getByText("Searching hello")).toBeVisible();
@@ -46,7 +46,7 @@ test("can edit Grid layout", async ({ page }) => {
   await expect(bb1.x).toBeGreaterThan(bb2.x);
 
   // Can still use interactive elements
-  await page.getByRole("textbox").fill("hello");
+  await page.getByRole("textbox").first().fill("hello");
   await expect(page.getByText("Searching hello")).toBeVisible();
 
   // Can toggle to Vertical layout

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,7 +89,7 @@
     "react-resizable-panels": "^0.0.55",
     "react-use-event-hook": "^0.9.6",
     "react-vega": "^7.6.0",
-    "reactflow": "^11.7.4",
+    "reactflow": "^11.9.4",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
     "timestring": "^7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,6 +89,7 @@
     "react-resizable-panels": "^0.0.55",
     "react-use-event-hook": "^0.9.6",
     "react-vega": "^7.6.0",
+    "reactflow": "^11.7.4",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
     "timestring": "^7.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -236,6 +236,9 @@ dependencies:
   react-vega:
     specifier: ^7.6.0
     version: 7.6.0(react@18.2.0)(vega-lite@5.16.1)(vega@5.25.0)
+  reactflow:
+    specifier: ^11.7.4
+    version: 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -4498,6 +4501,114 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@reactflow/background@11.2.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-SYQbCRCU0GuxT/40Tm7ZK+l5wByGnNJSLtZhbL9C/Hl7JhsJXV3UGXr0vrlhVZUBEtkWA7XhZM/5S9XEA5XSFA==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      classcat: 5.0.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.4.3(@types/react@18.2.36)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+    dev: false
+
+  /@reactflow/controls@11.1.15(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-//33XfBYu8vQ6brfmlZwKrDoh+8hh93xO2d88XiqfIbrPEEb32SYjsb9mS9VuHKNlSIW+eB27fBA1Gt00mEj5w==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      classcat: 5.0.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.4.3(@types/react@18.2.36)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+    dev: false
+
+  /@reactflow/core@11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-nt0T8ERp8TE7YCDQViaoEY9lb0StDPrWHVx3zBjhStFYET3wc88t8QRasZdf99xRTmyNtI3U3M40M5EBLNUpMw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@types/d3': 7.4.2
+      '@types/d3-drag': 3.0.6
+      '@types/d3-selection': 3.0.9
+      '@types/d3-zoom': 3.0.7
+      classcat: 5.0.4
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.4.3(@types/react@18.2.36)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+    dev: false
+
+  /@reactflow/minimap@11.5.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-1tDBj2zX2gxu2oHU6qvH5RGNrOWRfRxu8369KhDotuuBN5yJrGXJzWIKikwhzjsNsQJYOB+B0cS44yWAfwSwzw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@types/d3-selection': 3.0.9
+      '@types/d3-zoom': 3.0.7
+      classcat: 5.0.4
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.4.3(@types/react@18.2.36)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+    dev: false
+
+  /@reactflow/node-resizer@2.1.1(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5Q+IBmZfpp/bYsw3+KRVJB1nUbj6W3XAp5ycx4uNWH+K98vbssymyQsW0vvKkIhxEPg6tkiMzO4UWRWvwBwt1g==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      classcat: 5.0.4
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.4.3(@types/react@18.2.36)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+    dev: false
+
+  /@reactflow/node-toolbar@1.2.3(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-uFQy9xpog92s0G1wsPLniwV9nyH4i/MmL7QoMsWdnKaOi7XMhd8SJcCzUdHC3imR21HltsuQITff/XQ51ApMbg==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      classcat: 5.0.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.4.3(@types/react@18.2.36)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+    dev: false
+
   /@replit/codemirror-vim@6.0.14(@codemirror/commands@6.3.0)(@codemirror/language@6.9.2)(@codemirror/search@6.5.4)(@codemirror/state@6.3.1)(@codemirror/view@6.22.0):
     resolution: {integrity: sha512-wwhqhvL76FdRTdwfUWpKCbv0hkp2fvivfMosDVlL/popqOiNLtUhL02ThgHZH8mus/NkVr5Mj582lyFZqQrjOA==}
     peerDependencies:
@@ -6079,6 +6190,185 @@ packages:
       '@types/node': 20.8.10
     dev: true
 
+  /@types/d3-array@3.2.0:
+    resolution: {integrity: sha512-tjU8juPSfhMnu6mJZPOCVVGba4rZoE0tjHDPb81PYwA8CzbaFscGjgkUM7juUJu6iWA1cCVWNEVwxZ5HN9Jj8Q==}
+    dev: false
+
+  /@types/d3-axis@3.0.5:
+    resolution: {integrity: sha512-ufDAV3SQzju+uB3Jlty7SUb/jMigjpIlvDDcSGvGmmO6OT/sNO93UE0dRzwWOZeBLzrLSA0CQM4bf3iq1std3A==}
+    dependencies:
+      '@types/d3-selection': 3.0.9
+    dev: false
+
+  /@types/d3-brush@3.0.5:
+    resolution: {integrity: sha512-JROQXZNq1X6QdWstESDUv1VilwZ2hBCQnWB91yal+5yZvYwGQvYsGCjrkHGfKK/8/AcX1JnERmpQzdDDuLRUsA==}
+    dependencies:
+      '@types/d3-selection': 3.0.9
+    dev: false
+
+  /@types/d3-chord@3.0.5:
+    resolution: {integrity: sha512-rs26AIhJjtc+XLR4YQU8IjPTLOlDVO4PR1y+pVFYEHzKh2tE5tYz3MF4QV6iz7HboXQEaYpJQt8dH9uUkne8yA==}
+    dev: false
+
+  /@types/d3-color@3.1.2:
+    resolution: {integrity: sha512-At+Ski7dL8Bs58E8g8vPcFJc8tGcaC12Z4m07+p41+DRqnZQcAlp3NfYjLrhNYv+zEyQitU1CUxXNjqUyf+c0g==}
+    dev: false
+
+  /@types/d3-contour@3.0.5:
+    resolution: {integrity: sha512-wLvjwdOQVd1NL1IcW90CCt1VtpeZ3V20p/OTXlkT8uAiprrJnq2PNNnRNe1QCez4U9aMU29Z14zpJQVLW1+Lcg==}
+    dependencies:
+      '@types/d3-array': 3.2.0
+      '@types/geojson': 7946.0.4
+    dev: false
+
+  /@types/d3-delaunay@6.0.3:
+    resolution: {integrity: sha512-+Lf5NPKZ4JBC9tbudVkKceQXRxU3jJs0el9aKQvinMtdnFSOG84eVXyhCNgIFuXNQO3iIcYs7sgzN359FEOZnQ==}
+    dev: false
+
+  /@types/d3-dispatch@3.0.5:
+    resolution: {integrity: sha512-hxvq2kc+9hydVppo21JCGfcM0tLTh1DXnG3MLN0KlxsNZJH4bsdl1iXDuWtXFpWWlBrCMwSqlnoLPDxNAZU3Bg==}
+    dev: false
+
+  /@types/d3-drag@3.0.6:
+    resolution: {integrity: sha512-5ZlIsUSK/xxSbcg7y+Jh5orvmSM3U0bOu/6X3wk3DNgIeWJxRcZrdLDlqqCN22xC66p9zQiQx5emYYTodDlCTg==}
+    dependencies:
+      '@types/d3-selection': 3.0.9
+    dev: false
+
+  /@types/d3-dsv@3.0.6:
+    resolution: {integrity: sha512-Lx1CROFmWCuP6eBw3Hl00QMt7/NLRMb5jIn0vzogrfQi8cFS5OpqHV7Kfg1Zg9k2q6yQ+601RH+ZC3v1OPrvYQ==}
+    dev: false
+
+  /@types/d3-ease@3.0.1:
+    resolution: {integrity: sha512-VZofjpEt8HWv3nxUAosj5o/+4JflnJ7Bbv07k17VO3T2WRuzGdZeookfaF60iVh5RdhVG49LE5w6LIshVUC6rg==}
+    dev: false
+
+  /@types/d3-fetch@3.0.6:
+    resolution: {integrity: sha512-pusA8HqnYmj8h5ePCjnRLacF8xgB6il54jD5VxU90ur9/AyQQ3zR3Ib3hqSok9pEUaYXDOJcGK6LWcMF7a7PhA==}
+    dependencies:
+      '@types/d3-dsv': 3.0.6
+    dev: false
+
+  /@types/d3-force@3.0.8:
+    resolution: {integrity: sha512-3oEkLUuUf9a0V/kRiFRbEivtODZ3bKGpUTLMrPr7C5jJlJ/1++/SUsc8rYfi2E8BVNoUSNXm3ABntiIEIuJYwA==}
+    dev: false
+
+  /@types/d3-format@3.0.3:
+    resolution: {integrity: sha512-kxuLXSAEJykTeL/EI3tUiEfGqru7PRdqEy099YBnqFl+fF167UVSB4+wntlZv86ZdoYf0DHjsRHnTIm8kcH7qw==}
+    dev: false
+
+  /@types/d3-geo@3.0.7:
+    resolution: {integrity: sha512-j5I/HcDPe0z8AjUnjpweKtzjx+aTGU8Q6R6jnR4jqVlhHBp82hedaT31HVCEsIatacNtSe12XuibJDCQAP0zRg==}
+    dependencies:
+      '@types/geojson': 7946.0.4
+    dev: false
+
+  /@types/d3-hierarchy@3.1.5:
+    resolution: {integrity: sha512-DEcBUj1IL3WyPLDlh4m2nsNXnMLITXM5Vwcu4G85yJHtf2cVGPBjgky3L11WBnT+ayHKf06Tchk5mY1eGmd4WQ==}
+    dev: false
+
+  /@types/d3-interpolate@3.0.3:
+    resolution: {integrity: sha512-6OZ2EIB4lLj+8cUY7I/Cgn9Q+hLdA4DjJHYOQDiHL0SzqS1K9DL5xIOVBSIHgF+tiuO9MU1D36qvdIvRDRPh+Q==}
+    dependencies:
+      '@types/d3-color': 3.1.2
+    dev: false
+
+  /@types/d3-path@3.0.1:
+    resolution: {integrity: sha512-blRhp7ki7pVznM8k6lk5iUU9paDbVRVq+/xpf0RRgSJn5gr6SE7RcFtxooYGMBOc1RZiGyqRpVdu5AD0z0ooMA==}
+    dev: false
+
+  /@types/d3-polygon@3.0.1:
+    resolution: {integrity: sha512-nrcWPk7B9qs6xnpq60Cls44zm9eDmFAv65qi/N/emh/oftnG6uYz49aIS0mdFaGeJxVN8H3pHneMuZMV8EwFdw==}
+    dev: false
+
+  /@types/d3-quadtree@3.0.4:
+    resolution: {integrity: sha512-B725MopFDIOQ6njFbeOxIEf42HVO2Xv+FmcxQISdOKErvLbFqWz3Riu+OWujUYoogreqqyHBHcGGL/JzzXQYsw==}
+    dev: false
+
+  /@types/d3-random@3.0.2:
+    resolution: {integrity: sha512-8QhsqkKs6mymAZMrg3ZFXPxKA34rdgp3ZrtB8o6mhFsKAd1gOvR1gocWnca+kmXypQdwgnzKm9gZE2Uw8NjjKw==}
+    dev: false
+
+  /@types/d3-scale-chromatic@3.0.1:
+    resolution: {integrity: sha512-Ob7OrwiTeQXY/WBBbRHGZBOn6rH1h7y3jjpTSKYqDEeqFjktql6k2XSgNwLrLDmAsXhEn8P9NHDY4VTuo0ZY1w==}
+    dev: false
+
+  /@types/d3-scale@4.0.7:
+    resolution: {integrity: sha512-/YEbMIOtqSFSELqUT8desdT3a7iybPkSQiIx/wN4CZ/5b7wrCvmyXWELTMUYB10k0N5rzHVu4f/OkhulG1b3Lw==}
+    dependencies:
+      '@types/d3-time': 3.0.2
+    dev: false
+
+  /@types/d3-selection@3.0.9:
+    resolution: {integrity: sha512-kpej1+FX3sdL6E3f5R2eySrTVYSRh8OSOWKgEtElTM0ajxOparPf2H6mc32CPJ7aey2NErwenSy/CgNrUvZp0g==}
+    dev: false
+
+  /@types/d3-shape@3.1.4:
+    resolution: {integrity: sha512-M2/xsWPsjaZc5ifMKp1EBp0gqJG0eO/zlldJNOC85Y/5DGsBQ49gDkRJ2h5GY7ZVD6KUumvZWsylSbvTaJTqKg==}
+    dependencies:
+      '@types/d3-path': 3.0.1
+    dev: false
+
+  /@types/d3-time-format@4.0.2:
+    resolution: {integrity: sha512-wr08C1Gh77qaN8JIkrn5Rz/bdt5M9bdEqFmEOcYhUSq2t2sHvLTBfb4XAtGB3D4hm0ubj50NXWWXoXyp5tPXDg==}
+    dev: false
+
+  /@types/d3-time@3.0.2:
+    resolution: {integrity: sha512-kbdRXTmUgNfw5OTE3KZnFQn6XdIc4QGroN5UixgdrXATmYsdlPQS6pEut9tVlIojtzuFD4txs/L+Rq41AHtLpg==}
+    dev: false
+
+  /@types/d3-timer@3.0.1:
+    resolution: {integrity: sha512-GGTvzKccVEhxmRfJEB6zhY9ieT4UhGVUIQaBzFpUO9OXy2ycAlnPCSJLzmGGgqt3KVjqN3QCQB4g1rsZnHsWhg==}
+    dev: false
+
+  /@types/d3-transition@3.0.7:
+    resolution: {integrity: sha512-WY4/HKVWU9Nce8u3szfQVeu0vC9HiB0t80zen2lJza6sE3JZPGTd5omwkUU2PVaosieUgbiGsHx45fZ5ylXO8Q==}
+    dependencies:
+      '@types/d3-selection': 3.0.9
+    dev: false
+
+  /@types/d3-zoom@3.0.7:
+    resolution: {integrity: sha512-CXmqq+sFP5GUHzZvni6lgYCrI35FJq39bbzYBqbuaQ8Q4DnQX9l45bkRQxyrqZDuUqg8m/vWoOyg1lOO+wdCRg==}
+    dependencies:
+      '@types/d3-interpolate': 3.0.3
+      '@types/d3-selection': 3.0.9
+    dev: false
+
+  /@types/d3@7.4.2:
+    resolution: {integrity: sha512-Y4g2Yb30ZJmmtqAJTqMRaqXwRawfvpdpVmyEYEcyGNhrQI/Zvkq3k7yE1tdN07aFSmNBfvmegMQ9Fe2qy9ZMhw==}
+    dependencies:
+      '@types/d3-array': 3.2.0
+      '@types/d3-axis': 3.0.5
+      '@types/d3-brush': 3.0.5
+      '@types/d3-chord': 3.0.5
+      '@types/d3-color': 3.1.2
+      '@types/d3-contour': 3.0.5
+      '@types/d3-delaunay': 6.0.3
+      '@types/d3-dispatch': 3.0.5
+      '@types/d3-drag': 3.0.6
+      '@types/d3-dsv': 3.0.6
+      '@types/d3-ease': 3.0.1
+      '@types/d3-fetch': 3.0.6
+      '@types/d3-force': 3.0.8
+      '@types/d3-format': 3.0.3
+      '@types/d3-geo': 3.0.7
+      '@types/d3-hierarchy': 3.1.5
+      '@types/d3-interpolate': 3.0.3
+      '@types/d3-path': 3.0.1
+      '@types/d3-polygon': 3.0.1
+      '@types/d3-quadtree': 3.0.4
+      '@types/d3-random': 3.0.2
+      '@types/d3-scale': 4.0.7
+      '@types/d3-scale-chromatic': 3.0.1
+      '@types/d3-selection': 3.0.9
+      '@types/d3-shape': 3.1.4
+      '@types/d3-time': 3.0.2
+      '@types/d3-time-format': 4.0.2
+      '@types/d3-timer': 3.0.1
+      '@types/d3-transition': 3.0.7
+      '@types/d3-zoom': 3.0.7
+    dev: false
+
   /@types/debug@4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
@@ -7656,6 +7946,10 @@ packages:
       clsx: 2.0.0
     dev: false
 
+  /classcat@5.0.4:
+    resolution: {integrity: sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g==}
+    dev: false
+
   /clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
@@ -8264,6 +8558,14 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+    dev: false
+
   /d3-dsv@3.0.1:
     resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
     engines: {node: '>=12'}
@@ -8272,6 +8574,11 @@ packages:
       commander: 7.2.0
       iconv-lite: 0.6.3
       rw: 1.3.3
+    dev: false
+
+  /d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
     dev: false
 
   /d3-force@1.2.1:
@@ -8379,6 +8686,11 @@ packages:
       d3-time-format: 4.1.0
     dev: false
 
+  /d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /d3-shape@1.3.7:
     resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
     dependencies:
@@ -8423,6 +8735,31 @@ packages:
   /d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
+    dev: false
+
+  /d3-transition@3.0.1(d3-selection@3.0.0):
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+    dev: false
+
+  /d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
     dev: false
 
   /d@1.0.1:
@@ -13382,6 +13719,25 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+
+  /reactflow@11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-QI6+oc1Ft6oFeLSdHlp+SmgymbI5Tm49wj5JyE84O4A54yN/ImfYaBhLit9Cmfzxn9Tz6tDqmGMGbk4bdtB8/w==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@reactflow/background': 11.2.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/controls': 11.1.15(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/minimap': 11.5.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/node-resizer': 2.1.1(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/node-toolbar': 1.2.3(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+    dev: false
 
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -237,8 +237,8 @@ dependencies:
     specifier: ^7.6.0
     version: 7.6.0(react@18.2.0)(vega-lite@5.16.1)(vega@5.25.0)
   reactflow:
-    specifier: ^11.7.4
-    version: 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^11.9.4
+    version: 11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
@@ -4501,13 +4501,13 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@reactflow/background@11.2.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-SYQbCRCU0GuxT/40Tm7ZK+l5wByGnNJSLtZhbL9C/Hl7JhsJXV3UGXr0vrlhVZUBEtkWA7XhZM/5S9XEA5XSFA==}
+  /@reactflow/background@11.3.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-bgwvqWxF09chwmdkyClpYEMaewBspdwjgLbbFlLf4SpWPFMYyuvCBQrcISsvy/EDEWO9i3Uj9ktgGAhvtSQsmA==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
       classcat: 5.0.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -4517,13 +4517,13 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/controls@11.1.15(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-//33XfBYu8vQ6brfmlZwKrDoh+8hh93xO2d88XiqfIbrPEEb32SYjsb9mS9VuHKNlSIW+eB27fBA1Gt00mEj5w==}
+  /@reactflow/controls@11.2.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-x6e5p9iHjC6gd+4SoZ3DOOp0F1MefGKQ8hT6yPVdqxfo1+rV2WhrWvrX/MCoEu12Dp7457LdLfa0giy3aho8tQ==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
       classcat: 5.0.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -4533,16 +4533,16 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/core@11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-nt0T8ERp8TE7YCDQViaoEY9lb0StDPrWHVx3zBjhStFYET3wc88t8QRasZdf99xRTmyNtI3U3M40M5EBLNUpMw==}
+  /@reactflow/core@11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Ko7nKPOYalwDTTbRHi2+QXDiidSAcpUzGN3G+0B+QysLZkcaPCkpkMjjHiDC4c/Z1BJBzs1FRJg/T6BXaBnYkg==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@types/d3': 7.4.2
-      '@types/d3-drag': 3.0.6
-      '@types/d3-selection': 3.0.9
-      '@types/d3-zoom': 3.0.7
+      '@types/d3': 7.4.3
+      '@types/d3-drag': 3.0.7
+      '@types/d3-selection': 3.0.10
+      '@types/d3-zoom': 3.0.8
       classcat: 5.0.4
       d3-drag: 3.0.0
       d3-selection: 3.0.0
@@ -4555,15 +4555,15 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/minimap@11.5.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-1tDBj2zX2gxu2oHU6qvH5RGNrOWRfRxu8369KhDotuuBN5yJrGXJzWIKikwhzjsNsQJYOB+B0cS44yWAfwSwzw==}
+  /@reactflow/minimap@11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Jo1R+uDey9IV7O2s3m0gK2+cZpg9M8hq2EZJb3NGfOSzMAPhj3mby0fNJIgTzycreuht0TpA51c2YfjGI3YIOw==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
-      '@types/d3-selection': 3.0.9
-      '@types/d3-zoom': 3.0.7
+      '@reactflow/core': 11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@types/d3-selection': 3.0.10
+      '@types/d3-zoom': 3.0.8
       classcat: 5.0.4
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
@@ -4575,13 +4575,13 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/node-resizer@2.1.1(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-5Q+IBmZfpp/bYsw3+KRVJB1nUbj6W3XAp5ycx4uNWH+K98vbssymyQsW0vvKkIhxEPg6tkiMzO4UWRWvwBwt1g==}
+  /@reactflow/node-resizer@2.2.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-+p271/hAsM5M1+RQTWW/02pbNkCHeGXwxGimIlL1tMIagyuko0NX2vOz2B8jxJnPKlF09Wj18BcXBNUm3nDcSg==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
       classcat: 5.0.4
       d3-drag: 3.0.0
       d3-selection: 3.0.0
@@ -4593,13 +4593,13 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/node-toolbar@1.2.3(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-uFQy9xpog92s0G1wsPLniwV9nyH4i/MmL7QoMsWdnKaOi7XMhd8SJcCzUdHC3imR21HltsuQITff/XQ51ApMbg==}
+  /@reactflow/node-toolbar@1.3.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-TfcmpXHRBb2mUfzKGjburiU6FWqRME9pPFs1OwIC1z5e9BjupQhNDEKEk8XHi7PKL/mAiDfwuGXaM1BVVFuPqw==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
       classcat: 5.0.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -6190,183 +6190,183 @@ packages:
       '@types/node': 20.8.10
     dev: true
 
-  /@types/d3-array@3.2.0:
-    resolution: {integrity: sha512-tjU8juPSfhMnu6mJZPOCVVGba4rZoE0tjHDPb81PYwA8CzbaFscGjgkUM7juUJu6iWA1cCVWNEVwxZ5HN9Jj8Q==}
+  /@types/d3-array@3.2.1:
+    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
     dev: false
 
-  /@types/d3-axis@3.0.5:
-    resolution: {integrity: sha512-ufDAV3SQzju+uB3Jlty7SUb/jMigjpIlvDDcSGvGmmO6OT/sNO93UE0dRzwWOZeBLzrLSA0CQM4bf3iq1std3A==}
+  /@types/d3-axis@3.0.6:
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
     dependencies:
-      '@types/d3-selection': 3.0.9
+      '@types/d3-selection': 3.0.10
     dev: false
 
-  /@types/d3-brush@3.0.5:
-    resolution: {integrity: sha512-JROQXZNq1X6QdWstESDUv1VilwZ2hBCQnWB91yal+5yZvYwGQvYsGCjrkHGfKK/8/AcX1JnERmpQzdDDuLRUsA==}
+  /@types/d3-brush@3.0.6:
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
     dependencies:
-      '@types/d3-selection': 3.0.9
+      '@types/d3-selection': 3.0.10
     dev: false
 
-  /@types/d3-chord@3.0.5:
-    resolution: {integrity: sha512-rs26AIhJjtc+XLR4YQU8IjPTLOlDVO4PR1y+pVFYEHzKh2tE5tYz3MF4QV6iz7HboXQEaYpJQt8dH9uUkne8yA==}
+  /@types/d3-chord@3.0.6:
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
     dev: false
 
-  /@types/d3-color@3.1.2:
-    resolution: {integrity: sha512-At+Ski7dL8Bs58E8g8vPcFJc8tGcaC12Z4m07+p41+DRqnZQcAlp3NfYjLrhNYv+zEyQitU1CUxXNjqUyf+c0g==}
+  /@types/d3-color@3.1.3:
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
     dev: false
 
-  /@types/d3-contour@3.0.5:
-    resolution: {integrity: sha512-wLvjwdOQVd1NL1IcW90CCt1VtpeZ3V20p/OTXlkT8uAiprrJnq2PNNnRNe1QCez4U9aMU29Z14zpJQVLW1+Lcg==}
+  /@types/d3-contour@3.0.6:
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
     dependencies:
-      '@types/d3-array': 3.2.0
+      '@types/d3-array': 3.2.1
       '@types/geojson': 7946.0.4
     dev: false
 
-  /@types/d3-delaunay@6.0.3:
-    resolution: {integrity: sha512-+Lf5NPKZ4JBC9tbudVkKceQXRxU3jJs0el9aKQvinMtdnFSOG84eVXyhCNgIFuXNQO3iIcYs7sgzN359FEOZnQ==}
+  /@types/d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
     dev: false
 
-  /@types/d3-dispatch@3.0.5:
-    resolution: {integrity: sha512-hxvq2kc+9hydVppo21JCGfcM0tLTh1DXnG3MLN0KlxsNZJH4bsdl1iXDuWtXFpWWlBrCMwSqlnoLPDxNAZU3Bg==}
+  /@types/d3-dispatch@3.0.6:
+    resolution: {integrity: sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==}
     dev: false
 
-  /@types/d3-drag@3.0.6:
-    resolution: {integrity: sha512-5ZlIsUSK/xxSbcg7y+Jh5orvmSM3U0bOu/6X3wk3DNgIeWJxRcZrdLDlqqCN22xC66p9zQiQx5emYYTodDlCTg==}
+  /@types/d3-drag@3.0.7:
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
     dependencies:
-      '@types/d3-selection': 3.0.9
+      '@types/d3-selection': 3.0.10
     dev: false
 
-  /@types/d3-dsv@3.0.6:
-    resolution: {integrity: sha512-Lx1CROFmWCuP6eBw3Hl00QMt7/NLRMb5jIn0vzogrfQi8cFS5OpqHV7Kfg1Zg9k2q6yQ+601RH+ZC3v1OPrvYQ==}
+  /@types/d3-dsv@3.0.7:
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
     dev: false
 
-  /@types/d3-ease@3.0.1:
-    resolution: {integrity: sha512-VZofjpEt8HWv3nxUAosj5o/+4JflnJ7Bbv07k17VO3T2WRuzGdZeookfaF60iVh5RdhVG49LE5w6LIshVUC6rg==}
+  /@types/d3-ease@3.0.2:
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
     dev: false
 
-  /@types/d3-fetch@3.0.6:
-    resolution: {integrity: sha512-pusA8HqnYmj8h5ePCjnRLacF8xgB6il54jD5VxU90ur9/AyQQ3zR3Ib3hqSok9pEUaYXDOJcGK6LWcMF7a7PhA==}
+  /@types/d3-fetch@3.0.7:
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
     dependencies:
-      '@types/d3-dsv': 3.0.6
+      '@types/d3-dsv': 3.0.7
     dev: false
 
-  /@types/d3-force@3.0.8:
-    resolution: {integrity: sha512-3oEkLUuUf9a0V/kRiFRbEivtODZ3bKGpUTLMrPr7C5jJlJ/1++/SUsc8rYfi2E8BVNoUSNXm3ABntiIEIuJYwA==}
+  /@types/d3-force@3.0.9:
+    resolution: {integrity: sha512-IKtvyFdb4Q0LWna6ymywQsEYjK/94SGhPrMfEr1TIc5OBeziTi+1jcCvttts8e0UWZIxpasjnQk9MNk/3iS+kA==}
     dev: false
 
-  /@types/d3-format@3.0.3:
-    resolution: {integrity: sha512-kxuLXSAEJykTeL/EI3tUiEfGqru7PRdqEy099YBnqFl+fF167UVSB4+wntlZv86ZdoYf0DHjsRHnTIm8kcH7qw==}
+  /@types/d3-format@3.0.4:
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
     dev: false
 
-  /@types/d3-geo@3.0.7:
-    resolution: {integrity: sha512-j5I/HcDPe0z8AjUnjpweKtzjx+aTGU8Q6R6jnR4jqVlhHBp82hedaT31HVCEsIatacNtSe12XuibJDCQAP0zRg==}
+  /@types/d3-geo@3.0.8:
+    resolution: {integrity: sha512-eDivwKKB4ELHw93QNxigleCxZczcyrFgtKyHK5HoCQoeUD0i5feT8i5tH6RxXvt5hPPhpruvKWDSwvfsW448zQ==}
     dependencies:
       '@types/geojson': 7946.0.4
     dev: false
 
-  /@types/d3-hierarchy@3.1.5:
-    resolution: {integrity: sha512-DEcBUj1IL3WyPLDlh4m2nsNXnMLITXM5Vwcu4G85yJHtf2cVGPBjgky3L11WBnT+ayHKf06Tchk5mY1eGmd4WQ==}
+  /@types/d3-hierarchy@3.1.6:
+    resolution: {integrity: sha512-qlmD/8aMk5xGorUvTUWHCiumvgaUXYldYjNVOWtYoTYY/L+WwIEAmJxUmTgr9LoGNG0PPAOmqMDJVDPc7DOpPw==}
     dev: false
 
-  /@types/d3-interpolate@3.0.3:
-    resolution: {integrity: sha512-6OZ2EIB4lLj+8cUY7I/Cgn9Q+hLdA4DjJHYOQDiHL0SzqS1K9DL5xIOVBSIHgF+tiuO9MU1D36qvdIvRDRPh+Q==}
+  /@types/d3-interpolate@3.0.4:
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
     dependencies:
-      '@types/d3-color': 3.1.2
+      '@types/d3-color': 3.1.3
     dev: false
 
-  /@types/d3-path@3.0.1:
-    resolution: {integrity: sha512-blRhp7ki7pVznM8k6lk5iUU9paDbVRVq+/xpf0RRgSJn5gr6SE7RcFtxooYGMBOc1RZiGyqRpVdu5AD0z0ooMA==}
+  /@types/d3-path@3.0.2:
+    resolution: {integrity: sha512-WAIEVlOCdd/NKRYTsqCpOMHQHemKBEINf8YXMYOtXH0GA7SY0dqMB78P3Uhgfy+4X+/Mlw2wDtlETkN6kQUCMA==}
     dev: false
 
-  /@types/d3-polygon@3.0.1:
-    resolution: {integrity: sha512-nrcWPk7B9qs6xnpq60Cls44zm9eDmFAv65qi/N/emh/oftnG6uYz49aIS0mdFaGeJxVN8H3pHneMuZMV8EwFdw==}
+  /@types/d3-polygon@3.0.2:
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
     dev: false
 
-  /@types/d3-quadtree@3.0.4:
-    resolution: {integrity: sha512-B725MopFDIOQ6njFbeOxIEf42HVO2Xv+FmcxQISdOKErvLbFqWz3Riu+OWujUYoogreqqyHBHcGGL/JzzXQYsw==}
+  /@types/d3-quadtree@3.0.5:
+    resolution: {integrity: sha512-Cb1f3jyNBnvMMkf4KBZ7IgAQVWd9yzBwYcrxGqg3aPCUgWELAS+nyeB7r76aqu1e3+CGDjhk4BrWaFBekMwigg==}
     dev: false
 
-  /@types/d3-random@3.0.2:
-    resolution: {integrity: sha512-8QhsqkKs6mymAZMrg3ZFXPxKA34rdgp3ZrtB8o6mhFsKAd1gOvR1gocWnca+kmXypQdwgnzKm9gZE2Uw8NjjKw==}
+  /@types/d3-random@3.0.3:
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
     dev: false
 
-  /@types/d3-scale-chromatic@3.0.1:
-    resolution: {integrity: sha512-Ob7OrwiTeQXY/WBBbRHGZBOn6rH1h7y3jjpTSKYqDEeqFjktql6k2XSgNwLrLDmAsXhEn8P9NHDY4VTuo0ZY1w==}
+  /@types/d3-scale-chromatic@3.0.2:
+    resolution: {integrity: sha512-kpKNZMDT3OAX6b5ct5nS/mv6LULagnUy4DmS6yyNjclje1qVe7vbjPwY3q1TGz6+Wr2IUkgFatCzqYUl54fHag==}
     dev: false
 
-  /@types/d3-scale@4.0.7:
-    resolution: {integrity: sha512-/YEbMIOtqSFSELqUT8desdT3a7iybPkSQiIx/wN4CZ/5b7wrCvmyXWELTMUYB10k0N5rzHVu4f/OkhulG1b3Lw==}
+  /@types/d3-scale@4.0.8:
+    resolution: {integrity: sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==}
     dependencies:
-      '@types/d3-time': 3.0.2
+      '@types/d3-time': 3.0.3
     dev: false
 
-  /@types/d3-selection@3.0.9:
-    resolution: {integrity: sha512-kpej1+FX3sdL6E3f5R2eySrTVYSRh8OSOWKgEtElTM0ajxOparPf2H6mc32CPJ7aey2NErwenSy/CgNrUvZp0g==}
+  /@types/d3-selection@3.0.10:
+    resolution: {integrity: sha512-cuHoUgS/V3hLdjJOLTT691+G2QoqAjCVLmr4kJXR4ha56w1Zdu8UUQ5TxLRqudgNjwXeQxKMq4j+lyf9sWuslg==}
     dev: false
 
-  /@types/d3-shape@3.1.4:
-    resolution: {integrity: sha512-M2/xsWPsjaZc5ifMKp1EBp0gqJG0eO/zlldJNOC85Y/5DGsBQ49gDkRJ2h5GY7ZVD6KUumvZWsylSbvTaJTqKg==}
+  /@types/d3-shape@3.1.5:
+    resolution: {integrity: sha512-dfEWpZJ1Pdg8meLlICX1M3WBIpxnaH2eQV2eY43Y5ysRJOTAV9f3/R++lgJKFstfrEOE2zdJ0sv5qwr2Bkic6Q==}
     dependencies:
-      '@types/d3-path': 3.0.1
+      '@types/d3-path': 3.0.2
     dev: false
 
-  /@types/d3-time-format@4.0.2:
-    resolution: {integrity: sha512-wr08C1Gh77qaN8JIkrn5Rz/bdt5M9bdEqFmEOcYhUSq2t2sHvLTBfb4XAtGB3D4hm0ubj50NXWWXoXyp5tPXDg==}
+  /@types/d3-time-format@4.0.3:
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
     dev: false
 
-  /@types/d3-time@3.0.2:
-    resolution: {integrity: sha512-kbdRXTmUgNfw5OTE3KZnFQn6XdIc4QGroN5UixgdrXATmYsdlPQS6pEut9tVlIojtzuFD4txs/L+Rq41AHtLpg==}
+  /@types/d3-time@3.0.3:
+    resolution: {integrity: sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==}
     dev: false
 
-  /@types/d3-timer@3.0.1:
-    resolution: {integrity: sha512-GGTvzKccVEhxmRfJEB6zhY9ieT4UhGVUIQaBzFpUO9OXy2ycAlnPCSJLzmGGgqt3KVjqN3QCQB4g1rsZnHsWhg==}
+  /@types/d3-timer@3.0.2:
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
     dev: false
 
-  /@types/d3-transition@3.0.7:
-    resolution: {integrity: sha512-WY4/HKVWU9Nce8u3szfQVeu0vC9HiB0t80zen2lJza6sE3JZPGTd5omwkUU2PVaosieUgbiGsHx45fZ5ylXO8Q==}
+  /@types/d3-transition@3.0.8:
+    resolution: {integrity: sha512-ew63aJfQ/ms7QQ4X7pk5NxQ9fZH/z+i24ZfJ6tJSfqxJMrYLiK01EAs2/Rtw/JreGUsS3pLPNV644qXFGnoZNQ==}
     dependencies:
-      '@types/d3-selection': 3.0.9
+      '@types/d3-selection': 3.0.10
     dev: false
 
-  /@types/d3-zoom@3.0.7:
-    resolution: {integrity: sha512-CXmqq+sFP5GUHzZvni6lgYCrI35FJq39bbzYBqbuaQ8Q4DnQX9l45bkRQxyrqZDuUqg8m/vWoOyg1lOO+wdCRg==}
+  /@types/d3-zoom@3.0.8:
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
     dependencies:
-      '@types/d3-interpolate': 3.0.3
-      '@types/d3-selection': 3.0.9
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.10
     dev: false
 
-  /@types/d3@7.4.2:
-    resolution: {integrity: sha512-Y4g2Yb30ZJmmtqAJTqMRaqXwRawfvpdpVmyEYEcyGNhrQI/Zvkq3k7yE1tdN07aFSmNBfvmegMQ9Fe2qy9ZMhw==}
+  /@types/d3@7.4.3:
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
     dependencies:
-      '@types/d3-array': 3.2.0
-      '@types/d3-axis': 3.0.5
-      '@types/d3-brush': 3.0.5
-      '@types/d3-chord': 3.0.5
-      '@types/d3-color': 3.1.2
-      '@types/d3-contour': 3.0.5
-      '@types/d3-delaunay': 6.0.3
-      '@types/d3-dispatch': 3.0.5
-      '@types/d3-drag': 3.0.6
-      '@types/d3-dsv': 3.0.6
-      '@types/d3-ease': 3.0.1
-      '@types/d3-fetch': 3.0.6
-      '@types/d3-force': 3.0.8
-      '@types/d3-format': 3.0.3
-      '@types/d3-geo': 3.0.7
-      '@types/d3-hierarchy': 3.1.5
-      '@types/d3-interpolate': 3.0.3
-      '@types/d3-path': 3.0.1
-      '@types/d3-polygon': 3.0.1
-      '@types/d3-quadtree': 3.0.4
-      '@types/d3-random': 3.0.2
-      '@types/d3-scale': 4.0.7
-      '@types/d3-scale-chromatic': 3.0.1
-      '@types/d3-selection': 3.0.9
-      '@types/d3-shape': 3.1.4
-      '@types/d3-time': 3.0.2
-      '@types/d3-time-format': 4.0.2
-      '@types/d3-timer': 3.0.1
-      '@types/d3-transition': 3.0.7
-      '@types/d3-zoom': 3.0.7
+      '@types/d3-array': 3.2.1
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.6
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.9
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.0.8
+      '@types/d3-hierarchy': 3.1.6
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.0.2
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.5
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.8
+      '@types/d3-scale-chromatic': 3.0.2
+      '@types/d3-selection': 3.0.10
+      '@types/d3-shape': 3.1.5
+      '@types/d3-time': 3.0.3
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.8
+      '@types/d3-zoom': 3.0.8
     dev: false
 
   /@types/debug@4.1.7:
@@ -13720,18 +13720,18 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
-  /reactflow@11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-QI6+oc1Ft6oFeLSdHlp+SmgymbI5Tm49wj5JyE84O4A54yN/ImfYaBhLit9Cmfzxn9Tz6tDqmGMGbk4bdtB8/w==}
+  /reactflow@11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-IHAKBkJngNvU9y1vZ5Nw9rvA3Z+zc9geTgQQIi9qq9Y9knGLlDDr9KfsjbFMew9AycAAgVg8TvBEakF4IT5lqg==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/background': 11.2.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/controls': 11.1.15(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/core': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/minimap': 11.5.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/node-resizer': 2.1.1(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/node-toolbar': 1.2.3(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/background': 11.3.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/controls': 11.2.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.9.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/minimap': 11.7.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/node-resizer': 2.2.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/node-toolbar': 1.3.4(@types/react@18.2.36)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:

--- a/frontend/src/components/dependency-graph/constants.ts
+++ b/frontend/src/components/dependency-graph/constants.ts
@@ -1,0 +1,8 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+
+// Co-located to keep these numbers changed together
+export const DependencyGraphConstants = {
+  nodeWidth: 250,
+  // includes nodeWidth and a gutters for the arrows
+  panelClassName: "w-[320px]",
+};

--- a/frontend/src/components/dependency-graph/constants.ts
+++ b/frontend/src/components/dependency-graph/constants.ts
@@ -1,8 +1,0 @@
-/* Copyright 2023 Marimo. All rights reserved. */
-
-// Co-located to keep these numbers changed together
-export const DependencyGraphConstants = {
-  nodeWidth: 250,
-  // includes nodeWidth and a gutters for the arrows
-  panelClassName: "w-[320px]",
-};

--- a/frontend/src/components/dependency-graph/custom-node.tsx
+++ b/frontend/src/components/dependency-graph/custom-node.tsx
@@ -4,19 +4,26 @@ import { TinyCode } from "@/editor/cell/TinyCode";
 import { cn } from "@/lib/utils";
 import { Atom, useAtomValue } from "jotai";
 import { memo } from "react";
-import { Handle, Position, NodeProps } from "reactflow";
-import { DependencyGraphConstants } from "./constants";
+import { Handle, Position, NodeProps, useStore } from "reactflow";
 
 export function getHeight(linesOfCode: number) {
   return Math.min(linesOfCode * 10 + 40, 200);
 }
 
+function getWidth(canvasWidth: number) {
+  const minWidth = 100;
+  const maxWidth = 400;
+  const padding = 50;
+  return Math.min(Math.max(canvasWidth - padding * 2, minWidth), maxWidth);
+}
+
 export const CustomNode = memo((props: NodeProps<{ atom: Atom<CellData> }>) => {
   const { data, selected, id } = props;
   const cell = useAtomValue(data.atom);
-  const nonSelectedColor = "var(--gray7)";
-  const selectedColor = "var(--gray10)";
+  const nonSelectedColor = "var(--gray-3)";
+  const selectedColor = "var(--gray-9)";
   const color = selected ? selectedColor : nonSelectedColor;
+  const reactFlowWidth = useStore(({ width }) => width);
 
   const linesOfCode = cell.code.split("\n").length;
   return (
@@ -35,18 +42,20 @@ export const CustomNode = memo((props: NodeProps<{ atom: Atom<CellData> }>) => {
       />
       <div
         className={cn(
-          "flex flex-col bg-card border border-gray-200 rounded-md p-2 mx-[2px]",
+          "flex flex-col bg-card border border-input/50 rounded-md mx-[2px] overflow-hidden",
           selected && "border-primary"
         )}
         style={{
           height: getHeight(linesOfCode),
-          width: DependencyGraphConstants.nodeWidth,
+          width: getWidth(reactFlowWidth),
         }}
       >
-        <div className="text-muted-foreground font-semibold text-xs pb-1">
+        <div className="text-muted-foreground font-semibold text-xs py-1 px-2 bg-muted border-b">
           Cell {id}
         </div>
-        <TinyCode code={cell.code} />
+        <div className="p-2">
+          <TinyCode code={cell.code} />
+        </div>
       </div>
       <Handle
         type="source"

--- a/frontend/src/components/dependency-graph/custom-node.tsx
+++ b/frontend/src/components/dependency-graph/custom-node.tsx
@@ -1,0 +1,65 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { CellData } from "@/core/model/cells";
+import { TinyCode } from "@/editor/cell/TinyCode";
+import { cn } from "@/lib/utils";
+import { Atom, useAtomValue } from "jotai";
+import { memo } from "react";
+import { Handle, Position, NodeProps } from "reactflow";
+
+export function getHeight(linesOfCode: number) {
+  return Math.min(linesOfCode * 10 + 40, 200);
+}
+
+export const CustomNode = memo((props: NodeProps<{ atom: Atom<CellData> }>) => {
+  const { data, selected, id } = props;
+  const cell = useAtomValue(data.atom);
+  const nonSelectedColor = "var(--gray7)";
+  const selectedColor = "var(--gray10)";
+  const color = selected ? selectedColor : nonSelectedColor;
+
+  const linesOfCode = cell.code.split("\n").length;
+  return (
+    <div>
+      <Handle
+        type="target"
+        id="inputs"
+        position={Position.Left}
+        style={{ background: color }}
+      />
+      <Handle
+        type="source"
+        id="inputs"
+        position={Position.Left}
+        style={{ background: color }}
+      />
+      <div
+        className={cn(
+          "flex flex-col bg-card border border-gray-200 rounded-md p-2 mx-[2px]",
+          selected && "border-primary"
+        )}
+        style={{
+          height: getHeight(linesOfCode),
+          width: 150,
+        }}
+      >
+        <div className="text-muted-foreground font-semibold text-xs pb-1">
+          Cell {id}
+        </div>
+        <TinyCode code={cell.code} />
+      </div>
+      <Handle
+        type="source"
+        id="outputs"
+        position={Position.Right}
+        style={{ background: color }}
+      />
+      <Handle
+        type="target"
+        id="outputs"
+        position={Position.Right}
+        style={{ background: color }}
+      />
+    </div>
+  );
+});
+CustomNode.displayName = "CustomNode";

--- a/frontend/src/components/dependency-graph/custom-node.tsx
+++ b/frontend/src/components/dependency-graph/custom-node.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { Atom, useAtomValue } from "jotai";
 import { memo } from "react";
 import { Handle, Position, NodeProps } from "reactflow";
+import { DependencyGraphConstants } from "./constants";
 
 export function getHeight(linesOfCode: number) {
   return Math.min(linesOfCode * 10 + 40, 200);
@@ -39,7 +40,7 @@ export const CustomNode = memo((props: NodeProps<{ atom: Atom<CellData> }>) => {
         )}
         style={{
           height: getHeight(linesOfCode),
-          width: 150,
+          width: DependencyGraphConstants.nodeWidth,
         }}
       >
         <div className="text-muted-foreground font-semibold text-xs pb-1">

--- a/frontend/src/components/dependency-graph/custom-node.tsx
+++ b/frontend/src/components/dependency-graph/custom-node.tsx
@@ -7,7 +7,8 @@ import { memo } from "react";
 import { Handle, Position, NodeProps, useStore } from "reactflow";
 
 export function getHeight(linesOfCode: number) {
-  return Math.min(linesOfCode * 10 + 40, 200);
+  const LINE_HEIGHT = 11; // matches TinyCode.css
+  return Math.min(linesOfCode * LINE_HEIGHT + 35, 200);
 }
 
 function getWidth(canvasWidth: number) {
@@ -53,9 +54,7 @@ export const CustomNode = memo((props: NodeProps<{ atom: Atom<CellData> }>) => {
         <div className="text-muted-foreground font-semibold text-xs py-1 px-2 bg-muted border-b">
           Cell {id}
         </div>
-        <div className="p-2">
-          <TinyCode code={cell.code} />
-        </div>
+        <TinyCode code={cell.code} />
       </div>
       <Handle
         type="source"

--- a/frontend/src/components/dependency-graph/dependency-graph.css
+++ b/frontend/src/components/dependency-graph/dependency-graph.css
@@ -1,0 +1,7 @@
+.react-flow__pane.react-flow__pane {
+  cursor: default;
+}
+
+.react-flow__node.react-flow__node {
+  cursor: pointer;
+}

--- a/frontend/src/components/dependency-graph/dependency-graph.css
+++ b/frontend/src/components/dependency-graph/dependency-graph.css
@@ -5,3 +5,7 @@
 .react-flow__node.react-flow__node {
   cursor: pointer;
 }
+
+.react-flow__handle.react-flow__handle {
+  @apply border-background;
+}

--- a/frontend/src/components/dependency-graph/dependency-graph.tsx
+++ b/frontend/src/components/dependency-graph/dependency-graph.tsx
@@ -6,6 +6,7 @@ import ReactFlow, {
   ReactFlowProvider,
   useEdgesState,
   useNodesState,
+  PanOnScrollMode,
 } from "reactflow";
 import "reactflow/dist/style.css";
 
@@ -19,6 +20,7 @@ import { CellId } from "@/core/model/ids";
 import { CellData } from "@/core/model/cells";
 import { Atom } from "jotai";
 import { store } from "@/core/state/jotai";
+import { DependencyGraphConstants } from "./constants";
 
 interface Props {
   cellIds: CellId[];
@@ -52,49 +54,45 @@ const DependencyGraphInternal: React.FC<Props> = ({
   const [nodes] = useNodesState(initialNodes);
 
   return (
-    <div className="w-full h-full relative">
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        // onScroll={}
-        onNodeClick={(_event, node) => {
-          const id = node.id;
-          const selectedEdges = initialEdges.filter(
-            (edge) =>
-              (edge.source === id && edge.data.direction === "outputs") ||
-              (edge.target === id && edge.data.direction === "inputs")
-          );
-          console.log(selectedEdges.length);
-          setEdges([]);
-          requestAnimationFrame(() => {
-            setEdges(selectedEdges);
-          });
-        }}
-        // On
-        snapToGrid={true}
-        fitView={true}
-        elementsSelectable={true}
-        // Off
-        minZoom={1}
-        maxZoom={1}
-        draggable={false}
-        // zoomOnScroll={false}
-        zoomOnDoubleClick={false}
-        nodesDraggable={false}
-        nodesConnectable={false}
-        nodesFocusable={false}
-        edgesFocusable={false}
-        // edgesUpdatable={false}
-        selectNodesOnDrag={false}
-        panOnDrag={false}
-        preventScrolling={false}
-        zoomOnPinch={false}
-        panOnScroll={true}
-        autoPanOnNodeDrag={false}
-        autoPanOnConnect={false}
-      />
-    </div>
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      onNodeClick={(_event, node) => {
+        const id = node.id;
+        const selectedEdges = initialEdges.filter(
+          (edge) =>
+            (edge.source === id && edge.data.direction === "outputs") ||
+            (edge.target === id && edge.data.direction === "inputs")
+        );
+        console.log(selectedEdges.length);
+        setEdges([]);
+        requestAnimationFrame(() => {
+          setEdges(selectedEdges);
+        });
+      }}
+      // On
+      snapToGrid={true}
+      fitView={true}
+      elementsSelectable={true}
+      // Off
+      minZoom={1}
+      maxZoom={1}
+      draggable={false}
+      panOnScrollMode={PanOnScrollMode.Vertical}
+      zoomOnDoubleClick={false}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      nodesFocusable={false}
+      edgesFocusable={false}
+      selectNodesOnDrag={false}
+      panOnDrag={false}
+      preventScrolling={false}
+      zoomOnPinch={false}
+      panOnScroll={true}
+      autoPanOnNodeDrag={false}
+      autoPanOnConnect={false}
+    />
   );
 };
 
@@ -126,10 +124,8 @@ function createNode(id: string, atom: Atom<CellData>, prevY: number): Node {
   return {
     id: id,
     data: { atom },
-    // data: { linesOfCode, label: `${id} (${linesOfCode})`, code },
-    width: 100,
+    width: DependencyGraphConstants.nodeWidth,
     type: "custom",
-    // height: 50,
     height: height,
     position: { x: 0, y: prevY + 20 },
   };

--- a/frontend/src/components/dependency-graph/dependency-graph.tsx
+++ b/frontend/src/components/dependency-graph/dependency-graph.tsx
@@ -8,7 +8,6 @@ import ReactFlow, {
   useNodesState,
   PanOnScrollMode,
 } from "reactflow";
-import "reactflow/dist/style.css";
 
 import React from "react";
 import {
@@ -21,6 +20,9 @@ import { CellData } from "@/core/model/cells";
 import { Atom } from "jotai";
 import { store } from "@/core/state/jotai";
 import { DependencyGraphConstants } from "./constants";
+
+import "reactflow/dist/style.css";
+import "./dependency-graph.css";
 
 interface Props {
   cellIds: CellId[];
@@ -65,7 +67,6 @@ const DependencyGraphInternal: React.FC<Props> = ({
             (edge.source === id && edge.data.direction === "outputs") ||
             (edge.target === id && edge.data.direction === "inputs")
         );
-        console.log(selectedEdges.length);
         setEdges([]);
         requestAnimationFrame(() => {
           setEdges(selectedEdges);

--- a/frontend/src/components/dependency-graph/dependency-graph.tsx
+++ b/frontend/src/components/dependency-graph/dependency-graph.tsx
@@ -1,0 +1,166 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import ReactFlow, {
+  Node,
+  Edge,
+  MarkerType,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+} from "reactflow";
+import "reactflow/dist/style.css";
+
+import React from "react";
+import {
+  CustomNode,
+  getHeight,
+} from "@/components/dependency-graph/custom-node";
+import { Variables } from "@/core/variables/types";
+import { CellId } from "@/core/model/ids";
+import { CellData } from "@/core/model/cells";
+import { Atom } from "jotai";
+import { store } from "@/core/state/jotai";
+
+interface Props {
+  cellIds: CellId[];
+  variables: Variables;
+  cellAtoms: Array<Atom<CellData>>;
+}
+
+const nodeTypes = {
+  custom: CustomNode,
+};
+
+export const DependencyGraph: React.FC<Props> = (props) => {
+  return (
+    <ReactFlowProvider>
+      <DependencyGraphInternal {...props} />
+    </ReactFlowProvider>
+  );
+};
+
+const DependencyGraphInternal: React.FC<Props> = ({
+  cellIds,
+  variables,
+  cellAtoms,
+}) => {
+  const { nodes: initialNodes, edges: initialEdges } = createElements(
+    cellIds,
+    cellAtoms,
+    variables
+  );
+  const [edges, setEdges] = useEdgesState([]);
+  const [nodes] = useNodesState(initialNodes);
+
+  return (
+    <div className="w-full h-full relative">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        // onScroll={}
+        onNodeClick={(_event, node) => {
+          const id = node.id;
+          const selectedEdges = initialEdges.filter(
+            (edge) =>
+              (edge.source === id && edge.data.direction === "outputs") ||
+              (edge.target === id && edge.data.direction === "inputs")
+          );
+          console.log(selectedEdges.length);
+          setEdges([]);
+          requestAnimationFrame(() => {
+            setEdges(selectedEdges);
+          });
+        }}
+        // On
+        snapToGrid={true}
+        fitView={true}
+        elementsSelectable={true}
+        // Off
+        minZoom={1}
+        maxZoom={1}
+        draggable={false}
+        // zoomOnScroll={false}
+        zoomOnDoubleClick={false}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        nodesFocusable={false}
+        edgesFocusable={false}
+        // edgesUpdatable={false}
+        selectNodesOnDrag={false}
+        panOnDrag={false}
+        preventScrolling={false}
+        zoomOnPinch={false}
+        panOnScroll={true}
+        autoPanOnNodeDrag={false}
+        autoPanOnConnect={false}
+      />
+    </div>
+  );
+};
+
+function createEdge(source: CellId, target: CellId, direction: string): Edge {
+  return {
+    type: "smoothstep",
+    pathOptions: {
+      offset: 20,
+      borderRadius: 100,
+    },
+    data: {
+      direction: direction,
+    },
+    // animated: true,
+    markerEnd: {
+      type: MarkerType.Arrow,
+    },
+    id: `${source}-${target}-${direction}`,
+    source: source,
+    sourceHandle: direction,
+    targetHandle: direction,
+    target: target,
+  };
+}
+
+function createNode(id: string, atom: Atom<CellData>, prevY: number): Node {
+  const linesOfCode = store.get(atom).code.trim().split("\n").length;
+  const height = getHeight(linesOfCode);
+  return {
+    id: id,
+    data: { atom },
+    // data: { linesOfCode, label: `${id} (${linesOfCode})`, code },
+    width: 100,
+    type: "custom",
+    // height: 50,
+    height: height,
+    position: { x: 0, y: prevY + 20 },
+  };
+}
+
+function createElements(
+  cellIds: CellId[],
+  cellAtoms: Array<Atom<CellData>>,
+  variables: Variables
+) {
+  let prevY = 0;
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  let index = 0;
+  for (const cellId of cellIds) {
+    const node = createNode(cellId, cellAtoms[index], prevY);
+    nodes.push(node);
+    prevY = node.position.y + (node.height || 0);
+    index++;
+  }
+
+  for (const variable of Object.values(variables)) {
+    const { declaredBy, usedBy } = variable;
+    for (const fromId of declaredBy) {
+      for (const toId of usedBy) {
+        edges.push(
+          createEdge(fromId, toId, "inputs"),
+          createEdge(fromId, toId, "outputs")
+        );
+      }
+    }
+  }
+  return { nodes, edges };
+}

--- a/frontend/src/core/state/__tests__/cells.test.ts
+++ b/frontend/src/core/state/__tests__/cells.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../cells";
 import { CellId } from "@/core/model/ids";
 
-const { initialCellState, reducer, createActions } = exportedForTesting;
+const { initialNotebookState, reducer, createActions } = exportedForTesting;
 
 function formatCells(notebook: NotebookState) {
   const cells = notebookCells(notebook);
@@ -30,7 +30,7 @@ describe("cell reducer", () => {
   beforeEach(() => {
     CellId.reset();
 
-    state = initialCellState();
+    state = initialNotebookState();
     actions.createNewCell({ cellId: undefined!, before: false });
     firstCellId = state.cellIds[0];
   });

--- a/frontend/src/core/state/cells.ts
+++ b/frontend/src/core/state/cells.ts
@@ -1,5 +1,5 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { atom, useAtomValue, useSetAtom } from "jotai";
+import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { ReducerWithoutAction, createRef, useMemo } from "react";
 import { CellMessage } from "../kernel/messages";
 import {
@@ -26,6 +26,7 @@ import { CellHandle } from "@/editor/Cell";
 import { Logger } from "@/utils/Logger";
 import { Objects } from "@/utils/objects";
 import { EditorView } from "@codemirror/view";
+import { splitAtom, selectAtom } from "jotai/utils";
 
 /**
  * The state of the notebook.
@@ -549,6 +550,13 @@ export const getNotebook = () => store.get(notebookAtom);
  */
 export const getCells = () => store.get(notebookAtom).cellIds;
 
+const cellDataAtoms = splitAtom(
+  selectAtom(notebookAtom, (cells) =>
+    cells.cellIds.map((id) => cells.cellData[id])
+  )
+);
+export const useCellDataAtoms = () => useAtom(cellDataAtoms);
+
 /**
  * Get the editor views for all cells.
  */
@@ -661,5 +669,5 @@ export type CellActions = ReturnType<typeof createActions>;
 export const exportedForTesting = {
   reducer,
   createActions,
-  initialCellState: initialNotebookState,
+  initialCellData: initialNotebookState,
 };

--- a/frontend/src/core/state/cells.ts
+++ b/frontend/src/core/state/cells.ts
@@ -669,5 +669,5 @@ export type CellActions = ReturnType<typeof createActions>;
 export const exportedForTesting = {
   reducer,
   createActions,
-  initialCellData: initialNotebookState,
+  initialNotebookState,
 };

--- a/frontend/src/editor/cell/TinyCode.css
+++ b/frontend/src/editor/cell/TinyCode.css
@@ -1,0 +1,9 @@
+.tiny-code .cm-editor {
+  padding: 0;
+  margin: 0;
+  font-size: 8px;
+}
+
+.tiny-code .cm-editor .cm-scroller {
+  line-height: 11px;
+}

--- a/frontend/src/editor/cell/TinyCode.tsx
+++ b/frontend/src/editor/cell/TinyCode.tsx
@@ -1,29 +1,41 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import React from "react";
+import CodeMirror, { minimalSetup } from "@uiw/react-codemirror";
+import { python } from "@codemirror/lang-python";
+
+import "./TinyCode.css";
+import { useTheme } from "@/theme/useTheme";
 
 interface Props {
   code: string;
 }
 
 export const TinyCode: React.FC<Props> = ({ code }) => {
+  const { theme } = useTheme();
+
   return (
-    <div
-      className="text-muted-foreground flex flex-col overflow-hidden"
-      style={{
-        fontSize: "8px",
-        lineHeight: "10px",
-      }}
-    >
-      {code
-        .trim()
-        .split("\n")
-        .map((line, idx) => {
-          return (
-            <code className="whitespace-pre min-h-[10px]" key={idx}>
-              {line}
-            </code>
-          );
-        })}
+    <div className="text-muted-foreground flex flex-col overflow-hidden">
+      <CodeMirror
+        minHeight="10px"
+        theme={theme === "dark" ? "dark" : "light"}
+        height="100%"
+        className="tiny-code"
+        editable={false}
+        basicSetup={false}
+        extensions={[
+          python(),
+          minimalSetup({
+            syntaxHighlighting: true,
+            // Rest false
+            highlightSpecialChars: false,
+            history: false,
+            drawSelection: false,
+            defaultKeymap: false,
+            historyKeymap: false,
+          }),
+        ]}
+        value={code}
+      />
     </div>
   );
 };

--- a/frontend/src/editor/chrome/panels/dependency-graph-panel.tsx
+++ b/frontend/src/editor/chrome/panels/dependency-graph-panel.tsx
@@ -3,6 +3,8 @@ import { useCellDataAtoms, useCellIds } from "@/core/state/cells";
 import { useVariables } from "@/core/variables/state";
 import React from "react";
 import { DependencyGraph } from "../../../components/dependency-graph/dependency-graph";
+import { cn } from "@/lib/utils";
+import { DependencyGraphConstants } from "@/components/dependency-graph/constants";
 
 export const DependencyGraphPanel: React.FC = () => {
   const variables = useVariables();
@@ -10,7 +12,12 @@ export const DependencyGraphPanel: React.FC = () => {
   const [cells] = useCellDataAtoms();
 
   return (
-    <div className="w-[300px] flex-1 mx-auto">
+    <div
+      className={cn(
+        DependencyGraphConstants.panelClassName,
+        "flex-1 mx-auto -mb-4 relative"
+      )}
+    >
       <DependencyGraph
         cellAtoms={cells}
         variables={variables}

--- a/frontend/src/editor/chrome/panels/dependency-graph-panel.tsx
+++ b/frontend/src/editor/chrome/panels/dependency-graph-panel.tsx
@@ -4,7 +4,6 @@ import { useVariables } from "@/core/variables/state";
 import React from "react";
 import { DependencyGraph } from "../../../components/dependency-graph/dependency-graph";
 import { cn } from "@/lib/utils";
-import { DependencyGraphConstants } from "@/components/dependency-graph/constants";
 
 export const DependencyGraphPanel: React.FC = () => {
   const variables = useVariables();
@@ -12,12 +11,7 @@ export const DependencyGraphPanel: React.FC = () => {
   const [cells] = useCellDataAtoms();
 
   return (
-    <div
-      className={cn(
-        DependencyGraphConstants.panelClassName,
-        "flex-1 mx-auto -mb-4 relative"
-      )}
-    >
+    <div className={cn("w-full h-full flex-1 mx-auto -mb-4 relative")}>
       <DependencyGraph
         cellAtoms={cells}
         variables={variables}

--- a/frontend/src/editor/chrome/panels/dependency-graph-panel.tsx
+++ b/frontend/src/editor/chrome/panels/dependency-graph-panel.tsx
@@ -1,0 +1,21 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { useCellDataAtoms, useCellIds } from "@/core/state/cells";
+import { useVariables } from "@/core/variables/state";
+import React from "react";
+import { DependencyGraph } from "../../../components/dependency-graph/dependency-graph";
+
+export const DependencyGraphPanel: React.FC = () => {
+  const variables = useVariables();
+  const cellIds = useCellIds();
+  const [cells] = useCellDataAtoms();
+
+  return (
+    <div className="w-[300px] flex-1 mx-auto">
+      <DependencyGraph
+        cellAtoms={cells}
+        variables={variables}
+        cellIds={cellIds}
+      />
+    </div>
+  );
+};

--- a/frontend/src/editor/chrome/panels/variable-panel.tsx
+++ b/frontend/src/editor/chrome/panels/variable-panel.tsx
@@ -1,0 +1,14 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { VariableTable } from "@/components/variables/variables-table";
+import { useCellIds } from "@/core/state/cells";
+import { useVariables } from "@/core/variables/state";
+import React from "react";
+
+export const VariablePanel: React.FC = () => {
+  const variables = useVariables();
+  const cellIds = useCellIds();
+
+  return (
+    <VariableTable className="flex-1" cellIds={cellIds} variables={variables} />
+  );
+};

--- a/frontend/src/editor/chrome/types.ts
+++ b/frontend/src/editor/chrome/types.ts
@@ -1,2 +1,2 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-export type PanelType = "errors" | "variables" | "outline";
+export type PanelType = "errors" | "variables" | "outline" | "dependencies";

--- a/frontend/src/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/editor/chrome/wrapper/app-chrome.tsx
@@ -62,7 +62,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
         }
       }}
       className={cn(
-        "border-border no-print",
+        "border-border no-print z-10",
         isOpen ? "resize-handle" : "resize-handle-collapsed",
         panelLocation === "left" ? "vertical" : "horizontal"
       )}

--- a/frontend/src/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/editor/chrome/wrapper/app-chrome.tsx
@@ -11,20 +11,17 @@ import "./app-chrome.css";
 import { useChromeActions, useChromeState } from "../state";
 import { cn } from "@/lib/utils";
 import { createStorage } from "./storage";
-import { VariableTable } from "@/components/variables/variables-table";
-import { useVariables } from "@/core/variables/state";
-import { useCellIds } from "@/core/state/cells";
 import { Button } from "@/components/ui/button";
 import { XIcon } from "lucide-react";
 import { ErrorsPanel } from "../panels/error-panel";
 import { OutlinePanel } from "../panels/outline-panel";
+import { DependencyGraphPanel } from "@/editor/chrome/panels/dependency-graph-panel";
+import { VariablePanel } from "../panels/variable-panel";
 
 export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
   const { isOpen, selectedPanel, panelLocation } = useChromeState();
   const { setIsOpen } = useChromeActions();
   const sidebarRef = React.useRef<ImperativePanelHandle>(null);
-  const variables = useVariables();
-  const cellIds = useCellIds();
 
   // sync sidebar
   useEffect(() => {
@@ -88,13 +85,8 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
         </Button>
       </div>
       {selectedPanel === "errors" && <ErrorsPanel />}
-      {selectedPanel === "variables" && (
-        <VariableTable
-          className="flex-1"
-          cellIds={cellIds}
-          variables={variables}
-        />
-      )}
+      {selectedPanel === "variables" && <VariablePanel />}
+      {selectedPanel === "dependencies" && <DependencyGraphPanel />}
       {selectedPanel === "outline" && <OutlinePanel />}
     </div>
   );

--- a/frontend/src/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/editor/chrome/wrapper/footer.tsx
@@ -6,6 +6,7 @@ import {
   CircleEqualIcon,
   XCircleIcon,
   ScrollTextIcon,
+  NetworkIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useChromeActions, useChromeState } from "../state";
@@ -45,6 +46,13 @@ export const Footer: React.FC = () => {
         onClick={() => openApplication("outline")}
       >
         <ScrollTextIcon className={cn("h-4 w-4")} />
+      </FooterItem>
+      <FooterItem
+        tooltip="Explore dependencies"
+        selected={selectedPanel === "dependencies"}
+        onClick={() => openApplication("dependencies")}
+      >
+        <NetworkIcon className={cn("h-4 w-4")} />
       </FooterItem>
       <div className="mx-auto" />
       <FooterItem

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,5 +1,6 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { useEffect, useState } from "react";
+import { debounce } from "lodash-es";
+import { useEffect, useMemo, useState } from "react";
 import useEvent from "react-use-event-hook";
 
 export function useDebounce<T>(value: T, delay: number): T {
@@ -74,4 +75,14 @@ export function useDebounceControlledState<T>(opts: {
       setInternalValue(value);
     },
   };
+}
+
+export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
+  callback: T,
+  delay: number
+) {
+  const internalCallback = useEvent(callback);
+  return useMemo(() => {
+    return debounce(internalCallback, delay);
+  }, [internalCallback, delay]);
 }


### PR DESCRIPTION
Adds a panel for a vertical dependency tree. the edges are along the side only when a node it clicked. 
This is using the library https://reactflow.dev

Some alternatives:
* add a button for more of a tree view (TB or LR). Could additional focus on an element so there is an inverted-tree above and a tree below
* add more controls for zoom/pan


