### PR TITLE
fix: opening notebooks from the UI

### DIFF
--- a/frontend/src/components/editor/file-tree/file-explorer.tsx
+++ b/frontend/src/components/editor/file-tree/file-explorer.tsx
@@ -163,10 +163,10 @@ const Show = ({ node }: { node: NodeApi<FileInfo> }) => {
     <span
       className="flex-1"
       onClick={(e) => {
-        e.stopPropagation();
         if (node.data.isDirectory) {
           return;
         }
+        e.stopPropagation();
         node.select();
       }}
     >

--- a/marimo/_server/file_manager.py
+++ b/marimo/_server/file_manager.py
@@ -21,7 +21,6 @@ LOGGER = _loggers.marimo_logger()
 class AppFileManager:
     def __init__(self, filename: Optional[str]) -> None:
         self.filename = filename
-        self.path = self._get_file_path(filename)
         self.app = self._load_app(self.path)
 
     @staticmethod
@@ -111,14 +110,13 @@ class AppFileManager:
             self._create_file(new_filename)
 
         self.filename = new_filename
-        self.path = self._get_file_path(new_filename)
 
-    @staticmethod
-    def _get_file_path(filename: Optional[str]) -> Optional[str]:
-        if filename is None:
+    @property
+    def path(self) -> Optional[str]:
+        if self.filename is None:
             return None
         try:
-            return os.path.abspath(filename)
+            return os.path.abspath(self.filename)
         except AttributeError:
             return None
 

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -396,7 +396,6 @@ class SessionManager:
         lsp_server: LspServer,
     ) -> None:
         self.filename = filename
-        self.path = self._get_file_path(filename)
         self.mode = mode
         self.development_mode = development_mode
         self.quiet = quiet
@@ -439,7 +438,7 @@ class SessionManager:
         or opened another file.
         """
         self.filename = filename
-        self.app_metadata.filename = self._get_file_path(filename)
+        self.app_metadata.filename = self.path
 
     def create_session(
         self, session_id: SessionId, session_consumer: SessionConsumer
@@ -507,12 +506,12 @@ class SessionManager:
         )
         return None
 
-    @staticmethod
-    def _get_file_path(filename: Optional[str]) -> Optional[str]:
-        if filename is None:
+    @property
+    def path(self) -> Optional[str]:
+        if self.filename is None:
             return None
         try:
-            return os.path.abspath(filename)
+            return os.path.abspath(self.filename)
         except AttributeError:
             return None
 


### PR DESCRIPTION
We had multiple sources of truth for `filename` and `path`, and renaming the filename got `SessionManager` out of state. this makes `path` a computer property based on `filename`