### PR TITLE
fix: guard against modules that don't have a `__spec__` attr

### DIFF
--- a/marimo/_runtime/packages/module_registry.py
+++ b/marimo/_runtime/packages/module_registry.py
@@ -12,8 +12,8 @@ def _is_module_installed(module_name: str) -> bool:
     # importlib.util.find_spec retrieves a module's ModuleSpec, which
     # is typically available as a dunder attribute on the module, i.e.
     # module.__spec__. However, some packages are non-compliant and don't
-    # include a __spec__ attr (e.g., manim-slides), which can cause find_spec to
-    # throw if the module has already been imported.
+    # include a __spec__ attr (e.g., manim-slides), which can cause find_spec
+    # to throw if the module has already been imported.
     #
     # We don't actually need the spec, we just need to see if a package is
     # available, so we first check if the module is in sys.modules without

--- a/marimo/_runtime/packages/module_registry.py
+++ b/marimo/_runtime/packages/module_registry.py
@@ -2,9 +2,26 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 
 from marimo._ast.cell import CellId_t
 from marimo._runtime.dataflow import DirectedGraph
+
+
+def _is_module_installed(module_name: str) -> bool:
+    # importlib.util.find_spec retrieves a module's ModuleSpec, which
+    # is typically available as a dunder attribute on the module, i.e.
+    # module.__spec__. However, some packages are non-compliant and don't
+    # include a __spec__ attr (e.g., manim-slides), which can cause find_spec to
+    # throw if the module has already been imported.
+    #
+    # We don't actually need the spec, we just need to see if a package is
+    # available, so we first check if the module is in sys.modules without
+    # checking for a __spec__ attr.
+    return (
+        module_name in sys.modules
+        or importlib.util.find_spec(module_name) is not None
+    )
 
 
 class ModuleRegistry:
@@ -35,10 +52,6 @@ class ModuleRegistry:
     def missing_modules(self) -> set[str]:
         """Modules that will fail to import."""
         return (
-            set(
-                mod
-                for mod in self.modules()
-                if importlib.util.find_spec(mod) is None
-            )
+            set(mod for mod in self.modules() if not _is_module_installed(mod))
             - self.excluded_modules
         )

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -452,7 +452,9 @@ class Kernel:
             defs_to_delete, exclude_defs if exclude_defs is not None else set()
         )
 
-        missing_modules_after_deletion = self.module_registry.missing_modules()
+        missing_modules_after_deletion = (
+            missing_modules_before_deletion & self.module_registry.modules()
+        )
         if (
             self.package_manager is not None
             and missing_modules_after_deletion

--- a/marimo/_smoke_tests/bugs/1055.py
+++ b/marimo/_smoke_tests/bugs/1055.py
@@ -1,0 +1,21 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.3.8"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import manim_slides
+    return manim_slides,
+
+
+@app.cell
+def __():
+    print(1)
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Some modules, like `manim_slides`, mess with Python's import system and don't have a `__spec__` attr after being imported. This was causing marimo to crash.

Fixes #1055 