### PR TITLE
fix: more defensive clearing of codemirror event listeners

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -323,6 +323,13 @@ const CellEditorInternal = ({
     serializedEditorState,
   ]);
 
+  // Destroy the editor when the component is unmounted
+  useEffect(() => {
+    return () => {
+      editorViewRef.current?.destroy();
+    };
+  }, [editorViewRef]);
+
   const showCode = async () => {
     if (hidden) {
       await saveCellConfig({ configs: { [cellId]: { hide_code: false } } });

--- a/frontend/src/core/codemirror/go-to-definition/underline.ts
+++ b/frontend/src/core/codemirror/go-to-definition/underline.ts
@@ -56,6 +56,7 @@ class MetaUnderlineVariablePlugin {
 
     window.addEventListener("keydown", this.keydown);
     window.addEventListener("keyup", this.keyup);
+    window.addEventListener("blur", this.windowBlur);
   }
 
   update(update: ViewUpdate) {
@@ -67,6 +68,7 @@ class MetaUnderlineVariablePlugin {
   destroy() {
     window.removeEventListener("keydown", this.keydown);
     window.removeEventListener("keyup", this.keyup);
+    window.removeEventListener("blur", this.windowBlur);
     this.view.dom.removeEventListener("mousemove", this.mousemove);
     this.view.dom.removeEventListener("click", this.click);
   }
@@ -82,6 +84,16 @@ class MetaUnderlineVariablePlugin {
 
   // Exit the cmd+click mode
   private keyup = (event: KeyboardEvent) => {
+    if (event.key === "Meta" || event.key === "Control") {
+      this.commandClickMode = false;
+      this.view.dom.removeEventListener("mousemove", this.mousemove);
+      this.view.dom.removeEventListener("click", this.click);
+      this.clearUnderline();
+    }
+  };
+
+  // Handle window blur event to reset state
+  private windowBlur = () => {
     if (this.commandClickMode) {
       this.commandClickMode = false;
       this.view.dom.removeEventListener("mousemove", this.mousemove);


### PR DESCRIPTION
We previously did not call `.destroy` on the codemirror editor, leading to a memory leak