### PR TITLE
improvement: allow renaming markdown files when enabled

### DIFF
--- a/frontend/src/components/editor/header/filename-input.tsx
+++ b/frontend/src/components/editor/header/filename-input.tsx
@@ -20,6 +20,7 @@ import { PopoverAnchor } from "@radix-ui/react-popover";
 import { FileInfo } from "@/core/network/types";
 
 import "./filename-input.css";
+import { getFeatureFlag } from "@/core/config/feature-flag";
 
 interface FilenameInputProps {
   resetOnBlur?: boolean;
@@ -205,13 +206,17 @@ function getSuggestion(
     return;
   }
 
-  if (search.endsWith(".")) {
+  // Matches allowed files in marimo/_utils/marimo_path.py
+  const extensionsToLeave = getFeatureFlag("markdown")
+    ? new Set(["py", "md", "markdown", "qmd"])
+    : new Set(["py"]);
+
+  if (extensionsToLeave.has(Paths.extension(search))) {
+    // If ends with an allowed extension, leave as is
+  } else if (search.endsWith(".")) {
     search = `${search}py`;
   } else if (search.endsWith(".p")) {
     search = `${search}y`;
-  } else if (search.endsWith(".py")) {
-    // If ends with .py, leave as is
-    // noop
   } else {
     search = `${search}.py`;
   }

--- a/frontend/src/utils/__tests__/path.test.ts
+++ b/frontend/src/utils/__tests__/path.test.ts
@@ -120,4 +120,12 @@ describe("PathBuilder", () => {
       expect(pathBuilder.dirname("file" as FilePath)).toBe("");
     });
   });
+
+  describe("extension", () => {
+    it("should return the extension of a file", () => {
+      expect(Paths.extension("file.txt")).toBe("txt");
+      expect(Paths.extension("file")).toBe("");
+      expect(Paths.extension("file.tar.gz")).toBe("gz");
+    });
+  });
 });

--- a/frontend/src/utils/paths.ts
+++ b/frontend/src/utils/paths.ts
@@ -11,6 +11,13 @@ export const Paths = {
   basename: (path: string) => {
     return PathBuilder.guessDeliminator(path).basename(path as FilePath);
   },
+  extension: (filename: string): string => {
+    const parts = filename.split(".");
+    if (parts.length === 1) {
+      return "";
+    }
+    return parts.at(-1) ?? "";
+  },
 };
 
 export class PathBuilder {

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -23,6 +23,7 @@ from marimo._cli.upgrade import check_for_updates
 from marimo._server.file_router import AppFileRouter
 from marimo._server.model import SessionMode
 from marimo._server.start import start
+from marimo._utils.marimo_path import MarimoPath
 
 DEVELOPMENT_MODE = False
 QUIET = False
@@ -357,7 +358,7 @@ def run(
     codegen.get_app(name)
 
     start(
-        file_router=AppFileRouter.from_filename(name),
+        file_router=AppFileRouter.from_filename(MarimoPath(name)),
         development_mode=DEVELOPMENT_MODE,
         quiet=QUIET,
         host=host,
@@ -485,11 +486,11 @@ def tutorial(
     source = inspect.getsource(tutorials[name])
     d = tempfile.TemporaryDirectory()
     fname = os.path.join(d.name, name + ".py")
-    with open(fname, "w", encoding="utf-8") as f:
-        f.write(source)
+    path = MarimoPath(fname)
+    path.write_text(source)
 
     start(
-        file_router=AppFileRouter.from_filename(fname),
+        file_router=AppFileRouter.from_filename(path),
         development_mode=DEVELOPMENT_MODE,
         quiet=QUIET,
         host=host,

--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -13,6 +13,7 @@ from typing import Optional
 import click
 
 from marimo._cli.print import green
+from marimo._utils.marimo_path import MarimoPath
 from marimo._utils.url import is_url
 
 STATIC_HTML_CODE_PREFIX = '<marimo-code hidden="">'
@@ -89,8 +90,10 @@ def validate_name(
             f"    marimo convert {name} > {prefix}.py\n\n"
             f"  then open with marimo edit {prefix}.py"
         )
-    elif path.suffix != ".py":
-        raise click.UsageError("Invalid NAME - %s is not a Python file" % name)
+    elif not MarimoPath.is_valid_path(path):
+        raise click.UsageError(
+            "Invalid NAME - %s is not a Python or Markdown file" % name
+        )
 
     if is_github_src(name, ext=".py"):
         temp_dir = TemporaryDirectory()

--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -1,8 +1,11 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import abc
 from typing import TYPE_CHECKING, List, Tuple
 
 from marimo._server.file_router import AppFileRouter
+from marimo._utils.marimo_path import MarimoPath
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp
@@ -114,7 +117,7 @@ def create_asgi_app(
 
         def _build_app(self, path: str, root: str) -> "ASGIAppBuilder":
             session_manager = SessionManager(
-                file_router=AppFileRouter.from_filename(root),
+                file_router=AppFileRouter.from_filename(MarimoPath(root)),
                 mode=SessionMode.RUN,
                 development_mode=False,
                 quiet=quiet,

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -15,12 +15,13 @@ from marimo._server.model import ConnectionState, SessionConsumer, SessionMode
 from marimo._server.models.export import ExportAsHTMLRequest
 from marimo._server.models.models import InstantiateRequest
 from marimo._server.session.session_view import SessionView
+from marimo._utils.marimo_path import MarimoPath
 
 
 def export_as_script(
-    filename: str,
+    path: MarimoPath,
 ) -> tuple[str, str]:
-    file_router = AppFileRouter.from_filename(filename)
+    file_router = AppFileRouter.from_filename(path)
     file_key = file_router.get_unique_file_key()
     assert file_key is not None
     file_manager = file_router.get_file_manager(file_key)
@@ -29,9 +30,9 @@ def export_as_script(
 
 
 def export_as_md(
-    filename: str,
+    path: MarimoPath,
 ) -> tuple[str, str]:
-    file_router = AppFileRouter.from_filename(filename)
+    file_router = AppFileRouter.from_filename(path)
     file_key = file_router.get_unique_file_key()
     assert file_key is not None
     file_manager = file_router.get_file_manager(file_key)
@@ -40,12 +41,12 @@ def export_as_md(
 
 
 async def run_app_then_export_as_html(
-    filename: str,
+    path: MarimoPath,
     include_code: bool,
     cli_args: SerializedCLIArgs,
 ) -> tuple[str, str]:
     # Create a file router and file manager
-    file_router = AppFileRouter.from_filename(filename)
+    file_router = AppFileRouter.from_filename(path)
     file_key = file_router.get_unique_file_key()
     assert file_key is not None
     file_manager = file_router.get_file_manager(file_key)

--- a/marimo/_server/file_manager.py
+++ b/marimo/_server/file_manager.py
@@ -108,7 +108,7 @@ class AppFileManager:
 
         self._assert_path_does_not_exist(new_filename)
 
-        if self.filename is not None:
+        if self._is_named():
             self._rename_file(new_filename)
         else:
             self._create_file(new_filename)
@@ -169,7 +169,7 @@ class AppFileManager:
             configs=configs,
         )
 
-        if self.filename is not None and not self._is_same_path(filename):
+        if self._is_named() and not self._is_same_path(filename):
             raise HTTPException(
                 status_code=HTTPStatus.BAD_REQUEST,
                 detail="Save handler cannot rename files.",
@@ -199,7 +199,7 @@ class AppFileManager:
         header_comments = codegen.get_header_comments(filename)
         self._create_file(filename, contents, header_comments)
 
-        if self.filename is None:
+        if self._is_unnamed():
             self.rename(filename)
 
     def to_code(self) -> str:
@@ -211,6 +211,12 @@ class AppFileManager:
             config=self.app.config,
         )
         return contents
+
+    def _is_unnamed(self) -> bool:
+        return self.filename is None
+
+    def _is_named(self) -> bool:
+        return self.filename is not None
 
     def read_file(self) -> str:
         """Read the contents of the file."""

--- a/marimo/_server/file_router.py
+++ b/marimo/_server/file_router.py
@@ -198,9 +198,7 @@ class LazyListOfFilesAppFileRouter(AppFileRouter):
                 full_path = os.path.join(root, filename)
                 relative_path = os.path.relpath(full_path, directory)
                 # Python files must contain "marimo.App", or markdown files
-                if not filename.endswith(".py") or self._is_marimo_app(
-                    full_path
-                ):
+                if self._is_marimo_app(full_path):
                     files.append(
                         MarimoFile(
                             name=filename,
@@ -213,8 +211,13 @@ class LazyListOfFilesAppFileRouter(AppFileRouter):
 
     def _is_marimo_app(self, full_path: str) -> bool:
         try:
-            with open(full_path, "r", encoding="utf-8") as f:
-                return "marimo.App" in f.read()
+            path = MarimoPath(full_path)
+            contents = path.read_text()
+            if path.is_markdown():
+                return "marimo-version:" in contents
+            if path.is_python():
+                return "marimo.App" in contents
+            return False
         except Exception as e:
             LOGGER.debug("Error reading file %s: %s", full_path, e)
             return False

--- a/marimo/_server/file_router.py
+++ b/marimo/_server/file_router.py
@@ -9,6 +9,7 @@ from marimo import _loggers
 from marimo._server.api.status import HTTPException, HTTPStatus
 from marimo._server.file_manager import AppFileManager
 from marimo._server.models.home import MarimoFile
+from marimo._utils.marimo_path import MarimoPath
 
 LOGGER = _loggers.marimo_logger()
 
@@ -27,7 +28,7 @@ class AppFileRouter(abc.ABC):
     def infer(path: str) -> AppFileRouter:
         if os.path.isfile(path):
             LOGGER.debug("Routing to file %s", path)
-            return AppFileRouter.from_filename(path)
+            return AppFileRouter.from_filename(MarimoPath(path))
         if os.path.isdir(path):
             LOGGER.debug("Routing to directory %s", path)
             return AppFileRouter.from_directory(path)
@@ -37,12 +38,12 @@ class AppFileRouter(abc.ABC):
         )
 
     @staticmethod
-    def from_filename(filename: str) -> AppFileRouter:
+    def from_filename(file: MarimoPath) -> AppFileRouter:
         files = [
             MarimoFile(
-                name=filename,
-                path=os.path.abspath(filename),
-                last_modified=os.path.getmtime(filename),
+                name=file.relative_name,
+                path=file.absolute_name,
+                last_modified=file.last_modified,
             )
         ]
         return ListOfFilesAppFileRouter(files)

--- a/marimo/_server/utils.py
+++ b/marimo/_server/utils.py
@@ -26,7 +26,7 @@ def print_tabbed(string: str, n_tabs: int = 1) -> None:
 
 def canonicalize_filename(filename: str) -> str:
     # If its not a valid Python or Markdown file, then add .py
-    if MarimoPath.is_valid_path(filename):
+    if not MarimoPath.is_valid_path(filename):
         filename += ".py"
     return os.path.expanduser(filename)
 

--- a/marimo/_server/utils.py
+++ b/marimo/_server/utils.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 import asyncio
 import os
-import pathlib
 import sys
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from marimo import _loggers
+from marimo._utils.marimo_path import MarimoPath
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
@@ -25,7 +25,8 @@ def print_tabbed(string: str, n_tabs: int = 1) -> None:
 
 
 def canonicalize_filename(filename: str) -> str:
-    if pathlib.Path(filename).suffix != ".py":
+    # If its not a valid Python or Markdown file, then add .py
+    if MarimoPath.is_valid_path(filename):
         filename += ".py"
     return os.path.expanduser(filename)
 

--- a/marimo/_utils/marimo_path.py
+++ b/marimo/_utils/marimo_path.py
@@ -45,7 +45,7 @@ class MarimoPath:
 
     def rename(self, new_path: Path) -> None:
         if self.strict:
-            if not new_path.is_relative_to(self.cwd):
+            if not MarimoPath(new_path).is_relative_to(self.cwd):
                 raise ValueError(
                     "Cannot rename files outside of "
                     "the current working directory"
@@ -74,15 +74,21 @@ class MarimoPath:
     @property
     def relative_name(self) -> str:
         if self.strict:
-            if not self.path.is_relative_to(self.cwd):
+            if not self.is_relative_to(self.cwd):
                 raise ValueError(
                     "Cannot get relative name for files outside"
                     " of the current working directory"
                 )
         # If can't return relative path, return absolute path
-        if not self.path.is_relative_to(self.cwd):
+        if not self.is_relative_to(self.cwd):
             return self.path.absolute().as_posix()
         return self.path.relative_to(self.cwd).as_posix()
+
+    def is_relative_to(self, other: Path) -> bool:
+        # In python 3.8, is_relative_to is not available
+        if not hasattr(self.path, "is_relative_to"):
+            return self.path.relative_to(other) == self.path
+        return self.path.is_relative_to(other)  # type: ignore
 
     @property
     def absolute_name(self) -> str:

--- a/marimo/_utils/marimo_path.py
+++ b/marimo/_utils/marimo_path.py
@@ -87,7 +87,11 @@ class MarimoPath:
     def is_relative_to(self, other: Path) -> bool:
         # In python 3.8, is_relative_to is not available
         if not hasattr(self.path, "is_relative_to"):
-            return self.path.relative_to(other) == self.path
+            try:
+                self.path.relative_to(other)
+                return True
+            except ValueError:
+                return False
         return self.path.is_relative_to(other)  # type: ignore
 
     @property

--- a/marimo/_utils/marimo_path.py
+++ b/marimo/_utils/marimo_path.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class MarimoPath:
+    """
+    Wrapper around pathlib.Path to provide additional functionality for Marimo.
+    And reduce API surface area of pathlib.Path.
+    """
+
+    def __init__(self, path: str | Path, strict: bool = False) -> None:
+        self.path: Path = Path(path)
+        # Do this on initialization to avoid issues with changing directories
+        self.cwd = Path.cwd()
+        # strict means can only operate in
+        # anything under the current working directory
+        self.strict = strict
+
+        self.validate()
+
+    def validate(self) -> None:
+        if not self.is_valid():
+            raise ValueError(
+                f"File {self.path} is not a Python or Markdown file."
+            )
+
+    @staticmethod
+    def is_valid_path(path: str | Path) -> bool:
+        try:
+            MarimoPath(path)
+            return True
+        except ValueError:
+            return False
+
+    def is_valid(self) -> bool:
+        return self.is_python() or self.is_markdown()
+
+    def is_python(self) -> bool:
+        return self.path.suffix == ".py"
+
+    def is_markdown(self) -> bool:
+        allowed = {".md", ".markdown", ".qmd"}
+        return self.path.suffix in allowed
+
+    def rename(self, new_path: Path) -> None:
+        if self.strict:
+            if not new_path.is_relative_to(self.cwd):
+                raise ValueError(
+                    "Cannot rename files outside of "
+                    "the current working directory"
+                )
+
+        # Cannot rename if already exists
+        if new_path.exists():
+            raise ValueError(
+                f"Cannot rename {self.path} to {new_path}"
+                " because it already exists"
+            )
+
+        self.path.rename(new_path)
+
+    def write_text(self, data: str, encoding: str = "utf-8") -> None:
+        # By default, write as utf-8
+        self.path.write_text(data, encoding)
+
+    @property
+    def short_name(self) -> str:
+        return self.path.name
+
+    @property
+    def relative_name(self) -> str:
+        if self.strict:
+            if not self.path.is_relative_to(self.cwd):
+                raise ValueError(
+                    "Cannot get relative name for files outside"
+                    " of the current working directory"
+                )
+        # If can't return relative path, return absolute path
+        if not self.path.is_relative_to(self.cwd):
+            return self.path.absolute().as_posix()
+        return self.path.relative_to(self.cwd).as_posix()
+
+    @property
+    def absolute_name(self) -> str:
+        return self.path.absolute().as_posix()
+
+    @property
+    def last_modified(self) -> float:
+        return self.path.stat().st_mtime
+
+    def __str__(self) -> str:
+        return str(self.path)

--- a/marimo/_utils/marimo_path.py
+++ b/marimo/_utils/marimo_path.py
@@ -21,7 +21,9 @@ class MarimoPath:
 
     def validate(self) -> None:
         if not self.is_valid():
-            raise ValueError(f"File {self.path} is not a Python or Markdown file.")
+            raise ValueError(
+                f"File {self.path} is not a Python or Markdown file."
+            )
 
     @staticmethod
     def is_valid_path(path: str | Path) -> bool:
@@ -45,13 +47,15 @@ class MarimoPath:
         if self.strict:
             if not MarimoPath(new_path).is_relative_to(self.cwd):
                 raise ValueError(
-                    "Cannot rename files outside of " "the current working directory"
+                    "Cannot rename files outside of "
+                    "the current working directory"
                 )
 
         # Cannot rename if already exists
         if new_path.exists():
             raise ValueError(
-                f"Cannot rename {self.path} to {new_path}" " because it already exists"
+                f"Cannot rename {self.path} to {new_path}"
+                " because it already exists"
             )
 
         self.path.rename(new_path)

--- a/marimo/_utils/marimo_path.py
+++ b/marimo/_utils/marimo_path.py
@@ -21,9 +21,7 @@ class MarimoPath:
 
     def validate(self) -> None:
         if not self.is_valid():
-            raise ValueError(
-                f"File {self.path} is not a Python or Markdown file."
-            )
+            raise ValueError(f"File {self.path} is not a Python or Markdown file.")
 
     @staticmethod
     def is_valid_path(path: str | Path) -> bool:
@@ -47,15 +45,13 @@ class MarimoPath:
         if self.strict:
             if not MarimoPath(new_path).is_relative_to(self.cwd):
                 raise ValueError(
-                    "Cannot rename files outside of "
-                    "the current working directory"
+                    "Cannot rename files outside of " "the current working directory"
                 )
 
         # Cannot rename if already exists
         if new_path.exists():
             raise ValueError(
-                f"Cannot rename {self.path} to {new_path}"
-                " because it already exists"
+                f"Cannot rename {self.path} to {new_path}" " because it already exists"
             )
 
         self.path.rename(new_path)
@@ -81,8 +77,8 @@ class MarimoPath:
                 )
         # If can't return relative path, return absolute path
         if not self.is_relative_to(self.cwd):
-            return self.path.absolute().as_posix()
-        return self.path.relative_to(self.cwd).as_posix()
+            return str(self.path.absolute())
+        return str(self.path.relative_to(self.cwd))
 
     def is_relative_to(self, other: Path) -> bool:
         # In python 3.8, is_relative_to is not available
@@ -92,7 +88,7 @@ class MarimoPath:
 
     @property
     def absolute_name(self) -> str:
-        return self.path.absolute().as_posix()
+        return str(self.path.absolute())
 
     @property
     def last_modified(self) -> float:

--- a/marimo/_utils/marimo_path.py
+++ b/marimo/_utils/marimo_path.py
@@ -64,6 +64,9 @@ class MarimoPath:
         # By default, write as utf-8
         self.path.write_text(data, encoding)
 
+    def read_text(self, encoding: str = "utf-8") -> str:
+        return self.path.read_text(encoding)
+
     @property
     def short_name(self) -> str:
         return self.path.name

--- a/tests/_cli/test_markdown_conversion.py
+++ b/tests/_cli/test_markdown_conversion.py
@@ -16,6 +16,7 @@ from marimo._server.export.utils import format_filename_title
 
 # Just a handful of scripts to test
 from marimo._tutorials import dataflow, marimo_for_jupyter_users
+from marimo._utils.marimo_path import MarimoPath
 from tests.mocks import snapshotter
 
 modules = {
@@ -45,7 +46,7 @@ def convert_from_py(py: str) -> str:
             tempfile_name = f.name
             f.write(py)
             f.seek(0)
-            output = export_as_md(tempfile_name)[0]
+            output = export_as_md(MarimoPath(tempfile_name))[0]
     finally:
         os.remove(tempfile_name)
 
@@ -62,7 +63,7 @@ def convert_from_py(py: str) -> str:
 )
 def test_markdown_snapshots() -> None:
     for name, mod in modules.items():
-        output = sanitized_version(export_as_md(mod.__file__)[0])
+        output = sanitized_version(export_as_md(MarimoPath(mod.__file__))[0])
         snapshot(f"{name}.md.txt", output)
 
 

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -12,7 +12,7 @@ from reload_test_utils import random_modname, update_file
 
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._runtime.requests import SetCellConfigRequest, SetUserConfigRequest
+from marimo._runtime.requests import SetUserConfigRequest
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
 

--- a/tests/_server/mocks.py
+++ b/tests/_server/mocks.py
@@ -8,6 +8,7 @@ from marimo._config.manager import UserConfigManager
 from marimo._server.file_router import AppFileRouter
 from marimo._server.model import SessionMode
 from marimo._server.sessions import NoopLspServer, SessionManager
+from marimo._utils.marimo_path import MarimoPath
 
 if TYPE_CHECKING:
     from fastapi.testclient import TestClient
@@ -44,7 +45,7 @@ if __name__ == "__main__":
     lsp_server = NoopLspServer()
 
     sm = SessionManager(
-        file_router=AppFileRouter.from_filename(temp_file.name),
+        file_router=AppFileRouter.from_filename(MarimoPath(temp_file.name)),
         mode=SessionMode.EDIT,
         development_mode=False,
         quiet=False,

--- a/tests/_server/test_file_router.py
+++ b/tests/_server/test_file_router.py
@@ -30,16 +30,22 @@ class TestAppFileRouter(unittest.TestCase):
         self.test_file2 = tempfile.NamedTemporaryFile(
             delete=False, dir=self.test_dir, suffix=".py"
         )
+        self.test_file_3 = tempfile.NamedTemporaryFile(
+            delete=False, dir=self.test_dir, suffix=".md"
+        )
         # Write to the temporary files
         self.test_file1.write(file_contents.encode())
         self.test_file1.close()
         self.test_file2.write(file_contents.encode())
         self.test_file2.close()
+        self.test_file_3.write("marimo-version: 0.0.0".encode())
+        self.test_file_3.close()
 
     def tearDown(self):
         # Clean up temporary files and directory
         os.unlink(self.test_file1.name)
         os.unlink(self.test_file2.name)
+        os.unlink(self.test_file_3.name)
         os.rmdir(self.test_dir)
 
     def test_infer_file(self):
@@ -100,9 +106,6 @@ class TestAppFileRouter(unittest.TestCase):
             self.test_dir, include_markdown=True
         )
         # Create markdown files
-        _markdown_file1 = tempfile.NamedTemporaryFile(
-            dir=self.test_dir, suffix=".md"
-        )
         files = router.files
         assert len(files) == 3
 

--- a/tests/_utils/test_marimo_path.py
+++ b/tests/_utils/test_marimo_path.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from marimo._utils.marimo_path import MarimoPath
+
+
+def test_init():
+    # Test with a valid Python file
+    path = Path(__file__)
+    mp = MarimoPath(path)
+    assert mp.path == path
+
+    # Test with a valid Markdown file
+    path = Path("README.md")
+    mp = MarimoPath(path)
+    assert mp.path == path
+
+    # Test with an invalid file
+    path = Path("invalid.txt")
+    with pytest.raises(ValueError):
+        MarimoPath(path)
+
+
+def test_is_valid_path():
+    # Test with a valid Python file
+    assert MarimoPath.is_valid_path(__file__)
+
+    # Test with a valid Markdown file
+    assert MarimoPath.is_valid_path("README.md")
+
+    # Test with an invalid file
+    assert not MarimoPath.is_valid_path("invalid.txt")
+
+
+def test_is_valid():
+    # Test with a Python file
+    mp = MarimoPath(__file__)
+    assert mp.is_valid()
+    assert mp.is_python()
+    assert not mp.is_markdown()
+
+    # Test with a Markdown file
+    mp = MarimoPath("README.md")
+    assert mp.is_valid()
+    assert not mp.is_python()
+    assert mp.is_markdown()
+
+
+def test_rename(tmp_path: Path):
+    # Create a temporary file
+    tmp_file = tmp_path / "test.py"
+    tmp_file.write_text("test")
+
+    # Rename the file
+    new_file = tmp_path / "new_test.py"
+    mp = MarimoPath(tmp_file)
+    mp.rename(new_file)
+    assert not tmp_file.exists()
+    assert new_file.exists()
+
+    # Try to rename to an existing file
+    with pytest.raises(ValueError):
+        mp.rename(new_file)
+
+
+def test_write_text(tmp_path: Path):
+    # Create a temporary file
+    tmp_file = tmp_path / "test.py"
+    mp = MarimoPath(tmp_file)
+
+    # Write some text to the file
+    text = "Hello, world!"
+    mp.write_text(text)
+    assert tmp_file.read_text() == text
+
+
+def test_properties():
+    mp = MarimoPath(__file__)
+
+    # Test short_name
+    assert mp.short_name == os.path.basename(__file__)
+
+    # Test relative_name
+    assert mp.relative_name == os.path.relpath(__file__)
+
+    # Test absolute_name
+    assert mp.absolute_name == os.path.abspath(__file__)
+
+    # Test last_modified
+    assert mp.last_modified == os.path.getmtime(__file__)


### PR DESCRIPTION
- Adds a `MarimoPath` class with useful validation tools. This might be overkill now, but can help consolidate our renaming/validation logic over time
- Allow renaming `.md` files in the frontend 