### PR TITLE
fix: package versions in envinfo

### DIFF
--- a/marimo/_utils/health.py
+++ b/marimo/_utils/health.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import importlib.metadata
 import subprocess
 import sys
 from typing import Optional
@@ -28,9 +29,9 @@ def get_node_version() -> Optional[str]:
 
 
 def get_required_modules_list() -> dict[str, str]:
-    allowlist = [
+    packages = [
         "click",
-        "importlib_resources",
+        "importlib-resources",
         "jedi",
         "markdown",
         "pymdown-extensions",
@@ -42,15 +43,18 @@ def get_required_modules_list() -> dict[str, str]:
         "typing_extensions",
         "black",
     ]
+
+    package_versions: dict[str, str] = {}
     # Consider listing all installed modules and their versions
     # Submodules and private modules are can be filtered with:
     #  if not ("." in m or m.startswith("_")):
-    return {
-        module: getattr(
-            sys.modules.get(module, _DefaultModule), "__version__", "--"
-        )
-        for module in allowlist
-    }
+    for package in packages:
+        try:
+            package_versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            package_versions[package] = "missing"
+
+    return package_versions
 
 
 def get_chrome_version() -> Optional[str]:

--- a/marimo/_utils/health.py
+++ b/marimo/_utils/health.py
@@ -7,11 +7,6 @@ import sys
 from typing import Optional
 
 
-# Stub for missing modules
-class _DefaultModule:
-    __version__ = "missing"
-
-
 def get_node_version() -> Optional[str]:
     try:
         process = subprocess.Popen(
@@ -40,7 +35,7 @@ def get_required_modules_list() -> dict[str, str]:
         "uvicorn",
         "starlette",
         "websocket",
-        "typing_extensions",
+        "typing-extensions",
         "black",
     ]
 

--- a/tests/_cli/test_envinfo.py
+++ b/tests/_cli/test_envinfo.py
@@ -13,14 +13,18 @@ def test_get_node_version() -> None:
     assert node_version is None or isinstance(node_version, str)
 
 
-def test_get_pip_list() -> None:
+def test_get_package_versions() -> None:
     system_info = get_system_info()
     assert "Requirements" in system_info
-    pip_list = system_info["Requirements"]
+    package_versions = system_info["Requirements"]
 
-    assert isinstance(pip_list, dict)
-    assert "click" in pip_list
-    assert "starlette" in pip_list
+    assert isinstance(package_versions, dict)
+    assert "click" in package_versions
+    assert "starlette" in package_versions
+    assert (
+        "pymdown-extensions" in package_versions
+        and package_versions["pymdown-extensions"] != "missing"
+    )
 
 
 def test_get_system_info() -> None:


### PR DESCRIPTION
This PR uses `importlib.metadata` to get package versions for marimo env. This fixes a bug in which packages that were not imported before running marimo env had missing package versions.

importlib.metadata looks at Python's site-packages, so does not require any specific package manager to be installed.