### PR TITLE
fix: download as yaml in WASM

### DIFF
--- a/frontend/src/components/debug/indicator.tsx
+++ b/frontend/src/components/debug/indicator.tsx
@@ -5,7 +5,7 @@ export const TailwindIndicator = () => {
   }
 
   return (
-    <div className="fixed bottom-2 left-[60px] z-50 flex size-5 items-center justify-center rounded-lg bg-gray-800 py-3 px-4 font-mono text-xs text-white">
+    <div className="fixed bottom-2 right-[60px] z-50 flex size-5 items-center justify-center rounded-lg bg-gray-800 py-3 px-4 font-mono text-xs text-white">
       <div className="block sm:hidden">xs</div>
       <div className="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">
         sm

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -24,7 +24,7 @@ export const Footer: React.FC = () => {
   };
 
   return (
-    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md pl-1 pr-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50 divide-x">
+    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md pl-1 pr-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50">
       <FooterItem
         tooltip="View errors"
         selected={selectedPanel === "errors"}
@@ -64,6 +64,8 @@ export const Footer: React.FC = () => {
           <span>{config.runtime.auto_instantiate ? "autorun" : "lazy"}</span>
         </div>
       </FooterItem>
+
+      <div className="border-r border-border h-6 mx-1" />
 
       <FooterItem
         tooltip={

--- a/frontend/src/core/pyodide/worker/worker.ts
+++ b/frontend/src/core/pyodide/worker/worker.ts
@@ -179,6 +179,18 @@ const requestHandler = createRPCRequestHandler({
         `);
     }
 
+    // Special case to lazily install pyaml on export_markdown
+    if (functionName === "export_markdown") {
+      await self.pyodide.runPythonAsync(`
+        import micropip
+
+        try:
+          import pyaml
+        except ModuleNotFoundError:
+          await micropip.install("pyaml")
+        `);
+    }
+
     // Perform the function call to the Python bridge
     const bridge = await bridgeReady.promise;
 

--- a/frontend/src/core/pyodide/worker/worker.ts
+++ b/frontend/src/core/pyodide/worker/worker.ts
@@ -185,9 +185,9 @@ const requestHandler = createRPCRequestHandler({
         import micropip
 
         try:
-          import pyaml
+          import yaml
         except ModuleNotFoundError:
-          await micropip.install("pyaml")
+          await micropip.install("pyyaml")
         `);
     }
 


### PR DESCRIPTION
Fixes #1547

Download `pyyaml` beforehand if it doesn't exist