### PR TITLE
fix: dragging cells when in wide mode

### DIFF
--- a/frontend/src/components/editor/SortableCell.tsx
+++ b/frontend/src/components/editor/SortableCell.tsx
@@ -5,6 +5,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVerticalIcon } from "lucide-react";
 import { CellId } from "@/core/cells/ids";
+import { cn } from "@/utils/cn";
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   cellId: CellId;
@@ -36,7 +37,8 @@ const SortableCellInternal = React.forwardRef(
     const style: React.CSSProperties = {
       transform: transform
         ? CSS.Transform.toString({
-            x: transform.x,
+            // No x-transform since only sorting in the y-axis
+            x: 0,
             y: transform.y,
             scaleX: 1,
             scaleY: 1,
@@ -60,8 +62,16 @@ const SortableCellInternal = React.forwardRef(
       </div>
     );
 
+    const isMoving = Boolean(transform);
+
     return (
-      <div tabIndex={-1} ref={mergedRef} {...props} style={style}>
+      <div
+        tabIndex={-1}
+        ref={mergedRef}
+        {...props}
+        className={cn(props.className, isMoving && "is-moving")}
+        style={style}
+      >
         <DragHandleSlot.Provider value={dragHandle}>
           {props.children}
         </DragHandleSlot.Provider>

--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -64,7 +64,7 @@ export const CellActionsContextMenu = ({ children, ...props }: Props) => {
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger>{children}</ContextMenuTrigger>
+      <ContextMenuTrigger asChild={true}>{children}</ContextMenuTrigger>
       <ContextMenuContent className="w-[300px]">
         {[DEFAULT_CONTEXT_MENU_ITEMS, ...actions].map((group, i) => (
           <Fragment key={i}>

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -284,6 +284,14 @@
   }
 }
 
+/* Hide tray when dragging a cell, to prevent messing up the measurements. */
+.Cell.is-moving {
+  .tray::before,
+  .tray::after {
+    display: none;
+  }
+}
+
 :root {
   /* In wide mode, this will overextend, but that's fine */
   --gutter-width: calc(50vw - (var(--content-width) / 2));


### PR DESCRIPTION
The tray that extended to the edged would mess up the transforms with the drag-and-drop library. So we hide the trays (just used for hover actions) when we are dragging any cells