### PR TITLE
fix: add markdown sanitization for malicious notebooks

### DIFF
--- a/marimo/_cli/convert/markdown.py
+++ b/marimo/_cli/convert/markdown.py
@@ -220,7 +220,7 @@ class SanitizeProcessor(Preprocessor):
     stash: dict[str, Any]
 
     def run(self, lines: list[str]) -> list[str]:
-        # Note, an empty stash is not sufficent since partially open code
+        # Note, an empty stash is not sufficient since partially open code
         # blocks could be in the text.
         if not lines:
             return lines

--- a/marimo/_cli/convert/markdown.py
+++ b/marimo/_cli/convert/markdown.py
@@ -39,6 +39,13 @@ def _is_code_tag(text: str) -> bool:
     return bool(re.search(r"\{.*python.*\}", head))
 
 
+def formatted_code_block(code: str) -> str:
+    guard = "```"
+    while guard in code:
+        guard += "`"
+    return "\n".join([f"""{guard}{{.python.marimo}}""", code, guard, ""])
+
+
 def _tree_to_app(root: Element) -> str:
     # Extract meta data from root attributes.
     config_keys = {"title": "app_title"}
@@ -63,25 +70,21 @@ def _tree_to_app(root: Element) -> str:
     return generate_from_sources(sources, app_config)
 
 
-class MarimoParser(Markdown):
-    """Parses Markdown to marimo notebook."""
+class IdentityParser(Markdown):
+    """Leaves markdown unchanged."""
 
     # Considering how ubiquitous "markdown" is, it's a little surprising the
     # internal structure isn't cleaner/ more modular. This "monkey-patching"
     # is comparable to some of the code in markdown extensions- and given this
     # library has been around since 2004, the internals should be relatively
     # stable.
-    output_formats: dict[Literal["marimo"], Callable[[Element], str]] = {  # type: ignore[assignment, misc]
-        "marimo": _tree_to_app,
+    output_formats: dict[Literal["identity"], Callable[[Element], str]] = {  # type: ignore[assignment, misc]
+        "identity": lambda x: x.text if x.text else "",
     }
-    meta: dict[str, Any]
 
-    def build_parser(self) -> MarimoParser:
+    def build_parser(self) -> IdentityParser:
         """
         Creates blank registries as a base.
-
-        Note that evoked by itself, will create an infinite loop, since
-        block-parsers will never dequeue the extracted blocks.
         """
         self.preprocessors = Registry()
         self.parser = BlockParser(self)
@@ -89,6 +92,76 @@ class MarimoParser(Markdown):
         self.treeprocessors = Registry()
         self.postprocessors = Registry()
         return self
+
+    def convert(self, text: str) -> str:
+        """Override the convert method to return the parsed text.
+
+        Note that evoked by itself, would create an infinite loop, since
+        block-parsers will never dequeue the extracted blocks.
+        """
+        if len(self.parser.blockprocessors) == 0:
+            self.parser.blockprocessors.register(
+                IdentityProcessor(self.parser), "identity", 1
+            )
+
+        return super().convert(text)
+
+
+class MarimoParser(IdentityParser):
+    """Parses Markdown to marimo notebook string."""
+
+    meta: dict[str, Any]
+
+    output_formats: dict[Literal["marimo"], Callable[[Element], str]] = {  # type: ignore[assignment, misc]
+        "marimo": _tree_to_app,
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Build here opposed to the parent class since there is intermediate
+        # logic after the parser is built, and it is more clear here what is
+        # registered.
+        self.stripTopLevelTags = False
+
+        # Note: MetaPreprocessor does not properly handle frontmatter yaml, so
+        # cleanup occurs in the block-processor.
+        self.preprocessors.register(
+            FrontMatterPreprocessor(self), "frontmatter", 100
+        )
+        fences_ext = SuperFencesCodeExtension()
+        fences_ext.extendMarkdown(self)
+        # TODO: Consider adding the admonition extension, and integrating it
+        # with mo.markdown callouts.
+
+        block_processor = ExpandAndClassifyProcessor(self.parser)
+        block_processor.stash = fences_ext.stash.stash
+        self.parser.blockprocessors.register(
+            block_processor, "marimo-processor", 10
+        )
+
+
+class SanitizeParser(IdentityParser):
+    """Sanitizes Markdown to non-executable string."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Potentially no need for a separate sanitizer. We could use a
+        # heuristic to determine if this block should be treated as code, but
+        # to catch all edgecases, just run it through the similar superfence
+        # logic.
+        self.stripTopLevelTags = False
+
+        fences_ext = SuperFencesCodeExtension()
+        fences_ext.extendMarkdown(self)
+
+        preprocessor = SanitizeProcessor(self)
+        preprocessor.stash = fences_ext.stash.stash
+        self.preprocessors.register(preprocessor, "marimo-sanitizer", 1)
+
+        # Add back in identity to dequeue.
+        self.parser.blockprocessors.register(
+            IdentityProcessor(self.parser), "identity", 1
+        )
 
 
 class FrontMatterPreprocessor(Preprocessor):
@@ -135,6 +208,55 @@ class FrontMatterPreprocessor(Preprocessor):
             except yaml.YAMLError as e:
                 raise e
         return doc.split("\n")
+
+
+class SanitizeProcessor(Preprocessor):
+    """Prevent unintended executable code block injection.
+
+    Typically run on Markdown fragments (e.g. cells) to prevent code injection.
+    **Note***: Must run after SuperFencesCodeExtension.
+    """
+
+    stash: dict[str, Any]
+
+    def run(self, lines: list[str]) -> list[str]:
+        # Note, an empty stash is not sufficent since partially open code
+        # blocks could be in the text.
+        if not lines:
+            return lines
+
+        is_code = False
+        for i, line in enumerate(lines):
+            # Still need to do all replacements
+            if HTML_PLACEHOLDER_RE.match(line.strip()):
+                lookup = line.strip()[1:-1]
+                code = self.stash[lookup][0]
+                lines[i] = code
+                # This is a tag we would normally parse on.
+                # So protect it from being parsed improperly, by just treating
+                # it as code.
+                is_code = is_code or _is_code_tag(code)
+            # We also need to check for code block delimiters that superfences
+            # did not catch, as this will break other code blocks.
+            is_code = is_code or line.startswith("```")
+
+        if not is_code:
+            return lines
+
+        return formatted_code_block(
+            markdown_to_marimo("\n".join(lines))
+        ).split("\n")
+
+
+class IdentityProcessor(BlockProcessor):
+    """Leaves markdown unchanged."""
+
+    def test(*_args: Any) -> bool:
+        return True
+
+    def run(self, parent: Element, blocks: list[str]) -> None:
+        parent.text = "\n\n".join(blocks)
+        blocks.clear()
 
 
 class ExpandAndClassifyProcessor(BlockProcessor):
@@ -188,31 +310,15 @@ class ExpandAndClassifyProcessor(BlockProcessor):
         blocks.clear()
 
 
-def _build_marimo_parser() -> MarimoParser:
-    # Build here opposed to the parent class since there is intermediate logic
-    # after the parser is built, and it is more clear here what is registered.
-    md = MarimoParser(output_format="marimo")  # type: ignore[arg-type]
-    md.stripTopLevelTags = False
-
-    # Note: MetaPreprocessor does not properly handle frontmatter yaml, so
-    # cleanup occurs in the block-processor.
-    md.preprocessors.register(FrontMatterPreprocessor(md), "frontmatter", 100)
-    fences_ext = SuperFencesCodeExtension()
-    fences_ext.extendMarkdown(md)
-    # TODO: Consider adding the admonition extension, and integrating it with
-    # mo.markdown callouts.
-
-    block_processors = ExpandAndClassifyProcessor(md.parser)
-    block_processors.stash = fences_ext.stash.stash
-    md.parser.blockprocessors.register(
-        block_processors, "marimo-processor", 10
-    )
-
-    return md
-
-
 def convert_from_md(text: str) -> str:
-    if not text:
-        raise ValueError("No content found in markdown.")
-    md = _build_marimo_parser()
-    return md.convert(text)
+    return MarimoParser(output_format="marimo").convert(text)  # type: ignore[arg-type]
+
+
+def sanitize_markdown(text: str) -> str:
+    return SanitizeParser(output_format="identity").convert(text)  # type: ignore[arg-type]
+
+
+def is_sanitized_markdown(text: str) -> bool:
+    # "Unsanitized" markdown contains potentially unintended executatable code
+    # block, which require backticks.
+    return "```" not in text or sanitize_markdown(text) == text

--- a/marimo/_cli/convert/markdown.py
+++ b/marimo/_cli/convert/markdown.py
@@ -19,7 +19,10 @@ from markdown.preprocessors import Preprocessor
 from markdown.util import HTML_PLACEHOLDER_RE, Registry
 
 # As are extensions
-from pymdownx.superfences import SuperFencesCodeExtension  # type: ignore
+from pymdownx.superfences import (  # type: ignore
+    RE_NESTED_FENCE_START,
+    SuperFencesCodeExtension,
+)
 
 from marimo._ast.app import _AppConfig
 from marimo._cli.convert.utils import generate_from_sources, markdown_to_marimo
@@ -238,7 +241,7 @@ class SanitizeProcessor(Preprocessor):
                 is_code = is_code or _is_code_tag(code)
             # We also need to check for code block delimiters that superfences
             # did not catch, as this will break other code blocks.
-            is_code = is_code or line.startswith("```")
+            is_code = is_code or RE_NESTED_FENCE_START.match(line)
 
         if not is_code:
             return lines

--- a/marimo/_server/export/utils.py
+++ b/marimo/_server/export/utils.py
@@ -81,6 +81,7 @@ def get_markdown_from_cell(
         else:
             return None
         assert value.func.value.id == "mo"
+        md_lines = _const_string(value.args).split("\n")
     except (AssertionError, AttributeError, ValueError):
         # No reason to explicitly catch exceptions if we can't parse out
         # markdown. Just handle it as a code block.
@@ -88,10 +89,10 @@ def get_markdown_from_cell(
 
     # Dedent behavior is a little different that in marimo js, so handle
     # accordingly.
-    md_lines = _const_string(value.args).split("\n")
     md_lines = [line.rstrip() for line in md_lines]
     md = dedent(md_lines[0]) + "\n" + dedent("\n".join(md_lines[1:]))
     md = md.strip()
+
     if callout:
         md = dedent(
             f"""

--- a/tests/_cli/snapshots/marimo_for_jupyter_users.md.txt
+++ b/tests/_cli/snapshots/marimo_for_jupyter_users.md.txt
@@ -66,25 +66,17 @@ reactive execution model: interactions automatically trigger execution of
 cells that refer to them.
 
 In contrast, Jupyter's lack of reactivity makes IPyWidgets difficult to use.
+## Shareable as apps
 
-````{.python.marimo}
-mo.md(
-    rf"""
-    ## Shareable as apps
+marimo notebooks can be shared as read-only web apps: just serve it with
 
-    marimo notebooks can be shared as read-only web apps: just serve it with
+```marimo run your_notebook.py```
 
-    ```marimo run your_notebook.py```
+at the command-line.
 
-    at the command-line.
-
-    Not every marimo notebook needs to be shared as an app, but marimo makes it
-    seamless to do so if you want to. In this way, marimo works as a replacement
-    for both Jupyter and Streamlit.
-    """
-)
-````
-
+Not every marimo notebook needs to be shared as an app, but marimo makes it
+seamless to do so if you want to. In this way, marimo works as a replacement
+for both Jupyter and Streamlit.
 ## Cell order
 
 In marimo, cells can be arranged in any order — marimo figures out the one true way to execute them based on variable declarations and references (in a ["topologically sorted"](https://en.wikipedia.org/wiki/Topological_sorting#:~:text=In%20computer%20science%2C%20a%20topological,before%20v%20in%20the%20ordering.) order)

--- a/tests/_cli/snapshots/marimo_for_jupyter_users.md.txt
+++ b/tests/_cli/snapshots/marimo_for_jupyter_users.md.txt
@@ -66,17 +66,25 @@ reactive execution model: interactions automatically trigger execution of
 cells that refer to them.
 
 In contrast, Jupyter's lack of reactivity makes IPyWidgets difficult to use.
-## Shareable as apps
 
-marimo notebooks can be shared as read-only web apps: just serve it with
+````{.python.marimo}
+mo.md(
+    rf"""
+    ## Shareable as apps
 
-```marimo run your_notebook.py```
+    marimo notebooks can be shared as read-only web apps: just serve it with
 
-at the command-line.
+    ```marimo run your_notebook.py```
 
-Not every marimo notebook needs to be shared as an app, but marimo makes it
-seamless to do so if you want to. In this way, marimo works as a replacement
-for both Jupyter and Streamlit.
+    at the command-line.
+
+    Not every marimo notebook needs to be shared as an app, but marimo makes it
+    seamless to do so if you want to. In this way, marimo works as a replacement
+    for both Jupyter and Streamlit.
+    """
+)
+````
+
 ## Cell order
 
 In marimo, cells can be arranged in any order — marimo figures out the one true way to execute them based on variable declarations and references (in a ["topologically sorted"](https://en.wikipedia.org/wiki/Topological_sorting#:~:text=In%20computer%20science%2C%20a%20topological,before%20v%20in%20the%20ordering.) order)

--- a/tests/_cli/snapshots/unsafe-app.md.txt
+++ b/tests/_cli/snapshots/unsafe-app.md.txt
@@ -1,0 +1,68 @@
+---
+title: Test Notebook
+marimo-version: 0.0.0
+---
+
+```{.python.marimo}
+import marimo as mo
+```
+
+````{.python.marimo}
+mo.md("""
+    # Code blocks in code blocks
+    Output code for Hello World!
+    ```python
+    print("Hello World")
+    ```
+    Execute print
+    ```{python}
+    print("Hello World")
+    ```
+""")
+````
+
+````{.python.marimo}
+mo.md(f"""
+    with f-string too!
+    ```{{python}}
+    print("Hello World")
+    ```
+""")
+````
+
+````{.python.marimo}
+mo.md(f"""
+    Not markdown
+    ```{{python}}
+    print("1 + 1 = {1 + 1}")
+    ```
+""")
+````
+
+Nested fence
+````text
+The guards are
+```{python}
+````
+
+````{.python.marimo}
+"""
+```
+"""
+````
+
+````{.python.marimo}
+mo.md("""
+    Cross cell injection
+    ```python
+""")
+````
+
+```{.python.marimo}
+1 + 1
+```
+
+```{.python.marimo}
+# Actual print
+print("Hello World")
+```

--- a/tests/_cli/snapshots/unsafe-app.py.txt
+++ b/tests/_cli/snapshots/unsafe-app.py.txt
@@ -1,0 +1,96 @@
+import marimo
+
+__generated_with = "0.0.0"
+app = marimo.App(app_title="Test Notebook")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    mo.md("""
+        # Code blocks in code blocks
+        Output code for Hello World!
+        ```python
+        print("Hello World")
+        ```
+        Execute print
+        ```{python}
+        print("Hello World")
+        ```
+    """)
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(f"""
+        with f-string too!
+        ```{{python}}
+        print("Hello World")
+        ```
+    """)
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(f"""
+        Not markdown
+        ```{{python}}
+        print("1 + 1 = {1 + 1}")
+        ```
+    """)
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        Nested fence
+        ````text
+        The guards are
+        ```{python}
+        ````
+        """
+    )
+    return
+
+
+@app.cell
+def __():
+    """
+    ```
+    """
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md("""
+        Cross cell injection
+        ```python
+    """)
+    return
+
+
+@app.cell
+def __():
+    1 + 1
+    return
+
+
+@app.cell
+def __():
+    # Actual print
+    print("Hello World")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_cli/snapshots/unsafe-doc.md.txt
+++ b/tests/_cli/snapshots/unsafe-doc.md.txt
@@ -1,0 +1,31 @@
+---
+title: Casually malicious md
+marimo-version: 0.0.0
+---
+
+What happens if I just leave a \"\"\"
+" ' ! @ # $ % ^ & * ( ) + = - _ [ ] { } | \ /
+
+# Notebook
+<!--
+\
+
+```{.python.marimo}
+print("Hello, World!")
+```
+
+-->
+
+```marimo run convert document.md```
+
+<!-- Actually markdown -->
+```{python} `
+  print("Hello, World!")
+
+<!-- Normal code block -->
+
+```{.python.marimo}
+1 + 1
+```
+
+-->

--- a/tests/_cli/snapshots/unsafe-doc.py.txt
+++ b/tests/_cli/snapshots/unsafe-doc.py.txt
@@ -1,0 +1,63 @@
+import marimo
+
+__generated_with = "0.0.0"
+app = marimo.App(app_title="Casually malicious md")
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        What happens if I just leave a \"\"\"
+        " ' ! @ # $ % ^ & * ( ) + = - _ [ ] { } | \ /
+
+        # Notebook
+        <!--
+        \
+        """
+    )
+    return
+
+
+@app.cell
+def __():
+    print("Hello, World!")
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        -->
+
+        ```marimo run convert document.md```
+
+        <!-- Actually markdown -->
+        ```{python} `
+          print("Hello, World!")
+
+        <!-- Normal code block -->
+        """
+    )
+    return
+
+
+@app.cell
+def __():
+    1 + 1
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        -->
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_cli/test_markdown_conversion.py
+++ b/tests/_cli/test_markdown_conversion.py
@@ -206,14 +206,11 @@ def test_python_to_md_code_injection() -> None:
         """[1:]
     )
     maybe_unsafe_md = convert_from_py(unsafe_app).strip()
-    print("-----------------------------------------------")
     maybe_unsafe_py = sanitized_version(
         convert_from_md(maybe_unsafe_md).strip()
     )
     snapshot("unsafe-app.py.txt", maybe_unsafe_py)
-    # print(maybe_unsafe_py)
     snapshot("unsafe-app.md.txt", maybe_unsafe_md)
-    # print(maybe_unsafe_md)
 
     # Idempotent even under strange conditions.
     assert convert_from_py(maybe_unsafe_py).strip() == maybe_unsafe_md
@@ -242,18 +239,30 @@ def test_md_to_python_code_injection() -> None:
     ```{.python.marimo}
     print("Hello, World!")
     ```
+    -->
+
+    ```marimo run convert document.md```
+
+    <!-- Actually markdown -->
+    ```{python} `
+      print("Hello, World!")
+
+    <!-- Normal code block -->
+    ```{python}
+    1 + 1
+    ```
 
     -->
     """[1:]
     )
 
     maybe_unsafe_py = sanitized_version(convert_from_md(script).strip())
-    print(maybe_unsafe_py)
     maybe_unsafe_md = convert_from_py(maybe_unsafe_py)
-    print(maybe_unsafe_md)
 
     # Idempotent even under strange conditions.
     assert maybe_unsafe_py == sanitized_version(
         convert_from_md(maybe_unsafe_md).strip()
     )
-    # raise NotImplementedError("This test is not yet implemented.")
+
+    snapshot("unsafe-doc.py.txt", maybe_unsafe_py)
+    snapshot("unsafe-doc.md.txt", maybe_unsafe_md)


### PR DESCRIPTION
Was looking over the merge this morning and realized it would be possible to "inject" code blocks.

I don't think this could be used that maliciously since running a notebook is already pretty risky. Maybe injecting a <script> tag that would only appear during conversion.

Either way, it's a bug. If you can think of more unsafe behavior let me know. Might be a cool chance to use one of those LLM fuzzers.