### PR TITLE
fix: random ids for ui elements made in functions

### DIFF
--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -62,11 +62,12 @@ class KernelRuntimeContext(RuntimeContext):
 
     @contextmanager
     def provide_ui_ids(self, prefix: str) -> Iterator[None]:
+        old_id_provider = self._id_provider
         try:
             self._id_provider = IDProvider(prefix)
             yield
         finally:
-            self._id_provider = None
+            self._id_provider = old_id_provider
 
     def take_id(self) -> str:
         if self._id_provider is None:


### PR DESCRIPTION
RPC triggered creation of a UI element (`altair_chart`), which then incorrectly evicted an existing UI element from the registry.

PR is exactly the same as #1397 -- pulling it out into its own PR so it's not blocked on routes. We can close #1397 after merging this.