### PR TITLE
improvement: improve download menu nesting and add more actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:weekly"],
+  "extends": ["config:base", "schedule:monthly"],
   "labels": ["dependencies"],
   "pin": false,
   "rangeStrategy": "bump",

--- a/frontend/e2e-tests/cells.spec.ts
+++ b/frontend/e2e-tests/cells.spec.ts
@@ -135,6 +135,6 @@ test("page renders 2 cells", async ({ page }) => {
   await expect(page.locator("h1")).toHaveText(["Cell 1", "Cell 2"]);
 });
 
-test("export as HTML", async ({ page }) => {
+test("download as HTML", async ({ page }) => {
   await exportAsHTMLAndTakeScreenshot(page);
 });

--- a/frontend/e2e-tests/helper.ts
+++ b/frontend/e2e-tests/helper.ts
@@ -86,7 +86,7 @@ export async function pressShortcut(page: Page, action: HotkeyAction) {
 }
 
 /**
- * Export as HTML
+ * Download as HTML
  *
  * Download HTML of the current notebook and take a screenshot
  */
@@ -101,7 +101,10 @@ export async function exportAsHTMLAndTakeScreenshot(page: Page) {
       .getByTestId("notebook-menu-dropdown")
       .click()
       .then(() => {
-        return page.getByText("Export as HTML").click();
+        return page.getByText("Download", { exact: true }).hover();
+      })
+      .then(() => {
+        return page.getByText("Download as HTML", { exact: true }).click();
       }),
   ]);
 
@@ -137,7 +140,10 @@ export async function exportAsPNG(page: Page) {
       .getByTestId("notebook-menu-dropdown")
       .click()
       .then(() => {
-        return page.getByText("Export as PNG").click();
+        return page.getByText("Download", { exact: true }).hover();
+      })
+      .then(() => {
+        return page.getByText("Download as PNG", { exact: true }).click();
       }),
   ]);
 

--- a/frontend/e2e-tests/kitchen-sink.spec.ts
+++ b/frontend/e2e-tests/kitchen-sink.spec.ts
@@ -9,14 +9,14 @@ import {
 
 const appUrl = getAppUrl("kitchen_sink.py//edit");
 
-test("can screenshot and export as html", async ({ page }) => {
+test("can screenshot and download as html", async ({ page }) => {
   await page.goto(appUrl);
 
   await takeScreenshot(page, __filename);
   await exportAsHTMLAndTakeScreenshot(page);
 });
 
-test.skip("can screenshot and export as png", async ({ page }) => {
+test.skip("can screenshot and download as png", async ({ page }) => {
   await page.goto(appUrl);
 
   await exportAsPNG(page);

--- a/frontend/src/components/editor/CommandPalette.tsx
+++ b/frontend/src/components/editor/CommandPalette.tsx
@@ -19,13 +19,16 @@ import { atom, useAtom } from "jotai";
 import { useNotebookActions } from "./actions/useNotebookActions";
 import { Objects } from "@/utils/objects";
 import { parseShortcut } from "@/core/hotkeys/shortcuts";
+import { isParentAction, flattenActions } from "./actions/types";
 
 export const commandPaletteAtom = atom(false);
 
 export const CommandPalette = () => {
   const [open, setOpen] = useAtom(commandPaletteAtom);
   const registeredActions = useRegisteredActions();
-  const notebookActions = useNotebookActions();
+  let notebookActions = useNotebookActions();
+  notebookActions = flattenActions(notebookActions);
+
   const notebookActionsWithoutHotkeys = notebookActions.filter(
     (action) => !action.hotkey,
   );
@@ -113,7 +116,7 @@ export const CommandPalette = () => {
                 }
                 // Other action
                 const action = keyedNotebookActions[shortcut];
-                if (action) {
+                if (action && !isParentAction(action)) {
                   return renderCommandItem(action.label, action.handle);
                 }
                 return null;

--- a/frontend/src/components/editor/actions/types.ts
+++ b/frontend/src/components/editor/actions/types.ts
@@ -8,10 +8,34 @@ import { HotkeyAction } from "@/core/hotkeys/hotkeys";
 export interface ActionButton {
   label: string;
   variant?: "danger";
-  hotkey?: HotkeyAction;
   disableClick?: boolean;
   icon?: React.ReactNode;
   hidden?: boolean;
   rightElement?: React.ReactNode;
+  hotkey?: HotkeyAction;
   handle: (event?: Event) => void;
+  divider?: boolean;
+  dropdown?: ActionButton[];
+}
+
+export function isParentAction(
+  action: ActionButton,
+): action is ActionButton & { dropdown: ActionButton[] } {
+  return action.dropdown !== undefined;
+}
+
+/**
+ * Flattens all actions into a single array.
+ * Any parent actions will be removed, but their labels will be prepended to the child actions.
+ */
+export function flattenActions(
+  actions: ActionButton[],
+  prevLabel = "",
+): ActionButton[] {
+  return actions.flatMap((action) => {
+    if (isParentAction(action)) {
+      return flattenActions(action.dropdown, `${prevLabel + action.label} > `);
+    }
+    return { ...action, label: prevLabel + action.label };
+  });
 }

--- a/frontend/src/components/editor/chrome/types.ts
+++ b/frontend/src/components/editor/chrome/types.ts
@@ -1,4 +1,16 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { Objects } from "@/utils/objects";
+import {
+  XCircleIcon,
+  FolderTreeIcon,
+  FunctionSquareIcon,
+  NetworkIcon,
+  ScrollTextIcon,
+  BookMarkedIcon,
+  FileTextIcon,
+  LucideIcon,
+} from "lucide-react";
+
 export type PanelType =
   | "files"
   | "errors"
@@ -7,3 +19,15 @@ export type PanelType =
   | "dependencies"
   | "documentation"
   | "logs";
+
+export const PANEL_ICONS: Record<PanelType, LucideIcon> = {
+  errors: XCircleIcon,
+  files: FolderTreeIcon,
+  variables: FunctionSquareIcon,
+  dependencies: NetworkIcon,
+  outline: ScrollTextIcon,
+  documentation: BookMarkedIcon,
+  logs: FileTextIcon,
+};
+
+export const PANEL_TYPES: PanelType[] = Objects.keys(PANEL_ICONS);

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -1,26 +1,23 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import React, { PropsWithChildren } from "react";
-import {
-  FunctionSquareIcon,
-  XCircleIcon,
-  ScrollTextIcon,
-  NetworkIcon,
-  FileTextIcon,
-  MessageCircleQuestionIcon,
-  BookMarkedIcon,
-  FolderTreeIcon,
-} from "lucide-react";
+import { MessageCircleQuestionIcon } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { useChromeActions, useChromeState } from "../state";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useAtomValue } from "jotai";
 import { cellErrorCount } from "@/core/cells/cells";
 import { FeedbackButton } from "../footer/feedback-button";
+import { PANEL_ICONS, PanelType } from "../types";
 
 export const Footer: React.FC = () => {
   const { selectedPanel } = useChromeState();
   const { openApplication } = useChromeActions();
   const errorCount = useAtomValue(cellErrorCount);
+
+  const renderIcon = (type: PanelType, className?: string) => {
+    const Icon = PANEL_ICONS[type];
+    return <Icon className={cn("h-5 w-5", className)} />;
+  };
 
   return (
     <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md px-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50">
@@ -29,54 +26,50 @@ export const Footer: React.FC = () => {
         selected={selectedPanel === "errors"}
         onClick={() => openApplication("errors")}
       >
-        <XCircleIcon
-          className={cn("h-5 w-5 mr-1", {
-            "text-destructive": errorCount > 0,
-          })}
-        />
-        <span className="font-mono mt-[0.125rem]">{errorCount}</span>
+        {renderIcon("errors", errorCount > 0 ? "text-destructive" : "")}
+        <span className="ml-1 font-mono mt-[0.125rem]">{errorCount}</span>
       </FooterItem>
       <FooterItem
         tooltip="View files"
         selected={selectedPanel === "files"}
         onClick={() => openApplication("files")}
       >
-        <FolderTreeIcon className={cn("h-5 w-5")} />
+        {renderIcon("files")}
       </FooterItem>
       <FooterItem
         tooltip="Explore variables"
         selected={selectedPanel === "variables"}
         onClick={() => openApplication("variables")}
       >
-        <FunctionSquareIcon className={cn("h-5 w-5 ")} />
+        {renderIcon("variables")}
       </FooterItem>
       <FooterItem
         tooltip="Explore dependencies"
         selected={selectedPanel === "dependencies"}
         onClick={() => openApplication("dependencies")}
       >
-        <NetworkIcon className={cn("h-5 w-5")} />
+        {renderIcon("dependencies")}
       </FooterItem>
       <FooterItem
         tooltip="View outline"
         selected={selectedPanel === "outline"}
         onClick={() => openApplication("outline")}
       >
-        <ScrollTextIcon className={cn("h-5 w-5")} />
+        {renderIcon("outline")}
       </FooterItem>
       <FooterItem
         tooltip="View documentation"
         selected={selectedPanel === "documentation"}
         onClick={() => openApplication("documentation")}
       >
-        <BookMarkedIcon className={cn("h-5 w-5")} />
+        {renderIcon("documentation")}
       </FooterItem>
       <FooterItem
         tooltip="Notebook logs"
         selected={selectedPanel === "logs"}
         onClick={() => openApplication("logs")}
       >
-        <FileTextIcon className={cn("h-5 w-5")} />
+        {renderIcon("logs")}
       </FooterItem>
 
       <FeedbackButton>

--- a/frontend/src/components/editor/notebook-menu-dropdown.tsx
+++ b/frontend/src/components/editor/notebook-menu-dropdown.tsx
@@ -6,10 +6,16 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { renderMinimalShortcut } from "../shortcuts/renderShortcut";
 import { useNotebookActions } from "./actions/useNotebookActions";
+import { ActionButton } from "./actions/types";
 
 export const NotebookMenuDropdown: React.FC = () => {
   const actions = useNotebookActions();
@@ -27,22 +33,63 @@ export const NotebookMenuDropdown: React.FC = () => {
     </Button>
   );
 
+  const renderLabel = (action: ActionButton) => {
+    return (
+      <>
+        {action.icon && <span className="flex-0 mr-2">{action.icon}</span>}
+        <span className="flex-1">{action.label}</span>
+        {action.hotkey && renderMinimalShortcut(action.hotkey)}
+        {action.rightElement}
+      </>
+    );
+  };
+
+  const renderLeafAction = (action: ActionButton) => {
+    return (
+      <DropdownMenuItem
+        key={action.label}
+        variant={action.variant}
+        onSelect={(evt) => action.handle(evt)}
+        data-testid={`notebook-menu-dropdown-${action.label}`}
+      >
+        {renderLabel(action)}
+      </DropdownMenuItem>
+    );
+  };
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild={true}>{button}</DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="no-print w-[220px]">
-        {actions.map((action) => (
-          <DropdownMenuItem
-            key={action.label}
-            variant={action.variant}
-            onSelect={(evt) => action.handle(evt)}
-            data-testid={`notebook-menu-dropdown-${action.label}`}
-          >
-            {action.icon && <span className="flex-0 mr-2">{action.icon}</span>}
-            <span className="flex-1">{action.label}</span>
-            {action.hotkey && renderMinimalShortcut(action.hotkey)}
-          </DropdownMenuItem>
-        ))}
+        {actions.map((action) => {
+          if (action.hidden) {
+            return null;
+          }
+
+          if (action.dropdown) {
+            return (
+              <DropdownMenuSub key={action.label}>
+                <DropdownMenuSubTrigger
+                  data-testid={`notebook-menu-dropdown-${action.label}`}
+                >
+                  {renderLabel(action)}
+                </DropdownMenuSubTrigger>
+                <DropdownMenuPortal>
+                  <DropdownMenuSubContent>
+                    {action.dropdown.map(renderLeafAction)}
+                  </DropdownMenuSubContent>
+                </DropdownMenuPortal>
+              </DropdownMenuSub>
+            );
+          }
+
+          return (
+            <React.Fragment key={action.label}>
+              {action.divider && <DropdownMenuSeparator />}
+              {renderLeafAction(action)}
+            </React.Fragment>
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/frontend/src/components/ui/context-menu.tsx
+++ b/frontend/src/components/ui/context-menu.tsx
@@ -149,7 +149,7 @@ const ContextMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ContextMenuPrimitive.Separator
     ref={ref}
-    className={cn("my-1", menuSeparatorVariants({ className }))}
+    className={cn(menuSeparatorVariants({ className }))}
     {...props}
   />
 ));

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -149,7 +149,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("mb-1", menuSeparatorVariants({ className }))}
+    className={menuSeparatorVariants({ className })}
     {...props}
   />
 ));

--- a/frontend/src/components/ui/menu-items.tsx
+++ b/frontend/src/components/ui/menu-items.tsx
@@ -63,7 +63,7 @@ export const menuItemVariants = cva(
   },
 );
 
-export const menuSeparatorVariants = cva("-mx-1 h-px bg-border", {
+export const menuSeparatorVariants = cva("-mx-1 my-1 h-px bg-border", {
   variants: {},
 });
 

--- a/frontend/src/core/pyodide/bridge.ts
+++ b/frontend/src/core/pyodide/bridge.ts
@@ -33,6 +33,7 @@ import InlineWorker from "./worker/worker?worker&inline";
 import { UserConfigLocalStorage } from "../config/config-schema";
 import { createShareableLink } from "./share";
 import { PyodideRouter } from "./router";
+import { Paths } from "@/utils/paths";
 
 export type BridgeFunctionAndPayload = {
   [P in keyof RawBridge]: {
@@ -233,7 +234,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
 
   openFile = async (request: { path: string }): Promise<null> => {
     // Open the file in a new tab by file path
-    const filename = request.path.split("/").pop();
+    const filename = Paths.basename(request.path);
     const url = createShareableLink({
       code: null,
       baseUrl: window.location.origin,

--- a/frontend/src/core/static/download-html.ts
+++ b/frontend/src/core/static/download-html.ts
@@ -8,6 +8,7 @@ import { serializeJsonToBase64 } from "@/utils/json/base64";
 import { readCode } from "../network/requests";
 import { downloadBlob } from "@/utils/download";
 import { toast } from "@/components/ui/use-toast";
+import { Paths } from "@/utils/paths";
 
 // For Testing:
 // Flip this to `true` to use local assets instead of CDN
@@ -56,7 +57,7 @@ export async function downloadAsHTML(opts: { filename: string }) {
   const { filename } = opts;
   const html = await createStaticHTMLNotebook();
 
-  const filenameWithoutPath = filename.split("/").pop() ?? "notebook.py";
+  const filenameWithoutPath = Paths.basename(filename) ?? "notebook.py";
   const filenameWithoutExtension =
     filenameWithoutPath.split(".").shift() ?? "app";
 

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -21,7 +21,7 @@ export async function downloadHTMLAsImage(
   } catch {
     toast({
       title: "Error",
-      description: "Failed to export as PNG.",
+      description: "Failed to download as PNG.",
       variant: "danger",
     });
   } finally {


### PR DESCRIPTION
This improves the "framework" side of the notebook actions as well as adds new ones or cleans up existing ones. 

* Adds nesting to actions
* Adds Helper panel actions
* Consolidate "Download" and "Share"

<img width="683" alt="Screenshot 2024-02-22 at 3 25 20 PM" src="https://github.com/marimo-team/marimo/assets/2753772/a212fa95-857b-42db-9075-bb646217ab42">
<img width="657" alt="Screenshot 2024-02-22 at 3 25 14 PM" src="https://github.com/marimo-team/marimo/assets/2753772/e5bbc4d0-0889-473f-bd1e-b39d6ce21312">
<img width="440" alt="Screenshot 2024-02-22 at 3 24 57 PM" src="https://github.com/marimo-team/marimo/assets/2753772/c96fb650-93b5-4811-8f06-46d3c102ad88">
<img width="483" alt="Screenshot 2024-02-22 at 3 24 52 PM" src="https://github.com/marimo-team/marimo/assets/2753772/c45e4aa0-5e2b-443b-aa2e-eae07d900b4a">
<img width="477" alt="Screenshot 2024-02-22 at 3 24 48 PM" src="https://github.com/marimo-team/marimo/assets/2753772/9e1c427c-992d-45dc-af17-7a6faf90f723">

