### PR TITLE
fix: change KeyboardShortcut control to CommandPalette, amd some mobile fixes

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -19,7 +19,7 @@ import {
   PanelLeftIcon,
   CheckIcon,
 } from "lucide-react";
-import { commandPaletteAtom } from "../CommandPalette";
+import { commandPaletteAtom } from "../controls/command-palette";
 import {
   disabledCellIds,
   enabledCellIds,

--- a/frontend/src/components/editor/cell/cell-actions.tsx
+++ b/frontend/src/components/editor/cell/cell-actions.tsx
@@ -78,10 +78,12 @@ export const CellActionsDropdown = ({ children, ...props }: Props) => {
                     <CommandItem
                       key={action.label}
                       onSelect={() => {
+                        if (action.disableClick) {
+                          return;
+                        }
                         action.handle();
                         setOpen(false);
                       }}
-                      disabled={action.disableClick}
                       variant={action.variant}
                     >
                       <div className="flex items-center flex-1">

--- a/frontend/src/components/editor/controls/Controls.tsx
+++ b/frontend/src/components/editor/controls/Controls.tsx
@@ -10,19 +10,20 @@ import {
 
 import { cn } from "@/utils/cn";
 import { Button } from "@/components/editor/inputs/Inputs";
-import { KeyboardShortcuts } from "@/components/editor/KeyboardShortcuts";
-import { ShutdownButton } from "@/components/editor/ShutdownButton";
+import { KeyboardShortcuts } from "@/components/editor/controls/keyboard-shortcuts";
+import { ShutdownButton } from "@/components/editor/controls/shutdown-button";
 import { RecoveryButton } from "@/components/editor/RecoveryButton";
 
-import { Tooltip } from "../ui/tooltip";
-import { renderShortcut } from "../shortcuts/renderShortcut";
-import { useCellActions } from "../../core/cells/cells";
-import { AppConfigButton } from "../app-config/app-config-button";
-import { LayoutSelect } from "./renderers/layout-select";
-import { NotebookMenuDropdown } from "@/components/editor/notebook-menu-dropdown";
+import { Tooltip } from "../../ui/tooltip";
+import { renderShortcut } from "../../shortcuts/renderShortcut";
+import { useCellActions } from "../../../core/cells/cells";
+import { AppConfigButton } from "../../app-config/app-config-button";
+import { LayoutSelect } from "../renderers/layout-select";
+import { NotebookMenuDropdown } from "@/components/editor/controls/notebook-menu-dropdown";
 import { FindReplace } from "@/components/find-replace/find-replace";
 import { AppConfig } from "@/core/config/config-schema";
-import { useShouldShowInterrupt } from "./cell/useShouldShowInterrupt";
+import { useShouldShowInterrupt } from "../cell/useShouldShowInterrupt";
+import { CommandPaletteButton } from "./command-palette-button";
 
 interface ControlsProps {
   filename: string | null;
@@ -142,6 +143,7 @@ export const Controls = ({
           </Button>
         </Tooltip>
 
+        <CommandPaletteButton />
         <KeyboardShortcuts />
       </div>
 

--- a/frontend/src/components/editor/controls/command-palette-button.tsx
+++ b/frontend/src/components/editor/controls/command-palette-button.tsx
@@ -1,0 +1,21 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { renderShortcut } from "@/components/shortcuts/renderShortcut";
+import { Tooltip } from "@/components/ui/tooltip";
+import { CommandIcon } from "lucide-react";
+import React from "react";
+import { Button } from "../inputs/Inputs";
+import { useSetAtom } from "jotai";
+import { commandPaletteAtom } from "./command-palette";
+
+export const CommandPaletteButton: React.FC = () => {
+  const setCommandPaletteOpen = useSetAtom(commandPaletteAtom);
+  const toggle = () => setCommandPaletteOpen((value) => !value);
+
+  return (
+    <Tooltip content={renderShortcut("global.commandPalette")}>
+      <Button onClick={toggle} shape="rectangle" color="white">
+        <CommandIcon strokeWidth={1.5} />
+      </Button>
+    </Tooltip>
+  );
+};

--- a/frontend/src/components/editor/controls/command-palette.tsx
+++ b/frontend/src/components/editor/controls/command-palette.tsx
@@ -10,16 +10,16 @@ import {
   CommandSeparator,
   CommandShortcut,
 } from "@/components/ui/command";
-import { useRegisteredActions } from "../../core/hotkeys/actions";
-import { useRecentCommands } from "../../hooks/useRecentCommands";
-import { Kbd } from "../ui/kbd";
-import { prettyPrintHotkey } from "../shortcuts/renderShortcut";
+import { useRegisteredActions } from "../../../core/hotkeys/actions";
+import { useRecentCommands } from "../../../hooks/useRecentCommands";
+import { Kbd } from "../../ui/kbd";
+import { prettyPrintHotkey } from "../../shortcuts/renderShortcut";
 import { HOTKEYS, HotkeyAction, isHotkeyAction } from "@/core/hotkeys/hotkeys";
 import { atom, useAtom } from "jotai";
-import { useNotebookActions } from "./actions/useNotebookActions";
+import { useNotebookActions } from "../actions/useNotebookActions";
 import { Objects } from "@/utils/objects";
 import { parseShortcut } from "@/core/hotkeys/shortcuts";
-import { isParentAction, flattenActions } from "./actions/types";
+import { isParentAction, flattenActions } from "../actions/types";
 
 export const commandPaletteAtom = atom(false);
 

--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -1,33 +1,32 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { useRef } from "react";
-import { KeyboardIcon } from "lucide-react";
+import { useState } from "react";
 
-import { Button } from "@/components/editor/inputs/Inputs";
-import { useHotkey } from "../../hooks/useHotkey";
-import { Tooltip } from "../ui/tooltip";
-import { Kbd } from "../ui/kbd";
+import { useHotkey } from "../../../hooks/useHotkey";
+import { Kbd } from "../../ui/kbd";
 import {
   Dialog,
   DialogContent,
   DialogPortal,
   DialogOverlay,
-  DialogTrigger,
+  DialogHeader,
   DialogTitle,
-} from "../ui/dialog";
-import { prettyPrintHotkey, renderShortcut } from "../shortcuts/renderShortcut";
+} from "../../ui/dialog";
+import { prettyPrintHotkey } from "../../shortcuts/renderShortcut";
 import { HOTKEYS, HotkeyAction, HotkeyGroup } from "@/core/hotkeys/hotkeys";
 
-export const KeyboardShortcuts = (): JSX.Element => {
-  const ref = useRef<HTMLButtonElement | null>(null);
+export const KeyboardShortcuts: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
 
-  useHotkey("global.showHelp", () => {
-    ref.current?.click();
-  });
+  useHotkey("global.showHelp", () => setIsOpen((v) => !v));
+
+  if (!isOpen) {
+    return null;
+  }
 
   const renderItem = (action: HotkeyAction) => {
     const hotkey = HOTKEYS.getHotkey(action);
     return (
-      <div className="keyboard-shortcut" key={action}>
+      <div className="keyboard-shortcut flex flex-col" key={action}>
         <div className="flex gap-1">
           {prettyPrintHotkey(hotkey.key).map((key) => (
             <Kbd key={key}>{key}</Kbd>
@@ -42,7 +41,7 @@ export const KeyboardShortcuts = (): JSX.Element => {
   const renderGroup = (group: HotkeyGroup) => {
     const items = groups[group];
     return (
-      <div className="keyboard-shortcut-group">
+      <div className="keyboard-shortcut-group gap-2 flex flex-col">
         <h3 className="text-lg font-medium">{group}</h3>
 
         {items.map((item) => renderItem(item))}
@@ -51,23 +50,17 @@ export const KeyboardShortcuts = (): JSX.Element => {
   };
 
   return (
-    <Dialog>
-      <Tooltip content={renderShortcut("global.showHelp")}>
-        <DialogTrigger asChild={true}>
-          <Button ref={ref} shape="rectangle" color="white">
-            <KeyboardIcon className="help-icon" strokeWidth={1.5} />
-          </Button>
-        </DialogTrigger>
-      </Tooltip>
-
+    <Dialog open={isOpen} onOpenChange={(open) => setIsOpen(open)}>
       {/* Manually portal so we can adjust positioning: shortcuts modal is too large to offset from top for some screens. */}
       <DialogPortal className="sm:items-center sm:top-0">
         <DialogOverlay />
         <DialogContent
           usePortal={false}
-          className="max-h-[90vh] overflow-y-auto min-w-[850px]"
+          className="max-h-screen sm:max-h-[90vh] overflow-y-auto sm:max-w-[850px]"
         >
-          <DialogTitle>Shortcuts</DialogTitle>
+          <DialogHeader>
+            <DialogTitle>Shortcuts</DialogTitle>
+          </DialogHeader>
           <div className="flex flex-row gap-3">
             <div className="w-1/2">
               {renderGroup("Editing")}

--- a/frontend/src/components/editor/controls/notebook-menu-dropdown.tsx
+++ b/frontend/src/components/editor/controls/notebook-menu-dropdown.tsx
@@ -13,9 +13,9 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { renderMinimalShortcut } from "../shortcuts/renderShortcut";
-import { useNotebookActions } from "./actions/useNotebookActions";
-import { ActionButton } from "./actions/types";
+import { renderMinimalShortcut } from "../../shortcuts/renderShortcut";
+import { useNotebookActions } from "../actions/useNotebookActions";
+import { ActionButton } from "../actions/types";
 
 export const NotebookMenuDropdown: React.FC = () => {
   const actions = useNotebookActions();

--- a/frontend/src/components/editor/controls/shutdown-button.tsx
+++ b/frontend/src/components/editor/controls/shutdown-button.tsx
@@ -1,18 +1,16 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { AlertDialogDestructiveAction } from "../ui/alert-dialog";
-import { Button } from "./inputs/Inputs";
-import { Tooltip } from "../ui/tooltip";
-import { useImperativeModal } from "../modal/ImperativeModal";
+import { AlertDialogDestructiveAction } from "../../ui/alert-dialog";
+import { Button } from "../inputs/Inputs";
+import { Tooltip } from "../../ui/tooltip";
+import { useImperativeModal } from "../../modal/ImperativeModal";
 import { XIcon } from "lucide-react";
 
-interface ShutdownButtonProps {
+interface Props {
   onShutdown: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const ShutdownButton = ({
-  onShutdown,
-}: ShutdownButtonProps): JSX.Element => {
+export const ShutdownButton: React.FC<Props> = ({ onShutdown }) => {
   const { openConfirm, closeModal } = useImperativeModal();
 
   return (

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
@@ -16,7 +16,7 @@ export const VerticalLayoutWrapper: React.FC<PropsWithChildren<Props>> = ({
   children,
 }) => {
   return (
-    <div className={cn("sm:px-16 md:px-32", className)}>
+    <div className={cn("px-1 sm:px-16 md:px-32", className)}>
       <div
         className={cn(
           // Large mobile bottom padding due to mobile browser navigation bar

--- a/frontend/src/components/indicator.tsx
+++ b/frontend/src/components/indicator.tsx
@@ -1,0 +1,19 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+export const TailwindIndicator = () => {
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-2 right-3 z-50 flex size-5 items-center justify-center rounded-lg bg-gray-800 py-3 px-4 font-mono text-xs text-white">
+      <div className="block sm:hidden">xs</div>
+      <div className="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">
+        sm
+      </div>
+      <div className="hidden md:block lg:hidden xl:hidden 2xl:hidden">md</div>
+      <div className="hidden lg:block xl:hidden 2xl:hidden">lg</div>
+      <div className="hidden xl:block 2xl:hidden">xl</div>
+      <div className="hidden 2xl:block">2xl</div>
+    </div>
+  );
+};

--- a/frontend/src/core/App.tsx
+++ b/frontend/src/core/App.tsx
@@ -11,7 +11,7 @@ import {
   sendShutdown,
 } from "@/core/network/requests";
 
-import { Controls } from "@/components/editor/Controls";
+import { Controls } from "@/components/editor/controls/Controls";
 import { DirCompletionInput } from "@/components/editor/DirCompletionInput";
 import { FilenameForm } from "@/components/editor/FilenameForm";
 import { WebSocketState } from "./websocket/types";

--- a/frontend/src/core/MarimoApp.tsx
+++ b/frontend/src/core/MarimoApp.tsx
@@ -10,7 +10,7 @@ import { TooltipProvider } from "../components/ui/tooltip";
 import { Toaster } from "../components/ui/toaster";
 import { ModalProvider } from "../components/modal/ImperativeModal";
 import { DayPickerProvider } from "react-day-picker";
-import { CommandPalette } from "../components/editor/CommandPalette";
+import { CommandPalette } from "../components/editor/controls/command-palette";
 import { useAppConfig, useUserConfig } from "@/core/config/config";
 import { initialMode } from "./mode";
 import { AppChrome } from "../components/editor/chrome/wrapper/app-chrome";
@@ -20,6 +20,7 @@ import { useAsyncData } from "@/hooks/useAsyncData";
 import { isPyodide } from "./pyodide/utils";
 import { PyodideBridge } from "./pyodide/bridge";
 import { LargeSpinner } from "@/components/icons/large-spinner";
+import { TailwindIndicator } from "@/components/indicator";
 
 /**
  * The root component of the Marimo app.
@@ -62,6 +63,7 @@ export const MarimoApp: React.FC = memo(() => {
               >
                 {body}
               </CssVariables>
+              <TailwindIndicator />
             </ModalProvider>
           </PyodideLoader>
         </DayPickerProvider>

--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -112,6 +112,9 @@ export const basicBundle = (
       // Having fixed position prevents tooltips from being repositioned
       // and bouncing distractingly
       position: "fixed",
+      // This the z-index multiple tooltips being stacked
+      // For example, if we have a hover tooltip and a completion tooltip
+      parent: document.querySelector<HTMLElement>("#App") ?? undefined,
     }),
     scrollActiveLineIntoView(),
     theme === "dark" ? oneDark : [],

--- a/frontend/src/css/Header.css
+++ b/frontend/src/css/Header.css
@@ -60,7 +60,6 @@
   /* [shortcut] [auto:whitespace] [description] */
   grid-template-columns: 1fr auto 1fr;
   display: grid;
-  margin: 15px 5px;
   align-items: baseline;
 }
 

--- a/frontend/src/css/common.css
+++ b/frontend/src/css/common.css
@@ -1,6 +1,10 @@
 /* Hover actions */
-.hover-action {
-  display: none !important;
+
+/* Ignore for touch devices */
+@media (hover: hover) and (pointer: fine) {
+  .hover-action {
+    display: none !important;
+  }
 }
 
 .hover-action:hover {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 const plugin = require("tailwindcss/plugin");
+const { fontFamily } = require("tailwindcss/defaultTheme");
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -96,8 +97,9 @@ module.exports = {
         },
       },
       fontFamily: {
-        prose: "var(--text-font)",
-        code: "var(--monospace-font)",
+        prose: ["var(--text-font)", ...fontFamily.sans],
+        code: ["var(--monospace-font)", ...fontFamily.mono],
+        heading: ["var(--heading-font)", ...fontFamily.sans],
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
- Change the bottom action from KeyboardShortcut to CommandPalette
- Add responsive indicator when in dev-mode
- Fix a bug in renaming cells (the input was disabled)
- Disable "show actions on hover" for touch devices
- Fix z-index issue with hover/completion tooltips
- make keyboard shortcuts mobile friendly

Misc:
- Move some files to a new folder, rename for consistency