### PR TITLE
feat: show rows, columns of truncated dataframes

### DIFF
--- a/marimo/_cli/envinfo.py
+++ b/marimo/_cli/envinfo.py
@@ -15,7 +15,7 @@ def get_system_info() -> dict[str, Union[str, dict[str, str]]]:
         "marimo": __version__,
         "OS": platform.system(),
         "OS Version": platform.release(),
-         # e.g., x86 or arm
+        # e.g., x86 or arm
         "Processor": platform.processor(),
         "Python Version": platform.python_version(),
     }


### PR DESCRIPTION
When a Pandas dataframe is truncated, show the dimensions.

Closes #389