### PR TITLE
enable SetUIElementValue on unnamed elements

### DIFF
--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -107,11 +107,6 @@ class UIElementRegistry:
     def get_object(self, object_id: UIElementId) -> UIElement[Any, Any]:
         if object_id not in self._objects:
             raise KeyError(f"UIElement with id {object_id} not found")
-        # UI elements are only updated if a global is bound to it. This ensures
-        # that the UI element update triggers reactivity, but also means that
-        # elements stored as, say, attributes on an object won't be updated.
-        if not self.bound_names(object_id):
-            raise NameError(f"UIElement with id {object_id} has no bindings")
         obj = self._objects[object_id]()
         assert obj is not None
         return obj

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1027,10 +1027,9 @@ class Kernel:
                     object_id,
                     value,
                 )
-            except (KeyError, NameError):
+            except KeyError:
                 # KeyError: A UI element may go out of scope if it was not
                 # assigned to a global variable
-                # NameError: UI element might not have bindings
                 LOGGER.debug("Could not find UIElement with id %s", object_id)
                 continue
 


### PR DESCRIPTION
This is needed to give make mo.ui.dataframe() work when unnamed (RPC alone wasn't enough).

This also enables on_change to work on unnamed elements, as long as someone is holding a reference to the element.