### PR TITLE
fix: mpl interactive with large plot sizes

### DIFF
--- a/marimo/_output/builder.py
+++ b/marimo/_output/builder.py
@@ -88,6 +88,7 @@ class _HTMLBuilder:
     @staticmethod
     def iframe(
         src: Optional[str] = None,
+        srcdoc: Optional[str] = None,
         width: Optional[str] = None,
         height: Optional[str] = None,
         style: Optional[str] = None,
@@ -96,6 +97,8 @@ class _HTMLBuilder:
         params: List[Tuple[str, Union[str, None]]] = []
         if src:
             params.append(("src", src))
+        if srcdoc:
+            params.append(("srcdoc", srcdoc))
         if width:
             params.append(("width", width))
         if height:


### PR DESCRIPTION
`__resizeIframe` doesnt work when using `src` due to cors. this switches to using `srcdoc`