### PR TITLE
fix: resuming when auto-instantiate is false

### DIFF
--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -81,7 +81,7 @@ export function useMarimoWebSocket(opts: {
           // A cell is stale if we did not auto-instantiate (i.e. nothing has run yet)
           // or if the code has changed since the last time it was run.
           let edited = false;
-          if (autoInstantiate) {
+          if (autoInstantiate || resumed) {
             const lastCodeRun = last_executed_code[cellId];
             if (lastCodeRun) {
               edited = lastCodeRun !== code;


### PR DESCRIPTION
When resuming a session and auto-instantiate is false, restore history of which cells have been executed and which are stale.

Fixes #1050 