### PR TITLE
feat: support ibis and the dataframe protocol

### DIFF
--- a/frontend/src/core/datasets/state.ts
+++ b/frontend/src/core/datasets/state.ts
@@ -34,9 +34,12 @@ const {
       seen.add(key);
       return true;
     });
+    const sortedTables = dedupedTables.sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    });
     return {
       ...state,
-      tables: dedupedTables,
+      tables: sortedTables,
     };
   },
   filterDatasetsFromVariables: (state, variableNames: VariableName[]) => {

--- a/marimo/_data/get_datasets.py
+++ b/marimo/_data/get_datasets.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from marimo import _loggers
 from marimo._data.models import DataTable, DataTableColumn
 from marimo._plugins.ui._impl.tables.utils import get_table_manager_or_none
+
+LOGGER = _loggers.marimo_logger()
 
 
 def get_datasets_from_variables(
@@ -22,16 +25,25 @@ def get_datasets_from_variables(
 def get_data_table(value: object, variable_name: str) -> Optional[DataTable]:
     table = get_table_manager_or_none(value)
     if table is not None:
-        return DataTable(
-            name=variable_name,
-            variable_name=variable_name,
-            num_rows=table.get_num_rows(),
-            num_columns=table.get_num_columns(),
-            source=f"Local ({table.type})",
-            columns=[
+        try:
+            columns = [
                 DataTableColumn(name=column_name, type=column_type)
                 for column_name, column_type in table.get_field_types().items()
-            ],
-        )
+            ]
+            return DataTable(
+                name=variable_name,
+                variable_name=variable_name,
+                num_rows=table.get_num_rows(),
+                num_columns=table.get_num_columns(),
+                source=f"Local ({table.type})",
+                columns=columns,
+            )
+        except Exception as e:
+            LOGGER.error(
+                "Failed to get table data for variable %s",
+                variable_name,
+                exc_info=e,
+            )
+            return None
 
     return None

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -98,6 +98,21 @@ class DependencyManager:
             ) from None
 
     @staticmethod
+    def require_pyarrow(why: str) -> None:
+        """
+        Raise an ModuleNotFoundError if pyarrow is not installed.
+
+        Args:
+            why: A string of the form "for <reason>" that will be appended
+
+        """
+        if not DependencyManager.has_pyarrow():
+            raise ModuleNotFoundError(
+                f"pyarrow is required {why}. "
+                + "You can install it with 'pip install pyarrow'"
+            ) from None
+
+    @staticmethod
     def has(pkg: str) -> bool:
         """Return True if any lib is installed."""
         return importlib.util.find_spec(pkg) is not None

--- a/marimo/_plugins/ui/_impl/data_explorer.py
+++ b/marimo/_plugins/ui/_impl/data_explorer.py
@@ -8,6 +8,7 @@ from marimo._plugins.ui._impl.tables.utils import get_table_manager
 if TYPE_CHECKING:
     import pandas as pd
     import polars as pl
+    import pyarrow as pa
 
 
 import marimo._output.data.data as mo_data
@@ -39,7 +40,7 @@ class data_explorer(UIElement[Dict[str, Any], Dict[str, Any]]):
 
     def __init__(
         self,
-        df: Union[pd.DataFrame, pl.DataFrame],
+        df: Union[pd.DataFrame, pl.DataFrame, pa.Table],
         on_change: Optional[Callable[[Dict[str, Any]], None]] = None,
     ) -> None:
         self._data = df

--- a/marimo/_plugins/ui/_impl/tables/default_table.py
+++ b/marimo/_plugins/ui/_impl/tables/default_table.py
@@ -47,9 +47,6 @@ class DefaultTableManager(TableManager[JsonTableData]):
             or DependencyManager.has_pyarrow()
         )
 
-    def supports_selection(self) -> bool:
-        return True
-
     def to_data(self) -> JSONType:
         return self._normalize_data(self.data)
 

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -31,6 +31,15 @@ class TableManager(abc.ABC, Generic[T]):
         """
         return mo_data.csv(self.to_csv()).url
 
+    def supports_download(self) -> bool:
+        return True
+
+    def supports_selection(self) -> bool:
+        return True
+
+    def supports_altair(self) -> bool:
+        return True
+
     @abc.abstractmethod
     def to_csv(self) -> bytes:
         raise NotImplementedError
@@ -72,9 +81,6 @@ class TableManager(abc.ABC, Generic[T]):
     @abc.abstractmethod
     def get_num_columns(self) -> int:
         raise NotImplementedError
-
-    def supports_altair(self) -> bool:
-        return True
 
 
 class TableManagerFactory(abc.ABC):

--- a/marimo/_plugins/ui/_impl/tables/types.py
+++ b/marimo/_plugins/ui/_impl/tables/types.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DataFrameLike(Protocol):
+    def __dataframe__(
+        self, nan_as_null: bool = False, allow_copy: bool = True
+    ) -> Any: ...

--- a/marimo/_plugins/ui/_impl/tables/utils.py
+++ b/marimo/_plugins/ui/_impl/tables/utils.py
@@ -83,4 +83,4 @@ def arrow_table_from_dataframe_protocol(
             if isinstance(result, pa.Table):
                 return result
 
-    return pi.from_dataframe(dfi_df)
+    return pi.from_dataframe(dfi_df)  # type: ignore[no-any-return]

--- a/marimo/_plugins/ui/_impl/tables/utils.py
+++ b/marimo/_plugins/ui/_impl/tables/utils.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any, List
+from typing import TYPE_CHECKING, Any, List
 
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._plugins.ui._impl.tables.default_table import DefaultTableManager
@@ -18,6 +18,10 @@ from marimo._plugins.ui._impl.tables.table_manager import (
     TableManager,
     TableManagerFactory,
 )
+from marimo._plugins.ui._impl.tables.types import DataFrameLike
+
+if TYPE_CHECKING:
+    import pyarrow
 
 MANAGERS: List[TableManagerFactory] = [
     PandasTableManagerFactory(),
@@ -31,10 +35,52 @@ def get_table_manager(data: Any) -> TableManager[Any]:
 
 
 def get_table_manager_or_none(data: Any) -> TableManager[Any] | None:
+    if data is None:
+        return None
+
+    # Try to find a manager specifically for the data type
     for manager_factory in MANAGERS:
         if DependencyManager.has(manager_factory.package_name()):
             manager = manager_factory.create()
             if manager.is_type(data):
                 return manager(data)
 
+    # If we have a DataFrameLike object, try to convert it the pyarrow table
+    if isinstance(data, DataFrameLike):
+        DependencyManager.require_pyarrow(
+            "For table support using the dataframe protocol"
+        )
+        return PyArrowTableManagerFactory.create()(
+            arrow_table_from_dataframe_protocol(data)
+        )
+
     return None
+
+
+# Copied from Altair
+# https://github.com/vega/altair/blob/18a2c3c237014591d172284560546a2f0ac1a883/altair/utils/data.py#L343
+def arrow_table_from_dataframe_protocol(
+    dfi_df: DataFrameLike,
+) -> "pyarrow.lib.Table":
+    """
+    Convert a DataFrame Interchange Protocol compatible object
+    to an Arrow Table
+    """
+    import pyarrow as pa
+    import pyarrow.interchange as pi
+
+    # First check if the dataframe object has a method to convert to arrow.
+    # Give this preference over the pyarrow from_dataframe function
+    # since the object
+    # has more control over the conversion, and may have broader compatibility.
+    # This is the case for Polars, which supports Date32 columns in
+    # direct conversion
+    # while pyarrow does not yet support this type in from_dataframe
+    for convert_method_name in ("arrow", "to_arrow", "to_arrow_table"):
+        convert_method = getattr(dfi_df, convert_method_name, None)
+        if callable(convert_method):
+            result = convert_method()
+            if isinstance(result, pa.Table):
+                return result
+
+    return pi.from_dataframe(dfi_df)

--- a/marimo/_smoke_tests/dataframe.py
+++ b/marimo/_smoke_tests/dataframe.py
@@ -212,14 +212,41 @@ def __():
 
 
 @app.cell
-def __(mo):
+def __():
     import ibis
 
     ibis.options.interactive = True
 
-    t = ibis.read_csv("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv", table_name="penguins")
-    mo.ui.table(t)
-    return ibis, t
+    ibis_data = ibis.read_csv("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv", table_name="penguins")
+    ibis_data
+    return ibis, ibis_data
+
+
+@app.cell
+def __(ibis_data, mo):
+    ibis_penguins = mo.ui.table(ibis_data)
+    return ibis_penguins,
+
+
+@app.cell
+def __(alt, ibis_data):
+    _chart = (
+        alt.Chart(ibis_data)
+        .mark_bar()
+        .encode(
+            y=alt.Y("island", type="nominal"),
+            x=alt.X("count()", type="quantitative"),
+        )
+        .properties(width="container")
+    )
+    _chart
+    return
+
+
+@app.cell
+def __(ibis_penguins):
+    ibis_penguins.value
+    return
 
 
 @app.cell
@@ -229,9 +256,10 @@ def __():
     import polars as pl
     import pyarrow as pa
     import vega_datasets
+    import altair as alt
 
     cars = vega_datasets.data.cars()
-    return cars, mo, pa, pd, pl, vega_datasets
+    return alt, cars, mo, pa, pd, pl, vega_datasets
 
 
 if __name__ == "__main__":

--- a/marimo/_smoke_tests/dataframe.py
+++ b/marimo/_smoke_tests/dataframe.py
@@ -2,11 +2,11 @@
 
 import marimo
 
-__generated_with = "0.3.10"
+__generated_with = "0.6.12"
 app = marimo.App(width="full")
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("# 🤖 Lists/Dicts")
     return
@@ -61,13 +61,13 @@ def __(as_primitives):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("# 🐼 Pandas")
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("## mo.ui.dataframe")
     return
@@ -80,7 +80,7 @@ def __(cars, mo):
     return dataframe,
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("## mo.ui.table")
     return
@@ -92,7 +92,7 @@ def __(dataframe, mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("## .value")
     return
@@ -110,7 +110,7 @@ def __(dataframe):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("## mo.ui.data_explorer")
     return
@@ -122,13 +122,13 @@ def __(mo, pl_dataframe):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("# 🐻‍❄️ Polars")
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("## mo.ui.table")
     return
@@ -141,7 +141,7 @@ def __(cars, mo, pl):
     return pl_dataframe,
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("## mo.ui.data_explorer")
     return
@@ -153,7 +153,7 @@ def __(mo, pl_dataframe):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("# 🏹 Arrow")
     return
@@ -166,7 +166,7 @@ def __(cars, mo, pa):
     return arrow_table,
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("## mo.ui.table")
     return
@@ -179,7 +179,7 @@ def __(arrow_table, mo):
     return arrow_table_el,
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md("## .value")
     return
@@ -189,6 +189,37 @@ def __(mo):
 def __(arrow_table_el):
     arrow_table_el.value
     return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        rf"""
+        # 💽 Dataframe protocol
+        > See the [API](https://data-apis.org/dataframe-protocol/latest/API.html)
+        """
+    )
+    return
+
+
+@app.cell
+def __():
+    import dask.dataframe as dd
+
+    dask_df = dd.read_csv("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv")
+    dask_df
+    return dask_df, dd
+
+
+@app.cell
+def __(mo):
+    import ibis
+
+    ibis.options.interactive = True
+
+    t = ibis.read_csv("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/penguins.csv", table_name="penguins")
+    mo.ui.table(t)
+    return ibis, t
 
 
 @app.cell

--- a/marimo/_smoke_tests/dataframe.py
+++ b/marimo/_smoke_tests/dataframe.py
@@ -192,6 +192,12 @@ def __(arrow_table_el):
 
 
 @app.cell
+def __(arrow_table, mo):
+    mo.ui.data_explorer(arrow_table)
+    return
+
+
+@app.cell
 def __(mo):
     mo.md(
         rf"""
@@ -203,11 +209,11 @@ def __(mo):
 
 
 @app.cell
-def __():
+def __(dask_dfda):
     import dask.dataframe as dd
 
     dask_df = dd.read_csv("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv")
-    dask_df
+    dask_dfda
     return dask_df, dd
 
 
@@ -223,29 +229,33 @@ def __():
 
 
 @app.cell
-def __(ibis_data, mo):
-    ibis_penguins = mo.ui.table(ibis_data)
-    return ibis_penguins,
+def __(mo):
+    mo.md(rf"## mo.ui.table")
+    return
 
 
 @app.cell
-def __(alt, ibis_data):
-    _chart = (
-        alt.Chart(ibis_data)
-        .mark_bar()
-        .encode(
-            y=alt.Y("island", type="nominal"),
-            x=alt.X("count()", type="quantitative"),
-        )
-        .properties(width="container")
-    )
-    _chart
-    return
+def __(ibis_data, mo):
+    ibis_penguins = mo.ui.table(ibis_data)
+    ibis_penguins
+    return ibis_penguins,
 
 
 @app.cell
 def __(ibis_penguins):
     ibis_penguins.value
+    return
+
+
+@app.cell(hide_code=True)
+def __(mo):
+    mo.md(rf"## mo.ui.data_explorer")
+    return
+
+
+@app.cell
+def __(ibis_data, mo):
+    mo.ui.data_explorer(ibis_data)
     return
 
 


### PR DESCRIPTION
## 📝 Summary

This adds support for Ibis and the [dataframe protocol](https://data-apis.org/dataframe-protocol/latest/) in `mo.ui.table` and `mo.ui.data_explorer` as well as the new datasources panel.

This is using the pyarrow interchange to convert to a pyarrow table, so we can use leverage our existing infrastructure downstream.

It isn't quite necessary to try to convert to pandas or polars from the dataframe protocol since most of the libraries that implement the dataframe protocol (i.e. ibis) already require pyarrow. If we wanted to add this later, we ccan