### PR TITLE
feat: enable toggling to md mode automatically via mod-shift-m

### DIFF
--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -2,7 +2,11 @@
 import { sendDeleteCell } from "@/core/network/requests";
 import { downloadCellOutput } from "@/components/export/export-output-button";
 import { Switch } from "@/components/ui/switch";
-import { formatEditorViews } from "@/core/codemirror/format";
+import {
+  canToggleMarkdown,
+  formatEditorViews,
+  toggleToMarkdown,
+} from "@/core/codemirror/format";
 import { useCellActions } from "@/core/cells/cells";
 import {
   ImageIcon,
@@ -39,6 +43,7 @@ import {
   DialogHeader,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { MarkdownIcon } from "../cell/code/icons";
 
 export interface CellActionButtonProps
   extends Pick<CellData, "name" | "config"> {
@@ -176,6 +181,18 @@ export function useCellActionButtons({ cell }: Props) {
             return;
           }
           formatEditorViews({ [cellId]: editorView }, updateCellCode);
+        },
+      },
+      {
+        icon: <MarkdownIcon />,
+        label: "Markdown mode",
+        hotkey: "cell.markdownMode",
+        hidden: !canToggleMarkdown(editorView),
+        handle: () => {
+          if (!editorView) {
+            return;
+          }
+          toggleToMarkdown(cellId, editorView, updateCellCode);
         },
       },
       {

--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -5,7 +5,8 @@ import { Switch } from "@/components/ui/switch";
 import {
   canToggleMarkdown,
   formatEditorViews,
-  toggleToMarkdown,
+  getEditorViewMode,
+  toggleMarkdown,
 } from "@/core/codemirror/format";
 import { useCellActions } from "@/core/cells/cells";
 import {
@@ -43,7 +44,7 @@ import {
   DialogHeader,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { MarkdownIcon } from "../cell/code/icons";
+import { MarkdownIcon, PythonIcon } from "../cell/code/icons";
 
 export interface CellActionButtonProps
   extends Pick<CellData, "name" | "config"> {
@@ -184,15 +185,25 @@ export function useCellActionButtons({ cell }: Props) {
         },
       },
       {
-        icon: <MarkdownIcon />,
-        label: "Markdown mode",
-        hotkey: "cell.markdownMode",
-        hidden: !canToggleMarkdown(editorView),
+        icon:
+          getEditorViewMode(editorView) === "python" ? (
+            <MarkdownIcon />
+          ) : (
+            <PythonIcon />
+          ),
+        label:
+          getEditorViewMode(editorView) === "python"
+            ? "View as Markdown"
+            : "View as Python",
+        hotkey: "cell.viewAsMarkdown",
+        hidden:
+          !canToggleMarkdown(editorView) &&
+          getEditorViewMode(editorView) !== "markdown",
         handle: () => {
           if (!editorView) {
             return;
           }
-          toggleToMarkdown(cellId, editorView, updateCellCode);
+          toggleMarkdown(cellId, editorView, updateCellCode);
         },
       },
       {

--- a/frontend/src/core/codemirror/extensions.ts
+++ b/frontend/src/core/codemirror/extensions.ts
@@ -1,7 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { EditorView, keymap, placeholder } from "@codemirror/view";
 import { CellId } from "../cells/ids";
-import { formatEditorViews } from "./format";
+import { formatEditorViews, toggleToMarkdown } from "./format";
 import { smartScrollIntoView } from "../../utils/scroll";
 import { HOTKEYS } from "@/core/hotkeys/hotkeys";
 import { CellActions } from "../cells/cells";
@@ -64,6 +64,14 @@ export function formatKeymapExtension(
       preventDefault: true,
       run: (ev) => {
         formatEditorViews({ [cellId]: ev }, updateCellCode);
+        return true;
+      },
+    },
+    {
+      key: HOTKEYS.getHotkey("cell.markdownMode").key,
+      preventDefault: true,
+      run: (ev) => {
+        toggleToMarkdown(cellId, ev, updateCellCode);
         return true;
       },
     },

--- a/frontend/src/core/codemirror/extensions.ts
+++ b/frontend/src/core/codemirror/extensions.ts
@@ -1,7 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { EditorView, keymap, placeholder } from "@codemirror/view";
 import { CellId } from "../cells/ids";
-import { formatEditorViews, toggleToMarkdown } from "./format";
+import { formatEditorViews, toggleMarkdown } from "./format";
 import { smartScrollIntoView } from "../../utils/scroll";
 import { HOTKEYS } from "@/core/hotkeys/hotkeys";
 import { CellActions } from "../cells/cells";
@@ -68,10 +68,10 @@ export function formatKeymapExtension(
       },
     },
     {
-      key: HOTKEYS.getHotkey("cell.markdownMode").key,
+      key: HOTKEYS.getHotkey("cell.viewAsMarkdown").key,
       preventDefault: true,
       run: (ev) => {
-        toggleToMarkdown(cellId, ev, updateCellCode);
+        toggleMarkdown(cellId, ev, updateCellCode);
         return true;
       },
     },

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -104,6 +104,11 @@ const DEFAULT_HOT_KEY = {
     group: "Editing",
     key: "Mod-b",
   },
+  "cell.markdownMode": {
+    name: "Markdown mode",
+    group: "Editing",
+    key: "Mod-Shift-m",
+  },
   "cell.complete": {
     name: "Code completion",
     group: "Editing",

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -104,8 +104,8 @@ const DEFAULT_HOT_KEY = {
     group: "Editing",
     key: "Mod-b",
   },
-  "cell.markdownMode": {
-    name: "Markdown mode",
+  "cell.viewAsMarkdown": {
+    name: "View as Markdown",
     group: "Editing",
     key: "Mod-Shift-m",
   },


### PR DESCRIPTION
Features demonstrated in video:
- markdown toggle in cell menu
- markdown toggle doesnt show in cell menu when non-markdown-convertible code
- markdown shortcut works (mod-shift-m)

However, it seems that when a cell is created, the `editorView` is null until _something_ is typed. For this reason, I only know how to get this working after typing some whitespace character first, not sure how to actually initialize the EditorView.

Fixes #1003 

https://github.com/marimo-team/marimo/assets/33243383/4dca535f-7611-4594-9613-136213a2bfd7

