### PR TITLE
improvement: make footer more visible

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -23,14 +23,14 @@ export const Footer: React.FC = () => {
   const errorCount = useAtomValue(cellErrorCount);
 
   return (
-    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md px-6 border-t border-border select-none no-print text-sm">
+    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md px-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50">
       <FooterItem
         tooltip="View errors"
         selected={selectedPanel === "errors"}
         onClick={() => openApplication("errors")}
       >
         <XCircleIcon
-          className={cn("h-4 w-4 mr-1", {
+          className={cn("h-5 w-5 mr-1", {
             "text-destructive": errorCount > 0,
           })}
         />
@@ -41,50 +41,52 @@ export const Footer: React.FC = () => {
         selected={selectedPanel === "variables"}
         onClick={() => openApplication("variables")}
       >
-        <CircleEqualIcon className={cn("h-4 w-4")} />
+        <CircleEqualIcon className={cn("h-5 w-5 ")} />
       </FooterItem>
       <FooterItem
         tooltip="View outline"
         selected={selectedPanel === "outline"}
         onClick={() => openApplication("outline")}
       >
-        <ScrollTextIcon className={cn("h-4 w-4")} />
+        <ScrollTextIcon className={cn("h-5 w-5")} />
       </FooterItem>
       <FooterItem
         tooltip="Explore dependencies"
         selected={selectedPanel === "dependencies"}
         onClick={() => openApplication("dependencies")}
       >
-        <NetworkIcon className={cn("h-4 w-4")} />
+        <NetworkIcon className={cn("h-5 w-5")} />
       </FooterItem>
       <FooterItem
         tooltip="Notebook logs"
         selected={selectedPanel === "logs"}
         onClick={() => openApplication("logs")}
       >
-        <FileTextIcon className={cn("h-4 w-4")} />
+        <FileTextIcon className={cn("h-5 w-5")} />
       </FooterItem>
+
+      <FeedbackButton>
+        <FooterItem tooltip="Send feedback!" selected={false}>
+          <MessageCircleQuestionIcon className="h-5 w-5" />
+        </FooterItem>
+      </FeedbackButton>
+
       <div className="mx-auto" />
+
       <FooterItem
         tooltip="Move panel to the left"
         selected={panelLocation === "left"}
         onClick={() => changePanelLocation("left")}
       >
-        <PanelLeftIcon className="h-4 w-4" />
+        <PanelLeftIcon className="h-5 w-5" />
       </FooterItem>
       <FooterItem
         tooltip="Move panel to the bottom"
         selected={panelLocation === "bottom"}
         onClick={() => changePanelLocation("bottom")}
       >
-        <PanelBottomIcon className="h-4 w-4" />
+        <PanelBottomIcon className="h-5 w-5" />
       </FooterItem>
-
-      <FeedbackButton>
-        <FooterItem tooltip="Send feedback!" selected={false}>
-          <MessageCircleQuestionIcon className="h-4 w-4" />
-        </FooterItem>
-      </FeedbackButton>
     </footer>
   );
 };


### PR DESCRIPTION
This change makes the footer bar and the footer buttons more noticeable by:

- adding a slight shadow,
- increasing the size of the icons,
- moving the help icon next to the panel icons (it's not a panel, but it's more visible there and the discongruity is ok)

I also tried experimenting with turning the icons black or blue, and floating them in the left as a sidebar instead of a footer. The sidebar could be a better long-term solution -- right now we don't really have any design elements to bring the user's eyes to the bottom of the screen -- but would require some finessing to get right. Hopefully this PR combined with better docs is sufficient  ... we can wait and see how users respond.