### PR TITLE
Fix JSON encodings - use utf-8

### DIFF
--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -220,7 +220,7 @@ RECOVERY_CELL_MARKER = "ↁ"
 
 def recover(filename: str) -> str:
     """Generate a module for code recovered from a disconnected frontend"""
-    with open(filename, "r") as f:
+    with open(filename, "r", encoding="utf-8") as f:
         contents = f.read()
     cells = json.loads(contents)["cells"]
     codes, names, configs = tuple(

--- a/marimo/_cli/ipynb_to_marimo.py
+++ b/marimo/_cli/ipynb_to_marimo.py
@@ -18,7 +18,7 @@ def convert_from_path(ipynb_path: str) -> str:
             .decode("utf-8")
         )
     else:
-        with open(ipynb_path, "r") as f:
+        with open(ipynb_path, "r", encoding="utf-8") as f:
             notebook = json.loads(f.read())
 
     return convert(notebook)

--- a/marimo/_smoke_tests/code_editor.py
+++ b/marimo/_smoke_tests/code_editor.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.73"


### PR DESCRIPTION
Read JSON with encoding="utf-8" to handle platforms where utf-8 is not the default encoding.

Fixes #540.