### PR TITLE
Take completion queue off the kernel's main thread ...

### DIFF
--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -73,7 +73,7 @@ class ConfigurationRequest:
     config: str
 
 
-Request = Union[
+ControlRequest = Union[
     ExecuteMultipleRequest,
     CreationRequest,
     DeleteRequest,
@@ -81,6 +81,5 @@ Request = Union[
     SetCellConfigRequest,
     SetUIElementValueRequest,
     StopRequest,
-    CompletionRequest,
     ConfigurationRequest,
 ]

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -9,7 +9,6 @@ import io
 import itertools
 import multiprocessing as mp
 import os
-import queue
 import signal
 import sys
 import threading
@@ -66,12 +65,12 @@ from marimo._runtime.requests import (
     AppMetadata,
     CompletionRequest,
     ConfigurationRequest,
+    ControlRequest,
     CreationRequest,
     DeleteRequest,
     ExecuteMultipleRequest,
     ExecutionRequest,
     FunctionCallRequest,
-    Request,
     SetCellConfigRequest,
     SetUIElementValueRequest,
     StopRequest,
@@ -221,12 +220,19 @@ class Kernel:
         # was invoked. New state updates evict older ones.
         self.state_updates: dict[State[Any], CellId_t] = {}
 
-        self.completion_thread: Optional[threading.Thread] = None
-        self.completion_queue: queue.Queue[CompletionRequest] = queue.Queue()
-
         # an empty string represents the current directory
         exec("import sys; sys.path.append('')", self.globals)
         exec("import marimo as __marimo__", self.globals)
+
+    def start_completion_worker(
+        self, completion_queue: QueueType[CompletionRequest]
+    ) -> None:
+        """Must be called after context is initialized"""
+        threading.Thread(
+            target=complete,
+            args=(completion_queue, self.graph, get_context().stream),
+            daemon=True,
+        ).start()
 
     @contextlib.contextmanager
     def _install_execution_context(
@@ -1043,17 +1049,6 @@ class Kernel:
             None,
         )
 
-    def complete(self, request: CompletionRequest) -> None:
-        """Code completion"""
-        if self.completion_thread is None:
-            self.completion_thread = threading.Thread(
-                target=complete,
-                args=(self.completion_queue, self.graph, get_context().stream),
-            )
-            self.completion_thread.start()
-
-        self.completion_queue.put(request)
-
     def instantiate(self, request: CreationRequest) -> None:
         """Instantiate the kernel with cells and UIElement initial values
 
@@ -1075,7 +1070,8 @@ class Kernel:
 
 
 def launch_kernel(
-    control_queue: QueueType[Request],
+    control_queue: QueueType[ControlRequest],
+    completion_queue: QueueType[CompletionRequest] | None,
     input_queue: QueueType[str],
     socket_addr: tuple[str, int],
     is_edit_mode: bool,
@@ -1114,17 +1110,19 @@ def launch_kernel(
 
     kernel = Kernel(
         cell_configs=configs,
+        app_metadata=app_metadata,
         stream=stream,
         stdout=stdout,
         stderr=stderr,
         stdin=stdin,
         input_override=input_override,
-        app_metadata=app_metadata,
     )
     initialize_context(
         kernel=kernel,
         stream=stream,
     )
+    if completion_queue is not None:
+        kernel.start_completion_worker(completion_queue)
 
     if is_edit_mode:
         # In edit mode, kernel runs in its own process so it's interruptible.
@@ -1225,8 +1223,6 @@ def launch_kernel(
             CompletedRun().broadcast()
         elif isinstance(request, DeleteRequest):
             kernel.delete(request)
-        elif isinstance(request, CompletionRequest):
-            kernel.complete(request)
         elif isinstance(request, ConfigurationRequest):
             # Kernel runs in a separate process than server in edit mode,
             # and configuration is only allowed in edit mode. As of

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1071,7 +1071,7 @@ class Kernel:
 
 def launch_kernel(
     control_queue: QueueType[ControlRequest],
-    completion_queue: QueueType[CompletionRequest] | None,
+    completion_queue: QueueType[CompletionRequest],
     input_queue: QueueType[str],
     socket_addr: tuple[str, int],
     is_edit_mode: bool,
@@ -1121,10 +1121,11 @@ def launch_kernel(
         kernel=kernel,
         stream=stream,
     )
-    if completion_queue is not None:
-        kernel.start_completion_worker(completion_queue)
 
     if is_edit_mode:
+        # completions only provided in edit mode
+        kernel.start_completion_worker(completion_queue)
+
         # In edit mode, kernel runs in its own process so it's interruptible.
         from marimo._output.formatters.formatters import register_formatters
 

--- a/marimo/_server/api/endpoints/config.py
+++ b/marimo/_server/api/endpoints/config.py
@@ -66,7 +66,7 @@ async def save_user_config(
         LOGGER.debug("Starting copilot server")
         await app_state.session_manager.start_lsp_server()
     # Update the kernel's view of the config
-    app_state.require_current_session().put_request(
+    app_state.require_current_session().put_control_request(
         requests.ConfigurationRequest(str(body.config))
     )
 

--- a/marimo/_server/api/endpoints/editing.py
+++ b/marimo/_server/api/endpoints/editing.py
@@ -31,7 +31,7 @@ async def code_complete(request: Request) -> BaseResponse:
     """Complete a code fragment."""
     app_state = AppState(request)
     body = await parse_request(request, cls=CodeCompleteRequest)
-    app_state.require_current_session().put_request(
+    app_state.require_current_session().put_completion_request(
         requests.CompletionRequest(
             completion_id=body.id,
             document=body.document,
@@ -48,7 +48,7 @@ async def delete_cell(request: Request) -> BaseResponse:
     """Complete a code fragment."""
     app_state = AppState(request)
     body = await parse_request(request, cls=DeleteCellRequest)
-    app_state.require_current_session().put_request(
+    app_state.require_current_session().put_control_request(
         requests.DeleteRequest(cell_id=body.cell_id)
     )
 
@@ -85,7 +85,7 @@ async def set_cell_config(request: Request) -> BaseResponse:
     """Set the config for a cell."""
     app_state = AppState(request)
     body = await parse_request(request, cls=SetCellConfigRequest)
-    app_state.require_current_session().put_request(
+    app_state.require_current_session().put_control_request(
         requests.SetCellConfigRequest(configs=body.configs)
     )
 

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -40,7 +40,7 @@ async def set_ui_element_values(
     """
     app_state = AppState(request)
     body = await parse_request(request, cls=UpdateComponentValuesRequest)
-    app_state.require_current_session().put_request(
+    app_state.require_current_session().put_control_request(
         SetUIElementValueRequest(
             list(
                 zip(
@@ -70,7 +70,7 @@ async def instantiate(
         for cell_data in notebook.cell_manager.cell_data()
     )
 
-    app_state.require_current_session().put_request(
+    app_state.require_current_session().put_control_request(
         CreationRequest(
             execution_requests=execution_requests,
             set_ui_element_value_request=SetUIElementValueRequest(
@@ -90,7 +90,7 @@ async def function_call(
     """Invoke an RPC"""
     app_state = AppState(request)
     body = await parse_request(request, cls=FunctionCallRequest)
-    app_state.require_current_session().put_request(
+    app_state.require_current_session().put_control_request(
         requests.FunctionCallRequest(
             function_call_id=body.function_call_id,
             namespace=body.namespace,
@@ -130,7 +130,7 @@ async def run_cell(
     """
     app_state = AppState(request)
     body = await parse_request(request, cls=RunRequest)
-    app_state.require_current_session().put_request(
+    app_state.require_current_session().put_control_request(
         requests.ExecuteMultipleRequest(
             tuple(
                 requests.ExecutionRequest(cell_id=cid, code=code)

--- a/marimo/_server/session/session_view.py
+++ b/marimo/_server/session/session_view.py
@@ -15,10 +15,10 @@ from marimo._messaging.ops import (
     VariableValues,
 )
 from marimo._runtime.requests import (
+    ControlRequest,
     CreationRequest,
     ExecuteMultipleRequest,
     ExecutionRequest,
-    Request,
     SetUIElementValueRequest,
 )
 from marimo._utils.parse_dataclass import parse_raw
@@ -59,7 +59,7 @@ class SessionView:
         operation = parse_raw({"operation": raw_operation}, _Container)
         self.add_operation(operation.operation)
 
-    def add_request(self, request: Request) -> None:
+    def add_control_request(self, request: ControlRequest) -> None:
         if isinstance(request, SetUIElementValueRequest):
             for object_id, value in request.ids_and_values:
                 self._add_ui_value(object_id, value)

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -103,6 +103,10 @@ class QueueManager:
             self.input_queue.cancel_join_thread()
             self.input_queue.close()
 
+        if isinstance(self.completion_queue, MPQueue):
+            self.completion_queue.cancel_join_thread()
+            self.completion_queue.close()
+
 
 class KernelManager:
     def __init__(

--- a/tests/_server/session/test_session_view.py
+++ b/tests/_server/session/test_session_view.py
@@ -121,13 +121,15 @@ def test_session_view_variable_values() -> None:
 
 def test_ui_values():
     session_view = SessionView()
-    session_view.add_request(SetUIElementValueRequest([("test_ui", 123)]))
+    session_view.add_control_request(
+        SetUIElementValueRequest([("test_ui", 123)])
+    )
     assert "test_ui" in session_view.ui_values
     assert session_view.ui_values["test_ui"] == 123
 
     # Can add multiple values
     # and can overwrite values
-    session_view.add_request(
+    session_view.add_control_request(
         SetUIElementValueRequest([("test_ui2", 456), ("test_ui", 789)])
     )
     assert "test_ui2" in session_view.ui_values
@@ -136,7 +138,7 @@ def test_ui_values():
     assert session_view.ui_values["test_ui"] == 789
 
     # Can add from CreationRequest
-    session_view.add_request(
+    session_view.add_control_request(
         CreationRequest(
             execution_requests=(),
             set_ui_element_value_request=SetUIElementValueRequest(
@@ -149,7 +151,7 @@ def test_ui_values():
 
 def test_last_run_code():
     session_view = SessionView()
-    session_view.add_request(
+    session_view.add_control_request(
         ExecuteMultipleRequest(
             execution_requests=(
                 ExecutionRequest(cell_id=cell_id, code="print('hello')"),
@@ -159,7 +161,7 @@ def test_last_run_code():
     assert session_view.last_executed_code[cell_id] == "print('hello')"
 
     # Can overwrite values and add multiple
-    session_view.add_request(
+    session_view.add_control_request(
         ExecuteMultipleRequest(
             execution_requests=(
                 ExecutionRequest(cell_id=cell_id, code="print('hello world')"),
@@ -173,7 +175,7 @@ def test_last_run_code():
     assert session_view.last_executed_code["cell_2"] == "print('hello world')"
 
     # Can add from CreationRequest
-    session_view.add_request(
+    session_view.add_control_request(
         CreationRequest(
             execution_requests=(
                 ExecutionRequest(cell_id=cell_id, code="print('hello')"),

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -18,19 +18,27 @@ app_metadata = AppMetadata(filename="test.py")
 
 def test_queue_manager() -> None:
     # Test with multiprocessing queues
-    queue_manager_mp = QueueManager(use_multiprocessing=True)
+    queue_manager_mp = QueueManager(
+        use_multiprocessing=True, provide_completions=True
+    )
     assert isinstance(queue_manager_mp.control_queue, MPQueue)
+    assert isinstance(queue_manager_mp.completion_queue, MPQueue)
     assert isinstance(queue_manager_mp.input_queue, MPQueue)
 
     # Test with threading queues
-    queue_manager_thread = QueueManager(use_multiprocessing=False)
+    queue_manager_thread = QueueManager(
+        use_multiprocessing=False, provide_completions=False
+    )
     assert isinstance(queue_manager_thread.control_queue, queue.Queue)
+    assert queue_manager_thread.completion_queue is None
     assert isinstance(queue_manager_thread.input_queue, queue.Queue)
 
 
 def test_kernel_manager() -> None:
     # Mock objects and data for testing
-    queue_manager = QueueManager(use_multiprocessing=False)
+    queue_manager = QueueManager(
+        use_multiprocessing=False, provide_completions=False
+    )
     mode = SessionMode.RUN
 
     # Instantiate a KernelManager
@@ -55,7 +63,9 @@ def test_kernel_manager() -> None:
 def test_session() -> None:
     session_consumer: Any = MagicMock()
     session_consumer.connection_state.return_value = ConnectionState.OPEN
-    queue_manager = QueueManager(use_multiprocessing=False)
+    queue_manager = QueueManager(
+        use_multiprocessing=False, provide_completions=False
+    )
     kernel_manager = KernelManager(
         queue_manager, SessionMode.RUN, {}, app_metadata
     )
@@ -90,7 +100,9 @@ def test_session() -> None:
 def test_session_disconnect_reconnect() -> None:
     session_consumer: Any = MagicMock()
     session_consumer.connection_state.return_value = ConnectionState.OPEN
-    queue_manager = QueueManager(use_multiprocessing=False)
+    queue_manager = QueueManager(
+        use_multiprocessing=False, provide_completions=False
+    )
     kernel_manager = KernelManager(
         queue_manager, SessionMode.RUN, {}, AppMetadata()
     )

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -18,27 +18,21 @@ app_metadata = AppMetadata(filename="test.py")
 
 def test_queue_manager() -> None:
     # Test with multiprocessing queues
-    queue_manager_mp = QueueManager(
-        use_multiprocessing=True, provide_completions=True
-    )
+    queue_manager_mp = QueueManager(use_multiprocessing=True)
     assert isinstance(queue_manager_mp.control_queue, MPQueue)
     assert isinstance(queue_manager_mp.completion_queue, MPQueue)
     assert isinstance(queue_manager_mp.input_queue, MPQueue)
 
     # Test with threading queues
-    queue_manager_thread = QueueManager(
-        use_multiprocessing=False, provide_completions=False
-    )
+    queue_manager_thread = QueueManager(use_multiprocessing=False)
     assert isinstance(queue_manager_thread.control_queue, queue.Queue)
-    assert queue_manager_thread.completion_queue is None
+    assert isinstance(queue_manager_thread.completion_queue, queue.Queue)
     assert isinstance(queue_manager_thread.input_queue, queue.Queue)
 
 
 def test_kernel_manager() -> None:
     # Mock objects and data for testing
-    queue_manager = QueueManager(
-        use_multiprocessing=False, provide_completions=False
-    )
+    queue_manager = QueueManager(use_multiprocessing=False)
     mode = SessionMode.RUN
 
     # Instantiate a KernelManager
@@ -63,9 +57,7 @@ def test_kernel_manager() -> None:
 def test_session() -> None:
     session_consumer: Any = MagicMock()
     session_consumer.connection_state.return_value = ConnectionState.OPEN
-    queue_manager = QueueManager(
-        use_multiprocessing=False, provide_completions=False
-    )
+    queue_manager = QueueManager(use_multiprocessing=False)
     kernel_manager = KernelManager(
         queue_manager, SessionMode.RUN, {}, app_metadata
     )
@@ -100,9 +92,7 @@ def test_session() -> None:
 def test_session_disconnect_reconnect() -> None:
     session_consumer: Any = MagicMock()
     session_consumer.connection_state.return_value = ConnectionState.OPEN
-    queue_manager = QueueManager(
-        use_multiprocessing=False, provide_completions=False
-    )
+    queue_manager = QueueManager(use_multiprocessing=False)
     kernel_manager = KernelManager(
         queue_manager, SessionMode.RUN, {}, AppMetadata()
     )


### PR DESCRIPTION
... and drain the completion queue on each completion.

This PR takes the completion queue off the kernel's main thread. Instead, it adds a completion queue to the server's QueueManager, and completion requests are enqueued by the server endpoint (so that they reach the completion worker without going through the kernel).

As a result, completions now work even when the kernel is executing code.

Additionally, this PR changes the completion worker to drain its queue when retrieving completions, processing only the newest completion requests and ignoring ones that it had received but has not yet processed.

As a result, stale completions that take a long time to process (such as for numpy, torch, tensorflow, ...) no longer waste the completion worker's time (previously we would process all requests, even ones the frontend no longer needed).