### PR TITLE
Add processor to marimo env

### DIFF
--- a/marimo/_cli/envinfo.py
+++ b/marimo/_cli/envinfo.py
@@ -15,6 +15,8 @@ def get_system_info() -> dict[str, Union[str, dict[str, str]]]:
         "marimo": __version__,
         "OS": platform.system(),
         "OS Version": platform.release(),
+         # e.g., x86 or arm
+        "Processor": platform.processor(),
         "Python Version": platform.python_version(),
     }
 


### PR DESCRIPTION
So we can tell if users are using x86 or arm.

Example:

```
{
  "marimo": "0.1.64",
  "OS": "Linux",
  "OS Version": "6.2.0-36-generic",
  "Processor": "x86_64",
  "Python Version": "3.10.12",
  "Binaries": {
    "Chrome": "119.0.6045.159",
    "Node": "v18.13.0"
  },
  "Requirements": {
    "black": "23.3.0",
    "click": "8.1.3",
    "jedi": "0.18.2",
    "pymdown-extensions": "10.0.1",
    "tomlkit": "0.12.1",
    "tornado": "6.2",
    "typing_extensions": "4.4.0"
  }
}
```