### PR TITLE
misc: allow uploading notebook as shared page

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -10,6 +10,7 @@ import {
   BookMarkedIcon,
   FolderDownIcon,
   ClipboardCopyIcon,
+  Share2Icon,
 } from "lucide-react";
 import { commandPalletteAtom } from "../CommandPallette";
 import {
@@ -24,9 +25,12 @@ import { ActionButton } from "./types";
 import { downloadAsHTML } from "@/core/static/download-html";
 import { toast } from "@/components/ui/use-toast";
 import { useFilename } from "@/core/saving/filename";
+import { useImperativeModal } from "@/components/modal/ImperativeModal";
+import { ShareStaticNotebookModal } from "@/components/static-html/share-modal";
 
 export function useNotebookActions() {
   const [filename] = useFilename();
+  const { openModal, closeModal } = useImperativeModal();
 
   const notebook = useNotebook();
   const { updateCellConfig } = useCellActions();
@@ -62,6 +66,13 @@ export function useNotebookActions() {
           return;
         }
         await downloadAsHTML({ filename });
+      },
+    },
+    {
+      icon: <Share2Icon size={14} strokeWidth={1.5} />,
+      label: "Share as static notebook",
+      handle: async () => {
+        openModal(<ShareStaticNotebookModal onClose={closeModal} />);
       },
     },
     {

--- a/frontend/src/components/editor/chrome/footer/feedback-button.tsx
+++ b/frontend/src/components/editor/chrome/footer/feedback-button.tsx
@@ -12,6 +12,7 @@ import React, { PropsWithChildren } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/use-toast";
+import { Constants } from "@/core/constants";
 
 export const FeedbackButton: React.FC<PropsWithChildren> = ({ children }) => {
   const { openModal, closeModal } = useImperativeModal();
@@ -68,7 +69,7 @@ const FeedbackModal: React.FC<{
             Let us know what you think about marimo! If you have a bug that you
             would like to report, please use the{" "}
             <a
-              href="https://github.com/marimo-team/marimo/issues"
+              href={Constants.issuesPage}
               target="_blank"
               rel="noreferrer"
               className="underline"

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -1,0 +1,177 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { useImperativeModal } from "@/components/modal/ImperativeModal";
+import {
+  DialogFooter,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Slot } from "@radix-ui/react-slot";
+import React, { PropsWithChildren, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/use-toast";
+import { Input } from "../ui/input";
+import { CopyIcon } from "lucide-react";
+import { Events } from "@/utils/events";
+import { Tooltip } from "../ui/tooltip";
+import { createStaticHTMLNotebook } from "@/core/static/download-html";
+import { Constants } from "@/core/constants";
+
+export const ShareStaticNotebookButton: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  const { openModal, closeModal } = useImperativeModal();
+
+  return (
+    <Slot
+      onClick={() =>
+        openModal(<ShareStaticNotebookModal onClose={closeModal} />)
+      }
+    >
+      {children}
+    </Slot>
+  );
+};
+
+export const ShareStaticNotebookModal: React.FC<{
+  onClose: () => void;
+}> = ({ onClose }) => {
+  const [slug, setSlug] = useState("");
+  // 4 character random string
+  const randomHash = useRef(Math.random().toString(36).slice(2, 6)).current;
+
+  const path = `${slug}-${randomHash}`;
+  const url = `https://marimo.io/static/${path}`;
+
+  return (
+    <DialogContent className="w-fit">
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+
+          onClose();
+          const html = await createStaticHTMLNotebook();
+
+          const prevToast = toast({
+            title: "Uploading static notebook...",
+            description: "Please wait.",
+          });
+
+          await fetch("https://marimo.io/api/static", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              html: html,
+              path: path,
+            }),
+          }).catch(() => {
+            prevToast.update({
+              title: "Error uploading static page",
+              description: (
+                <div>
+                  Please try again later. If the problem persists, please file a
+                  bug report on{" "}
+                  <a
+                    href={Constants.issuesPage}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline"
+                  >
+                    GitHub
+                  </a>
+                  .
+                </div>
+              ),
+            });
+          });
+
+          prevToast.update({
+            title: "Static page uploaded!",
+            description: (
+              <div>
+                You can access the page at{" "}
+                <a href={url} target="_blank" rel="noreferrer">
+                  {url}
+                </a>
+              </div>
+            ),
+          });
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>Share static notebook</DialogTitle>
+          <DialogDescription>
+            You can share a static, non-interactive version of this notebook. We
+            will create a link for you that lives on{" "}
+            <a href="https://marimo.io" target="_blank" rel="noreferrer">
+              https://marimo.io
+            </a>
+            .
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-6 py-4">
+          <Input
+            id="slug"
+            autoFocus={true}
+            value={slug}
+            placeholder="Notebook slug"
+            onChange={(e) => {
+              const newSlug = e.target.value
+                .toLowerCase()
+                .replaceAll(/\s/g, "-")
+                .replaceAll(/[^\da-z-]/g, "");
+              setSlug(newSlug);
+            }}
+            required={true}
+            autoComplete="off"
+          />
+
+          <div className="font-semibold text-sm text-muted-foreground gap-2 flex flex-col">
+            You will be able to access your notebook at this URL:
+            <div className="flex items-center gap-2">
+              <CopyButton text={url} />
+              <span className="text-primary">{url}</span>
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            aria-label="Save"
+            variant="default"
+            type="submit"
+            onClick={() => {
+              navigator.clipboard.writeText(url);
+            }}
+          >
+            Create
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  );
+};
+
+const CopyButton = (props: { text: string }) => {
+  const [copied, setCopied] = React.useState(false);
+
+  const copy = Events.stopPropagation((e) => {
+    e.preventDefault();
+    navigator.clipboard.writeText(props.text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  });
+
+  return (
+    <Tooltip content="Copied!" open={copied}>
+      <Button onClick={copy} size="xs" variant="secondary">
+        <CopyIcon size={14} strokeWidth={1.5} />
+      </Button>
+    </Tooltip>
+  );
+};

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -68,7 +68,8 @@ export const ShareStaticNotebookModal: React.FC<{
               path: path,
             }),
           }).catch(() => {
-            prevToast.update({
+            prevToast.dismiss();
+            toast({
               title: "Error uploading static page",
               description: (
                 <div>
@@ -88,14 +89,14 @@ export const ShareStaticNotebookModal: React.FC<{
             });
           });
 
-          prevToast.update({
+          prevToast.dismiss();
+          toast({
             title: "Static page uploaded!",
             description: (
               <div>
-                You can access the page at{" "}
-                <a href={url} target="_blank" rel="noreferrer">
-                  {url}
-                </a>
+                The URL has been copied to your clipboard.
+                <br />
+                You can share it with anyone.
               </div>
             ),
           });

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -1,5 +1,4 @@
 /* Copyright 2023 Marimo. All rights reserved. */
-import { useImperativeModal } from "@/components/modal/ImperativeModal";
 import {
   DialogFooter,
   DialogContent,
@@ -7,8 +6,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
-import { Slot } from "@radix-ui/react-slot";
-import React, { PropsWithChildren, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import { Input } from "../ui/input";
@@ -18,21 +16,7 @@ import { Tooltip } from "../ui/tooltip";
 import { createStaticHTMLNotebook } from "@/core/static/download-html";
 import { Constants } from "@/core/constants";
 
-export const ShareStaticNotebookButton: React.FC<PropsWithChildren> = ({
-  children,
-}) => {
-  const { openModal, closeModal } = useImperativeModal();
-
-  return (
-    <Slot
-      onClick={() =>
-        openModal(<ShareStaticNotebookModal onClose={closeModal} />)
-      }
-    >
-      {children}
-    </Slot>
-  );
-};
+const BASE_URL = "https://marimo.io";
 
 export const ShareStaticNotebookModal: React.FC<{
   onClose: () => void;
@@ -41,8 +25,9 @@ export const ShareStaticNotebookModal: React.FC<{
   // 4 character random string
   const randomHash = useRef(Math.random().toString(36).slice(2, 6)).current;
 
+  // Globally unique path
   const path = `${slug}-${randomHash}`;
-  const url = `https://marimo.io/static/${path}`;
+  const url = `${BASE_URL}/static/${path}`;
 
   return (
     <DialogContent className="w-fit">
@@ -58,7 +43,7 @@ export const ShareStaticNotebookModal: React.FC<{
             description: "Please wait.",
           });
 
-          await fetch("https://marimo.io/api/static", {
+          await fetch(`${BASE_URL}/api/static`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -107,8 +92,8 @@ export const ShareStaticNotebookModal: React.FC<{
           <DialogDescription>
             You can share a static, non-interactive version of this notebook. We
             will create a link for you that lives on{" "}
-            <a href="https://marimo.io" target="_blank" rel="noreferrer">
-              https://marimo.io
+            <a href={BASE_URL} target="_blank" rel="noreferrer">
+              {BASE_URL}
             </a>
             .
           </DialogDescription>

--- a/frontend/src/components/ui/use-toast.ts
+++ b/frontend/src/components/ui/use-toast.ts
@@ -140,7 +140,7 @@ type Toast = Omit<ToasterToast, "id">;
 function toast({ ...props }: Toast) {
   const id = genId();
 
-  const update = (props: ToasterToast) =>
+  const update = (props: Toast) =>
     dispatch({
       type: "UPDATE_TOAST",
       toast: { ...props, id },

--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -1,0 +1,4 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+export const Constants = {
+  issuesPage: "https://github.com/marimo-team/marimo/issues",
+};

--- a/frontend/src/core/static/__tests__/download-html.test.ts
+++ b/frontend/src/core/static/__tests__/download-html.test.ts
@@ -98,7 +98,6 @@ describe("download-html", () => {
       },
       code: "import marimo as mo\n\nmo.html('<h1>hello</h1>')",
       assetUrl: `https://cdn.jsdelivr.net/npm/@marimo-team/frontend@${version}/dist`,
-      filename: "app",
       existingDocument: new JSDOM(DOC).window.document,
     });
 

--- a/frontend/src/core/static/download-html.ts
+++ b/frontend/src/core/static/download-html.ts
@@ -17,8 +17,7 @@ const ENABLE_LOCAL_ASSETS = false;
 /**
  * Downloads the current notebook as an HTML file.
  */
-export async function downloadAsHTML(opts: { filename: string }) {
-  const { filename } = opts;
+export async function createStaticHTMLNotebook() {
   const notebook = getNotebook();
   const version = getMarimoVersion();
 
@@ -38,19 +37,28 @@ export async function downloadAsHTML(opts: { filename: string }) {
     throw error;
   });
 
-  const filenameWithoutPath = filename.split("/").pop() ?? "app.py";
-  const filenameWithoutExtension =
-    filenameWithoutPath.split(".").shift() ?? "app";
-
   const html = constructHTML({
     notebookState: notebook,
     version: version,
     assetUrl: assetUrl,
-    filename: filenameWithoutPath,
     existingDocument: document,
     files: await downloadVirtualFiles(),
     code: codeResponse.contents,
   });
+
+  return html;
+}
+
+/**
+ * Downloads the current notebook as an HTML file.
+ */
+export async function downloadAsHTML(opts: { filename: string }) {
+  const { filename } = opts;
+  const html = await createStaticHTMLNotebook();
+
+  const filenameWithoutPath = filename.split("/").pop() ?? "app.py";
+  const filenameWithoutExtension =
+    filenameWithoutPath.split(".").shift() ?? "app";
 
   downloadBlob(
     new Blob([html], { type: "text/html" }),
@@ -65,7 +73,6 @@ export function constructHTML(opts: {
   version: string;
   notebookState: Pick<NotebookState, "cellIds" | "cellData" | "cellRuntime">;
   assetUrl: string;
-  filename: string;
   files: StaticVirtualFiles;
   existingDocument: Document;
   code: string;

--- a/frontend/src/utils/events.ts
+++ b/frontend/src/utils/events.ts
@@ -1,6 +1,8 @@
 /* Copyright 2023 Marimo. All rights reserved. */
 export const Events = {
-  stopPropagation: <E extends Pick<Event, "stopPropagation">>(
+  stopPropagation: <
+    E extends Pick<Event, "stopPropagation" | "preventDefault">
+  >(
     callback?: (evt: E) => void
   ) => {
     return (event: E) => {


### PR DESCRIPTION
This adds a notebook dropdown to quickly share the static notebook. This create an anonymous like for users to easily share non-sensitive notebook

To test this locally, run:
```
NODE_ENV=test make fe
marimo tutorial intro
```
<img width="776" alt="Screenshot 2024-01-08 at 11 01 08 PM" src="https://github.com/marimo-team/marimo/assets/2753772/eaaaa97d-fa13-4643-9b1f-3bbb3cdd70c3">

<img width="430" alt="Screenshot 2024-01-08 at 11 03 01 PM" src="https://github.com/marimo-team/marimo/assets/2753772/457edfb0-0933-4690-9322-d954117782ec">
