### PR TITLE
feat: configurable package manager + uv, rye support

### DIFF
--- a/frontend/src/components/app-config/common.tsx
+++ b/frontend/src/components/app-config/common.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren } from "react";
 
 export const SettingTitle: React.FC<PropsWithChildren> = ({ children }) => {
   return (
-    <div className="text-sm font-semibold text-muted-foreground uppercase tracking-wide  mb-1">
+    <div className="text-md font-semibold text-muted-foreground uppercase tracking-wide  mb-1">
       {children}
     </div>
   );
@@ -11,7 +11,7 @@ export const SettingTitle: React.FC<PropsWithChildren> = ({ children }) => {
 
 export const SettingSubtitle: React.FC<PropsWithChildren> = ({ children }) => {
   return (
-    <div className="text-sm font-semibold underline decoration-solid decoration-gray-400 underline-offset-2 text-muted-foreground uppercase tracking-wide">
+    <div className="text-sm font-semibold underline-offset-2 text-accent-foreground uppercase tracking-wide">
       {children}
     </div>
   );

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -283,6 +283,35 @@ export const UserConfigForm: React.FC = () => {
             )}
           />
         </div>
+
+        <div className="flex flex-col gap-3">
+          <SettingSubtitle>Package Management</SettingSubtitle>
+          <FormField
+            control={form.control}
+            disabled={isWasm}
+            name="package_management.manager"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Manager</FormLabel>
+                <FormControl>
+                  <NativeSelect
+                    onChange={(e) => field.onChange(e.target.value)}
+                    value={field.value}
+                    disabled={field.disabled}
+                    className="inline-flex mr-2"
+                  >
+                    {["pip", "uv", "rye"].map((option) => (
+                      <option value={option} key={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </NativeSelect>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
         <div className="flex flex-col gap-3">
           <SettingSubtitle>Runtime</SettingSubtitle>
           <FormField

--- a/frontend/src/components/editor/package-alert.tsx
+++ b/frontend/src/components/editor/package-alert.tsx
@@ -24,10 +24,12 @@ import React from "react";
 import { Button } from "../ui/button";
 import { PackageInstallationStatus } from "@/core/kernel/messages";
 import { logNever } from "@/utils/assertNever";
+import { useUserConfig } from "@/core/config/config";
 
 export const PackageAlert: React.FC = (props) => {
   const { packageAlert } = useAlerts();
   const { addPackageAlert, clearPackageAlert } = useAlertActions();
+  const [userConfig] = useUserConfig();
 
   if (packageAlert === null) {
     return null;
@@ -72,6 +74,7 @@ export const PackageAlert: React.FC = (props) => {
               {packageAlert.isolated ? (
                 <InstallPackagesButton
                   packages={packageAlert.packages}
+                  manager={userConfig.package_management.manager}
                   addPackageAlert={addPackageAlert}
                 />
               ) : (
@@ -214,6 +217,7 @@ const ProgressIcon = ({
 
 async function installPackages(
   packages: string[],
+  manager: "pip" | "uv" | "rye",
   addPackageAlert: (
     alert: MissingPackageAlert | InstallingPackageAlert,
   ) => void,
@@ -226,14 +230,16 @@ async function installPackages(
     packages: packageStatus,
   });
   RuntimeState.INSTANCE.registerRunStart();
-  await sendInstallMissingPackages({ manager: "pip" });
+  await sendInstallMissingPackages({ manager: manager });
 }
 
 const InstallPackagesButton = ({
   packages,
+  manager,
   addPackageAlert,
 }: {
   packages: string[];
+  manager: "pip" | "uv" | "rye";
   addPackageAlert: (
     alert: MissingPackageAlert | InstallingPackageAlert,
   ) => void;
@@ -242,10 +248,10 @@ const InstallPackagesButton = ({
     <Button
       variant="outline"
       size="sm"
-      onClick={() => installPackages(packages, addPackageAlert)}
+      onClick={() => installPackages(packages, manager, addPackageAlert)}
     >
       <DownloadCloudIcon className="w-4 h-4 mr-2" />
-      <span className="font-semibold">Install with pip</span>
+      <span className="font-semibold">Install with {manager}</span>
     </Button>
   );
 };

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -31,6 +31,9 @@ test("default UserConfig - empty", () => {
       "keymap": {
         "preset": "default",
       },
+      "package_management": {
+        "manager": "pip",
+      },
       "runtime": {
         "auto_instantiate": true,
       },
@@ -70,6 +73,9 @@ test("default UserConfig - one level", () => {
       },
       "keymap": {
         "preset": "default",
+      },
+      "package_management": {
+        "manager": "pip",
       },
       "runtime": {
         "auto_instantiate": true,

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -55,6 +55,9 @@ export const UserConfigSchema = z
         cell_output: z.enum(["above", "below"]).default("above"),
       })
       .default({}),
+    package_management: z
+      .object({ manager: z.enum(["pip", "uv", "rye"]).default("pip") })
+      .default({ manager: "pip" }),
     experimental: z
       .object({
         ai: z.boolean().optional(),

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -96,7 +96,7 @@ export interface SendStdin {
 
 // In the future may include things like package manager, index URL, ...
 export interface SendInstallMissingPackages {
-  manager: "pip";
+  manager: "pip" | "uv" | "rye";
 }
 
 export interface ValueUpdate {

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -73,6 +73,9 @@ const props: CellProps = {
     formatting: {
       line_length: 79,
     },
+    package_management: {
+      manager: "pip",
+    },
     experimental: {},
   },
 };

--- a/lsp/pnpm-lock.yaml
+++ b/lsp/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   copilot-node-server:
-    specifier: 1.19.2
-    version: 1.19.2
+    specifier: 1.20.1
+    version: 1.20.1
 
 devDependencies:
   '@sourcegraph/vscode-ws-jsonrpc':
@@ -400,8 +400,8 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
-  /copilot-node-server@1.19.2:
-    resolution: {integrity: sha512-mM+AuMY0UPXIWnlx9CFx0BUPGLHP4dVVz6d3Alio2ZdjGGpxUHRNTYP+tgndtM6FNXaFxQoUfhaCiG4XusSC7w==}
+  /copilot-node-server@1.20.1:
+    resolution: {integrity: sha512-jROFkpMGJtwGyRYHvGvirQWdSCxWtIzImP9/jq4WQeCuT/QbDBP3IPkJONaCjWFtZj+GIAN+X4wdg2W9xYolig==}
     hasBin: true
     dev: false
 

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -109,6 +109,17 @@ class ServerConfig(TypedDict, total=False):
     browser: Union[Literal["default"], str]
 
 
+class PackageManagementConfig(TypedDict, total=False):
+    """Configuration options for package management.
+
+    **Keys.**
+
+    - `manager`: the package manager to use
+    """
+
+    manager: Literal["pip", "rye", "uv"]
+
+
 @mddoc
 class MarimoConfig(TypedDict, total=False):
     """Configuration for the marimo editor.
@@ -136,6 +147,7 @@ class MarimoConfig(TypedDict, total=False):
     runtime: RuntimeConfig
     save: SaveConfig
     server: ServerConfig
+    package_management: PackageManagementConfig
     experimental: Dict[str, Any]
 
 
@@ -154,6 +166,7 @@ DEFAULT_CONFIG: MarimoConfig = {
         "autosave_delay": 1000,
         "format_on_save": False,
     },
+    "package_management": {"manager": "pip"},
     "server": {"browser": "default"},
 }
 

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -22,9 +22,6 @@ from marimo._runtime import handlers, requests
 from marimo._runtime.context import initialize_context
 from marimo._runtime.input_override import input_override
 from marimo._runtime.marimo_pdb import MarimoPdb
-from marimo._runtime.packages.pypi_package_manager import (
-    MicropipPackageManager,
-)
 from marimo._runtime.requests import (
     AppMetadata,
     CompletionRequest,
@@ -326,7 +323,7 @@ def launch_pyodide_kernel(
         stdin=stdin,
         input_override=input_override,
         debugger_override=debugger,
-        package_manager=MicropipPackageManager(),
+        package_manager="micropip" if is_edit_mode else None,
     )
     initialize_context(
         kernel=kernel,

--- a/marimo/_runtime/packages/package_manager.py
+++ b/marimo/_runtime/packages/package_manager.py
@@ -7,6 +7,8 @@ import abc
 class PackageManager(abc.ABC):
     """Interface for a package manager that can install packages."""
 
+    name: str
+
     @abc.abstractmethod
     def module_to_package(self, module_name: str) -> str:
         """Canonicalizes a module name to a package name."""

--- a/marimo/_runtime/packages/package_managers.py
+++ b/marimo/_runtime/packages/package_managers.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Marimo. All rights reserved.
+from marimo._runtime.packages.package_manager import PackageManager
+from marimo._runtime.packages.pypi_package_manager import (
+    MicropipPackageManager,
+    PipPackageManager,
+    RyePackageManager,
+    UvPackageManager,
+)
+from marimo._utils.platform import is_pyodide
+
+PACKAGE_MANAGERS = {
+    MicropipPackageManager.name: MicropipPackageManager,
+    PipPackageManager.name: PipPackageManager,
+    RyePackageManager.name: RyePackageManager,
+    UvPackageManager.name: UvPackageManager,
+}
+
+
+def create_package_manager(name: str) -> PackageManager:
+    if is_pyodide():
+        # user config has name "pip", but micropip's name is "micropip" ...
+        return MicropipPackageManager()
+
+    if name in PACKAGE_MANAGERS:
+        return PACKAGE_MANAGERS[name]()  # type:ignore[abstract]
+    raise RuntimeError(
+        f"Unknown package manager {name}. "
+        "This is a bug in marimo."
+        "Please file an issue: "
+        "https://github.com/marimo-team/marimo/issues"
+    )

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -54,11 +54,15 @@ class PypiPackageManager(PackageManager):
 
 
 class PipPackageManager(PypiPackageManager):
+    name = "pip"
+
     async def install(self, package: str) -> bool:
         return subprocess.run(["pip", "install", package]).returncode == 0
 
 
 class MicropipPackageManager(PypiPackageManager):
+    name = "pip"
+
     async def install(self, package: str) -> bool:
         assert is_pyodide()
         import micropip  # type: ignore
@@ -68,3 +72,19 @@ class MicropipPackageManager(PypiPackageManager):
             return True
         except ValueError:
             return False
+
+
+class UvPackageManager(PypiPackageManager):
+    name = "uv"
+
+    async def install(self, package: str) -> bool:
+        return (
+            subprocess.run(["uv", "pip", "install", package]).returncode == 0
+        )
+
+
+class RyePackageManager(PypiPackageManager):
+    name = "rye"
+
+    async def install(self, package: str) -> bool:
+        return subprocess.run(["rye", "add", package]).returncode == 0

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -61,7 +61,7 @@ class PipPackageManager(PypiPackageManager):
 
 
 class MicropipPackageManager(PypiPackageManager):
-    name = "pip"
+    name = "micropip"
 
     async def install(self, package: str) -> bool:
         assert is_pyodide()

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -37,6 +37,7 @@ def start(
     # Find a free port if none is specified
     # if the user specifies a port, we don't try to find a free one
     port = port or find_free_port(DEFAULT_PORT)
+    user_config_mgr = UserConfigManager()
 
     session_manager = initialize_manager(
         filename=filename,
@@ -45,6 +46,9 @@ def start(
         quiet=quiet,
         include_code=include_code,
         port=port,
+        package_manager=user_config_mgr.config["package_management"][
+            "manager"
+        ],
     )
 
     log_level = "info" if development_mode else "error"
@@ -57,7 +61,7 @@ def start(
     app.state.watch = watch
     app.state.session_manager = session_manager
     app.state.base_url = base_url
-    app.state.config_manager = UserConfigManager()
+    app.state.config_manager = user_config_mgr
 
     server = uvicorn.Server(
         uvicorn.Config(

--- a/tests/_config/test_config.py
+++ b/tests/_config/test_config.py
@@ -21,6 +21,7 @@ def test_configure_full() -> None:
                 "format_on_save": False,
             },
             keymap={"preset": "vim"},
+            package_management={"manager": "pip"},
         )
     )
 

--- a/tests/_runtime/packages/test_package_managers.py
+++ b/tests/_runtime/packages/test_package_managers.py
@@ -1,0 +1,22 @@
+import pytest
+
+from marimo._runtime.packages.package_managers import create_package_manager
+from marimo._runtime.packages.pypi_package_manager import (
+    MicropipPackageManager,
+    PipPackageManager,
+    RyePackageManager,
+    UvPackageManager,
+)
+
+
+def test_create_package_managers() -> None:
+    assert isinstance(create_package_manager("pip"), PipPackageManager)
+    assert isinstance(
+        create_package_manager("micropip"), MicropipPackageManager
+    )
+    assert isinstance(create_package_manager("rye"), RyePackageManager)
+    assert isinstance(create_package_manager("uv"), UvPackageManager)
+
+    with pytest.raises(RuntimeError) as e:
+        create_package_manager("foobar")
+    assert "Unknown package manager" in str(e)

--- a/tests/_server/mocks.py
+++ b/tests/_server/mocks.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
         quiet=False,
         include_code=True,
         lsp_server=lsp_server,
+        package_manager="pip",
     )
     sm.server_token = "fake-token"
     return sm

--- a/tests/_server/test_session_manager.py
+++ b/tests/_server/test_session_manager.py
@@ -28,6 +28,7 @@ def session_manager():
         quiet=False,
         include_code=True,
         lsp_server=MagicMock(spec=LspServer),
+        package_manager="pip",
     )
 
 

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -54,7 +54,7 @@ def test_kernel_manager() -> None:
     mode = SessionMode.RUN
 
     # Instantiate a KernelManager
-    kernel_manager = KernelManager(queue_manager, mode, {}, app_metadata)
+    kernel_manager = KernelManager(queue_manager, mode, {}, app_metadata, "pip")
 
     kernel_manager.start_kernel()
 
@@ -78,7 +78,7 @@ def test_session() -> None:
     session_consumer.connection_state.return_value = ConnectionState.OPEN
     queue_manager = QueueManager(use_multiprocessing=False)
     kernel_manager = KernelManager(
-        queue_manager, SessionMode.RUN, {}, app_metadata
+        queue_manager, SessionMode.RUN, {}, app_metadata, "pip"
     )
 
     # Instantiate a Session
@@ -117,7 +117,7 @@ def test_session_disconnect_reconnect() -> None:
     session_consumer.connection_state.return_value = ConnectionState.OPEN
     queue_manager = QueueManager(use_multiprocessing=False)
     kernel_manager = KernelManager(
-        queue_manager, SessionMode.RUN, {}, AppMetadata()
+        queue_manager, SessionMode.RUN, {}, AppMetadata(), "pip"
     )
 
     # Instantiate a Session

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -54,7 +54,9 @@ def test_kernel_manager() -> None:
     mode = SessionMode.RUN
 
     # Instantiate a KernelManager
-    kernel_manager = KernelManager(queue_manager, mode, {}, app_metadata, "pip")
+    kernel_manager = KernelManager(
+        queue_manager, mode, {}, app_metadata, "pip"
+    )
 
     kernel_manager.start_kernel()
 


### PR DESCRIPTION
This PR adds a key `package_management` to our marimo.toml-based user config, and an option to select the package manager.

It also adds support for `rye` and `uv`.