### PR TITLE
fix: `try` blocks delete context variable afterwards, but marimo still considers them refs or defs if used

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -202,7 +202,7 @@ class ScopedVisitor(ast.NodeVisitor):
         self.obscured_scope_stack.append(ObscuredScope(obscured=obscured))
 
     def _pop_obscured_scope(self) -> None:
-        """Push scope onto the stack."""
+        """Pop scope from the stack."""
         self.obscured_scope_stack.pop()
 
     def generic_visit(self, node: ast.AST) -> None:

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -197,7 +197,7 @@ class ScopedVisitor(ast.NodeVisitor):
         """Pop a block from the block stack."""
         self.block_stack.pop()
 
-    def _push_obscured_scope(self, obscured: str) -> None:
+    def _push_obscured_scope(self, obscured: Optional[str]) -> None:
         """Push scope onto the stack."""
         self.obscured_scope_stack.append(ObscuredScope(obscured=obscured))
 
@@ -255,6 +255,7 @@ class ScopedVisitor(ast.NodeVisitor):
         elif isinstance(node, ast.Try) or (
             sys.version_info >= (3, 11) and isinstance(node, ast.TryStar)
         ):
+            assert isinstance(node, ast.Try) or isinstance(node, ast.TryStar)
             # "Try" nodes have "handlers" that introduce exception context
             # variables that are tied to the try block, and don't exist beyond
             # it.

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -255,7 +255,8 @@ class ScopedVisitor(ast.NodeVisitor):
         elif isinstance(node, ast.Try) or (
             sys.version_info >= (3, 11) and isinstance(node, ast.TryStar)
         ):
-            assert isinstance(node, ast.Try) or isinstance(node, ast.TryStar)
+            if sys.version_info < (3, 11):
+                assert isinstance(node, ast.Try)
             # "Try" nodes have "handlers" that introduce exception context
             # variables that are tied to the try block, and don't exist beyond
             # it.

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -55,6 +55,13 @@ class Block:
 
 
 @dataclass
+class ObscuredScope:
+    """The scope in which a name is hidden."""
+    # Variable id if this block hides a name
+    obscured: Optional[str] = None
+
+
+@dataclass
 class RefData:
     """Metadata about variables referenced but not defined by a cell"""
 
@@ -67,6 +74,7 @@ class RefData:
 class ScopedVisitor(ast.NodeVisitor):
     def __init__(self, mangle_prefix: Optional[str] = None) -> None:
         self.block_stack: list[Block] = [Block()]
+        self.obscured_scope_stack: list[ObscuredScope] = []
         # Mapping from referenced names to their metadata
         self._refs: dict[Name, RefData] = {}
         # Unique prefix used to mangle cell-local variable names
@@ -180,13 +188,21 @@ class ScopedVisitor(ast.NodeVisitor):
         block_idx = 0 if name in self.block_stack[-1].global_names else -1
         self._define_in_block(name, variable_data, block_idx=block_idx)
 
-    def _push_block(self, is_comprehension: bool) -> None:
+    def _push_block(self, is_comprehension: bool, obscured : Optional[str]=None) -> None:
         """Push a block onto the block stack."""
         self.block_stack.append(Block(is_comprehension=is_comprehension))
 
     def _pop_block(self) -> None:
         """Pop a block from the block stack."""
         self.block_stack.pop()
+
+    def _push_obscured_scope(self, obscured : str) -> None:
+        """Push scope onto the stack."""
+        self.obscured_scope_stack.append(ObscuredScope(obscured=obscured))
+
+    def _pop_obscured_scope(self) -> None:
+        """Push scope onto the stack."""
+        self.obscured_scope_stack.pop()
 
     def generic_visit(self, node: ast.AST) -> None:
         """Visits the children of node and manages the block stack.
@@ -235,6 +251,20 @@ class ScopedVisitor(ast.NodeVisitor):
             self.visit(node.value)
             self.visit(node.key)
             self._pop_block()
+        elif isinstance(node, ast.Try) or (sys.version_info >= (3, 11) and
+                                           isinstance(node, ast.TryStar)):
+            # Try nodes have handlers that introduce exception handler names that
+            # are tied to the try block.
+            for stmt in node.body:
+                self.visit(stmt)
+            for handler in node.handlers:
+                self._push_obscured_scope(obscured=handler.name)
+                self.visit(handler)
+                self._pop_obscured_scope()
+            for stmt in node.orelse:
+                self.visit(stmt)
+            for stmt in node.finalbody:
+                self.visit(stmt)
         elif sys.version_info >= (3, 12) and isinstance(node, ast.TypeAlias):
             self.visit(node.name)
             self._push_block(is_comprehension=False)
@@ -350,6 +380,18 @@ class ScopedVisitor(ast.NodeVisitor):
         # are not tracked at the attribute level. The default behavior
         # with our implemented visitors does the right thing (foo.bar[.*]
         # generates a ref to foo if foo has not been def'd).
+        #
+        # NB: Nodes like Try nodes have handlers that introduce exception
+        # handler names, which have the behavior of deleting the name
+        # afterwards. We traverse blocks to see if the name is "obscured" in
+        # this way.
+
+        # Guards against obscured names.
+        for scope in self.obscured_scope_stack:
+            if node.id == scope.obscured:
+                self.generic_visit(node)
+                return
+
         if isinstance(node.ctx, ast.Store):
             node.id = self._if_local_then_mangle(node.id)
             self._define(node.id, VariableData(kind="variable"))

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -789,6 +789,7 @@ class TestExecution:
                         1 / 0
                     except ZeroDivisionError as exc:
                         e = exc
+                        exc = e
                     """
                 ),
             ]

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -749,6 +749,56 @@ class TestExecution:
         assert not k.errors
         assert k.globals["x"] == 10
 
+    @staticmethod
+    async def test_exception_not_captured(
+        any_kernel: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        k = any_kernel
+
+        await k.run(
+            [
+                er_1 := exec_req.get(
+                    """
+                    exc = None
+                    try:
+                        1 / 0
+                    except ZeroDivisionError as exc:
+                        e = exc
+                    """
+                ),
+            ]
+        )
+        assert not k.errors
+        assert "exc" not in k.globals
+        assert "exc" not in k.graph.cells[er_1.cell_id].refs
+        assert "exc" in k.graph.cells[er_1.cell_id].defs
+        assert "e" in k.globals
+        assert isinstance(k.globals["e"], ZeroDivisionError)
+
+    @staticmethod
+    async def test_exception_scope_not_captured(
+        any_kernel: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        k = any_kernel
+
+        await k.run(
+            [
+                er_1 := exec_req.get(
+                    """
+                    try:
+                        1 / 0
+                    except ZeroDivisionError as exc:
+                        e = exc
+                    """
+                ),
+            ]
+        )
+        assert not k.errors
+        assert "exc" not in k.globals
+        assert "exc" not in k.graph.cells[er_1.cell_id].refs
+        assert "exc" not in k.graph.cells[er_1.cell_id].defs
+        assert "e" in k.globals
+
 
 class TestStoredOutput:
     async def test_ui_element_in_output_stored(


### PR DESCRIPTION
## 📝 Summary

previously

```python
try:
   1 / 0
except Exception as e:
   f = e
   e = 2
refs(), defs()
```

Would give `ref=e`, `def=e,f`. At first glance, this seems fine- but "e" is scoped to the try block and is deleted afterwards, so the correct solution is `ref=[]`, `def=[f]`

Note in the case


```python
e = 7
try:
   1 / 0
except Exception as e:
   f = e
   e = 2
   print("woops")
```

e is no longer set if the except block triggers, but because it was set outside of the block, `ref=`, `def=e,f` is correct

## 🔍 Description of Changes

Added an `ObscuredScope` context to remove Name references if they are obscured by the try block + added some unit tests

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
