### PR TITLE
fix: disconnect from consumer if there is a stale connection

### DIFF
--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -257,6 +257,8 @@ class WebsocketHandler(SessionConsumer):
             existing_session = mgr.get_session(session_id)
             if existing_session is not None:
                 LOGGER.debug("Reconnecting session %s", session_id)
+                # In case their is a lingering connection, close it
+                existing_session.disconnect_consumer()
                 await self._reconnect_session(existing_session, replay=False)
                 return existing_session
 

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -257,7 +257,7 @@ class WebsocketHandler(SessionConsumer):
             existing_session = mgr.get_session(session_id)
             if existing_session is not None:
                 LOGGER.debug("Reconnecting session %s", session_id)
-                # In case their is a lingering connection, close it
+                # In case there is a lingering connection, close it
                 existing_session.maybe_disconnect_consumer()
                 await self._reconnect_session(existing_session, replay=False)
                 return existing_session

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -258,7 +258,7 @@ class WebsocketHandler(SessionConsumer):
             if existing_session is not None:
                 LOGGER.debug("Reconnecting session %s", session_id)
                 # In case their is a lingering connection, close it
-                existing_session.disconnect_consumer()
+                existing_session.maybe_disconnect_consumer()
                 await self._reconnect_session(existing_session, replay=False)
                 return existing_session
 

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -364,6 +364,10 @@ class Session:
         self.unsubscribe_consumer()
         self.session_consumer = None
 
+    def maybe_disconnect_consumer(self) -> None:
+        if self.session_consumer is not None:
+            self.disconnect_consumer()
+
     def connect_consumer(self, session_consumer: SessionConsumer) -> None:
         """Connect or resume the session with a new consumer"""
         assert (


### PR DESCRIPTION
Sometimes a proxy can hang onto to a connection, but the client is already disconnected (and trying to reconnect). This disconnects if there is still a connection