### PR TITLE
fix: remove Ctrl+k keyboard shortcut in CommandPalette component

### DIFF
--- a/frontend/src/components/editor/CommandPallette.tsx
+++ b/frontend/src/components/editor/CommandPallette.tsx
@@ -38,7 +38,7 @@ export const CommandPallette = () => {
 
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
+      if (e.key === "k" && e.metaKey && !e.shiftKey) {
         e.preventDefault();
         setOpen((open) => !open);
       }


### PR DESCRIPTION
This removes `Ctrl+k` from opening the Command Palette as it is a used hot-key, and instead just opens on `Meta+k` (for Mac, it would be `Cmd+k`)

Fixes https://github.com/marimo-team/marimo/issues/466