### PR TITLE
chore: cleanup singleton logic to cache on the window

### DIFF
--- a/frontend/src/core/dom/uiregistry.ts
+++ b/frontend/src/core/dom/uiregistry.ts
@@ -40,7 +40,6 @@ export class UIElementRegistry {
   }
 
   private constructor() {
-    repl(UIElementRegistry.INSTANCE, "UIElementRegistry");
     this.entries = new Map();
   }
 

--- a/frontend/src/core/dom/uiregistry.ts
+++ b/frontend/src/core/dom/uiregistry.ts
@@ -31,7 +31,13 @@ export class UIElementRegistry {
   /**
    * Shared instance of UIElementRegistry since this must be a singleton.
    */
-  static readonly INSTANCE = new UIElementRegistry();
+  static get INSTANCE(): UIElementRegistry {
+    const KEY = "_marimo_private_UIElementRegistry";
+    if (!window[KEY]) {
+      window[KEY] = new UIElementRegistry();
+    }
+    return window[KEY] as UIElementRegistry;
+  }
 
   private constructor() {
     repl(UIElementRegistry.INSTANCE, "UIElementRegistry");

--- a/frontend/src/core/dom/uiregistry.ts
+++ b/frontend/src/core/dom/uiregistry.ts
@@ -1,5 +1,4 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { repl } from "../../utils/repl";
 import type { CellId, UIElementId } from "../cells/ids";
 import {
   ValueType,

--- a/frontend/src/core/functions/FunctionRegistry.ts
+++ b/frontend/src/core/functions/FunctionRegistry.ts
@@ -13,7 +13,5 @@ export const FUNCTIONS_REGISTRY = new DeferredRequestRegistry<
   await sendFunctionRequest({
     functionCallId: requestId,
     ...req,
-  }).catch((error) => {
-    throw error;
   });
 });

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -17,12 +17,12 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   /**
    * Lazy singleton instance of the IslandsPyodideBridge.
    */
-  private static _instance: IslandsPyodideBridge | undefined;
-  public static get INSTANCE() {
-    if (!IslandsPyodideBridge._instance) {
-      IslandsPyodideBridge._instance = new IslandsPyodideBridge();
+  static get INSTANCE(): IslandsPyodideBridge {
+    const KEY = "_marimo_private_IslandsPyodideBridge";
+    if (!window[KEY]) {
+      window[KEY] = new IslandsPyodideBridge();
     }
-    return IslandsPyodideBridge._instance;
+    return window[KEY] as IslandsPyodideBridge;
   }
 
   private rpc: ReturnType<typeof getWorkerRPC<WorkerSchema>>;

--- a/frontend/src/core/islands/main.ts
+++ b/frontend/src/core/islands/main.ts
@@ -40,6 +40,12 @@ export async function initialize() {
   const islands = document.querySelectorAll<HTMLElement>(
     MarimoIslandElement.tagName,
   );
+
+  // If no islands are found, we can skip the rest of the initialization.
+  if (islands.length === 0) {
+    return;
+  }
+
   for (const island of islands) {
     island.classList.add(MarimoIslandElement.styleNamespace);
   }

--- a/frontend/src/core/kernel/RuntimeState.ts
+++ b/frontend/src/core/kernel/RuntimeState.ts
@@ -12,10 +12,18 @@ import { Logger } from "@/utils/Logger";
  * Manager to track running cells.
  */
 export class RuntimeState {
+  private hasStarted = false;
+
   /**
    * Shared instance of RuntimeState since this must be a singleton.
    */
-  static readonly INSTANCE = new RuntimeState(UI_ELEMENT_REGISTRY);
+  static get INSTANCE(): RuntimeState {
+    const KEY = "_marimo_private_RuntimeState";
+    if (!window[KEY]) {
+      window[KEY] = new RuntimeState(UI_ELEMENT_REGISTRY);
+    }
+    return window[KEY] as RuntimeState;
+  }
 
   /**
    * ObjectIds of UIElements whose values need to be updated in the kernel
@@ -37,15 +45,25 @@ export class RuntimeState {
    * Start listening for events from UIElements
    */
   start(sendComponentValues: RunRequests["sendComponentValues"]) {
+    if (this.hasStarted) {
+      Logger.warn("RuntimeState already started");
+      return;
+    }
     this._sendComponentValues = sendComponentValues;
     document.addEventListener(marimoValueReadyEvent, this.handleReadyEvent);
+    this.hasStarted = true;
   }
 
   /**
    * Stop listening for events from UIElements
    */
   stop() {
+    if (!this.hasStarted) {
+      Logger.warn("RuntimeState already stopped");
+      return;
+    }
     document.removeEventListener(marimoValueReadyEvent, this.handleReadyEvent);
+    this.hasStarted = false;
   }
 
   private handleReadyEvent = (e: MarimoValueReadyEventType) => {

--- a/frontend/src/core/kernel/RuntimeState.ts
+++ b/frontend/src/core/kernel/RuntimeState.ts
@@ -30,9 +30,7 @@ export class RuntimeState {
    */
   private _sendComponentValues: RunRequests["sendComponentValues"] | undefined;
 
-  constructor(private uiElementRegistry: UIElementRegistry) {
-    repl(RuntimeState.INSTANCE, "RuntimeState");
-  }
+  constructor(private uiElementRegistry: UIElementRegistry) {}
 
   private get sendComponentValues(): RunRequests["sendComponentValues"] {
     if (!this._sendComponentValues) {

--- a/frontend/src/core/kernel/RuntimeState.ts
+++ b/frontend/src/core/kernel/RuntimeState.ts
@@ -5,7 +5,6 @@ import {
 } from "../dom/events";
 import { UI_ELEMENT_REGISTRY, UIElementRegistry } from "../dom/uiregistry";
 import { RunRequests } from "../network/types";
-import { repl } from "@/utils/repl";
 import { Logger } from "@/utils/Logger";
 
 /**

--- a/frontend/src/core/kernel/__tests__/RuntimeState.test.ts
+++ b/frontend/src/core/kernel/__tests__/RuntimeState.test.ts
@@ -32,7 +32,14 @@ describe("RuntimeState", () => {
     );
   });
 
+  test("it can only start once", () => {
+    runtimeState.start(mockSendComponentValues);
+    runtimeState.start(mockSendComponentValues);
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+  });
+
   test("stop should remove event listener", () => {
+    runtimeState.start(mockSendComponentValues);
     runtimeState.stop();
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       marimoValueReadyEvent,

--- a/frontend/src/core/pyodide/bridge.ts
+++ b/frontend/src/core/pyodide/bridge.ts
@@ -37,7 +37,13 @@ import { getInitialAppMode } from "../mode";
 const { handleResponseReturnNull } = API;
 
 export class PyodideBridge implements RunRequests, EditRequests {
-  static INSTANCE = new PyodideBridge();
+  static get INSTANCE(): PyodideBridge {
+    const KEY = "_marimo_private_PyodideBridge";
+    if (!window[KEY]) {
+      window[KEY] = new PyodideBridge();
+    }
+    return window[KEY] as PyodideBridge;
+  }
 
   private rpc!: ReturnType<typeof getWorkerRPC<WorkerSchema>>;
   private saveRpc!: ReturnType<typeof getWorkerRPC<SaveWorkerSchema>>;

--- a/frontend/src/core/static/virtual-file-tracker.ts
+++ b/frontend/src/core/static/virtual-file-tracker.ts
@@ -24,7 +24,7 @@ export class VirtualFileTracker {
   virtualFiles = new Map<CellId, Set<string>>();
 
   private constructor() {
-    repl(VirtualFileTracker.INSTANCE, "VirtualFileTracker");
+    // Private
   }
 
   track(message: Pick<CellMessage, "cell_id" | "output">): void {

--- a/frontend/src/core/static/virtual-file-tracker.ts
+++ b/frontend/src/core/static/virtual-file-tracker.ts
@@ -13,7 +13,13 @@ export class VirtualFileTracker {
   /**
    * Shared instance of VirtualFileTracker since this must be a singleton.
    */
-  static readonly INSTANCE = new VirtualFileTracker();
+  static get INSTANCE(): VirtualFileTracker {
+    const KEY = "_marimo_private_VirtualFileTracker";
+    if (!window[KEY]) {
+      window[KEY] = new VirtualFileTracker();
+    }
+    return window[KEY] as VirtualFileTracker;
+  }
 
   virtualFiles = new Map<CellId, Set<string>>();
 

--- a/frontend/src/core/static/virtual-file-tracker.ts
+++ b/frontend/src/core/static/virtual-file-tracker.ts
@@ -1,7 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { CellMessage } from "../kernel/messages";
 import { CellId } from "../cells/ids";
-import { repl } from "@/utils/repl";
 
 // Virtual files are of the form /@file/<file-name>.<extension>
 const VIRTUAL_FILE_REGEX = /\/@file\/([^\s/]+)\.([\dA-Za-z]+)/g;


### PR DESCRIPTION
This will help for the vscode plugin - since each renderer may need to import their own js script