### PR TITLE
improvement: less scroll shift

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -306,7 +306,7 @@ const CellEditorInternal = ({
         editorViewRef.current?.focus();
         editorViewRef.current?.dom.scrollIntoView({
           behavior: "smooth",
-          block: "center",
+          block: "nearest",
         });
       });
     }

--- a/frontend/src/core/cells/scrollCellIntoView.ts
+++ b/frontend/src/core/cells/scrollCellIntoView.ts
@@ -63,7 +63,7 @@ export function focusAndScrollCellIntoView({
 
   element.scrollIntoView({
     behavior: "smooth",
-    block: "center",
+    block: "nearest",
   });
 }
 


### PR DESCRIPTION
This change modifies scrolling to cells to use block nearest instead of center, keeping the page as is if the element is already in view.

As a result, running shift enter, adding or deleting a cell no longer scrolls the page (unless eg the created cell is not in the viewport).

3 users have complained about our scroll being too jumpy, especially on cell run -- this addresses that feedback.