### PR TITLE
improvement: add .apply_selection() to mo.ui.altair_chart for layered/stacked charts

### DIFF
--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -14,6 +14,8 @@ from typing import (
     Union,
 )
 
+from altair import UndefinedType
+
 from marimo import _loggers
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.rich_help import mddoc
@@ -245,7 +247,7 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
             chart_selection = False
             legend_selection = False
 
-        self.dataframe = chart.data
+        self.dataframe: UndefinedType | pd.DataFrame = chart.data
 
         # Private attributes
         self._chart = chart
@@ -275,6 +277,12 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
 
             return pd.DataFrame()
 
+        # When using layered charts, you can no longer access the
+        # chart data directly
+        # Instead, we should push user to call .apply_selection(df)
+        if isinstance(self.dataframe, UndefinedType):
+            return self.dataframe
+
         # If we have transforms, we need to filter the dataframe
         # with those transforms, before applying the selection
         if _has_transforms(self._spec):
@@ -291,3 +299,57 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
                 return _filter_dataframe(self.dataframe, value)
 
         return _filter_dataframe(self.dataframe, value)
+
+    def apply_selection(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Apply the selection to a DataFrame.
+
+        This method is useful when you have a layered chart and you want to
+        apply the selection to a DataFrame.
+
+        **Example.**
+
+        ```python
+        import altair as alt
+        import marimo as mo
+        from vega_datasets import data
+
+        cars = data.cars()
+
+        _chart = (
+            alt.Chart(cars)
+            .mark_point()
+            .encode(
+                x="Horsepower",
+                y="Miles_per_Gallon",
+                color="Origin",
+            )
+        )
+
+        chart = mo.ui.altair_chart(_chart)
+        chart
+
+        # In another cell
+        selected_df = chart.apply_selection(cars)
+        ```
+
+        **Args.**
+
+        - `df`: a Pandas DataFrame to apply the selection to
+
+        **Returns.**
+
+        - a Pandas DataFrame of the plot data filtered by the selections
+        """
+        return _filter_dataframe(df, self.selections)
+
+    @property
+    def value(self) -> pd.DataFrame:
+        value = super().value
+        if isinstance(value, UndefinedType):
+            sys.stderr.write(
+                "The underlying chart data is not available in layered"
+                " or stacked charts. "
+                "Use `.apply_selection(df)` to filter a DataFrame"
+                " based on the selection.",
+            )
+        return value

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -14,8 +14,6 @@ from typing import (
     Union,
 )
 
-from altair import UndefinedType
-
 from marimo import _loggers
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.rich_help import mddoc
@@ -247,7 +245,7 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
             chart_selection = False
             legend_selection = False
 
-        self.dataframe: UndefinedType | pd.DataFrame = chart.data
+        self.dataframe: alt.UndefinedType | pd.DataFrame = chart.data
 
         # Private attributes
         self._chart = chart
@@ -270,6 +268,8 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
         return self._chart_selection
 
     def _convert_value(self, value: ChartSelection) -> Any:
+        from altair import UndefinedType
+
         self._chart_selection = value
         flat, _ = flatten.flatten(value)
         if not value or not flat:
@@ -344,6 +344,8 @@ class altair_chart(UIElement[ChartSelection, "pd.DataFrame"]):
 
     @property
     def value(self) -> pd.DataFrame:
+        from altair import UndefinedType
+
         value = super().value
         if isinstance(value, UndefinedType):
             sys.stderr.write(

--- a/marimo/_smoke_tests/bugs/1545.py
+++ b/marimo/_smoke_tests/bugs/1545.py
@@ -1,0 +1,74 @@
+import marimo
+
+__generated_with = "0.6.14"
+app = marimo.App(width="full")
+
+
+@app.cell
+def __():
+    import altair as alt
+    import marimo as mo
+    import pandas as pd
+    return alt, mo, pd
+
+
+@app.cell
+def __(pd):
+    df = pd.DataFrame(
+        data={
+            "annotation": ["w", "x", "y", "a", "b", "c", "d", "e", "f", "g"],
+            "x": [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6],
+            "y": pd.Series(
+                [9, 4, 1, 0, 1, 4, 9, 16, 25, 36],
+                index=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ),
+        },
+        index=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    )
+    return df,
+
+
+@app.cell
+def __(alt, df, pd):
+    scatter = alt.Chart(df).mark_point().encode(x="x", y="y", tooltip="annotation")
+    y_line = (
+        alt.Chart(pd.DataFrame({"var1": [0, 0], "var2": [0, 40]}))
+        .mark_line(color="grey")
+        .encode(alt.X("var1"), alt.Y("var2"))
+    )
+    return scatter, y_line
+
+
+@app.cell
+def __(alt, mo, scatter, y_line):
+    layer_plot = mo.ui.altair_chart(
+        alt.layer(scatter, y_line)
+        .configure_axis(grid=False)
+        .configure_view(strokeWidth=0)
+    )
+
+    layer_plot
+    return layer_plot,
+
+
+@app.cell
+def __(layer_plot):
+    layer_plot.selections
+    return
+
+
+@app.cell
+def __(layer_plot):
+    print(layer_plot.value)
+    return
+
+
+@app.cell
+def __(df, layer_plot):
+    print(layer_plot.apply_selection(df))
+    # should return a table of selected points based on the scatter plot
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Adds `.apply_selection` to a altair_chart widget:

Apply the selection to a DataFrame.

  This method is useful when you have a layered chart and you want to
  apply the selection to a DataFrame.

  **Example.**

  ```python
  import altair as alt
  import marimo as mo
  from vega_datasets import data

  cars = data.cars()

  _chart = (
      alt.Chart(cars)
      .mark_point()
      .encode(
          x="Horsepower",
          y="Miles_per_Gallon",
          color="Origin",
      )
  )

  chart = mo.ui.altair_chart(_chart)
  chart

  # In another cell
  selected_df = chart.apply_selection(cars)
  ```

  **Args.**

  - `df`: a Pandas DataFrame to apply the selection to

  **Returns.**

  - a Pandas DataFrame of the plot data filtered by the selections