### PR TITLE
fix: open markdown links in a new tab

### DIFF
--- a/marimo/_output/md.py
+++ b/marimo/_output/md.py
@@ -61,12 +61,12 @@ def _md(text: str, apply_markdown_class: bool = True) -> Html:
         extension_configs=extension_configs,
     ).strip()
     # replace <p> tags with <span> as HTML doesn't allow nested <div>s in <p>s
-    html_text = html_text.replace("<p>", "<span class='paragraph'>").replace(
+    html_text = html_text.replace("<p>", '<span class="paragraph">').replace(
         "</p>", "</span>"
     )
 
     if apply_markdown_class:
-        return Html("<span class='markdown'>" + html_text + "</span>")
+        return Html('<span class="markdown">' + html_text + "</span>")
     else:
         return Html(html_text)
 

--- a/marimo/_output/md.py
+++ b/marimo/_output/md.py
@@ -6,6 +6,7 @@ from inspect import cleandoc
 import markdown  # type: ignore
 
 from marimo._output.hypertext import Html
+from marimo._output.md_extensions.external_links import ExternalLinksExtension
 from marimo._output.rich_help import mddoc
 
 extension_configs = {
@@ -54,6 +55,8 @@ def _md(text: str, apply_markdown_class: bool = True) -> Html:
             "toc",
             # Footnotes
             "footnotes",
+            # Links
+            ExternalLinksExtension(),
         ],
         extension_configs=extension_configs,
     ).strip()

--- a/marimo/_output/md_extensions/__init__.py
+++ b/marimo/_output/md_extensions/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2024 Marimo. All rights reserved.

--- a/marimo/_output/md_extensions/external_links.py
+++ b/marimo/_output/md_extensions/external_links.py
@@ -1,0 +1,35 @@
+# Copyright 2024 Marimo. All rights reserved.
+from urllib.parse import urlparse
+from xml.etree.ElementTree import Element
+
+from markdown import Extension, Markdown, treeprocessors  # type: ignore
+
+# Adapted from https://github.com/squidfunk/mkdocs-material/discussions/3660#discussioncomment-6725823
+
+
+class ExternalLinksTreeProcessor(treeprocessors.Treeprocessor):  # type: ignore[misc]
+    """
+    Adds target="_blank" and rel="noopener" to external links.
+    """
+
+    def run(self, root: Element) -> None:
+        for element in root.iter():
+            if element.tag != "a":
+                continue
+
+            href = element.get("href", "")
+
+            parsed_url = urlparse(href)
+
+            if parsed_url.scheme in ["http", "https"]:
+                element.set("target", "_blank")
+                element.set("rel", "noopener")
+
+
+class ExternalLinksExtension(Extension):  # type: ignore[misc]
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.treeprocessors.register(
+            ExternalLinksTreeProcessor(md),
+            "external_links",
+            -1000,
+        )

--- a/marimo/_smoke_tests/latex.py
+++ b/marimo/_smoke_tests/latex.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.2.1"

--- a/marimo/_smoke_tests/md.py
+++ b/marimo/_smoke_tests/md.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.2.1"
@@ -54,16 +55,34 @@ def __(mo):
     mo.md(
         """
         Here's a short footnote,[^1] and here's a longer one.[^longnote]
-        
+
         [^1]: This is a short footnote.
-        
+
         [^longnote]: This is a longer footnote with paragraphs, and code.
-        
+
             Indent paragraphs to include them in the footnote.
-        
+
             `{ my code }` add some code, if you like.
-        
+
             Add as many paragraphs as you need.
+        """
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md("# External links")
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        """
+        This is [an example](http://example.com/ "Title") inline link.
+
+        [This link](http://example.net/) has no title attribute.
         """
     )
     return

--- a/tests/_output/test_md.py
+++ b/tests/_output/test_md.py
@@ -22,7 +22,7 @@ def test_md_code_blocks() -> None:
     assert _md(code_input, apply_markdown_class=False).text == expected_output
 
 
-def test_md_lates() -> None:
+def test_md_latex() -> None:
     # Test LaTeX conversion
     latex_input = "Here is an equation: ||(E=mc^2||)"
     expected_output = '<span class="paragraph">Here is an equation: ||(E=mc^2||)</span>'  # noqa: E501

--- a/tests/_output/test_md.py
+++ b/tests/_output/test_md.py
@@ -1,0 +1,49 @@
+from marimo._output.md import _md
+
+
+def test_md():
+    # Test basic markdown conversion
+    input_text = "This is **bold** and this is _italic_."
+    expected_output = '<span class="markdown"><span class="paragraph">This is <strong>bold</strong> and this is <em>italic</em>.</span></span>'  # noqa: E501
+    assert _md(input_text).text == expected_output
+
+    # Test disabling markdown class
+    expected_output_no_class = '<span class="paragraph">This is <strong>bold</strong> and this is <em>italic</em>.</span>'  # noqa: E501
+    assert (
+        _md(input_text, apply_markdown_class=False).text
+        == expected_output_no_class
+    )
+
+
+def test_md_code_blocks():
+    # Test code block conversion
+    code_input = "```python\nprint('Hello, world!')\n```"
+    expected_output = '<div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Hello, world!&#39;</span><span class="p">)</span>\n</code></pre></div>'  # noqa: E501
+    assert _md(code_input, apply_markdown_class=False).text == expected_output
+
+
+def test_md_lates():
+    # Test LaTeX conversion
+    latex_input = "Here is an equation: ||(E=mc^2||)"
+    expected_output = '<span class="paragraph">Here is an equation: ||(E=mc^2||)</span>'  # noqa: E501
+    assert _md(latex_input, apply_markdown_class=False).text == expected_output
+
+
+def test_md_links():
+    # Test external link conversion
+    link_input = "[Google](https://google.com)"
+    expected_output = '<span class="paragraph"><a href="https://google.com" rel="noopener" target="_blank">Google</a></span>'  # noqa: E501
+    assert _md(link_input, apply_markdown_class=False).text == (
+        expected_output
+    )
+
+
+def test_md_footnotes():
+    # Test footnote conversion
+    footnote_input = (
+        "Here is a footnote reference[^1].\n\n[^1]: Here is the footnote."
+    )
+    expected_output = '<span class="paragraph">Here is a footnote reference<sup id="fnref:2-1"><a class="footnote-ref" href="#fn:2-1">1</a></sup>.</span>\n<div class="footnote">\n<hr />\n<ol>\n<li id="fn:2-1">\n<span class="paragraph">Here is the footnote.&#160;<a class="footnote-backref" href="#fnref:2-1" title="Jump back to footnote 1 in the text">&#8617;</a></span>\n</li>\n</ol>\n</div>'  # noqa: E501
+    assert _md(footnote_input, apply_markdown_class=False).text == (
+        expected_output
+    )

--- a/tests/_output/test_md.py
+++ b/tests/_output/test_md.py
@@ -1,7 +1,7 @@
 from marimo._output.md import _md
 
 
-def test_md():
+def test_md() -> None:
     # Test basic markdown conversion
     input_text = "This is **bold** and this is _italic_."
     expected_output = '<span class="markdown"><span class="paragraph">This is <strong>bold</strong> and this is <em>italic</em>.</span></span>'  # noqa: E501
@@ -15,21 +15,21 @@ def test_md():
     )
 
 
-def test_md_code_blocks():
+def test_md_code_blocks() -> None:
     # Test code block conversion
     code_input = "```python\nprint('Hello, world!')\n```"
     expected_output = '<div class="codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Hello, world!&#39;</span><span class="p">)</span>\n</code></pre></div>'  # noqa: E501
     assert _md(code_input, apply_markdown_class=False).text == expected_output
 
 
-def test_md_lates():
+def test_md_lates() -> None:
     # Test LaTeX conversion
     latex_input = "Here is an equation: ||(E=mc^2||)"
     expected_output = '<span class="paragraph">Here is an equation: ||(E=mc^2||)</span>'  # noqa: E501
     assert _md(latex_input, apply_markdown_class=False).text == expected_output
 
 
-def test_md_links():
+def test_md_links() -> None:
     # Test external link conversion
     link_input = "[Google](https://google.com)"
     expected_output = '<span class="paragraph"><a href="https://google.com" rel="noopener" target="_blank">Google</a></span>'  # noqa: E501
@@ -38,7 +38,7 @@ def test_md_links():
     )
 
 
-def test_md_footnotes():
+def test_md_footnotes() -> None:
     # Test footnote conversion
     footnote_input = (
         "Here is a footnote reference[^1].\n\n[^1]: Here is the footnote."


### PR DESCRIPTION
Open markdown links in a new tab - you rarely (if ever) want to open in your current tab.
