### PR TITLE
fix: output append should not render lazily

### DIFF
--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -39,7 +39,7 @@ def replace(value: object) -> None:
     elif value is None:
         ctx.kernel.execution_context.output = None
     else:
-        ctx.kernel.execution_context.output = [value]
+        ctx.kernel.execution_context.output = [formatting.as_html(value)]
     write_internal(cell_id=ctx.kernel.execution_context.cell_id, value=value)
 
 
@@ -59,9 +59,9 @@ def append(value: object) -> None:
         return
 
     if ctx.kernel.execution_context.output is None:
-        ctx.kernel.execution_context.output = [value]
+        ctx.kernel.execution_context.output = [formatting.as_html(value)]
     else:
-        ctx.kernel.execution_context.output.append(value)
+        ctx.kernel.execution_context.output.append(formatting.as_html(value))
     write_internal(
         cell_id=ctx.kernel.execution_context.cell_id,
         value=vstack(ctx.kernel.execution_context.output),

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -45,6 +45,7 @@ from marimo._messaging.ops import (
 )
 from marimo._messaging.streams import Stderr, Stdin, Stdout, Stream
 from marimo._output import formatting
+from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import MarimoConvertValueException
@@ -143,7 +144,7 @@ class ExecutionContext:
     cell_id: CellId_t
     setting_element_value: bool
     # output object set imperatively
-    output: Optional[list[object]] = None
+    output: Optional[list[Html]] = None
 
 
 @dataclasses.dataclass

--- a/marimo/_tutorials/intro.py
+++ b/marimo/_tutorials/intro.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.88"


### PR DESCRIPTION
This fixes a bug in which appended outputs were re-formatted each time an output message was set. This was incorrect because the appended objects may be mutated.