### PR TITLE
Add utility for printing banned cell names

### DIFF
--- a/scripts/print_banned_cell_names.py
+++ b/scripts/print_banned_cell_names.py
@@ -1,0 +1,47 @@
+import marimo
+
+__generated_with = "0.1.38"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    def format_keywords(l: list[str]):
+        print('\n'.join(l))
+    return format_keywords,
+
+
+@app.cell
+def __():
+    RESERVED_BY_MARIMO = [
+        # We reserve tokens starting with two underscores for
+        # the future
+        "__*",
+        # We import marimo in the notebook file
+        "marimo",
+        # The notebook/app object
+        "app"
+    ]
+    return RESERVED_BY_MARIMO,
+
+
+@app.cell
+def __(keyword):
+    RESERVED_BY_PYTHON = keyword.softkwlist + keyword.kwlist
+    return RESERVED_BY_PYTHON,
+
+
+@app.cell
+def __(RESERVED_BY_MARIMO, RESERVED_BY_PYTHON, format_keywords):
+    print(format_keywords(RESERVED_BY_MARIMO + RESERVED_BY_PYTHON))
+    return
+
+
+@app.cell
+def __():
+    import keyword
+    return keyword,
+
+
+if __name__ == "__main__":
+    app.run()

--- a/scripts/print_banned_cell_names.py
+++ b/scripts/print_banned_cell_names.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.1.38"
+__generated_with = "0.1.69"
 app = marimo.App()
 
 


### PR DESCRIPTION
This change adds a utility for printing a list of banned names for cells. Run it with

`python scripts/print_banned_cell_names.py`

(The utility is a marimo notebook!)