### PR TITLE
Only distribute the marimo package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,9 @@ homepage = "https://github.com/marimo-team/marimo"
 [tool.setuptools.dynamic]
 version = { attr = "marimo.__version__" }
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+# project source is entirely contained in the `marimo` package
+include = ["marimo*"]
 
 [tool.ruff]
 line-length=79


### PR DESCRIPTION
Update pyproject.toml to explicitly include only the `marimo` package. This fixes an issue surfaced by https://github.com/conda-forge/staged-recipes/pull/24865, in which `examples`, `frontend`, and `docs` where also getting installed as top-level packages.