### PR TITLE
fix: flush empty outputs

### DIFF
--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -81,10 +81,10 @@ def flush() -> None:
         return
 
     if ctx.kernel.execution_context.output is not None:
-        write_internal(
-            cell_id=ctx.kernel.execution_context.cell_id,
-            value=vstack(ctx.kernel.execution_context.output),
-        )
+        value = vstack(ctx.kernel.execution_context.output)
+    else:
+        value = None
+    write_internal(cell_id=ctx.kernel.execution_context.cell_id, value=value)
 
 
 def remove(value: object) -> None:

--- a/marimo/_runtime/output/test_output.py
+++ b/marimo/_runtime/output/test_output.py
@@ -1,0 +1,37 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._runtime.conftest import ExecReqProvider, MockedKernel
+
+
+def test_spinner_removed(
+    mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+) -> None:
+    mocked_kernel.k.run(
+        [
+            exec_req.get(
+                """
+                import marimo as mo
+
+                with mo.status.spinner():
+                    ...
+                123
+                """
+            )
+        ]
+    )
+    found_progress = False
+    for i, msg in enumerate(mocked_kernel.stream.messages):
+        if (
+            msg[0] == "cell-op"
+            and msg[1]["output"] is not None
+            and "marimo-progress" in msg[1]["output"]["data"]
+        ):
+            # the spinner should be cleared immediately after the context
+            # manager exits
+            found_progress = True
+            # kernel uses text/plain + empty string to denote empty output
+            assert (
+                mocked_kernel.stream.messages[i + 1][1]["output"]["data"] == ""
+            )
+    assert found_progress


### PR DESCRIPTION
This change fixes a bug that prevented `mo.spinner()` from being cleared on context manager exit (previously it was only cleared at the end of cell execution, by the cell's last expression -- but when running in a callback there is no "last expression").