### PR TITLE
Use r-string to ignore escaping

### DIFF
--- a/docs/apps/output.py
+++ b/docs/apps/output.py
@@ -15,7 +15,7 @@ def __(array, ax, dictionary, mo, plots, table, text):
     tabs = mo.tabs(
         {
             "markdown": mo.md(
-                """
+                r"""
                 Use `mo.md` to write markdown, with support for LaTeX:
 
                 \[

--- a/examples/sine_wave.py
+++ b/examples/sine_wave.py
@@ -22,7 +22,7 @@ def __(mo, np):
 @app.cell
 def __(amplitude, mo, period):
     mo.md(
-        f"""
+        rf"""
         Here's a plot of
         $f(x) = {amplitude.value:.02f}\sin((2\pi/{period.value:.02f}) x)$:
         """

--- a/marimo/_tutorials/dataflow.py
+++ b/marimo/_tutorials/dataflow.py
@@ -131,7 +131,7 @@ def __(matplotlib_installed, mo, np, numpy_installed, plt):
         plt.ylim(-2, 2)
         plt.xticks(
             [0, np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi],
-            [0, "$\pi/2$", "$\pi$", "$3\pi/2$", "$2\pi$"],
+            [0, r"$\pi/2$", r"$\pi$", r"$3\pi/2$", r"$2\pi$"],
         )
         plt.yticks([-2, -1, 0, 1, 2])
         plt.gcf().set_size_inches(6.5, 2.4)

--- a/marimo/_tutorials/markdown.py
+++ b/marimo/_tutorials/markdown.py
@@ -298,7 +298,7 @@ def __(amplitude, mo, period):
 @app.cell
 def __(amplitude, mo, period, plotsin):
     mo.md(
-        f"""
+        rf"""
 
         You're viewing the graph of
 


### PR DESCRIPTION
I'm getting a lot of syntax warnings when running `marimo tutorial ...`

```
❯ marimo tutorial markdown
<unknown>:18: SyntaxWarning: invalid escape sequence '\p'
<unknown>:18: SyntaxWarning: invalid escape sequence '\p'
<unknown>:18: SyntaxWarning: invalid escape sequence '\p'
<unknown>:18: SyntaxWarning: invalid escape sequence '\p'
<unknown>:16: SyntaxWarning: invalid escape sequence '\p'
<unknown>:16: SyntaxWarning: invalid escape sequence '\p'
<unknown>:16: SyntaxWarning: invalid escape sequence '\p'
<unknown>:16: SyntaxWarning: invalid escape sequence '\p'
<unknown>:14: SyntaxWarning: invalid escape sequence '\['
<unknown>:14: SyntaxWarning: invalid escape sequence '\s'
<unknown>:14: SyntaxWarning: invalid escape sequence '\]'
<unknown>:12: SyntaxWarning: invalid escape sequence '\['
<unknown>:12: SyntaxWarning: invalid escape sequence '\s'
<unknown>:12: SyntaxWarning: invalid escape sequence '\]'
/var/folders/rz/q1r4tv0n6ll38q18fbk419mc0000gn/T/tmpluy5y49a/markdown.py:311: SyntaxWarning: invalid escape sequence '\['
  """
/var/folders/rz/q1r4tv0n6ll38q18fbk419mc0000gn/T/tmpluy5y49a/markdown.py:311: SyntaxWarning: invalid escape sequence '\s'
  """
/var/folders/rz/q1r4tv0n6ll38q18fbk419mc0000gn/T/tmpluy5y49a/markdown.py:311: SyntaxWarning: invalid escape sequence '\]'
  """
<unknown>:14: SyntaxWarning: invalid escape sequence '\['
<unknown>:14: SyntaxWarning: invalid escape sequence '\s'
<unknown>:14: SyntaxWarning: invalid escape sequence '\]'
<unknown>:12: SyntaxWarning: invalid escape sequence '\['
<unknown>:12: SyntaxWarning: invalid escape sequence '\s'
<unknown>:12: SyntaxWarning: invalid escape sequence '\]'

        Edit markdown.py in your browser 📝

        URL: http://localhost:2718

<unknown>:14: SyntaxWarning: invalid escape sequence '\['
<unknown>:14: SyntaxWarning: invalid escape sequence '\s'
<unknown>:14: SyntaxWarning: invalid escape sequence '\]'
<unknown>:12: SyntaxWarning: invalid escape sequence '\['
<unknown>:12: SyntaxWarning: invalid escape sequence '\s'
<unknown>:12: SyntaxWarning: invalid escape sequence '\]'
<unknown>:14: SyntaxWarning: invalid escape sequence '\['
<unknown>:14: SyntaxWarning: invalid escape sequence '\s'
<unknown>:14: SyntaxWarning: invalid escape sequence '\]'
<unknown>:12: SyntaxWarning: invalid escape sequence '\['
<unknown>:12: SyntaxWarning: invalid escape sequence '\s'
<unknown>:12: SyntaxWarning: invalid escape sequence '\]'
<unknown>:14: SyntaxWarning: invalid escape sequence '\['
<unknown>:14: SyntaxWarning: invalid escape sequence '\s'
<unknown>:14: SyntaxWarning: invalid escape sequence '\]'
<unknown>:12: SyntaxWarning: invalid escape sequence '\['
<unknown>:12: SyntaxWarning: invalid escape sequence '\s'
<unknown>:12: SyntaxWarning: invalid escape sequence '\]'
<unknown>:12: SyntaxWarning: invalid escape sequence '\['
<unknown>:12: SyntaxWarning: invalid escape sequence '\s'
<unknown>:12: SyntaxWarning: invalid escape sequence '\]'
```

The non-`\p` ones are from syntax errors inside of the `.py` files, I haven't figured out where the `\p` in the beginning come from... It seems to me that these errors are from somewhere inside `marimo` as the warnings are not repeated when i re-execute all cells.

I'm using `marimo` from `conda-forge`, this is `marimo env`:
```json
{
  "marimo": "0.1.76",
  "OS": "Darwin",
  "OS Version": "23.2.0",
  "Processor": "arm",
  "Python Version": "3.12.1",
  "Binaries": {
    "Chrome": "120.0.6099.216",
    "Node": "v21.5.0"
  },
  "Requirements": {
    "black": "23.12.1",
    "click": "8.1.7",
    "jedi": "0.19.1",
    "pymdown-extensions": "10.7",
    "tomlkit": "0.12.3",
    "tornado": "6.3.3"
  }
}
```
