### PR TITLE
feat: run_button

### DIFF
--- a/docs/api/inputs/button.md
+++ b/docs/api/inputs/button.md
@@ -1,5 +1,12 @@
 # Button
 
+```{admonition} Looking for a submit/run button?
+:class: tip
+
+If you're looking for a button to trigger computation on click, consider
+using [`mo.ui.run_button`](/api/inputs/run_button.md).
+```
+
 ```{eval-rst}
 .. marimo-embed::
     @app.cell

--- a/docs/api/inputs/run_button.md
+++ b/docs/api/inputs/run_button.md
@@ -17,7 +17,7 @@
 
     @app.cell
     def __():
-        mo.stop(b.value, "Click `run` to submit the slider's value")
+        mo.stop(not b.value, "Click `run` to submit the slider's value")
 
         s.value
         return

--- a/docs/api/inputs/run_button.md
+++ b/docs/api/inputs/run_button.md
@@ -1,0 +1,31 @@
+# Run Button
+
+```{eval-rst}
+.. marimo-embed::
+    @app.cell
+    def __():
+        b = mo.ui.run_button()
+        b
+        return
+
+    @app.cell
+    def __():
+        s = mo.ui.slider(1, 10)
+        s
+        return
+
+
+    @app.cell
+    def __():
+        mo.stop(b.value, "Click `run` to submit the slider's value")
+
+        s.value
+        return
+```
+
+```{eval-rst}
+.. autoclass:: marimo.ui.run_button
+  :members:
+
+  .. autoclasstoc:: marimo._plugins.ui._impl.run_button.run_button
+```

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -388,6 +388,36 @@ form.value
 
 ## Working with buttons
 
+### Create a button that triggers computation when clicked
+
+**Use cases.** To trigger a computation on button click and only on button
+click, use [`mo.ui.run_button()`](/api/inputs/run_button.md).
+
+**Recipe.**
+
+1. Import packages
+
+```python
+import marimo as mo
+```
+
+2. Create a run button
+
+```python
+button = mo.ui.run_button()
+button
+```
+
+3. Run something only if the button has been clicked.
+
+```python
+mo.stop(not button.value, "Click 'run' to generate a random number")
+
+import random
+random.randint(0, 1000)
+```
+
+
 ### Create a counter button
 
 **Use cases.** A counter button, i.e. a button that counts the number of times

--- a/marimo/_plugins/ui/__init__.py
+++ b/marimo/_plugins/ui/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "radio",
     "range_slider",
     "refresh",
+    "run_button",
     "slider",
     "switch",
     "table",
@@ -62,6 +63,7 @@ from marimo._plugins.ui._impl.input import (
 from marimo._plugins.ui._impl.microphone import microphone
 from marimo._plugins.ui._impl.plotly import plotly
 from marimo._plugins.ui._impl.refresh import refresh
+from marimo._plugins.ui._impl.run_button import run_button
 from marimo._plugins.ui._impl.switch import switch
 from marimo._plugins.ui._impl.table import table
 from marimo._plugins.ui._impl.tabs import tabs

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -379,6 +379,10 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         if self._on_change is not None:
             self._on_change(self._value)
 
+    def _on_update_completion(self) -> None:
+        """Callback to run after the kernel has processed a value update."""
+        return
+
     def _clone(self) -> UIElement[S, T]:
         """Clone a UIElement, returning one with a different id
 

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -990,6 +990,7 @@ class button(UIElement[Any, Any]):
     ) -> None:
         self._on_click = (lambda _: value) if on_click is None else on_click
         self._initial_value = value
+        # This should be kept in sync with mo.ui.run_button()
         super().__init__(
             component_name=button._name,
             # frontend's value is always a counter

--- a/marimo/_plugins/ui/_impl/run_button.py
+++ b/marimo/_plugins/ui/_impl/run_button.py
@@ -1,0 +1,117 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import Any, Callable, Final, Literal, Optional
+
+from marimo._output.rich_help import mddoc
+from marimo._plugins.ui._core.ui_element import UIElement
+from marimo._plugins.ui._impl.input import button
+from marimo._runtime.context.types import ContextNotInitializedError
+
+
+@mddoc
+class run_button(UIElement[Any, Any]):
+    """
+    A button that can be used to trigger computation.
+
+    **Example.**
+
+    ```python
+    # a button that when clicked will have its value set to True;
+    # any cells referencing that button will automatically run.
+    button = mo.ui.button()
+    button
+    ```
+
+    ```python
+    slider = mo.ui.slider(1, 10)
+    slider
+    ```
+
+    ```python
+    # if the button hasn't been clicked, don't run.
+    mo.stop(not button.value)
+
+    slider.value
+    ```
+
+    When clicked, `run_button`'s value is set to `True`, and any cells
+    referencing it are run. After those cells are run, `run_button`'s
+    value will automatically be set back to `False` as long as automatic
+    execution is enabled.
+
+    **Attributes.**
+
+    - `value`: the value of the button; `True` when clicked, and reset to
+      `False` after cells referencing the button finish running (when
+      automatic execution is enabled).
+
+    **Initialization Args.**
+
+    - `kind`: 'neutral', 'success', 'warn', or 'danger'
+    - `disabled`: whether the button is disabled
+    - `tooltip`: a tooltip to display for the button
+    - `label`: text label for the element
+    - `on_change`: optional callback to run when this element's value changes
+    - `full_width`: whether the input should take up the full width of its
+        container
+    """
+
+    _name: Final[str] = "marimo-button"
+
+    def __init__(
+        self,
+        kind: Literal["neutral", "success", "warn", "danger"] = "neutral",
+        disabled: bool = False,
+        tooltip: Optional[str] = None,
+        *,
+        label: str = "click to run",
+        on_change: Optional[Callable[[Any], None]] = None,
+        full_width: bool = False,
+    ) -> None:
+        self._initial_value = False
+        super().__init__(
+            # We reuse the button plugin on the frontend, since the UI
+            # is the same.
+            component_name=button._name,
+            # frontend's value is a counter
+            initial_value=0,
+            label=label,
+            args={
+                "kind": kind,
+                "disabled": disabled,
+                "tooltip": tooltip,
+                "full-width": full_width,
+            },
+            on_change=on_change,
+        )
+
+    def _convert_value(self, value: Any) -> Any:
+        if value == 0:
+            # frontend's value == 0 only during initialization; first value
+            # frontend will send is 1
+            return False
+        else:
+            return True
+
+    def _on_update_completion(self) -> None:
+        from marimo._runtime.context import get_context
+        from marimo._runtime.context.kernel_context import KernelRuntimeContext
+
+        try:
+            ctx = get_context()
+        except ContextNotInitializedError:
+            self._value = False
+            return
+
+        if isinstance(ctx, KernelRuntimeContext) and ctx.lazy:
+            # Resetting to False in lazy kernels makes the button pointless,
+            # since its value hasn't been read by downstream cells on update
+            # completion.
+            #
+            # The right thing to do would be to somehow set to False after
+            # all cells that were marked stale because of the update were run,
+            # but that's too complicated.
+            return
+        else:
+            self._value = False

--- a/marimo/_plugins/ui/_impl/run_button.py
+++ b/marimo/_plugins/ui/_impl/run_button.py
@@ -19,7 +19,7 @@ class run_button(UIElement[Any, Any]):
     ```python
     # a button that when clicked will have its value set to True;
     # any cells referencing that button will automatically run.
-    button = mo.ui.button()
+    button = mo.ui.run_button()
     button
     ```
 

--- a/marimo/_plugins/ui/_impl/run_button.py
+++ b/marimo/_plugins/ui/_impl/run_button.py
@@ -57,7 +57,8 @@ class run_button(UIElement[Any, Any]):
         container
     """
 
-    _name: Final[str] = "marimo-button"
+    # We reuse the button plugin on the frontend, UI/logic are the same
+    _name: Final[str] = button._name
 
     def __init__(
         self,
@@ -71,8 +72,6 @@ class run_button(UIElement[Any, Any]):
     ) -> None:
         self._initial_value = False
         super().__init__(
-            # We reuse the button plugin on the frontend, since the UI
-            # is the same.
             component_name=button._name,
             # frontend's value is a counter
             initial_value=0,

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -44,6 +44,10 @@ class KernelRuntimeContext(RuntimeContext):
         return self._kernel.execution_context
 
     @property
+    def lazy(self) -> bool:
+        return self._kernel.lazy()
+
+    @property
     def cell_id(self) -> Optional[CellId_t]:
         """Get the cell id of the currently executing cell, if any."""
         if self._kernel.execution_context is not None:

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -25,24 +25,45 @@ from marimo._ast.visitor import Name, is_local
 from marimo._config.config import MarimoConfig, OnCellChangeType
 from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.errors import Error, MarimoSyntaxError, UnknownError
-from marimo._messaging.ops import (Alert, CellOp, CompletedRun,
-                                   FunctionCallResult, HumanReadableStatus,
-                                   InstallingPackageAlert, MissingPackageAlert,
-                                   PackageStatusType, RemoveUIElements,
-                                   VariableDeclaration, Variables,
-                                   VariableValue, VariableValues)
-from marimo._messaging.streams import (ThreadSafeStderr, ThreadSafeStdin,
-                                       ThreadSafeStdout, ThreadSafeStream)
+from marimo._messaging.ops import (
+    Alert,
+    CellOp,
+    CompletedRun,
+    FunctionCallResult,
+    HumanReadableStatus,
+    InstallingPackageAlert,
+    MissingPackageAlert,
+    PackageStatusType,
+    RemoveUIElements,
+    VariableDeclaration,
+    Variables,
+    VariableValue,
+    VariableValues,
+)
+from marimo._messaging.streams import (
+    ThreadSafeStderr,
+    ThreadSafeStdin,
+    ThreadSafeStdout,
+    ThreadSafeStream,
+)
 from marimo._messaging.tracebacks import write_traceback
-from marimo._messaging.types import (KernelMessage, Stderr, Stdin, Stdout,
-                                     Stream)
+from marimo._messaging.types import (
+    KernelMessage,
+    Stderr,
+    Stdin,
+    Stdout,
+    Stream,
+)
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import MarimoConvertValueException
 from marimo._runtime import dataflow, handlers, marimo_pdb, patches
 from marimo._runtime.complete import complete, completion_worker
-from marimo._runtime.context import (ContextNotInitializedError,
-                                     ExecutionContext, get_context)
+from marimo._runtime.context import (
+    ContextNotInitializedError,
+    ExecutionContext,
+    get_context,
+)
 from marimo._runtime.context.kernel_context import initialize_kernel_context
 from marimo._runtime.control_flow import MarimoInterrupt
 from marimo._runtime.input_override import input_override
@@ -54,23 +75,33 @@ from marimo._runtime.params import CLIArgs, QueryParams
 from marimo._runtime.redirect_streams import redirect_streams
 from marimo._runtime.reload.autoreload import ModuleReloader
 from marimo._runtime.reload.module_watcher import ModuleWatcher
-from marimo._runtime.requests import (AppMetadata, CompletionRequest,
-                                      ControlRequest, CreationRequest,
-                                      DeleteRequest, ExecuteMultipleRequest,
-                                      ExecuteStaleRequest, ExecutionRequest,
-                                      FunctionCallRequest,
-                                      InstallMissingPackagesRequest,
-                                      SetCellConfigRequest,
-                                      SetUIElementValueRequest,
-                                      SetUserConfigRequest, StopRequest)
+from marimo._runtime.requests import (
+    AppMetadata,
+    CompletionRequest,
+    ControlRequest,
+    CreationRequest,
+    DeleteRequest,
+    ExecuteMultipleRequest,
+    ExecuteStaleRequest,
+    ExecutionRequest,
+    FunctionCallRequest,
+    InstallMissingPackagesRequest,
+    SetCellConfigRequest,
+    SetUIElementValueRequest,
+    SetUserConfigRequest,
+    StopRequest,
+)
 from marimo._runtime.runner import cell_runner
-from marimo._runtime.runner.hooks import (ON_FINISH_HOOKS,
-                                          POST_EXECUTION_HOOKS,
-                                          PRE_EXECUTION_HOOKS,
-                                          PREPARATION_HOOKS)
+from marimo._runtime.runner.hooks import (
+    ON_FINISH_HOOKS,
+    POST_EXECUTION_HOOKS,
+    PRE_EXECUTION_HOOKS,
+    PREPARATION_HOOKS,
+)
 from marimo._runtime.state import State
-from marimo._runtime.utils.set_ui_element_request_manager import \
-    SetUIElementRequestManager
+from marimo._runtime.utils.set_ui_element_request_manager import (
+    SetUIElementRequestManager,
+)
 from marimo._runtime.validate_graph import check_for_errors
 from marimo._runtime.win32_interrupt_handler import Win32InterruptHandler
 from marimo._server.types import QueueType

--- a/marimo/_smoke_tests/run_button.py
+++ b/marimo/_smoke_tests/run_button.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Marimo. All rights reserved.
+
+import marimo
+
+__generated_with = "0.6.11"
+app = marimo.App()
+
+
+@app.cell
+def __(mo):
+    b = mo.ui.run_button()
+    b
+    return b,
+
+
+@app.cell
+def __(mo):
+    s = mo.ui.slider(1, 10)
+    s
+    return s,
+
+
+@app.cell
+def __(b, mo, s):
+    mo.stop(not b.value, "Click `run` to submit the slider's value")
+
+    s.value
+    return
+
+
+@app.cell
+def __(b, mo):
+    mo.stop(not b.value)
+
+    import random
+    random.randint(0, 1000)
+    return random,
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## 📝 Summary

Adds `mo.ui.run_button()`, which can be used to trigger computations when a button is pressed and ONLY when a button is pressed.

## 🔍 Description of Changes

When the button is pressed, its value is set to `True` and its descendants are run. After its descendants have run, marimo automatically sets the button's value back to False. In this way, cells can gate computations on `run_button.value` -- updates to other variables won't spuriously cause the cell to run.

Caveat: The button's value is only reset to `False` when the runtime is configured to autorun cells, since the lazy runtime doesn't know when the button's descendants will/have been run. This should be fine in practice, since `ui.run_button` has no real use in lazy kernels anyway.

The implementation reuses the frontend plugin for `mo.ui.button()`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
