### PR TITLE
fix: scroll to variable

### DIFF
--- a/frontend/src/components/dependency-graph/dependency-graph-minimap.tsx
+++ b/frontend/src/components/dependency-graph/dependency-graph-minimap.tsx
@@ -24,7 +24,7 @@ import { Atom } from "jotai";
 
 import { NodeData, VerticalElementsBuilder } from "./elements";
 import useEvent from "react-use-event-hook";
-import { scrollToCell } from "../editor/links/cell-link";
+import { scrollAndHighlightCell } from "../editor/links/cell-link";
 import { GraphSelectionPanel } from "./panels";
 import { useFitToViewOnDimensionChange } from "./utils/useFitToViewOnDimensionChange";
 
@@ -132,7 +132,7 @@ export const DependencyGraphMinimap: React.FC<PropsWithChildren<Props>> = ({
         setEdges([]);
       }}
       onNodeDoubleClick={(_event, node) => {
-        scrollToCell(node.id as CellId, "focus");
+        scrollAndHighlightCell(node.id as CellId, "focus");
       }}
       onEdgeClick={(_event, edge) => {
         setSelectedEdge(edge);

--- a/frontend/src/components/dependency-graph/dependency-graph-tree.tsx
+++ b/frontend/src/components/dependency-graph/dependency-graph-tree.tsx
@@ -23,7 +23,7 @@ import { NodeData, TreeElementsBuilder } from "./elements";
 import { layoutElements } from "./utils/layout";
 import { GraphSelection, GraphSettings, LayoutDirection } from "./types";
 import useEvent from "react-use-event-hook";
-import { scrollToCell } from "../editor/links/cell-link";
+import { scrollAndHighlightCell } from "../editor/links/cell-link";
 import { GraphSelectionPanel } from "./panels";
 import { useFitToViewOnDimensionChange } from "./utils/useFitToViewOnDimensionChange";
 
@@ -113,7 +113,7 @@ export const DependencyGraphTree: React.FC<PropsWithChildren<Props>> = ({
           });
         }}
         onNodeDoubleClick={(_event, node) => {
-          scrollToCell(node.id as CellId, "focus");
+          scrollAndHighlightCell(node.id as CellId, "focus");
         }}
         fitView={true}
         onNodesChange={onNodesChange}

--- a/frontend/src/components/editor/links/cell-link-list.tsx
+++ b/frontend/src/components/editor/links/cell-link-list.tsx
@@ -12,6 +12,7 @@ import { useCellIds } from "@/core/cells/cells";
 interface Props {
   maxCount: number;
   cellIds: CellId[];
+  skipScroll?: boolean;
   onClick?: (cellId: CellId) => void;
 }
 
@@ -19,6 +20,7 @@ export const CellLinkList: React.FC<Props> = ({
   maxCount,
   cellIds,
   onClick,
+  skipScroll,
 }) => {
   const cellIndex = useCellIds();
   const sortedCellIds = [...cellIds].sort((a, b) => {
@@ -37,6 +39,7 @@ export const CellLinkList: React.FC<Props> = ({
             variant="focus"
             key={cellId}
             cellId={cellId}
+            skipScroll={skipScroll}
             className="whitespace-nowrap"
             onClick={onClick ? () => onClick(cellId) : undefined}
           />

--- a/frontend/src/components/editor/links/cell-link.tsx
+++ b/frontend/src/components/editor/links/cell-link.tsx
@@ -8,13 +8,15 @@ import { useCellIds, useCellNames } from "@/core/cells/cells";
 interface Props {
   cellId: CellId;
   className?: string;
+  shouldScroll?: boolean;
+  skipScroll?: boolean;
   onClick?: () => void;
   variant?: "destructive" | "focus";
 }
 
 /* Component that adds a link to a cell, with styling. */
 export const CellLink = (props: Props): JSX.Element => {
-  const { className, cellId, variant, onClick } = props;
+  const { className, cellId, variant, onClick, skipScroll } = props;
   const cellName = useCellNames()[cellId] ?? "";
   const cellIndex = useCellIds().indexOf(cellId);
 
@@ -27,7 +29,7 @@ export const CellLink = (props: Props): JSX.Element => {
       onClick={(e) => {
         e.stopPropagation();
         e.preventDefault();
-        const succeeded = scrollToCell(cellId, variant);
+        const succeeded = scrollAndHighlightCell(cellId, variant, skipScroll);
         if (succeeded) {
           onClick?.();
         }
@@ -45,9 +47,10 @@ export const CellLinkError = (
   return <CellLink {...props} variant={"destructive"} />;
 };
 
-export function scrollToCell(
+export function scrollAndHighlightCell(
   cellId: CellId,
   variant?: "destructive" | "focus",
+  skipScroll?: boolean,
 ): boolean {
   const cellHtmlId = HTMLCellId.create(cellId);
   const cell: HTMLElement | null = document.getElementById(cellHtmlId);
@@ -56,7 +59,9 @@ export function scrollToCell(
     Logger.error(`Cell ${cellHtmlId} not found on page.`);
     return false;
   } else {
-    cell.scrollIntoView({ behavior: "smooth", block: "center" });
+    if (!skipScroll) {
+      cell.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
 
     if (variant === "destructive") {
       cell.classList.add("error-outline");

--- a/frontend/src/components/variables/common.tsx
+++ b/frontend/src/components/variables/common.tsx
@@ -3,19 +3,28 @@ import React from "react";
 import { toast } from "../ui/use-toast";
 import { Badge } from "../ui/badge";
 
-interface Props {
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
   name: string;
   declaredBy: string[];
 }
 
-export const VariableName: React.FC<Props> = ({ name, declaredBy }) => {
+export const VariableName: React.FC<Props> = ({
+  name,
+  declaredBy,
+  onClick,
+  ...rest
+}) => {
   return (
-    <div className="max-w-[130px]">
+    <div className="max-w-[130px]" {...rest}>
       <Badge
         title={name}
         variant={declaredBy.length > 1 ? "destructive" : "outline"}
         className="rounded-sm text-ellipsis block overflow-hidden max-w-fit cursor-pointer font-medium"
-        onClick={() => {
+        onClick={(evt) => {
+          if (onClick) {
+            onClick(evt);
+            return;
+          }
           navigator.clipboard.writeText(name);
           toast({ title: "Copied to clipboard" });
         }}

--- a/frontend/src/components/variables/variables-table.tsx
+++ b/frontend/src/components/variables/variables-table.tsx
@@ -137,6 +137,7 @@ const COLUMNS = [
               <CellLink
                 variant="focus"
                 cellId={declaredBy[0]}
+                skipScroll={true}
                 onClick={() => highlightInCell(declaredBy[0])}
               />
             ) : (
@@ -147,6 +148,7 @@ const COLUMNS = [
                       variant="focus"
                       key={cellId}
                       cellId={cellId}
+                      skipScroll={true}
                       className="whitespace-nowrap text-destructive"
                       onClick={() => highlightInCell(cellId)}
                     />
@@ -164,6 +166,7 @@ const COLUMNS = [
             <CellLinkList
               maxCount={3}
               cellIds={usedBy}
+              skipScroll={true}
               onClick={highlightInCell}
             />
           </div>

--- a/marimo/_smoke_tests/bugs/1362.py
+++ b/marimo/_smoke_tests/bugs/1362.py
@@ -1,0 +1,160 @@
+import marimo
+
+__generated_with = "0.5.2"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    """
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+
+    """
+    qwerty = 10
+    return qwerty,
+
+
+@app.cell
+def __(qwerty):
+    """
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+    hello, this is a cell
+
+    """
+    a = f"{qwerty} 10"
+    return a,
+
+
+@app.cell
+def __(a):
+    a
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #1362 

This improves the scroll to variable logic by using the syntax tree as well as using CodeMirrors scroll to focus