### PR TITLE
fix: pickle-ability of functions/classes

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -202,6 +202,8 @@ class App:
 
         self._maybe_initialize()
 
+        # No need to provide `file`, `input_override` here, since this
+        # function is only called when running as a script
         with patch_main_module_context() as module:
             glbls = module.__dict__
 

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -33,6 +33,7 @@ from marimo._ast.errors import (
 )
 from marimo._output.rich_help import mddoc
 from marimo._runtime.dataflow import DirectedGraph, topological_sort
+from marimo._runtime.patches import patch_main_module_context
 
 LOGGER = _loggers.marimo_logger()
 
@@ -200,28 +201,34 @@ class App:
             )
 
         self._maybe_initialize()
-        glbls: dict[Any, Any] = {}
 
-        # Execute cells and collect outputs
-        outputs: dict[CellId_t, Any] = {}
-        for cid in self._execution_order:
-            cell_function = self._cell_manager.cell_data_at(cid).cell_function
-            if cell_function is not None:
-                outputs[cid] = execute_cell(cell_function.cell, glbls)
+        with patch_main_module_context() as module:
+            glbls = module.__dict__
 
-        # Return
-        # - the outputs, sorted in the order that cells were added to the
-        #   graph
-        # - dict of defs -> values
-        return (
-            tuple(outputs[cid] for cid in self._cell_manager.valid_cell_ids()),
-            # omit defs that were never defined at runtime, eg due to
-            # conditional definitions like
-            #
-            # if cond:
-            #   x = 0
-            {name: glbls[name] for name in self._defs if name in glbls},
-        )
+            # Execute cells and collect outputs
+            outputs: dict[CellId_t, Any] = {}
+            for cid in self._execution_order:
+                cell_function = self._cell_manager.cell_data_at(
+                    cid
+                ).cell_function
+                if cell_function is not None:
+                    outputs[cid] = execute_cell(cell_function.cell, glbls)
+
+            # Return
+            # - the outputs, sorted in the order that cells were added to the
+            #   graph
+            # - dict of defs -> values
+            return (
+                tuple(
+                    outputs[cid] for cid in self._cell_manager.valid_cell_ids()
+                ),
+                # omit defs that were never defined at runtime, eg due to
+                # conditional definitions like
+                #
+                # if cond:
+                #   x = 0
+                {name: glbls[name] for name in self._defs if name in glbls},
+            )
 
 
 class CellManager:

--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import contextlib
+import functools
+import sys
+import types
+from typing import Any, Callable, Iterator
+
+from marimo._runtime import marimo_pdb
+
+
+def patch_pdb(debugger: marimo_pdb.MarimoPdb) -> None:
+    import pdb
+
+    # Patch Pdb so manually instantiated debuggers create our debugger
+    pdb.Pdb = marimo_pdb.MarimoPdb  # type: ignore[misc, assignment]
+    pdb.set_trace = functools.partial(marimo_pdb.set_trace, debugger=debugger)
+
+
+def patch_main_module(
+    file: str | None, input_override: Callable[[Any], str] | None
+) -> types.ModuleType:
+    """Patches __main__ so that functions are pickleable."""
+
+    _module = types.ModuleType(
+        "__main__", doc="Created for the marimo kernel."
+    )
+    _module.__dict__.setdefault("__builtin__", globals()["__builtins__"])
+    _module.__dict__.setdefault("__builtins__", globals()["__builtins__"])
+    if input_override is not None:
+        _module.__dict__.setdefault("input", input_override)
+    if file is not None:
+        _module.__dict__.setdefault("__file__", file)
+    sys.modules[_module.__name__] = _module
+    return _module
+
+
+@contextlib.contextmanager
+def patch_main_module_context(
+    file: str | None = None, input_override: Callable[[Any], str] | None = None
+) -> Iterator[types.ModuleType]:
+    main = sys.modules["__main__"]
+    try:
+        yield patch_main_module(file, input_override)
+    finally:
+        sys.modules["__main__"] = main

--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -28,10 +28,17 @@ def patch_main_module(
     )
     _module.__dict__.setdefault("__builtin__", globals()["__builtins__"])
     _module.__dict__.setdefault("__builtins__", globals()["__builtins__"])
+
     if input_override is not None:
         _module.__dict__.setdefault("input", input_override)
+
     if file is not None:
         _module.__dict__.setdefault("__file__", file)
+    else:
+        _module.__dict__.setdefault(
+            "__file__", sys.modules["__main__"].__file__
+        )
+
     sys.modules[_module.__name__] = _module
     return _module
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import builtins
 import contextlib
 import dataclasses
-import functools
 import io
 import itertools
 import os
@@ -60,7 +59,7 @@ from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import MarimoConvertValueException
-from marimo._runtime import cell_runner, dataflow, marimo_pdb
+from marimo._runtime import cell_runner, dataflow, marimo_pdb, patches
 from marimo._runtime.complete import complete
 from marimo._runtime.context import (
     ContextNotInitializedError,
@@ -179,15 +178,6 @@ class Kernel:
     - input_override: a function that overrides the builtin input() function
     """
 
-    def patch_pdb(self, debugger: marimo_pdb.MarimoPdb) -> None:
-        import pdb
-
-        # Patch Pdb so manually instantiated debuggers create our debugger
-        pdb.Pdb = marimo_pdb.MarimoPdb  # type: ignore[misc, assignment]
-        pdb.set_trace = functools.partial(
-            marimo_pdb.set_trace, debugger=debugger
-        )
-
     def __init__(
         self,
         cell_configs: dict[CellId_t, CellConfig],
@@ -206,14 +196,11 @@ class Kernel:
         self.debugger = marimo_pdb.MarimoPdb(
             stdout=self.stdout, stdin=self.stdin
         )
-        self.patch_pdb(self.debugger)
+        patches.patch_pdb(self.debugger)
+        self._module = patches.patch_main_module(
+            file=self.app_metadata.filename, input_override=input_override
+        )
 
-        self.globals: dict[Any, Any] = {
-            "__name__": "__main__",
-            "__builtins__": globals()["__builtins__"],
-            "input": input_override,
-            "__file__": self.app_metadata.filename,
-        }
         self.graph = dataflow.DirectedGraph()
         self.cell_metadata: dict[CellId_t, CellMetadata] = {
             cell_id: CellMetadata(config=config)
@@ -232,6 +219,10 @@ class Kernel:
         # an empty string represents the current directory
         exec("import sys; sys.path.append('')", self.globals)
         exec("import marimo as __marimo__", self.globals)
+
+    @property
+    def globals(self) -> dict[Any, Any]:
+        return self._module.__dict__
 
     def start_completion_worker(
         self, completion_queue: QueueType[CompletionRequest]

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from marimo._ast.app import App
@@ -327,3 +329,29 @@ class TestApp:
 
         # obj should not be in the defs dictionary
         assert "obj" not in defs
+
+    @staticmethod
+    def test_run_pickle() -> None:
+        app = App()
+
+        @app.cell
+        def __() -> tuple[Any]:
+            import pickle
+
+            return (pickle,)
+
+        @app.cell
+        def __() -> tuple[Any]:
+            def foo():
+                ...
+
+            return (foo,)
+
+        @app.cell
+        def __(pickle, foo) -> tuple[Any]:
+            out = pickle.dumps(foo)
+            return (out,)
+
+        _, defs = app.run()
+
+        assert defs["out"] is not None

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -793,3 +793,21 @@ def test_cell_state_invalidated(k: Kernel, exec_req: ExecReqProvider) -> None:
     # invalidated
     k.run([ExecutionRequest(er_1.cell_id, "x = 0; raise RuntimeError")])
     assert "y" not in k.globals
+
+
+def test_pickle(k: Kernel, exec_req: ExecReqProvider) -> None:
+    k.run(
+        [
+            exec_req.get("import pickle"),
+            exec_req.get(
+                """
+                def foo():
+                    ...
+
+                pickle_output = None
+                pickle_output = pickle.dumps(foo)
+                """
+            ),
+        ]
+    )
+    assert k.globals["pickle_output"] is not None

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -777,7 +777,7 @@ def test_file_path(k: Kernel, exec_req: ExecReqProvider) -> None:
         ]
     )
 
-    assert k.globals["x"] == "/app/test.py"
+    assert k.globals["x"].endswith("pytest")
 
 
 def test_cell_state_invalidated(k: Kernel, exec_req: ExecReqProvider) -> None:

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -777,7 +777,7 @@ def test_file_path(k: Kernel, exec_req: ExecReqProvider) -> None:
         ]
     )
 
-    assert k.globals["x"].endswith("pytest")
+    assert "pytest" in k.globals["x"]
 
 
 def test_cell_state_invalidated(k: Kernel, exec_req: ExecReqProvider) -> None:

--- a/tests/_server/conftest.py
+++ b/tests/_server/conftest.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
-from typing import Generator
+import sys
+from typing import Generator, Iterator
 
 import pytest
 import uvicorn
@@ -26,7 +27,8 @@ def client_with_lifespans() -> Generator[TestClient, None, None]:
 
 
 @pytest.fixture(scope="function")
-def client() -> TestClient:
+def client() -> Iterator[TestClient]:
+    main = sys.modules["__main__"]
     app.state.session_manager = get_mock_session_manager()
     app.state.config_manager = UserConfigManager()
     client = TestClient(app)
@@ -39,7 +41,8 @@ def client() -> TestClient:
     app.state.host = "localhost"
     app.state.port = 1234
     app.state.base_url = ""
-    return client
+    yield client
+    sys.modules["__main__"] = main
 
 
 def get_session_manager(client: TestClient) -> SessionManager:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
+import sys
 import textwrap
 from typing import Any, Generator
 
@@ -82,6 +83,7 @@ class MockedKernel:
         self.stdout = MockStdout(self.stream)
         self.stderr = MockStderr(self.stream)
         self.stdin = MockStdin(self.stream)
+        self._main = sys.modules["__main__"]
 
         self.k = Kernel(
             stream=self.stream,
@@ -90,7 +92,7 @@ class MockedKernel:
             stdin=self.stdin,
             cell_configs={},
             app_metadata=AppMetadata(
-                filename="/app/test.py",
+                filename=None,
             ),
         )
 
@@ -104,6 +106,7 @@ class MockedKernel:
         teardown_context()
         self.stdout._watcher.stop()
         self.stderr._watcher.stop()
+        sys.modules["__main__"] = self._main
 
 
 # fixture that provides a kernel (and tears it down)


### PR DESCRIPTION
Replace the `__main__` module with a dummy module, and use this dummy module's `__dict__` as our globals, to fix an issue with pickling (only functions defined at module scope can be pickled).

I ran into this issue when testing top-level await. Another one of our users also found this issue and mentioned it in a blog post.