### PR TITLE
Fix: kernel process should not be daemonic

### DIFF
--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -270,7 +270,9 @@ class Session:
             self.kernel_task = mp.Process(
                 target=runtime.launch_kernel,
                 args=(self.queue, listener.address, is_edit_mode, configs),
-                daemon=True,
+                # The process can't be a daemon, because daemonic processes
+                # can't create children
+                daemon=False,
             )
         else:
             # We use threads in run mode to minimize memory consumption;

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -272,6 +272,7 @@ class Session:
                 args=(self.queue, listener.address, is_edit_mode, configs),
                 # The process can't be a daemon, because daemonic processes
                 # can't create children
+                # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.daemon  # noqa: E501
                 daemon=False,
             )
         else:
@@ -298,6 +299,8 @@ class Session:
             self.kernel_task = threading.Thread(
                 target=launch_kernel_with_cleanup,
                 args=(self.queue, listener.address, is_edit_mode, configs),
+                # daemon threads can create child processes, unlike
+                # daemon processes
                 daemon=True,
             )
         self.kernel_task.start()


### PR DESCRIPTION
The kernel process should not be daemonic, since daemon processes can't create children (notebooks may use multiprocessing).

The process was previously made daemonic as a precaution to make sure it terminated when the parent did. We have since hardened the code to make sure that the kernel process is terminated, and shouldn't need the daemon flag anymore.