### PR TITLE
Deduplicate code completion form description field

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -250,10 +250,6 @@ export const UserConfigForm: React.FC = () => {
                     />
                   </span>
                 </FormControl>
-                <FormDescription>
-                  When unchecked, code completion is still available through a
-                  hotkey.
-                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}


### PR DESCRIPTION
I just noticed this when reexamining the screenshot associated with another issue I filed.