### PR TITLE
feat: adding initialization indicator to marimo islands

### DIFF
--- a/marimo/_islands/island_generator.py
+++ b/marimo/_islands/island_generator.py
@@ -413,7 +413,7 @@ class MarimoIslandGenerator:
         This should be included in the <body> tag of the page.
 
         *Args:*
-        - include_init_island (bool): It True, adds initialization loader.
+        - include_init_island (bool): If True, adds initialization loader.
         - max_width (str): CSS style max_width property.
         - margin (str): CSS style margin property.
         - style (str): CSS style. Overrides max_width and margin.
@@ -468,7 +468,7 @@ class MarimoIslandGenerator:
 
         - version_override (str): Marimo version to use for loaded js/css.
         - _development_url (str): If True, uses local marimo islands js.
-        - include_init_island (bool): It True, adds initialization loader.
+        - include_init_island (bool): If True, adds initialization loader.
         - max_width (str): CSS style max_width property.
         - margin (str): CSS style margin property.
         - style (str): CSS style. Overrides max_width and margin.

--- a/marimo/_islands/island_generator.py
+++ b/marimo/_islands/island_generator.py
@@ -395,14 +395,6 @@ class MarimoIslandGenerator:
                   class="size-20 animate-spin text-primary"
                 >
                   <path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  class="size-20 animate-spin text-primary"
-                >
-                  <path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
                 </svg>
                 <div>Initializing...</div>
               </div>

--- a/tests/_islands/test_island_generator.py
+++ b/tests/_islands/test_island_generator.py
@@ -40,15 +40,6 @@ async def test_render():
     block1 = generator.add_code("import marimo as mo")
     block2 = generator.add_code("mo.md('Hello, islands!')")
 
-    # Check if render raises an error when build() is not called
-    with pytest.raises(AssertionError) as e:
-        block1.render()
-    assert "You must call build() before rendering" in str(e.value)
-
-    with pytest.raises(AssertionError) as e:
-        block2.render(display_code=False)
-    assert "You must call build() before rendering" in str(e.value)
-
     await generator.build()
 
     with pytest.raises(ValueError) as e:


### PR DESCRIPTION
## 📝 Summary

This PR adds a `include_initialization_indicator` flag to the `MarimoIslandsGenerator.render_body()` function to indicate to the user when the Pyodide initialization is done.

Fixes #1468.

## 🔍 Description of Changes

Specifically, it prepends the following div in the rendered stubs:

```html
  <div class="marimo" style="--tw-bg-opacity: 0;">
    <div class="flex flex-col items-center justify-center">
      <svg
        xmlns="http://www.w3.org/2000/svg"
        width="24"
        height="24"
        viewBox="0 0 24 24"
        fill="none"
        stroke="currentColor"
        stroke-width="1"
        stroke-linecap="round"
        stroke-linejoin="round"
        class="size-20 animate-spin text-primary"
      >
        <path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
      </svg>
      <div>Initializing...</div>
    </div>
  </div>
```
which uses the `animate-spin` class loaded with the marimo css to display something like the following:
![Screenshot from 2024-05-27 13-34-18](https://github.com/marimo-team/marimo/assets/19610677/ddc30841-ef2a-4bef-9132-43ec615470e6)

Note this can be used with or without the asynchronous app build. Consider the following code:

```python
import asyncio
from marimo import MarimoIslandGenerator

generator = MarimoIslandGenerator.from_file("notebook.py")
#app = asyncio.run(generator.build())
body = generator.render_body(include_initialization_indicator=True)
```
If the app is not built, then only the above indicator is displayed (i.e. no static html prerender), see [here](https://gvarnavi.observablehq.cloud/marimo-framework/marimo-pyodide-bug). Note this also addresses points 1 & 2 in #1468.

If the app is built as usual, then this will appear temporarily on the top of the static html prerender, see [here](https://gvarnavi.observablehq.cloud/marimo-framework/marimo-intro).

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick @dmadisetti 
