### PR TITLE
feat: support input() and stdin

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,9 @@ coverage:
         # this allows a 5% drop from the previous base commit coverage
         # we'll decrease this as our testing matures
         threshold: 5%
+    patch:
+      default:
+        target: auto
+        # this allows a 15% drop from the previous base commit coverage
+        # we'll decrease this as our testing matures
+        threshold: 15%

--- a/frontend/e2e-tests/py/stdin.py
+++ b/frontend/e2e-tests/py/stdin.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.1.77"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def __():
+    value = input("what is your name?")
+    return (value,)
+
+
+@app.cell
+def __(mo, value):
+    mo.md(f"## 👋 Hi {value}")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/frontend/e2e-tests/stdin.spec.ts
+++ b/frontend/e2e-tests/stdin.spec.ts
@@ -1,0 +1,34 @@
+/* Copyright 2023 Marimo. All rights reserved. */
+import { test, expect } from "@playwright/test";
+import { getAppUrl } from "../playwright.config";
+
+const appUrl = getAppUrl("stdin.py//edit");
+
+test("stdin works", async ({ page }) => {
+  await page.goto(appUrl);
+
+  expect(page.getByText("stdin.py")).toBeTruthy();
+
+  // Check that "what is your name?" exists in the console
+  await expect(page.getByTestId("console-output-area")).toHaveText(
+    "what is your name?"
+  );
+
+  // Expect loading spinner
+  await expect(page.getByTestId("loading-indicator")).toBeVisible();
+
+  // Get input inside the console
+  const consoleInput = page
+    .getByTestId("console-output-area")
+    .getByRole("textbox");
+  // Type "marimo" into the console
+  await consoleInput.fill("marimo");
+  // Hit enter
+  await consoleInput.press("Enter");
+
+  // Check that "Hi, marimo" exists on the page
+  await expect(page.getByText("Hi marimo")).toBeVisible();
+
+  // Expect not loading spinner
+  await expect(page.getByTestId("loading-indicator")).not.toBeVisible();
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -36,6 +36,7 @@ const appToOptions = {
   "layout_grid_max_width.py//run": { port: port(), command: "run" },
   "output.py//run": { port: port(), command: "run" },
   "kitchen_sink.py//edit": { port: port(), command: "edit" },
+  "stdin.py//edit": { port: port(), command: "edit" },
 } satisfies Record<string, ServerOptions>;
 
 export type ApplicationNames = keyof typeof appToOptions;

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
 } from "react";
 
-import { saveCellConfig, sendRun, sendStdIn } from "@/core/network/requests";
+import { saveCellConfig, sendRun, sendStdin } from "@/core/network/requests";
 import { autocompletionKeymap } from "@/core/codemirror/cm";
 import { clearTooltips } from "@/core/codemirror/completion/hints";
 import { UserConfig } from "../../core/config/config-schema";
@@ -81,6 +81,7 @@ export interface CellProps
       | "moveCell"
       | "moveToNextCell"
       | "updateCellConfig"
+      | "setStdinResponse"
       | "sendToBottom"
       | "sendToTop"
     > {
@@ -125,6 +126,7 @@ const CellComponent = (
     deleteCell,
     focusCell,
     moveCell,
+    setStdinResponse,
     moveToNextCell,
     updateCellConfig,
     sendToBottom,
@@ -442,7 +444,10 @@ const CellComponent = (
           consoleOutputs={consoleOutputs}
           stale={consoleOutputStale}
           cellName={name}
-          onSubmitDebugger={(text) => sendStdIn({ text })}
+          onSubmitDebugger={(text, index) => {
+            setStdinResponse({ cellId, response: text, outputIndex: index });
+            sendStdin({ text });
+          }}
           cellId={cellId}
         />
       </SortableCell>

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
 } from "react";
 
-import { saveCellConfig, sendRun } from "@/core/network/requests";
+import { saveCellConfig, sendRun, sendStdIn } from "@/core/network/requests";
 import { autocompletionKeymap } from "@/core/codemirror/cm";
 import { clearTooltips } from "@/core/codemirror/completion/hints";
 import { UserConfig } from "../../core/config/config-schema";
@@ -442,6 +442,7 @@ const CellComponent = (
           consoleOutputs={consoleOutputs}
           stale={consoleOutputStale}
           cellName={name}
+          onSubmitDebugger={(text) => sendStdIn({ text })}
           cellId={cellId}
         />
       </SortableCell>

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -27,6 +27,7 @@ export const ConsoleOutput = (props: Props): React.ReactNode => {
   return (
     <div
       title={stale ? "This console output is stale" : undefined}
+      data-testid="console-output-area"
       className={cn(
         "console-output-area overflow-hidden rounded-b-lg",
         stale && "marimo-output-stale",
@@ -43,7 +44,7 @@ export const ConsoleOutput = (props: Props): React.ReactNode => {
                   type="text"
                   autoComplete="off"
                   autoFocus={true}
-                  className="w-full"
+                  className="m-0"
                   placeholder="stdin"
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && !e.shiftKey) {

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -13,7 +13,7 @@ interface Props {
   cellName: string;
   consoleOutputs: OutputMessage[];
   stale: boolean;
-  onSubmitDebugger: (text: string) => void;
+  onSubmitDebugger: (text: string, index: number) => void;
 }
 
 export const ConsoleOutput = (props: Props): React.ReactNode => {
@@ -35,21 +35,29 @@ export const ConsoleOutput = (props: Props): React.ReactNode => {
     >
       {consoleOutputs.map((output, idx) => {
         if (output.channel === "stdin") {
+          if (output.response == null) {
+            return (
+              <div key={idx} className="flex gap-2 items-center">
+                <span>{output.data}</span>
+                <Input
+                  type="text"
+                  autoComplete="off"
+                  autoFocus={true}
+                  className="w-full"
+                  placeholder="stdin"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      onSubmitDebugger(e.currentTarget.value, idx);
+                    }
+                  }}
+                />
+              </div>
+            );
+          }
           return (
             <div key={idx} className="flex gap-2 items-center">
-              {output.data}
-              <Input
-                type="text"
-                autoComplete="off"
-                autoFocus={true}
-                className="w-full"
-                placeholder="stdin"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey) {
-                    onSubmitDebugger(e.currentTarget.value);
-                  }
-                }}
-              />
+              <span>{output.data}</span>
+              <span className="text-[var(--sky-11)]">{output.response}</span>
             </div>
           );
         }

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -6,16 +6,18 @@ import { cn } from "@/utils/cn";
 import { DEFAULT_CELL_NAME } from "@/core/cells/names";
 import { NameCellContentEditable } from "../actions/name-cell-input";
 import { CellId } from "@/core/cells/ids";
+import { Input } from "@/components/ui/input";
 
 interface Props {
   cellId: CellId;
   cellName: string;
   consoleOutputs: OutputMessage[];
   stale: boolean;
+  onSubmitDebugger: (text: string) => void;
 }
 
 export const ConsoleOutput = (props: Props): React.ReactNode => {
-  const { consoleOutputs, stale, cellName, cellId } = props;
+  const { consoleOutputs, stale, cellName, cellId, onSubmitDebugger } = props;
   const hasOutputs = consoleOutputs.length > 0;
 
   if (!hasOutputs && cellName === DEFAULT_CELL_NAME) {
@@ -31,11 +33,33 @@ export const ConsoleOutput = (props: Props): React.ReactNode => {
         hasOutputs ? "p-5" : "p-3"
       )}
     >
-      {consoleOutputs.map((output, idx) => (
-        <React.Fragment key={idx}>
-          {formatOutput({ message: output })}
-        </React.Fragment>
-      ))}
+      {consoleOutputs.map((output, idx) => {
+        if (output.channel === "stdin") {
+          return (
+            <div key={idx} className="flex gap-2 items-center">
+              {output.data}
+              <Input
+                type="text"
+                autoComplete="off"
+                autoFocus={true}
+                className="w-full"
+                placeholder="stdin"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    onSubmitDebugger(e.currentTarget.value);
+                  }
+                }}
+              />
+            </div>
+          );
+        }
+
+        return (
+          <React.Fragment key={idx}>
+            {formatOutput({ message: output })}
+          </React.Fragment>
+        );
+      })}
       <NameCellContentEditable
         value={cellName}
         cellId={cellId}

--- a/frontend/src/components/editor/output/TextOutput.tsx
+++ b/frontend/src/components/editor/output/TextOutput.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/utils/cn";
 
 interface Props {
   text: string;
-  channel?: OutputChannel;
+  channel?: OutputChannel | "stdin";
 }
 
 export const TextOutput = ({ text, channel }: Props): JSX.Element => {

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -53,6 +53,7 @@ export const CellArray: React.FC<CellArrayProps> = ({
     unfoldAll,
     sendToBottom,
     sendToTop,
+    setStdinResponse,
   } = useCellActions();
   const { theme } = useTheme();
   const { togglePanel } = useChromeActions();
@@ -113,6 +114,7 @@ export const CellArray: React.FC<CellArrayProps> = ({
           deleteCell={onDeleteCell}
           focusCell={focusCell}
           moveToNextCell={moveToNextCell}
+          setStdinResponse={setStdinResponse}
           updateCellConfig={updateCellConfig}
           moveCell={moveCell}
           mode={mode}

--- a/frontend/src/core/App.tsx
+++ b/frontend/src/core/App.tsx
@@ -391,6 +391,7 @@ const DisconnectedIcon = () => (
 const RunningIcon = () => (
   <div
     className={topLeftStatus}
+    data-testid="loading-indicator"
     title={"Marimo is busy computing. Hang tight!"}
   >
     <HourglassIcon className="running-app-icon" size={30} strokeWidth={1} />

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -407,7 +407,10 @@ const { reducer, createActions } = createReducer(initialNotebookState, {
       }
 
       consoleOutputs[outputIndex] = {
-        ...stdinOutput,
+        channel: "stdin",
+        mimetype: stdinOutput.mimetype,
+        data: stdinOutput.data,
+        timestamp: stdinOutput.timestamp,
         response,
       };
 

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -393,6 +393,30 @@ const { reducer, createActions } = createReducer(initialNotebookState, {
       cellLogs: [...nextState.cellLogs, ...getCellLogsForMessage(message)],
     };
   },
+  setStdinResponse: (
+    state,
+    action: { cellId: CellId; response: string; outputIndex: number }
+  ) => {
+    const { cellId, response, outputIndex } = action;
+    return updateCellRuntimeState(state, cellId, (cell) => {
+      const consoleOutputs = [...cell.consoleOutputs];
+      const stdinOutput = consoleOutputs[outputIndex];
+      if (stdinOutput.channel !== "stdin") {
+        Logger.warn("Expected stdin output");
+        return cell;
+      }
+
+      consoleOutputs[outputIndex] = {
+        ...stdinOutput,
+        response,
+      };
+
+      return {
+        ...cell,
+        consoleOutputs,
+      };
+    });
+  },
   setCells: (state, cells: CellData[]) => {
     return {
       ...state,

--- a/frontend/src/core/kernel/messages.ts
+++ b/frontend/src/core/kernel/messages.ts
@@ -58,6 +58,12 @@ export type OutputMessage =
       mimetype: "application/json";
       data: unknown;
       timestamp: number;
+    }
+  | {
+      channel: "stdin";
+      mimetype: "text/plain";
+      data: string;
+      timestamp: number;
     };
 
 /**

--- a/frontend/src/core/kernel/messages.ts
+++ b/frontend/src/core/kernel/messages.ts
@@ -63,6 +63,11 @@ export type OutputMessage =
       channel: "stdin";
       mimetype: "text/plain";
       data: string;
+      /**
+       * This is not saved to the server, but we update this field
+       * after sending the message to the kernel.
+       */
+      response?: string;
       timestamp: number;
     };
 

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -21,7 +21,7 @@ import {
   SendFunctionRequest,
   RunRequests,
   EditRequests,
-  SendStdIn,
+  SendStdin,
 } from "./types";
 import { invariant } from "@/utils/invariant";
 
@@ -131,8 +131,8 @@ function createNetworkRequests(): EditRequests & RunRequests {
     sendFunctionRequest: (request) => {
       return API.post<SendFunctionRequest>("/kernel/function_call/", request);
     },
-    sendStdIn: (request) => {
-      return API.post<SendStdIn>("/kernel/stdin/", request);
+    sendStdin: (request) => {
+      return API.post<SendStdin>("/kernel/stdin/", request);
     },
     readCode: () => {
       return API.post<{}, { contents: string }>("/kernel/read_code/", {});
@@ -144,7 +144,7 @@ export const {
   sendComponentValues,
   sendRename,
   sendSave,
-  sendStdIn,
+  sendStdin,
   sendFormat,
   sendInterrupt,
   sendShutdown,

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -21,6 +21,7 @@ import {
   SendFunctionRequest,
   RunRequests,
   EditRequests,
+  SendStdIn,
 } from "./types";
 import { invariant } from "@/utils/invariant";
 
@@ -130,6 +131,9 @@ function createNetworkRequests(): EditRequests & RunRequests {
     sendFunctionRequest: (request) => {
       return API.post<SendFunctionRequest>("/kernel/function_call/", request);
     },
+    sendStdIn: (request) => {
+      return API.post<SendStdIn>("/kernel/stdin/", request);
+    },
     readCode: () => {
       return API.post<{}, { contents: string }>("/kernel/read_code/", {});
     },
@@ -140,6 +144,7 @@ export const {
   sendComponentValues,
   sendRename,
   sendSave,
+  sendStdIn,
   sendFormat,
   sendInterrupt,
   sendShutdown,

--- a/frontend/src/core/network/static-requests.ts
+++ b/frontend/src/core/network/static-requests.ts
@@ -48,7 +48,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     saveUserConfig: throwNotInEditMode,
     saveAppConfig: throwNotInEditMode,
     saveCellConfig: throwNotInEditMode,
-    sendStdIn: throwNotInEditMode,
+    sendStdin: throwNotInEditMode,
     readCode: throwNotInEditMode,
   };
 }

--- a/frontend/src/core/network/static-requests.ts
+++ b/frontend/src/core/network/static-requests.ts
@@ -48,6 +48,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     saveUserConfig: throwNotInEditMode,
     saveAppConfig: throwNotInEditMode,
     saveCellConfig: throwNotInEditMode,
+    sendStdIn: throwNotInEditMode,
     readCode: throwNotInEditMode,
   };
 }

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -97,7 +97,7 @@ export interface SendFunctionRequest {
   functionName: string;
 }
 
-export interface SendStdIn {
+export interface SendStdin {
   text: string;
 }
 
@@ -121,7 +121,7 @@ export interface RunRequests {
 export interface EditRequests {
   sendRename: (filename: string | null) => Promise<null>;
   sendSave: (request: SaveKernelRequest) => Promise<null>;
-  sendStdIn: (request: SendStdIn) => Promise<null>;
+  sendStdin: (request: SendStdin) => Promise<null>;
   sendRun: (cellIds: CellId[], codes: string[]) => Promise<null>;
   sendInterrupt: () => Promise<null>;
   sendShutdown: () => Promise<null>;

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -97,6 +97,10 @@ export interface SendFunctionRequest {
   functionName: string;
 }
 
+export interface SendStdIn {
+  text: string;
+}
+
 interface ValueUpdate {
   objectId: string;
   value: unknown;
@@ -117,6 +121,7 @@ export interface RunRequests {
 export interface EditRequests {
   sendRename: (filename: string | null) => Promise<null>;
   sendSave: (request: SaveKernelRequest) => Promise<null>;
+  sendStdIn: (request: SendStdIn) => Promise<null>;
   sendRun: (cellIds: CellId[], codes: string[]) => Promise<null>;
   sendInterrupt: () => Promise<null>;
   sendShutdown: () => Promise<null>;

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -44,6 +44,7 @@ const props: CellProps = {
   sendToBottom: Logger.log,
   sendToTop: Logger.log,
   updateCellConfig: Logger.log,
+  setStdinResponse: Logger.log,
   config: {},
   userConfig: {
     completion: {

--- a/marimo/_messaging/console_output_worker.py
+++ b/marimo/_messaging/console_output_worker.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
     from marimo._messaging.streams import Stream
 
-StreamT = Literal["stdout", "stderr"]
+StreamT = Literal["stdout", "stderr", "stdin"]
 
 # Flush console outputs every 10ms
 TIMEOUT_S = 0.01

--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -159,7 +159,7 @@ class Stdin:
     def __init__(self, stream: Stream):
         self.stream = stream
 
-    def _readline_with_prompt(self, prompt: str = "", size: int = -1) -> str:
+    def _readline_with_prompt(self, prompt: str = "") -> str:
         """Read input from the standard in stream, with an optional prompt."""
         assert self.stream.cell_id is not None
         if not isinstance(prompt, str):
@@ -182,10 +182,13 @@ class Stdin:
             )
             self.stream.console_msg_cv.notify()
 
-        return self.stream.input_queue.get()[:size]
+        return self.stream.input_queue.get()
 
     def readline(self, size: int = -1) -> str:
-        return self._readline_with_prompt(prompt="", size=size)
+        # size only included for compatibility with sys.stdin.readline API;
+        # we don't support it.
+        del size
+        return self._readline_with_prompt(prompt="")
 
     def write(self, data: str) -> None:
         # stdin is not writable in Python

--- a/marimo/_runtime/context.py
+++ b/marimo/_runtime/context.py
@@ -111,6 +111,9 @@ def initialize_context(
     """Initializes thread-local/session-specific context.
 
     Must be called exactly once for each client thread.
+
+    stdout, stderr, and stdin are optional because in `run` mode the
+    standard streams are not redirected/replaced.
     """
     from marimo._plugins.ui._core.registry import UIElementRegistry
     from marimo._runtime.virtual_file import VirtualFileRegistry

--- a/marimo/_runtime/context.py
+++ b/marimo/_runtime/context.py
@@ -18,7 +18,7 @@ from marimo._runtime.functions import FunctionRegistry
 
 if TYPE_CHECKING:
     from marimo._ast.cell import CellId_t
-    from marimo._messaging.streams import Stderr, Stdout, Stream
+    from marimo._messaging.streams import Stderr, Stdin, Stdout, Stream
     from marimo._plugins.ui._core.registry import UIElementRegistry
     from marimo._runtime.runtime import Kernel
     from marimo._runtime.virtual_file import VirtualFileRegistry
@@ -57,6 +57,7 @@ class RuntimeContext:
     stream: Stream
     stdout: Optional[Stdout]
     stderr: Optional[Stderr]
+    stdin: Optional[Stdin]
     _id_provider: Optional[IDProvider] = None
 
     @property
@@ -105,6 +106,7 @@ def initialize_context(
     stream: Stream,
     stdout: Optional[Stdout],
     stderr: Optional[Stderr],
+    stdin: Optional[Stdin],
 ) -> None:
     """Initializes thread-local/session-specific context.
 
@@ -127,6 +129,7 @@ def initialize_context(
             stream=stream,
             stdout=stdout,
             stderr=stderr,
+            stdin=stdin,
         )
         _THREAD_LOCAL_CONTEXT.initialize(runtime_context=runtime_context)
 

--- a/marimo/_runtime/input_override.py
+++ b/marimo/_runtime/input_override.py
@@ -1,6 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
 import functools
-from typing import Any
 
 from marimo._runtime.context import get_context
 

--- a/marimo/_runtime/input_override.py
+++ b/marimo/_runtime/input_override.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Marimo. All rights reserved.
+import functools
+from typing import Any
+
+from marimo._runtime.context import get_context
+
+
+@functools.wraps(input)
+def input_override(prompt: str = "") -> str:
+    assert (stdin := get_context().stdin) is not None
+    return stdin._readline_with_prompt(prompt)

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -78,6 +78,7 @@ def redirect_streams(cell_id: CellId_t) -> Iterator[None]:
 
     py_stdout = sys.stdout
     py_stderr = sys.stderr
+    py_stdin = sys.stdin
     sys.stdout = ctx.stdout  # type: ignore
     sys.stderr = ctx.stderr  # type: ignore
     sys.stdin = ctx.stdin  # type: ignore
@@ -108,8 +109,9 @@ def redirect_streams(cell_id: CellId_t) -> Iterator[None]:
         os.close(stdout_read_fd)
         os.close(stderr_read_fd)
 
-        # Restore Python stdout/stderr
+        # Restore Python stdout/stderr/stdin
         sys.stdout = py_stdout
         sys.stderr = py_stderr
+        sys.stdin = py_stdin
 
         ctx.stream.cell_id = None

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -74,8 +74,8 @@ def redirect_streams(cell_id: CellId_t) -> Iterator[None]:
         target=forward_os_stream, args=(ctx.stderr, stderr_read_fd)
     )
 
-    # TODO(akshayka): Redirect fd for stdin?
-
+    # NB: Python doesn't allow monkey patching methods builtins, so
+    # we replace these streams outright
     py_stdout = sys.stdout
     py_stderr = sys.stderr
     py_stdin = sys.stdin

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -54,6 +54,8 @@ def redirect_streams(cell_id: CellId_t) -> Iterator[None]:
             ctx.stream.cell_id = None
         return
 
+    # Redirect file descriptors for writable streams (stdout, stderr).
+    #
     # All six of these file descriptors will need to be closed later
     stdout_duped, stdout_read_fd, stdout_fd = dup2newfd(sys.stdout.fileno())
     stderr_duped, stderr_read_fd, stderr_fd = dup2newfd(sys.stderr.fileno())
@@ -72,10 +74,13 @@ def redirect_streams(cell_id: CellId_t) -> Iterator[None]:
         target=forward_os_stream, args=(ctx.stderr, stderr_read_fd)
     )
 
+    # TODO(akshayka): Redirect fd for stdin?
+
     py_stdout = sys.stdout
     py_stderr = sys.stderr
     sys.stdout = ctx.stdout  # type: ignore
     sys.stderr = ctx.stderr  # type: ignore
+    sys.stdin = ctx.stdin  # type: ignore
 
     stdout_thread.start()
     stderr_thread.start()

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -153,6 +153,14 @@ class CellMetadata:
 
 
 class Kernel:
+    """Kernel that manages the dependency graph and its execution.
+
+    Args:
+
+    - cell_configs: initial configuration for each cell
+    - input_override: a function that overrides the builtin input() function
+    """
+
     def __init__(
         self,
         cell_configs: dict[CellId_t, CellConfig],

--- a/marimo/_server/api/__init__.py
+++ b/marimo/_server/api/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "SaveUserConfigurationHandler",
     "SetCellConfigHandler",
     "SetUIElementValueHandler",
+    "StdinHandler",
     "VirtualFileHandler",
 ]
 
@@ -35,4 +36,5 @@ from marimo._server.api.save_app_config import SaveAppConfigurationHandler
 from marimo._server.api.save_user_config import SaveUserConfigurationHandler
 from marimo._server.api.set_cell_config import SetCellConfigHandler
 from marimo._server.api.set_ui_element_value import SetUIElementValueHandler
+from marimo._server.api.stdin import StdinHandler
 from marimo._server.api.virtual_file import VirtualFileHandler

--- a/marimo/_server/api/code_complete.py
+++ b/marimo/_server/api/code_complete.py
@@ -24,7 +24,7 @@ class CodeCompleteHandler(ValidatedHandler):
     def post(self) -> None:
         args = parse_raw(self.request.body, CodeComplete)
         session = sessions.require_session_from_header(self.request.headers)
-        session.queue.put(
+        session.control_queue.put(
             requests.CompletionRequest(
                 completion_id=args.id,
                 document=args.document,

--- a/marimo/_server/api/delete.py
+++ b/marimo/_server/api/delete.py
@@ -24,4 +24,4 @@ class DeleteHandler(ValidatedHandler):
         args = parse_raw(self.request.body, Delete)
         cell_id = CellId_t(args.cell_id)
         request = requests.DeleteRequest(cell_id=cell_id)
-        session.queue.put(request)
+        session.control_queue.put(request)

--- a/marimo/_server/api/function_call.py
+++ b/marimo/_server/api/function_call.py
@@ -34,4 +34,4 @@ class FunctionHandler(ValidatedHandler):
             function_name=args.function_name,
             args=args.args,
         )
-        session.queue.put(request)
+        session.control_queue.put(request)

--- a/marimo/_server/api/instantiate.py
+++ b/marimo/_server/api/instantiate.py
@@ -50,4 +50,4 @@ class InstantiateHandler(ValidatedHandler):
                 zip(args.object_ids, args.values)
             ),
         )
-        session.queue.put(request)
+        session.control_queue.put(request)

--- a/marimo/_server/api/run.py
+++ b/marimo/_server/api/run.py
@@ -38,4 +38,4 @@ class RunHandler(ValidatedHandler):
                 for cid, code in zip(args.cell_ids, args.codes)
             )
         )
-        session.queue.put(request)
+        session.control_queue.put(request)

--- a/marimo/_server/api/save_user_config.py
+++ b/marimo/_server/api/save_user_config.py
@@ -75,4 +75,6 @@ class SaveUserConfigurationHandler(ValidatedHandler):
             LOGGER.debug("Starting copilot server")
             sessions.get_manager().start_lsp_server()
         # Update the kernel's view of the config
-        session.queue.put(requests.ConfigurationRequest(str(args.config)))
+        session.control_queue.put(
+            requests.ConfigurationRequest(str(args.config))
+        )

--- a/marimo/_server/api/set_cell_config.py
+++ b/marimo/_server/api/set_cell_config.py
@@ -21,4 +21,4 @@ class SetCellConfigHandler(ValidatedHandler):
     def post(self) -> None:
         session = sessions.require_session_from_header(self.request.headers)
         args = parse_raw(self.request.body, SetCellConfig)
-        session.queue.put(requests.SetCellConfigRequest(args.configs))
+        session.control_queue.put(requests.SetCellConfigRequest(args.configs))

--- a/marimo/_server/api/set_ui_element_value.py
+++ b/marimo/_server/api/set_ui_element_value.py
@@ -22,7 +22,7 @@ class SetUIElementValueHandler(ValidatedHandler):
     def post(self) -> None:
         session = sessions.require_session_from_header(self.request.headers)
         args = parse_raw(self.request.body, SetUIElementValue)
-        session.queue.put(
+        session.control_queue.put(
             requests.SetUIElementValueRequest(
                 zip(
                     args.object_ids,

--- a/marimo/_server/api/stdin.py
+++ b/marimo/_server/api/stdin.py
@@ -1,0 +1,23 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from marimo._server import sessions
+from marimo._server.api.validated_handler import ValidatedHandler
+from marimo._utils.parse_dataclass import parse_raw
+
+
+@dataclass
+class Stdin:
+    text: str
+
+
+class StdinHandler(ValidatedHandler):
+    """Send input to the stdin stream."""
+
+    @sessions.requires_edit
+    def post(self) -> None:
+        args = parse_raw(self.request.body, Stdin)
+        session = sessions.require_session_from_header(self.request.headers)
+        session.input_queue.put(args.text)

--- a/marimo/_server/server.py
+++ b/marimo/_server/server.py
@@ -217,6 +217,10 @@ def construct_app(
                 api.SaveAppConfigurationHandler,
             ),
             (
+                r"/api/kernel/stdin/",
+                api.StdinHandler,
+            ),
+            (
                 r"/api/kernel/read_code/",
                 api.ReadCodeHandler,
             ),

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -276,7 +276,7 @@ class Session:
             # with a SIGINT; we don't mind the additional memory consumption,
             # since there's only one client session
             self.control_queue = mpctx.Queue()
-            self.input_queue = mpctx.Queue()
+            self.input_queue = mpctx.Queue(maxsize=1)
             self.kernel_task = mp.Process(
                 target=runtime.launch_kernel,
                 args=(
@@ -296,7 +296,7 @@ class Session:
             # launching a process would copy the entire program state,
             # which (as of writing) is around 150MB
             self.control_queue = queue.Queue()
-            self.input_queue = queue.Queue()
+            self.input_queue = queue.Queue(maxsize=1)
             loop = tornado.ioloop.IOLoop.current()
 
             # We can't terminate threads, so we have to wait until they

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -249,7 +249,16 @@ class Session:
         mgr = get_manager()
         self.socket = socket_handler
         self.cancel_close_handle: Optional[object] = None
-        self.queue: mp.Queue[requests.Request] | queue.Queue[requests.Request]
+
+        # Control messages for the kernel (run, autocomplete,
+        # set UI element, set config, etc ) are sent through the control queue
+        self.control_queue: mp.Queue[requests.Request] | queue.Queue[
+            requests.Request
+        ]
+        # Input messages for the user's Python code are sent through the
+        # input queue
+        self.input_queue: mp.Queue[str] | queue.Queue[str]
+
         self.kernel_task: threading.Thread | mp.Process
         self.read_conn: connection.Connection
 
@@ -266,10 +275,17 @@ class Session:
             # We use a process in edit mode so that we can interrupt the app
             # with a SIGINT; we don't mind the additional memory consumption,
             # since there's only one client session
-            self.queue = mpctx.Queue()
+            self.control_queue = mpctx.Queue()
+            self.input_queue = mpctx.Queue()
             self.kernel_task = mp.Process(
                 target=runtime.launch_kernel,
-                args=(self.queue, listener.address, is_edit_mode, configs),
+                args=(
+                    self.control_queue,
+                    self.input_queue,
+                    listener.address,
+                    is_edit_mode,
+                    configs,
+                ),
                 # The process can't be a daemon, because daemonic processes
                 # can't create children
                 # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.daemon  # noqa: E501
@@ -279,7 +295,8 @@ class Session:
             # We use threads in run mode to minimize memory consumption;
             # launching a process would copy the entire program state,
             # which (as of writing) is around 150MB
-            self.queue = queue.Queue()
+            self.control_queue = queue.Queue()
+            self.input_queue = queue.Queue()
             loop = tornado.ioloop.IOLoop.current()
 
             # We can't terminate threads, so we have to wait until they
@@ -298,7 +315,13 @@ class Session:
             # down all client sessions
             self.kernel_task = threading.Thread(
                 target=launch_kernel_with_cleanup,
-                args=(self.queue, listener.address, is_edit_mode, configs),
+                args=(
+                    self.control_queue,
+                    self.input_queue,
+                    listener.address,
+                    is_edit_mode,
+                    configs,
+                ),
                 # daemon threads can create child processes, unlike
                 # daemon processes
                 daemon=True,
@@ -352,10 +375,12 @@ class Session:
             # guaranteed to be a multiprocessing Queue; annoying to assert
             # this, because mp.Queue appears to be a function
             #
-            # don't care if queue still has things in it; don't make the
+            # don't care if the queues still have things in it; don't make the
             # child process wait for it to empty.
-            self.queue.cancel_join_thread()  # type: ignore
-            self.queue.close()  # type: ignore
+            self.control_queue.cancel_join_thread()  # type: ignore
+            self.control_queue.close()  # type: ignore
+            self.input_queue.cancel_join_thread()  # type: ignore
+            self.input_queue.close()  # type: ignore
             if self.kernel_task.is_alive():
                 # Explicitly terminate the process
                 self.kernel_task.terminate()
@@ -366,7 +391,7 @@ class Session:
         elif self.kernel_task.is_alive():
             # kernel thread cleans up read/write conn and IOloop handler on
             # exit; we don't join the thread because we don't want to block
-            self.queue.put(requests.StopRequest())
+            self.control_queue.put(requests.StopRequest())
         # 1000 - normal closure
         self.socket.close(1000, "MARIMO_SHUTDOWN")
 

--- a/marimo/_smoke_tests/inputs.py
+++ b/marimo/_smoke_tests/inputs.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.76"

--- a/marimo/_smoke_tests/stdin.py
+++ b/marimo/_smoke_tests/stdin.py
@@ -1,0 +1,26 @@
+import marimo
+
+__generated_with = "0.1.77"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __():
+    value = input("what is your name?")
+    return value,
+
+
+@app.cell
+def __(mo, value):
+    mo.md(f"## 👋 Hi {value}")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/stdin.py
+++ b/marimo/_smoke_tests/stdin.py
@@ -1,4 +1,3 @@
-# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.77"
@@ -20,6 +19,18 @@ def __():
 @app.cell
 def __(mo, value):
     mo.md(f"## 👋 Hi {value}")
+    return
+
+
+@app.cell
+def __():
+    print('hi')
+    return
+
+
+@app.cell
+def __():
+    print('there')
     return
 
 

--- a/marimo/_smoke_tests/stdin.py
+++ b/marimo/_smoke_tests/stdin.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.77"

--- a/tests/_messaging/test_streams.py
+++ b/tests/_messaging/test_streams.py
@@ -1,0 +1,76 @@
+from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider, MockedKernel
+
+
+# Make sure that standard in is installed; stdin is not writable so we
+# just check that its methods are callable and return mocked values.
+class TestStdin:
+    @staticmethod
+    def test_input_installed(k: Kernel, exec_req: ExecReqProvider) -> None:
+        k.run([exec_req.get("output = input('hello')")])
+        assert k.globals["output"] == "hello"
+
+    @staticmethod
+    def test_readline_installed(k: Kernel, exec_req: ExecReqProvider) -> None:
+        k.run([exec_req.get("output = sys.stdin.readline()")])
+        assert k.globals["output"] == ""
+
+    @staticmethod
+    def test_readlines_installed(k: Kernel, exec_req: ExecReqProvider) -> None:
+        k.run([exec_req.get("output = sys.stdin.readlines()")])
+        assert k.globals["output"] == [""]
+
+
+class TestStdout:
+    @staticmethod
+    def test_print(
+        mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+    ) -> None:
+        mocked_kernel.k.run([exec_req.get("print('hello'); print('there')")])
+        assert mocked_kernel.stdout.messages == ["hello", "\n", "there", "\n"]
+
+    @staticmethod
+    def test_write(
+        mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+    ) -> None:
+        mocked_kernel.k.run(
+            [exec_req.get("import sys; sys.stdout.write('hello')")]
+        )
+        assert mocked_kernel.stdout.messages == ["hello"]
+
+    @staticmethod
+    def test_writelines(
+        mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+    ) -> None:
+        mocked_kernel.k.run(
+            [
+                exec_req.get(
+                    "import sys; sys.stdout.writelines(['hello', 'there'])"
+                )
+            ]
+        )
+        assert mocked_kernel.stdout.messages == ["hello", "there"]
+
+
+class TestStderr:
+    @staticmethod
+    def test_write(
+        mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+    ) -> None:
+        mocked_kernel.k.run(
+            [exec_req.get("import sys; sys.stderr.write('hello')")]
+        )
+        assert mocked_kernel.stderr.messages == ["hello"]
+
+    @staticmethod
+    def test_writelines(
+        mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+    ) -> None:
+        mocked_kernel.k.run(
+            [
+                exec_req.get(
+                    "import sys; sys.stderr.writelines(['hello', 'there'])"
+                )
+            ]
+        )
+        assert mocked_kernel.stderr.messages == ["hello", "there"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ class MockedKernel:
             stream=self.stream,  # type: ignore
             stdout=self.stdout,  # type: ignore
             stderr=self.stderr,  # type: ignore
+            stdin=None,  # TODO(akshayka): test stidn ...
         )
 
     def __del__(self) -> None:


### PR DESCRIPTION
This change implements support for using the `input()` function and reading from standard in.

![image](https://github.com/marimo-team/marimo/assets/1994308/b2ed3b57-9356-469d-b04b-5e1d4c718365)

This is achieved by adding a new queue to each session/kernel pair, the
`input_queue`. The `input()` builtin and `sys.stdin.readline` function are
patched to send a control message to the frontend, requesting input.
They then pull an input from the input queue, blocking until an input is
available.

A new route is added, `/api/kernel/stdin`, that just accepts text and puts
it in the input queue.