### PR TITLE
Disable touch in carousel for UI element compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,6 +81,9 @@ jobs:
             python-version: "3.9"
             dependencies: "core"
           - os: ubuntu-latest
+            python-version: "3.10"
+            dependencies: "core"
+          - os: ubuntu-latest
             python-version: "3.11"
             dependencies: "core"
           - os: ubuntu-latest
@@ -88,6 +91,9 @@ jobs:
             dependencies: "core"
           - os: ubuntu-latest
             python-version: "3.9"
+            dependencies: "core,optional"
+          - os: ubuntu-latest
+            python-version: "3.10"
             dependencies: "core,optional"
           - os: ubuntu-latest
             python-version: "3.11"

--- a/frontend/src/plugins/layout/CarouselPlugin.tsx
+++ b/frontend/src/plugins/layout/CarouselPlugin.tsx
@@ -74,7 +74,8 @@ const CarouselComponent = ({
       zoom={{
         maxRatio: 5,
       }}
-      simulateTouch={true}
+      // touch controls interfere with UI elements
+      simulateTouch={false}
       keyboard={{
         enabled: true,
         onlyInViewport: true,


### PR DESCRIPTION
When touch-to-swipe was active, trying to scrub a slider ended up changing the slide instead