### PR TITLE
Fix mpl interactive: remove asyncio.run()

### DIFF
--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -13,6 +13,7 @@ import io
 import mimetypes
 import signal
 import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
@@ -210,9 +211,9 @@ def get_or_create_application() -> Starlette:
 
         threading.Thread(target=start_server).start()
 
-        # arbitrary wait 100ms for the server to start
+        # arbitrary wait 200ms for the server to start
         # this only happens once per session
-        asyncio.run(asyncio.sleep(0.02))
+        time.sleep(0.02)
 
     return _app
 


### PR DESCRIPTION
We were previously waiting with `asyncio.sleep`, but marimo runs in an event loop now so we can't do that.

Closes #978 