### PR TITLE
Add a guide on how to run marimo in the browser using Pyodide and WebAssembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ marimo run your_notebook.py
 
 <img src="docs/_static/docs-model-comparison.gif" style="border-radius: 8px" width="450px" />
 
-_This app is deployed on [marimo cloud](https://marimo.io/cloud)._
-
 **Execute as scripts.** marimo notebooks can be executed as scripts at the
 command line:
 

--- a/docs/guides/deploying/deploying_marimo_cloud.md
+++ b/docs/guides/deploying/deploying_marimo_cloud.md
@@ -1,7 +1,0 @@
-# Deploying to marimo cloud
-
-**marimo cloud** makes it easy to deploy and share your marimo notebooks and apps.
-
-If you would like to deploy your application to our [public gallery](https://marimo.io/@public), please reach out in our [Discord](https://discord.gg/JE7nhX6mD8).
-
-For privately hosted deployments, please join our waitlist for [marimo cloud](https://marimo.io/cloud).

--- a/docs/guides/deploying/deploying_public_gallery.md
+++ b/docs/guides/deploying/deploying_public_gallery.md
@@ -1,0 +1,9 @@
+# Deploying to our public gallery
+
+If you would like to deploy your application to our [public
+gallery](https://marimo.io/@public), please reach out on
+[Discord](https://discord.gg/JE7nhX6mD8).
+
+You can also easily share your notebooks on the public web using [WASM
+notebooks](../../guides/wasm.md), which run entirely in the browser, no backend
+required.

--- a/docs/guides/deploying/index.md
+++ b/docs/guides/deploying/index.md
@@ -9,12 +9,23 @@
   deploying_marimo_cloud
 ```
 
-These guides help you deploy marimo notebooks and apps to your cloud or ours.
+These guides help you deploy marimo notebooks.
 
-|                               |                                                     |
-| :---------------------------- | :-------------------------------------------------- |
-| {doc}`deploying_docker`       | Deploying marimo notebooks and apps with Docker     |
-| {doc}`deploying_marimo_cloud` | Deploying marimo notebooks and apps to marimo cloud |
+|                                 |                                                           |
+| :------------------------------ | :-------------------------------------------------------- |
+| {doc}`deploying_docker`         | Deploying marimo notebooks and apps with Docker           |
+| {doc}`deploying_public_gallery` | Deploying marimo notebooks and apps to our public gallery |
+
+```{admonition} Sharing notebooks on the public web
+:class: tip
+
+To share notebooks on the public web, try using [WASM
+notebooks](../../guides/wasm.md), an implementation of marimo that runs
+entirely in the browser -- no backend required.
+
+WASM notebooks support most but not all Python features and packages. See our
+[guide on WASM notebooks](../../guides/wasm.md) to learn more.
+```
 
 ## Health and status endpoints
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -15,26 +15,28 @@
   state
   apps
   scripts
+  wasm
   best_practices
   deploying/index
 ```
 
 These guides cover marimo's core concepts.
 
-|                        |                                                     |
-| :--------------------- | :-------------------------------------------------- |
-| {doc}`overview`        | An overview of basic concepts                       |
-| {doc}`reactivity`      | How reactive execution works                        |
-| {doc}`interactivity`   | Using interactive UI elements                       |
-| {doc}`outputs`         | Markdown, plots, and other visual outputs           |
-| {doc}`editor_features` | View variables, cell dependencies, errors, and more |
-| {doc}`dataframes`      | Working with dataframes                             |
-| {doc}`plotting`        | Interactive and reactive plots                      |
-| {doc}`state`           | Mutable, reactive state                             |
-| {doc}`apps`            | Running notebooks as apps                           |
-| {doc}`scripts`         | Running notebooks as scripts                        |
-| {doc}`best_practices`  | Best practices when working with marimo             |
-| {doc}`deploying/index` | Deploying marimo notebooks and apps                 |
+|                        |                                                         |
+| :--------------------- | :------------------------------------------------------ |
+| {doc}`overview`        | An overview of basic concepts                           |
+| {doc}`reactivity`      | How reactive execution works                            |
+| {doc}`interactivity`   | Using interactive UI elements                           |
+| {doc}`outputs`         | Markdown, plots, and other visual outputs               |
+| {doc}`editor_features` | View variables, cell dependencies, errors, and more     |
+| {doc}`dataframes`      | Working with dataframes                                 |
+| {doc}`plotting`        | Interactive and reactive plots                          |
+| {doc}`state`           | Mutable, reactive state                                 |
+| {doc}`apps`            | Running notebooks as apps                               |
+| {doc}`scripts`         | Running notebooks as scripts                            |
+| {doc}`wasm`            | Running notebooks in the browser (no backend required!) |
+| {doc}`deploying/index` | Deploying marimo notebooks and apps                     |
+| {doc}`best_practices`  | Best practices when working with marimo                 |
 
 ```{admonition} Learn by doing!
 :class: tip

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -34,9 +34,9 @@ These guides cover marimo's core concepts.
 | {doc}`state`           | Mutable, reactive state                                 |
 | {doc}`apps`            | Running notebooks as apps                               |
 | {doc}`scripts`         | Running notebooks as scripts                            |
+| {doc}`best_practices`  | Best practices when working with marimo                 |
 | {doc}`wasm`            | Running notebooks in the browser (no backend required!) |
 | {doc}`deploying/index` | Deploying marimo notebooks and apps                     |
-| {doc}`best_practices`  | Best practices when working with marimo                 |
 
 ```{admonition} Learn by doing!
 :class: tip

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -1,0 +1,130 @@
+# WASM Notebooks
+
+It's possible to run marimo **entirely in the browser** -- no backend required! marimo
+notebooks that run entirely in the browser are called **WebAssembly
+notebooks**, or **WASM notebooks** for short.
+
+In contrast to marimo notebooks that you create with the CLI, WASM notebooks
+run without a web server and Python process; instead, the web browser executes
+your Python code. For this reason, WASM makes it extremely easy to
+share marimo notebooks, and make it possible to tinker with notebooks without
+having to install Python on your machine.
+
+```{admonition} WASM?
+:class: note
+
+marimo-in-the-browser is powered by a technology called
+[WebAssembly](https://webassembly.org/), or "WASM" for short. Hence the
+name "WASM notebook".
+```
+
+**You can try a WASM notebook today!** Just navigate to
+[https://marimo.new](https://marimo.new).
+
+
+XXX TODO
+
+- marimo.new: playground
+- marimo.app: opens whatever you were last working on (tutorials)
+- read mode (?mode=read) (XXX short links?)
+
+- running as an app
+
+- packages: preloaded, micropip
+
+- use cases
+  - embedding
+  - embedding a REPL in a webpage (iframe)
+  - embedding a notebook in a webpage
+  - embedding an app in a webpage
+  - sharing
+  - playground
+
+## Creating a WASM notebook
+
+- go from local -> shareable with Get WebAssembly Link
+- from local notebook
+- from `marimo.app` (create short link)
+
+## Configuration
+
+Your `marimo.app` URLs can be configured using the following parameters.
+
+### Read-only mode
+
+To view a notebook in read-only mode, with
+code cells locked, append `&mode=read` to your URL's list of query parameters
+(or `?mode=read` if your URL doesn't have a query string).
+
+Examples:
+
+- `https://marimo.app/?slug=c7h6pz&mode=read`
+- `https://marimo.app/l/83qamt?mode=read`
+
+### Embed
+
+To hide the `marimo.app` header, append `&embed=true` to your URL's list of query
+parameters (or `?embed=true` if your URL doesn't have a query string).
+
+Examples:
+
+- `https://marimo.app/?slug=c7h6pz&embed=true`
+- `https://marimo.app/l/83qamt?embed=true`
+
+See the [section on embedding](#embedding) for examples of how to embed marimo
+notebooks in your own webpages.
+
+### Excluding code
+
+By default, WASM notebooks expose your Python code to viewers. If you've
+enabled read-only mode, you can exclude code with
+`&include-code=false`.
+
+A sufficiently determined user would still be able
+to obtain your code, so **don't** think of this as a security feature; instead,
+think of it as an aesthetic or practical choice.
+
+## Embedding
+
+WASM notebooks can be embedded into other webpages using the HTML `<iframe>`
+tag.
+
+### Embedding an blank notebook
+
+Use the following snippet to embed a blank marimo notebook into your web page,
+providing your users with an interactive code playground.
+
+```html
+<iframe src="https://marimo.app/?slug=aojjhb&embed=true" width="800" height="300"></iframe>
+```
+
+<iframe src="https://marimo.app/?slug=aojjhb&embed=true" width="800" height="300"></iframe>
+
+### Embedding an existing notebook
+
+To embed existing marimo notebooks into a webpage, first, [obtain a
+URL to your notebook](#creating-a-wasm-notebook), then put it in an iframe.
+
+```html
+<iframe src="https://marimo.app/?slug=c7h6pz&embed=true" width="800" height="300"></iframe>
+```
+
+<iframe src="https://marimo.app/?slug=c7h6pz&embed=true" width="800" height="600"></iframe>
+
+After obtaining a URL to your
+notebook,
+
+### Embedding an existing notebook in read-only mode
+
+You can optionally render embedded notebooks in read-only mode by appending
+`&mode=read` to your URL.
+
+```html
+<iframe
+	src="https://marimo.app/?slug=c7h6pz&mode=read"
+	width="800"
+	height="300"
+></iframe>
+```
+
+<iframe src="https://marimo.app/?slug=c7h6pz&mode=read&embed=true" width="800" height="600"></iframe>

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -21,6 +21,7 @@ name "WASM notebook".
 **You can try a WASM notebook today!** Just navigate to
 [https://marimo.new](https://marimo.new).
 
+**Common use cases.** XXX bullets
 
 XXX TODO
 
@@ -40,11 +41,65 @@ XXX TODO
   - sharing
   - playground
 
-## Creating a WASM notebook
+## Creating and sharing WASM notebooks
+
+XXX TODO
 
 - go from local -> shareable with Get WebAssembly Link
-- from local notebook
-- from `marimo.app` (create short link)
+
+- from `marimo.new` - scratch pad / blank notebook
+- from `marimo.app` : load your most recent notebook
+  - from `Get short link`
+
+## Installing packages
+
+WASM notebooks come with many packages pre-installed, including
+NumPy, SciPy, scikit-learn, pandas, and matplotlib; see [Pyodide's
+documentation](https://pyodide.org/en/stable/usage/packages-in-pyodide.html)
+for a full list.
+
+To install other packages, use `micropip`:
+
+In one cell, import micropip:
+
+```python
+import micropip
+```
+
+In the next one, install packages:
+
+```python
+await micropip.install("plotly")
+import plotly
+```
+
+**Try it!** A WASM notebook is embedded below. Try installing a package.
+
+<iframe src="https://marimo.app/l/wvz76s?embed=true" width=800 height=300>
+</iframe>
+
+## Limitations
+
+WASM lets you get up and running with marimo instantly, and makes sharing
+marimo notebooks frictionless. That said, WASM notebooks do have some
+limitations.
+
+**Packages.** Not all packages are available in WASM notebooks; see [Pyodide's
+documentation](https://pyodide.org/en/stable/usage/packages-in-pyodide.html),
+to learn more about which packages are supported.
+
+**Threading and multi-processing.** WASM notebooks do not support multithreading
+and multiprocessing. This may change in the future.
+
+**Code completion.** Code completion and docstring hints are not
+currently supported. This restriction will be removed in the future.
+
+In general, WASM notebooks are not well-suited for notebooks that do heavy computation
+or rely on packages not supported by Pyodide. In contrast, they are excellent
+for sharing your work, quickly experimenting with code and models, doing
+lightweight data analysis, authoring blog posts, tutorials, and educational
+articles, and even building internal tools.
+
 
 ## Configuration
 
@@ -56,9 +111,8 @@ To view a notebook in read-only mode, with
 code cells locked, append `&mode=read` to your URL's list of query parameters
 (or `?mode=read` if your URL doesn't have a query string).
 
-Examples:
+Example:
 
-- `https://marimo.app/?slug=c7h6pz&mode=read`
 - `https://marimo.app/l/83qamt?mode=read`
 
 ### Embed
@@ -66,10 +120,10 @@ Examples:
 To hide the `marimo.app` header, append `&embed=true` to your URL's list of query
 parameters (or `?embed=true` if your URL doesn't have a query string).
 
-Examples:
+Example:
 
-- `https://marimo.app/?slug=c7h6pz&embed=true`
 - `https://marimo.app/l/83qamt?embed=true`
+- `https://marimo.app/l/83qamt?mode=read&embed=true`
 
 See the [section on embedding](#embedding) for examples of how to embed marimo
 notebooks in your own webpages.
@@ -95,18 +149,26 @@ Use the following snippet to embed a blank marimo notebook into your web page,
 providing your users with an interactive code playground.
 
 ```html
-<iframe src="https://marimo.app/?slug=aojjhb&embed=true" width="800" height="300"></iframe>
+<iframe
+	src="https://marimo.app/l/aojjhb?embed=true"
+	width="800"
+	height="300"
+></iframe>
 ```
 
-<iframe src="https://marimo.app/?slug=aojjhb&embed=true" width="800" height="300"></iframe>
+<iframe src="https://marimo.app/l/aojjhb?embed=true" width="800" height="300"></iframe>
 
 ### Embedding an existing notebook
 
 To embed existing marimo notebooks into a webpage, first, [obtain a
-URL to your notebook](#creating-a-wasm-notebook), then put it in an iframe.
+URL to your notebook](#creating-and-sharing-wasm-notebooks), then put it in an iframe.
 
 ```html
-<iframe src="https://marimo.app/?slug=c7h6pz&embed=true" width="800" height="300"></iframe>
+<iframe
+	src="https://marimo.app/?slug=c7h6pz&embed=true"
+	width="800"
+	height="300"
+></iframe>
 ```
 
 <iframe src="https://marimo.app/?slug=c7h6pz&embed=true" width="800" height="600"></iframe>

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -1,4 +1,4 @@
-# WASM Notebooks
+# WASM notebooks
 
 It's possible to run marimo **entirely in the browser** -- no backend required! marimo
 notebooks that run entirely in the browser are called **WebAssembly
@@ -7,8 +7,11 @@ notebooks**, or **WASM notebooks** for short.
 In contrast to marimo notebooks that you create with the CLI, WASM notebooks
 run without a web server and Python process; instead, the web browser executes
 your Python code. For this reason, WASM makes it extremely easy to
-share marimo notebooks, and make it possible to tinker with notebooks without
+share marimo notebooks, and makes it possible to tinker with notebooks without
 having to install Python on your machine.
+
+**Try a WASM notebook today!** Just navigate to
+[https://marimo.new](https://marimo.new).
 
 ```{admonition} WASM?
 :class: note
@@ -18,38 +21,67 @@ marimo-in-the-browser is powered by a technology called
 name "WASM notebook".
 ```
 
-**You can try a WASM notebook today!** Just navigate to
-[https://marimo.new](https://marimo.new).
+```{admonition} When should I use WASM notebooks?
+:class: note
 
-**Common use cases.** XXX bullets
+WASM notebooks are excellent for sharing your work, quickly experimenting with
+code and models, doing lightweight data exploration, authoring blog posts,
+tutorials, and educational materials, and even building tools. They are
+not well-suited for notebooks that do heavy computation.
+```
 
-XXX TODO
+```{admonition} Issues?
+:class: warning
 
-- marimo.new: playground
-- marimo.app: opens whatever you were last working on (tutorials)
-- read mode (?mode=read) (XXX short links?)
+WASM notebooks are a new feature. If you run into
+problems, please open a [GitHub issue](https://github.com/marimo-team/marimo/issues).
+```
 
-- running as an app
-
-- packages: preloaded, micropip
-
-- use cases
-  - embedding
-  - embedding a REPL in a webpage (iframe)
-  - embedding a notebook in a webpage
-  - embedding an app in a webpage
-  - sharing
-  - playground
 
 ## Creating and sharing WASM notebooks
 
-XXX TODO
+WASM notebooks run at [marimo.app](https://marimo.app).
 
-- go from local -> shareable with Get WebAssembly Link
+### Creating new notebooks
 
-- from `marimo.new` - scratch pad / blank notebook
-- from `marimo.app` : load your most recent notebook
-  - from `Get short link`
+To create a new WASM notebook, just visit
+[marimo.new](https://marimo.new).
+
+Think of [marimo.new](https://marimo.new) as your own personal
+scratchpad for experimenting with code, data, and models and for prototyping
+tools, available to you at all times and on all devices.
+
+```{admonition} Saving WASM notebooks
+:class: tip
+
+When you save a WASM notebook, a copy of your code is saved to your
+web browser's local storage. When you return to [marimo.app](https://marimo.app),
+the last notebook you worked on will be re-opened.
+```
+
+### Creating shareable permalinks
+
+At [marimo.app](https://marimo.app), save your notebook and then click the
+`Create short URL` button to generate a shareable permalink to your
+notebook.
+
+XXX pic or vid
+
+Please be aware that marimo permalinks are publicly accessible.
+
+### Creating WASM notebooks from local notebooks
+
+In the marimo editor's notebook action menu, use `Share > Create WebAssembly
+link` to get a `marimo.app/...` URL representing your notebook: 
+
+XXX pic or vid
+
+WASM notebooks come with common Python packages installed, but you may need to
+[install additional packages using micropip](#installing-packages).
+
+The obtained URL encodes your notebook code as a parameter, so it can be
+quite long. If you want a URL that's easier to share, you can [create a
+shareable permalink](#creating-shareable-permalinks).
 
 ## Installing packages
 
@@ -77,29 +109,6 @@ import plotly
 
 <iframe src="https://marimo.app/l/wvz76s?embed=true" width=800 height=300>
 </iframe>
-
-## Limitations
-
-WASM lets you get up and running with marimo instantly, and makes sharing
-marimo notebooks frictionless. That said, WASM notebooks do have some
-limitations.
-
-**Packages.** Not all packages are available in WASM notebooks; see [Pyodide's
-documentation](https://pyodide.org/en/stable/usage/packages-in-pyodide.html),
-to learn more about which packages are supported.
-
-**Threading and multi-processing.** WASM notebooks do not support multithreading
-and multiprocessing. This may change in the future.
-
-**Code completion.** Code completion and docstring hints are not
-currently supported. This restriction will be removed in the future.
-
-In general, WASM notebooks are not well-suited for notebooks that do heavy computation
-or rely on packages not supported by Pyodide. In contrast, they are excellent
-for sharing your work, quickly experimenting with code and models, doing
-lightweight data analysis, authoring blog posts, tutorials, and educational
-articles, and even building internal tools.
-
 
 ## Configuration
 
@@ -165,13 +174,13 @@ URL to your notebook](#creating-and-sharing-wasm-notebooks), then put it in an i
 
 ```html
 <iframe
-	src="https://marimo.app/?slug=c7h6pz&embed=true"
+	src="https://marimo.app/l/c7h6pz?embed=true"
 	width="800"
 	height="300"
 ></iframe>
 ```
 
-<iframe src="https://marimo.app/?slug=c7h6pz&embed=true" width="800" height="600"></iframe>
+<iframe src="https://marimo.app/l/c7h6pz?embed=true" width="800" height="600"></iframe>
 
 After obtaining a URL to your
 notebook,
@@ -183,10 +192,28 @@ You can optionally render embedded notebooks in read-only mode by appending
 
 ```html
 <iframe
-	src="https://marimo.app/?slug=c7h6pz&mode=read"
+	src="https://marimo.app/l/c7h6pz?mode=read&embed=true"
 	width="800"
 	height="300"
 ></iframe>
 ```
 
-<iframe src="https://marimo.app/?slug=c7h6pz&mode=read&embed=true" width="800" height="600"></iframe>
+<iframe src="https://marimo.app/l/c7h6pz?mode=read&embed=true" width="800" height="600"></iframe>
+
+## Limitations
+
+While WASM notebooks let you get up and running with marimo instantly, they
+have some limitations.
+
+**Packages.** Not all packages are available in WASM notebooks; see [Pyodide's
+documentation on supported packages.](https://pyodide.org/en/stable/usage/packages-in-pyodide.html)
+
+
+**Code completion.** Code completion and docstring hints are not
+currently supported. This will be fixed in the future.
+
+**PDB.** PDB is not currently supported. This may be fixed in the future.
+
+**Threading and multi-processing.** WASM notebooks do not support multithreading
+and multiprocessing. [This may be fixed in the future](https://github.com/pyodide/pyodide/issues/237).
+

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -62,10 +62,8 @@ the last notebook you worked on will be re-opened.
 ### Creating shareable permalinks
 
 At [marimo.app](https://marimo.app), save your notebook and then click the
-`Create short URL` button to generate a shareable permalink to your
+`Create permalink` button to generate a shareable permalink to your
 notebook.
-
-XXX pic or vid
 
 Please be aware that marimo permalinks are publicly accessible.
 
@@ -74,7 +72,12 @@ Please be aware that marimo permalinks are publicly accessible.
 In the marimo editor's notebook action menu, use `Share > Create WebAssembly
 link` to get a `marimo.app/...` URL representing your notebook: 
 
-XXX pic or vid
+<div align="center">
+<figure>
+<img src="/_static/share-wasm-link.gif"/>
+</figure>
+</div>
+
 
 WASM notebooks come with common Python packages installed, but you may need to
 [install additional packages using micropip](#installing-packages).

--- a/frontend/public/files/wasm-intro.py
+++ b/frontend/public/files/wasm-intro.py
@@ -37,8 +37,8 @@ def __(mo):
             click the "Share WASM notebook" button to get a shareable URL. You can
             also embed your notebook in other webpages via an `<iframe>`.
 
-            WASM are well-suited for quickly experimenting with code and
-            models, doing lightweight data analysis, authoring blog
+            WASM notebooks are well-suited for quickly experimenting with code
+            and models, doing lightweight data analysis, authoring blog
             posts, tutorials, and educational articles, and even building internal
             tools. They are not well-suited for notebooks that do heavy
             computation, and they don't support multi-threading nor


### PR DESCRIPTION
Add a guide on using "WASM notebooks".

The guide explains what WASM notebooks are, how to create and share them, how to embed them on web pages, when they are useful, and what their limitations are today.

We can separately work through terminology. Many (most?) of our users won't know what WASM is. But I wanted to get this guide up in the meantime.