### PR TITLE
Fix: truncate dataframes rows, columns in output

### DIFF
--- a/marimo/_output/formatters/pandas_formatters.py
+++ b/marimo/_output/formatters/pandas_formatters.py
@@ -15,20 +15,28 @@ class PandasFormatter(FormatterFactory):
     def register(self) -> None:
         import pandas as pd
 
+        pd.set_option("display.max_rows", 10)
+        pd.set_option("display.max_columns", 20)
+
         from marimo._output import formatting
 
         @formatting.formatter(pd.DataFrame)
         def _show_dataframe(df: pd.DataFrame) -> tuple[str, str]:
+            max_rows = pd.get_option("display.max_rows")
+            max_columns = pd.get_option("display.max_columns")
             # Flatten the HTML to avoid indentation issues when
             # interpolating into other HTML/Markdown with an f-string
             return (
                 "text/html",
-                flatten_string(df.to_html()),
+                flatten_string(
+                    df.to_html(max_rows=max_rows, max_cols=max_columns)
+                ),
             )
 
         @formatting.formatter(pd.Series)
         def _show_series(series: pd.Series[Any]) -> tuple[str, str]:
+            max_rows = pd.get_option("display.max_rows")
             return (
                 "text/html",
-                flatten_string(series.to_frame().to_html()),
+                flatten_string(series.to_frame().to_html(max_rows=max_rows)),
             )


### PR DESCRIPTION
Previously the formatter showed the entire dataframe, which can make the frontend slow and unresponsive. This change sets pandas options for `display.max_rows` and `display.max_columns` to 10 and 20.

Users can override these options using `pd.set_option` or the pandas option context manager. Or they can output the HTML themselves: `mo.Html(df.to_html())`.

![image](https://github.com/marimo-team/marimo/assets/1994308/c04336b6-5fb8-4463-b578-1b070e6e34d1)

Fixes #339 