### PR TITLE
feat: `marimo export script`, to export notebook as a flat script

### DIFF
--- a/docs/guides/editor_features.md
+++ b/docs/guides/editor_features.md
@@ -22,7 +22,6 @@ To access these settings, click the gear icon in the top-right of the editor.
 </figure>
 </div>
 
-
 ## Overview panels
 
 marimo ships with the following IDE-like panels that help provide an overview
@@ -120,7 +119,6 @@ You can also export to HTML at the command-line:
 ```bash
 marimo export html notebook.py -o notebook.html
 ```
-
 
 ## Configuration
 

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -1,0 +1,41 @@
+# Exporting
+
+## Export to static HTML
+
+Export the current view your notebook to static HTML via the notebook
+menu:
+
+<div align="center">
+<figure>
+<img src="/_static/docs-html-export.png"/>
+<figcaption>Download as static HTML.</figcaption>
+</figure>
+</div>
+
+You can also export to HTML at the command-line:
+
+```bash
+marimo export html notebook.py -o notebook.html
+```
+
+or watch the notebook for changes and automatically export to HTML:
+
+```bash
+marimo export html notebook.py -o notebook.html --watch
+```
+
+## Export to a Python script
+
+Export the notebook to a flat Python script at the command-line.
+This exports the notebook in topological order, so the cells adhere to their dependency graph.
+
+```bash
+marimo export script notebook.py -o notebook.script.py
+```
+
+```{admonition} Top-level await not supported
+:class: warning
+
+Exporting to a flat Python script does not support top-level await.
+If you have top-level await in your notebook, you can still execute the notebook as a script with `python notebook.py`.
+```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -21,6 +21,7 @@
   ai_completion
   best_practices
   performance
+  exporting
   deploying/index
 ```
 
@@ -44,6 +45,7 @@ These guides cover marimo's core concepts.
 | {doc}`performance`                   | Writing performant notebooks                            |
 | {doc}`wasm`                          | Running notebooks in the browser (no backend required!) |
 | {doc}`ai_completion`                 | Using AI to speed up your coding                        |
+| {doc}`exporting`                     | Exporting notebooks to HTML and flat scripts            |
 | {doc}`deploying/index`               | Deploying marimo notebooks and apps                     |
 
 ```{admonition} Learn by doing!

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -8,7 +8,10 @@ import click
 
 from marimo._cli.parse_args import parse_args
 from marimo._cli.print import green
-from marimo._server.export.utils import run_app_then_export_as_html
+from marimo._server.export.utils import (
+    export_as_script,
+    run_app_then_export_as_html,
+)
 from marimo._utils.file_watcher import FileWatcher
 from marimo._utils.paths import maybe_make_dirs
 
@@ -123,4 +126,94 @@ def html(
     asyncio.run(start())
 
 
+@click.command(
+    help="""
+Export a marimo notebook as a flat script, in topological order.
+
+Example:
+
+    \b
+    * marimo export script notebook.py -o notebook.script.py
+
+Watch for changes and regenerate the script on modification:
+
+    \b
+    * marimo export script notebook.py -o notebook.script.py --watch
+"""
+)
+@click.option(
+    "--watch/--no-watch",
+    default=False,
+    show_default=True,
+    type=bool,
+    help="""
+    Watch notebook for changes and regenerate the script on modification.
+    If watchdog is installed, it will be used to watch the file.
+    Otherwise, file watcher will poll the file every 1s.
+    """,
+)
+@click.option(
+    "-o",
+    "--output",
+    type=str,
+    default=None,
+    help="""
+    Output file to save the script to.
+    If not provided, the script will be printed to stdout.
+    """,
+)
+@click.argument("name", required=True)
+def script(
+    name: str,
+    output: str,
+    watch: bool,
+) -> None:
+    """
+    Export a marimo notebook as a flat script, in topological order.
+    """
+    if watch and not output:
+        raise click.UsageError(
+            "Cannot use --watch without providing "
+            + "an output file with --output."
+        )
+
+    def write_script(script: str) -> None:
+        if output:
+            # Make dirs if needed
+            maybe_make_dirs(output)
+            with open(output, "w") as f:
+                f.write(script)
+                f.close()
+        else:
+            click.echo(script)
+
+    # No watch, just run once
+    if not watch:
+        (html, _filename) = export_as_script(name)
+        write_script(html)
+        return
+
+    async def on_file_changed(file_path: Path) -> None:
+        click.echo(
+            f"File {str(file_path)} changed. Re-exporting to {green(output)}"
+        )
+        (script, _filename) = export_as_script(str(file_path))
+        write_script(script)
+
+    async def start() -> None:
+        # Watch the file for changes
+        watcher = FileWatcher.create(Path(name), on_file_changed)
+        click.echo(f"Watching {green(name)} for changes...")
+        watcher.start()
+        try:
+            # Run forever
+            while True:
+                await asyncio.sleep(1)
+        except KeyboardInterrupt:
+            watcher.stop()
+
+    asyncio.run(start())
+
+
 export.add_command(html)
+export.add_command(script)

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from starlette.authentication import requires
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, PlainTextResponse
 
 from marimo import _loggers
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
 from marimo._server.export.exporter import Exporter
-from marimo._server.models.export import ExportAsHTMLRequest
+from marimo._server.models.export import (
+    ExportAsHTMLRequest,
+    ExportAsScriptRequest,
+)
 from marimo._server.router import APIRouter
 
 if TYPE_CHECKING:
@@ -52,5 +55,34 @@ async def export_as_html(
     # Download the HTML
     return HTMLResponse(
         content=html,
+        headers=headers,
+    )
+
+
+@router.post("/script")
+@requires("edit")
+async def export_as_script(
+    *,
+    request: Request,
+) -> PlainTextResponse:
+    """
+    Export the notebook as a script.
+    """
+    app_state = AppState(request)
+    body = await parse_request(request, cls=ExportAsScriptRequest)
+    session = app_state.require_current_session()
+
+    python, filename = Exporter().export_as_script(
+        file_manager=session.app_file_manager,
+    )
+
+    if body.download:
+        headers = {"Content-Disposition": f"attachment; filename={filename}"}
+    else:
+        headers = {}
+
+    # Download the Script
+    return PlainTextResponse(
+        content=python,
         headers=headers,
     )

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -99,6 +99,8 @@ class Exporter:
     ) -> tuple[str, str]:
         # Check if any code is async, if so, raise an error
         for cell in file_manager.app.cell_manager.cells():
+            if not cell:
+                continue
             if cell._is_coroutine():
                 raise UsageError(
                     "Cannot export a notebook with async code to a flat script"

--- a/marimo/_server/export/utils.py
+++ b/marimo/_server/export/utils.py
@@ -17,6 +17,17 @@ from marimo._server.models.models import InstantiateRequest
 from marimo._server.sessions import Session
 
 
+def export_as_script(
+    filename: str,
+) -> tuple[str, str]:
+    file_router = AppFileRouter.from_filename(filename)
+    file_key = file_router.get_unique_file_key()
+    assert file_key is not None
+    file_manager = file_router.get_file_manager(file_key)
+
+    return Exporter().export_as_script(file_manager)
+
+
 async def run_app_then_export_as_html(
     filename: str,
     include_code: bool,

--- a/marimo/_server/models/export.py
+++ b/marimo/_server/models/export.py
@@ -11,3 +11,8 @@ class ExportAsHTMLRequest:
     files: List[str]
     include_code: bool
     asset_url: Optional[str] = None
+
+
+@dataclass
+class ExportAsScriptRequest:
+    download: bool

--- a/marimo/_server/router.py
+++ b/marimo/_server/router.py
@@ -11,6 +11,7 @@ from starlette.responses import (
     FileResponse,
     HTMLResponse,
     JSONResponse,
+    PlainTextResponse,
     Response,
     StreamingResponse,
 )
@@ -55,6 +56,8 @@ class APIRouter(Router):
                 if isinstance(response, StreamingResponse):
                     return response
                 if isinstance(response, HTMLResponse):
+                    return response
+                if isinstance(response, PlainTextResponse):
                     return response
 
                 if dataclasses.is_dataclass(response):

--- a/tests/_cli/snapshots/script.txt
+++ b/tests/_cli/snapshots/script.txt
@@ -1,0 +1,8 @@
+
+__generated_with = "0.4.2"
+
+import marimo as mo
+
+# ---
+
+slider = mo.ui.slider(0, 10)

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import asyncio
 import subprocess
 from os import path
 
@@ -10,105 +11,202 @@ from tests.mocks import snapshotter
 snapshot = snapshotter(__file__)
 
 
-def test_cli_export_html(temp_marimo_file: str) -> None:
-    p = subprocess.run(
-        ["marimo", "export", "html", temp_marimo_file],
-        capture_output=True,
-    )
-    assert p.returncode == 0, p.stderr.decode()
-    html = normalize_index_html(p.stdout.decode())
-    # Remove folder path
-    dirname = path.dirname(temp_marimo_file)
-    html = html.replace(dirname, "path")
-    assert '<marimo-code hidden=""></marimo-code>' not in html
+class TestExportHTML:
+    @staticmethod
+    def test_cli_export_html(temp_marimo_file: str) -> None:
+        p = subprocess.run(
+            ["marimo", "export", "html", temp_marimo_file],
+            capture_output=True,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+        html = normalize_index_html(p.stdout.decode())
+        # Remove folder path
+        dirname = path.dirname(temp_marimo_file)
+        html = html.replace(dirname, "path")
+        assert '<marimo-code hidden=""></marimo-code>' not in html
+
+    @staticmethod
+    def test_cli_export_html_no_code(temp_marimo_file: str) -> None:
+        p = subprocess.run(
+            [
+                "marimo",
+                "export",
+                "html",
+                temp_marimo_file,
+                "--no-include-code",
+            ],
+            capture_output=True,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+        html = normalize_index_html(p.stdout.decode())
+        # Remove folder path
+        dirname = path.dirname(temp_marimo_file)
+        html = html.replace(dirname, "path")
+        assert '<marimo-code hidden=""></marimo-code>' in html
+
+    @staticmethod
+    def test_cli_export_async(temp_async_marimo_file: str) -> None:
+        p = subprocess.run(
+            ["marimo", "export", "html", temp_async_marimo_file],
+            capture_output=True,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+        assert "ValueError" not in p.stderr.decode()
+        assert "Traceback" not in p.stderr.decode()
+        html = normalize_index_html(p.stdout.decode())
+        # Remove folder path
+        dirname = path.dirname(temp_async_marimo_file)
+        html = html.replace(dirname, "path")
+        assert '<marimo-code hidden=""></marimo-code>' not in html
+
+    @staticmethod
+    async def test_export_watch(temp_marimo_file: str) -> None:
+        temp_out_file = temp_marimo_file.replace(".py", ".html")
+        p = subprocess.Popen(  # noqa: ASYNC101
+            [
+                "marimo",
+                "export",
+                "html",
+                temp_marimo_file,
+                "--watch",
+                "--output",
+                temp_out_file,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        # Wait for the message
+        while True:
+            line = p.stdout.readline().decode()
+            if line:
+                assert f"Watching {temp_marimo_file}" in line
+                break
+
+        assert not path.exists(temp_out_file)
+
+        # Modify file
+        with open(temp_marimo_file, "a") as f:  # noqa: ASYNC101
+            f.write("\n# comment\n")
+
+        assert p.poll() is None
+        # Wait for rebuild
+        while True:
+            line = p.stdout.readline().decode()
+            if line:
+                assert "Re-exporting" in line
+                break
+
+    @staticmethod
+    def test_export_watch_no_out_dir(temp_marimo_file: str) -> None:
+        p = subprocess.Popen(
+            [
+                "marimo",
+                "export",
+                "html",
+                temp_marimo_file,
+                "--watch",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        # Should return an error
+        while True:
+            line = p.stderr.readline().decode()
+            if line:
+                assert (
+                    "Cannot use --watch without providing "
+                    + "an output file with --output."
+                    in line
+                )
+                break
 
 
-def test_cli_export_html_no_code(temp_marimo_file: str) -> None:
-    p = subprocess.run(
-        ["marimo", "export", "html", temp_marimo_file, "--no-include-code"],
-        capture_output=True,
-    )
-    assert p.returncode == 0, p.stderr.decode()
-    html = normalize_index_html(p.stdout.decode())
-    # Remove folder path
-    dirname = path.dirname(temp_marimo_file)
-    html = html.replace(dirname, "path")
-    assert '<marimo-code hidden=""></marimo-code>' in html
+class TestExportScript:
+    @staticmethod
+    def test_export_script(temp_marimo_file: str) -> None:
+        p = subprocess.run(
+            ["marimo", "export", "script", temp_marimo_file],
+            capture_output=True,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+        snapshot("script.txt", p.stdout.decode())
 
+    @staticmethod
+    def test_export_script_async(temp_async_marimo_file: str) -> None:
+        p = subprocess.run(
+            ["marimo", "export", "script", temp_async_marimo_file],
+            capture_output=True,
+        )
+        assert p.returncode == 2, p.stderr.decode()
+        assert (
+            "Cannot export a notebook with async code to a flat script"
+            in p.stderr.decode()
+        )
 
-def test_cli_export_async(temp_async_marimo_file: str) -> None:
-    p = subprocess.run(
-        ["marimo", "export", "html", temp_async_marimo_file],
-        capture_output=True,
-    )
-    assert p.returncode == 0, p.stderr.decode()
-    assert "ValueError" not in p.stderr.decode()
-    assert "Traceback" not in p.stderr.decode()
-    html = normalize_index_html(p.stdout.decode())
-    # Remove folder path
-    dirname = path.dirname(temp_async_marimo_file)
-    html = html.replace(dirname, "path")
-    assert '<marimo-code hidden=""></marimo-code>' not in html
+    @staticmethod
+    async def test_export_watch_script(temp_marimo_file: str) -> None:
+        temp_out_file = temp_marimo_file.replace(".py", ".script.py")
+        p = subprocess.Popen(  # noqa: ASYNC101
+            [
+                "marimo",
+                "export",
+                "script",
+                temp_marimo_file,
+                "--watch",
+                "--output",
+                temp_out_file,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
+        # Wait for the message
+        while True:
+            line = p.stdout.readline().decode()
+            if line:
+                assert f"Watching {temp_marimo_file}" in line
+                break
 
-async def test_export_watch(temp_marimo_file: str) -> None:
-    temp_out_file = temp_marimo_file.replace(".py", ".html")
-    p = subprocess.Popen(  # noqa: ASYNC101
-        [
-            "marimo",
-            "export",
-            "html",
-            temp_marimo_file,
-            "--watch",
-            "--output",
-            temp_out_file,
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+        assert not path.exists(temp_out_file)
 
-    # Wait for the message
-    while True:
-        line = p.stdout.readline().decode()
-        if line:
-            assert f"Watching {temp_marimo_file}" in line
-            break
+        # Modify file
+        with open(temp_marimo_file, "a") as f:  # noqa: ASYNC101
+            f.write("\n# comment\n")
 
-    assert not path.exists(temp_out_file)
+        assert p.poll() is None
+        # Wait for rebuild
+        while True:
+            line = p.stdout.readline().decode()
+            if line:
+                assert "Re-exporting" in line
+                break
 
-    # Modify file
-    with open(temp_marimo_file, "a") as f:  # noqa: ASYNC101
-        f.write("\n# comment\n")
+        await asyncio.sleep(0.1)
+        assert path.exists(temp_out_file)
 
-    assert p.poll() is None
-    # Wait for rebuild
-    while True:
-        line = p.stdout.readline().decode()
-        if line:
-            assert "Re-exporting" in line
-            break
+    @staticmethod
+    def test_export_watch_script_no_out_dir(temp_marimo_file: str) -> None:
+        p = subprocess.Popen(
+            [
+                "marimo",
+                "export",
+                "script",
+                temp_marimo_file,
+                "--watch",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
-
-def test_export_watch_no_out_dir(temp_marimo_file: str) -> None:
-    p = subprocess.Popen(
-        [
-            "marimo",
-            "export",
-            "html",
-            temp_marimo_file,
-            "--watch",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    # Should return an error
-    while True:
-        line = p.stderr.readline().decode()
-        if line:
-            assert (
-                "Cannot use --watch without providing "
-                + "an output file with --output."
-                in line
-            )
-            break
+        # Should return an error
+        while True:
+            line = p.stderr.readline().decode()
+            if line:
+                assert (
+                    "Cannot use --watch without providing "
+                    + "an output file with --output."
+                    in line
+                )
+                break

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -53,3 +53,16 @@ def test_export_html_no_code(client: TestClient) -> None:
     )
     body = response.text
     assert '<marimo-code hidden=""></marimo-code>' in body
+
+
+@with_session(SESSION_ID)
+def test_export_script(client: TestClient) -> None:
+    response = client.post(
+        "/api/export/script",
+        headers=HEADERS,
+        json={
+            "download": False,
+        },
+    )
+    assert response.status_code == 200
+    assert "__generated_with = " in response.text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,11 @@ def temp_marimo_file() -> Generator[str, None, None]:
             import marimo as mo
             return mo,
 
+        @app.cell
+        def __(mo):
+            slider = mo.ui.slider(0, 10)
+            return slider,
+
         if __name__ == "__main__":
             app.run()
         """


### PR DESCRIPTION
Part of #717 

Adds the ability to generate a flat python script from the command line as well as `watch`:

```bash
# prints to stdout
marimo export script notebook.py > notebook.script.py
# writes to the outfile
marimo export script notebook.py --output notebook.script.py
# writes to the outfile and watch notebook.py for changes
marimo export script notebook.py --watch --output notebook.script.py
```