### PR TITLE
fix: tab re-render

### DIFF
--- a/frontend/src/components/editor/code/readonly-python-code.tsx
+++ b/frontend/src/components/editor/code/readonly-python-code.tsx
@@ -8,7 +8,7 @@ import { CopyIcon, EyeIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Events } from "@/utils/events";
 import { toast } from "@/components/ui/use-toast";
-import { useThemeForPlugin } from "@/theme/useTheme";
+import { useTheme } from "@/theme/useTheme";
 import { cn } from "@/utils/cn";
 import { customPythonLanguageSupport } from "@/core/codemirror/language/python";
 
@@ -20,7 +20,7 @@ export const ReadonlyPythonCode = memo(
       initiallyHideCode?: boolean;
     } & ReactCodeMirrorProps,
   ) => {
-    const { theme } = useThemeForPlugin();
+    const { theme } = useTheme();
     const { code, className, initiallyHideCode, ...rest } = props;
     const [hideCode, setHideCode] = useState(initiallyHideCode);
 

--- a/frontend/src/components/editor/output/JsonOutput.tsx
+++ b/frontend/src/components/editor/output/JsonOutput.tsx
@@ -7,7 +7,7 @@ import { ImageOutput } from "./ImageOutput";
 import { TextOutput } from "./TextOutput";
 import { VideoOutput } from "./VideoOutput";
 import { logNever } from "../../../utils/assertNever";
-import { useThemeForPlugin } from "../../../theme/useTheme";
+import { useTheme } from "../../../theme/useTheme";
 
 interface Props {
   /**
@@ -30,7 +30,7 @@ interface Props {
  */
 export const JsonOutput: React.FC<Props> = memo(
   ({ data, format = "auto", name = false, className }) => {
-    const { theme } = useThemeForPlugin();
+    const { theme } = useTheme();
     if (format === "auto") {
       format = inferBestFormat(data);
     }

--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -36,7 +36,7 @@ import { renderError } from "./BadPlugin";
 import { renderHTML } from "./RenderHTML";
 import { invariant } from "../../utils/invariant";
 import { Logger } from "../../utils/Logger";
-import { useThemeForPlugin } from "@/theme/useTheme";
+import { useTheme } from "@/theme/useTheme";
 import { FUNCTIONS_REGISTRY } from "@/core/functions/FunctionRegistry";
 import { getUIElementObjectId } from "@/core/dom/UIElement";
 import { PluginFunctions } from "./rpc";
@@ -86,7 +86,7 @@ function PluginSlotInternal<T>(
 ): JSX.Element {
   const [childNodes, setChildNodes] = useState<ReactNode>(children);
   const [value, setValue] = useState<T>(getInitialValue());
-  const { theme } = useThemeForPlugin();
+  const { theme } = useTheme();
 
   const [parsedResult, setParsedResult] = useState(() => {
     return plugin.validator.safeParse(parseDataset(hostElement));

--- a/frontend/src/plugins/impl/CodeEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/CodeEditorPlugin.tsx
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { IPlugin, IPluginProps, Setter } from "../types";
 
 import { Labeled } from "./common/labeled";
-import { Theme, useThemeForPlugin } from "@/theme/useTheme";
+import { Theme, useTheme } from "@/theme/useTheme";
 import { lazy } from "react";
 
 type T = string;
@@ -51,7 +51,7 @@ interface CodeEditorComponentProps extends Data {
 }
 
 const CodeEditorComponent = (props: CodeEditorComponentProps) => {
-  const { theme } = useThemeForPlugin();
+  const { theme } = useTheme();
   const finalTheme = props.theme || theme;
   const minHeight = props.minHeight ? `${props.minHeight}px` : "70px";
 

--- a/frontend/src/plugins/impl/TabsPlugin.tsx
+++ b/frontend/src/plugins/impl/TabsPlugin.tsx
@@ -53,9 +53,22 @@ const TabComponent = ({
   children,
 }: PropsWithChildren<TabComponentProps>): JSX.Element => {
   // We use the index since labels are raw HTML and can't be used as keys
-  const selectedTab = value || "0";
+  // Tabs default to the first tab if the value is not set
+  const [internalValue, setInternalValue] = React.useState(value || "0");
+
+  const handleChange = (newValue: T) => {
+    setInternalValue(newValue);
+    setValue(newValue);
+  };
+
+  // Reset the internal value if the value is changed externally
+  // and not empty
+  if (value !== internalValue && !!value) {
+    setInternalValue(value);
+  }
+
   return (
-    <Tabs value={selectedTab} onValueChange={setValue}>
+    <Tabs value={internalValue} onValueChange={handleChange}>
       <TabsList>
         {tabs.map((tab, index) => (
           <TabsTrigger key={index} value={index.toString()}>

--- a/frontend/src/plugins/impl/vega/VegaPlugin.tsx
+++ b/frontend/src/plugins/impl/vega/VegaPlugin.tsx
@@ -19,7 +19,7 @@ import { useAsyncData } from "@/hooks/useAsyncData";
 import { fixRelativeUrl } from "./fix-relative-url";
 
 import "./vega.css";
-import { useThemeForPlugin } from "@/theme/useTheme";
+import { useTheme } from "@/theme/useTheme";
 import { Objects } from "@/utils/objects";
 import { asURL } from "@/utils/url";
 
@@ -141,7 +141,7 @@ const LoadedVegaComponent = ({
   fieldSelection,
   spec,
 }: VegaComponentProps<T>): JSX.Element => {
-  const { theme } = useThemeForPlugin();
+  const { theme } = useTheme();
   const vegaView = useRef<View>();
   const [error, setError] = useState<Error>();
 

--- a/frontend/src/plugins/layout/mermaid/mermaid.tsx
+++ b/frontend/src/plugins/layout/mermaid/mermaid.tsx
@@ -4,7 +4,7 @@ import mermaid from "mermaid";
 import type { MermaidConfig } from "mermaid";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { Logger } from "@/utils/Logger";
-import { useThemeForPlugin } from "@/theme/useTheme";
+import { useTheme } from "@/theme/useTheme";
 
 interface Props {
   diagram: string;
@@ -64,7 +64,7 @@ const Mermaid: React.FC<Props> = ({ diagram }) => {
   // eslint-disable-next-line react/hook-use-state
   const [id] = useState(() => randomAlpha());
 
-  const darkMode = useThemeForPlugin().theme === "dark";
+  const darkMode = useTheme().theme === "dark";
   mermaid.initialize({
     ...DEFAULT_CONFIG,
     theme: darkMode ? "dark" : "forest",

--- a/frontend/src/theme/useTheme.ts
+++ b/frontend/src/theme/useTheme.ts
@@ -1,7 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { store } from "@/core/state/jotai";
 import { atom, useAtomValue } from "jotai";
-import { useEffect, useState } from "react";
 import { userConfigAtom } from "@/core/config/config";
 
 export type Theme = "light" | "dark" | "system";
@@ -39,26 +38,6 @@ const resolvedThemeAtom = atom((get) => {
  * This is stored in the user config.
  */
 export function useTheme(): { theme: ResolvedTheme } {
-  const theme = useAtomValue(resolvedThemeAtom);
-  return { theme };
-}
-
-function getTheme(): ResolvedTheme {
-  return store.get(resolvedThemeAtom);
-}
-
-/**
- * Plugins are in a different react tree, so we cannot use useAtom as it looks
- * for an existing Provider in the react tree.
- * Instead we need to subscribe to the atom directly.
- */
-export function useThemeForPlugin(): { theme: ResolvedTheme } {
-  const [theme, setTheme] = useState(getTheme());
-  useEffect(() => {
-    return store.sub(resolvedThemeAtom, () => {
-      setTheme(getTheme());
-    });
-  }, []);
-
+  const theme = useAtomValue(resolvedThemeAtom, { store });
   return { theme };
 }

--- a/marimo/_plugins/ui/_impl/tabs.py
+++ b/marimo/_plugins/ui/_impl/tabs.py
@@ -75,14 +75,14 @@ class tabs(UIElement[str, str]):
         tab_labels = list(md(label).text for label in tabs.keys())
 
         index = (
-            self._tab_keys.index(value)
+            str(self._tab_keys.index(value))
             if value in self._tab_keys and tabs
-            else 0
+            else None
         )
 
         super().__init__(
             component_name=self._name,
-            initial_value=str(index),
+            initial_value=index or "",
             label=label,
             args={"tabs": tab_labels},
             on_change=on_change,
@@ -90,5 +90,7 @@ class tabs(UIElement[str, str]):
         )
 
     def _convert_value(self, value: str) -> str:
+        if not value:
+            return self._tab_keys[0]
         index = int(value)
         return self._tab_keys[index]


### PR DESCRIPTION
Fixes #779 

The plugin backend will send `""` when not selected, and the frontend will default to the `(last selected || first item)`

Also removes the need for `useThemeForPlugin`