### PR TITLE
fix: pyodide additional remounting

### DIFF
--- a/frontend/src/core/websocket/useWebSocket.tsx
+++ b/frontend/src/core/websocket/useWebSocket.tsx
@@ -45,10 +45,6 @@ export function useWebSocket(options: UseWebSocketOptions) {
     onMessage && ws.addEventListener("message", onMessage);
 
     return () => {
-      // Don't disconnect if we're using Pyodide
-      if (isPyodide()) {
-        return;
-      }
       onOpen && ws.removeEventListener("open", onOpen);
       onClose && ws.removeEventListener("close", onClose);
       onError && ws.removeEventListener("error", onError);

--- a/frontend/src/hooks/useAsyncData.ts
+++ b/frontend/src/hooks/useAsyncData.ts
@@ -18,7 +18,7 @@ export function useAsyncData<T>(
   deps: DependencyList,
 ): AsyncDataResponse<T> {
   const [data, setData] = useState<T | undefined>(undefined);
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | undefined>(undefined);
 
   useEffect(() => {


### PR DESCRIPTION
The `useAsyncData` would not start in the load state, which would cause an additional re-render while in pyodide mounting/unmounting the application and missing some initialization code.

This also fixes the autosave since that was not initialized with the correct data. 