### PR TITLE
remove margin left from controls in user/app config forms

### DIFF
--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -69,7 +69,7 @@ export const AppConfigForm: React.FC = () => {
                   onChange={(e) => field.onChange(e.target.value)}
                   value={field.value}
                   disabled={field.disabled}
-                  className="inline-flex mx-2"
+                  className="inline-flex mr-2"
                 >
                   {APP_WIDTHS.map((option) => (
                     <option value={option} key={option}>

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -86,7 +86,7 @@ export const UserConfigForm: React.FC = () => {
               <FormItem className="mb-2">
                 <FormLabel>Autosave delay (seconds)</FormLabel>
                 <FormControl>
-                  <span className="inline-flex mx-2">
+                  <span className="inline-flex mr-2">
                     <Input
                       type="number"
                       className="m-0 w-20 inline-flex"
@@ -137,7 +137,7 @@ export const UserConfigForm: React.FC = () => {
                   Maximum line length when formatting code.
                 </FormDescription>
                 <FormControl>
-                  <span className="inline-flex mx-2">
+                  <span className="inline-flex mr-2">
                     <Input
                       type="number"
                       className="m-0 w-20 inline-flex"
@@ -188,7 +188,7 @@ export const UserConfigForm: React.FC = () => {
                     onChange={(e) => field.onChange(e.target.value)}
                     value={field.value}
                     disabled={field.disabled}
-                    className="inline-flex mx-2"
+                    className="inline-flex mr-2"
                   >
                     {KEYMAP_PRESETS.map((option) => (
                       <option value={option} key={option}>
@@ -215,7 +215,7 @@ export const UserConfigForm: React.FC = () => {
                     onChange={(e) => field.onChange(e.target.value)}
                     value={field.value}
                     disabled={field.disabled}
-                    className="inline-flex mx-2"
+                    className="inline-flex mr-2"
                   >
                     {THEMES.map((option) => (
                       <option value={option} key={option}>
@@ -235,7 +235,7 @@ export const UserConfigForm: React.FC = () => {
               <FormItem className="mb-2">
                 <FormLabel>Code editor font size</FormLabel>
                 <FormControl>
-                  <span className="inline-flex mx-2">
+                  <span className="inline-flex mr-2">
                     <Input
                       type="number"
                       className="m-0 w-20 inline-flex"
@@ -266,7 +266,7 @@ export const UserConfigForm: React.FC = () => {
                     onChange={(e) => field.onChange(e.target.value)}
                     value={field.value}
                     disabled={field.disabled}
-                    className="inline-flex mx-2"
+                    className="inline-flex mr-2"
                   >
                     {["above", "below"].map((option) => (
                       <option value={option} key={option}>


### PR DESCRIPTION
This makes the config forms more legible

<img width="329" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/ccce285d-d9b9-4491-ab7b-2b0c6e18011e">
