### PR TITLE
fix: allow resetting plotly zoom/pan externally

### DIFF
--- a/frontend/src/utils/objects.ts
+++ b/frontend/src/utils/objects.ts
@@ -85,7 +85,10 @@ export const Objects = {
     return result;
   },
 
-  omit<V extends object, K extends keyof V>(obj: V, keys: K[]): Partial<V> {
+  omit<V extends object, K extends keyof V>(
+    obj: V,
+    keys: K[] | Set<K>,
+  ): Partial<V> {
     const set = new Set<K>(keys);
     return Objects.filter(obj, (_, key) => !set.has(key));
   },

--- a/marimo/_smoke_tests/bugs/1273.py
+++ b/marimo/_smoke_tests/bugs/1273.py
@@ -1,0 +1,41 @@
+import marimo
+
+__generated_with = "0.4.7"
+app = marimo.App(width="full")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import plotly.express as px
+    return mo, px
+
+
+@app.cell
+def __(mo):
+    s = mo.ui.range_slider(start=-5, stop=5, show_value=True, label='x range')
+    x, y = list(range(10)), [i * i for i in range(-5, 5)]
+    return s, x, y
+
+
+@app.cell
+def __(mo, px, s, x, y):
+    # takes affect when using the slider
+    mo.vstack([
+        s,
+        px.scatter(x=x, y=y, range_x=s.value, title=f'range_x: {s.value}')
+    ])
+    return
+
+
+@app.cell
+def __(mo, px, s, x, y):
+    # takes affect when using the slider
+    # also is zoom/range is persisted across app view, but reset when the slider changes the range
+    plot = mo.ui.plotly(px.scatter(x=x, y=y, range_x=s.value, title=f'range_x: {s.value}'))
+    plot
+    return plot,
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #1273

Previously we stored the state in the component value without letting the external change update the component. This fixes that