### PR TITLE
fix: traceback line number

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -29,7 +29,7 @@ def code_key(code: str) -> int:
 
 def cell_id_from_filename(filename: str) -> Optional[CellId_t]:
     """Parse cell id from filename."""
-    matches = re.findall(r"__marimo__cell_([0-9]+)", filename)
+    matches = re.findall(r"__marimo__cell_(.*)_", filename)
     if matches:
         return str(matches[0])
     return None
@@ -37,7 +37,7 @@ def cell_id_from_filename(filename: str) -> Optional[CellId_t]:
 
 def get_filename(cell_id: CellId_t, suffix: str = "") -> str:
     """Get a temporary Python filename that encodes the cell id in it."""
-    basename = f"__marimo__cell_{cell_id}"
+    basename = f"__marimo__cell_{cell_id}_"
     return os.path.join(get_tmpdir(), basename + suffix + ".py")
 
 

--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -29,7 +29,7 @@ def code_key(code: str) -> int:
 
 def cell_id_from_filename(filename: str) -> Optional[CellId_t]:
     """Parse cell id from filename."""
-    matches = re.findall(r"__marimo__cell_(.*)_", filename)
+    matches = re.findall(r"__marimo__cell_(.*?)_", filename)
     if matches:
         return str(matches[0])
     return None

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from functools import partial
 
 from marimo._ast import compiler
+from marimo._ast.app import CellManager
 
 compile_cell = partial(compiler.compile_cell, cell_id="0")
 
@@ -100,7 +101,9 @@ class TestCellFactory:
 
 
 def test_cell_id_from_filename() -> None:
-    assert compiler.cell_id_from_filename(compiler.get_filename("0")) == "0"
-    assert compiler.cell_id_from_filename(compiler.get_filename("2")) == "2"
-    assert compiler.cell_id_from_filename(compiler.get_filename("23")) == "23"
+    cell_id = CellManager().create_cell_id()
+    assert (
+        compiler.cell_id_from_filename(compiler.get_filename(cell_id))
+        == cell_id
+    )
     assert compiler.cell_id_from_filename("random_file.py") is None

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -106,4 +106,11 @@ def test_cell_id_from_filename() -> None:
         compiler.cell_id_from_filename(compiler.get_filename(cell_id))
         == cell_id
     )
+    assert (
+        compiler.cell_id_from_filename(
+            compiler.get_filename(cell_id, suffix="_abcd")
+        )
+        == cell_id
+    )
+
     assert compiler.cell_id_from_filename("random_file.py") is None

--- a/tests/_runtime/test_virtual_file.py
+++ b/tests/_runtime/test_virtual_file.py
@@ -229,7 +229,7 @@ def test_cached_vfile_disposal(k: Kernel, exec_req: ExecReqProvider) -> None:
     k.run([exec_req.get("vfiles[:] = []")])
     # NB: this test may be flaky! refcount decremented when `__del__` is called
     # but we can't rely on when it will be called.
-    k.run([exec_req.get("gc.collect()")])
+    k.run([exec_req.get("import gc; gc.collect()")])
     assert ctx.virtual_file_registry.refcount(vfile) == 0
 
     # create another vfile. the old one should be deleted

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from typing import Any, Generator
 
 import pytest
 
+from marimo._ast.app import CellManager
 from marimo._ast.cell import CellId_t
 from marimo._messaging.streams import Stderr, Stdin, Stdout
 from marimo._runtime.context import (
@@ -113,11 +114,10 @@ def mocked_kernel() -> Generator[MockedKernel, None, None]:
 # Factory to create ExecutionRequests and abstract away cell ID
 class ExecReqProvider:
     def __init__(self) -> None:
-        self.counter = 0
+        self.cell_manager = CellManager()
 
     def get(self, code: str) -> ExecutionRequest:
-        key = str(self.counter)
-        self.counter += 1
+        key = self.cell_manager.create_cell_id()
         return ExecutionRequest(cell_id=key, code=textwrap.dedent(code))
 
     def get_with_id(self, cell_id: CellId_t, code: str) -> ExecutionRequest:


### PR DESCRIPTION
This change fixes tracebacks, which regressed and stopped showing line numbers when we changed the cell ID format.

This change also modifies the tests to catch bugs like this in the future, by making `ExecutionRequestProvider` use the `CellManager` for creating cell IDs.