### PR TITLE
feat: allow status.progress_bar to be used as a context manager

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -295,7 +295,8 @@ class progress_bar:
             bar.update()
     ```
 
-The `update` method accepts the optional keyword arguments `increment` (defaults to `1`), `title`, and `subtitle`.
+The `update` method accepts the optional keyword
+arguments `increment` (defaults to `1`), `title`, and `subtitle`.
     For performance reasons, the progress bar is only updated in the UI
     every 150ms.
 

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -295,6 +295,7 @@ class progress_bar:
             bar.update()
     ```
 
+The `update` method accepts the optional keyword arguments `increment` (defaults to `1`), `title`, and `subtitle`.
     For performance reasons, the progress bar is only updated in the UI
     every 150ms.
 
@@ -342,7 +343,7 @@ class progress_bar:
         elif total is None:
             raise ValueError(
                 "`total` is required when using as a context manager"
-            ) from None
+            )
 
         self.progress = ProgressBar(
             title=title,

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -272,17 +272,7 @@ class spinner:
         return self.spinner._mime_()
 
 
-def progress_bar(
-    collection: Collection[S | int],
-    *,
-    title: Optional[str] = None,
-    subtitle: Optional[str] = None,
-    completion_title: Optional[str] = None,
-    completion_subtitle: Optional[str] = None,
-    total: Optional[int] = None,
-    show_rate: bool = True,
-    show_eta: bool = True,
-) -> Iterable[S | int]:
+class progress_bar:
     """Iterate over a collection and show a progress bar
 
     **Example.**
@@ -295,12 +285,22 @@ def progress_bar(
     You can optionally provide a title and subtitle to show
     during iteration, and a title/subtitle to show upon completion.
 
+    You can also use progress_bar with a context manager and manually update
+    the bar:
+
+    ```python
+    with mo.status.progress_bar(total=10) as bar:
+        for i in range(10):
+            ...
+            bar.update()
+    ```
+
     For performance reasons, the progress bar is only updated in the UI
     every 150ms.
 
     **Args.**
 
-    - `collection`: a collection to iterate over
+    - `collection`: optional collection to iterate over
     - `title`: optional title
     - `subtitle`: optional subtitle
     - `completion_title`: optional title to show during completion
@@ -308,30 +308,67 @@ def progress_bar(
     - `total`: optional total number of items to iterate over
     - `show_rate`: if True, show the rate of progress (items per second)
     - `show_eta`: if True, show the estimated time of completion
-
-    **Returns.**
-
-    An iterable object that wraps `collection`
     """
-    try:
-        total = total or len(collection)
-        step = collection.step if isinstance(collection, range) else 1
-    except TypeError:  # if collection is a generator
-        raise TypeError(
-            "fail to determine length of collection, use `total` to specify"
-        ) from None
-    progress = ProgressBar(
-        title=title,
-        subtitle=subtitle,
-        total=total,
-        show_rate=show_rate,
-        show_eta=show_eta,
-    )
-    output.append(progress)
-    for item in collection:
-        yield item
-        progress.update(increment=step)
-    progress.update(
-        increment=0, title=completion_title, subtitle=completion_subtitle
-    )
-    progress.close()
+
+    def __init__(
+        self,
+        collection: Optional[Collection[S | int]] = None,
+        *,
+        title: Optional[str] = None,
+        subtitle: Optional[str] = None,
+        completion_title: Optional[str] = None,
+        completion_subtitle: Optional[str] = None,
+        total: Optional[int] = None,
+        show_rate: bool = True,
+        show_eta: bool = True,
+    ):
+        self.completion_title = completion_title
+        self.completion_subtitle = completion_subtitle
+
+        if collection is not None:
+            self.collection = collection
+
+            try:
+                total = total or len(collection)
+                self.step = (
+                    collection.step if isinstance(collection, range) else 1
+                )
+            except TypeError:  # if collection is a generator
+                raise TypeError(
+                    "fail to determine length of collection, use `total`"
+                    + "to specify"
+                ) from None
+
+        elif total is None:
+            raise ValueError(
+                "`total` is required when using as a context manager"
+            ) from None
+
+        self.progress = ProgressBar(
+            title=title,
+            subtitle=subtitle,
+            total=total,
+            show_rate=show_rate,
+            show_eta=show_eta,
+        )
+        output.append(self.progress)
+
+    def __iter__(self) -> Iterable[S | int]:
+        for item in self.collection:
+            yield item
+            self.progress.update(increment=self.step)
+        self._finish()
+
+    def __enter__(self) -> ProgressBar:
+        return self.progress
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self._finish()
+
+    def _finish(self) -> None:
+        self.progress.update(
+            increment=0,
+            title=self.completion_title,
+            subtitle=self.completion_subtitle,
+        )
+        self.progress.close()

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -295,8 +295,10 @@ class progress_bar:
             bar.update()
     ```
 
-The `update` method accepts the optional keyword
-arguments `increment` (defaults to `1`), `title`, and `subtitle`.
+    The `update` method accepts the optional keyword
+    arguments `increment` (defaults to `1`), `title`,
+    and `subtitle`.
+    
     For performance reasons, the progress bar is only updated in the UI
     every 150ms.
 

--- a/marimo/_smoke_tests/status.py
+++ b/marimo/_smoke_tests/status.py
@@ -34,6 +34,12 @@ def __(mo, time):
         time.sleep(0.5)
     return
 
+@app.cell
+def __(mo, time):
+    with mo.status.progress_bar(title='Loading', subtitle='Please wait') as bar:
+        for _ in range(10):
+            time.sleep(0.5)
+            bar.update()
 
 @app.cell
 def __(mo, time):


### PR DESCRIPTION
Hi! Thanks for all the good work with marimo. I found myself wanting to update the subtitle while the progress bar was running, which is a pattern I've used before with `tqdm`.

I modified progress_bar to also be usable as a context manager, which exposes the underlying `ProgressBar` and allows for manual calls to `update`. This achieves the functionality I'm looking for, and still allows for using the normal iterable method.

Happy to make any changes if needed 😄 