### PR TITLE
feat: support media in file viewer, allow editing files

### DIFF
--- a/frontend/src/components/editor/file-tree/file-viewer.tsx
+++ b/frontend/src/components/editor/file-tree/file-viewer.tsx
@@ -1,24 +1,78 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { generateColumns } from "@/components/data-table/columns";
 import { DataTable } from "@/components/data-table/data-table";
-import { sendFileDetails } from "@/core/network/requests";
+import { sendFileDetails, sendUpdateFile } from "@/core/network/requests";
 import { FileInfo } from "@/core/network/types";
 import { useAsyncData } from "@/hooks/useAsyncData";
-import AnyLanguageCodeMirror from "@/plugins/impl/code/any-language-editor";
+import { LazyAnyLanguageCodeMirror } from "@/plugins/impl/code/LazyAnyLanguageCodeMirror";
 import { ErrorBanner } from "@/plugins/impl/common/error-banner";
 import { parseCsvData } from "@/plugins/impl/vega/loader";
+import { useTheme } from "@/theme/useTheme";
 import { Objects } from "@/utils/objects";
-import { EditorView } from "@codemirror/view";
-import React, { useMemo } from "react";
+import { EditorView, keymap } from "@codemirror/view";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "../inputs/Inputs";
+import { CopyIcon, DownloadIcon, SaveIcon } from "lucide-react";
+import { renderShortcut } from "@/components/shortcuts/renderShortcut";
+import { Tooltip } from "@/components/ui/tooltip";
+import { HOTKEYS } from "@/core/hotkeys/hotkeys";
+import { downloadBlob, downloadByURL } from "@/utils/download";
+import { Base64String, base64ToDataURL } from "@/utils/json/base64";
 
 interface Props {
   file: FileInfo;
 }
 
+const unsavedContentsForFile = new Map<string, string>();
+
 export const FileViewer: React.FC<Props> = ({ file }) => {
-  const { data, loading, error } = useAsyncData(() => {
-    return sendFileDetails({ path: file.path });
+  const { theme } = useTheme();
+  // undefined value means not modified yet
+  const [internalValue, setInternalValue] = useState<string>("");
+
+  const { data, loading, error, setData } = useAsyncData(async () => {
+    const details = await sendFileDetails({ path: file.path });
+    const contents = details.contents || "";
+    setInternalValue(unsavedContentsForFile.get(file.path) || contents);
+    return details;
   }, [file.path]);
+
+  const handleSaveFile = async () => {
+    if (internalValue === data?.contents) {
+      return;
+    }
+
+    await sendUpdateFile({ path: file.path, contents: internalValue }).then(
+      (response) => {
+        if (response.success) {
+          // Update the last saved value
+          setData((prev) =>
+            prev ? { ...prev, contents: internalValue } : undefined,
+          );
+          setInternalValue(internalValue);
+        }
+      },
+    );
+  };
+
+  // On file change or unmount, save the unsaved contents
+  // We use a ref for internalValue so we don't call this effect on each keystroke
+  const internalValueRef = useRef<string>(internalValue);
+  internalValueRef.current = internalValue;
+  useEffect(() => {
+    return () => {
+      if (!data) {
+        return;
+      }
+      const draft = internalValueRef.current;
+      if (draft === data.contents) {
+        unsavedContentsForFile.delete(file.path);
+      } else {
+        unsavedContentsForFile.set(file.path, draft);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [file.path, data?.contents]);
 
   if (error) {
     return <ErrorBanner error={error} />;
@@ -28,6 +82,8 @@ export const FileViewer: React.FC<Props> = ({ file }) => {
     return null;
   }
 
+  const mimeType = data.mimeType || "text/plain";
+
   if (!data.contents) {
     // Show details instead of contents
     return (
@@ -35,31 +91,132 @@ export const FileViewer: React.FC<Props> = ({ file }) => {
         <div className="font-bold text-muted-foreground">Name</div>
         <div>{data.file.name}</div>
         <div className="font-bold text-muted-foreground">Type</div>
-        <div>{data.mimeType}</div>
+        <div>{mimeType}</div>
       </div>
     );
   }
 
-  if (data.mimeType === "text/csv") {
+  const handleDownload = () => {
+    if (isMedia(mimeType)) {
+      const dataURL = base64ToDataURL(data.contents as Base64String, mimeType);
+      downloadByURL(dataURL, data.file.name);
+      return;
+    }
+
+    downloadBlob(
+      new Blob([data.contents || internalValue], { type: mimeType }),
+      data.file.name,
+    );
+  };
+
+  const header = (
+    <div className="text-xs text-muted-foreground p-1 flex justify-end gap-2 border-b">
+      <Tooltip content="Download">
+        <Button size="small" onClick={handleDownload}>
+          <DownloadIcon />
+        </Button>
+      </Tooltip>
+      {!isMedia(mimeType) && (
+        <>
+          <Tooltip content="Copy contents to clipboard">
+            <Button
+              size="small"
+              onClick={() => {
+                navigator.clipboard.writeText(internalValue);
+              }}
+            >
+              <CopyIcon />
+            </Button>
+          </Tooltip>
+          <Tooltip content={renderShortcut("global.save")}>
+            <Button
+              size="small"
+              color={internalValue === data.contents ? undefined : "green"}
+              onClick={handleSaveFile}
+              disabled={internalValue === data.contents}
+            >
+              <SaveIcon />
+            </Button>
+          </Tooltip>
+        </>
+      )}
+    </div>
+  );
+
+  if (mimeType.startsWith("image/")) {
     return (
-      <div className="flex-1 overflow-hidden flex flex-col">
-        <CsvViewer contents={data.contents} />
-      </div>
+      <>
+        {header}
+        <div className="flex-1 overflow-hidden flex flex-col">
+          <ImageViewer base64={data.contents as Base64String} mime={mimeType} />
+        </div>
+      </>
+    );
+  }
+
+  if (mimeType === "text/csv") {
+    return (
+      <>
+        {header}
+        <div className="flex-1 overflow-hidden flex flex-col">
+          <CsvViewer contents={data.contents} />
+        </div>
+      </>
+    );
+  }
+
+  if (mimeType.startsWith("audio/")) {
+    return (
+      <>
+        {header}
+        <div className="flex-1 overflow-hidden flex flex-col">
+          <AudioViewer base64={data.contents as Base64String} mime={mimeType} />
+        </div>
+      </>
+    );
+  }
+
+  if (mimeType.startsWith("video/")) {
+    return (
+      <>
+        {header}
+        <div className="flex-1 overflow-hidden flex flex-col">
+          <VideoViewer base64={data.contents as Base64String} mime={mimeType} />
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="flex-1 overflow-auto">
-      <AnyLanguageCodeMirror
-        language={
-          mimeToLanguage[data.mimeType || "default"] || mimeToLanguage.default
-        }
-        className="border-b"
-        extensions={[EditorView.lineWrapping]}
-        value={data.contents}
-        readOnly={true}
-      />
-    </div>
+    <>
+      {header}
+      <div className="flex-1 overflow-auto">
+        <LazyAnyLanguageCodeMirror
+          theme={theme === "dark" ? "dark" : "light"}
+          language={mimeToLanguage[mimeType] || mimeToLanguage.default}
+          className="border-b"
+          extensions={[
+            EditorView.lineWrapping,
+            // Command S for save
+            keymap.of([
+              {
+                key: HOTKEYS.getHotkey("global.save").key,
+                stopPropagation: true,
+                run: () => {
+                  if (internalValue !== data.contents) {
+                    handleSaveFile();
+                    return true;
+                  }
+                  return false;
+                },
+              },
+            ]),
+          ]}
+          value={internalValue}
+          onChange={setInternalValue}
+        />
+      </div>
+    </>
   );
 };
 
@@ -80,6 +237,40 @@ const CsvViewer: React.FC<{ contents: string }> = ({ contents }) => {
   );
 };
 
+const ImageViewer: React.FC<{ base64: Base64String; mime: string }> = ({
+  mime,
+  base64,
+}) => {
+  return <img src={base64ToDataURL(base64, mime)} alt="Preview" />;
+};
+
+const AudioViewer: React.FC<{ base64: Base64String; mime: string }> = ({
+  mime,
+  base64,
+}) => {
+  // eslint-disable-next-line jsx-a11y/media-has-caption
+  return <audio controls={true} src={base64ToDataURL(base64, mime)} />;
+};
+
+const VideoViewer: React.FC<{ base64: Base64String; mime: string }> = ({
+  mime,
+  base64,
+}) => {
+  // eslint-disable-next-line jsx-a11y/media-has-caption
+  return <video controls={true} src={base64ToDataURL(base64, mime)} />;
+};
+
+const isMedia = (mime: string) => {
+  if (!mime) {
+    return false;
+  }
+  return (
+    mime.startsWith("image/") ||
+    mime.startsWith("audio/") ||
+    mime.startsWith("video/")
+  );
+};
+
 const mimeToLanguage: Record<string, string> = {
   "application/javascript": "javascript",
   "text/markdown": "markdown",
@@ -90,5 +281,6 @@ const mimeToLanguage: Record<string, string> = {
   "application/xml": "xml",
   "text/x-yaml": "yaml",
   "text/csv": "markdown",
+  "text/plain": "markdown",
   default: "markdown",
 };

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -26,6 +26,7 @@ import {
   FileDeleteRequest,
   FileUpdateRequest,
   FileDetailsResponse,
+  FileMoveRequest,
 } from "./types";
 import { invariant } from "@/utils/invariant";
 
@@ -168,6 +169,12 @@ export function createNetworkRequests(): EditRequests & RunRequests {
       );
     },
     sendRenameFileOrFolder: (request) => {
+      return API.post<FileMoveRequest, FileOperationResponse>(
+        "/files/move",
+        request,
+      );
+    },
+    sendUpdateFile: (request) => {
       return API.post<FileUpdateRequest, FileOperationResponse>(
         "/files/update",
         request,

--- a/frontend/src/core/network/requests-static.ts
+++ b/frontend/src/core/network/requests-static.ts
@@ -55,6 +55,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     sendCreateFileOrFolder: throwNotInEditMode,
     sendDeleteFileOrFolder: throwNotInEditMode,
     sendRenameFileOrFolder: throwNotInEditMode,
+    sendUpdateFile: throwNotInEditMode,
     sendFileDetails: throwNotInEditMode,
     sendInstallMissingPackages: throwNotInEditMode,
   };

--- a/frontend/src/core/network/requests-toasting.ts
+++ b/frontend/src/core/network/requests-toasting.ts
@@ -31,6 +31,7 @@ export function createErrorToastingRequests(
     sendCreateFileOrFolder: "Failed to create file or folder",
     sendDeleteFileOrFolder: "Failed to delete file or folder",
     sendRenameFileOrFolder: "Failed to rename file or folder",
+    sendUpdateFile: "Failed to update file",
     sendFileDetails: "Failed to get file details",
     sendInstallMissingPackages: "Failed to install missing packages",
   };

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -40,5 +40,6 @@ export const {
   sendCreateFileOrFolder,
   sendDeleteFileOrFolder,
   sendRenameFileOrFolder,
+  sendUpdateFile,
   sendFileDetails,
 } = getRequest();

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -134,9 +134,14 @@ export interface FileDeleteRequest {
   path: FilePath;
 }
 
-export interface FileUpdateRequest {
+export interface FileMoveRequest {
   path: FilePath;
   newPath: FilePath;
+}
+
+export interface FileUpdateRequest {
+  path: FilePath;
+  contents: string;
 }
 
 export interface FileOperationResponse {
@@ -191,6 +196,9 @@ export interface EditRequests {
     request: FileDeleteRequest,
   ) => Promise<FileOperationResponse>;
   sendRenameFileOrFolder: (
+    request: FileMoveRequest,
+  ) => Promise<FileOperationResponse>;
+  sendUpdateFile: (
     request: FileUpdateRequest,
   ) => Promise<FileOperationResponse>;
   sendFileDetails: (request: { path: string }) => Promise<FileDetailsResponse>;

--- a/frontend/src/core/pyodide/bridge.ts
+++ b/frontend/src/core/pyodide/bridge.ts
@@ -10,6 +10,7 @@ import {
   FileDetailsResponse,
   FileListRequest,
   FileListResponse,
+  FileMoveRequest,
   FileOperationResponse,
   FileUpdateRequest,
   FormatRequest,
@@ -300,10 +301,20 @@ export class PyodideBridge implements RunRequests, EditRequests {
   };
 
   sendRenameFileOrFolder = async (
+    request: FileMoveRequest,
+  ): Promise<FileOperationResponse> => {
+    const response = await this.rpc.proxy.request.bridge({
+      functionName: "move_file_or_directory",
+      payload: request,
+    });
+    return response as FileOperationResponse;
+  };
+
+  sendUpdateFile = async (
     request: FileUpdateRequest,
   ): Promise<FileOperationResponse> => {
     const response = await this.rpc.proxy.request.bridge({
-      functionName: "update_file_or_directory",
+      functionName: "update_file",
       payload: request,
     });
     return response as FileOperationResponse;

--- a/frontend/src/core/pyodide/worker/types.ts
+++ b/frontend/src/core/pyodide/worker/types.ts
@@ -7,6 +7,7 @@ import type {
   FileDetailsResponse,
   FileListRequest,
   FileListResponse,
+  FileMoveRequest,
   FileOperationResponse,
   FileUpdateRequest,
   FormatRequest,
@@ -52,9 +53,10 @@ export interface RawBridge {
   delete_file_or_directory(
     request: FileDeleteRequest,
   ): Promise<FileOperationResponse>;
-  update_file_or_directory(
-    request: FileUpdateRequest,
+  move_file_or_directory(
+    request: FileMoveRequest,
   ): Promise<FileOperationResponse>;
+  update_file(request: FileUpdateRequest): Promise<FileOperationResponse>;
   load_packages(request: string): Promise<string>;
   read_file(request: string): Promise<string>;
   set_interrupt_buffer(request: Uint8Array): Promise<string>;

--- a/frontend/src/core/pyodide/worker/worker.ts
+++ b/frontend/src/core/pyodide/worker/worker.ts
@@ -222,7 +222,8 @@ const namesThatRequireSync = new Set<keyof RawBridge>([
   "rename_file",
   "create_file_or_directory",
   "delete_file_or_directory",
-  "update_file_or_directory",
+  "move_file_or_directory",
+  "update_file",
 ]);
 
 function getMarimoVersion() {

--- a/frontend/src/css/Cell.css
+++ b/frontend/src/css/Cell.css
@@ -316,8 +316,6 @@
   padding-right: 24px;
 
   &.cm-focused {
-    outline: 0;
-
     .cm-activeLineGutter {
       background: #e2f2ff;
     }

--- a/frontend/src/css/codemirror.css
+++ b/frontend/src/css/codemirror.css
@@ -5,6 +5,10 @@
   background-color: #d7d4f0 !important;
 }
 
+.cm-focused.cm-focused {
+  outline: none;
+}
+
 /* -- Gutters -- */
 
 .cm .cm-gutters {

--- a/frontend/src/hooks/useAsyncData.ts
+++ b/frontend/src/hooks/useAsyncData.ts
@@ -1,5 +1,13 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { DependencyList, useState, useEffect } from "react";
+import { SetStateAction } from "jotai";
+import { DependencyList, useState, useEffect, Dispatch } from "react";
+
+interface AsyncDataResponse<T> {
+  data: T | undefined;
+  loading: boolean;
+  error: Error | undefined;
+  setData: Dispatch<SetStateAction<T | undefined>>;
+}
 
 /**
  * A hook that loads data asynchronously.
@@ -8,11 +16,7 @@ import { DependencyList, useState, useEffect } from "react";
 export function useAsyncData<T>(
   loader: () => Promise<T>,
   deps: DependencyList,
-): {
-  data: T | undefined;
-  loading: boolean;
-  error: Error | undefined;
-} {
+): AsyncDataResponse<T> {
   const [data, setData] = useState<T | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | undefined>(undefined);
@@ -47,5 +51,5 @@ export function useAsyncData<T>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 
-  return { data, loading, error };
+  return { data, loading, error, setData };
 }

--- a/frontend/src/utils/json/base64.ts
+++ b/frontend/src/utils/json/base64.ts
@@ -14,3 +14,7 @@ export function deserializeBase64ToJson<T>(base64: Base64String): T {
   const decodedString = decodeURIComponent(atob(base64));
   return JSON.parse(decodedString) as T;
 }
+
+export function base64ToDataURL(base64: Base64String, mimeType: string) {
+  return `data:${mimeType};base64,${base64}`;
+}

--- a/marimo/_server/api/endpoints/file_explorer.py
+++ b/marimo/_server/api/endpoints/file_explorer.py
@@ -18,6 +18,8 @@ from marimo._server.models.files import (
     FileDetailsResponse,
     FileListRequest,
     FileListResponse,
+    FileMoveRequest,
+    FileMoveResponse,
     FileUpdateRequest,
     FileUpdateResponse,
 )
@@ -98,9 +100,26 @@ async def delete_file_or_directory(
         return FileDeleteResponse(success=False, message=str(e))
 
 
+@router.post("/move")
+@requires("edit")
+async def move_file_or_directory(
+    *,
+    request: Request,
+) -> FileMoveResponse:
+    """Rename or move a file or directory."""
+    body = await parse_request(request, cls=FileMoveRequest)
+    try:
+        file_system.get_details(body.path)
+        info = file_system.move_file_or_directory(body.path, body.new_path)
+        return FileMoveResponse(success=True, info=info)
+    except Exception as e:
+        LOGGER.error(f"Error updating file or directory: {e}")
+        return FileMoveResponse(success=False, message=str(e))
+
+
 @router.post("/update")
 @requires("edit")
-async def update_file_or_directory(
+async def update_file(
     *,
     request: Request,
 ) -> FileUpdateResponse:
@@ -108,7 +127,7 @@ async def update_file_or_directory(
     body = await parse_request(request, cls=FileUpdateRequest)
     try:
         file_system.get_details(body.path)
-        info = file_system.update_file_or_directory(body.path, body.new_path)
+        info = file_system.update_file(body.path, body.contents)
         return FileUpdateResponse(success=True, info=info)
     except Exception as e:
         LOGGER.error(f"Error updating file or directory: {e}")

--- a/marimo/_server/files/file_system.py
+++ b/marimo/_server/files/file_system.py
@@ -49,6 +49,11 @@ class FileSystem(ABC):
         pass
 
     @abstractmethod
-    def update_file_or_directory(self, path: str, new_path: str) -> FileInfo:
+    def move_file_or_directory(self, path: str, new_path: str) -> FileInfo:
         """Rename or move a file or directory."""
+        pass
+
+    @abstractmethod
+    def update_file(self, path: str, contents: str) -> FileInfo:
+        """Update the contents of a file."""
         pass

--- a/marimo/_server/models/files.py
+++ b/marimo/_server/models/files.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from marimo._server.models.models import BaseResponse
+
 
 @dataclass
 class FileInfo:
@@ -60,11 +62,19 @@ class FileDeleteRequest:
 
 
 @dataclass
-class FileUpdateRequest:
+class FileMoveRequest:
     # The current path of the file or directory
     path: str
     # The new path or name for the file or directory
     new_path: str
+
+
+@dataclass
+class FileUpdateRequest:
+    # The current path of the file or directory
+    path: str
+    # The new contents of the file
+    contents: str
 
 
 @dataclass
@@ -81,23 +91,27 @@ class FileDetailsResponse:
 
 
 @dataclass
-class FileCreateResponse:
-    success: bool
+class FileCreateResponse(BaseResponse):
     # Additional information, e.g., error message
     message: Optional[str] = None
     info: Optional[FileInfo] = None
 
 
 @dataclass
-class FileDeleteResponse:
-    success: bool
+class FileDeleteResponse(BaseResponse):
     # Additional information, e.g., error message
     message: Optional[str] = None
 
 
 @dataclass
-class FileUpdateResponse:
-    success: bool
+class FileUpdateResponse(BaseResponse):
+    # Additional information, e.g., error message
+    message: Optional[str] = None
+    info: Optional[FileInfo] = None
+
+
+@dataclass
+class FileMoveResponse(BaseResponse):
     # Additional information, e.g., error message
     message: Optional[str] = None
     info: Optional[FileInfo] = None

--- a/tests/_server/api/endpoints/test_file_explorer.py
+++ b/tests/_server/api/endpoints/test_file_explorer.py
@@ -68,20 +68,6 @@ def test_create_and_delete_file_or_directory(client: TestClient) -> None:
     assert response.json()["success"] is True
 
 
-def test_move_file_or_directory(client: TestClient) -> None:
-    response = client.post(
-        "/api/files/move",
-        headers=HEADERS,
-        json={
-            "path": test_file_path,
-            "new_path": os.path.join(test_dir, "renamed.txt"),
-        },
-    )
-    assert response.status_code == 200, response.text
-    assert response.headers["content-type"] == "application/json"
-    assert response.json()["success"] is True
-
-
 def test_update_file(client: TestClient) -> None:
     response = client.post(
         "/api/files/update",
@@ -98,3 +84,17 @@ def test_update_file(client: TestClient) -> None:
         assert f.read() == "new content"
     with open(test_file_path, "w") as f:
         f.write(test_content)
+
+
+def test_move_file_or_directory(client: TestClient) -> None:
+    response = client.post(
+        "/api/files/move",
+        headers=HEADERS,
+        json={
+            "path": test_file_path,
+            "new_path": os.path.join(test_dir, "renamed.txt"),
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["success"] is True

--- a/tests/_server/api/endpoints/test_file_explorer.py
+++ b/tests/_server/api/endpoints/test_file_explorer.py
@@ -68,9 +68,9 @@ def test_create_and_delete_file_or_directory(client: TestClient) -> None:
     assert response.json()["success"] is True
 
 
-def test_update_file_or_directory(client: TestClient) -> None:
+def test_move_file_or_directory(client: TestClient) -> None:
     response = client.post(
-        "/api/files/update",
+        "/api/files/move",
         headers=HEADERS,
         json={
             "path": test_file_path,
@@ -80,3 +80,21 @@ def test_update_file_or_directory(client: TestClient) -> None:
     assert response.status_code == 200, response.text
     assert response.headers["content-type"] == "application/json"
     assert response.json()["success"] is True
+
+
+def test_update_file(client: TestClient) -> None:
+    response = client.post(
+        "/api/files/update",
+        headers=HEADERS,
+        json={
+            "path": test_file_path,
+            "contents": "new content",
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "application/json"
+    assert response.json()["success"] is True
+    with open(test_file_path, "r") as f:
+        assert f.read() == "new content"
+    with open(test_file_path, "w") as f:
+        f.write(test_content)

--- a/tests/_server/files/test_os_file_system.py
+++ b/tests/_server/files/test_os_file_system.py
@@ -109,13 +109,23 @@ class TestOSFileSystem(unittest.TestCase):
         self.fs.delete_file_or_directory(file_path)
         assert not os.path.exists(file_path)
 
-    def test_update_file(self):
+    def test_move_file(self):
         original_file_name = "original.txt"
         new_file_name = "new.txt"
         original_path = os.path.join(self.test_dir, original_file_name)
         new_path = os.path.join(self.test_dir, new_file_name)
         with open(original_path, "w") as f:
             f.write("Test")
-        self.fs.update_file_or_directory(original_path, new_path)
+        self.fs.move_file_or_directory(original_path, new_path)
         assert os.path.exists(new_path)
         assert not os.path.exists(original_path)
+
+    def test_update_file(self):
+        test_file_name = "test_file.txt"
+        file_path = os.path.join(self.test_dir, test_file_name)
+        with open(file_path, "w") as f:
+            f.write("Initial content")
+        new_content = "Updated content"
+        self.fs.update_file(file_path, new_content)
+        with open(file_path, "r") as f:
+            assert f.read() == new_content


### PR DESCRIPTION
This PR:
* adds a new endpoint to update file contents 
* renames an existing `update` endpoint, to `move`
* supports saving, downloading, copying from the file-viewer
* adds a basic media view for image, audio, video, 
* fixes a dark-mode bug with the editor


<img width="938" alt="Screenshot 2024-03-29 at 9 49 11 AM" src="https://github.com/marimo-team/marimo/assets/2753772/6fa0475c-27ec-4ed2-997f-bdd9ced67a7f">
<img width="905" alt="Screenshot 2024-03-29 at 9 49 25 AM" src="https://github.com/marimo-team/marimo/assets/2753772/9cac354b-746f-42fc-af72-ddcb8efdf242">