### PR TITLE
fix: tooltip should not obscure code

### DIFF
--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -75,6 +75,7 @@ export function hintTooltip() {
       blur: (event, view) => {
         // Only close tooltip, not view; blur for completion handled by
         // cell editor, so that completion text is selectable
+        // TODO: make text in cursor tooltips selectable
         clearTooltips(view);
       },
     }),

--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -42,7 +42,7 @@
 #App .cm-tooltip.mo-cm-tooltip,
 #App .cm-tooltip.cm-completionInfo {
   max-height: 45vh; /* 45% of viewport height */
-  max-width: 40vw; /* 40% of viewport width */
+  max-width: 80vw; /* 80% of viewport width */
   overflow: auto;
 
   /* Respect newlines. */
@@ -55,7 +55,7 @@
 }
 
 #App .cm-tooltip .external-docs {
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
 }
 
 /* Hover tooltips get highest priority in display. */
@@ -97,23 +97,43 @@
 
 .mo-cm-tooltip pre {
   margin: 0;
-  white-space: pre-wrap;
+
+  /* We previously used pre-wrap, but this caused tooltips at the end
+   * (right) of a cell to obscure code. */
+  white-space: pre;
 }
 
 /* -- Completion Info -- */
 
+/* Compeltion Symbol */
+#App .cm-tooltip-autocomplete {
+  /* CodeMirror's default is too wide. */
+  max-width: 200px;
+}
+
 #App .cm-tooltip-autocomplete ul li[aria-selected] {
   background: #1177ccb0;
+  max-width: 200px;
 }
 
 .dark #App .cm-tooltip-autocomplete ul li[aria-selected] {
   background: #1177cc80;
+  max-width: 200px;
 }
 
 #App .cm-tooltip.cm-completionInfo {
   /* Codemirror generates an inline style for these properties,
    * so we have to override them with !important. */
   top: 0 !important;
+
+  /* CodeMirror's default of 400px is often too small. */
+  max-width: 36rem !important;
+}
+
+#App .cm-completionInfo.cm-completionInfo-right-narrow {
+  /* CodeMirror's default makes the completionInfo overlap with the
+   * compeltion symbol */
+  left: 100%;
 }
 
 /* Completion Info may show up to the left or right of another menu item.


### PR DESCRIPTION
- white-space: pre-wrap on pre elements was obscuring code at the end (right) of a cell; change to white-space: pre instead.
- pre over pre-wrap means that user may sometimes need to scroll horizontally to see complete docstring text; this is an acceptable tradeoff compared to obscuring the code the user was trying to type

also tweaks some settings to make more of docstrings visible, without compromising legibility too much