### PR TITLE
fix: pyodide interrupts

### DIFF
--- a/frontend/src/core/pyodide/bridge.ts
+++ b/frontend/src/core/pyodide/bridge.ts
@@ -69,6 +69,8 @@ export class PyodideBridge implements RunRequests, EditRequests {
   constructor() {
     if (isPyodide()) {
       this.worker = new InlineWorker();
+      console.log("ISOLATED?");
+      console.log(crossOriginIsolated);
       this.worker.onmessage = this.handleWorkerMessage;
     }
   }

--- a/frontend/src/core/pyodide/worker/bootstrap.ts
+++ b/frontend/src/core/pyodide/worker/bootstrap.ts
@@ -16,6 +16,8 @@ export async function bootstrap() {
     throw new Error("loadPyodide is not defined");
   }
 
+  console.log("BOOTSTRAP, CONTEXT ISOLATED?");
+  console.log(crossOriginIsolated);
   // Load pyodide and packages
   const pyodide = await loadPyodide({
     // Perf: These get loaded while pyodide is being bootstrapped
@@ -56,7 +58,7 @@ export async function startSession(
     fallbackCode: string;
     filename: string | null;
   },
-  messageCallback: (data: string) => void,
+  messageCallback: (data: string) => void
 ): Promise<SerializedBridge> {
   // Set up the filesystem
   const { filename, content } = await mountFilesystem({ pyodide, ...opts });
@@ -88,7 +90,7 @@ export async function startSession(
       instantiate(session)
       asyncio.create_task(session.start())
 
-      bridge`,
+      bridge`
   );
 
   self.bridge = bridge;

--- a/frontend/src/core/pyodide/worker/bootstrap.ts
+++ b/frontend/src/core/pyodide/worker/bootstrap.ts
@@ -16,8 +16,6 @@ export async function bootstrap() {
     throw new Error("loadPyodide is not defined");
   }
 
-  console.log("BOOTSTRAP, CONTEXT ISOLATED?");
-  console.log(crossOriginIsolated);
   // Load pyodide and packages
   const pyodide = await loadPyodide({
     // Perf: These get loaded while pyodide is being bootstrapped
@@ -58,7 +56,7 @@ export async function startSession(
     fallbackCode: string;
     filename: string | null;
   },
-  messageCallback: (data: string) => void
+  messageCallback: (data: string) => void,
 ): Promise<SerializedBridge> {
   // Set up the filesystem
   const { filename, content } = await mountFilesystem({ pyodide, ...opts });
@@ -90,7 +88,7 @@ export async function startSession(
       instantiate(session)
       asyncio.create_task(session.start())
 
-      bridge`
+      bridge`,
   );
 
   self.bridge = bridge;

--- a/frontend/src/core/pyodide/worker/types.ts
+++ b/frontend/src/core/pyodide/worker/types.ts
@@ -18,7 +18,7 @@ import type {
 export interface RawBridge {
   put_control_request(operation: object): Promise<string>;
   put_input(input: string): Promise<string>;
-  interrupt(): Promise<string>;
+  interrupt(buffer: Uint8Array): Promise<string>;
   code_complete(request: CodeCompletionRequest): Promise<string>;
   read_code(): Promise<{ contents: string }>;
   format(request: FormatRequest): Promise<FormatResponse>;

--- a/frontend/src/core/pyodide/worker/types.ts
+++ b/frontend/src/core/pyodide/worker/types.ts
@@ -38,6 +38,7 @@ export interface RawBridge {
   ): Promise<FileOperationResponse>;
   load_packages(request: string): Promise<string>;
   read_file(request: string): Promise<string>;
+  set_interrupt_buffer(request: Uint8Array): Promise<string>;
 }
 
 export type SerializedBridge = {

--- a/frontend/src/core/pyodide/worker/worker.ts
+++ b/frontend/src/core/pyodide/worker/worker.ts
@@ -25,7 +25,7 @@ async function loadPyodideAndPackages() {
 }
 const pyodideReadyPromise = loadPyodideAndPackages();
 const messageBuffer = new MessageBuffer((m: string) =>
-  postMessage({ type: "message", message: m }),
+  postMessage({ type: "message", message: m })
 );
 
 // Initialize the session
@@ -73,7 +73,7 @@ self.onmessage = async (event: MessageEvent<WorkerServerPayload>) => {
     if (functionName === "load_packages") {
       invariant(
         typeof payload === "string",
-        "Expected a string payload for load_packages",
+        "Expected a string payload for load_packages"
       );
       await self.pyodide.loadPackagesFromImports(payload, {
         messageCallback: console.log,
@@ -87,10 +87,21 @@ self.onmessage = async (event: MessageEvent<WorkerServerPayload>) => {
     if (functionName === "read_file") {
       invariant(
         typeof payload === "string",
-        "Expected a string payload for read_file",
+        "Expected a string payload for read_file"
       );
       const file = self.pyodide.FS.readFile(payload, { encoding: "utf8" });
       postMessage({ type: "response", response: file, id });
+      return;
+    }
+    // Special case for interrupting kernel execution
+    if (functionName == "interrupt") {
+      invariant(
+        payload instanceof Uint8Array,
+        "Expected a Uint8Array payload for interrupt"
+      );
+      console.log("Setting interrupt buffer");
+      self.pyodide.setInterruptBuffer(payload);
+      postMessage({ type: "response", response: null, id });
       return;
     }
     // Special case to lazily install black on format

--- a/frontend/src/core/pyodide/worker/worker.ts
+++ b/frontend/src/core/pyodide/worker/worker.ts
@@ -25,7 +25,7 @@ async function loadPyodideAndPackages() {
 }
 const pyodideReadyPromise = loadPyodideAndPackages();
 const messageBuffer = new MessageBuffer((m: string) =>
-  postMessage({ type: "message", message: m })
+  postMessage({ type: "message", message: m }),
 );
 
 // Initialize the session
@@ -73,7 +73,7 @@ self.onmessage = async (event: MessageEvent<WorkerServerPayload>) => {
     if (functionName === "load_packages") {
       invariant(
         typeof payload === "string",
-        "Expected a string payload for load_packages"
+        "Expected a string payload for load_packages",
       );
       await self.pyodide.loadPackagesFromImports(payload, {
         messageCallback: console.log,
@@ -87,17 +87,18 @@ self.onmessage = async (event: MessageEvent<WorkerServerPayload>) => {
     if (functionName === "read_file") {
       invariant(
         typeof payload === "string",
-        "Expected a string payload for read_file"
+        "Expected a string payload for read_file",
       );
       const file = self.pyodide.FS.readFile(payload, { encoding: "utf8" });
       postMessage({ type: "response", response: file, id });
       return;
     }
-    // Special case for interrupting kernel execution
-    if (functionName == "interrupt") {
+
+    // Special case for installing the interrupt buffer
+    if (functionName == "set_interrupt_buffer") {
       invariant(
         payload instanceof Uint8Array,
-        "Expected a Uint8Array payload for interrupt"
+        "Expected a Uint8Array payload for interrupt",
       );
       console.log("Setting interrupt buffer");
       self.pyodide.setInterruptBuffer(payload);

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -100,6 +100,10 @@ export default defineConfig({
         },
       },
     },
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
   },
   resolve: {
     dedupe: ["react", "react-dom", "@emotion/react", "@emotion/cache"],

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import json
+import signal
 from typing import Any, Callable, Optional
 
 from marimo import _loggers
@@ -16,7 +17,7 @@ from marimo._pyodide.streams import (
     PyodideStdout,
     PyodideStream,
 )
-from marimo._runtime import requests
+from marimo._runtime import handlers, requests
 from marimo._runtime.context import initialize_context
 from marimo._runtime.input_override import input_override
 from marimo._runtime.requests import (
@@ -319,6 +320,7 @@ def launch_pyodide_kernel(
         stream=stream,
         virtual_files_supported=False,
     )
+    signal.signal(signal.SIGINT, handlers.construct_interrupt_handler(kernel))
 
     if is_edit_mode:
         from marimo._output.formatters.formatters import register_formatters

--- a/marimo/_runtime/handlers.py
+++ b/marimo/_runtime/handlers.py
@@ -1,0 +1,75 @@
+# Copyright 2024 Marimo. All rights reserved.
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
+
+from marimo import _loggers
+from marimo._messaging.ops import Interrupted
+from marimo._runtime.context import get_context
+from marimo._runtime.control_flow import MarimoInterrupt
+
+LOGGER = _loggers.marimo_logger()
+
+if TYPE_CHECKING:
+    from marimo._runtime.runtime import Kernel
+
+
+def construct_interrupt_handler(
+    kernel: "Kernel",
+) -> Callable[[int, Any], None]:
+    def interrupt_handler(signum: int, frame: Any) -> None:
+        """Tries to interrupt the kernel."""
+        del signum
+        del frame
+
+        LOGGER.debug("Interrupt request received")
+        # TODO(akshayka): if kernel is in `run` but not executing,
+        # it won't be interrupted, which isn't right ... but the
+        # probability of that happening is low.
+        if kernel.execution_context is not None:
+            Interrupted().broadcast()
+            raise MarimoInterrupt
+
+    return interrupt_handler
+
+
+def construct_sigterm_handler(kernel: "Kernel") -> Callable[[int, Any], None]:
+    del kernel
+
+    @dataclass
+    class Bit:
+        value: bool = False
+
+    shutting_down = Bit()
+
+    def sigterm_handler(signum: int, frame: Any) -> None:
+        """Cleans up the kernel ands exit."""
+        del signum
+        del frame
+
+        if shutting_down.value:
+            # give previous SIGTERM a chance to quit ... makes
+            # sure this method is reentrant
+            return
+        shutting_down.value = True
+
+        get_context().virtual_file_registry.shutdown()
+        # Force this process to exit.
+        #
+        # We use os._exit() instead of sys.exit() because we don't want the
+        # child process to also run atexit handlers, which may result in
+        # undefined behavior. Using sys.exit() on Linux sometimes causes
+        # the parent process to hang on shutdown, leading to orphaned
+        # processes and port.
+        #
+        # TODO(akshayka): The Python docs say this method is appropriate
+        # for processes created with fork(), but they don't say anything
+        # about processes made with spawn. macOS and Windows default to
+        # spawn. If we have further issues with clean exits, we might
+        # investigate here.
+        #
+        # https://docs.python.org/3/library/os.html#os._exit
+        # https://www.unixguide.net/unix/programming/1.1.3.shtml
+        os._exit(0)
+
+    return sigterm_handler


### PR DESCRIPTION
This change gets interrupts working in WASM notebooks. The implementation uses `SharedArrayBuffer`, [as recommended by Pyodide](https://pyodide.org/en/stable/usage/keyboard-interrupts.html), which only works in secure contexts.

An example where interrupts now work:

```python
while True:
  ...
```

For some reason, `time.sleep()` cannot be interrupted -- this tripped me up for a while, because I thought my interruption implementation was incorrect.
