### PR TITLE
fix: Python 3.12 type parameter syntax

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,16 +53,24 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest
             python-version: "3.8"
           - os: macos-latest
             python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.12"
           - os: windows-latest
             python-version: "3.8"
           - os: windows-latest
             python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -5,7 +5,7 @@ import builtins
 import importlib.util
 import json
 from collections.abc import Sequence
-from typing import Any, Optional, Union, cast
+from typing import Any, List, Optional, Union, cast
 
 from marimo import __version__
 from marimo._ast.app import App, _AppConfig
@@ -227,7 +227,7 @@ def recover(filename: str) -> str:
         )
     )
     return generate_filecontents(
-        cast(list[str], codes),
-        cast(list[str], names),
-        cast(list[CellConfig], configs),
+        cast(List[str], codes),
+        cast(List[str], names),
+        cast(List[CellConfig], configs),
     )

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -5,7 +5,7 @@ import builtins
 import importlib.util
 import json
 from collections.abc import Sequence
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 from marimo import __version__
 from marimo._ast.app import App, _AppConfig
@@ -226,4 +226,8 @@ def recover(filename: str) -> str:
             ]
         )
     )
-    return generate_filecontents(codes, names, configs)
+    return generate_filecontents(
+        cast(list[str], codes),
+        cast(list[str], names),
+        cast(list[CellConfig], configs),
+    )

--- a/marimo/_ast/test_visitor.py
+++ b/marimo/_ast/test_visitor.py
@@ -556,3 +556,29 @@ def test_from_import_star() -> None:
     v.visit(mod)
     assert v.defs == set()
     assert v.refs == set()
+
+
+def test_type_alias_scoped() -> None:
+    expr = "type alias[T] = list[T]"
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(expr)
+    v.visit(mod)
+    # T should not be among the refs or defs
+    assert v.defs == set(["alias"])
+    assert v.refs == set(["list"])
+
+
+def test_type_var_generic_class() -> None:
+    expr = cleandoc(
+        """
+    class A[T]:
+        def hello(self, x: T) -> T:
+            T
+    """
+    )
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(expr)
+    v.visit(mod)
+    # T should not be among the refs or defs
+    assert v.defs == set(["A"])
+    assert v.refs == set()

--- a/marimo/_ast/test_visitor.py
+++ b/marimo/_ast/test_visitor.py
@@ -558,6 +558,7 @@ def test_from_import_star() -> None:
     assert v.refs == set()
 
 
+@pytest.mark.skipif("sys.version_info < (3, 12)")
 def test_type_alias_scoped() -> None:
     expr = "type alias[T] = list[T]"
     v = visitor.ScopedVisitor()
@@ -568,6 +569,7 @@ def test_type_alias_scoped() -> None:
     assert v.refs == set(["list"])
 
 
+@pytest.mark.skipif("sys.version_info < (3, 12)")
 def test_type_var_generic_class() -> None:
     expr = cleandoc(
         """

--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -13,7 +13,7 @@ class AltairFormatter(FormatterFactory):
     def register(self) -> None:
         import html
 
-        import altair  # type:ignore[import]
+        import altair  # type:ignore[import-not-found]
 
         from marimo._output import formatting
 

--- a/marimo/_output/formatters/plotly_formatters.py
+++ b/marimo/_output/formatters/plotly_formatters.py
@@ -14,8 +14,8 @@ class PlotlyFormatter(FormatterFactory):
         return "plotly"
 
     def register(self) -> None:
-        import plotly.graph_objects  # type:ignore[import]
-        import plotly.io  # type:ignore[import]
+        import plotly.graph_objects  # type:ignore[import-not-found]
+        import plotly.io  # type:ignore[import-not-found]
 
         from marimo._output import formatting
 

--- a/marimo/_output/formatters/seaborn_formatters.py
+++ b/marimo/_output/formatters/seaborn_formatters.py
@@ -12,7 +12,7 @@ class SeabornFormatter(FormatterFactory):
     def register(self) -> None:
         from typing import Any, cast
 
-        import seaborn  # type:ignore[import]
+        import seaborn  # type:ignore[import-not-found]
 
         from marimo._output import formatting
         from marimo._output.mime import MIME

--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -153,7 +153,7 @@ class MplApplication(tornado.web.Application):
                 self.write_message(data_uri)
 
     def __init__(self, figure: Any) -> None:
-        import matplotlib as mpl  # type: ignore[import]
+        import matplotlib as mpl  # type: ignore[import-not-found]
         from matplotlib.backends.backend_webagg import (
             FigureManagerWebAgg,
             new_figure_manager_given_figure,
@@ -234,7 +234,7 @@ def interactive(figure: "Figure | Axes") -> Html:  # type: ignore[name-defined] 
     """
     # No top-level imports of matplotlib, since it isn't a required
     # dependency
-    from matplotlib.axes import Axes  # type: ignore[import]
+    from matplotlib.axes import Axes  # type: ignore[import-not-found]
 
     if isinstance(figure, Axes):
         figure = figure.get_figure()

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -26,7 +26,7 @@ from marimo._utils import flatten
 LOGGER = _loggers.marimo_logger()
 
 if TYPE_CHECKING:
-    import altair  # type:ignore[import]
+    import altair  # type:ignore[import-not-found]
     import pandas as pd
 
 # Selection is a dictionary of the form:

--- a/marimo/_plugins/ui/_impl/charts/altair_transformer.py
+++ b/marimo/_plugins/ui/_impl/charts/altair_transformer.py
@@ -1,14 +1,14 @@
 # Copyright 2023 Marimo. All rights reserved.
 import json
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, TypedDict, Union
 
 import marimo._output.data.data as mo_data
 
 if TYPE_CHECKING:
     import pandas as pd
 
-Data = Union[dict[Any, Any], "pd.DataFrame"]
-_DataType = Union[dict[Any, Any], "pd.DataFrame"]
+Data = Union[Dict[Any, Any], "pd.DataFrame"]
+_DataType = Union[Dict[Any, Any], "pd.DataFrame"]
 
 
 class _JsonFormatDict(TypedDict):

--- a/marimo/_plugins/ui/_impl/charts/altair_transformer.py
+++ b/marimo/_plugins/ui/_impl/charts/altair_transformer.py
@@ -1,14 +1,14 @@
 # Copyright 2023 Marimo. All rights reserved.
 import json
-from typing import TYPE_CHECKING, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
 
 import marimo._output.data.data as mo_data
 
 if TYPE_CHECKING:
     import pandas as pd
 
-Data = Union[dict, "pd.DataFrame"]
-_DataType = Union[dict, "pd.DataFrame"]
+Data = Union[dict[Any, Any], "pd.DataFrame"]
+_DataType = Union[dict[Any, Any], "pd.DataFrame"]
 
 
 class _JsonFormatDict(TypedDict):
@@ -52,7 +52,7 @@ def _to_marimo_csv(data: Data) -> _ToCsvReturnUrlDict:
 # Copied from https://github.com/altair-viz/altair/blob/0ca83784e2455f2b84d0f6d789af2abbe8814348/altair/utils/data.py#L263C1-L288C10
 def _data_to_json_string(data: _DataType) -> str:
     """Return a JSON string representation of the input data"""
-    import altair as alt  # type: ignore[import]
+    import altair as alt  # type: ignore[import-not-found]
     import pandas as pd
 
     if isinstance(data, pd.DataFrame):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
     # have the rust toolchain installed on CI
     "polars==0.19.12",
     "pytest~=7.4.0",
-    "mypy~=1.4.1",
+    "mypy~=1.7.0",
     "ruff~=0.0.275",
     # For docs
     "pypandoc~=1.11",


### PR DESCRIPTION
Python 3.12 introduced a new type parameter syntax, with scoping rules. This change implements those rules.

Before this change, in the statement

```python
type Alias[T] = list[T]
```

`T` was incorrectly parsed as a ref. This change ensures that `T` doesn't leak from its annotation scope.

More information here:
https://docs.python.org/3/whatsnew/3.12.html#pep-695-type-parameter-syntax