### PR TITLE
marimo convert: from github url

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -382,6 +382,9 @@ def tutorial(
 def convert(ipynb: str) -> None:
     """Convert a Jupyter notebook to a marimo notebook.
 
+    The argument may be either a path to a local .ipynb file,
+    or an .ipynb file hosted on Github.
+
     Example usage:
 
         marimo convert your_nb.ipynb > your_app.py

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -383,7 +383,7 @@ def convert(ipynb: str) -> None:
     """Convert a Jupyter notebook to a marimo notebook.
 
     The argument may be either a path to a local .ipynb file,
-    or an .ipynb file hosted on Github.
+    or an .ipynb file hosted on GitHub.
 
     Example usage:
 

--- a/marimo/_cli/ipynb_to_marimo.py
+++ b/marimo/_cli/ipynb_to_marimo.py
@@ -2,14 +2,23 @@
 from __future__ import annotations
 
 import json
+import urllib.request
 
 from marimo._ast import codegen
 from marimo._ast.cell import CellConfig
+from marimo._cli.file_path import get_github_src_url, is_github_src
 
 
 def convert(ipynb_path: str) -> str:
-    with open(ipynb_path, "r") as f:
-        notebook = json.loads(f.read())
+    if is_github_src(ipynb_path, ext=".ipynb"):
+        notebook = json.loads(
+            urllib.request.urlopen(get_github_src_url(ipynb_path))
+            .read()
+            .decode("utf-8")
+        )
+    else:
+        with open(ipynb_path, "r") as f:
+            notebook = json.loads(f.read())
     sources = []
     has_markdown = False
     for cell in notebook["cells"]:

--- a/marimo/_cli/test_file_path.py
+++ b/marimo/_cli/test_file_path.py
@@ -12,7 +12,7 @@ from marimo._cli.file_path import (
     _find_python_code_in_github_issue,
     _handle_github_issue,
     _is_github_issue_url,
-    _is_github_py,
+    is_github_src,
     validate_name,
 )
 
@@ -57,12 +57,12 @@ def test_is_github_issue_url_with_valid_url() -> None:
     assert _is_github_issue_url(invalid_url) is False
 
 
-def test_is_github_py_with_valid_url() -> None:
+def test_is_github_src_with_valid_url() -> None:
     valid_url = "https://github.com/marimo-team/marimo/blob/main/example.py"
-    assert _is_github_py(valid_url) is True
+    assert is_github_src(valid_url, ext=".py") is True
 
     invalid_url = "https://github.com/marimo-team/marimo/blob/main/example.txt"
-    assert _is_github_py(invalid_url) is False
+    assert is_github_src(invalid_url, ext=".py") is False
 
 
 @patch("urllib.request.urlopen")


### PR DESCRIPTION
This change updates `marimo convert` to handle github URLs.

Example:

`marimo convert https://github.com/cvxgrp/pymde/blob/main/examples/drawing_graphs.ipynb`