### PR TITLE
fix: render altair layered charts (dedupe selection params)

### DIFF
--- a/frontend/src/plugins/impl/vega/__tests__/__snapshots__/make-selectable.test.ts.snap
+++ b/frontend/src/plugins/impl/vega/__tests__/__snapshots__/make-selectable.test.ts.snap
@@ -517,10 +517,10 @@ exports[`makeSelectable > should work for multi-layered charts 1`] = `
             "test": {
               "and": [
                 {
-                  "param": "select_point",
+                  "param": "select_point_1",
                 },
                 {
-                  "param": "select_interval",
+                  "param": "select_interval_1",
                 },
               ],
             },
@@ -542,7 +542,7 @@ exports[`makeSelectable > should work for multi-layered charts 1`] = `
       },
       "params": [
         {
-          "name": "select_point",
+          "name": "select_point_1",
           "select": {
             "encodings": [
               "x",
@@ -552,7 +552,7 @@ exports[`makeSelectable > should work for multi-layered charts 1`] = `
           },
         },
         {
-          "name": "select_interval",
+          "name": "select_interval_1",
           "select": {
             "encodings": [
               "x",
@@ -571,5 +571,135 @@ exports[`makeSelectable > should work for multi-layered charts 1`] = `
     },
   ],
   "width": "container",
+}
+`;
+
+exports[`makeSelectable > should work for multi-layered charts with different selections 1`] = `
+{
+  "layer": [
+    {
+      "encoding": {
+        "opacity": {
+          "condition": {
+            "test": {
+              "and": [
+                {
+                  "param": "select_point_0",
+                },
+                {
+                  "param": "select_interval_0",
+                },
+              ],
+            },
+            "value": 1,
+          },
+          "value": 0.2,
+        },
+        "x": {
+          "aggregate": "min",
+          "field": "temp_min",
+          "scale": {
+            "domain": [
+              -15,
+              45,
+            ],
+          },
+          "title": "Temperature (°C)",
+          "type": "quantitative",
+        },
+        "x2": {
+          "aggregate": "max",
+          "field": "temp_max",
+        },
+        "y": {
+          "field": "date",
+          "timeUnit": "month",
+          "title": null,
+          "type": "ordinal",
+        },
+      },
+      "mark": {
+        "cornerRadius": 10,
+        "cursor": "pointer",
+        "height": 10,
+        "tooltip": true,
+        "type": "bar",
+      },
+      "params": [
+        {
+          "name": "select_point_0",
+          "select": {
+            "encodings": [
+              "y",
+            ],
+            "type": "point",
+          },
+        },
+        {
+          "name": "select_interval_0",
+          "select": {
+            "encodings": [
+              "y",
+            ],
+            "mark": {
+              "fill": "#669EFF",
+              "fillOpacity": 0.07,
+              "stroke": "#669EFF",
+              "strokeOpacity": 0.4,
+            },
+            "type": "interval",
+          },
+        },
+      ],
+    },
+    {
+      "encoding": {
+        "text": {
+          "aggregate": "min",
+          "field": "temp_min",
+          "type": "quantitative",
+        },
+        "x": {
+          "aggregate": "min",
+          "field": "temp_min",
+          "type": "quantitative",
+        },
+        "y": {
+          "field": "date",
+          "timeUnit": "month",
+          "type": "ordinal",
+        },
+      },
+      "mark": {
+        "align": "right",
+        "dx": -5,
+        "type": "text",
+      },
+    },
+    {
+      "encoding": {
+        "text": {
+          "aggregate": "max",
+          "field": "temp_max",
+          "type": "quantitative",
+        },
+        "x": {
+          "aggregate": "max",
+          "field": "temp_max",
+          "type": "quantitative",
+        },
+        "y": {
+          "field": "date",
+          "timeUnit": "month",
+          "type": "ordinal",
+        },
+      },
+      "mark": {
+        "align": "left",
+        "dx": 5,
+        "type": "text",
+      },
+    },
+  ],
 }
 `;

--- a/frontend/src/plugins/impl/vega/__tests__/make-selectable.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/make-selectable.test.ts
@@ -287,8 +287,68 @@ describe("makeSelectable", () => {
     expect(newSpec).toMatchSnapshot();
 
     expect(getSelectionParamNames(newSpec)).toEqual([
-      "select_point",
-      "select_interval",
+      "select_point_1",
+      "select_interval_1",
+    ]);
+  });
+
+  it("should work for multi-layered charts with different selections", () => {
+    const spec = {
+      layer: [
+        {
+          mark: { type: "bar", cornerRadius: 10, height: 10 },
+          encoding: {
+            x: {
+              aggregate: "min",
+              field: "temp_min",
+              scale: { domain: [-15, 45] },
+              title: "Temperature (°C)",
+              type: "quantitative",
+            },
+            x2: { aggregate: "max", field: "temp_max" },
+            y: {
+              field: "date",
+              timeUnit: "month",
+              title: null,
+              type: "ordinal",
+            },
+          },
+        },
+        {
+          mark: { type: "text", align: "right", dx: -5 },
+          encoding: {
+            text: {
+              aggregate: "min",
+              field: "temp_min",
+              type: "quantitative",
+            },
+            x: { aggregate: "min", field: "temp_min", type: "quantitative" },
+            y: { field: "date", timeUnit: "month", type: "ordinal" },
+          },
+        },
+        {
+          mark: { type: "text", align: "left", dx: 5 },
+          encoding: {
+            text: {
+              aggregate: "max",
+              field: "temp_max",
+              type: "quantitative",
+            },
+            x: { aggregate: "max", field: "temp_max", type: "quantitative" },
+            y: { field: "date", timeUnit: "month", type: "ordinal" },
+          },
+        },
+      ],
+    } as VegaLiteSpec;
+
+    const newSpec = makeSelectable(spec, {
+      chartSelection: true,
+    });
+
+    expect(newSpec).toMatchSnapshot();
+    expect(getSelectionParamNames(newSpec)).toEqual([
+      "select_point_0",
+      "select_interval_0",
     ]);
   });
 });

--- a/frontend/src/plugins/impl/vega/params.ts
+++ b/frontend/src/plugins/impl/vega/params.ts
@@ -12,8 +12,15 @@ import { LayerSpec, UnitSpec } from "vega-lite/build/src/spec";
 import { uniq } from "lodash-es";
 
 const ParamNames = {
-  LEGEND_SELECTION: "legend_selection",
-  SELECT: "select",
+  point(layerNum: number | undefined) {
+    return layerNum == null ? "select_point" : `select_point_${layerNum}`;
+  },
+  interval(layerNum: number | undefined) {
+    return layerNum == null ? "select_interval" : `select_interval_${layerNum}`;
+  },
+  legendSelection(field: string) {
+    return `legend_selection_${field}`;
+  },
   HIGHLIGHT: "highlight",
 };
 
@@ -24,9 +31,12 @@ export const Params = {
       select: { type: "point", on: "mouseover" },
     };
   },
-  interval(spec: VegaLiteUnitSpec): SelectionParameter<"interval"> {
+  interval(
+    spec: VegaLiteUnitSpec,
+    layerNum: number | undefined,
+  ): SelectionParameter<"interval"> {
     return {
-      name: `${ParamNames.SELECT}_interval`,
+      name: ParamNames.interval(layerNum),
       select: {
         type: "interval",
         encodings: getEncodingAxisForMark(spec),
@@ -39,9 +49,12 @@ export const Params = {
       },
     };
   },
-  point(spec: VegaLiteUnitSpec): SelectionParameter<"point"> {
+  point(
+    spec: VegaLiteUnitSpec,
+    layerNum: number | undefined,
+  ): SelectionParameter<"point"> {
     return {
-      name: `${ParamNames.SELECT}_point`,
+      name: ParamNames.point(layerNum),
       select: {
         type: "point",
         encodings: getEncodingAxisForMark(spec),
@@ -50,7 +63,7 @@ export const Params = {
   },
   legend(field: string): SelectionParameter<"point"> {
     return {
-      name: `${ParamNames.LEGEND_SELECTION}_${field}`,
+      name: ParamNames.legendSelection(field),
       select: {
         type: "point",
         fields: [field],

--- a/marimo/_smoke_tests/bugs/altair-bug.py
+++ b/marimo/_smoke_tests/bugs/altair-bug.py
@@ -1,0 +1,84 @@
+import marimo
+
+__generated_with = "0.3.1"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import altair as alt
+    from vega_datasets import data
+    return alt, data, mo
+
+
+@app.cell
+def __(alt, data, mo):
+    source = data.seattle_weather()
+
+    bar = (
+        alt.Chart(source)
+        .mark_bar(cornerRadius=10, height=10)
+        .encode(
+            x=alt.X("min(temp_min):Q")
+            .scale(domain=[-15, 45])
+            .title("Temperature (°C)"),
+            x2="max(temp_max):Q",
+            y=alt.Y("month(date):O").title(None),
+        )
+    )
+
+    text_min = (
+        alt.Chart(source)
+        .mark_text(align="right", dx=-5)
+        .encode(
+            x="min(temp_min):Q", y=alt.Y("month(date):O"), text="min(temp_min):Q"
+        )
+    )
+
+    text_max = (
+        alt.Chart(source)
+        .mark_text(align="left", dx=5)
+        .encode(
+            x="max(temp_max):Q", y=alt.Y("month(date):O"), text="max(temp_max):Q"
+        )
+    )
+
+    _chart = (bar + text_min + text_max).properties(
+        title=alt.Title(
+            text="Temperature variation by month",
+            subtitle="Seatle weather, 2012-2015",
+        )
+    )
+    # Bug: chart_selection does not work when not false
+    # This is due to month(date) being an aggregatation that we cannot back out.
+    chart = mo.ui.altair_chart(_chart, chart_selection=False)
+    return bar, chart, source, text_max, text_min
+
+
+@app.cell
+def __(chart):
+    chart
+    return
+
+
+@app.cell
+def __(chart):
+    chart.selections
+    return
+
+
+@app.cell
+def __(chart):
+    chart.value
+    return
+
+
+@app.cell
+def __(chart):
+    chart.dataframe
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
This fixes a bug, but also uncovers another bug that is not fixed.

This fixes rendering layered charts with multiple selection. If there are multiple layers with multiple point selections, we would give the params the same name which would cause errors. We now dedupe them

This also uncovers that we don't support selection in `timeUnit` aggregations. so doing `month(date)` makes it hard for us to back into filter the date by a month. This is because `month(date)` is an binning function that altair performs on the frontend. but the backend does the filtering and does not have this transformation. 