### PR TITLE
fix: elminate bouncing of tooltip

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -17,7 +17,7 @@ import {
 
 import { sendRun } from "@/core/network/requests";
 import { autocompletionKeymap, setupCodeMirror } from "@/core/codemirror/cm";
-
+import { clearTooltips } from "@/core/codemirror/completion/hints";
 import { UserConfig } from "../../core/config/config-schema";
 import { CellData, CellRuntimeState } from "../../core/cells/types";
 import { CellActions, useCellActions } from "../../core/cells/cells";
@@ -357,6 +357,7 @@ const CellComponent = (
       editorView.current !== null
     ) {
       closeCompletion(editorView.current);
+      clearTooltips(editorView.current);
     }
   }, []);
 

--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -128,8 +128,9 @@ export const basicBundle = (
     lineNumbers(),
     rectangularSelection(),
     tooltips({
-      // Having absolute position makes it possible to select text in the tooltip
-      position: "absolute",
+      // Having fixed position prevents tooltips from being repositioned
+      // and bouncing distractingly
+      position: "fixed",
     }),
     scrollActiveLineIntoView(),
     theme === "dark" ? oneDark : [],

--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -70,15 +70,8 @@ export function hintTooltip() {
         },
       ])
     ),
-    // Clear tooltips on blur
-    EditorView.domEventObservers({
-      blur: (event, view) => {
-        // Only close tooltip, not view; blur for completion handled by
-        // cell editor, so that completion text is selectable
-        // TODO: make text in cursor tooltips selectable
-        clearTooltips(view);
-      },
-    }),
+    // Removing tooltips (and completion) on blur is handled by cell editor, so
+    // that text is selectable
   ];
 }
 

--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -42,7 +42,7 @@
 #App .cm-tooltip.mo-cm-tooltip,
 #App .cm-tooltip.cm-completionInfo {
   max-height: 45vh; /* 45% of viewport height */
-  max-width: 80vw; /* 80% of viewport width */
+  max-width: 40vw; /* 40% of viewport width */
   overflow: auto;
 
   /* Respect newlines. */


### PR DESCRIPTION
Prior to this fix, cursor tooltips would bounce distractingly when typing near the end of a cell, as codemirror would think the tooltip exceeded its space and therefore repositioned it.

This change eliminates that bounce by switching back to fixed positioning for tooltips.

This change does NOT regress selectable completion text.
- Previously, we had switched from fixed to absolute to allow text to be selected, but this came with downsides (including tooltip bounce).
- To ensure text is selectable, we make the Cell responsible for closing completions/tooltips on blur. (The cell was already responsible for closing completions, for this very reason.)
- As a bonus, cursor tooltips are now selectable, whereas they previously weren't.