### PR TITLE
Fix #1428 - Update Browser Tab Title When Notebook is Renamed

### DIFF
--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -115,10 +115,11 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
       }
     });
 
-    return sendRename(name)
+      return sendRename(name)
       .then(() => {
         setFilename(name);
-        document.title = name || "Untitled Notebook"; // Assign a default title if name is null
+         // Set document title: app_title takes precedence, then filename, then default
+        document.title = appConfig.app_title || name || "Untitled Notebook"; 
         return name;
       })
       .catch((error) => {
@@ -127,10 +128,11 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
       });
   });
 
-  // Update document title whenever filename changes
+  // Update document title whenever filename or app_title changes 
   useEffect(() => {
-    document.title = filename || "Untitled Notebook"; // Assign a default title if filename is null
-  }, [filename]);
+    // Set document title: app_title takes precedence, then filename, then default
+    document.title = appConfig.app_title || filename || "Untitled Notebook"; 
+  }, [appConfig.app_title, filename]);
 
   const cells = notebookCells(notebook);
   const cellIds = cells.map((cell) => cell.id);

--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -118,6 +118,7 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
     return sendRename(name)
       .then(() => {
         setFilename(name);
+        document.title = name || "Untitled Notebook"; // Assign a default title if name is null
         return name;
       })
       .catch((error) => {
@@ -125,6 +126,11 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
         return null;
       });
   });
+
+  // Update document title whenever filename changes
+  useEffect(() => {
+    document.title = filename || "Untitled Notebook"; // Assign a default title if filename is null
+  }, [filename]);
 
   const cells = notebookCells(notebook);
   const cellIds = cells.map((cell) => cell.id);


### PR DESCRIPTION
## 📝 Summary

This pull request addresses the issue where the browser tab title does not update when a notebook is renamed. Fixes #1428 .

## 🔍 Description of Changes

- Updated the `handleFilenameChange` function in the EditApp component to set `document.title` with the new filename.
- Added a `useEffect` hook to update `document.title` whenever the filename changes, ensuring the browser tab title stays in sync with the notebook name.
- Added a default value ("Untitled Notebook") for the document title in case the filename is null.

https://github.com/marimo-team/marimo/assets/123119434/37c1bbd6-ec64-4bf1-afee-c91b30de8ca6


## 📋 Checklist

- [✓ ] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [✓ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka #1428 
