### PR TITLE
fix: use basename for document title (#1630)

### DIFF
--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -57,6 +57,7 @@ import { getSessionId } from "./kernel/session";
 import { updateQueryParams } from "@/utils/urls";
 import { AppHeader } from "@/components/editor/header/app-header";
 import { AppContainer } from "../components/editor/app-container";
+import { Paths } from "@/utils/paths";
 
 interface AppProps {
   userConfig: UserConfig;
@@ -68,7 +69,6 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
   const { setCells, updateCellCode } = useCellActions();
   const [viewState, setViewState] = useAtom(viewStateAtom);
   const [filename, setFilename] = useFilename();
-  const filetitle = filename ? filename.split("/").pop() : null;
   const [lastSavedNotebook, setLastSavedNotebook] =
     useState<LastSavedNotebook>();
   const layout = useLayoutState();
@@ -121,7 +121,7 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
         setFilename(name);
         // Set document title: app_title takes precedence, then filename, then default
         document.title =
-          appConfig.app_title || filetitle || "Untitled Notebook";
+          appConfig.app_title || Paths.basename(name) || "Untitled Notebook";
         return name;
       })
       .catch((error) => {
@@ -133,8 +133,11 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
   // Update document title whenever filename or app_title changes
   useEffect(() => {
     // Set document title: app_title takes precedence, then filename, then default
-    document.title = appConfig.app_title || filetitle || "Untitled Notebook";
-  }, [appConfig.app_title, filetitle]);
+    document.title =
+      appConfig.app_title ||
+      Paths.basename(filename ?? "") ||
+      "Untitled Notebook";
+  }, [appConfig.app_title, filename]);
 
   const cells = notebookCells(notebook);
   const cellIds = cells.map((cell) => cell.id);

--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -52,7 +52,7 @@ import { useRunStaleCells } from "../components/editor/cell/useRunCells";
 import { formatAll } from "./codemirror/format";
 import { cn } from "@/utils/cn";
 import { isStaticNotebook } from "./static/static-state";
-import { useFilename, useFiletitle } from "./saving/filename";
+import { useFilename } from "./saving/filename";
 import { getSessionId } from "./kernel/session";
 import { updateQueryParams } from "@/utils/urls";
 import { AppHeader } from "@/components/editor/header/app-header";
@@ -68,7 +68,7 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
   const { setCells, updateCellCode } = useCellActions();
   const [viewState, setViewState] = useAtom(viewStateAtom);
   const [filename, setFilename] = useFilename();
-  const [filetitle] = useFiletitle();
+  const filetitle = filename ? filename.split("/").pop() : null;
   const [lastSavedNotebook, setLastSavedNotebook] =
     useState<LastSavedNotebook>();
   const layout = useLayoutState();

--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -52,7 +52,7 @@ import { useRunStaleCells } from "../components/editor/cell/useRunCells";
 import { formatAll } from "./codemirror/format";
 import { cn } from "@/utils/cn";
 import { isStaticNotebook } from "./static/static-state";
-import { useFilename } from "./saving/filename";
+import { useFilename, useFiletitle } from "./saving/filename";
 import { getSessionId } from "./kernel/session";
 import { updateQueryParams } from "@/utils/urls";
 import { AppHeader } from "@/components/editor/header/app-header";
@@ -68,6 +68,7 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
   const { setCells, updateCellCode } = useCellActions();
   const [viewState, setViewState] = useAtom(viewStateAtom);
   const [filename, setFilename] = useFilename();
+  const [filetitle] = useFiletitle();
   const [lastSavedNotebook, setLastSavedNotebook] =
     useState<LastSavedNotebook>();
   const layout = useLayoutState();
@@ -119,7 +120,8 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
       .then(() => {
         setFilename(name);
         // Set document title: app_title takes precedence, then filename, then default
-        document.title = appConfig.app_title || name || "Untitled Notebook";
+        document.title =
+          appConfig.app_title || filetitle || "Untitled Notebook";
         return name;
       })
       .catch((error) => {
@@ -131,8 +133,8 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
   // Update document title whenever filename or app_title changes
   useEffect(() => {
     // Set document title: app_title takes precedence, then filename, then default
-    document.title = appConfig.app_title || filename || "Untitled Notebook";
-  }, [appConfig.app_title, filename]);
+    document.title = appConfig.app_title || filetitle || "Untitled Notebook";
+  }, [appConfig.app_title, filetitle]);
 
   const cells = notebookCells(notebook);
   const cellIds = cells.map((cell) => cell.id);

--- a/frontend/src/core/saving/filename.ts
+++ b/frontend/src/core/saving/filename.ts
@@ -5,15 +5,6 @@ import { getFilenameFromDOM } from "../dom/htmlUtils";
 
 const filenameAtom = atom<string | null>(getFilenameFromDOM());
 
-const filetitleAtom = atom((get) => {
-  const filename = get(filenameAtom);
-  return filename ? filename.split("/").pop() : null;
-});
-
 export function useFilename() {
   return useAtom(filenameAtom);
-}
-
-export function useFiletitle() {
-  return useAtom(filetitleAtom);
 }

--- a/frontend/src/core/saving/filename.ts
+++ b/frontend/src/core/saving/filename.ts
@@ -5,6 +5,15 @@ import { getFilenameFromDOM } from "../dom/htmlUtils";
 
 const filenameAtom = atom<string | null>(getFilenameFromDOM());
 
+const filetitleAtom = atom((get) => {
+  const filename = get(filenameAtom);
+  return filename ? filename.split("/").pop() : null;
+});
+
 export function useFilename() {
   return useAtom(filenameAtom);
+}
+
+export function useFiletitle() {
+  return useAtom(filetitleAtom);
 }


### PR DESCRIPTION
## 📝 Summary

<!-- 
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123). 
-->

This PR fixes #1630 by displaying the basename only instead of the entire path in the tab.

## 🔍 Description of Changes

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

I introduced a new atom `useFiletitle()` which simply extracts the string after the last `/` character in the path (path.basename not available in the client). It depends on the full filename so reacts to changes in the filename accordingly.

## 📋 Checklist

- [x] I have read the [contributor guidelines](../CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
