### PR TITLE
fix: add notebook's current directory to path

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -8,6 +8,7 @@ import dataclasses
 import io
 import itertools
 import os
+import pathlib
 import signal
 import sys
 import threading
@@ -273,6 +274,20 @@ class Kernel:
         self._module = patches.patch_main_module(
             file=self.app_metadata.filename, input_override=input_override
         )
+        if self.app_metadata.filename is not None:
+            try:
+                sys.path.insert(
+                    0,
+                    str(
+                        pathlib.Path(
+                            self.app_metadata.filename
+                        ).parent.absolute()
+                    ),
+                )
+            except Exception as e:
+                LOGGER.warning(
+                    "Failed to add directory to path (error %e)", str(e)
+                )
 
         self.graph = dataflow.DirectedGraph()
         self.cell_metadata: dict[CellId_t, CellMetadata] = {

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -276,14 +276,11 @@ class Kernel:
         )
         if self.app_metadata.filename is not None:
             try:
-                sys.path.insert(
-                    0,
-                    str(
-                        pathlib.Path(
-                            self.app_metadata.filename
-                        ).parent.absolute()
-                    ),
+                notebook_directory = str(
+                    pathlib.Path(self.app_metadata.filename).parent.absolute()
                 )
+                if notebook_directory not in sys.path:
+                    sys.path.insert(0, notebook_directory)
             except Exception as e:
                 LOGGER.warning(
                     "Failed to add directory to path (error %e)", str(e)

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -2,19 +2,22 @@
 from __future__ import annotations
 
 import sys
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import pytest
 
+from marimo._config.config import DEFAULT_CONFIG
 from marimo._messaging.errors import (
     CycleError,
     DeleteNonlocalError,
     Error,
     MultipleDefinitionError,
 )
+from marimo._messaging.types import NoopStream
 from marimo._plugins.ui._core.ids import IDProvider
 from marimo._runtime.dataflow import Edge
 from marimo._runtime.requests import (
+    AppMetadata,
     CreationRequest,
     DeleteRequest,
     ExecutionRequest,
@@ -23,6 +26,9 @@ from marimo._runtime.requests import (
 )
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
+
+if TYPE_CHECKING:
+    import pathlib
 
 
 def _check_edges(error: Error, expected_edges: Sequence[Edge]) -> None:
@@ -1065,3 +1071,22 @@ class TestAsyncIO:
         )
         assert not k.errors
         assert k.globals["res"] == "done"
+
+    def test_sys_path_updated(self, tmp_path: pathlib.Path):
+        try:
+            filename = str(tmp_path / "notebook.py")
+            Kernel(
+                stream=NoopStream(),
+                stdout=None,
+                stderr=None,
+                stdin=None,
+                cell_configs={},
+                user_config=DEFAULT_CONFIG,
+                app_metadata=AppMetadata(query_params={}, filename=filename),
+            )
+            assert str(tmp_path) in sys.path
+            assert str(tmp_path) == sys.path[0]
+        finally:
+            idx = sys.path.index(str(tmp_path))
+            if idx > 0:
+                sys.path.pop(idx)


### PR DESCRIPTION
Fixes module resolution for notebooks opened in a directory different from where marimo was called.