### PR TITLE
fix: check python id before deleting UI element

### DIFF
--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -151,8 +151,10 @@ class UIElementRegistry:
             return
 
         ui_element = self._objects[object_id]()
-        del self._objects[object_id]
-
+        # We guard against UIElement's destructor racing against
+        # registration of another element when a cell re-runs by checking
+        # the Python object id. This isn't perfect because python ids can
+        # be reused ...
         registered_python_id = (
             id(ui_element) if ui_element is not None else None
         )
@@ -160,8 +162,6 @@ class UIElementRegistry:
             registered_python_id is not None
             and registered_python_id != python_id
         ):
-            # guards against UIElement's destructor racing against
-            # registration of another element when a cell re-runs
             return
 
         try:
@@ -175,3 +175,4 @@ class UIElementRegistry:
             del self._bindings[object_id]
         if object_id in self._constructing_cells:
             del self._constructing_cells[object_id]
+        del self._objects[object_id]

--- a/tests/_plugins/ui/_core/test_registry.py
+++ b/tests/_plugins/ui/_core/test_registry.py
@@ -168,3 +168,25 @@ async def test_parent_bound_to_view(
     array = k.globals["array"]
     registry = get_context().ui_element_registry
     assert registry.bound_names(array._id) == set(["array", "child"])
+
+
+async def test_dont_delete_element_with_wrong_python_id(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    await k.run(
+        [
+            exec_req.get("import marimo as mo"),
+            exec_req.get(
+                """
+                s = mo.ui.slider(1, 10)
+                """
+            ),
+        ]
+    )
+    # Make sure that the slider is registered
+    s = k.globals["s"]
+    assert get_context().ui_element_registry.get_object(s._id) == s
+
+    # If the Python id doesn't match, don't delete the object.
+    get_context().ui_element_registry.delete(s._id, -1)
+    assert get_context().ui_element_registry.get_object(s._id) == s


### PR DESCRIPTION
## 📝 Summary

Fix a regression in which we were accidentally removing a UI element from the registry.

Fixes #1438 

## 🔍 Description of Changes

Need to test the Python id in addition to the object id.

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
