### PR TITLE
fix: Fix handling of None and empty values in QueryParams class

### DIFF
--- a/marimo/_runtime/query_params.py
+++ b/marimo/_runtime/query_params.py
@@ -63,6 +63,9 @@ class QueryParams(State[SerializedQueryParams]):
         return str(self._params)
 
     def __setitem__(self, key: str, value: Union[str, List[str]]) -> None:
+        if value is None or value == []:  # type: ignore
+            self.remove(key)
+            return
         # We always overwrite the value
         self._params[key] = value
         QueryParamsSet(key, value).broadcast(self._stream)

--- a/tests/_runtime/test_query_params.py
+++ b/tests/_runtime/test_query_params.py
@@ -55,6 +55,26 @@ class TestQueryParams(unittest.TestCase):
             "data": {"key": "key3", "value": "value4"},
         }
 
+    def test_setitem_null(self):
+        self.params["key1"] = None  # type: ignore
+        assert self.params.get("key1") is None
+
+        assert self.mock_stream.write.call_count == 1
+        assert self.mock_stream.write.call_args[1] == {
+            "op": "query-params-delete",
+            "data": {"key": "key1", "value": None},
+        }
+
+    def test_setitem_empty(self):
+        self.params["key1"] = []
+        assert self.params.get("key1") is None
+
+        assert self.mock_stream.write.call_count == 1
+        assert self.mock_stream.write.call_args[1] == {
+            "op": "query-params-delete",
+            "data": {"key": "key1", "value": None},
+        }
+
     def test_set(self):
         self.params.set("key1", "value5")
         assert self.params.get("key1") == "value5"
@@ -63,6 +83,26 @@ class TestQueryParams(unittest.TestCase):
         assert self.mock_stream.write.call_args[1] == {
             "op": "query-params-set",
             "data": {"key": "key1", "value": "value5"},
+        }
+
+    def test_set_null(self):
+        self.params.set("key1", None)  # type: ignore
+        assert self.params.get("key1") is None
+
+        assert self.mock_stream.write.call_count == 1
+        assert self.mock_stream.write.call_args[1] == {
+            "op": "query-params-delete",
+            "data": {"key": "key1", "value": None},
+        }
+
+    def test_set_empty(self):
+        self.params.set("key1", [])
+        assert self.params.get("key1") is None
+
+        assert self.mock_stream.write.call_count == 1
+        assert self.mock_stream.write.call_args[1] == {
+            "op": "query-params-delete",
+            "data": {"key": "key1", "value": None},
         }
 
     def test_append(self):


### PR DESCRIPTION
We should remove queryparams when we set to `None` or `[]`