### PR TITLE
Fix: Don't Delete Cached Virtual Files

### DIFF
--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -197,12 +197,15 @@ class CleanupHandle(CellLifecycleItem):
         del context
         pass
 
-    def dispose(self, context: RuntimeContext) -> bool:
+    def dispose(self, context: RuntimeContext, deletion: bool) -> bool:
         del context
+        del deletion
         if self.shutdown_event is not None:
             self.shutdown_event.set()
         # TODO: if Html containing server is cached, disposal still trashes
-        # it, which is a bug ...
+        # it, which is a bug ... fix this. Use `deletion` flag to make
+        # sure shutdown happens on cell deletion, otherwise need to
+        # find a way to keep server alive if its Html is cached.
         return True
 
 

--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -197,10 +197,13 @@ class CleanupHandle(CellLifecycleItem):
         del context
         pass
 
-    def dispose(self, context: RuntimeContext) -> None:
+    def dispose(self, context: RuntimeContext) -> bool:
         del context
         if self.shutdown_event is not None:
             self.shutdown_event.set()
+        # TODO: if Html containing server is cached, disposal still trashes
+        # it, which is a bug ...
+        return True
 
 
 @mddoc

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -191,12 +191,13 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
             args,
             slotted_html,
         )
-        self._text = (
+        text = (
             f"<marimo-ui-element object-id='{self._id}' "
             + f"random-id='{self._random_id}'>"
             + self._inner_text
             + "</marimo-ui-element>"
         )
+        super().__init__(text=text)
 
     def _dispose(self) -> None:
         """Handle used by the registry to clean-up this element on removal."""
@@ -212,6 +213,8 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
             ctx.ui_element_registry.delete(self._id, id(self))
         except ContextNotInitializedError:
             pass
+
+        super().__del__()
 
     @abc.abstractmethod
     def _convert_value(self, value: S) -> T:

--- a/marimo/_runtime/cell_lifecycle_item.py
+++ b/marimo/_runtime/cell_lifecycle_item.py
@@ -11,8 +11,27 @@ if TYPE_CHECKING:
 class CellLifecycleItem(abc.ABC):
     @abc.abstractmethod
     def create(self, context: "RuntimeContext") -> None:
+        """Create this item
+
+        This method is executed at the beginning of a cell's lifecycle.
+        Use it to run side-effects or create state.
+        """
         ...
 
     @abc.abstractmethod
-    def dispose(self, context: "RuntimeContext") -> bool:
+    def dispose(self, context: "RuntimeContext", deletion: bool) -> bool:
+        """Dispose this item
+
+        This method is executed at the end of a cell's lifecycle. Use
+        it to clean-up side-effects or state associated with the lifecycle
+        item.
+
+        The `deletion` flag indicates whether the cell is being removed
+        from the graph, which may influence disposal strategy.
+
+        Return True if the disposal is successful and the lifecycle item
+        should be removed from the registry. Return False if the disposal
+        needs to be retried in the next cell lifecycle (note that `create`
+        will not be re-run, only `dispose`).
+        """
         ...

--- a/marimo/_runtime/cell_lifecycle_item.py
+++ b/marimo/_runtime/cell_lifecycle_item.py
@@ -14,5 +14,5 @@ class CellLifecycleItem(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def dispose(self, context: "RuntimeContext") -> None:
+    def dispose(self, context: "RuntimeContext") -> bool:
         ...

--- a/marimo/_runtime/cell_lifecycle_registry.py
+++ b/marimo/_runtime/cell_lifecycle_registry.py
@@ -39,7 +39,9 @@ class CellLifecycleRegistry:
         from marimo._runtime.context import get_context
 
         ctx = get_context()
+        persisted_lifecycle_items = set()
         if cell_id in self.registry:
             for lifecycle_item in self.registry[cell_id]:
-                lifecycle_item.dispose(context=ctx)
-            del self.registry[cell_id]
+                if not lifecycle_item.dispose(context=ctx):
+                    persisted_lifecycle_items.add(lifecycle_item)
+        self.registry[cell_id] = persisted_lifecycle_items

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -291,7 +291,10 @@ class Kernel:
                 del self.globals["__annotations__"][name]
 
     def _invalidate_cell_state(
-        self, cell_id: CellId_t, exclude_defs: Optional[set[str]] = None
+        self,
+        cell_id: CellId_t,
+        exclude_defs: Optional[set[str]] = None,
+        deletion: bool = False,
     ) -> None:
         """Cleanup state associated with this cell.
 
@@ -303,7 +306,9 @@ class Kernel:
         self._delete_names(
             defs_to_delete, exclude_defs if exclude_defs is not None else set()
         )
-        get_context().cell_lifecycle_registry.dispose(cell_id)
+        get_context().cell_lifecycle_registry.dispose(
+            cell_id, deletion=deletion
+        )
         RemoveUIElements(cell_id=cell_id).broadcast()
 
     def _deactivate_cell(self, cell_id: CellId_t) -> set[CellId_t]:
@@ -315,7 +320,7 @@ class Kernel:
         from the kernel and graph.
         """
         if cell_id not in self.errors:
-            self._invalidate_cell_state(cell_id)
+            self._invalidate_cell_state(cell_id, deletion=True)
             return self.graph.delete_cell(cell_id)
         else:
             # An errored cell can be thought of as a cell that's in the graph

--- a/marimo/_runtime/test_virtual_file.py
+++ b/marimo/_runtime/test_virtual_file.py
@@ -44,3 +44,195 @@ def test_virtual_file_deletion(k: Kernel, exec_req: ExecReqProvider) -> None:
 
     k.delete(DeleteRequest(er.cell_id))
     assert not get_context().virtual_file_registry.registry
+
+
+def test_cached_virtual_file_not_deleted(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    k.run(
+        [
+            exec_req.get(
+                """
+                import io
+                import marimo as mo
+                import functools
+                """
+            ),
+            vfile_cache := exec_req.get(
+                """
+                @functools.lru_cache()
+                def create_vfile(arg):
+                    del arg
+                    bytestream = io.BytesIO(b"hello world")
+                    return mo.pdf(bytestream)
+                """
+            ),
+            create_vfile_1 := exec_req.get("create_vfile(1)"),
+        ]
+    )
+    assert len(get_context().virtual_file_registry.registry) == 1
+
+    # Rerun the cell that created the vfile: make sure that the vfile
+    # still exists
+    k.run([create_vfile_1])
+    assert len(get_context().virtual_file_registry.registry) == 1
+
+    # Create a new vfile, make sure we have two now
+    k.run([create_vfile_2 := exec_req.get("create_vfile(2)")])
+    assert len(get_context().virtual_file_registry.registry) == 2
+
+    # Remove the cells that create the vfiles
+    k.delete(DeleteRequest(create_vfile_1.cell_id))
+    k.delete(DeleteRequest(create_vfile_2.cell_id))
+
+    # Reset the vfile cache
+    k.run([vfile_cache])
+
+
+def test_cell_deletion_clears_vfiles(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    k.run(
+        [
+            exec_req.get(
+                """
+                import io
+                import marimo as mo
+                import functools
+                """
+            ),
+            vfile_cache := exec_req.get(
+                """
+                @functools.lru_cache()
+                def create_vfile(arg):
+                    del arg
+                    bytestream = io.BytesIO(b"hello world")
+                    return mo.pdf(bytestream)
+                """
+            ),
+            exec_req.get("create_vfile(1)"),
+        ]
+    )
+    assert len(get_context().virtual_file_registry.registry) == 1
+
+    # Delete the vfile cache: virtual file registry should be empty
+    k.delete(DeleteRequest(vfile_cache.cell_id))
+    assert len(get_context().virtual_file_registry.registry) == 0
+
+
+def test_vfile_refcount_incremented(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    k.run(
+        [
+            exec_req.get(
+                """
+                import io
+                import marimo as mo
+                import functools
+                """
+            ),
+            exec_req.get(
+                """
+                @functools.lru_cache()
+                def create_vfile(arg):
+                    del arg
+                    bytestream = io.BytesIO(b"hello world")
+                    return mo.pdf(bytestream)
+                """
+            ),
+            exec_req.get("md = mo.md(f'{create_vfile(1)}')"),
+        ]
+    )
+    assert len(get_context().virtual_file_registry.registry) == 1
+    vfile = list(get_context().virtual_file_registry.filenames())[0]
+
+    #   1 reference for the cached `mo.pdf`
+    # + 1 reference for the markdown
+    # ---
+    #   2 references
+    assert get_context().virtual_file_registry.refcount(vfile) == 2
+
+
+def test_vfile_refcount_decremented(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    k.run(
+        [
+            exec_req.get(
+                """
+                import io
+                import marimo as mo
+                import gc
+                """
+            ),
+            # no caching in this test
+            exec_req.get(
+                """
+                def create_vfile(arg):
+                    del arg
+                    bytestream = io.BytesIO(b"hello world")
+                    return mo.pdf(bytestream)
+                """
+            ),
+            make_vfile := exec_req.get("mo.md(f'{create_vfile(1)}')"),
+        ]
+    )
+    ctx = get_context()
+    assert len(ctx.virtual_file_registry.registry) == 1
+    vfile = list(ctx.virtual_file_registry.filenames())[0]
+
+    # 0 references because HTML not bound to a variable
+    # NB: this test may be flaky! refcount decremented when `__del__` is called
+    # but we can't rely on when it will be called.
+    k.run([exec_req.get("gc.collect()")])
+    assert ctx.virtual_file_registry.refcount(vfile) == 0
+
+    # this should dispose the old vfile (because its refcount is 0) and create
+    # a new one
+    k.run([make_vfile])
+    # the previous vfile should not be in the registry
+    assert vfile not in ctx.virtual_file_registry.registry
+    assert len(ctx.virtual_file_registry.registry) == 1
+
+
+def test_cached_vfile_disposal(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            exec_req.get(
+                """
+                import io
+                import marimo as mo
+                import functools
+                """
+            ),
+            exec_req.get(
+                """
+                vfiles = []
+                def create_vfile(arg):
+                    del arg
+                    bytestream = io.BytesIO(b"hello world")
+                    return mo.pdf(bytestream)
+                """
+            ),
+            append_vfile := exec_req.get("vfiles.append(create_vfile(1))"),
+        ]
+    )
+    ctx = get_context()
+    assert len(ctx.virtual_file_registry.registry) == 1
+    vfile = list(ctx.virtual_file_registry.filenames())[0]
+
+    # 1 reference, in the list
+    assert ctx.virtual_file_registry.refcount(vfile) == 1
+
+    # clear the list, refcount should be decremented
+    k.run([exec_req.get("vfiles[:] = []")])
+    # NB: this test may be flaky! refcount decremented when `__del__` is called
+    # but we can't rely on when it will be called.
+    k.run([exec_req.get("gc.collect()")])
+    assert ctx.virtual_file_registry.refcount(vfile) == 0
+
+    # create another vfile. the old one should be deleted
+    k.run([append_vfile])
+    assert len(ctx.virtual_file_registry.registry) == 1
+    assert vfile not in ctx.virtual_file_registry.filenames()

--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -148,7 +148,6 @@ class VirtualFileRegistry:
         """Increment the reference count"""
         if filename in self.registry:
             self.registry[filename].refcount += 1
-            print(filename + ": " + str(self.registry[filename].refcount))
 
     def dereference(self, filename: str) -> None:
         """Decrement the reference count"""

--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -91,16 +91,18 @@ class VirtualFileLifecycleItem(CellLifecycleItem):
         self._virtual_file = VirtualFile(filename, self.buffer)
         context.virtual_file_registry.add(self._virtual_file)
 
-    def dispose(self, context: "RuntimeContext") -> bool:
-        # TODO: when cell is getting deleted, should force removal, even
-        # if refcount is > 0
-        if (
+    def dispose(self, context: "RuntimeContext", deletion: bool) -> bool:
+        # Remove the file if the refcount is 0, or if the cell is being
+        # deleted. (We can't rely on when the refcount will be
+        # decremented, so we need to check for deletion explictly to prevent
+        # leaks.)
+        if deletion or (
             context.virtual_file_registry.refcount(self.virtual_file.filename)
             <= 0
         ):
             context.virtual_file_registry.remove(self.virtual_file)
             return True
-        # Refcount > 0, so need to keep this disposal hook around
+        # refcount > 0, so need to keep this disposal hook around
         return False
 
 


### PR DESCRIPTION
This PR includes an important fix to the management of virtual file lifecycles.

Previously, all of a cell's virtual files were deleted at the end of its lifecycle. This broke cached HTML that referenced those virtual files (e.g., with a `@functools.cache` decorator).

This change adds reference counting to virtual files, to prevent them from being deleted when objects exist referencing them. We assume that only HTML objects will reference virtual files, and we implement the ref-counting by string matching on HTML text: on object creation, we search the text to find its virtual files and increment their refcounts, on deletion we decrement these refcounts. String matching was the simplest solution we could find that is compatible with using f-string interpolation of HTML text into other HTML text, which is common in marimo (e.g., f-strings with `mo.md`).

This change also gives `CellLifecycleItems` the option to persist into the next lifecycle. This is needed for virtual files, since when theirt refcount is greater than 0 we can't delete them, but instead must try to delete them in the next lifecycle.