### PR TITLE
feat: add support for --base-url from marimo run

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <base href='{{ base_url }}/' />
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <!-- Preload is necessary because we show these images when we disconnect from the server,

--- a/frontend/src/core/network/api.ts
+++ b/frontend/src/core/network/api.ts
@@ -9,8 +9,6 @@ export function getXsrfCookie(): string {
   return r ? r[1] : "";
 }
 
-const BASE_URL = "/api";
-
 const getServerTokenOnce = once(() => {
   return getMarimoServerToken();
 });
@@ -21,6 +19,8 @@ const getServerTokenOnce = once(() => {
  */
 export const API = {
   post<REQ, RESP = null>(url: string, body: REQ): Promise<RESP> {
+    const BASE_URL = `${document.baseURI}api`;
+
     const fullUrl = BASE_URL + url;
     return fetch(fullUrl, {
       method: "POST",

--- a/frontend/src/core/static/__tests__/__snapshots__/download-html.test.ts.snap
+++ b/frontend/src/core/static/__tests__/__snapshots__/download-html.test.ts.snap
@@ -4,6 +4,8 @@ exports[`download-html > should construct html correctly 1`] = `
 "<!doctype html>
 <html>
   <head>
+    <base href="/" />
+
     <meta charset="utf-8" />
     <link
       rel="icon"

--- a/frontend/src/core/static/download-html.ts
+++ b/frontend/src/core/static/download-html.ts
@@ -96,6 +96,7 @@ export function constructHTML(opts: {
   <!DOCTYPE html>
   <html>
     <head>
+      <base href="/">
       ${staticHead.innerHTML}
     </head>
 
@@ -200,9 +201,16 @@ export function constructHTML(opts: {
 
 function updateAssetUrl(existingUrl: string, assetBaseUrl: string) {
   // Will convert: https://localhost:8080/assets/index-c78b8d10.js
+  //  Or will convert ./assets/index-c78b8d10.js
+  //  Or will convert /assets/index-c78b8d10.js
   // into: https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.1.43/dist/assets/index-c78b8d10.js
 
-  // relative path
+  // relative './...'
+  if (existingUrl.startsWith("./")) {
+    return `${assetBaseUrl}${existingUrl.slice(1)}`;
+  }
+
+  // relative '/...'
   if (existingUrl.startsWith("/")) {
     return `${assetBaseUrl}${existingUrl}`;
   }
@@ -216,3 +224,7 @@ function updateAssetUrl(existingUrl: string, assetBaseUrl: string) {
   // otherwise, leave as is
   return existingUrl;
 }
+
+export const visibleForTesting = {
+  updateAssetUrl,
+};

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -63,6 +63,8 @@ const htmlDevPlugin = (): Plugin => {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // This allows for a dynamic <base> tag in index.html
+  base: "./",
   server: {
     host: "localhost",
     port: 3000,

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -28,6 +28,7 @@ const htmlDevPlugin = (): Plugin => {
 
       // copies these elements from server to dev
       const copyElements = [
+        "base",
         "title",
         "marimo-filename",
         "marimo-version",

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -274,7 +274,7 @@ Example:
     show_default=True,
     type=str,
     help="Base URL for the server. Should start with a /.",
-    callback=validators.start_with_slash,
+    callback=validators.base_url,
 )
 @click.argument("name", required=True)
 def run(

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -267,6 +267,14 @@ Example:
     type=bool,
     help="Include notebook code in the app.",
 )
+@click.option(
+    "--base-url",
+    default="",
+    show_default=True,
+    type=str,
+    help="Base URL for the server. Should start with a /.",
+    # TODO: validate that it starts with a /
+)
 @click.argument("name", required=True)
 def run(
     port: Optional[int],
@@ -274,6 +282,7 @@ def run(
     headless: bool,
     include_code: bool,
     name: str,
+    base_url: str,
 ) -> None:
     # Validate name, or download from URL
     # The second return value is an optional temporary directory. It is unused,
@@ -293,6 +302,7 @@ def run(
         filename=name,
         mode=SessionMode.RUN,
         include_code=include_code,
+        base_url=base_url,
     )
 
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, Optional
 
 import click
 
+import marimo._cli.cli_validators as validators
 from marimo import __version__, _loggers
 from marimo._ast import codegen
 from marimo._cli import ipynb_to_marimo
@@ -273,7 +274,7 @@ Example:
     show_default=True,
     type=str,
     help="Base URL for the server. Should start with a /.",
-    # TODO: validate that it starts with a /
+    callback=validators.start_with_slash,
 )
 @click.argument("name", required=True)
 def run(

--- a/marimo/_cli/cli_validators.py
+++ b/marimo/_cli/cli_validators.py
@@ -1,12 +1,15 @@
 # Copyright 2024 Marimo. All rights reserved.
-from typing import Any
+from typing import Any, Optional
 
 import click
 
 
-def start_with_slash(ctx: Any, param: Any, value: str) -> str:
+def base_url(ctx: Any, param: Any, value: Optional[str]) -> str:
     del ctx
     del param
+    if value is None or value == "":
+        return ""
+
     if not value.startswith("/"):
         raise click.BadParameter("Must start with /")
     return value

--- a/marimo/_cli/cli_validators.py
+++ b/marimo/_cli/cli_validators.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Marimo. All rights reserved.
+from typing import Any
+
+import click
+
+
+def start_with_slash(ctx: Any, param: Any, value: str) -> str:
+    del ctx
+    del param
+    if not value.startswith("/"):
+        raise click.BadParameter("Must start with /")
+    return value

--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -44,7 +44,9 @@ class VirtualFile:
         # Create a file URL with the buffer size
         # This is a hack so when we pull from shared memory we know how
         # many bytes to read.
-        self.url = url or f"/@file/{len(buffer)}-{filename}"
+        # Also, URL is intentionally relative, so it can be resolved with
+        # different base URLs.
+        self.url = url or f"./@file/{len(buffer)}-{filename}"
 
     @staticmethod
     def from_external_url(url: str) -> VirtualFile:
@@ -57,7 +59,9 @@ class VirtualFile:
 
 EMPTY_VIRTUAL_FILE = VirtualFile(
     filename="empty.txt",
-    url="/@file/0-empty.txt",
+    # URL is intentionally relative, so it can be resolved with
+    # different base URLs.
+    url="@file/0-empty.txt",
     buffer=b"",
 )
 

--- a/marimo/_server/api/deps.py
+++ b/marimo/_server/api/deps.py
@@ -34,6 +34,9 @@ class AppState:
         assert request.app.state.server is not None, "Server not initialized"
         assert request.app.state.host is not None, "Host not initialized"
         assert request.app.state.port is not None, "Port not initialized"
+        assert (
+            request.app.state.base_url is not None
+        ), "Base URL not initialized"
 
         self.session_manager: SessionManager = (
             request.app.state.session_manager
@@ -42,6 +45,7 @@ class AppState:
         self._server: Server = request.app.state.server
         self._host: str = request.app.state.host
         self._port: int = request.app.state.port
+        self._base_url: str = request.app.state.base_url
 
     def get_current_session_id(self) -> Optional[SessionId]:
         """Get the current session."""
@@ -96,6 +100,10 @@ class AppState:
     @property
     def port(self) -> int:
         return self._port
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
 
     @property
     def server_token(self) -> str:

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -49,6 +49,7 @@ async def index(request: Request) -> HTMLResponse:
     index_html = os.path.join(root, "index.html")
     with open(index_html, "r") as f:
         html = f.read()
+        html = html.replace("{{ base_url }}", app_state.base_url)
         html = html.replace("{{ title }}", title)
         html = html.replace("{{ user_config }}", json.dumps(user_config))
         html = html.replace("{{ app_config }}", json.dumps(app_config))
@@ -59,6 +60,9 @@ async def index(request: Request) -> HTMLResponse:
             "{{ mode }}",
             "read" if app_state.mode == SessionMode.RUN else "edit",
         )
+        # Remove all href's that start with '/'
+        # This is so that we can use the base_url to serve the files
+        html = re.sub(r'href="/', 'href="', html)
 
     return HTMLResponse(html)
 

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -60,9 +60,6 @@ async def index(request: Request) -> HTMLResponse:
             "{{ mode }}",
             "read" if app_state.mode == SessionMode.RUN else "edit",
         )
-        # Remove all href's that start with '/'
-        # This is so that we can use the base_url to serve the files
-        html = re.sub(r'href="/', 'href="', html)
 
     return HTMLResponse(html)
 

--- a/marimo/_server/api/endpoints/files.py
+++ b/marimo/_server/api/endpoints/files.py
@@ -175,8 +175,11 @@ async def open_file(
     mgr.rename(filename)
     host = app_state.host
     port = app_state.port
+    base_url = app_state.base_url
     run = app_state.mode == SessionMode.RUN
-    print_startup(filename=filename, url=f"http://{host}:{port}", run=run)
+    print_startup(
+        filename=filename, url=f"http://{host}:{port}{base_url}", run=run
+    )
 
     return SuccessResponse()
 

--- a/marimo/_server/api/lifespans.py
+++ b/marimo/_server/api/lifespans.py
@@ -104,7 +104,8 @@ async def lsp(app: Starlette) -> AsyncIterator[None]:
 async def open_browser(app: Starlette) -> AsyncIterator[None]:
     host = app.state.host
     port = app.state.port
-    url = f"http://{host}:{port}"
+    base_url = app.state.base_url
+    url = f"http://{host}:{port}{base_url}"
     user_config = get_configuration()
     headless = app.state.headless
     if not headless:
@@ -122,12 +123,13 @@ async def logging(app: Starlette) -> AsyncIterator[None]:
     manager = get_manager()
     host = app.state.host
     port = app.state.port
+    base_url = app.state.base_url
 
     # Startup message
     if not manager.quiet:
         print_startup(
             manager.filename,
-            f"http://{host}:{port}",
+            f"http://{host}:{port}{base_url}",
             manager.mode == SessionMode.RUN,
         )
 

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -9,8 +9,8 @@ from starlette.authentication import (
     BaseUser,
     SimpleUser,
 )
-from starlette.responses import JSONResponse
 from starlette.requests import HTTPConnection, Request
+from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from marimo._server.model import SessionMode

--- a/marimo/_server/router.py
+++ b/marimo/_server/router.py
@@ -20,10 +20,8 @@ DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., Any])
 
 @dataclass
 class APIRouter(Router):
-    # Prefix to append to routes
-    prefix: str = ""
-
-    def __init__(self) -> None:
+    def __init__(self, prefix: str = "") -> None:
+        self.prefix = prefix
         super().__init__()
 
     def __post_init__(self) -> None:
@@ -120,4 +118,4 @@ class APIRouter(Router):
                 route.routes.extend(router.routes)
                 return
 
-        self.mount(path=prefix, app=router, name=name)
+        self.mount(path=self.prefix + prefix, app=router, name=name)

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -5,7 +5,7 @@ from typing import Optional
 import uvicorn
 
 from marimo._config.config import get_configuration
-from marimo._server.main import app
+from marimo._server.main import create_starlette_app
 from marimo._server.model import SessionMode
 from marimo._server.sessions import initialize_manager
 from marimo._server.utils import (
@@ -26,6 +26,7 @@ def start(
     headless: bool,
     port: Optional[int],
     host: str,
+    base_url: str = "",
 ) -> None:
     """
     Start the server.
@@ -46,10 +47,13 @@ def start(
 
     log_level = "info" if development_mode else "error"
 
+    app = create_starlette_app(base_url=base_url)
+
     app.state.headless = headless
     app.state.port = port
     app.state.host = host or "localhost"
     app.state.session_manager = session_manager
+    app.state.base_url = base_url
     app.state.user_config = get_configuration()
 
     server = uvicorn.Server(

--- a/tests/_server/api/test_middleware.py
+++ b/tests/_server/api/test_middleware.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
-from starlette.testclient import TestClient
 import uvicorn
+from starlette.testclient import TestClient
 
 from marimo import __version__
 from marimo._config.config import get_configuration

--- a/tests/_server/api/test_middleware.py
+++ b/tests/_server/api/test_middleware.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Marimo. All rights reserved.
+from starlette.testclient import TestClient
+import uvicorn
+
+from marimo import __version__
+from marimo._config.config import get_configuration
+from marimo._server.main import create_starlette_app
+from tests._server.mocks import get_mock_session_manager
+
+
+def test_base_url() -> None:
+    app = create_starlette_app(base_url="/foo")
+    app.state.session_manager = get_mock_session_manager()
+    app.state.user_config = get_configuration()
+    app.state.session_manager = get_mock_session_manager()
+    app.state.user_config = get_configuration()
+    client = TestClient(app)
+
+    # Mock out the server
+    uvicorn_server = uvicorn.Server(uvicorn.Config(app))
+    uvicorn_server.servers = []
+
+    app.state.server = uvicorn_server
+    app.state.host = "localhost"
+    app.state.port = 1234
+    app.state.base_url = "/foo"
+
+    client = TestClient(app)
+
+    # Infra routes, allows fallback
+    response = client.get("/foo/health")
+    assert response.status_code == 200, response.text
+    response = client.get("/foo/healthz")
+    assert response.status_code == 200, response.text
+    response = client.get("/health")
+    assert response.status_code == 200, response.text
+    response = client.get("/healthz")
+    assert response.status_code == 200, response.text
+
+    # Index, allows fallback
+    response = client.get("/foo/")
+    assert response.status_code == 200, response.text
+    response = client.get("/")
+    assert response.status_code == 200, response.text
+
+    # Favicon, fails when missing base_url
+    response = client.get("/foo/favicon.ico")
+    assert response.status_code == 200, response.text
+    response = client.get("/favicon.ico")
+    assert response.status_code == 404, response.text
+
+    # API, fails when missing base_url
+    response = client.get("/foo/api/status")
+    assert response.status_code == 200, response.text
+    response = client.get("/api/status")
+    assert response.status_code == 404, response.text

--- a/tests/_server/conftest.py
+++ b/tests/_server/conftest.py
@@ -6,10 +6,12 @@ import uvicorn
 from starlette.testclient import TestClient
 
 from marimo._config.config import get_configuration
-from marimo._server.main import app
+from marimo._server.main import create_starlette_app
 from marimo._server.sessions import SessionManager
 from marimo._server.utils import initialize_asyncio
 from tests._server.mocks import get_mock_session_manager
+
+app = create_starlette_app(base_url="")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/_server/conftest.py
+++ b/tests/_server/conftest.py
@@ -38,6 +38,7 @@ def client() -> TestClient:
     app.state.server = uvicorn_server
     app.state.host = "localhost"
     app.state.port = 1234
+    app.state.base_url = ""
     return client
 
 


### PR DESCRIPTION
This adds support for `--base-url=/foo` when running `marimo run`.

Closes https://github.com/marimo-team/marimo/issues/721