### PR TITLE
fix: handle duplicate column names in CSV data

### DIFF
--- a/frontend/src/plugins/impl/vega/__tests__/vega.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/vega.test.ts
@@ -1,6 +1,11 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { describe, expect, it, vi } from "vitest";
-import { uniquifyColumnNames, vegaLoadData, vegaLoader } from "../loader";
+import {
+  ZERO_WIDTH_SPACE,
+  uniquifyColumnNames,
+  vegaLoadData,
+  vegaLoader,
+} from "../loader";
 
 describe("vega loader", () => {
   it("should parse csv data", async () => {
@@ -46,21 +51,22 @@ describe("uniquifyColumnNames", () => {
 
   it("should uniquify headers with some duplicates", () => {
     const csvData = "Name,Age,Location,Name\nAlice,30,New York,Bob";
-    const expectedResult = "Name,Age,Location,Name_1\nAlice,30,New York,Bob";
+    const expectedResult = `Name,Age,Location,Name${ZERO_WIDTH_SPACE}\nAlice,30,New York,Bob`;
     const result = uniquifyColumnNames(csvData);
     expect(result).toBe(expectedResult);
+    expect(result).not.toMatch(csvData);
   });
 
   it("should uniquify headers with all duplicates", () => {
-    const csvData = "Name,Name,Name,Name\nAlice,Bob,Charlie,David";
-    const expectedResult = "Name,Name_1,Name_2,Name_3\nAlice,Bob,Charlie,David";
+    const csvData = "Name,Name,Name\nAlice,Bob,Charlie";
+    const expectedResult = `Name,Name${ZERO_WIDTH_SPACE},Name${ZERO_WIDTH_SPACE}${ZERO_WIDTH_SPACE}\nAlice,Bob,Charlie`;
     const result = uniquifyColumnNames(csvData);
     expect(result).toBe(expectedResult);
   });
 
   it("should handle empty column names", () => {
     const csvData = "Name,,Location,Name\nAlice,30,New York,Bob";
-    const expectedResult = "Name,,Location,Name_1\nAlice,30,New York,Bob";
+    const expectedResult = `Name,,Location,Name${ZERO_WIDTH_SPACE}\nAlice,30,New York,Bob`;
     const result = uniquifyColumnNames(csvData);
     expect(result).toBe(expectedResult);
   });
@@ -74,8 +80,7 @@ describe("uniquifyColumnNames", () => {
 
   it("should handle commas in quoted column names", () => {
     const csvData = '"Name,Name",Name,Name,Name\nAlice,Bob,Charlie,David';
-    const expectedResult =
-      '"Name,Name",Name,Name_1,Name_2\nAlice,Bob,Charlie,David';
+    const expectedResult = `"Name,Name",Name,Name${ZERO_WIDTH_SPACE},Name${ZERO_WIDTH_SPACE}${ZERO_WIDTH_SPACE}\nAlice,Bob,Charlie,David`;
     const result = uniquifyColumnNames(csvData);
     expect(result).toBe(expectedResult);
   });

--- a/frontend/src/plugins/impl/vega/__tests__/vega.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/vega.test.ts
@@ -1,6 +1,6 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 import { describe, expect, it, vi } from "vitest";
-import { vegaLoadData, vegaLoader } from "../loader";
+import { uniquifyColumnNames, vegaLoadData, vegaLoader } from "../loader";
 
 describe("vega loader", () => {
   it("should parse csv data", async () => {
@@ -28,5 +28,49 @@ active,username,id
         },
       ]
     `);
+  });
+});
+
+describe("uniquifyColumnNames", () => {
+  it("should return the same header if no duplicates exist", () => {
+    const csvData = "Name,Age,Location\nAlice,30,New York";
+    const result = uniquifyColumnNames(csvData);
+    expect(result).toBe(csvData);
+  });
+
+  it("should uniquify headers with some duplicates", () => {
+    const csvData = "Name,Age,Location,Name\nAlice,30,New York,Bob";
+    const expectedResult = "Name,Age,Location,Name_1\nAlice,30,New York,Bob";
+    const result = uniquifyColumnNames(csvData);
+    expect(result).toBe(expectedResult);
+  });
+
+  it("should uniquify headers with all duplicates", () => {
+    const csvData = "Name,Name,Name,Name\nAlice,Bob,Charlie,David";
+    const expectedResult = "Name,Name_1,Name_2,Name_3\nAlice,Bob,Charlie,David";
+    const result = uniquifyColumnNames(csvData);
+    expect(result).toBe(expectedResult);
+  });
+
+  it("should handle empty column names", () => {
+    const csvData = "Name,,Location,Name\nAlice,30,New York,Bob";
+    const expectedResult = "Name,,Location,Name_1\nAlice,30,New York,Bob";
+    const result = uniquifyColumnNames(csvData);
+    expect(result).toBe(expectedResult);
+  });
+
+  it("should handle special characters in column names", () => {
+    const csvData = "Na!me,Na@me,Na#me,Na$me\nAlice,Bob,Charlie,David";
+    const expectedResult = "Na!me,Na@me,Na#me,Na$me\nAlice,Bob,Charlie,David";
+    const result = uniquifyColumnNames(csvData);
+    expect(result).toBe(expectedResult);
+  });
+
+  it("should handle commas in quoted column names", () => {
+    const csvData = '"Name,Name",Name,Name,Name\nAlice,Bob,Charlie,David';
+    const expectedResult =
+      '"Name,Name",Name,Name_1,Name_2\nAlice,Bob,Charlie,David';
+    const result = uniquifyColumnNames(csvData);
+    expect(result).toBe(expectedResult);
   });
 });

--- a/frontend/src/plugins/impl/vega/__tests__/vega.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/vega.test.ts
@@ -32,6 +32,12 @@ active,username,id
 });
 
 describe("uniquifyColumnNames", () => {
+  it("should handle empty cases", () => {
+    expect(uniquifyColumnNames("")).toBe("");
+    expect(uniquifyColumnNames(" ")).toBe(" ");
+    expect(uniquifyColumnNames("\n")).toBe("\n");
+  });
+
   it("should return the same header if no duplicates exist", () => {
     const csvData = "Name,Age,Location\nAlice,30,New York";
     const result = uniquifyColumnNames(csvData);

--- a/frontend/src/plugins/impl/vega/loader.ts
+++ b/frontend/src/plugins/impl/vega/loader.ts
@@ -54,11 +54,13 @@ export function uniquifyColumnNames(csvData: string): string {
   return lines.join("\n");
 }
 
+export const ZERO_WIDTH_SPACE = "\u200B";
+
 function getUniqueKey(key: string, existingKeys: Set<string>): string {
   let result = key;
   let count = 1;
   while (existingKeys.has(result)) {
-    result = `${key}_${count}`;
+    result = `${key}${ZERO_WIDTH_SPACE.repeat(count)}`;
     count++;
   }
 

--- a/frontend/src/plugins/impl/vega/loader.ts
+++ b/frontend/src/plugins/impl/vega/loader.ts
@@ -33,6 +33,10 @@ export function vegaLoadData(
 }
 
 export function uniquifyColumnNames(csvData: string): string {
+  if (!csvData || !csvData.includes(",")) {
+    return csvData;
+  }
+
   const lines = csvData.split("\n");
   const header = lines[0];
   const headerNames = header.split(",");


### PR DESCRIPTION
Fixes https://github.com/marimo-team/marimo/issues/507

Make each csv column name unique before converting to JS objects, by appending zero-width-spaces

Other options:
* larger refactor of passing around objects in a columnar format
* change each column name to index, and create a mapping table to its key
* append `_1`, `_2` to each

<img width="976" alt="image" src="https://github.com/marimo-team/marimo/assets/2753772/110bc0f2-e9f3-4e9a-9f7a-bebec123f9b7">
