### PR TITLE
fix: don't parse floats as BigInts

### DIFF
--- a/frontend/src/plugins/impl/vega/loader.ts
+++ b/frontend/src/plugins/impl/vega/loader.ts
@@ -12,7 +12,18 @@ const bigIntIntegerParser = (v: string) => {
   if (v === "") {
     return "";
   }
-  return isNumber(Number.parseInt(v)) ? BigInt(v) : "";
+
+  if (isNumber(Number.parseInt(v))) {
+    try {
+      return BigInt(v);
+    } catch {
+      // Floats like 2.0 are parseable as ints but not
+      // as BigInt
+      return previousIntegerParser(v);
+    }
+  } else {
+    return "";
+  }
 };
 
 function enableBigInt() {

--- a/marimo/_smoke_tests/bugs/881.py
+++ b/marimo/_smoke_tests/bugs/881.py
@@ -1,0 +1,17 @@
+import marimo
+
+__generated_with = "0.2.12"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import pandas as pd
+    import marimo as mo
+    df = pd.DataFrame({"data": [2.0]})
+    mo.ui.table(df)
+    return df, mo, pd
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes an edge case in which numbers like `2.0` were being parsed as BigInts in `ui.table`, and then failing

Fixes #881 