### PR TITLE
feat: add export as markdown from the UI

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -28,7 +28,11 @@ import {
   disabledCellIds,
   enabledCellIds,
 } from "@/core/cells/utils";
-import { readCode, saveCellConfig } from "@/core/network/requests";
+import {
+  exportAsMarkdown,
+  readCode,
+  saveCellConfig,
+} from "@/core/network/requests";
 import { Objects } from "@/utils/objects";
 import { ActionButton } from "./types";
 import { downloadAsHTML } from "@/core/static/download-html";
@@ -43,6 +47,8 @@ import { useChromeActions, useChromeState } from "../chrome/state";
 import { PANEL_ICONS, PANEL_TYPES } from "../chrome/types";
 import { startCase } from "lodash-es";
 import { keyboardShortcutsAtom } from "../controls/keyboard-shortcuts";
+import { MarkdownIcon } from "@/components/editor/cell/code/icons";
+import { Filenames } from "@/utils/filenames";
 
 const NOOP_HANDLER = (event?: Event) => {
   event?.preventDefault();
@@ -134,6 +140,19 @@ export function useNotebookActions() {
             });
 
             toasted.dismiss();
+          },
+        },
+        {
+          icon: (
+            <MarkdownIcon strokeWidth={1.5} style={{ width: 14, height: 14 }} />
+          ),
+          label: "Download as Markdown",
+          handle: async () => {
+            const md = await exportAsMarkdown({ download: false });
+            downloadBlob(
+              new Blob([md], { type: "text/plain" }),
+              Filenames.toMarkdown(Paths.basename(filename || "notebook.py")),
+            );
           },
         },
         {

--- a/frontend/src/components/editor/cell/code/icons.tsx
+++ b/frontend/src/components/editor/cell/code/icons.tsx
@@ -20,6 +20,7 @@ export const MarkdownIcon = (props: SVGProps<SVGSVGElement>) => (
     width="1em"
     height="1em"
     viewBox="0 0 640 512"
+    fill="currentColor"
     {...props}
   >
     <path d="M593.8 59.1H46.2C20.7 59.1 0 79.8 0 105.2v301.5c0 25.5 20.7 46.2 46.2 46.2h547.7c25.5 0 46.2-20.7 46.1-46.1V105.2c0-25.4-20.7-46.1-46.2-46.1zM338.5 360.6H277v-120l-61.5 76.9-61.5-76.9v120H92.3V151.4h61.5l61.5 76.9 61.5-76.9h61.5v209.2zm135.3 3.1L381.5 256H443V151.4h61.5V256H566z" />

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -14,7 +14,7 @@ import { CopyIcon } from "lucide-react";
 import { Events } from "@/utils/events";
 import { Tooltip } from "../ui/tooltip";
 import { Constants } from "@/core/constants";
-import { exportHTML } from "@/core/network/requests";
+import { exportAsHTML } from "@/core/network/requests";
 import { VirtualFileTracker } from "@/core/static/virtual-file-tracker";
 
 const BASE_URL = "https://static.marimo.app";
@@ -37,7 +37,7 @@ export const ShareStaticNotebookModal: React.FC<{
           e.preventDefault();
 
           onClose();
-          const html = await exportHTML({
+          const html = await exportAsHTML({
             download: false,
             includeCode: true,
             files: VirtualFileTracker.INSTANCE.filenames(),

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -78,7 +78,10 @@ export const UserConfigSchema = z
       })
       .default({}),
     experimental: z
-      .object({})
+      .object({
+        markdown: z.boolean().optional(),
+        // Add new experimental features here
+      })
       // Pass through so that we don't remove any extra keys that the user has added.
       .passthrough()
       .default({}),

--- a/frontend/src/core/config/feature-flag.ts
+++ b/frontend/src/core/config/feature-flag.ts
@@ -8,9 +8,12 @@ import { getUserConfig } from "./config";
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ExperimentalFeatures {
   // Add new feature flags here
+  markdown: boolean;
 }
 
-const defaultValues: ExperimentalFeatures = {};
+const defaultValues: ExperimentalFeatures = {
+  markdown: import.meta.env.DEV,
+};
 
 export function getFeatureFlag<T extends keyof ExperimentalFeatures>(
   feature: T,

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -154,7 +154,8 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   sendRenameFileOrFolder = throwNotImplemented;
   sendUpdateFile = throwNotImplemented;
   sendFileDetails = throwNotImplemented;
-  exportHTML = throwNotImplemented;
+  exportAsHTML = throwNotImplemented;
+  exportAsMarkdown = throwNotImplemented;
   getRecentFiles = throwNotImplemented;
   getWorkspaceFiles = throwNotImplemented;
   getRunningNotebooks = throwNotImplemented;

--- a/frontend/src/core/network/api.ts
+++ b/frontend/src/core/network/api.ts
@@ -32,12 +32,16 @@ export const API = {
       },
       body: JSON.stringify(body),
     })
-      .then((response) => {
+      .then(async (response) => {
+        const isJson = response.headers
+          .get("Content-Type")
+          ?.startsWith("application/json");
         if (!response.ok) {
-          throw new Error(response.statusText);
-        } else if (
-          response.headers.get("Content-Type")?.startsWith("application/json")
-        ) {
+          const errorBody = isJson
+            ? await response.json()
+            : await response.text();
+          throw new Error(response.statusText, { cause: errorBody });
+        } else if (isJson) {
           return response.json() as RESP;
         } else {
           return response.text() as unknown as RESP;

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -34,6 +34,7 @@ import type {
   ExportAsHTMLRequest,
   UsageResponse,
   ExportAsMarkdownRequest,
+  WorkspaceFilesRequest,
 } from "./types";
 import { invariant } from "@/utils/invariant";
 
@@ -202,8 +203,11 @@ export function createNetworkRequests(): EditRequests & RunRequests {
     getRecentFiles: () => {
       return API.post<{}, RecentFilesResponse>("/home/recent_files", {});
     },
-    getWorkspaceFiles: () => {
-      return API.post<{}, WorkspaceFilesResponse>("/home/workspace_files", {});
+    getWorkspaceFiles: (request) => {
+      return API.post<WorkspaceFilesRequest, WorkspaceFilesResponse>(
+        "/home/workspace_files",
+        request,
+      );
     },
     getRunningNotebooks: () => {
       return API.post<{}, RunningNotebooksResponse>(

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -31,8 +31,9 @@ import type {
   WorkspaceFilesResponse,
   RunningNotebooksResponse,
   ShutdownSessionRequest,
-  ExportHTMLRequest,
+  ExportAsHTMLRequest,
   UsageResponse,
+  ExportAsMarkdownRequest,
 } from "./types";
 import { invariant } from "@/utils/invariant";
 
@@ -213,7 +214,7 @@ export function createNetworkRequests(): EditRequests & RunRequests {
     shutdownSession: (request: ShutdownSessionRequest) => {
       return API.post("/home/shutdown_session", request);
     },
-    exportHTML: async (request: ExportHTMLRequest) => {
+    exportAsHTML: async (request: ExportAsHTMLRequest) => {
       if (
         process.env.NODE_ENV === "development" ||
         process.env.NODE_ENV === "test"
@@ -221,6 +222,9 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         request.assetUrl = window.location.origin;
       }
       return API.post("/export/html", request);
+    },
+    exportAsMarkdown: async (request: ExportAsMarkdownRequest) => {
+      return API.post("/export/markdown", request);
     },
   };
 }

--- a/frontend/src/core/network/requests-static.ts
+++ b/frontend/src/core/network/requests-static.ts
@@ -64,6 +64,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     getWorkspaceFiles: throwNotInEditMode,
     getRunningNotebooks: throwNotInEditMode,
     shutdownSession: throwNotInEditMode,
-    exportHTML: throwNotInEditMode,
+    exportAsHTML: throwNotInEditMode,
+    exportAsMarkdown: throwNotInEditMode,
   };
 }

--- a/frontend/src/core/network/requests-toasting.ts
+++ b/frontend/src/core/network/requests-toasting.ts
@@ -40,7 +40,8 @@ export function createErrorToastingRequests(
     getWorkspaceFiles: "Failed to get workspace files",
     getRunningNotebooks: "Failed to get running notebooks",
     shutdownSession: "Failed to shutdown session",
-    exportHTML: "Failed to export HTML",
+    exportAsHTML: "Failed to export HTML",
+    exportAsMarkdown: "Failed to export Markdown",
   };
 
   const handlers = {} as EditRequests & RunRequests;

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -57,5 +57,6 @@ export const {
   getWorkspaceFiles,
   getRunningNotebooks,
   shutdownSession,
-  exportHTML,
+  exportAsHTML,
+  exportAsMarkdown,
 } = getRequest();

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -184,6 +184,10 @@ export interface RecentFilesResponse {
   files: MarimoNotebook[];
 }
 
+export interface WorkspaceFilesRequest {
+  includeMarkdown: boolean;
+}
+
 export interface WorkspaceFilesResponse {
   files: MarimoNotebook[];
 }
@@ -270,7 +274,9 @@ export interface EditRequests {
   sendFileDetails: (request: { path: string }) => Promise<FileDetailsResponse>;
   // Homepage requests
   getRecentFiles: () => Promise<RecentFilesResponse>;
-  getWorkspaceFiles: () => Promise<WorkspaceFilesResponse>;
+  getWorkspaceFiles: (
+    request: WorkspaceFilesRequest,
+  ) => Promise<WorkspaceFilesResponse>;
   getRunningNotebooks: () => Promise<RunningNotebooksResponse>;
   shutdownSession: (
     request: ShutdownSessionRequest,

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -196,10 +196,14 @@ export interface ShutdownSessionRequest {
   sessionId: SessionId;
 }
 
-export interface ExportHTMLRequest {
+export interface ExportAsHTMLRequest {
   assetUrl?: string;
   includeCode: boolean;
   files: string[];
+  download: boolean;
+}
+
+export interface ExportAsMarkdownRequest {
   download: boolean;
 }
 
@@ -271,7 +275,8 @@ export interface EditRequests {
   shutdownSession: (
     request: ShutdownSessionRequest,
   ) => Promise<RunningNotebooksResponse>;
-  exportHTML: (request: ExportHTMLRequest) => Promise<string>;
+  exportAsHTML: (request: ExportAsHTMLRequest) => Promise<string>;
+  exportAsMarkdown: (request: ExportAsMarkdownRequest) => Promise<string>;
 }
 
 export type RequestKey = keyof (EditRequests & RunRequests);

--- a/frontend/src/core/pyodide/bridge.ts
+++ b/frontend/src/core/pyodide/bridge.ts
@@ -5,7 +5,8 @@ import type { CellId } from "../cells/ids";
 import type {
   CodeCompletionRequest,
   EditRequests,
-  ExportHTMLRequest,
+  ExportAsHTMLRequest,
+  ExportAsMarkdownRequest,
   FileCreateRequest,
   FileDeleteRequest,
   FileDetailsResponse,
@@ -364,7 +365,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
     return response as FileDetailsResponse;
   };
 
-  exportHTML = async (request: ExportHTMLRequest): Promise<string> => {
+  exportAsHTML = async (request: ExportAsHTMLRequest): Promise<string> => {
     if (
       process.env.NODE_ENV === "development" ||
       process.env.NODE_ENV === "test"
@@ -373,6 +374,16 @@ export class PyodideBridge implements RunRequests, EditRequests {
     }
     const response = await this.rpc.proxy.request.bridge({
       functionName: "export_html",
+      payload: request,
+    });
+    return response as string;
+  };
+
+  exportAsMarkdown = async (
+    request: ExportAsMarkdownRequest,
+  ): Promise<string> => {
+    const response = await this.rpc.proxy.request.bridge({
+      functionName: "export_markdown",
       payload: request,
     });
     return response as string;

--- a/frontend/src/core/pyodide/worker/types.ts
+++ b/frontend/src/core/pyodide/worker/types.ts
@@ -2,7 +2,7 @@
 import type { PyodideInterface } from "pyodide";
 import type {
   CodeCompletionRequest,
-  ExportHTMLRequest,
+  ExportAsHTMLRequest,
   FileCreateRequest,
   FileDeleteRequest,
   FileDetailsResponse,
@@ -72,7 +72,8 @@ export interface RawBridge {
   load_packages(request: string): Promise<string>;
   read_file(request: string): Promise<string>;
   set_interrupt_buffer(request: Uint8Array): Promise<string>;
-  export_html(request: ExportHTMLRequest): Promise<string>;
+  export_html(request: ExportAsHTMLRequest): Promise<string>;
+  export_markdown(request: ExportAsHTMLRequest): Promise<string>;
 }
 
 export type SerializedBridge = {

--- a/frontend/src/core/static/download-html.ts
+++ b/frontend/src/core/static/download-html.ts
@@ -1,26 +1,25 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { exportHTML } from "../network/requests";
+import { exportAsHTML } from "../network/requests";
 import { downloadBlob } from "@/utils/download";
 import { Paths } from "@/utils/paths";
 import { VirtualFileTracker } from "./virtual-file-tracker";
+import { Filenames } from "@/utils/filenames";
 
 /**
  * Downloads the current notebook as an HTML file.
  */
 export async function downloadAsHTML(opts: { filename: string }) {
   const { filename } = opts;
-  const html = await exportHTML({
+  const html = await exportAsHTML({
     download: true,
     includeCode: true,
     files: VirtualFileTracker.INSTANCE.filenames(),
   });
   const filenameWithoutPath = Paths.basename(filename) ?? "notebook.py";
-  const filenameWithoutExtension =
-    filenameWithoutPath.split(".").shift() ?? "app";
 
   downloadBlob(
     new Blob([html], { type: "text/html" }),
-    `${filenameWithoutExtension}.html`,
+    Filenames.toHTML(filenameWithoutPath),
   );
 }
 

--- a/frontend/src/utils/__tests__/filenames.test.ts
+++ b/frontend/src/utils/__tests__/filenames.test.ts
@@ -1,0 +1,29 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { Filenames } from "../filenames";
+import { describe, expect, it } from "vitest";
+
+describe("Filenames", () => {
+  it("should convert filename to markdown", () => {
+    expect(Filenames.toMarkdown("test")).toEqual("test.md");
+    expect(Filenames.toMarkdown("test.txt")).toEqual("test.md");
+    expect(Filenames.toMarkdown("test.foo.py")).toEqual("test.foo.md");
+  });
+
+  it("should convert filename to HTML", () => {
+    expect(Filenames.toHTML("test")).toEqual("test.html");
+    expect(Filenames.toHTML("test.txt")).toEqual("test.html");
+    expect(Filenames.toHTML("test.foo.py")).toEqual("test.foo.html");
+  });
+
+  it("should convert filename to PNG", () => {
+    expect(Filenames.toPNG("test")).toEqual("test.png");
+    expect(Filenames.toPNG("test.txt")).toEqual("test.png");
+    expect(Filenames.toPNG("test.foo.py")).toEqual("test.foo.png");
+  });
+
+  it("should remove extension from filename", () => {
+    expect(Filenames.withoutExtension("test")).toEqual("test");
+    expect(Filenames.withoutExtension("test.txt")).toEqual("test");
+    expect(Filenames.withoutExtension("test.foo.txt")).toEqual("test.foo");
+  });
+});

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -1,6 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { toPng } from "html-to-image";
 import { toast } from "@/components/ui/use-toast";
+import { Filenames } from "@/utils/filenames";
 
 export async function downloadHTMLAsImage(
   element: HTMLElement,
@@ -14,10 +15,7 @@ export async function downloadHTMLAsImage(
   try {
     // Get screenshot
     const dataUrl = await toPng(element);
-    downloadByURL(
-      dataUrl,
-      filename.endsWith(".png") ? filename : `${filename}.png`,
-    );
+    downloadByURL(dataUrl, Filenames.toPNG(filename));
   } catch {
     toast({
       title: "Error",

--- a/frontend/src/utils/filenames.ts
+++ b/frontend/src/utils/filenames.ts
@@ -1,0 +1,26 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+export const Filenames = {
+  toMarkdown: (filename: string): string => {
+    return Filenames.replace(filename, "md");
+  },
+  toHTML: (filename: string): string => {
+    return Filenames.replace(filename, "html");
+  },
+  toPNG: (filename: string): string => {
+    return Filenames.replace(filename, "png");
+  },
+  withoutExtension: (filename: string): string => {
+    // Just remove the last extension
+    const parts = filename.split(".");
+    if (parts.length === 1) {
+      return filename;
+    }
+    return parts.slice(0, -1).join(".");
+  },
+  replace: (filename: string, extension: string): string => {
+    if (filename.endsWith(`.${extension}`)) {
+      return filename;
+    }
+    return `${Filenames.withoutExtension(filename)}.${extension}`;
+  },
+};

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -344,6 +344,13 @@ class PyodideBridge:
         )
         return json.dumps(html)
 
+    def export_markdown(self, request: str) -> str:
+        del request
+        md, _filename = Exporter().export_as_md(
+            file_manager=self.session.app_manager,
+        )
+        return json.dumps(md)
+
 
 def launch_pyodide_kernel(
     control_queue: asyncio.Queue[ControlRequest],

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from starlette.authentication import requires
+from starlette.exceptions import HTTPException
 from starlette.responses import HTMLResponse, PlainTextResponse
 
 from marimo import _loggers
 from marimo._server.api.deps import AppState
+from marimo._server.api.status import HTTPStatus
 from marimo._server.api.utils import parse_request
 from marimo._server.export.exporter import Exporter
 from marimo._server.models.export import (
     ExportAsHTMLRequest,
+    ExportAsMarkdownRequest,
     ExportAsScriptRequest,
 )
 from marimo._server.router import APIRouter
@@ -84,5 +87,42 @@ async def export_as_script(
     # Download the Script
     return PlainTextResponse(
         content=python,
+        headers=headers,
+    )
+
+
+@router.post("/markdown")
+@requires("edit")
+async def export_as_markdown(
+    *,
+    request: Request,
+) -> PlainTextResponse:
+    """
+    Export the notebook as a markdown.
+    """
+    app_state = AppState(request)
+    body = await parse_request(request, cls=ExportAsMarkdownRequest)
+    app_file_manager = app_state.require_current_session().app_file_manager
+    # Reload the file manager to get the latest state
+    app_file_manager.reload()
+
+    if not app_file_manager.path:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="File must be saved before downloading",
+        )
+
+    markdown, filename = Exporter().export_as_md(
+        file_manager=app_file_manager,
+    )
+
+    if body.download:
+        headers = {"Content-Disposition": f"attachment; filename={filename}"}
+    else:
+        headers = {}
+
+    # Download the Markdown
+    return PlainTextResponse(
+        content=markdown,
         headers=headers,
     )

--- a/marimo/_server/api/endpoints/files.py
+++ b/marimo/_server/api/endpoints/files.py
@@ -41,6 +41,13 @@ async def read_code(
     app_state = AppState(request)
     """Handler for reading code from the server."""
     session = app_state.require_current_session()
+
+    if not session.app_file_manager.path:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="File must be saved before downloading",
+        )
+
     contents = session.app_file_manager.read_file()
 
     return ReadCodeResponse(contents=contents)

--- a/marimo/_server/api/status.py
+++ b/marimo/_server/api/status.py
@@ -23,3 +23,7 @@ class HTTPException(Exception):
     ) -> None:
         self.status_code = status_code
         self.detail = detail
+
+
+def is_client_error(status_code: int) -> bool:
+    return 400 <= status_code < 500

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -1,21 +1,31 @@
 # Copyright 2024 Marimo. All rights reserved.
-from typing import Any, List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.middleware.cors import CORSMiddleware
-from starlette.requests import Request
 from starlette.responses import JSONResponse
-from starlette.types import Lifespan
 
+from marimo import _loggers
 from marimo._server.api.middleware import (
     AuthBackend,
     ValidateServerTokensMiddleware,
 )
 from marimo._server.api.router import build_routes
-from marimo._server.api.status import HTTPException as MarimoHTTPException
+from marimo._server.api.status import (
+    HTTPException as MarimoHTTPException,
+    is_client_error,
+)
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+    from starlette.types import Lifespan
+
+LOGGER = _loggers.marimo_logger()
 
 
 # Convert exceptions to JSON responses
@@ -26,6 +36,9 @@ async def handle_error(request: Request, response: Any) -> Any:
             {"detail": response.detail}, status_code=response.status_code
         )
     if isinstance(response, MarimoHTTPException):
+        # Log server errors
+        if not is_client_error(response.status_code):
+            LOGGER.exception(response)
         return JSONResponse(
             {"detail": response.detail}, status_code=response.status_code
         )
@@ -64,5 +77,6 @@ def create_starlette_app(
         exception_handlers={
             Exception: handle_error,
             HTTPException: handle_error,
+            MarimoHTTPException: handle_error,
         },
     )

--- a/marimo/_server/models/export.py
+++ b/marimo/_server/models/export.py
@@ -16,3 +16,8 @@ class ExportAsHTMLRequest:
 @dataclass
 class ExportAsScriptRequest:
     download: bool
+
+
+@dataclass
+class ExportAsMarkdownRequest:
+    download: bool

--- a/marimo/_server/models/home.py
+++ b/marimo/_server/models/home.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -23,6 +25,11 @@ class MarimoFile:
 @dataclass
 class RecentFilesResponse:
     files: List[MarimoFile]
+
+
+@dataclass
+class WorkspaceFilesRequest:
+    include_markdown: bool = False
 
 
 @dataclass

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from marimo import __version__
 from tests._server.conftest import get_session_manager
 from tests._server.mocks import with_session
 from tests.mocks import snapshotter
@@ -66,3 +67,17 @@ def test_export_script(client: TestClient) -> None:
     )
     assert response.status_code == 200
     assert "__generated_with = " in response.text
+
+
+@with_session(SESSION_ID)
+def test_export_markdown(client: TestClient) -> None:
+    response = client.post(
+        "/api/export/markdown",
+        headers=HEADERS,
+        json={
+            "download": False,
+        },
+    )
+    assert response.status_code == 200
+    assert f"marimo-version: {__version__}" in response.text
+    assert "```{.python.marimo}" in response.text

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -5,9 +5,6 @@ import os
 import random
 from typing import TYPE_CHECKING
 
-import pytest
-
-from marimo._server.api.status import HTTPException
 from tests._server.conftest import get_session_manager
 from tests._server.mocks import with_session
 
@@ -188,26 +185,26 @@ def test_save_with_invalid_file(client: TestClient) -> None:
 
 @with_session(SESSION_ID)
 def test_save_file_cannot_rename(client: TestClient) -> None:
-    with pytest.raises(HTTPException) as response:
-        client.post(
-            "/api/kernel/save",
-            headers=HEADERS,
-            json={
-                "cell_ids": ["1"],
-                "filename": "random_filename.py",
-                "codes": ["import marimo as mo"],
-                "names": ["my_cell"],
-                "configs": [
-                    {
-                        "hideCode": True,
-                        "disabled": False,
-                    }
-                ],
-            },
-        )
-    assert response.value.status_code == 400
-    assert response.value.detail
-    assert "cannot rename" in response.value.detail
+    response = client.post(
+        "/api/kernel/save",
+        headers=HEADERS,
+        json={
+            "cell_ids": ["1"],
+            "filename": "random_filename.py",
+            "codes": ["import marimo as mo"],
+            "names": ["my_cell"],
+            "configs": [
+                {
+                    "hideCode": True,
+                    "disabled": False,
+                }
+            ],
+        },
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["detail"]
+    assert "cannot rename" in body["detail"]
 
 
 @with_session(SESSION_ID)

--- a/tests/_server/api/endpoints/test_home.py
+++ b/tests/_server/api/endpoints/test_home.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import sys
 
 import pytest
@@ -24,6 +25,7 @@ def test_workspace_files(client: TestClient) -> None:
     response = client.post(
         "/api/home/workspace_files",
         headers=HEADERS,
+        json={"include_markdown": False},
     )
     body = response.json()
     files = body["files"]

--- a/tests/_server/test_file_router.py
+++ b/tests/_server/test_file_router.py
@@ -72,7 +72,9 @@ class TestAppFileRouter(unittest.TestCase):
 
     def test_lazy_list_of_files(self):
         # Test the lazy loading of files in a directory
-        router = LazyListOfFilesAppFileRouter(self.test_dir)
+        router = LazyListOfFilesAppFileRouter(
+            self.test_dir, include_markdown=False
+        )
         files = router.files
         assert (
             len(files) == 2
@@ -83,9 +85,33 @@ class TestAppFileRouter(unittest.TestCase):
         # Create a broken symlink
         broken_symlink = os.path.join(self.test_dir, "broken_symlink.py")
         os.symlink("non_existent_file", broken_symlink)
-        router = LazyListOfFilesAppFileRouter(self.test_dir)
+        router = LazyListOfFilesAppFileRouter(
+            self.test_dir, include_markdown=False
+        )
         files = router.files
         assert len(files) == 2
 
         # Remove the broken symlink
         os.unlink(broken_symlink)
+
+    def test_lazy_list_with_markdown(self):
+        # Test the lazy loading of files in a directory with markdown
+        router = LazyListOfFilesAppFileRouter(
+            self.test_dir, include_markdown=True
+        )
+        # Create markdown files
+        _markdown_file1 = tempfile.NamedTemporaryFile(
+            dir=self.test_dir, suffix=".md"
+        )
+        files = router.files
+        assert len(files) == 3
+
+        # Toggling markdown
+        router = router.toggle_markdown(False)
+        files = router.files
+        assert len(files) == 2
+
+        # Toggle markdown back
+        router = router.toggle_markdown(True)
+        files = router.files
+        assert len(files) == 3


### PR DESCRIPTION
Add "export as markdown" from the UI.

Also:
* cleans up marimo exceptions that are 400s to not spam the console
* improve error message in the toast
* show markdown on homepage behind a feature-flag