### PR TITLE
improvement: use xpath when heading does not contain an ID

### DIFF
--- a/frontend/src/components/editor/chrome/panels/outline-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/outline-panel.tsx
@@ -6,6 +6,9 @@ import { cn } from "@/utils/cn";
 import { ScrollTextIcon } from "lucide-react";
 import { PanelEmptyState } from "./empty-state";
 
+import { OutlineItem } from "@/core/cells/outline";
+import { Logger } from "@/utils/Logger";
+
 import "./outline-panel.css";
 
 export const OutlinePanel: React.FC = () => {
@@ -21,34 +24,53 @@ export const OutlinePanel: React.FC = () => {
     );
   }
 
-  const handleGoToItem = (id: string, index: number) => {
-    // Selectors may be duplicated, so we need to use querySelectorAll
-    // IDs that start with a number are invalid, so we need to escape them
-    const elems = document.querySelectorAll(`[id="${CSS.escape(id)}"]`);
-    const el = elems[index];
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
+  const handleGoToItem = (item: OutlineItem, index: number) => {
+    let element: HTMLElement | null = null;
 
-      // Add underline to the element for a few seconds
-      el.classList.add("outline-item-highlight");
-      setTimeout(() => {
-        el.classList.remove("outline-item-highlight");
-      }, 3000);
+    if ("id" in item.by) {
+      // Selectors may be duplicated, so we need to use querySelectorAll
+      // IDs that start with a number are invalid, so we need to escape them
+      const elems = document.querySelectorAll<HTMLElement>(
+        `[id="${CSS.escape(item.by.id)}"]`,
+      );
+      element = elems[index];
+    } else {
+      const el = document.evaluate(
+        item.by.path,
+        document,
+        null,
+        XPathResult.FIRST_ORDERED_NODE_TYPE,
+        null,
+      ).singleNodeValue as HTMLElement;
+      element = el;
     }
+    if (!element) {
+      Logger.warn("Could not find element for outline item", item);
+      return;
+    }
+
+    element.scrollIntoView({ behavior: "smooth", block: "start" });
+
+    // Add underline to the element for a few seconds
+    element.classList.add("outline-item-highlight");
+    setTimeout(() => {
+      element.classList.remove("outline-item-highlight");
+    }, 3000);
   };
 
   // Map of selector to its occurrences
   const seen = new Map<string, number>();
   return (
     <div className="flex flex-col overflow-auto py-4 pl-2">
-      {outline.items.map((item) => {
+      {outline.items.map((item, idx) => {
+        const identifier = "id" in item.by ? item.by.id : item.by.path;
         // Keep track of how many times we've seen this selector
-        const occurrences = seen.get(item.id) ?? 0;
-        seen.set(item.id, occurrences + 1);
+        const occurrences = seen.get(identifier) ?? 0;
+        seen.set(identifier, occurrences + 1);
 
         return (
           <div
-            key={item.id}
+            key={`${identifier}-${idx}`}
             className={cn(
               "px-2 py-1 cursor-pointer hover:bg-accent/50 hover:text-accent-foreground rounded-l",
               item.level === 1 && "font-semibold",
@@ -56,7 +78,7 @@ export const OutlinePanel: React.FC = () => {
               item.level === 3 && "ml-6",
               item.level === 4 && "ml-9",
             )}
-            onClick={() => handleGoToItem(item.id, occurrences)}
+            onClick={() => handleGoToItem(item, occurrences)}
           >
             {item.name}
           </div>

--- a/frontend/src/core/cells/outline.ts
+++ b/frontend/src/core/cells/outline.ts
@@ -5,7 +5,13 @@
  */
 export interface OutlineItem {
   name: string;
-  id: string;
+  by:
+    | {
+        id: string;
+      }
+    | {
+        path: string;
+      };
   level: number;
 }
 

--- a/frontend/src/core/dom/__tests__/outline.test.ts
+++ b/frontend/src/core/dom/__tests__/outline.test.ts
@@ -23,17 +23,23 @@ describe("parseOutline", () => {
       {
         "items": [
           {
-            "id": "welcome-to-marimo",
+            "by": {
+              "id": "welcome-to-marimo",
+            },
             "level": 1,
             "name": "Welcome to marimo! 🌊🍃",
           },
           {
-            "id": "what-is-marimo",
+            "by": {
+              "id": "what-is-marimo",
+            },
             "level": 2,
             "name": "What is marimo?",
           },
           {
-            "id": "how-do-i-use-marimo",
+            "by": {
+              "id": "how-do-i-use-marimo",
+            },
             "level": 2,
             "name": "How do I use marimo?",
           },
@@ -65,42 +71,58 @@ describe("parseOutline", () => {
       {
         "items": [
           {
-            "id": "experiment-1",
+            "by": {
+              "id": "experiment-1",
+            },
             "level": 1,
             "name": "Experiment 1",
           },
           {
-            "id": "setup",
+            "by": {
+              "id": "setup",
+            },
             "level": 2,
             "name": "Setup",
           },
           {
-            "id": "instructions",
+            "by": {
+              "id": "instructions",
+            },
             "level": 2,
             "name": "Instructions",
           },
           {
-            "id": "experiment-2",
+            "by": {
+              "id": "experiment-2",
+            },
             "level": 1,
             "name": "Experiment 2",
           },
           {
-            "id": "setup",
+            "by": {
+              "id": "setup",
+            },
             "level": 2,
             "name": "Setup",
           },
           {
-            "id": "instructions",
+            "by": {
+              "id": "instructions",
+            },
             "level": 2,
             "name": "Instructions",
           },
           {
-            "id": "ack",
+            "by": {
+              "id": "ack",
+            },
             "level": 1,
             "name": "Acknowledgements",
           },
           {
-            "id": "marimo",
+            "by": {
+              "id": "marimo",
+            },
             "level": 3,
             "name": "marimo",
           },
@@ -143,6 +165,32 @@ describe("parseOutline", () => {
       channel: "output",
       data: html,
     });
-    expect(outline).toEqual({ items: [] });
+    expect(outline).toMatchInlineSnapshot(`
+      {
+        "items": [
+          {
+            "by": {
+              "path": "//H1[contains(., "foo")]",
+            },
+            "level": 1,
+            "name": "foo",
+          },
+          {
+            "by": {
+              "path": "//H2[contains(., "bar")]",
+            },
+            "level": 2,
+            "name": "bar",
+          },
+          {
+            "by": {
+              "path": "//H3[contains(., "baz")]",
+            },
+            "level": 3,
+            "name": "baz",
+          },
+        ],
+      }
+    `);
   });
 });

--- a/frontend/src/core/dom/outline.ts
+++ b/frontend/src/core/dom/outline.ts
@@ -18,13 +18,17 @@ function getOutline(html: string): Outline {
       continue;
     }
 
-    const id = heading.id;
-    if (!id) {
-      continue;
-    }
-
     const level = Number.parseInt(heading.tagName[1], 10);
-    items.push({ name, id, level });
+    const id = heading.id;
+    if (id) {
+      items.push({ name, level, by: { id } });
+    } else {
+      items.push({
+        name,
+        level,
+        by: { path: `//${heading.tagName}[contains(., "${name}")]` },
+      });
+    }
   }
 
   return { items };


### PR DESCRIPTION
Fixes #1582 

While it's better to use `.id`, we can fallback to an xpath to find the correct heading to navigate to