### PR TITLE
fix: fix RuntimeState to be able to recover from failed ui element updates

### DIFF
--- a/frontend/src/components/editor/cell/useRunCells.ts
+++ b/frontend/src/components/editor/cell/useRunCells.ts
@@ -1,5 +1,5 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { RuntimeState } from "@/core/RuntimeState";
+import { RuntimeState } from "@/core/kernel/RuntimeState";
 import { CellId } from "@/core/cells/ids";
 import { sendRun } from "@/core/network/requests";
 import { staleCellIds, useNotebook } from "@/core/cells/cells";

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from "react";
 import { sendDeleteCell } from "@/core/network/requests";
 import { Cell } from "@/components/editor/Cell";
-import { RuntimeState } from "../../../core/RuntimeState";
+import { RuntimeState } from "../../../core/kernel/RuntimeState";
 import {
   ConnectionStatus,
   WebSocketState,

--- a/frontend/src/core/App.tsx
+++ b/frontend/src/core/App.tsx
@@ -47,7 +47,7 @@ import { SortableCellsProvider } from "../components/sort/SortableCellsProvider"
 import { CellId, HTMLCellId } from "./cells/ids";
 import { CellConfig } from "./cells/types";
 import { CellArray } from "../components/editor/renderers/CellArray";
-import { RuntimeState } from "./RuntimeState";
+import { RuntimeState } from "./kernel/RuntimeState";
 import { CellsRenderer } from "../components/editor/renderers/cells-renderer";
 import { getSerializedLayout } from "./layout/layout";
 import { useAtom } from "jotai";

--- a/frontend/src/core/functions/FunctionRegistry.ts
+++ b/frontend/src/core/functions/FunctionRegistry.ts
@@ -1,6 +1,6 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 
-import { RuntimeState } from "@/core/RuntimeState";
+import { RuntimeState } from "@/core/kernel/RuntimeState";
 import { sendFunctionRequest } from "@/core/network/requests";
 import { FunctionCallResultMessage } from "../kernel/messages";
 import { DeferredRequestRegistry } from "../network/DeferredRequestRegistry";

--- a/frontend/src/core/kernel/__tests__/RuntimeState.test.ts
+++ b/frontend/src/core/kernel/__tests__/RuntimeState.test.ts
@@ -1,0 +1,174 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { marimoValueReadyEvent } from "@/core/dom/events";
+import { UIElementRegistry } from "@/core/dom/uiregistry";
+import { describe, beforeEach, expect, vi, test, MockedFunction } from "vitest";
+import { RuntimeState } from "../RuntimeState";
+import { RunRequests } from "@/core/network/types";
+import { UIElementId } from "@/core/cells/ids";
+
+const elementOne = document.createElement("div");
+const uiElementOneId = "uiElementOne" as UIElementId;
+const elementTwo = document.createElement("div");
+const uiElementTwoId = "uiElementTwo" as UIElementId;
+
+const addEventListenerSpy = vi.spyOn(document, "addEventListener");
+const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
+
+describe("RuntimeState", () => {
+  let runtimeState: RuntimeState;
+  let mockSendComponentValues: MockedFunction<
+    RunRequests["sendComponentValues"]
+  >;
+  let uiElementRegistry: UIElementRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendComponentValues = vi.fn((args) => Promise.resolve(null));
+    uiElementRegistry = UIElementRegistry.INSTANCE;
+    uiElementRegistry.entries.clear();
+
+    runtimeState = new RuntimeState(uiElementRegistry, {
+      sendComponentValues: mockSendComponentValues,
+    });
+  });
+
+  test("start should register event listener", () => {
+    runtimeState.start();
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      marimoValueReadyEvent,
+      expect.any(Function)
+    );
+  });
+
+  test("stop should remove event listener", () => {
+    runtimeState.stop();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      marimoValueReadyEvent,
+      expect.any(Function)
+    );
+  });
+
+  test("registerRunStart should increment runningCount", () => {
+    runtimeState.registerRunStart();
+    expect(runtimeState.running()).toBe(true);
+  });
+
+  test("registerRunEnd should decrement runningCount", () => {
+    runtimeState.registerRunStart();
+    runtimeState.registerRunStart();
+    runtimeState.registerRunEnd();
+    expect(runtimeState.running()).toBe(true); // still running
+    runtimeState.registerRunEnd();
+    expect(runtimeState.running()).toBe(false); // not running
+  });
+
+  test("flushUpdates should not call sendComponentValues if no updates", () => {
+    runtimeState.flushUpdates();
+    expect(mockSendComponentValues).not.toHaveBeenCalled();
+  });
+
+  test("flushUpdates should call sendComponentValues with updates", async () => {
+    runtimeState.start();
+    uiElementRegistry.registerInstance(uiElementOneId, elementOne);
+    expect(uiElementRegistry.entries).toHaveLength(1);
+    expect(mockSendComponentValues).not.toHaveBeenCalled();
+
+    uiElementRegistry.broadcastValueUpdate(elementOne, uiElementOneId, "10");
+    expect(mockSendComponentValues).toHaveBeenCalledOnce();
+    expect(mockSendComponentValues.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "objectId": "uiElementOne",
+          "value": "10",
+        },
+      ]
+    `);
+    expect(runtimeState.running()).toBe(true);
+  });
+
+  test("will only send one broadcast at a time and hold future events", () => {
+    runtimeState.start();
+    uiElementRegistry.registerInstance(uiElementOneId, elementOne);
+    uiElementRegistry.registerInstance(uiElementTwoId, elementTwo);
+    uiElementRegistry.broadcastValueUpdate(elementOne, uiElementOneId, "10");
+    // Set while running
+    uiElementRegistry.broadcastValueUpdate(elementTwo, uiElementTwoId, "20");
+    uiElementRegistry.broadcastValueUpdate(elementOne, uiElementOneId, "30");
+    expect(mockSendComponentValues).toHaveBeenCalledOnce();
+    expect(mockSendComponentValues.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "objectId": "uiElementOne",
+          "value": "10",
+        },
+      ]
+    `);
+    expect(runtimeState.running()).toBe(true);
+
+    // End run
+    runtimeState.registerRunEnd();
+    expect(runtimeState.running()).toBe(false);
+
+    // Start another run, this overwrites the previous value that was not sent
+    uiElementRegistry.broadcastValueUpdate(elementTwo, uiElementTwoId, "40");
+    expect(mockSendComponentValues).toHaveBeenCalledTimes(2);
+    // We expect 2 values to be sent, the last value of uiElementTwo and the last value of uiElementOne
+    // both that were set while running
+    expect(mockSendComponentValues.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "objectId": "uiElementTwo",
+          "value": "40",
+        },
+        {
+          "objectId": "uiElementOne",
+          "value": "30",
+        },
+      ]
+    `);
+    expect(runtimeState.running()).toBe(true);
+  });
+
+  test("handle when sendComponentValues fails", async () => {
+    runtimeState.start();
+    uiElementRegistry.registerInstance(uiElementOneId, elementOne);
+    uiElementRegistry.registerInstance(uiElementTwoId, elementTwo);
+    expect(uiElementRegistry.entries).toHaveLength(2);
+    expect(mockSendComponentValues).not.toHaveBeenCalled();
+
+    const error = new Error("Failed to send component values");
+    mockSendComponentValues.mockRejectedValueOnce(error);
+
+    uiElementRegistry.broadcastValueUpdate(elementOne, uiElementOneId, "10");
+    // flush the event loop
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockSendComponentValues).toHaveBeenCalledOnce();
+    expect(mockSendComponentValues.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "objectId": "uiElementOne",
+          "value": "10",
+        },
+      ]
+    `);
+
+    // It should not be running anymore
+    expect(runtimeState.running()).toBe(false);
+
+    // And if we try another element, we should send both (since the previous one failed)
+    uiElementRegistry.broadcastValueUpdate(elementTwo, uiElementTwoId, "20");
+    expect(mockSendComponentValues).toHaveBeenCalledTimes(2);
+    expect(mockSendComponentValues.mock.lastCall?.[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "objectId": "uiElementOne",
+          "value": "10",
+        },
+        {
+          "objectId": "uiElementTwo",
+          "value": "20",
+        },
+      ]
+    `);
+  });
+});

--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -5,7 +5,7 @@ import { connectionAtom } from "../network/connection";
 import { useWebSocket } from "@/core/websocket/useWebSocket";
 import { logNever } from "@/utils/assertNever";
 import { useCellActions } from "@/core/cells/cells";
-import { RuntimeState } from "@/core/RuntimeState";
+import { RuntimeState } from "@/core/kernel/RuntimeState";
 import { AUTOCOMPLETER } from "@/core/codemirror/completion/Autocompleter";
 import { UI_ELEMENT_REGISTRY } from "@/core/dom/uiregistry";
 import { OperationMessage } from "@/core/kernel/messages";


### PR DESCRIPTION
Previously if `sendComponentUpdates` failed with a 403 or any other network request, the app would not be able to send any more updates. This makes sure we can recover from those