### PR TITLE
fix: add mapping for cv2 module

### DIFF
--- a/marimo/_runtime/packages/conda_package_manager.py
+++ b/marimo/_runtime/packages/conda_package_manager.py
@@ -1,0 +1,23 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import subprocess
+
+from marimo._runtime.packages.module_name_to_conda_name import (
+    module_name_to_conda_name,
+)
+from marimo._runtime.packages.package_manager import (
+    CanonicalizingPackageManager,
+)
+
+
+class CondaPackageManager(CanonicalizingPackageManager):
+    def _construct_module_name_mapping(self) -> dict[str, str]:
+        return module_name_to_conda_name()
+
+
+class PixiPackageManager(CondaPackageManager):
+    name = "pixi"
+
+    async def install(self, package: str) -> bool:
+        return subprocess.run(["pixi", "add", package]).returncode == 0

--- a/marimo/_runtime/packages/module_name_to_conda_name.py
+++ b/marimo/_runtime/packages/module_name_to_conda_name.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._runtime.packages.module_name_to_pypi_name import (
+    module_name_to_pypi_name,
+)
+
+
+def module_name_to_conda_name() -> dict[str, str]:
+    # as a heuristic, start with pypi mapping and sub out things
+    # that known to be incorrect; this doesn't handle channels ...
+    mapping = module_name_to_pypi_name()
+    mapping["cv2"] = "opencv"
+    return mapping

--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -1,11 +1,12 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-# Mapping from a module name to the corresponding package name # on PyPI
 
-
+# Mapping from a module name to the corresponding package name
+# on PyPI
 def module_name_to_pypi_name() -> dict[str, str]:
     return {
+        "cv2": "opencv-python",
         "shopify": "ShopifyAPI",
         "bigquery": "google-cloud-bigquery",
         "carbon3d": "carbon3d-client",

--- a/marimo/_runtime/packages/package_manager.py
+++ b/marimo/_runtime/packages/package_manager.py
@@ -31,3 +31,57 @@ class PackageManager(abc.ABC):
         Returns True if installation succeeded, else False.
         """
         ...
+
+
+class CanonicalizingPackageManager(PackageManager):
+    """Base class for package managers.
+
+    Has a heuristic for mapping from package names to module names and back,
+    using a registry of well-known packages and basic rules for package
+    names.
+
+    Subclasses needs to implement _construct_module_name_mapping.
+    """
+
+    def __init__(self) -> None:
+        # Initialized lazily
+        self._module_name_to_repo_name: dict[str, str] | None = None
+        self._repo_name_to_module_name: dict[str, str] | None = None
+
+    @abc.abstractmethod
+    def _construct_module_name_mapping(self) -> dict[str, str]:
+        ...
+
+    def _initialize_mappings(self) -> None:
+        if self._module_name_to_repo_name is None:
+            self._module_name_to_repo_name = (
+                self._construct_module_name_mapping()
+            )
+
+        if self._repo_name_to_module_name is None:
+            self._repo_name_to_module_name = {
+                v: k for k, v in self._module_name_to_repo_name.items()
+            }
+
+    def module_to_package(self, module_name: str) -> str:
+        """Canonicalizes a module name to a package name on PyPI."""
+        if self._module_name_to_repo_name is None:
+            self._initialize_mappings()
+        assert self._module_name_to_repo_name is not None
+
+        if module_name in self._module_name_to_repo_name:
+            return self._module_name_to_repo_name[module_name]
+        else:
+            return module_name.replace("_", "-")
+
+    def package_to_module(self, package_name: str) -> str:
+        """Canonicalizes a package name to a module name."""
+        if self._repo_name_to_module_name is None:
+            self._initialize_mappings()
+        assert self._repo_name_to_module_name is not None
+
+        return (
+            self._repo_name_to_module_name[package_name]
+            if package_name in self._repo_name_to_module_name
+            else package_name.replace("-", "_")
+        )

--- a/marimo/_runtime/packages/package_managers.py
+++ b/marimo/_runtime/packages/package_managers.py
@@ -1,9 +1,9 @@
 # Copyright 2024 Marimo. All rights reserved.
+from marimo._runtime.packages.conda_package_manager import PixiPackageManager
 from marimo._runtime.packages.package_manager import PackageManager
 from marimo._runtime.packages.pypi_package_manager import (
     MicropipPackageManager,
     PipPackageManager,
-    PixiPackageManager,
     PoetryPackageManager,
     RyePackageManager,
     UvPackageManager,

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -6,54 +6,15 @@ import subprocess
 from marimo._runtime.packages.module_name_to_pypi_name import (
     module_name_to_pypi_name,
 )
-from marimo._runtime.packages.package_manager import PackageManager
+from marimo._runtime.packages.package_manager import (
+    CanonicalizingPackageManager,
+)
 from marimo._utils.platform import is_pyodide
 
 
-class PypiPackageManager(PackageManager):
-    """Base class for package managers that use PyPI.
-
-    Has a heuristic for mapping from package names to module names and back,
-    using a registry of well-known packages and basic rules for package
-    names.
-    """
-
-    def __init__(self) -> None:
-        # Initialized lazily
-        self._module_name_to_pypi_name: dict[str, str] | None = None
-        self._pypi_name_to_module_name: dict[str, str] | None = None
-
-    def _initialize_mappings(self) -> None:
-        if self._module_name_to_pypi_name is None:
-            self._module_name_to_pypi_name = module_name_to_pypi_name()
-
-        if self._pypi_name_to_module_name is None:
-            self._pypi_name_to_module_name = {
-                v: k for k, v in self._module_name_to_pypi_name.items()
-            }
-
-    def module_to_package(self, module_name: str) -> str:
-        """Canonicalizes a module name to a package name on PyPI."""
-        if self._module_name_to_pypi_name is None:
-            self._initialize_mappings()
-        assert self._module_name_to_pypi_name is not None
-
-        if module_name in self._module_name_to_pypi_name:
-            return self._module_name_to_pypi_name[module_name]
-        else:
-            return module_name.replace("_", "-")
-
-    def package_to_module(self, package_name: str) -> str:
-        """Canonicalizes a package name to a module name."""
-        if self._pypi_name_to_module_name is None:
-            self._initialize_mappings()
-        assert self._pypi_name_to_module_name is not None
-
-        return (
-            self._pypi_name_to_module_name[package_name]
-            if package_name in self._pypi_name_to_module_name
-            else package_name.replace("-", "_")
-        )
+class PypiPackageManager(CanonicalizingPackageManager):
+    def _construct_module_name_mapping(self) -> dict[str, str]:
+        return module_name_to_pypi_name()
 
 
 class PipPackageManager(PypiPackageManager):
@@ -101,15 +62,3 @@ class PoetryPackageManager(PypiPackageManager):
 
     async def install(self, package: str) -> bool:
         return subprocess.run(["poetry", "add", package]).returncode == 0
-
-
-# Pixi actually uses Conda by default ... but the package-to-module
-# resolution that we use for Pypi packages seems to work fine, so
-# we subclass PypiPackageManager.
-#
-# Can change the base class if/when needed.
-class PixiPackageManager(PypiPackageManager):
-    name = "pixi"
-
-    async def install(self, package: str) -> bool:
-        return subprocess.run(["pixi", "add", package]).returncode == 0


### PR DESCRIPTION
- map it to opencv-python for pip and opencv for conda
- split package manager base class for pypi/conda

Fixes #1071 