### PR TITLE
fix: grid improvements

### DIFF
--- a/frontend/src/components/editor/cell/TinyCode.tsx
+++ b/frontend/src/components/editor/cell/TinyCode.tsx
@@ -5,16 +5,23 @@ import { python } from "@codemirror/lang-python";
 
 import "./TinyCode.css";
 import { useTheme } from "@/theme/useTheme";
+import { cn } from "@/utils/cn";
 
 interface Props {
   code: string;
+  className?: string;
 }
 
-export const TinyCode: React.FC<Props> = memo(({ code }) => {
+export const TinyCode: React.FC<Props> = memo(({ code, className }) => {
   const { theme } = useTheme();
 
   return (
-    <div className="text-muted-foreground flex flex-col overflow-hidden">
+    <div
+      className={cn(
+        className,
+        "text-muted-foreground flex flex-col overflow-hidden"
+      )}
+    >
       <CodeMirror
         minHeight="10px"
         theme={theme === "dark" ? "dark" : "light"}

--- a/frontend/src/components/editor/renderers/grid-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/plugin.tsx
@@ -1,0 +1,135 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { ICellRendererPlugin } from "../types";
+import {
+  GridLayout,
+  GridLayoutCellSide,
+  SerializedGridLayout,
+  SerializedGridLayoutCell,
+} from "./types";
+import { Logger } from "@/utils/Logger";
+import { z } from "zod";
+import { Maps } from "@/utils/maps";
+import { GridLayoutRenderer } from "./grid-layout";
+import { CellId } from "@/core/cells/ids";
+
+/**
+ * Plugin definition for the grid layout.
+ */
+
+export const GridLayoutPlugin: ICellRendererPlugin<
+  SerializedGridLayout,
+  GridLayout
+> = {
+  type: "grid",
+  name: "Grid",
+
+  validator: z.object({
+    columns: z.number().min(1),
+    rowHeight: z.number().min(1),
+    maxWidth: z.number().optional(),
+    cells: z.array(
+      z.object({
+        position: z
+          .tuple([z.number(), z.number(), z.number(), z.number()])
+          .nullable(),
+        scrollable: z.boolean().optional(),
+        alignment: z.enum(["top", "bottom", "left", "right"]).optional(),
+      })
+    ),
+  }),
+
+  deserializeLayout: (serialized, cells): GridLayout => {
+    if (serialized.cells.length === 0) {
+      return {
+        columns: serialized.columns,
+        rowHeight: serialized.rowHeight,
+        scrollableCells: new Set(),
+        cellSide: new Map(),
+        cells: [],
+      };
+    }
+
+    if (serialized.cells.length !== cells.length) {
+      Logger.warn(
+        "Number of cells in layout does not match number of cells in notebook"
+      );
+    }
+
+    const scrollableCells = new Set<CellId>();
+    const cellSide = new Map<CellId, GridLayoutCellSide>();
+
+    const cellLayouts = serialized.cells.flatMap((cellLayout, idx) => {
+      const position = cellLayout.position;
+      if (!position) {
+        return [];
+      }
+      const cell = cells[idx];
+      if (!cell) {
+        return [];
+      }
+      if (cellLayout.scrollable) {
+        scrollableCells.add(cell.id);
+      }
+      if (cellLayout.side) {
+        cellSide.set(cell.id, cellLayout.side);
+      }
+
+      return {
+        i: cell.id,
+        x: position[0],
+        y: position[1],
+        w: position[2],
+        h: position[3],
+      };
+    });
+
+    return {
+      columns: serialized.columns,
+      rowHeight: serialized.rowHeight,
+      maxWidth: serialized.maxWidth,
+      cells: cellLayouts,
+      cellSide: cellSide,
+      scrollableCells: scrollableCells,
+    };
+  },
+
+  serializeLayout: (layout, cells): SerializedGridLayout => {
+    const layoutsByKey = Maps.keyBy(layout.cells, (cell) => cell.i);
+    const serializedCells: SerializedGridLayoutCell[] = cells.map((cell) => {
+      const cellLayout = layoutsByKey.get(cell.id);
+      if (!cellLayout) {
+        return {
+          position: null,
+        };
+      }
+      const out: SerializedGridLayoutCell = {
+        position: [cellLayout.x, cellLayout.y, cellLayout.w, cellLayout.h],
+      };
+      if (layout.scrollableCells.has(cell.id)) {
+        out.scrollable = true;
+      }
+      if (layout.cellSide.has(cell.id)) {
+        out.side = layout.cellSide.get(cell.id);
+      }
+      return out;
+    });
+
+    return {
+      columns: layout.columns,
+      rowHeight: layout.rowHeight,
+      maxWidth: layout.maxWidth,
+      cells: serializedCells,
+    };
+  },
+
+  Component: GridLayoutRenderer,
+
+  getInitialLayout: () => ({
+    columns: 24,
+    rowHeight: 20,
+    maxWidth: 1400,
+    scrollableCells: new Set(),
+    cellSide: new Map(),
+    cells: [],
+  }),
+};

--- a/frontend/src/components/editor/renderers/grid-layout/types.ts
+++ b/frontend/src/components/editor/renderers/grid-layout/types.ts
@@ -1,5 +1,7 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 
+import { CellId } from "@/core/cells/ids";
+
 /**
  * The serialized form of a grid layout.
  * This must be backwards-compatible as it is stored on the user's disk.
@@ -23,6 +25,11 @@ export interface SerializedGridLayout {
   rowHeight: number;
 
   /**
+   * The max-width of the grid layout.
+   */
+  maxWidth?: number;
+
+  /**
    * The cells in the layout.
    * Cells don't have IDs at rest but are indexed based.
    *
@@ -38,7 +45,19 @@ export interface SerializedGridLayoutCell {
    * If null, the cell is not in the layout.
    */
   position: SerializedGridLayoutCellPosition | null;
+
+  /**
+   * True if the cell is scrollable.
+   */
+  scrollable?: boolean;
+
+  /**
+   * The cell's alignment.
+   */
+  side?: GridLayoutCellSide;
 }
+
+export type GridLayoutCellSide = "top" | "left" | "right" | "bottom";
 
 export interface GridLayout extends Omit<SerializedGridLayout, "cells"> {
   /**
@@ -51,6 +70,10 @@ export interface GridLayout extends Omit<SerializedGridLayout, "cells"> {
     w: number;
     h: number;
   }>;
+
+  scrollableCells: Set<CellId>;
+
+  cellSide: Map<CellId, GridLayoutCellSide>;
 }
 
 export type SerializedGridLayoutCellPosition = [

--- a/frontend/src/components/editor/renderers/plugins.ts
+++ b/frontend/src/components/editor/renderers/plugins.ts
@@ -1,5 +1,5 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { GridLayoutPlugin } from "./grid-layout/grid-layout";
+import { GridLayoutPlugin } from "./grid-layout/plugin";
 import { ICellRendererPlugin, LayoutType } from "./types";
 import { CellData } from "@/core/cells/types";
 


### PR DESCRIPTION
few changes to make grids more usable, will list them out once done:
* move drag handle outside of the content to avoid clicks and drags
* add scroll config to each panel
* add `side`: "left", "right" to each output. can later add top/bottom and start/end
* add max-width
* make it easier to drag items down

- [x] ~move sidebar to somewhere else~ maybe will in a followup instead. but for-now added a max-width options
- [x] make expanding below easier