### PR TITLE
fix: check mimetype when merging console outputs in BE

### DIFF
--- a/marimo/_messaging/console_output_worker.py
+++ b/marimo/_messaging/console_output_worker.py
@@ -49,6 +49,10 @@ def _write_console_output(
     ).broadcast(stream)
 
 
+def _can_merge_outputs(first: ConsoleMsg, second: ConsoleMsg) -> bool:
+    return first.stream == second.stream and first.mimetype == second.mimetype
+
+
 def _add_output_to_buffer(
     console_output: ConsoleMsg,
     outputs_buffered_per_cell: dict[CellId_t, list[ConsoleMsg]],
@@ -59,7 +63,7 @@ def _add_output_to_buffer(
         if cell_id in outputs_buffered_per_cell
         else None
     )
-    if buffer and buffer[-1].stream == console_output.stream:
+    if buffer and _can_merge_outputs(buffer[-1], console_output):
         buffer[-1].data += console_output.data
     elif buffer:
         buffer.append(console_output)

--- a/marimo/_smoke_tests/admonitions.py
+++ b/marimo/_smoke_tests/admonitions.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.6.0"


### PR DESCRIPTION
The backend merges console outputs when it can before sending them to the frontend, but we weren't checking the mimetype (since they all used to be `text/plain`). This was causing tracebacks (text/html) to be incorrectly merged with `text/plain` stderr messages.