### PR TITLE
improvement: fallback to jedi interpeter in completion

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -59,7 +59,7 @@ def compile_cell(code: str, cell_id: CellId_t) -> CellImpl:
     #
     # See https://github.com/pyodide/pyodide/issues/3337,
     #     https://github.com/marimo-team/marimo/issues/1546
-    code = code.replace("\u00A0", " ")
+    code = code.replace("\u00a0", " ")
     module = compile(
         code,
         "<unknown>",

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -332,7 +332,7 @@ def complete(
     - `request`: the completion request
     - `graph`: dataflow graph backing the marimo program
     - `glbls`: global namespace
-    - `glbls_lock`: lock protecting the global namespace, for interpeter-based
+    - `glbls_lock`: lock protecting the global namespace, for interpreter-based
          completion
     - `stream`: Stream through which to communicate completion results
     - `docstrings_limit`: limit past which we won't attempt to fetch type hints

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -1,9 +1,8 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import threading
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterator, Optional
 
 from marimo._messaging.types import Stderr, Stdout
@@ -30,7 +29,6 @@ class KernelRuntimeContext(RuntimeContext):
     """Encapsulates runtime state for a session."""
 
     _kernel: Kernel
-    _globals_lock: threading.RLock = field(default_factory=threading.RLock)
     _id_provider: Optional[IDProvider] = None
 
     @property
@@ -40,10 +38,6 @@ class KernelRuntimeContext(RuntimeContext):
     @property
     def globals(self) -> dict[str, Any]:
         return self._kernel.globals
-
-    @property
-    def globals_lock(self) -> threading.RLock:
-        return self._globals_lock
 
     @property
     def execution_context(self) -> ExecutionContext | None:

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -1,8 +1,9 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import threading
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterator, Optional
 
 from marimo._messaging.types import Stderr, Stdout
@@ -29,6 +30,7 @@ class KernelRuntimeContext(RuntimeContext):
     """Encapsulates runtime state for a session."""
 
     _kernel: Kernel
+    _globals_lock: threading.RLock = field(default_factory=threading.RLock)
     _id_provider: Optional[IDProvider] = None
 
     @property
@@ -38,6 +40,10 @@ class KernelRuntimeContext(RuntimeContext):
     @property
     def globals(self) -> dict[str, Any]:
         return self._kernel.globals
+
+    @property
+    def globals_lock(self) -> threading.RLock:
+        return self._globals_lock
 
     @property
     def execution_context(self) -> ExecutionContext | None:

--- a/marimo/_runtime/context/utils.py
+++ b/marimo/_runtime/context/utils.py
@@ -1,10 +1,21 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import functools
+import sys
+from typing import Callable, TypeVar
+
 from marimo._output.rich_help import mddoc
-from marimo._runtime.context import (
-    ContextNotInitializedError,
-    get_context,
-)
+from marimo._runtime.context import ContextNotInitializedError, get_context
 from marimo._runtime.context.kernel_context import KernelRuntimeContext
+
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
 
 
 @mddoc
@@ -17,3 +28,20 @@ def running_in_notebook() -> bool:
         return False
     else:
         return isinstance(ctx, KernelRuntimeContext)
+
+
+def lock_globals(f: Callable[P, T]) -> Callable[P, T]:
+    @functools.wraps(f)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        try:
+            ctx = get_context()
+        except ContextNotInitializedError:
+            return f(*args, **kwargs)
+
+        if not isinstance(ctx, KernelRuntimeContext):
+            return f(*args, **kwargs)
+
+        with ctx.globals_lock:
+            return f(*args, **kwargs)
+
+    return wrapper

--- a/marimo/_runtime/context/utils.py
+++ b/marimo/_runtime/context/utils.py
@@ -1,21 +1,9 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import functools
-import sys
-from typing import Callable, TypeVar
-
 from marimo._output.rich_help import mddoc
 from marimo._runtime.context import ContextNotInitializedError, get_context
 from marimo._runtime.context.kernel_context import KernelRuntimeContext
-
-if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec
-else:
-    from typing import ParamSpec
-
-T = TypeVar("T")
-P = ParamSpec("P")
 
 
 @mddoc
@@ -28,20 +16,3 @@ def running_in_notebook() -> bool:
         return False
     else:
         return isinstance(ctx, KernelRuntimeContext)
-
-
-def lock_globals(f: Callable[P, T]) -> Callable[P, T]:
-    @functools.wraps(f)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-        try:
-            ctx = get_context()
-        except ContextNotInitializedError:
-            return f(*args, **kwargs)
-
-        if not isinstance(ctx, KernelRuntimeContext):
-            return f(*args, **kwargs)
-
-        with ctx.globals_lock:
-            return f(*args, **kwargs)
-
-    return wrapper

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -400,14 +400,25 @@ class Kernel:
         """Must be called after context is initialized"""
         threading.Thread(
             target=completion_worker,
-            args=(completion_queue, self.graph, get_context().stream),
+            args=(
+                completion_queue,
+                self.graph,
+                self.globals,
+                get_context().stream,
+            ),
             daemon=True,
         ).start()
 
     def code_completion(
         self, request: CompletionRequest, docstrings_limit: int
     ) -> None:
-        complete(request, self.graph, get_context().stream, docstrings_limit)
+        complete(
+            request,
+            self.graph,
+            self.globals,
+            get_context().stream,
+            docstrings_limit,
+        )
 
     @contextlib.contextmanager
     def _install_execution_context(

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1368,7 +1368,7 @@ class Kernel:
         """
         # acquiring and releasing an RLock takes ~100ns; the overhead is
         # negligible because the lock is coarse.
-        with self._globals_lock:
+        with self.lock_globals():
             if isinstance(request, CreationRequest):
                 await self.instantiate(request)
                 CompletedRun().broadcast()

--- a/marimo/_smoke_tests/bugs/1545.py
+++ b/marimo/_smoke_tests/bugs/1545.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.6.14"

--- a/marimo/_smoke_tests/bugs/643.py
+++ b/marimo/_smoke_tests/bugs/643.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.6.13"

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -744,7 +744,7 @@ class TestExecution:
         k = any_kernel
         # u00A0 is a non-breaking space (nbsp), which gets inserted on some
         # platforms/browsers; marimo converts these characters to spaces ...
-        code = "x \u00A0 = 10"
+        code = "x \u00a0 = 10"
         await k.run([exec_req.get(code)])
         assert not k.errors
         assert k.globals["x"] == 10


### PR DESCRIPTION
This change improves the responsiveness and coverage of code completion.

- Fallback to the Jedi `Interpreter` class when static analysis-based completion turns up empty. (Jedi's static completer fails on some libraries, like ibis.) The `Interpreter` completer evaluates code, so care is taken to avoid race conditions with the kernel by introducing a lock on the globals dictionary. Acquiring/releasing the lock works in Pyodide, even though Pyodide doesn't support creating threads, so no separate codepath was needed for WASM.  
- Decrease the docstring limit when running locally from 1000 to 80.
- Add a cumulative timeout across completions, after which we stop computing completion info. 

As a result:
- We now get completions for Ibis, and probably other libraries that we were failing to complete.
-  Pandas and NumPy completions are much faster (due to the docstring limit / timeout); previously, they were so slow as to not really work at all.

Note: While the `Interpreter` completer is running, the user won't be able to run code /  the kernel won't process control requests. For this reason the Interpreter completer has a timeout of 1 second (we can make this even lower if needed). In practice I believe this won't be a problem since the Interpreter completer is only a fallback.

Tested: manually, by playing with a notebook that uses Ibis, Pandas, and NumPy locally.

In the future, we could make docstring fetching lazy, in which case we could remove the docstring limit.