### PR TITLE
feat: model/base-url settings for AI completion, bring out of experimental

### DIFF
--- a/docs/guides/ai_completion.md
+++ b/docs/guides/ai_completion.md
@@ -26,14 +26,13 @@ This feature is currently experimental and is not enabled by default. To enable 
 1. You need add the following to your `~/.marimo.toml`:
 
 ```toml
-[experimental]
-ai = true
-```
-
-2. Add your OpenAI API key to your environment:
-
-```bash
-export OPENAI_API_KEY=your-api-key
+[ai.open_ai]
+# Get your API key from https://platform.openai.com/account/api-keys
+api_key = "sk-..."
+# Choose a model, we recommend "gpt-3.5-turbo"
+model = "gpt-3.5-turbo"
+# Change the base_url if you are using a different OpenAI-compatible API
+base_url = "https://api.openai.com"
 ```
 
 Once enabled, you can use AI completion by pressing `Ctrl/Cmd-Shift-e` in a cell. This will open an input to modify the cell using AI.
@@ -44,3 +43,9 @@ Once enabled, you can use AI completion by pressing `Ctrl/Cmd-Shift-e` in a cell
 <figcaption>Use AI to modify a cell by pressing `Ctrl/Cmd-Shift-e`.</figcaption>
 </figure>
 </div>
+
+### Using other AI providers
+
+marimo supports OpenAI's GPT-3.5 API by default. If your provider is compatible with OpenAI's API, you can use it by changing the `base_url` in the configuration.
+
+For other providers not compatible with OpenAI's API, please submit a [feature request](https://github.com/marimo-team/marimo/issues) or "thumbs up" an existing one.

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -23,6 +23,7 @@ import { SettingTitle, SettingDescription, SettingSubtitle } from "./common";
 import { THEMES } from "@/theme/useTheme";
 import { isPyodide } from "@/core/pyodide/utils";
 import { PackageManagerNames } from "../../core/config/config-schema";
+import { Kbd } from "../ui/kbd";
 
 export const UserConfigForm: React.FC = () => {
   const [config, setConfig] = useUserConfig();
@@ -331,6 +332,64 @@ export const UserConfigForm: React.FC = () => {
                 <FormLabel className="font-normal">
                   Autorun on startup
                 </FormLabel>
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="flex flex-col gap-3">
+          <SettingSubtitle>AI Assist</SettingSubtitle>
+          <p className="text-sm text-muted-secondary">
+            You will need to store an API key in your{" "}
+            <Kbd className="inline">~/.marimo.toml</Kbd> file. See the{" "}
+            <a
+              className="text-link hover:underline"
+              href="https://docs.marimo.io/guides/ai_completion.html"
+              target="_blank"
+              rel="noreferrer"
+            >
+              documentation
+            </a>{" "}
+            for more information.
+          </p>
+          <FormField
+            control={form.control}
+            disabled={isWasm}
+            name="ai.open_ai.base_url"
+            render={({ field }) => (
+              <FormItem className="mb-2">
+                <FormLabel>Base URL</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="code-editor-font-size-input"
+                    className="m-0 inline-flex"
+                    {...field}
+                    value={field.value}
+                    placeholder="https://api.openai.com"
+                    onChange={(e) => field.onChange(e.target.value)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            disabled={isWasm}
+            name="ai.open_ai.model"
+            render={({ field: { value, onChange, ...field } }) => (
+              <FormItem className="mb-2">
+                <FormLabel>Model</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="code-editor-font-size-input"
+                    className="m-0 inline-flex"
+                    {...field}
+                    defaultValue={value}
+                    placeholder="gpt-3.5-turbo"
+                    onBlur={(e) => onChange(e.target.value)}
+                  />
+                </FormControl>
+                <FormMessage />
               </FormItem>
             )}
           />

--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -34,7 +34,6 @@ import { saveCellConfig } from "@/core/network/requests";
 import { EditorView } from "@codemirror/view";
 import { useRunCell } from "../cell/useRunCells";
 import { NameCellInput } from "./name-cell-input";
-import { getFeatureFlag } from "@/core/config/feature-flag";
 import { useSetAtom } from "jotai";
 import { aiCompletionCellAtom } from "@/core/ai/state";
 import { useImperativeModal } from "@/components/modal/ImperativeModal";
@@ -45,6 +44,7 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { MarkdownIcon, PythonIcon } from "../cell/code/icons";
+import { useUserConfig } from "@/core/config/config";
 
 export interface CellActionButtonProps
   extends Pick<CellData, "name" | "config"> {
@@ -72,6 +72,7 @@ export function useCellActionButtons({ cell }: Props) {
   const runCell = useRunCell(cell?.cellId);
   const { openModal } = useImperativeModal();
   const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
+  const [userConfig] = useUserConfig();
   if (!cell) {
     return [];
   }
@@ -159,7 +160,7 @@ export function useCellActionButtons({ cell }: Props) {
       {
         icon: <SparklesIcon size={13} strokeWidth={1.5} />,
         label: "AI completion",
-        hidden: !getFeatureFlag("ai"),
+        hidden: !userConfig.ai.open_ai?.api_key,
         handle: () => {
           setAiCompletionCell((current) =>
             current === cellId ? null : cellId,

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -15,6 +15,7 @@ test("default UserConfig - empty", () => {
   const defaultConfig = UserConfigSchema.parse({});
   expect(defaultConfig).toMatchInlineSnapshot(`
     {
+      "ai": {},
       "completion": {
         "activate_on_typing": true,
         "copilot": false,
@@ -58,6 +59,7 @@ test("default UserConfig - one level", () => {
   });
   expect(defaultConfig).toMatchInlineSnapshot(`
     {
+      "ai": {},
       "completion": {
         "activate_on_typing": true,
         "copilot": false,

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -67,10 +67,19 @@ export const UserConfigSchema = z
         manager: z.enum(PackageManagerNames).default("pip"),
       })
       .default({ manager: "pip" }),
-    experimental: z
+    ai: z
       .object({
-        ai: z.boolean().optional(),
+        open_ai: z
+          .object({
+            api_key: z.string().optional(),
+            base_url: z.string().optional(),
+            model: z.string().optional(),
+          })
+          .optional(),
       })
+      .default({}),
+    experimental: z
+      .object({})
       // Pass through so that we don't remove any extra keys that the user has added.
       .passthrough()
       .default({}),

--- a/frontend/src/core/config/feature-flag.ts
+++ b/frontend/src/core/config/feature-flag.ts
@@ -7,13 +7,10 @@ import { getUserConfig } from "./config";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ExperimentalFeatures {
-  // None yet
-  ai: boolean;
+  // Add new feature flags here
 }
 
-const defaultValues: ExperimentalFeatures = {
-  ai: process.env.NODE_ENV === "development",
-};
+const defaultValues: ExperimentalFeatures = {};
 
 export function getFeatureFlag<T extends keyof ExperimentalFeatures>(
   feature: T,

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -76,6 +76,7 @@ const props: CellProps = {
     package_management: {
       manager: "pip",
     },
+    ai: {},
     experimental: {},
   },
 };

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -1,14 +1,21 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, Optional, TypedDict, Union, cast
+import sys
+
+if sys.version_info < (3, 11):
+    from typing_extensions import NotRequired
+else:
+    from typing import NotRequired
+
+from typing import Any, Dict, Literal, TypedDict, Union, cast
 
 from marimo._output.rich_help import mddoc
 from marimo._utils.deep_merge import deep_merge
 
 
 @mddoc
-class CompletionConfig(TypedDict, total=False):
+class CompletionConfig(TypedDict):
     """Configuration for code completion.
 
     A dict with key/value pairs configuring code completion in the marimo
@@ -22,12 +29,11 @@ class CompletionConfig(TypedDict, total=False):
     """
 
     activate_on_typing: bool
-
     copilot: bool
 
 
 @mddoc
-class SaveConfig(TypedDict, total=False):
+class SaveConfig(TypedDict):
     """Configuration for saving.
 
     **Keys.**
@@ -55,7 +61,7 @@ class KeymapConfig(TypedDict, total=False):
 
 
 @mddoc
-class RuntimeConfig(TypedDict, total=False):
+class RuntimeConfig(TypedDict):
     """Configuration for runtime.
 
     **Keys.**
@@ -70,7 +76,7 @@ class RuntimeConfig(TypedDict, total=False):
 
 
 @mddoc
-class DisplayConfig(TypedDict, total=False):
+class DisplayConfig(TypedDict):
     """Configuration for display.
 
     **Keys.**
@@ -86,7 +92,7 @@ class DisplayConfig(TypedDict, total=False):
 
 
 @mddoc
-class FormattingConfig(TypedDict, total=False):
+class FormattingConfig(TypedDict):
     """Configuration for code formatting.
 
     **Keys.**
@@ -97,7 +103,7 @@ class FormattingConfig(TypedDict, total=False):
     line_length: int
 
 
-class ServerConfig(TypedDict, total=False):
+class ServerConfig(TypedDict):
     """Configuration for the server.
 
     **Keys.**
@@ -109,7 +115,7 @@ class ServerConfig(TypedDict, total=False):
     browser: Union[Literal["default"], str]
 
 
-class PackageManagementConfig(TypedDict, total=False):
+class PackageManagementConfig(TypedDict):
     """Configuration options for package management.
 
     **Keys.**
@@ -120,7 +126,7 @@ class PackageManagementConfig(TypedDict, total=False):
     manager: Literal["pip", "rye", "uv", "poetry", "pixi"]
 
 
-class AiConfig(TypedDict, total=False):
+class AiConfig(TypedDict):
     """Configuration options for AI.
 
     **Keys.**
@@ -128,10 +134,10 @@ class AiConfig(TypedDict, total=False):
     - `open_ai`: the OpenAI config
     """
 
-    open_ai: Optional[OpenAiConfig]
+    open_ai: OpenAiConfig
 
 
-class OpenAiConfig(TypedDict, total=False):
+class OpenAiConfig(TypedDict):
     """Configuration options for OpenAI or OpenAI-compatible services.
 
     **Keys.**
@@ -141,19 +147,14 @@ class OpenAiConfig(TypedDict, total=False):
     - `base_url`: the base URL for the API
     """
 
-    api_key: Optional[str]
-    model: Optional[str]
-    base_url: Optional[str]
+    api_key: str
+    model: NotRequired[str]
+    base_url: NotRequired[str]
 
 
 @mddoc
-class MarimoConfig(TypedDict, total=False):
-    """Configuration for the marimo editor.
-
-    A marimo configuration is a Python `dict`. Configurations
-    can be partially specified, with just a subset of possible keys.
-    Partial configs will be augmented with default options.
-    """
+class MarimoConfig(TypedDict):
+    """Configuration for the marimo editor"""
 
     completion: CompletionConfig
     display: DisplayConfig
@@ -163,8 +164,8 @@ class MarimoConfig(TypedDict, total=False):
     save: SaveConfig
     server: ServerConfig
     package_management: PackageManagementConfig
-    ai: AiConfig
-    experimental: Dict[str, Any]
+    ai: NotRequired[AiConfig]
+    experimental: NotRequired[Dict[str, Any]]
 
 
 DEFAULT_CONFIG: MarimoConfig = {

--- a/marimo/_config/utils.py
+++ b/marimo/_config/utils.py
@@ -8,7 +8,7 @@ from marimo import _loggers
 from marimo._config.config import (
     DEFAULT_CONFIG,
     MarimoConfig,
-    merge_config,
+    merge_default_config,
 )
 
 LOGGER = _loggers.marimo_logger()
@@ -103,7 +103,7 @@ def load_config() -> MarimoConfig:
             LOGGER.error("Failed to read user config at %s", path)
             LOGGER.error(str(e))
             return DEFAULT_CONFIG
-        return merge_config(cast(MarimoConfig, user_config))
+        return merge_default_config(cast(MarimoConfig, user_config))
     else:
         LOGGER.debug("No config found; loading default settings.")
     return DEFAULT_CONFIG

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -1,8 +1,8 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import os
-from typing import Generator
+from ast import Dict
+from typing import Generator, Optional
 
 from starlette.authentication import requires
 from starlette.exceptions import HTTPException
@@ -37,16 +37,41 @@ async def ai_completion(
 
     app_state = AppState(request)
     app_state.require_current_session()
+    config = app_state.config_manager.get_config(hide_secrets=False)
     body = await parse_request(request, cls=AiCompletionRequest)
-    key = os.environ.get("OPENAI_API_KEY")
 
+    if "ai" not in config:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail="OpenAI not configured"
+        )
+    if "open_ai" not in config["ai"]:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail="OpenAI not configured"
+        )
+    if "api_key" not in config["ai"]["open_ai"]:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="OpenAI API key not configured",
+        )
+
+    key: str = config["ai"]["open_ai"]["api_key"]
     if not key:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
-            detail="OpenAI API key not found in environment",
+            detail="OpenAI API key not configured",
         )
+    base_url: Optional[str] = (
+        config.get("ai", {}).get("open_ai", {}).get("base_url", None)
+    )
+    if not base_url:
+        base_url = None
+    model: str = (
+        config.get("ai", {}).get("open_ai", {}).get("model", "gpt-3.5-turbo")
+    )
+    if not model:
+        model = "gpt-3.5-turbo"
 
-    client = OpenAI(api_key=key)
+    client = OpenAI(api_key=key, base_url=base_url)
 
     system_prompt = (
         "You are a helpful assistant that can answer questions "
@@ -64,7 +89,7 @@ async def ai_completion(
         prompt = f"{prompt}\n\nCurrent code:\n{body.code}"
 
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model=model,
         messages=[
             {
                 "role": "system",

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from ast import Dict
 from typing import Generator, Optional
 
 from starlette.authentication import requires

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # websockets for use with starlette
     "websockets >= 10.0.0,<13.0.0",
     # python <=3.10 compatibility
-    "typing_extensions>=4.4.0; python_version < \"3.10\"",
+    "typing_extensions>=4.4.0; python_version < \"3.11\"",
     # for rst parsing
     "docutils>=0.17.0",
     # for cell formatting; if user version is not compatible, no-op

--- a/tests/_config/test_config.py
+++ b/tests/_config/test_config.py
@@ -99,7 +99,7 @@ def test_remove_secret_placeholders() -> None:
     assert config["ai"]["open_ai"]["api_key"] == "********"
 
     new_config = remove_secret_placeholders(config)
-    assert new_config["ai"]["open_ai"]["api_key"] is None
+    assert "api_key" not in new_config["ai"]["open_ai"]
 
     # Ensure the original config is not modified
     assert config["ai"]["open_ai"]["api_key"] == "********"

--- a/tests/_config/test_config.py
+++ b/tests/_config/test_config.py
@@ -1,9 +1,16 @@
 # Copyright 2024 Marimo. All rights reserved.
-from marimo._config.config import DEFAULT_CONFIG, MarimoConfig, merge_config
+from marimo._config.config import (
+    DEFAULT_CONFIG,
+    MarimoConfig,
+    mask_secrets,
+    merge_config,
+    merge_default_config,
+    remove_secret_placeholders,
+)
 
 
 def assert_config(override: MarimoConfig) -> None:
-    user_config = merge_config(override)
+    user_config = merge_default_config(override)
     assert user_config == {**DEFAULT_CONFIG, **override}
 
 
@@ -28,3 +35,71 @@ def test_configure_full() -> None:
 
 def test_configure_unknown() -> None:
     assert_config({"super cool future config key": {"secret": "value"}})  # type: ignore[typeddict-unknown-key] # noqa: E501
+
+
+def test_merge_config() -> None:
+    prev_config = merge_default_config(
+        MarimoConfig(
+            ai={
+                "open_ai": {
+                    "api_key": "super_secret",
+                }
+            },
+        )
+    )
+    assert prev_config["ai"]["open_ai"]["api_key"] == "super_secret"
+
+    new_config = merge_config(
+        prev_config,
+        MarimoConfig(
+            ai={
+                "open_ai": {
+                    "model": "davinci",
+                }
+            },
+        ),
+    )
+
+    assert new_config["ai"]["open_ai"]["api_key"] == "super_secret"
+    assert new_config["ai"]["open_ai"]["model"] == "davinci"
+
+
+def test_mask_secrets() -> None:
+    config = MarimoConfig(ai={"open_ai": {"api_key": "super_secret"}})
+    assert config["ai"]["open_ai"]["api_key"] == "super_secret"
+
+    new_config = mask_secrets(config)
+    assert new_config["ai"]["open_ai"]["api_key"] == "********"
+
+    # Ensure the original config is not modified
+    assert config["ai"]["open_ai"]["api_key"] == "super_secret"
+
+
+def test_mask_secrets_empty() -> None:
+    config = MarimoConfig(ai={"open_ai": {"model": "davinci"}})
+    assert config["ai"]["open_ai"]["model"] == "davinci"
+
+    new_config = mask_secrets(config)
+    assert new_config["ai"]["open_ai"]["model"] == "davinci"
+    # Not added until the key is present
+    assert "api_key" not in new_config["ai"]["open_ai"]
+
+    # Ensure the original config is not modified
+    assert config["ai"]["open_ai"]["model"] == "davinci"
+
+    # Not added when key is ""
+    config["ai"]["open_ai"]["api_key"] = ""
+    new_config = mask_secrets(config)
+    assert new_config["ai"]["open_ai"]["api_key"] == ""
+    assert config["ai"]["open_ai"]["api_key"] == ""
+
+
+def test_remove_secret_placeholders() -> None:
+    config = MarimoConfig(ai={"open_ai": {"api_key": "********"}})
+    assert config["ai"]["open_ai"]["api_key"] == "********"
+
+    new_config = remove_secret_placeholders(config)
+    assert new_config["ai"]["open_ai"]["api_key"] is None
+
+    # Ensure the original config is not modified
+    assert config["ai"]["open_ai"]["api_key"] == "********"

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -1,0 +1,76 @@
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+from marimo._config.config import merge_default_config
+from marimo._config.manager import MarimoConfig, UserConfigManager
+
+
+class TestUserConfigManager(unittest.TestCase):
+    @patch("tomlkit.dump")
+    @patch("marimo._config.manager.load_config")
+    def test_save_config(self, mock_load: Any, mock_dump: Any) -> None:
+        mock_config = merge_default_config(MarimoConfig())
+        mock_load.return_value = mock_config
+        manager = UserConfigManager()
+
+        result = manager.save_config(mock_config)
+
+        mock_load.assert_called_once()
+        assert result == manager.config
+
+        assert mock_dump.mock_calls[0][1][0] == result
+
+    @patch("tomlkit.dump")
+    @patch("marimo._config.manager.load_config")
+    def test_can_save_secrets(self, mock_load: Any, mock_dump: Any) -> None:
+        mock_config = merge_default_config(MarimoConfig())
+        mock_load.return_value = mock_config
+        manager = UserConfigManager()
+
+        manager.save_config(
+            merge_default_config(
+                MarimoConfig(ai={"open_ai": {"api_key": "super_secret"}})
+            )
+        )
+
+        assert (
+            mock_dump.mock_calls[0][1][0]["ai"]["open_ai"]["api_key"]
+            == "super_secret"
+        )
+
+        # Do not overwrite secrets
+        manager.save_config(
+            merge_default_config(
+                MarimoConfig(ai={"open_ai": {"api_key": "********"}})
+            )
+        )
+        assert (
+            mock_dump.mock_calls[1][1][0]["ai"]["open_ai"]["api_key"]
+            == "super_secret"
+        )
+
+    @patch("marimo._config.manager.load_config")
+    def test_can_read_secrets(self, mock_load: Any) -> None:
+        mock_config = merge_default_config(
+            MarimoConfig(ai={"open_ai": {"api_key": "super_secret"}})
+        )
+        mock_load.return_value = mock_config
+        manager = UserConfigManager()
+
+        assert manager.get_config()["ai"]["open_ai"]["api_key"] == "********"
+        assert (
+            manager.get_config(hide_secrets=False)["ai"]["open_ai"]["api_key"]
+            == "super_secret"
+        )
+
+    @patch("marimo._config.manager.load_config")
+    def test_get_config(self, mock_load: Any) -> None:
+        mock_config = merge_default_config(MarimoConfig())
+        mock_load.return_value = mock_config
+        manager = UserConfigManager()
+
+        result = manager.get_config()
+
+        mock_load.assert_called_once()
+        assert result == manager.config

--- a/tests/_server/conftest.py
+++ b/tests/_server/conftest.py
@@ -47,3 +47,7 @@ def client() -> Iterator[TestClient]:
 
 def get_session_manager(client: TestClient) -> SessionManager:
     return client.app.state.session_manager  # type: ignore
+
+
+def get_user_config_manager(client: TestClient) -> UserConfigManager:
+    return client.app.state.config_manager  # type: ignore


### PR DESCRIPTION
This adds an optional config setting for `ai -> open_ai -> model/base_url/api_key`. The api key is not configured in the UI. There is also some additional logic for masking the config and then being able to update the config that has been masked. 

- [x] The typings are a bit of a pain with a TypedDict and being optional