### PR TITLE
fix: don't break on vendored dependencies

### DIFF
--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -82,7 +82,9 @@ def register_formatters() -> None:
     for finder in sys.meta_path:
         # Note: "Vendored" dependencies may not have a find_spec method.
         # E.g. `six` bundled with a project.
-        original_find_spec = getattr(finder, "find_spec", lambda x: x)
+        original_find_spec = getattr(finder, "find_spec", None)
+        if original_find_spec is None:
+            continue
 
         # We include `original_find_spec` as a kwarg to force it to be bound
         # to the new `find_spec` method; this is needed because closures are

--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -80,7 +80,9 @@ def register_formatters() -> None:
     # Because Python's import system caches modules, our formatters'
     # register methods will be called at most once.
     for finder in sys.meta_path:
-        original_find_spec = finder.find_spec
+        # Note: "Vendored" dependencies may not have a find_spec method.
+        # E.g. `six` bundled with a project.
+        original_find_spec = getattr(finder, "find_spec", lambda x: x)
 
         # We include `original_find_spec` as a kwarg to force it to be bound
         # to the new `find_spec` method; this is needed because closures are


### PR DESCRIPTION
# Pull Request Template

## 📝 Summary

Running some old converted jupyter notebooks gave me a kernel failure:

```txt
Process Process-1:                                                                                                                                                                                                               
Traceback (most recent call last):                                                                                                                                                                                               
  File "/nix/store/ddhcwc8k9ma093n5vlpa9l617p4q2cax-python3-3.10.5/lib/python3.10/multiprocessing/process.py", line 315, in _bootstrap                                                                                           
    self.run()                                                                                                                                                                                                                   
  File "/nix/store/ddhcwc8k9ma093n5vlpa9l617p4q2cax-python3-3.10.5/lib/python3.10/multiprocessing/process.py", line 108, in run                                                                                                  
    self._target(*self._args, **self._kwargs)                                                                                                                                                                                    
  File "/home/dylan/.cache/bazel/_bazel_dylan/8bbdcf70ee87482f767b06aac75f66d1/execroot/drt/bazel-out/k8-fastbuild/bin/notebooks/marimo.runfiles/deps/pypi__marimo/marimo/_runtime/runtime.py", line 1397, in launch_kernel      
    register_formatters()                                                                                                                                                                                                        
  File "/home/dylan/.cache/bazel/_bazel_dylan/8bbdcf70ee87482f767b06aac75f66d1/execroot/drt/bazel-out/k8-fastbuild/bin/notebooks/marimo.runfiles/deps/pypi__marimo/marimo/_output/formatters/formatters.py", line 83, in register
_formatters                                                                                                                                                                                                                      
    original_find_spec = finder.find_spec                                                                                                                                                                                        
AttributeError: '_SixMetaPathImporter' object has no attribute 'find_spec'  
```

It looks like certain packages will "vendor" or include their own version of a package- e.g. with six<1.16 is this was common: https://blog.pecar.me/six-warnings

The blog post suggests just updating deps, which is fair- but their issue also didn't cause failure, just warnings

## 🔍 Description of Changes

use `gettatr` and set default
I don't really know the broader implications of this? Might be a won't fix, just wanted to document it either way

## 🛠️ Additional Information

<!-- 
Include any additional information or context that might be helpful for reviewers. This could include additional dependencies, screenshots, performance improvements, or any other relevant information.
-->

## 📋 Checklist Before Submitting

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md) and the Pull Request section.
- [ ] This PR fixes an issue (If applicable, specify issue number #).
- [ ] This change was discussed or approved through an issue or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added necessary tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 🧩 Related Issues

<!-- 
If this PR fixes any issues, list them here by number (e.g., Fixes #123). 
-->

## 📜 Who Can Review?

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request. This helps expedite the review process and ensures that the PR receives timely attention.
-->

<!-- Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
