### PR TITLE
fix: __ for cell names in marimo convert

### DIFF
--- a/marimo/_cli/ipynb_to_marimo.py
+++ b/marimo/_cli/ipynb_to_marimo.py
@@ -52,6 +52,6 @@ def convert(notebook: dict[str, Any]) -> str:
 
     return codegen.generate_filecontents(
         sources,
-        ["_" for _ in sources],
+        ["__" for _ in sources],
         [CellConfig() for _ in range(len(sources))],
     )

--- a/tests/_cli/test_ipynb_to_marimo.py
+++ b/tests/_cli/test_ipynb_to_marimo.py
@@ -80,7 +80,7 @@ def test_arithmetic() -> None:
     assert len(codes) == 2
     assert codes[0] == "x = 0\nx"
     assert codes[1] == "x + 1"
-    assert names == ["_", "_"]
+    assert names == ["__", "__"]
 
 
 def test_blank() -> None:
@@ -88,7 +88,7 @@ def test_blank() -> None:
 
     assert len(codes) == 1
     assert codes[0] == ""
-    assert names == ["_"]
+    assert names == ["__"]
 
 
 def test_unparsable() -> None:
@@ -97,4 +97,4 @@ def test_unparsable() -> None:
     assert len(codes) == 2
     assert codes[0] == "!echo hello, world\n\nx = 0"
     assert codes[1] == "x"
-    assert names == ["_", "_"]
+    assert names == ["__", "__"]


### PR DESCRIPTION
We use two underscores for unnamed cells