### PR TITLE
fix: notebook control positioning

### DIFF
--- a/frontend/src/components/editor/RecoveryButton.tsx
+++ b/frontend/src/components/editor/RecoveryButton.tsx
@@ -122,7 +122,7 @@ export const RecoveryButton = (props: {
         className="rectangle"
         color={needsSave ? "yellow" : "gray"}
       >
-        <SaveIcon strokeWidth={1.5} />
+        <SaveIcon strokeWidth={1.5} size={18}/>
       </EditorButton>
     </Tooltip>
   );

--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -116,7 +116,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       collapsible={true}
       className={cn(
         "bg-white dark:bg-[var(--slate-1)] no-print",
-        isOpen && "ml-12 border-r border-l border-[var(--slate-7)]",
+        isOpen && "border-r border-l border-[var(--slate-7)]",
       )}
       minSize={10}
       // We can't make the default size greater than 0, otherwise it will start open

--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -17,7 +17,7 @@ export const Sidebar: React.FC = () => {
   };
 
   return (
-    <div className="h-full py-4 px-1 flex flex-col items-start text-muted-foreground text-md select-none no-print text-sm z-50 absolute">
+    <div className="h-full py-4 px-1 flex flex-col items-start text-muted-foreground text-md select-none no-print text-sm z-50">
       <SidebarItem
         tooltip="View files"
         selected={selectedPanel === "files"}

--- a/frontend/src/components/editor/controls/Controls.tsx
+++ b/frontend/src/components/editor/controls/Controls.tsx
@@ -8,7 +8,6 @@ import {
   Undo2Icon,
 } from "lucide-react";
 
-import { cn } from "@/utils/cn";
 import { Button } from "@/components/editor/inputs/Inputs";
 import { KeyboardShortcuts } from "@/components/editor/controls/keyboard-shortcuts";
 import { ShutdownButton } from "@/components/editor/controls/shutdown-button";
@@ -24,6 +23,7 @@ import { FindReplace } from "@/components/find-replace/find-replace";
 import { AppConfig } from "@/core/config/config-schema";
 import { useShouldShowInterrupt } from "../cell/useShouldShowInterrupt";
 import { CommandPaletteButton } from "./command-palette-button";
+import { cn } from "@/utils/cn";
 
 interface ControlsProps {
   filename: string | null;
@@ -96,8 +96,8 @@ export const Controls = ({
 
       <div
         className={cn(
-          bottomLeftControls,
-          appWidth === "normal" && "xl:flex-row",
+          bottomRightControls,
+          appWidth === "normal" && "xl:flex-row items-end",
         )}
       >
         {closed ? (
@@ -115,7 +115,7 @@ export const Controls = ({
               color={needsSave ? "yellow" : "hint-green"}
               onClick={handleSaveClick}
             >
-              <SaveIcon strokeWidth={1.5} />
+              <SaveIcon strokeWidth={1.5} size={18} />
             </Button>
           </Tooltip>
         )}
@@ -125,31 +125,33 @@ export const Controls = ({
             data-testid="hide-code-button"
             id="preview-button"
             shape="rectangle"
-            color="white"
+            color="hint-green"
             onClick={onTogglePresenting}
           >
             {presenting ? (
-              <EditIcon strokeWidth={1.5} />
+              <EditIcon strokeWidth={1.5} size={18} />
             ) : (
-              <LayoutTemplateIcon strokeWidth={1.5} />
+              <LayoutTemplateIcon strokeWidth={1.5} size={18} />
             )}
           </Button>
         </Tooltip>
 
         <CommandPaletteButton />
         <KeyboardShortcuts />
-      </div>
 
-      <div className={bottomRightControls}>
-        {undoControl}
-        {!closed && (
-          <RunControlButton
-            running={running}
-            needsRun={needsRun}
-            onRun={onRun}
-            onInterrupt={onInterrupt}
-          />
-        )}
+        <div />
+
+        <div className="flex flex-col gap-2 items-center">
+          {undoControl}
+          {!closed && (
+            <RunControlButton
+              running={running}
+              needsRun={needsRun}
+              onRun={onRun}
+              onInterrupt={onInterrupt}
+            />
+          )}
+        </div>
       </div>
     </>
   );
@@ -218,7 +220,4 @@ const topRightControls =
   "absolute top-3 right-5 m-0 flex items-center space-x-3 min-h-[28px] no-print pointer-events-auto z-30";
 
 const bottomRightControls =
-  "absolute bottom-5 right-5 flex items-center space-x-3 no-print pointer-events-auto z-30";
-
-const bottomLeftControls =
-  "absolute bottom-5 left-3 m-0 flex flex-col-reverse gap-2 items-center no-print pointer-events-auto z-50";
+  "absolute bottom-5 right-5 flex flex-col gap-2 items-center no-print pointer-events-auto z-30";

--- a/frontend/src/components/editor/controls/command-palette-button.tsx
+++ b/frontend/src/components/editor/controls/command-palette-button.tsx
@@ -17,9 +17,9 @@ export const CommandPaletteButton: React.FC = () => {
         data-testid="command-palette-button"
         onClick={toggle}
         shape="rectangle"
-        color="white"
+        color="hint-green"
       >
-        <CommandIcon strokeWidth={1.5} />
+        <CommandIcon strokeWidth={1.5} size={18} />
       </Button>
     </Tooltip>
   );

--- a/frontend/src/components/editor/header/status.tsx
+++ b/frontend/src/components/editor/header/status.tsx
@@ -19,7 +19,7 @@ export const StatusOverlay: React.FC<{
 };
 
 const topLeftStatus =
-  "absolute top-4 left-4 m-0 ml-8 flex items-center space-x-3 min-h-[28px] no-print pointer-events-auto z-50 hover:cursor-pointer";
+  "absolute top-4 left-4 m-0 flex items-center space-x-3 min-h-[28px] no-print pointer-events-auto z-50 hover:cursor-pointer";
 
 const DisconnectedIcon = () => (
   <Tooltip content="App disconnected">

--- a/frontend/src/components/editor/inputs/Inputs.styles.ts
+++ b/frontend/src/components/editor/inputs/Inputs.styles.ts
@@ -3,7 +3,7 @@ import { cva } from "class-variance-authority";
 import "./Inputs.css";
 
 export const button = cva(
-  "flex items-center justify-center m-0 leading-none font-medium border border-foreground/10 shadow-xsSolid shadow-foreground/10 hover:cursor-pointer focus:shadow-md dark:border-border text-sm",
+  "flex items-center justify-center m-0 leading-none font-medium border border-foreground/10 shadow-xsSolid hover:cursor-pointer active:shadow-none dark:border-border text-sm",
   {
     variants: {
       color: {


### PR DESCRIPTION
This change fixes positioning bugs with sidebars and the notebook "bottom-left" controls (save, preview, command palette).

Previously, the panel sidebar and `mo.ui.sidebar()` overlapped, and both of these sidebars overlapped the save/preview/command palette buttons.

- This change updates the panel sidebar to not have absolute positioning, fixing the sidebar overlap problem.
- Save/preview/command palette buttons are moved to the bottom right (by the run button), fixing positioning conflicts with both sidebars. This also makes the notebook controls more intuitive by putting them all in one place.
- Undo button stacks on top of run bottom (column flex) to avoid button shift.
- In narrow screens, controls stack with column flex.

Also fixes some styles on the save/preview/command-palette buttons.

Fixes #1495.

**With change.**

<img width="1292" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/58c1a00f-7c55-4086-b5ee-6526b4e57d73">

**Without.**

<img width="1295" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/db0c504a-bbd4-465d-8acb-3f2f0769203d">
