### PR TITLE
avoid server error when encountering broken symlinks

### DIFF
--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -35,7 +35,14 @@ class OSFileSystem(FileSystem):
                 ):
                     continue
 
-                is_directory = entry.is_dir()
+                try:
+                    is_directory = entry.is_dir()
+                    entry_stat = entry.stat()
+                except OSError:
+                    # do not include files that fail to read
+                    # (e.g. recursive/broken symlinks)
+                    continue
+
                 info = FileInfo(
                     id=entry.path,
                     path=entry.path,
@@ -43,7 +50,7 @@ class OSFileSystem(FileSystem):
                     is_directory=is_directory,
                     is_marimo_file=not is_directory
                     and self._is_marimo_file(entry.path),
-                    last_modified_date=entry.stat().st_mtime,
+                    last_modified_date=entry_stat.st_mtime,
                 )
                 files.append(info)
 


### PR DESCRIPTION
When there is a bad symbolic link in a directory, [this line](https://github.com/marimo-team/marimo/blob/413bc9dbb20aa7be86b6cf661606134583ae5e6b/marimo/_server/files/os_file_system.py#L46) will lead to an "Internal Server Error". ("Bad" can either be a recursive link (ln -s broken) or a link pointing to a non-existing file (ln -s broken notthere).)

