### PR TITLE
fix: don't load marimo mpl backend in script context

### DIFF
--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -97,13 +97,8 @@ from marimo._runtime.capture import (
     redirect_stderr,
     redirect_stdout,
 )
+from marimo._runtime.context.utils import running_in_notebook
 from marimo._runtime.control_flow import MarimoStopError, stop
-from marimo._runtime.runtime import (
-    cli_args,
-    defs,
-    query_params,
-    refs,
-    running_in_notebook,
-)
+from marimo._runtime.runtime import cli_args, defs, query_params, refs
 from marimo._runtime.state import state
 from marimo._server.asgi import create_asgi_app

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -35,7 +35,6 @@ from marimo._messaging.mimetypes import KnownMimeType
 from marimo._messaging.types import NoopStream
 from marimo._output.rich_help import mddoc
 from marimo._runtime import dataflow
-from marimo._runtime.context.types import teardown_context
 from marimo._runtime.patches import patch_main_module_context
 
 if TYPE_CHECKING:
@@ -291,7 +290,10 @@ class App:
         from marimo._runtime.context.script_context import (
             initialize_script_context,
         )
-        from marimo._runtime.context.types import runtime_context_installed
+        from marimo._runtime.context.types import (
+            runtime_context_installed,
+            teardown_context,
+        )
 
         if self._unparsable:
             raise UnparsableError(

--- a/marimo/_messaging/tracebacks.py
+++ b/marimo/_messaging/tracebacks.py
@@ -20,7 +20,7 @@ def _highlight_traceback(traceback: str) -> str:
 
 
 def write_traceback(traceback: str) -> None:
-    from marimo._runtime.runtime import running_in_notebook
+    from marimo._runtime.context.utils import running_in_notebook
 
     if running_in_notebook():
         sys.stderr.write(_highlight_traceback(traceback))

--- a/marimo/_output/formatters/matplotlib_formatters.py
+++ b/marimo/_output/formatters/matplotlib_formatters.py
@@ -15,13 +15,13 @@ class MatplotlibFormatter(FormatterFactory):
 
         from marimo._runtime.context import (
             get_global_context,
-            runtime_context_installed,
         )
+        from marimo._runtime.context.utils import running_in_notebook
 
         get_global_context().set_mpl_installed(True)
         from marimo._output import mpl  # noqa: F401
 
-        if runtime_context_installed():
+        if running_in_notebook():
             matplotlib.use("module://marimo._output.mpl")
 
         import base64

--- a/marimo/_runtime/context/utils.py
+++ b/marimo/_runtime/context/utils.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Marimo. All rights reserved.
+from marimo._output.rich_help import mddoc
+from marimo._runtime.context import (
+    ContextNotInitializedError,
+    get_context,
+)
+from marimo._runtime.context.kernel_context import KernelRuntimeContext
+
+
+@mddoc
+def running_in_notebook() -> bool:
+    """Returns True if running in a marimo notebook, False otherwise"""
+
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        return False
+    else:
+        return isinstance(ctx, KernelRuntimeContext)

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -237,19 +237,6 @@ def cli_args() -> CLIArgs:
     return get_context().cli_args
 
 
-@mddoc
-def running_in_notebook() -> bool:
-    """Returns True if running in a marimo notebook, False otherwise"""
-    from marimo._runtime.context.kernel_context import KernelRuntimeContext
-
-    try:
-        ctx = get_context()
-    except ContextNotInitializedError:
-        return False
-    else:
-        return isinstance(ctx, KernelRuntimeContext)
-
-
 @dataclasses.dataclass
 class CellMetadata:
     """CellMetadata

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -348,7 +348,8 @@ class TestApp:
 
         @app.cell
         def __() -> tuple[Any]:
-            def foo() -> None: ...
+            def foo() -> None:
+                ...
 
             return (foo,)
 
@@ -404,6 +405,10 @@ class TestApp:
 
         assert defs["backend"] != "module://marimo._output.mpl"
 
+    @pytest.mark.skipif(
+        condition=not DependencyManager.has_matplotlib(),
+        reason="requires matplotlib",
+    )
     def test_app_run_matplotlib_figures_closed(self) -> None:
         from matplotlib.axes import Axes
 

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -14,6 +14,7 @@ from marimo._ast.errors import (
     MultipleDefinitionError,
     UnparsableError,
 )
+from marimo._dependencies.dependencies import DependencyManager
 
 if TYPE_CHECKING:
     import pathlib
@@ -384,6 +385,24 @@ class TestApp:
 
         assert defs["x"] == 0
         assert defs["y"] == 1
+
+    @pytest.mark.skipif(
+        condition=not DependencyManager.has_matplotlib(),
+        reason="requires matplotlib",
+    )
+    def test_marimo_mpl_backend_not_used(self):
+        app = App()
+
+        @app.cell
+        def __() -> tuple[str]:
+            import matplotlib
+
+            backend = matplotlib.get_backend()
+            return (backend,)
+
+        _, defs = app.run()
+
+        assert defs["backend"] != "module://marimo._output.mpl"
 
 
 def test_app_config() -> None:

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -24,7 +24,7 @@ from marimo._runtime.requests import (
     SetCellConfigRequest,
     SetUIElementValueRequest,
 )
-from marimo._runtime.runtime import Kernel, running_in_notebook
+from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
 
 if TYPE_CHECKING:
@@ -904,6 +904,8 @@ async def test_running_in_notebook(
 
 
 def test_not_running_in_notebook() -> None:
+    from marimo._runtime.context.utils import running_in_notebook
+
     assert not running_in_notebook()
 
 


### PR DESCRIPTION
This was fixed earlier but regressed when we added `running_in_notebook`.

Fixes an issue mentioned in #1142 

Adds a simple unit test instead of the entire smoke test mentioned in that issue, since `plt.show()` blocks.