### PR TITLE
improve: multi-select filter function

### DIFF
--- a/frontend/src/core/kernel/RuntimeState.ts
+++ b/frontend/src/core/kernel/RuntimeState.ts
@@ -7,6 +7,7 @@ import {
 import { UI_ELEMENT_REGISTRY, UIElementRegistry } from "../dom/uiregistry";
 import { isStaticNotebook } from "../static/static-state";
 import { RunRequests } from "../network/types";
+import { repl } from "@/utils/repl";
 
 /**
  * Manager to track running cells.
@@ -40,6 +41,7 @@ export class RuntimeState {
   ) {
     this.runningCount = 0;
     this.componentsToUpdate = new Set();
+    repl(RuntimeState.INSTANCE, "RuntimeState");
   }
 
   /**
@@ -86,7 +88,7 @@ export class RuntimeState {
           })).filter((update) => update.value !== undefined)
         )
         .catch(() => {
-          // This happens if the run was failed ot register (403, network error, etc.)
+          // This happens if the run was failed ot register (401, 403, network error, etc.)
           // If the run fails, restore the components to update and finish the run
           // A run may fail if the kernel is restarted or the notebook is closed,
           // but if we don't restore registerRunEnd() will never be able to flush updates.

--- a/frontend/src/plugins/impl/MultiselectPlugin.tsx
+++ b/frontend/src/plugins/impl/MultiselectPlugin.tsx
@@ -58,6 +58,7 @@ const Multiselect = (props: MultiselectProps): JSX.Element => {
         displayValue={(option) => option}
         placeholder="Select..."
         multiple={true}
+        filterFn={multiselectFilterFn}
         className={cn({
           "w-full": props.fullWidth,
         })}
@@ -72,4 +73,29 @@ const Multiselect = (props: MultiselectProps): JSX.Element => {
       </Combobox>
     </Labeled>
   );
+};
+
+/**
+ * We override the default filter function which focuses on sorting by relevance with a fuzzy-match,
+ * instead of filtering out.
+ * The default filter function is `command-score`.
+ *
+ * Our filter function only matches if all words in the value are present in the option.
+ * This is more strict than the default, but more lenient than an exact match.
+ *
+ * Examples:
+ * - "foo bar" matches "foo bar"
+ * - "bar foo" matches "foo bar"
+ * - "foob" does not matches "foo bar"
+ */
+function multiselectFilterFn(option: string, value: string): number {
+  const words = value.split(/\s+/);
+  const match = words.every((word) =>
+    option.toLowerCase().includes(word.toLowerCase())
+  );
+  return match ? 1 : 0;
+}
+
+export const exportedForTesting = {
+  multiselectFilterFn,
 };

--- a/frontend/src/plugins/impl/__tests__/MultiSelectPlugin.test.ts
+++ b/frontend/src/plugins/impl/__tests__/MultiSelectPlugin.test.ts
@@ -1,0 +1,42 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { expect, it } from "vitest";
+import { exportedForTesting } from "../MultiselectPlugin";
+
+const filterFn = exportedForTesting.multiselectFilterFn;
+function filterOptions(filter: string, items: string[]) {
+  return items.filter((option) => filterFn(option, filter));
+}
+
+it("can filter to relevant words", () => {
+  const options = ["a", "b", "c", "foo", "bar", "foo bar", "foobar"];
+
+  expect(filterOptions("a", options)).toEqual([
+    "a",
+    "bar",
+    "foo bar",
+    "foobar",
+  ]);
+
+  expect(filterOptions("b", options)).toEqual([
+    "b",
+    "bar",
+    "foo bar",
+    "foobar",
+  ]);
+
+  expect(filterOptions("f", options)).toEqual(["foo", "foo bar", "foobar"]);
+
+  expect(filterOptions("foo", options)).toEqual(["foo", "foo bar", "foobar"]);
+
+  expect(filterOptions("foo ", options)).toEqual(["foo", "foo bar", "foobar"]);
+
+  expect(filterOptions("foo b", options)).toEqual(["foo bar", "foobar"]);
+
+  expect(filterOptions("foo ba", options)).toEqual(["foo bar", "foobar"]);
+
+  expect(filterOptions("foo bar", options)).toEqual(["foo bar", "foobar"]);
+
+  expect(filterOptions("foob", options)).toEqual(["foobar"]);
+
+  expect(filterOptions("foob foo", options)).toEqual(["foobar"]);
+});

--- a/frontend/src/utils/repl.ts
+++ b/frontend/src/utils/repl.ts
@@ -16,7 +16,7 @@ export function repl(item: unknown, name: string) {
   }
 
   const fullName = `__marimo__${name}`;
-  if (window[fullName]) {
+  if (window[fullName] && process.env.NODE_ENV !== "test") {
     Logger.warn(`Overwriting existing debug object ${fullName}`);
   }
   window[fullName] = item;


### PR DESCRIPTION
Previous the `filterFn` used in multi-select could return more results than desired. This is because the `filterFn` focused on sorting by relevance if it was a fuzzy-match instead of fully filtering out items that only matched a little. 

This PR instead overrides the `filterFn` to still be a little fuzzy but only by word boundaries and lowercase - see the test cases for examples.

Closes https://github.com/marimo-team/marimo/issues/457