### PR TITLE
Change WS port for copilot behind proxy

### DIFF
--- a/frontend/src/core/codemirror/copilot/client.ts
+++ b/frontend/src/core/codemirror/copilot/client.ts
@@ -82,8 +82,10 @@ export function copilotServer() {
 const DEVELOPMENT_WS_PORT = 27_180;
 export function createWsUrl(): string {
   // TODO: this should be configurable, but instead we add a 0 and hope it is free
+  // NOTE: window.location.port may also be empty if running behind a proxy
+  // (plain 80 or 443 just gives a protocol), so default to the development port.
   const LSP_PORT =
-    process.env.NODE_ENV === "development"
+    process.env.NODE_ENV === "development" || (!window.location.port)
       ? DEVELOPMENT_WS_PORT
       : `${window.location.port}0`;
   const protocol = window.location.protocol === "https:" ? "wss" : "ws";


### PR DESCRIPTION
## 📝 Summary
 Closes #1484 !

Copilot previously tried to connect on `:0`