### PR TITLE
improvement: persist sidebar across refreshes

### DIFF
--- a/frontend/src/components/debug/indicator.tsx
+++ b/frontend/src/components/debug/indicator.tsx
@@ -5,7 +5,7 @@ export const TailwindIndicator = () => {
   }
 
   return (
-    <div className="fixed bottom-2 right-[240px] z-50 flex size-5 items-center justify-center rounded-lg bg-gray-800 py-3 px-4 font-mono text-xs text-white">
+    <div className="fixed bottom-2 left-[60px] z-50 flex size-5 items-center justify-center rounded-lg bg-gray-800 py-3 px-4 font-mono text-xs text-white">
       <div className="block sm:hidden">xs</div>
       <div className="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">
         sm

--- a/frontend/src/components/editor/chrome/state.ts
+++ b/frontend/src/components/editor/chrome/state.ts
@@ -2,12 +2,27 @@
 import { createReducerAndAtoms } from "@/utils/createReducer";
 import { useAtomValue } from "jotai";
 import { PanelType } from "./types";
+import { ZodLocalStorage } from "@/utils/localStorage";
+import { z } from "zod";
 
 export interface ChromeState {
   selectedPanel: PanelType | undefined;
   isOpen: boolean;
   panelLocation: "left" | "bottom";
 }
+
+const storage = new ZodLocalStorage<ChromeState>(
+  "marimo:sidebar",
+  z.object({
+    selectedPanel: z
+      .string()
+      .optional()
+      .transform((v) => v as PanelType),
+    isOpen: z.boolean(),
+    panelLocation: z.union([z.literal("left"), z.literal("bottom")]),
+  }),
+  initialState,
+);
 
 function initialState(): ChromeState {
   return {
@@ -22,23 +37,27 @@ const {
   createActions,
   valueAtom: chromeAtom,
   useActions,
-} = createReducerAndAtoms(initialState, {
-  openApplication: (state, selectedPanel: PanelType) => ({
-    ...state,
-    selectedPanel,
-    // If it was closed, open it
-    // If it was open, keep it open unless it was the same application
-    isOpen: state.isOpen ? state.selectedPanel !== selectedPanel : true,
-  }),
-  openPanel: (state) => ({ ...state, isOpen: true }),
-  closePanel: (state) => ({ ...state, isOpen: false }),
-  togglePanel: (state) => ({ ...state, isOpen: !state.isOpen }),
-  setIsOpen: (state, isOpen: boolean) => ({ ...state, isOpen }),
-  changePanelLocation: (state, panelLocation: "left" | "bottom") => ({
-    ...state,
-    panelLocation,
-  }),
-});
+} = createReducerAndAtoms(
+  () => storage.get(),
+  {
+    openApplication: (state, selectedPanel: PanelType) => ({
+      ...state,
+      selectedPanel,
+      // If it was closed, open it
+      // If it was open, keep it open unless it was the same application
+      isOpen: state.isOpen ? state.selectedPanel !== selectedPanel : true,
+    }),
+    openPanel: (state) => ({ ...state, isOpen: true }),
+    closePanel: (state) => ({ ...state, isOpen: false }),
+    togglePanel: (state) => ({ ...state, isOpen: !state.isOpen }),
+    setIsOpen: (state, isOpen: boolean) => ({ ...state, isOpen }),
+    changePanelLocation: (state, panelLocation: "left" | "bottom") => ({
+      ...state,
+      panelLocation,
+    }),
+  },
+  [(_prevState, newState) => storage.set(newState)],
+);
 
 export const useChromeState = () => {
   const state = useAtomValue(chromeAtom);

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
@@ -16,7 +16,7 @@ export const VerticalLayoutWrapper: React.FC<PropsWithChildren<Props>> = ({
   children,
 }) => {
   return (
-    <div className={cn("px-1 sm:px-16 md:px-20", className)}>
+    <div className={cn("px-1 sm:px-16 md:px-20 xl:px-24", className)}>
       <div
         className={cn(
           // Large mobile bottom padding due to mobile browser navigation bar

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
@@ -16,7 +16,7 @@ export const VerticalLayoutWrapper: React.FC<PropsWithChildren<Props>> = ({
   children,
 }) => {
   return (
-    <div className={cn("px-1 sm:px-16 md:px-32", className)}>
+    <div className={cn("px-1 sm:px-16 md:px-20", className)}>
       <div
         className={cn(
           // Large mobile bottom padding due to mobile browser navigation bar

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -207,7 +207,7 @@
     justify-content: flex-end;
     height: 100%;
     position: absolute;
-    right: -98px;
+    right: -94px;
     width: 80px;
     gap: 4px;
     z-index: 2;


### PR DESCRIPTION
- persist sidebar across refreshes in local storage (it's jarring when a session is resumed, by the sidebar is not)
- reduce some padding on the side (with the sidebar open more, its quite useful padding


## After 
<img width="1293" alt="Screenshot 2024-05-30 at 8 28 37 AM" src="https://github.com/marimo-team/marimo/assets/2753772/6b61c938-bb79-446e-acd1-ea82a1bdd40b">


## Before
<img width="1294" alt="Screenshot 2024-05-30 at 8 28 17 AM" src="https://github.com/marimo-team/marimo/assets/2753772/0652e5a6-0ecd-4859-a698-01bf5212de18">
