### PR TITLE
feat: Backspace on empty cell deletes cell

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -88,13 +88,13 @@ const CellEditorInternal = ({
   const loading = status === "running" || status === "queued";
   const { sendToTop, sendToBottom } = useCellActions();
 
-  const handleDelete = useEvent(() => {
+  const handleDelete = useEvent((deleteIfFirst?: boolean) => {
     // Cannot delete running cells, since we're waiting for their output.
     if (loading) {
       return false;
     }
 
-    deleteCell({ cellId });
+    deleteCell({ cellId, deleteIfFirst });
     return true;
   });
 

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -88,13 +88,13 @@ const CellEditorInternal = ({
   const loading = status === "running" || status === "queued";
   const { sendToTop, sendToBottom } = useCellActions();
 
-  const handleDelete = useEvent((deleteIfFirst?: boolean) => {
+  const handleDelete = useEvent((options?: { deleteIfFirst: boolean }) => {
     // Cannot delete running cells, since we're waiting for their output.
     if (loading) {
       return false;
     }
 
-    deleteCell({ cellId, deleteIfFirst });
+    deleteCell({ cellId, ...options });
     return true;
   });
 

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -250,13 +250,15 @@ const { reducer, createActions } = createReducer(initialNotebookState, {
       scrollKey: cellId,
     };
   },
-  deleteCell: (state, action: { cellId: CellId }) => {
+  deleteCell: (state, action: { cellId: CellId; deleteIfFirst?: boolean }) => {
     const cellId = action.cellId;
-    if (state.cellIds.length === 1) {
+    const index = state.cellIds.indexOf(cellId);
+    // Default to deleting the first cell if not specified
+    const deleteIfFirst = action.deleteIfFirst ?? true;
+    if (state.cellIds.length === 1 || (!deleteIfFirst && index === 0)) {
       return state;
     }
 
-    const index = state.cellIds.indexOf(cellId);
     const cellKey = state.cellIds[index];
     const focusIndex = index === 0 ? 1 : index - 1;
     const scrollKey = state.cellIds[focusIndex];

--- a/frontend/src/core/codemirror/cells/extensions.ts
+++ b/frontend/src/core/codemirror/cells/extensions.ts
@@ -13,7 +13,7 @@ import { isAtEndOfEditor, isAtStartOfEditor } from "../utils";
 export interface MovementCallbacks
   extends Pick<CellActions, "sendToTop" | "sendToBottom" | "moveToNextCell"> {
   onRun: () => void;
-  deleteCell: (deleteIfFirst?: boolean) => void;
+  deleteCell: (options?: { deleteIfFirst: boolean }) => void;
   createAbove: () => void;
   createBelow: () => void;
   moveUp: () => void;

--- a/frontend/src/core/codemirror/cells/extensions.ts
+++ b/frontend/src/core/codemirror/cells/extensions.ts
@@ -13,7 +13,7 @@ import { isAtEndOfEditor, isAtStartOfEditor } from "../utils";
 export interface MovementCallbacks
   extends Pick<CellActions, "sendToTop" | "sendToBottom" | "moveToNextCell"> {
   onRun: () => void;
-  deleteCell: () => void;
+  deleteCell: (deleteIfFirst?: boolean) => void;
   createAbove: () => void;
   createBelow: () => void;
   moveUp: () => void;

--- a/frontend/src/core/codemirror/keymaps/keymaps.ts
+++ b/frontend/src/core/codemirror/keymaps/keymaps.ts
@@ -14,7 +14,7 @@ export function keymapBundle(
   callbacks: {
     focusUp: () => void;
     focusDown: () => void;
-    deleteCell: (deleteIfFirst?: boolean) => void;
+    deleteCell: (options?: { deleteIfFirst: boolean }) => void;
   },
 ): Extension[] {
   switch (config.preset) {
@@ -38,7 +38,7 @@ export function keymapBundle(
             run: (cm) => {
               // Delete cell if it is empty and it is not the first cell
               if (cm.state.doc.toString() === "") {
-                callbacks.deleteCell(false);
+                callbacks.deleteCell({ deleteIfFirst: false });
                 return true;
               }
               return false;

--- a/frontend/src/core/codemirror/keymaps/keymaps.ts
+++ b/frontend/src/core/codemirror/keymaps/keymaps.ts
@@ -14,7 +14,7 @@ export function keymapBundle(
   callbacks: {
     focusUp: () => void;
     focusDown: () => void;
-    deleteCell: () => void;
+    deleteCell: (deleteIfFirst?: boolean) => void;
   },
 ): Extension[] {
   switch (config.preset) {
@@ -28,6 +28,20 @@ export function keymapBundle(
             run: (cm) => {
               cm.contentDOM.blur();
               return true;
+            },
+          },
+        ]),
+        keymap.of([
+          {
+            key: "Backspace",
+            preventDefault: true,
+            run: (cm) => {
+              // Delete cell if it is empty and it is not the first cell
+              if (cm.state.doc.toString() === "") {
+                callbacks.deleteCell(false);
+                return true;
+              }
+              return false;
             },
           },
         ]),


### PR DESCRIPTION
In normal mode, I suggest deleting a cell when it is empty backspace is pressed. If my memory serves me right, this feature exists in Pluto.jl. See if you like it, feel free to close this if you are not interested -- this was an excuse to familiarise myself with the codebase more than anything else.

I've had to add an argument to the `deleteCell` callback as removing the first cell results in a counter-intuitive UI (the cursor cannot move to the previous cell, as would be expected). I don't like the fact that `deleteCell(false)` isn't very explicit about what it is doing -- would you prefer that `deleteCell` takes a `{ deleteIfFirst?: boolean }` object? Or can you think of a better way of doing this? 

EDIT: I've turned the argument into an object, the resulting code is clearer imo. Feel free still to make further suggestions!