### PR TITLE
fix: allow converting to markdown when empty

### DIFF
--- a/frontend/src/components/editor/RecoveryButton.tsx
+++ b/frontend/src/components/editor/RecoveryButton.tsx
@@ -44,7 +44,10 @@ const RecoveryModal = (props: {
         <DialogTitle className="text-accent mb-6">
           Download unsaved changes?
         </DialogTitle>
-        <DialogDescription className="markdown">
+        <DialogDescription
+          className="markdown break-words"
+          style={{ wordBreak: "break-word" }}
+        >
           <p>This app has unsaved changes. To recover:</p>
 
           <ol>

--- a/frontend/src/components/editor/renderers/vertical-layout/useDelayVisibility.ts
+++ b/frontend/src/components/editor/renderers/vertical-layout/useDelayVisibility.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { AppMode } from "@/core/mode";
-import { getAllEditorViews } from "@/core/cells/cells";
+import { getNotebook } from "@/core/cells/cells";
 import { useState, useEffect } from "react";
 
 export function useDelayVisibility(numCells: number, mode: AppMode) {
@@ -28,8 +28,14 @@ export function useDelayVisibility(numCells: number, mode: AppMode) {
 }
 
 function focusFirstEditor() {
-  const editors = getAllEditorViews();
-  if (editors.length > 0) {
-    editors[0].focus();
+  const { cellIds, cellData, cellHandles } = getNotebook();
+  // Focus on the first cell if it's been mounted and is not hidden
+  for (const cellId of cellIds) {
+    const handle = cellHandles[cellId];
+    const hidden = cellData[cellId].config.hide_code;
+    if (!hidden && handle?.current?.editorView) {
+      handle.current.editorView.focus();
+      return;
+    }
   }
 }

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -56,7 +56,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed z-50 grid w-full gap-4 rounded-b-lg border bg-background p-6 shadow-sm animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:max-w-lg sm:rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",
+        "fixed z-50 grid w-full gap-4 rounded-b-lg border bg-background p-6 shadow-sm animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:max-w-2xl sm:mx-4 sm:rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",
         className,
       )}
       {...restoreFocus}

--- a/frontend/src/core/codemirror/config/extension.ts
+++ b/frontend/src/core/codemirror/config/extension.ts
@@ -2,6 +2,7 @@
 import { CompletionConfig } from "@/core/config/config-schema";
 import { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { Facet } from "@codemirror/state";
+import { MovementCallbacks } from "../cells/extensions";
 
 export const completionConfigState = Facet.define<
   CompletionConfig,
@@ -13,6 +14,18 @@ export const completionConfigState = Facet.define<
 export const hotkeysProviderState = Facet.define<
   HotkeyProvider,
   HotkeyProvider
+>({
+  combine: (values) => values[0],
+});
+
+export type PlaceholderType = "marimo-import" | "ai" | "none";
+export const placeholderState = Facet.define<PlaceholderType, PlaceholderType>({
+  combine: (values) => values[0],
+});
+
+export const movementCallbacksState = Facet.define<
+  MovementCallbacks,
+  MovementCallbacks
 >({
   combine: (values) => values[0],
 });

--- a/frontend/src/core/codemirror/copilot/extension.ts
+++ b/frontend/src/core/codemirror/copilot/extension.ts
@@ -23,6 +23,11 @@ export const copilotBundle = (): Extension => {
           return "";
         }
 
+        // If no text, don't fetch
+        if (view.doc.length === 0) {
+          return "";
+        }
+
         // wait 10ms so that the view is updated first
         await new Promise((resolve) => setTimeout(resolve, 10));
 

--- a/frontend/src/core/codemirror/language/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/utils.test.ts
@@ -9,19 +9,23 @@ import { EditorView } from "@codemirror/view";
 import { describe, it, expect } from "vitest";
 import { adaptiveLanguageConfiguration, switchLanguage } from "../extension";
 import { OverridingHotkeyProvider } from "@/core/hotkeys/hotkeys";
+import { MovementCallbacks } from "../../cells/extensions";
 
 function createEditor(doc: string) {
   return new EditorView({
     state: EditorState.create({
       doc,
       extensions: [
-        adaptiveLanguageConfiguration(
-          {
+        adaptiveLanguageConfiguration({
+          completionConfig: {
             activate_on_typing: true,
             copilot: false,
           },
-          new OverridingHotkeyProvider({}),
-        ),
+          hotkeys: new OverridingHotkeyProvider({}),
+          showPlaceholder: true,
+          enableAI: true,
+          cellMovementCallbacks: {} as MovementCallbacks,
+        }),
       ],
     }),
   });

--- a/frontend/src/core/codemirror/language/extension.ts
+++ b/frontend/src/core/codemirror/language/extension.ts
@@ -12,7 +12,6 @@ import { MarkdownLanguageAdapter } from "./markdown";
 import { clamp } from "@/utils/math";
 import { CompletionConfig } from "@/core/config/config-schema";
 import {
-  PlaceholderType,
   completionConfigState,
   hotkeysProviderState,
   movementCallbacksState,
@@ -168,7 +167,16 @@ function createLanguagePanel(view: EditorView): Panel {
 /**
  * Set of extensions to enable adaptive language configuration.
  */
-export function adaptiveLanguageConfiguration(opts: CodeMirrorSetupOpts) {
+export function adaptiveLanguageConfiguration(
+  opts: Pick<
+    CodeMirrorSetupOpts,
+    | "completionConfig"
+    | "hotkeys"
+    | "showPlaceholder"
+    | "enableAI"
+    | "cellMovementCallbacks"
+  >,
+) {
   const {
     showPlaceholder,
     enableAI,

--- a/frontend/src/core/codemirror/language/extension.ts
+++ b/frontend/src/core/codemirror/language/extension.ts
@@ -12,14 +12,18 @@ import { MarkdownLanguageAdapter } from "./markdown";
 import { clamp } from "@/utils/math";
 import { CompletionConfig } from "@/core/config/config-schema";
 import {
+  PlaceholderType,
   completionConfigState,
   hotkeysProviderState,
+  movementCallbacksState,
+  placeholderState,
 } from "../config/extension";
 import { historyCompartment } from "../editing/extensions";
 import { history } from "@codemirror/commands";
 import { formattingChangeEffect } from "../format";
 import { getEditorCodeAsPython } from "./utils";
 import { HotkeyProvider } from "@/core/hotkeys/hotkeys";
+import { CodeMirrorSetupOpts } from "../cm";
 
 export const LanguageAdapters: Record<
   LanguageAdapter["type"],
@@ -104,7 +108,8 @@ function updateLanguageAdapterAndCode(
   const code = view.state.doc.toString();
   const completionConfig = view.state.facet(completionConfigState);
   const hotkeysProvider = view.state.facet(hotkeysProviderState);
-
+  const placeholderType = view.state.facet(placeholderState);
+  const movementCallbacks = view.state.facet(movementCallbacksState);
   // Update the code
   const [codeOut, cursorDiff1] = currentLanguage.transformOut(code);
   const [newCode, cursorDiff2] = nextLanguage.transformIn(codeOut);
@@ -120,7 +125,12 @@ function updateLanguageAdapterAndCode(
     effects: [
       setLanguageAdapter.of(nextLanguage),
       languageCompartment.reconfigure(
-        nextLanguage.getExtension(completionConfig, hotkeysProvider),
+        nextLanguage.getExtension(
+          completionConfig,
+          hotkeysProvider,
+          placeholderType,
+          movementCallbacks,
+        ),
       ),
       // Clear history
       historyCompartment.reconfigure([]),
@@ -158,16 +168,36 @@ function createLanguagePanel(view: EditorView): Panel {
 /**
  * Set of extensions to enable adaptive language configuration.
  */
-export function adaptiveLanguageConfiguration(
-  completionConfig: CompletionConfig,
-  hotkeysProvider: HotkeyProvider,
-) {
+export function adaptiveLanguageConfiguration(opts: CodeMirrorSetupOpts) {
+  const {
+    showPlaceholder,
+    enableAI,
+    completionConfig,
+    hotkeys,
+    cellMovementCallbacks,
+  } = opts;
+
+  const placeholderType = showPlaceholder
+    ? "marimo-import"
+    : enableAI
+      ? "ai"
+      : "none";
+
   return [
+    // Store state
     completionConfigState.of(completionConfig),
-    hotkeysProviderState.of(hotkeysProvider),
+    hotkeysProviderState.of(hotkeys),
+    placeholderState.of(placeholderType),
+    movementCallbacksState.of(cellMovementCallbacks),
+    // Language adapter
     languageToggle(completionConfig),
     languageCompartment.of(
-      LanguageAdapters.python().getExtension(completionConfig, hotkeysProvider),
+      LanguageAdapters.python().getExtension(
+        completionConfig,
+        hotkeys,
+        placeholderType,
+        cellMovementCallbacks,
+      ),
     ),
     languageAdapterState,
   ];
@@ -204,7 +234,14 @@ export function reconfigureLanguageEffect(
   hotkeysProvider: HotkeyProvider,
 ) {
   const language = view.state.field(languageAdapterState);
+  const placeholderType = view.state.facet(placeholderState);
+  const movementCallbacks = view.state.facet(movementCallbacksState);
   return languageCompartment.reconfigure(
-    language.getExtension(completionConfig, hotkeysProvider),
+    language.getExtension(
+      completionConfig,
+      hotkeysProvider,
+      placeholderType,
+      movementCallbacks,
+    ),
   );
 }

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -93,6 +93,10 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
   }
 
   isSupported(pythonCode: string): boolean {
+    if (pythonCode.trim() === "") {
+      return true;
+    }
+
     if (pythonCode.trim() === "mo.md()") {
       return true;
     }
@@ -113,7 +117,7 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
   getExtension(
     _completionConfig: CompletionConfig,
     hotkeys: HotkeyProvider,
-  ): Extension {
+  ): Extension[] {
     return [
       markdown({
         codeLanguages: languages,

--- a/frontend/src/core/codemirror/language/types.ts
+++ b/frontend/src/core/codemirror/language/types.ts
@@ -2,6 +2,8 @@
 import { CompletionConfig } from "@/core/config/config-schema";
 import { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { Extension } from "@codemirror/state";
+import { PlaceholderType } from "../config/extension";
+import { MovementCallbacks } from "../cells/extensions";
 
 /**
  * A language adapter is a class that can transform code from one language to
@@ -16,5 +18,7 @@ export interface LanguageAdapter {
   getExtension(
     completionConfig: CompletionConfig,
     hotkeys: HotkeyProvider,
-  ): Extension;
+    placeholderType: PlaceholderType,
+    movementCallbacks: MovementCallbacks,
+  ): Extension[];
 }

--- a/frontend/src/stories/editor.stories.tsx
+++ b/frontend/src/stories/editor.stories.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 import { EditorState, Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import CodeMirror from "@uiw/react-codemirror";
-import { basicBundle } from "../core/codemirror/cm";
+import { CodeMirrorSetupOpts, basicBundle } from "../core/codemirror/cm";
 import { python } from "@codemirror/lang-python";
 import { CopilotConfig } from "@/core/codemirror/copilot/copilot-config";
 import { copilotBundle } from "@/core/codemirror/copilot/extension";
@@ -61,11 +61,11 @@ export const Primary: Story = {
   render: (args, ctx) => (
     <div className="Cell m-20 w-[60%] overflow-hidden">
       <Editor
-        extensions={basicBundle(
-          { activate_on_typing: false, copilot: false },
-          ctx.globals.theme,
-          new OverridingHotkeyProvider({}),
-        )}
+        extensions={basicBundle({
+          completionConfig: { activate_on_typing: false, copilot: false },
+          theme: ctx.globals.theme,
+          hotkeys: new OverridingHotkeyProvider({}),
+        } as unknown as CodeMirrorSetupOpts)}
       />
     </div>
   ),


### PR DESCRIPTION
* don't show placeholders in markdown
* allow toggling markdown when no text is written
* Some styling cleanup to the recover dialog