### PR TITLE
fix: fix incorrect staleness indicator of outputs in run mode

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -39,6 +39,7 @@ import { AppMode } from "@/core/mode";
 import useEvent from "react-use-event-hook";
 import { CellEditor } from "./cell/code/cell-editor";
 import { getEditorCodeAsPython } from "@/core/codemirror/language/utils";
+import { outputIsStale } from "@/core/cells/cell";
 
 /**
  * Imperative interface of the cell.
@@ -134,18 +135,11 @@ const CellComponent = (
 
   const needsRun = edited || interrupted;
   const loading = status === "running" || status === "queued";
-  // output may or may not be refreshed while a cell is running, so
-  // we need to check if an output was received
-  const outputReceivedWhileRunning =
-    status === "running" &&
-    output !== null &&
-    runStartTimestamp !== null &&
-    output.timestamp > runStartTimestamp;
-  const outputStale =
-    ((loading && !outputReceivedWhileRunning) ||
-      edited ||
-      status === "stale") &&
-    !interrupted;
+  const outputStale = outputIsStale(
+    { status, output, runStartTimestamp, interrupted },
+    edited
+  );
+
   // console output is cleared immediately on run, so check for queued instead
   // of loading to determine staleness
   const consoleOutputStale =

--- a/frontend/src/components/editor/code/readonly-python-code.tsx
+++ b/frontend/src/components/editor/code/readonly-python-code.tsx
@@ -1,6 +1,5 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { memo } from "react";
-import { python } from "@codemirror/lang-python";
 import CodeMirror, {
   EditorView,
   ReactCodeMirrorProps,
@@ -11,6 +10,7 @@ import { Events } from "@/utils/events";
 import { toast } from "@/components/ui/use-toast";
 import { useThemeForPlugin } from "@/theme/useTheme";
 import { cn } from "@/utils/cn";
+import { customPythonLanguageSupport } from "@/core/codemirror/language/python";
 
 export const ReadonlyPythonCode = memo(
   (props: { className?: string; code: string } & ReactCodeMirrorProps) => {
@@ -25,7 +25,7 @@ export const ReadonlyPythonCode = memo(
           theme={theme === "dark" ? "dark" : "light"}
           height="100%"
           editable={true}
-          extensions={[python(), EditorView.lineWrapping]}
+          extensions={[customPythonLanguageSupport(), EditorView.lineWrapping]}
           value={code}
           readOnly={true}
         />

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -69,7 +69,6 @@ interface VerticalCellProps
     | "interrupted"
     | "runStartTimestamp"
   > {
-  cellRuntime: CellRuntimeState;
   cellId: CellId;
   code: string;
   mode: AppMode;

--- a/frontend/src/core/cells/__tests__/cell.test.ts
+++ b/frontend/src/core/cells/__tests__/cell.test.ts
@@ -1,0 +1,163 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { expect, describe, it } from "vitest";
+import { outputIsStale } from "../cell";
+import { CellStatus } from "../types";
+import { OutputMessage } from "@/core/kernel/messages";
+
+const STATUSES: CellStatus[] = [
+  "queued",
+  "running",
+  "idle",
+  "stale",
+  "disabled-transitively",
+];
+
+function createOutput(): OutputMessage {
+  return {
+    channel: "output",
+    mimetype: "application/json",
+    data: {
+      foo: "bar",
+    },
+    timestamp: Date.now(),
+  };
+}
+
+describe("outputIsStale", () => {
+  it.each(STATUSES)(
+    "should return true if the cell is edited and status is %s",
+    (status) => {
+      const cell = {
+        status: status,
+        output: null,
+        runStartTimestamp: null,
+        interrupted: false,
+      };
+      const edited = true;
+      expect(outputIsStale(cell, edited)).toBe(true);
+    }
+  );
+
+  it("should return true if the cell is loading", () => {
+    const cell = {
+      status: "running" as CellStatus,
+      output: null,
+      runStartTimestamp: null,
+      interrupted: false,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(true);
+  });
+
+  it("should return false if the cell is running and output is received after run started", () => {
+    const cell = {
+      status: "running" as CellStatus,
+      output: createOutput(),
+      runStartTimestamp: Date.now() - 1000, // Output received after run started
+      interrupted: false,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(false);
+  });
+
+  it("should return true if the cell status is stale", () => {
+    const cell = {
+      status: "stale" as CellStatus,
+      output: null,
+      runStartTimestamp: null,
+      interrupted: false,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(true);
+  });
+
+  it("should return false if the cell is interrupted", () => {
+    const cell = {
+      status: "running" as CellStatus,
+      output: null,
+      runStartTimestamp: null,
+      interrupted: true,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(false);
+  });
+
+  it("should return true if the cell is running and output is received before run started", () => {
+    const cell = {
+      status: "running" as CellStatus,
+      output: createOutput(),
+      runStartTimestamp: Date.now() + 1000, // Output received before run started
+      interrupted: false,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(true);
+  });
+
+  it("should return false if the cell is idle and output is received", () => {
+    const cell = {
+      status: "idle" as CellStatus,
+      output: createOutput(),
+      runStartTimestamp: null,
+      interrupted: false,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(false);
+  });
+
+  it("should return true if the cell is queued", () => {
+    const cell = {
+      status: "queued" as CellStatus,
+      output: null,
+      runStartTimestamp: null,
+      interrupted: false,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(true);
+  });
+
+  it("should return true if the cell is running but no output is received", () => {
+    const cell = {
+      status: "running" as CellStatus,
+      output: null,
+      runStartTimestamp: Date.now(),
+      interrupted: false,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(true);
+  });
+
+  it("should return false if the cell is idle and not edited", () => {
+    const cell = {
+      status: "idle" as CellStatus,
+      output: null,
+      runStartTimestamp: null,
+      interrupted: false,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(false);
+  });
+
+  it("should return false if the cell is interrupted but also edited", () => {
+    // We likely don't get in this state since before a cell is interrupted, it is run and we remove the edited state
+    const cell = {
+      status: "idle" as CellStatus,
+      output: null,
+      runStartTimestamp: null,
+      interrupted: true,
+    };
+    const edited = true;
+    expect(outputIsStale(cell, edited)).toBe(false);
+  });
+
+  it("should return true if the cell is interrupted but has a stale status", () => {
+    // We likely don't get in this state since when a cell is interrupted, it's status is set to idle
+    const cell = {
+      status: "stale" as CellStatus,
+      output: null,
+      runStartTimestamp: null,
+      interrupted: true,
+    };
+    const edited = false;
+    expect(outputIsStale(cell, edited)).toBe(false);
+  });
+});

--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -48,10 +48,7 @@ export class PythonLanguageAdapter implements LanguageAdapter {
         closeOnBlur: false,
         override: [completer],
       }),
-      new LanguageSupport(customizedPython, [
-        customizedPython.data.of({ autocomplete: localCompletionSource }),
-        customizedPython.data.of({ autocomplete: globalCompletion }),
-      ]),
+      customPythonLanguageSupport(),
     ];
   }
 }
@@ -66,3 +63,14 @@ const customizedPython = pythonLanguage.configure({
     }),
   ],
 });
+
+/**
+ * This provide LanguageSupport for Python, but with a custom LRLanguage
+ * that supports folding additional syntax nodes at the top-level.
+ */
+export function customPythonLanguageSupport(): LanguageSupport {
+  return new LanguageSupport(customizedPython, [
+    customizedPython.data.of({ autocomplete: localCompletionSource }),
+    customizedPython.data.of({ autocomplete: globalCompletion }),
+  ]);
+}


### PR DESCRIPTION
Fixes https://github.com/marimo-team/marimo/issues/448

* Refactor output staleness check in Cell component to use shared function
* Test said function

This issue existed since we render cells slightly differently in run mode vs edit mode. We do this to avoid extra logic like drag handlers and edit UI, so ideally we DRY up logic between the two