### PR TITLE
fix: remove multiprocessing mock for WASM

### DIFF
--- a/frontend/src/core/pyodide/worker/bootstrap.ts
+++ b/frontend/src/core/pyodide/worker/bootstrap.ts
@@ -31,20 +31,9 @@ export async function bootstrap() {
   const marimoWheel =
     process.env.NODE_ENV === "production"
       ? "marimo >= 0.2.5"
-      : "http://localhost:8000/dist/marimo-0.2.8-py3-none-any.whl";
+      : "http://localhost:8000/dist/marimo-0.2.9-py3-none-any.whl";
   await pyodide.runPythonAsync(`
     import micropip
-
-    micropip.add_mock_package("multiprocessing", "*", modules={
-      "multiprocessing": None,
-      "multiprocessing.connection": None,
-      "multiprocessing.context": None,
-      "multiprocessing.managers": None,
-      "multiprocessing.pool": None,
-      "multiprocessing.sharedctypes": None,
-      "multiprocessing.shared_memory": None,
-      "multiprocessing.spawn": None,
-    })
 
     await micropip.install(
       [

--- a/marimo/_runtime/virtual_file.py
+++ b/marimo/_runtime/virtual_file.py
@@ -9,7 +9,6 @@ import string
 import sys
 import threading
 from collections.abc import Iterable
-from multiprocessing import shared_memory
 from typing import TYPE_CHECKING, Optional, cast
 
 from marimo import _loggers
@@ -21,6 +20,10 @@ if TYPE_CHECKING:
     from marimo._runtime.context import RuntimeContext
 
 LOGGER = _loggers.marimo_logger()
+
+if "pyodide" not in sys.modules:
+    # the shared_memory module is not supported in the Pyodide distribution
+    from multiprocessing import shared_memory
 
 
 _ALPHABET = string.ascii_letters + string.digits


### PR DESCRIPTION
This change removes the multiprocessing mock in order to extend compatibility to packages that import multiprocessing but don't use offending features. In particular, with this fix it is now possible to import `sklearn` in WASM notebooks.

Of the modules that were previously mocked, the only one that actually fails to be imported under pyodide is `shared_memory`. Instead of mocking this module, this PR updates our runtime code to just not import this module when running under Pyodide.