### PR TITLE
fix: star is not a name

### DIFF
--- a/marimo/_ast/test_visitor.py
+++ b/marimo/_ast/test_visitor.py
@@ -547,3 +547,12 @@ def test_from_import() -> None:
     v.visit(mod)
     assert v.defs == set(["d"])
     assert v.refs == set()
+
+
+def test_from_import_star() -> None:
+    expr = "from a.b.c import *"
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(expr)
+    v.visit(mod)
+    assert v.defs == set()
+    assert v.refs == set()

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -294,10 +294,16 @@ class ScopedVisitor(ast.NodeVisitor):
     # Import and ImportFrom statements have symbol names in alias nodes
     def visit_alias(self, node: ast.alias) -> None:
         if node.asname is None:
-            # (1) Don't mangle - user has no control over package name
-            # (2) for "a.b.c", register "a" as the def
+            # imported name, no "as" clause; examples:
+            #   import [a.b.c] - we define a
+            #   from foo import [a] - we define a
+            #   from foo import [*] - we don't define anything
+            #
+            # Note:
+            # Don't mangle - user has no control over package name
             basename = node.name.split(".")[0]
-            self._define(basename)
+            if basename != "*":
+                self._define(basename)
         else:
             node.asname = self._if_local_then_mangle(node.asname)
             self._define(node.asname)


### PR DESCRIPTION
`from foo import *` should not register `*` as a definition