### PR TITLE
fix: handle backslashes in md (marimo convert)

### DIFF
--- a/marimo/_cli/ipynb_to_marimo.py
+++ b/marimo/_cli/ipynb_to_marimo.py
@@ -33,7 +33,8 @@ def convert(ipynb_path: str) -> str:
             source = "\n".join(
                 [
                     "mo.md(",
-                    codegen.indent_text('"""'),
+                    # r-string: a backslash is just a backslash!
+                    codegen.indent_text('r"""'),
                     codegen.indent_text(source),
                     codegen.indent_text('"""'),
                     ")",

--- a/marimo/_cli/test_ipynb_to_marimo.py
+++ b/marimo/_cli/test_ipynb_to_marimo.py
@@ -43,7 +43,7 @@ def test_markdown() -> None:
         == textwrap.dedent(
             """
             mo.md(
-                \"\"\"
+                r\"\"\"
                 # Hello, markdown
 
                 \\"\\"\\"
@@ -60,10 +60,10 @@ def test_markdown() -> None:
         == textwrap.dedent(
             """
             mo.md(
-                \"\"\"
+                r\"\"\"
                 Here is some math
 
-                $x = 0$
+                $x \\approx 0$
                 \"\"\"
             )
             """

--- a/marimo/_plugins/ui/_impl/utils/dataframe.py
+++ b/marimo/_plugins/ui/_impl/utils/dataframe.py
@@ -74,6 +74,6 @@ def _get_row_headers_for_index(
             or dtype == "category"
         ):
             name = str(index.name) if index.name else ""
-            return [(name, index.tolist())]   # type: ignore[list-item]
+            return [(name, index.tolist())]  # type: ignore[list-item]
 
     return []

--- a/marimo/_test_utils/ipynb_data/markdown.ipynb.txt
+++ b/marimo/_test_utils/ipynb_data/markdown.ipynb.txt
@@ -20,7 +20,7 @@
    "source": [
     "Here is some math\n",
     "\n",
-    "$x = 0$"
+    "$x \\approx 0$"
    ]
   }
  ],


### PR DESCRIPTION
In marimo convert, emit raw string literals to properly handle backslashes. An alternative would be to escape backslashes, but this feels cleaner, especially in the presence of LaTeX.

Closes #423 