### PR TITLE
docs: improve batch recipe + faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,9 +14,11 @@
   - [How do I prevent matplotlib plots from being cut off?](#faq-mpl-cutoff)
   - [How do I display interactive matplotlib plots?](#faq-interactive-plots)
   - [How do I display objects in rows and columns?](#faq-rows-columns)
-  - [What packages can I use?](#faq-packages)
+  - [How do I create an output with a dynamic number of UI elements?](#faq-dynamic-ui-elements)
+  - [Why aren't my `on_change` handlers being called?](#faq-on-change-called)
   - [How do I reload modules?](#faq-reload)
   - [How does marimo treat type annotations?](#faq-annotations)
+  - [What packages can I use?](#faq-packages)
   - [How do I deploy apps?](#faq-app-deploy)
   - [Is marimo free?](#faq-marimo-free)
 
@@ -199,10 +201,21 @@ Use `marimo.hstack` and `marimo.vstack`. See the layout tutorial for details:
 marimo tutorial layout
 ```
 
-<a name="faq-packages" ></a>
-**What packages can I use?**
+<a name="faq-dynamic-ui-elements"></a>
+**How do I create an output with a dynamic number of UI elements?**
 
-You can use any Python package. marimo cells run arbitrary Python code.
+Use [`mo.ui.array`](/api/inputs/array.md#marimo.ui.array),
+[`mo.ui.dictionary`](/api/inputs/dictionary.md#marimo.ui.dictionary), or
+[`mo.ui.batch`](/api/inputs/batch.md#marimo.ui.batch) to create a UI element
+that wraps a dynamic number of other UI elements.
+
+If you need custom
+formatting, use [`mo.ui.batch`](/api/inputs/batch.md#marimo.ui.batch), otherwise
+use [`mo.ui.array`](/api/inputs/array.md#marimo.ui.array) or
+[`mo.ui.dictionary`](/api/inputs/dictionary.md#marimo.ui.dictionary).
+
+For usage examples, see the
+[recipes for grouping UI elements together](/recipes.md#grouping-ui-elements-together).
 
 <a name="faq-reload" ></a>
 **How do I reload modules?**
@@ -218,6 +231,26 @@ importlib.reload(mymodule)
 
 Running this cell will reload `mymodule` with your new edits and automatically
 re-run any cells using `mymodule`.
+
+<a name="faq-on-change-called"></a>
+**Why aren't my `on_change`/`on_click` handlers being called?**
+
+A UI Element's `on_change` (or for buttons, `on_click`) handlers are only
+called if the element is bound to a global variable. For example, this won't work
+
+```python
+mo.vstack([mo.ui.button(on_change=lambda _: print('I was called")) for _ in range(10)])
+```
+
+In such cases (when you want to output a dynamic number of UI elements),
+you need to use 
+[`mo.ui.array`](/api/inputs/array.md#marimo.ui.array),
+[`mo.ui.dictionary`](/api/inputs/dictionary.md#marimo.ui.dictionary), or
+[`mo.ui.batch`](/api/inputs/batch.md#marimo.ui.batch).
+
+See the
+[recipes for grouping UI elements together](/recipes.md#grouping-ui-elements-together)
+for example code.
 
 <a name="faq-annotations"></a>
 **How does marimo treat type annotations?**
@@ -245,6 +278,10 @@ x: "A" = ...
 
 For Python 3.12+, marimo additionally implements annotation scoping.
 
+<a name="faq-packages" ></a>
+**What packages can I use?**
+
+You can use any Python package. marimo cells run arbitrary Python code.
 
 <a name="faq-app-deploy" ></a>
 **How do I deploy apps?**

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -219,7 +219,7 @@ to interpolate UI elements into it to create a new UI element batching the
 consituent ones (like `mo.ui.dictionary`).
 
 ```python
-# n_items, checkboxes, and texts are just placeholders: replace them
+# n_items, checkboxes, and texts are just example data: replace them
 # with the real data you want to put in the batch
 import random
 n_items = random.randint(1, 10)
@@ -229,32 +229,113 @@ texts = {
 }
 
 
-# a utility function
-def _brace_wrap(name) -> str:
+# a utility function that creates a placeholder that will be substituted
+# for a UI element
+def _placeholder(name) -> str:
     return "{" + name + "}"
 
 
-# a batch is just like mo.ui.dictionary(), but lets you have custom formatting
+# A batch is just like mo.ui.dictionary(), but lets you have custom formatting.
+#
+# To use batch, first create an HTML object with placeholders for 
+# the UI elements. A placeholder is a string key closed in braces,
+# such as "{my_button}".
+#
+# Then, call `batch()` with keys equal to placeholder
+# names and values equal to the UI elements you want to substitute, such as
+# `.batch(my_button=mo.ui.button())`.
+#
+# If you have many placeholders, create a dict with the placeholders as keys
+# and their UI elements as values, and unpack them when you call batch:
+# `.batch(**placeholders_and_values)`.
 batch = mo.md(
     f"""
     Here's a TODO list of {n_items} items\n\n
     """
     + "\n\n".join(
         [
-            _brace_wrap(cb) + " " + _brace_wrap(t)
-            for cb, t in zip(checkboxes.keys(), texts.keys())
+            _placeholder(checkbox_key) + " " + _placeholder(text_key)
+            for checkbox_key, text_key in zip(checkboxes.keys(), texts.keys())
         ]
     )
 ).batch(**checkboxes, **texts)
 batch
 ```
 
-3. Get the value of the batch as a Python `dict`, keyed by the names of
-the UI elements in the HTML template.
+3. Get the value of the batch as a Python `dict`, with placeholders as keys
+and their UI element values as values.
 
 ```python
 batch.value
 ```
+
+### Create a vstack (or hstack) of UI elements with `on_change` handlers
+
+**Use cases.** Arrange a dynamic number of UI elements in a vstack or hstack,
+for example some number of buttons, and execute some side-effect when an
+element is interacted with, e.g. when a button is clicked.
+
+**Recipe.**
+
+1. Import packages
+
+```python
+import marimo as mo
+```
+
+2. Create an HTML template, and use [`Html.batch`](api/html.md#marimo.Html.batch)
+to interpolate UI elements into it to create a new UI element batching the
+consituent ones (like `mo.ui.dictionary`).
+
+```python
+import random
+
+
+def on_change(v):
+   # replace with your code
+   ...
+
+# create a dictionary of your UI elements, keyed by placeholder names
+buttons = {
+   f"button_{i}": mo.ui.button(label=i, on_change=on_change)
+   for i in range(random.randint(3, 10)
+}
+
+
+# a utility function that creates a placeholder that will be substituted
+# for a UI element
+def _placeholder(name) -> str:
+    return "{" + name + "}"
+
+
+# A batch is just like mo.ui.dictionary(), but lets you have custom formatting.
+#
+# To use batch, first create an HTML object with placeholders for 
+# the UI elements. A placeholder is a string key closed in braces,
+# such as "{my_button}".
+#
+# Then, call `batch()` with keys equal to placeholder
+# names and values equal to the UI elements you want to substitute, such as
+# `.batch(my_button=mo.ui.button())`.
+#
+# If you have many placeholders, create a dict with the placeholders as keys
+# and their UI elements as values, and unpack them when you call batch:
+# `.batch(**placeholders_and_values)`.
+batch = mo.vstack([
+   _placeholder(name) for name in buttons.keys()
+]).batch(**buttons)
+
+# Output the batched vstack
+batch
+```
+
+3. Get the value of the batch as a Python `dict`, with placeholders as keys
+and their UI element values as values.
+
+```python
+batch.value
+```
+
 
 ### Create a form with multiple UI elements
 


### PR DESCRIPTION
Improve the docs recipes and FAQs for creating outputs with a dynamic number of UI elements. Also add a FAQ for "Why aren't my `on_change` handlers being called?`.

In the future, we can experiment with error messages that point people to the FAQ/recipes if they have unbound UI elements with handlers, and/or experiment with `mo.ui.vstack` and `mo.ui.hstack`.