### PR TITLE
fix: Invalid virtual file returns 404

### DIFF
--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -101,8 +101,19 @@ def virtual_file(
     LOGGER.debug("Getting virtual file: %s", filename_and_length)
     if filename_and_length == EMPTY_VIRTUAL_FILE.filename:
         return Response(content=b"", media_type="application/octet-stream")
+    if "-" not in filename_and_length:
+        raise HTTPException(
+            status_code=404,
+            detail="Invalid virtual file request",
+        )
 
     byte_length, filename = filename_and_length.split("-", 1)
+    if not byte_length.isdigit():
+        raise HTTPException(
+            status_code=404,
+            detail="Invalid byte length in virtual file request",
+        )
+
     buffer_contents = read_virtual_file(filename, int(byte_length))
     mimetype, _ = mimetypes.guess_type(filename)
     return Response(

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -87,3 +87,15 @@ def test_unknown_file(client: TestClient) -> None:
     assert response.status_code == 404
     assert response.headers["content-type"] == "application/json"
     assert response.json() == {"detail": "Not Found"}
+
+
+def test_vfile(client: TestClient) -> None:
+    response = client.get("/@file/empty.txt")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "application/octet-stream"
+    assert response.content == b""
+
+    response = client.get("/@file/bad.txt")
+    assert response.status_code == 404, response.text
+    assert response.headers["content-type"] == "application/json"
+    assert response.json() == {"detail": "Invalid virtual file request"}


### PR DESCRIPTION
404s are less noisy to the console and if its not in the right format, it wont be found 