### PR TITLE
Update plotting example to use vega_datasets module, replacing obsole altair.load_dataset()

### DIFF
--- a/docs/guides/plotting.md
+++ b/docs/guides/plotting.md
@@ -49,14 +49,13 @@ _Reactive plots are just one way that marimo **makes your data tangible**._
 ```python
 import marimo as mo
 import altair as alt
+import vega_datasets
 
 # Load some data
-cars = alt.load_dataset('cars')
+cars = vega_datasets.data.cars()
 
 # Create an Altair chart
-chart = alt.Chart(cars)
-  .mark_point() # Mark type
-  .encode(
+chart = alt.Chart(cars).mark_point().encode(
     x='Horsepower', # Encoding along the x-axis
     y='Miles_per_Gallon', # Encoding along the y-axis
     color='Origin', # Category encoding by color


### PR DESCRIPTION
The code for the Altair [plotting example](https://docs.marimo.io/guides/plotting.html) makes a call to `altair.load_datset` to load the `cars` dataset. However, this was [deprecated a few years back](https://github.com/altair-viz/altair/issues/644) and has now been removed in favour of using the [vega-datasets](https://pypi.org/project/vega-datasets/) module.

This PR updates the code example accordingly.

It also reformats the `.mark_point().encode()` calls onto a single line, so that the code can be copied and run into marimo without syntax errors.

Thanks for all of your work on marimo — it's a beautiful project, and I really appreciate all of the care that you have put into the design and developer experience!