### PR TITLE
improvement: Add ArrowUp/ArrowDown hotkey support for moving between cells

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -42,7 +42,7 @@ import { getEditorCodeAsPython } from "@/core/codemirror/language/utils";
 import { outputIsStale } from "@/core/cells/cell";
 import { RuntimeState } from "@/core/kernel/RuntimeState";
 import { isOutputEmpty } from "@/core/cells/outputs";
-import { useHotkeysOnElement } from "@/hooks/useHotkey";
+import { useHotkeysOnElement, useKeydownOnElement } from "@/hooks/useHotkey";
 
 /**
  * Imperative interface of the cell.
@@ -301,6 +301,17 @@ const CellComponent = (
     "cell.focusUp": () => moveToNextCell({ cellId, before: true }),
     "cell.sendToBottom": () => sendToBottom({ cellId }),
     "cell.sendToTop": () => sendToTop({ cellId }),
+  });
+
+  useKeydownOnElement(editing ? cellRef.current : null, {
+    ArrowDown: () => {
+      moveToNextCell({ cellId, before: false, noCreate: true });
+      return true;
+    },
+    ArrowUp: () => {
+      moveToNextCell({ cellId, before: true, noCreate: true });
+      return true;
+    },
   });
 
   if (!editing) {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -415,13 +415,16 @@ const { reducer, createActions } = createReducer(initialNotebookState, {
    *
    * Replicates Shift+Enter functionality of Jupyter
    */
-  moveToNextCell: (state, action: { cellId: CellId; before: boolean }) => {
-    const { cellId, before } = action;
+  moveToNextCell: (
+    state,
+    action: { cellId: CellId; before: boolean; noCreate?: boolean }
+  ) => {
+    const { cellId, before, noCreate = false } = action;
     const index = state.cellIds.indexOf(cellId);
     const nextCellIndex = before ? index - 1 : index + 1;
     // Create a new cell at the end; no need to update scrollKey,
     // because cell will be created with autoScrollIntoView
-    if (nextCellIndex === state.cellIds.length) {
+    if (nextCellIndex === state.cellIds.length && !noCreate) {
       const newCellId = CellId.create();
       return {
         ...state,
@@ -441,7 +444,7 @@ const { reducer, createActions } = createReducer(initialNotebookState, {
       };
       // Create a new cell at the beginning; again, no need to update
       // scrollKey
-    } else if (nextCellIndex === -1) {
+    } else if (nextCellIndex === -1 && !noCreate) {
       const newCellId = CellId.create();
       return {
         ...state,

--- a/frontend/src/core/codemirror/__tests__/__snapshots__/setup.test.ts.snap
+++ b/frontend/src/core/codemirror/__tests__/__snapshots__/setup.test.ts.snap
@@ -5,6 +5,12 @@ exports[`snapshot all duplicate keymaps > default keymaps 2`] = `
   "ArrowDown": [
     {
       "key": "ArrowDown",
+      "preventDefault": true,
+      "run": "run",
+      "stopPropagation": true,
+    },
+    {
+      "key": "ArrowDown",
       "run": "<no name>",
     },
     {
@@ -15,6 +21,12 @@ exports[`snapshot all duplicate keymaps > default keymaps 2`] = `
     },
   ],
   "ArrowUp": [
+    {
+      "key": "ArrowUp",
+      "preventDefault": true,
+      "run": "run",
+      "stopPropagation": true,
+    },
     {
       "key": "ArrowUp",
       "run": "<no name>",
@@ -117,6 +129,12 @@ exports[`snapshot all duplicate keymaps > vim keymaps 2`] = `
   "ArrowDown": [
     {
       "key": "ArrowDown",
+      "preventDefault": true,
+      "run": "run",
+      "stopPropagation": true,
+    },
+    {
+      "key": "ArrowDown",
       "run": "<no name>",
     },
     {
@@ -127,6 +145,12 @@ exports[`snapshot all duplicate keymaps > vim keymaps 2`] = `
     },
   ],
   "ArrowUp": [
+    {
+      "key": "ArrowUp",
+      "preventDefault": true,
+      "run": "run",
+      "stopPropagation": true,
+    },
     {
       "key": "ArrowUp",
       "run": "<no name>",

--- a/frontend/src/core/codemirror/__tests__/setup.test.ts
+++ b/frontend/src/core/codemirror/__tests__/setup.test.ts
@@ -89,7 +89,7 @@ describe("snapshot all duplicate keymaps", () => {
     );
     // Total duplicates:
     // if this changes, please make sure to validate they are not conflicting
-    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot("20");
+    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot(`22`);
     expect(duplicates).toMatchSnapshot();
   });
 
@@ -102,7 +102,7 @@ describe("snapshot all duplicate keymaps", () => {
     );
     // Total duplicates:
     // if this changes, please make sure to validate they are not conflicting
-    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot("19");
+    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot(`21`);
     expect(duplicates).toMatchSnapshot();
   });
 });

--- a/frontend/src/core/codemirror/cells/extensions.ts
+++ b/frontend/src/core/codemirror/cells/extensions.ts
@@ -113,6 +113,35 @@ export function cellMovementBundle(
       },
     },
     {
+      key: "ArrowUp",
+      preventDefault: true,
+      stopPropagation: true,
+      run: (ev) => {
+        const main = ev.state.selection.main;
+        if (main.from === 0 && main.to === 0) {
+          focusUp();
+          return true;
+        }
+        return false;
+      },
+    },
+    {
+      key: "ArrowDown",
+      preventDefault: true,
+      stopPropagation: true,
+      run: (ev) => {
+        const main = ev.state.selection.main;
+        if (
+          main.from === ev.state.doc.length &&
+          main.to === ev.state.doc.length
+        ) {
+          focusDown();
+          return true;
+        }
+        return false;
+      },
+    },
+    {
       key: HOTKEYS.getHotkey("cell.focusDown").key,
       preventDefault: true,
       stopPropagation: true,

--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -69,3 +69,24 @@ export function useHotkeysOnElement<T extends HotkeyAction>(
     }
   });
 }
+
+/**
+ * Registers a hotkey listener on a given element.
+ */
+export function useKeydownOnElement(
+  element: HTMLElement | null,
+  handlers: Record<string, HotkeyHandler>
+) {
+  useEventListener(element, "keydown", (e) => {
+    for (const [key, callback] of Objects.entries(handlers)) {
+      if (parseShortcut(key)(e)) {
+        const response = callback();
+        // Prevent default if the callback does not return false
+        if (response !== false) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
Adds arrow hotkeys to move between cells. VIM users can still use the arrow keys, but I did not hook up j/k