### PR TITLE
Fix: stream restoration order

### DIFF
--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -66,10 +66,14 @@ def redirect_streams(
     sys.stderr = stderr  # type: ignore
     sys.stdin = stdin  # type: ignore
 
-    with redirect(stdout, py_stdout.fileno()), redirect(
-        stderr, py_stderr.fileno()
-    ):
-        yield
+    try:
+        with redirect(stdout, py_stdout.fileno()), redirect(
+            stderr, py_stderr.fileno()
+        ):
+            yield
+    finally:
+        # These have to be restored after the redirect context managers have
+        # exited
         sys.stdout = py_stdout
         sys.stderr = py_stderr
         sys.stdin = py_stdin


### PR DESCRIPTION
`stream.cell_id` has to be set as long as streams are redirected