### PR TITLE
fix: Add support for recognizing Alt key in shortcuts

### DIFF
--- a/frontend/src/core/hotkeys/__tests__/shortcuts.test.ts
+++ b/frontend/src/core/hotkeys/__tests__/shortcuts.test.ts
@@ -82,4 +82,15 @@ describe("parseShortcut", () => {
     expect(parseShortcut("Shift-Enter")(event)).toBe(false);
     expect(parseShortcut("Cmd-Shift-Enter")(event)).toBe(true);
   });
+
+  it("should not recognize shortcuts when Alt is not part of the shortcut but is pressed", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      altKey: true,
+    });
+
+    expect(parseShortcut("Shift-Enter")(event)).toBe(false);
+    expect(parseShortcut("Alt-Shift-Enter")(event)).toBe(true);
+  });
 });

--- a/frontend/src/core/hotkeys/shortcuts.ts
+++ b/frontend/src/core/hotkeys/shortcuts.ts
@@ -35,6 +35,9 @@ export function parseShortcut(shortcut: string): (e: KeyboardEvent) => boolean {
         case "Shift":
           satisfied &&= e.shiftKey;
           break;
+        case "Alt":
+          satisfied &&= e.altKey;
+          break;
         case "Space":
           satisfied &&= e.code === "Space";
           break;
@@ -55,6 +58,9 @@ export function parseShortcut(shortcut: string): (e: KeyboardEvent) => boolean {
     }
     if (!keys.includes("Cmd")) {
       satisfied &&= !e.metaKey;
+    }
+    if (!keys.includes("Alt")) {
+      satisfied &&= !e.altKey;
     }
     return satisfied;
   };

--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -7,6 +7,7 @@ import { useEvent } from "./useEvent";
 import { useSetRegisteredAction } from "../core/hotkeys/actions";
 import { HOTKEYS, HotkeyAction } from "@/core/hotkeys/hotkeys";
 import { Objects } from "@/utils/objects";
+import { Logger } from "@/utils/Logger";
 
 type HotkeyHandler = () => boolean | void | undefined | Promise<void>;
 
@@ -58,7 +59,7 @@ export function useHotkeysOnElement<T extends HotkeyAction>(
     for (const [shortcut, callback] of Objects.entries(handlers)) {
       const key = HOTKEYS.getHotkey(shortcut).key;
       if (parseShortcut(key)(e)) {
-        console.log("Satisfied", key, e);
+        Logger.debug("Satisfied", key, e);
         const response = callback();
         // Prevent default if the callback does not return false
         if (response !== false) {
@@ -80,6 +81,7 @@ export function useKeydownOnElement(
   useEventListener(element, "keydown", (e) => {
     for (const [key, callback] of Objects.entries(handlers)) {
       if (parseShortcut(key)(e)) {
+        Logger.debug("Satisfied", key, e);
         const response = callback();
         // Prevent default if the callback does not return false
         if (response !== false) {


### PR DESCRIPTION
When i tried `Alt-Up` and `Alt-Down` - i would end up moving between cells, when i didnt want to 