### PR TITLE
fix: clear serializedEditorState after used

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -83,6 +83,7 @@ export interface CellProps
       | "moveCell"
       | "moveToNextCell"
       | "updateCellConfig"
+      | "clearSerializedEditorState"
       | "setStdinResponse"
       | "sendToBottom"
       | "sendToTop"
@@ -131,6 +132,7 @@ const CellComponent = (
     setStdinResponse,
     moveToNextCell,
     updateCellConfig,
+    clearSerializedEditorState,
     sendToBottom,
     sendToTop,
     userConfig,
@@ -407,6 +409,7 @@ const CellComponent = (
             moveCell={moveCell}
             moveToNextCell={moveToNextCell}
             updateCellConfig={updateCellConfig}
+            clearSerializedEditorState={clearSerializedEditorState}
             userConfig={userConfig}
             editorViewRef={editorView}
             hidden={cellConfig.hide_code}

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -41,6 +41,7 @@ export interface CellEditorProps
       | "moveCell"
       | "moveToNextCell"
       | "updateCellConfig"
+      | "clearSerializedEditorState"
     > {
   runCell: () => void;
   theme: Theme;
@@ -73,6 +74,7 @@ const CellEditorInternal = ({
   moveCell,
   moveToNextCell,
   updateCellConfig,
+  clearSerializedEditorState,
   userConfig,
   editorViewRef,
   hidden,
@@ -211,6 +213,8 @@ const CellEditorInternal = ({
         ),
       });
       shouldFocus = true;
+      // Clear the serialized state so that we don't re-create the editor next time
+      clearSerializedEditorState({ cellId });
     }
 
     if (
@@ -254,6 +258,7 @@ const CellEditorInternal = ({
     handleDelete,
     runCell,
     serializedEditorState,
+    clearSerializedEditorState,
   ]);
 
   useLayoutEffect(() => {

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -45,6 +45,7 @@ export const CellArray: React.FC<CellArrayProps> = ({
     moveCell,
     moveToNextCell,
     updateCellConfig,
+    clearSerializedEditorState,
     focusCell,
     createNewCell,
     focusBottomCell,
@@ -124,6 +125,7 @@ export const CellArray: React.FC<CellArrayProps> = ({
           moveToNextCell={moveToNextCell}
           setStdinResponse={setStdinResponse}
           updateCellConfig={updateCellConfig}
+          clearSerializedEditorState={clearSerializedEditorState}
           moveCell={moveCell}
           mode={mode}
           appClosed={connStatus.state !== WebSocketState.OPEN}

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -316,6 +316,15 @@ const { reducer, createActions } = createReducer(initialNotebookState, {
       };
     }
   },
+  clearSerializedEditorState: (state, action: { cellId: CellId }) => {
+    const { cellId } = action;
+    return updateCellData(state, cellId, (cell) => {
+      return {
+        ...cell,
+        serializedEditorState: null,
+      };
+    });
+  },
   updateCellCode: (
     state,
     action: {

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -47,6 +47,7 @@ const props: CellProps = {
   sendToTop: Logger.log,
   updateCellConfig: Logger.log,
   setStdinResponse: Logger.log,
+  clearSerializedEditorState: Logger.log,
   config: {},
   userConfig: {
     completion: {


### PR DESCRIPTION
If you delete a cell and bring it back, we hydrate it with its old `serializedEditorState`. But if the cell unmount/remounts, we re-do that even if the cell's code changed. This clears the `serializedEditorState` after consuming it. 