### PR TITLE
fix: fix edge case with packages and autoreload

### DIFF
--- a/marimo/_smoke_tests/bugs/1161.py
+++ b/marimo/_smoke_tests/bugs/1161.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.4.0"

--- a/marimo/_smoke_tests/bugs/1165.py
+++ b/marimo/_smoke_tests/bugs/1165.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.4.0"


### PR DESCRIPTION
Sometimes modulefinder turns up empty when inspecting packages. Add a heuristic to handle those cases ...