### PR TITLE
fix: batch/dict should only update when necessary

### DIFF
--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -13,7 +13,7 @@ class AltairFormatter(FormatterFactory):
     def register(self) -> None:
         import html
 
-        import altair  # type:ignore[import-not-found]
+        import altair  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
 
         from marimo._output import formatting
 

--- a/marimo/_output/formatters/plotly_formatters.py
+++ b/marimo/_output/formatters/plotly_formatters.py
@@ -14,8 +14,8 @@ class PlotlyFormatter(FormatterFactory):
         return "plotly"
 
     def register(self) -> None:
-        import plotly.graph_objects  # type:ignore[import-not-found]
-        import plotly.io  # type:ignore[import-not-found]
+        import plotly.graph_objects  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        import plotly.io  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
 
         from marimo._output import formatting
 

--- a/marimo/_output/formatters/seaborn_formatters.py
+++ b/marimo/_output/formatters/seaborn_formatters.py
@@ -12,7 +12,9 @@ class SeabornFormatter(FormatterFactory):
     def register(self) -> None:
         from typing import Any, cast
 
-        import seaborn  # type:ignore[import-not-found]
+        # unused-ignore is needed since in development we may sometimes have
+        # seaborn installed, in which case import-not-found is not applicable
+        import seaborn  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
 
         from marimo._output import formatting
         from marimo._output.mime import MIME

--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -153,7 +153,7 @@ class MplApplication(tornado.web.Application):
                 self.write_message(data_uri)
 
     def __init__(self, figure: Any) -> None:
-        import matplotlib as mpl  # type: ignore[import-not-found]
+        import matplotlib as mpl  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
         from matplotlib.backends.backend_webagg import (
             FigureManagerWebAgg,
             new_figure_manager_given_figure,
@@ -234,7 +234,9 @@ def interactive(figure: "Figure | Axes") -> Html:  # type: ignore[name-defined] 
     """
     # No top-level imports of matplotlib, since it isn't a required
     # dependency
-    from matplotlib.axes import Axes  # type: ignore[import-not-found]
+    from matplotlib.axes import (  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        Axes,
+    )
 
     if isinstance(figure, Axes):
         figure = figure.get_figure()

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -26,7 +26,7 @@ from marimo._utils import flatten
 LOGGER = _loggers.marimo_logger()
 
 if TYPE_CHECKING:
-    import altair  # type:ignore[import-not-found]
+    import altair  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
     import pandas as pd
 
 # Selection is a dictionary of the form:

--- a/marimo/_plugins/ui/_impl/array.py
+++ b/marimo/_plugins/ui/_impl/array.py
@@ -104,7 +104,7 @@ class array(UIElement[Dict[str, JSONType], Sequence[object]]):
             for k, v in value.items():
                 element = self._elements[int(k)]
                 # only call update if the value has changed
-                if element and element._value_frontend != v:
+                if element._value_frontend != v:
                     element._update(v)
         return [e._value for e in self._elements]
 

--- a/marimo/_plugins/ui/_impl/batch.py
+++ b/marimo/_plugins/ui/_impl/batch.py
@@ -49,7 +49,10 @@ class _batch_base(UIElement[Dict[str, JSONType], Dict[str, object]]):
     def _convert_value(self, value: dict[str, JSONType]) -> dict[str, object]:
         if self._initialized:
             for k, v in value.items():
-                self._elements[k]._update(v)
+                element = self._elements[k]
+                # only call update if the value has changed
+                if element._value_frontend != v:
+                    element._update(v)
         return {
             key: wrapped_element._value
             for key, wrapped_element in self._elements.items()

--- a/marimo/_plugins/ui/_impl/charts/altair_transformer.py
+++ b/marimo/_plugins/ui/_impl/charts/altair_transformer.py
@@ -52,7 +52,7 @@ def _to_marimo_csv(data: Data) -> _ToCsvReturnUrlDict:
 # Copied from https://github.com/altair-viz/altair/blob/0ca83784e2455f2b84d0f6d789af2abbe8814348/altair/utils/data.py#L263C1-L288C10
 def _data_to_json_string(data: _DataType) -> str:
     """Return a JSON string representation of the input data"""
-    import altair as alt  # type: ignore[import-not-found]
+    import altair as alt  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
     import pandas as pd
 
     if isinstance(data, pd.DataFrame):

--- a/marimo/_plugins/ui/_impl/test_batch.py
+++ b/marimo/_plugins/ui/_impl/test_batch.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._output.hypertext import Html
+from marimo._plugins import ui
+
+
+def test_update_on_frontend_value_change_only() -> None:
+    b = ui.batch(
+        Html("{a} {b}"),
+        elements={
+            "a": ui.button(value=0, on_click=lambda v: v + 1),
+            "b": ui.button(value=0, on_click=lambda v: v + 1),
+        },
+    )
+    # Multiple updates with the same value -- should only register once
+    b._update({"a": 2})
+    b._update({"a": 2})
+    b._update({"a": 2})
+    b._update({"b": 2})
+    b._update({"b": 2})
+    b._update({"b": 2})
+    assert b.value == {"a": 1, "b": 1}

--- a/marimo/_plugins/ui/_impl/test_dictionary.py
+++ b/marimo/_plugins/ui/_impl/test_dictionary.py
@@ -42,3 +42,12 @@ def test_nested_dict() -> None:
     outer._update({"inner": {"slider": 7}})
     assert outer.value == {"inner": {"slider": 7}}
     assert inner.value == {"slider": 1}
+
+
+def test_update_on_frontend_value_change_only() -> None:
+    d = ui.dictionary({"0": ui.button(value=0, on_click=lambda v: v + 1)})
+    # Multiple updates with the same value -- should only register once
+    d._update({"0": 2})
+    d._update({"0": 2})
+    d._update({"0": 2})
+    assert d.value == {"0": 1}


### PR DESCRIPTION
`ui.batch` and `ui.dictionary` should only update their children when the new value is different from the old value, like `ui.array`.