### PR TITLE
fix: graceful exit when running as a script

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 
 import contextlib
 import time
-from typing import TYPE_CHECKING, Iterable, Iterator, Optional, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Iterable,
+    Iterator,
+    Optional,
+    TypeVar,
+)
 
 import marimo._runtime.output._output as output
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import build_stateless_plugin
 from marimo._utils.debounce import debounce
+from marimo._utils.exiting import python_exiting
 
 if TYPE_CHECKING:
     from collections.abc import Collection
@@ -45,7 +53,12 @@ class _Progress(Html):
         self.start_time = time.time()
         super().__init__(self._get_text())
 
-    def __del__(self) -> None:
+    def __del__(
+        self, _python_exiting: Callable[..., bool] = python_exiting
+    ) -> None:
+        if _python_exiting():
+            return
+
         super().__del__()
 
     def update_progress(

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -240,7 +240,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         try:
             ctx = get_context()
             ctx.ui_element_registry.delete(self._id, id(self))
-        except Exception:
+        except ContextNotInitializedError:
             pass
 
         super().__del__()

--- a/marimo/_utils/exiting.py
+++ b/marimo/_utils/exiting.py
@@ -11,8 +11,10 @@ class Exiting:
 _PYTHON_EXITING = Exiting()
 
 
-def python_exiting() -> bool:
-    return _PYTHON_EXITING.value
+# bind the global _PYTHON_EXITING to ensure it still exists
+# at Python destruction time; for graceful exits when running as a script
+def python_exiting(_exiting: Exiting = _PYTHON_EXITING) -> bool:
+    return _exiting.value
 
 
 def _exit() -> None:

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -2,11 +2,16 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import subprocess
 from os import path
+from typing import TYPE_CHECKING
 
 from tests._server.templates.utils import normalize_index_html
 from tests.mocks import snapshotter
+
+if TYPE_CHECKING:
+    import pathlib
 
 snapshot = snapshotter(__file__)
 
@@ -121,6 +126,95 @@ class TestExportHTML:
                     in line
                 )
                 break
+
+
+class TestExportHtmlSmokeTests:
+    def assert_not_errored(
+        self, p: subprocess.CompletedProcess[bytes]
+    ) -> None:
+        assert p.returncode == 0
+        assert not any(
+            line.startswith("Traceback")
+            for line in p.stderr.decode().splitlines()
+        )
+        assert not any(
+            line.startswith("Traceback")
+            for line in p.stdout.decode().splitlines()
+        )
+
+    def test_export_intro_tutorial(self, tmp_path: pathlib.Path) -> None:
+        from marimo._tutorials import intro
+
+        file = tmp_path / "intro.py"
+        out = tmp_path / "out.html"
+        file.write_text(inspect.getsource(intro))
+        p = subprocess.run(
+            ["marimo", "export", "html", str(file), "-o", str(out)],
+            capture_output=True,
+        )
+        self.assert_not_errored(p)
+
+    def test_export_ui_tutorial(self, tmp_path: pathlib.Path) -> None:
+        from marimo._tutorials import ui as mod
+
+        file = tmp_path / "mod.py"
+        file.write_text(inspect.getsource(mod))
+        out = tmp_path / "out.html"
+        p = subprocess.run(
+            ["marimo", "export", "html", str(file), "-o", str(out)],
+            capture_output=True,
+        )
+        self.assert_not_errored(p)
+
+    def test_export_dataflow_tutorial(self, tmp_path: pathlib.Path) -> None:
+        from marimo._tutorials import dataflow as mod
+
+        file = tmp_path / "mod.py"
+        file.write_text(inspect.getsource(mod))
+        out = tmp_path / "out.html"
+        p = subprocess.run(
+            ["marimo", "export", "html", str(file), "-o", str(out)],
+            capture_output=True,
+        )
+        self.assert_not_errored(p)
+
+    def test_export_layout_tutorial(self, tmp_path: pathlib.Path) -> None:
+        from marimo._tutorials import layout as mod
+
+        file = tmp_path / "mod.py"
+        file.write_text(inspect.getsource(mod))
+        out = tmp_path / "out.html"
+        p = subprocess.run(
+            ["marimo", "export", "html", str(file), "-o", str(out)],
+            capture_output=True,
+        )
+        self.assert_not_errored(p)
+
+    def test_export_plots_tutorial(self, tmp_path: pathlib.Path) -> None:
+        from marimo._tutorials import plots
+
+        file = tmp_path / "plots.py"
+        file.write_text(inspect.getsource(plots))
+        out = tmp_path / "out.html"
+        p = subprocess.run(
+            ["marimo", "export", "html", str(file), "-o", str(out)],
+            capture_output=True,
+        )
+        self.assert_not_errored(p)
+
+    def test_export_marimo_for_jupyter_users(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        from marimo._tutorials import marimo_for_jupyter_users as mod
+
+        file = tmp_path / "mod.py"
+        file.write_text(inspect.getsource(mod))
+        out = tmp_path / "out.html"
+        p = subprocess.run(
+            ["marimo", "export", "html", str(file), "-o", str(out)],
+            capture_output=True,
+        )
+        self.assert_not_errored(p)
 
 
 class TestExportScript:


### PR DESCRIPTION
`__del__` methods were previously throwing on script exit. Bind globals needed to detect whether Python is exiting as locals on `__del__` methods.