### PR TITLE
fix: show stale save after layout edit, add scroll to bordered grid

### DIFF
--- a/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
@@ -150,8 +150,7 @@ export const GridLayoutRenderer: React.FC<Props> = ({
         // Disable animations and add padding when reading
         isReading && "disable-animation px-4 ",
         // Add border styles
-        layout.bordered &&
-          "border-t border-x rounded-t shadow-sm overflow-hidden",
+        layout.bordered && "border-t border-x rounded-t shadow-sm",
         // Add additional padding if bordered when reading
         layout.bordered && isReading && "pt-4 w-[calc(100%-2rem)]",
         !layout.maxWidth && "min-w-[800px]",

--- a/frontend/src/components/editor/renderers/layout-select.tsx
+++ b/frontend/src/components/editor/renderers/layout-select.tsx
@@ -13,10 +13,16 @@ import {
 } from "@/components/ui/select";
 import { LayoutType } from "./types";
 import { SquareIcon, Grid3x3Icon, ListIcon } from "lucide-react";
+import { isPyodide } from "@/core/pyodide/utils";
 
 export const LayoutSelect: React.FC = () => {
   const [layoutType, setLayoutType] = useAtom(layoutViewAtom);
   const layouts: LayoutType[] = ["vertical", "grid"];
+
+  // Layouts are not supported in Pyodide
+  if (isPyodide()) {
+    return null;
+  }
 
   return (
     <Select

--- a/frontend/src/core/App.tsx
+++ b/frontend/src/core/App.tsx
@@ -48,8 +48,8 @@ import { CellId, HTMLCellId } from "./cells/ids";
 import { CellArray } from "../components/editor/renderers/CellArray";
 import { RuntimeState } from "./kernel/RuntimeState";
 import { CellsRenderer } from "../components/editor/renderers/cells-renderer";
-import { getSerializedLayout } from "./layout/layout";
-import { useAtom } from "jotai";
+import { getSerializedLayout, layoutDataAtom } from "./layout/layout";
+import { useAtom, useAtomValue } from "jotai";
 import { useRunStaleCells } from "../components/editor/cell/useRunCells";
 import { formatAll } from "./codemirror/format";
 import { cn } from "@/utils/cn";
@@ -69,6 +69,7 @@ export const App: React.FC<AppProps> = ({ userConfig, appConfig }) => {
   const [filename, setFilename] = useFilename();
   const [lastSavedNotebook, setLastSavedNotebook] =
     useState<LastSavedNotebook>();
+  const layoutData = useAtomValue(layoutDataAtom);
   const { openModal, closeModal, openAlert } = useImperativeModal();
 
   const isEditing = viewState.mode === "edit";
@@ -91,12 +92,12 @@ export const App: React.FC<AppProps> = ({ userConfig, appConfig }) => {
   const { connStatus } = useMarimoWebSocket({
     autoInstantiate:
       userConfig.runtime.auto_instantiate || viewState.mode === "read",
-    setCells: (cells) => {
+    setCells: (cells, layout) => {
       setCells(cells);
       const names = cells.map((cell) => cell.name);
       const codes = cells.map((cell) => cell.code);
       const configs = cells.map((cell) => cell.config);
-      setLastSavedNotebook({ names, codes, configs });
+      setLastSavedNotebook({ names, codes, configs, layout });
     },
     sessionId: getSessionId(),
   });
@@ -125,7 +126,7 @@ export const App: React.FC<AppProps> = ({ userConfig, appConfig }) => {
   const codes = cells.map((cell) => cell.code);
   const cellNames = cells.map((cell) => cell.name);
   const configs = cells.map((cell) => cell.config);
-  const needsSave = notebookNeedsSave(notebook, lastSavedNotebook);
+  const needsSave = notebookNeedsSave(notebook, layoutData, lastSavedNotebook);
 
   // Save the notebook with the given filename
   const saveNotebook = useEvent((filename: string, userInitiated: boolean) => {
@@ -161,7 +162,12 @@ export const App: React.FC<AppProps> = ({ userConfig, appConfig }) => {
             formatAll(updateCellCode);
           }
         }
-        setLastSavedNotebook({ names: cellNames, codes, configs });
+        setLastSavedNotebook({
+          names: cellNames,
+          codes,
+          configs,
+          layout: layoutData,
+        });
       })
       .catch((error) => {
         openAlert(error.message);

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -32,6 +32,8 @@ import { CellLog, getCellLogsForMessage } from "./logs";
 import { deserializeBase64ToJson } from "@/utils/json/base64";
 import { historyField } from "@codemirror/commands";
 import { clamp } from "@/utils/math";
+import { LayoutData } from "../layout/layout";
+import { isEqual } from "lodash-es";
 
 /**
  * The state of the notebook.
@@ -76,6 +78,7 @@ export interface LastSavedNotebook {
   codes: string[];
   configs: CellConfig[];
   names: string[];
+  layout: LayoutData;
 }
 
 /**
@@ -595,7 +598,7 @@ function updateCellData(
 
 /// ATOMS
 
-const notebookAtom = atom<NotebookState>(initialNotebookState());
+export const notebookAtom = atom<NotebookState>(initialNotebookState());
 
 const cellIdsAtom = atom((get) => get(notebookAtom).cellIds);
 
@@ -723,6 +726,7 @@ export function notebookIsRunning(state: NotebookState) {
 
 export function notebookNeedsSave(
   state: NotebookState,
+  layout: LayoutData,
   lastSavedNotebook: LastSavedNotebook | undefined,
 ) {
   if (!lastSavedNotebook) {
@@ -736,7 +740,8 @@ export function notebookNeedsSave(
   return (
     !arrayShallowEquals(codes, lastSavedNotebook.codes) ||
     !arrayShallowEquals(configs, lastSavedNotebook.configs) ||
-    !arrayShallowEquals(names, lastSavedNotebook.names)
+    !arrayShallowEquals(names, lastSavedNotebook.names) ||
+    !isEqual(layout, lastSavedNotebook.layout)
   );
 }
 

--- a/frontend/src/core/layout/layout.ts
+++ b/frontend/src/core/layout/layout.ts
@@ -7,6 +7,8 @@ import { atom } from "jotai";
 import { getNotebook, notebookCells } from "../cells/cells";
 import { store } from "../state/jotai";
 
+export type LayoutData = GridLayout | undefined;
+
 /**
  * The currently selected layout type to show.
  */
@@ -15,7 +17,7 @@ export const layoutViewAtom = atom<LayoutType>("vertical");
 /**
  * The layout data
  */
-export const layoutDataAtom = atom<GridLayout | undefined>(undefined);
+export const layoutDataAtom = atom<LayoutData>(undefined);
 
 /**
  * Get the serialized layout data, to be used when saving.

--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -14,7 +14,7 @@ import { CellData } from "../cells/types";
 import { createCell } from "../cells/types";
 import { useErrorBoundary } from "react-error-boundary";
 import { Logger } from "@/utils/Logger";
-import { layoutDataAtom, layoutViewAtom } from "../layout/layout";
+import { LayoutData, layoutDataAtom, layoutViewAtom } from "../layout/layout";
 import { deserializeLayout } from "@/components/editor/renderers/plugins";
 import { useVariablesActions } from "../variables/state";
 import { toast } from "@/components/ui/use-toast";
@@ -36,7 +36,7 @@ import { generateUUID } from "@/utils/uuid";
 export function useMarimoWebSocket(opts: {
   sessionId: SessionId;
   autoInstantiate: boolean;
-  setCells: (cells: CellData[]) => void;
+  setCells: (cells: CellData[], layout: LayoutData) => void;
 }) {
   // Track whether we want to try reconnecting.
   const shouldTryReconnecting = useRef<boolean>(true);
@@ -94,11 +94,13 @@ export function useMarimoWebSocket(opts: {
           });
         });
 
+        let layoutData: LayoutData = undefined;
         if (layout) {
           setLayoutView(layout.type);
-          setLayoutData(deserializeLayout(layout.type, layout.data, cells));
+          layoutData = deserializeLayout(layout.type, layout.data, cells);
+          setLayoutData(layoutData);
         }
-        setCells(cells);
+        setCells(cells, layoutData);
 
         // If resumed, we don't need to instantiate the UI elements,
         // and we should read in th existing values from the kernel.


### PR DESCRIPTION
Fix: 
1) Fix scrolling in grid when bordered=true
2) Fix auto-save indicator when layout has changed
3) Hide layouts in pyodide (we don't support it when shared)