### PR TITLE
fix: safari overflow on hover

### DIFF
--- a/frontend/src/components/editor/cell/code/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/cell/code/ai-completion-editor.tsx
@@ -84,7 +84,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
   ];
 
   return (
-    <div className="flex flex-col w-full rounded-[inherit]">
+    <div className="flex flex-col w-full rounded-[inherit] overflow-hidden">
       <div
         className={cn(
           "flex items-center gap-2 border-b px-3 transition-[height] rounded-[inherit] rounded-b-none duration-300 overflow-hidden",


### PR DESCRIPTION
Webkit has a weird bug that some hidden text is being shown again on hover. this just adds another layer of overflow prevention