### PR TITLE
import typed dict from typing

### DIFF
--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -1,9 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, Optional, Union, cast
-
-from typing_extensions import TypedDict
+from typing import Any, Dict, Literal, Optional, TypedDict, Union, cast
 
 from marimo._output.rich_help import mddoc
 from marimo._utils.deep_merge import deep_merge


### PR DESCRIPTION
TypedDict is in typing for all python versions we support.