### PR TITLE
improvement: configurable editor font-size

### DIFF
--- a/frontend/src/components/app-config/app-config-button.tsx
+++ b/frontend/src/components/app-config/app-config-button.tsx
@@ -27,7 +27,7 @@ export const AppConfigButton = () => {
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-80"
+        className="w-80 h-[90vh] overflow-auto"
         align="end"
         side="bottom"
         // prevent focus outside to hack around a bug in which

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -220,6 +220,29 @@ export const UserConfigForm: React.FC = () => {
               </FormItem>
             )}
           />
+          <FormField
+            control={form.control}
+            name="display.code_editor_font_size"
+            render={({ field }) => (
+              <FormItem className="mb-2">
+                <FormLabel>Code editor font size</FormLabel>
+                <FormControl>
+                  <span className="inline-flex mx-2">
+                    <Input
+                      type="number"
+                      className="m-0 w-20 inline-flex"
+                      {...field}
+                      value={field.value}
+                      min={8}
+                      max={20}
+                      onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                    />
+                  </span>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
         </div>
         <div className="flex flex-col gap-3">
           <SettingSubtitle>Runtime</SettingSubtitle>

--- a/frontend/src/core/MarimoApp.tsx
+++ b/frontend/src/core/MarimoApp.tsx
@@ -49,7 +49,7 @@ export const MarimoApp: React.FC = () => {
           <ModalProvider>
             <CssVariables
               variables={{
-                "--marimo-api-code-editor-font-size": `${userConfig.display.code_editor_font_size}px`,
+                "--marimo-code-editor-font-size": `${userConfig.display.code_editor_font_size}px`,
               }}
             >
               {body}

--- a/frontend/src/core/MarimoApp.tsx
+++ b/frontend/src/core/MarimoApp.tsx
@@ -49,7 +49,9 @@ export const MarimoApp: React.FC = () => {
           <ModalProvider>
             <CssVariables
               variables={{
-                "--marimo-code-editor-font-size": `${userConfig.display.code_editor_font_size}px`,
+                "--marimo-code-editor-font-size": `${toRem(
+                  userConfig.display.code_editor_font_size
+                )}`,
               }}
             >
               {body}
@@ -60,3 +62,7 @@ export const MarimoApp: React.FC = () => {
     </ErrorBoundary>
   );
 };
+
+function toRem(px: number) {
+  return `${px / 16}rem`;
+}

--- a/frontend/src/core/MarimoApp.tsx
+++ b/frontend/src/core/MarimoApp.tsx
@@ -14,6 +14,7 @@ import { useAppConfig, useUserConfig } from "@/core/config/config";
 import { initialMode } from "./mode";
 import { AppChrome } from "../components/editor/chrome/wrapper/app-chrome";
 import { StaticBanner } from "../components/static-html/static-banner";
+import { CssVariables } from "@/theme/ThemeProvider";
 
 /**
  * The root component of the Marimo app.
@@ -45,7 +46,15 @@ export const MarimoApp: React.FC = () => {
     <ErrorBoundary>
       <TooltipProvider>
         <DayPickerProvider initialProps={{}}>
-          <ModalProvider>{body}</ModalProvider>
+          <ModalProvider>
+            <CssVariables
+              variables={{
+                "--marimo-api-code-editor-font-size": `${userConfig.display.code_editor_font_size}px`,
+              }}
+            >
+              {body}
+            </CssVariables>
+          </ModalProvider>
         </DayPickerProvider>
       </TooltipProvider>
     </ErrorBoundary>

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -42,8 +42,12 @@ export const UserConfigSchema = z
     display: z
       .object({
         theme: z.enum(["light", "dark"]).default("light"),
+        code_editor_font_size: z.number().nonnegative().default(14),
       })
-      .default({ theme: "light" }),
+      .default({
+        theme: "light",
+        code_editor_font_size: 14,
+      }),
     experimental: z
       .object({
         layouts: z.boolean().optional(),

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -284,7 +284,7 @@
 }
 
 .cm-editor {
-  font-size: 0.875rem;
+  font-size: var(--marimo-api-code-editor-font-size);
   border: 1px solid transparent;
   padding: 3px;
 
@@ -318,7 +318,7 @@
   }
 
   .cm-content {
-    font-size: 0.875rem;
+    font-size: var(--marimo-api-code-editor-font-size);
     font-family: var(--monospace-font);
   }
 }

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -284,7 +284,7 @@
 }
 
 .cm-editor {
-  font-size: var(--marimo-api-code-editor-font-size);
+  font-size: var(--marimo-code-editor-font-size);
   border: 1px solid transparent;
   padding: 3px;
 
@@ -318,7 +318,7 @@
   }
 
   .cm-content {
-    font-size: var(--marimo-api-code-editor-font-size);
+    font-size: var(--marimo-code-editor-font-size);
     font-family: var(--monospace-font);
   }
 }

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -57,6 +57,7 @@ const props: CellProps = {
     },
     display: {
       theme: "light",
+      code_editor_font_size: 14,
     },
     runtime: {
       auto_instantiate: true,

--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -19,3 +19,14 @@ export const ThemeProvider: React.FC<PropsWithChildren> = memo(
   }
 );
 ThemeProvider.displayName = "ThemeProvider";
+
+export const CssVariables: React.FC<{
+  variables: Record<`--marimo-api-${string}`, string>;
+  children: React.ReactNode;
+}> = ({ variables, children }) => {
+  return (
+    <div className="contents" style={variables}>
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -21,7 +21,7 @@ export const ThemeProvider: React.FC<PropsWithChildren> = memo(
 ThemeProvider.displayName = "ThemeProvider";
 
 export const CssVariables: React.FC<{
-  variables: Record<`--marimo-api-${string}`, string>;
+  variables: Record<`--marimo-${string}`, string>;
   children: React.ReactNode;
 }> = ({ variables, children }) => {
   return (

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -79,9 +79,12 @@ class DisplayConfig(TypedDict, total=False):
     **Keys.**
 
     - `theme`: `"light"` or `"dark"`
+    - `code_editor_font_size`: font size for the code editor
     """
 
     theme: Literal["light", "dark"]
+    code_editor_font_size: int
+
 
 @mddoc
 class FormattingConfig(TypedDict, total=False):
@@ -139,7 +142,10 @@ class MarimoConfig(TypedDict, total=False):
 
 DEFAULT_CONFIG: MarimoConfig = {
     "completion": {"activate_on_typing": True, "copilot": False},
-    "display": {"theme": "light"},
+    "display": {
+        "theme": "light",
+        "code_editor_font_size": 14,
+    },
     "formatting": {"line_length": 79},
     "keymap": {"preset": "default"},
     "runtime": {"auto_instantiate": True},


### PR DESCRIPTION
Fixes https://github.com/marimo-team/marimo/issues/534

Configurable editor font-size. 

Alternative names:
- `code-font-size`
- `editor-font-size`