### PR TITLE
fix: rpc serialization and gracefully handle errors

### DIFF
--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -21,6 +21,7 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    cast,
 )
 
 from marimo import _loggers as loggers
@@ -44,7 +45,10 @@ LOGGER = loggers.marimo_logger()
 
 
 def serialize(datacls: Any) -> dict[str, JSONType]:
-    return json.loads(json.dumps(datacls, cls=WebComponentEncoder))
+    return cast(
+        dict[str, JSONType],
+        json.loads(json.dumps(datacls, cls=WebComponentEncoder)),
+    )
 
 
 @dataclass

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from types import ModuleType
 from typing import (
     Any,
@@ -44,11 +44,19 @@ from marimo._runtime.layout.layout import LayoutConfig
 LOGGER = loggers.marimo_logger()
 
 
-def serialize(datacls: Any) -> dict[str, JSONType]:
-    return cast(
-        dict[str, JSONType],
-        json.loads(json.dumps(datacls, cls=WebComponentEncoder)),
-    )
+def serialize(datacls: Any) -> Dict[str, JSONType]:
+    try:
+        # Try to serialize as a dataclass
+        return cast(
+            Dict[str, JSONType],
+            asdict(datacls),
+        )
+    except Exception:
+        # If that fails, try to serialize using the WebComponentEncoder
+        return cast(
+            Dict[str, JSONType],
+            json.loads(json.dumps(datacls, cls=WebComponentEncoder)),
+        )
 
 
 @dataclass
@@ -272,7 +280,7 @@ class FunctionCallResult(Op):
 
     def serialize(self) -> dict[str, Any]:
         try:
-            return super().serialize()
+            return serialize(self)
         except Exception as e:
             LOGGER.exception(
                 "Error serializing function call result %s: %s",

--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import json
 from json import JSONEncoder
@@ -13,6 +14,9 @@ class WebComponentEncoder(JSONEncoder):
     """Custom JSON encoder for WebComponents"""
 
     def default(self, obj: Any) -> Any:
+        if dataclasses.is_dataclass(obj):
+            return dataclasses.asdict(obj)
+
         # Handle numpy objects
         if DependencyManager.has_numpy():
             import numpy as np

--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -13,7 +13,8 @@ from marimo._dependencies.dependencies import DependencyManager
 class WebComponentEncoder(JSONEncoder):
     """Custom JSON encoder for WebComponents"""
 
-    def default(self, obj: Any) -> Any:
+    def default(self, o: Any) -> Any:
+        obj = o
         if dataclasses.is_dataclass(obj):
             return dataclasses.asdict(obj)
 


### PR DESCRIPTION
- use our WebEncoder which handles more edge-cases for serialization
- gracefully handle serialization errors and still return a response