### PR TITLE
feat: add output replace_by_index function

### DIFF
--- a/frontend/e2e-tests/output.spec.ts
+++ b/frontend/e2e-tests/output.spec.ts
@@ -25,5 +25,9 @@ test("it can clear and append output", async ({ page }) => {
   // Test that Cleared does not exist
   await expect(page.getByText("Cleared!")).not.toBeVisible();
 
+  // Test that Replaced by index is visible and To be replaced is not
+  await expect(page.getByText("To be replaced.")).not.toBeVisible();
+  await expect(page.getByText("Replaced by index!")).toBeVisible();
+
   await takeScreenshot(page, __filename);
 });

--- a/frontend/e2e-tests/py/output.py
+++ b/frontend/e2e-tests/py/output.py
@@ -55,5 +55,12 @@ def __(loop_append, mo):
     return
 
 
+@app.cell
+def __(mo):
+    mo.output.append("To be replaced.")
+    mo.output.replace_at_index(mo.md("Replaced by index!"), 0)
+    return
+
+
 if __name__ == "__main__":
     app.run()

--- a/marimo/_runtime/output/__init__.py
+++ b/marimo/_runtime/output/__init__.py
@@ -5,6 +5,12 @@ __all__ = [
     "append",
     "clear",
     "replace",
+    "replace_at_index",
 ]
 
-from marimo._runtime.output._output import append, clear, replace
+from marimo._runtime.output._output import (
+    append,
+    clear,
+    replace,
+    replace_at_index,
+)

--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -45,6 +45,36 @@ def replace(value: object) -> None:
 
 
 @mddoc
+def replace_at_index(value: object, idx: int) -> None:
+    """Replace a cell's output at the given index with value.
+
+    Call this function to replace an existing object in a cell's output. If idx
+    is equal to the length of the output, this is equivalent to an append.
+
+    **Args:**
+
+    - `value`: new object to replace an existing object
+    - `idx`: index of output to replace
+    """
+
+    ctx = get_context()
+    if ctx.execution_context is None or ctx.execution_context.output is None:
+        return
+    elif idx > len(ctx.execution_context.output):
+        raise IndexError(
+            f"idx is {idx}, must be <= {len(ctx.execution_context.output)}"
+        )
+    elif idx == len(ctx.execution_context.output):
+        ctx.execution_context.output.append(formatting.as_html(value))
+    else:
+        ctx.execution_context.output[idx] = formatting.as_html(value)
+    write_internal(
+        cell_id=ctx.execution_context.cell_id,
+        value=vstack(ctx.execution_context.output),
+    )
+
+
+@mddoc
 def append(value: object) -> None:
     """Append a new object to a cell's output.
 

--- a/marimo/_smoke_tests/output.py
+++ b/marimo/_smoke_tests/output.py
@@ -107,5 +107,11 @@ def __(time):
     return
 
 
+@app.cell
+def __(mo):
+    mo.output.append(mo.md("To be replaced."))
+    mo.output.replace_at_index(mo.md("Replaced at index"), 0)
+
+
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
## 📝 Summary

This PR adds an output function `replace_at_index` which allows a specific index of the output to be replaced.

The intended use case is something like this:

```python
import marimo as mo
import time

for i in mo.status.progress_bar(range(10)):
    time.sleep(0.5)
    mo.output.replace_at_index(mo.md(f'Iteration: {i}'), 1)
```

Closes #1417 

## 🔍 Description of Changes

This adds the `mo.output.replace_at_index` function, which allows a specific index of the output to be replaced. If the index is equal to the length of the output, this is equivalent to an append, so that the use case above works.

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). #1417 
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
