### PR TITLE
Fix: form internal value

### DIFF
--- a/frontend/src/plugins/impl/FormPlugin.tsx
+++ b/frontend/src/plugins/impl/FormPlugin.tsx
@@ -63,7 +63,7 @@ export const FormPlugin = createPlugin("marimo-form")
       clearButtonLabel: z.string().default("Clear"),
       clearButtonTooltip: z.string().optional(),
       shouldValidate: z.boolean().optional(),
-    }),
+    })
   )
   .withFunctions<Functions>({
     validate: rpc
@@ -127,7 +127,7 @@ export const FormWrapper = <T,>({
           const response = await validate({ value: newValue }).catch(
             (error_) => {
               setError(error_.message ?? "Error validating");
-            },
+            }
           );
           if (response != null) {
             setError(response);
@@ -178,7 +178,7 @@ export const FormWrapper = <T,>({
               >
                 {clearButtonLabel}
               </Button>,
-              clearButtonTooltip,
+              clearButtonTooltip
             )}
           {withTooltip(
             <Button
@@ -189,7 +189,7 @@ export const FormWrapper = <T,>({
               {loading && <Loader2Icon className="h-4 w-4 mr-2 animate-spin" />}
               {submitButtonLabel}
             </Button>,
-            submitButtonTooltip,
+            submitButtonTooltip
           )}
         </div>
       </div>
@@ -216,7 +216,7 @@ const Form = ({
   // value of the plugin, which is the value of the wrapped plugin when
   // the submit button was last clicked/activated.
   const [internalValue, setInternalValue] = useState<T>(
-    UI_ELEMENT_REGISTRY.lookupValue(elementId),
+    UI_ELEMENT_REGISTRY.lookupValue(elementId)
   );
 
   // The Form may be rendered before the child plugin is, so after mount
@@ -224,6 +224,14 @@ const Form = ({
   useEffect(() => {
     setInternalValue(UI_ELEMENT_REGISTRY.lookupValue(elementId));
   }, [elementId]);
+
+  // Edge case: the Form plugin may be re-created in Python with the same
+  // wrapped `elementId`, meaning the value of the wrapped element
+  // can change without the plugin generating an event
+  const wrappedValue = UI_ELEMENT_REGISTRY.lookupValue(elementId);
+  if (UI_ELEMENT_REGISTRY.lookupValue(elementId) !== internalValue) {
+    setInternalValue(wrappedValue);
+  }
 
   useEffect(() => {
     // Spy on when the plugin generates an event (MarimoValueInputEvent)


### PR DESCRIPTION
This PR handles an edge case in which the form's wrapped element changes its value without firing an event, due to Python re-creating the form

Fixes #840 