### PR TITLE
fix: refuse to create dropdown, multiselect with >1k options

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -59,7 +59,7 @@ def compile_cell(code: str, cell_id: CellId_t) -> CellImpl:
     #
     # See https://github.com/pyodide/pyodide/issues/3337,
     #     https://github.com/marimo-team/marimo/issues/1546
-    code = code.replace("\u00A0", " ")
+    code = code.replace("\u00a0", " ")
     module = compile(
         code,
         "<unknown>",

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -800,6 +800,7 @@ class dropdown(UIElement[List[str], Any]):
         container
     """
 
+    _MAX_OPTIONS: Final[int] = 1000
     _name: Final[str] = "marimo-dropdown"
     _selected_key: Optional[str] = None
 
@@ -813,6 +814,17 @@ class dropdown(UIElement[List[str], Any]):
         on_change: Optional[Callable[[Any], None]] = None,
         full_width: bool = False,
     ) -> None:
+        if len(options) > dropdown._MAX_OPTIONS:
+            raise ValueError(
+                "The maximum number of dropdown options allowed "
+                f"is {dropdown._MAX_OPTIONS}, but your dropdown has "
+                f"{len(options)} options. "
+                "If you really want to expose that many options, consider "
+                "using `mo.ui.text()` to let the user type an option name, "
+                "and `mo.ui.table()` to present the options matching the "
+                "user's query.",
+            )
+
         if not isinstance(options, dict):
             options = {option: option for option in options}
 
@@ -889,6 +901,7 @@ class multiselect(UIElement[List[str], List[object]]):
     - `max_selections`: maximum number of items that can be selected
     """
 
+    _MAX_OPTIONS: Final[int] = 1000
     _name: Final[str] = "marimo-multiselect"
 
     def __init__(
@@ -901,6 +914,17 @@ class multiselect(UIElement[List[str], List[object]]):
         full_width: bool = False,
         max_selections: Optional[int] = None,
     ) -> None:
+        if len(options) > multiselect._MAX_OPTIONS:
+            raise ValueError(
+                "The maximum number of options allowed "
+                f"is {multiselect._MAX_OPTIONS}, but your multiselect has "
+                f"{len(options)} options. "
+                "If you really want to expose that many options, consider "
+                "using `mo.ui.text()` to let the user type an option name, "
+                "and `mo.ui.table()` to present the options matching the "
+                "user's query.",
+            )
+
         if not isinstance(options, dict):
             options = {option: option for option in options}
 

--- a/marimo/_smoke_tests/bugs/1545.py
+++ b/marimo/_smoke_tests/bugs/1545.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.6.14"

--- a/marimo/_smoke_tests/bugs/643.py
+++ b/marimo/_smoke_tests/bugs/643.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.6.13"

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -256,6 +256,13 @@ def test_dropdown() -> None:
     assert dd.value == 2
 
 
+def test_dropdown_too_many_options() -> None:
+    with pytest.raises(ValueError) as e:
+        ui.dropdown(options={str(i): i for i in range(2000)})
+
+    assert "maximum number" in str(e.value)
+
+
 def test_multiselect() -> None:
     options_list = ["Apples", "Oranges", "Bananas"]
     ms = ui.multiselect(options=options_list)
@@ -292,6 +299,13 @@ def test_multiselect() -> None:
 
     with pytest.raises(ValueError):
         ms = ui.multiselect(options=options_list, max_selections=-10)
+
+
+def test_multiselect_too_many_options() -> None:
+    with pytest.raises(ValueError) as e:
+        ui.multiselect(options={str(i): i for i in range(2000)})
+
+    assert "maximum number" in str(e.value)
 
 
 def test_button() -> None:

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -744,7 +744,7 @@ class TestExecution:
         k = any_kernel
         # u00A0 is a non-breaking space (nbsp), which gets inserted on some
         # platforms/browsers; marimo converts these characters to spaces ...
-        code = "x \u00A0 = 10"
+        code = "x \u00a0 = 10"
         await k.run([exec_req.get(code)])
         assert not k.errors
         assert k.globals["x"] == 10


### PR DESCRIPTION
Raise an error if a dropdown/multiselect has too many options.

Without this limit, dropdowns/multiselect can crash the frontend.