### PR TITLE
Add markdown edgecase test

### DIFF
--- a/tests/_cli/snapshots/unsafe-doc.md.txt
+++ b/tests/_cli/snapshots/unsafe-doc.md.txt
@@ -63,3 +63,18 @@ print("Hello, World!")
 ```
 
 -->
+
+<!-- from the notebook, should remain unchanged -->
+
+````{.python.marimo}
+mo.md("""
+  This is a markdown cell with an execution block in it
+  ```{python}
+  # To ambiguous to convert
+  ```
+  """)
+````
+
+```{.python.marimo}
+
+```

--- a/tests/_cli/snapshots/unsafe-doc.py.txt
+++ b/tests/_cli/snapshots/unsafe-doc.py.txt
@@ -131,8 +131,26 @@ def __(mo):
         ```
 
         -->
+
+        <!-- from the notebook, should remain unchanged -->
         """
     )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md("""
+      This is a markdown cell with an execution block in it
+      ```{python}
+      # To ambiguous to convert
+      ```
+      """)
+    return
+
+
+@app.cell
+def __():
     return
 
 

--- a/tests/_cli/test_markdown_conversion.py
+++ b/tests/_cli/test_markdown_conversion.py
@@ -284,6 +284,17 @@ def test_md_to_python_code_injection() -> None:
     ```
 
     -->
+
+    <!-- from the notebook, should remain unchanged -->
+    ````{.python.marimo}
+    mo.md(\"""
+      This is a markdown cell with an execution block in it
+      ```{python}
+      # To ambiguous to convert
+      ```
+      \""")
+    ````
+
     """[1:]
     )
 


### PR DESCRIPTION
## 📝 Summary

Not sure what happened, but I noticed that markdown strings do not preserve `r` or `f.` Which causes breakage
Currently effecting the markdown_format tutorial (open it directly and then close).

Opening as a min repro, but I can make an issue too

## 🔍 Description of Changes

Added snapshot tests from scratch

## 📋 Checklist

@akshayka OR @mscolnick
