### PR TITLE
fix: stale editor view in cell action buttons

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -190,6 +190,9 @@ const CellComponent = (
     [editorView, prepareToRunEffects],
   );
 
+  // Callback to get the editor view.
+  const getEditorView = useCallback(() => editorView.current, [editorView]);
+
   const handleRun = useEvent(async () => {
     if (loading) {
       return;
@@ -385,7 +388,7 @@ const CellComponent = (
       cellId={cellId}
       config={cellConfig}
       status={status}
-      editorView={editorView.current}
+      getEditorView={getEditorView}
       hasOutput={hasOutput}
       name={name}
     >
@@ -459,7 +462,7 @@ const CellComponent = (
                 ref={cellActionDropdownRef}
                 cellId={cellId}
                 status={status}
-                editorView={editorView.current}
+                getEditorView={getEditorView}
                 name={name}
                 config={cellConfig}
                 hasOutput={hasOutput}

--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -44,8 +44,8 @@ export interface CellActionButtonProps
   extends Pick<CellData, "name" | "config"> {
   cellId: CellId;
   status: CellStatus;
-  editorView: EditorView | null;
   hasOutput: boolean;
+  getEditorView: () => EditorView | null;
 }
 
 interface Props {
@@ -66,11 +66,11 @@ export function useCellActionButtons({ cell }: Props) {
   const runCell = useRunCell(cell?.cellId);
   const { openModal } = useImperativeModal();
   const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
-
   if (!cell) {
     return [];
   }
-  const { cellId, config, editorView, name, hasOutput, status } = cell;
+  const { cellId, config, getEditorView, name, hasOutput, status } = cell;
+  const editorView = getEditorView();
 
   const toggleDisabled = async () => {
     const newConfig = { disabled: !config.disabled };

--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -48,7 +48,8 @@ export const CellActionsContextMenu = ({ children, ...props }: Props) => {
       label: "Paste",
       icon: <ClipboardPasteIcon size={13} strokeWidth={1.5} />,
       handle: async () => {
-        const { editorView } = props;
+        const { getEditorView } = props;
+        const editorView = getEditorView();
         if (!editorView) {
           return;
         }

--- a/frontend/src/core/cells/focus.ts
+++ b/frontend/src/core/cells/focus.ts
@@ -4,7 +4,6 @@ import { CellId } from "./ids";
 import { notebookAtom } from "./cells";
 import { EditorView } from "@codemirror/view";
 import { CellConfig, CellStatus } from "./types";
-import { useCallback } from "react";
 
 /**
  * Holds state for the last focused cell.
@@ -30,7 +29,7 @@ export const lastFocusedCellAtom = atom<{
   if (!data || !runtime || !handle) {
     return null;
   }
-  const getEditorView = useCallback(() => handle.editorView, [handle]);
+  const getEditorView = () => handle.editorView;
 
   return {
     cellId,

--- a/frontend/src/core/cells/focus.ts
+++ b/frontend/src/core/cells/focus.ts
@@ -4,6 +4,7 @@ import { CellId } from "./ids";
 import { notebookAtom } from "./cells";
 import { EditorView } from "@codemirror/view";
 import { CellConfig, CellStatus } from "./types";
+import { useCallback } from "react";
 
 /**
  * Holds state for the last focused cell.
@@ -15,7 +16,7 @@ export const lastFocusedCellAtom = atom<{
   config: CellConfig;
   cellId: CellId;
   status: CellStatus;
-  editorView: EditorView | null;
+  getEditorView: () => EditorView | null;
   hasOutput: boolean;
 } | null>((get) => {
   const cellId = get(lastFocusedCellIdAtom);
@@ -29,13 +30,14 @@ export const lastFocusedCellAtom = atom<{
   if (!data || !runtime || !handle) {
     return null;
   }
+  const getEditorView = useCallback(() => handle.editorView, [handle]);
 
   return {
     cellId,
     name: data.name,
     config: data.config,
     status: runtime.status,
-    editorView: handle.editorView,
+    getEditorView: getEditorView,
     hasOutput: runtime.output !== null,
   };
 });


### PR DESCRIPTION
Cell actions only had a snapshot of the ref's current value, which is `null` when the component  is first created.

@riyavsinha this should fix the last issue you noted in #1021 