### PR TITLE
Temporarily disable go-to-definition codemirror extension

### DIFF
--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -58,7 +58,6 @@ import {
   clickablePlaceholderExtension,
   smartPlaceholderExtension,
 } from "./placeholder/extensions";
-import { goToDefinitionBundle } from "./go-to-definition/extension";
 
 export interface CodeMirrorSetupOpts {
   cellId: CellId;
@@ -93,7 +92,8 @@ export const setupCodeMirror = ({
     // Comes last so that it can be overridden
     basicBundle(completionConfig, theme),
     // Underline cmd+clickable placeholder
-    goToDefinitionBundle(),
+    // Temporarily disabled due to Issue #1462
+    // goToDefinitionBundle(),
     showPlaceholder
       ? Prec.highest(smartPlaceholderExtension("import marimo as mo"))
       : enableAI


### PR DESCRIPTION
The go-to-definition codemirror extension has introduced an urgent usability bug that often makes it impossible to continue coding in a marimo notebook (#1462).

This PR disables the extension. We can re-enable it once we fix this issue.