### PR TITLE
improvement: mo.ui.spinner can display without a context manager

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -237,13 +237,7 @@ class spinner:
     You can also show the spinner without a context manager:
 
     ```python
-    mo.hstack(
-        [
-            mo.status.spinner(title="Loading ...")
-            if condition
-            else mo.md("Done!")
-        ]
-    )
+    mo.status.spinner(title="Loading ...") if condition else mo.md("Done!")
     ```
 
     **Args:**
@@ -263,7 +257,6 @@ class spinner:
         self.subtitle = subtitle
         self.remove_on_exit = remove_on_exit
         self.spinner = Spinner(title=self.title, subtitle=self.subtitle)
-        # output.append(self.spinner)
 
     def __enter__(self) -> Spinner:
         output.append(self.spinner)

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -265,11 +265,11 @@ class spinner:
         self.spinner = Spinner(title=self.title, subtitle=self.subtitle)
         # output.append(self.spinner)
 
-    def __enter__(self):
+    def __enter__(self) -> Spinner:
         output.append(self.spinner)
         return self.spinner
 
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         if self.remove_on_exit:
             self.spinner.clear()
         # TODO(akshayka): else consider transitioning to a done state

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import contextlib
 import time
 from typing import (
     TYPE_CHECKING,
@@ -218,7 +217,7 @@ class Spinner(_Progress):
 
 
 @mddoc
-class spinner(contextlib.AbstractContextManager[Spinner]):
+class spinner:
     """Show a loading spinner
 
     Use `mo.status.spinner()` as a context manager to show a loading spinner.

--- a/marimo/_smoke_tests/bugs/1271.py
+++ b/marimo/_smoke_tests/bugs/1271.py
@@ -1,0 +1,40 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.4.7"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    with mo.status.spinner(remove_on_exit=False):
+        pass
+    return
+
+
+@app.cell
+def __(mo):
+    counter_button = mo.ui.button(
+        value=0, on_click=lambda value: value + 1, label="increment"
+    )
+    counter_button
+    return counter_button,
+
+
+@app.cell
+def __(counter_button, mo):
+    mo.vstack([
+        counter_button.value,
+        mo.status.spinner(remove_on_exit=False) if counter_button.value < 3 else mo.md("Done!"),
+    ])
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -48,7 +48,9 @@ def wrap_generate_filecontents(
     cell_configs: Optional[list[CellConfig]] = None,
     config: Optional[_AppConfig] = None,
 ) -> str:
-    """Wraps codegen.generate_filecontents to make the cell_configs argument optional."""
+    """
+    Wraps codegen.generate_filecontents to make the
+    cell_configs argument optional."""
     if cell_configs is None:
         resolved_configs = [CellConfig() for _ in range(len(codes))]
     else:


### PR DESCRIPTION
Fixes #1271

Add a `_mime_()` to the spinner class to display without a context manager