### PR TITLE
feat: import and run named cells

### DIFF
--- a/docs/api/cell.md
+++ b/docs/api/cell.md
@@ -1,0 +1,8 @@
+# Cell
+
+```{eval-rst}
+.. autoclass:: marimo.ACell
+  :members:
+
+  .. autoclasstoc::
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -16,6 +16,7 @@
   control_flow
   html
   state
+  cell
   debugging
 ```
 
@@ -40,4 +41,5 @@ Use the marimo library in marimo notebooks (`import marimo as mo`) to
 | {doc}`control_flow`  | Control how cells execute                                 |
 | {doc}`html`          | Manipulate HTML objects                                   |
 | {doc}`state`         | Synchronize multiple UI elements with `mo.state`          |
+| {doc}`cell`          | Run cells defined in another notebook                     |
 | {doc}`debugging`     | Debugging utilities                                       |

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -14,6 +14,7 @@ marimo is designed to be:
 
 __all__ = [
     "App",
+    "Cell",
     "MarimoStopError",
     "accordion",
     "as_html",
@@ -54,6 +55,7 @@ __all__ = [
 __version__ = "0.2.8"
 
 from marimo._ast.app import App
+from marimo._ast.cell import Cell
 from marimo._output.doc import doc
 from marimo._output.formatting import as_html
 from marimo._output.hypertext import Html

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -6,7 +6,7 @@ import random
 import string
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
-from typing import Any, Callable, Iterable, Literal, Optional
+from typing import Any, Callable, Iterable, Iterator, Literal, Optional
 
 from marimo import _loggers
 from marimo._ast.cell import Cell, CellConfig, CellId_t, execute_cell_async
@@ -73,10 +73,10 @@ class _Namespace(Mapping[str, object]):
     def __getitem__(self, item: str) -> object:
         return self._dict[item]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self._dict)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._dict)
 
     def _mime_(self) -> tuple[KnownMimeType, str]:

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import random
 import string
-import threading
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from typing import (
@@ -102,13 +101,6 @@ class App:
 
         self._unparsable = False
         self._initialized = False
-
-        self._loop: asyncio.AbstractEventLoop | None = None
-        self._loop_runner: threading.Thread | None = None
-
-    def __del__(self) -> None:
-        if self._loop is not None:
-            self._loop.call_soon_threadsafe(self._loop.stop)
 
     def cell(
         self,

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -250,6 +250,7 @@ class CellManager:
         func: Callable[..., Any] | None,
         disabled: bool,
         hide_code: bool,
+        app: InternalApp | None = None,
     ) -> Cell | Callable[..., Cell]:
         cell_config = CellConfig(disabled=disabled, hide_code=hide_code)
 
@@ -257,6 +258,8 @@ class CellManager:
             cell = cell_factory(func, cell_id=self.create_cell_id())
             cell._cell.configure(cell_config)
             self._register_cell(cell)
+            if app is not None:
+                cell._register_app(app)
             return cell
 
         if func is None:
@@ -409,3 +412,13 @@ class InternalApp:
             )
         self._app._cell_manager = new_cell_manager
         return self
+
+    def run_cell(
+        self, cell: Cell, kwargs: dict[str, Any]
+    ) -> tuple[Any, dict[str, Any]]:
+        self._app._maybe_initialize()
+        # TODO(akshayka):
+        # - substitute refs[kwargs]
+        # - for unsubstituted refs, get parents
+        # - run parents + this cell in topo order
+        raise NotImplementedError

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -18,10 +18,8 @@ from typing import (
 from marimo import _loggers
 from marimo._ast.cell import (
     Cell,
-    CellImpl,
     CellConfig,
     CellId_t,
-    execute_cell,
     execute_cell_async,
 )
 from marimo._ast.compiler import cell_factory

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -111,7 +111,7 @@ class App:
 
     def __del__(self) -> None:
         if self._loop is not None:
-            self._loop.stop()
+            self._loop.call_soon_threadsafe(self._loop.stop)
 
     def cell(
         self,

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -417,8 +417,24 @@ class InternalApp:
         self, cell: Cell, kwargs: dict[str, Any]
     ) -> tuple[Any, dict[str, Any]]:
         self._app._maybe_initialize()
-        # TODO(akshayka):
-        # - substitute refs[kwargs]
-        # - for unsubstituted refs, get parents
-        # - run parents + this cell in topo order
+        cell_impl = cell._cell
+
+        # Substitute kwargs for refs
+        glbls: dict[str, Any] = {}
+        for argname, argvalue in kwargs.items():
+            if argname in cell_impl.refs:
+                glbls[argname] = argvalue
+            else:
+                raise ValueError(
+                    f"Cell {cell.name} got unexpected argument {argname}"
+                    f"The allowed arguments are {cell_impl.refs}."
+                )
+
+        # TODO
+        # get the transitive closure of parents defining unsubstituted refs
+        substitutions = set(kwargs.values())
+        unsubstituted_refs = cell_impl.refs - substitutions
+
+        # TODO:
+        # run collected cells in the correct order; return output, defs dict
         raise NotImplementedError

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -6,7 +6,15 @@ import random
 import string
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
-from typing import Any, Callable, Iterable, Iterator, Literal, Optional, Mapping
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    Literal,
+    Mapping,
+    Optional,
+)
 
 from marimo import _loggers
 from marimo._ast.cell import Cell, CellConfig, CellId_t, execute_cell_async

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 import asyncio
 import random
 import string
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass
-from typing import Any, Callable, Iterable, Iterator, Literal, Optional
+from typing import Any, Callable, Iterable, Iterator, Literal, Optional, Mapping
 
 from marimo import _loggers
 from marimo._ast.cell import Cell, CellConfig, CellId_t, execute_cell_async

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -315,7 +315,8 @@ class Cell:
 
         - You may pass values for any of this cell's references as keyword
           arguments. marimo will automatically compute values for any refs
-          that are not provided by executing the parent cells that compute them.
+          that are not provided by executing the parent cells that compute
+          them.
 
         **Returns**:
 

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 import ast
 import dataclasses
 import inspect
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable
 from types import CodeType
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
+from typing import TYPE_CHECKING, Any, Callable, Literal, Mapping, Optional
 
 from marimo._ast.visitor import Name, VariableData
 from marimo._utils.deep_merge import deep_merge

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -162,9 +162,27 @@ class Cell:
 
     async def run_async(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
         assert self._app is not None
-        return await self._app.run_cell(cell=self, kwargs=kwargs)
+        return await self._app.run_cell_async(cell=self, kwargs=kwargs)
 
     def run(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+        """Run this cell and return its visual output and definitions
+
+        **Note**: If this cell is a coroutine function (starting with `async`),
+        or if its ancestors are coroutine functions, `run_async` should be used
+        instead.
+
+
+        **Returns**:
+        - a tuple `(output, defs)`, where `output` is the cell's last
+          expression and `defs` is a `dict` mapping the cell's defined
+          names to their values.
+
+        **Raises**:
+
+        - `RuntimeError`, if the wrapped function is a coroutine function,
+          or if any of the ancestors required to produce its refs are
+          coroutiine functions
+        """
         assert self._app is not None
         return self._app.run_cell_sync(cell=self, kwargs=kwargs)
 

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -333,12 +333,14 @@ class Cell:
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         del args
         del kwargs
-        # TODO: docs link
+        if self._is_coroutine():
+            call_str = f"`outputs, defs = await {self.name}.run()`"
+        else:
+            call_str = f"`outputs, defs = {self.name}.run()`"
+
         raise RuntimeError(
             f"Calling marimo cells using `{self.name}()` is not supported. "
-            f"Use `outputs, defs = {self.name}.run()` instead, "
-            f"or  `await outputs, defs = {self.name}.run_async()` for "
-            "WASM notebooks. See docs more for info."
+            f"Use {call_str} instead. "
         )
 
 

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -175,7 +175,7 @@ class Cell:
         raise RuntimeError(
             f"Calling marimo cell's using `{self.name}()` is not supported. "
             f"Use `outputs, defs = {self.name}.run()` instead, "
-            f"or  await `outputs, defs = {self.name}.run_async()` for "
+            f"or  `await outputs, defs = {self.name}.run_async()` for "
             "WASM notebooks. See docs more for info."
         )
 

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -146,6 +146,28 @@ class CellImpl:
 
 @dataclasses.dataclass
 class Cell:
+    """An executable notebook cell
+
+    `A Cell` object can be executed as a function via its `run()` method, which
+    returns the cell's last expression (output) and a mapping from its defined
+    names to its values.
+
+    Cells can be named via the marimo editor in the browser, or by
+    changing the cell's function name in the notebook file. Named
+    cells can then be executed for use in other notebooks, or to test
+    in unit tests.
+
+    For example:
+
+    ```python
+    from my_notebook import my_cell
+
+    output, definitions = my_cell.run()
+    ```
+
+    See the documentation of `run` for info and examples.
+    """
+
     # Function from which this cell was created
     _f: Callable[..., Any]
 

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import ast
 import dataclasses
 import inspect
-from types import CodeType, MethodType
+from types import CodeType
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
 
 from marimo._ast.visitor import Name, VariableData
@@ -214,34 +214,11 @@ class Cell:
     def _register_app(self, app: InternalApp) -> None:
         self._app = app
 
-    def __getattr__(self, attr: str) -> Any:
-        if attr == "run":
-            if self._is_coroutine():
-
-                async def run(
-                    self, **kwargs: Any
-                ) -> tuple[Any, dict[str, Any]]:
-                    assert self._app is not None
-                    return await self._app.run_cell_async(
-                        cell=self, kwargs=kwargs
-                    )
-
-                self.run = MethodType(run, self)
-            else:
-
-                def run(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
-                    assert self._app is not None
-                    return self._app.run_cell_sync(cell=self, kwargs=kwargs)
-
-                self.run = MethodType(run, self)
-            return self.run
-        raise AttributeError(f"'Cell' object has no attribute '{attr}'")
-
-    async def _run_async(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+    async def run_async(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
         assert self._app is not None
         return await self._app.run_cell_async(cell=self, kwargs=kwargs)
 
-    def _run(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+    def run(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
         """Run this cell and return its visual output and definitions
 
         **Note**: If this cell is a coroutine function (starting with `async`),

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -170,6 +170,10 @@ class Cell:
         return self._cell.defs
 
     def _is_coroutine(self) -> bool:
+        """Whether this cell is a coroutine function.
+
+        If True, then this cell's `run` method returns an awaitable.
+        """
         if hasattr(self, "_is_coro_cached"):
             return self._is_coro_cached
         assert self._app is not None

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import ast
 import dataclasses
 import inspect
-from types import CodeType
+from types import CodeType, MethodType
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
 
 from marimo._ast.visitor import Name, VariableData
@@ -214,11 +214,34 @@ class Cell:
     def _register_app(self, app: InternalApp) -> None:
         self._app = app
 
-    async def run_async(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+    def __getattr__(self, attr: str) -> Any:
+        if attr == "run":
+            if self._is_coroutine():
+
+                async def run(
+                    self, **kwargs: Any
+                ) -> tuple[Any, dict[str, Any]]:
+                    assert self._app is not None
+                    return await self._app.run_cell_async(
+                        cell=self, kwargs=kwargs
+                    )
+
+                self.run = MethodType(run, self)
+            else:
+
+                def run(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+                    assert self._app is not None
+                    return self._app.run_cell_sync(cell=self, kwargs=kwargs)
+
+                self.run = MethodType(run, self)
+            return self.run
+        raise AttributeError(f"'Cell' object has no attribute '{attr}'")
+
+    async def _run_async(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
         assert self._app is not None
         return await self._app.run_cell_async(cell=self, kwargs=kwargs)
 
-    def run(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+    def _run(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
         """Run this cell and return its visual output and definitions
 
         **Note**: If this cell is a coroutine function (starting with `async`),

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -11,7 +11,7 @@ from typing import Any, List, Optional, Union, cast
 
 from marimo import __version__
 from marimo._ast.app import App, _AppConfig
-from marimo._ast.cell import Cell, CellConfig
+from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
 from marimo._ast.visitor import Name
 
@@ -56,7 +56,7 @@ def _to_decorator(config: Optional[CellConfig]) -> str:
 
 
 def to_functiondef(
-    cell: Cell, name: str, unshadowed_builtins: Optional[set[Name]] = None
+    cell: CellImpl, name: str, unshadowed_builtins: Optional[set[Name]] = None
 ) -> str:
     # unshadowed builtins is the set of builtins that haven't been
     # overridden (shadowed) by other cells in the app. These names
@@ -150,7 +150,7 @@ def generate_filecontents(
     config: Optional[_AppConfig] = None,
 ) -> str:
     """Translates a sequences of codes (cells) to a Python file"""
-    cell_function_data: list[Union[Cell, tuple[str, CellConfig]]] = []
+    cell_data: list[Union[CellImpl, tuple[str, CellConfig]]] = []
     defs: set[Name] = set()
 
     cell_id = 0
@@ -160,15 +160,15 @@ def generate_filecontents(
                 cell_config
             )
             defs |= cell.defs
-            cell_function_data.append(cell)
+            cell_data.append(cell)
         except SyntaxError:
-            cell_function_data.append((code, cell_config))
+            cell_data.append((code, cell_config))
         cell_id += 1
 
     unshadowed_builtins = set(builtins.__dict__.keys()) - defs
     fndefs: list[str] = []
-    for data, name in zip(cell_function_data, names):
-        if isinstance(data, Cell):
+    for data, name in zip(cell_data, names):
+        if isinstance(data, CellImpl):
             fndefs.append(to_functiondef(data, name, unshadowed_builtins))
         else:
             fndefs.append(

--- a/marimo/_output/formatters/cell.py
+++ b/marimo/_output/formatters/cell.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._ast.cell import Cell
+from marimo._messaging.mimetypes import KnownMimeType
+from marimo._output import formatting
+from marimo._output.formatters.formatter_factory import FormatterFactory
+
+
+class CellFormatter(FormatterFactory):
+    @staticmethod
+    def package_name() -> None:
+        return None
+
+    def register(self) -> None:
+        @formatting.formatter(Cell)
+        def _format_cell(cell: Cell) -> tuple[KnownMimeType, str]:
+            return cell._help()._mime_()

--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -118,7 +118,7 @@ def register_formatters() -> None:
 
         # Use the __get__ descriptor to bind find_spec to this finder object,
         # to make sure self/cls gets passed
-        finder.find_spec = find_spec.__get__(finder)  # type: ignore[method-assign]
+        finder.find_spec = find_spec.__get__(finder)  # type: ignore[method-assign]  # noqa: E501
 
     # These factories are for builtins or other things that don't require a
     # package import. So we can register them at program start-up.

--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Sequence
 
 from marimo._output.formatters.altair_formatters import AltairFormatter
 from marimo._output.formatters.bokeh_formatters import BokehFormatter
+from marimo._output.formatters.cell import CellFormatter
 from marimo._output.formatters.formatter_factory import FormatterFactory
 from marimo._output.formatters.holoviews_formatters import HoloViewsFormatter
 from marimo._output.formatters.leafmap_formatters import LeafmapFormatter
@@ -33,6 +34,7 @@ THIRD_PARTY_FACTORIES: dict[str, FormatterFactory] = {
 # third-party module import. These formatters' register methods need to be
 # fast: we don't want their registration to noticeably delay program start-up.
 NATIVE_FACTORIES: Sequence[FormatterFactory] = [
+    CellFormatter(),
     StructuresFormatter(),
 ]
 

--- a/marimo/_output/md_extensions/external_links.py
+++ b/marimo/_output/md_extensions/external_links.py
@@ -4,10 +4,10 @@ from xml.etree.ElementTree import Element
 
 from markdown import Extension, Markdown, treeprocessors  # type: ignore
 
-# Adapted from https://github.com/squidfunk/mkdocs-material/discussions/3660#discussioncomment-6725823
+# Adapted from https://github.com/squidfunk/mkdocs-material/discussions/3660#discussioncomment-6725823  # noqa: E501
 
 
-class ExternalLinksTreeProcessor(treeprocessors.Treeprocessor):  # type: ignore[misc]
+class ExternalLinksTreeProcessor(treeprocessors.Treeprocessor):  # type: ignore[misc]  # noqa: E501
     """
     Adds target="_blank" and rel="noopener" to external links.
     """

--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -88,11 +88,9 @@ class UIElementRegistry:
                 value, object_id
             ):
                 bindings.add(name)
-            elif (
-                isinstance(value, _Namespace)
-                and self._find_bindings_in_namespace(object_id, value)
-                is not None
-            ):
+            elif isinstance(
+                value, _Namespace
+            ) and self._find_bindings_in_namespace(object_id, value):
                 bindings.add(name)
         return bindings
 

--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 import weakref
+from collections.abc import Mapping
 from typing import Any, Dict, Iterable, TypeVar, Union
 
 if sys.version_info < (3, 10):
@@ -10,6 +11,7 @@ if sys.version_info < (3, 10):
 else:
     from typing import TypeAlias
 
+from marimo._ast.app import _Namespace
 from marimo._ast.cell import CellId_t
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._runtime.context import get_context
@@ -71,22 +73,34 @@ class UIElementRegistry:
                 return self._has_parent_id(element, parent_id)
         return False
 
-    def _register_bindings(self, object_id: UIElementId) -> None:
-        kernel = get_context().kernel
+    def _find_bindings_in_namespace(
+        self, object_id: UIElementId, glbls: Mapping[str, Any]
+    ) -> set[str]:
         # Get all variable names that are either:
         #   1. bound to this UI element, or
         #   2. bound to a view (child) of this element
-        names = set(
-            [
-                name
-                for name in kernel.globals
-                if (
-                    isinstance(kernel.globals[name], UIElement)
-                    and self._has_parent_id(kernel.globals[name], object_id)
-                )
-            ]
+        #
+        # Also introspects _Namespace objects, including the name of the
+        # _Namespace if it contains `object_id`
+        bindings: set[str] = set()
+        for name, value in glbls.items():
+            if isinstance(value, UIElement) and self._has_parent_id(
+                value, object_id
+            ):
+                bindings.add(name)
+            elif (
+                isinstance(value, _Namespace)
+                and self._find_bindings_in_namespace(object_id, value)
+                is not None
+            ):
+                bindings.add(name)
+        return bindings
+
+    def _register_bindings(self, object_id: UIElementId) -> None:
+        kernel = get_context().kernel
+        self._bindings[object_id] = self._find_bindings_in_namespace(
+            object_id, kernel.globals
         )
-        self._bindings[object_id] = names
 
     def get_object(self, object_id: UIElementId) -> UIElement[Any, Any]:
         if object_id not in self._objects:

--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 import sys
 import weakref
-from collections.abc import Mapping
-from typing import Any, Dict, Iterable, TypeVar, Union
+from typing import Any, Dict, Iterable, Mapping, TypeVar, Union
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias

--- a/marimo/_plugins/ui/_impl/dataframes/handlers.py
+++ b/marimo/_plugins/ui/_impl/dataframes/handlers.py
@@ -182,7 +182,7 @@ class TransformHandlers:
         # Pandas type-checking doesn't like the fact that the values
         # are lists of strings (function names), even though the docs permit
         # such a value
-        return cast("pd.DataFrame", df.agg(dict_of_aggs))  # type: ignore[arg-type]
+        return cast("pd.DataFrame", df.agg(dict_of_aggs))  # type: ignore[arg-type]  # noqa: E501
 
     @staticmethod
     def handle_select_columns(

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -441,7 +441,7 @@ class Runner:
         if cell_impl.is_coroutine():
             raise RuntimeError(
                 "A coroutine function can't be run synchronously."
-                f"Use `run_async()` instead"
+                "Use `run_async()` instead"
             )
 
         Runner._validate_kwargs(cell_impl, kwargs)
@@ -449,7 +449,7 @@ class Runner:
 
         if any(graph.cells[cid].is_coroutine() for cid in ancestor_ids):
             raise RuntimeError(
-                f"Cell has an ancestor that is a "
+                "Cell has an ancestor that is a "
                 "coroutine (async) cell. Use `run_async()` instead"
             )
 

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -281,17 +281,24 @@ class DirectedGraph:
 
 
 def transitive_closure(
-    graph: DirectedGraph, cell_ids: set[CellId_t]
+    graph: DirectedGraph, cell_ids: set[CellId_t], children: bool = True
 ) -> set[CellId_t]:
-    """Return a set of the passed-in cells and their descendants."""
+    """Return a set of the passed-in cells and their descendants or ancestors
+
+    If children is True, returns descendants; otherwise, returns ancestors
+    """
     cells = set()
     queue = list(cell_ids)
+
+    def relatives(cid: CellId_t) -> set[CellId_t]:
+        return graph.children[cid] if children else graph.parents[cid]
+
     while queue:
         cid = queue.pop(0)
         cells.add(cid)
-        for child_id in graph.children[cid]:
-            if child_id not in cells:
-                queue.append(child_id)
+        for relative in relatives(cid):
+            if relative not in cells:
+                queue.append(relative)
     return cells
 
 

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -352,7 +352,17 @@ def topological_sort(
 
 
 class Runner:
-    """Utility class for running individual cells in a graph"""
+    """Utility for running individual cells in a graph
+
+    This class provides methods to a run a cell in the graph and obtain its
+    output (last expression) and the values of its defs.
+
+    If needed, the runner will recursively compute the values of the cell's
+    refs by executing its ancestors. Refs can also be substituted by the
+    caller.
+
+    TODO(akshayka): Add an API for caching defs across cell runs.
+    """
 
     def __init__(self, graph: DirectedGraph) -> None:
         self._graph = graph
@@ -387,7 +397,7 @@ class Runner:
             [
                 parent_id
                 for parent_id in graph.parents[cell_impl.cell_id]
-                if graph.cells[parent_id].refs.intersection(unsubstituted_refs)
+                if graph.cells[parent_id].defs.intersection(unsubstituted_refs)
             ]
         )
         return transitive_closure(graph, parent_ids, children=False)

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 import threading
 from collections.abc import Collection
 from dataclasses import dataclass, field
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from marimo import _loggers
-from marimo._ast.cell import CellId_t, CellImpl
+from marimo._ast.cell import (
+    CellId_t,
+    CellImpl,
+    execute_cell,
+    execute_cell_async,
+)
 from marimo._ast.compiler import code_key
 from marimo._ast.visitor import Name
 
@@ -344,3 +349,115 @@ def topological_sort(
                 roots.append(child)
     # TODO make sure parents for each id is empty, otherwise cycle
     return sorted_cell_ids
+
+
+class Runner:
+    """Utility class for running individual cells in a graph"""
+
+    def __init__(self, graph: DirectedGraph) -> None:
+        self._graph = graph
+
+    @staticmethod
+    def _returns(cell_impl: CellImpl, glbls: dict[str, Any]) -> dict[str, Any]:
+        return {name: glbls[name] for name in cell_impl.defs if name in glbls}
+
+    @staticmethod
+    def _substitute_refs(
+        cell_impl: CellImpl,
+        glbls: dict[str, Any],
+        kwargs: dict[str, Any],
+    ) -> None:
+        for argname, argvalue in kwargs.items():
+            if argname in cell_impl.refs:
+                glbls[argname] = argvalue
+            else:
+                raise ValueError(
+                    f"Cell got unexpected argument {argname}"
+                    f"The allowed arguments are {cell_impl.refs}."
+                )
+
+    def _get_ancestors(
+        self, cell_impl: CellImpl, kwargs: dict[str, Any]
+    ) -> set[CellId_t]:
+        # Get the transitive closure of parents defining unsubstituted refs
+        graph = self._graph
+        substitutions = set(kwargs.values())
+        unsubstituted_refs = cell_impl.refs - substitutions
+        parent_ids = set(
+            [
+                parent_id
+                for parent_id in graph.parents[cell_impl.cell_id]
+                if graph.cells[parent_id].refs.intersection(unsubstituted_refs)
+            ]
+        )
+        return transitive_closure(graph, parent_ids, children=False)
+
+    @staticmethod
+    def _validate_kwargs(cell_impl: CellImpl, kwargs: dict[str, Any]) -> None:
+        for argname in kwargs:
+            if argname not in cell_impl.refs:
+                raise ValueError(
+                    f"Cell got unexpected argument {argname}"
+                    f"The allowed arguments are {cell_impl.refs}."
+                )
+
+    async def run_cell_async(
+        self, cell_id: CellId_t, kwargs: dict[str, Any]
+    ) -> tuple[Any, dict[str, Any]]:
+        """Run a possibly async cell and its ancestors
+
+        Substitutes kwargs as refs for the cell, omitting ancestors that
+        whose refs are substituted.
+        """
+        graph = self._graph
+        cell_impl = graph.cells[cell_id]
+        Runner._validate_kwargs(cell_impl, kwargs)
+        ancestor_ids = self._get_ancestors(cell_impl, kwargs)
+
+        glbls: dict[str, Any] = {}
+        for cid in topological_sort(graph, ancestor_ids):
+            await execute_cell_async(graph.cells[cid], glbls)
+
+        Runner._substitute_refs(cell_impl, glbls, kwargs)
+        output = await execute_cell_async(
+            graph.cells[cell_impl.cell_id], glbls
+        )
+        defs = Runner._returns(cell_impl, glbls)
+        return output, defs
+
+    def run_cell_sync(
+        self, cell_id: CellId_t, kwargs: dict[str, Any]
+    ) -> tuple[Any, dict[str, Any]]:
+        """Run a synchronous cell and its ancestors
+
+        Substitutes kwargs as refs for the cell, omitting ancestors that
+        whose refs are substituted.
+
+        Raises a `RuntimeError` if the cell or any of its unsubstituted
+        ancestors are coroutine functions.
+        """
+        graph = self._graph
+        cell_impl = graph.cells[cell_id]
+        if cell_impl.is_coroutine():
+            raise RuntimeError(
+                "A coroutine function can't be run synchronously."
+                f"Use `run_async()` instead"
+            )
+
+        Runner._validate_kwargs(cell_impl, kwargs)
+        ancestor_ids = self._get_ancestors(cell_impl, kwargs)
+
+        if any(graph.cells[cid].is_coroutine() for cid in ancestor_ids):
+            raise RuntimeError(
+                f"Cell has an ancestor that is a "
+                "coroutine (async) cell. Use `run_async()` instead"
+            )
+
+        glbls: dict[str, Any] = {}
+        for cid in topological_sort(graph, ancestor_ids):
+            execute_cell(graph.cells[cid], glbls)
+
+        self._substitute_refs(cell_impl, glbls, kwargs)
+        output = execute_cell(graph.cells[cell_impl.cell_id], glbls)
+        defs = Runner._returns(cell_impl, glbls)
+        return output, defs

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -401,6 +401,14 @@ class Runner:
                     f"The allowed arguments are {cell_impl.refs}."
                 )
 
+    def is_coroutine(self, cell_id: CellId_t) -> bool:
+        return self._graph.cells[cell_id].is_coroutine() or any(
+            self._graph.cells[cid].is_coroutine()
+            for cid in self._get_ancestors(
+                self._graph.cells[cell_id], kwargs={}
+            )
+        )
+
     async def run_cell_async(
         self, cell_id: CellId_t, kwargs: dict[str, Any]
     ) -> tuple[Any, dict[str, Any]]:
@@ -440,7 +448,7 @@ class Runner:
         cell_impl = graph.cells[cell_id]
         if cell_impl.is_coroutine():
             raise RuntimeError(
-                "A coroutine function can't be run synchronously."
+                "A coroutine function can't be run synchronously. "
                 "Use `run_async()` instead"
             )
 

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
 from marimo import _loggers
-from marimo._ast.cell import Cell, CellId_t
+from marimo._ast.cell import CellId_t, CellImpl
 from marimo._ast.compiler import code_key
 from marimo._ast.visitor import Name
 
@@ -21,7 +21,7 @@ LOGGER = _loggers.marimo_logger()
 @dataclass(frozen=True)
 class DirectedGraph:
     # Nodes in the graph
-    cells: dict[CellId_t, Cell] = field(default_factory=dict)
+    cells: dict[CellId_t, CellImpl] = field(default_factory=dict)
 
     # Edge (u, v) means v is a child of u, i.e., v has a reference
     # to something defined in u
@@ -85,7 +85,7 @@ class DirectedGraph:
                     queue.append((cid, next_path))
         return []
 
-    def register_cell(self, cell_id: CellId_t, cell: Cell) -> None:
+    def register_cell(self, cell_id: CellId_t, cell: CellImpl) -> None:
         """Add a cell to the graph.
 
         Mutates the graph, acquiring `self.lock`.

--- a/marimo/_server/models/base.py
+++ b/marimo/_server/models/base.py
@@ -18,7 +18,7 @@ def to_camel_case(snake_str: str) -> str:
 
 def deep_to_camel_case(snake_dict: Any) -> dict[str, Any]:
     if isinstance(snake_dict, list):
-        return [deep_to_camel_case(item) for item in snake_dict]  # type: ignore
+        return [deep_to_camel_case(item) for item in snake_dict]  # type: ignore  # noqa: E501
     if isinstance(snake_dict, str):
         return to_camel_case(snake_dict)  # type: ignore
 

--- a/marimo/_smoke_tests/import_named_cells.py
+++ b/marimo/_smoke_tests/import_named_cells.py
@@ -27,13 +27,19 @@ def __(mo):
 @app.cell
 def __(display_slider):
     slider_output, slider_defs = display_slider.run()
-    slider_output, slider_defs
+    slider_output
     return slider_defs, slider_output
 
 
 @app.cell
 def __(mo):
     mo.md("_Notice that set-ui-element value requests make it into the defs_")
+    return
+
+
+@app.cell
+def __(slider_defs):
+    slider_defs
     return
 
 

--- a/marimo/_smoke_tests/import_named_cells.py
+++ b/marimo/_smoke_tests/import_named_cells.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
 __generated_with = "0.2.8"
@@ -25,15 +26,20 @@ def __(mo):
 
 @app.cell
 def __(display_slider):
-    _o, _d = display_slider.run()
-    slider = _d["slider"]
-    _o
-    return slider,
+    slider_output, slider_defs = display_slider.run()
+    slider_output, slider_defs
+    return slider_defs, slider_output
 
 
 @app.cell
-def __(slider):
-    slider.value
+def __(mo):
+    mo.md("_Notice that set-ui-element value requests make it into the defs_")
+    return
+
+
+@app.cell
+def __(slider_defs):
+    slider_defs["slider"].value
     return
 
 

--- a/marimo/_smoke_tests/import_named_cells.py
+++ b/marimo/_smoke_tests/import_named_cells.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.2.8"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __():
+    from named_cells import display_slider, display_element
+    return display_element, display_slider
+
+
+@app.cell
+def __(mo):
+    mo.md("**A cell that creates and shows a slider**")
+    return
+
+
+@app.cell
+def __(display_slider):
+    _o, _d = display_slider.run()
+    slider = _d["slider"]
+    _o
+    return slider,
+
+
+@app.cell
+def __(slider):
+    slider.value
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md("**A cell that shows a parametrizable UI element**")
+    return
+
+
+@app.cell
+def __(display_element, mo):
+    text = mo.ui.text(placeholder="custom input")
+    _o, _ = display_element.run(element=text)
+    _o
+    return text,
+
+
+@app.cell
+def __(text):
+    text.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/named_cells.py
+++ b/marimo/_smoke_tests/named_cells.py
@@ -1,0 +1,34 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.2.8"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def display_slider(mo):
+    slider = mo.ui.slider(1, 10)
+    mo.md(f"Here is a slider: {slider}")
+    return slider,
+
+
+@app.cell
+def __(mo):
+    element = mo.ui.checkbox(False)
+    return element,
+
+
+@app.cell
+def display_element(element, mo):
+    mo.md(f"Here is an element: {element}")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ exclude = [
     "tests/_ast/codegen_data",
     "tests/_ast/cell_data",
     "tests/_cli/ipynb_data",
+    "tests/_runtime/runtime_data",
     "frontend",
     "docs",
     "build",
@@ -174,6 +175,7 @@ extend-exclude = """
     | ^/tests/_ast/codegen_data/*
     | ^/tests/_ast/cell_data/*
     | ^/tests/_cli/ipynb_data/*
+    | ^/tests/_runtime/runtime_data/*
     | ^/marimo/_tutorials/*
     | ^/marimo/_smoke_tests/*
 )
@@ -186,6 +188,7 @@ exclude = [
     'tests/_ast/codegen_data',
     'tests/_ast/cell_data',
     'tests/_cli/ipynb_data',
+    'tests/_runtime/runtime_data',
     'marimo/_tutorials/',
     'marimo/_smoke_tests/',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ exclude = [
     "marimo/_test_utils/codegen_data",
     "marimo/_test_utils/_tutorials",
     "tests/_ast/codegen_data",
+    "tests/_ast/cell_data",
     "tests/_cli/ipynb_data",
     "frontend",
     "docs",
@@ -171,6 +172,7 @@ extend-exclude = """
 (
     ^/examples/*
     | ^/tests/_ast/codegen_data/*
+    | ^/tests/_ast/cell_data/*
     | ^/tests/_cli/ipynb_data/*
     | ^/marimo/_tutorials/*
     | ^/marimo/_smoke_tests/*
@@ -182,6 +184,7 @@ strict = true
 exclude = [
     'examples',
     'tests/_ast/codegen_data',
+    'tests/_ast/cell_data',
     'tests/_cli/ipynb_data',
     'marimo/_tutorials/',
     'marimo/_smoke_tests/',

--- a/tests/_ast/cell_data/named_cells.py
+++ b/tests/_ast/cell_data/named_cells.py
@@ -1,0 +1,27 @@
+import marimo
+
+__generated_with = "0.2.8"
+app = marimo.App()
+
+
+@app.cell
+def f():
+    x = 0
+    return (x,)
+
+
+@app.cell
+def g(x):
+    y = x + 1
+    return (y,)
+
+
+@app.cell
+def h(y):
+    z = y + 1
+    z
+    return (z,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_ast/test_app_cell.py
+++ b/tests/_ast/test_app_cell.py
@@ -65,7 +65,7 @@ def test_decorator_with_unknown_args() -> None:
     assert cell.run() == (None, {"x": 4})
 
 
-def test_decorator_async() -> None:
+async def test_decorator_async() -> None:
     # Decorator uncalled
     async def __(asyncio) -> tuple[int]:
         await asyncio.sleep(0.1)
@@ -82,7 +82,7 @@ def test_decorator_async() -> None:
 
     import asyncio
 
-    assert cell.run(asyncio=asyncio) == (None, {"z": 6})
+    assert await cell.run_async(asyncio=asyncio) == (None, {"z": 6})
 
 
 # TODO(akshayka): test cell.run() with multiple cells in graph, outputs, ...

--- a/tests/_ast/test_app_cell.py
+++ b/tests/_ast/test_app_cell.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Awaitable
 
 from marimo._ast.app import App
 
@@ -82,7 +83,9 @@ async def test_decorator_async() -> None:
 
     import asyncio
 
-    assert await cell.run_async(asyncio=asyncio) == (None, {"z": 6})
+    result = cell.run(asyncio=asyncio)
+    assert isinstance(result, Awaitable)
+    assert await result == (None, {"z": 6})
 
 
 # TODO(akshayka): test cell.run() with multiple cells in graph, outputs, ...

--- a/tests/_ast/test_app_cell.py
+++ b/tests/_ast/test_app_cell.py
@@ -4,95 +4,85 @@ from __future__ import annotations
 import inspect
 
 from marimo._ast.app import App
-from marimo._ast.cell import CellFunction, CellFuncType
-
-# Arg capture
-cell_function: CellFunction[CellFuncType] = None  # type: ignore[assignment]
-
-
-def mock_register_cell(cf: CellFunction[CellFuncType]) -> None:
-    global cell_function
-    cell_function = cf
-
-
-app = App()
-app._cell_manager._register_cell_function = mock_register_cell  # type: ignore[method-assign, assignment] # noqa: E501
 
 
 def test_decorator_called() -> None:
-    # Decorator called
-    @app.cell()
     def mock_func1() -> tuple[int]:
         x = 2 + 2
         return (x,)
 
-    assert cell_function.cell.code == "x = 2 + 2"
-    assert cell_function.cell.config.disabled is False
-    assert len(cell_function.args) == 0
-    assert cell_function.__name__ == "mock_func1"
-    assert cell_function.__call__ is not None
-    assert cell_function.__call__() == (4,)
+    app = App()
+    cell = app.cell()(mock_func1)
+    assert cell is not None
+    assert cell._cell.code == "x = 2 + 2"
+    assert cell._cell.config.disabled is False
+    assert cell.name == "mock_func1"
+    assert cell.run() == (None, {"x": 4})
 
 
 def test_decorator_uncalled() -> None:
-    # Decorator uncalled
-    @app.cell
     def __() -> tuple[int]:
         z = 3 + 3
         return (z,)
 
-    assert cell_function.cell.code == "z = 3 + 3"
-    assert cell_function.cell.config.disabled is False
-    assert len(cell_function.args) == 0
-    assert cell_function.__name__ == "__"
-    assert cell_function.__call__ is not None
-    assert cell_function.__call__() == (6,)
+    app = App()
+    cell = app.cell(__)
+    assert cell is not None
+    assert cell._cell.code == "z = 3 + 3"
+    assert cell._cell.config.disabled is False
+    assert cell.name == "__"
+    assert cell.run() == (None, {"z": 6})
 
 
 def test_decorator_with_args() -> None:
-    # Decorator with args
-    @app.cell(disabled=True)
     def mock_func3(x: int) -> tuple[int]:
         y = x + 2
         return (y,)
 
-    assert cell_function.cell.code == "y = x + 2"
-    assert cell_function.cell.config.disabled is True
-    assert cell_function.args == {"x"}
-    assert cell_function.__name__ == "mock_func3"
-    assert cell_function.__call__ is not None
-    assert cell_function.__call__(2) == (4,)
+    app = App()
+    cell = app.cell(disabled=True)(mock_func3)
+    assert cell is not None
+
+    assert cell._cell.code == "y = x + 2"
+    assert cell._cell.config.disabled is True
+    assert cell.name == "mock_func3"
+    assert cell.run(x=1) == (None, {"y": 3})
 
 
 def test_decorator_with_unknown_args() -> None:
     # Decorator with unknown args
-    @app.cell(foo=True)
     def __() -> tuple[int]:
         x = 2 + 2
         return (x,)
 
-    assert cell_function.cell.code == "x = 2 + 2"
-    assert cell_function.cell.config.disabled is False
-    assert len(cell_function.args) == 0
-    assert cell_function.__name__ == "__"
-    assert cell_function.__call__ is not None
-    assert cell_function.__call__() == (4,)
+    app = App()
+    cell = app.cell(foo=True)(__)
+    assert cell is not None
+
+    assert cell._cell.code == "x = 2 + 2"
+    assert cell._cell.config.disabled is False
+    assert cell.name == "__"
+    assert cell.run() == (None, {"x": 4})
 
 
-async def test_decorator_async() -> None:
+def test_decorator_async() -> None:
     # Decorator uncalled
-    @app.cell
     async def __(asyncio) -> tuple[int]:
         await asyncio.sleep(0.1)
         z = 3 + 3
         return (z,)
 
-    assert inspect.iscoroutinefunction(cell_function)
-    assert cell_function.cell.config.disabled is False
-    assert len(cell_function.args) == 1
-    assert cell_function.__name__ == "__"
-    assert cell_function.__call__ is not None
+    app = App()
+    cell = app.cell(__)
+    assert cell is not None
+
+    assert inspect.iscoroutinefunction(cell._f)
+    assert cell._cell.config.disabled is False
+    assert cell.name == "__"
 
     import asyncio
 
-    assert (await cell_function(asyncio)) == (6,)
+    assert cell.run(asyncio=asyncio) == (None, {"z": 6})
+
+
+# TODO(akshayka): test cell.run() with multiple cells in graph, outputs, ...

--- a/tests/_ast/test_cell.py
+++ b/tests/_ast/test_cell.py
@@ -173,17 +173,32 @@ class TestCellRun:
         assert f.run() == (None, {})
 
     @staticmethod
-    def help_smoke() -> None:
-        app = App()
+    def test_import() -> None:
+        from cell_data.named_cells import f, g, h
 
-        @app.cell
-        async def f(x):
-            await x
-            return
+        assert f.name == "f"
+        assert g.name == "g"
+        assert h.name == "h"
 
-        @app.cell
-        def g():
-            return
+        assert f.run() == (None, {"x": 0})
+        assert g.run() == (None, {"y": 1})
+        assert h.run() == (2, {"z": 2})
 
-        assert "Async" in f._help().text
-        assert "Async" not in g._help().text
+        assert g.run(x=1) == (None, {"y": 2})
+        assert h.run(y=2) == (3, {"z": 3})
+
+
+def help_smoke() -> None:
+    app = App()
+
+    @app.cell
+    async def f(x):
+        await x
+        return
+
+    @app.cell
+    def g():
+        return
+
+    assert "Async" in f._help().text
+    assert "Async" not in g._help().text

--- a/tests/_ast/test_cell.py
+++ b/tests/_ast/test_cell.py
@@ -1,0 +1,189 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from collections.abc import Awaitable
+
+import pytest
+
+from marimo._ast.app import App
+
+
+class TestCellRun:
+    @staticmethod
+    def test_cell_basic() -> None:
+        def f() -> tuple[int]:
+            x = 2 + 2
+            "output"
+            return (x,)
+
+        app = App()
+        cell = app.cell(f)
+        assert cell.name == "f"
+        assert not cell.refs
+        assert cell.defs == set(["x"])
+        assert not cell._is_coroutine()
+        assert cell.run() == ("output", {"x": 4})
+
+    @staticmethod
+    async def test_async_cell_basic() -> None:
+        async def f(asyncio) -> tuple[int]:
+            await asyncio.sleep(0)
+
+            x = 2 + 2
+            "output"
+            return (x,)
+
+        app = App()
+        cell = app.cell(f)
+        assert cell.name == "f"
+        assert cell.refs == {"asyncio"}
+        assert cell.defs == {"x"}
+        assert cell._is_coroutine()
+
+        import asyncio
+
+        ret = cell.run(asyncio=asyncio)
+        assert isinstance(ret, Awaitable)
+        assert await ret == ("output", {"x": 4})
+
+    @staticmethod
+    def test_unknown_ref_raises() -> None:
+        def f() -> None:
+            ...
+
+        app = App()
+        cell = app.cell(f)
+        with pytest.raises(ValueError) as einfo:
+            cell.run(foo=1)
+        assert "unexpected argument" in str(einfo.value)
+
+    @staticmethod
+    def test_substituted_ref_basic() -> None:
+        app = App()
+
+        @app.cell
+        def g():
+            x = 0
+            y = 1
+            return (x, y)
+
+        @app.cell
+        def h(x, y):
+            z = x + y
+            return (z,)
+
+        assert h.run() == (None, {"z": 1})
+        assert h.run(x=1) == (None, {"z": 2})
+        assert h.run(y=0) == (None, {"z": 0})
+        assert h.run(x=1, y=2) == (None, {"z": 3})
+
+    @staticmethod
+    def test_substituted_ref_chain() -> None:
+        app = App()
+
+        @app.cell
+        def f():
+            x = 0
+            return (x,)
+
+        @app.cell
+        def g(x):
+            y = x + 1
+            return (y,)
+
+        @app.cell
+        def h(y):
+            z = 2 * y
+            return (z,)
+
+        assert h.run() == (None, {"z": 2})
+        assert h.run(y=0) == (None, {"z": 0})
+
+        with pytest.raises(ValueError) as e:
+            h.run(x=1)
+        assert "unexpected argument" in str(e.value)
+
+    @staticmethod
+    def test_async_parent() -> None:
+        app = App()
+
+        @app.cell
+        async def g(arg):
+            await arg
+            x = 0
+            return (x,)
+
+        @app.cell
+        def h(x):
+            y = x
+            return (y,)
+
+        assert g._is_coroutine()
+        # h is a coroutine because it depends on the execution of an async
+        # function
+        assert h._is_coroutine()
+
+    @staticmethod
+    def test_async_chain() -> None:
+        app = App()
+
+        @app.cell
+        async def f(arg):
+            await arg
+            x = 0
+            return (x,)
+
+        @app.cell
+        def g(x):
+            y = x
+            return (y,)
+
+        @app.cell
+        def h(y):
+            z = y
+            return (z,)
+
+        assert f._is_coroutine()
+        assert g._is_coroutine()
+        assert h._is_coroutine()
+
+    @staticmethod
+    def test_empty_cell() -> None:
+        app = App()
+
+        @app.cell
+        def f():
+            return
+
+        assert f.run() == (None, {})
+
+    @staticmethod
+    def test_conditional_def() -> None:
+        app = App()
+
+        @app.cell
+        def f():
+            if False:
+                x = 0
+            return (x,)
+
+        # "x" was statically declared
+        assert f.defs == {"x"}
+        # "x" should not be in returns because it wasn't defined at runtime
+        assert f.run() == (None, {})
+
+    @staticmethod
+    def help_smoke() -> None:
+        app = App()
+
+        @app.cell
+        async def f(x):
+            await x
+            return
+
+        @app.cell
+        def g():
+            return
+
+        assert "Async" in f._help().text
+        assert "Async" not in g._help().text

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -84,9 +84,9 @@ class TestCellFactory:
             x = 10  # noqa: F841
             y = 20  # noqa: F841
 
-        cf = compiler.cell_factory(f, cell_id="0")
-        assert cf.cell.defs == {"x", "y"}
-        assert not cf.cell.refs
+        cell = compiler.cell_factory(f, cell_id="0")
+        assert cell._cell.defs == {"x", "y"}
+        assert not cell._cell.refs
 
     @staticmethod
     def test_refs() -> None:
@@ -95,9 +95,9 @@ class TestCellFactory:
         def f() -> None:
             x = y  # noqa: F841 F821
 
-        cf = compiler.cell_factory(f, cell_id="0")
-        assert cf.cell.defs == {"x"}
-        assert cf.cell.refs == {"y"}
+        cell = compiler.cell_factory(f, cell_id="0")
+        assert cell._cell.defs == {"x"}
+        assert cell._cell.refs == {"y"}
 
 
 def test_cell_id_from_filename() -> None:

--- a/tests/_plugins/ui/_impl/test_altair_chart.py
+++ b/tests/_plugins/ui/_impl/test_altair_chart.py
@@ -9,7 +9,7 @@ from marimo._plugins.ui._impl.altair_chart import (
     _filter_dataframe,
 )
 from marimo._runtime.runtime import Kernel
-from tests.conftest import ExecReqProvider, MockedKernel
+from tests.conftest import ExecReqProvider
 
 HAS_DEPS = DependencyManager.has_pandas() and DependencyManager.has_altair()
 

--- a/tests/_runtime/runtime_data/cell_ui_element.py
+++ b/tests/_runtime/runtime_data/cell_ui_element.py
@@ -1,0 +1,17 @@
+import marimo
+
+__generated_with = "0.2.8"
+app = marimo.App()
+
+
+@app.cell
+def make_slider():
+    import marimo as mo
+
+    slider = mo.ui.slider(0, 10)
+    slider
+    return (mo, slider)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -841,15 +841,22 @@ async def test_set_ui_element_value_with_cell_run(
             exec_req.get(
                 "from runtime_data.cell_ui_element import make_slider"
             ),
-            exec_req.get("output, defs = make_slider.run()"),
+            exec_req.get("_, defs = make_slider.run()"),
+            exec_req.get("_, second_defs = make_slider.run()"),
+            exec_req.get("counter = [0]"),
             exec_req.get("slider_value = defs['slider'].value + 1"),
+            exec_req.get("second_defs; counter[0] += 1"),
         ]
     )
     assert k.globals["defs"]["slider"].value == 0
+    assert k.globals["counter"][0] == 1
     element_id = k.globals["defs"]["slider"]._id
     await k.set_ui_element_value(SetUIElementValueRequest([(element_id, 5)]))
     assert k.globals["defs"]["slider"].value == 5
     assert k.globals["slider_value"] == 6
+    # reactive execution on the slider in `defs` shouldn't trigger reactive
+    # execution on `second_defs`
+    assert k.globals["counter"][0] == 1
 
 
 class TestAsyncIO:


### PR DESCRIPTION
This PR makes it possible to import named cells from one notebook into another, and to run the imported cells programmatically to obtain their output and definitions.

For example:

```python
from my_notebook import my_cell

# refs is any subset of the cell's refs
refs: dict[str, Any] | None = { ... }
output, defs = my_cell.run(**refs)
```

This helps make notebooks more testable: you can import named cells in a `pytest` module, run it, and check their outputs or defs. It also also helps with code re-use, making it possible to re-use cells across notebooks, especially if the cells are written in a functional way.

The main changes are in `cell.py`: we've introduced a new public `Cell` class. Calling its `run()` method executes the cell's ancestors, and then the cell itself, returning a tuple of its output and a `Mapping` of def names to values. The caller can supply any subset of the cell's refs as keyword arguments to short-circuit / prevent computation of ancestors and run the cell with custom arguments.

The returned `defs` `Mapping` is an internal `_Namespace` object; the runtime has been updated so that `set-ui-element-value` requests on objects in namespaces trigger reactive execution of cells that reference the namespace. 

This feature has some limitations.

- Interacting with the returned output doesn't trigger reactivity inside the cell's containing `App` -- so if the output contains UI elements that have `on_change` handlers that set reactive state, the state updates will just be dropped / won't trigger reactive execution. Full reactivity is left for later, when we add `App` composition
- No caching is implemented. This means if two cells have common ancestors, running them without providing `refs` will recompute their ancestors. This is a conscious choice for correctness, but we can add an option to enable caching in the future.