### PR TITLE
fix: traceback should contain line number, stack trace

### DIFF
--- a/marimo/_runtime/cell_runner.py
+++ b/marimo/_runtime/cell_runner.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import re
 import sys
 import traceback
 from collections.abc import Container
@@ -9,6 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 from marimo._ast.cell import CellId_t, execute_cell
+from marimo._ast.compiler import cell_id_from_filename
 from marimo._runtime import dataflow
 from marimo._runtime.control_flow import MarimoInterrupt, MarimoStopError
 
@@ -19,14 +19,6 @@ if TYPE_CHECKING:
 def cell_filename(cell_id: CellId_t) -> str:
     """Filename to use when running cells through exec."""
     return f"<cell-{cell_id}>"
-
-
-def cell_id_from_filename(filename: str) -> Optional[CellId_t]:
-    """Parses cell id from filename."""
-    matches = re.findall(r"<cell-([0-9]+)>", filename)
-    if matches:
-        return str(matches[0])
-    return None
 
 
 def format_traceback(graph: dataflow.DirectedGraph) -> str:

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -82,3 +82,10 @@ class TestCellFactory:
         cf = compiler.cell_factory(f, cell_id="0")
         assert cf.cell.defs == {"x"}
         assert cf.cell.refs == {"y"}
+
+
+def test_cell_id_from_filename() -> None:
+    assert compiler.cell_id_from_filename(compiler.get_filename("0")) == "0"
+    assert compiler.cell_id_from_filename(compiler.get_filename("2")) == "2"
+    assert compiler.cell_id_from_filename(compiler.get_filename("23")) == "23"
+    assert compiler.cell_id_from_filename("random_file.py") is None

--- a/tests/_runtime/test_cell_runner.py
+++ b/tests/_runtime/test_cell_runner.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
+from marimo._runtime.capture import capture_stderr
 from marimo._runtime.cell_runner import Runner
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
@@ -14,3 +15,29 @@ def test_cell_output(k: Kernel, exec_req: ExecReqProvider) -> None:
     run_result = runner.run(er.cell_id)
     # last expression of cell is output
     assert run_result.output == 123
+
+
+def test_traceback_includes_lineno(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    # Raise an exception and test that the runner generates a traceback that
+    # includes the line number where the exception was raised
+    #
+    # first run the cell to populate the graph
+    k.run(
+        [
+            er := exec_req.get(
+                """
+                x = 0
+                raise ValueError
+                """
+            )
+        ]
+    )
+
+    runner = Runner(
+        cell_ids=set(k.graph.cells.keys()), graph=k.graph, glbls=k.globals
+    )
+    with capture_stderr() as buffer:
+        runner.run(er.cell_id)
+    assert "line 3" in buffer.getvalue()


### PR DESCRIPTION
This fixes a bug in which tracebacks were missing for exceptions raised in cells.

Fixes #649 