### PR TITLE
fix: handle duplicate columns in pandas when inferring datatype

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -115,7 +115,14 @@ class PandasTableManagerFactory(TableManagerFactory):
                 }
 
             @staticmethod
-            def _get_field_type(series: pd.Series[Any]) -> FieldType:
+            def _get_field_type(
+                series: pd.Series[Any] | pd.DataFrame,
+            ) -> FieldType:
+                # If a df has duplicate columns, it won't be a series, but
+                # a dataframe. In this case, we just return 'unknown'.
+                if isinstance(series, pd.DataFrame):
+                    return "unknown"
+
                 dtype = str(series.dtype)
                 if dtype.startswith("interval"):
                     return "string"

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -119,11 +119,12 @@ class PandasTableManagerFactory(TableManagerFactory):
                 series: pd.Series[Any] | pd.DataFrame,
             ) -> FieldType:
                 # If a df has duplicate columns, it won't be a series, but
-                # a dataframe. In this case, we just return 'unknown'.
+                # a dataframe. In this case, we take the dtype of the columns
                 if isinstance(series, pd.DataFrame):
-                    return "unknown"
+                    dtype = str(series.columns.dtype)
+                else:
+                    dtype = str(series.dtype)
 
-                dtype = str(series.dtype)
                 if dtype.startswith("interval"):
                     return "string"
                 if dtype.startswith("int") or dtype.startswith("uint"):

--- a/marimo/_smoke_tests/bugs/1312.py
+++ b/marimo/_smoke_tests/bugs/1312.py
@@ -1,0 +1,29 @@
+import marimo
+
+__generated_with = "0.4.11"
+app = marimo.App()
+
+
+@app.cell
+def __(pd):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
+    renamed = df.rename({"b": "a"}, axis=1)
+    renamed
+    return df, renamed
+
+
+@app.cell
+def __(mo, renamed):
+    mo.ui.table(renamed)
+    return
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import pandas as pd
+    return mo, pd
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -157,3 +157,54 @@ class TestPandasTableManager(unittest.TestCase):
             self.factory.create()(complex_data).get_field_types()
             == expected_field_types
         )
+
+    def test_get_fields_types_duplicate_columns(self) -> None:
+        import pandas as pd
+
+        # Different types
+        data = pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": ["a", "b", "c"],
+            }
+        )
+        data = data.rename(columns={"A": "B"})
+        expected_field_types = {
+            "B": "unknown",
+        }
+        assert (
+            self.factory.create()(data).get_field_types()
+            == expected_field_types
+        )
+
+        # Both strings
+        data = pd.DataFrame(
+            {
+                "A": ["a", "b", "c"],
+                "B": ["d", "e", "f"],
+            }
+        )
+        data = data.rename(columns={"A": "B"})
+        expected_field_types = {
+            "B": "unknown",
+        }
+        assert (
+            self.factory.create()(data).get_field_types()
+            == expected_field_types
+        )
+
+        # Both integers
+        data = pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": [4, 5, 6],
+            }
+        )
+        data = data.rename(columns={"A": "B"})
+        expected_field_types = {
+            "B": "unknown",
+        }
+        assert (
+            self.factory.create()(data).get_field_types()
+            == expected_field_types
+        )

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -170,7 +170,7 @@ class TestPandasTableManager(unittest.TestCase):
         )
         data = data.rename(columns={"A": "B"})
         expected_field_types = {
-            "B": "unknown",
+            "B": "string",
         }
         assert (
             self.factory.create()(data).get_field_types()
@@ -186,7 +186,7 @@ class TestPandasTableManager(unittest.TestCase):
         )
         data = data.rename(columns={"A": "B"})
         expected_field_types = {
-            "B": "unknown",
+            "B": "string",
         }
         assert (
             self.factory.create()(data).get_field_types()
@@ -202,7 +202,7 @@ class TestPandasTableManager(unittest.TestCase):
         )
         data = data.rename(columns={"A": "B"})
         expected_field_types = {
-            "B": "unknown",
+            "B": "string",
         }
         assert (
             self.factory.create()(data).get_field_types()


### PR DESCRIPTION
Fixes #1312

Our frontend can handle duplicate datatypes but since add `.get_field_types` to the TableManager, it can fail on duplicate headers (which returns a nested `dataframe` instead of a series)