### PR TITLE
improvement: hold on to unnamed UI elements

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -589,6 +589,7 @@ class Kernel:
         get_context().cell_lifecycle_registry.dispose(
             cell_id, deletion=deletion
         )
+        get_context().ui_element_registry.delete_elements_for_cell(cell_id)
         RemoveUIElements(cell_id=cell_id).broadcast()
 
     def _deactivate_cell(self, cell_id: CellId_t) -> set[CellId_t]:
@@ -1022,11 +1023,8 @@ class Kernel:
                     object_id,
                     value,
                 )
-            except (KeyError, NameError):
-                # KeyError: A UI element may go out of scope if it was not
-                # assigned to a global variable
-                # NameError: UI element might not have bindings
-                LOGGER.debug("Could not find UIElement with id %s", object_id)
+            except KeyError:
+                LOGGER.error("Could not find UIElement with id %s", object_id)
                 continue
 
             with self._install_execution_context(


### PR DESCRIPTION
Changes the semantics of the UIRegistry to hold on to unnamed UI elements.

This makes function call requests work on unnamed UI elements.

The registry now keeps track of all the UI elements registered to a cell, and exposes a method to unregister them. The runtime unregisters all UI elements for a cell when cell state is invalidated.

STATUS: DRAFT.

[ ] Think through second-order effects.
[ ] Might need to change destructor logic for UI elements.
[ ] Update existing tests, rewrite new ones.