### PR TITLE
fix: graceful shutdown for uvicorn==0.29.0

### DIFF
--- a/marimo/_server/uvicorn_utils.py
+++ b/marimo/_server/uvicorn_utils.py
@@ -1,7 +1,9 @@
 # Copyright 2024 Marimo. All rights reserved.
 import signal
+import sys
 
 import uvicorn
+from packaging import version
 
 from marimo import _loggers
 
@@ -10,5 +12,9 @@ LOGGER = _loggers.marimo_logger()
 
 def close_uvicorn(server: uvicorn.Server) -> None:
     LOGGER.debug("Shutting down uvicorn")
-    server.handle_exit(signal.SIGINT, None)
-    LOGGER.debug("Uvicorn shut down")
+    # 0.29.0 changed how uvicorn handles signals
+    # https://github.com/encode/uvicorn/pull/1600
+    if version.parse(uvicorn.__version__) < version.parse("0.29.0"):
+        server.handle_exit(signal.SIGINT, None)
+    else:
+        sys.exit(0)


### PR DESCRIPTION
Fixes a bug in graceful shutdown caused by version 0.29.0 of uvicorn (which fixed a bug we were previously compensating for)