### PR TITLE
fix: race condition in module watcher

### DIFF
--- a/tests/_runtime/reload/reload_test_utils.py
+++ b/tests/_runtime/reload/reload_test_utils.py
@@ -23,5 +23,5 @@ def update_file(path: pathlib.Path, code: str) -> None:
     (because that is stored in the file).  The only reliable way
     to achieve this seems to be to sleep.
     """
-    time.sleep(1.05)
+    time.sleep(1.5)
     path.write_text(textwrap.dedent(code))


### PR DESCRIPTION
This PR fixes a race condition in which the module watcher was iterating over `sys.modules` while the kernel may have been modifying it.

Fixes the race mentioned in #https://github.com/marimo-team/marimo/pull/1179#issuecomment-2073974729