### PR TITLE
improvement: option to show code in static html

### DIFF
--- a/frontend/e2e-tests/helper.ts
+++ b/frontend/e2e-tests/helper.ts
@@ -114,12 +114,12 @@ export async function exportAsHTMLAndTakeScreenshot(page: Page) {
   await takeScreenshot(exportPage, path);
 
   // Toggle code
-  await page.getByTestId("show-code").click();
+  await exportPage.getByTestId("show-code").click();
   // wait 100ms for the code to be shown
-  await page.waitForTimeout(100);
+  await exportPage.waitForTimeout(100);
 
   // Take screenshot of code
-  await takeScreenshot(page, `code-${path}`);
+  await takeScreenshot(exportPage, `code-${path}`);
 }
 
 export async function exportAsPNG(page: Page) {

--- a/frontend/e2e-tests/helper.ts
+++ b/frontend/e2e-tests/helper.ts
@@ -112,6 +112,14 @@ export async function exportAsHTMLAndTakeScreenshot(page: Page) {
     waitUntil: "networkidle",
   });
   await takeScreenshot(exportPage, path);
+
+  // Toggle code
+  await page.getByTestId("show-code").click();
+  // wait 100ms for the code to be shown
+  await page.waitForTimeout(100);
+
+  // Take screenshot of code
+  await takeScreenshot(page, `code-${path}`);
 }
 
 export async function exportAsPNG(page: Page) {

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,7 +1,9 @@
+/* Copyright 2023 Marimo. All rights reserved. */
 module.exports = {
   plugins: {
+    "tailwindcss/nesting": {},
     tailwindcss: {},
-    autoprefixer: {},
     ...(process.env.NODE_ENV === "production" ? { cssnano: {} } : {}),
+    autoprefixer: {},
   },
 };

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -56,27 +56,27 @@ export interface CellHandle {
 
 export interface CellProps
   extends Pick<
-    CellRuntimeState,
-    | "consoleOutputs"
-    | "status"
-    | "output"
-    | "errored"
-    | "interrupted"
-    | "stopped"
-    | "runStartTimestamp"
-    | "runElapsedTimeMs"
-  >,
-  Pick<CellData, "id" | "code" | "edited" | "config">,
-  Pick<
-    CellActions,
-    | "updateCellCode"
-    | "prepareForRun"
-    | "createNewCell"
-    | "deleteCell"
-    | "focusCell"
-    | "moveCell"
-    | "moveToNextCell"
-  > {
+      CellRuntimeState,
+      | "consoleOutputs"
+      | "status"
+      | "output"
+      | "errored"
+      | "interrupted"
+      | "stopped"
+      | "runStartTimestamp"
+      | "runElapsedTimeMs"
+    >,
+    Pick<CellData, "id" | "code" | "edited" | "config">,
+    Pick<
+      CellActions,
+      | "updateCellCode"
+      | "prepareForRun"
+      | "createNewCell"
+      | "deleteCell"
+      | "focusCell"
+      | "moveCell"
+      | "moveToNextCell"
+    > {
   theme: Theme;
   showPlaceholder: boolean;
   registerRunStart: () => void;

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -56,27 +56,27 @@ export interface CellHandle {
 
 export interface CellProps
   extends Pick<
-      CellRuntimeState,
-      | "consoleOutputs"
-      | "status"
-      | "output"
-      | "errored"
-      | "interrupted"
-      | "stopped"
-      | "runStartTimestamp"
-      | "runElapsedTimeMs"
-    >,
-    Pick<CellData, "id" | "code" | "edited" | "config">,
-    Pick<
-      CellActions,
-      | "updateCellCode"
-      | "prepareForRun"
-      | "createNewCell"
-      | "deleteCell"
-      | "focusCell"
-      | "moveCell"
-      | "moveToNextCell"
-    > {
+    CellRuntimeState,
+    | "consoleOutputs"
+    | "status"
+    | "output"
+    | "errored"
+    | "interrupted"
+    | "stopped"
+    | "runStartTimestamp"
+    | "runElapsedTimeMs"
+  >,
+  Pick<CellData, "id" | "code" | "edited" | "config">,
+  Pick<
+    CellActions,
+    | "updateCellCode"
+    | "prepareForRun"
+    | "createNewCell"
+    | "deleteCell"
+    | "focusCell"
+    | "moveCell"
+    | "moveToNextCell"
+  > {
   theme: Theme;
   showPlaceholder: boolean;
   registerRunStart: () => void;
@@ -251,6 +251,7 @@ const CellComponent = (
 
   const className = clsx("Cell", "hover-actions-parent", {
     published: !editing,
+    interactive: editing,
     "needs-run": needsRun,
     "has-error": errored,
     stopped: stopped,

--- a/frontend/src/components/editor/code/readonly-python-code.tsx
+++ b/frontend/src/components/editor/code/readonly-python-code.tsx
@@ -1,3 +1,4 @@
+/* Copyright 2023 Marimo. All rights reserved. */
 import { memo } from "react";
 import { python } from "@codemirror/lang-python";
 import CodeMirror, {
@@ -16,8 +17,8 @@ export const ReadonlyPythonCode = memo(
     const { theme } = useThemeForPlugin();
     const { code, className, ...rest } = props;
     return (
-      <div className={cn("relative hover-actions-parent", props.className)}>
-        <FloatingCopyButton text={props.code} />
+      <div className={cn("relative hover-actions-parent", className)}>
+        <FloatingCopyButton text={code} />
         <CodeMirror
           {...rest}
           className="cm"
@@ -25,13 +26,14 @@ export const ReadonlyPythonCode = memo(
           height="100%"
           editable={true}
           extensions={[python(), EditorView.lineWrapping]}
-          value={props.code}
+          value={code}
           readOnly={true}
         />
       </div>
     );
   }
 );
+ReadonlyPythonCode.displayName = "ReadonlyPythonCode";
 
 const FloatingCopyButton = (props: { text: string }) => {
   const copy = Events.stopPropagation(() => {

--- a/frontend/src/components/editor/code/readonly-python-code.tsx
+++ b/frontend/src/components/editor/code/readonly-python-code.tsx
@@ -1,0 +1,52 @@
+import { memo } from "react";
+import { python } from "@codemirror/lang-python";
+import CodeMirror, {
+  EditorView,
+  ReactCodeMirrorProps,
+} from "@uiw/react-codemirror";
+import { CopyIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Events } from "@/utils/events";
+import { toast } from "@/components/ui/use-toast";
+import { useThemeForPlugin } from "@/theme/useTheme";
+import { cn } from "@/utils/cn";
+
+export const ReadonlyPythonCode = memo(
+  (props: { className?: string; code: string } & ReactCodeMirrorProps) => {
+    const { theme } = useThemeForPlugin();
+    const { code, className, ...rest } = props;
+    return (
+      <div className={cn("relative hover-actions-parent", props.className)}>
+        <FloatingCopyButton text={props.code} />
+        <CodeMirror
+          {...rest}
+          className="cm"
+          theme={theme === "dark" ? "dark" : "light"}
+          height="100%"
+          editable={true}
+          extensions={[python(), EditorView.lineWrapping]}
+          value={props.code}
+          readOnly={true}
+        />
+      </div>
+    );
+  }
+);
+
+const FloatingCopyButton = (props: { text: string }) => {
+  const copy = Events.stopPropagation(() => {
+    navigator.clipboard.writeText(props.text);
+    toast({ title: "Copied to clipboard" });
+  });
+
+  return (
+    <Button
+      onClick={copy}
+      className="absolute top-0 right-0 m-1 z-10 hover-action"
+      size="xs"
+      variant="secondary"
+    >
+      <CopyIcon size={14} strokeWidth={1.5} />
+    </Button>
+  );
+};

--- a/frontend/src/components/editor/code/readonly-python-code.tsx
+++ b/frontend/src/components/editor/code/readonly-python-code.tsx
@@ -17,7 +17,7 @@ export const ReadonlyPythonCode = memo(
     const { theme } = useThemeForPlugin();
     const { code, className, ...rest } = props;
     return (
-      <div className={cn("relative hover-actions-parent", className)}>
+      <div className={cn("relative hover-actions-parent w-full", className)}>
         <FloatingCopyButton text={code} />
         <CodeMirror
           {...rest}
@@ -44,7 +44,7 @@ const FloatingCopyButton = (props: { text: string }) => {
   return (
     <Button
       onClick={copy}
-      className="absolute top-0 right-0 m-1 z-10 hover-action"
+      className="absolute top-0 right-0 m-2 z-10 hover-action"
       size="xs"
       variant="secondary"
     >

--- a/frontend/src/components/editor/inputs/Inputs.styles.ts
+++ b/frontend/src/components/editor/inputs/Inputs.styles.ts
@@ -3,7 +3,7 @@ import { cva } from "class-variance-authority";
 import "./Inputs.css";
 
 export const button = cva(
-  "flex items-center justify-center m-0 leading-none font-medium border border-foreground/10 shadow-xsSolid shadow-foreground/10 hover:cursor-pointer focus:shadow-md dark:border-border",
+  "flex items-center justify-center m-0 leading-none font-medium border border-foreground/10 shadow-xsSolid shadow-foreground/10 hover:cursor-pointer focus:shadow-md dark:border-border text-sm",
   {
     variants: {
       color: {

--- a/frontend/src/components/editor/renderers/plugins.ts
+++ b/frontend/src/components/editor/renderers/plugins.ts
@@ -2,11 +2,13 @@
 import { GridLayoutPlugin } from "./grid-layout/plugin";
 import { ICellRendererPlugin, LayoutType } from "./types";
 import { CellData } from "@/core/cells/types";
+import { VerticalLayoutPlugin } from "./vertical-layout/vertical-layout";
 
 // If more renderers are added, we may want to consider lazy loading them.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const cellRendererPlugins: Array<ICellRendererPlugin<any, any>> = [
   GridLayoutPlugin,
+  VerticalLayoutPlugin,
 ];
 
 export function deserializeLayout(

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -41,8 +41,8 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
           interrupted={cell.interrupted}
         />
       ))}
-      {canShowCode && (
-        <div className="fixed m-4 left-0 bottom-0">
+      {!canShowCode && (
+        <div className="fixed m-4 left-0 top-0">
           <Button
             onClick={() => setShowCode((prev) => !prev)}
             data-testid="show-code"

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -92,12 +92,12 @@ const VerticalCell = memo(
     const HTMLId = HTMLCellId.create(cellId);
     const hidden = errored || interrupted || stopped;
 
-    // Read mode + show code
-    if (showCode) {
+    // Read mode and show code
+    if (mode === "read" && showCode) {
       return (
         <div tabIndex={-1} id={HTMLId} ref={cellRef} className={className}>
           <OutputArea
-            allowExpand={mode === "edit"}
+            allowExpand={true}
             output={output}
             className="output-area"
             cellId={cellId}

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -9,9 +9,9 @@ import { z } from "zod";
 import { useDelayVisibility } from "./useDelayVisiblity";
 import { AppMode } from "@/core/mode";
 import { ReadonlyPythonCode } from "@/components/editor/code/readonly-python-code";
-import { Button } from "../../inputs/Inputs";
 import { Code2Icon } from "lucide-react";
 import { cn } from "@/utils/cn";
+import { Button } from "@/components/ui/button";
 
 type VerticalLayout = null;
 type VerticalLayoutProps = ICellRendererProps<VerticalLayout>;
@@ -41,9 +41,10 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
           interrupted={cell.interrupted}
         />
       ))}
-      {!canShowCode && (
-        <div className="fixed m-4 left-0 top-0">
+      {canShowCode && (
+        <div className="absolute m-4 left-0 top-0">
           <Button
+            variant="secondary"
             onClick={() => setShowCode((prev) => !prev)}
             data-testid="show-code"
           >

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -26,11 +26,7 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
   const [showCode, setShowCode] = useState(false);
   const canShowCode = mode === "read" && isStaticNotebook();
   return (
-    <VerticalLayoutWrapper
-      className="sm:pt-8"
-      invisible={invisible}
-      appConfig={appConfig}
-    >
+    <VerticalLayoutWrapper invisible={invisible} appConfig={appConfig}>
       {cells.map((cell) => (
         <VerticalCell
           key={cell.id}
@@ -83,10 +79,11 @@ const VerticalCell = memo(
     const cellRef = useRef<HTMLDivElement>(null);
     const loading = status === "running" || status === "queued";
 
-    const className = clsx("Cell", "hover-actions-parent flex flex-col", {
+    const className = clsx("Cell", "hover-actions-parent", {
       published: true,
       "has-error": errored,
       stopped: stopped,
+      "flex flex-col": showCode && code,
     });
 
     const HTMLId = HTMLCellId.create(cellId);

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -1,3 +1,10 @@
+/*
+ * Cell can have many states:
+ * - interactive (can hover, focus, click), while in edit mode
+ * - stale
+ * - error
+ * - disabled
+ * */
 .Cell {
   position: relative;
   margin-bottom: 21px;
@@ -7,6 +14,172 @@
   border: 1px solid transparent;
   box-shadow: var(--light-shadow);
 
+  &:focus-visible {
+    /* focus-visible outlines the entire cell body in black, but the cell's
+     * body is an irregular shape because of pseudo-elements that extend
+     * its hit-box / hover area. */
+    outline: none;
+  }
+
+  /* Interactive */
+  &.interactive {
+    /* Only restrain output length in edit mode. */
+    .output-area,
+    .console-output-area {
+      max-height: 610px;
+      overflow: auto;
+    }
+
+    .output-area {
+      border-top-left-radius: 8px;
+      border-top-right-radius: 8px;
+    }
+
+    &:hover {
+      box-shadow: var(--medium-shadow);
+    }
+
+    &:focus-within {
+      border: 1px solid var(--gray-5);
+
+      /* a sharp box shadow with a slight blur to outline the element */
+      box-shadow: var(--heavy-shadow);
+
+      /* a little bit of motion
+      *
+      * Note: we use left/top instead of transform because transform creates a new
+      * stacking context and makes completion tooltip appear below surrounding
+      * cells/outputs. See
+      *
+      * https://stackoverflow.com/questions/20851452/z-index-is-canceled-by-setting-transformrotate,
+      * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+      * */
+      left: -1px;
+      top: -1px;
+    }
+  }
+
+  /* Stale styles for Cell */
+  &.stale,
+  &.disabled.stale {
+    .output-area,
+    .cm-gutters,
+    .cm {
+      background-color: var(--gray-2);
+      opacity: 0.5;
+    }
+  }
+
+  /* Disabled styles for Cell */
+  &.disabled,
+  &.disabled.has-error,
+  &.disabled:hover,
+  &.disabled.has-error:hover {
+    box-shadow: var(--light-shadow);
+
+    &:focus-within {
+      box-shadow: var(--heavy-shadow);
+    }
+
+    .output-area,
+    .cm-gutters,
+    .cm {
+      background-color: var(--gray-1);
+      opacity: 0.5;
+    }
+  }
+
+  /* Needs Run */
+  &.needs-run {
+    box-shadow: var(--light-shadow-stale);
+
+    &:hover {
+      box-shadow: var(--medium-shadow-stale);
+    }
+
+    &:focus-within:hover,
+    &:focus-within {
+      box-shadow: var(--heavy-shadow-stale);
+    }
+
+    &:focus-within .cm-editor {
+      box-shadow: none;
+      border: 1px solid transparent;
+    }
+
+    .output-area {
+      border-bottom: 1px solid var(--stale-color);
+    }
+
+    .RunButton {
+      visibility: visible;
+    }
+  }
+
+  /* Error styles for Cell */
+  &.has-error,
+  &.error-outline {
+    outline: 1px solid var(--red-4);
+    box-shadow: var(--light-shadow-error);
+  }
+
+  &.has-error:hover {
+    box-shadow: var(--medium-shadow-error);
+  }
+
+  &.has-error:focus-within,
+  &.has-error:focus-within:hover {
+    box-shadow: var(--heavy-shadow-error);
+  }
+
+  &.error-outline,
+  &.error-outline:focus-within {
+    box-shadow: 8px 8px 0 0 hsl(var(--error) / 80%);
+    background-color: var(--red-2);
+  }
+
+  /* Focus state */
+  &.focus-outline {
+    border-color: var(--blue-8);
+
+    /* custom shadow until our theme overrides can support colored shadow */
+    --tw-shadow: 0 4px 0px -1px var(--blue-8), 0 2px 4px -2px var(--blue-8) !important;
+
+    @apply shadow-lg;
+  }
+
+  /* Published - when its just the output */
+  &.published {
+    margin-bottom: 0;
+    border: none;
+    box-shadow: none;
+
+    .output-area {
+      /* flow-root interferes with margin collapsing, but appears to be unneeded
+      * when cell outlines are hidden; clear:both is sufficient.
+      *
+      * if developers just use css-grid instead of float, this won't matter.
+      * */
+      display: block;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+
+    &:hover {
+      border: none;
+      box-shadow: none;
+    }
+
+    &:focus-within {
+      transform: none;
+    }
+
+    .output-area {
+      border: none;
+      box-shadow: none;
+    }
+  }
+
   @apply bg-background;
 }
 
@@ -14,117 +187,61 @@
   @apply border-border;
 }
 
-/* Background determined by disconnected gradient/noise. */
-#App.disconnected .Cell,
-#App.disconnected .console-output-area,
-#App.disconnected .cm .cm-gutters,
-#App.disconnected .Cell .cm-editor.cm-focused .cm-activeLineGutter,
-#App.disconnected .Cell .cm-editor.cm-focused .cm-activeLine,
-#App.disconnected .Cell .ShoulderButton {
-  background-color: transparent;
-}
+#App.disconnected {
+  /* Background determined by disconnected gradient/noise. */
+  .Cell,
+  .console-output-area,
+  .cm .cm-gutters,
+  .Cell .cm-editor.cm-focused .cm-activeLineGutter,
+  .Cell .cm-editor.cm-focused .cm-activeLine,
+  .Cell .ShoulderButton {
+    background-color: transparent;
+  }
 
-/* Hide when disconnected. */
-#App.disconnected .cell-running-icon,
-#App.disconnected .cell-queued-icon,
-#App.disconnected .elapsed-time {
-  visibility: hidden;
-  animation: none;
-}
+  /* Hide when disconnected. */
+  .cell-running-icon,
+  .cell-queued-icon,
+  .elapsed-time {
+    visibility: hidden;
+    animation: none;
+  }
 
-#App.disconnected .console-output-area {
-  border-color: transparent;
-}
-
-.Cell:not(.disabled):hover {
-  box-shadow: var(--medium-shadow);
-}
-
-.Cell.disabled .output-area,
-.Cell.disabled.stale .output-area,
-.Cell.disabled .cm-gutters,
-.Cell.disabled.stale .cm-gutters,
-.Cell.disabled .cm,
-.Cell.disabled.stale .cm {
-  background-color: var(--gray-2);
-  opacity: 0.5;
-}
-
-.Cell.stale .output-area,
-.Cell.stale .cm,
-.Cell.stale .cm-gutters {
-  background-color: var(--gray-1);
-  opacity: 0.5;
-}
-
-.Cell.has-error,
-.Cell.error-outline {
-  outline: 1px solid var(--red-4);
-  box-shadow: var(--light-shadow-error);
-}
-
-.Cell.has-error:hover {
-  box-shadow: var(--medium-shadow-error);
-}
-
-.Cell:not(.published).has-error:focus-within {
-  box-shadow: var(--heavy-shadow-error);
-}
-
-.Cell.error-outline,
-.Cell:not(.published).error-outline:focus-within {
-  box-shadow: 8px 8px 0 0 hsl(var(--error) / 80%);
-  background-color: var(--red-2);
-}
-
-.Cell.focus-outline {
-  border-color: var(--blue-8);
-
-  /* custom shadow until our theme overrides can support colored shadow */
-  --tw-shadow: 0 4px 0px -1px var(--blue-8), 0 2px 4px -2px var(--blue-8) !important;
-
-  @apply shadow-lg;
-}
-
-.Cell:focus-visible {
-  /* focus-visible outlines the entire cell body in black, but the cell's
-   * body is an irregular shape because of psuedo-elements that extend
-   * its hit-box / hover area. */
-  outline: none;
-}
-
-.Cell:not(.published):focus-within {
-  border: 1px solid var(--gray-5);
-
-  /* a sharp box shadow with a slight blur to outline the element */
-  box-shadow: var(--heavy-shadow);
-
-  /* a little bit of motion
-   *
-   * Note: we use left/top instead of transform because transform creates a new
-   * stacking context and makes completion tooltip appear below surrounding
-   * cells/outputs. See
-   *
-   * https://stackoverflow.com/questions/20851452/z-index-is-canceled-by-setting-transformrotate,
-   * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-   * */
-  left: -1px;
-  top: -1px;
+  .console-output-area {
+    border-color: transparent;
+  }
 }
 
 .tray {
   display: flex;
   position: relative;
-}
 
-.tray:first-child .cm-editor {
-  border-top-left-radius: 9px;
-  border-top-right-radius: 9px;
-}
+  &:first-child .cm-editor {
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+  }
 
-.tray:last-child .cm-editor {
-  border-bottom-left-radius: 9px;
-  border-bottom-right-radius: 9px;
+  &:last-child .cm-editor {
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+  }
+
+  /* expand the hover area left and right */
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    width: var(--gutter-width);
+    max-width: var(--gutter-width);
+    height: 100%;
+  }
+
+  &::before {
+    left: calc(var(--gutter-width) * -1);
+  }
+
+  &::after {
+    right: calc(var(--gutter-width) * -1);
+  }
 }
 
 :root {
@@ -132,65 +249,48 @@
   --gutter-width: calc(50vw - (var(--content-width) / 2));
 }
 
-/* expand the hover area left and right */
-.tray::before,
-.tray::after {
-  content: "";
-  position: absolute;
-  width: var(--gutter-width);
-  max-width: var(--gutter-width);
-  height: 100%;
-}
-
-.tray::before {
-  left: calc(var(--gutter-width) * -1);
-}
-
-.tray::after {
-  right: calc(var(--gutter-width) * -1);
-}
-
 /* -------------------------- Shoulders/Buttons ---------------------------- */
-.Cell .shoulder-left {
-  position: absolute;
-  left: -34px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  justify-content: center;
-  height: 100%;
-  z-index: 2;
-}
+.Cell {
+  .shoulder-left {
+    position: absolute;
+    left: -34px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    justify-content: center;
+    height: 100%;
+    z-index: 2;
+  }
 
-.shoulder-elem-top {
-  margin-bottom: auto;
-}
+  .shoulder-elem-top {
+    margin-bottom: auto;
+  }
 
-.shoulder-elem-bottom {
-  vertical-align: bottom;
-}
+  .shoulder-elem-bottom {
+    vertical-align: bottom;
+  }
 
-.Cell .shoulder-right {
-  display: inline-flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  height: 100%;
-  position: absolute;
-  right: -98px;
-  width: 80px;
-  gap: 4px;
-  z-index: 2;
-}
+  .shoulder-right {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    height: 100%;
+    position: absolute;
+    right: -98px;
+    width: 80px;
+    gap: 4px;
+    z-index: 2;
+  }
 
-.Cell .shoulder-bottom {
-  position: absolute;
-  bottom: -2px;
-  right: 2px;
-  z-index: 2; /* lie above editor */
+  .shoulder-bottom {
+    position: absolute;
+    bottom: -2px;
+    right: 2px;
+    z-index: 2; /* lie above editor */
+  }
 }
 
 /* ------------------------ CodeMirror Editor ----------------------------- */
-
 .cm {
   width: 100%;
 }
@@ -204,36 +304,47 @@
   padding-right: 24px;
 }
 
-/* .Cell is needed to take precedence over codemirror's generated class ... */
-.Cell .cm-editor.cm-focused {
-  outline: 0;
+.Cell .cm {
+  border-radius: 8px;
 }
 
-.Cell .cm-editor.cm-focused .cm-activeLineGutter {
-  background: #e2f2ff;
+/* .Cell is needed to take precedence over codemirror's generated class ... */
+.Cell .cm-editor {
+  &.cm-focused {
+    outline: 0;
+
+    .cm-activeLineGutter {
+      background: #e2f2ff;
+    }
+
+    .cm-activeLine {
+      background: hsl(210deg 100% 50% / 3%);
+    }
+  }
+
+  .cm-activeLine {
+    background: transparent;
+
+    /* Soften the corners of the active-line highlight. */
+    border-radius: 2px;
+  }
+
+  .cm-activeLineGutter {
+    background: transparent;
+  }
+
+  .cm-content {
+    font-size: 0.875rem;
+    font-family: var(--monospace-font);
+  }
 }
 
 .dark .Cell .cm-editor.cm-focused .cm-activeLineGutter {
   background: #0e1e25;
 }
 
-.Cell .cm-editor .cm-activeLineGutter {
-  background: transparent;
-}
-
-.Cell .cm-editor.cm-focused .cm-activeLine {
-  background: hsl(210deg 100% 50% / 3%);
-}
-
 .dark .Cell .cm-editor.cm-focused .cm-activeLine {
   background: hsl(210deg 100% 2% / 20%);
-}
-
-.Cell .cm-editor .cm-activeLine {
-  background: transparent;
-
-  /* Soften the corners of the active-line highlight. */
-  border-radius: 2px;
 }
 
 /* ------------------------------ Output Areas ------------------------------ */
@@ -251,13 +362,6 @@
   /* TODO: Find a way to accommodate large elements, ideally in a way that
    * doesn't break margin collapse. Setting overflow (eg, overflow: auto)
    * breaks margin collapse. */
-}
-
-/* Only restrain output length in edit mode. */
-.Cell:not(.published) .output-area,
-.console-output-area {
-  max-height: 600px;
-  overflow: auto;
 }
 
 .marimo-output-stale,
@@ -282,76 +386,4 @@
   border-right: 1px solid var(--gray-3);
   border-left: 1px solid var(--gray-3);
   background-color: var(--gray-1);
-}
-
-/* ------------------------------- Published -------------------------------- */
-
-.Cell.published .output-area {
-  /* flow-root interferes with margin collapsing, but appears to be unneeded
-   * when cell outlines are hidden; clear:both is sufficient.
-   *
-   * if developers just use css-grid instead of float, this won't matter.
-   * */
-  display: block;
-  padding-top: 0%;
-  padding-bottom: 0%;
-}
-
-/* We remove all borders and vertical padding to make sure that margins
- * collapse across cells. Removing the borders will cause a 1px shift/jump,
- * but nothing can be done about that. */
-.Cell.published:hover {
-  border: none;
-  box-shadow: none;
-}
-
-.Cell.published:focus-within {
-  transform: none;
-}
-
-.Cell:focus-within .cm-editor {
-  box-shadow: none;
-  border: 1px solid transparent;
-}
-
-.Cell.published {
-  margin-bottom: 0;
-}
-
-.Cell.published,
-.Cell.published .output-area,
-.Cell.published .console-output-area {
-  border: none;
-  box-shadow: none;
-}
-
-.Cell .cm-content {
-  font-size: 0.875rem;
-  font-family: var(--monospace-font);
-}
-
-/* ------------------------------ Needs Run---------------------------------- */
-.Cell.needs-run {
-  box-shadow: var(--light-shadow-stale);
-}
-
-.Cell.needs-run:hover {
-  box-shadow: var(--medium-shadow-stale);
-}
-
-.Cell.needs-run:focus-within {
-  box-shadow: var(--heavy-shadow-stale);
-}
-
-.Cell.needs-run:focus-within .cm-editor {
-  box-shadow: none;
-  border: 1px solid transparent;
-}
-
-.Cell.needs-run .output-area {
-  border-bottom: 1px solid var(--stale-color);
-}
-
-.Cell.needs-run .RunButton {
-  visibility: visible;
 }

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -57,6 +57,10 @@
       left: -1px;
       top: -1px;
     }
+
+    .cm {
+      border-radius: 8px;
+    }
   }
 
   /* Stale styles for Cell */
@@ -163,6 +167,8 @@
       display: block;
       padding-top: 0;
       padding-bottom: 0;
+      border: none;
+      box-shadow: none;
     }
 
     &:hover {
@@ -173,11 +179,45 @@
     &:focus-within {
       transform: none;
     }
+  }
 
-    .output-area {
-      border: none;
-      box-shadow: none;
-    }
+  /* -------------------------- Shoulders/Buttons ---------------------------- */
+  .shoulder-left {
+    position: absolute;
+    left: -34px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    justify-content: center;
+    height: 100%;
+    z-index: 2;
+  }
+
+  .shoulder-elem-top {
+    margin-bottom: auto;
+  }
+
+  .shoulder-elem-bottom {
+    vertical-align: bottom;
+  }
+
+  .shoulder-right {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    height: 100%;
+    position: absolute;
+    right: -98px;
+    width: 80px;
+    gap: 4px;
+    z-index: 2;
+  }
+
+  .shoulder-bottom {
+    position: absolute;
+    bottom: -2px;
+    right: 2px;
+    z-index: 2; /* lie above editor */
   }
 
   @apply bg-background;
@@ -249,47 +289,6 @@
   --gutter-width: calc(50vw - (var(--content-width) / 2));
 }
 
-/* -------------------------- Shoulders/Buttons ---------------------------- */
-.Cell {
-  .shoulder-left {
-    position: absolute;
-    left: -34px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    justify-content: center;
-    height: 100%;
-    z-index: 2;
-  }
-
-  .shoulder-elem-top {
-    margin-bottom: auto;
-  }
-
-  .shoulder-elem-bottom {
-    vertical-align: bottom;
-  }
-
-  .shoulder-right {
-    display: inline-flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    height: 100%;
-    position: absolute;
-    right: -98px;
-    width: 80px;
-    gap: 4px;
-    z-index: 2;
-  }
-
-  .shoulder-bottom {
-    position: absolute;
-    bottom: -2px;
-    right: 2px;
-    z-index: 2; /* lie above editor */
-  }
-}
-
 /* ------------------------ CodeMirror Editor ----------------------------- */
 .cm {
   width: 100%;
@@ -302,10 +301,6 @@
 
   /* leave some room for UI elements inside the code editor */
   padding-right: 24px;
-}
-
-.Cell .cm {
-  border-radius: 8px;
 }
 
 /* .Cell is needed to take precedence over codemirror's generated class ... */

--- a/frontend/src/plugins/impl/data-frames/python/code-panel.tsx
+++ b/frontend/src/plugins/impl/data-frames/python/code-panel.tsx
@@ -1,14 +1,8 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import React, { memo } from "react";
+import React from "react";
 import { Transformations } from "../schema";
-import { python } from "@codemirror/lang-python";
-import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { pythonPrintTransforms } from "./python-print";
-import { CopyIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Events } from "@/utils/events";
-import { toast } from "@/components/ui/use-toast";
-import { useThemeForPlugin } from "@/theme/useTheme";
+import { ReadonlyPythonCode } from "@/components/editor/code/readonly-python-code";
 
 interface Props {
   dataframeName: string;
@@ -21,45 +15,10 @@ export const CodePanel: React.FC<Props> = ({ transforms, dataframeName }) => {
   }
 
   return (
-    <PythonCode
+    <ReadonlyPythonCode
+      className="min-h-[200px]"
+      minHeight="200px"
       code={pythonPrintTransforms(dataframeName, transforms.transforms)}
     />
-  );
-};
-
-const PythonCode = memo((props: { code: string }) => {
-  const { theme } = useThemeForPlugin();
-  return (
-    <div className="relative min-h-[200px]">
-      <FloatingCopyButton text={props.code} />
-      <CodeMirror
-        minHeight="200px"
-        className="cm"
-        theme={theme === "dark" ? "dark" : "light"}
-        height="100%"
-        editable={true}
-        extensions={[python(), EditorView.lineWrapping]}
-        value={props.code}
-        readOnly={true}
-      />
-    </div>
-  );
-});
-PythonCode.displayName = "PythonCode";
-
-const FloatingCopyButton = (props: { text: string }) => {
-  const copy = Events.stopPropagation(() => {
-    navigator.clipboard.writeText(props.text);
-    toast({ title: "Copied to clipboard" });
-  });
-
-  return (
-    <Button
-      onClick={copy}
-      className="absolute top-0 right-0 m-2 z-10"
-      variant="secondary"
-    >
-      <CopyIcon size={16} strokeWidth={1.5} />
-    </Button>
   );
 };


### PR DESCRIPTION
* always show a button in the static export to view the code
* code is shown **above** 
* defaults to hidden, but can expose this by a query-param in future if requested
* option to copy each code on hover

![Screenshot 2023-12-06 at 3 11 11 PM](https://github.com/marimo-team/marimo/assets/2753772/d54f0212-f2ed-46b0-b65b-aa2d7056938a)
