### PR TITLE
Invalidate cell state before running queued cells

### DIFF
--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -778,3 +778,18 @@ def test_file_path(k: Kernel, exec_req: ExecReqProvider) -> None:
     )
 
     assert k.globals["x"] == "/app/test.py"
+
+
+def test_cell_state_invalidated(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            (er_1 := exec_req.get("x = 0")),
+            (exec_req.get("x; y = 1")),
+        ]
+    )
+    assert k.globals["y"] == 1
+
+    # "y" should not have run, and its global state should have been
+    # invalidated
+    k.run([ExecutionRequest(er_1.cell_id, "x = 0; raise RuntimeError")])
+    assert "y" not in k.globals


### PR DESCRIPTION
Invalidate cell state early on to relieve memory pressure.

Fixes #806 

Verified that CUDA memory is freed on re-run with a test script:

```python
import marimo

__generated_with = "0.2.5"
app = marimo.App()


@app.cell
def __():
    import torch
    return torch,


@app.cell
def __():
    import time
    return time,


@app.cell
def __(time, torch):
    control = None
    torch.cuda.empty_cache()
    time.sleep(20)
    return control,


@app.cell
def __(control, torch):
    control
    t = torch.randn((3000000, 500), device='cuda')
    t
    return t,


if __name__ == "__main__":
    app.run()
 ```