### PR TITLE
fix: don't make cells stale after formatting code

### DIFF
--- a/frontend/src/core/codemirror/format.ts
+++ b/frontend/src/core/codemirror/format.ts
@@ -46,8 +46,8 @@ export async function formatEditorViews(
       continue;
     }
 
-    updateEditorCodeFromPython(view, formattedCode);
     updateCellCode({ cellId, code: formattedCode, formattingChange: true });
+    updateEditorCodeFromPython(view, formattedCode);
   }
 }
 


### PR DESCRIPTION
Order matters here (unfortunately fragile). Basically we were updating the cell editor first which made the cell stale