### PR TITLE
draft: potential fix for #1298.

### DIFF
--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -121,9 +121,12 @@ class ServerConfig(TypedDict):
 
     - `browser`: the web browser to use. `"default"` or a browser registered
         with Python's webbrowser module (eg, `"firefox"` or `"chrome"`)
+    - `follow_symlink`: if true, the server will follow symlinks it finds
+        inside its static assets directory.
     """
 
     browser: Union[Literal["default"], str]
+    follow_symlink: bool
 
 
 class PackageManagementConfig(TypedDict):
@@ -199,7 +202,10 @@ DEFAULT_CONFIG: MarimoConfig = {
         "format_on_save": False,
     },
     "package_management": {"manager": "pip"},
-    "server": {"browser": "default"},
+    "server": {
+        "browser": "default",
+        "follow_symlink": False,
+    },
 }
 
 

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -11,6 +11,7 @@ from starlette.responses import FileResponse, HTMLResponse, Response
 from starlette.staticfiles import StaticFiles
 
 from marimo import _loggers
+from marimo._config.manager import UserConfigManager
 from marimo._runtime.virtual_file import EMPTY_VIRTUAL_FILE, read_virtual_file
 from marimo._server.api.deps import AppState
 from marimo._server.router import APIRouter
@@ -31,9 +32,14 @@ router = APIRouter()
 # Root directory for static assets
 root = os.path.realpath(str(import_files("marimo").joinpath("_static")))
 
+config = UserConfigManager().get_config().get("server", {})
+
 router.mount(
     "/assets",
-    app=StaticFiles(directory=os.path.join(root, "assets")),
+    app=StaticFiles(
+        directory=os.path.join(root, "assets"),
+        follow_symlink=config.get("follow_symlink", False),
+    ),
     name="assets",
 )
 


### PR DESCRIPTION
Hi maintainers, this is a draft of a fix for #1298. It adds a `follow_symlink` boolean flag to Marimo's ServerConfig (defaulting to false), and propagates it to the call site where the StaticFiles for `/assets` is constructed. This allows users to set it via their `~/.marimo.toml` files like so:

```toml
[server]
follow_symlink = true
 ```

I've verified this works by patching this PR into my Bazel repo using the setup described here: https://github.com/marimo-team/marimo/issues/1298#issuecomment-2091813225. I also verified this PR passes ruff and mypy.

I've kept this PR simple. This is the first time I've tried to change marimo's codebase, so I could definitely have missed things from the discussion in #1298. Suggestions are welcome.