### PR TITLE
fix: file upload should serialize raw bytes

### DIFF
--- a/frontend/src/components/editor/file-tree/upload.tsx
+++ b/frontend/src/components/editor/file-tree/upload.tsx
@@ -37,11 +37,12 @@ export function useFileExplorerUpload(options: DropzoneOptions = {}) {
     },
     onDrop: async (acceptedFiles) => {
       for (const file of acceptedFiles) {
+        const buffer = Array.from(new Uint8Array(await file.arrayBuffer()));
         await sendCreateFileOrFolder({
           path: "" as FilePath, // add to root
           type: "file",
           name: file.name,
-          contents: await file.text(),
+          contents: buffer,
         }).catch((error) => {
           console.error(error);
           toast({

--- a/frontend/src/components/editor/file-tree/upload.tsx
+++ b/frontend/src/components/editor/file-tree/upload.tsx
@@ -2,6 +2,7 @@
 import { toast } from "@/components/ui/use-toast";
 import { sendCreateFileOrFolder } from "@/core/network/requests";
 import { FilePath } from "@/utils/paths";
+import { serializeBlob } from "@/utils/blob";
 import { DropzoneOptions, useDropzone } from "react-dropzone";
 import { refreshRoot } from "./state";
 
@@ -37,12 +38,17 @@ export function useFileExplorerUpload(options: DropzoneOptions = {}) {
     },
     onDrop: async (acceptedFiles) => {
       for (const file of acceptedFiles) {
-        const buffer = Array.from(new Uint8Array(await file.arrayBuffer()));
+        // File contents are sent base64-encoded to support arbitrary
+        // bytes data
+        //
+        // get the raw base64-encoded data from a string starting with
+        // data:*/*;base64,
+        const base64 = (await serializeBlob(file)).split(",")[1];
         await sendCreateFileOrFolder({
           path: "" as FilePath, // add to root
           type: "file",
           name: file.name,
-          contents: buffer,
+          contents: base64,
         }).catch((error) => {
           console.error(error);
           toast({

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -121,7 +121,7 @@ export interface FileCreateRequest {
   path: FilePath;
   type: "file" | "directory";
   name: string;
-  contents: string | undefined;
+  contents: number[] | undefined;
 }
 
 export interface FileDeleteRequest {

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -121,7 +121,8 @@ export interface FileCreateRequest {
   path: FilePath;
   type: "file" | "directory";
   name: string;
-  contents: number[] | undefined;
+  // base64 representation of contents
+  contents: string | undefined;
 }
 
 export interface FileDeleteRequest {

--- a/marimo/_server/files/file_system.py
+++ b/marimo/_server/files/file_system.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
@@ -32,7 +34,7 @@ class FileSystem(ABC):
         path: str,
         file_type: str,
         name: str,
-        contents: Optional[list[int]],
+        contents: Optional[bytes],
     ) -> FileInfo:
         """
         Create a new file or directory

--- a/marimo/_server/files/file_system.py
+++ b/marimo/_server/files/file_system.py
@@ -32,7 +32,7 @@ class FileSystem(ABC):
         path: str,
         file_type: str,
         name: str,
-        contents: Optional[str],
+        contents: Optional[list[int]],
     ) -> FileInfo:
         """
         Create a new file or directory

--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import mimetypes
 import os
 import shutil
@@ -61,10 +63,12 @@ class OSFileSystem(FileSystem):
             last_modified_date=stat.st_mtime,
         )
 
-    def get_details(self, path: str, mode: str = "r") -> FileDetailsResponse:
+    def get_details(
+        self, path: str, encoding: str | None = None
+    ) -> FileDetailsResponse:
         file_info = self._get_file_info(path)
         contents = (
-            self.open_file(path, mode=mode)
+            self.open_file(path, encoding=encoding)
             if not file_info.is_directory
             else None
         )
@@ -80,8 +84,8 @@ class OSFileSystem(FileSystem):
         with open(path, "r") as file:
             return "app = marimo.App(" in file.read()
 
-    def open_file(self, path: str, mode="r") -> str:
-        with open(path, mode) as file:
+    def open_file(self, path: str, encoding: str | None = None) -> str:
+        with open(path, mode="r", encoding=encoding) as file:
             return file.read()
 
     def create_file_or_directory(
@@ -110,7 +114,7 @@ class OSFileSystem(FileSystem):
             with open(full_path, "wb") as file:
                 if contents:
                     file.write(bytes(contents))
-        return self.get_details(full_path, mode="rb").file
+        return self.get_details(full_path, encoding="latin-1").file
 
     def delete_file_or_directory(self, path: str) -> bool:
         if os.path.isdir(path):

--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -61,10 +61,10 @@ class OSFileSystem(FileSystem):
             last_modified_date=stat.st_mtime,
         )
 
-    def get_details(self, path: str) -> FileDetailsResponse:
+    def get_details(self, path: str, mode: str = "r") -> FileDetailsResponse:
         file_info = self._get_file_info(path)
         contents = (
-            self.open_file(path, mode="rb")
+            self.open_file(path, mode=mode)
             if not file_info.is_directory
             else None
         )
@@ -110,7 +110,7 @@ class OSFileSystem(FileSystem):
             with open(full_path, "wb") as file:
                 if contents:
                     file.write(bytes(contents))
-        return self.get_details(full_path).file
+        return self.get_details(full_path, mode="rb").file
 
     def delete_file_or_directory(self, path: str) -> bool:
         if os.path.isdir(path):

--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -93,7 +93,7 @@ class OSFileSystem(FileSystem):
         path: str,
         file_type: str,
         name: str,
-        contents: Optional[list[int]],
+        contents: Optional[bytes],
     ) -> FileInfo:
         full_path = os.path.join(path, name)
         # If the file already exists, generate a new name
@@ -113,7 +113,9 @@ class OSFileSystem(FileSystem):
         else:
             with open(full_path, "wb") as file:
                 if contents:
-                    file.write(bytes(contents))
+                    file.write(contents)
+        # encoding latin-1 to get an invertible representation of the
+        # bytes as a string ...
         return self.get_details(full_path, encoding="latin-1").file
 
     def delete_file_or_directory(self, path: str) -> bool:

--- a/marimo/_server/models/files.py
+++ b/marimo/_server/models/files.py
@@ -48,7 +48,7 @@ class FileCreateRequest:
     # The name of the file or directory
     name: str
     # The contents of the file
-    contents: Optional[str] = None
+    contents: Optional[list[int]] = None
 
 
 @dataclass

--- a/marimo/_server/models/files.py
+++ b/marimo/_server/models/files.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -48,7 +50,7 @@ class FileCreateRequest:
     # The name of the file or directory
     name: str
     # The contents of the file
-    contents: Optional[list[int]] = None
+    contents: Optional[List[int]] = None
 
 
 @dataclass

--- a/marimo/_server/models/files.py
+++ b/marimo/_server/models/files.py
@@ -49,8 +49,8 @@ class FileCreateRequest:
     type: str
     # The name of the file or directory
     name: str
-    # The contents of the file
-    contents: Optional[List[int]] = None
+    # The contents of the file, base64-encoded
+    contents: Optional[str] = None
 
 
 @dataclass

--- a/marimo/_smoke_tests/bugs/924.py
+++ b/marimo/_smoke_tests/bugs/924.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.3.2"

--- a/marimo/_smoke_tests/bugs/altair-bug.py
+++ b/marimo/_smoke_tests/bugs/altair-bug.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.3.1"

--- a/tests/_server/files/test_os_file_system.py
+++ b/tests/_server/files/test_os_file_system.py
@@ -56,7 +56,10 @@ class TestOSFileSystem(unittest.TestCase):
     def test_get_details(self):
         test_file_name = "test_file.txt"
         self.fs.create_file_or_directory(
-            self.test_dir, "file", test_file_name, "some content"
+            self.test_dir,
+            "file",
+            test_file_name,
+            "some content".encode("utf-8"),
         )
         file_info = self.fs.get_details(
             os.path.join(self.test_dir, test_file_name)
@@ -81,7 +84,7 @@ class TestOSFileSystem(unittest.TestCase):
                 app.run()
             """
         self.fs.create_file_or_directory(
-            self.test_dir, "file", test_file_name, content
+            self.test_dir, "file", test_file_name, content.encode("utf-8")
         )
         file_path = os.path.join(self.test_dir, test_file_name)
         file_info = self.fs.get_details(file_path)


### PR DESCRIPTION
This PR fixes the editor's file upload to send raw bytes to the kernel. Previously, we assumed that files were encoded as `UTF-8`, which is not always the case.

File contents are now base64-encoded in the frontend and decoded in the backend. This adds some overhead that we can optimize away in the future should we need to.

This bug was surfaced by #938, but it isn't specific to WASM.

Fixes #938 