### PR TITLE
fix: reference fonts by css vars

### DIFF
--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -22,6 +22,7 @@ html {
   --content-width: 740px;
   --monospace-font: "Fira Mono";
   --text-font: "PT Sans", sans-serif;
+  --heading-font: Lora, serif;
 }
 
 #App {

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -5,7 +5,7 @@
 .markdown span:not(.arithmatex *, code *, .MuiBox-root) {
   /* the not selector makes sure we don't change katex/LaTeX styles */
   line-height: 1.5rem;
-  font-family: "PT Sans", sans-serif;
+  font-family: var(--text-font);
 }
 
 .markdown p:first-child,
@@ -96,7 +96,7 @@
 .markdown h4,
 .markdown h5,
 .markdown h6 {
-  font-family: Lora, serif;
+  font-family: var(--heading-font);
 }
 
 .markdown pre {

--- a/frontend/src/plugins/impl/plotly/plotly.css
+++ b/frontend/src/plugins/impl/plotly/plotly.css
@@ -3,13 +3,13 @@
 .js-plotly-plot .plotly,
 .js-plotly-plot .plotly div {
   direction: ltr;
-  font-family: "Open Sans", verdana, arial, sans-serif;
+  font-family: var(--text-font);
   margin: 0;
   padding: 0;
 }
 .js-plotly-plot .plotly input,
 .js-plotly-plot .plotly button {
-  font-family: "Open Sans", verdana, arial, sans-serif;
+  font-family: var(--text-font);
 }
 .js-plotly-plot .plotly input:focus,
 .js-plotly-plot .plotly button:focus {
@@ -237,7 +237,7 @@
 }
 
 .plotly-notifier {
-  font-family: "Open Sans", verdana, arial, sans-serif;
+  font-family: var(--text-font);
   position: fixed;
   top: 50px;
   right: 20px;


### PR DESCRIPTION
This makes it easy to override if you do choose so

<img width="942" alt="Screenshot 2024-01-22 at 11 09 16 PM" src="https://github.com/marimo-team/marimo/assets/2753772/c0b69600-f967-49a8-bb7f-be024b4dd9ca">
