### PR TITLE
Helpful error for marimo edit foo.ipynb

### DIFF
--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -12,8 +12,8 @@ from typing import Optional
 
 import click
 
-from marimo._utils.url import is_url
 from marimo._cli.print import green
+from marimo._utils.url import is_url
 
 
 def is_github_src(url: str, ext: str) -> bool:
@@ -61,7 +61,7 @@ def validate_name(
 
     path = pathlib.Path(name)
     if path.suffix == ".ipynb":
-        prefix = str(path)[:-len(".ipynb")]
+        prefix = str(path)[: -len(".ipynb")]
         raise click.UsageError(
             f"Invalid NAME - {name} is not a Python file.\n\n"
             f"  {green('Tip:')} Convert {name} to a marimo notebook with\n\n"

--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -13,6 +13,7 @@ from typing import Optional
 import click
 
 from marimo._utils.url import is_url
+from marimo._cli.print import green
 
 
 def is_github_src(url: str, ext: str) -> bool:
@@ -59,7 +60,15 @@ def validate_name(
         return _handle_github_issue(name, temp_dir), temp_dir
 
     path = pathlib.Path(name)
-    if path.suffix != ".py":
+    if path.suffix == ".ipynb":
+        prefix = str(path)[:-len(".ipynb")]
+        raise click.UsageError(
+            f"Invalid NAME - {name} is not a Python file.\n\n"
+            f"  {green('Tip:')} Convert {name} to a marimo notebook with\n\n"
+            f"    marimo convert {name} > {prefix}.py\n\n"
+            f"  then open with marimo edit {prefix}.py"
+        )
+    elif path.suffix != ".py":
         raise click.UsageError("Invalid NAME - %s is not a Python file" % name)
 
     if is_github_src(name, ext=".py"):


### PR DESCRIPTION
Prints a helpful error message on using marimo convert if user tries to edit a Jupyter notebook.

<img width="424" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/638d4d0f-f170-4d6c-99ee-76fd8abe0a30">

Closes #392 