### PR TITLE
fix: wait for content to render before screenshot

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -40,12 +40,12 @@ export function useNotebookActions() {
       icon: <ImageIcon size={14} strokeWidth={1.5} />,
       label: "Export as PNG",
       handle: async () => {
-        await runDuringPresentMode(() => {
+        await runDuringPresentMode(async () => {
           const app = document.getElementById("App");
           if (!app) {
             return;
           }
-          downloadHTMLAsImage(app, filename || "screenshot.png");
+          await downloadHTMLAsImage(app, filename || "screenshot.png");
         });
       },
     },

--- a/frontend/src/core/mode.ts
+++ b/frontend/src/core/mode.ts
@@ -56,17 +56,21 @@ interface ViewState {
 
 export const initialMode = getInitialAppMode();
 
-export async function runDuringPresentMode(fn: () => void): Promise<void> {
+export async function runDuringPresentMode(
+  fn: () => void | Promise<void>
+): Promise<void> {
   const state = store.get(viewStateAtom);
   if (state.mode === "present") {
-    return fn();
+    return await fn();
   }
 
   store.set(viewStateAtom, { ...state, mode: "present" });
-  // wait 2 frames
+  // Wait 100ms to allow the page to render
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  // Wait 2 frames
   await new Promise((resolve) => requestAnimationFrame(resolve));
   await new Promise((resolve) => requestAnimationFrame(resolve));
-  fn();
+  await fn();
   store.set(viewStateAtom, { ...state, mode: "edit" });
   return undefined;
 }


### PR DESCRIPTION
Fix async/await  to properly wait for the 2 frames before screenshotting. Also added 100ms which is arbitrary, but gives enough time for the browser to load (cached) files.

In future, we can design something more robust with timers and mutation observers.
