### PR TITLE
feat: basic-auth support and minimal login page

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1,0 +1,67 @@
+# Authentication
+
+marimo provides a simple way to add token/password protection to your marimo server. Given that authentication is a complex topic, marimo does not provide a built-in authentication/authorization system, but instead makes it easy to add your own through ASGI middleware.
+
+## Enabling Basic Authentication
+
+Authentication is disabled by default, however this may change in the future. To enable authentication, you must pass `--token` to your `marimo edit/run/new` command from the Terminal. This will use a randomly generated token in `Edit mode` and a deterministic token in `Run mode` (based on the code of the notebook).
+
+```bash
+marimo run my_notebook.py --auth --token="sup3rs3cr3t"
+```
+
+### Ways to Authenticate
+
+In order to authenticate, you must either pass the token as a password in the `Authorization` header, or as a query parameter under `access_token` in the URL.
+
+1. Basic Authorization header:
+
+To authenticate using the `Authorization` header, you must pass the token as a password in the `Authorization` header using the [Basic authentication scheme](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication). For example, to authenticate with the token `sup3rs3cr3t`, you would pass the header `Authorization Basic base64("any_username:sup3rs3cr3t")`.
+
+This is not necessary when using a browser, as the browser will automatically prompt you for a username and password. Note: any username can be used.
+
+2. Query parameter:
+
+To authenticate using a query parameter, you must pass the token as a query parameter under `access_token` in the URL. For example, to authenticate with the token `sup3rs3cr3t`, you would pass the query parameter `http://localhost:2718?access_token=sup3rs3cr3t`.
+
+For convenience, when running locally, marimo will automatically open the URL with the query parameter in your default browser.
+
+## Custom Authentication
+
+If you choose to make your marimo application public, you may want to add your own authentication system, along with authorization, rate limiting, etc. You can do this by creating a marimo application programmatically and adding your own middleware to the ASGI application.
+
+Here's an example of how you can add authentication to a marimo application using FastAPI:
+
+```python
+from typing import Annotated, Callable, Coroutine
+from fastapi.responses import HTMLResponse, RedirectResponse
+import marimo
+from fastapi import FastAPI, Form, Request, Response
+# Custom auth middleware and login page
+from my_auth_module import auth_middleware, my_login_route
+
+
+# Create a marimo asgi app
+server = (
+    marimo.create_asgi_app()
+    .with_app(path="", root="./pages/index.py")
+    .with_app(path="/dashboard", root="./pages/dashboard.py")
+    .with_app(path="/sales", root="./pages/sales.py")
+)
+
+# Create a FastAPI app
+app = FastAPI()
+
+app.add_middleware(auth_middleware)
+app.add_route("/login", my_login_route, methods=["POST"])
+
+app.mount("/", server.build())
+
+# Run the server
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="localhost", port=8000)
+```
+
+or for a full example on implementing OAuth2 with FastAPI, see the [FastAPI OAuth2 example](https://fastapi.tiangolo.com/tutorial/security/oauth2-jwt/).

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -14,17 +14,21 @@ marimo run my_notebook.py --token --token-password="sup3rs3cr3t"
 
 In order to authenticate, you must either pass the token as a password in the `Authorization` header, or as a query parameter under `access_token` in the URL.
 
-1. Basic Authorization header:
+1. Enter the token in the login page:
 
-To authenticate using the `Authorization` header, you must pass the token as a password in the `Authorization` header using the [Basic authentication scheme](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication). For example, to authenticate with the token `sup3rs3cr3t`, you would pass the header `Authorization Basic base64("any_username:sup3rs3cr3t")`.
-
-This is not necessary when using a browser, as the browser will automatically prompt you for a username and password. Note: any username can be used.
+If you try to access marimo from a browser, you will be redirected to a login page where you can enter the token.
 
 2. Query parameter:
 
 To authenticate using a query parameter, you must pass the token as a query parameter under `access_token` in the URL. For example, to authenticate with the token `sup3rs3cr3t`, you would pass the query parameter `http://localhost:2718?access_token=sup3rs3cr3t`.
 
 For convenience, when running locally, marimo will automatically open the URL with the query parameter in your default browser.
+
+3. Basic Authorization header:
+
+To authenticate using the `Authorization` header, you must pass the token as a password in the `Authorization` header using the [Basic authentication scheme](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication). For example, to authenticate with the token `sup3rs3cr3t`, you would pass the header `Authorization Basic base64("any_username:sup3rs3cr3t")`.
+
+This is not necessary when using a browser, as the marimo server will redirect you to a minimal login page where you can enter the token.
 
 ## Custom Authentication
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -4,10 +4,10 @@ marimo provides a simple way to add token/password protection to your marimo ser
 
 ## Enabling Basic Authentication
 
-Authentication is disabled by default, however this may change in the future. To enable authentication, you must pass `--token` to your `marimo edit/run/new` command from the Terminal. This will use a randomly generated token in `Edit mode` and a deterministic token in `Run mode` (based on the code of the notebook).
+Authentication is enabled by default when running `marimo edit/tutorial/new`. To disable authentication, you may pass `--no-token` to your `marimo edit/run/new` command from the Terminal. The auth token will be randomly generated when in `Edit mode` and deterministically generated in `Run mode` (based on the code of the notebook). However, you can also pass your own token/password using the `--token-password` flag.
 
 ```bash
-marimo run my_notebook.py --auth --token="sup3rs3cr3t"
+marimo run my_notebook.py --token --token-password="sup3rs3cr3t"
 ```
 
 ### Ways to Authenticate

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -22,6 +22,7 @@
   ai_completion
   best_practices
   performance
+  authentication
   exporting
   deploying/index
 ```
@@ -48,6 +49,7 @@ These guides cover marimo's core concepts.
 | {doc}`wasm`                          | Running notebooks in the browser (no backend required!) |
 | {doc}`ai_completion`                 | Using AI to speed up your coding                        |
 | {doc}`exporting`                     | Exporting notebooks to HTML and flat scripts            |
+| {doc}`authentication`                | Authentication and security                             |
 | {doc}`deploying/index`               | Deploying marimo notebooks and apps                     |
 
 ```{admonition} Learn by doing!

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -176,7 +176,7 @@ const config: PlaywrightTestConfig = {
       const baseUrl = options.command === "run" ? options.baseUrl : undefined;
 
       const pathToApp = path.join(pydir, app);
-      let marimoCmd = `marimo -q ${command} ${pathToApp} -p ${port} --headless`;
+      let marimoCmd = `marimo -q ${command} ${pathToApp} -p ${port} --headless --no-token`;
       if (baseUrl) {
         marimoCmd += ` --base-url=${baseUrl}`;
       }
@@ -188,7 +188,7 @@ const config: PlaywrightTestConfig = {
       };
     }),
     {
-      command: `marimo -q edit -p ${EDIT_PORT} --headless`,
+      command: `marimo -q edit -p ${EDIT_PORT} --headless --no-token`,
       url: getUrl(EDIT_PORT),
       reuseExistingServer: false,
     },

--- a/frontend/src/core/network/auth.ts
+++ b/frontend/src/core/network/auth.ts
@@ -1,0 +1,12 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { updateQueryParams } from "@/utils/urls";
+
+/**
+ * Remove access_token from the query string.
+ */
+export function cleanupAuthQueryParams() {
+  updateQueryParams((params) => {
+    params.delete("access_token");
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,9 +11,11 @@ import { patchFetch, patchVegaLoader } from "./core/static/files";
 import { isStaticNotebook } from "./core/static/static-state";
 import { vegaLoader } from "./plugins/impl/vega/loader";
 import { initializePlugins } from "./plugins/plugins";
+import { cleanupAuthQueryParams } from "./core/network/auth";
 
 maybeRegisterVSCodeBindings();
 initializePlugins();
+cleanupAuthQueryParams();
 
 /**
  * Main entry point for the Marimo app.

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -23,6 +23,7 @@ from marimo._cli.upgrade import check_for_updates
 from marimo._server.file_router import AppFileRouter
 from marimo._server.model import SessionMode
 from marimo._server.start import start
+from marimo._server.tokens import AuthToken
 from marimo._utils.marimo_path import MarimoPath
 
 DEVELOPMENT_MODE = False
@@ -66,6 +67,18 @@ def _key_value_bullets(items: list[tuple[str, str]]) -> str:
     return "\n".join(lines)
 
 
+def _resolve_token(
+    token: bool, token_password: Optional[str]
+) -> Optional[AuthToken]:
+    if token_password:
+        return AuthToken(token_password)
+    elif token is False:
+        # Empty means no auth
+        return AuthToken("")
+    # None means use the default (generated) token
+    return None
+
+
 main_help_msg = "\n".join(
     [
         "\b",
@@ -101,6 +114,20 @@ main_help_msg = "\n".join(
         ),
     ]
 )
+
+token_message = """
+    Use a token for authentication.
+    This enables session-based authentication.
+    A random token will be generated if --token-password is not set.
+
+    If --no-token is set, session-based authentication will not be used.
+    """
+
+token_password_message = """
+    Use a specific token for authentication.
+    This enables session-based authentication.
+    A random token will be generated if not set.
+    """
 
 
 @click.group(help=main_help_msg)
@@ -182,12 +209,28 @@ edit_help_msg = "\n".join(
     type=bool,
     help="Don't launch a browser.",
 )
+@click.option(
+    "--token/--no-token",
+    default=True,
+    show_default=True,
+    type=bool,
+    help=token_message,
+)
+@click.option(
+    "--token-password",
+    default=None,
+    show_default=True,
+    type=str,
+    help=token_password_message,
+)
 @click.argument("name", required=False)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def edit(
     port: Optional[int],
     host: str,
     headless: bool,
+    token: bool,
+    token_password: Optional[str],
     name: Optional[str],
     args: tuple[str],
 ) -> None:
@@ -228,6 +271,7 @@ def edit(
         include_code=True,
         watch=False,
         cli_args=parse_args(args),
+        auth_token=_resolve_token(token, token_password),
     )
 
 
@@ -255,10 +299,26 @@ def edit(
     type=bool,
     help="Don't launch a browser.",
 )
+@click.option(
+    "--token/--no-token",
+    default=True,
+    show_default=True,
+    type=bool,
+    help=token_message,
+)
+@click.option(
+    "--token-password",
+    default=None,
+    show_default=True,
+    type=str,
+    help=token_password_message,
+)
 def new(
     port: Optional[int],
     host: str,
     headless: bool,
+    token: bool,
+    token_password: Optional[str],
 ) -> None:
     start(
         file_router=AppFileRouter.new_file(),
@@ -271,6 +331,7 @@ def new(
         include_code=True,
         watch=False,
         cli_args={},
+        auth_token=_resolve_token(token, token_password),
     )
 
 
@@ -309,6 +370,20 @@ Example:
     help="Don't launch a browser.",
 )
 @click.option(
+    "--token/--no-token",
+    default=False,
+    show_default=True,
+    type=bool,
+    help=token_message,
+)
+@click.option(
+    "--token-password",
+    default=None,
+    show_default=True,
+    type=str,
+    help=token_password_message,
+)
+@click.option(
     "--include-code",
     is_flag=True,
     default=False,
@@ -342,6 +417,8 @@ def run(
     port: Optional[int],
     host: str,
     headless: bool,
+    token: bool,
+    token_password: Optional[str],
     include_code: bool,
     watch: bool,
     base_url: str,
@@ -369,6 +446,7 @@ def run(
         watch=watch,
         base_url=base_url,
         cli_args=parse_args(args),
+        auth_token=_resolve_token(token, token_password),
     )
 
 
@@ -431,6 +509,20 @@ Recommended sequence:
     type=bool,
     help="Don't launch a browser.",
 )
+@click.option(
+    "--token/--no-token",
+    default=True,
+    show_default=True,
+    type=bool,
+    help=token_message,
+)
+@click.option(
+    "--token-password",
+    default=None,
+    show_default=True,
+    type=str,
+    help=token_password_message,
+)
 @click.argument(
     "name",
     required=True,
@@ -451,6 +543,8 @@ def tutorial(
     port: Optional[int],
     host: str,
     headless: bool,
+    token: bool,
+    token_password: Optional[str],
     name: Literal[
         "intro",
         "dataflow",
@@ -500,6 +594,7 @@ def tutorial(
         headless=headless,
         watch=False,
         cli_args={},
+        auth_token=_resolve_token(token, token_password),
     )
 
 

--- a/marimo/_runtime/params.py
+++ b/marimo/_runtime/params.py
@@ -25,6 +25,8 @@ from marimo._runtime.state import State
 class QueryParams(State[SerializedQueryParams]):
     """Query parameters for a marimo app."""
 
+    IGNORED_KEYS = {"access_token", "refresh_token", "session_id"}
+
     def __init__(
         self,
         params: Dict[str, Union[str, List[str]]],

--- a/marimo/_server/api/auth.py
+++ b/marimo/_server/api/auth.py
@@ -175,9 +175,6 @@ class CustomSessionMiddleware(SessionMiddleware):
             return
 
         state = AppState.from_app(scope["app"])
-        # disabled = state.session_manager.mode != SessionMode.EDIT
-        # if disabled:
-        #     return await self.app(scope, receive, send)
 
         # We key the token cookie by port to avoid conflicts
         # with multiple marimo instances running on the same host

--- a/marimo/_server/api/auth.py
+++ b/marimo/_server/api/auth.py
@@ -1,0 +1,190 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import base64
+import secrets
+import typing
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+import starlette.status as status
+from starlette.datastructures import Secret
+from starlette.exceptions import HTTPException
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.responses import JSONResponse
+
+from marimo import _loggers
+
+if TYPE_CHECKING:
+    from starlette.authentication import AuthenticationError
+    from starlette.requests import HTTPConnection
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+from marimo._server.api.deps import AppState
+
+LOGGER = _loggers.marimo_logger()
+TOKEN_QUERY_PARAM = "access_token"
+
+
+# Validates auth
+# - Checking for existing session cookie (already authenticated)
+# - Or authenticates by access_token in query params
+# - Or authenticates by basic auth
+def validate_auth(conn: HTTPConnection) -> bool:
+    state = AppState.from_app(conn.app)
+    auth_token = str(state.session_manager.auth_token)
+
+    # Check for session cookie
+    cookie_session = CookieSession(conn.session)
+    # Validate the cookie
+    if cookie_session.get_access_token() == auth_token:
+        return True  # Success
+
+    # Check for access_token
+    if TOKEN_QUERY_PARAM in conn.query_params:
+        # Validate the access_token
+        if conn.query_params[TOKEN_QUERY_PARAM] == auth_token:
+            LOGGER.debug("Validated access_token")
+            # Set the cookie
+            cookie_session.set_access_token(auth_token)
+            return True  # Success
+
+    # Check for basic auth
+    auth = conn.headers.get("Authorization")
+    if auth is not None:
+        username, password = _parse_basic_auth_header(auth)
+        if username and password == auth_token:
+            LOGGER.debug("Validated basic auth")
+            # Set the cookie
+            cookie_session.set_access_token(auth_token)
+            cookie_session.set_username(username)
+            return True  # Success
+
+    LOGGER.debug("Invalid auth")
+    return False
+
+
+def _parse_basic_auth_header(
+    header: str,
+) -> tuple[Optional[str], Optional[str]]:
+    scheme, _, credentials = header.partition(" ")
+
+    if scheme.lower() != "basic":
+        LOGGER.debug("Invalid auth scheme: %s", scheme)
+        return None, None
+
+    decoded = base64.b64decode(credentials).decode("utf-8")
+    username, _, password = decoded.partition(":")
+
+    if not password:
+        return None, None
+
+    LOGGER.debug("Validated basic auth for user: %s", username)
+
+    return username, password
+
+
+def raise_basic_auth_error() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Authorization header required",
+        headers={"WWW-Authenticate": "Basic"},
+    )
+
+
+def on_auth_error(
+    request: HTTPConnection, error: AuthenticationError
+) -> JSONResponse:
+    del request
+    del error
+    return JSONResponse(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        content={"detail": "Authorization header required"},
+        headers={"WWW-Authenticate": "Basic"},
+    )
+
+
+# This is random/new for each server instance
+RANDOM_SECRET = Secret(secrets.token_hex(32))
+
+
+class CookieSession:
+    """
+    Wrapper around starlette's Session to add typesafety
+    """
+
+    def __init__(self, session_state: Dict[str, Any]) -> None:
+        self.session_state = session_state
+
+    def get_access_token(self) -> str:
+        access_token: str = self.session_state.get("access_token", "")
+        return access_token
+
+    def get_username(self) -> str:
+        username: str = self.session_state.get("username", "")
+        return username
+
+    def set_access_token(self, token: str) -> None:
+        self.session_state["access_token"] = token
+
+    def set_username(self, username: str) -> None:
+        self.session_state["username"] = username
+
+
+class CustomSessionMiddleware(SessionMiddleware):
+    """
+    Wrapper around starlette's SessionMiddleware to:
+     - customize the session cookie based on the the port
+     - only run in Edit mode
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        secret_key: typing.Union[str, Secret],
+        session_cookie: str = "session",
+        max_age: typing.Optional[int] = 14
+        * 24
+        * 60
+        * 60,  # 14 days, in seconds
+        path: str = "/",
+        same_site: typing.Literal["lax", "strict", "none"] = "lax",
+        https_only: bool = False,
+        domain: typing.Optional[str] = None,
+    ) -> None:
+        # We can't update the cookie here since
+        # we don't have access to the app state
+
+        self.original_session_cookie = session_cookie
+
+        super().__init__(
+            app,
+            secret_key,
+            session_cookie,
+            max_age,
+            path,
+            same_site,
+            https_only,
+            domain,
+        )
+
+    async def __call__(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        state = AppState.from_app(scope["app"])
+        # disabled = state.session_manager.mode != SessionMode.EDIT
+        # if disabled:
+        #     return await self.app(scope, receive, send)
+
+        # We key the token cookie by port to avoid conflicts
+        # with multiple marimo instances running on the same host
+        maybe_port = state.maybe_port
+        if maybe_port is not None:
+            self.session_cookie = (
+                f"{self.original_session_cookie}_{maybe_port}"
+            )
+
+        return await super().__call__(scope, receive, send)

--- a/marimo/_server/api/deps.py
+++ b/marimo/_server/api/deps.py
@@ -1,49 +1,106 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from marimo._config.manager import UserConfigManager
 from marimo._server.ids import SessionId
 from marimo._server.model import SessionMode
 from marimo._server.sessions import Session, SessionManager
+from marimo._server.tokens import SkewProtectionToken
 
 if TYPE_CHECKING:
+    from starlette.applications import Starlette
+    from starlette.datastructures import State
     from starlette.requests import Request
     from starlette.websockets import WebSocket
     from uvicorn import Server
 
 
-def app_state(request: Request) -> AppState:
-    """Get the app state."""
-    return AppState(request.app)
-
-
-class AppState:
+class AppStateBase:
     """The app state."""
 
-    def __init__(self, request: Union[Request, WebSocket]) -> None:
+    @staticmethod
+    def from_request(request: Union[Request, WebSocket]) -> AppState:
+        """Get the app state with a request."""
+        return AppState(request)
+
+    @staticmethod
+    def from_app(asgi: Starlette) -> AppStateBase:
+        """Get the app state with an ASGIApp app."""
+        return AppStateBase(cast(Any, asgi).state)
+
+    def __init__(self, state: State) -> None:
         """Initialize the app state."""
+        self.state = state
+
+    @property
+    def session_manager(self) -> SessionManager:
+        return cast(SessionManager, self.state.session_manager)
+
+    @property
+    def mode(self) -> SessionMode:
+        return self.session_manager.mode
+
+    @property
+    def quiet(self) -> bool:
+        return self.session_manager.quiet
+
+    @property
+    def development_mode(self) -> bool:
+        return self.session_manager.development_mode
+
+    @property
+    def host(self) -> str:
+        host: str = self.state.host
+        return host
+
+    @property
+    def port(self) -> int:
+        post: int = self.state.port
+        return post
+
+    @property
+    def maybe_port(self) -> Optional[int]:
+        return self.state._state.get("port")
+
+    @property
+    def base_url(self) -> str:
+        base_url: str = self.state.base_url
+        return base_url
+
+    @property
+    def server(self) -> Server:
+        server: Server = self.state.server
+        return server
+
+    @property
+    def config_manager(self) -> UserConfigManager:
+        cm: UserConfigManager = self.state.config_manager
+        return cm
+
+    @property
+    def watch(self) -> bool:
+        watch: bool = self.state.watch
+        return watch
+
+    @property
+    def headless(self) -> bool:
+        headless: bool = self.state.headless
+        return headless
+
+    @property
+    def skew_protection_token(self) -> SkewProtectionToken:
+        return self.session_manager.skew_protection_token
+
+
+class AppState(AppStateBase):
+    """The app state with a request."""
+
+    def __init__(self, request: Union[Request, WebSocket]) -> None:
+        """Initialize the app state with a request."""
+        super().__init__(request.app.state)
         self.request = request
-
-        assert (
-            request.app.state.session_manager is not None
-        ), "Session manager not initialized"
-        self.session_manager: SessionManager = (
-            request.app.state.session_manager
-        )
-
-        assert (
-            request.app.state.base_url is not None
-        ), "Base URL not initialized"
-        self._base_url: str = request.app.state.base_url
-
-        assert (
-            request.app.state.config_manager is not None
-        ), "Config manager not initialized"
-        self._config_manager: UserConfigManager = (
-            request.app.state.config_manager
-        )
 
     def get_current_session_id(self) -> Optional[SessionId]:
         """Get the current session."""
@@ -70,50 +127,6 @@ class AppState:
         if session is None:
             raise ValueError(f"Invalid session id: {session_id}")
         return session
-
-    @property
-    def mode(self) -> SessionMode:
-        return self.session_manager.mode
-
-    @property
-    def quiet(self) -> bool:
-        return self.session_manager.quiet
-
-    @property
-    def development_mode(self) -> bool:
-        return self.session_manager.development_mode
-
-    @property
-    def host(self) -> str:
-        assert self.request.app.state.host is not None, "Host not initialized"
-        host: str = self.request.app.state.host
-        return host
-
-    @property
-    def port(self) -> int:
-        assert self.request.app.state.port is not None, "Port not initialized"
-        post: int = self.request.app.state.port
-        return post
-
-    @property
-    def base_url(self) -> str:
-        return self._base_url
-
-    @property
-    def server_token(self) -> str:
-        return self.session_manager.server_token
-
-    @property
-    def server(self) -> Server:
-        assert (
-            self.request.app.state.server is not None
-        ), "Server not initialized"
-        server: Server = self.request.app.state.server
-        return server
-
-    @property
-    def config_manager(self) -> UserConfigManager:
-        return self._config_manager
 
     def require_query_params(self, param: str) -> str:
         """Get a query parameter or raise an error."""

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -48,7 +48,7 @@ FILE_QUERY_PARAM_KEY = "file"
 
 
 @router.get("/")
-@requires("read")
+@requires("read", redirect="auth:login_page")
 async def index(request: Request) -> HTMLResponse:
     app_state = AppState(request)
     user_config = app_state.config_manager.get_config()

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -6,6 +6,7 @@ import os
 import re
 from typing import TYPE_CHECKING
 
+from starlette.authentication import requires
 from starlette.exceptions import HTTPException
 from starlette.responses import FileResponse, HTMLResponse, Response
 from starlette.staticfiles import StaticFiles
@@ -47,6 +48,7 @@ FILE_QUERY_PARAM_KEY = "file"
 
 
 @router.get("/")
+@requires("read")
 async def index(request: Request) -> HTMLResponse:
     app_state = AppState(request)
     user_config = app_state.config_manager.get_config()
@@ -67,7 +69,7 @@ async def index(request: Request) -> HTMLResponse:
             html=html,
             base_url=app_state.base_url,
             user_config=user_config,
-            server_token=app_state.server_token,
+            server_token=app_state.skew_protection_token,
         )
     else:
         # We have a file key, so we can render the app with the file
@@ -79,7 +81,7 @@ async def index(request: Request) -> HTMLResponse:
             html=html,
             base_url=app_state.base_url,
             user_config=user_config,
-            server_token=app_state.server_token,
+            server_token=app_state.skew_protection_token,
             app_config=app_config,
             filename=app_manager.filename,
             mode=app_state.mode,
@@ -98,6 +100,7 @@ STATIC_FILES = [
 
 
 @router.get("/@file/{filename_and_length:path}")
+@requires("read")
 def virtual_file(
     request: Request,
 ) -> Response:

--- a/marimo/_server/api/endpoints/health.py
+++ b/marimo/_server/api/endpoints/health.py
@@ -31,6 +31,7 @@ router.add_route("/healthz", health_check, methods=["GET"])
 
 
 @router.get("/api/status")
+@requires("edit")
 async def status(request: Request) -> JSONResponse:
     app_state = AppState(request)
     files = [

--- a/marimo/_server/api/endpoints/login.py
+++ b/marimo/_server/api/endpoints/login.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl
+
+from starlette.responses import (
+    HTMLResponse,
+    RedirectResponse,
+    Response,
+)
+
+from marimo._server.api.auth import validate_auth
+from marimo._server.router import APIRouter
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+router = APIRouter()
+
+# Minimal login page
+LOGIN_PAGE = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Login Page</title>
+</head>
+<body style="
+    background-color: #f4f4f9;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;">
+  <form method="POST" action="/auth/login" style="
+    padding: 20px;
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    width: 300px;
+    text-align: center;">
+    <div style="margin-bottom: 20px;">
+      <label for="password" style="
+        display: block;
+        margin-bottom: 5px;
+        font-size: 16px;
+        color: #333;">Password</label>
+      <input id="password" name="password" type="password" style="
+        width: 100%;
+        box-sizing: border-box;
+        padding: 8px;
+        border: 1px solid #ccc;
+        border-radius: 4px;">
+    </div>
+    <button type="submit" style="
+        background-color: #1C7362;
+        color: white;
+        padding: 10px 20px;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        width: 100%;
+        font-size: 16px;">Login</button>
+    <p style="color: red;">{error}</p>
+  </form>
+</body>
+</html>
+"""
+
+
+@router.post("/login")
+async def login_submit(request: Request) -> Response:
+    error = ""
+    redirect_url = request.query_params.get("next", "/")
+
+    if request.user.is_authenticated:
+        return RedirectResponse("/", 302)
+
+    if request.method == "POST":
+        body = (await request.body()).decode()
+        data = dict(parse_qsl(body))
+        password = data.get("password", "")
+        if not password:
+            error = "Password is required"
+        else:
+            success = validate_auth(request, data)
+            if success:
+                return RedirectResponse(redirect_url, 302)
+            else:
+                error = "Invalid password"
+
+    return HTMLResponse(content=LOGIN_PAGE.format(error=error))
+
+
+@router.get("/login", name="login_page")
+async def login_page(request: Request) -> HTMLResponse:
+    del request
+    return HTMLResponse(content=LOGIN_PAGE.format(error=""))

--- a/marimo/_server/api/endpoints/login.py
+++ b/marimo/_server/api/endpoints/login.py
@@ -44,7 +44,7 @@ LOGIN_PAGE = """
         display: block;
         margin-bottom: 5px;
         font-size: 16px;
-        color: #333;">Password</label>
+        color: #333;">Access Token / Password</label>
       <input id="password" name="password" type="password" style="
         width: 100%;
         box-sizing: border-box;

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -287,7 +287,7 @@ class WebsocketHandler(SessionConsumer):
             # session was created.
             query_params = QueryParams({}, NoopStream())
             for key, value in self.websocket.query_params.multi_items():
-                if SESSION_QUERY_PARAM_KEY == key:
+                if key in QueryParams.IGNORED_KEYS:
                     continue
                 query_params.append(key, value)
 

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -69,6 +69,11 @@ class SkewProtectionMiddleware:
         # If not POST request, then skip
         if request.method != "POST":
             return await self.app(scope, receive, send)
+        # If is a form, then skip
+        if request.headers.get("Content-Type", "").startswith(
+            "application/x-www-form-urlencoded"
+        ):
+            return await self.app(scope, receive, send)
         # If ws, skip
         if request.url.path.startswith("/ws") or request.url.path.endswith(
             "/ws"

--- a/marimo/_server/api/router.py
+++ b/marimo/_server/api/router.py
@@ -18,6 +18,7 @@ from marimo._server.api.endpoints.file_explorer import (
 from marimo._server.api.endpoints.files import router as files_router
 from marimo._server.api.endpoints.health import router as health_router
 from marimo._server.api.endpoints.home import router as home_router
+from marimo._server.api.endpoints.login import router as login_router
 from marimo._server.api.endpoints.ws import router as ws_router
 from marimo._server.router import APIRouter
 
@@ -46,6 +47,7 @@ def build_routes(base_url: str = "") -> List[BaseRoute]:
     )
     app_router.include_router(ai_router, prefix="/api/ai", name="ai")
     app_router.include_router(home_router, prefix="/api/home", name="home")
+    app_router.include_router(login_router, prefix="/auth", name="auth")
     app_router.include_router(
         export_router, prefix="/api/export", name="export"
     )

--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from marimo._server.file_router import AppFileRouter
+from marimo._server.tokens import AuthToken
 from marimo._utils.marimo_path import MarimoPath
 
 if TYPE_CHECKING:
@@ -25,6 +26,7 @@ def create_asgi_app(
     *,
     quiet: bool = False,
     include_code: bool = False,
+    token: Optional[str] = None,
 ) -> ASGIAppBuilder:
     """
     Public API to create an ASGI app that can serve multiple notebooks.
@@ -87,6 +89,8 @@ def create_asgi_app(
 
     - quiet (bool, optional): Suppress standard out
     - include_code (bool, optional): Include notebook code in the app
+    - token (str, optional): Auth token to use for the app.
+        If not provided, an empty token is used.
 
     **Returns.**
 
@@ -104,6 +108,14 @@ def create_asgi_app(
 
     user_config_mgr = UserConfigManager()
     base_app = Starlette()
+
+    # Default to an empty token
+    # If a user is using the create_asgi_app API,
+    # they likely want to provide their own authN/authZ
+    if not token:
+        auth_token = AuthToken("")
+    else:
+        auth_token = AuthToken(token)
 
     # We call the entrypoint `root` instead of `filename` incase we want to
     # support directories or code in the future
@@ -130,6 +142,7 @@ def create_asgi_app(
                 # since we don't want to read arbitrary args and apply them
                 # to each application
                 cli_args={},
+                auth_token=auth_token,
             )
             app = create_starlette_app(
                 base_url="",
@@ -140,6 +153,7 @@ def create_asgi_app(
                         lifespans.signal_handler,
                     ]
                 ),
+                enable_auth=not AuthToken.is_empty(auth_token),
             )
             app.state.session_manager = session_manager
             app.state.base_url = path

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -25,6 +25,7 @@ from marimo._server.file_manager import AppFileManager
 from marimo._server.models.export import ExportAsHTMLRequest
 from marimo._server.session.session_view import SessionView
 from marimo._server.templates.templates import static_notebook_template
+from marimo._server.tokens import SkewProtectionToken
 from marimo._utils.paths import import_files
 
 # Root directory for static assets
@@ -74,7 +75,7 @@ class Exporter:
         html = static_notebook_template(
             html=index_html,
             user_config=config,
-            server_token="static",
+            server_token=SkewProtectionToken("static"),
             app_config=file_manager.app.config,
             filename=file_manager.filename,
             code=code,

--- a/marimo/_server/router.py
+++ b/marimo/_server/router.py
@@ -12,6 +12,7 @@ from starlette.responses import (
     HTMLResponse,
     JSONResponse,
     PlainTextResponse,
+    RedirectResponse,
     Response,
     StreamingResponse,
 )
@@ -59,6 +60,8 @@ class APIRouter(Router):
                     return response
                 if isinstance(response, PlainTextResponse):
                     return response
+                if isinstance(response, RedirectResponse):
+                    return response
 
                 if dataclasses.is_dataclass(response):
                     return JSONResponse(
@@ -80,7 +83,10 @@ class APIRouter(Router):
         return decorator
 
     def get(
-        self, path: str, include_in_schema: bool = True
+        self,
+        path: str,
+        include_in_schema: bool = True,
+        name: Optional[str] = None,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         """Get method."""
 
@@ -94,6 +100,10 @@ class APIRouter(Router):
                 if isinstance(response, StreamingResponse):
                     return response
                 if isinstance(response, PlainTextResponse):
+                    return response
+                if isinstance(response, RedirectResponse):
+                    return response
+                if isinstance(response, HTMLResponse):
                     return response
 
                 if dataclasses.is_dataclass(response):
@@ -110,6 +120,7 @@ class APIRouter(Router):
                 endpoint=wrapper_func,
                 methods=["GET"],
                 include_in_schema=include_in_schema,
+                name=name,
             )
             return func
 

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -13,6 +13,7 @@ from marimo._server.file_router import AppFileRouter
 from marimo._server.main import create_starlette_app
 from marimo._server.model import SessionMode
 from marimo._server.sessions import LspServer, SessionManager
+from marimo._server.tokens import AuthToken
 from marimo._server.utils import find_free_port, initialize_asyncio
 from marimo._server.uvicorn_utils import initialize_signals
 from marimo._utils.paths import import_files
@@ -33,6 +34,7 @@ def start(
     watch: bool,
     cli_args: SerializedCLIArgs,
     base_url: str = "",
+    auth_token: Optional[AuthToken],
 ) -> None:
     """
     Start the server.
@@ -52,6 +54,7 @@ def start(
         lsp_server=LspServer(port * 10),
         user_config_manager=user_config_mgr,
         cli_args=cli_args,
+        auth_token=auth_token,
     )
 
     log_level = "info" if development_mode else "error"
@@ -68,6 +71,7 @@ def start(
                 lifespans.open_browser,
             ]
         ),
+        enable_auth=not AuthToken.is_empty(session_manager.auth_token),
     )
 
     app.state.headless = headless

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -13,17 +13,18 @@ from marimo._messaging.cell_output import CellOutput
 from marimo._output.utils import uri_encode_component
 from marimo._server.api.utils import parse_title
 from marimo._server.model import SessionMode
+from marimo._server.tokens import SkewProtectionToken
 
 
 def home_page_template(
     html: str,
     base_url: str,
     user_config: MarimoConfig,
-    server_token: str,
+    server_token: SkewProtectionToken,
 ) -> str:
     html = html.replace("{{ base_url }}", base_url)
     html = html.replace("{{ user_config }}", json.dumps(user_config))
-    html = html.replace("{{ server_token }}", server_token)
+    html = html.replace("{{ server_token }}", str(server_token))
     html = html.replace("{{ version }}", __version__)
 
     html = html.replace("{{ title }}", "marimo")
@@ -38,14 +39,14 @@ def notebook_page_template(
     html: str,
     base_url: str,
     user_config: MarimoConfig,
-    server_token: str,
+    server_token: SkewProtectionToken,
     app_config: _AppConfig,
     filename: Optional[str],
     mode: SessionMode,
 ) -> str:
     html = html.replace("{{ base_url }}", base_url)
     html = html.replace("{{ user_config }}", json.dumps(user_config))
-    html = html.replace("{{ server_token }}", server_token)
+    html = html.replace("{{ server_token }}", str(server_token))
     html = html.replace("{{ version }}", __version__)
 
     html = html.replace(
@@ -67,7 +68,7 @@ def notebook_page_template(
 def static_notebook_template(
     html: str,
     user_config: MarimoConfig,
-    server_token: str,
+    server_token: SkewProtectionToken,
     app_config: _AppConfig,
     filename: Optional[str],
     code: str,
@@ -87,7 +88,7 @@ def static_notebook_template(
     html = html.replace(
         "{{ user_config }}", json.dumps(user_config, sort_keys=True)
     )
-    html = html.replace("{{ server_token }}", server_token)
+    html = html.replace("{{ server_token }}", str(server_token))
     html = html.replace("{{ version }}", __version__)
 
     html = html.replace(

--- a/marimo/_server/tokens.py
+++ b/marimo/_server/tokens.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import secrets
+
+from starlette.datastructures import Secret
+
+
+class AuthToken(Secret):
+    @staticmethod
+    def random() -> AuthToken:
+        return AuthToken(secrets.token_urlsafe(16))
+
+    @staticmethod
+    def from_code(code: str) -> AuthToken:
+        return AuthToken(str(hash(code)))
+
+    @staticmethod
+    def is_empty(token: AuthToken) -> bool:
+        return str(token) == ""
+
+
+class SkewProtectionToken:
+    """
+    Provides a token that is sent to the client on the first request and
+    is used to protect against version skew bugs.
+
+    This can happen when new code is deployed to the server but the client
+    still has only application loaded.
+    """
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    @staticmethod
+    def from_code(code: str) -> SkewProtectionToken:
+        return SkewProtectionToken(str(hash(code)))
+
+    @staticmethod
+    def random() -> SkewProtectionToken:
+        return SkewProtectionToken(secrets.token_urlsafe(16))
+
+    def __str__(self) -> str:
+        return self.token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "docutils>=0.17.0",
     # to show RAM, CPU usage, other system utilities
     "psutil>=5.0",
+    # required dependency in Starlette for SessionMiddleware support
+    "itsdangerous>=2.0.0",
     # for cell formatting; if user version is not compatible, no-op
     # so no lower bound needed
     "black",

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -1,21 +1,25 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, List
+from typing import TYPE_CHECKING, Any, List
 from unittest.mock import MagicMock, patch
 
 import pytest
-from starlette.testclient import TestClient
 
 from marimo._config.manager import UserConfigManager
 from marimo._dependencies.dependencies import DependencyManager
 from tests._server.conftest import get_user_config_manager
-from tests._server.mocks import with_session
+from tests._server.mocks import token_header, with_session
+
+if TYPE_CHECKING:
+    from starlette.testclient import TestClient
 
 SESSION_ID = "session-123"
 HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 HAS_DEPS = DependencyManager.has_openai()

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, cast
 
+from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_title
 from marimo._server.file_router import AppFileRouter
-from marimo._server.sessions import SessionManager
 from tests._server.mocks import token_header, with_file_router
 
 if TYPE_CHECKING:
@@ -14,11 +14,13 @@ if TYPE_CHECKING:
 
 
 def test_index(client: TestClient) -> None:
-    session_manager: SessionManager = cast(
-        Any, client.app
-    ).state.session_manager
+    session_manager = AppState.from_app(cast(Any, client.app)).session_manager
+
+    # Login page
     response = client.get("/")  # no header
-    assert response.status_code == 401, response.text
+    assert response.status_code == 200, response.text
+    assert "Login" in response.text
+    assert "marimo-filename" not in response.text
 
     response = client.get("/", headers=token_header())
     assert response.status_code == 200, response.text
@@ -34,8 +36,11 @@ def test_index(client: TestClient) -> None:
 
 @with_file_router(AppFileRouter.from_files([]))
 def test_index_when_empty(client: TestClient) -> None:
+    # Login page
     response = client.get("/")  # no header
-    assert response.status_code == 401, response.text
+    assert response.status_code == 200, response.text
+    assert "Login" in response.text
+    assert "marimo-filename" not in response.text
 
     response = client.get("/", headers=token_header())
     assert response.status_code == 200, response.text
@@ -47,8 +52,11 @@ def test_index_when_empty(client: TestClient) -> None:
 
 @with_file_router(AppFileRouter.new_file())
 def test_index_when_new_file(client: TestClient) -> None:
+    # Login page
     response = client.get("/")  # no header
-    assert response.status_code == 401, response.text
+    assert response.status_code == 200, response.text
+    assert "Login" in response.text
+    assert "marimo-filename" not in response.text
 
     response = client.get("/", headers=token_header())
     assert response.status_code == 200, response.text

--- a/tests/_server/api/endpoints/test_config_endpoints.py
+++ b/tests/_server/api/endpoints/test_config_endpoints.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from tests._server.conftest import get_user_config_manager
-from tests._server.mocks import with_session
+from tests._server.mocks import token_header, with_session
 
 if TYPE_CHECKING:
     from starlette.testclient import TestClient
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 SESSION_ID = "session-123"
 HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 

--- a/tests/_server/api/endpoints/test_editing.py
+++ b/tests/_server/api/endpoints/test_editing.py
@@ -1,14 +1,17 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
-from starlette.testclient import TestClient
+from tests._server.mocks import token_header, with_session
 
-from tests._server.mocks import with_session
+if TYPE_CHECKING:
+    from starlette.testclient import TestClient
 
 SESSION_ID = "session-123"
 HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from marimo import __version__
 from tests._server.conftest import get_session_manager
-from tests._server.mocks import with_session
+from tests._server.mocks import token_header, with_session
 from tests.mocks import snapshotter
 
 if TYPE_CHECKING:
@@ -16,7 +16,7 @@ snapshot = snapshotter(__file__)
 SESSION_ID = "session-123"
 HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 
@@ -36,6 +36,27 @@ def test_export_html(client: TestClient) -> None:
     )
     body = response.text
     assert '<marimo-code hidden=""></marimo-code>' not in body
+
+
+@with_session(SESSION_ID)
+def test_export_html_skew_protection(client: TestClient) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.filename = "test.py"
+    response = client.post(
+        "/api/export/html",
+        headers={
+            **HEADERS,
+            "Marimo-Server-Token": "old-skew-id",
+        },
+        json={
+            "download": False,
+            "files": [],
+            "include_code": True,
+        },
+    )
+    assert response.status_code == 401
+    assert response.json() == {"error": "Invalid server token"}
 
 
 @with_session(SESSION_ID)

--- a/tests/_server/api/endpoints/test_file_explorer.py
+++ b/tests/_server/api/endpoints/test_file_explorer.py
@@ -1,13 +1,17 @@
 # Copyright 2024 Marimo. All rights reserved.
-
+from __future__ import annotations
 
 import os
 from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
 
-from starlette.testclient import TestClient
+from tests._server.mocks import token_header
+
+if TYPE_CHECKING:
+    from starlette.testclient import TestClient
 
 HEADERS = {
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 temp_dir = TemporaryDirectory()

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -6,7 +6,7 @@ import random
 from typing import TYPE_CHECKING
 
 from tests._server.conftest import get_session_manager
-from tests._server.mocks import with_session
+from tests._server.mocks import token_header, with_session
 
 if TYPE_CHECKING:
     from fastapi.testclient import TestClient
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 SESSION_ID = "session-123"
 HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 

--- a/tests/_server/api/endpoints/test_health.py
+++ b/tests/_server/api/endpoints/test_health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from marimo import __version__
+from tests._server.mocks import token_header
 
 if TYPE_CHECKING:
     from starlette.testclient import TestClient
@@ -19,7 +20,11 @@ def test_health(client: TestClient) -> None:
 
 
 def test_status(client: TestClient) -> None:
+    # Unauthorized
     response = client.get("/api/status")
+    assert response.status_code == 401, response.text
+
+    response = client.get("/api/status", headers=token_header())
     assert response.status_code == 200, response.text
     content = response.json()
     assert content["status"] == "healthy"
@@ -37,7 +42,11 @@ def test_version(client: TestClient) -> None:
 
 
 def test_memory(client: TestClient) -> None:
-    response = client.get("/api/usage")
+    # Unauthorized
+    response = client.get("/api/status")
+    assert response.status_code == 401, response.text
+
+    response = client.get("/api/usage", headers=token_header())
     assert response.status_code == 200, response.text
     memory = response.json()["memory"]
     assert memory["total"] > 0

--- a/tests/_server/api/endpoints/test_home.py
+++ b/tests/_server/api/endpoints/test_home.py
@@ -1,17 +1,21 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
 
 import sys
+from typing import TYPE_CHECKING
 
 import pytest
-from starlette.testclient import TestClient
 
 from tests._server.conftest import get_session_manager
-from tests._server.mocks import with_session
+from tests._server.mocks import token_header, with_session
+
+if TYPE_CHECKING:
+    from starlette.testclient import TestClient
 
 SESSION_ID = "session-123"
 HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 

--- a/tests/_server/api/endpoints/test_resume_session.py
+++ b/tests/_server/api/endpoints/test_resume_session.py
@@ -7,6 +7,7 @@ from marimo._messaging.ops import KernelReady
 from marimo._server.sessions import Session
 from marimo._utils.parse_dataclass import parse_raw
 from tests._server.conftest import get_session_manager
+from tests._server.mocks import token_header
 
 if TYPE_CHECKING:
     from starlette.testclient import TestClient
@@ -33,12 +34,12 @@ def create_response(
 def headers(session_id: str) -> dict[str, str]:
     return {
         "Marimo-Session-Id": session_id,
-        "Marimo-Server-Token": "fake-token",
+        **token_header("fake-token"),
     }
 
 
 HEADERS = {
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 

--- a/tests/_server/api/endpoints/test_ws.py
+++ b/tests/_server/api/endpoints/test_ws.py
@@ -12,6 +12,7 @@ from marimo._server.model import SessionMode
 from marimo._server.sessions import SessionManager
 from marimo._utils.parse_dataclass import parse_raw
 from tests._server.conftest import get_session_manager
+from tests._server.mocks import token_header
 
 if TYPE_CHECKING:
     from starlette.testclient import TestClient
@@ -36,7 +37,7 @@ def create_response(
 
 
 HEADERS = {
-    "Marimo-Server-Token": "fake-token",
+    **token_header("fake-token"),
 }
 
 

--- a/tests/_server/api/test_auth.py
+++ b/tests/_server/api/test_auth.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import pytest
+from starlette.applications import Starlette
+from starlette.datastructures import Headers, QueryParams
+from starlette.requests import HTTPConnection
+
+from marimo._config.manager import UserConfigManager
+from marimo._server.api.auth import (
+    AppState,
+    CustomSessionMiddleware,
+    validate_auth,
+)
+from marimo._server.main import create_starlette_app
+from tests._server.mocks import get_mock_session_manager
+
+
+async def mock_receive() -> Any:
+    return {}
+
+
+async def mock_send(message: Any) -> None:
+    del message
+    pass
+
+
+async def test_custom_session_middleware_call(app: Starlette):
+    middleware = CustomSessionMiddleware(app, "secret_key")
+    scope = create_connection(app).scope
+
+    await middleware(scope, mock_receive, mock_send)
+    assert middleware.session_cookie == "session_1234"
+
+
+async def test_custom_session_middleware_call_with_port():
+    app = Starlette()
+    middleware = CustomSessionMiddleware(app, "secret_key")
+    scope = create_connection(app).scope
+
+    await middleware(scope, mock_receive, mock_send)
+    assert middleware.session_cookie == "session"
+
+
+@pytest.fixture
+def app() -> Starlette:
+    app = create_starlette_app(base_url="", enable_auth=True)
+    app.state.session_manager = get_mock_session_manager()
+    app.state.config_manager = UserConfigManager()
+    app.state.host = "localhost"
+    app.state.port = 1234
+    app.state.base_url = ""
+    return app
+
+
+def create_connection(app: Starlette) -> HTTPConnection:
+    conn = HTTPConnection(
+        {
+            "type": "http",
+            "app": app,
+            "headers": {},
+            "query_string": "",
+            "method": "GET",
+            "path": "/",
+        }
+    )
+    return conn
+
+
+async def test_validate_auth_with_valid_cookie(app: Starlette):
+    conn = create_connection(app)
+    # Run all middleware
+    await app.build_middleware_stack()(conn.scope, mock_receive, mock_send)
+    conn.session["access_token"] = str(
+        AppState.from_app(app).session_manager.auth_token
+    )
+
+    assert validate_auth(conn) is True
+
+
+async def test_validate_auth_with_bad_cookie(app: Starlette):
+    conn = create_connection(app)
+    # Run all middleware
+    await app.build_middleware_stack()(conn.scope, mock_receive, mock_send)
+    conn.session["access_token"] = "bad_token"
+
+    assert validate_auth(conn) is False
+
+
+async def test_validate_auth_with_valid_access_token(app: Starlette):
+    conn = create_connection(app)
+    # Run all middleware
+    await app.build_middleware_stack()(conn.scope, mock_receive, mock_send)
+    token = str(AppState.from_app(app).session_manager.auth_token)
+    conn._query_params = QueryParams([("access_token", token)])
+
+    assert validate_auth(conn) is True
+
+
+async def test_validate_auth_with_invalid_access_token(app: Starlette):
+    conn = create_connection(app)
+    # Run all middleware
+    await app.build_middleware_stack()(conn.scope, mock_receive, mock_send)
+    conn._query_params = QueryParams([("access_token", "bad_token")])
+
+    assert validate_auth(conn) is False
+
+
+async def test_validate_auth_with_valid_basic_auth(app: Starlette):
+    conn = create_connection(app)
+    auth_token = AppState.from_app(app).session_manager.auth_token
+    # Run all middleware
+    await app.build_middleware_stack()(conn.scope, mock_receive, mock_send)
+    basic_auth_header = (
+        f"Basic {base64.b64encode(f'user:{auth_token}'.encode()).decode()}"
+    )
+    conn._headers = Headers({"Authorization": basic_auth_header})
+
+    assert validate_auth(conn) is True
+
+
+async def test_validate_auth_with_missing_password_in_basic_auth(
+    app: Starlette,
+):
+    conn = create_connection(app)
+    # Run all middleware
+    await app.build_middleware_stack()(conn.scope, mock_receive, mock_send)
+    basic_auth_header = f"Basic {base64.b64encode('test:'.encode()).decode()}"
+    conn._headers = Headers({"Authorization": basic_auth_header})
+
+    assert validate_auth(conn) is False
+
+
+async def test_validate_auth_with_no_auth(app: Starlette):
+    conn = create_connection(app)
+    # Run all middleware
+    await app.build_middleware_stack()(conn.scope, mock_receive, mock_send)
+    assert validate_auth(conn) is False

--- a/tests/_server/api/test_middleware.py
+++ b/tests/_server/api/test_middleware.py
@@ -66,12 +66,12 @@ def test_base_url() -> None:
 def test_skew_protection(edit_app: Starlette) -> None:
     client = TestClient(edit_app)
     # Unauthorized access
-    response = client.get("/")
+    response = client.get("/api/status")
     assert response.status_code == 401, response.text
     assert response.headers.get("Set-Cookie") is None
 
     # Authorized access
-    response = client.get("/", headers=token_header("fake-token"))
+    response = client.get("/api/status", headers=token_header("fake-token"))
     assert response.status_code == 200, response.text
     assert response.headers.get("Set-Cookie") is not None
 
@@ -167,10 +167,18 @@ def no_auth_app(request: Any) -> Starlette:
 
 
 class TestAuth:
-    def test_no_auth(self, app: Starlette) -> None:
+    def test_no_auth_index_page(self, app: Starlette) -> None:
         # Test unauthorized access
         client = TestClient(app)
         response = client.get("/")
+        assert response.status_code == 200, response.text
+        assert response.headers.get("Set-Cookie") is None
+        assert "Login" in response.text
+
+    def test_no_auth_api_route(self, app: Starlette) -> None:
+        # Test unauthorized access
+        client = TestClient(app)
+        response = client.get("/api/status")
         assert response.status_code == 401, response.text
         assert response.headers.get("Set-Cookie") is None
 
@@ -206,7 +214,7 @@ class TestAuth:
     def test_bad_auth_header(self, app: Starlette) -> None:
         # Test unauthorized access with bad auth token
         client = TestClient(app)
-        response = client.get("/", headers=token_header("bad-token"))
+        response = client.get("/api/status", headers=token_header("bad-token"))
         assert response.status_code == 401, response.text
         assert response.headers.get("Set-Cookie") is None
 

--- a/tests/_server/api/test_middleware.py
+++ b/tests/_server/api/test_middleware.py
@@ -1,10 +1,20 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
 import uvicorn
 from starlette.testclient import TestClient
 
 from marimo._config.manager import UserConfigManager
 from marimo._server.main import create_starlette_app
-from tests._server.mocks import get_mock_session_manager
+from marimo._server.model import SessionMode
+from marimo._server.tokens import AuthToken
+from tests._server.mocks import get_mock_session_manager, token_header
+
+if TYPE_CHECKING:
+    from starlette.applications import Starlette
 
 
 def test_base_url() -> None:
@@ -34,8 +44,8 @@ def test_base_url() -> None:
     response = client.get("/healthz")
     assert response.status_code == 404, response.text
 
-    # Index
-    response = client.get("/foo/")
+    # Index (requires auth)
+    response = client.get("/foo/", headers=token_header("fake-token"))
     assert response.status_code == 200, response.text
     response = client.get("/")
     assert response.status_code == 404, response.text
@@ -51,3 +61,173 @@ def test_base_url() -> None:
     assert response.status_code == 200, response.text
     response = client.get("/api/status")
     assert response.status_code == 404, response.text
+
+
+def test_skew_protection(edit_app: Starlette) -> None:
+    client = TestClient(edit_app)
+    # Unauthorized access
+    response = client.get("/")
+    assert response.status_code == 401, response.text
+    assert response.headers.get("Set-Cookie") is None
+
+    # Authorized access
+    response = client.get("/", headers=token_header("fake-token"))
+    assert response.status_code == 200, response.text
+    assert response.headers.get("Set-Cookie") is not None
+
+    # POST with a new passing skew protection token
+    response = client.post(
+        "/api/home/running_notebooks",
+        headers=token_header("fake-token"),
+    )
+    assert response.status_code == 200, response.text
+
+    # POST with a new skew protection token
+    response = client.post(
+        "/api/home/running_notebooks",
+        headers=token_header("fake-token", "old-skew-id"),
+    )
+    assert response.status_code == 401, response.text
+
+
+@pytest.fixture
+def edit_app() -> Starlette:
+    app = create_starlette_app(base_url="")
+    app.state.session_manager = get_mock_session_manager()
+    app.state.session_manager.mode = SessionMode.EDIT
+    app.state.config_manager = UserConfigManager()
+    # Mock out the server
+    uvicorn_server = uvicorn.Server(uvicorn.Config(app))
+    uvicorn_server.servers = []
+    app.state.server = uvicorn_server
+    app.state.host = "localhost"
+    app.state.port = 1234
+    app.state.base_url = ""
+    return app
+
+
+@pytest.fixture
+def read_app() -> Starlette:
+    app = create_starlette_app(base_url="")
+    app.state.session_manager = get_mock_session_manager()
+    app.state.session_manager.mode = SessionMode.RUN
+    app.state.config_manager = UserConfigManager()
+    # Mock out the server
+    uvicorn_server = uvicorn.Server(uvicorn.Config(app))
+    uvicorn_server.servers = []
+    app.state.server = uvicorn_server
+    app.state.host = "localhost"
+    app.state.port = 1234
+    app.state.base_url = ""
+    return app
+
+
+@pytest.fixture(params=["read_app", "edit_app"])
+def app(request: Any) -> Starlette:
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def no_auth_edit_app() -> Starlette:
+    app = create_starlette_app(base_url="", enable_auth=False)
+    app.state.session_manager = get_mock_session_manager()
+    app.state.session_manager.mode = SessionMode.EDIT
+    app.state.session_manager.auth_token = AuthToken("")  # no auth
+    app.state.config_manager = UserConfigManager()
+    # Mock out the server
+    uvicorn_server = uvicorn.Server(uvicorn.Config(app))
+    uvicorn_server.servers = []
+    app.state.server = uvicorn_server
+    app.state.host = "localhost"
+    app.state.port = 1234
+    app.state.base_url = ""
+    return app
+
+
+@pytest.fixture
+def no_auth_read_app() -> Starlette:
+    app = create_starlette_app(base_url="", enable_auth=False)
+    app.state.session_manager = get_mock_session_manager()
+    app.state.session_manager.mode = SessionMode.RUN
+    app.state.session_manager.auth_token = AuthToken("")  # no auth
+    app.state.config_manager = UserConfigManager()
+    # Mock out the server
+    uvicorn_server = uvicorn.Server(uvicorn.Config(app))
+    uvicorn_server.servers = []
+    app.state.server = uvicorn_server
+    app.state.host = "localhost"
+    app.state.port = 1234
+    app.state.base_url = ""
+    return app
+
+
+@pytest.fixture(params=["no_auth_read_app", "no_auth_edit_app"])
+def no_auth_app(request: Any) -> Starlette:
+    return request.getfixturevalue(request.param)
+
+
+class TestAuth:
+    def test_no_auth(self, app: Starlette) -> None:
+        # Test unauthorized access
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 401, response.text
+        assert response.headers.get("Set-Cookie") is None
+
+    def test_auth_by_query(self, app: Starlette) -> None:
+        # Test authorized access by auth_token in query
+        client = TestClient(app)
+        response = client.get("/?access_token=fake-token")
+        assert response.status_code == 200, response.text
+        assert response.headers.get("Set-Cookie") is not None
+
+        # Can access again with cookie
+        response = client.get("/")
+        assert response.status_code == 200, response.text
+
+    def tets_bath_auth_query(self, app: Starlette) -> None:
+        # Test unauthorized access with bad auth token
+        client = TestClient(app)
+        response = client.get("/?access_token=bad-token")
+        assert response.status_code == 401, response.text
+        assert response.headers.get("Set-Cookie") is None
+
+    def test_auth_by_header(self, app: Starlette) -> None:
+        # Test authorized access by auth_token in header (basic auth login)
+        client = TestClient(app)
+        response = client.get("/", headers=token_header("fake-token"))
+        assert response.status_code == 200, response.text
+        assert response.headers.get("Set-Cookie") is not None
+
+        # Can access again with cookie
+        response = client.get("/")
+        assert response.status_code == 200, response.text
+
+    def test_bad_auth_header(self, app: Starlette) -> None:
+        # Test unauthorized access with bad auth token
+        client = TestClient(app)
+        response = client.get("/", headers=token_header("bad-token"))
+        assert response.status_code == 401, response.text
+        assert response.headers.get("Set-Cookie") is None
+
+
+class TestNoAuth:
+    def test_no_auth(self, no_auth_app: Starlette) -> None:
+        client = TestClient(no_auth_app)
+        response = client.get("/")
+        assert response.status_code == 200, response.text
+        assert response.headers.get("Set-Cookie") is None
+
+    def tets_any_query(self, no_auth_app: Starlette) -> None:
+        # Test unauthorized access with bad auth token
+        client = TestClient(no_auth_app)
+        response = client.get("/?access_token=bad-token")
+        assert response.status_code == 200, response.text
+        assert response.headers.get("Set-Cookie") is None
+
+    def test_any_header(self, no_auth_app: Starlette) -> None:
+        # Test unauthorized access with bad auth token
+        client = TestClient(no_auth_app)
+        response = client.get("/", headers=token_header("bad-token"))
+        assert response.status_code == 200, response.text
+        assert response.headers.get("Set-Cookie") is None

--- a/tests/_server/conftest.py
+++ b/tests/_server/conftest.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import sys
 from typing import Generator, Iterator
 
@@ -12,7 +14,7 @@ from marimo._server.sessions import SessionManager
 from marimo._server.utils import initialize_asyncio
 from tests._server.mocks import get_mock_session_manager
 
-app = create_starlette_app(base_url="")
+app = create_starlette_app(base_url="", enable_auth=True)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/_server/templates/test_templates.py
+++ b/tests/_server/templates/test_templates.py
@@ -10,6 +10,7 @@ from marimo._config.config import DEFAULT_CONFIG
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._server.model import SessionMode
 from marimo._server.templates import templates
+from marimo._server.tokens import SkewProtectionToken
 from tests._server.templates.utils import normalize_index_html
 from tests.mocks import snapshotter
 
@@ -121,7 +122,7 @@ class TestStaticNotebookTemplate(unittest.TestCase):
             self.html = f.read()
 
         self.user_config = DEFAULT_CONFIG
-        self.server_token = "token"
+        self.server_token = SkewProtectionToken("token")
         self.app_config = _AppConfig()
         self.filename = "notebook.py"
         self.code = "print('Hello, World!')"

--- a/tests/_server/test_session_manager.py
+++ b/tests/_server/test_session_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from unittest.mock import MagicMock, Mock
 
@@ -33,6 +35,7 @@ def session_manager():
         lsp_server=MagicMock(spec=LspServer),
         user_config_manager=UserConfigManager(),
         cli_args={},
+        auth_token=None,
     )
 
 


### PR DESCRIPTION
Fixes #395

This adds basic auth support. It is both _basic_ and uses the `Basic` auth schema.

Overview:
* it is enabled by default for `marimo edit/tutorial/new`, and not enabled by default for `marimo run`
* You can enable/disable with `--token/--no-token` and `--token-password` to customize the password
* Rename `ValidateServerTokenMiddleware` to `SkewProtectionMiddleware`

---

In order to authenticate, you must either pass the token as a password in the `Authorization` header, or as a query parameter under `access_token` in the URL.

1. Basic Authorization header:

To authenticate using the `Authorization` header, you must pass the token as a password in the `Authorization` header using the [Basic authentication scheme](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication). For example, to authenticate with the token `sup3rs3cr3t`, you would pass the header `Authorization Basic base64("any_username:sup3rs3cr3t")`.

This is not necessary when using a browser, as we will redirect you to a minimal login page

2. Query parameter (most common flow):

To authenticate using a query parameter, you must pass the token as a query parameter under `access_token` in the URL. For example, to authenticate with the token `sup3rs3cr3t`, you would pass the query parameter `http://localhost:2718?access_token=sup3rs3cr3t`.

For convenience, when running locally, marimo will automatically open the URL with the query parameter in your default browser.
