### PR TITLE
fix: cloning of forms in arrays/dicts

### DIFF
--- a/marimo/_plugins/ui/_impl/array.py
+++ b/marimo/_plugins/ui/_impl/array.py
@@ -125,7 +125,11 @@ class array(UIElement[Dict[str, JSONType], Sequence[object]]):
         return [e._value for e in self._elements]
 
     def _clone(self) -> array:
-        return array(elements=self.elements, label=self._label)
+        return array(
+            elements=self.elements,
+            label=self._label,
+            on_change=self._on_change,
+        )
 
     def __len__(self) -> int:
         return len(self.elements)

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -1531,6 +1531,3 @@ class form(UIElement[Optional[JSONTypeBound], Optional[T]]):
             return None
         self.element._update(value)
         return self.element.value
-
-    def _clone(self) -> form[JSONTypeBound, T]:
-        return form(element=self.element)

--- a/marimo/_smoke_tests/sidebar.py
+++ b/marimo/_smoke_tests/sidebar.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.5.1"

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from marimo._plugins import ui
@@ -317,6 +319,15 @@ def test_on_change() -> None:
     assert state == [False]
     button._update(True)
     assert state == [False, True]
+
+
+def test_form_in_array_retains_on_change() -> None:
+    def on_change(*args: Any) -> None:
+        del args
+        ...
+
+    array = ui.array([ui.form(ui.checkbox(), on_change=on_change)])
+    assert array[0]._on_change == on_change
 
 
 # TODO(akshayka): test file


### PR DESCRIPTION
Fix clone method of form -- don't need to special case it. Previously we were dropping form info on clone.

Fixes #1131 