### PR TITLE
disable codecov

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -182,17 +182,7 @@ jobs:
           fi
           uv pip install --upgrade pip
           uv pip install .[testcore,testoptional]
-          # Only collect coverage on the 3.11
-          if [ "${{ matrix.python-version }}" == "3.11" ]; then
-            pytest -v tests/ -k "not test_cli" --cov=marimo --cov-branch
-          else
-            pytest -v tests/ -k "not test_cli"
-          fi
-      - name: Upload coverage reports to Codecov
-        if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          pytest -v tests/ -k "not test_cli"
 
   typos:
     name: Check for typos


### PR DESCRIPTION
- slows down CI
- we're not referring to it right now

can add back in later if there is a need, or run codecov somewhere else

Fixes #1598 