### PR TITLE
feat: emojis autcomplete in markdown

### DIFF
--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -111,6 +111,10 @@
   max-width: 200px;
 }
 
+#App .cm-tooltip.cm-tooltip-autocomplete > ul {
+  min-width: unset;
+}
+
 #App .cm-tooltip-autocomplete ul li[aria-selected] {
   background: #1177ccb0;
   max-width: 200px;


### PR DESCRIPTION
Just for fun - emoji auto-complete when in markdown mode via `:`.

I pull emojis from a CDN to avoid the cost when bundling (although could lazy load), which should be a fine tradeoffs since when offline, it is ok to miss this feature. (although happy to bundle/lazy-load)