### PR TITLE
fix UnicodeDecodeError

### DIFF
--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -92,8 +92,8 @@ class OSFileSystem(FileSystem):
         if not path.endswith(".py"):
             return False
 
-        with open(path, "r") as file:
-            return "app = marimo.App(" in file.read()
+        with open(path, "rb") as file:
+            return b"app = marimo.App(" in file.read()
 
     def open_file(self, path: str, encoding: str | None = None) -> str:
         try:

--- a/tests/_server/files/test_os_file_system.py
+++ b/tests/_server/files/test_os_file_system.py
@@ -100,10 +100,34 @@ class TestOSFileSystem(unittest.TestCase):
                 return mo,
 
             if __name__ == "__main__":
+                # mäin
                 app.run()
             """
         self.fs.create_file_or_directory(
             self.test_dir, "file", test_file_name, content.encode("utf-8")
+        )
+        file_path = os.path.join(self.test_dir, test_file_name)
+        file_info = self.fs.get_details(file_path)
+        assert isinstance(file_info, FileDetailsResponse)
+        assert file_info.file.is_marimo_file
+
+    def test_get_details_marimo_file_nonutf(self) -> None:
+        test_file_name = "app.py"
+        content = """
+            import marimo
+            app = marimo.App()
+
+            @app.cell
+            def __():
+                import marimo as mo
+                return mo,
+
+            if __name__ == "__main__":
+                # mäin
+                app.run()
+            """
+        self.fs.create_file_or_directory(
+            self.test_dir, "file", test_file_name, content.encode("iso-8859-1")
         )
         file_path = os.path.join(self.test_dir, test_file_name)
         file_info = self.fs.get_details(file_path)


### PR DESCRIPTION
Fixes the error
```
...
  File "[home]/ProjekteAktuell/marimo/marimo/_server/files/os_file_system.py", line 96, in _is_marimo_file
    return "app = marimo.App(" in file.read()
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 1535: invalid continuation byte
```
that will occur when trying to open the file browser in a directory that contains a file that is not utf8-encoded.

To reproduce the error, run the following cell in a marimo notebook and reload the file browser:
`open("babylon.py", "wb").write(b"\xe4")`