### PR TITLE
fix: disallow `import *` in marimo notebooks

### DIFF
--- a/marimo/_ast/test_visitor.py
+++ b/marimo/_ast/test_visitor.py
@@ -553,6 +553,8 @@ def test_from_import_star() -> None:
     expr = "from a.b.c import *"
     v = visitor.ScopedVisitor()
     mod = ast.parse(expr)
-    v.visit(mod)
+    with pytest.raises(SyntaxError) as e:
+        v.visit(mod)
+    assert "`import *` is not allowed in marimo." in str(e)
     assert v.defs == set()
     assert v.refs == set()

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -308,9 +308,13 @@ class ScopedVisitor(ast.NodeVisitor):
             # Don't mangle - user has no control over package name
             basename = node.name.split(".")[0]
             if basename == "*":
-                raise SyntaxError(
+                line = (
                     f"line {node.lineno}"
-                    " SyntaxError: `import *` is not allowed in marimo."
+                    if hasattr(node, "lineno")
+                    else "line ..."
+                )
+                raise SyntaxError(
+                    f"{line} SyntaxError: `import *` is not allowed in marimo."
                 )
             self._define(basename)
         else:

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -293,6 +293,11 @@ class ScopedVisitor(ast.NodeVisitor):
     # that needs to be tracked?
     # Import and ImportFrom statements have symbol names in alias nodes
     def visit_alias(self, node: ast.alias) -> None:
+        """Visiting names in import statements
+
+        NB: We disallow `import *` because Python only allows
+        star imports at module-level, but we store cells as functions.
+        """
         if node.asname is None:
             # imported name, no "as" clause; examples:
             #   import [a.b.c] - we define a
@@ -302,8 +307,12 @@ class ScopedVisitor(ast.NodeVisitor):
             # Note:
             # Don't mangle - user has no control over package name
             basename = node.name.split(".")[0]
-            if basename != "*":
-                self._define(basename)
+            if basename == "*":
+                raise SyntaxError(
+                    f"line {node.lineno}"
+                    " SyntaxError: `import *` is not allowed in marimo."
+                )
+            self._define(basename)
         else:
             node.asname = self._if_local_then_mangle(node.asname)
             self._define(node.asname)


### PR DESCRIPTION
Python disallows `import *` everywhere except at the module-level. We store marimo code in functions, so we can't support `import *`. Star imports are also not great because they introduce globals that marimo can't easily track

This fixes a bug in which a user could create a notebook with a `star` import but then couldn't re-open it due to the syntax error.