### PR TITLE
fixed "AssertionError: .value can only be used after the context manager exits

### DIFF
--- a/tests/_utils/test_parse_dataclass.py
+++ b/tests/_utils/test_parse_dataclass.py
@@ -171,7 +171,7 @@ class TestParseRaw:
         # handle error
         with pytest.raises(ValueError) as e:
             parsed = parse_raw(serialize({"config": "invalid"}), Nested)
-            assert "invalid" in str(e.value)
+        assert "invalid" in str(e.value)
 
     def test_enums(self) -> None:
         @dataclass
@@ -187,7 +187,7 @@ class TestParseRaw:
         # handle error
         with pytest.raises(ValueError) as e:
             parsed = parse_raw(serialize({"config": "invalid"}), Nested)
-            assert "invalid" in str(e.value)
+        assert "invalid" in str(e.value)
 
     def test_discriminated_union(self) -> None:
         @dataclass
@@ -210,7 +210,7 @@ class TestParseRaw:
             parsed = parse_raw(
                 serialize({"config": {"invalid": True}}), Nested
             )
-            assert "invalid" in str(e.value)
+        assert "invalid" in str(e.value)
 
     def test_build_optional(self) -> None:
         @dataclass


### PR DESCRIPTION
Fixes the error mentioned in the title, cf. [the comment under this answer](https://stackoverflow.com/a/57560632/143931).

(Note: seems to be correct in all other tests.)