### PR TITLE
fix: no silent errors in module autoreloading

### DIFF
--- a/marimo/_runtime/reload/autoreload.py
+++ b/marimo/_runtime/reload/autoreload.py
@@ -315,18 +315,19 @@ def superreload(
     try:
         module = reload(module)
     except Exception as e:
-        if isinstance(e, SyntaxError):
-            # User introduced a SyntaxError -- they should be told,
-            # and module dict should not be restored, ie don't fail
-            # silently.
-            tmpio = io.StringIO()
-            traceback.print_exc(file=tmpio)
-            tmpio.seek(0)
-            write_traceback(tmpio.read())
-        else:
-            # restore module dictionary on failed reload
-            if old_dict is not None:
-                module.__dict__.update(old_dict)
+        # User introduced a SyntaxError, ModuleNotFoundError, etc -- they
+        # should be told, and module dict should not be restored, ie don't fail
+        # silently.
+        #
+        # It's possible that the module fails to reload for some other reason.
+        # In this case, too, the failure shouldn't be silent!
+        sys.stderr.write(
+            f"Error trying to reload module {module.__name__}: {str(e)} \n"
+        )
+        tmpio = io.StringIO()
+        traceback.print_exc(file=tmpio)
+        tmpio.seek(0)
+        write_traceback(tmpio.read())
         raise
 
     # iterate over all objects and update functions & classes

--- a/tests/_runtime/reload/test_autoreload.py
+++ b/tests/_runtime/reload/test_autoreload.py
@@ -34,3 +34,67 @@ def test_reload_function(tmp_path: pathlib.Path, py_modname: str):
     )
     reloader.check(sys.modules, reload=True)
     assert mod.foo() == 2
+
+
+def test_reload_module_with_error(tmp_path: pathlib.Path, py_modname: str):
+    sys.path.append(str(tmp_path))
+    reloader = ModuleReloader()
+    py_file = tmp_path / pathlib.Path(py_modname + ".py")
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            def foo():
+                return 1
+            """
+        )
+    )
+    mod = importlib.import_module(py_modname)
+    reloader.check(sys.modules, reload=False)
+    assert mod.foo() == 1
+    update_file(
+        py_file,
+        """
+        import this_module_does_not_exist
+        def foo():
+            return 2
+        """,
+    )
+    reloader.check(sys.modules, reload=True)
+
+    assert str(py_file) in reloader.failed
+    # module is still in sys.modules ...
+    assert py_modname in sys.modules
+    # ... but it's basically empty
+    assert not hasattr(mod, "foo")
+
+
+def test_reload_module_with_syntax_error(
+    tmp_path: pathlib.Path, py_modname: str
+):
+    sys.path.append(str(tmp_path))
+    reloader = ModuleReloader()
+    py_file = tmp_path / pathlib.Path(py_modname + ".py")
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            def foo():
+                return 1
+            """
+        )
+    )
+    mod = importlib.import_module(py_modname)
+    reloader.check(sys.modules, reload=False)
+    assert mod.foo() == 1
+    update_file(
+        py_file,
+        """
+        t h _ i s is in va lid python
+        """,
+    )
+    reloader.check(sys.modules, reload=True)
+
+    assert str(py_file) in reloader.failed
+    # module is still in sys.modules ...
+    assert py_modname in sys.modules
+    # ... but it's basically empty
+    assert not hasattr(mod, "foo")


### PR DESCRIPTION
This escalates all errors encountered when reloading a module.

Previously, one could introduce errors like faulty imports and have them silently failed. I ran into this and was confused why I wasn't seeing the latest changes in my notebook.