### PR TITLE
fix: boolean parsing for pandas and ui.table

### DIFF
--- a/frontend/src/css/admonition.css
+++ b/frontend/src/css/admonition.css
@@ -25,6 +25,7 @@
 
   .paragraph {
     font-weight: initial;
+
     @apply text-foreground tracking-normal;
   }
 }

--- a/frontend/src/plugins/impl/vega/loader.ts
+++ b/frontend/src/plugins/impl/vega/loader.ts
@@ -53,7 +53,7 @@ const customNumberParser = (v: string) => {
 // Pandas serializes booleans as True/False, but JSON (and vega) requires
 // lowercase
 const customBooleanParser = (v: string) => {
-  if (v == "True") {
+  if (v === "True") {
     return true;
   }
   if (v === "False") {

--- a/frontend/src/plugins/impl/vega/loader.ts
+++ b/frontend/src/plugins/impl/vega/loader.ts
@@ -5,6 +5,7 @@ import { typeParsers, createLoader, read, FieldTypes } from "./vega-loader";
 
 // Augment the typeParsers to support Date
 typeParsers.date = (value: string) => new Date(value).toISOString();
+const previousBooleanParser = typeParsers.boolean;
 const previousNumberParser = typeParsers.number;
 const previousIntegerParser = typeParsers.integer;
 
@@ -46,6 +47,22 @@ const customNumberParser = (v: string) => {
   }
   return previousNumberParser(v);
 };
+
+// Custom boolean parser:
+//
+// Pandas serializes booleans as True/False, but JSON (and vega) requires
+// lowercase
+const customBooleanParser = (v: string) => {
+  if (v == "True") {
+    return true;
+  }
+  if (v === "False") {
+    return false;
+  }
+  return previousBooleanParser(v);
+};
+
+typeParsers.boolean = customBooleanParser;
 
 function enableBigInt() {
   typeParsers.integer = customIntegerParser;


### PR DESCRIPTION
Implement a custom boolean parser on the frontend that accounts for the fact that pandas serialized bools start with uppercase letters.

Fixes #1459 