### PR TITLE
improvement: special case list formatter for matplotlib.

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -143,6 +143,11 @@ class DependencyManager:
         return importlib.util.find_spec("plotly") is not None
 
     @staticmethod
+    def has_matplotlib() -> bool:
+        """Return True if plotly is installed."""
+        return importlib.util.find_spec("matplotlib") is not None
+
+    @staticmethod
     def has_anywidget() -> bool:
         """Return True if anywidget is installed."""
         return importlib.util.find_spec("anywidget") is not None

--- a/marimo/_output/formatters/structures.py
+++ b/marimo/_output/formatters/structures.py
@@ -52,7 +52,7 @@ class StructuresFormatter(FormatterFactory):
                 # line, which typically have identitical figures. Without this
                 # special case, if a plot had (say) 5 lines, it would be shown
                 # 5 times.
-                import matplotlib.artist
+                import matplotlib.artist  # type: ignore
 
                 if all(isinstance(i, matplotlib.artist.Artist) for i in t):
                     figs = [getattr(i, "figure", None) for i in t]

--- a/marimo/_output/formatters/structures.py
+++ b/marimo/_output/formatters/structures.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import Any, Union
 
 from marimo._messaging.mimetypes import KnownMimeType
@@ -44,6 +45,21 @@ class StructuresFormatter(FormatterFactory):
         def _format_structure(
             t: Union[tuple[Any, ...], list[Any], dict[str, Any]],
         ) -> tuple[KnownMimeType, str]:
+            if t and "matplotlib" in sys.modules:
+                # Special case for matplotlib:
+                #
+                # plt.plot() returns a list of lines 2D objects, one for each
+                # line, which typically have identitical figures. Without this
+                # special case, if a plot had (say) 5 lines, it would be shown
+                # 5 times.
+                import matplotlib.artist
+
+                if all(isinstance(i, matplotlib.artist.Artist) for i in t):
+                    figs = [getattr(i, "figure", None) for i in t]
+                    if all(f is not None and f == figs[0] for f in figs):
+                        matplotlib_formatter = formatting.get_formatter(figs[0])
+                        if matplotlib_formatter is not None:
+                            return matplotlib_formatter(figs[0])
             try:
                 formatted_structure = format_structure(t)
             except CyclicStructureError:

--- a/marimo/_output/formatters/structures.py
+++ b/marimo/_output/formatters/structures.py
@@ -57,7 +57,9 @@ class StructuresFormatter(FormatterFactory):
                 if all(isinstance(i, matplotlib.artist.Artist) for i in t):
                     figs = [getattr(i, "figure", None) for i in t]
                     if all(f is not None and f == figs[0] for f in figs):
-                        matplotlib_formatter = formatting.get_formatter(figs[0])
+                        matplotlib_formatter = formatting.get_formatter(
+                            figs[0]
+                        )
                         if matplotlib_formatter is not None:
                             return matplotlib_formatter(figs[0])
             try:

--- a/tests/_output/formatters/test_structures.py
+++ b/tests/_output/formatters/test_structures.py
@@ -29,6 +29,5 @@ async def test_matplotlib_special_case(
 
         formatter = executing_kernel.globals["formatter"]
         lines = executing_kernel.globals["lines"]
-        # TODO: debug
         assert formatter is not None
         assert formatter(lines)[0].startswith("image")

--- a/tests/_output/formatters/test_structures.py
+++ b/tests/_output/formatters/test_structures.py
@@ -1,0 +1,34 @@
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider
+
+
+async def test_matplotlib_special_case(
+    executing_kernel: Kernel, exec_req: ExecReqProvider
+) -> None:
+    if DependencyManager.has_matplotlib() and DependencyManager.has_numpy():
+        from marimo._output.formatters.formatters import register_formatters
+
+        register_formatters()
+
+        await executing_kernel.run(
+            [
+                exec_req.get(
+                    """
+                    import numpy as np
+                    import matplotlib.pyplot as plt
+                    from marimo._output.formatting import get_formatter
+
+                    arr = np.random.randn(12, 5)
+                    lines = plt.plot(arr)
+                    formatter = get_formatter(lines)
+                    """
+                )
+            ]
+        )
+
+        formatter = executing_kernel.globals["formatter"]
+        lines = executing_kernel.globals["lines"]
+        # TODO: debug
+        assert formatter is not None
+        assert formatter(lines)[0].startswith("image")


### PR DESCRIPTION
This PR improves formatting of the output of `matplotlib.pyplot`'s `plot` function.

Previously, when `plt.plot()` was the last expression of a cell, multiple copies of the same plot would be displayed, one for each line in the plot. This is because `plt.plot()` returns a list of `Lines2D` objects, one for each line in the figure, but each object is attached to the same figure.

This PR special-cases the structures formatter for lists that contain only matplotlib objects on the same figure to show the figure just once.