### PR TITLE
fix: uninstantiated logic

### DIFF
--- a/frontend/src/core/cells/types.ts
+++ b/frontend/src/core/cells/types.ts
@@ -5,7 +5,6 @@ import { Outline } from "./outline";
 import { CellId } from "./ids";
 import { DEFAULT_CELL_NAME } from "./names";
 import { Milliseconds, Seconds } from "@/utils/time";
-import { getUserConfig } from "../config/config";
 import { CellConfig, CellStatus } from "../network/types";
 
 /**
@@ -39,13 +38,12 @@ export function createCell({
 export function createCellRuntimeState(
   state?: Partial<CellRuntimeState>,
 ): CellRuntimeState {
-  const auto_instantiate = getUserConfig().runtime.auto_instantiate;
   return {
     outline: null,
     output: null,
     consoleOutputs: [],
     status: "idle" as CellStatus,
-    staleInputs: !auto_instantiate,
+    staleInputs: false,
     interrupted: false,
     errored: false,
     stopped: false,


### PR DESCRIPTION
This change fixes a bug in which cells were incorrectly marked as stale on session startup/resume.

Previously, the frontend set a cell's `staleInputs` to `true` if autorun-on-startup was disabled or if a cell didn't have an execution time. But errored cells don't have execution times. And in general, setting `staleInputs` is error-prone and only something the BE can determine.

This change instead initializes with `staleInputs=False`, letting session replay override it as usual, and makes the check for whether a cell is `uninstantiated` more robust.

Tested by manually playing around with a lot of edge cases.