### PR TITLE
Remove cursor tooltip

### DIFF
--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -50,7 +50,6 @@ export function hintTooltip() {
         hideOnChange: true,
       }
     ),
-    cursorTooltipField,
     Prec.highest(
       keymap.of([
         {

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -218,29 +218,6 @@ def complete(
                 # Don't complete ...
                 completions = []
 
-                # Get docstring in function context. A bit of a hack, since
-                # this isn't actually a completion, just a tooltip.
-                #
-                # If no completions, we might be getting a signature ...
-                # for example, if the document is "mo.ui.slider(start=1,
-                signatures = script.get_signatures()
-                if signatures:
-                    _write_completion_result(
-                        stream=stream,
-                        completion_id=request.completion_id,
-                        prefix_length=0,
-                        options=[
-                            CompletionOption(
-                                name=signatures[0].name,
-                                type="tooltip",
-                                completion_info=_get_completion_info(
-                                    signatures[0]
-                                ),
-                            )
-                        ],
-                    )
-                    continue
-
             if not completions:
                 # If there are still no completions, then bail.
                 _write_no_completions(stream, request.completion_id)


### PR DESCRIPTION
Cursor tooltips get in the way of code too often, especially when editing markdown, or editing the middle of a long expression inside a function call. 

This PR just disables cursor tooltips. Fine-tuning them (eg better positioning, preventing them from re-opening after user hitting escape, and surely other tweaks) would take more effort than it's worth right now. Now that we have hover tooltips, the need for cursor tooltips is much less.

@mscolnick open to discuss if you disagree