### PR TITLE
fix: use data urls for vfiles when running as a script

### DIFF
--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -4,7 +4,6 @@ import io
 from typing import Union
 
 from marimo._plugins.core.media import is_data_empty
-from marimo._runtime.context import get_context
 from marimo._runtime.virtual_file import (
     EMPTY_VIRTUAL_FILE,
     VirtualFile,
@@ -24,7 +23,7 @@ def pdf(data: bytes) -> VirtualFile:
     A `VirtualFile` object.
     """
     item = VirtualFileLifecycleItem(ext="pdf", buffer=data)
-    get_context().cell_lifecycle_registry.add(item)
+    item.add_to_cell_lifecycle_registry()
     return item.virtual_file
 
 
@@ -40,7 +39,7 @@ def image(data: bytes, ext: str = "png") -> VirtualFile:
     A `VirtualFile` object.
     """
     item = VirtualFileLifecycleItem(ext=ext, buffer=data)
-    get_context().cell_lifecycle_registry.add(item)
+    item.add_to_cell_lifecycle_registry()
     return item.virtual_file
 
 
@@ -56,7 +55,7 @@ def audio(data: bytes, ext: str = "wav") -> VirtualFile:
     A `VirtualFile` object.
     """
     item = VirtualFileLifecycleItem(ext=ext, buffer=data)
-    get_context().cell_lifecycle_registry.add(item)
+    item.add_to_cell_lifecycle_registry()
     return item.virtual_file
 
 
@@ -144,7 +143,7 @@ def any_data(data: Union[str, bytes, io.BytesIO], ext: str) -> VirtualFile:
         base64str = data.split(",")[1]
         buffer = base64.b64decode(base64str)
         item = VirtualFileLifecycleItem(ext=ext, buffer=buffer)
-        get_context().cell_lifecycle_registry.add(item)
+        item.add_to_cell_lifecycle_registry()
         return item.virtual_file
 
     # URL
@@ -154,13 +153,13 @@ def any_data(data: Union[str, bytes, io.BytesIO], ext: str) -> VirtualFile:
     # Bytes
     if isinstance(data, bytes):
         item = VirtualFileLifecycleItem(ext=ext, buffer=data)
-        get_context().cell_lifecycle_registry.add(item)
+        item.add_to_cell_lifecycle_registry()
         return item.virtual_file
 
     # String
     if isinstance(data, str):
         item = VirtualFileLifecycleItem(ext=ext, buffer=data.encode("utf-8"))
-        get_context().cell_lifecycle_registry.add(item)
+        item.add_to_cell_lifecycle_registry()
         return item.virtual_file
 
     # BytesIO
@@ -168,7 +167,7 @@ def any_data(data: Union[str, bytes, io.BytesIO], ext: str) -> VirtualFile:
         # clone before reading, so we don't consume the stream
         buffer = io.BytesIO(data.getvalue()).read()
         item = VirtualFileLifecycleItem(ext=ext, buffer=buffer)
-        get_context().cell_lifecycle_registry.add(item)
+        item.add_to_cell_lifecycle_registry()
         return item.virtual_file
 
     raise ValueError(f"Unsupported data type: {type(data)}")

--- a/marimo/_runtime/functions.py
+++ b/marimo/_runtime/functions.py
@@ -33,13 +33,20 @@ class Function(Generic[S, T]):
         arg_cls: Type[S],
         function: Callable[[S], T],
     ) -> None:
-        from marimo._runtime.context import get_context
+        from marimo._runtime.context import (
+            ContextNotInitializedError,
+            get_context,
+        )
 
         self.name = name
         self.arg_cls = arg_cls
         self.function = function
 
-        ctx = get_context()
+        try:
+            ctx = get_context()
+        except ContextNotInitializedError:
+            ctx = None
+
         if ctx is not None and ctx.kernel.execution_context is not None:
             self.cell_id = ctx.kernel.execution_context.cell_id
         else:

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 import mimetypes


### PR DESCRIPTION
previously running a script that created a mo.ui.table() would throw a ContextNotInitializedException