### PR TITLE
Fix broken docs CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ dev = [
     # For testing mo.ui.chart
     "pandas>=1.3.0",
     "pandas-stubs>=1.3.0",
-    "polars>=0.19.12",
+    # polars 0.19.13 requires building maturn from source, but we don't
+    # have the rust toolchain installed on CI
+    "polars==0.19.12",
     "pytest~=7.4.0",
     "mypy~=1.4.1",
     "ruff~=0.0.275",


### PR DESCRIPTION
Polars `0.19.13` requires maturin to be built from source, which breaks our CI (https://github.com/pola-rs/polars/pull/12370)