### PR TITLE
improvement: clip mo.ui.dataframe preview to 100 rows, add dropdown for pagination to find specific page

### DIFF
--- a/frontend/src/components/data-table/pagination.tsx
+++ b/frontend/src/components/data-table/pagination.tsx
@@ -55,6 +55,12 @@ export const DataTablePagination = <TData,>({
     return `${count} items`;
   };
 
+  const currentPage = Math.min(
+    table.getState().pagination.pageIndex + 1,
+    table.getPageCount()
+  );
+  const totalPages = table.getPageCount();
+
   return (
     <div className="flex flex-1 items-center justify-between px-2">
       <div className="text-sm text-muted-foreground">{renderTotal()}</div>
@@ -79,13 +85,20 @@ export const DataTablePagination = <TData,>({
           <span className="sr-only">Go to previous page</span>
           <ChevronLeft className="h-4 w-4" />
         </Button>
-        <div className="flex w-[100px] items-center justify-center text-xs font-medium">
-          Page{" "}
-          {Math.min(
-            table.getState().pagination.pageIndex + 1,
-            table.getPageCount()
-          )}{" "}
-          of {table.getPageCount()}
+        <div className="flex items-center justify-center text-xs font-medium gap-1">
+          <span>Page</span>
+          <select
+            className="cursor-pointer border rounded"
+            value={currentPage}
+            onChange={(e) => table.setPageIndex(Number(e.target.value) - 1)}
+          >
+            {Array.from({ length: totalPages }, (_, i) => (
+              <option key={i} value={i + 1}>
+                {i + 1}
+              </option>
+            ))}
+          </select>
+          <span className="flex-shrink-0">of {prettyNumber(totalPages)}</span>
         </div>
         <Button
           size="xs"
@@ -111,3 +124,7 @@ export const DataTablePagination = <TData,>({
     </div>
   );
 };
+
+function prettyNumber(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}

--- a/frontend/src/plugins/impl/common/error-banner.tsx
+++ b/frontend/src/plugins/impl/common/error-banner.tsx
@@ -10,6 +10,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/utils/cn";
+import { VariantProps, cva } from "class-variance-authority";
 
 export const ErrorBanner = ({
   error,
@@ -28,15 +29,13 @@ export const ErrorBanner = ({
 
   return (
     <>
-      <div
-        className={cn(
-          "text-error border-[var(--red-6)] bg-[var(--red-2)] text-sm p-2 border cursor-pointer hover:bg-[var(--red-3)] whitespace-pre-wrap",
-          className
-        )}
+      <Banner
+        className={className}
+        clickable={true}
         onClick={() => setOpen(true)}
       >
         <span className="line-clamp-4">{message}</span>
-      </div>
+      </Banner>
       <AlertDialog open={open} onOpenChange={setOpen}>
         <AlertDialogContent className="max-w-[80%]">
           <AlertDialogHeader>
@@ -51,5 +50,52 @@ export const ErrorBanner = ({
         </AlertDialogContent>
       </AlertDialog>
     </>
+  );
+};
+
+const bannerStyle = cva("text-sm p-2 border whitespace-pre-wrap", {
+  variants: {
+    kind: {
+      danger: `text-error border-[var(--red-6)] bg-[var(--red-2)]`,
+      info: `text-primary border-[var(--blue-6)] bg-[var(--blue-2)]`,
+      warn: `text-warning border-[var(--yellow-6)] bg-[var(--yellow-2)]`,
+    },
+    clickable: {
+      true: "cursor-pointer",
+    },
+  },
+  compoundVariants: [
+    {
+      clickable: true,
+      kind: "danger",
+      className: "hover:bg-[var(--red-3)]",
+    },
+    {
+      clickable: true,
+      kind: "info",
+      className: "hover:bg-[var(--blue-3)]",
+    },
+    {
+      clickable: true,
+      kind: "warn",
+      className: "hover:bg-[var(--yellow-3)]",
+    },
+  ],
+  defaultVariants: {
+    kind: "info",
+  },
+});
+
+export const Banner = ({
+  kind,
+  clickable,
+  className,
+  children,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof bannerStyle>) => {
+  return (
+    <div className={cn(bannerStyle({ kind, clickable }), className)} {...rest}>
+      {children}
+    </div>
   );
 };

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -24,6 +24,8 @@ from .transforms import Transformations
 @dataclass
 class GetDataFrameResponse:
     url: str
+    has_more: bool
+    total_rows: int
     row_headers: List[tuple[str, List[str | int | float]]]
 
 
@@ -111,12 +113,19 @@ class dataframe(UIElement[Dict[str, Any], "pd.DataFrame"]):
         )
 
     def get_dataframe(self, _args: EmptyArgs) -> GetDataFrameResponse:
+        # Only get the first 100 (for performance reasons)
+        # Could make this configurable in the arguments later if desired.
+        LIMIT = 100
+
         if self._error is not None:
             raise Exception(self._error)
 
-        url = mo_data.csv(self._value).url
+        url = mo_data.csv(self._value.head(LIMIT)).url
+        total_rows = len(self._value)
         return GetDataFrameResponse(
             url=url,
+            total_rows=total_rows,
+            has_more=total_rows > LIMIT,
             row_headers=get_row_headers(self._value),
         )
 


### PR DESCRIPTION
1. clip mo.ui.dataframe preview to 100 row
<img width="1059" alt="Screenshot 2024-01-14 at 12 28 41 PM" src="https://github.com/marimo-team/marimo/assets/2753772/6610c189-8ea3-4f1f-9c69-0207975d5209">

2. add dropdown for pagination to find specific page
<img width="851" alt="Screenshot 2024-01-14 at 12 42 31 PM" src="https://github.com/marimo-team/marimo/assets/2753772/dd7fc146-6f49-485b-be08-b2de1724e9a6">
