### PR TITLE
fix: ignore third-party packages in module watcher

### DIFF
--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import itertools
+import pathlib
 import sys
 import threading
 import time
@@ -48,6 +49,7 @@ def is_submodule(src_name: str, target_name: str) -> bool:
 
 def _depends_on(
     src_module: types.ModuleType,
+    modules_excluded_from_analysis: list[str],
     target_modules: set[types.ModuleType],
     failed_filenames: set[str],
 ) -> bool:
@@ -58,7 +60,7 @@ def _depends_on(
     if src_module.__file__ in failed_filenames:
         return False
 
-    finder = ModuleFinder()
+    finder = ModuleFinder(excludes=modules_excluded_from_analysis)
     try:
         finder.run_script(src_module.__file__)
     except SyntaxError:
@@ -95,6 +97,13 @@ def _depends_on(
     return False
 
 
+def _is_third_party_module(module: types.ModuleType) -> bool:
+    filepath = getattr(module, "__file__", None)
+    if filepath is None:
+        return False
+    return "site-packages" in pathlib.Path(filepath).parts
+
+
 def _check_modules(
     modules: dict[str, types.ModuleType],
     reloader: ModuleReloader,
@@ -103,9 +112,16 @@ def _check_modules(
     """Returns the set of modules used by the graph that have been modified"""
     stale_modules: dict[str, types.ModuleType] = {}
     modified_modules = reloader.check(modules=sys.modules, reload=False)
+    modules_excluded_from_analysis = [
+        modname
+        for modname in sys.modules
+        if (m := sys.modules.get(modname)) is not None
+        and _is_third_party_module(m)
+    ]
     for modname, module in modules.items():
         if _depends_on(
             src_module=module,
+            modules_excluded_from_analysis=modules_excluded_from_analysis,
             target_modules=set(m for m in modified_modules if m is not None),
             failed_filenames=failed_filenames,
         ):
@@ -154,8 +170,7 @@ def watch_modules(
                 stale_cell_ids = dataflow.transitive_closure(
                     graph,
                     set(
-                        modname_to_cell_id[modname]
-                        for modname in stale_modules
+                        modname_to_cell_id[modname] for modname in stale_modules
                     ),
                 )
                 for cid in stale_cell_ids:

--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -170,7 +170,8 @@ def watch_modules(
                 stale_cell_ids = dataflow.transitive_closure(
                     graph,
                     set(
-                        modname_to_cell_id[modname] for modname in stale_modules
+                        modname_to_cell_id[modname]
+                        for modname in stale_modules
                     ),
                 )
                 for cid in stale_cell_ids:

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -6,14 +6,14 @@ import pathlib
 import sys
 import textwrap
 from queue import Queue
-from marimo._dependencies.dependencies import DependencyManager
 
+import pytest
 from reload_test_utils import random_modname, update_file
 
 from marimo._config.config import DEFAULT_CONFIG
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._runtime.requests import ExecuteStaleRequest, SetUserConfigRequest
 from marimo._runtime.runtime import Kernel
-import pytest
 from tests.conftest import ExecReqProvider
 
 

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -6,12 +6,14 @@ import pathlib
 import sys
 import textwrap
 from queue import Queue
+from marimo._dependencies.dependencies import DependencyManager
 
 from reload_test_utils import random_modname, update_file
 
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._runtime.requests import ExecuteStaleRequest, SetUserConfigRequest
 from marimo._runtime.runtime import Kernel
+import pytest
 from tests.conftest import ExecReqProvider
 
 
@@ -260,6 +262,61 @@ async def test_reload_package(
     assert k.globals[b_name]
     assert k.globals["x"] == 1
     update_file(nested_module, "func = lambda : 2")
+
+    # wait for the watcher to pick up the change
+    await asyncio.sleep(1.5)
+    assert k.graph.cells[er_1.cell_id].stale
+    assert k.graph.cells[er_2.cell_id].stale
+    assert not k.graph.cells[er_3.cell_id].stale
+    await k.run_stale_cells()
+    assert not k.graph.cells[er_1.cell_id].stale
+    assert not k.graph.cells[er_2.cell_id].stale
+    assert not k.graph.cells[er_3.cell_id].stale
+    assert k.globals["x"] == 2
+
+
+@pytest.mark.skipif(
+    not DependencyManager.has_numpy(), reason="NumPy not installed"
+)
+async def test_reload_third_party(
+    tmp_path: pathlib.Path,
+    py_modname: str,
+    k: Kernel,
+    exec_req: ExecReqProvider,
+):
+    # make sure that importing a third-party package like numpy doesn't
+    # break the module finder
+    sys.path.append(str(tmp_path))
+    py_file = tmp_path / pathlib.Path(py_modname + ".py")
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            import numpy as np
+
+            def foo():
+                return 1
+            """
+        )
+    )
+
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["runtime"]["auto_reload"] = "detect"
+    k.set_user_config(SetUserConfigRequest(config=config))
+    await k.run(
+        [
+            er_1 := exec_req.get(f"from {py_modname} import foo"),
+            er_2 := exec_req.get("x = foo()"),
+            er_3 := exec_req.get("pass"),
+        ]
+    )
+    assert k.globals["x"] == 1
+    update_file(
+        py_file,
+        """
+        def foo():
+            return 2
+        """,
+    )
 
     # wait for the watcher to pick up the change
     await asyncio.sleep(1.5)


### PR DESCRIPTION
ModuleFinder often fails on large modules, such as numpy, scipy, torch, pandas ...

Ignore third-party packages (installed in site-packages) so that scripts or user namespace packages importing these modules can still be used with autorun reloading.

Fixes #1174 