### PR TITLE
fix: fix standard stream direction + multiprocessing 

### DIFF
--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -67,9 +67,7 @@ def redirect_streams(
     sys.stdin = stdin  # type: ignore
 
     try:
-        with redirect(stdout, py_stdout.fileno()), redirect(
-            stderr, py_stderr.fileno()
-        ):
+        with redirect(stdout), redirect(stderr):
             yield
     finally:
         # The redirect context manager relies on these being installed;

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1237,4 +1237,9 @@ def launch_kernel(
             break
         else:
             raise ValueError(f"Unknown request {request}")
+
+    if stdout is not None:
+        stdout._watcher.stop()
+    if stderr is not None:
+        stderr._watcher.stop()
     get_context().virtual_file_registry.shutdown()

--- a/tests/_messaging/test_streams.py
+++ b/tests/_messaging/test_streams.py
@@ -98,3 +98,21 @@ class TestStderr:
             ]
         )
         assert mocked_kernel.stderr.messages == ["hello", "there"]
+
+
+def test_import_multiprocessing(
+    mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+) -> None:
+    # https://github.com/marimo-team/marimo/issues/684
+    mocked_kernel.k.run(
+        [
+            exec_req.get(
+                """
+                from multiprocessing import Manager
+                Manager().dict()
+                print("hello")
+                """
+            )
+        ]
+    )
+    assert mocked_kernel.stdout.messages == ["hello", "\n"]


### PR DESCRIPTION
This change fixes a bad interaction between standard stream redirection
and multiprocessing, in which the forwarding thread would fail to join.

Instead of creating a new forwarding thread for each cell execution,
this change creates the forwarding threads at runtime start, and keeps
them alive for the duration of the kernel process. Similarly, instead
of creating a pipe for the redirection on each cell execution, this
change just creates the pipes once.

Addresses #684 