### PR TITLE
fix: altair when using marimo_csv data_transformer

### DIFF
--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -1,10 +1,11 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import html
+
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._output.builder import h
 from marimo._output.formatters.formatter_factory import FormatterFactory
-from marimo._output.formatters.utils import src_or_src_doc
 from marimo._output.utils import flatten_string
 
 
@@ -37,7 +38,10 @@ class AltairFormatter(FormatterFactory):
                 (
                     flatten_string(
                         h.iframe(
-                            **src_or_src_doc(chart.to_html()),
+                            # Must be srcdoc, or if you try to use src, see
+                            # https://github.com/marimo-team/marimo/issues/1279
+                            # and 1279.py
+                            srcdoc=html.escape(chart.to_html()),
                             onload="__resizeIframe(this)",
                             style="width: 100%",
                         )

--- a/marimo/_smoke_tests/bugs/1279.py
+++ b/marimo/_smoke_tests/bugs/1279.py
@@ -1,0 +1,34 @@
+import marimo
+
+__generated_with = "0.4.7"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import altair as alt
+    import polars as pl
+    alt.data_transformers.enable("marimo_csv")
+
+    counts = pl.DataFrame(
+        {
+            "category": ["A", "D", "E", "G", "M", "A1", "A2", "G1", "G2", "G3", "G4"],
+            "count": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110],
+        }
+    )
+
+    (
+        alt.Chart(counts.to_pandas())
+        .encode(
+            y="count",
+            x=alt.X(
+                "category",
+            ),
+        )
+        .mark_bar()
+    )
+    return alt, counts, pl
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_output/formatters/test_altair.py
+++ b/tests/_output/formatters/test_altair.py
@@ -37,4 +37,4 @@ async def test_altair(
     result = executing_kernel.globals["result"]
     assert result is not None
     assert result[0] == "text/html"
-    assert result[1].startswith("<iframe src=")
+    assert result[1].startswith("<iframe srcdoc=")


### PR DESCRIPTION
Fixes #1279 

Using src makes the filepath for virual files a bit funky and fails when loading data via a virtual file