### PR TITLE
fix: snippet endpoint

### DIFF
--- a/marimo/_server/api/endpoints/documentation.py
+++ b/marimo/_server/api/endpoints/documentation.py
@@ -1,8 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from functools import lru_cache
-
 from starlette.requests import Request
 
 from marimo import _loggers
@@ -15,10 +13,7 @@ LOGGER = _loggers.marimo_logger()
 router = APIRouter()
 
 
-# Cache the snippets
-@lru_cache(1)
-async def _read_snippets_once() -> Snippets:
-    return await read_snippets()
+_SNIPPETS: list[Snippets] = []
 
 
 @router.get("/snippets")
@@ -26,4 +21,6 @@ async def load_snippets(
     request: Request,
 ) -> Snippets:
     del request
-    return await _read_snippets_once()
+    if not _SNIPPETS:
+        _SNIPPETS.append(await read_snippets())
+    return _SNIPPETS[0]

--- a/marimo/_snippets/snippets.py
+++ b/marimo/_snippets/snippets.py
@@ -61,7 +61,9 @@ async def read_snippets() -> Snippets:
 
         snippets.append(Snippet(title=title, sections=sections))
 
-    return Snippets(snippets=snippets)
+    return Snippets(
+        snippets=sorted(snippets, key=lambda snippet: snippet.title)
+    )
 
 
 def should_ignore_code(code: str) -> bool:

--- a/tests/_server/api/endpoints/test_documentation.py
+++ b/tests/_server/api/endpoints/test_documentation.py
@@ -8,3 +8,13 @@ def test_snippets(client: TestClient) -> None:
     content = response.json()
     assert content["snippets"] is not None
     assert len(content["snippets"]) > 0
+    snippets = content["snippets"]
+
+    # call the endpoint a second time and make sure the
+    # same snippets are retrieved
+    response = client.get("/api/documentation/snippets")
+    assert response.status_code == 200, response.text
+    content = response.json()
+    assert content["snippets"] is not None
+    assert len(content["snippets"]) > 0
+    assert content["snippets"] == snippets


### PR DESCRIPTION
`@lru_cache` doesn't play well with async functions (the first call to the doc endpoint would succeed, all future ones would fail)