### PR TITLE
improvement: flush sync in wasm instead of async

### DIFF
--- a/frontend/src/core/pyodide/worker/message-buffer.ts
+++ b/frontend/src/core/pyodide/worker/message-buffer.ts
@@ -1,0 +1,32 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+/**
+ * A buffer for messages that are received before the worker is ready to process them.
+ * Once the worker is ready, the buffer is flushed.
+ */
+export class MessageBuffer<T> {
+  private buffer: T[];
+  private started = false;
+
+  constructor(private onMessage: (data: T) => void) {
+    this.buffer = [];
+  }
+
+  push = (data: T) => {
+    if (this.started) {
+      this.onMessage(data);
+    } else {
+      this.buffer.push(data);
+    }
+  };
+
+  /**
+   * Start processing messages
+   */
+  start = () => {
+    this.started = true;
+    // Flush the buffer
+    this.buffer.forEach((data) => this.onMessage(data));
+    this.buffer = [];
+  };
+}

--- a/frontend/src/core/pyodide/worker/types.ts
+++ b/frontend/src/core/pyodide/worker/types.ts
@@ -38,7 +38,6 @@ export interface RawBridge {
   ): Promise<FileOperationResponse>;
   load_packages(request: string): Promise<string>;
   read_file(request: string): Promise<string>;
-  [Symbol.asyncIterator](): AsyncIterator<string>;
 }
 
 export type SerializedBridge = {

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -227,7 +227,11 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
                 vega_spec["autosize"] = "fit-x"
 
         # Selection for binned charts is not yet implemented
-        if _has_binning(vega_spec):
+        has_chart_selection = chart_selection is not False
+        has_legend_selection = legend_selection is not False
+        if _has_binning(vega_spec) and (
+            has_chart_selection or has_legend_selection
+        ):
             sys.stderr.write(
                 "Binning + selection is not yet supported in "
                 "marimo.ui.chart.\n"

--- a/marimo/_pyodide/streams.py
+++ b/marimo/_pyodide/streams.py
@@ -157,7 +157,7 @@ class PyodideStdin(Stdin):
         CellOp(
             cell_id=self.stream.cell_id,
             console=CellOutput(
-                channel=CellChannel.STDERR,
+                channel=CellChannel.STDIN,
                 mimetype="text/plain",
                 data=prompt,
             ),


### PR DESCRIPTION
Pass down a message callback to flush sync instead of using async-iterators + queue to handle a message. This is actually a simpler implementation, but provides the benefit that std out and stream outputs appear right away instead of at the end of the cell's code. 