### PR TITLE
improvement: support plotly config and renderers

### DIFF
--- a/marimo/_output/formatters/plotly_formatters.py
+++ b/marimo/_output/formatters/plotly_formatters.py
@@ -25,26 +25,24 @@ class PlotlyFormatter(FormatterFactory):
         def _show_plotly_figure(
             fig: plotly.graph_objects.Figure,
         ) -> tuple[KnownMimeType, str]:
-            resolved_config: dict[str, Any] = {}
-            try:
-                default_renderer: Any = pio.renderers[pio.renderers.default]
-                resolved_config = default_renderer.config or {}
-            except AttributeError:
-                pass
-
             json_str: str = pio.to_json(fig)
-            plugin = PlotlyFormatter.render_plotly_dict(
-                json.loads(json_str), resolved_config
-            )
+            plugin = PlotlyFormatter.render_plotly_dict(json.loads(json_str))
             return ("text/html", plugin.text)
 
     @staticmethod
-    def render_plotly_dict(
-        json: dict[Any, Any], config: dict[str, Any]
-    ) -> Html:
+    def render_plotly_dict(json: dict[Any, Any]) -> Html:
+        import plotly.io as pio  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+
+        resolved_config: dict[str, Any] = {}
+        try:
+            default_renderer: Any = pio.renderers[pio.renderers.default]
+            resolved_config = default_renderer.config or {}
+        except AttributeError:
+            pass
+
         return Html(
             build_stateless_plugin(
                 component_name="marimo-plotly",
-                args={"figure": json, "config": config},
+                args={"figure": json, "config": resolved_config},
             )
         )

--- a/marimo/_plugins/ui/_impl/plotly.py
+++ b/marimo/_plugins/ui/_impl/plotly.py
@@ -122,7 +122,7 @@ class plotly(UIElement[PlotlySelection, List[Dict[str, Any]]]):
             default_renderer: Any = pio.renderers[resolved_name]
             if default_renderer is not None:
                 try:
-                    resolved_config = default_renderer.config
+                    resolved_config = default_renderer.config or {}
                 except AttributeError:
                     LOGGER.warning(
                         "Could not find default renderer configuration. "

--- a/marimo/_smoke_tests/bugs/1161.py
+++ b/marimo/_smoke_tests/bugs/1161.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.4.0"

--- a/marimo/_smoke_tests/bugs/1165.py
+++ b/marimo/_smoke_tests/bugs/1165.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.4.0"

--- a/marimo/_smoke_tests/bugs/846.py
+++ b/marimo/_smoke_tests/bugs/846.py
@@ -9,7 +9,7 @@ app = marimo.App()
 @app.cell
 def __(mo):
     mo.md(
-        "This notebook covers a couple different cases for rendering plotly under different configs and with diferrent renderers."
+        "This notebook covers a couple different cases for rendering plotly under different configs and with different renderers."
     )
     return
 

--- a/marimo/_smoke_tests/bugs/846.py
+++ b/marimo/_smoke_tests/bugs/846.py
@@ -1,0 +1,99 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.4.0"
+app = marimo.App()
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        "This notebook covers a couple different cases for rendering plotly under different configs and with diferrent renderers."
+    )
+    return
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import plotly.io as pio
+
+    pio.renderers.default = "notebook"
+    pio.renderers["notebook"].config["scrollZoom"] = True
+    pio.renderers["notebook"].config["editable"] = True
+    return mo, pio
+
+
+@app.cell
+def __(pio):
+    pio.renderers.default
+    return
+
+
+@app.cell
+def __(pio):
+    pio.renderers[pio.renderers.default].config
+    return
+
+
+@app.cell
+def __(mo, pio):
+    keys = list(pio.renderers.keys())
+
+
+    def get_config(renderer):
+        try:
+            return str(renderer.config)
+        except:
+            return "none"
+
+
+    printed_configs = [
+        {"name": key, "config": get_config(pio.renderers[key])} for key in keys
+    ]
+    mo.ui.table(printed_configs)
+    return get_config, keys, printed_configs
+
+
+@app.cell
+def __(pio):
+    pio.renderers
+    return
+
+
+@app.cell
+def __():
+    import plotly.express as px
+
+    x_data = [1, 2, 3, 4, 5, 6]
+    y_data = [1, 2, 3, 2, 3, 4]
+    fig = px.scatter(x=x_data, y=y_data)
+    return fig, px, x_data, y_data
+
+
+@app.cell
+def __(fig, mo):
+    mo.ui.plotly(fig)  # Uses the default renderer "notebook"
+    return
+
+
+@app.cell
+def __(fig, mo):
+    mo.ui.plotly(fig, config={})  # Uses the empty config
+    return
+
+
+@app.cell
+def __(fig, mo):
+    mo.ui.plotly(fig, config={"staticPlot": True})  # Uses the passed config
+    return
+
+
+@app.cell
+def __(fig, mo):
+    mo.ui.plotly(fig, renderer_name="browser")  # Uses a pre-defined rendererer
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/bugs/846.py
+++ b/marimo/_smoke_tests/bugs/846.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
 __generated_with = "0.4.0"
@@ -69,6 +70,12 @@ def __():
     y_data = [1, 2, 3, 2, 3, 4]
     fig = px.scatter(x=x_data, y=y_data)
     return fig, px, x_data, y_data
+
+
+@app.cell
+def __(fig):
+    fig  # Uses the default renderer "notebook"
+    return
 
 
 @app.cell


### PR DESCRIPTION
Fixes #846 

Adds support for plotly config and using their `pio.renderers` feature.

```python
@app.cell
def __(fig, mo):
    fig  # Uses the default renderer
    return

@app.cell
def __(fig, mo):
    mo.ui.plotly(fig)  # Uses the default renderer
    return


@app.cell
def __(fig, mo):
    mo.ui.plotly(fig, config={})  # Uses the empty config
    return


@app.cell
def __(fig, mo):
    mo.ui.plotly(fig, config={"staticPlot": True})  # Uses the passed config
    return


@app.cell
def __(fig, mo):
    mo.ui.plotly(fig, renderer_name="browser")  # Uses a pre-defined rendererer
    return
```