### PR TITLE
fix: catch base exceptions

### DIFF
--- a/marimo/_runtime/cell_runner.py
+++ b/marimo/_runtime/cell_runner.py
@@ -34,7 +34,7 @@ class RunResult:
     # Raw output of cell
     output: Any
     # Exception raised by cell, if any
-    exception: Optional[Exception | MarimoInterrupt | MarimoStopError]
+    exception: Optional[BaseException]
 
     def success(self) -> bool:
         """Whether the cell expected successfully"""
@@ -244,11 +244,9 @@ class Runner:
             run_result = RunResult(output=e.output, exception=e)
             # don't print a traceback, since quitting is the intended
             # behavior (like sys.exit())
-        except Exception as e:
-            # Don't catch BaseExceptions:
-            # - KeyboardInterrupt shouldn't be raised, since marimo
-            #   redirects it to a MarimoInterrupt
-            # - SystemExit should kill the process
+        except BaseException as e:
+            # Catch-all: some libraries have bugs and raise BaseExceptions,
+            # which shouldn't crash the marimo kernel
             if isinstance(e, ModuleNotFoundError):
                 self.missing_packages = True
 

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -231,7 +231,6 @@ async def test_reload_nested_module_import_module_autorun(
 
 async def test_reload_package(
     tmp_path: pathlib.Path,
-    py_modname: str,
     k: Kernel,
     exec_req: ExecReqProvider,
 ):

--- a/tests/_runtime/test_cell_runner.py
+++ b/tests/_runtime/test_cell_runner.py
@@ -47,3 +47,34 @@ async def test_traceback_includes_lineno(
     with capture_stderr() as buffer:
         await runner.run(er.cell_id)
     assert "line 3" in buffer.getvalue()
+
+
+async def test_base_exception_caught(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    # Raise an exception and test that the runner generates a traceback that
+    # includes the line number where the exception was raised
+    #
+    # Make sure BaseException is caught
+    #
+    # first run the cell to populate the graph
+    await k.run(
+        [
+            er := exec_req.get(
+                """
+                x = 0
+                raise BaseException
+                """
+            )
+        ]
+    )
+
+    runner = Runner(
+        cell_ids=set(k.graph.cells.keys()),
+        graph=k.graph,
+        glbls=k.globals,
+        debugger=k.debugger,
+    )
+    with capture_stderr() as buffer:
+        await runner.run(er.cell_id)
+    assert "line 3" in buffer.getvalue()


### PR DESCRIPTION
To prevent bugs in imported libraries from crashing the kernel

Closes #1176 

Context: We started catching `BaseExceptions` in https://github.com/marimo-team/marimo/pull/253. But since we now use `os._exit(0)` instead of `sys.exit()` (latter throws a `SystemExit` exception), it's fine to catch `BaseException`s, the process should still terminate ...