### PR TITLE
Revert "bump pyodide to 0.26.0 (#1499)"

### DIFF
--- a/frontend/src/core/pyodide/worker/getPyodideVersion.ts
+++ b/frontend/src/core/pyodide/worker/getPyodideVersion.ts
@@ -4,7 +4,7 @@ const ALLOW_DEV_VERSIONS = false;
 export function getPyodideVersion(marimoVersion: string) {
   return marimoVersion.includes("dev") && ALLOW_DEV_VERSIONS
     ? "dev"
-    : "v0.26.0";
+    : "v0.25.0";
 }
 
 export async function importPyodide(marimoVersion: string) {


### PR DESCRIPTION
This reverts commit e01f1829fb267baaf9344693b67b494fc75aa3cf.

FE appears to be incompatible with 0.26.0, needs debugging.