### PR TITLE
improvement: move cursor to variable when clicked in variable explorer

### DIFF
--- a/frontend/src/components/editor/links/cell-link.tsx
+++ b/frontend/src/components/editor/links/cell-link.tsx
@@ -8,12 +8,13 @@ import { useCellIds, useCellNames } from "@/core/cells/cells";
 interface Props {
   cellId: CellId;
   className?: string;
+  onClick?: () => void;
   variant?: "destructive" | "focus";
 }
 
 /* Component that adds a link to a cell, with styling. */
 export const CellLink = (props: Props): JSX.Element => {
-  const { className, cellId, variant } = props;
+  const { className, cellId, variant, onClick } = props;
   const cellName = useCellNames()[cellId] ?? "";
   const cellIndex = useCellIds().indexOf(cellId);
   const cellHtmlId = HTMLCellId.create(cellId);
@@ -47,6 +48,8 @@ export const CellLink = (props: Props): JSX.Element => {
               cell.classList.remove("focus-outline");
             }, 1500);
           }
+
+          onClick?.();
         }
       }}
     >

--- a/frontend/src/core/codemirror/find-replace/search-highlight.ts
+++ b/frontend/src/core/codemirror/find-replace/search-highlight.ts
@@ -146,3 +146,30 @@ export const highlightTheme = EditorView.baseTheme({
     backgroundColor: "#6199ff88 !important",
   },
 });
+
+/**
+ * Poor-man's go to definition.
+ *
+ * This function will select the first occurrence of the given variable name.
+ */
+export function goToDefinition(view: EditorView, variableName: string) {
+  const state = view.state;
+  const search = new SearchQuery({
+    search: variableName,
+    caseSensitive: true,
+    regexp: false,
+    replace: "",
+    wholeWord: true,
+  });
+  const query = asQueryCreator(search).create();
+  const result = query.nextMatch(state, 0, 0);
+  if (result) {
+    view.focus();
+    view.dispatch({
+      selection: {
+        anchor: result.from,
+        head: result.from,
+      },
+    });
+  }
+}

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -161,10 +161,11 @@
 
   /* Focus state */
   &.focus-outline {
-    border-color: var(--blue-8);
+    border-color: var(--blue-8) !important;
 
     /* custom shadow until our theme overrides can support colored shadow */
     --tw-shadow: 0 4px 0px -1px var(--blue-8), 0 2px 4px -2px var(--blue-8) !important;
+    box-shadow: var(--tw-shadow) !important;
 
     @apply shadow-lg;
   }


### PR DESCRIPTION
This improves the go-to variable. There is an edge case where it finds the first occurrence (as in could be in a comment) instead of the first variable occurrence. 