### PR TITLE
fix pandas typecheck

### DIFF
--- a/marimo/_plugins/ui/_impl/dataframes/handlers.py
+++ b/marimo/_plugins/ui/_impl/dataframes/handlers.py
@@ -182,7 +182,7 @@ class TransformHandlers:
         # Pandas type-checking doesn't like the fact that the values
         # are lists of strings (function names), even though the docs permit
         # such a value
-        return cast(pd.DataFrame, df.agg(dict_of_aggs))  # type: ignore[arg-type]
+        return cast("pd.DataFrame", df.agg(dict_of_aggs))  # type: ignore[arg-type]
 
     @staticmethod
     def handle_select_columns(

--- a/marimo/_plugins/ui/_impl/dataframes/handlers.py
+++ b/marimo/_plugins/ui/_impl/dataframes/handlers.py
@@ -178,7 +178,11 @@ class TransformHandlers:
             column_id: transform.aggregations
             for column_id in transform.column_ids
         }
-        return df.agg(dict_of_aggs)  # type: ignore[arg-type]
+
+        # Pandas type-checking doesn't like the fact that the values
+        # are lists of strings (function names), even though the docs permit
+        # such a value
+        return cast(pd.DataFrame, df.agg(dict_of_aggs))  # type: ignore[arg-type]
 
     @staticmethod
     def handle_select_columns(


### PR DESCRIPTION
Pandas `agg` function missing a typing for arg, leading it to incorrectly think we are returning a `Series`