### PR TITLE
Fix #1490 `docs: Fix LazyComponent example by installing missing dependency` 

### DIFF
--- a/docs/api/layouts/lazy.md
+++ b/docs/api/layouts/lazy.md
@@ -12,6 +12,7 @@
     @app.cell
     def __():
         import time
+        import random
 
         def expensive_number():
             time.sleep(1)


### PR DESCRIPTION
## 📝 Summary

This PR addresses the issue with the `LazyComponent` example in the `docs/api/layouts` section, where the example code was not functioning correctly due to a missing library dependency. Fixes #1490.

## 🔍 Description of Changes

The issue was caused by the absence of the random library, which is required for the `LazyComponent` preview code in docs to work correctly. To resolve this, the following changes have been made:

1. The `random` library has been imported.
2. The updated example code now runs as expected, demonstrating the correct usage of the `mo.lazy`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick (saw that this feature was introduced by him in the PR [here](https://github.com/marimo-team/marimo/pull/1052).
