### PR TITLE
Update tooltip position to absolute

### DIFF
--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -128,8 +128,8 @@ export const basicBundle = (
     lineNumbers(),
     rectangularSelection(),
     tooltips({
-      position: "fixed",
-      parent: document.getElementById("App") ?? undefined,
+      // Having absolute position makes it possible to select text in the tooltip
+      position: "absolute",
     }),
     scrollActiveLineIntoView(),
     theme === "dark" ? oneDark : [],


### PR DESCRIPTION
currently there is a tradeoff, and I spent some time trying for no tradeoff, but was unable to find a solution.

when `position: absolute` is enabled, we can select text within the tooltip without losing focus of the editor.
when `position: fixed` is enabled, the autocomplete and hover tooltip take up a bit more space up to the edges thus utilizing more space.