### PR TITLE
improve: Select folders and select all in File Browser

### DIFF
--- a/frontend/src/plugins/impl/FileBrowserPlugin.tsx
+++ b/frontend/src/plugins/impl/FileBrowserPlugin.tsx
@@ -120,6 +120,7 @@ export const FileBrowser = ({
   list_directory,
 }: FileBrowserProps): JSX.Element | null => {
   const [path, setPath] = useState(initialPath);
+  const [selectAllLabel, setSelectAllLabel] = useState("Select all");
 
   const { data, loading, error } = useAsyncData(
     () =>
@@ -153,19 +154,18 @@ export const FileBrowser = ({
   // Rendered list of selected files
   const selectedFiles = value.map((x) => <li key={x.id}>{x.path}</li>);
 
-  /**
-   * Set new path from user input or selection.
-   *
-   * @param {string} newPath - New path
-   */
   function setNewPath(newPath: string) {
     // Navigate to parent directory
     if (newPath === "..") {
-      newPath = Paths.dirname(path);
-    }
+      if (path === "") {
+        return;
+      }
 
-    if (newPath === "") {
-      return;
+      newPath = Paths.dirname(path);
+
+      if (newPath === "") {
+        newPath = path.includes("/") ? "/" : "\\";
+      }
     }
 
     // If restricting navigation, check if path is outside bounds
@@ -182,6 +182,7 @@ export const FileBrowser = ({
     }
 
     setPath(newPath);
+    setSelectAllLabel("Select all");
   }
 
   function createFileInfo(path: string, name: string): FileInfo {
@@ -200,6 +201,7 @@ export const FileBrowser = ({
     if (multiple) {
       if (selectedPaths.has(path)) {
         setValue(value.filter((x) => x.path !== path));
+        setSelectAllLabel("Select all");
       } else {
         setValue([...value, fileInfo]);
       }
@@ -210,6 +212,7 @@ export const FileBrowser = ({
 
   function deselectAllFiles() {
     setValue(value.filter((x) => Paths.dirname(x.path) !== path));
+    setSelectAllLabel("Select all");
   }
 
   function selectAllFiles() {
@@ -228,6 +231,7 @@ export const FileBrowser = ({
     }
 
     setValue([...value, ...filesInView]);
+    setSelectAllLabel("Deselect all");
   }
 
   // Create rows for directories and files
@@ -306,27 +310,20 @@ export const FileBrowser = ({
   return (
     <section>
       {multiple ? (
-        <div className="grid grid-cols-12 gap-2">
-          <div className="col-span-8 flex flex-row items-center">
-            {labelText}
-          </div>
-          <div className="col-span-2 flex flex-row items-center">
+        <div className="grid grid-cols-2 items-center border-1">
+          <div className="justify-self-start mb-1">{labelText}</div>
+          <div className="justify-self-end">
             <Button
               size="xs"
+              variant="link"
               className="w-full"
-              onClick={() => selectAllFiles()}
+              onClick={
+                selectAllLabel === "Select all"
+                  ? () => selectAllFiles()
+                  : () => deselectAllFiles()
+              }
             >
-              {renderHTML({ html: "Select all" })}
-            </Button>
-          </div>
-          <div className="col-span-2 flex flex-row items-center">
-            <Button
-              variant="secondary"
-              size="xs"
-              className="w-full"
-              onClick={() => deselectAllFiles()}
-            >
-              {renderHTML({ html: "Deselect all" })}
+              {renderHTML({ html: selectAllLabel })}
             </Button>
           </div>
         </div>

--- a/frontend/src/plugins/impl/FileBrowserPlugin.tsx
+++ b/frontend/src/plugins/impl/FileBrowserPlugin.tsx
@@ -13,7 +13,7 @@ import {
   guessFileType,
 } from "@/components/editor/file-tree/types";
 import { renderHTML } from "../core/RenderHTML";
-import { PathBuilder, Paths } from "@/utils/paths";
+import { FilePath, PathBuilder, Paths } from "@/utils/paths";
 import { CornerLeftUp } from "lucide-react";
 import { Logger } from "@/utils/Logger";
 import { Button } from "@/components/ui/button";
@@ -148,23 +148,23 @@ export const FileBrowser = ({
     files = [];
   }
 
-  // List of selected file paths
-  const selectedPaths = new Set(value.map((x) => x.path));
+  const delimiter = path.includes("/") ? "/" : "\\";
+  const pathBuilder = new PathBuilder(delimiter);
 
-  // Rendered list of selected files
+  const selectedPaths = new Set(value.map((x) => x.path));
   const selectedFiles = value.map((x) => <li key={x.id}>{x.path}</li>);
 
   function setNewPath(newPath: string) {
     // Navigate to parent directory
     if (newPath === "..") {
-      if (path === "") {
+      if (path === delimiter) {
         return;
       }
 
       newPath = Paths.dirname(path);
 
       if (newPath === "") {
-        newPath = path.includes("/") ? "/" : "\\";
+        newPath = delimiter;
       }
     }
 
@@ -251,11 +251,12 @@ export const FileBrowser = ({
     </TableRow>,
   );
 
-  const delimiter = path.includes("/") ? "/" : "\\";
-  const pathBuilder = new PathBuilder(delimiter);
-
   for (const file of files) {
-    const filePath = pathBuilder.join(path, file.name);
+    let filePath = pathBuilder.join(path, file.name);
+
+    if (filePath.startsWith("//")) {
+      filePath = filePath.slice(1) as FilePath;
+    }
 
     // Click handler
     const handleClick = file.is_directory ? setNewPath : handleSelection;

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -1190,9 +1190,10 @@ class file_browser(UIElement[List[Dict[str, Any]], Sequence[FileInfo]]):
 
     **Initialization Args.**
 
-    - `initial_path`: the directory to start from.
+    - `initial_path`: starting directory, default current working directory.
     - `filetypes`: the file types to display in each directory; for example,
        `filetypes=[".txt", ".csv"]`. If `None`, all files are displayed.
+    - `selection_mode`: either "file" or "directory".
     - `multiple`: if True, allow the user to select multiple files.
     - `restrict_navigation`: if True, prevent the user from navigating
        any level above the given path.
@@ -1206,6 +1207,7 @@ class file_browser(UIElement[List[Dict[str, Any]], Sequence[FileInfo]]):
         self,
         initial_path: str = "",
         filetypes: Optional[Sequence[str]] = None,
+        selection_mode: str = "file",
         multiple: bool = True,
         restrict_navigation: bool = False,
         *,
@@ -1213,6 +1215,19 @@ class file_browser(UIElement[List[Dict[str, Any]], Sequence[FileInfo]]):
         on_change: Optional[Callable[[Sequence[FileInfo]], None]] = None,
     ) -> None:
         self.filetypes = filetypes
+
+        if (
+            selection_mode != "file"
+            and selection_mode != "directory"
+            and selection_mode != "all"
+        ):
+            raise ValueError(
+                "Invalid argument for selection_mode. "
+                + "Must be either 'file' or 'directory'."
+            )
+        else:
+            self.filetypes = None
+            self.selection_mode = selection_mode
 
         if not initial_path:
             initial_path = os.getcwd()
@@ -1223,6 +1238,7 @@ class file_browser(UIElement[List[Dict[str, Any]], Sequence[FileInfo]]):
             label=label,
             args={
                 "initial-path": initial_path,
+                "selection-mode": selection_mode,
                 "filetypes": filetypes if filetypes is not None else [],
                 "multiple": multiple,
                 "restrict-navigation": restrict_navigation,
@@ -1243,6 +1259,9 @@ class file_browser(UIElement[List[Dict[str, Any]], Sequence[FileInfo]]):
 
         for file in files_in_path:
             _, extension = os.path.splitext(file.name)
+
+            if self.selection_mode == "directory" and not file.is_directory:
+                continue
 
             if self.filetypes and not file.is_directory:
                 if extension not in self.filetypes:


### PR DESCRIPTION
## 📝 Summary

Enhances the File Browser component (fulfilling #1478) with a few bug fixes.

## 🔍 Description of Changes

- Adds `selection_mode` parameter to allow the user to select files, directories, or both.
  - To select a directory, user must check the checkbox next to the directory name. Clicking the table row still "opens" the directory.
- Adds "Select all" / "Deselect all" button to allow user to select or deselect all files in the current directory.
  - If `multiple == False`, then these buttons are not rendered.
- Fixes error when clicking ".." at the topmost directory.
- TODO: Prints a more readable representation of a FileInfo list.

<img width="1512" alt="Screenshot 2024-06-04 at 10 15 15 PM" src="https://github.com/marimo-team/marimo/assets/7220175/23f9ad39-ffce-4e00-bf12-4b84a8f0853f">

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

- @mscolnick
