### PR TITLE
Update Documentation for mo.tabs to mo.ui.tabs to Remove Deprecation …

### DIFF
--- a/docs/api/inputs/tabs.md
+++ b/docs/api/inputs/tabs.md
@@ -22,7 +22,7 @@
 
     @app.cell
     def __():
-        mo.tabs(
+        mo.ui.tabs(
             {
                 "📈 Sales": bar,
                 "📊 Subscriptions": bar,


### PR DESCRIPTION
## 📝 Summary

This pull request addresses the outdated documentation for the `mo.tabs` UI element. The current documentation (code editor preview) shows a deprecation warning indicating that `mo.tabs` should be replaced with `mo.ui.tabs`. This PR updates the documentation to use `mo.ui.tabs` instead, ensuring it is current and accurate. Fixes #1636.

## 🔍 Description of Changes

- Replaced the instance of `mo.tabs` with `mo.ui.tabs` in the documentation for the `mo.tabs` UI element.

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick