### PR TITLE
Persist comment headers while resaving notebooks

### DIFF
--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import ast
 import builtins
 import importlib.util
 import json
@@ -249,10 +250,37 @@ def recover(filename: str) -> str:
 
 
 def get_header_comments(filename: str) -> Optional[str]:
+    """Gets the header comments from a file. Returns
+    None if the file does not exist or the header is
+    invalid, which is determined by:
+        1. If the file is does not contain the marimo
+            import statement
+        2. If the section before the marimo import
+            statement contains any non-comment code
+    """
+
+    def is_multiline_comment(node: ast.stmt) -> bool:
+        """Checks if a node is a docstring or a multiline comment."""
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            return True
+        return False
+
     if not os.path.exists(filename):
         return None
+
     with open(filename, "r", encoding="utf-8") as f:
         contents = f.read()
 
+    if "import marimo" not in contents:
+        return None
+
     header, _ = contents.split("import marimo", 1)
+
+    # Ensure the header only contains non-executable code
+    # ast parses out single line comments, so we only
+    # need to check that every node is not a multiline comment
+    module = ast.parse(header)
+    if any(not is_multiline_comment(node) for node in module.body):
+        return None
+
     return header

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import builtins
 import importlib.util
 import json
+import os
 from collections.abc import Sequence
 from typing import Any, List, Optional, Union, cast
 
@@ -245,3 +246,13 @@ def recover(filename: str) -> str:
         cast(List[str], names),
         cast(List[CellConfig], configs),
     )
+
+
+def get_header_comments(filename: str) -> Optional[str]:
+    if not os.path.exists(filename):
+        return None
+    with open(filename, "r", encoding="utf-8") as f:
+        contents = f.read()
+
+    header, _ = contents.split("import marimo", 1)
+    return header

--- a/marimo/_server/api/endpoints/files.py
+++ b/marimo/_server/api/endpoints/files.py
@@ -238,7 +238,10 @@ async def save(
         )
         LOGGER.debug("Saving app to %s", filename)
         try:
+            header_comments = codegen.get_header_comments(filename)
             with open(filename, "w", encoding="utf-8") as f:
+                if header_comments:
+                    f.write(header_comments.rstrip() + "\n\n")
                 f.write(contents)
         except Exception as e:
             raise HTTPException(

--- a/tests/_ast/codegen_data/test_get_header_comments.py
+++ b/tests/_ast/codegen_data/test_get_header_comments.py
@@ -1,0 +1,27 @@
+"""Docstring"""
+
+"""multi
+    line
+"""
+
+# A copyright license
+
+# A linter/formatter directive
+
+import marimo
+
+__generated_with = "0.1.0"
+app = marimo.App()
+
+
+@app.cell
+def one(): return
+
+
+@app.cell
+def two():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_ast/codegen_data/test_get_header_comments_invalid.py
+++ b/tests/_ast/codegen_data/test_get_header_comments_invalid.py
@@ -1,0 +1,30 @@
+"""Docstring"""
+
+"""
+This is an invalid header since there is 
+    a statement before the import marmio command
+"""
+
+print("Hello World") 
+
+# A copyright license
+
+# A linter/formatter directive
+
+import marimo
+
+__generated_with = "0.1.0"
+app = marimo.App()
+
+
+@app.cell
+def one(): return
+
+
+@app.cell
+def two():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -428,3 +428,21 @@ def test_recover() -> None:
 # TODO(akshayka): more tests for attributes, classdefs, and closures
 # TODO(akshayka): test builtin functions
 # TODO(akshayka): test delete cell
+
+
+def test_get_header_comments() -> None:
+    filepath = get_filepath("test_get_header_comments")
+    comments = codegen.get_header_comments(filepath)
+
+    assert comments, "No comments found"
+    assert '"""Docstring"""' in comments, "Docstring not found"
+    assert '"""multi\n    line\n"""' in comments, "Multiline string not found"
+    assert "# A copyright" in comments, "Comment not found"
+    assert "# A linter" in comments, "Comment not found"
+
+
+def test_get_header_comments_invalid() -> None:
+    filepath = get_filepath("test_get_header_comments_invalid")
+    comments = codegen.get_header_comments(filepath)
+
+    assert comments is None, "Comments found when there should be none"

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -107,6 +107,46 @@ def test_save_file(client: TestClient) -> None:
 
 
 @with_session(SESSION_ID)
+def test_save_with_header(client: TestClient) -> None:
+    filename = get_session_manager(client).filename
+    assert filename
+    assert os.path.exists(filename)
+
+    header = (
+        '"""This is a docstring"""\n\n' + "# Copyright 2024\n# Linter ignore\n"
+    )
+    # Prepend a header to the file
+    contents = open(filename).read()
+    contents = header + contents
+    open(filename, "w", encoding="UTF-8").write(contents)
+
+    response = client.post(
+        "/api/kernel/save",
+        headers=HEADERS,
+        json={
+            "cell_ids": ["1"],
+            "filename": filename,
+            "codes": ["import marimo as mo"],
+            "names": ["my_cell"],
+            "configs": [
+                {
+                    "hideCode": True,
+                    "disabled": False,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["success"] is True
+    file_contents = open(filename).read()
+    assert "import marimo as mo" in file_contents
+    assert file_contents.startswith(header.rstrip()), "Header was removed"
+    assert "@app.cell(hide_code=True)" in file_contents
+    assert "my_cell" in file_contents
+
+
+@with_session(SESSION_ID)
 def test_save_file_cannot_rename(client: TestClient) -> None:
     response = client.post(
         "/api/kernel/save",

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -147,6 +147,48 @@ def test_save_with_header(client: TestClient) -> None:
 
 
 @with_session(SESSION_ID)
+def test_save_with_invalid_file(client: TestClient) -> None:
+    filename = get_session_manager(client).filename
+    assert filename
+    assert os.path.exists(filename)
+
+    header = (
+        '"""This is a docstring"""\n\n'
+        + 'print("dont do this!")\n'
+        + "# Linter ignore\n"
+    )
+
+    # Prepend a header to the file
+    contents = open(filename).read()
+    contents = header + contents
+    open(filename, "w", encoding="UTF-8").write(contents)
+
+    response = client.post(
+        "/api/kernel/save",
+        headers=HEADERS,
+        json={
+            "cell_ids": ["1"],
+            "filename": filename,
+            "codes": ["import marimo as mo"],
+            "names": ["my_cell"],
+            "configs": [
+                {
+                    "hideCode": True,
+                    "disabled": False,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["success"] is True
+    file_contents = open(filename).read()
+    assert file_contents.startswith("import marimo"), "Header was not removed"
+    assert "@app.cell(hide_code=True)" in file_contents
+    assert "my_cell" in file_contents
+
+
+@with_session(SESSION_ID)
 def test_save_file_cannot_rename(client: TestClient) -> None:
     response = client.post(
         "/api/kernel/save",


### PR DESCRIPTION
## Summary
This PR allows `marimo` to not overwrite the headers in a notebook while saving. It does so by extracting the header while writing the file, and prepending the header (the portion of the source file until the `import marimo` line) to the new content. 

## Motivation
We often automatically add license headers to all the source files that we develop commercially. Moreover, `mypy` and `ruff` seem to complain over `marimo` notebook. Thus, a common header to solve these issues would be
```
# Copyright 2024

# ruff: noqa
# mypy: ignore-errors

import marimo
...
```
Before this PR, every time I save the notebook it removes these headers and causes unnecessary file changes and a lot of red in the `precommit` checks. 

I took the liberty of giving it a shot and adapting `marimo` to support persisting these headers. Given I am not familiar with the codebase, so criticism is very welcome!