### PR TITLE
feat: add 'marimo config show' CLI command

### DIFF
--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -41,6 +41,8 @@ jobs:
 
       - name: 📦 Build frontend
         run: make fe
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
 
       - name: 🐍 Setup Python 3.10
         uses: actions/setup-python@v5

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -28,7 +28,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { downloadHTMLAsImage } from "@/utils/download";
-import { useFilename } from "@/core/saving/filename";
 import { downloadAsHTML } from "@/core/static/download-html";
 
 type VerticalLayout = null;

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -12,6 +12,7 @@ import click
 import marimo._cli.cli_validators as validators
 from marimo import __version__, _loggers
 from marimo._ast import codegen
+from marimo._cli.config.commands import config
 from marimo._cli.convert.commands import convert
 from marimo._cli.envinfo import get_system_info
 from marimo._cli.export.commands import export
@@ -601,3 +602,4 @@ def env() -> None:
 
 main.command()(convert)
 main.add_command(export)
+main.add_command(config)

--- a/marimo/_cli/config/commands.py
+++ b/marimo/_cli/config/commands.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import click
+import tomlkit
+
+from marimo._cli.config.utils import highlight_toml_headers
+from marimo._cli.print import green
+from marimo._config.manager import UserConfigManager
+
+
+@click.group(help="""Various commands for the marimo config.""")
+def config() -> None:
+    pass
+
+
+@click.command(help="""Show the marimo config""")
+def show() -> None:
+    """
+    Print out marimo config information.
+    Example usage:
+
+        marimo config show
+    """
+    config_manager = UserConfigManager()
+    click.echo(f"User config from {green(config_manager.get_config_path())}\n")
+    toml_string = tomlkit.dumps(config_manager.get_config())
+    click.echo(highlight_toml_headers(toml_string))
+
+
+config.add_command(show)

--- a/marimo/_cli/config/utils.py
+++ b/marimo/_cli/config/utils.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from marimo._cli.print import orange
+
+
+def highlight_toml_headers(toml_string: str) -> str:
+    lines = toml_string.splitlines()
+    highlighted_lines: list[str] = []
+
+    for line in lines:
+        stripped_line = line.strip()
+        if stripped_line.startswith("[") and stripped_line.endswith("]"):
+            highlighted_lines.append(orange(line))
+        else:
+            highlighted_lines.append(line)
+
+    return "\n".join(highlighted_lines)

--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -23,7 +23,7 @@ class UserConfigManager:
     def save_config(self, config: MarimoConfig) -> MarimoConfig:
         import tomlkit
 
-        config_path = self._get_config_path()
+        config_path = self.get_config_path()
         LOGGER.debug("Saving user configuration to %s", config_path)
         # Remove the secret placeholders from the incoming config
         config = remove_secret_placeholders(config)
@@ -41,7 +41,7 @@ class UserConfigManager:
             return mask_secrets(self.config)
         return self.config
 
-    def _get_config_path(self) -> str:
+    def get_config_path(self) -> str:
         return get_config_path() or self._default_config_path()
 
     def _default_config_path(self) -> str:

--- a/scripts/buildfrontend.sh
+++ b/scripts/buildfrontend.sh
@@ -20,4 +20,5 @@ if $cmd; then
   echo "Compilation succeeded.\n"
 else
   echo "Frontend compilation failed.\n"
+  exit 1
 fi

--- a/tests/_cli/test_cli_config.py
+++ b/tests/_cli/test_cli_config.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import subprocess
+
+
+def test_config_show() -> None:
+    p = subprocess.run(
+        ["marimo", "config", "show"],
+        capture_output=True,
+    )
+    assert p.returncode == 0, p.stderr.decode()
+    output = p.stdout.decode()
+    assert "User config from" in output
+    assert "[formatting]" in output


### PR DESCRIPTION
This adds a new CLI command `marimo config show`.  It's kinda hidden that we store user config in a config file on the user's computer and a few users have missed this - hopefully this helps with some education.

 
`show` is the only command under `marimo config` but its future looking for other commands.

<img width="832" alt="Screenshot 2024-05-28 at 3 31 57 PM" src="https://github.com/marimo-team/marimo/assets/2753772/461e628d-1a46-4357-85a3-3d70a1556278">
