### PR TITLE
fix: edit mode on linux

### DIFF
--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -65,6 +65,10 @@ def start(
             if development_mode
             else None,
             log_level=log_level,
+            # uvicorn times out HTTP connections (i.e. TCP sockets) every 5
+            # seconds by default; for some reason breaks the server in
+            # mysterious ways (it stops processing requests) in edit mode.
+            timeout_keep_alive=300 if mode == SessionMode.RUN else int(1e9),
             # ping the websocket once a second to prevent intermittent
             # disconnections
             ws_ping_interval=1,


### PR DESCRIPTION
This change fixes edit mode on Linux/POSIX systems by keeping the TCP socket open indefinitely. Tornado's keep-alive was apparently much higher than uvicorn's 5 seconds. For some reason, closing and re-opening these sockets interacts badly with multiprocessing on linux, causing the server to stop accepting requests.

We can look into sending an connection: close header on unload to make these connections close, but not sure if that would resurface the issue that this change is trying to patch over.