### PR TITLE
fix: wait to render before downloading png

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -115,13 +115,24 @@ export function useNotebookActions() {
           icon: <ImageIcon size={14} strokeWidth={1.5} />,
           label: "Download as PNG",
           handle: async () => {
+            const toasted = toast({
+              title: "Starting download",
+              description: "Downloading as PNG...",
+            });
+
             await runDuringPresentMode(async () => {
               const app = document.getElementById("App");
               if (!app) {
                 return;
               }
+
+              // Wait 2 seconds for the app to render
+              await new Promise((resolve) => setTimeout(resolve, 2000));
+
               await downloadHTMLAsImage(app, filename || "screenshot.png");
             });
+
+            toasted.dismiss();
           },
         },
         {


### PR DESCRIPTION
We now wait 2 seconds before downloading. In future we can make this more robust and checking for loading indicators, but this is a sufficient quick fix now.

Closes https://github.com/marimo-team/marimo/issues/861