### PR TITLE
fix: Persist stale cells on session resume

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -155,20 +155,28 @@ const CellComponent = (
   const editorView = useRef<EditorView | null>(null);
   const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
 
+  const uninstantiated =
+    !userConfig.runtime.auto_instantiate && !runElapsedTimeMs;
   const disabledOrAncestorDisabled =
     cellConfig.disabled || status === "disabled-transitively";
   const needsRun =
-    edited || interrupted || (staleInputs && !disabledOrAncestorDisabled);
+    edited ||
+    interrupted ||
+    (staleInputs && !disabledOrAncestorDisabled) ||
+    uninstantiated;
   const loading = status === "running" || status === "queued";
+
   const outputStale = outputIsStale(
     { status, output, runStartTimestamp, interrupted, staleInputs },
     edited,
+    uninstantiated,
   );
 
   // console output is cleared immediately on run, so check for queued instead
   // of loading to determine staleness
   const consoleOutputStale =
-    (status === "queued" || edited || staleInputs) && !interrupted;
+    (status === "queued" || edited || staleInputs || uninstantiated) &&
+    !interrupted;
   const editing = mode === "edit";
 
   // Performs side-effects that must run whenever the cell is run, but doesn't
@@ -451,6 +459,7 @@ const CellComponent = (
               disabled={cellConfig.disabled ?? false}
               elapsedTime={runElapsedTimeMs}
               runStartTimestamp={runStartTimestamp}
+              uninstantiated={uninstantiated}
             />
             <div className="flex align-bottom">
               <RunButton

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -145,7 +145,7 @@ const CellComponent = (
     config: cellConfig,
     name,
   }: CellProps,
-  ref: React.ForwardedRef<CellHandle>
+  ref: React.ForwardedRef<CellHandle>,
 ) => {
   useCellRenderCount().countRender();
 
@@ -163,7 +163,7 @@ const CellComponent = (
 
   const outputStale = outputIsStale(
     { status, output, runStartTimestamp, interrupted, staleInputs },
-    edited
+    edited,
   );
 
   // console output is cleared immediately on run, so check for queued instead
@@ -192,7 +192,7 @@ const CellComponent = (
       },
       registerRun: prepareToRunEffects,
     }),
-    [editorView, prepareToRunEffects]
+    [editorView, prepareToRunEffects],
   );
 
   // Callback to get the editor view.
@@ -212,11 +212,11 @@ const CellComponent = (
 
   const createBelow = useCallback(
     () => createNewCell({ cellId, before: false }),
-    [cellId, createNewCell]
+    [cellId, createNewCell],
   );
   const createAbove = useCallback(
     () => createNewCell({ cellId, before: true }),
-    [cellId, createNewCell]
+    [cellId, createNewCell],
   );
 
   // Close completion when focus leaves the cell's subtree.
@@ -260,7 +260,7 @@ const CellComponent = (
       editorView.current.focus();
       return;
     },
-    [cellRef, editorView]
+    [cellRef, editorView],
   );
 
   const outputArea = (

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -145,7 +145,7 @@ const CellComponent = (
     config: cellConfig,
     name,
   }: CellProps,
-  ref: React.ForwardedRef<CellHandle>,
+  ref: React.ForwardedRef<CellHandle>
 ) => {
   useCellRenderCount().countRender();
 
@@ -155,28 +155,21 @@ const CellComponent = (
   const editorView = useRef<EditorView | null>(null);
   const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
 
-  const uninstantiated =
-    !userConfig.runtime.auto_instantiate && !runElapsedTimeMs;
   const disabledOrAncestorDisabled =
     cellConfig.disabled || status === "disabled-transitively";
   const needsRun =
-    edited ||
-    interrupted ||
-    (staleInputs && !disabledOrAncestorDisabled) ||
-    uninstantiated;
+    edited || interrupted || (staleInputs && !disabledOrAncestorDisabled);
   const loading = status === "running" || status === "queued";
 
   const outputStale = outputIsStale(
     { status, output, runStartTimestamp, interrupted, staleInputs },
-    edited,
-    uninstantiated,
+    edited
   );
 
   // console output is cleared immediately on run, so check for queued instead
   // of loading to determine staleness
   const consoleOutputStale =
-    (status === "queued" || edited || staleInputs || uninstantiated) &&
-    !interrupted;
+    (status === "queued" || edited || staleInputs) && !interrupted;
   const editing = mode === "edit";
 
   // Performs side-effects that must run whenever the cell is run, but doesn't
@@ -199,7 +192,7 @@ const CellComponent = (
       },
       registerRun: prepareToRunEffects,
     }),
-    [editorView, prepareToRunEffects],
+    [editorView, prepareToRunEffects]
   );
 
   // Callback to get the editor view.
@@ -219,11 +212,11 @@ const CellComponent = (
 
   const createBelow = useCallback(
     () => createNewCell({ cellId, before: false }),
-    [cellId, createNewCell],
+    [cellId, createNewCell]
   );
   const createAbove = useCallback(
     () => createNewCell({ cellId, before: true }),
-    [cellId, createNewCell],
+    [cellId, createNewCell]
   );
 
   // Close completion when focus leaves the cell's subtree.
@@ -267,7 +260,7 @@ const CellComponent = (
       editorView.current.focus();
       return;
     },
-    [cellRef, editorView],
+    [cellRef, editorView]
   );
 
   const outputArea = (
@@ -392,6 +385,9 @@ const CellComponent = (
   };
 
   const hasOutput = !isOutputEmpty(output);
+
+  const uninstantiated =
+    !userConfig.runtime.auto_instantiate && !runElapsedTimeMs;
 
   return (
     <CellActionsContextMenu

--- a/frontend/src/components/editor/cell/CellStatus.tsx
+++ b/frontend/src/components/editor/cell/CellStatus.tsx
@@ -24,6 +24,7 @@ export interface CellStatusComponentProps
   disabled: boolean;
   staleInputs: boolean;
   elapsedTime: number | null;
+  uninstantiated: boolean;
 }
 
 export const CellStatusComponent: React.FC<CellStatusComponentProps> = ({
@@ -35,6 +36,7 @@ export const CellStatusComponent: React.FC<CellStatusComponentProps> = ({
   interrupted,
   elapsedTime,
   runStartTimestamp,
+  uninstantiated,
 }) => {
   if (!editing) {
     return null;
@@ -158,13 +160,15 @@ export const CellStatusComponent: React.FC<CellStatusComponentProps> = ({
   }
 
   // outdated: cell needs to be re-run
-  if (edited || interrupted || staleInputs) {
+  if (edited || interrupted || staleInputs || uninstantiated) {
     const elapsedTimeStr = formatElapsedTime(elapsedTime);
 
     // Customize tooltips based on why the cell needs to be re-run
     let title = "";
     let timerTitle = "";
-    if (interrupted) {
+    if (uninstantiated) {
+      title = "This cell has not yet been run";
+    } else if (interrupted) {
       title = "This cell was interrupted when it was last run";
       timerTitle = `This cell ran for ${elapsedTimeStr} before being interrupted`;
     } else if (edited) {
@@ -172,7 +176,7 @@ export const CellStatusComponent: React.FC<CellStatusComponentProps> = ({
       timerTitle = `This cell took ${elapsedTimeStr} to run`;
     } else {
       // staleInputs
-      title = "This cell has not been run with the latest inputs.";
+      title = "This cell has not been run with the latest inputs";
       timerTitle = `This cell took ${elapsedTimeStr} to run`;
     }
 

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -45,7 +45,6 @@ export function transitionCell(
           (message.timestamp - cell.runStartTimestamp) as Seconds,
         ).toMilliseconds();
         nextCell.runStartTimestamp = null;
-        nextCell.staleInputs = false;
       }
       nextCell.debuggerActive = false;
       break;

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -150,6 +150,7 @@ export function outputIsStale(
     "status" | "output" | "runStartTimestamp" | "interrupted" | "staleInputs"
   >,
   edited: boolean,
+  uninstantiated?: boolean,
 ): boolean {
   const { status, output, runStartTimestamp, interrupted, staleInputs } = cell;
 
@@ -159,7 +160,7 @@ export function outputIsStale(
   }
 
   // If edited, the cell's output is stale
-  if (edited) {
+  if (edited || uninstantiated) {
     return true;
   }
 

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -8,7 +8,7 @@ import { Seconds, Time } from "@/utils/time";
 
 export function transitionCell(
   cell: CellRuntimeState,
-  message: CellMessage
+  message: CellMessage,
 ): CellRuntimeState {
   const nextCell = { ...cell };
 
@@ -42,7 +42,7 @@ export function transitionCell(
     case "idle":
       if (cell.runStartTimestamp) {
         nextCell.runElapsedTimeMs = Time.fromSeconds(
-          (message.timestamp - cell.runStartTimestamp) as Seconds
+          (message.timestamp - cell.runStartTimestamp) as Seconds,
         ).toMilliseconds();
         nextCell.runStartTimestamp = null;
         nextCell.staleInputs = false;
@@ -117,7 +117,7 @@ export function transitionCell(
   const newConsoleOutputs = [message.console].flat().filter(Boolean);
   const pdbOutputs = newConsoleOutputs.filter(
     (output): output is Extract<OutputMessage, { channel: "pdb" }> =>
-      output.channel === "pdb"
+      output.channel === "pdb",
   );
   const hasPdbOutput = pdbOutputs.length > 0;
   if (hasPdbOutput && pdbOutputs.some((output) => output.data === "start")) {
@@ -130,7 +130,7 @@ export function transitionCell(
 // Should be called when a cell's code is registered with the kernel for
 // execution.
 export function prepareCellForExecution(
-  cell: CellRuntimeState
+  cell: CellRuntimeState,
 ): CellRuntimeState {
   const nextCell = { ...cell };
 
@@ -150,7 +150,7 @@ export function outputIsStale(
     CellRuntimeState,
     "status" | "output" | "runStartTimestamp" | "interrupted" | "staleInputs"
   >,
-  edited: boolean
+  edited: boolean,
 ): boolean {
   const { status, output, runStartTimestamp, interrupted, staleInputs } = cell;
 

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -8,7 +8,7 @@ import { Seconds, Time } from "@/utils/time";
 
 export function transitionCell(
   cell: CellRuntimeState,
-  message: CellMessage,
+  message: CellMessage
 ): CellRuntimeState {
   const nextCell = { ...cell };
 
@@ -42,9 +42,10 @@ export function transitionCell(
     case "idle":
       if (cell.runStartTimestamp) {
         nextCell.runElapsedTimeMs = Time.fromSeconds(
-          (message.timestamp - cell.runStartTimestamp) as Seconds,
+          (message.timestamp - cell.runStartTimestamp) as Seconds
         ).toMilliseconds();
         nextCell.runStartTimestamp = null;
+        nextCell.staleInputs = false;
       }
       nextCell.debuggerActive = false;
       break;
@@ -116,7 +117,7 @@ export function transitionCell(
   const newConsoleOutputs = [message.console].flat().filter(Boolean);
   const pdbOutputs = newConsoleOutputs.filter(
     (output): output is Extract<OutputMessage, { channel: "pdb" }> =>
-      output.channel === "pdb",
+      output.channel === "pdb"
   );
   const hasPdbOutput = pdbOutputs.length > 0;
   if (hasPdbOutput && pdbOutputs.some((output) => output.data === "start")) {
@@ -129,7 +130,7 @@ export function transitionCell(
 // Should be called when a cell's code is registered with the kernel for
 // execution.
 export function prepareCellForExecution(
-  cell: CellRuntimeState,
+  cell: CellRuntimeState
 ): CellRuntimeState {
   const nextCell = { ...cell };
 
@@ -149,8 +150,7 @@ export function outputIsStale(
     CellRuntimeState,
     "status" | "output" | "runStartTimestamp" | "interrupted" | "staleInputs"
   >,
-  edited: boolean,
-  uninstantiated?: boolean,
+  edited: boolean
 ): boolean {
   const { status, output, runStartTimestamp, interrupted, staleInputs } = cell;
 
@@ -160,7 +160,7 @@ export function outputIsStale(
   }
 
   // If edited, the cell's output is stale
-  if (edited || uninstantiated) {
+  if (edited) {
     return true;
   }
 

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -119,7 +119,7 @@ function initialNotebookState(): NotebookState {
         ...createCellRuntimeState(),
         output: output ? deserializeJson(deserializeBase64(output)) : null,
         consoleOutputs: outputs.map((output) =>
-          deserializeJson(deserializeBase64(output))
+          deserializeJson(deserializeBase64(output)),
         ),
       };
     }
@@ -165,7 +165,7 @@ const {
       lastExecutionTime?: number;
       newCellId?: CellId;
       autoFocus?: boolean;
-    }
+    },
   ) => {
     const {
       cellId,
@@ -400,7 +400,7 @@ const {
        * if so, the 'edited' state will be handled differently.
        */
       formattingChange: boolean;
-    }
+    },
   ) => {
     const { cellId, code, formattingChange } = action;
     const cellIndex = state.cellIds.indexOf(cellId);
@@ -436,7 +436,7 @@ const {
   },
   updateCellConfig: (
     state,
-    action: { cellId: CellId; config: Partial<CellConfig> }
+    action: { cellId: CellId; config: Partial<CellConfig> },
   ) => {
     const { cellId, config } = action;
     return updateCellData(state, cellId, (cell) => {
@@ -471,7 +471,7 @@ const {
   },
   setStdinResponse: (
     state,
-    action: { cellId: CellId; response: string; outputIndex: number }
+    action: { cellId: CellId; response: string; outputIndex: number },
   ) => {
     const { cellId, response, outputIndex } = action;
     return updateCellRuntimeState(state, cellId, (cell) => {
@@ -506,7 +506,7 @@ const {
         createCellRuntimeState({
           staleInputs: !cellData[cell.id].lastExecutionTime,
         }),
-      ])
+      ]),
     );
 
     return {
@@ -515,7 +515,7 @@ const {
       cellData: cellData,
       cellRuntime: cellRuntime,
       cellHandles: Object.fromEntries(
-        cells.map((cell) => [cell.id, createRef()])
+        cells.map((cell) => [cell.id, createRef()]),
       ),
     };
   },
@@ -530,7 +530,7 @@ const {
    */
   moveToNextCell: (
     state,
-    action: { cellId: CellId; before: boolean; noCreate?: boolean }
+    action: { cellId: CellId; before: boolean; noCreate?: boolean },
   ) => {
     const { cellId, before, noCreate = false } = action;
     const index = state.cellIds.indexOf(cellId);
@@ -623,14 +623,14 @@ const {
   },
   foldAll: (state) => {
     const targets = Object.values(state.cellHandles).map(
-      (handle) => handle.current?.editorView
+      (handle) => handle.current?.editorView,
     );
     foldAllBulk(targets);
     return state;
   },
   unfoldAll: (state) => {
     const targets = Object.values(state.cellHandles).map(
-      (handle) => handle.current?.editorView
+      (handle) => handle.current?.editorView,
     );
     unfoldAllBulk(targets);
     return state;
@@ -652,7 +652,7 @@ const {
     }
 
     const { beforeCursorCode, afterCursorCode } = splitEditor(
-      cellHandle.editorView
+      cellHandle.editorView,
     );
 
     updateEditorCodeFromPython(cellHandle.editorView, beforeCursorCode);
@@ -699,7 +699,7 @@ const {
 function updateCellRuntimeState(
   state: NotebookState,
   cellId: CellId,
-  cellReducer: ReducerWithoutAction<CellRuntimeState>
+  cellReducer: ReducerWithoutAction<CellRuntimeState>,
 ) {
   if (!(cellId in state.cellRuntime)) {
     Logger.warn(`Cell ${cellId} not found in state`);
@@ -717,7 +717,7 @@ function updateCellRuntimeState(
 function updateCellData(
   state: NotebookState,
   cellId: CellId,
-  cellReducer: ReducerWithoutAction<CellData>
+  cellReducer: ReducerWithoutAction<CellData>,
 ) {
   if (!(cellId in state.cellData)) {
     Logger.warn(`Cell ${cellId} not found in state`);
@@ -756,7 +756,7 @@ const cellErrorsAtom = atom((get) => {
         // These are errors that are caused by a cell that was stopped,
         // but nothing the user can take action on.
         const nonAncestorErrors = cell.output.data.filter(
-          (error) => error.type !== "ancestor-stopped"
+          (error) => error.type !== "ancestor-stopped",
         );
 
         if (nonAncestorErrors.length > 0) {
@@ -787,7 +787,7 @@ export const cellErrorCount = atom((get) => get(cellErrorsAtom).length);
 export const cellIdToNamesMap = atom((get) => {
   const { cellIds, cellData } = get(notebookAtom);
   const names: Record<CellId, string | undefined> = Objects.fromEntries(
-    cellIds.map((cellId) => [cellId, cellData[cellId]?.name])
+    cellIds.map((cellId) => [cellId, cellData[cellId]?.name]),
   );
   return names;
 });
@@ -841,13 +841,13 @@ export const getCellNames = () => {
 
 const cellDataAtoms = splitAtom(
   selectAtom(notebookAtom, (cells) =>
-    cells.cellIds.map((id) => cells.cellData[id])
-  )
+    cells.cellIds.map((id) => cells.cellData[id]),
+  ),
 );
 export const useCellDataAtoms = () => useAtom(cellDataAtoms);
 
 export const notebookIsRunningAtom = atom((get) =>
-  notebookIsRunning(get(notebookAtom))
+  notebookIsRunning(get(notebookAtom)),
 );
 
 /**
@@ -879,7 +879,7 @@ export function staleCellIds(state: NotebookState) {
         !(
           cellRuntime[cellId].status === "disabled-transitively" ||
           cellData[cellId].config.disabled
-        ))
+        )),
   );
 }
 

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -119,7 +119,7 @@ function initialNotebookState(): NotebookState {
         ...createCellRuntimeState(),
         output: output ? deserializeJson(deserializeBase64(output)) : null,
         consoleOutputs: outputs.map((output) =>
-          deserializeJson(deserializeBase64(output)),
+          deserializeJson(deserializeBase64(output))
         ),
       };
     }
@@ -165,7 +165,7 @@ const {
       lastExecutionTime?: number;
       newCellId?: CellId;
       autoFocus?: boolean;
-    },
+    }
   ) => {
     const {
       cellId,
@@ -400,7 +400,7 @@ const {
        * if so, the 'edited' state will be handled differently.
        */
       formattingChange: boolean;
-    },
+    }
   ) => {
     const { cellId, code, formattingChange } = action;
     const cellIndex = state.cellIds.indexOf(cellId);
@@ -436,7 +436,7 @@ const {
   },
   updateCellConfig: (
     state,
-    action: { cellId: CellId; config: Partial<CellConfig> },
+    action: { cellId: CellId; config: Partial<CellConfig> }
   ) => {
     const { cellId, config } = action;
     return updateCellData(state, cellId, (cell) => {
@@ -471,7 +471,7 @@ const {
   },
   setStdinResponse: (
     state,
-    action: { cellId: CellId; response: string; outputIndex: number },
+    action: { cellId: CellId; response: string; outputIndex: number }
   ) => {
     const { cellId, response, outputIndex } = action;
     return updateCellRuntimeState(state, cellId, (cell) => {
@@ -498,15 +498,24 @@ const {
     });
   },
   setCells: (state, cells: CellData[]) => {
+    const cellData = Object.fromEntries(cells.map((cell) => [cell.id, cell]));
+
+    const cellRuntime = Object.fromEntries(
+      cells.map((cell) => [
+        cell.id,
+        createCellRuntimeState({
+          staleInputs: !cellData[cell.id].lastExecutionTime,
+        }),
+      ])
+    );
+
     return {
       ...state,
       cellIds: cells.map((cell) => cell.id),
-      cellData: Object.fromEntries(cells.map((cell) => [cell.id, cell])),
+      cellData: cellData,
+      cellRuntime: cellRuntime,
       cellHandles: Object.fromEntries(
-        cells.map((cell) => [cell.id, createRef()]),
-      ),
-      cellRuntime: Object.fromEntries(
-        cells.map((cell) => [cell.id, createCellRuntimeState()]),
+        cells.map((cell) => [cell.id, createRef()])
       ),
     };
   },
@@ -521,7 +530,7 @@ const {
    */
   moveToNextCell: (
     state,
-    action: { cellId: CellId; before: boolean; noCreate?: boolean },
+    action: { cellId: CellId; before: boolean; noCreate?: boolean }
   ) => {
     const { cellId, before, noCreate = false } = action;
     const index = state.cellIds.indexOf(cellId);
@@ -614,14 +623,14 @@ const {
   },
   foldAll: (state) => {
     const targets = Object.values(state.cellHandles).map(
-      (handle) => handle.current?.editorView,
+      (handle) => handle.current?.editorView
     );
     foldAllBulk(targets);
     return state;
   },
   unfoldAll: (state) => {
     const targets = Object.values(state.cellHandles).map(
-      (handle) => handle.current?.editorView,
+      (handle) => handle.current?.editorView
     );
     unfoldAllBulk(targets);
     return state;
@@ -643,7 +652,7 @@ const {
     }
 
     const { beforeCursorCode, afterCursorCode } = splitEditor(
-      cellHandle.editorView,
+      cellHandle.editorView
     );
 
     updateEditorCodeFromPython(cellHandle.editorView, beforeCursorCode);
@@ -690,7 +699,7 @@ const {
 function updateCellRuntimeState(
   state: NotebookState,
   cellId: CellId,
-  cellReducer: ReducerWithoutAction<CellRuntimeState>,
+  cellReducer: ReducerWithoutAction<CellRuntimeState>
 ) {
   if (!(cellId in state.cellRuntime)) {
     Logger.warn(`Cell ${cellId} not found in state`);
@@ -708,7 +717,7 @@ function updateCellRuntimeState(
 function updateCellData(
   state: NotebookState,
   cellId: CellId,
-  cellReducer: ReducerWithoutAction<CellData>,
+  cellReducer: ReducerWithoutAction<CellData>
 ) {
   if (!(cellId in state.cellData)) {
     Logger.warn(`Cell ${cellId} not found in state`);
@@ -747,7 +756,7 @@ const cellErrorsAtom = atom((get) => {
         // These are errors that are caused by a cell that was stopped,
         // but nothing the user can take action on.
         const nonAncestorErrors = cell.output.data.filter(
-          (error) => error.type !== "ancestor-stopped",
+          (error) => error.type !== "ancestor-stopped"
         );
 
         if (nonAncestorErrors.length > 0) {
@@ -778,7 +787,7 @@ export const cellErrorCount = atom((get) => get(cellErrorsAtom).length);
 export const cellIdToNamesMap = atom((get) => {
   const { cellIds, cellData } = get(notebookAtom);
   const names: Record<CellId, string | undefined> = Objects.fromEntries(
-    cellIds.map((cellId) => [cellId, cellData[cellId]?.name]),
+    cellIds.map((cellId) => [cellId, cellData[cellId]?.name])
   );
   return names;
 });
@@ -832,13 +841,13 @@ export const getCellNames = () => {
 
 const cellDataAtoms = splitAtom(
   selectAtom(notebookAtom, (cells) =>
-    cells.cellIds.map((id) => cells.cellData[id]),
-  ),
+    cells.cellIds.map((id) => cells.cellData[id])
+  )
 );
 export const useCellDataAtoms = () => useAtom(cellDataAtoms);
 
 export const notebookIsRunningAtom = atom((get) =>
-  notebookIsRunning(get(notebookAtom)),
+  notebookIsRunning(get(notebookAtom))
 );
 
 /**
@@ -870,7 +879,7 @@ export function staleCellIds(state: NotebookState) {
         !(
           cellRuntime[cellId].status === "disabled-transitively" ||
           cellData[cellId].config.disabled
-        )),
+        ))
   );
 }
 

--- a/frontend/src/core/cells/types.ts
+++ b/frontend/src/core/cells/types.ts
@@ -47,7 +47,7 @@ export function createCell({
 }
 
 export function createCellRuntimeState(
-  state?: Partial<CellRuntimeState>
+  state?: Partial<CellRuntimeState>,
 ): CellRuntimeState {
   const auto_instantiate = getUserConfig().runtime.auto_instantiate;
   return {

--- a/frontend/src/core/cells/types.ts
+++ b/frontend/src/core/cells/types.ts
@@ -5,6 +5,7 @@ import { Outline } from "./outline";
 import { CellId } from "./ids";
 import { DEFAULT_CELL_NAME } from "./names";
 import { Milliseconds, Seconds } from "@/utils/time";
+import { getUserConfig } from "../config/config";
 
 /**
  * The status of a cell.
@@ -45,19 +46,23 @@ export function createCell({
   };
 }
 
-export function createCellRuntimeState(): CellRuntimeState {
+export function createCellRuntimeState(
+  state?: Partial<CellRuntimeState>
+): CellRuntimeState {
+  const auto_instantiate = getUserConfig().runtime.auto_instantiate;
   return {
     outline: null,
     output: null,
     consoleOutputs: [],
-    status: "idle",
-    staleInputs: false,
+    status: "idle" as CellStatus,
+    staleInputs: !auto_instantiate,
     interrupted: false,
     errored: false,
     stopped: false,
     runElapsedTimeMs: null,
     runStartTimestamp: null,
     debuggerActive: false,
+    ...state,
   };
 }
 


### PR DESCRIPTION
## 📝 Summary

Fixes #1444, an edge case bug that caused cells to lose "stale" status on session resume.

Important to note that this bug was only for uninstantiated cells, or effectively, the first session resume. Cells that had been run and later became stale were already persisted on subsequent resumes.

## 🔍 Description of Changes

- In `createCellRuntimeState()`, pass `staleInputs: true` if `lastExecutionTime == null`, which will only be null for an uninstantiated cell.
- Update cell status tooltip with more relevant "This cell has not yet been run" hint for uninstantiated cells.'

Uninstantiated cells after session resume:
<img width="1376" alt="Screenshot 2024-06-16 at 1 06 57 PM" src="https://github.com/marimo-team/marimo/assets/7220175/f21fa951-33cd-4e30-849b-cde84901eb96">
Stale cells after session resume:
<img width="1448" alt="Screenshot 2024-06-16 at 4 53 13 PM" src="https://github.com/marimo-team/marimo/assets/7220175/d3d46edf-5cfb-4084-9425-d0cd972de6b8">

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
