### PR TITLE
improvement: runtime configuration in footer

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -24,7 +24,7 @@ export const Footer: React.FC = () => {
   };
 
   return (
-    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md pl-1 pr-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50">
+    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md pl-1 pr-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50 divide-x">
       <FooterItem
         tooltip="View errors"
         selected={selectedPanel === "errors"}
@@ -41,7 +41,6 @@ export const Footer: React.FC = () => {
             : "Enable autorun on startup"
         }
         selected={false}
-        className="border-r"
         onClick={async () => {
           const newConfig = {
             ...config,

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -41,6 +41,7 @@ export const Footer: React.FC = () => {
             : "Enable autorun on startup"
         }
         selected={false}
+        className="border-r"
         onClick={async () => {
           const newConfig = {
             ...config,
@@ -54,7 +55,7 @@ export const Footer: React.FC = () => {
           );
         }}
       >
-        <div className="font-prose text-sm flex items-center gap-1 border-r pr-2">
+        <div className="font-prose text-sm flex items-center gap-1">
           <span>on startup: </span>
           {config.runtime.auto_instantiate ? (
             <ZapIcon size={14} />
@@ -88,7 +89,7 @@ export const Footer: React.FC = () => {
           );
         }}
       >
-        <div className="font-prose text-sm flex items-center gap-1 border-r pr-2">
+        <div className="font-prose text-sm flex items-center gap-1">
           <span>on cell change: </span>
           {config.runtime.on_cell_change === "autorun" ? (
             <ZapIcon size={14} />

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -7,10 +7,15 @@ import { useAtomValue } from "jotai";
 import { cellErrorCount } from "@/core/cells/cells";
 import { PANEL_ICONS, PanelType } from "../types";
 import { MachineStats } from "./machine-stats";
+import { useUserConfig } from "@/core/config/config";
+import { ZapIcon, ZapOffIcon } from "lucide-react";
+import { saveUserConfig } from "@/core/network/requests";
+import { UserConfig } from "@/core/config/config-schema";
 
 export const Footer: React.FC = () => {
   const { selectedPanel } = useChromeState();
   const { openApplication } = useChromeActions();
+  const [config, setConfig] = useUserConfig();
   const errorCount = useAtomValue(cellErrorCount);
 
   const renderIcon = (type: PanelType, className?: string) => {
@@ -28,6 +33,72 @@ export const Footer: React.FC = () => {
         {renderIcon("errors", errorCount > 0 ? "text-destructive" : "")}
         <span className="ml-1 font-mono mt-[0.125rem]">{errorCount}</span>
       </FooterItem>
+
+      <FooterItem
+        tooltip={
+          config.runtime.auto_instantiate
+            ? "Disable autorun on startup"
+            : "Enable autorun on startup"
+        }
+        selected={false}
+        onClick={async () => {
+          const newConfig = {
+            ...config,
+            runtime: {
+              ...config.runtime,
+              auto_instantiate: !config.runtime.auto_instantiate,
+            },
+          };
+          await saveUserConfig({ config: newConfig }).then(() =>
+            setConfig(newConfig),
+          );
+        }}
+      >
+        <div className="font-prose text-sm flex items-center gap-1 border-r pr-2">
+          <span>on startup: </span>
+          {config.runtime.auto_instantiate ? (
+            <ZapIcon size={14} />
+          ) : (
+            <ZapOffIcon size={16} />
+          )}
+          <span>{config.runtime.auto_instantiate ? "autorun" : "lazy"}</span>
+        </div>
+      </FooterItem>
+
+      <FooterItem
+        tooltip={
+          config.runtime.on_cell_change === "autorun"
+            ? "Disable autorun"
+            : "Enable autorun"
+        }
+        selected={false}
+        onClick={async () => {
+          const newConfig: UserConfig = {
+            ...config,
+            runtime: {
+              ...config.runtime,
+              on_cell_change:
+                config.runtime.on_cell_change === "autorun"
+                  ? "lazy"
+                  : "autorun",
+            },
+          };
+          await saveUserConfig({ config: newConfig }).then(() =>
+            setConfig(newConfig),
+          );
+        }}
+      >
+        <div className="font-prose text-sm flex items-center gap-1 border-r pr-2">
+          <span>on cell change: </span>
+          {config.runtime.on_cell_change === "autorun" ? (
+            <ZapIcon size={14} />
+          ) : (
+            <ZapOffIcon size={16} />
+          )}
+          <span>{config.runtime.on_cell_change}</span>
+        </div>
+      </FooterItem>
+
       <div className="mx-auto" />
 
       <MachineStats />

--- a/frontend/src/core/codemirror/copilot/client.ts
+++ b/frontend/src/core/codemirror/copilot/client.ts
@@ -85,7 +85,7 @@ export function createWsUrl(): string {
   // NOTE: window.location.port may also be empty if running behind a proxy
   // (plain 80 or 443 just gives a protocol), so default to the development port.
   const LSP_PORT =
-    process.env.NODE_ENV === "development" || (!window.location.port)
+    process.env.NODE_ENV === "development" || !window.location.port
       ? DEVELOPMENT_WS_PORT
       : `${window.location.port}0`;
   const protocol = window.location.protocol === "https:" ? "wss" : "ws";

--- a/frontend/src/core/codemirror/language/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/utils.test.ts
@@ -100,7 +100,7 @@ describe("splitEditor", () => {
 
     const result2 = splitEditor(mockEditor);
     expect(result2.beforeCursorCode).toEqual(
-      "print('Hello')\nprint('Goodbye')"
+      "print('Hello')\nprint('Goodbye')",
     );
     expect(result2.afterCursorCode).toEqual("");
   });

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -26,7 +26,7 @@ const quoteKinds = [
 ];
 // explode into all combinations
 const pairs = prefixKinds.flatMap((prefix) =>
-  quoteKinds.map(([start, end]) => [prefix + start, end])
+  quoteKinds.map(([start, end]) => [prefix + start, end]),
 );
 
 const regexes = pairs.map(
@@ -35,7 +35,7 @@ const regexes = pairs.map(
     [
       start,
       new RegExp(`^mo\\.md\\(\\s*${start}(.*)${end}\\s*\\)$`, "s"),
-    ] as const
+    ] as const,
 );
 
 /**
@@ -155,7 +155,7 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
 function splitQuotePrefix(quote: string): [PrefixKind, string] {
   // start with the longest prefix
   const prefixKindsByLength = [...prefixKinds].sort(
-    (a, b) => b.length - a.length
+    (a, b) => b.length - a.length,
   );
   for (const prefix of prefixKindsByLength) {
     if (quote.startsWith(prefix)) {
@@ -218,7 +218,7 @@ const emojiCompletionSource: CompletionSource = async (context) => {
 // everything works fine, except for autocompletion of emojis
 const getEmojiList = once(async (): Promise<Completion[]> => {
   const emojiList = await fetch(
-    "https://unpkg.com/emojilib@3.0.11/dist/emoji-en-US.json"
+    "https://unpkg.com/emojilib@3.0.11/dist/emoji-en-US.json",
   ).then((res) => res.json() as unknown as Record<string, string[]>);
 
   return Object.entries(emojiList).map(([emoji, names]) => ({


### PR DESCRIPTION
Expose some runtime configuration in the footer:

- autorun on startup
- on cell change

and make it toggle-able on click. This change increases the information density of our UI, making these settings more discoverable.

<img width="531" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/ffdc6b9a-e168-4d0a-80ec-bd0d7df0838f">

<img width="358" alt="image" src="https://github.com/marimo-team/marimo/assets/1994308/0970d094-07de-41cd-8593-1382230228ad">
