### PR TITLE
fix: check for module staleness when registering a cell

### DIFF
--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -125,7 +125,7 @@ class CellImpl:
 
     @property
     def imports(self) -> Iterable[ImportData]:
-        """Return a set of the namespaces imported by this cell."""
+        """Return a set of import data for this cell."""
         return [
             data.import_data
             for _, data in self.variable_data.items()

--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -9,32 +9,17 @@ import time
 from modulefinder import ModuleFinder
 from typing import TYPE_CHECKING, Callable, Literal
 
-from marimo._ast.cell import CellId_t, CellImpl
 from marimo._messaging.types import Stream
 from marimo._runtime import dataflow
-from marimo._runtime.reload.autoreload import ModuleReloader
+from marimo._runtime.reload.autoreload import (
+    ModuleReloader,
+    modules_imported_by_cell,
+)
 
 if TYPE_CHECKING:
     import types
 
-
-def _modules_imported_by_cell(
-    cell: CellImpl, sys_modules: dict[str, types.ModuleType]
-) -> set[str]:
-    """Get the modules imported by a cell"""
-    modules = set()
-    for import_data in cell.imports:
-        if import_data.module in sys_modules:
-            modules.add(import_data.module)
-        if import_data.imported_symbol in sys_modules:
-            # The imported symbol may or may not be a module, which
-            # is why we check if it's in sys.modules
-            #
-            # e.g., from a import b
-            #
-            # a.b could be a module, but it could also be a function, ...
-            modules.add(import_data.imported_symbol)
-    return modules
+    from marimo._ast.cell import CellId_t
 
 
 def is_submodule(src_name: str, target_name: str) -> bool:
@@ -140,6 +125,7 @@ def _check_modules(
 
 def watch_modules(
     graph: dataflow.DirectedGraph,
+    reloader: ModuleReloader,
     mode: Literal["lazy", "autorun"],
     enqueue_run_stale_cells: Callable[[], None],
     should_exit: threading.Event,
@@ -152,7 +138,6 @@ def watch_modules(
     modules imported by the notebook as well as the modules imported by those
     modules, recursively.
     """
-    reloader = ModuleReloader()
     # modules that failed to be analyzed
     failed_filenames: set[str] = set()
     # work with a copy to avoid race conditions
@@ -165,7 +150,7 @@ def watch_modules(
         modname_to_cell_id: dict[str, CellId_t] = {}
         with graph.lock:
             for cell_id, cell in graph.cells.items():
-                for modname in _modules_imported_by_cell(cell, sys_modules):
+                for modname in modules_imported_by_cell(cell, sys_modules):
                     if modname in sys_modules:
                         modules[modname] = sys_modules[modname]
                         modname_to_cell_id[modname] = cell_id
@@ -205,6 +190,7 @@ class ModuleWatcher:
     def __init__(
         self,
         graph: dataflow.DirectedGraph,
+        reloader: ModuleReloader,
         mode: Literal["lazy", "autorun"],
         enqueue_run_stale_cells: Callable[[], None],
         stream: Stream,
@@ -212,6 +198,8 @@ class ModuleWatcher:
         # ModuleWatcher uses the graph to determine the modules used by the
         # notebook
         self.graph = graph
+        # Reloader is used to keep track of stale modules
+        self.reloader = reloader
         # When set, signals the watcher thread to exit
         self.should_exit = threading.Event()
         # When False, an ExecuteStaleRequest is inflight to the kernel
@@ -227,6 +215,7 @@ class ModuleWatcher:
             target=watch_modules,
             args=(
                 self.graph,
+                self.reloader,
                 self.mode,
                 self.enqueue_run_stale_cells,
                 self.should_exit,

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -12,7 +12,7 @@ from reload_test_utils import random_modname, update_file
 
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._runtime.requests import SetUserConfigRequest
+from marimo._runtime.requests import SetCellConfigRequest, SetUserConfigRequest
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
 
@@ -332,4 +332,68 @@ async def test_reload_third_party(
     assert not k.graph.cells[er_1.cell_id].stale
     assert not k.graph.cells[er_2.cell_id].stale
     assert not k.graph.cells[er_3.cell_id].stale
+    assert k.globals["x"] == 2
+
+
+async def test_reload_with_modified_cell(
+    tmp_path: pathlib.Path,
+    py_modname: str,
+    k: Kernel,
+    exec_req: ExecReqProvider,
+):
+    sys.path.append(str(tmp_path))
+    py_file = tmp_path / pathlib.Path(py_modname + ".py")
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            def foo():
+                return 1
+            """
+        )
+    )
+
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["runtime"]["auto_reload"] = "lazy"
+    k.set_user_config(SetUserConfigRequest(config=config))
+    await k.run(
+        [
+            er_1 := exec_req.get(f"from {py_modname} import foo"),
+            er_2 := exec_req.get("x = foo()"),
+            er_3 := exec_req.get("pass"),
+        ]
+    )
+    assert k.globals["x"] == 1
+    update_file(
+        py_file,
+        """
+        def foo():
+            return 2
+        """,
+    )
+
+    # wait for the watcher to pick up the change
+    await asyncio.sleep(2.5)
+    assert k.graph.cells[er_1.cell_id].stale
+    assert k.graph.cells[er_2.cell_id].stale
+    assert not k.graph.cells[er_3.cell_id].stale
+
+    # modify the first cell and make sure it is still marked as stale!
+    # disable it first so we can check its staleness
+    # TODO: test doesn't seem to exercise the right thing ...
+    await k.set_cell_config(
+        SetCellConfigRequest(configs={er_1.cell_id: {"disabled": True}})
+    )
+    await k.run(
+        [
+            er_1 := exec_req.get_with_id(
+                er_1.cell_id, f"from {py_modname} import foo; 1"
+            ),
+        ]
+    )
+    assert k.graph.cells[er_1.cell_id].stale
+
+    await k.set_cell_config(
+        SetCellConfigRequest(configs={er_1.cell_id: {"disabled": False}})
+    )
+    assert not k.graph.get_stale()
     assert k.globals["x"] == 2

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -377,23 +377,6 @@ async def test_reload_with_modified_cell(
     assert k.graph.cells[er_2.cell_id].stale
     assert not k.graph.cells[er_3.cell_id].stale
 
-    # modify the first cell and make sure it is still marked as stale!
-    # disable it first so we can check its staleness
-    # TODO: test doesn't seem to exercise the right thing ...
-    await k.set_cell_config(
-        SetCellConfigRequest(configs={er_1.cell_id: {"disabled": True}})
-    )
-    await k.run(
-        [
-            er_1 := exec_req.get_with_id(
-                er_1.cell_id, f"from {py_modname} import foo; 1"
-            ),
-        ]
-    )
-    assert k.graph.cells[er_1.cell_id].stale
-
-    await k.set_cell_config(
-        SetCellConfigRequest(configs={er_1.cell_id: {"disabled": False}})
-    )
-    assert not k.graph.get_stale()
-    assert k.globals["x"] == 2
+    # modify the first cell and make sure it is still marked as stale;
+    k._maybe_register_cell(er_1.cell_id, f"from {py_modname} import foo; 1")
+    assert er_1.cell_id in k.graph.get_stale()


### PR DESCRIPTION
Fixes a bug in which registering a new cell or editing an existing cell wouldn't mark the cell as stale even if it used a stale module. This led to an unfortunate bug where the frontend thought a cell was stale but the backend didn't, since we try to minimize the number of stale status changes sent to the FE to prevent re-renders.

The set of stale modules is stored on a `ModuleReloader` object, which is shared between the `module_watcher` thread and the main thread. To avoid races I made the `ModuleReloader` thread-safe with a coarse lock. Tested manually and the performance impact is not noticeable. 