### PR TITLE
fix: button styling with nested markdown

### DIFF
--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -156,8 +156,7 @@
 /* stylelint-disable unit-allowed-list */
 
 /* pad iconify-icon when next to text */
-a .markdown .paragraph:has(iconify-icon),
-button .markdown .paragraph:has(iconify-icon) {
+a .markdown .paragraph:has(iconify-icon) {
   gap: 0.4em;
 }
 
@@ -169,7 +168,12 @@ a .markdown iconify-icon:first-child {
 /* align icons with buttons better */
 button .markdown .paragraph {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
+  gap: 0.4em;
+
+  iconify-icon {
+    align-self: center;
+  }
 }
 
 /* stylelint-enable unit-allowed-list */


### PR DESCRIPTION
## after 

<img width="344" alt="Screenshot 2024-05-22 at 3 01 59 PM" src="https://github.com/marimo-team/marimo/assets/2753772/59647372-3287-47af-835c-f0be75cdc713">

## before

<img width="476" alt="Screenshot 2024-05-22 at 3 01 43 PM" src="https://github.com/marimo-team/marimo/assets/2753772/8b27ee48-6b5f-464e-8610-75758ef0bab3">
