### PR TITLE
fix: fix how names bound to lensed elements are resolved

### DIFF
--- a/marimo/_smoke_tests/ansi.py
+++ b/marimo/_smoke_tests/ansi.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.88"

--- a/marimo/_smoke_tests/third_party/rich.py
+++ b/marimo/_smoke_tests/third_party/rich.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.1.88"

--- a/tests/_plugins/ui/_core/test_registry.py
+++ b/tests/_plugins/ui/_core/test_registry.py
@@ -149,3 +149,20 @@ def test_lens_not_bound(k: Kernel, exec_req: ExecReqProvider) -> None:
     registry = get_context().ui_element_registry
     assert not registry.bound_names(array[0]._id)
     assert registry.bound_names(array._id) == set(["array"])
+
+
+def test_parent_bound_to_view(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            exec_req.get(
+                """
+                import marimo as mo
+                array = mo.ui.array([mo.ui.text(), mo.ui.slider(1, 10)])
+                child = array[0]
+                """
+            )
+        ]
+    )
+    array = k.globals["array"]
+    registry = get_context().ui_element_registry
+    assert registry.bound_names(array._id) == set(["array", "child"])

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -132,6 +132,29 @@ def test_set_ui_element_value_lensed(
     assert k.globals["x"] == 6
 
 
+def test_set_ui_element_value_lensed_bound_child(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    """Test setting the value of a lensed element.
+
+    Make sure reactivity flows through its parent and also to names bound
+    to children.
+    """
+    k.run([exec_req.get(code="import marimo as mo")])
+
+    cell_one_code = """
+    array = mo.ui.array([mo.ui.slider(0, 10, value=1)])
+    child = array[0]
+    """
+    k.run([exec_req.get(code=cell_one_code)])
+    k.run([exec_req.get(code="x = child.value + 1")])
+
+    array_id = k.globals["array"]._id
+    k.set_ui_element_value(SetUIElementValueRequest([(array_id, {"0": 5})]))
+    assert k.globals["array"].value == [5]
+    assert k.globals["x"] == 6
+
+
 def test_set_ui_element_value_lensed_with_state(
     k: Kernel, exec_req: ExecReqProvider
 ) -> None:


### PR DESCRIPTION
When a parent UI element has a child bound to a global, interacting with the parent should trigger reactive execution of cells referring to the child.