### PR TITLE
fix: patched `find_spec` should be a bound method

### DIFF
--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -80,11 +80,13 @@ def register_formatters() -> None:
         # to the new `find_spec` method; this is needed because closures are
         # late-binding and we're in a for loop ...
         def find_spec(  # type:ignore[no-untyped-def]
+            self,
             fullname,
             path=None,
             target=None,
             original_find_spec=original_find_spec,
         ) -> Any:
+            del self
             spec = original_find_spec(fullname, path, target)
             if spec is None:
                 return spec
@@ -114,7 +116,9 @@ def register_formatters() -> None:
 
             return spec
 
-        finder.find_spec = find_spec  # type: ignore[method-assign]
+        # Use the __get__ descriptor to bind find_spec to this finder object,
+        # to make sure self/cls gets passed
+        finder.find_spec = find_spec.__get__(finder)  # type: ignore[method-assign]
 
     # These factories are for builtins or other things that don't require a
     # package import. So we can register them at program start-up.

--- a/tests/_output/formatters/test_formatters.py
+++ b/tests/_output/formatters/test_formatters.py
@@ -1,0 +1,16 @@
+import importlib
+import os.path
+
+from marimo._output.formatters.formatters import register_formatters
+
+
+def test_path_finder_find_spec() -> None:
+    # exercises a bug surfaced in
+    # https://github.com/marimo-team/marimo/issues/763, in which find_spec
+    # would fail because it was incorrectly patched
+    register_formatters()
+
+    spec = importlib.machinery.PathFinder.find_spec(
+        "test_formatters", [os.path.dirname(__file__)]
+    )
+    assert spec is not None


### PR DESCRIPTION
This PR fixes a bug in which patched `find_spec` methods for finders in the importlib process were not bound to the instance.

Fixes #763