### PR TITLE
fix: re-enable cmd click go-to-definition

### DIFF
--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -58,6 +58,7 @@ import {
   clickablePlaceholderExtension,
   smartPlaceholderExtension,
 } from "./placeholder/extensions";
+import { goToDefinitionBundle } from "./go-to-definition/extension";
 
 export interface CodeMirrorSetupOpts {
   cellId: CellId;
@@ -92,8 +93,7 @@ export const setupCodeMirror = ({
     // Comes last so that it can be overridden
     basicBundle(completionConfig, theme),
     // Underline cmd+clickable placeholder
-    // Temporarily disabled due to Issue #1462
-    // goToDefinitionBundle(),
+    goToDefinitionBundle(),
     showPlaceholder
       ? Prec.highest(smartPlaceholderExtension("import marimo as mo"))
       : enableAI


### PR DESCRIPTION
* fixes the cmd+click crashing the codemirror editor (the reason it broke #1462 was because our plugin cashed the editor. this error was apparent in the console). So we removed the logic in `update()`)
* few performance improvements on mousemove