### PR TITLE
feat: vertical slider

### DIFF
--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -22,13 +22,27 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Root
       ref={ref}
       className={cn(
-        "relative flex w-full touch-none select-none items-center hover:cursor-pointer",
+        "relative flex touch-none select-none hover:cursor-pointer",
+        "data-[orientation=horizontal]:w-full data-[orientation=horizontal]:items-center",
+        "data-[orientation=vertical]:h-full data-[orientation=vertical]:justify-center",
         className,
       )}
       {...props}
     >
-      <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-slate-200 dark:bg-accent/60">
-        <SliderPrimitive.Range className="absolute h-full bg-blue-500 dark:bg-primary" />
+      <SliderPrimitive.Track
+        className={cn(
+          "relative grow overflow-hidden rounded-full bg-slate-200 dark:bg-accent/60",
+          "data-[orientation=horizontal]:h-2 data-[orientation=horizontal]:w-full",
+          "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2",
+        )}
+      >
+        <SliderPrimitive.Range
+          className={cn(
+            "absolute bg-blue-500 dark:bg-primary",
+            "data-[orientation=horizontal]:h-full",
+            "data-[orientation=vertical]:w-full",
+          )}
+        />
       </SliderPrimitive.Track>
       <TooltipProvider>
         <TooltipRoot delayDuration={0} open={open}>

--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -78,7 +78,7 @@ const SliderComponent = ({
       <div
         className={cn(
           "flex items-center gap-2",
-          orientation === "vertical" && "items-end",
+          orientation === "vertical" && "items-end justify-center w-full",
         )}
       >
         <Slider
@@ -107,7 +107,9 @@ const SliderComponent = ({
           }}
         />
         {showValue && (
-          <div className="text-xs text-muted-foreground">{internalValue}</div>
+          <div className="text-xs text-muted-foreground min-w-[16px]">
+            {internalValue}
+          </div>
         )}
       </div>
     </Labeled>

--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { IPlugin, IPluginProps, Setter } from "../types";
 import { Slider } from "../../components/ui/slider";
 import { Labeled } from "./common/labeled";
+import { cn } from "@/utils/cn";
 
 type T = number;
 
@@ -14,6 +15,8 @@ interface Data {
   step?: T;
   label: string | null;
   debounce: boolean;
+  orientation: "horizontal" | "vertical";
+  showValue: boolean;
 }
 
 export class SliderPlugin implements IPlugin<T, Data> {
@@ -26,6 +29,8 @@ export class SliderPlugin implements IPlugin<T, Data> {
     stop: z.number(),
     step: z.number().optional(),
     debounce: z.boolean().default(false),
+    orientation: z.enum(["horizontal", "vertical"]).default("horizontal"),
+    showValue: z.boolean().default(false),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -52,6 +57,8 @@ const SliderComponent = ({
   stop,
   step,
   debounce,
+  orientation,
+  showValue,
 }: SliderProps): JSX.Element => {
   const id = useId();
 
@@ -63,28 +70,46 @@ const SliderComponent = ({
   }, [value]);
 
   return (
-    <Labeled label={label} id={id}>
-      <Slider
-        id={id}
-        className={"relative flex items-center select-none w-36"}
-        value={[internalValue]}
-        min={start}
-        max={stop}
-        step={step}
-        // Triggered on all value changes
-        onValueChange={([nextValue]) => {
-          setInternalValue(nextValue);
-          if (!debounce) {
-            setValue(nextValue);
-          }
-        }}
-        // Triggered on mouse up
-        onValueCommit={([nextValue]) => {
-          if (debounce) {
-            setValue(nextValue);
-          }
-        }}
-      />
+    <Labeled
+      label={label}
+      id={id}
+      align={orientation === "horizontal" ? "left" : "top"}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          orientation === "vertical" && "items-end",
+        )}
+      >
+        <Slider
+          id={id}
+          className={cn(
+            "relative flex items-center select-none",
+            "data-[orientation=horizontal]:w-36 data-[orientation=vertical]:h-36",
+          )}
+          value={[internalValue]}
+          min={start}
+          max={stop}
+          step={step}
+          orientation={orientation}
+          // Triggered on all value changes
+          onValueChange={([nextValue]) => {
+            setInternalValue(nextValue);
+            if (!debounce) {
+              setValue(nextValue);
+            }
+          }}
+          // Triggered on mouse up
+          onValueCommit={([nextValue]) => {
+            if (debounce) {
+              setValue(nextValue);
+            }
+          }}
+        />
+        {showValue && (
+          <div className="text-xs text-muted-foreground">{internalValue}</div>
+        )}
+      </div>
     </Labeled>
   );
 };

--- a/frontend/src/plugins/plugins.ts
+++ b/frontend/src/plugins/plugins.ts
@@ -71,7 +71,6 @@ const LAYOUT_PLUGINS: Array<IStatelessPlugin<unknown>> = [
   new JsonOutputPlugin(),
   new ProgressPlugin(),
   new StatPlugin(),
-  new TabsPlugin(),
   new TexPlugin(),
   new MermaidPlugin(),
 ];

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -141,6 +141,9 @@ class slider(UIElement[Numeric, Numeric]):
     - `value`: default value
     - `debounce`: whether to debounce the slider to only send
         the value on mouse-up or drag-end
+    - `orientation`: the orientation of the slider,
+        either "horizontal" or "vertical"
+    - `show_value`: whether to display the current value of the slider
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
@@ -154,6 +157,8 @@ class slider(UIElement[Numeric, Numeric]):
         step: Optional[float] = None,
         value: Optional[float] = None,
         debounce: bool = False,
+        orientation: Literal["horizontal", "vertical"] = "horizontal",
+        show_value: bool = False,
         *,
         label: str = "",
         on_change: Optional[Callable[[Optional[Numeric]], None]] = None,
@@ -194,6 +199,8 @@ class slider(UIElement[Numeric, Numeric]):
                 "stop": stop,
                 "step": step if step is not None else None,
                 "debounce": debounce,
+                "orientation": orientation,
+                "show-value": show_value,
             },
             on_change=on_change,
         )

--- a/marimo/_smoke_tests/inputs.py
+++ b/marimo/_smoke_tests/inputs.py
@@ -1,7 +1,8 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.1.77"
+__generated_with = "0.2.8"
 app = marimo.App()
 
 
@@ -23,8 +24,12 @@ def __(disabled, mo):
     mo.vstack(
         [
             mo.ui.text(label="Your name", disabled=disabled.value),
-            mo.ui.text(label="Your tagline", max_length=30, disabled=disabled.value),
-            mo.ui.text_area(label="Your bio", max_length=180, disabled=disabled.value),
+            mo.ui.text(
+                label="Your tagline", max_length=30, disabled=disabled.value
+            ),
+            mo.ui.text_area(
+                label="Your bio", max_length=180, disabled=disabled.value
+            ),
         ]
     )
     return
@@ -52,6 +57,24 @@ def __(mo, options):
 @app.cell
 def __(mo, options):
     mo.ui.radio(options, label="Radio buttons", inline=True)
+    return
+
+
+@app.cell
+def __(mo):
+    slider = mo.ui.slider(0, 10, label="Horizontal slider")
+    vslider = mo.ui.slider(0, 10, orientation="vertical", label="Vertical slider")
+    mo.hstack([slider, vslider])
+    return slider, vslider
+
+
+@app.cell
+def __(mo):
+    _slider = mo.ui.slider(0, 100, label="Horizontal slider", show_value=True)
+    _vslider = mo.ui.slider(
+        0, 100, orientation="vertical", label="Vertical slider", show_value=True
+    )
+    mo.hstack([_slider, _vslider])
     return
 
 


### PR DESCRIPTION
Adds 2 new args to slider for orientation and showing the value (at rest)

Closes #836 

```diff
mo.ui.slider(
+       orientation: Literal["horizontal", "vertical"] = "horizontal",
+       show_value: bool = False,
)
```

<img width="971" alt="Screenshot 2024-02-26 at 3 48 57 PM" src="https://github.com/marimo-team/marimo/assets/2753772/9f40fa24-c83f-488e-a2d0-9ffcd7cdd0b6">
