### PR TITLE
fix: renaming a file extension should save in file format

### DIFF
--- a/marimo/_server/file_manager.py
+++ b/marimo/_server/file_manager.py
@@ -139,7 +139,9 @@ class AppFileManager:
         self._assert_path_does_not_exist(new_filename)
 
         need_save = False
-        # Explicitly check filename to satisfy mypy.
+        # Check if filename is not None to satisfy mypy's type checking.
+        # This ensures that filename is treated as a non-optional str,
+        # preventing potential type errors in subsequent code.
         if self._is_named() and self.filename is not None:
             # Force a save after rename in case filetype changed.
             need_save = self.filename[-3:] != new_filename[-3:]

--- a/marimo/_server/file_manager.py
+++ b/marimo/_server/file_manager.py
@@ -138,12 +138,24 @@ class AppFileManager:
 
         self._assert_path_does_not_exist(new_filename)
 
-        if self._is_named():
+        need_save = False
+        # Explicitly check filename to satisfy mypy.
+        if self._is_named() and self.filename is not None:
+            # Force a save after rename in case filetype changed.
+            need_save = self.filename[-3:] != new_filename[-3:]
             self._rename_file(new_filename)
         else:
             self._create_file(new_filename)
 
         self.filename = new_filename
+        if need_save:
+            self._save_file(
+                self.filename,
+                list(self.app.cell_manager.codes()),
+                list(self.app.cell_manager.names()),
+                list(self.app.cell_manager.configs()),
+                self.app.config,
+            )
 
     def read_layout_config(self) -> Optional[LayoutConfig]:
         if self.app.config.layout_file is not None and isinstance(

--- a/tests/_server/test_file_manager.py
+++ b/tests/_server/test_file_manager.py
@@ -106,6 +106,21 @@ def test_rename_create_new_file(app_file_manager: AppFileManager) -> None:
         os.remove(new_filename)
 
 
+def test_rename_different_filetype(app_file_manager: AppFileManager) -> None:
+    initial_filename = app_file_manager.filename
+    assert initial_filename.endswith(".py")
+    with open(app_file_manager.filename, "r") as f:
+        contents = f.read()
+        assert "app = marimo.App()" in contents
+        assert "marimo-version" not in contents
+    app_file_manager.rename(initial_filename[:-3] + ".md")
+    assert app_file_manager.filename.endswith(".md")
+    with open(app_file_manager.filename, "r") as f:
+        contents = f.read()
+        assert "marimo-version" in contents
+        assert "app = marimo.App()" not in contents
+
+
 def test_save_app_config_valid(app_file_manager: AppFileManager) -> None:
     app_file_manager.filename = "app_config.py"
     try:


### PR DESCRIPTION
# Pull Request Template

Sorry for the spam, I just patch these things as I find them.

## 📝 Summary

I was converting some notebooks today, and used the rename functionality to go from py -> md. I noticed that if I didn't save after the rename, I'd end up with a markdown file with Python content.

## 🔍 Description of Changes

Fix just runs save if the suffix is different