### PR TITLE
improvement: improved shortcut symbols

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -18,6 +18,7 @@ import {
   CodeIcon,
   PanelLeftIcon,
   CheckIcon,
+  KeyboardIcon,
 } from "lucide-react";
 import { commandPaletteAtom } from "../controls/command-palette";
 import {
@@ -40,6 +41,7 @@ import { Paths } from "@/utils/paths";
 import { useChromeActions, useChromeState } from "../chrome/state";
 import { PANEL_ICONS, PANEL_TYPES } from "../chrome/types";
 import { startCase } from "lodash-es";
+import { keyboardShortcutsAtom } from "../controls/keyboard-shortcuts";
 
 const NOOP_HANDLER = (event?: Event) => {
   event?.preventDefault();
@@ -56,6 +58,7 @@ export function useNotebookActions() {
   const { updateCellConfig } = useCellActions();
   const restartKernel = useRestartKernel();
   const setCommandPaletteOpen = useSetAtom(commandPaletteAtom);
+  const setKeyboardShortcutsOpen = useSetAtom(keyboardShortcutsAtom);
 
   const disabledCells = disabledCellIds(notebook);
   const enabledCells = enabledCellIds(notebook);
@@ -210,6 +213,13 @@ export function useNotebookActions() {
       label: "Command palette",
       hotkey: "global.commandPalette",
       handle: () => setCommandPaletteOpen((open) => !open),
+    },
+
+    {
+      icon: <KeyboardIcon size={14} strokeWidth={1.5} />,
+      label: "Keyboard shortcuts",
+      hotkey: "global.showHelp",
+      handle: () => setKeyboardShortcutsOpen((open) => !open),
     },
 
     {

--- a/frontend/src/components/editor/controls/command-palette.tsx
+++ b/frontend/src/components/editor/controls/command-palette.tsx
@@ -12,8 +12,7 @@ import {
 } from "@/components/ui/command";
 import { useRegisteredActions } from "../../../core/hotkeys/actions";
 import { useRecentCommands } from "../../../hooks/useRecentCommands";
-import { Kbd } from "../../ui/kbd";
-import { prettyPrintHotkey } from "../../shortcuts/renderShortcut";
+import { KeyboardHotkeys } from "../../shortcuts/renderShortcut";
 import { HOTKEYS, HotkeyAction, isHotkeyAction } from "@/core/hotkeys/hotkeys";
 import { atom, useAtom } from "jotai";
 import { useNotebookActions } from "../actions/useNotebookActions";
@@ -73,11 +72,7 @@ export const CommandPalette = () => {
       >
         <span>{hotkey.name}</span>
         <CommandShortcut>
-          <span className="flex ml-2 gap-1">
-            {prettyPrintHotkey(hotkey.key).map((key) => (
-              <Kbd key={key}>{key}</Kbd>
-            ))}
-          </span>
+          <KeyboardHotkeys shortcut={hotkey.key} />
         </CommandShortcut>
       </CommandItem>
     );

--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -1,6 +1,4 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { useState } from "react";
-
 import { useHotkey } from "../../../hooks/useHotkey";
 import {
   Dialog,
@@ -12,9 +10,12 @@ import {
 } from "../../ui/dialog";
 import { KeyboardHotkeys } from "../../shortcuts/renderShortcut";
 import { HOTKEYS, HotkeyAction, HotkeyGroup } from "@/core/hotkeys/hotkeys";
+import { atom, useAtom } from "jotai";
+
+export const keyboardShortcutsAtom = atom(false);
 
 export const KeyboardShortcuts: React.FC = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useAtom(keyboardShortcutsAtom);
 
   useHotkey("global.showHelp", () => setIsOpen((v) => !v));
 

--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -2,7 +2,6 @@
 import { useState } from "react";
 
 import { useHotkey } from "../../../hooks/useHotkey";
-import { Kbd } from "../../ui/kbd";
 import {
   Dialog,
   DialogContent,
@@ -11,7 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../../ui/dialog";
-import { prettyPrintHotkey } from "../../shortcuts/renderShortcut";
+import { KeyboardHotkeys } from "../../shortcuts/renderShortcut";
 import { HOTKEYS, HotkeyAction, HotkeyGroup } from "@/core/hotkeys/hotkeys";
 
 export const KeyboardShortcuts: React.FC = () => {
@@ -27,11 +26,7 @@ export const KeyboardShortcuts: React.FC = () => {
     const hotkey = HOTKEYS.getHotkey(action);
     return (
       <div className="keyboard-shortcut flex flex-col" key={action}>
-        <div className="flex gap-1">
-          {prettyPrintHotkey(hotkey.key).map((key) => (
-            <Kbd key={key}>{key}</Kbd>
-          ))}
-        </div>
+        <KeyboardHotkeys shortcut={hotkey.key} />
         <span>{hotkey.name.toLowerCase()}</span>
       </div>
     );

--- a/frontend/src/components/shortcuts/renderShortcut.tsx
+++ b/frontend/src/components/shortcuts/renderShortcut.tsx
@@ -26,16 +26,15 @@ export const KeyboardHotkeys: React.FC<{ shortcut: string }> = ({
       {keys.map(prettyPrintHotkey).map(([label, symbol]) => {
         if (symbol) {
           return (
-            <Kbd key={label}>
-              <Tooltip
-                key={label}
-                content={label}
-                asChild={false}
-                delayDuration={300}
-              >
-                {symbol}
-              </Tooltip>
-            </Kbd>
+            <Tooltip
+              asChild={false}
+              tabIndex={-1}
+              key={label}
+              content={label}
+              delayDuration={300}
+            >
+              <Kbd key={label}>{symbol}</Kbd>
+            </Tooltip>
           );
         }
         return <Kbd key={label}>{capitalize(label)}</Kbd>;
@@ -53,7 +52,12 @@ export function renderMinimalShortcut(shortcut: HotkeyAction) {
       {keys.map(prettyPrintHotkey).map(([label, symbol]) => {
         if (symbol) {
           return (
-            <Tooltip key={label} content={label} delayDuration={300}>
+            <Tooltip
+              key={label}
+              content={label}
+              delayDuration={300}
+              tabIndex={-1}
+            >
               <span key={label}>{symbol}</span>
             </Tooltip>
           );

--- a/frontend/src/components/shortcuts/renderShortcut.tsx
+++ b/frontend/src/components/shortcuts/renderShortcut.tsx
@@ -3,53 +3,167 @@ import { HotkeyAction, HOTKEYS } from "@/core/hotkeys/hotkeys";
 import { isPlatformMac } from "@/core/hotkeys/shortcuts";
 import { Kbd } from "../ui/kbd";
 import { DropdownMenuShortcut } from "../ui/dropdown-menu";
+import { Tooltip } from "../ui/tooltip";
 
 export function renderShortcut(shortcut: HotkeyAction) {
   const hotkey = HOTKEYS.getHotkey(shortcut);
 
   return (
     <span className="flex">
-      {hotkey.name}{" "}
-      <span className="flex ml-1 gap-1">
-        {prettyPrintHotkey(hotkey.key).map((key) => (
-          <Kbd key={key}>{capitalize(key)}</Kbd>
-        ))}
-      </span>
+      <span className="mr-2">{hotkey.name}</span>
+      <KeyboardHotkeys shortcut={hotkey.key} />
     </span>
   );
 }
 
+export const KeyboardHotkeys: React.FC<{ shortcut: string }> = ({
+  shortcut,
+}) => {
+  const keys = shortcut.split("-");
+
+  return (
+    <div className="flex gap-1">
+      {keys.map(prettyPrintHotkey).map(([label, symbol]) => {
+        if (symbol) {
+          return (
+            <Kbd key={label}>
+              <Tooltip
+                key={label}
+                content={label}
+                asChild={false}
+                delayDuration={300}
+              >
+                {symbol}
+              </Tooltip>
+            </Kbd>
+          );
+        }
+        return <Kbd key={label}>{capitalize(label)}</Kbd>;
+      })}
+    </div>
+  );
+};
+
 export function renderMinimalShortcut(shortcut: HotkeyAction) {
   const hotkey = HOTKEYS.getHotkey(shortcut);
+  const keys = hotkey.key.split("-");
 
   return (
     <DropdownMenuShortcut className="flex gap-1 items-center font-mono">
-      {prettyPrintHotkey(hotkey.key).map((key) => (
-        <span key={key}>{capitalize(key)}</span>
-      ))}
+      {keys.map(prettyPrintHotkey).map(([label, symbol]) => {
+        if (symbol) {
+          return (
+            <Tooltip key={label} content={label} delayDuration={300}>
+              <span key={label}>{symbol}</span>
+            </Tooltip>
+          );
+        }
+        return <span key={label}>{capitalize(label)}</span>;
+      })}
     </DropdownMenuShortcut>
   );
 }
 
-export function prettyPrintHotkey(keyboard: string) {
-  return keyboard.split("-").map((key) => {
-    switch (key.toLowerCase()) {
-      case "cmd":
-        return "⌘";
-      case "meta":
-        return isPlatformMac() ? "⌘" : "ctrl";
-      case "shift":
-        return "shift";
-      case "alt":
-        return isPlatformMac() ? "⌥" : "alt";
-      case "control":
-      case "ctrl":
-        return isPlatformMac() ? "⌃" : "ctrl";
-      default:
-        return key.toLowerCase();
-    }
-  });
+function prettyPrintHotkey(key: string): [label: string, symbol?: string] {
+  const platform = isPlatformMac() ? "mac" : "default";
+
+  const lowerKey = key.toLowerCase();
+  const keyData = KEY_MAPPINGS[key.toLowerCase()];
+  if (keyData) {
+    const symbol = keyData.symbols[platform] || keyData.symbols.default;
+    return [keyData.label, symbol];
+  }
+
+  return [lowerKey];
 }
+
+interface KeyData {
+  symbols: {
+    mac?: string;
+    windows?: string;
+    default: string;
+  };
+  label: string;
+}
+
+const KEY_MAPPINGS: Record<string, KeyData> = {
+  enter: {
+    symbols: { mac: "↩", default: "↵" },
+    label: "Enter",
+  },
+  ctrl: {
+    symbols: { mac: "⌃", default: "Ctrl" },
+    label: "Control",
+  },
+  control: {
+    symbols: { mac: "⌃", default: "Ctrl" },
+    label: "Control",
+  },
+  shift: {
+    symbols: { mac: "⇧", default: "Shift" },
+    label: "Shift",
+  },
+  alt: {
+    symbols: { mac: "⌥", default: "Alt" },
+    label: "Alt/Option",
+  },
+  escape: {
+    symbols: { mac: "⎋", default: "Esc" },
+    label: "Escape",
+  },
+  arrowup: {
+    symbols: { default: "↑" },
+    label: "Arrow Up",
+  },
+  arrowdown: {
+    symbols: { default: "↓" },
+    label: "Arrow Down",
+  },
+  arrowleft: {
+    symbols: { default: "←" },
+    label: "Arrow Left",
+  },
+  arrowright: {
+    symbols: { default: "→" },
+    label: "Arrow Right",
+  },
+  backspace: {
+    symbols: { mac: "⌫", default: "⟵" },
+    label: "Backspace",
+  },
+  tab: {
+    symbols: { mac: "⇥", default: "⭾" },
+    label: "Tab",
+  },
+  capslock: {
+    symbols: { default: "⇪" },
+    label: "Caps Lock",
+  },
+  fn: {
+    symbols: { default: "Fn" },
+    label: "Fn",
+  },
+  cmd: {
+    symbols: { mac: "⌘", windows: "⊞ Win", default: "Command" },
+    label: "Command",
+  },
+  insert: {
+    symbols: { default: "Ins" },
+    label: "Insert",
+  },
+  delete: {
+    symbols: { mac: "⌦", default: "Del" },
+    label: "Delete",
+  },
+  home: {
+    symbols: { mac: "↖", default: "Home" },
+    label: "Home",
+  },
+  end: {
+    symbols: { mac: "↘", default: "End" },
+    label: "End",
+  },
+};
 
 function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);

--- a/frontend/src/components/shortcuts/renderShortcut.tsx
+++ b/frontend/src/components/shortcuts/renderShortcut.tsx
@@ -48,7 +48,7 @@ export function renderMinimalShortcut(shortcut: HotkeyAction) {
   const keys = hotkey.key.split("-");
 
   return (
-    <DropdownMenuShortcut className="flex gap-1 items-center font-mono">
+    <DropdownMenuShortcut className="flex gap-1 items-center">
       {keys.map(prettyPrintHotkey).map(([label, symbol]) => {
         if (symbol) {
           return (
@@ -91,10 +91,6 @@ interface KeyData {
 }
 
 const KEY_MAPPINGS: Record<string, KeyData> = {
-  enter: {
-    symbols: { mac: "↩", default: "↵" },
-    label: "Enter",
-  },
   ctrl: {
     symbols: { mac: "⌃", default: "Ctrl" },
     label: "Control",

--- a/frontend/src/components/ui/kbd.tsx
+++ b/frontend/src/components/ui/kbd.tsx
@@ -13,7 +13,7 @@ export const Kbd: React.FC<Props> = (props) => {
         props.className,
         // text-[0.75rem]: don't want to set line height; want to inherit
         // whatever line height is used to make sure text is not off-center
-        "rounded-md bg-muted/40 px-2 text-[0.75rem] font-code center border border-foreground/20 text-muted-foreground block",
+        "rounded-md bg-muted/40 px-2 text-[0.75rem] font-prose center border border-foreground/20 text-muted-foreground block",
       )}
     >
       {props.children}

--- a/frontend/src/components/ui/kbd.tsx
+++ b/frontend/src/components/ui/kbd.tsx
@@ -13,7 +13,7 @@ export const Kbd: React.FC<Props> = (props) => {
         props.className,
         // text-[0.75rem]: don't want to set line height; want to inherit
         // whatever line height is used to make sure text is not off-center
-        "rounded-md border border-border bg-muted px-2 text-[0.75rem] font-code",
+        "rounded-md bg-muted/40 px-2 text-[0.75rem] font-code center border border-foreground/20 text-muted-foreground",
       )}
     >
       {props.children}

--- a/frontend/src/components/ui/kbd.tsx
+++ b/frontend/src/components/ui/kbd.tsx
@@ -13,7 +13,7 @@ export const Kbd: React.FC<Props> = (props) => {
         props.className,
         // text-[0.75rem]: don't want to set line height; want to inherit
         // whatever line height is used to make sure text is not off-center
-        "rounded-md bg-muted/40 px-2 text-[0.75rem] font-code center border border-foreground/20 text-muted-foreground",
+        "rounded-md bg-muted/40 px-2 text-[0.75rem] font-code center border border-foreground/20 text-muted-foreground block",
       )}
     >
       {props.children}

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -31,11 +31,19 @@ const Tooltip: React.FC<
     content: React.ReactNode;
     usePortal?: boolean;
     children: React.ReactNode;
+    asChild?: boolean;
     side?: TooltipPrimitive.TooltipContentProps["side"];
   } & React.ComponentPropsWithoutRef<typeof TooltipRoot>
-> = ({ content, children, usePortal = true, side, ...rootProps }) => (
+> = ({
+  content,
+  children,
+  usePortal = true,
+  asChild = true,
+  side,
+  ...rootProps
+}) => (
   <TooltipRoot disableHoverableContent={true} {...rootProps}>
-    <TooltipTrigger asChild={true}>{children}</TooltipTrigger>
+    <TooltipTrigger asChild={asChild}>{children}</TooltipTrigger>
     {usePortal ? (
       <TooltipPrimitive.TooltipPortal>
         <TooltipContent side={side}>{content}</TooltipContent>

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -33,17 +33,21 @@ const Tooltip: React.FC<
     children: React.ReactNode;
     asChild?: boolean;
     side?: TooltipPrimitive.TooltipContentProps["side"];
+    tabIndex?: number;
   } & React.ComponentPropsWithoutRef<typeof TooltipRoot>
 > = ({
   content,
   children,
   usePortal = true,
   asChild = true,
+  tabIndex,
   side,
   ...rootProps
 }) => (
   <TooltipRoot disableHoverableContent={true} {...rootProps}>
-    <TooltipTrigger asChild={asChild}>{children}</TooltipTrigger>
+    <TooltipTrigger asChild={asChild} tabIndex={tabIndex}>
+      {children}
+    </TooltipTrigger>
     {usePortal ? (
       <TooltipPrimitive.TooltipPortal>
         <TooltipContent side={side}>{content}</TooltipContent>

--- a/frontend/src/core/codemirror/copilot/client.ts
+++ b/frontend/src/core/codemirror/copilot/client.ts
@@ -79,9 +79,13 @@ export function copilotServer() {
   });
 }
 
+const DEVELOPMENT_WS_PORT = 27_180;
 export function createWsUrl(): string {
   // TODO: this should be configurable, but instead we add a 0 and hope it is free
-  const LSP_PORT = window.location.port + 0;
+  const LSP_PORT =
+    process.env.NODE_ENV === "development"
+      ? DEVELOPMENT_WS_PORT
+      : window.location.port + 0;
   const protocol = window.location.protocol === "https:" ? "wss" : "ws";
   return `${protocol}://${window.location.hostname}:${LSP_PORT}/copilot`;
 }

--- a/frontend/src/core/codemirror/copilot/language-server.ts
+++ b/frontend/src/core/codemirror/copilot/language-server.ts
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import {
+import type {
   CompletionItem,
   CompletionList,
   CompletionParams,
@@ -7,8 +7,8 @@ import {
   DidOpenTextDocumentParams,
   Hover,
   HoverParams,
-  VersionedTextDocumentIdentifier,
 } from "vscode-languageserver-protocol";
+import { VersionedTextDocumentIdentifier } from "vscode-languageserver-protocol";
 
 import { LanguageServerClient } from "codemirror-languageserver";
 import {
@@ -26,10 +26,11 @@ import {
 } from "./types";
 import { isCopilotEnabled } from "./state";
 import { getCodes } from "./getCodes";
+import { Logger } from "@/utils/Logger";
 
 // A map of request methods and their parameters and return types
 export interface LSPRequestMap {
-  checkStatus: [{}, { status: CopilotStatus }];
+  checkStatus: [{}, { status: CopilotStatus; user: string }];
   signInInitiate: [CopilotSignInInitiateParams, CopilotSignInInitiateResult];
   signInConfirm: [CopilotSignInConfirmParams, CopilotSignInConfirmResult];
   signOut: [CopilotSignOutParams, CopilotSignOutResult];
@@ -111,7 +112,8 @@ export class CopilotLanguageServerClient extends LanguageServerClient {
   }
 
   async signedIn() {
-    const { status } = await this._request("checkStatus", {});
+    const { status, user } = await this._request("checkStatus", {});
+    Logger.debug("Copilot#signedIn", status, user);
     return (
       status === "SignedIn" || status === "AlreadySignedIn" || status === "OK"
     );

--- a/frontend/src/core/codemirror/copilot/types.ts
+++ b/frontend/src/core/codemirror/copilot/types.ts
@@ -12,6 +12,10 @@ export interface CopilotSignInInitiateResult {
 export interface CopilotSignInConfirmParams {
   userCode: string;
 }
+
+/**
+ * Copilot account status.
+ */
 export type CopilotStatus =
   | "SignedIn"
   | "AlreadySignedIn"
@@ -19,6 +23,12 @@ export type CopilotStatus =
   | "NotAuthorized"
   | "NotSignedIn"
   | "OK";
+
+/**
+ * Copilot status.
+ */
+export type CopilotRequestStatus = "InProgress" | "Warning" | "Normal";
+
 export interface CopilotSignInConfirmResult {
   status: CopilotStatus;
   user: string;
@@ -44,6 +54,7 @@ export interface CopilotGetCompletionsParams {
     };
   };
 }
+
 export interface CopilotGetCompletionsResult {
   completions: Array<{
     text: string;

--- a/frontend/src/hooks/useElapsedTime.ts
+++ b/frontend/src/hooks/useElapsedTime.ts
@@ -18,7 +18,7 @@ export function useElapsedTime(initialStartTimeMs: Milliseconds) {
     }, step);
 
     return () => clearInterval(interval);
-  });
+  }, []);
 
   return endTime - startTime.current;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -99,6 +99,7 @@ module.exports = {
       fontFamily: {
         prose: ["var(--text-font)", ...fontFamily.sans],
         code: ["var(--monospace-font)", ...fontFamily.mono],
+        mono: ["var(--monospace-font)", ...fontFamily.mono],
         heading: ["var(--heading-font)", ...fontFamily.sans],
       },
       borderRadius: {


### PR DESCRIPTION
Use more symbols where possible. And add tooltip over the symbols

## After
<img width="1231" alt="Screenshot 2024-02-26 at 1 00 08 PM" src="https://github.com/marimo-team/marimo/assets/2753772/789bdf05-ccea-454e-89d3-b29c85f8e5b8">

## Before 
<img width="1229" alt="Screenshot 2024-02-26 at 1 00 17 PM" src="https://github.com/marimo-team/marimo/assets/2753772/192c5f71-bb48-4a30-a783-204e67abf36e">
