### PR TITLE
Create kernel with configs on the backend

### DIFF
--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -9,7 +9,7 @@ import { RuntimeState } from "@/core/kernel/RuntimeState";
 import { AUTOCOMPLETER } from "@/core/codemirror/completion/Autocompleter";
 import { UI_ELEMENT_REGISTRY } from "@/core/dom/uiregistry";
 import { OperationMessage } from "@/core/kernel/messages";
-import { saveCellConfig, sendInstantiate } from "../network/requests";
+import { sendInstantiate } from "../network/requests";
 import { CellId } from "../cells/ids";
 import { CellConfig, CellData } from "../cells/types";
 import { createCell } from "../cells/types";
@@ -92,16 +92,6 @@ export function useMarimoWebSocket(opts: {
         UI_ELEMENT_REGISTRY.entries.forEach((entry, objectId) => {
           objectIds.push(objectId);
           values.push(entry.value);
-        });
-        // Register the configs
-        saveCellConfig({
-          configs: Object.fromEntries(
-            cells.map((cell) => [cell.id, cell.config])
-          ),
-        }).catch((error) => {
-          showBoundary(
-            new Error("Failed to register configs", { cause: error })
-          );
         });
         // Send the instantiate message
         if (autoInstantiate) {

--- a/marimo/_runtime/conftest.py
+++ b/marimo/_runtime/conftest.py
@@ -36,7 +36,9 @@ class _MockStdStream:
 
 @dataclasses.dataclass
 class MockedKernel:
-    k: Kernel = dataclasses.field(default_factory=Kernel)
+    k: Kernel = dataclasses.field(
+        default_factory=lambda: Kernel(cell_configs={})
+    )
     stream: _MockStream = dataclasses.field(default_factory=_MockStream)
     stdout: _MockStdStream = dataclasses.field(default_factory=_MockStdStream)
     stderr: _MockStdStream = dataclasses.field(default_factory=_MockStdStream)


### PR DESCRIPTION
This PR fixes a race condition in which the frontend sent configs to the kernel without awaiting and instantiated it with code at the same time.

The fix is to just create the kernel with the configs in the backend, and remove the initial saveCellConfig request from the frontend.