### PR TITLE
UX improvement: panel footer icons -> sidebar

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -7,6 +7,7 @@ import {
   type ImperativePanelHandle,
 } from "react-resizable-panels";
 import { Footer } from "./footer";
+import { Sidebar } from "./sidebar";
 import "./app-chrome.css";
 import { useChromeActions, useChromeState } from "../state";
 import { cn } from "@/utils/cn";
@@ -114,8 +115,8 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       collapsedSize={0}
       collapsible={true}
       className={cn(
-        "bg-white dark:bg-[var(--slate-1)] rounded-lg no-print shadow-mdNeutral",
-        isOpen && "m-4",
+        "bg-white dark:bg-[var(--slate-1)] no-print",
+        isOpen && "ml-12 border-r border-l border-[var(--slate-7)]",
       )}
       minSize={10}
       // We can't make the default size greater than 0, otherwise it will start open
@@ -150,8 +151,11 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
         direction={panelLocation === "left" ? "horizontal" : "vertical"}
         storage={createStorage(panelLocation)}
       >
-        {panelLocation === "left" ? helperPane : appBody}
-        {panelLocation === "left" ? appBody : helperPane}
+        {/*If we ever support panelLocation !== left, this layout needs to be
+        updated */}
+        <Sidebar />
+        {helperPane}
+        {appBody}
       </PanelGroup>
       <ErrorBoundary>
         <Footer />

--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -73,7 +73,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       className={cn(
         "border-border no-print z-10",
         isOpen ? "resize-handle" : "resize-handle-collapsed",
-        panelLocation === "left" ? "vertical" : "horizontal",
+        panelLocation === "left" ? "vertical" : "horizontal"
       )}
     />
   );
@@ -116,7 +116,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       collapsible={true}
       className={cn(
         "bg-white dark:bg-[var(--slate-1)] no-print",
-        isOpen && "ml-12 border-r border-l border-[var(--slate-7)]",
+        isOpen && "ml-12 border-r border-l border-[var(--slate-7)]"
       )}
       minSize={10}
       // We can't make the default size greater than 0, otherwise it will start open
@@ -143,6 +143,8 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
     </Panel>
   );
 
+  // If we ever support panelLocation !== left, this layout needs to be
+  // updated.
   return (
     <div className="flex flex-col flex-1 overflow-hidden absolute inset-0">
       <PanelGroup
@@ -151,8 +153,6 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
         direction={panelLocation === "left" ? "horizontal" : "vertical"}
         storage={createStorage(panelLocation)}
       >
-        {/*If we ever support panelLocation !== left, this layout needs to be
-        updated */}
         <Sidebar />
         {helperPane}
         {appBody}

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -1,12 +1,10 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import React, { PropsWithChildren } from "react";
-import { MessageCircleQuestionIcon } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { useChromeActions, useChromeState } from "../state";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useAtomValue } from "jotai";
 import { cellErrorCount } from "@/core/cells/cells";
-import { FeedbackButton } from "../components/feedback-button";
 import { PANEL_ICONS, PanelType } from "../types";
 import { MachineStats } from "./machine-stats";
 
@@ -21,7 +19,7 @@ export const Footer: React.FC = () => {
   };
 
   return (
-    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md px-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50">
+    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md pl-1 pr-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50">
       <FooterItem
         tooltip="View errors"
         selected={selectedPanel === "errors"}
@@ -30,62 +28,6 @@ export const Footer: React.FC = () => {
         {renderIcon("errors", errorCount > 0 ? "text-destructive" : "")}
         <span className="ml-1 font-mono mt-[0.125rem]">{errorCount}</span>
       </FooterItem>
-      <FooterItem
-        tooltip="View files"
-        selected={selectedPanel === "files"}
-        onClick={() => openApplication("files")}
-      >
-        {renderIcon("files")}
-      </FooterItem>
-      <FooterItem
-        tooltip="Explore variables"
-        selected={selectedPanel === "variables"}
-        onClick={() => openApplication("variables")}
-      >
-        {renderIcon("variables")}
-      </FooterItem>
-      <FooterItem
-        tooltip="Explore dependencies"
-        selected={selectedPanel === "dependencies"}
-        onClick={() => openApplication("dependencies")}
-      >
-        {renderIcon("dependencies")}
-      </FooterItem>
-      <FooterItem
-        tooltip="View outline"
-        selected={selectedPanel === "outline"}
-        onClick={() => openApplication("outline")}
-      >
-        {renderIcon("outline")}
-      </FooterItem>
-      <FooterItem
-        tooltip="View live docs"
-        selected={selectedPanel === "documentation"}
-        onClick={() => openApplication("documentation")}
-      >
-        {renderIcon("documentation")}
-      </FooterItem>
-      <FooterItem
-        tooltip="Notebook logs"
-        selected={selectedPanel === "logs"}
-        onClick={() => openApplication("logs")}
-      >
-        {renderIcon("logs")}
-      </FooterItem>
-      <FooterItem
-        tooltip="Snippets"
-        selected={selectedPanel === "snippets"}
-        onClick={() => openApplication("snippets")}
-      >
-        {renderIcon("snippets")}
-      </FooterItem>
-
-      <FeedbackButton>
-        <FooterItem tooltip="Send feedback!" selected={false}>
-          <MessageCircleQuestionIcon className="h-5 w-5" />
-        </FooterItem>
-      </FeedbackButton>
-
       <div className="mx-auto" />
 
       <MachineStats />

--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -1,0 +1,103 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import React, { PropsWithChildren } from "react";
+import { MessageCircleQuestionIcon } from "lucide-react";
+import { cn } from "@/utils/cn";
+import { useChromeActions, useChromeState } from "../state";
+import { Tooltip } from "@/components/ui/tooltip";
+import { FeedbackButton } from "../components/feedback-button";
+import { PANEL_ICONS, PanelType } from "../types";
+
+export const Sidebar: React.FC = () => {
+  const { selectedPanel } = useChromeState();
+  const { openApplication } = useChromeActions();
+
+  const renderIcon = (type: PanelType, className?: string) => {
+    const Icon = PANEL_ICONS[type];
+    return <Icon className={cn("h-5 w-5", className)} />;
+  };
+
+  return (
+    <div className="h-full py-4 px-1 flex flex-col items-start text-muted-foreground text-md border-t border-border select-none no-print text-sm z-50 absolute">
+      <SidebarItem
+        tooltip="View files"
+        selected={selectedPanel === "files"}
+        onClick={() => openApplication("files")}
+      >
+        {renderIcon("files")}
+      </SidebarItem>
+      <SidebarItem
+        tooltip="Explore variables"
+        selected={selectedPanel === "variables"}
+        onClick={() => openApplication("variables")}
+      >
+        {renderIcon("variables")}
+      </SidebarItem>
+      <SidebarItem
+        tooltip="Explore dependencies"
+        selected={selectedPanel === "dependencies"}
+        onClick={() => openApplication("dependencies")}
+      >
+        {renderIcon("dependencies")}
+      </SidebarItem>
+      <SidebarItem
+        tooltip="View outline"
+        selected={selectedPanel === "outline"}
+        onClick={() => openApplication("outline")}
+      >
+        {renderIcon("outline")}
+      </SidebarItem>
+      <SidebarItem
+        tooltip="View live docs"
+        selected={selectedPanel === "documentation"}
+        onClick={() => openApplication("documentation")}
+      >
+        {renderIcon("documentation")}
+      </SidebarItem>
+      <SidebarItem
+        tooltip="Notebook logs"
+        selected={selectedPanel === "logs"}
+        onClick={() => openApplication("logs")}
+      >
+        {renderIcon("logs")}
+      </SidebarItem>
+      <SidebarItem
+        tooltip="Snippets"
+        selected={selectedPanel === "snippets"}
+        onClick={() => openApplication("snippets")}
+      >
+        {renderIcon("snippets")}
+      </SidebarItem>
+
+      <FeedbackButton>
+        <SidebarItem tooltip="Send feedback!" selected={false}>
+          <MessageCircleQuestionIcon className="h-5 w-5" />
+        </SidebarItem>
+      </FeedbackButton>
+    </div>
+  );
+};
+
+const SidebarItem: React.FC<
+  PropsWithChildren<
+    {
+      selected: boolean;
+      tooltip: React.ReactNode;
+    } & React.HTMLAttributes<HTMLDivElement>
+  >
+> = ({ children, tooltip, selected, className, ...rest }) => {
+  return (
+    <Tooltip content={tooltip} side="top" delayDuration={200}>
+      <div
+        className={cn(
+          "flex items-center p-2 text-sm mx-[1px] shadow-inset font-mono cursor-pointer rounded",
+          !selected && "hover:bg-[var(--sage-3)]",
+          selected && "bg-[var(--sage-4)]",
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </div>
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
This change adds a sidebar with panel icons, moving the panel icons from the footer to the sidebar (except for the errors icon) while keeping the footer.

This has two effects:

1. It makes the panel icons much more discoverable. We received feedback that they were not visible.
2. It frees up space in the footer for more UI elements -- in the future, we can surface options like runtime config in the footer, instead of hiding it in the settings menu.

**Closed**

<img width="1512" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/5308d898-fa28-4327-b626-cb6c514db753">

**Open**

<img width="1512" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/e526e5a0-a87f-4989-8a26-1817961813fc">


