### PR TITLE
fix: replace nbsp with space

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -54,6 +54,12 @@ def cache(filename: str, code: str) -> None:
 
 
 def compile_cell(code: str, cell_id: CellId_t) -> CellImpl:
+    # Replace non-breaking spaces with regular spaces -- some frontends
+    # send nbsp in place of space, which is a syntax error.
+    #
+    # See https://github.com/pyodide/pyodide/issues/3337,
+    #     https://github.com/marimo-team/marimo/issues/1546
+    code = code.replace("\u00A0", " ")
     module = compile(
         code,
         "<unknown>",

--- a/tests/_cli/snapshots/marimo_for_jupyter_users.md.txt
+++ b/tests/_cli/snapshots/marimo_for_jupyter_users.md.txt
@@ -84,7 +84,7 @@ for both Jupyter and Streamlit.
 <!---->
 ## Cell order
 
-In marimo, cells can be arranged in any order — marimo figures out the one true way to execute them based on variable declarations and references (in a ["topologically sorted"](https://en.wikipedia.org/wiki/Topological_sorting#:~:text=In%20computer%20science%2C%20a%20topological,before%20v%20in%20the%20ordering.) order)
+In marimo, cells can be arranged in any order — marimo figures out the one true way to execute them based on variable declarations and references (in a ["topologically sorted"](https://en.wikipedia.org/wiki/Topological_sorting#:~:text=In%20computer%20science%2C%20a%20topological,before%20v%20in%20the%20ordering.) order)
 
 ```{.python.marimo}
 z.value

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -738,6 +738,17 @@ class TestExecution:
         assert k.graph.cells[er_1.cell_id].config.disabled
         assert "x" not in k.globals
 
+    async def test_run_code_with_nbsp(
+        self, any_kernel: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        k = any_kernel
+        # u00A0 is a non-breaking space (nbsp), which gets inserted on some
+        # platforms/browsers; marimo converts these characters to spaces ...
+        code = "x \u00A0 = 10"
+        await k.run([exec_req.get(code)])
+        assert not k.errors
+        assert k.globals["x"] == 10
+
 
 class TestStoredOutput:
     async def test_ui_element_in_output_stored(


### PR DESCRIPTION
Some browsers might send the nbsp character (U00A0) instead of spaces, causing syntax errors when trying to run Python.

This change uniformly replaces nbsp characters with spaces when compiling code.

This seems okay to me, but not sure if this has second-order effects that I'm unaware of ...

Fixes #1546 