### PR TITLE
fix: clear global search in the backend for dataframes

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -194,6 +194,9 @@ export const LoadingDataTableComponent = memo(
         });
 
         tableData = searchResults;
+      } else {
+        // Send an empty search to clear the backend search state
+        void search<T>({});
       }
 
       // If we already have the data, return it


### PR DESCRIPTION
Followup from #1641 
Need to clear the filters 