### PR TITLE
fix: cross-platform server shutdown

### DIFF
--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -151,6 +151,5 @@ async def shutdown(
     LOGGER.debug("Received shutdown request")
     app_state = AppState(request)
     app_state.session_manager.shutdown()
-
-    await close_uvicorn(app_state.server)
+    close_uvicorn(app_state.server)
     return SuccessResponse()

--- a/marimo/_server/api/lifespans.py
+++ b/marimo/_server/api/lifespans.py
@@ -45,7 +45,7 @@ async def _shutdown(app: Starlette, with_error: bool = False) -> None:
         LOGGER.fatal("marimo shut down with an error.")
     mgr.shutdown()
     if with_error:
-        await close_uvicorn(app.state.server)
+        close_uvicorn(app.state.server)
 
 
 # Compound lifespans
@@ -145,7 +145,7 @@ async def signal_handler(app: Starlette) -> AsyncIterator[None]:
     # Interrupt handler
     def shutdown() -> None:
         manager.shutdown()
-        asyncio.create_task(close_uvicorn(app.state.server))
+        close_uvicorn(app.state.server)
 
     InterruptHandler(
         quiet=manager.quiet,

--- a/marimo/_server/uvicorn_utils.py
+++ b/marimo/_server/uvicorn_utils.py
@@ -8,10 +8,7 @@ from marimo import _loggers
 LOGGER = _loggers.marimo_logger()
 
 
-async def close_uvicorn(server: uvicorn.Server) -> None:
+def close_uvicorn(server: uvicorn.Server) -> None:
     LOGGER.debug("Shutting down uvicorn")
-    for s in server.servers:
-        s.close()
-        await s.wait_closed()
     server.handle_exit(signal.SIGINT, None)
     LOGGER.debug("Uvicorn shut down")


### PR DESCRIPTION
This change fixes shutdown via Ctrl+C and the shutdown route on Windows. The event loop previously endlessly awaited `wait_closed()` in `close_uvicorn`, preventing the server from shutting down.

The server appears to shut down fine without us waiting for its own servers to shut down.