### PR TITLE
fix: base64 encode vfile buffers in html export

### DIFF
--- a/marimo/_output/utils.py
+++ b/marimo/_output/utils.py
@@ -8,6 +8,7 @@ from marimo._messaging.mimetypes import KnownMimeType
 
 
 def build_data_url(mimetype: KnownMimeType, data: bytes) -> str:
+    # `data` must be base64 encoded
     str_repr = data.decode("utf-8").replace("\n", "")
     return f"data:{mimetype};base64,{str_repr}"
 

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import base64
 import io
 import mimetypes
 import os
@@ -61,7 +62,8 @@ class Exporter:
                 None,
             )
             files[filename_and_length] = build_data_url(
-                cast(KnownMimeType, mime_type), buffer_contents
+                cast(KnownMimeType, mime_type),
+                base64.b64encode(buffer_contents),
             )
 
         config = _deep_copy(DEFAULT_CONFIG)


### PR DESCRIPTION
## 📝 Summary

Fixes a bug in which notebooks containing images and other media couldn't be exported as HTML (reported on Discord).


## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
