### PR TITLE
fix: increase fd limit on the marimo server

### DIFF
--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -15,7 +15,11 @@ from marimo._server.main import create_starlette_app
 from marimo._server.model import SessionMode
 from marimo._server.sessions import LspServer, SessionManager
 from marimo._server.tokens import AuthToken
-from marimo._server.utils import find_free_port, initialize_asyncio
+from marimo._server.utils import (
+    find_free_port,
+    initialize_asyncio,
+    initialize_fd_limit,
+)
 from marimo._server.uvicorn_utils import initialize_signals
 from marimo._utils.paths import import_files
 
@@ -125,7 +129,12 @@ def start(
     app.state.base_url = base_url
     app.state.config_manager = user_config_mgr
 
+    # Resource initialization
+    # Increase the limit on open file descriptors to prevent resource
+    # exhaustion when opening multiple notebooks in the same server.
+    initialize_fd_limit(limit=4096)
     initialize_signals()
+
     server = uvicorn.Server(
         uvicorn.Config(
             app,

--- a/marimo/_server/utils.py
+++ b/marimo/_server/utils.py
@@ -70,6 +70,22 @@ def initialize_asyncio() -> None:
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
+def initialize_fd_limit(limit: int) -> None:
+    """Raise the limit on open file descriptors.
+
+    Not applicable on Windows.
+    """
+    try:
+        import resource
+    except ImportError:
+        # Windows
+        return
+
+    old_soft, old_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if limit > old_soft and limit <= old_hard:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (limit, old_hard))
+
+
 T = TypeVar("T")
 
 


### PR DESCRIPTION
With this change, one should be able to open > 100 notebooks in a single marimo server on macOS, which should be more than enough.

Previously the limit was ~8.

Fixes #1610 