### PR TITLE
Add testcore, testoptional deps to pyproject.toml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,11 +92,13 @@ jobs:
           cp frontend/index.html marimo/_static/index.html
           cp frontend/public/favicon.ico marimo/_static/favicon.ico
       # Lint, typecheck
+      # Each run command runs in a separate shell, so we need to
+      # reactivate the virtual environment every time
       - name: Install marimo with dev dependencies
         run: |
           python -m venv marimo-dev-env
           if [ "$RUNNER_OS" == "Windows" ]; then
-            marimo-dev-env\Scripts\activate
+            marimo-dev-env\\Scripts\\activate
           else
             source marimo-dev-env/bin/activate
           fi
@@ -105,7 +107,7 @@ jobs:
       - name: Lint
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
-            marimo-dev-env\Scripts\activate
+            marimo-dev-env\\Scripts\\activate
           else
             source marimo-dev-env/bin/activate
           fi
@@ -114,7 +116,7 @@ jobs:
         if: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.10' }}
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
-            marimo-dev-env\Scripts\activate
+            marimo-dev-env\\Scripts\\activate
           else
             source marimo-dev-env/bin/activate
           fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,10 +104,20 @@ jobs:
           pip install .[dev]
       - name: Lint
         run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            marimo-dev-env\Scripts\activate
+          else
+            source marimo-dev-env/bin/activate
+          fi
           ruff marimo/
       - name: Typecheck
         if: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.10' }}
         run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            marimo-dev-env\Scripts\activate
+          else
+            source marimo-dev-env/bin/activate
+          fi
           mypy --config-file pyproject.toml marimo/
       # Test with minimal dependencies
       - name: Test with minimal dependencies
@@ -115,7 +125,7 @@ jobs:
           deactivate
           python -m venv marimo-test-env
           if [ "$RUNNER_OS" == "Windows" ]; then
-            marimo-test-env\Scripts\activate
+            marimo-test-env\\Scripts\\activate
           else
             source marimo-test-env/bin/activate
           fi
@@ -128,7 +138,7 @@ jobs:
           deactivate
           python -m venv marimo-test-optional-env
           if [ "$RUNNER_OS" == "Windows" ]; then
-            marimo-test-optional-env\Scripts\activate
+            marimo-test-optional-env\\Scripts\\activate
           else
             source marimo-test-optional-env/bin/activate
           fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,8 @@ jobs:
     name: Tests on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     defaults:
-      shell: bash
+      run:
+        shell: bash
 
     strategy:
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,8 +81,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      # This step is needed since some of our tests rely on the index.html file
+      - name: Create assets directory, copy over index.html
+        run: |
+          mkdir -p marimo/_static/assets
+          cp frontend/index.html marimo/_static/index.html
+          cp frontend/public/favicon.ico marimo/_static/favicon.ico
+      # Lint, typecheck
       - name: Install marimo with dev dependencies
         run: |
+          python -m venv marimo-dev-env
+          source marimo-dev-env/bin/activate
           python -m pip install --upgrade pip
           pip install .[dev]
       - name: Lint
@@ -92,14 +101,23 @@ jobs:
         if: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.10' }}
         run: |
           mypy --config-file pyproject.toml marimo/
-      # This step is needed since some of our tests rely on the index.html file
-      - name: Create assets directory, copy over index.html
+      # Test with minimal dependencies
+      - name: Test with minimal dependencies
         run: |
-          mkdir -p marimo/_static/assets
-          cp frontend/index.html marimo/_static/index.html
-          cp frontend/public/favicon.ico marimo/_static/favicon.ico
-      - name: Test
+          deactivate
+          python -m venv marimo-test-env
+          source marimo-test-env/bin/activate
+          python -m pip install --upgrade pip
+          pip install .[testcore]
+          pytest -v tests/ -k "not test_cli"
+      # Test with optional dependencies
+      - name: Test with optional dependencies
         run: |
+          deactivate
+          python -m venv marimo-test-optional-env
+          source marimo-test-optional-env/bin/activate
+          python -m pip install --upgrade pip
+          pip install .[testoptional]
           pytest -v tests/ -k "not test_cli" --cov=marimo --cov-branch
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -124,7 +124,6 @@ jobs:
       # Test with minimal dependencies
       - name: Test with minimal dependencies
         run: |
-          deactivate
           python -m venv marimo-test-env
           if [ "$RUNNER_OS" == "Windows" ]; then
             marimo-test-env\\Scripts\\activate
@@ -137,7 +136,6 @@ jobs:
       # Test with optional dependencies
       - name: Test with optional dependencies
         run: |
-          deactivate
           python -m venv marimo-test-optional-env
           if [ "$RUNNER_OS" == "Windows" ]; then
             marimo-test-optional-env\\Scripts\\activate

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,7 +143,7 @@ jobs:
             source marimo-test-optional-env/bin/activate
           fi
           python -m pip install --upgrade pip
-          pip install .[testoptional]
+          pip install .[testcore,testoptional]
           pytest -v tests/ -k "not test_cli" --cov=marimo --cov-branch
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,9 @@ jobs:
   test_python:
     name: Tests on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      shell: bash
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -91,7 +94,11 @@ jobs:
       - name: Install marimo with dev dependencies
         run: |
           python -m venv marimo-dev-env
-          source marimo-dev-env/bin/activate
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            marimo-dev-env\Scripts\activate
+          else
+            source marimo-dev-env/bin/activate
+          fi
           python -m pip install --upgrade pip
           pip install .[dev]
       - name: Lint
@@ -106,7 +113,11 @@ jobs:
         run: |
           deactivate
           python -m venv marimo-test-env
-          source marimo-test-env/bin/activate
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            marimo-test-env\Scripts\activate
+          else
+            source marimo-test-env/bin/activate
+          fi
           python -m pip install --upgrade pip
           pip install .[testcore]
           pytest -v tests/ -k "not test_cli"
@@ -115,7 +126,11 @@ jobs:
         run: |
           deactivate
           python -m venv marimo-test-optional-env
-          source marimo-test-optional-env/bin/activate
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            marimo-test-optional-env\Scripts\activate
+          else
+            source marimo-test-optional-env/bin/activate
+          fi
           python -m pip install --upgrade pip
           pip install .[testoptional]
           pytest -v tests/ -k "not test_cli" --cov=marimo --cov-branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ testcore = [
 
 testoptional = [
     # For testing mo.ui.chart
+    "altair>=5.0.0",
     "pandas>=1.3.0",
     "pandas-stubs>=1.3.0",
     # polars 0.19.13 requires building maturn from source, but we don't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,23 @@ dev = [
     "furo==2023.5.20"
 ]
 
+testcore = [
+    "click < 8.1.4",  # https://github.com/pallets/click/issues/2558,
+    # for server testing
+    "httpx~=0.26.0",
+    "pytest~=7.4.0",
+    "pytest-codecov~=0.5.1"
+]
+
+testoptional = [
+    # For testing mo.ui.chart
+    "pandas>=1.3.0",
+    "pandas-stubs>=1.3.0",
+    # polars 0.19.13 requires building maturn from source, but we don't
+    # have the rust toolchain installed on CI
+    "polars==0.19.12",
+]
+
 [project.urls]
 homepage = "https://github.com/marimo-team/marimo"
 

--- a/tests/_plugins/ui/_impl/dataframes/test_handlers.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_handlers.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
-import pandas as pd
+import pytest
 
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._plugins.ui._impl.dataframes.handlers import (
     TransformsContainer,
     apply_transforms,
@@ -21,358 +22,372 @@ from marimo._plugins.ui._impl.dataframes.transforms import (
     TransformType,
 )
 
+HAS_DEPS = DependencyManager.has_pandas()
 
-def apply(df: pd.DataFrame, transform: Transform) -> pd.DataFrame:
-    return apply_transforms(df, Transformations(transforms=[transform]))
-
-
-def test_handle_column_conversion() -> None:
-    # 1 string to int
-    df = pd.DataFrame({"A": ["1", "2", "3"]})
-    transform = ColumnConversionTransform(
-        type=TransformType.COLUMN_CONVERSION,
-        column_id="A",
-        data_type="int",
-        errors="raise",
-    )
-    result = apply(df, transform)
-    assert result["A"].dtype == "int"
-    # 2 float to string
-    df = pd.DataFrame({"A": [1.1, 2.2, 3.3]})
-    transform = ColumnConversionTransform(
-        type=TransformType.COLUMN_CONVERSION,
-        column_id="A",
-        data_type="str",
-        errors="raise",
-    )
-    result = apply(df, transform)
-    assert result["A"].dtype == "object"
-    assert result["A"].tolist() == ["1.1", "2.2", "3.3"]
-    # 3 with errors
-    df = pd.DataFrame({"A": ["1", "2", "3", "a"]})
-    transform = ColumnConversionTransform(
-        type=TransformType.COLUMN_CONVERSION,
-        column_id="A",
-        data_type="int",
-        errors="ignore",
-    )
-    result = apply(df, transform)
-    assert result["A"].dtype == "object"
-    assert result["A"].tolist() == ["1", "2", "3", "a"]
+if HAS_DEPS:
+    import pandas as pd
 
 
-def test_handle_rename_column() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3]})
-    transform = RenameColumnTransform(
-        type=TransformType.RENAME_COLUMN, column_id="A", new_column_id="B"
-    )
-    result = apply(df, transform)
-    assert "B" in result.columns
-    assert "A" not in result.columns
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+class TestHandlers:
+    @staticmethod
+    def apply(df: "pd.DataFrame", transform: Transform) -> "pd.DataFrame":
+        return apply_transforms(df, Transformations(transforms=[transform]))
 
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = RenameColumnTransform(
-        type=TransformType.RENAME_COLUMN, column_id="B", new_column_id="C"
-    )
-    result = apply(df, transform)
-    assert "C" in result.columns
-    assert "B" not in result.columns
+    @staticmethod
+    def test_handle_column_conversion() -> None:
+        # 1 string to int
+        df = pd.DataFrame({"A": ["1", "2", "3"]})
+        transform = ColumnConversionTransform(
+            type=TransformType.COLUMN_CONVERSION,
+            column_id="A",
+            data_type="int",
+            errors="raise",
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].dtype == "int"
+        # 2 float to string
+        df = pd.DataFrame({"A": [1.1, 2.2, 3.3]})
+        transform = ColumnConversionTransform(
+            type=TransformType.COLUMN_CONVERSION,
+            column_id="A",
+            data_type="str",
+            errors="raise",
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].dtype == "object"
+        assert result["A"].tolist() == ["1.1", "2.2", "3.3"]
+        # 3 with errors
+        df = pd.DataFrame({"A": ["1", "2", "3", "a"]})
+        transform = ColumnConversionTransform(
+            type=TransformType.COLUMN_CONVERSION,
+            column_id="A",
+            data_type="int",
+            errors="ignore",
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].dtype == "object"
+        assert result["A"].tolist() == ["1", "2", "3", "a"]
 
+    @staticmethod
+    def test_handle_rename_column() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3]})
+        transform = RenameColumnTransform(
+            type=TransformType.RENAME_COLUMN, column_id="A", new_column_id="B"
+        )
+        result = TestHandlers.apply(df, transform)
+        assert "B" in result.columns
+        assert "A" not in result.columns
 
-def test_handle_sort_column() -> None:
-    df = pd.DataFrame({"A": [3, 2, 1]})
-    transform = SortColumnTransform(
-        type=TransformType.SORT_COLUMN,
-        column_id="A",
-        ascending=True,
-        na_position="last",
-    )
-    result = apply(df, transform)
-    assert result["A"].tolist() == [1, 2, 3]
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = RenameColumnTransform(
+            type=TransformType.RENAME_COLUMN, column_id="B", new_column_id="C"
+        )
+        result = TestHandlers.apply(df, transform)
+        assert "C" in result.columns
+        assert "B" not in result.columns
 
-    df = pd.DataFrame({"A": [3, 2, 1], "B": [1, 3, 2]})
-    transform = SortColumnTransform(
-        type=TransformType.SORT_COLUMN,
-        column_id="B",
-        ascending=False,
-        na_position="last",
-    )
-    result = apply(df, transform)
-    assert result["B"].tolist() == [3, 2, 1]
+    @staticmethod
+    def test_handle_sort_column() -> None:
+        df = pd.DataFrame({"A": [3, 2, 1]})
+        transform = SortColumnTransform(
+            type=TransformType.SORT_COLUMN,
+            column_id="A",
+            ascending=True,
+            na_position="last",
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].tolist() == [1, 2, 3]
 
+        df = pd.DataFrame({"A": [3, 2, 1], "B": [1, 3, 2]})
+        transform = SortColumnTransform(
+            type=TransformType.SORT_COLUMN,
+            column_id="B",
+            ascending=False,
+            na_position="last",
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["B"].tolist() == [3, 2, 1]
 
-def test_handle_filter_rows_1() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="keep_rows",
-        where=[Condition(column_id="A", operator=">=", value=2)],
-    )
-    result = apply(df, transform)
-    assert result["A"].tolist() == [2, 3]
+    @staticmethod
+    def test_handle_filter_rows_1() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=[Condition(column_id="A", operator=">=", value=2)],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].tolist() == [2, 3]
 
+    @staticmethod
+    def test_handle_filter_rows_2() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="remove_rows",
+            where=[Condition(column_id="B", operator="!=", value=5)],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["B"].tolist() == [5]
 
-def test_handle_filter_rows_2() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="remove_rows",
-        where=[Condition(column_id="B", operator="!=", value=5)],
-    )
-    result = apply(df, transform)
-    assert result["B"].tolist() == [5]
+    @staticmethod
+    def test_handle_filter_rows_3() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3, 4, 5]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=[Condition(column_id="A", operator="<", value=4)],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].tolist() == [1, 2, 3]
 
+    @staticmethod
+    def test_handle_filter_rows_4() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="remove_rows",
+            where=[Condition(column_id="A", operator="==", value=2)],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].tolist() == [1, 3]
 
-def test_handle_filter_rows_3() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3, 4, 5]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="keep_rows",
-        where=[Condition(column_id="A", operator="<", value=4)],
-    )
-    result = apply(df, transform)
-    assert result["A"].tolist() == [1, 2, 3]
+    @staticmethod
+    def test_handle_filter_rows_5() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=[Condition(column_id="B", operator=">=", value=5)],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["B"].tolist() == [5, 6]
 
+    @staticmethod
+    def test_handle_filter_rows_6() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="remove_rows",
+            where=[Condition(column_id="B", operator="<", value=6)],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["B"].tolist() == [6]
 
-def test_handle_filter_rows_4() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="remove_rows",
-        where=[Condition(column_id="A", operator="==", value=2)],
-    )
-    result = apply(df, transform)
-    assert result["A"].tolist() == [1, 3]
+    @staticmethod
+    def test_handle_filter_rows_multiple_conditions_1() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": [5, 4, 3, 2, 1]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=[
+                Condition(column_id="A", operator=">=", value=3),
+                Condition(column_id="B", operator="<=", value=3),
+            ],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].tolist() == [3, 4, 5]
+        assert result["B"].tolist() == [3, 2, 1]
 
+    @staticmethod
+    def test_handle_filter_rows_multiple_conditions_2() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": [5, 4, 3, 2, 1]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="remove_rows",
+            where=[
+                Condition(column_id="A", operator="==", value=2),
+                Condition(column_id="B", operator="==", value=4),
+            ],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].tolist() == [1, 3, 4, 5]
+        assert result["B"].tolist() == [5, 3, 2, 1]
 
-def test_handle_filter_rows_5() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="keep_rows",
-        where=[Condition(column_id="B", operator=">=", value=5)],
-    )
-    result = apply(df, transform)
-    assert result["B"].tolist() == [5, 6]
+    @staticmethod
+    def test_handle_filter_rows_boolean() -> None:
+        df = pd.DataFrame({"A": [True, False, True, False]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=[Condition(column_id="A", operator="is_true")],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].tolist() == [True, True]
 
+        df = pd.DataFrame({"A": [True, False, True, False]})
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="remove_rows",
+            where=[Condition(column_id="A", operator="is_false")],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"].tolist() == [True, True]
 
-def test_handle_filter_rows_6() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="remove_rows",
-        where=[Condition(column_id="B", operator="<", value=6)],
-    )
-    result = apply(df, transform)
-    assert result["B"].tolist() == [6]
+    @staticmethod
+    def test_handle_group_by() -> None:
+        df = pd.DataFrame({"A": ["foo", "foo", "bar"], "B": [1, 2, 3]})
+        transform = GroupByTransform(
+            type=TransformType.GROUP_BY,
+            column_ids=["A"],
+            drop_na=False,
+            aggregation="sum",
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["B"].tolist() == [3, 3]
 
+        df = pd.DataFrame(
+            {"A": ["foo", "foo", "bar", "bar"], "B": [1, 2, 3, 4]}
+        )
+        transform = GroupByTransform(
+            type=TransformType.GROUP_BY,
+            column_ids=["A"],
+            drop_na=False,
+            aggregation="mean",
+        )
+        result = TestHandlers.apply(df, transform)
+        assert set(result["B"].tolist()) == set([1.5, 3.5])
 
-def test_handle_filter_rows_multiple_conditions_1() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": [5, 4, 3, 2, 1]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="keep_rows",
-        where=[
-            Condition(column_id="A", operator=">=", value=3),
-            Condition(column_id="B", operator="<=", value=3),
-        ],
-    )
-    result = apply(df, transform)
-    assert result["A"].tolist() == [3, 4, 5]
-    assert result["B"].tolist() == [3, 2, 1]
+    @staticmethod
+    def test_handle_aggregate() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = AggregateTransform(
+            type=TransformType.AGGREGATE,
+            column_ids=["A", "B"],
+            aggregations=["sum"],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"]["sum"] == 6
+        assert result["B"]["sum"] == 15
 
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = AggregateTransform(
+            type=TransformType.AGGREGATE,
+            column_ids=["A", "B"],
+            aggregations=["min", "max"],
+        )
+        result = TestHandlers.apply(df, transform)
+        assert result["A"]["min"] == 1
+        assert result["A"]["max"] == 3
+        assert result["B"]["min"] == 4
+        assert result["B"]["max"] == 6
 
-def test_handle_filter_rows_multiple_conditions_2() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": [5, 4, 3, 2, 1]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="remove_rows",
-        where=[
-            Condition(column_id="A", operator="==", value=2),
-            Condition(column_id="B", operator="==", value=4),
-        ],
-    )
-    result = apply(df, transform)
-    assert result["A"].tolist() == [1, 3, 4, 5]
-    assert result["B"].tolist() == [5, 3, 2, 1]
+    @staticmethod
+    def test_handle_select_columns() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = SelectColumnsTransform(
+            type=TransformType.SELECT_COLUMNS, column_ids=["A"]
+        )
+        result = TestHandlers.apply(df, transform)
+        assert "A" in result.columns
+        assert "B" not in result.columns
 
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = SelectColumnsTransform(
+            type=TransformType.SELECT_COLUMNS, column_ids=["B"]
+        )
+        result = TestHandlers.apply(df, transform)
+        assert "B" in result.columns
+        assert "A" not in result.columns
 
-def test_handle_filter_rows_boolean() -> None:
-    df = pd.DataFrame({"A": [True, False, True, False]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="keep_rows",
-        where=[Condition(column_id="A", operator="is_true")],
-    )
-    result = apply(df, transform)
-    assert result["A"].tolist() == [True, True]
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = SelectColumnsTransform(
+            type=TransformType.SELECT_COLUMNS, column_ids=["A", "B"]
+        )
+        result = TestHandlers.apply(df, transform)
+        assert "A" in result.columns
+        assert "B" in result.columns
 
-    df = pd.DataFrame({"A": [True, False, True, False]})
-    transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="remove_rows",
-        where=[Condition(column_id="A", operator="is_false")],
-    )
-    result = apply(df, transform)
-    assert result["A"].tolist() == [True, True]
+    @staticmethod
+    def test_shuffle_rows() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = ShuffleRowsTransform(
+            type=TransformType.SHUFFLE_ROWS, seed=42
+        )
+        result = TestHandlers.apply(df, transform)
+        assert len(result) == 3
+        assert "A" in result.columns
+        assert "B" in result.columns
 
+    @staticmethod
+    def test_sample_rows() -> None:
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        transform = SampleRowsTransform(
+            type=TransformType.SAMPLE_ROWS, n=2, seed=42, replace=False
+        )
+        result = TestHandlers.apply(df, transform)
+        assert len(result) == 2
+        assert "A" in result.columns
+        assert "B" in result.columns
 
-def test_handle_group_by() -> None:
-    df = pd.DataFrame({"A": ["foo", "foo", "bar"], "B": [1, 2, 3]})
-    transform = GroupByTransform(
-        type=TransformType.GROUP_BY,
-        column_ids=["A"],
-        drop_na=False,
-        aggregation="sum",
-    )
-    result = apply(df, transform)
-    assert result["B"].tolist() == [3, 3]
+    @staticmethod
+    def test_transforms_container() -> None:
+        # Create a sample dataframe
+        df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": [5, 4, 3, 2, 1]})
+        # Create a TransformsContainer object
+        container = TransformsContainer(df)
 
-    df = pd.DataFrame({"A": ["foo", "foo", "bar", "bar"], "B": [1, 2, 3, 4]})
-    transform = GroupByTransform(
-        type=TransformType.GROUP_BY,
-        column_ids=["A"],
-        drop_na=False,
-        aggregation="mean",
-    )
-    result = apply(df, transform)
-    assert set(result["B"].tolist()) == set([1.5, 3.5])
+        # Define some transformations
+        sort_transform = SortColumnTransform(
+            type=TransformType.SORT_COLUMN,
+            column_id="B",
+            ascending=False,
+            na_position="last",
+        )
+        filter_transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=[Condition(column_id="A", operator=">=", value=2)],
+        )
+        transformations = Transformations([sort_transform, filter_transform])
+        # Verify the next transformation
+        assert container._is_superset(transformations) is False
+        assert (
+            container._get_next_transformations(transformations)
+            == transformations
+        )
 
+        # Apply the transformations
+        result = container.apply(transformations)
 
-def test_handle_aggregate() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = AggregateTransform(
-        type=TransformType.AGGREGATE,
-        column_ids=["A", "B"],
-        aggregations=["sum"],
-    )
-    result = apply(df, transform)
-    assert result["A"]["sum"] == 6
-    assert result["B"]["sum"] == 15
+        # Get the transformed dataframe
+        # Check that the transformations were applied correctly
+        assert result["A"].tolist() == [2, 3, 4, 5]
+        assert result["B"].tolist() == [4, 3, 2, 1]
 
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = AggregateTransform(
-        type=TransformType.AGGREGATE,
-        column_ids=["A", "B"],
-        aggregations=["min", "max"],
-    )
-    result = apply(df, transform)
-    assert result["A"]["min"] == 1
-    assert result["A"]["max"] == 3
-    assert result["B"]["min"] == 4
-    assert result["B"]["max"] == 6
+        # Reapply transforms by adding a new one
+        filter_again_transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="remove_rows",
+            where=[Condition(column_id="B", operator="==", value=4)],
+        )
+        transformations = Transformations(
+            [sort_transform, filter_transform, filter_again_transform]
+        )
+        # Verify the next transformation
+        assert container._is_superset(transformations) is True
+        assert container._get_next_transformations(
+            transformations
+        ) == Transformations([filter_again_transform])
+        result = container.apply(
+            transformations,
+        )
+        # Check that the transformations were applied correctly
+        assert result["A"].tolist() == [3, 4, 5]
+        assert result["B"].tolist() == [3, 2, 1]
 
-
-def test_handle_select_columns() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = SelectColumnsTransform(
-        type=TransformType.SELECT_COLUMNS, column_ids=["A"]
-    )
-    result = apply(df, transform)
-    assert "A" in result.columns
-    assert "B" not in result.columns
-
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = SelectColumnsTransform(
-        type=TransformType.SELECT_COLUMNS, column_ids=["B"]
-    )
-    result = apply(df, transform)
-    assert "B" in result.columns
-    assert "A" not in result.columns
-
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = SelectColumnsTransform(
-        type=TransformType.SELECT_COLUMNS, column_ids=["A", "B"]
-    )
-    result = apply(df, transform)
-    assert "A" in result.columns
-    assert "B" in result.columns
-
-
-def test_shuffle_rows() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = ShuffleRowsTransform(type=TransformType.SHUFFLE_ROWS, seed=42)
-    result = apply(df, transform)
-    assert len(result) == 3
-    assert "A" in result.columns
-    assert "B" in result.columns
-
-
-def test_sample_rows() -> None:
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    transform = SampleRowsTransform(
-        type=TransformType.SAMPLE_ROWS, n=2, seed=42, replace=False
-    )
-    result = apply(df, transform)
-    assert len(result) == 2
-    assert "A" in result.columns
-    assert "B" in result.columns
-
-
-def test_transforms_container() -> None:
-    # Create a sample dataframe
-    df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": [5, 4, 3, 2, 1]})
-    # Create a TransformsContainer object
-    container = TransformsContainer(df)
-
-    # Define some transformations
-    sort_transform = SortColumnTransform(
-        type=TransformType.SORT_COLUMN,
-        column_id="B",
-        ascending=False,
-        na_position="last",
-    )
-    filter_transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="keep_rows",
-        where=[Condition(column_id="A", operator=">=", value=2)],
-    )
-    transformations = Transformations([sort_transform, filter_transform])
-    # Verify the next transformation
-    assert container._is_superset(transformations) is False
-    assert (
-        container._get_next_transformations(transformations) == transformations
-    )
-
-    # Apply the transformations
-    result = container.apply(transformations)
-
-    # Get the transformed dataframe
-    # Check that the transformations were applied correctly
-    assert result["A"].tolist() == [2, 3, 4, 5]
-    assert result["B"].tolist() == [4, 3, 2, 1]
-
-    # Reapply transforms by adding a new one
-    filter_again_transform = FilterRowsTransform(
-        type=TransformType.FILTER_ROWS,
-        operation="remove_rows",
-        where=[Condition(column_id="B", operator="==", value=4)],
-    )
-    transformations = Transformations(
-        [sort_transform, filter_transform, filter_again_transform]
-    )
-    # Verify the next transformation
-    assert container._is_superset(transformations) is True
-    assert container._get_next_transformations(
-        transformations
-    ) == Transformations([filter_again_transform])
-    result = container.apply(
-        transformations,
-    )
-    # Check that the transformations were applied correctly
-    assert result["A"].tolist() == [3, 4, 5]
-    assert result["B"].tolist() == [3, 2, 1]
-
-    transformations = Transformations([sort_transform, filter_transform])
-    # Verify the next transformation
-    assert container._is_superset(transformations) is False
-    assert (
-        container._get_next_transformations(transformations) == transformations
-    )
-    # Reapply by removing the last transform
-    result = container.apply(
-        transformations,
-    )
-    # Check that the transformations were applied correctly
-    assert result["A"].tolist() == [2, 3, 4, 5]
-    assert result["B"].tolist() == [4, 3, 2, 1]
+        transformations = Transformations([sort_transform, filter_transform])
+        # Verify the next transformation
+        assert container._is_superset(transformations) is False
+        assert (
+            container._get_next_transformations(transformations)
+            == transformations
+        )
+        # Reapply by removing the last transform
+        result = container.apply(
+            transformations,
+        )
+        # Check that the transformations were applied correctly
+        assert result["A"].tolist() == [2, 3, 4, 5]
+        assert result["B"].tolist() == [4, 3, 2, 1]

--- a/tests/_plugins/ui/_impl/test_altair_chart.py
+++ b/tests/_plugins/ui/_impl/test_altair_chart.py
@@ -1,95 +1,106 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import pandas as pd
+import pytest
 
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._plugins.ui._impl.altair_chart import (
     ChartSelection,
     _filter_dataframe,
 )
 
+HAS_DEPS = DependencyManager.has_pandas() and DependencyManager.has_altair()
 
-def test_filter_dataframe() -> None:
-    df = pd.DataFrame(
-        {
-            "field": ["value1", "value2", "value3", "value4"],
-            "color": ["red", "red", "blue", "blue"],
-            "field_2": [1, 2, 3, 4],
-            "field_3": [10, 20, 30, 40],
+if HAS_DEPS:
+    import pandas as pd
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+class TestAltairChart:
+    @staticmethod
+    def test_filter_dataframe() -> None:
+        df = pd.DataFrame(
+            {
+                "field": ["value1", "value2", "value3", "value4"],
+                "color": ["red", "red", "blue", "blue"],
+                "field_2": [1, 2, 3, 4],
+                "field_3": [10, 20, 30, 40],
+            }
+        )
+
+        # Define a point selection
+        point_selection: ChartSelection = {
+            "signal_channel_1": {"vlPoint": [1], "field": ["value1", "value2"]}
         }
-    )
+        # Filter the DataFrame with the point selection
+        assert len(_filter_dataframe(df, point_selection)) == 2
 
-    # Define a point selection
-    point_selection: ChartSelection = {
-        "signal_channel_1": {"vlPoint": [1], "field": ["value1", "value2"]}
-    }
-    # Filter the DataFrame with the point selection
-    assert len(_filter_dataframe(df, point_selection)) == 2
-
-    # Point selected with a no fields
-    point_selection = {
-        "select_point": {
-            "_vgsid_": [2, 3],  # vega is 1-indexed
-            "vlPoint": [""],
-        },
-    }
-    # Filter the DataFrame with the point selection
-    assert len(_filter_dataframe(df, point_selection)) == 2
-    first, second = _filter_dataframe(df, point_selection)["field"].values
-    assert first == "value2"
-    assert second == "value3"
-
-    # Define an interval selection
-    interval_selection: ChartSelection = {
-        "signal_channel_2": {"field_2": [1, 3]}
-    }
-    # Filter the DataFrame with the interval selection
-    assert len(_filter_dataframe(df, interval_selection)) == 3
-
-    # Define an interval selection with multiple fields
-    multi_field_selection: ChartSelection = {
-        "signal_channel_1": {"field_2": [1, 3], "field_3": [30, 40]}
-    }
-    # Filter the DataFrame with the multi-field selection
-    assert len(_filter_dataframe(df, multi_field_selection)) == 1
-
-    # Define an interval selection with multiple fields
-    interval_and_point_selection: ChartSelection = {
-        "signal_channel_1": {"field_2": [1, 3], "field_3": [20, 40]},
-        "signal_channel_2": {"vlPoint": [1], "color": ["red"]},
-    }
-    # Filter the DataFrame with the multi-field selection
-    assert len(_filter_dataframe(df, interval_and_point_selection)) == 1
-
-
-def test_filter_dataframe_with_dates() -> None:
-    df = pd.DataFrame(
-        {
-            "field": ["value1", "value2", "value3", "value4"],
-            "color": ["red", "red", "blue", "blue"],
-            "field_2": [1, 2, 3, 4],
-            "field_3": [10, 20, 30, 40],
-            "date": pd.to_datetime(
-                ["2020-01-01", "2020-01-03", "2020-01-05", "2020-01-07"]
-            ),
+        # Point selected with a no fields
+        point_selection = {
+            "select_point": {
+                "_vgsid_": [2, 3],  # vega is 1-indexed
+                "vlPoint": [""],
+            },
         }
-    )
+        # Filter the DataFrame with the point selection
+        assert len(_filter_dataframe(df, point_selection)) == 2
+        first, second = _filter_dataframe(df, point_selection)["field"].values
+        assert first == "value2"
+        assert second == "value3"
 
-    # Check that the date column is a datetime64[ns] column
-    assert df["date"].dtype == "datetime64[ns]"
-
-    # Define an interval selection
-    interval_selection: ChartSelection = {
-        "signal_channel_2": {
-            "date": [
-                # Vega passes back milliseconds since epoch
-                1577000000000,  # Sunday, December 22, 2019 7:33:20 AM
-                1578009600000,  # Friday, January 3, 2020 12:00:00 AM
-            ]
+        # Define an interval selection
+        interval_selection: ChartSelection = {
+            "signal_channel_2": {"field_2": [1, 3]}
         }
-    }
-    # Filter the DataFrame with the interval selection
-    assert len(_filter_dataframe(df, interval_selection)) == 2
-    first, second = _filter_dataframe(df, interval_selection)["field"].values
-    assert first == "value1"
-    assert second == "value2"
+        # Filter the DataFrame with the interval selection
+        assert len(_filter_dataframe(df, interval_selection)) == 3
+
+        # Define an interval selection with multiple fields
+        multi_field_selection: ChartSelection = {
+            "signal_channel_1": {"field_2": [1, 3], "field_3": [30, 40]}
+        }
+        # Filter the DataFrame with the multi-field selection
+        assert len(_filter_dataframe(df, multi_field_selection)) == 1
+
+        # Define an interval selection with multiple fields
+        interval_and_point_selection: ChartSelection = {
+            "signal_channel_1": {"field_2": [1, 3], "field_3": [20, 40]},
+            "signal_channel_2": {"vlPoint": [1], "color": ["red"]},
+        }
+        # Filter the DataFrame with the multi-field selection
+        assert len(_filter_dataframe(df, interval_and_point_selection)) == 1
+
+    @staticmethod
+    def test_filter_dataframe_with_dates() -> None:
+        df = pd.DataFrame(
+            {
+                "field": ["value1", "value2", "value3", "value4"],
+                "color": ["red", "red", "blue", "blue"],
+                "field_2": [1, 2, 3, 4],
+                "field_3": [10, 20, 30, 40],
+                "date": pd.to_datetime(
+                    ["2020-01-01", "2020-01-03", "2020-01-05", "2020-01-07"]
+                ),
+            }
+        )
+
+        # Check that the date column is a datetime64[ns] column
+        assert df["date"].dtype == "datetime64[ns]"
+
+        # Define an interval selection
+        interval_selection: ChartSelection = {
+            "signal_channel_2": {
+                "date": [
+                    # Vega passes back milliseconds since epoch
+                    1577000000000,  # Sunday, December 22, 2019 7:33:20 AM
+                    1578009600000,  # Friday, January 3, 2020 12:00:00 AM
+                ]
+            }
+        }
+        # Filter the DataFrame with the interval selection
+        assert len(_filter_dataframe(df, interval_selection)) == 2
+        first, second = _filter_dataframe(df, interval_selection)[
+            "field"
+        ].values
+        assert first == "value1"
+        assert second == "value2"


### PR DESCRIPTION
- To facilitate CI testing with minimal possible set of dependencies.
- Refactor pandas/altair tests to only run when deps installed
- Updates CI to run tests with and without the optional dependencies, to make sure we don't accidentally require an optional dep.