### PR TITLE
fix: clear underline on mouseleave

### DIFF
--- a/frontend/src/core/codemirror/go-to-definition/underline.ts
+++ b/frontend/src/core/codemirror/go-to-definition/underline.ts
@@ -57,6 +57,7 @@ class MetaUnderlineVariablePlugin {
     window.addEventListener("keydown", this.keydown);
     window.addEventListener("keyup", this.keyup);
     window.addEventListener("blur", this.windowBlur);
+    window.addEventListener("mouseleave", this.windowBlur);
   }
 
   update(update: ViewUpdate) {
@@ -69,6 +70,7 @@ class MetaUnderlineVariablePlugin {
     window.removeEventListener("keydown", this.keydown);
     window.removeEventListener("keyup", this.keyup);
     window.removeEventListener("blur", this.windowBlur);
+    window.removeEventListener("mouseleave", this.windowBlur);
     this.view.dom.removeEventListener("mousemove", this.mousemove);
     this.view.dom.removeEventListener("click", this.click);
   }


### PR DESCRIPTION
Noticed that GTD underline sometimes was not cleared on mouse leave, allowing multiple symbols to become underlined.