### PR TITLE
fix: helper message to open the native browser search, fix when a dialog is open

### DIFF
--- a/frontend/src/components/find-replace/find-replace.tsx
+++ b/frontend/src/components/find-replace/find-replace.tsx
@@ -32,6 +32,8 @@ import {
   clearGlobalSearchQuery,
   setGlobalSearchQuery,
 } from "@/core/codemirror/find-replace/search-highlight";
+import { KeyboardHotkeys } from "../shortcuts/renderShortcut";
+import { HOTKEYS } from "@/core/hotkeys/hotkeys";
 
 export const FindReplace: React.FC = () => {
   const [isFocused, setIsFocused] = useState(false);
@@ -261,6 +263,13 @@ export const FindReplace: React.FC = () => {
               {currentMatch + 1} of {matches.count}
             </span>
           )}
+        </div>
+        <div className="text-xs text-muted-foreground flex gap-1 mt-2">
+          Press{" "}
+          <KeyboardHotkeys
+            shortcut={HOTKEYS.getHotkey("cell.findAndReplace").key}
+          />{" "}
+          again to open the native browser search.
         </div>
       </div>
     </FocusScope>

--- a/frontend/src/core/codemirror/find-replace/state.ts
+++ b/frontend/src/core/codemirror/find-replace/state.ts
@@ -91,13 +91,14 @@ export const findReplaceAtom = atomWithReducer<FindReplaceState, Action>(
 
 export function openFindReplacePanel(initialView?: EditorView): boolean {
   // If any radix dialog is open, don't open the find/replace panel
-  // they have role="dialog" and data-state="open" and has children
-  const element = document.querySelector('[role="dialog"][data-state="open"]');
-  if (
-    element &&
-    element instanceof HTMLElement &&
-    element.children.length > 0
-  ) {
+  // if they have role="dialog" and data-state="open" and has children
+  const element = document.querySelectorAll(
+    '[role="dialog"][data-state="open"]',
+  );
+  const someHasChildren = [...element].some(
+    (el) => el instanceof HTMLElement && el.childNodes.length > 0,
+  );
+  if (someHasChildren) {
     return false;
   }
 


### PR DESCRIPTION
## 📝 Summary

* add helper message to open the native browser search
* fix when a dialog is open

## 🔍 Description of Changes

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
