### PR TITLE
improvement: add --include-code to marimo run

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { memo, useRef, useState } from "react";
+import React, { memo, useRef, useState } from "react";
 import { CellRuntimeState } from "@/core/cells/types";
 import { CellId, HTMLCellId } from "@/core/cells/ids";
 import { OutputArea } from "@/components/editor/Output";
@@ -13,6 +13,7 @@ import { Code2Icon } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { Button } from "@/components/ui/button";
 import { outputIsStale } from "@/core/cells/cell";
+import { isStaticNotebook } from "@/core/static/static-state";
 
 type VerticalLayout = null;
 type VerticalLayoutProps = ICellRendererProps<VerticalLayout>;
@@ -44,7 +45,15 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
         />
       ))}
       {canShowCode && (
-        <div className="absolute m-4 left-0 top-0">
+        <div
+          className={cn(
+            "right-0 top-0 z-10 m-4",
+            // If the notebook is static, we have a banner at the top, so
+            // we can't use fixed positioning. Ideally this is sticky, but the
+            // current dom structure makes that difficult.
+            isStaticNotebook() ? "absolute" : "fixed"
+          )}
+        >
           <Button
             variant="secondary"
             onClick={() => setShowCode((prev) => !prev)}

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -213,6 +213,7 @@ def edit(
             headless=headless,
             filename=name,
             run=False,
+            show_code=True,
         )
     )
 
@@ -244,8 +245,18 @@ Example:
     type=bool,
     help="Don't launch a browser.",
 )
+@click.option(
+    "--show-code",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    type=bool,
+    help="Show code in the notebook.",
+)
 @click.argument("name", required=True)
-def run(port: Optional[int], headless: bool, name: str) -> None:
+def run(
+    port: Optional[int], headless: bool, show_code: bool, name: str
+) -> None:
     # Validate name, or download from URL
     # The second return value is an optional temporary directory. It is unused,
     # but must be kept around because its lifetime on disk is bound to the life
@@ -263,6 +274,7 @@ def run(port: Optional[int], headless: bool, name: str) -> None:
             headless=headless,
             filename=name,
             run=True,
+            show_code=show_code,
         )
     )
 
@@ -373,6 +385,7 @@ def tutorial(
             headless=headless,
             filename=fname,
             run=False,
+            show_code=True,
         )
     )
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -213,7 +213,7 @@ def edit(
             headless=headless,
             filename=name,
             run=False,
-            show_code=True,
+            include_code=True,
         )
     )
 
@@ -246,16 +246,16 @@ Example:
     help="Don't launch a browser.",
 )
 @click.option(
-    "--show-code",
+    "--include-code",
     is_flag=True,
     default=False,
     show_default=True,
     type=bool,
-    help="Show code in the notebook.",
+    help="Include notebook code in the app.",
 )
 @click.argument("name", required=True)
 def run(
-    port: Optional[int], headless: bool, show_code: bool, name: str
+    port: Optional[int], headless: bool, include_code: bool, name: str
 ) -> None:
     # Validate name, or download from URL
     # The second return value is an optional temporary directory. It is unused,
@@ -274,7 +274,7 @@ def run(
             headless=headless,
             filename=name,
             run=True,
-            show_code=show_code,
+            include_code=include_code,
         )
     )
 
@@ -385,7 +385,7 @@ def tutorial(
             headless=headless,
             filename=fname,
             run=False,
-            show_code=True,
+            include_code=True,
         )
     )
 

--- a/marimo/_cli/test_cli.py
+++ b/marimo/_cli/test_cli.py
@@ -110,7 +110,7 @@ def test_cli_run_with_show_code() -> None:
 
     port = _get_port()
     p = subprocess.Popen(
-        ["marimo", "run", path, "-p", str(port), "--headless", "--show-code"]
+        ["marimo", "run", path, "-p", str(port), "--headless", "--include-code"]
     )
     contents = _try_fetch(port)
     _check_contents(p, b"marimo-mode data-mode=read", contents)

--- a/marimo/_cli/test_cli.py
+++ b/marimo/_cli/test_cli.py
@@ -99,6 +99,26 @@ def test_cli_run() -> None:
     )
 
 
+def test_cli_run_with_show_code() -> None:
+    filecontents = codegen.generate_filecontents(
+        ["import marimo as mo"], ["one"], cell_configs=[CellConfig()]
+    )
+    d = tempfile.TemporaryDirectory()
+    path = os.path.join(d.name, "run.py")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(filecontents)
+
+    port = _get_port()
+    p = subprocess.Popen(
+        ["marimo", "run", path, "-p", str(port), "--headless", "--show-code"]
+    )
+    contents = _try_fetch(port)
+    _check_contents(p, b"marimo-mode data-mode=read", contents)
+    _check_contents(
+        p, f"marimo-version data-version={__version__}".encode(), contents
+    )
+
+
 def test_cli_tutorial() -> None:
     port = _get_port()
     p = subprocess.Popen(

--- a/marimo/_cli/test_cli.py
+++ b/marimo/_cli/test_cli.py
@@ -110,7 +110,15 @@ def test_cli_run_with_show_code() -> None:
 
     port = _get_port()
     p = subprocess.Popen(
-        ["marimo", "run", path, "-p", str(port), "--headless", "--include-code"]
+        [
+            "marimo",
+            "run",
+            path,
+            "-p",
+            str(port),
+            "--headless",
+            "--include-code",
+        ]
     )
     contents = _try_fetch(port)
     _check_contents(p, b"marimo-mode data-mode=read", contents)

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -307,7 +307,7 @@ async def start_server(
     run: bool = False,
     development_mode: bool = False,
     quiet: bool = False,
-    show_code: bool = False,
+    include_code: bool = False,
 ) -> None:
     """Start the server.
 
@@ -319,7 +319,7 @@ async def start_server(
     run: if True, starts the server in run (read-only) mode; if False, runs
         in edit (read-write) mode.
     development_mode: if True, enables tornado debug logging and autoreloading
-    show_code: if True, return the code to the frontend when in run mode
+    include_code: if True, return the code to the frontend when in run mode
     """
 
     initialize_mimetypes()
@@ -339,7 +339,7 @@ async def start_server(
         port=port,
         development_mode=development_mode,
         quiet=quiet,
-        show_code=show_code,
+        include_code=include_code,
     )
 
     try:

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -307,6 +307,7 @@ async def start_server(
     run: bool = False,
     development_mode: bool = False,
     quiet: bool = False,
+    show_code: bool = False,
 ) -> None:
     """Start the server.
 
@@ -318,6 +319,7 @@ async def start_server(
     run: if True, starts the server in run (read-only) mode; if False, runs
         in edit (read-write) mode.
     development_mode: if True, enables tornado debug logging and autoreloading
+    show_code: if True, return the code to the frontend when in run mode
     """
 
     initialize_mimetypes()
@@ -337,6 +339,7 @@ async def start_server(
         port=port,
         development_mode=development_mode,
         quiet=quiet,
+        show_code=show_code,
     )
 
     try:

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -392,7 +392,7 @@ class SessionManager:
         port: int,
         development_mode: bool,
         quiet: bool,
-        show_code: bool,
+        include_code: bool,
     ) -> None:
         self.filename = filename
         self.mode = mode
@@ -403,7 +403,7 @@ class SessionManager:
         self.quiet = quiet
         self.sessions: dict[str, Session] = {}
         self.app_config: Optional[_AppConfig]
-        self.show_code = show_code
+        self.include_code = include_code
         # token uniquely identifying this server
 
         if (app := self.load_app()) is not None:
@@ -538,7 +538,7 @@ class SessionManager:
 
     def should_send_code_to_frontend(self) -> bool:
         """Returns True if the server can send messages to the frontend."""
-        return self.mode == SessionMode.EDIT or self.show_code
+        return self.mode == SessionMode.EDIT or self.include_code
 
 
 def requires_edit(handler: Callable[..., Any]) -> Callable[..., Any]:
@@ -565,7 +565,7 @@ def initialize_manager(
     port: int,
     development_mode: bool,
     quiet: bool,
-    show_code: bool,
+    include_code: bool,
 ) -> SessionManager:
     """Must be called on server start."""
     global SESSION_MANAGER
@@ -575,7 +575,7 @@ def initialize_manager(
         port=port,
         development_mode=development_mode,
         quiet=quiet,
-        show_code=show_code,
+        include_code=include_code,
     )
     return SESSION_MANAGER
 


### PR DESCRIPTION
Add a command-line flag to include the code when running a marimo notebook as an app. This enables a button in the app that allows the user to toggle between notebook view and app view:

`marimo run notebook.py --include-code`