### PR TITLE
fix: enable rpcs unnamed UI elems

### DIFF
--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -200,6 +200,10 @@ class CellImpl:
     def set_output(self, output: Any) -> None:
         self._output.output = output
 
+    @property
+    def output(self) -> Any:
+        return self._output.output
+
 
 @dataclasses.dataclass
 class Cell:

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -80,6 +80,11 @@ class CellStaleState:
     state: bool = False
 
 
+@dataclasses.dataclass
+class CellOutput:
+    output: Any = None
+
+
 @dataclasses.dataclass(frozen=True)
 class CellImpl:
     # hash of code
@@ -99,9 +104,12 @@ class CellImpl:
     # Mutable fields
     # config: explicit configuration of cell
     config: CellConfig = dataclasses.field(default_factory=CellConfig)
-    # status: status, inferred at runtime
+    # status: execution status, inferred at runtime
     _status: CellStatus = dataclasses.field(default_factory=CellStatus)
+    # whether the cell is stale, inferred at runtime
     _stale: CellStaleState = dataclasses.field(default_factory=CellStaleState)
+    # cells can optionally hold a reference to their output
+    _output: CellOutput = dataclasses.field(default_factory=CellOutput)
 
     def configure(self, update: dict[str, Any] | CellConfig) -> CellImpl:
         """Update the cell config.
@@ -188,6 +196,9 @@ class CellImpl:
         CellOp.broadcast_stale(
             cell_id=self.cell_id, stale=stale, stream=stream
         )
+
+    def set_output(self, output: Any) -> None:
+        self._output.output = output
 
 
 @dataclasses.dataclass

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -557,10 +557,11 @@ class Kernel:
         `exclude_defs`, and instructs the frontend to invalidate its UI
         elements.
         """
+        cell = self.graph.cells[cell_id]
         missing_modules_before_deletion = (
             self.module_registry.missing_modules()
         )
-        defs_to_delete = self.graph.cells[cell_id].defs
+        defs_to_delete = cell.defs
         self._delete_names(
             defs_to_delete, exclude_defs if exclude_defs is not None else set()
         )
@@ -589,6 +590,7 @@ class Kernel:
                     isolated=is_python_isolated(),
                 ).broadcast()
 
+        cell.set_output(None)
         get_context().cell_lifecycle_registry.dispose(
             cell_id, deletion=deletion
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,3 +300,6 @@ extend-exclude = [
     "**/__demo__/*",
     "base64.test.ts",
 ]
+
+[tool.black]
+line-length = 79

--- a/tests/_cli/snapshots/ipynb.txt
+++ b/tests/_cli/snapshots/ipynb.txt
@@ -11,11 +11,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "MJUe",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "markdown"
+    "control_dep = None\n",
+    "mo.md(\"markdown\")"
    ]
   },
   {
@@ -25,6 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "control_dep\n",
     "mo.md(f\"parametrized markdown {123}\")"
    ]
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,11 +278,13 @@ def temp_marimo_file_with_md() -> Generator[str, None, None]:
 
         @app.cell
         def __(mo):
+            control_dep = None
             mo.md("markdown")
-            return
+            return control_dep
 
         @app.cell
-        def __(mo):
+        def __(mo, control_dep):
+            control_dep
             mo.md(f"parametrized markdown {123}")
             return
 


### PR DESCRIPTION
- if the output of a cell contains a UIElement, store a reference to it
- the stored reference is released when a cell's state is invalidated
  (on rerun, deletion, etc)

We check for UI elements by using flatten -- covers bare UI elements
and lists, tuples, dicts. Custom datastructures not supported but
should cover almost all real cases, including the very common
practice of ending a cell with `mo.ui.table()`.

- [x] unit tests