### PR TITLE
fix: continue pdb when a cell finishes executing

### DIFF
--- a/marimo/_runtime/cell_runner.py
+++ b/marimo/_runtime/cell_runner.py
@@ -9,8 +9,12 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from marimo._ast.cell import CellId_t, execute_cell
 from marimo._ast.compiler import cell_id_from_filename
+from marimo._loggers import marimo_logger
 from marimo._runtime import dataflow
 from marimo._runtime.control_flow import MarimoInterrupt, MarimoStopError
+from marimo._runtime.marimo_pdb import MarimoPdb
+
+LOGGER = marimo_logger()
 
 if TYPE_CHECKING:
     from marimo._runtime.state import State
@@ -89,8 +93,10 @@ class Runner:
         cell_ids: set[CellId_t],
         graph: dataflow.DirectedGraph,
         glbls: dict[Any, Any],
+        debugger: MarimoPdb,
     ):
         self.graph = graph
+        self.debugger = debugger
         # runtime globals
         self.glbls = glbls
         # cells that the runner will run.
@@ -240,6 +246,29 @@ class Runner:
             self.cancel(cell_id)
             run_result = RunResult(output=None, exception=e)
             self.print_traceback()
+        finally:
+            # if a debugger is active, force it to skip past marimo code.
+            try:
+                # Bdb defines the botframe attribute and sets it to non-None
+                # when it starts up
+                if (
+                    hasattr(self.debugger, "botframe")
+                    and self.debugger.botframe is not None
+                ):
+                    self.debugger.set_continue()
+            except Exception as debugger_error:
+                # This has never been hit, but just in case -- don't want
+                # to crash the kernel.
+                LOGGER.error(
+                    """Internal marimo error. Please copy this message and
+                    paste it in a GitHub issue:
+
+                    https://github.com/marimo-team/marimo/issues
+
+                    An exception raised attempting to continue debugger (%s).
+                    """,
+                    str(debugger_error),
+                )
 
         if run_result.exception is not None:
             self.exceptions[cell_id] = run_result.exception

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -188,10 +188,10 @@ class Kernel:
         self.stdout = stdout
         self.stderr = stderr
         self.stdin = stdin
-        self._debugger = marimo_pdb.MarimoPdb(
+        self.debugger = marimo_pdb.MarimoPdb(
             stdout=self.stdout, stdin=self.stdin
         )
-        self.patch_pdb(self._debugger)
+        self.patch_pdb(self.debugger)
 
         self.globals: dict[Any, Any] = {
             "__name__": "__main__",
@@ -613,6 +613,7 @@ class Kernel:
             cell_ids=cell_ids,
             graph=self.graph,
             glbls=self.globals,
+            debugger=self.debugger,
         )
 
         # I/O

--- a/tests/_runtime/test_cell_runner.py
+++ b/tests/_runtime/test_cell_runner.py
@@ -10,7 +10,10 @@ def test_cell_output(k: Kernel, exec_req: ExecReqProvider) -> None:
     k.run([er := exec_req.get("'hello'; 123")])
 
     runner = Runner(
-        cell_ids=set(k.graph.cells.keys()), graph=k.graph, glbls=k.globals
+        cell_ids=set(k.graph.cells.keys()),
+        graph=k.graph,
+        glbls=k.globals,
+        debugger=k.debugger,
     )
     run_result = runner.run(er.cell_id)
     # last expression of cell is output
@@ -36,7 +39,10 @@ def test_traceback_includes_lineno(
     )
 
     runner = Runner(
-        cell_ids=set(k.graph.cells.keys()), graph=k.graph, glbls=k.globals
+        cell_ids=set(k.graph.cells.keys()),
+        graph=k.graph,
+        glbls=k.globals,
+        debugger=k.debugger,
     )
     with capture_stderr() as buffer:
         runner.run(er.cell_id)

--- a/tests/_runtime/test_control_flow.py
+++ b/tests/_runtime/test_control_flow.py
@@ -63,7 +63,9 @@ def test_stop_output(k: Kernel) -> None:
         ]
     )
     # Run the cell through the runner to get the output
-    runner = cell_runner.Runner(set(["0"]), k.graph, k.globals)
+    runner = cell_runner.Runner(
+        set(["0"]), graph=k.graph, glbls=k.globals, debugger=k.debugger
+    )
     run_result = runner.run("0")
     # Check that the cell was stopped and its output is the stop output
     assert run_result.output == "stopped!"

--- a/tests/_runtime/test_marimo_pdb.py
+++ b/tests/_runtime/test_marimo_pdb.py
@@ -8,5 +8,5 @@ def test_pdb_patched(k: Kernel, exec_req: ExecReqProvider):
 
     pdb = k.globals["pdb"]
     assert pdb.Pdb == MarimoPdb
-    assert k._debugger.stdout is k.stdout
-    assert k._debugger.stdin is k.stdin
+    assert k.debugger.stdout is k.stdout
+    assert k.debugger.stdin is k.stdin


### PR DESCRIPTION
This fixes a bug in which pdb continued stepping through marimo's internal codebase and tried writing to the kernel's stream, which had been unset (causing the kernel to crash).

It also generally improves the usability of pdb in marimo.