### PR TITLE
fix: missing defs at runtime in app.run()

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -297,5 +297,10 @@ class App:
                 # exclude unparsable cells
                 if cid in outputs
             ),
-            {name: glbls[name] for name in self._defs},
+            # omit defs that were never defined at runtime, eg due to
+            # conditional definitions like
+            #
+            # if cond:
+            #   x = 0
+            {name: glbls[name] for name in self._defs if name in glbls},
         )

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -295,7 +295,7 @@ class TestApp:
         assert configs[1].hide_code
 
     @staticmethod
-    def test_condition_definition() -> None:
+    def test_conditional_definition() -> None:
         app = App()
 
         @app.cell
@@ -309,3 +309,19 @@ class TestApp:
 
         # x should not be in the defs dictionary
         assert defs == {"y": 1}
+
+    @staticmethod
+    def test_empty_iteration_conditional_definition() -> None:
+        app = App()
+
+        @app.cell
+        def _() -> tuple[int]:
+            objects = iter([])
+            for obj in objects:
+                pass
+            return (obj, objects)
+
+        _, defs = app.run()
+
+        # obj should not be in the defs dictionary
+        assert "obj" not in defs

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -293,3 +293,19 @@ class TestApp:
         configs = tuple(app._configs())
         assert configs[0].disabled
         assert configs[1].hide_code
+
+    @staticmethod
+    def test_condition_definition() -> None:
+        app = App()
+
+        @app.cell
+        def _() -> tuple[int]:
+            if False:
+                x = 0
+            y = 1
+            return (x, y)
+
+        _, defs = app.run()
+
+        # x should not be in the defs dictionary
+        assert defs == {"y": 1}


### PR DESCRIPTION
This change fixes a bug with app.run() and cells that conditionally define variables. app.run() shouldn't return defs that don't exist after running.

Fixes #599 