### PR TITLE
fix: Interrupts on Windows

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -53,12 +53,24 @@ from marimo._messaging.streams import (
     ThreadSafeStream,
 )
 from marimo._messaging.tracebacks import write_traceback
-from marimo._messaging.types import KernelMessage, Stderr, Stdin, Stdout, Stream
+from marimo._messaging.types import (
+    KernelMessage,
+    Stderr,
+    Stdin,
+    Stdout,
+    Stream,
+)
 from marimo._output import formatting
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import MarimoConvertValueException
-from marimo._runtime import cell_runner, dataflow, handlers, marimo_pdb, patches
+from marimo._runtime import (
+    cell_runner,
+    dataflow,
+    handlers,
+    marimo_pdb,
+    patches,
+)
 from marimo._runtime.complete import complete, completion_worker
 from marimo._runtime.context import (
     ContextNotInitializedError,
@@ -409,7 +421,9 @@ class Kernel:
                 if self.module_reloader is not None:
                     # Reload modules if they have changed
                     modules = set(sys.modules)
-                    self.module_reloader.check(modules=sys.modules, reload=True)
+                    self.module_reloader.check(
+                        modules=sys.modules, reload=True
+                    )
                 yield self.execution_context
             finally:
                 self.execution_context = None
@@ -530,7 +544,9 @@ class Kernel:
         `exclude_defs`, and instructs the frontend to invalidate its UI
         elements.
         """
-        missing_modules_before_deletion = self.module_registry.missing_modules()
+        missing_modules_before_deletion = (
+            self.module_registry.missing_modules()
+        )
         defs_to_delete = self.graph.cells[cell_id].defs
         self._delete_names(
             defs_to_delete, exclude_defs if exclude_defs is not None else set()
@@ -630,7 +646,9 @@ class Kernel:
 
         # Register and delete cells
         for er in execution_requests:
-            old_children, error = self._maybe_register_cell(er.cell_id, er.code)
+            old_children, error = self._maybe_register_cell(
+                er.cell_id, er.code
+            )
             cells_that_were_children_of_mutated_cells |= old_children
             if error is None:
                 registered_cell_ids.add(er.cell_id)
@@ -701,7 +719,8 @@ class Kernel:
         # Cells that previously had errors (eg, multiple definition or cycle)
         # that no longer have errors need to be refreshed.
         cells_that_no_longer_have_errors = (
-            cells_with_errors_before_mutation - cells_with_errors_after_mutation
+            cells_with_errors_before_mutation
+            - cells_with_errors_after_mutation
         ) & cells_in_graph
         for cid in cells_that_no_longer_have_errors:
             # clear error outputs before running
@@ -724,7 +743,8 @@ class Kernel:
         # code didn't change), so its previous children were not added to
         # cells_that_were_children_of_mutated_cells
         cells_transitioned_to_error = (
-            cells_with_errors_after_mutation - cells_with_errors_before_mutation
+            cells_with_errors_after_mutation
+            - cells_with_errors_before_mutation
         ) & cells_before_mutation
 
         # Invalidate state defined by error-ed cells, with the exception of
@@ -1039,7 +1059,9 @@ class Kernel:
                 )
             )
 
-    async def run(self, execution_requests: Sequence[ExecutionRequest]) -> None:
+    async def run(
+        self, execution_requests: Sequence[ExecutionRequest]
+    ) -> None:
         """Run cells and their descendants.
 
 
@@ -1117,7 +1139,9 @@ class Kernel:
             except (KeyError, RuntimeError):
                 # KeyError: Trying to access an unnamed UIElement
                 # RuntimeError: UIElement was deleted somehow
-                LOGGER.debug("Could not resolve UIElement with id%s", object_id)
+                LOGGER.debug(
+                    "Could not resolve UIElement with id%s", object_id
+                )
                 continue
             resolved_requests[resolved_id] = resolved_value
         del request

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -53,24 +53,12 @@ from marimo._messaging.streams import (
     ThreadSafeStream,
 )
 from marimo._messaging.tracebacks import write_traceback
-from marimo._messaging.types import (
-    KernelMessage,
-    Stderr,
-    Stdin,
-    Stdout,
-    Stream,
-)
+from marimo._messaging.types import KernelMessage, Stderr, Stdin, Stdout, Stream
 from marimo._output import formatting
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import MarimoConvertValueException
-from marimo._runtime import (
-    cell_runner,
-    dataflow,
-    handlers,
-    marimo_pdb,
-    patches,
-)
+from marimo._runtime import cell_runner, dataflow, handlers, marimo_pdb, patches
 from marimo._runtime.complete import complete, completion_worker
 from marimo._runtime.context import (
     ContextNotInitializedError,
@@ -107,6 +95,7 @@ from marimo._runtime.requests import (
 )
 from marimo._runtime.state import State
 from marimo._runtime.validate_graph import check_for_errors
+from marimo._runtime.win32_interrupt_handler import Win32InterruptHandler
 from marimo._server.types import QueueType
 from marimo._utils.platform import is_pyodide
 from marimo._utils.signals import restore_signals
@@ -420,9 +409,7 @@ class Kernel:
                 if self.module_reloader is not None:
                     # Reload modules if they have changed
                     modules = set(sys.modules)
-                    self.module_reloader.check(
-                        modules=sys.modules, reload=True
-                    )
+                    self.module_reloader.check(modules=sys.modules, reload=True)
                 yield self.execution_context
             finally:
                 self.execution_context = None
@@ -543,9 +530,7 @@ class Kernel:
         `exclude_defs`, and instructs the frontend to invalidate its UI
         elements.
         """
-        missing_modules_before_deletion = (
-            self.module_registry.missing_modules()
-        )
+        missing_modules_before_deletion = self.module_registry.missing_modules()
         defs_to_delete = self.graph.cells[cell_id].defs
         self._delete_names(
             defs_to_delete, exclude_defs if exclude_defs is not None else set()
@@ -645,9 +630,7 @@ class Kernel:
 
         # Register and delete cells
         for er in execution_requests:
-            old_children, error = self._maybe_register_cell(
-                er.cell_id, er.code
-            )
+            old_children, error = self._maybe_register_cell(er.cell_id, er.code)
             cells_that_were_children_of_mutated_cells |= old_children
             if error is None:
                 registered_cell_ids.add(er.cell_id)
@@ -718,8 +701,7 @@ class Kernel:
         # Cells that previously had errors (eg, multiple definition or cycle)
         # that no longer have errors need to be refreshed.
         cells_that_no_longer_have_errors = (
-            cells_with_errors_before_mutation
-            - cells_with_errors_after_mutation
+            cells_with_errors_before_mutation - cells_with_errors_after_mutation
         ) & cells_in_graph
         for cid in cells_that_no_longer_have_errors:
             # clear error outputs before running
@@ -742,8 +724,7 @@ class Kernel:
         # code didn't change), so its previous children were not added to
         # cells_that_were_children_of_mutated_cells
         cells_transitioned_to_error = (
-            cells_with_errors_after_mutation
-            - cells_with_errors_before_mutation
+            cells_with_errors_after_mutation - cells_with_errors_before_mutation
         ) & cells_before_mutation
 
         # Invalidate state defined by error-ed cells, with the exception of
@@ -1058,9 +1039,7 @@ class Kernel:
                 )
             )
 
-    async def run(
-        self, execution_requests: Sequence[ExecutionRequest]
-    ) -> None:
+    async def run(self, execution_requests: Sequence[ExecutionRequest]) -> None:
         """Run cells and their descendants.
 
 
@@ -1138,9 +1117,7 @@ class Kernel:
             except (KeyError, RuntimeError):
                 # KeyError: Trying to access an unnamed UIElement
                 # RuntimeError: UIElement was deleted somehow
-                LOGGER.debug(
-                    "Could not resolve UIElement with id%s", object_id
-                )
+                LOGGER.debug("Could not resolve UIElement with id%s", object_id)
                 continue
             resolved_requests[resolved_id] = resolved_value
         del request

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1435,6 +1435,7 @@ def launch_kernel(
     app_metadata: AppMetadata,
     user_config: MarimoConfig,
     virtual_files_supported: bool,
+    interrupt_queue: QueueType[bool] | None = None,
 ) -> None:
     LOGGER.debug("Launching kernel")
     if is_edit_mode:
@@ -1515,6 +1516,7 @@ def launch_kernel(
         )
 
         if sys.platform == "win32" or sys.platform == "cygwin":
+            Win32InterruptHandler().start()
             # windows doesn't handle SIGTERM
             signal.signal(
                 signal.SIGBREAK, handlers.construct_sigterm_handler(kernel)

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1492,8 +1492,9 @@ def launch_kernel(
             signal.SIGINT, handlers.construct_interrupt_handler(kernel)
         )
 
-        if sys.platform == "win32" or sys.platform == "cygwin":
-            Win32InterruptHandler().start()
+        if sys.platform == "win32":
+            if interrupt_queue is not None:
+                Win32InterruptHandler(interrupt_queue).start()
             # windows doesn't handle SIGTERM
             signal.signal(
                 signal.SIGBREAK, handlers.construct_sigterm_handler(kernel)

--- a/marimo/_runtime/win32_interrupt_handler.py
+++ b/marimo/_runtime/win32_interrupt_handler.py
@@ -1,0 +1,26 @@
+import queue
+import signal
+import threading
+from _thread import interrupt_main
+
+from marimo._server.types import QueueType
+
+
+class Win32InterruptHandler(threading.Thread):
+    def __init__(self, interrupt_queue: QueueType[bool]) -> None:
+        super(Win32InterruptHandler, self).__init__()
+        self.daemon = True
+        self.interrupt_queue = interrupt_queue
+
+    def run(self):
+        while True:
+            self.interrupt_queue.get()
+            print("got interrupt")
+            try:
+                while self.interrupt_queue.get_nowait():
+                    pass
+            except queue.Empty
+                pass
+            if callable(signal.getsignal(signal.SIGINT)):
+                print("interrupting main")
+                interrupt_main()

--- a/marimo/_runtime/win32_interrupt_handler.py
+++ b/marimo/_runtime/win32_interrupt_handler.py
@@ -19,7 +19,7 @@ class Win32InterruptHandler(threading.Thread):
             try:
                 while self.interrupt_queue.get_nowait():
                     pass
-            except queue.Empty
+            except queue.Empty:
                 pass
             if callable(signal.getsignal(signal.SIGINT)):
                 print("interrupting main")

--- a/marimo/_runtime/win32_interrupt_handler.py
+++ b/marimo/_runtime/win32_interrupt_handler.py
@@ -3,11 +3,11 @@ import signal
 import threading
 from _thread import interrupt_main
 
-from marimo._server.types import QueueType
+from multiprocessing import Queue
 
 
 class Win32InterruptHandler(threading.Thread):
-    def __init__(self, interrupt_queue: QueueType[bool]) -> None:
+    def __init__(self, interrupt_queue: Queue) -> None:
         super(Win32InterruptHandler, self).__init__()
         self.daemon = True
         self.interrupt_queue = interrupt_queue

--- a/marimo/_runtime/win32_interrupt_handler.py
+++ b/marimo/_runtime/win32_interrupt_handler.py
@@ -1,26 +1,27 @@
+# Copyright 2024 Marimo. All rights reserved.
 import queue
 import signal
 import threading
 from _thread import interrupt_main
+from typing import TYPE_CHECKING
 
-from multiprocessing import Queue
+if TYPE_CHECKING:
+    from multiprocessing import Queue
 
 
 class Win32InterruptHandler(threading.Thread):
-    def __init__(self, interrupt_queue: Queue) -> None:
+    def __init__(self, interrupt_queue: "Queue[bool]") -> None:
         super(Win32InterruptHandler, self).__init__()
         self.daemon = True
         self.interrupt_queue = interrupt_queue
 
-    def run(self):
+    def run(self) -> None:
         while True:
             self.interrupt_queue.get()
-            print("got interrupt")
             try:
                 while self.interrupt_queue.get_nowait():
                     pass
             except queue.Empty:
                 pass
             if callable(signal.getsignal(signal.SIGINT)):
-                print("interrupting main")
                 interrupt_main()

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -526,7 +526,8 @@ class SessionManager:
             maybe_session = self.get_session(new_session_id)
             if (
                 maybe_session
-                and maybe_session.connection_state() == ConnectionState.ORPHANED
+                and maybe_session.connection_state()
+                == ConnectionState.ORPHANED
             ):
                 LOGGER.debug(
                     "Found a resumable RUN session: prev_id=%s",

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -88,6 +88,14 @@ class QueueManager:
             context.Queue() if context is not None else queue.Queue()
         )
 
+        self.win32_interrupt_queue: QueueType[bool] | None
+        if sys.platform == "win32":
+            self.win32_interrupt_queue = (
+                context.Queue() if context is not None else queue.Queue()
+            )
+        else:
+            self.win32_interrupt_queue = None
+
         # Input messages for the user's Python code are sent through the
         # input queue
         self.input_queue: QueueType[str] = (
@@ -116,6 +124,10 @@ class QueueManager:
         if isinstance(self.completion_queue, MPQueue):
             self.completion_queue.cancel_join_thread()
             self.completion_queue.close()
+
+        if isinstance(self.win32_interrupt_queue, MPQueue):
+            self.win32_interrupt_queue.cancel_join_thread()
+            self.win32_interrupt_queue.close()
 
 
 class KernelManager:
@@ -158,6 +170,7 @@ class KernelManager:
                     self.app_metadata,
                     self.user_config_manager.config,
                     self._virtual_files_supported,
+                    self.queue_manager.win32_interrupt_queue,
                 ),
                 # The process can't be a daemon, because daemonic processes
                 # can't create children
@@ -195,6 +208,8 @@ class KernelManager:
                     self.app_metadata,
                     self.user_config_manager.config,
                     self._virtual_files_supported,
+                    # win32 interrupt queue
+                    None,
                 ),
                 # daemon threads can create child processes, unlike
                 # daemon processes
@@ -214,8 +229,13 @@ class KernelManager:
             isinstance(self.kernel_task, mp.Process)
             and self.kernel_task.pid is not None
         ):
-            LOGGER.debug("Sending SIGINT to kernel")
-            os.kill(self.kernel_task.pid, signal.SIGINT)
+            q = self.queue_manager.win32_interrupt_queue
+            if sys.platform == "win32" and q is not None:
+                LOGGER.debug("Queueing interrupt request for kernel.")
+                q.put_nowait(True)
+            else:
+                LOGGER.debug("Sending SIGINT to kernel")
+                os.kill(self.kernel_task.pid, signal.SIGINT)
 
     def close_kernel(self) -> None:
         assert self.kernel_task is not None, "kernel not started"
@@ -506,8 +526,7 @@ class SessionManager:
             maybe_session = self.get_session(new_session_id)
             if (
                 maybe_session
-                and maybe_session.connection_state()
-                == ConnectionState.ORPHANED
+                and maybe_session.connection_state() == ConnectionState.ORPHANED
             ):
                 LOGGER.debug(
                     "Found a resumable RUN session: prev_id=%s",

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -146,16 +146,17 @@ def test_kernel_manager_interrupt(tmp_path) -> None:
     time.sleep(0.5)
     kernel_manager.interrupt_kernel()
 
-    with open(file, "r") as f:
-        assert f.read() == "0"
+    try:
+        with open(file, "r") as f:
+            assert f.read() == "0"
+    finally:
+        assert queue_manager.input_queue.empty()
+        assert queue_manager.control_queue.empty()
 
-    assert queue_manager.input_queue.empty()
-    assert queue_manager.control_queue.empty()
-    kernel_manager.close_kernel()
-
-    # Assert shutdown
-    kernel_manager.kernel_task.join()
-    assert not kernel_manager.is_alive()
+        # Assert shutdown
+        kernel_manager.close_kernel()
+        kernel_manager.kernel_task.join()
+        assert not kernel_manager.is_alive()
 
 
 @save_and_restore_main

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import functools
 import inspect
 import queue
 import sys
@@ -9,14 +10,11 @@ from multiprocessing.queues import Queue as MPQueue
 from typing import Any
 from unittest.mock import MagicMock
 
-import decorator
-
 from marimo._ast.app import App, InternalApp
 from marimo._config.manager import UserConfigManager
 from marimo._runtime.requests import (
     AppMetadata,
     CreationRequest,
-    ExecuteMultipleRequest,
     ExecutionRequest,
     SetUIElementValueRequest,
 )
@@ -37,14 +35,15 @@ app_metadata = AppMetadata(
 def save_and_restore_main(f):
     """Kernels swap out the main module; restore it after running tests"""
 
-    def wrapper(f, *args, **kwargs) -> None:
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs) -> None:
         main = sys.modules["__main__"]
         try:
             f(*args, **kwargs)
         finally:
             sys.modules["__main__"] = main
 
-    return decorator.decorator(wrapper, f)
+    return wrapper
 
 
 @save_and_restore_main

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -37,7 +37,7 @@ def save_and_restore_main(f):
     """Kernels swap out the main module; restore it after running tests"""
 
     @functools.wraps(f)
-    def wrapper(*args, **kwargs) -> None:
+    def wrapper(*args: Any, **kwargs: Any) -> None:
         main = sys.modules["__main__"]
         try:
             f(*args, **kwargs)
@@ -118,7 +118,10 @@ def test_kernel_manager_interrupt(tmp_path) -> None:
         import string
 
         # Having trouble persisting the write to a temp file on Windows
-        file = "".join(random.choice(string.ascii_uppercase) for _ in range(10)) + ".txt"
+        file = (
+            "".join(random.choice(string.ascii_uppercase) for _ in range(10))
+            + ".txt"
+        )
     else:
         file = str(tmp_path / "output.txt")
 


### PR DESCRIPTION
This change fixes kernel execution in edit mode on Windows.

Windows doesn't support sending a `SIGINT` to a child process. Before this change, trying to interrupt running code would kill the kernel.

Originally tried using Windows events + `WaitForSingleObject`, similar to what IPython does, but ran into obscure issues. Opted for a simpler queue-based implementation, which is fine since we only support Python.

Tested with a new test.

Fixes #1162 , #834 