### PR TITLE
feat: autoreload

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -318,17 +318,12 @@ notebook menu in the top right and click "Restart kernel".
 
 ### How do I reload modules?
 
-To reload modules, use
-[`importlib.reload()`](https://docs.python.org/3/library/importlib.html#importlib.reload):
+Enable automatic reloading of modules via the runtime settings in your
+marimo installation's user configuration. (Click the "gear" icon in the
+top right of a marimo notebook).
 
-```
-import mymodule
-import importlib
-importlib.reload(mymodule)
-```
-
-Running this cell will reload `mymodule` with your new edits and automatically
-re-run any cells using `mymodule`.
+When enabled, marimo will automatically hot-reload modified modules
+before executing a cell.
 
 <a name="faq-on-change-called"></a>
 

--- a/frontend/e2e-tests/disabled.spec.ts
+++ b/frontend/e2e-tests/disabled.spec.ts
@@ -78,9 +78,7 @@ test("disabled cells", async ({ page }) => {
   await page.getByText("Disable").click();
 
   // Check they are still stale
-  await expect(page.getByTitle("This cell is disabled").count()).resolves.toBe(
-    2,
-  );
+  await expect(page.getByTitle("This cell is disabled")).toHaveCount(2);
   await expect(
     page
       .getByTestId("cell-status")
@@ -100,9 +98,7 @@ test("disabled cells", async ({ page }) => {
   await page.getByText("Enable").click();
 
   // Check the status
-  await expect(page.getByTitle("This cell is disabled").count()).resolves.toBe(
-    1,
-  );
+  await expect(page.getByTitle("This cell is disabled")).toHaveCount(1);
 
   // Enable the second
   await page.hover("text=Cell 2");
@@ -110,9 +106,7 @@ test("disabled cells", async ({ page }) => {
   await page.getByText("Enable").click();
 
   // Check the status
-  await expect(page.getByTitle("This cell is disabled").count()).resolves.toBe(
-    0,
-  );
+  await expect(page.getByTitle("This cell is disabled")).toHaveCount(0);
 
   await takeScreenshot(page, __filename);
 });

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -335,6 +335,31 @@ export const UserConfigForm: React.FC = () => {
               </FormItem>
             )}
           />
+          <FormField
+            control={form.control}
+            name="runtime.auto_reload"
+            render={({ field }) => (
+              <div className="flex flex-col gap-y-1">
+                <FormItem className="flex flex-row items-start space-x-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      data-testid="auto-reload-checkbox"
+                      disabled={field.disabled}
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormLabel className="font-normal">
+                    Autoreload modules
+                  </FormLabel>
+                </FormItem>
+                <FormDescription>
+                  When checked, marimo will automatically reload modules before
+                  executing cells.
+                </FormDescription>
+              </div>
+            )}
+          />
         </div>
         <div className="flex flex-col gap-3">
           <SettingSubtitle>AI Assist</SettingSubtitle>

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -37,6 +37,7 @@ test("default UserConfig - empty", () => {
       },
       "runtime": {
         "auto_instantiate": true,
+        "auto_reload": false,
       },
       "save": {
         "autosave": "after_delay",
@@ -81,6 +82,7 @@ test("default UserConfig - one level", () => {
       },
       "runtime": {
         "auto_instantiate": true,
+        "auto_reload": false,
       },
       "save": {
         "autosave": "after_delay",

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -53,6 +53,7 @@ export const UserConfigSchema = z
     runtime: z
       .object({
         auto_instantiate: z.boolean().default(true),
+        auto_reload: z.boolean().default(false),
       })
       .default({}),
     display: z

--- a/frontend/src/core/pyodide/bridge.ts
+++ b/frontend/src/core/pyodide/bridge.ts
@@ -37,6 +37,7 @@ import { getMarimoVersion } from "../dom/marimo-tag";
 import { getWorkerRPC } from "./rpc";
 import { API } from "../network/api";
 import { RuntimeState } from "@/core/kernel/RuntimeState";
+import { parseUserConfig } from "../config/config-schema";
 
 export class PyodideBridge implements RunRequests, EditRequests {
   static INSTANCE = new PyodideBridge();
@@ -88,6 +89,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
     const code = await notebookFileStore.readFile();
     const fallbackCode = await fallbackFileStore.readFile();
     const filename = PyodideRouter.getFilename();
+    const userConfig = parseUserConfig();
 
     const queryParameters: Record<string, string | string[]> = {};
     const searchParams = new URLSearchParams(window.location.search);
@@ -101,6 +103,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
       code,
       fallbackCode: fallbackCode || "",
       filename,
+      userConfig,
     });
   }
 
@@ -218,6 +221,11 @@ export class PyodideBridge implements RunRequests, EditRequests {
   };
 
   saveUserConfig = async (request: SaveUserConfigRequest): Promise<null> => {
+    await this.rpc.proxy.request.bridge({
+      functionName: "save_user_config",
+      payload: request,
+    });
+
     return API.post<SaveUserConfigRequest>(
       "/kernel/save_user_config",
       request,

--- a/frontend/src/core/pyodide/worker/bootstrap.ts
+++ b/frontend/src/core/pyodide/worker/bootstrap.ts
@@ -4,6 +4,7 @@ import { mountFilesystem } from "./fs";
 import { Logger } from "../../../utils/Logger";
 import { SerializedBridge, WasmController } from "./types";
 import { invariant } from "../../../utils/invariant";
+import { UserConfig } from "@/core/config/config-schema";
 
 declare let loadPyodide: (opts: {
   packages: string[];
@@ -84,6 +85,7 @@ export class DefaultWasmController implements WasmController {
     fallbackCode: string;
     filename: string | null;
     onMessage: (message: string) => void;
+    userConfig: UserConfig;
   }): Promise<SerializedBridge> {
     invariant(this.pyodide, "Pyodide not loaded");
 
@@ -103,6 +105,7 @@ export class DefaultWasmController implements WasmController {
       callback: opts.onMessage,
     };
     self.query_params = opts.queryParameters;
+    self.user_config = opts.userConfig;
 
     // Load packages from the code
     await this.pyodide.loadPackagesFromImports(content, {
@@ -124,6 +127,7 @@ export class DefaultWasmController implements WasmController {
         filename="${filename}",
         query_params=js.query_params.to_py(),
         message_callback=js.messenger.callback,
+        user_config=js.user_config.to_py(),
       )
       instantiate(session)
       asyncio.create_task(session.start())

--- a/frontend/src/core/pyodide/worker/types.ts
+++ b/frontend/src/core/pyodide/worker/types.ts
@@ -14,6 +14,7 @@ import type {
   FormatResponse,
   SaveAppConfigRequest,
   SaveKernelRequest,
+  SaveUserConfigRequest,
   SnippetsResponse,
 } from "../../network/types";
 
@@ -47,6 +48,7 @@ export interface RawBridge {
   format(request: FormatRequest): Promise<FormatResponse>;
   save(request: SaveKernelRequest): Promise<string>;
   save_app_config(request: SaveAppConfigRequest): Promise<string>;
+  save_user_config(request: SaveUserConfigRequest): Promise<null>;
   rename_file(request: string): Promise<string>;
   list_files(request: FileListRequest): Promise<FileListResponse>;
   file_details(request: { path: string }): Promise<FileDetailsResponse>;

--- a/frontend/src/core/pyodide/worker/worker.ts
+++ b/frontend/src/core/pyodide/worker/worker.ts
@@ -17,6 +17,7 @@ import { ParentSchema } from "../rpc";
 import { Logger } from "../../../utils/Logger";
 import { TRANSPORT_ID } from "./constants";
 import { invariant } from "../../../utils/invariant";
+import { UserConfig } from "vite";
 
 declare const self: Window & {
   pyodide: PyodideInterface;
@@ -73,6 +74,7 @@ const requestHandler = createRPCRequestHandler({
     code: string | null;
     fallbackCode: string;
     filename: string | null;
+    userConfig: UserConfig | null;
   }) => {
     await pyodideReadyPromise; // Make sure loading is done
 

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -66,6 +66,7 @@ const props: CellProps = {
     },
     runtime: {
       auto_instantiate: true,
+      auto_reload: false,
     },
     keymap: {
       preset: "default",

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -70,9 +70,12 @@ class RuntimeConfig(TypedDict):
         run on startup. This only applies when editing a notebook,
         and not when running as an application.
         The default is `True`.
+    - `auto_reload`: if `True`, modified modules will be automatically reloaded
+       before cell execution; similar to IPython's %autoreload 2.
     """
 
     auto_instantiate: bool
+    auto_reload: bool
 
 
 @mddoc
@@ -177,7 +180,7 @@ DEFAULT_CONFIG: MarimoConfig = {
     },
     "formatting": {"line_length": 79},
     "keymap": {"preset": "default"},
-    "runtime": {"auto_instantiate": True},
+    "runtime": {"auto_instantiate": True, "auto_reload": False},
     "save": {
         "autosave": "after_delay",
         "autosave_delay": 1000,

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -39,9 +39,11 @@ class IPythonFormatter(FormatterFactory):
         def unpatch() -> None:
             IPython.display.display = old_display
 
-        @formatting.formatter(IPython.display.HTML)
+        @formatting.formatter(
+            IPython.display.HTML  # type:ignore
+        )
         def _format_html(
-            html: IPython.display.HTML,
+            html: IPython.display.HTML,  # type:ignore
         ) -> tuple[KnownMimeType, str]:
             if html.url is not None:
                 # TODO(akshayka): resize iframe not working

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -20,7 +20,7 @@ cache: Dict[Any, UIElement[Any, Any]] = weakref.WeakKeyDictionary()  # type: ign
 def from_anywidget(widget: "AnyWidget") -> UIElement[Any, Any]:
     """Create a UIElement from an AnyWidget."""
     if widget not in cache:
-        cache[widget] = anywidget(widget)  # type: ignore[no-untyped-call, unused-ignore, assignment]
+        cache[widget] = anywidget(widget)  # type: ignore[no-untyped-call, unused-ignore, assignment]  # noqa: E501
     return cache[widget]
 
 
@@ -77,15 +77,15 @@ class anywidget(UIElement[T, T]):
             for key, value in change.items():
                 widget.set_trait(key, value)
 
-        js: str = widget._esm if hasattr(widget, "_esm") else ""  # type: ignore [unused-ignore]
-        css: str = widget._css if hasattr(widget, "_css") else ""  # type: ignore [unused-ignore]
+        js: str = widget._esm if hasattr(widget, "_esm") else ""  # type: ignore [unused-ignore]  # noqa: E501
+        css: str = widget._css if hasattr(widget, "_css") else ""  # type: ignore [unused-ignore]  # noqa: E501
 
         super().__init__(
             component_name="marimo-anywidget",
             initial_value=args,
             label="",
             args={
-                "js-url": mo_data.js(js).url if js else "",  # type: ignore [unused-ignore]
+                "js-url": mo_data.js(js).url if js else "",  # type: ignore [unused-ignore]  # noqa: E501
                 "css": css,
             },
             on_change=on_change,

--- a/marimo/_runtime/autoreload.py
+++ b/marimo/_runtime/autoreload.py
@@ -17,7 +17,7 @@ import weakref
 from dataclasses import dataclass
 from importlib import reload
 from importlib.util import source_from_cache
-from typing import Any, Callable, Generic, Type, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Tuple, Type, TypeVar
 
 from marimo import _loggers
 
@@ -40,7 +40,7 @@ class ModuleMTime:
 
 
 # (module-name, name) -> weakref, for replacing old code objects
-OldObjectsMapping = dict[tuple[str, str], list[weakref.ref[Any]]]
+OldObjectsMapping = Dict[Tuple[str, str], List[weakref.ref[Any]]]
 
 
 class ModuleReloader:

--- a/marimo/_runtime/autoreload.py
+++ b/marimo/_runtime/autoreload.py
@@ -40,7 +40,9 @@ class ModuleMTime:
 
 
 # (module-name, name) -> weakref, for replacing old code objects
-OldObjectsMapping = Dict[Tuple[str, str], List[weakref.ref[Any]]]
+OldObjectsMapping = Dict[
+    Tuple[str, str], List[weakref.ref]  # type:ignore[type-arg]
+]
 
 
 class ModuleReloader:

--- a/marimo/_runtime/autoreload.py
+++ b/marimo/_runtime/autoreload.py
@@ -1,0 +1,326 @@
+"""Module reloader
+
+In addition to reloading modules, the reloader also patches instances
+of reloaded objects with their code.
+
+Based on the autoreload extension from the IPython project (BSD-3 Clause).
+"""
+from __future__ import annotations
+
+import gc
+import os
+import sys
+import traceback
+import types
+import weakref
+from dataclasses import dataclass
+from importlib import reload
+from importlib.util import source_from_cache
+from typing import Any, cast
+
+from marimo import _loggers
+
+LOGGER = _loggers.marimo_logger()
+
+func_attrs = [
+    "__code__",
+    "__defaults__",
+    "__doc__",
+    "__closure__",
+    "__globals__",
+    "__dict__",
+]
+
+
+@dataclass
+class ModuleMTime:
+    name: str
+    mtime: float
+
+
+class ModuleReloader:
+    def __init__(self) -> None:
+        # Modules that failed to reload: {module: mtime-on-failed-reload, ...}
+        self.failed: dict[str, float] = {}
+        # (module-name, name) -> weakref, for replacing old code objects
+        self.old_objects: dict[tuple[str, str], weakref.ref[Any]] = {}
+        # module-name -> mtime (module modification timestamps)
+        self.modules_mtimes: dict[str, float] = {}
+
+    def filename_and_mtime(
+        self, module: types.ModuleType | None
+    ) -> ModuleMTime | None:
+        if module is None:
+            return None
+
+        if not hasattr(module, "__file__") or module.__file__ is None:
+            return None
+
+        if getattr(module, "__name__", None) in [
+            None,
+            "__mp_main__",
+            "__main__",
+        ]:
+            # we cannot reload(__main__) or reload(__mp_main__)
+            return None
+
+        filename = module.__file__
+        _, ext = os.path.splitext(filename)
+
+        if ext.lower() == ".py":
+            py_filename = filename
+        else:
+            try:
+                py_filename = source_from_cache(filename)
+            except ValueError:
+                return None
+
+        try:
+            pymtime = os.stat(py_filename).st_mtime
+        except OSError:
+            return None
+        return ModuleMTime(py_filename, pymtime)
+
+    def reload(self) -> None:
+        """Reload modules that need to be reloaded.
+
+        Also patches existing objects with hot-reloaded ones.
+        """
+
+        # materialize the module keys, since we'll be reloading while iterating
+        for modname in list(sys.modules.keys()):
+            m = sys.modules.get(modname, None)
+
+            module_mtime = self.filename_and_mtime(m)
+            if module_mtime is None:
+                continue
+            py_filename, pymtime = module_mtime.name, module_mtime.mtime
+
+            try:
+                if pymtime <= self.modules_mtimes[modname]:
+                    continue
+            except KeyError:
+                self.modules_mtimes[modname] = pymtime
+                continue
+            else:
+                if self.failed.get(py_filename, None) == pymtime:
+                    continue
+
+            self.modules_mtimes[modname] = pymtime
+
+            # If we've reached this point, we should try to reload the module
+            LOGGER.debug(f"Reloading '{modname}'.")
+            try:
+                superreload(m, self.old_objects)
+                if py_filename in self.failed:
+                    del self.failed[py_filename]
+            except:
+                LOGGER.debug(
+                    "[autoreload of {} failed: {}]".format(
+                        modname, traceback.format_exc(10)
+                    ),
+                )
+                self.failed[py_filename] = pymtime
+
+
+def update_function(old, new):
+    """Upgrade the code object of a function"""
+    for name in func_attrs:
+        try:
+            setattr(old, name, getattr(new, name))
+        except (AttributeError, TypeError):
+            pass
+
+
+def update_instances(old, new):
+    """Use garbage collector to find all instances that refer to the old
+    class definition and update their __class__ to point to the new class
+    definition"""
+
+    refs = gc.get_referrers(old)
+
+    for ref in refs:
+        if type(ref) is old:
+            object.__setattr__(ref, "__class__", new)
+
+
+def update_class(old, new):
+    """Replace stuff in the __dict__ of a class, and upgrade
+    method code objects, and add new methods, if any"""
+    for key in list(old.__dict__.keys()):
+        old_obj = getattr(old, key)
+        new_obj: object | None = None
+        try:
+            new_obj = getattr(new, key)
+            # explicitly checking that comparison returns True to handle
+            # cases where `==` doesn't return a boolean.
+            if (old_obj == new_obj) is True:
+                continue
+        except AttributeError:
+            # obsolete attribute: remove it
+            try:
+                delattr(old, key)
+            except (AttributeError, TypeError):
+                pass
+            continue
+        except ValueError:
+            # can't compare nested structures containing
+            # numpy arrays using `==`
+            pass
+
+        if new_obj is None or update_generic(old_obj, new_obj):
+            continue
+
+        try:
+            setattr(old, key, getattr(new, key))
+        except (AttributeError, TypeError):
+            pass  # skip non-writable attributes
+
+    for key in list(new.__dict__.keys()):
+        if key not in list(old.__dict__.keys()):
+            try:
+                setattr(old, key, getattr(new, key))
+            except (AttributeError, TypeError):
+                pass  # skip non-writable attributes
+
+    # update all instances of class
+    update_instances(old, new)
+
+
+def update_property(old, new):
+    """Replace get/set/del functions of a property"""
+    update_generic(old.fdel, new.fdel)
+    update_generic(old.fget, new.fget)
+    update_generic(old.fset, new.fset)
+
+
+def isinstance2(a, b, typ):
+    return isinstance(a, typ) and isinstance(b, typ)
+
+
+UPDATE_RULES = [
+    (lambda a, b: isinstance2(a, b, type), update_class),
+    (lambda a, b: isinstance2(a, b, types.FunctionType), update_function),
+    (lambda a, b: isinstance2(a, b, property), update_property),
+]
+UPDATE_RULES.extend(
+    [
+        (
+            lambda a, b: isinstance2(a, b, types.MethodType),
+            lambda a, b: update_function(a.__func__, b.__func__),
+        ),
+    ]
+)
+
+
+def update_generic(a, b):
+    for type_check, update in UPDATE_RULES:
+        if type_check(a, b):
+            update(a, b)
+            return True
+    return False
+
+
+class StrongRef:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __call__(self):
+        return self.obj
+
+
+mod_attrs = [
+    "__name__",
+    "__doc__",
+    "__package__",
+    "__loader__",
+    "__spec__",
+    "__file__",
+    "__cached__",
+    "__builtins__",
+]
+
+
+def append_obj(module, d, name, obj, autoload=False):
+    in_module = (
+        hasattr(obj, "__module__") and obj.__module__ == module.__name__
+    )
+    if autoload:
+        # check needed for module global built-ins
+        if not in_module and name in mod_attrs:
+            return False
+    else:
+        if not in_module:
+            return False
+
+    key = (module.__name__, name)
+    try:
+        d.setdefault(key, []).append(weakref.ref(obj))
+    except TypeError:
+        pass
+    return True
+
+
+def superreload(module, old_objects):
+    """Enhanced version of the builtin reload function.
+
+    superreload remembers objects previously in the module, and
+
+    - upgrades the class dictionary of every old class in the module
+    - upgrades the code object of every old function and method
+    - clears the module's namespace before reloading
+
+    """
+    if old_objects is None:
+        old_objects = {}
+
+    # collect old objects in the module
+    for name, obj in list(module.__dict__.items()):
+        if not append_obj(module, old_objects, name, obj):
+            continue
+        key = (module.__name__, name)
+        try:
+            old_objects.setdefault(key, []).append(weakref.ref(obj))
+        except TypeError:
+            pass
+
+    # reload module
+    old_dict: dict[str, Any] | None = None
+    try:
+        # clear namespace first from old cruft
+        old_dict = cast(dict[str, Any], module.__dict__.copy())
+        old_name = module.__name__
+        module.__dict__.clear()
+        module.__dict__["__name__"] = old_name
+        module.__dict__["__loader__"] = old_dict["__loader__"]
+    except (TypeError, AttributeError, KeyError):
+        pass
+
+    try:
+        module = reload(module)
+    except:
+        # restore module dictionary on failed reload
+        if old_dict is not None:
+            module.__dict__.update(old_dict)
+        raise
+
+    # iterate over all objects and update functions & classes
+    for name, new_obj in list(module.__dict__.items()):
+        key = (module.__name__, name)
+        if key not in old_objects:
+            continue
+
+        new_refs = []
+        for old_ref in old_objects[key]:
+            old_obj = old_ref()
+            if old_obj is None:
+                continue
+            new_refs.append(old_ref)
+            update_generic(old_obj, new_obj)
+
+        if new_refs:
+            old_objects[key] = new_refs
+        else:
+            del old_objects[key]
+
+    return module

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from marimo._ast.cell import CellId_t
+from marimo._config.config import MarimoConfig
 
 UIElementId = str
 CompletionRequestId = str
@@ -54,6 +55,12 @@ class SetCellConfigRequest:
 
 
 @dataclass
+class SetUserConfigRequest:
+    # MarimoConfig TypedDict
+    config: MarimoConfig
+
+
+@dataclass
 class CreationRequest:
     execution_requests: Tuple[ExecutionRequest, ...]
     set_ui_element_value_request: SetUIElementValueRequest
@@ -88,6 +95,7 @@ ControlRequest = Union[
     DeleteRequest,
     FunctionCallRequest,
     SetCellConfigRequest,
+    SetUserConfigRequest,
     SetUIElementValueRequest,
     StopRequest,
     InstallMissingPackagesRequest,

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -237,14 +237,13 @@ class Kernel:
 
     - cell_configs: initial configuration for each cell
     - app_metadata: metadata about the notebook
+    - user_config: the initial user configuration
     - stream: object used to communicate with the server/outside world
     - stdout: replacement for sys.stdout
     - stderr: replacement for sys.stderr
     - stdin: replacement for sys.stdin
     - input_override: a function that overrides the builtin input() function
     - debugger_override: a replacement for the built-in Pdb
-    - package_manager: default package manager to use
-    - autoreload: whether to autoreload modules before cell execution
     """
 
     def __init__(

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -316,6 +316,8 @@ class Kernel:
             self.package_manager = create_package_manager(package_manager)
         if autoreload and self.module_reloader is None:
             self.module_reloader = ModuleReloader()
+            # initialize package modification times
+            self.module_reloader.reload()
 
     @property
     def globals(self) -> dict[Any, Any]:

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -21,6 +21,7 @@ from marimo import _loggers
 from marimo._ast.cell import CellConfig, CellId_t
 from marimo._ast.compiler import compile_cell
 from marimo._ast.visitor import Name, is_local
+from marimo._config.config import MarimoConfig
 from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.errors import (
     Error,
@@ -70,6 +71,7 @@ from marimo._runtime import (
     marimo_pdb,
     patches,
 )
+from marimo._runtime.autoreload import ModuleReloader
 from marimo._runtime.complete import complete, completion_worker
 from marimo._runtime.context import (
     ContextNotInitializedError,
@@ -80,6 +82,7 @@ from marimo._runtime.context import (
 from marimo._runtime.control_flow import MarimoInterrupt, MarimoStopError
 from marimo._runtime.input_override import input_override
 from marimo._runtime.packages.module_registry import ModuleRegistry
+from marimo._runtime.packages.package_manager import PackageManager
 from marimo._runtime.packages.package_managers import create_package_manager
 from marimo._runtime.packages.utils import is_python_isolated
 from marimo._runtime.query_params import QueryParams
@@ -96,6 +99,7 @@ from marimo._runtime.requests import (
     InstallMissingPackagesRequest,
     SetCellConfigRequest,
     SetUIElementValueRequest,
+    SetUserConfigRequest,
     StopRequest,
 )
 from marimo._runtime.state import State
@@ -239,19 +243,21 @@ class Kernel:
     - stdin: replacement for sys.stdin
     - input_override: a function that overrides the builtin input() function
     - debugger_override: a replacement for the built-in Pdb
+    - package_manager: default package manager to use
+    - autoreload: whether to autoreload modules before cell execution
     """
 
     def __init__(
         self,
         cell_configs: dict[CellId_t, CellConfig],
         app_metadata: AppMetadata,
+        user_config: MarimoConfig,
         stream: Stream,
         stdout: Stdout | None,
         stderr: Stderr | None,
         stdin: Stdin | None,
         input_override: Callable[[Any], str] = input_override,
         debugger_override: marimo_pdb.MarimoPdb | None = None,
-        package_manager: str | None = None,
     ) -> None:
         self.app_metadata = app_metadata
         self.query_params = QueryParams(app_metadata.query_params)
@@ -276,12 +282,14 @@ class Kernel:
         self.module_registry = ModuleRegistry(
             self.graph, excluded_modules=set()
         )
-        self.package_manager = (
-            create_package_manager(package_manager)
-            if package_manager is not None
-            else None
-        )
 
+        # Load runtime settings from user config
+        self.package_manager: PackageManager | None = None
+        self.module_reloader: ModuleReloader | None = None
+        self.user_config = user_config
+        self._update_runtime_from_user_config(user_config)
+
+        # Set up the execution context
         self.execution_context: Optional[ExecutionContext] = None
         # initializers to override construction of ui elements
         self.ui_initializers: dict[str, Any] = {}
@@ -296,6 +304,18 @@ class Kernel:
         # an empty string represents the current directory
         exec("import sys; sys.path.append(''); del sys", self.globals)
         exec("import marimo as __marimo__", self.globals)
+
+    def _update_runtime_from_user_config(self, config: MarimoConfig) -> None:
+        self.user_config = config
+        package_manager = self.user_config["package_management"]["manager"]
+        autoreload = self.user_config["runtime"]["auto_reload"]
+        if (
+            self.package_manager is None
+            or package_manager != self.package_manager.name
+        ):
+            self.package_manager = create_package_manager(package_manager)
+        if autoreload and self.module_reloader is None:
+            self.module_reloader = ModuleReloader()
 
     @property
     def globals(self) -> dict[Any, Any]:
@@ -772,6 +792,9 @@ class Kernel:
             if cell.stale:
                 continue
 
+            if self.module_reloader is not None:
+                self.module_reloader.reload()
+
             LOGGER.debug("running cell %s", cell_id)
             cell.set_status(status="running")
 
@@ -1001,6 +1024,9 @@ class Kernel:
             await self._run_cells(
                 dataflow.transitive_closure(self.graph, cells_to_run)
             )
+
+    def set_user_config(self, request: SetUserConfigRequest) -> None:
+        self._update_runtime_from_user_config(request.config)
 
     async def set_ui_element_value(
         self, request: SetUIElementValueRequest
@@ -1284,6 +1310,9 @@ class Kernel:
             CompletedRun().broadcast()
         elif isinstance(request, SetCellConfigRequest):
             await self.set_cell_config(request)
+        elif isinstance(request, SetUserConfigRequest):
+            # TODO user config pyodide pkg mangagemetn ...
+            self.set_user_config(request)
         elif isinstance(request, SetUIElementValueRequest):
             await self.set_ui_element_value(request)
             CompletedRun().broadcast()
@@ -1314,7 +1343,7 @@ def launch_kernel(
     is_edit_mode: bool,
     configs: dict[CellId_t, CellConfig],
     app_metadata: AppMetadata,
-    package_manager: str,
+    user_config: MarimoConfig,
 ) -> None:
     LOGGER.debug("Launching kernel")
     if is_edit_mode:
@@ -1360,7 +1389,7 @@ def launch_kernel(
         stdin=stdin,
         input_override=input_override,
         debugger_override=debugger,
-        package_manager=package_manager if is_edit_mode else None,
+        user_config=user_config,
     )
     initialize_context(
         kernel=kernel,

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1317,7 +1317,6 @@ class Kernel:
         elif isinstance(request, SetCellConfigRequest):
             await self.set_cell_config(request)
         elif isinstance(request, SetUserConfigRequest):
-            # TODO user config pyodide pkg mangagemetn ...
             self.set_user_config(request)
         elif isinstance(request, SetUIElementValueRequest):
             await self.set_ui_element_value(request)

--- a/marimo/_server/api/endpoints/config.py
+++ b/marimo/_server/api/endpoints/config.py
@@ -5,6 +5,7 @@ from starlette.authentication import requires
 from starlette.requests import Request
 
 from marimo import _loggers
+from marimo._runtime.requests import SetUserConfigRequest
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
 from marimo._server.models.models import (
@@ -13,7 +14,6 @@ from marimo._server.models.models import (
     SuccessResponse,
 )
 from marimo._server.router import APIRouter
-from marimo._runtime.requests import SetUserConfigRequest
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_server/api/endpoints/config.py
+++ b/marimo/_server/api/endpoints/config.py
@@ -13,6 +13,7 @@ from marimo._server.models.models import (
     SuccessResponse,
 )
 from marimo._server.router import APIRouter
+from marimo._runtime.requests import SetUserConfigRequest
 
 LOGGER = _loggers.marimo_logger()
 
@@ -26,10 +27,7 @@ async def save_user_config(
     *,
     request: Request,
 ) -> BaseResponse:
-    """Run multiple cells (and their descendants).
-
-    Updates cell code in the kernel if needed; registers new cells
-    for unseen cell IDs.
+    """Update the user config on disk and in the kernel.
 
     Only allowed in edit mode.
     """
@@ -42,4 +40,8 @@ async def save_user_config(
         LOGGER.debug("Starting copilot server")
         await app_state.session_manager.start_lsp_server()
 
+    # Update the kernel's view of the config
+    app_state.require_current_session().put_control_request(
+        SetUserConfigRequest(body.config)
+    )
     return SuccessResponse()

--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -96,7 +96,6 @@ def create_asgi_app(
 
     user_config_mgr = UserConfigManager()
     base_app = Starlette()
-    package_manager = user_config_mgr.config["package_management"]["manager"]
 
     # We call the entrypoint `root` instead of `filename` incase we want to
     # support directories or code in the future
@@ -118,7 +117,7 @@ def create_asgi_app(
                 # Currently we only support run mode,
                 # which doesn't require an LSP server
                 lsp_server=NoopLspServer(),
-                package_manager=package_manager,
+                user_config_manager=user_config_mgr,
             )
             app = create_starlette_app(
                 base_url="",

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -402,7 +402,7 @@ class SessionManager:
         quiet: bool,
         include_code: bool,
         lsp_server: LspServer,
-        user_config_manager: UserConfigManager
+        user_config_manager: UserConfigManager,
     ) -> None:
         self.filename = filename
         self.mode = mode

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -30,6 +30,7 @@ from uuid import uuid4
 from marimo import _loggers
 from marimo._ast.app import InternalApp, _AppConfig
 from marimo._ast.cell import CellConfig, CellId_t
+from marimo._config.manager import UserConfigManager
 from marimo._messaging.ops import Alert, MessageOperation, Reload
 from marimo._messaging.types import KernelMessage
 from marimo._output.formatters.formatters import register_formatters
@@ -118,14 +119,14 @@ class KernelManager:
         mode: SessionMode,
         configs: dict[CellId_t, CellConfig],
         app_metadata: AppMetadata,
-        package_manager: str,
+        user_config_manager: UserConfigManager,
     ) -> None:
         self.kernel_task: Optional[threading.Thread] | Optional[mp.Process]
         self.queue_manager = queue_manager
         self.mode = mode
         self.configs = configs
         self.app_metadata = app_metadata
-        self.package_manager = package_manager
+        self.user_config_manager = user_config_manager
         self._read_conn: Optional[TypedConnection[KernelMessage]] = None
 
     def start_kernel(self) -> None:
@@ -147,7 +148,7 @@ class KernelManager:
                     is_edit_mode,
                     self.configs,
                     self.app_metadata,
-                    self.package_manager,
+                    self.user_config_manager.config,
                 ),
                 # The process can't be a daemon, because daemonic processes
                 # can't create children
@@ -183,7 +184,7 @@ class KernelManager:
                     is_edit_mode,
                     self.configs,
                     self.app_metadata,
-                    self.package_manager,
+                    self.user_config_manager.config,
                 ),
                 # daemon threads can create child processes, unlike
                 # daemon processes
@@ -241,13 +242,13 @@ class Session:
         mode: SessionMode,
         app_metadata: AppMetadata,
         app_file_manager: AppFileManager,
-        package_manager: str,
+        user_config_manager: UserConfigManager,
     ) -> Session:
         configs = app_file_manager.app.cell_manager.config_map()
         use_multiprocessing = mode == SessionMode.EDIT
         queue_manager = QueueManager(use_multiprocessing)
         kernel_manager = KernelManager(
-            queue_manager, mode, configs, app_metadata, package_manager
+            queue_manager, mode, configs, app_metadata, user_config_manager
         )
         return cls(
             session_consumer,
@@ -401,7 +402,7 @@ class SessionManager:
         quiet: bool,
         include_code: bool,
         lsp_server: LspServer,
-        package_manager: str,
+        user_config_manager: UserConfigManager
     ) -> None:
         self.filename = filename
         self.mode = mode
@@ -411,7 +412,7 @@ class SessionManager:
         self.include_code = include_code
         self.lsp_server = lsp_server
         self.watcher: Optional[FileWatcher] = None
-        self.package_manager = package_manager
+        self.user_config_manager = user_config_manager
 
         app = self._load_app()
 
@@ -464,7 +465,7 @@ class SessionManager:
                     query_params=query_params, filename=self.path
                 ),
                 app_file_manager=AppFileManager(self.path),
-                package_manager=self.package_manager,
+                user_config_manager=self.user_config_manager,
             )
         return self.sessions[session_id]
 

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -51,9 +51,7 @@ def start(
         quiet=quiet,
         include_code=include_code,
         lsp_server=LspServer(port * 10),
-        package_manager=user_config_mgr.config["package_management"][
-            "manager"
-        ],
+        user_config_manager=user_config_mgr,
     )
 
     log_level = "info" if development_mode else "error"

--- a/tests/_runtime/test_autoreload.py
+++ b/tests/_runtime/test_autoreload.py
@@ -8,9 +8,11 @@ import textwrap
 import time
 import types
 
-from tests.conftest import ExecReqProvider
+from marimo._config.config import DEFAULT_CONFIG
 from marimo._runtime.autoreload import ModuleReloader
+from marimo._runtime.requests import SetUserConfigRequest
 from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider
 
 
 def random_py_modname() -> str:
@@ -77,6 +79,10 @@ async def test_reload_function_kernel(
             """
         )
     )
+
+    config = DEFAULT_CONFIG.copy()
+    config["runtime"]["auto_reload"] = True
+    k.set_user_config(SetUserConfigRequest(config=config))
     await k.run([exec_req.get(f"import {py_modname}; x={py_modname}.foo()")])
     assert k.globals["x"] == 1
     update_file(
@@ -87,5 +93,5 @@ async def test_reload_function_kernel(
         """,
     )
 
-    await k.run([exec_req.get(f"import {py_modname}; x={py_modname}.foo()")])
-    assert k.globals["x"] == 1
+    await k.run([exec_req.get(f"y={py_modname}.foo()")])
+    assert k.globals["y"] == 2

--- a/tests/_runtime/test_autoreload.py
+++ b/tests/_runtime/test_autoreload.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib
+import pathlib
+import random
+import sys
+import textwrap
+import time
+import types
+
+from tests.conftest import ExecReqProvider
+from marimo._runtime.autoreload import ModuleReloader
+from marimo._runtime.runtime import Kernel
+
+
+def random_py_modname() -> str:
+    filename_chars = "abcdefghijklmopqrstuvwxyz"
+    return "".join(random.sample(filename_chars, 20))
+
+
+def update_file(path: pathlib.Path, code: str) -> None:
+    """
+    Comment from
+    https://github.com/ipython/ipython/blob/fe52b206ecd0e566fff935fea36d26e0903ec34b/IPython/extensions/tests/test_autoreload.py#L128
+
+    Python's .pyc files record the timestamp of their compilation
+    with a time resolution of one second.
+
+    Therefore, we need to force a timestamp difference between .py
+    and .pyc, without having the .py file be timestamped in the
+    future, and without changing the timestamp of the .pyc file
+    (because that is stored in the file).  The only reliable way
+    to achieve this seems to be to sleep.
+    """
+    time.sleep(1.05)
+    path.write_text(textwrap.dedent(code))
+
+
+def test_reload_function(tmp_path: pathlib.Path):
+    sys.path.append(str(tmp_path))
+    reloader = ModuleReloader()
+    py_modname = random_py_modname()
+    py_file = tmp_path / pathlib.Path(py_modname + ".py")
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            def foo():
+                return 1
+            """
+        )
+    )
+    mod = importlib.import_module(py_modname)
+    reloader.check(sys.modules, reload=False)
+    assert mod.foo() == 1
+    update_file(
+        py_file,
+        """
+        def foo():
+            return 2
+        """,
+    )
+    reloader.check(sys.modules, reload=True)
+    assert mod.foo() == 2
+
+
+async def test_reload_function_kernel(
+    tmp_path: pathlib.Path, k: Kernel, exec_req: ExecReqProvider
+):
+    sys.path.append(str(tmp_path))
+    py_modname = random_py_modname()
+    py_file = tmp_path / pathlib.Path(py_modname + ".py")
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            def foo():
+                return 1
+            """
+        )
+    )
+    await k.run([exec_req.get(f"import {py_modname}; x={py_modname}.foo()")])
+    assert k.globals["x"] == 1
+    update_file(
+        py_file,
+        """
+        def foo():
+            return 2
+        """,
+    )
+
+    await k.run([exec_req.get(f"import {py_modname}; x={py_modname}.foo()")])
+    assert k.globals["x"] == 1

--- a/tests/_server/mocks.py
+++ b/tests/_server/mocks.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from starlette.testclient import TestClient
 
+from marimo._config.manager import UserConfigManager
 from marimo._server.model import SessionMode
 from marimo._server.sessions import LspServer, SessionManager
 
@@ -43,7 +44,7 @@ if __name__ == "__main__":
         quiet=False,
         include_code=True,
         lsp_server=lsp_server,
-        package_manager="pip",
+        user_config_manager=UserConfigManager(),
     )
     sm.server_token = "fake-token"
     return sm

--- a/tests/_server/test_session_manager.py
+++ b/tests/_server/test_session_manager.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
+from marimo._config.manager import UserConfigManager
 from marimo._server.model import ConnectionState, SessionConsumer, SessionMode
 from marimo._server.sessions import LspServer, Session, SessionManager
 
@@ -28,7 +29,7 @@ def session_manager():
         quiet=False,
         include_code=True,
         lsp_server=MagicMock(spec=LspServer),
-        package_manager="pip",
+        user_config_manager=UserConfigManager(),
     )
 
 

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from marimo._ast.app import App, InternalApp
+from marimo._config.manager import UserConfigManager
 from marimo._runtime.requests import AppMetadata
 from marimo._server.file_manager import AppFileManager
 from marimo._server.model import ConnectionState, SessionMode
@@ -58,7 +59,7 @@ def test_kernel_manager() -> None:
 
     # Instantiate a KernelManager
     kernel_manager = KernelManager(
-        queue_manager, mode, {}, app_metadata, "pip"
+        queue_manager, mode, {}, app_metadata, UserConfigManager()
     )
 
     kernel_manager.start_kernel()
@@ -83,7 +84,7 @@ def test_session() -> None:
     session_consumer.connection_state.return_value = ConnectionState.OPEN
     queue_manager = QueueManager(use_multiprocessing=False)
     kernel_manager = KernelManager(
-        queue_manager, SessionMode.RUN, {}, app_metadata, "pip"
+        queue_manager, SessionMode.RUN, {}, app_metadata, UserConfigManager()
     )
 
     # Instantiate a Session
@@ -122,7 +123,11 @@ def test_session_disconnect_reconnect() -> None:
     session_consumer.connection_state.return_value = ConnectionState.OPEN
     queue_manager = QueueManager(use_multiprocessing=False)
     kernel_manager = KernelManager(
-        queue_manager, SessionMode.RUN, {}, AppMetadata(query_params={}), "pip"
+        queue_manager,
+        SessionMode.RUN,
+        {},
+        AppMetadata(query_params={}),
+        UserConfigManager(),
     )
 
     # Instantiate a Session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 
 from marimo._ast.app import CellManager
 from marimo._ast.cell import CellId_t
+from marimo._config.config import DEFAULT_CONFIG
 from marimo._messaging.streams import (
     ThreadSafeStderr,
     ThreadSafeStdin,
@@ -89,6 +90,7 @@ class MockedKernel:
             stderr=self.stderr,
             stdin=self.stdin,
             cell_configs={},
+            user_config=DEFAULT_CONFIG,
             app_metadata=AppMetadata(
                 query_params={},
                 filename=None,


### PR DESCRIPTION
This PR implements autoreloading of Python modules (including hot-reloading of objects). The implementation is based on IPython's autoreload extension, and in particular follows the popular `%autoreload 2` settings.

Autoreloading is not reactive, i.e., marimo does NOT watch files and automatically re-execute affected cells. Instead, when autoreloading is enabled, marimo hot-reloads modules before executing the cell.

In the future, if there's interest, we can support reactive autoreloading.

- [x]  Unit tests

Closes #998 , #292 