### PR TITLE
improvement: Add include-code=false query param for static notebooks to hide the code

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -14,7 +14,6 @@ import { cn } from "@/utils/cn";
 import { Button } from "@/components/ui/button";
 import { outputIsStale } from "@/core/cells/cell";
 import { isStaticNotebook } from "@/core/static/static-state";
-import { isPyodide } from "@/core/pyodide/utils";
 
 type VerticalLayout = null;
 type VerticalLayoutProps = ICellRendererProps<VerticalLayout>;

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -28,8 +28,24 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
     // Default to showing code if the notebook is static
     return isStaticNotebook();
   });
-  // Show code if there is at least one cell with code
-  const canShowCode = mode === "read" && cells.some((cell) => cell.code);
+  const evaluateCanShowCode = () => {
+    const cellsHaveCode = cells.some((cell) => cell.code);
+
+    // Only show code if in read mode and there is at least one cell with code
+    // If it is a state notebook, code is always included, but they can turn it off
+    // via a query parameter (include-code=false)
+
+    if (isStaticNotebook()) {
+      const urlParams = new URLSearchParams(window.location.search);
+      const includeCode = urlParams.get("include-code");
+      return includeCode !== "false" && cellsHaveCode;
+    }
+
+    return mode === "read" && cellsHaveCode;
+  };
+
+  const canShowCode = evaluateCanShowCode();
+
   return (
     <VerticalLayoutWrapper invisible={invisible} appConfig={appConfig}>
       {cells.map((cell) => (

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/utils/cn";
 import { Button } from "@/components/ui/button";
 import { outputIsStale } from "@/core/cells/cell";
 import { isStaticNotebook } from "@/core/static/static-state";
+import { isPyodide } from "@/core/pyodide/utils";
 
 type VerticalLayout = null;
 type VerticalLayoutProps = ICellRendererProps<VerticalLayout>;
@@ -32,16 +33,13 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
     const cellsHaveCode = cells.some((cell) => cell.code);
 
     // Only show code if in read mode and there is at least one cell with code
-    // If it is a state notebook, code is always included, but they can turn it off
-    // via a query parameter (include-code=false)
 
-    if (isStaticNotebook()) {
-      const urlParams = new URLSearchParams(window.location.search);
-      const includeCode = urlParams.get("include-code");
-      return includeCode !== "false" && cellsHaveCode;
-    }
+    // If it is a static-notebook or wasm-read-only-notebook, code is always included,
+    // but it can be turned it off via a query parameter (include-code=false)
 
-    return mode === "read" && cellsHaveCode;
+    const urlParams = new URLSearchParams(window.location.search);
+    const includeCode = urlParams.get("include-code");
+    return mode === "read" && includeCode !== "false" && cellsHaveCode;
   };
 
   const canShowCode = evaluateCanShowCode();

--- a/frontend/src/core/pyodide/utils.ts
+++ b/frontend/src/core/pyodide/utils.ts
@@ -1,4 +1,8 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+
+/**
+ * Whether the current environment is Pyodide/WASM
+ */
 export function isPyodide() {
   return document.querySelector("marimo-wasm") !== null;
 }


### PR DESCRIPTION
This is a case where you may want to share a static notebook or wasm-notebook without including the code. You can pass `include-code=false`