### PR TITLE
fix: syntax error handling in module reloading

### DIFF
--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -65,9 +65,9 @@ def _depends_on(
     try:
         finder.run_script(src_module.__file__)
     except SyntaxError:
-        # user introduced a syntax error, maybe; don't
-        # exclude this module from future searches
-        return True
+        # user introduced a syntax error, maybe; still check if the
+        # module itself has been modified
+        pass
     except Exception:
         # some modules like numpy fail when called with run_script;
         # run_script takes a long time before failing on them, so

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -348,8 +348,7 @@ class TestApp:
 
         @app.cell
         def __() -> tuple[Any]:
-            def foo() -> None:
-                ...
+            def foo() -> None: ...
 
             return (foo,)
 

--- a/tests/_smoke_tests/test_run_as_script.py
+++ b/tests/_smoke_tests/test_run_as_script.py
@@ -6,6 +6,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import pytest
+
 from marimo._dependencies.dependencies import DependencyManager
 
 if TYPE_CHECKING:
@@ -13,7 +14,9 @@ if TYPE_CHECKING:
 
 
 class TestRunTutorialsAsScripts:
-    def assert_not_errored(self, p: subprocess.CompletedProcess[bytes]) -> None:
+    def assert_not_errored(
+        self, p: subprocess.CompletedProcess[bytes]
+    ) -> None:
         assert p.returncode == 0
         assert not any(
             line.startswith("Traceback")


### PR DESCRIPTION
- syntax error doesn't mean automatically stale
- report syntax errors to the user