### PR TITLE
fix: disable pdb patch in marimo run

### DIFF
--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -20,6 +20,7 @@ from marimo._pyodide.streams import (
 from marimo._runtime import handlers, requests
 from marimo._runtime.context import initialize_context
 from marimo._runtime.input_override import input_override
+from marimo._runtime.marimo_pdb import MarimoPdb
 from marimo._runtime.requests import (
     AppMetadata,
     CompletionRequest,
@@ -298,6 +299,7 @@ def launch_pyodide_kernel(
     stdout = PyodideStdout(stream)
     stderr = PyodideStderr(stream)
     stdin = PyodideStdin(stream) if is_edit_mode else None
+    debugger = MarimoPdb(stdout=stdout, stdin=stdin) if is_edit_mode else None
 
     kernel = Kernel(
         cell_configs=configs,
@@ -307,6 +309,7 @@ def launch_pyodide_kernel(
         stderr=stderr,
         stdin=stdin,
         input_override=input_override,
+        debugger_override=debugger,
     )
     initialize_context(
         kernel=kernel,

--- a/marimo/_runtime/cell_runner.py
+++ b/marimo/_runtime/cell_runner.py
@@ -48,7 +48,7 @@ class Runner:
         cell_ids: set[CellId_t],
         graph: dataflow.DirectedGraph,
         glbls: dict[Any, Any],
-        debugger: MarimoPdb,
+        debugger: MarimoPdb | None,
     ):
         self.graph = graph
         self.debugger = debugger
@@ -257,7 +257,8 @@ class Runner:
                 # Bdb defines the botframe attribute and sets it to non-None
                 # when it starts up
                 if (
-                    hasattr(self.debugger, "botframe")
+                    self.debugger is not None
+                    and hasattr(self.debugger, "botframe")
                     and self.debugger.botframe is not None
                 ):
                     self.debugger.set_continue()

--- a/marimo/_runtime/marimo_pdb.py
+++ b/marimo/_runtime/marimo_pdb.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import inspect
 import sys
-from pdb import Pdb
+from pdb import Pdb as OldPdb
 from types import FrameType
 
 from marimo import _loggers
@@ -12,7 +12,7 @@ from marimo._messaging.types import Stdin, Stdout
 LOGGER = _loggers.marimo_logger()
 
 
-class MarimoPdb(Pdb):
+class MarimoPdb(OldPdb):
     def __init__(self, stdout: Stdout | None, stdin: Stdin | None):
         super().__init__(stdout=stdout, stdin=stdin)  # type: ignore[arg-type]
         # it's fine to use input() since marimo overrides it, but disable

--- a/marimo/_runtime/marimo_pdb.py
+++ b/marimo/_runtime/marimo_pdb.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import inspect
 import sys
-from pdb import Pdb as OldPdb
+from pdb import Pdb
 from types import FrameType
 
 from marimo import _loggers
@@ -12,7 +12,7 @@ from marimo._messaging.types import Stdin, Stdout
 LOGGER = _loggers.marimo_logger()
 
 
-class MarimoPdb(OldPdb):
+class MarimoPdb(Pdb):
     def __init__(self, stdout: Stdout | None, stdin: Stdin | None):
         super().__init__(stdout=stdout, stdin=stdin)  # type: ignore[arg-type]
         # it's fine to use input() since marimo overrides it, but disable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from marimo._messaging.streams import (
     ThreadSafeStream,
 )
 from marimo._runtime.context import initialize_context, teardown_context
+from marimo._runtime.marimo_pdb import MarimoPdb
 from marimo._runtime.requests import AppMetadata, ExecutionRequest
 from marimo._runtime.runtime import Kernel
 
@@ -91,6 +92,7 @@ class MockedKernel:
             app_metadata=AppMetadata(
                 filename=None,
             ),
+            debugger_override=MarimoPdb(stdout=self.stdout, stdin=self.stdin),
         )
 
         initialize_context(


### PR DESCRIPTION
Only patch Pdb in edit mode; in run mode, in addition to pdb not being useful, patching it is problematic since multiple threads share the same Python process.

This might fix #930 ...