### PR TITLE
improvement: Add scroll lock to bottom of console output

### DIFF
--- a/frontend/src/components/editor/code/readonly-python-code.tsx
+++ b/frontend/src/components/editor/code/readonly-python-code.tsx
@@ -25,7 +25,7 @@ export const ReadonlyPythonCode = memo(
     const [hideCode, setHideCode] = useState(initiallyHideCode);
 
     return (
-      <div className={cn("relative hover-actions-parent w-full", className)}>
+      <div className={cn("relative hover-actions-parent w-full overflow-hidden", className)}>
         {hideCode && <HideCodeButton onClick={() => setHideCode(false)} />}
         {!hideCode && <FloatingCopyButton text={code} />}
         <CodeMirror

--- a/frontend/src/components/editor/code/readonly-python-code.tsx
+++ b/frontend/src/components/editor/code/readonly-python-code.tsx
@@ -25,7 +25,12 @@ export const ReadonlyPythonCode = memo(
     const [hideCode, setHideCode] = useState(initiallyHideCode);
 
     return (
-      <div className={cn("relative hover-actions-parent w-full overflow-hidden", className)}>
+      <div
+        className={cn(
+          "relative hover-actions-parent w-full overflow-hidden",
+          className,
+        )}
+      >
         {hideCode && <HideCodeButton onClick={() => setHideCode(false)} />}
         {!hideCode && <FloatingCopyButton text={code} />}
         <CodeMirror

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import React from "react";
+import React, { useLayoutEffect } from "react";
 import { OutputMessage } from "@/core/kernel/messages";
 import { formatOutput } from "../Output";
 import { cn } from "@/utils/cn";
@@ -8,7 +8,6 @@ import { NameCellContentEditable } from "../actions/name-cell-input";
 import { CellId } from "@/core/cells/ids";
 import { Input } from "@/components/ui/input";
 import { AnsiUp } from "ansi_up";
-import { useLayoutEffect } from "react";
 
 const ansiUp = new AnsiUp();
 
@@ -40,6 +39,9 @@ export const ConsoleOutput = (props: Props): React.ReactNode => {
 
   // Keep scroll at the bottom if it is within 120px of the bottom,
   // so when we add new content, it will lock to the bottom
+  //
+  // We use flex flex-col-reverse to handle this, but it doesn't
+  // always work perfectly when moved form the bottom and back.
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) {
@@ -67,18 +69,20 @@ export const ConsoleOutput = (props: Props): React.ReactNode => {
     );
   };
 
+  const reversedOutputs = [...consoleOutputs].reverse();
+
   return (
     <div
       title={stale ? "This console output is stale" : undefined}
       data-testid="console-output-area"
       ref={ref}
       className={cn(
-        "console-output-area overflow-hidden rounded-b-lg",
+        "console-output-area overflow-hidden rounded-b-lg flex flex-col-reverse w-full",
         stale && "marimo-output-stale",
         hasOutputs ? "p-5" : "p-3",
       )}
     >
-      {consoleOutputs.map((output, idx) => {
+      {reversedOutputs.map((output, idx) => {
         if (output.channel === "pdb") {
           return null;
         }

--- a/frontend/src/core/cells/__tests__/collapseConsoleOutputs.test.ts
+++ b/frontend/src/core/cells/__tests__/collapseConsoleOutputs.test.ts
@@ -24,6 +24,25 @@ describe("collapseConsoleOutputs", () => {
     expect(result[0].data).toMatchInlineSnapshot(`"Hello World"`);
   });
 
+  it("should collapse last two text/plain outputs on the same channel if they end in newlines", () => {
+    const consoleOutputs: OutputMessage[] = [
+      {
+        mimetype: "text/plain",
+        channel: "output",
+        data: "Hello\n",
+        timestamp: 0,
+      },
+      {
+        mimetype: "text/plain",
+        channel: "output",
+        data: "World\n",
+        timestamp: 0,
+      },
+    ];
+    const result = collapseConsoleOutputs(consoleOutputs);
+    expect(result[0].data).toMatchInlineSnapshot(`"Hello\nWorld\n"`);
+  });
+
   it("should not collapse outputs on different channels", () => {
     const consoleOutputs: OutputMessage[] = [
       {

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -353,8 +353,7 @@
 
 /* ------------------------------ Output Areas ------------------------------ */
 
-.output-area,
-.console-output-area {
+.output-area {
   max-width: inherit;
   width: 100%;
 

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -356,6 +356,7 @@
 .output-area {
   max-width: inherit;
   width: 100%;
+  padding: 0.25rem 1.85rem;
 
   /* Prevent floated elements from extending out of the output areas and into
    * the editor. */
@@ -373,10 +374,6 @@
   opacity: 0.2;
   transition: opacity 300ms;
   transition-delay: 200ms;
-}
-
-.output-area {
-  padding: 0.25rem 1.85rem;
 }
 
 .console-output-area {


### PR DESCRIPTION
Closes https://github.com/marimo-team/marimo/issues/826

```
// Keep scroll at the bottom if it is within 120px of the bottom,
// so when we add new content, it will lock to the bottom
// This won't handle large jumps in the scroll position
// if there is a lot of content added at once.
```