### PR TITLE
fix: formatting when no formatter is found

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -18,9 +18,7 @@ taking precedence over the MIME protocol.
 from __future__ import annotations
 
 import inspect
-import io
 import json
-import pprint
 import traceback
 import types
 from dataclasses import dataclass
@@ -33,6 +31,7 @@ from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._output.utils import flatten_string
 from marimo._plugins.stateless.json_output import json_output
+from marimo._plugins.stateless.plain_text import plain_text
 
 T = TypeVar("T")
 
@@ -130,22 +129,22 @@ def try_format(obj: Any) -> FormattedOutput:
                 traceback=traceback.format_exc(),
             )
     else:
-        tmpio = io.StringIO()
         tb = None
-        if isinstance(obj, str):
-            tmpio.write(obj)
+        try:
+            data = str(obj)
+        except Exception:
+            tb = traceback.format_exc()
+            return FormattedOutput(
+                mimetype="text/plain",
+                data="",
+                traceback=tb,
+            )
         else:
-            try:
-                pprint.pprint(obj, stream=tmpio)
-            except Exception:  # noqa: E722
-                tmpio.write("")
-                tb = traceback.format_exc()
-        tmpio.seek(0)
-        return FormattedOutput(
-            mimetype="text/plain",
-            data=tmpio.read(),
-            traceback=tb,
-        )
+            return FormattedOutput(
+                mimetype="text/html",
+                data=plain_text(data).text,
+                traceback=tb,
+            )
 
 
 @mddoc

--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -140,10 +140,18 @@ def try_format(obj: Any) -> FormattedOutput:
                 traceback=tb,
             )
         else:
-            return FormattedOutput(
-                mimetype="text/html",
-                data=plain_text(data).text,
-                traceback=tb,
+            return (
+                FormattedOutput(
+                    mimetype="text/html",
+                    data=plain_text(escape(data)).text,
+                    traceback=tb,
+                )
+                if data
+                else FormattedOutput(
+                    mimetype="text/plain",
+                    data="",
+                    traceback=tb,
+                )
             )
 
 

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -36,6 +36,10 @@ class KernelRuntimeContext(RuntimeContext):
         return self._kernel.graph
 
     @property
+    def globals(self) -> dict[str, Any]:
+        return self._kernel.globals
+
+    @property
     def execution_context(self) -> ExecutionContext | None:
         return self._kernel.execution_context
 
@@ -68,10 +72,6 @@ class KernelRuntimeContext(RuntimeContext):
         if self._id_provider is None:
             raise NoIDProviderException
         return self._id_provider.take_id()
-
-    @property
-    def globals(self) -> dict[str, Any]:
-        return self._kernel.globals
 
     def get_ui_initial_value(self, object_id: str) -> Any:
         return self._kernel.get_ui_initial_value(object_id)

--- a/marimo/_runtime/context/script_context.py
+++ b/marimo/_runtime/context/script_context.py
@@ -40,6 +40,10 @@ class ScriptRuntimeContext(RuntimeContext):
         return self._app.graph
 
     @property
+    def globals(self) -> dict[str, Any]:
+        return {}
+
+    @property
     def execution_context(self) -> ExecutionContext | None:
         return self._app.execution_context
 

--- a/marimo/_runtime/context/types.py
+++ b/marimo/_runtime/context/types.py
@@ -74,6 +74,11 @@ class RuntimeContext(abc.ABC):
 
     @property
     @abc.abstractmethod
+    def globals(self) -> dict[str, Any]:
+        pass
+
+    @property
+    @abc.abstractmethod
     def execution_context(self) -> ExecutionContext | None:
         pass
 


### PR DESCRIPTION
- just print plaintext of str(obj): this is better for some objects, plus pprint can fail when str() doesn't
- without this, attempting to outupt duckdb.read_csv() failed

![image](https://github.com/marimo-team/marimo/assets/1994308/a93768e8-2aa9-48a1-9358-e83a8db26ed1)
