### PR TITLE
fix: content layouting of elements in <marimo-ui/>

### DIFF
--- a/frontend/e2e-tests/components.spec.ts
+++ b/frontend/e2e-tests/components.spec.ts
@@ -208,7 +208,7 @@ test("slider", async ({ page }) => {
   // Verify output
   await helper.verifyOutput("1");
   // Move slider
-  await element.dragTo(page.locator("marimo-slider"));
+  await element.dragTo(page.getByTestId("track"));
   // Verify output
   await helper.verifyOutput("6");
 
@@ -326,7 +326,7 @@ test("complex - array", async ({ page }) => {
   await expect(date).toBeVisible();
   // Fill
   await textbox.fill("hi marimo");
-  await slider.dragTo(page.locator("marimo-slider").first());
+  await slider.dragTo(page.getByTestId("track").first());
   await date.fill("2020-01-20");
   // Verify output
   await expect(

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -31,6 +31,7 @@ const Slider = React.forwardRef<
       {...props}
     >
       <SliderPrimitive.Track
+        data-testid="track"
         className={cn(
           "relative grow overflow-hidden rounded-full bg-slate-200 dark:bg-accent/60",
           "data-[orientation=horizontal]:h-2 data-[orientation=horizontal]:w-full",
@@ -38,6 +39,7 @@ const Slider = React.forwardRef<
         )}
       >
         <SliderPrimitive.Range
+          data-testid="range"
           className={cn(
             "absolute bg-blue-500 dark:bg-primary",
             "data-[orientation=horizontal]:h-full",
@@ -49,6 +51,7 @@ const Slider = React.forwardRef<
         <TooltipRoot delayDuration={0} open={open}>
           <TooltipTrigger asChild={true}>
             <SliderPrimitive.Thumb
+              data-testid="thumb"
               className="block h-4 w-4 rounded-full shadow-xsSolid border border-blue-500 dark:border-primary dark:bg-accent bg-white hover:bg-blue-300 focus:bg-blue-300 transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
               onFocus={openActions.setTrue}
               onBlur={openActions.setFalse}

--- a/frontend/src/core/dom/UIElement.ts
+++ b/frontend/src/core/dom/UIElement.ts
@@ -7,6 +7,8 @@ import { defineCustomElement } from "./defineCustomElement";
 import { MarimoValueInputEventType, marimoValueInputEvent } from "./events";
 import { UI_ELEMENT_REGISTRY } from "./uiregistry";
 
+import "./ui-element.css";
+
 const UI_ELEMENT_TAG_NAME = "MARIMO-UI-ELEMENT";
 
 interface IUIElement extends HTMLElement {

--- a/frontend/src/core/dom/ui-element.css
+++ b/frontend/src/core/dom/ui-element.css
@@ -1,0 +1,8 @@
+/* Both the `marimo-ui-element` and its child should be displayed as if they were not wrapped in a custom element. */
+marimo-ui-element {
+  display: contents;
+
+  > * {
+    display: contents;
+  }
+}


### PR DESCRIPTION
Add UI element CSS to marimo web components. these are used for logic and not styling. but in their current form, they are all display:block which can prevent the underlying component from rendering the way it wants