### PR TITLE
fix: mo.ui.altair_chart with transform_filter

### DIFF
--- a/docs/guides/plotting.md
+++ b/docs/guides/plotting.md
@@ -7,7 +7,6 @@ as you normally would.
 For Altair plots, marimo does something special: use [`mo.ui.altair_chart`](#reactive-plots)
 to connect frontend selections to Python!
 
-
 ```{admonition} Reactive plots!
 :class: important
 
@@ -16,7 +15,6 @@ marimo supports reactive plots via
 filter with your mouse, and marimo _automatically makes the selected data
 available in Python as a Pandas dataframe_!
 ```
-
 
 ## Reactive plots! ⚡
 
@@ -32,12 +30,12 @@ automatically made available as Pandas dataframes in Python._
 </figure>
 </div>
 
-
 ```{admonition} Requirements
 :class: warning
 Reactive plots currently require Altair. Install it with `pip install altair`
 In the future, we may make other plotting libraries reactive.
 ```
+
 Wrap an Altair chart in [`mo.ui.altair_chart`](../api/plotting.md#marimo.ui.altair_chart)
 to make it **reactive**: select data on the frontend, access it via the chart's
 `value` attribute (`chart.value`).
@@ -137,6 +135,19 @@ docs](../api/plotting.md#marimo.ui.altair_chart) for details.
 ```{admonition} Note
 You may still add your own selection parameters via Altair or Vega-Lite.
 marimo will not override your selections.
+```
+
+### Altair transformations
+
+Altair supports a variety of transformations, such as filtering, aggregation, and sorting. These transformations can be used to create more complex and nuanced visualizations. For example, you can use a filter to show only the points that meet a certain condition, or use an aggregation to show the average value of a variable.
+
+In order for marimo's reactive plots to work with transformations, you must install `vegafusion`, as this feature uses `chart.transformed_data` (which requires version 1.4.0 or greater of the `vegafusion` packages).
+
+```bash
+# These can be installed with pip using:
+pip install "vegafusion[embed]>=1.4.0"
+# Or with conda using:
+conda install -c conda-forge "vegafusion-python-embed>=1.4.0" "vegafusion>=1.4.0"
 ```
 
 ## matplotlib

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -271,7 +271,7 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
         # with those transforms, before applying the selection
         if _has_transforms(self._spec):
             try:
-                df: pd.DataFrame = self._chart.transformed_data()  # type: ignore[assignment]
+                df: pd.DataFrame = self._chart.transformed_data()
                 return _filter_dataframe(df, value)
             except ImportError as e:
                 sys.stderr.write(

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -124,6 +124,11 @@ def _parse_spec(spec: altair.TopLevelMixin) -> VegaSpec:
     return spec.to_dict()  # type: ignore
 
 
+def _has_transforms(spec: VegaSpec) -> bool:
+    """Return True if the spec has transforms."""
+    return "transform" in spec and len(spec["transform"]) > 0
+
+
 @mddoc
 class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
     """Make reactive charts with Altair
@@ -234,6 +239,10 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
 
         self.dataframe = chart.data
 
+        # Private attributes
+        self._chart = chart
+        self._spec = vega_spec
+
         super().__init__(
             component_name="marimo-vega",
             initial_value={},
@@ -257,4 +266,20 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
             import pandas as pd
 
             return pd.DataFrame()
+
+        # If we have transforms, we need to filter the dataframe
+        # with those transforms, before applying the selection
+        if _has_transforms(self._spec):
+            try:
+                df: pd.DataFrame = self._chart.transformed_data()  # type: ignore[assignment]
+                return _filter_dataframe(df, value)
+            except ImportError as e:
+                sys.stderr.write(
+                    "Failed to filter dataframe that includes a transform. "
+                    + "This could be due to a missing dependency.\n\n"
+                    + e.msg
+                )
+                # Fall back to the untransformed dataframe
+                return _filter_dataframe(self.dataframe, value)
+
         return _filter_dataframe(self.dataframe, value)

--- a/marimo/_smoke_tests/altair_charts.py
+++ b/marimo/_smoke_tests/altair_charts.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 
-__generated_with = "0.1.59"
+__generated_with = "0.2.1"
 app = marimo.App(width="full")
 
 
@@ -505,6 +505,41 @@ def __(alt, mo, np, pd):
 @app.cell
 def __(facet_chart, mo):
     mo.hstack([facet_chart.value, facet_chart.selections])
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        """
+    # With `transform_filter`
+    > Bug https://github.com/marimo-team/marimo/issues/727
+    """
+    )
+    return
+
+
+@app.cell
+def __(alt, data, mo):
+    from altair import datum
+
+    _chart = (
+        alt.Chart(data.cars())
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .transform_filter(datum.Origin == "Europe")
+    )
+    with_transform = mo.ui.altair_chart(_chart)
+    return datum, with_transform
+
+
+@app.cell
+def __(mo, with_transform):
+    mo.vstack([with_transform, with_transform.value])
     return
 
 


### PR DESCRIPTION
Fixes https://github.com/marimo-team/marimo/issues/727

This fixes `mo.ui.altair_chart` plot showing incorrect data with when using `transform_filter` and other `transform_*`. This is because the python side does not apply the `transform_filter` by default and lets the FE (vega) do that. 

But we can force the python side to support this by installing `vegafusion`. This PR adds docs and a clearer warning to install. 

When not installed, we fallback to the dataframe without the filter (but error to the user). We could hard-throw instead of falling back for correctness.
