### PR TITLE
fix: scroll in cell's console output

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -125,9 +125,6 @@ module.exports = {
     plugin(function ({ addUtilities }) {
       const newUtilities = {
         ".increase-pointer-area-x": {
-          position: "absolute",
-          width: "100%",
-          height: "100%",
           "&::before": {
             content: '""',
             position: "absolute",


### PR DESCRIPTION
Previously you could not scroll in the console area of a cell due to overlapping elements. This fixes that. 