### PR TITLE
improvement: include instructions for how to run static notebooks

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
@@ -19,7 +19,8 @@ export const VerticalLayoutWrapper: React.FC<PropsWithChildren<Props>> = ({
     <div className={cn("sm:px-16 md:px-32", className)}>
       <div
         className={cn(
-          "m-auto pb-12",
+          // Large mobile bottom padding due to mobile browser navigation bar
+          "m-auto pb-24 sm:pb-12",
           appConfig.width !== "full" && "max-w-contentWidth min-w-[400px]",
           // Hide the cells for a fake loading effect, to avoid flickering
           invisible && "invisible"

--- a/frontend/src/components/static-html/static-banner.tsx
+++ b/frontend/src/components/static-html/static-banner.tsx
@@ -1,4 +1,7 @@
 /* Copyright 2023 Marimo. All rights reserved. */
+/* eslint-disable react/jsx-no-comment-textnodes */
+/* eslint-disable react/jsx-no-target-blank */
+
 import { isStaticNotebook } from "@/core/static/static-state";
 import React from "react";
 import { Button } from "../ui/button";
@@ -6,6 +9,14 @@ import { toast } from "../ui/use-toast";
 import { getMarimoCode } from "@/core/dom/marimo-tag";
 import { downloadBlob } from "@/utils/download";
 import { getFilenameFromDOM } from "@/core/dom/htmlUtils";
+import {
+  DialogHeader,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
 import { CopyIcon, DownloadIcon } from "lucide-react";
 
 export const StaticBanner: React.FC = () => {
@@ -14,41 +25,99 @@ export const StaticBanner: React.FC = () => {
   }
 
   return (
-    <div className="px-4 py-2 bg-[var(--sky-2)] border-b border-[var(--sky-7)] text-md text-[var(--sky-11)] font-semibold flex justify-between items-center">
+    <div className="px-4 py-2 bg-[var(--sky-2)] border-b border-[var(--sky-7)] text-md text-[var(--sky-11)] font-semibold flex justify-between items-center gap-4">
       <span>
-        This is a static notebook. Some interactive features will not work,
-        however you can download the code and run it locally.
+        This is a static Python notebook built using{" "}
+        <a
+          href="https://github.com/marimo-team/marimo"
+          target="_blank"
+          className="underline"
+        >
+          marimo
+        </a>
+        .
+        <br />
+        Some interactive features may not work, however you can download the
+        code and run it locally.
       </span>
-      <span className="flex flex-wrap justify-end">
-        <Button
-          className="ml-2 flex-shrink-0"
-          variant="secondary"
-          size="xs"
-          onClick={() => {
-            const code = getMarimoCode();
-            window.navigator.clipboard.writeText(code);
-            toast({ title: "Copied to clipboard" });
-          }}
-        >
-          <CopyIcon className="w-4 h-4 mr-1" />
-          Copy code
-        </Button>
-        <Button
-          className="ml-2 flex-shrink-0"
-          variant="secondary"
-          size="xs"
-          onClick={() => {
-            const code = getMarimoCode();
-            downloadBlob(
-              new Blob([code], { type: "text/plain" }),
-              getFilenameFromDOM() || "app.py"
-            );
-          }}
-        >
-          <DownloadIcon className="w-4 h-4 mr-1" />
-          Download code
-        </Button>
+      <span className="flex-shrink-0">
+        <StaticBannerDialog />
       </span>
     </div>
+  );
+};
+
+const StaticBannerDialog = () => {
+  let filename = getFilenameFromDOM() || "app.py";
+  // Trim the path
+  const lastSlash = filename.lastIndexOf("/");
+  if (lastSlash !== -1) {
+    filename = filename.slice(lastSlash + 1);
+  }
+
+  const href = window.location.href;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild={true}>
+        <Button variant="secondary">Run or edit this notebook</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{filename}</DialogTitle>
+          <DialogDescription className="pt-4 text-md text-left">
+            This is a static notebook built using{" "}
+            <a
+              href="https://github.com/marimo-team/marimo"
+              target="_blank"
+              className="text-link hover:underline"
+            >
+              marimo
+            </a>
+            . marimo is an open-source next-generation Python notebook.
+            <hr className="my-3" />
+            In order to edit this notebook, you will need to download the code
+            locally, install marimo, and run the following in your terminal:
+            <div className="font-mono text-sm bg-[var(--sky-2)] rounded-md my-3 p-2 border border-[var(--sky-7)]">
+              pip install marimo
+              <br />
+              marimo edit {filename}
+            </div>
+            {!href.endsWith(".html") && (
+              <>
+                <hr className="my-3" />
+                You may also run:
+                <div className="font-mono text-sm bg-[var(--sky-2)] rounded-md my-3 p-2 border border-[var(--sky-7)] break-all">
+                  marimo edit {window.location.href}
+                </div>
+              </>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex gap-4 flex-wrap">
+          <Button
+            variant="secondary"
+            onClick={() => {
+              const code = getMarimoCode();
+              window.navigator.clipboard.writeText(code);
+              toast({ title: "Copied to clipboard" });
+            }}
+          >
+            <CopyIcon className="w-4 h-4 mr-1" />
+            Copy code
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              const code = getMarimoCode();
+              downloadBlob(new Blob([code], { type: "text/plain" }), filename);
+            }}
+          >
+            <DownloadIcon className="w-4 h-4 mr-1" />
+            Download code
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/core/static/download-html.ts
+++ b/frontend/src/core/static/download-html.ts
@@ -38,11 +38,15 @@ export async function downloadAsHTML(opts: { filename: string }) {
     throw error;
   });
 
+  const filenameWithoutPath = filename.split("/").pop() ?? "app.py";
+  const filenameWithoutExtension =
+    filenameWithoutPath.split(".").shift() ?? "app";
+
   const html = constructHTML({
     notebookState: notebook,
     version: version,
     assetUrl: assetUrl,
-    filename: filename || "notebook",
+    filename: filenameWithoutPath,
     existingDocument: document,
     files: await downloadVirtualFiles(),
     code: codeResponse.contents,
@@ -50,7 +54,7 @@ export async function downloadAsHTML(opts: { filename: string }) {
 
   downloadBlob(
     new Blob([html], { type: "text/html" }),
-    filename ? `${filename}.html` : "notebook.html"
+    `${filenameWithoutExtension}.html`
   );
 }
 


### PR DESCRIPTION
- add dialog for instructions to download
- cleanup filenames and extensions in static export
- support html files in `marimo edit <html_url>`

<img width="1031" alt="Screenshot 2023-12-03 at 6 55 02 PM" src="https://github.com/marimo-team/marimo/assets/2753772/e8793f0c-cd83-44be-b248-8f1b69e35d9f">
