### PR TITLE
Reorder notebook actions

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -41,16 +41,10 @@ export function useNotebookActions() {
 
   const actions: ActionButton[] = [
     {
-      icon: <ImageIcon size={14} strokeWidth={1.5} />,
-      label: "Export as PNG",
+      icon: <Share2Icon size={14} strokeWidth={1.5} />,
+      label: "Publish as HTML",
       handle: async () => {
-        await runDuringPresentMode(async () => {
-          const app = document.getElementById("App");
-          if (!app) {
-            return;
-          }
-          await downloadHTMLAsImage(app, filename || "screenshot.png");
-        });
+        openModal(<ShareStaticNotebookModal onClose={closeModal} />);
       },
     },
     {
@@ -69,10 +63,16 @@ export function useNotebookActions() {
       },
     },
     {
-      icon: <Share2Icon size={14} strokeWidth={1.5} />,
-      label: "Share as static notebook",
+      icon: <ImageIcon size={14} strokeWidth={1.5} />,
+      label: "Export as PNG",
       handle: async () => {
-        openModal(<ShareStaticNotebookModal onClose={closeModal} />);
+        await runDuringPresentMode(async () => {
+          const app = document.getElementById("App");
+          if (!app) {
+            return;
+          }
+          await downloadHTMLAsImage(app, filename || "screenshot.png");
+        });
       },
     },
     {

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -90,8 +90,8 @@ export const ShareStaticNotebookModal: React.FC<{
         <DialogHeader>
           <DialogTitle>Share static notebook</DialogTitle>
           <DialogDescription>
-            You can share a static, non-interactive version of this notebook. We
-            will create a link for you that lives on{" "}
+            You can publish a static, non-interactive version of this notebook
+            to the public web. We will create a link for you that lives on{" "}
             <a href={BASE_URL} target="_blank" rel="noreferrer">
               {BASE_URL}
             </a>
@@ -116,7 +116,7 @@ export const ShareStaticNotebookModal: React.FC<{
           />
 
           <div className="font-semibold text-sm text-muted-foreground gap-2 flex flex-col">
-            You will be able to access your notebook at this URL:
+            Anyone will be able to access your notebook at this URL:
             <div className="flex items-center gap-2">
               <CopyButton text={url} />
               <span className="text-primary">{url}</span>


### PR DESCRIPTION
Put share static notebook first, and rename it to
"Publish as HTML" for consistency ("Export as HTML", "Export as PNG")