### PR TITLE
 fix: vim jk movement should only be registered on cell when code is hidden

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -315,7 +315,9 @@ const CellComponent = (
       moveToNextCell({ cellId, before: true, noCreate: true });
       return true;
     },
-    ...(userConfig.keymap.preset === "vim"
+    // TODO: This appear to take precedence of the vimKeymapExtension;
+    // comment out for now ...
+    /*    ...(userConfig.keymap.preset === "vim"
       ? {
           j: () => {
             moveToNextCell({ cellId, before: false, noCreate: true });
@@ -326,7 +328,7 @@ const CellComponent = (
             return true;
           },
         }
-      : {}),
+          : {}),*/
   });
 
   if (!editing) {

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -315,9 +315,9 @@ const CellComponent = (
       moveToNextCell({ cellId, before: true, noCreate: true });
       return true;
     },
-    // TODO: This appear to take precedence of the vimKeymapExtension;
-    // comment out for now ...
-    /*    ...(userConfig.keymap.preset === "vim"
+    // only register j/k movement if the cell is hidden, so as to not
+    // interfere with editing
+    ...(userConfig.keymap.preset === "vim" && cellConfig.hide_code
       ? {
           j: () => {
             moveToNextCell({ cellId, before: false, noCreate: true });
@@ -328,7 +328,7 @@ const CellComponent = (
             return true;
           },
         }
-          : {}),*/
+      : {}),
   });
 
   if (!editing) {

--- a/frontend/src/core/codemirror/keymaps/keymaps.ts
+++ b/frontend/src/core/codemirror/keymaps/keymaps.ts
@@ -5,7 +5,7 @@ import { defaultKeymap } from "@codemirror/commands";
 import { Extension, Prec } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import { vim, Vim } from "@replit/codemirror-vim";
-import { vimKeymapExtension } from "./vim";
+// import { vimKeymapExtension } from "./vim";
 
 export const KEYMAP_PRESETS = ["default", "vim"] as const;
 
@@ -38,7 +38,10 @@ export function keymapBundle(
         callbacks.deleteCell();
       });
       return [
-        vimKeymapExtension(callbacks),
+        // TODO: This isn't quite working -- not possible to type "j"
+        // in insert mode (both linux/mac), it ends up going to the next
+        // cell
+        // vimKeymapExtension(callbacks),
         // delete the cell on double press of "d", if the cell is empty
         Prec.highest(
           doubleCharacterListener(

--- a/frontend/src/core/codemirror/keymaps/keymaps.ts
+++ b/frontend/src/core/codemirror/keymaps/keymaps.ts
@@ -5,7 +5,7 @@ import { defaultKeymap } from "@codemirror/commands";
 import { Extension, Prec } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import { vim, Vim } from "@replit/codemirror-vim";
-// import { vimKeymapExtension } from "./vim";
+import { vimKeymapExtension } from "./vim";
 
 export const KEYMAP_PRESETS = ["default", "vim"] as const;
 
@@ -38,10 +38,7 @@ export function keymapBundle(
         callbacks.deleteCell();
       });
       return [
-        // TODO: This isn't quite working -- not possible to type "j"
-        // in insert mode (both linux/mac), it ends up going to the next
-        // cell
-        // vimKeymapExtension(callbacks),
+        vimKeymapExtension(callbacks),
         // delete the cell on double press of "d", if the cell is empty
         Prec.highest(
           doubleCharacterListener(


### PR DESCRIPTION
This fixes a bug in which j/k movement was always registered on the cell (in addition to codemirror), even when the cell wasn't hidden. This made it impossible to type 'j' and 'k' in the last line of an editor in vim mode.