### PR TITLE
improvements for running as a script

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -246,6 +246,15 @@ class App:
             )
 
     def run(self) -> tuple[Sequence[Any], dict[str, Any]]:
+        # formatters aren't automatically registered when running as a script
+        from marimo._output.formatters.formatters import (
+            register_formatters,
+        )
+        from marimo._output.formatting import FORMATTERS
+
+        if not FORMATTERS:
+            register_formatters()
+
         return asyncio.run(self._run_async())
 
     async def _run_cell_async(

--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -63,11 +63,12 @@ class Html(MIME):
 
         from marimo._runtime.context import (
             ContextNotInitializedError,
+            RuntimeContext,
             get_context,
         )
 
         try:
-            self.ctx = get_context()
+            self.ctx: RuntimeContext | None = get_context()
         except ContextNotInitializedError:
             self.ctx = None
             return

--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -67,8 +67,9 @@ class Html(MIME):
         )
 
         try:
-            ctx = get_context()
+            self.ctx = get_context()
         except ContextNotInitializedError:
+            self.ctx = None
             return
 
         # Virtual File Refcounting
@@ -80,9 +81,9 @@ class Html(MIME):
         #
         # flatten the text to make sure searching isn't broken by newlines
         flat_text = flatten_string(self._text)
-        for virtual_filename in ctx.virtual_file_registry.filenames():
+        for virtual_filename in self.ctx.virtual_file_registry.filenames():
             if virtual_filename in flat_text:
-                ctx.virtual_file_registry.reference(virtual_filename)
+                self.ctx.virtual_file_registry.reference(virtual_filename)
                 self._virtual_filenames.append(virtual_filename)
 
     def __del__(self) -> None:
@@ -92,18 +93,9 @@ class Html(MIME):
         this method.
         """
 
-        from marimo._runtime.context import (
-            ContextNotInitializedError,
-            get_context,
-        )
-
-        try:
-            ctx = get_context()
-        except ContextNotInitializedError:
-            return
-
-        for f in self._virtual_filenames:
-            ctx.virtual_file_registry.dereference(f)
+        if self.ctx is not None:
+            for f in self._virtual_filenames:
+                self.ctx.virtual_file_registry.dereference(f)
 
     @property
     def text(self) -> str:

--- a/marimo/_utils/exiting.py
+++ b/marimo/_utils/exiting.py
@@ -1,0 +1,22 @@
+# Copyright 2024 Marimo. All rights reserved.
+import atexit
+from dataclasses import dataclass
+
+
+@dataclass
+class Exiting:
+    value: bool = False
+
+
+_PYTHON_EXITING = Exiting()
+
+
+def python_exiting() -> bool:
+    return _PYTHON_EXITING.value
+
+
+def _exit() -> None:
+    _PYTHON_EXITING.value = True
+
+
+atexit.register(_exit)


### PR DESCRIPTION
- don't import methods in destructors -- can lead to confusing errors when python is shutting down (fixes the issue one of our users was seeing at SLAC)

- register formatters in `app.run()` (helpful for generating HTML programmatically)