### PR TITLE
fix: dont allow renaming to '.' or '..', show dotfiles

### DIFF
--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -11,12 +11,11 @@ from marimo._server.files.file_system import FileSystem
 from marimo._server.models.files import FileDetailsResponse, FileInfo
 
 IGNORE_LIST = [
+    ".",
+    "..",
+    ".DS_Store",
     "__pycache__",
     "node_modules",
-]
-
-IGNORE_PREFIXES = [
-    ".",
 ]
 
 
@@ -30,11 +29,6 @@ class OSFileSystem(FileSystem):
             for entry in it:
                 if entry.name in IGNORE_LIST:
                     continue
-                if any(
-                    entry.name.startswith(prefix) for prefix in IGNORE_PREFIXES
-                ):
-                    continue
-
                 try:
                     is_directory = entry.is_dir()
                     entry_stat = entry.stat()
@@ -139,6 +133,11 @@ class OSFileSystem(FileSystem):
         return True
 
     def move_file_or_directory(self, path: str, new_path: str) -> FileInfo:
+        file_name = os.path.basename(new_path)
+        # Disallow renaming to . or ..
+        if file_name in [".", ".."]:
+            raise ValueError(f"Cannot rename to {new_path}")
+
         shutil.move(path, new_path)
         return self.get_details(new_path).file
 

--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -18,6 +18,11 @@ IGNORE_LIST = [
     "node_modules",
 ]
 
+DISALLOWED_NAMES = [
+    ".",
+    "..",
+]
+
 
 class OSFileSystem(FileSystem):
     def get_root(self) -> str:
@@ -102,6 +107,13 @@ class OSFileSystem(FileSystem):
         name: str,
         contents: Optional[bytes],
     ) -> FileInfo:
+        if name in DISALLOWED_NAMES:
+            raise ValueError(
+                f"Cannot create file or directory with name {name}"
+            )
+        if name.strip() == "":
+            raise ValueError("Cannot create file or directory with empty name")
+
         full_path = os.path.join(path, name)
         # If the file already exists, generate a new name
         if os.path.exists(full_path):
@@ -135,7 +147,7 @@ class OSFileSystem(FileSystem):
     def move_file_or_directory(self, path: str, new_path: str) -> FileInfo:
         file_name = os.path.basename(new_path)
         # Disallow renaming to . or ..
-        if file_name in [".", ".."]:
+        if file_name in DISALLOWED_NAMES:
             raise ValueError(f"Cannot rename to {new_path}")
 
         shutil.move(path, new_path)


### PR DESCRIPTION
* dont allow renaming to `.` or `..`,
* show dotfiles, like `.env`, but hide `.DS_STORE`

Fixes one of the issues from #1031