### PR TITLE
fix: limit console outputs to last 5000 lines per cell

### DIFF
--- a/frontend/src/core/cells/__tests__/collapseConsoleOutputs.test.ts
+++ b/frontend/src/core/cells/__tests__/collapseConsoleOutputs.test.ts
@@ -144,4 +144,96 @@ describe("collapseConsoleOutputs", () => {
     expect(result[0]).not.toBe(consoleOutputs[0]);
     expect(result[1]).not.toBe(consoleOutputs[1]);
   });
+
+  it("should truncate head of text/plain single message", () => {
+    const consoleOutputs: OutputMessage[] = [
+      {
+        mimetype: "text/plain",
+        channel: "output",
+        data: "Hello\nWorld\nBye\nWorld",
+        timestamp: 0,
+      },
+    ];
+    const result = collapseConsoleOutputs(consoleOutputs, 2);
+    expect(result.length).toBe(2);
+    // First result is a warning re: truncation
+    expect(result[0].data).toContain("Streaming output truncated");
+    // First two lines are truncated
+    expect(result[1].data).toBe("Bye\nWorld");
+  });
+
+  it("should truncate head of text/plain multiple channels", () => {
+    const consoleOutputs: OutputMessage[] = [
+      {
+        mimetype: "text/plain",
+        channel: "stdout",
+        data: "A\nB\nC\nD\n",
+        timestamp: 0,
+      },
+      {
+        mimetype: "text/plain",
+        channel: "stderr",
+        data: "E\nF\nG\nH\n",
+        timestamp: 0,
+      },
+    ];
+    const result = collapseConsoleOutputs(consoleOutputs, 7);
+    expect(result.length).toBe(3);
+    // First result is a warning re: truncation
+    expect(result[0].data).toContain("Streaming output truncated");
+    // First two lines are truncated, leaving 2 lines
+    expect(result[1].data).toBe("D\n");
+    // No truncation: 5 lines, for a total of 2 + 5 = 7 lines
+    expect(result[2].data).toBe("E\nF\nG\nH\n");
+  });
+
+  it("should truncate head of text/plain same channel", () => {
+    const consoleOutputs: OutputMessage[] = [
+      {
+        mimetype: "text/plain",
+        channel: "stdout",
+        data: "A\nB\nC\nD\n",
+        timestamp: 0,
+      },
+      {
+        mimetype: "text/plain",
+        channel: "stdout",
+        data: "E\nF\nG\nH\n",
+        timestamp: 0,
+      },
+    ];
+    const result = collapseConsoleOutputs(consoleOutputs, 7);
+    // 1 warning message, and 1 message containing merged stdout
+    expect(result.length).toBe(2);
+    // First result is a warning re: truncation
+    expect(result[0].data).toContain("Streaming output truncated");
+    // First two lines are truncated
+    expect(result[1].data).toBe("C\nD\nE\nF\nG\nH\n");
+  });
+
+  it("should truncate head with text/html counting as one line", () => {
+    const consoleOutputs: OutputMessage[] = [
+      {
+        mimetype: "text/plain",
+        channel: "stdout",
+        data: "A\nB\nC\nD\n",
+        timestamp: 0,
+      },
+      {
+        mimetype: "text/html",
+        channel: "output",
+        data: "<pre>E\nF\nG\nH\n</pre>",
+        timestamp: 0,
+      },
+    ];
+    const result = collapseConsoleOutputs(consoleOutputs, 3);
+    // 1 warning message, and 1 message containing merged stdout
+    expect(result.length).toBe(3);
+    // First result is a warning re: truncation
+    expect(result[0].data).toContain("Streaming output truncated");
+    // 2 lines
+    expect(result[1].data).toBe("D\n");
+    // heuristic: non-text counts as 1 line ...
+    expect(result[2].data).toBe("<pre>E\nF\nG\nH\n</pre>");
+  });
 });

--- a/frontend/src/core/cells/collapseConsoleOutputs.tsx
+++ b/frontend/src/core/cells/collapseConsoleOutputs.tsx
@@ -8,11 +8,12 @@ import { invariant } from "@/utils/invariant";
  */
 export function collapseConsoleOutputs(
   consoleOutputs: OutputMessage[],
+  maxLines = 5000,
 ): OutputMessage[] {
   const newConsoleOutputs = [...consoleOutputs];
 
   if (newConsoleOutputs.length < 2) {
-    return handleCarriageReturns(newConsoleOutputs);
+    return truncateHead(handleCarriageReturns(newConsoleOutputs), maxLines);
   }
 
   const lastOutput = newConsoleOutputs[newConsoleOutputs.length - 1];
@@ -26,7 +27,7 @@ export function collapseConsoleOutputs(
     newConsoleOutputs.pop();
   }
 
-  return truncateHead(handleCarriageReturns(newConsoleOutputs), 5000);
+  return truncateHead(handleCarriageReturns(newConsoleOutputs), maxLines);
 }
 
 function shouldCollapse(
@@ -92,18 +93,18 @@ function handleCarriageReturns(
 }
 
 function truncateHead(consoleOutputs: OutputMessage[], limit: number) {
-  let n_lines = 0;
+  let nLines = 0;
   let i;
-  for (i = consoleOutputs.length - 1; i >= 0 && n_lines < limit; i--) {
+  for (i = consoleOutputs.length - 1; i >= 0 && nLines < limit; i--) {
     const output = consoleOutputs[i];
     if (output.mimetype === "text/plain") {
-      n_lines += output.data.split("\n").length;
+      nLines += output.data.split("\n").length;
     } else {
-      n_lines++;
+      nLines++;
     }
   }
 
-  if (n_lines < limit) {
+  if (nLines < limit) {
     return consoleOutputs;
   }
 
@@ -117,11 +118,11 @@ function truncateHead(consoleOutputs: OutputMessage[], limit: number) {
   const output = consoleOutputs[cutoff];
   if (output.mimetype == "text/plain") {
     const output_lines = output.data.split("\n");
-    const n_lines_after_output = n_lines - output_lines.length;
-    const n_lines_to_keep = limit - n_lines_after_output;
+    const nLinesAfterOutput = nLines - output_lines.length;
+    const nLinesToKeep = limit - nLinesAfterOutput;
     return [
       warningOutput,
-      { ...output, data: output_lines.slice(-n_lines_to_keep).join("\n") },
+      { ...output, data: output_lines.slice(-nLinesToKeep).join("\n") },
       ...consoleOutputs.slice(cutoff + 1),
     ];
   } else {


### PR DESCRIPTION
# Pull Request Template

## 📝 Summary

Limit console outputs to last 5000 lines per cell. Fixes #1380 


## 🔍 Description of Changes

This PR limits the number of lines shown in the console output per cell to avoid overloading the frontend. The tail of the console output is shown, limited to 5000 lines.

## 🛠️ Additional Information

The number 5000 was chosen by comparison to Google Colab.

<img width="724" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/ccae24d5-e60a-485d-9a61-ef3a6f8c3b7a">


## 📋 Checklist Before Submitting

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md) and the Pull Request section.
- [x] This PR fixes an issue (If applicable, specify issue number #).
- [x] This change was discussed or approved through an issue or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added necessary tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 🧩 Related Issues

Fixes #1380 

## 📜 Who Can Review?

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request. This helps expedite the review process and ensures that the PR receives timely attention.
-->

<!-- Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
