### PR TITLE
improvement: start cell editor in markdown if is markdown-compatible

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -241,6 +241,11 @@ const CellEditorInternal = ({
           }),
         });
         shouldFocus = true;
+        // Initialize the language adapter
+        switchLanguage(
+          editorViewRef.current,
+          getInitialLanguageAdapter(editorViewRef.current.state).type,
+        );
       } else {
         editorViewRef.current.dispatch({
           effects: [
@@ -264,6 +269,11 @@ const CellEditorInternal = ({
           { history: historyField },
         ),
       });
+      // Initialize the language adapter
+      switchLanguage(
+        editorViewRef.current,
+        getInitialLanguageAdapter(editorViewRef.current.state).type,
+      );
       shouldFocus = true;
       // Clear the serialized state so that we don't re-create the editor next time
       clearSerializedEditorState({ cellId });
@@ -288,14 +298,6 @@ const CellEditorInternal = ({
           block: "center",
         });
       });
-    }
-
-    // Initialize the language adapter
-    if (editorViewRef.current !== null) {
-      switchLanguage(
-        editorViewRef.current,
-        getInitialLanguageAdapter(editorViewRef.current.state).type,
-      );
     }
 
     // We don't want to re-run this effect when `allowFocus` or `code` changes

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -351,7 +351,7 @@ const CellEditorInternal = ({
         className="relative w-full"
         onFocus={() => setLastFocusedCellId(cellId)}
       >
-        {canUseMarkdown && (
+        {canUseMarkdown && !hidden && (
           <div className="absolute top-1 right-1">
             <LanguageToggle
               editorView={editorViewRef.current}

--- a/frontend/src/components/editor/cell/code/language-toggle.tsx
+++ b/frontend/src/components/editor/cell/code/language-toggle.tsx
@@ -9,7 +9,7 @@ import { startCase } from "lodash-es";
 import { LanguageAdapter } from "@/core/codemirror/language/types";
 
 interface Props {
-  editorView: EditorView;
+  editorView: EditorView | null;
   canUseMarkdown: boolean;
   languageAdapter: LanguageAdapter["type"] | undefined;
 }
@@ -40,6 +40,9 @@ export const LanguageToggle: React.FC<Props> = ({
             fill={"var(--sky-11)"}
             fontSize={20}
             onClick={() => {
+              if (!editorView) {
+                return;
+              }
               switchLanguage(editorView, otherLanguage);
             }}
           />

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -156,15 +156,18 @@ const {
 } = createReducerAndAtoms(initialNotebookState, {
   createNewCell: (
     state,
-    action: { cellId: CellId | "__end__"; before: boolean; code?: string },
+    action: { cellId: CellId | "__end__"; before: boolean; code?: string, newCellId?: CellId},
   ) => {
     const { cellId, before, code } = action;
+    let { newCellId } = action;
     const index =
       cellId === "__end__"
         ? state.cellIds.length - 1
         : state.cellIds.indexOf(cellId);
     const insertionIndex = before ? index : index + 1;
-    const newCellId = CellId.create();
+    if (!newCellId) {
+      newCellId = CellId.create();
+    }
 
     return {
       ...state,

--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -217,6 +217,9 @@ describe("MarkdownLanguageAdapter", () => {
     it("should return true for supported markdown string formats", () => {
       const pythonCode = 'mo.md("""# Markdown Title\n\nSome content here.""")';
       expect(adapter.isSupported(pythonCode)).toBe(true);
+      expect(adapter.isSupported("mo.md()")).toBe(true);
+      expect(adapter.isSupported("mo.md('')")).toBe(true);
+      expect(adapter.isSupported('mo.md("")')).toBe(true);
     });
 
     it("should return false for unsupported string formats", () => {

--- a/frontend/src/core/codemirror/language/extension.ts
+++ b/frontend/src/core/codemirror/language/extension.ts
@@ -15,6 +15,7 @@ import { completionConfigState } from "../config/extension";
 import { historyCompartment } from "../editing/extensions";
 import { history } from "@codemirror/commands";
 import { formattingChangeEffect } from "../format";
+import { getEditorCodeAsPython } from "./utils";
 
 export const LanguageAdapters: Record<
   LanguageAdapter["type"],
@@ -166,7 +167,7 @@ export function adaptiveLanguageConfiguration(
 }
 
 export function getInitialLanguageAdapter(state: EditorView["state"]) {
-  const doc = state.doc.toString();
+  const doc = getEditorCodeAsPython({ state });
   // Empty doc defaults to Python
   if (!doc.trim()) {
     return LanguageAdapters.python();

--- a/frontend/src/core/codemirror/language/extension.ts
+++ b/frontend/src/core/codemirror/language/extension.ts
@@ -165,6 +165,20 @@ export function adaptiveLanguageConfiguration(
   ];
 }
 
+export function getInitialLanguageAdapter(state: EditorView["state"]) {
+  const doc = state.doc.toString();
+  // Empty doc defaults to Python
+  if (!doc.trim()) {
+    return LanguageAdapters.python();
+  }
+
+  if (LanguageAdapters.markdown().isSupported(doc)) {
+    return LanguageAdapters.markdown();
+  }
+
+  return LanguageAdapters.python();
+}
+
 /**
  * Switch the language of the editor.
  */

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -90,6 +90,10 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
   }
 
   isSupported(pythonCode: string): boolean {
+    if (pythonCode.trim() === "mo.md()") {
+      return true;
+    }
+
     const markdownLines = pythonCode
       .trim()
       .split("\n")

--- a/frontend/src/core/codemirror/language/utils.ts
+++ b/frontend/src/core/codemirror/language/utils.ts
@@ -1,13 +1,14 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { EditorView } from "@codemirror/view";
 import { languageAdapterState } from "./extension";
+import { EditorState } from "@codemirror/state";
 
 /**
  * Get the editor code as Python
  * Handles when the editor has a different language adapter
  */
 export function getEditorCodeAsPython(
-  editor: EditorView,
+  editor: { state: EditorState},
   fromPos?: number,
   toPos?: number,
 ): string {


### PR DESCRIPTION
Open to discussing if we want this. but this will make every cell that is markdown compatible, start with the markdown editor