### PR TITLE
feat: global table search

### DIFF
--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import React, { memo } from "react";
+import React, { memo, useEffect, useState } from "react";
 import {
   ColumnDef,
   OnChangeFn,
@@ -24,19 +24,33 @@ import {
 import { DataTablePagination } from "./pagination";
 import { DownloadActionProps, DownloadAs } from "./download-actions";
 import { cn } from "@/utils/cn";
+import { SearchIcon } from "lucide-react";
+import { Button } from "../ui/button";
+import { useDebounce } from "@uidotdev/usehooks";
+import useEvent from "react-use-event-hook";
+import { Tooltip } from "../ui/tooltip";
+import { Spinner } from "../icons/spinner";
 
 interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   wrapperClassName?: string;
   className?: string;
   columns: Array<ColumnDef<TData>>;
   data: TData[];
+  // Sorting
   sorting?: SortingState;
   setSorting?: OnChangeFn<SortingState>;
+  // Pagination
   pagination?: boolean;
   pageSize?: number;
+  // Selection
   selection?: "single" | "multi" | null;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  // Search
+  enableSearch?: boolean;
+  searchQuery?: string;
+  onSearchQueryChange?: (query: string) => void;
+  reloading?: boolean;
 }
 
 const DataTableInternal = <TData,>({
@@ -51,10 +65,22 @@ const DataTableInternal = <TData,>({
   downloadAs,
   pagination = false,
   onRowSelectionChange,
+  enableSearch = false,
+  searchQuery,
+  onSearchQueryChange,
+  reloading,
 }: DataTableProps<TData>) => {
+  const [isSearchEnabled, setIsSearchEnabled] = React.useState<boolean>(false);
   const [paginationState, setPaginationState] = React.useState<PaginationState>(
     { pageSize: pageSize, pageIndex: 0 },
   );
+
+  // If pageSize changes, reset pageSize
+  useEffect(() => {
+    if (paginationState.pageSize !== pageSize) {
+      setPaginationState((state) => ({ ...state, pageSize: pageSize }));
+    }
+  }, [pageSize, paginationState.pageSize]);
 
   const table = useReactTable({
     data,
@@ -78,31 +104,47 @@ const DataTableInternal = <TData,>({
     },
   });
 
+  const renderHeader = () => {
+    // Hide header if no results
+    if (!table.getRowModel().rows?.length) {
+      return;
+    }
+
+    return table.getHeaderGroups().map((headerGroup) => (
+      <TableRow key={headerGroup.id}>
+        {headerGroup.headers.map((header) => {
+          return (
+            <TableHead
+              key={header.id}
+              className="h-auto min-h-10 whitespace-nowrap align-baseline"
+            >
+              {header.isPlaceholder
+                ? null
+                : flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+            </TableHead>
+          );
+        })}
+      </TableRow>
+    ));
+  };
+
   return (
     <div className={cn(wrapperClassName, "flex flex-col space-y-2")}>
       <div className={cn(className || "rounded-md border")}>
+        {onSearchQueryChange && enableSearch && (
+          <SearchBar
+            value={searchQuery || ""}
+            onHide={() => setIsSearchEnabled(false)}
+            handleSearch={onSearchQueryChange}
+            hidden={!isSearchEnabled}
+            reloading={reloading}
+          />
+        )}
         <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead
-                      key={header.id}
-                      className="h-auto min-h-10 whitespace-nowrap align-baseline"
-                    >
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
+          <TableHeader>{renderHeader()}</TableHeader>
           <TableBody>
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
@@ -137,10 +179,76 @@ const DataTableInternal = <TData,>({
           </TableBody>
         </Table>
       </div>
-      <div className="flex align-items justify-between flex-shrink-0">
+      <div className="flex items-center justify-between flex-shrink-0">
+        {onSearchQueryChange && enableSearch && (
+          <Tooltip content="Search">
+            <Button
+              variant="text"
+              size="xs"
+              className="mb-0"
+              onClick={() => setIsSearchEnabled(!isSearchEnabled)}
+            >
+              <SearchIcon className="w-4 h-4 text-muted-foreground" />
+            </Button>
+          </Tooltip>
+        )}
         {pagination ? <DataTablePagination table={table} /> : <div />}
         {downloadAs && <DownloadAs downloadAs={downloadAs} />}
       </div>
+    </div>
+  );
+};
+
+const SearchBar = (props: {
+  hidden: boolean;
+  value: string;
+  handleSearch: (query: string) => void;
+  onHide: () => void;
+  reloading?: boolean;
+}) => {
+  const { reloading, value, handleSearch, hidden, onHide } = props;
+  const [internalValue, setInternalValue] = useState(value);
+  const debouncedSearch = useDebounce(internalValue, 500);
+  const onSearch = useEvent(handleSearch);
+  const ref = React.useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    onSearch(debouncedSearch);
+  }, [debouncedSearch, onSearch]);
+
+  useEffect(() => {
+    if (hidden) {
+      // Reset
+      setInternalValue("");
+    } else {
+      // Focus
+      ref.current?.focus();
+    }
+  }, [hidden]);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center space-x-2 h-8 px-2 border-b transition-all overflow-hidden duration-300 opacity-100",
+        hidden && "h-0 border-none opacity-0",
+      )}
+    >
+      <SearchIcon className="w-4 h-4 text-muted-foreground" />
+      <input
+        type="text"
+        ref={ref}
+        className="w-full h-full border-none bg-transparent focus:outline-none text-sm"
+        value={internalValue}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            onHide();
+          }
+        }}
+        autoFocus={true}
+        onChange={(e) => setInternalValue(e.target.value)}
+        placeholder="Search"
+      />
+      {reloading && <Spinner size="small" />}
     </div>
   );
 };

--- a/frontend/src/components/data-table/pagination.tsx
+++ b/frontend/src/components/data-table/pagination.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { PluralWord } from "@/utils/pluralize";
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;
@@ -20,7 +21,7 @@ export const DataTablePagination = <TData,>({
     const selected = table.getSelectedRowModel().rows.length;
     const isAllSelected = table.getIsAllRowsSelected();
     const isAllPageSelected = table.getIsAllPageRowsSelected();
-    const count = table.getFilteredRowModel().rows.length;
+    const numRows = table.getFilteredRowModel().rows.length;
 
     if (isAllPageSelected && !isAllSelected) {
       return (
@@ -33,7 +34,7 @@ export const DataTablePagination = <TData,>({
             className="mb-0 h-6"
             onClick={() => table.toggleAllRowsSelected(true)}
           >
-            Select all {prettyNumber(count)}
+            Select all {prettyNumber(numRows)}
           </Button>
         </>
       );
@@ -56,7 +57,11 @@ export const DataTablePagination = <TData,>({
       );
     }
 
-    return <span>{prettyNumber(count)} items</span>;
+    return (
+      <span>
+        {prettyNumber(numRows)} {new PluralWord("row").pluralize(numRows)}
+      </span>
+    );
   };
   const currentPage = Math.min(
     table.getState().pagination.pageIndex + 1,
@@ -66,9 +71,7 @@ export const DataTablePagination = <TData,>({
 
   return (
     <div className="flex flex-1 items-center justify-between px-2">
-      <div className="text-sm text-muted-foreground h-6 flex items-baseline">
-        {renderTotal()}
-      </div>
+      <div className="text-sm text-muted-foreground">{renderTotal()}</div>
       <div className="flex items-center space-x-2">
         <Button
           size="xs"

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const activeCommon = "active:shadow-xsSolid";
 const buttonVariants = cva(
   cn(
     "disabled:opacity-50 disabled:pointer-events-none",
-    "inline-flex mb-1 items-center justify-center rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background",
+    "inline-flex items-center justify-center rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background",
   ),
   {
     variants: {

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -168,7 +168,7 @@ export const DataFrameComponent = memo(
         </Tabs>
         {error && <ErrorBanner error={error} />}
         {has_more && total_rows != null && (
-          <Banner>
+          <Banner className="shadow-none!">
             Result clipped. Total rows {prettyNumber(total_rows)}.
           </Banner>
         )}
@@ -183,7 +183,13 @@ export const DataFrameComponent = memo(
           rowHeaders={row_headers || Arrays.EMPTY}
           showDownload={false}
           download_as={Functions.THROW}
-          sort_values={sort_values}
+          enableSearch={false}
+          search={({ sort }) => {
+            if (sort) {
+              return sort_values(sort);
+            }
+            return Promise.resolve(url || "");
+          }}
           showColumnSummaries={false}
           get_column_summaries={getColumnSummaries}
           value={Arrays.EMPTY}

--- a/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
+++ b/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`renderZodSchema > should render a form 1`] = `
           </div>
           <div>
             <button
-              class="disabled:opacity-50 disabled:pointer-events-none inline-flex mb-1 items-center justify-center font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background opacity-80 hover:opacity-100 active:opacity-100 h-7 px-2 rounded-md text-xs hover:text-accent-foreground"
+              class="disabled:opacity-50 disabled:pointer-events-none inline-flex items-center justify-center font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background opacity-80 hover:opacity-100 active:opacity-100 h-7 px-2 rounded-md text-xs hover:text-accent-foreground"
               data-testid="marimo-plugin-data-frames-add-array-item"
             >
               <svg
@@ -970,7 +970,7 @@ exports[`renderZodSchema > should render a form 8`] = `
       class="flex flex-row align-start"
     >
       <button
-        class="disabled:opacity-50 disabled:pointer-events-none inline-flex mb-1 items-center justify-center font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-input shadow-smSolid active:shadow-xsSolid h-7 px-2 rounded-md text-xs"
+        class="disabled:opacity-50 disabled:pointer-events-none inline-flex items-center justify-center font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-input shadow-smSolid active:shadow-xsSolid h-7 px-2 rounded-md text-xs"
         data-testid="marimo-plugin-data-frames-random-number-button"
       >
         <svg
@@ -1049,7 +1049,7 @@ exports[`renderZodSchema > should render a form 9`] = `
       class="flex flex-row align-start"
     >
       <button
-        class="disabled:opacity-50 disabled:pointer-events-none inline-flex mb-1 items-center justify-center font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-input shadow-smSolid active:shadow-xsSolid h-7 px-2 rounded-md text-xs"
+        class="disabled:opacity-50 disabled:pointer-events-none inline-flex items-center justify-center font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-input shadow-smSolid active:shadow-xsSolid h-7 px-2 rounded-md text-xs"
         data-testid="marimo-plugin-data-frames-random-number-button"
       >
         <svg

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -174,9 +174,9 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
         if self._error is not None:
             raise GetDataFrameError(self._error)
 
-        manager = get_table_manager(self._value).limit(self.DISPLAY_LIMIT)
-        url = mo_data.csv(manager.to_csv()).url
+        manager = get_table_manager(self._value)
         total_rows = manager.get_num_rows(force=True) or self.DISPLAY_LIMIT
+        url = mo_data.csv(manager.limit(self.DISPLAY_LIMIT).to_csv()).url
         return GetDataFrameResponse(
             url=url,
             total_rows=total_rows,

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -298,4 +298,6 @@ class table(
             result = result.search(args.query)
         if args.sort:
             result = result.sort_values(args.sort.by, args.sort.descending)
+        # Save the manager to be used for selection
+        self._manager = result
         return result.limit(TableManager.DEFAULT_LIMIT).to_data()

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -63,7 +63,13 @@ class ColumnSummaries:
 
 
 @dataclass
-class SortValuesArgs:
+class SearchTableArgs:
+    query: Optional[str] = None
+    sort: Optional[SortArgs] = None
+
+
+@dataclass
+class SortArgs:
     by: ColumnName
     descending: bool
 
@@ -230,9 +236,9 @@ class table(
                     function=self.get_column_summaries,
                 ),
                 Function(
-                    name=self.sort_values.__name__,
-                    arg_cls=SortValuesArgs,
-                    function=self.sort_values,
+                    name=self.search.__name__,
+                    arg_cls=SearchTableArgs,
+                    function=self.search,
                 ),
             ),
         )
@@ -286,9 +292,10 @@ class table(
 
         return ColumnSummaries(summaries)
 
-    def sort_values(self, args: SortValuesArgs) -> Union[JSONType, str]:
-        return (
-            self._unfiltered_manager.sort_values(args.by, args.descending)
-            .limit(TableManager.DEFAULT_LIMIT)
-            .to_data()
-        )
+    def search(self, args: SearchTableArgs) -> Union[JSONType, str]:
+        result = self._unfiltered_manager
+        if args.query:
+            result = result.search(args.query)
+        if args.sort:
+            result = result.sort_values(args.sort.by, args.sort.descending)
+        return result.limit(TableManager.DEFAULT_LIMIT).to_data()

--- a/marimo/_plugins/ui/_impl/tables/default_table.py
+++ b/marimo/_plugins/ui/_impl/tables/default_table.py
@@ -96,6 +96,38 @@ class DefaultTableManager(TableManager[JsonTableData]):
             )
         return DefaultTableManager(self.data[:num])
 
+    def search(self, query: str) -> DefaultTableManager:
+        query = query.lower()
+        if isinstance(self.data, dict):
+            mask: List[bool] = []
+            for row in range(self.get_num_rows() or 0):
+                mask.append(
+                    any(
+                        query in str(self.data[key][row]).lower()
+                        for key in self.data.keys()
+                    )
+                )
+            results: JsonTableData = {
+                key: [value[i] for i, match in enumerate(mask) if match]
+                for key, value in self.data.items()
+            }
+            return DefaultTableManager(results)
+        if isinstance(self.data, list):
+            return DefaultTableManager(
+                [
+                    row
+                    for row in self._normalize_data(self.data)
+                    if any(query in str(v).lower() for v in row.values())
+                ]
+            )
+        return DefaultTableManager(
+            [
+                row
+                for row in self._normalize_data(self.data)
+                if any(query in str(v).lower() for v in row.values())
+            ]
+        )
+
     def get_row_headers(self) -> list[tuple[str, list[str | int | float]]]:
         return []
 

--- a/marimo/_plugins/ui/_impl/tables/df_protocol_table.py
+++ b/marimo/_plugins/ui/_impl/tables/df_protocol_table.py
@@ -90,6 +90,9 @@ class DataFrameProtocolTableManager(TableManager[DataFrameLike]):
     def limit(self, num: int) -> TableManager[Union[pa.Table, pa.RecordBatch]]:
         return self._ensure_delegate().limit(num)
 
+    def search(self, query: str) -> TableManager[Any]:
+        return self._ensure_delegate().search(query)
+
     def get_summary(self, column: str) -> ColumnSummary:
         return self._ensure_delegate().get_summary(column)
 

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -128,6 +128,18 @@ class PandasTableManagerFactory(TableManagerFactory):
                     raise ValueError("Limit must be a positive integer")
                 return PandasTableManager(self.data.head(num))
 
+            def search(self, query: str) -> TableManager[Any]:
+                query = query.lower()
+
+                def contains_query(series: pd.Series[Any]) -> pd.Series[bool]:
+                    def search(s: Any) -> bool:
+                        return query in str(s).lower()
+
+                    return series.map(search)
+
+                mask = self.data.apply(contains_query)
+                return PandasTableManager(self.data.loc[mask.any(axis=1)])
+
             @staticmethod
             def _get_field_type(
                 series: pd.Series[Any] | pd.DataFrame,

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -76,6 +76,10 @@ class TableManager(abc.ABC, Generic[T]):
     def limit(self, num: int) -> TableManager[Any]:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def search(self, query: str) -> TableManager[Any]:
+        raise NotImplementedError
+
     @staticmethod
     @abc.abstractmethod
     def is_type(value: Any) -> bool:

--- a/marimo/_smoke_tests/datasources.py
+++ b/marimo/_smoke_tests/datasources.py
@@ -2,7 +2,7 @@
 
 import marimo
 
-__generated_with = "0.6.13"
+__generated_with = "0.6.19"
 app = marimo.App(width="full")
 
 
@@ -60,6 +60,18 @@ def __(df):
 @app.cell
 def __(mo, polars_df):
     mo.ui.table(polars_df)
+    return
+
+
+@app.cell
+def __(mo, pyarrow_df):
+    mo.ui.table(pyarrow_df)
+    return
+
+
+@app.cell
+def __(df, mo):
+    mo.ui.table(df)
     return
 
 

--- a/tests/_plugins/ui/_impl/tables/test_default_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_default_table.py
@@ -116,6 +116,19 @@ class TestDefaultTable(unittest.TestCase):
         ]
         assert sorted_data == expected_data
 
+    def test_search(self) -> None:
+        searched_manager = self.manager.search("alice")
+        expected_data = [
+            {"name": "Alice", "age": 30, "birth_year": date(1994, 5, 24)},
+        ]
+        assert searched_manager.data == expected_data
+
+        searched_manager = self.manager.search("1994")
+        expected_data = [
+            {"name": "Alice", "age": 30, "birth_year": date(1994, 5, 24)},
+        ]
+        assert searched_manager.data == expected_data
+
 
 class TestColumnarDefaultTable(unittest.TestCase):
     def setUp(self) -> None:
@@ -198,3 +211,19 @@ class TestColumnarDefaultTable(unittest.TestCase):
     def test_get_unique_column_values(self) -> None:
         unique_values = self.manager.get_unique_column_values("age")
         assert unique_values == [22, 25, 28, 30, 35]
+
+    def test_search(self) -> None:
+        searched_manager = self.manager.search("alice")
+        expected_data = {
+            "name": ["Alice"],
+            "age": [30],
+            "birth_year": [date(1994, 5, 24)],
+        }
+        assert searched_manager.data == expected_data
+
+        searched_manager = self.manager.search("1994")
+        expected_data = {
+            "name": ["Alice"],
+            "age": [30],
+            "birth_year": [date(1994, 5, 24)],
+        }

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -342,3 +342,19 @@ class TestPandasTableManager(unittest.TestCase):
     def test_get_unique_column_values(self) -> None:
         column = "B"
         assert self.manager.get_unique_column_values(column) == ["a", "b", "c"]
+
+    def test_search(self) -> None:
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": ["foo", "bar", "baz"],
+                "C": [True, False, True],
+            }
+        )
+        manager = self.factory.create()(df)
+        assert manager.search("foo").get_num_rows() == 1
+        assert manager.search("a").get_num_rows() == 2
+        assert manager.search("true").get_num_rows() == 2
+        assert manager.search("food").get_num_rows() == 0

--- a/tests/_plugins/ui/_impl/tables/test_polars_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_polars_table.py
@@ -209,3 +209,19 @@ class TestPolarsTableManagerFactory(unittest.TestCase):
         column = "A"
         unique_values = self.manager.get_unique_column_values(column)
         assert unique_values == [1, 2, 3]
+
+    def test_search(self) -> None:
+        import polars as pl
+
+        df = pl.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": ["foo", "bar", "baz"],
+                "C": [True, False, True],
+            }
+        )
+        manager = self.factory.create()(df)
+        assert manager.search("foo").get_num_rows() == 1
+        assert manager.search("a").get_num_rows() == 2
+        assert manager.search("true").get_num_rows() == 2
+        assert manager.search("food").get_num_rows() == 0

--- a/tests/_plugins/ui/_impl/tables/test_pyarrow.py
+++ b/tests/_plugins/ui/_impl/tables/test_pyarrow.py
@@ -25,7 +25,7 @@ class TestPyArrowTableManagerFactory(unittest.TestCase):
                 # Integer
                 "A": [1, 2, 3],
                 # String
-                "B": ["a", "b", "c"],
+                "B": ["aaa", "b", "c"],
                 # Float
                 "C": [1.0, 2.0, 3.0],
                 # Boolean
@@ -88,7 +88,7 @@ class TestPyArrowTableManagerFactory(unittest.TestCase):
         complex_data = pa.table(
             {
                 "A": [1, 2, 3],
-                "B": ["a", "b", "c"],
+                "B": ["aaa", "b", "c"],
                 "C": [1.0, 2.0, 3.0],
                 "D": [True, False, True],
                 "E": [None, None, None],
@@ -110,6 +110,10 @@ class TestPyArrowTableManagerFactory(unittest.TestCase):
         limited_manager = self.manager.limit(1)
         expected_data = self.data.take([0])
         assert limited_manager.data == expected_data
+
+    def test_limit_more_than_num_rows(self) -> None:
+        limited_manager = self.manager.limit(500)
+        assert limited_manager.data == self.data
 
     def test_summary_integer(self) -> None:
         column = "A"
@@ -171,4 +175,10 @@ class TestPyArrowTableManagerFactory(unittest.TestCase):
     def test_get_unique_column_values(self) -> None:
         column = "B"
         unique_values = self.manager.get_unique_column_values(column)
-        assert unique_values == ["a", "b", "c"]
+        assert unique_values == ["aaa", "b", "c"]
+
+    def test_search(self) -> None:
+        manager = self.factory.create()(self.data)
+        assert manager.search("aaa").get_num_rows() == 1
+        assert manager.search("true").get_num_rows() == 2
+        assert manager.search("baz").get_num_rows() == 0

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -210,7 +210,7 @@ def test_value():
     data = ["banana", "apple", "cherry", "date", "elderberry"]
     data = _normalize_data(data)
     table = ui.table(data)
-    table.value = []
+    assert list(table.value) == []
 
 
 def test_value_with_selection():

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import pytest
 
+from marimo._plugins import ui
+from marimo._plugins.ui._impl.table import SearchTableArgs, SortArgs
 from marimo._plugins.ui._impl.tables.default_table import DefaultTableManager
 from marimo._plugins.ui._impl.utils.dataframe import TableData
 from marimo._runtime.runtime import Kernel
@@ -202,3 +204,52 @@ def test_sort_dict_of_tuples(dtm: DefaultTableManager):
         {"key1": 17, "key2": 8, "key3": 65, "key4": 2, "key5": 9},
     ]
     assert sorted_data == _normalize_data(expected_data)
+
+
+def test_value():
+    data = ["banana", "apple", "cherry", "date", "elderberry"]
+    data = _normalize_data(data)
+    table = ui.table(data)
+    table.value = []
+
+
+def test_value_with_selection():
+    data = ["banana", "apple", "cherry", "date", "elderberry"]
+    data = _normalize_data(data)
+    table = ui.table(data)
+    assert list(table._convert_value(["0", "2"])) == [
+        {"value": "banana"},
+        {"value": "cherry"},
+    ]
+
+
+def test_value_with_sorting_then_selection():
+    data = ["banana", "apple", "cherry", "date", "elderberry"]
+    data = _normalize_data(data)
+    table = ui.table(data)
+
+    table.search(SearchTableArgs(sort=SortArgs("value", descending=True)))
+    assert list(table._convert_value(["0"])) == [
+        {"value": "elderberry"},
+    ]
+
+    table.search(SearchTableArgs(sort=SortArgs("value", descending=False)))
+    assert list(table._convert_value(["0"])) == [
+        {"value": "apple"},
+    ]
+
+
+def test_value_with_search_then_selection():
+    data = ["banana", "apple", "cherry", "date", "elderberry"]
+    data = _normalize_data(data)
+    table = ui.table(data)
+
+    table.search(SearchTableArgs(query="apple"))
+    assert list(table._convert_value(["0"])) == [
+        {"value": "apple"},
+    ]
+
+    table.search(SearchTableArgs(query="banana"))
+    assert list(table._convert_value(["0"])) == [
+        {"value": "banana"},
+    ]


### PR DESCRIPTION
Add global search to tables. Supports:
* polars
* pandas
* pyarrow
* lists/dicts

Bugfix:
* clear selection when filter or sort changes

Other:
* i removed the mb-1 on buttons. This caused lots of issues with composition, but if this was useful somewhere, we can add this back per-case.