### PR TITLE
docs: type out some settings for searchability

### DIFF
--- a/docs/guides/editor_features.md
+++ b/docs/guides/editor_features.md
@@ -62,7 +62,6 @@ Hit `Cmd/Ctrl+K` to open the command palette.
 </figure>
 </div>
 
-
 _Missing a command? File a
 [GitHub issue](https://github.com/marimo-team/marimo/issues)._
 
@@ -91,6 +90,15 @@ You can also enable GitHub Copilot from this menu.
 </figure>
 </div>
 
+A non-exhausted list of settings (for searchability):
+
+- Vim keymaps
+- Dark mode
+- Auto-save
+- Auto-complete
+- Editor font-size
+- Formatting rules
+- GitHub Copilot
 
 ## Send feedback
 


### PR DESCRIPTION
I've seen a couple people ask about Vim settings, and then later realize we already have it. Adding it to the docs so it can be searched at least (currently "vim" in the docs returns nothing)