### PR TITLE
Leaner requirements for Py>3.8

### DIFF
--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -1,18 +1,13 @@
 # Copyright 2023 Marimo. All rights reserved.
 from __future__ import annotations
 
-import sys
-from typing import Any, Dict, Optional, cast
-
-from typing_extensions import Literal
-
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
+from typing import TYPE_CHECKING, Any, Dict, TypedDict, cast
 
 from marimo._output.rich_help import mddoc
 from marimo._utils.deep_merge import deep_merge
+
+if TYPE_CHECKING:
+    from typing import Literal, Optional
 
 
 @mddoc

--- a/marimo/_messaging/console_output_worker.py
+++ b/marimo/_messaging/console_output_worker.py
@@ -5,12 +5,14 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from threading import Condition
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 from marimo._ast.cell import CellId_t
 from marimo._messaging.cell_output import CellOutput
 
 if TYPE_CHECKING:
+    from typing import Optional
+
     from marimo._messaging.streams import Stream
 
 StreamT = Literal["stdout", "stderr"]

--- a/marimo/_output/rich_help.py
+++ b/marimo/_output/rich_help.py
@@ -1,8 +1,17 @@
 # Copyright 2023 Marimo. All rights reserved.
-import inspect
-from typing import Any, Callable, Generic, Optional, Protocol, TypeVar, cast
+from __future__ import annotations
 
-from typing_extensions import runtime_checkable
+import inspect
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Optional,
+    Protocol,
+    TypeVar,
+    cast,
+    runtime_checkable,
+)
 
 from marimo._utils.format_signature import format_signature
 

--- a/marimo/_plugins/core/web_component.py
+++ b/marimo/_plugins/core/web_component.py
@@ -4,9 +4,24 @@ from __future__ import annotations
 import json
 import re
 from html import escape, unescape
-from typing import Mapping, Optional, Sequence, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Mapping,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
-from typing_extensions import TypeAlias
+if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info < (3, 10):
+        from typing_extensions import TypeAlias
+    else:
+        from typing import TypeAlias
+
+    from typing import Optional
 
 from marimo._output.md import md
 from marimo._output.mime import MIME

--- a/marimo/_plugins/ui/_impl/utils/dataframe.py
+++ b/marimo/_plugins/ui/_impl/utils/dataframe.py
@@ -74,6 +74,6 @@ def _get_row_headers_for_index(
             or dtype == "category"
         ):
             name = str(index.name) if index.name else ""
-            return [(name, index.tolist())]
+            return [(name, index.tolist())]   # type: ignore[list-item]
 
     return []

--- a/marimo/_plugins/ui/_impl/utils/dataframe.py
+++ b/marimo/_plugins/ui/_impl/utils/dataframe.py
@@ -74,6 +74,6 @@ def _get_row_headers_for_index(
             or dtype == "category"
         ):
             name = str(index.name) if index.name else ""
-            return [(name, index.tolist())]  # type: ignore[list-item]
+            return [(name, index.tolist())]
 
     return []

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -23,7 +23,6 @@ import webbrowser
 from shutil import which
 from typing import Any, Optional
 
-import importlib_resources
 import tornado.autoreload
 import tornado.ioloop
 import tornado.web
@@ -34,6 +33,11 @@ from marimo._config.config import get_configuration
 from marimo._config.utils import load_config
 from marimo._server import api, sessions
 from marimo._server.utils import TAB, print_tabbed
+
+if sys.version_info < (3, 10):
+    from importlib_resources import files as importlib_files
+else:
+    from importlib.resources import files as importlib_files
 
 DEFAULT_PORT = 2718
 UTF8_SUPPORTED = False
@@ -318,9 +322,7 @@ async def start_server(
     _loggers.initialize_tornado_loggers(development_mode)
     signal.signal(signal.SIGINT, interrupt_handler)
 
-    root = os.path.realpath(
-        importlib_resources.files("marimo").joinpath("_static")
-    )
+    root = os.path.realpath(importlib_files("marimo").joinpath("_static"))
     app = construct_app(root=root, development_mode=development_mode)
     port = connect_app(app, port)
     session_mgr = sessions.initialize_manager(

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -322,7 +322,7 @@ async def start_server(
     _loggers.initialize_tornado_loggers(development_mode)
     signal.signal(signal.SIGINT, interrupt_handler)
 
-    root = os.path.realpath(importlib_files("marimo").joinpath("_static"))
+    root = os.path.realpath(str(importlib_files("marimo").joinpath("_static")))
     app = construct_app(root=root, development_mode=development_mode)
     port = connect_app(app, port)
     session_mgr = sessions.initialize_manager(

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -34,7 +34,7 @@ from marimo._config.utils import load_config
 from marimo._server import api, sessions
 from marimo._server.utils import TAB, print_tabbed
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 9):
     from importlib_resources import files as importlib_files
 else:
     from importlib.resources import files as importlib_files

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -29,7 +29,6 @@ from multiprocessing import connection
 from typing import Any, Callable, Optional
 from uuid import uuid4
 
-import importlib_resources
 import tornado.httputil
 import tornado.ioloop
 import tornado.web
@@ -46,6 +45,11 @@ from marimo._runtime import requests, runtime
 from marimo._server.api.status import HTTPStatus
 from marimo._server.layout import LayoutConfig, read_layout_config
 from marimo._server.utils import print_tabbed
+
+if sys.version_info < (3, 10):
+    from importlib_resources import files as importlib_files
+else:
+    from importlib.resources import files as importlib_files
 
 LOGGER = _loggers.marimo_logger()
 SESSION_MANAGER: Optional["SessionManager"] = None
@@ -477,7 +481,7 @@ class SessionManager:
         try:
             LOGGER.debug("Starting LSP server at port %s...", self.lsp_port)
             lsp_bin = os.path.join(
-                str(importlib_resources.files("marimo").joinpath("_lsp")),
+                str(importlib_files("marimo").joinpath("_lsp")),
                 "index.js",
             )
             cmd = f"node {lsp_bin} --port {self.lsp_port}"

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -46,7 +46,7 @@ from marimo._server.api.status import HTTPStatus
 from marimo._server.layout import LayoutConfig, read_layout_config
 from marimo._server.utils import print_tabbed
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 9):
     from importlib_resources import files as importlib_files
 else:
     from importlib.resources import files as importlib_files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # cli
     "click>=8.0,<9",
     # python 3.8 compatibility
-    "importlib_resources>=5.10.2",
+    "importlib_resources>=5.10.2; python_version < \"3.9\"",
     # code completion
     "jedi>=0.18.0",
     # compile markdown to html
@@ -24,7 +24,7 @@ dependencies = [
     # web server
     "tornado>=6.1,<7",
     # python 3.8 compatibility
-    "typing_extensions>=4.4.0",
+    "typing_extensions>=4.4.0; python_version < \"3.9\"",
     # for cell formatting; if user version is not compatible, no-op
     "black",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,9 @@ select = [
 # Never try to fix `F401` (unused imports).
 unfixable = ["F401"]
 
+[tool.ruff.isort]
+required-imports = ["from __future__ import annotations"]
+
 [tool.black]
 line-length = 79
 extend-exclude = """
@@ -135,10 +138,6 @@ extend-exclude = """
     | ^/marimo/_smoke_tests/*
 )
 """
-
-[tool.isort]
-profile = "black"
-line_length = 79
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
     "tomlkit>= 0.12.0",
     # web server
     "tornado>=6.1,<7",
-    # python 3.8 compatibility
-    "typing_extensions>=4.4.0; python_version < \"3.9\"",
+    # python <=3.9 compatibility
+    "typing_extensions>=4.4.0; python_version < \"3.10\"",
     # for cell formatting; if user version is not compatible, no-op
     "black",
 ]


### PR DESCRIPTION
Since the following libraries are present only when installed with python <3.9, you can adopt the following requirements spec:

```toml
[project]
dependencies = [
    ...
    "importlib_resources>=5.10.2; python_version < \"3.9\"",
    "typing_extensions>=4.4.0; python_version < \"3.9\"",
    ...
]
```

In this way, they will only be installed for Python <3.9.