### PR TITLE
fix: dataframe be sorting follow-ups

### DIFF
--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -33,11 +33,8 @@ export const DataTableColumnHeader = <TData, TValue>({
     return <div className={cn(className)}>{header}</div>;
   }
 
-  const sortFn = column.getSortingFn();
-  const AscIcon =
-    sortFn === sortingFns.basic ? ArrowDown01Icon : ArrowDownNarrowWideIcon;
-  const DescIcon =
-    sortFn === sortingFns.basic ? ArrowDown10Icon : ArrowDownWideNarrowIcon;
+  const AscIcon = ArrowDownNarrowWideIcon;
+  const DescIcon = ArrowDownWideNarrowIcon;
 
   return (
     <DropdownMenu modal={false}>

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -1,11 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { Column, sortingFns } from "@tanstack/react-table";
+import { Column } from "@tanstack/react-table";
 import {
   ChevronsUpDown,
   ArrowDownNarrowWideIcon,
   ArrowDownWideNarrowIcon,
-  ArrowDown10Icon,
-  ArrowDown01Icon,
   CopyIcon,
 } from "lucide-react";
 

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -42,10 +42,10 @@ type PluginFunctions = {
     values: unknown[];
     too_many_values: boolean;
   }>;
-  sort_values: (req: {
+  sort_values: <T>(req: {
     by: string | null;
     descending: boolean;
-  }) => Promise<object[] | string>;
+  }) => Promise<T[] | string>;
 };
 
 // Value is selection, but it is not currently exposed to the user

--- a/frontend/src/plugins/impl/vega/loader.ts
+++ b/frontend/src/plugins/impl/vega/loader.ts
@@ -86,14 +86,14 @@ export const vegaLoader = createLoader();
  *
  * This resolves to an array of objects, where each object represents a row.
  */
-export function vegaLoadData(
+export function vegaLoadData<T = object>(
   url: string,
   format: DataFormat | undefined | { type: "csv"; parse: "auto" },
   opts: {
     handleBigInt?: boolean;
     replacePeriod?: boolean;
   } = {},
-): Promise<object[]> {
+): Promise<T[]> {
   const { handleBigInt = false, replacePeriod = false } = opts;
 
   return vegaLoader.load(url).then((csvData) => {
@@ -133,7 +133,7 @@ export function vegaLoadData(
       disableBigInt();
     }
 
-    return results;
+    return results as T[];
   });
 }
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -22,6 +22,7 @@ from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._plugins.ui._impl.tables.table_manager import (
+    ColumnName,
     TableManager,
 )
 from marimo._plugins.ui._impl.tables.utils import get_table_manager
@@ -63,7 +64,7 @@ class ColumnSummaries:
 
 @dataclass
 class SortValuesArgs:
-    by: str
+    by: ColumnName
     descending: bool
 
 

--- a/marimo/_plugins/ui/_impl/tables/default_table.py
+++ b/marimo/_plugins/ui/_impl/tables/default_table.py
@@ -23,7 +23,10 @@ from marimo._plugins.ui._impl.tables.polars_table import (
 from marimo._plugins.ui._impl.tables.pyarrow_table import (
     PyArrowTableManagerFactory,
 )
-from marimo._plugins.ui._impl.tables.table_manager import TableManager
+from marimo._plugins.ui._impl.tables.table_manager import (
+    ColumnName,
+    TableManager,
+)
 
 JsonTableData = Union[
     Sequence[Union[str, int, float, bool, MIME, None]],
@@ -141,9 +144,17 @@ class DefaultTableManager(TableManager[JsonTableData]):
             return list(first.keys())
         return ["value"]
 
-    def sort_values(self, by: str, descending: bool) -> DefaultTableManager:
+    def sort_values(
+        self, by: ColumnName, descending: bool
+    ) -> DefaultTableManager:
         normalized = self._normalize_data(self.data)
-        data = sorted(normalized, key=lambda x: x[by], reverse=descending)
+        try:
+            data = sorted(normalized, key=lambda x: x[by], reverse=descending)
+        except TypeError:
+            # Handle when all values are not comparable
+            data = sorted(
+                normalized, key=lambda x: str(x[by]), reverse=descending
+            )
         return DefaultTableManager(data)
 
     @staticmethod

--- a/marimo/_plugins/ui/_impl/tables/df_protocol_table.py
+++ b/marimo/_plugins/ui/_impl/tables/df_protocol_table.py
@@ -13,6 +13,7 @@ from marimo._plugins.ui._impl.tables.pyarrow_table import (
     PyArrowTableManagerFactory,
 )
 from marimo._plugins.ui._impl.tables.table_manager import (
+    ColumnName,
     FieldType,
     FieldTypes,
     TableManager,
@@ -93,6 +94,11 @@ class DataFrameProtocolTableManager(TableManager[DataFrameLike]):
 
     def get_column_names(self) -> list[str]:
         return list(self._df.column_names())
+
+    def sort_values(
+        self, by: ColumnName, descending: bool
+    ) -> TableManager[DataFrameLike]:
+        return self._ensure_delegate().sort_values(by, descending)
 
     @staticmethod
     def _get_field_type(column: Column) -> FieldType:

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from marimo._data.models import ColumnSummary
 from marimo._plugins.ui._impl.tables.table_manager import (
+    ColumnName,
     FieldType,
     FieldTypes,
     TableManager,
@@ -226,7 +227,7 @@ class PandasTableManagerFactory(TableManagerFactory):
                 return self.data.columns.tolist()
 
             def sort_values(
-                self, by: str, descending: bool
+                self, by: ColumnName, descending: bool
             ) -> PandasTableManager:
                 sorted_data = self.data.sort_values(
                     by, ascending=not descending

--- a/marimo/_plugins/ui/_impl/tables/polars_table.py
+++ b/marimo/_plugins/ui/_impl/tables/polars_table.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 from marimo._data.models import ColumnSummary, NonNestedLiteral
 from marimo._plugins.ui._impl.tables.table_manager import (
+    ColumnName,
     FieldType,
     FieldTypes,
     TableManager,
@@ -120,7 +121,7 @@ class PolarsTableManagerFactory(TableManagerFactory):
                 return self.data.columns
 
             def sort_values(
-                self, by: str, descending: bool
+                self, by: ColumnName, descending: bool
             ) -> PolarsTableManager:
                 sorted_data = self.data.sort(by, descending=descending)
                 return PolarsTableManager(sorted_data)

--- a/marimo/_plugins/ui/_impl/tables/pyarrow_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pyarrow_table.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import io
-from typing import Any, Literal, Union, cast
+from typing import Any, Union, cast
 
 from marimo._data.models import ColumnSummary
 from marimo._plugins.ui._impl.tables.table_manager import (
+    ColumnName,
     FieldType,
     FieldTypes,
     TableManager,
@@ -155,12 +156,11 @@ class PyArrowTableManagerFactory(TableManagerFactory):
                 return self.data.schema.names
 
             def sort_values(
-                self, by: str, descending: bool
+                self, by: ColumnName, descending: bool
             ) -> PyArrowTableManager:
-                ascending: Literal["ascending", "descending"] = (
-                    "ascending" if not descending else "descending"
+                sorted_data = self.data.sort_by(  # type: ignore
+                    [(by, "ascending" if not descending else "descending")]
                 )
-                sorted_data = self.data.sort_by([(by, ascending)])  # type: ignore
                 return PyArrowTableManager(sorted_data)
 
             @staticmethod

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -41,7 +41,9 @@ class TableManager(abc.ABC, Generic[T]):
         return True
 
     @abc.abstractmethod
-    def sort_values(self, by: ColumnName, descending: bool) -> TableManager[T]:
+    def sort_values(
+        self, by: ColumnName, descending: bool
+    ) -> TableManager[Any]:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -10,9 +10,9 @@ from marimo._plugins.core.web_component import JSONType
 
 T = TypeVar("T")
 
-
+ColumnName = str
 FieldType = DataType
-FieldTypes = Dict[str, FieldType]
+FieldTypes = Dict[ColumnName, FieldType]
 
 
 class TableManager(abc.ABC, Generic[T]):
@@ -40,7 +40,8 @@ class TableManager(abc.ABC, Generic[T]):
     def supports_altair(self) -> bool:
         return True
 
-    def sort_values(self, by: str, descending: bool) -> TableManager[T]:
+    @abc.abstractmethod
+    def sort_values(self, by: ColumnName, descending: bool) -> TableManager[T]:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/tests/_plugins/ui/_impl/tables/test_default_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_default_table.py
@@ -68,6 +68,48 @@ class TestDefaultTable(unittest.TestCase):
             {"name": "Alice", "age": 30, "birth_year": date(1994, 5, 24)},
         ]
         assert sorted_data == expected_data
+        # reverse sort
+        sorted_data = self.manager.sort_values(
+            by="name", descending=False
+        ).data
+        expected_data = [
+            {"name": "Alice", "age": 30, "birth_year": date(1994, 5, 24)},
+            {"name": "Bob", "age": 25, "birth_year": date(1999, 7, 14)},
+            {"name": "Charlie", "age": 35, "birth_year": date(1989, 12, 1)},
+            {"name": "Dave", "age": 28, "birth_year": date(1996, 3, 5)},
+            {"name": "Eve", "age": 22, "birth_year": date(2002, 1, 30)},
+        ]
+        assert sorted_data == expected_data
+
+    def test_sort_single_values(self) -> None:
+        manager = DefaultTableManager([1, 3, 2])
+        sorted_data = manager.sort_values(by="value", descending=True).data
+        expected_data = [{"value": 3}, {"value": 2}, {"value": 1}]
+        assert sorted_data == expected_data
+        # reverse sort
+        sorted_data = manager.sort_values(by="value", descending=False).data
+        expected_data = [{"value": 1}, {"value": 2}, {"value": 3}]
+        assert sorted_data == expected_data
+
+    def test_mixed_values(self) -> None:
+        manager = DefaultTableManager([1, "foo", 2, False])
+        sorted_data = manager.sort_values(by="value", descending=True).data
+        expected_data = [
+            {"value": "foo"},
+            {"value": False},
+            {"value": 2},
+            {"value": 1},
+        ]
+        assert sorted_data == expected_data
+        # reverse sort
+        sorted_data = manager.sort_values(by="value", descending=False).data
+        expected_data = [
+            {"value": 1},
+            {"value": 2},
+            {"value": False},
+            {"value": "foo"},
+        ]
+        assert sorted_data == expected_data
 
 
 class TestColumnarDefaultTable(unittest.TestCase):


### PR DESCRIPTION
- remove useEffect usage and consolidate loading logic in dataframe plugin
- better generic types in dataframe plugin
- handle sorting when types are not comparable in the `DefaultTableManager`
