### PR TITLE
fix: register_transformers when altair is imported

### DIFF
--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -17,6 +17,12 @@ class AltairFormatter(FormatterFactory):
         import altair  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
 
         from marimo._output import formatting
+        from marimo._plugins.ui._impl.charts.altair_transformer import (
+            register_transformers,
+        )
+
+        # add marimo transformers
+        register_transformers()
 
         @formatting.formatter(altair.TopLevelMixin)
         def _show_chart(chart: altair.Chart) -> tuple[KnownMimeType, str]:

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -18,9 +18,6 @@ from marimo import _loggers
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
-from marimo._plugins.ui._impl.charts.altair_transformer import (
-    register_transformers,
-)
 from marimo._utils import flatten
 
 LOGGER = _loggers.marimo_logger()
@@ -195,9 +192,6 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
         DependencyManager.require_altair(why="to use `mo.ui.altair_chart`")
 
         import altair as alt
-
-        # TODO: is this the right place to register the transformers?
-        register_transformers()
 
         if not isinstance(chart, (alt.TopLevelMixin)):
             raise ValueError(

--- a/marimo/_smoke_tests/bugs/877.py
+++ b/marimo/_smoke_tests/bugs/877.py
@@ -1,0 +1,16 @@
+import marimo
+
+__generated_with = "0.2.12"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import altair as alt
+
+    alt.data_transformers.enable("marimo_csv")
+    return alt,
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #877

This allows you to still use the transformers even without `mo.ui.altair_chart`