### PR TITLE
feat: mo.query_params

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -15,6 +15,7 @@
   outputs
   control_flow
   html
+  query_params
   state
   cell
   debugging
@@ -40,6 +41,7 @@ Use the marimo library in marimo notebooks (`import marimo as mo`) to
 | {doc}`outputs`       | Modify cell outputs, redirect console output              |
 | {doc}`control_flow`  | Control how cells execute                                 |
 | {doc}`html`          | Manipulate HTML objects                                   |
+| {doc}`query_params`  | Access and set query parameters with `mo.query_params`    |
 | {doc}`state`         | Synchronize multiple UI elements with `mo.state`          |
 | {doc}`cell`          | Run cells defined in another notebook                     |
 | {doc}`debugging`     | Debugging utilities                                       |

--- a/docs/api/query_params.md
+++ b/docs/api/query_params.md
@@ -1,0 +1,9 @@
+# Query Parameters
+
+Use `mo.query_params` to access query parameters passed to the notebook. You can also
+use `mo.query_params` to set query parameters in order to keep track of state in the
+URL. This is useful for bookmarking or sharing a particular state of the notebook while in running as an application.
+
+```{eval-rst}
+.. autofunction:: marimo.query_params
+```

--- a/docs/api/query_params.md
+++ b/docs/api/query_params.md
@@ -1,8 +1,9 @@
 # Query Parameters
 
-Use `mo.query_params` to access query parameters passed to the notebook. You can also
-use `mo.query_params` to set query parameters in order to keep track of state in the
-URL. This is useful for bookmarking or sharing a particular state of the notebook while in running as an application.
+Use `mo.query_params` to access query parameters passed to the notebook. You
+can also use `mo.query_params` to set query parameters in order to keep track
+of state in the URL. This is useful for bookmarking or sharing a particular
+state of the notebook while running as an application with `marimo run`.
 
 ```{eval-rst}
 .. autofunction:: marimo.query_params

--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -7,8 +7,7 @@ By default, apps are laid out as a concetentation of their outputs, with
 code hidden. You can customize the layout using marimo's built-in drag-and-drop
 grid editor; you can also choose to include code in the app view.
 
-
-## CLI 
+## CLI
 
 ```
 Usage: marimo run [OPTIONS] NAME
@@ -35,7 +34,6 @@ Options:
 While editing a notebook with `marimo edit`, you can preview the notebook
 as an app by clicking the preview button in the bottom-left of the editor.
 (You can also use the command palette.)
-
 
 ### Vertical layout
 
@@ -64,5 +62,3 @@ Enable the grid editor in the app preview, via a dropdown:
 marimo saves metadata about your constructed layout in a `layouts` folder;
 make sure to include this folder when sharing your notebook so that others
 can reconstruct your layout.
-
-

--- a/frontend/src/core/kernel/messages.ts
+++ b/frontend/src/core/kernel/messages.ts
@@ -267,6 +267,30 @@ export type OperationMessage =
       };
     }
   | {
+      op: "query-params-set";
+      data: {
+        key: string;
+        value: string | string[];
+      };
+    }
+  | {
+      op: "query-params-append";
+      data: {
+        key: string;
+        value: string;
+      };
+    }
+  | {
+      op: "query-params-delete";
+      data: {
+        key: string;
+        value: string | null;
+      };
+    }
+  | {
+      op: "query-params-clear";
+    }
+  | {
       // transient toast / alert
       op: "alert";
       data: {

--- a/frontend/src/core/pyodide/bridge.ts
+++ b/frontend/src/core/pyodide/bridge.ts
@@ -85,7 +85,16 @@ export class PyodideBridge implements RunRequests, EditRequests {
     const code = await notebookFileStore.readFile();
     const fallbackCode = await fallbackFileStore.readFile();
     const filename = PyodideRouter.getFilename();
+
+    const queryParameters: Record<string, string | string[]> = {};
+    const searchParams = new URLSearchParams(window.location.search);
+    for (const key of searchParams.keys()) {
+      const value = searchParams.getAll(key);
+      queryParameters[key] = value.length === 1 ? value[0] : value;
+    }
+
     await this.rpc.proxy.request.startSession({
+      queryParameters: queryParameters,
       code,
       fallbackCode: fallbackCode || "",
       filename,

--- a/frontend/src/core/pyodide/worker/bootstrap.ts
+++ b/frontend/src/core/pyodide/worker/bootstrap.ts
@@ -87,6 +87,7 @@ export class DefaultWasmController implements WasmController {
   }
 
   async startSession(opts: {
+    queryParameters: Record<string, string | string[]>;
     code: string | null;
     fallbackCode: string;
     filename: string | null;
@@ -106,7 +107,10 @@ export class DefaultWasmController implements WasmController {
     // during processing of a cell's code.
     //
     // This adds a messenger object to the global scope (import js; js.messenger.callback)
-    self.messenger = { callback: opts.onMessage };
+    self.messenger = {
+      callback: opts.onMessage,
+      query_params: opts.queryParameters,
+    };
 
     // Load packages from the code
     await this.pyodide.loadPackagesFromImports(content, {
@@ -122,8 +126,13 @@ export class DefaultWasmController implements WasmController {
       from marimo._pyodide.pyodide_session import create_session, instantiate
 
       assert js.messenger, "messenger is not defined"
+      assert js.query_params, "query_params is not defined"
 
-      session, bridge = create_session(filename="${filename}", message_callback=js.messenger.callback)
+      session, bridge = create_session(
+        filename="${filename}",
+        query_parameters=js.query_params,
+        message_callback=js.messenger.callback,
+      )
       instantiate(session)
       asyncio.create_task(session.start())
 

--- a/frontend/src/core/pyodide/worker/bootstrap.ts
+++ b/frontend/src/core/pyodide/worker/bootstrap.ts
@@ -109,8 +109,8 @@ export class DefaultWasmController implements WasmController {
     // This adds a messenger object to the global scope (import js; js.messenger.callback)
     self.messenger = {
       callback: opts.onMessage,
-      query_params: opts.queryParameters,
     };
+    self.query_params = opts.queryParameters;
 
     // Load packages from the code
     await this.pyodide.loadPackagesFromImports(content, {
@@ -130,7 +130,7 @@ export class DefaultWasmController implements WasmController {
 
       session, bridge = create_session(
         filename="${filename}",
-        query_parameters=js.query_params,
+        query_params=js.query_params.to_py(),
         message_callback=js.messenger.callback,
       )
       instantiate(session)

--- a/frontend/src/core/pyodide/worker/types.ts
+++ b/frontend/src/core/pyodide/worker/types.ts
@@ -28,6 +28,7 @@ export interface WasmController {
    * @param opts.filename - The filename to start with
    */
   startSession(opts: {
+    queryParameters: Record<string, string | string[]>;
     code: string | null;
     fallbackCode: string;
     filename: string | null;

--- a/frontend/src/core/pyodide/worker/worker.ts
+++ b/frontend/src/core/pyodide/worker/worker.ts
@@ -69,6 +69,7 @@ const requestHandler = createRPCRequestHandler({
    * Start the session
    */
   startSession: async (opts: {
+    queryParameters: Record<string, string | string[]>;
     code: string | null;
     fallbackCode: string;
     filename: string | null;

--- a/frontend/src/core/websocket/createWsUrl.ts
+++ b/frontend/src/core/websocket/createWsUrl.ts
@@ -7,7 +7,7 @@ export function createWsUrl(sessionId: string): string {
   url.protocol = protocol;
   url.pathname = `${withoutTrailingSlash(url.pathname)}/ws`;
 
-  const searchParams = new URLSearchParams(url.search);
+  const searchParams = new URLSearchParams(window.location.search);
   searchParams.set("session_id", sessionId);
   url.search = searchParams.toString();
 

--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -219,6 +219,41 @@ export function useMarimoWebSocket(opts: {
           kind: "installing",
         });
         return;
+      case "query-params-append": {
+        const url = new URL(window.location.href);
+        url.searchParams.append(msg.data.key, msg.data.value);
+        window.history.pushState({}, "", `${url.pathname}${url.search}`);
+        return;
+      }
+      case "query-params-set": {
+        const url = new URL(window.location.href);
+        if (Array.isArray(msg.data.value)) {
+          url.searchParams.delete(msg.data.key);
+          msg.data.value.forEach((v) =>
+            url.searchParams.append(msg.data.key, v),
+          );
+        } else {
+          url.searchParams.set(msg.data.key, msg.data.value);
+        }
+        window.history.pushState({}, "", `${url.pathname}${url.search}`);
+        return;
+      }
+      case "query-params-delete": {
+        const url = new URL(window.location.href);
+        if (msg.data.value == null) {
+          url.searchParams.delete(msg.data.key);
+        } else {
+          url.searchParams.delete(msg.data.key, msg.data.value);
+        }
+        window.history.pushState({}, "", `${url.pathname}${url.search}`);
+        return;
+      }
+      case "query-params-clear": {
+        const url = new URL(window.location.href);
+        url.search = "";
+        window.history.pushState({}, "", `${url.pathname}${url.search}`);
+        return;
+      }
       default:
         logNever(msg);
     }

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "capture_stderr",
     "center",
     "defs",
+    "query_params",
     "doc",
     "download",
     "hstack",
@@ -89,6 +90,6 @@ from marimo._runtime.capture import (
     redirect_stdout,
 )
 from marimo._runtime.control_flow import MarimoStopError, stop
-from marimo._runtime.runtime import defs, refs
+from marimo._runtime.runtime import defs, query_params, refs
 from marimo._runtime.state import state
 from marimo._server.asgi import create_asgi_app

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -386,21 +386,61 @@ class VariableValues(Op):
     variables: List[VariableValue]
 
 
+@dataclass
+class QueryParamsSet(Op):
+    """Set query parameters."""
+
+    name: ClassVar[str] = "query-params-set"
+    key: str
+    value: Union[str, List[str]]
+
+
+@dataclass
+class QueryParamsAppend(Op):
+    name: ClassVar[str] = "query-params-append"
+    key: str
+    value: str
+
+
+@dataclass
+class QueryParamsDelete(Op):
+    name: ClassVar[str] = "query-params-delete"
+    key: str
+    # If value is None, delete all values for the key
+    # If a value is provided, only that value is deleted
+    value: Optional[str]
+
+
+@dataclass
+class QueryParamsClear(Op):
+    # Clear all query parameters
+    name: ClassVar[str] = "query-params-clear"
+
+
 MessageOperation = Union[
+    # Cell operations
     CellOp,
-    HumanReadableStatus,
-    Reload,
-    Reconnected,
     FunctionCallResult,
     RemoveUIElements,
+    # Notebook operations
+    Reload,
+    Reconnected,
     Interrupted,
     CompletedRun,
     KernelReady,
+    # Editor operations
     CompletionResult,
+    # Alerts
     Alert,
     Banner,
     MissingPackageAlert,
     InstallingPackageAlert,
+    # Variables
     Variables,
     VariableValues,
+    # Query params
+    QueryParamsSet,
+    QueryParamsAppend,
+    QueryParamsDelete,
+    QueryParamsClear,
 ]

--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -24,6 +24,11 @@ class Stream(abc.ABC):
         pass
 
 
+class NoopStream(Stream):
+    def write(self, op: str, data: Dict[Any, Any]) -> None:
+        pass
+
+
 class Stdout(io.TextIOBase):
     name = "stdout"
 

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -28,6 +28,7 @@ from marimo._runtime.requests import (
     ControlRequest,
     CreationRequest,
     ExecutionRequest,
+    SerializedQueryParams,
     SetUIElementValueRequest,
 )
 from marimo._runtime.runtime import Kernel
@@ -76,6 +77,7 @@ def instantiate(session: PyodideSession) -> None:
 
 def create_session(
     filename: str,
+    query_params: SerializedQueryParams,
     message_callback: Callable[[str], None],
 ) -> tuple[PyodideSession, PyodideBridge]:
     def write_kernel_message(op: KernelMessage) -> None:
@@ -83,7 +85,7 @@ def create_session(
 
     app_file_manager = AppFileManager(filename=filename)
     app = app_file_manager.app
-    app_metadata = AppMetadata(filename=filename)
+    app_metadata = AppMetadata(query_params=query_params, filename=filename)
 
     session = PyodideSession(
         app_file_manager, SessionMode.EDIT, write_kernel_message, app_metadata

--- a/marimo/_runtime/packages/module_registry.py
+++ b/marimo/_runtime/packages/module_registry.py
@@ -14,7 +14,7 @@ class ModuleRegistry:
         self.graph = graph
         # modules that do not have corresponding packages on package index
         self.excluded_modules = (
-            excluded_modules if excluded_modules is not None else set()
+            excluded_modules if excluded_modules is not None else set[str]()
         )
 
     def defining_cell(self, module_name: str) -> CellId_t | None:

--- a/marimo/_runtime/packages/module_registry.py
+++ b/marimo/_runtime/packages/module_registry.py
@@ -14,7 +14,7 @@ class ModuleRegistry:
         self.graph = graph
         # modules that do not have corresponding packages on package index
         self.excluded_modules = (
-            excluded_modules if excluded_modules is not None else set[str]()
+            excluded_modules if excluded_modules is not None else set()
         )
 
     def defining_cell(self, module_name: str) -> CellId_t | None:

--- a/marimo/_runtime/query_params.py
+++ b/marimo/_runtime/query_params.py
@@ -7,7 +7,7 @@ from marimo._messaging.ops import (
     QueryParamsDelete,
     QueryParamsSet,
 )
-from marimo._messaging.types import NoopStream, Stream
+from marimo._messaging.types import Stream
 from marimo._output.rich_help import mddoc
 from marimo._runtime.requests import SerializedQueryParams
 from marimo._runtime.state import State
@@ -26,12 +26,11 @@ class QueryParams(State[SerializedQueryParams]):
         self._params = params
         self._stream = stream
 
-    @staticmethod
-    def empty_stream() -> "QueryParams":
-        return QueryParams({}, NoopStream())
-
     def get(self, key: str) -> Optional[Union[str, List[str]]]:
-        """Get the value of the query parameter associated with 'key'"""
+        """Get the value of the query parameter.
+
+        Returns a str if there is only one item, a list of str otherwise.
+        """
         if key not in self._params:
             return None
         return self._params[key]

--- a/marimo/_runtime/query_params.py
+++ b/marimo/_runtime/query_params.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Optional, Union
+# Copyright 2024 Marimo. All rights reserved.
+from typing import Dict, Iterator, List, Optional, Union
 
 from marimo._messaging.ops import (
     QueryParamsAppend,
@@ -14,6 +15,8 @@ from marimo._runtime.state import State
 
 @mddoc
 class QueryParams(State[SerializedQueryParams]):
+    """Query parameters for a marimo app."""
+
     def __init__(
         self,
         params: Dict[str, Union[str, List[str]]],
@@ -28,11 +31,13 @@ class QueryParams(State[SerializedQueryParams]):
         return QueryParams({}, NoopStream())
 
     def get(self, key: str) -> Optional[Union[str, List[str]]]:
+        """Get the value of the query parameter associated with 'key'"""
         if key not in self._params:
             return None
         return self._params[key]
 
     def get_all(self, key: str) -> List[str]:
+        """Get the value of a query parameter as a list."""
         value = self._params.get(key)
         if value is None:
             return []
@@ -49,7 +54,7 @@ class QueryParams(State[SerializedQueryParams]):
     def __len__(self) -> int:
         return len(self._params)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self._params)
 
     def __repr__(self) -> str:
@@ -58,22 +63,23 @@ class QueryParams(State[SerializedQueryParams]):
     def __str__(self) -> str:
         return str(self._params)
 
-    def __setitem__(self, key: str, value: Union[str, List[str]]):
+    def __setitem__(self, key: str, value: Union[str, List[str]]) -> None:
         # We always overwrite the value
         self._params[key] = value
         QueryParamsSet(key, value).broadcast(self._stream)
         self._set_value(self._params)
 
-    def __delitem__(self, key: str):
+    def __delitem__(self, key: str) -> None:
         del self._params[key]
         QueryParamsDelete(key, None).broadcast(self._stream)
         self._set_value(self._params)
 
-    def set(self, key: str, value: Union[str, List[str]]):
+    def set(self, key: str, value: Union[str, List[str]]) -> None:
+        """Set the value of a query parameter."""
         self[key] = value
 
-    def append(self, key: str, value: str):
-        # Append a value to a list of values
+    def append(self, key: str, value: str) -> None:
+        """Append a value to a list of values"""
         if key not in self._params:
             self._params[key] = value
             QueryParamsAppend(key, value).broadcast(self._stream)
@@ -89,8 +95,8 @@ class QueryParams(State[SerializedQueryParams]):
         QueryParamsAppend(key, value).broadcast(self._stream)
         self._set_value(self._params)
 
-    def remove(self, key: str, value: Optional[str] = None):
-        # Remove a value from a list of values
+    def remove(self, key: str, value: Optional[str] = None) -> None:
+        """Remove a value from a list of values."""
         if key not in self._params:
             return
         # If value is None, remove the key
@@ -109,7 +115,8 @@ class QueryParams(State[SerializedQueryParams]):
         QueryParamsDelete(key, value).broadcast(self._stream)
         self._set_value(self._params)
 
-    def clear(self):
+    def clear(self) -> None:
+        """Clear all query params."""
         self._params.clear()
         QueryParamsClear().broadcast(self._stream)
         self._set_value(self._params)

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -10,6 +10,8 @@ UIElementId = str
 CompletionRequestId = str
 FunctionCallId = str
 
+SerializedQueryParams = Dict[str, Union[str, List[str]]]
+
 
 @dataclass
 class ExecutionRequest:
@@ -39,6 +41,8 @@ class FunctionCallRequest:
 @dataclass
 class AppMetadata:
     """Hold metadata about the app, like its filename."""
+
+    query_params: SerializedQueryParams
 
     filename: Optional[str] = None
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -168,9 +168,36 @@ def refs() -> tuple[str, ...]:
 def query_params() -> QueryParams:
     """Get the query parameters.
 
+    **Examples**:
+
+    Keep the text input in sync with the URL query parameters
+
+    ```python3
+
+    # In it's own cell
+    query_params = mo.query_params()
+
+    # In another cell
+    search = mo.ui.text(
+        value=query_params["search"] or "",
+        on_change=lambda value: query_params.set("search", value),
+    )
+    search
+    ```
+
+    You can also set the query parameters reactively:
+
+    ```python3
+    toggle = mo.ui.switch(label="Toggle me")
+    toggle
+
+    # In another cell
+    query_params["is_enabled"] = toggle.value
+    ```
+
     **Returns**:
 
-    - QueryParams object containing the query parameters.
+    - A `QueryParams` object containing the query parameters.
     You can directly interact with this object like a dictionary,
     and it will persist changes to the frontend query parameters.
     """

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -166,14 +166,13 @@ def refs() -> tuple[str, ...]:
 
 @mddoc
 def query_params() -> QueryParams:
-    """Get the query parameters.
+    """Get the query parameters of a marimo app.
 
     **Examples**:
 
-    Keep the text input in sync with the URL query parameters
+    Keep the text input in sync with the URL query parameters.
 
     ```python3
-
     # In it's own cell
     query_params = mo.query_params()
 
@@ -198,8 +197,10 @@ def query_params() -> QueryParams:
     **Returns**:
 
     - A `QueryParams` object containing the query parameters.
-    You can directly interact with this object like a dictionary,
-    and it will persist changes to the frontend query parameters.
+      You can directly interact with this object like a dictionary.
+      If you mutate this object, changes will be persisted to the frontend
+      query parameters and any other cells referencing the query parameters
+      will automatically re-run.
     """
     return get_context().kernel.query_params
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1027,7 +1027,7 @@ class Kernel:
             resolved_requests[resolved_id] = resolved_value
         del request
 
-        referring_cells = set[CellId_t]()
+        referring_cells: set[CellId_t] = set()
         for object_id, value in resolved_requests.items():
             try:
                 component = ui_element_registry.get_object(object_id)

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -397,7 +397,7 @@ class Kernel:
           different code.
         - an `Error` if the cell couldn't be registered, `None` otherwise
         """
-        previous_children = set[CellId_t]()
+        previous_children: set[CellId_t] = set()
         error = None
         if not self.graph.is_cell_cached(cell_id, code):
             if cell_id in self.graph.cells:
@@ -532,11 +532,11 @@ class Kernel:
         cells_with_errors_before_mutation = set(self.errors.keys())
 
         # The set of cells that were successfully registered
-        registered_cell_ids = set[CellId_t]()
+        registered_cell_ids: set[CellId_t] = set()
 
         # The set of cells that need to be re-run due to cells being
         # deleted/re-registered.
-        cells_that_were_children_of_mutated_cells = set[CellId_t]()
+        cells_that_were_children_of_mutated_cells: set[CellId_t] = set()
 
         # Cells that were unable to be added to the graph due to syntax errors
         syntax_errors: dict[CellId_t, Error] = {}

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -23,6 +23,8 @@ from marimo._messaging.types import KernelMessage
 from marimo._plugins.core.json_encoder import WebComponentEncoder
 from marimo._plugins.core.web_component import JSONType
 from marimo._runtime.layout.layout import LayoutConfig, read_layout_config
+from marimo._runtime.query_params import QueryParams
+from marimo._runtime.requests import SerializedQueryParams
 from marimo._server.api.deps import AppState
 from marimo._server.model import (
     ConnectionState,
@@ -36,6 +38,8 @@ LOGGER = _loggers.marimo_logger()
 
 router = APIRouter()
 
+SESSION_QUERY_PARAM_KEY = "session_id"
+
 
 class WebSocketCodes(IntEnum):
     ALREADY_CONNECTED = 1003
@@ -47,7 +51,7 @@ async def websocket_endpoint(
     websocket: WebSocket,
 ) -> None:
     app_state = AppState(websocket)
-    session_id = app_state.query_params("session_id")
+    session_id = app_state.query_params(SESSION_QUERY_PARAM_KEY)
     if session_id is None:
         await websocket.close(
             WebSocketCodes.NORMAL_CLOSE, "MARIMO_NO_SESSION_ID"
@@ -265,7 +269,18 @@ class WebsocketHandler(SessionConsumer):
             if mgr.mode == SessionMode.EDIT:
                 mgr.close_all_sessions()
 
+            # Grab the query params from the websocket
+            # Note: if we resume a session, we don't pick up the new query
+            # params, and instead use the query params from when the
+            # session was created.
+            query_params = QueryParams.empty_stream()
+            for key, value in self.websocket.query_params.multi_items():
+                if SESSION_QUERY_PARAM_KEY == key:
+                    continue
+                query_params.append(key, value)
+
             new_session = mgr.create_session(
+                query_params=query_params.to_dict(),
                 session_id=session_id,
                 session_consumer=self,
             )

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -19,7 +19,7 @@ from marimo._messaging.ops import (
     Reconnected,
     serialize,
 )
-from marimo._messaging.types import KernelMessage
+from marimo._messaging.types import KernelMessage, NoopStream
 from marimo._plugins.core.json_encoder import WebComponentEncoder
 from marimo._plugins.core.web_component import JSONType
 from marimo._runtime.layout.layout import LayoutConfig, read_layout_config
@@ -272,7 +272,7 @@ class WebsocketHandler(SessionConsumer):
             # Note: if we resume a session, we don't pick up the new query
             # params, and instead use the query params from when the
             # session was created.
-            query_params = QueryParams.empty_stream()
+            query_params = QueryParams({}, NoopStream())
             for key, value in self.websocket.query_params.multi_items():
                 if SESSION_QUERY_PARAM_KEY == key:
                     continue

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -24,7 +24,6 @@ from marimo._plugins.core.json_encoder import WebComponentEncoder
 from marimo._plugins.core.web_component import JSONType
 from marimo._runtime.layout.layout import LayoutConfig, read_layout_config
 from marimo._runtime.query_params import QueryParams
-from marimo._runtime.requests import SerializedQueryParams
 from marimo._server.api.deps import AppState
 from marimo._server.model import (
     ConnectionState,

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -38,6 +38,7 @@ from marimo._runtime.requests import (
     AppMetadata,
     CreationRequest,
     ExecutionRequest,
+    SerializedQueryParams,
     SetUIElementValueRequest,
 )
 from marimo._server.file_manager import AppFileManager
@@ -413,7 +414,7 @@ class SessionManager:
 
         app = self._load_app()
 
-        self.app_metadata = AppMetadata(filename=self.path)
+        self.app_metadata = AppMetadata(query_params={}, filename=self.path)
 
         if mode == SessionMode.EDIT:
             # In edit mode, the server gets a random token to prevent
@@ -447,7 +448,10 @@ class SessionManager:
         self.filename = filename
 
     def create_session(
-        self, session_id: SessionId, session_consumer: SessionConsumer
+        self,
+        session_id: SessionId,
+        session_consumer: SessionConsumer,
+        query_params: SerializedQueryParams,
     ) -> Session:
         """Create a new session"""
         LOGGER.debug("Creating new session for id %s", session_id)
@@ -455,7 +459,9 @@ class SessionManager:
             self.sessions[session_id] = Session.create(
                 session_consumer=session_consumer,
                 mode=self.mode,
-                app_metadata=AppMetadata(filename=self.path),
+                app_metadata=AppMetadata(
+                    query_params=query_params, filename=self.path
+                ),
                 app_file_manager=AppFileManager(self.path),
                 package_manager=self.package_manager,
             )

--- a/marimo/_smoke_tests/query_params.py
+++ b/marimo/_smoke_tests/query_params.py
@@ -1,0 +1,44 @@
+import marimo
+
+__generated_with = "0.3.4"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        """
+    # Query params
+
+    Open this URL [/?foo=1&bar=2&bar=3&baz=4](/?foo=1&bar=2&bar=3&baz=4)
+    """
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.query_params().to_dict()
+    return
+
+
+@app.cell
+def __():
+    # mo.query_params()["abasdc"] = 11123123123
+    return
+
+
+@app.cell
+def __():
+    # mo.query_params().append("abc", 12)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/query_params.py
+++ b/marimo/_smoke_tests/query_params.py
@@ -5,52 +5,82 @@ app = marimo.App()
 
 
 @app.cell
-def __():
-    import marimo as mo
-    return mo,
-
-
-@app.cell
-def __(mo):
-    mo.md(
-        """
-    # Query params
-
-    Open this URL [/?foo=1&bar=2&bar=3&baz=4](/?foo=1&bar=2&bar=3&baz=4)
-    """
-    )
-    return
-
-
-@app.cell
 def __(mo):
     query_params = mo.query_params()
     return query_params,
 
 
 @app.cell
-def __(query_params):
+def __(mo, query_params, random):
+    # In another cell
+    print(random.randint(1, 50))
+    search = mo.ui.text(
+        value=query_params["search"] or "",
+        on_change=lambda v: query_params.set("search", v),
+    )
+    search
+    return search,
+
+
+@app.cell
+def __(mo):
+    toggle = mo.ui.switch(label="Toggle me")
+    toggle
+    return toggle,
+
+
+@app.cell
+def __(query_params, toggle):
     # change the value of a query param, and watch the next cell run automatically
-    query_params["foo"] = 8
+    query_params["has_run"] = toggle.value
     return
 
 
 @app.cell
-def __(query_params):
-    query_params
+def __(mo):
+    new_value = mo.ui.text(label="Text to add")
+    return new_value,
+
+
+@app.cell
+def __(mo, new_value, query_params):
+    append_button = mo.ui.button(
+        label="Add to query param",
+        on_click=lambda _: query_params.append("list", new_value.value),
+    )
+    replace_button = mo.ui.button(
+        label="Replace in query param",
+        on_click=lambda _: query_params.set("list", new_value.value),
+    )
+    mo.hstack([new_value, append_button, replace_button])
+    return append_button, replace_button
+
+
+@app.cell
+def __(mo, query_params):
+    items = [
+        {"key": key, "value": str(value)}
+        for key, value in query_params.to_dict().items()
+    ]
+    mo.ui.table(items, selection=None, label="Query params")
+    return items,
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        """
+    You can also initialized with query params. Open this URL [/?foo=1&bar=2&bar=3&baz=4](/?foo=1&bar=2&bar=3&baz=4) and restart the kernel
+    """
+    )
     return
 
 
 @app.cell
 def __():
-    # mo.query_params()["abasdc"] = 11123123123
-    return
-
-
-@app.cell
-def __():
-    # mo.query_params().append("abc", 12)
-    return
+    import marimo as mo
+    import random
+    return mo, random
 
 
 if __name__ == "__main__":

--- a/marimo/_smoke_tests/query_params.py
+++ b/marimo/_smoke_tests/query_params.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.3.4"
@@ -11,9 +12,8 @@ def __(mo):
 
 
 @app.cell
-def __(mo, query_params, random):
+def __(mo, query_params):
     # In another cell
-    print(random.randint(1, 50))
     search = mo.ui.text(
         value=query_params["search"] or "",
         on_change=lambda v: query_params.set("search", v),

--- a/marimo/_smoke_tests/query_params.py
+++ b/marimo/_smoke_tests/query_params.py
@@ -24,7 +24,20 @@ def __(mo):
 
 @app.cell
 def __(mo):
-    mo.query_params().to_dict()
+    query_params = mo.query_params()
+    return query_params,
+
+
+@app.cell
+def __(query_params):
+    # change the value of a query param, and watch the next cell run automatically
+    query_params["foo"] = 8
+    return
+
+
+@app.cell
+def __(query_params):
+    query_params
     return
 
 

--- a/tests/_runtime/test_query_params.py
+++ b/tests/_runtime/test_query_params.py
@@ -55,6 +55,16 @@ class TestQueryParams(unittest.TestCase):
             "data": {"key": "key3", "value": "value4"},
         }
 
+    def test_set(self):
+        self.params.set("key1", "value5")
+        assert self.params.get("key1") == "value5"
+
+        assert self.mock_stream.write.call_count == 1
+        assert self.mock_stream.write.call_args[1] == {
+            "op": "query-params-set",
+            "data": {"key": "key1", "value": "value5"},
+        }
+
     def test_append(self):
         self.params.append("key1", "value5")
         assert self.params.get("key1") == ["value1", "value5"]
@@ -63,11 +73,11 @@ class TestQueryParams(unittest.TestCase):
 
         assert self.mock_stream.write.call_count == 2
         assert self.mock_stream.write.call_args_list[0][1] == {
-            "op": "query-params-set",
+            "op": "query-params-append",
             "data": {"key": "key1", "value": "value5"},
         }
         assert self.mock_stream.write.call_args_list[1][1] == {
-            "op": "query-params-set",
+            "op": "query-params-append",
             "data": {"key": "key4", "value": "value6"},
         }
 
@@ -93,7 +103,7 @@ class TestQueryParams(unittest.TestCase):
             "data": {"key": "key1", "value": None},
         }
         assert self.mock_stream.write.call_args_list[1][1] == {
-            "op": "query-params-set",
+            "op": "query-params-append",
             "data": {"key": "key2", "value": "value4"},
         }
         assert self.mock_stream.write.call_args_list[2][1] == {

--- a/tests/_runtime/test_query_params.py
+++ b/tests/_runtime/test_query_params.py
@@ -1,0 +1,132 @@
+import unittest
+from unittest.mock import MagicMock
+
+from marimo._messaging.types import Stream
+from marimo._runtime.query_params import QueryParams
+
+
+class TestQueryParams(unittest.TestCase):
+    def setUp(self):
+        self.mock_stream = MagicMock(spec=Stream)
+        self.params = QueryParams(
+            {"key1": "value1", "key2": ["value2", "value3"]},
+            stream=self.mock_stream,
+        )
+
+    def test_get(self):
+        assert self.params.get("key1") == "value1"
+        assert self.params.get("key2") == ["value2", "value3"]
+
+    def test_get_all(self):
+        assert self.params.get_all("key1") == ["value1"]
+        assert self.params.get_all("key2") == ["value2", "value3"]
+        assert self.params.get_all("non_existent_key") == []
+
+    def test_contains(self):
+        assert "key1" in self.params
+        assert "non_existent_key" not in self.params
+
+    def test_len(self):
+        assert len(self.params) == 2
+
+    def test_iter(self):
+        keys = [key for key in self.params]
+        assert keys, ["key1", "key2"]
+
+    def test_repr(self):
+        assert (
+            repr(self.params)
+            == "QueryParams({'key1': 'value1', 'key2': ['value2', 'value3']})"
+        )
+
+    def test_str(self):
+        assert (
+            str(self.params)
+            == "{'key1': 'value1', 'key2': ['value2', 'value3']}"
+        )
+
+    def test_setitem(self):
+        self.params["key3"] = "value4"
+        assert self.params.get("key3") == "value4"
+
+        assert self.mock_stream.write.call_count == 1
+        assert self.mock_stream.write.call_args[1] == {
+            "op": "query-params-set",
+            "data": {"key": "key3", "value": "value4"},
+        }
+
+    def test_append(self):
+        self.params.append("key1", "value5")
+        assert self.params.get("key1") == ["value1", "value5"]
+        self.params.append("key4", "value6")
+        assert self.params.get("key4") == "value6"
+
+        assert self.mock_stream.write.call_count == 2
+        assert self.mock_stream.write.call_args_list[0][1] == {
+            "op": "query-params-set",
+            "data": {"key": "key1", "value": "value5"},
+        }
+        assert self.mock_stream.write.call_args_list[1][1] == {
+            "op": "query-params-set",
+            "data": {"key": "key4", "value": "value6"},
+        }
+
+    def test_delete(self):
+        del self.params["key1"]
+        assert "key1" not in self.params
+        assert len(self.params) == 1
+        assert str(self.params) == "{'key2': ['value2', 'value3']}"
+        assert (
+            repr(self.params) == "QueryParams({'key2': ['value2', 'value3']})"
+        )
+        self.params.append("key2", "value4")
+        assert self.params.get("key2") == ["value2", "value3", "value4"]
+        del self.params["key2"]
+        assert "key2" not in self.params
+        assert len(self.params) == 0
+        assert str(self.params) == "{}"
+        assert repr(self.params) == "QueryParams({})"
+
+        assert self.mock_stream.write.call_count == 3
+        assert self.mock_stream.write.call_args_list[0][1] == {
+            "op": "query-params-delete",
+            "data": {"key": "key1", "value": None},
+        }
+        assert self.mock_stream.write.call_args_list[1][1] == {
+            "op": "query-params-set",
+            "data": {"key": "key2", "value": "value4"},
+        }
+        assert self.mock_stream.write.call_args_list[2][1] == {
+            "op": "query-params-delete",
+            "data": {"key": "key2", "value": None},
+        }
+
+    def test_remove(self):
+        self.params.remove("key2", "value2")
+        assert self.params.get("key2") == ["value3"]
+        self.params.remove("key2")
+        assert self.params.get("key2") is None
+        self.params.remove("key2")
+        assert self.params.get("key2") is None
+
+        assert self.mock_stream.write.call_count == 2
+        assert self.mock_stream.write.call_args_list[0][1] == {
+            "op": "query-params-delete",
+            "data": {"key": "key2", "value": "value2"},
+        }
+        assert self.mock_stream.write.call_args_list[1][1] == {
+            "op": "query-params-delete",
+            "data": {"key": "key2", "value": None},
+        }
+
+    def test_clear(self):
+        self.params.clear()
+        assert len(self.params) == 0
+        assert str(self.params) == "{}"
+        assert repr(self.params) == "QueryParams({})"
+
+        assert self.mock_stream.write.call_count == 1
+        assert self.mock_stream.write.call_args_list[0][1] == {
+            "op": "query-params-clear",
+            "data": {},
+        }

--- a/tests/_server/test_session_manager.py
+++ b/tests/_server/test_session_manager.py
@@ -43,7 +43,9 @@ def test_create_session(
     session_manager: SessionManager, mock_session_consumer: SessionConsumer
 ):
     session_id = "test_session_id"
-    session = session_manager.create_session(session_id, mock_session_consumer)
+    session = session_manager.create_session(
+        session_id, mock_session_consumer, query_params={}
+    )
     assert session_id in session_manager.sessions
     assert session_manager.get_session(session_id) is session
     # Close ourselves to finish the test

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -15,7 +15,10 @@ from marimo._server.utils import initialize_asyncio
 initialize_asyncio()
 
 
-app_metadata = AppMetadata(filename="test.py")
+app_metadata = AppMetadata(
+    query_params={"some_param": "some_value"},
+    filename="test.py",
+)
 
 
 # TODO(akshayka): automatically do this for every test in our test suite
@@ -119,7 +122,7 @@ def test_session_disconnect_reconnect() -> None:
     session_consumer.connection_state.return_value = ConnectionState.OPEN
     queue_manager = QueueManager(use_multiprocessing=False)
     kernel_manager = KernelManager(
-        queue_manager, SessionMode.RUN, {}, AppMetadata(), "pip"
+        queue_manager, SessionMode.RUN, {}, AppMetadata(query_params={}), "pip"
     )
 
     # Instantiate a Session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,7 @@ class MockedKernel:
             stdin=self.stdin,
             cell_configs={},
             app_metadata=AppMetadata(
+                query_params={},
                 filename=None,
             ),
             debugger_override=MarimoPdb(stdout=self.stdout, stdin=self.stdin),


### PR DESCRIPTION
This adds the ability pass query_params to python and keep it in sync with the URL state.

```python
@app.cell
def __(mo):
    query_params = mo.query_params()
    return query_params,


@app.cell
def __(mo, query_params, random):
    # In another cell
    print(random.randint(1, 50))
    search = mo.ui.text(
        value=query_params["search"] or "",
        on_change=lambda v: query_params.set("search", v),
    )
    search
    return search,


@app.cell
def __(mo):
    toggle = mo.ui.switch(label="Toggle me")
    toggle
    return toggle,


@app.cell
def __(query_params, toggle):
    # change the value of a query param, and watch the next cell run automatically
    query_params["has_run"] = toggle.value
    return


@app.cell
def __(mo):
    new_value = mo.ui.text(label="Text to add")
    return new_value,


@app.cell
def __(mo, new_value, query_params):
    append_button = mo.ui.button(
        label="Add to query param",
        on_click=lambda _: query_params.append("list", new_value.value),
    )
    replace_button = mo.ui.button(
        label="Replace in query param",
        on_click=lambda _: query_params.set("list", new_value.value),
    )
    mo.hstack([new_value, append_button, replace_button])
    return append_button, replace_button
```


Closes #951 

- [x] Reactivity
- [x] Test wasm support
- [x] Docs
- [x] Better example for saving state lots of state in the URL params for read mode