### PR TITLE
improvement: load pyodide dev version on marimo dev releases

### DIFF
--- a/frontend/src/core/islands/worker/controller.ts
+++ b/frontend/src/core/islands/worker/controller.ts
@@ -14,6 +14,7 @@ export class ReadonlyWasmController extends DefaultWasmController {
 
   override async bootstrap(opts: {
     version: string;
+    pyodideVersion: string;
   }): Promise<PyodideInterface> {
     const pyodide = await super.bootstrap(opts);
 

--- a/frontend/src/core/islands/worker/worker.tsx
+++ b/frontend/src/core/islands/worker/worker.tsx
@@ -18,6 +18,10 @@ import { ReadonlyWasmController } from "./controller";
 import { OperationMessage } from "@/core/kernel/messages";
 import { JsonString } from "@/utils/json/base64";
 import { Logger } from "@/utils/Logger";
+import {
+  getPyodideVersion,
+  importPyodide,
+} from "@/core/pyodide/worker/getPyodideVersion";
 
 declare const self: Window & {
   pyodide: PyodideInterface;
@@ -26,12 +30,14 @@ declare const self: Window & {
 
 // Initialize pyodide
 async function loadPyodideAndPackages() {
-  // @ts-expect-error ehh TypeScript
-  await import("https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js");
+  const marimoVersion = getMarimoVersion();
+  const pyodideVersion = getPyodideVersion(marimoVersion);
+  await importPyodide(marimoVersion);
   try {
     self.controller = new ReadonlyWasmController();
     self.pyodide = await self.controller.bootstrap({
-      version: getMarimoVersion(),
+      version: marimoVersion,
+      pyodideVersion: pyodideVersion,
     });
   } catch (error) {
     console.error("Error bootstrapping", error);

--- a/frontend/src/core/pyodide/worker/bootstrap.ts
+++ b/frontend/src/core/pyodide/worker/bootstrap.ts
@@ -22,8 +22,11 @@ export class DefaultWasmController implements WasmController {
     return this.pyodide;
   }
 
-  async bootstrap(opts: { version: string }): Promise<PyodideInterface> {
-    const pyodide = await this.loadPyoideAndPackages();
+  async bootstrap(opts: {
+    version: string;
+    pyodideVersion: string;
+  }): Promise<PyodideInterface> {
+    const pyodide = await this.loadPyoideAndPackages(opts.pyodideVersion);
 
     const { version } = opts;
 
@@ -37,7 +40,9 @@ export class DefaultWasmController implements WasmController {
     return pyodide;
   }
 
-  private async loadPyoideAndPackages(): Promise<PyodideInterface> {
+  private async loadPyoideAndPackages(
+    pyodideVersion: string,
+  ): Promise<PyodideInterface> {
     if (!loadPyodide) {
       throw new Error("loadPyodide is not defined");
     }
@@ -49,7 +54,7 @@ export class DefaultWasmController implements WasmController {
       // Without this, this fails in Firefox with
       // `Could not extract indexURL path from pyodide module`
       // This fixes for Firefox and does not break Chrome/others
-      indexURL: "https://cdn.jsdelivr.net/pyodide/v0.25.0/full/",
+      indexURL: `https://cdn.jsdelivr.net/pyodide/${pyodideVersion}/full/`,
     });
     this.pyodide = pyodide;
     return pyodide;

--- a/frontend/src/core/pyodide/worker/getPyodideVersion.ts
+++ b/frontend/src/core/pyodide/worker/getPyodideVersion.ts
@@ -1,0 +1,13 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+export function getPyodideVersion(marimoVersion: string) {
+  return marimoVersion.includes("dev") ? "dev" : "v0.25.0";
+}
+
+export async function importPyodide(marimoVersion: string) {
+  // Vite does not like imports with dynamic urls
+  return marimoVersion.includes("dev")
+    ? // @ts-expect-error typescript does not like
+      await import(`https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js`)
+    : // @ts-expect-error typescript does not like
+      await import(`https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js`);
+}

--- a/frontend/src/core/pyodide/worker/types.ts
+++ b/frontend/src/core/pyodide/worker/types.ts
@@ -27,7 +27,10 @@ export interface WasmController {
    * Prepare the wasm environment
    * @param opts.version - The marimo version
    */
-  bootstrap(opts: { version: string }): Promise<PyodideInterface>;
+  bootstrap(opts: {
+    version: string;
+    pyodideVersion: string;
+  }): Promise<PyodideInterface>;
   /**
    * Start the session
    * @param opts.code - The code to start with

--- a/frontend/src/core/pyodide/worker/worker.ts
+++ b/frontend/src/core/pyodide/worker/worker.ts
@@ -20,6 +20,7 @@ import { invariant } from "../../../utils/invariant";
 import { OperationMessage } from "@/core/kernel/messages";
 import { JsonString } from "@/utils/json/base64";
 import { UserConfig } from "@/core/config/config-schema";
+import { getPyodideVersion, importPyodide } from "./getPyodideVersion";
 
 declare const self: Window & {
   pyodide: PyodideInterface;
@@ -28,14 +29,15 @@ declare const self: Window & {
 
 // Initialize pyodide
 async function loadPyodideAndPackages() {
-  // @ts-expect-error ehh TypeScript
-  await import("https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js");
   try {
-    const version = getMarimoVersion();
-    const controller = await getController(version);
+    const marimoVersion = getMarimoVersion();
+    const pyodideVersion = getPyodideVersion(marimoVersion);
+    await importPyodide(marimoVersion);
+    const controller = await getController(marimoVersion);
     self.controller = controller;
     self.pyodide = await controller.bootstrap({
-      version,
+      version: marimoVersion,
+      pyodideVersion: pyodideVersion,
     });
   } catch (error) {
     console.error("Error bootstrapping", error);


### PR DESCRIPTION
This is so we can test with new pyodide versions before they are released