### PR TITLE
improvement: more memory stats

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/machine-stats.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/machine-stats.tsx
@@ -39,7 +39,12 @@ export const MachineStats: React.FC = (props) => {
 
   return (
     <div className="flex gap-3">
-      {data && <MemoryUsageBar memory={data.memory} />}
+      {data && (
+        <MemoryUsageBar
+          memory={data.memory}
+          processMemory={data.processMemory}
+        />
+      )}
       {data && <CPUBar cpu={data.cpu} />}
       <BackendConnection connection={connection.state} />
     </div>
@@ -67,18 +72,26 @@ const BackendConnection: React.FC<{ connection: WebSocketState }> = ({
   );
 };
 
-const MemoryUsageBar: React.FC<{ memory: UsageResponse["memory"] }> = ({
-  memory,
-}) => {
+const MemoryUsageBar: React.FC<{
+  memory: UsageResponse["memory"];
+  processMemory: UsageResponse["processMemory"];
+}> = ({ memory, processMemory }) => {
   const { percent, total, used } = memory;
   const roundedPercent = Math.round(percent);
   return (
     <Tooltip
       delayDuration={200}
       content={
-        <span>
-          <b>Memory:</b> {asGB(used)} / {asGB(total)} GB ({roundedPercent}%)
-        </span>
+        <div className="flex flex-col gap-1">
+          <span>
+            <b>Memory:</b> {asGB(used)} / {asGB(total)} GB ({roundedPercent}%)
+          </span>
+          {Object.entries(processMemory).map(([name, mem]) => (
+            <span key={name}>
+              <b>{name}:</b> {asGB(mem)} GB
+            </span>
+          ))}
+        </div>
       }
     >
       <div className="flex items-center gap-1">

--- a/frontend/src/components/editor/chrome/wrapper/machine-stats.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/machine-stats.tsx
@@ -42,7 +42,8 @@ export const MachineStats: React.FC = (props) => {
       {data && (
         <MemoryUsageBar
           memory={data.memory}
-          processMemory={data.processMemory}
+          kernel={data.kernel}
+          server={data.server}
         />
       )}
       {data && <CPUBar cpu={data.cpu} />}
@@ -74,8 +75,9 @@ const BackendConnection: React.FC<{ connection: WebSocketState }> = ({
 
 const MemoryUsageBar: React.FC<{
   memory: UsageResponse["memory"];
-  processMemory: UsageResponse["processMemory"];
-}> = ({ memory, processMemory }) => {
+  kernel: UsageResponse["kernel"];
+  server: UsageResponse["server"];
+}> = ({ memory, kernel, server }) => {
   const { percent, total, used } = memory;
   const roundedPercent = Math.round(percent);
   return (
@@ -84,13 +86,19 @@ const MemoryUsageBar: React.FC<{
       content={
         <div className="flex flex-col gap-1">
           <span>
-            <b>Memory:</b> {asGB(used)} / {asGB(total)} GB ({roundedPercent}%)
+            <b>computer memory:</b> {asGB(used)} / {asGB(total)} GB (
+            {roundedPercent}%)
           </span>
-          {Object.entries(processMemory).map(([name, mem]) => (
-            <span key={name}>
-              <b>{name}:</b> {asGB(mem)} GB
+          {server?.memory && (
+            <span>
+              <b>marimo server:</b> {asGBorMB(server.memory)}
             </span>
-          ))}
+          )}
+          {kernel?.memory && (
+            <span>
+              <b>kernel:</b> {asGBorMB(kernel.memory)}
+            </span>
+          )}
         </div>
       }
     >
@@ -129,6 +137,21 @@ const Bar: React.FC<{ percent: number }> = ({ percent }) => {
     </div>
   );
 };
+
+function asGBorMB(bytes: number): string {
+  if (bytes > 1024 * 1024 * 1024) {
+    return `${asGB(bytes)} GB`;
+  }
+  return `${asMB(bytes)} MB`;
+}
+
+function asMB(bytes: number) {
+  // 0 decimal places
+  const format = new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
+  });
+  return format.format(bytes / (1024 * 1024));
+}
 
 function asGB(bytes: number) {
   // At most 2 decimal places

--- a/marimo/_server/api/endpoints/health.py
+++ b/marimo/_server/api/endpoints/health.py
@@ -163,7 +163,10 @@ async def usage(request: Request) -> JSONResponse:
     server_memory = main_process.memory_info().rss
     children = main_process.children(recursive=True)
     for child in children:
-        server_memory += child.memory_info().rss
+        try:
+            server_memory += child.memory_info().rss
+        except psutil.NoSuchProcess:
+            pass
 
     # Kernel memory
     kernel_memory: Optional[int] = None
@@ -173,7 +176,10 @@ async def usage(request: Request) -> JSONResponse:
         kernel_memory = kernel_process.memory_info().rss
         kernel_children = kernel_process.children(recursive=True)
         for child in kernel_children:
-            kernel_memory += child.memory_info().rss
+            try:
+                kernel_memory += child.memory_info().rss
+            except psutil.NoSuchProcess:
+                pass
 
     return JSONResponse(
         {

--- a/marimo/_server/api/endpoints/health.py
+++ b/marimo/_server/api/endpoints/health.py
@@ -145,6 +145,8 @@ async def usage(request: Request) -> JSONResponse:
 
     memory = psutil.virtual_memory()
     cpu = psutil.cpu_percent(interval=1)
+    # Process memory
+    process = psutil.Process()
 
     return JSONResponse(
         {
@@ -154,6 +156,10 @@ async def usage(request: Request) -> JSONResponse:
                 "percent": memory.percent,
                 "used": memory.used,
                 "free": memory.free,
+            },
+            "processMemory": {
+                "rss": process.memory_info().rss,
+                "vms": process.memory_info().vms,
             },
             "cpu": {
                 "percent": cpu,

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2146,6 +2146,11 @@ paths:
                     required:
                     - percent
                     type: object
+                  kernel:
+                    properties:
+                      memory:
+                        type: integer
+                    type: object
                   memory:
                     properties:
                       available:
@@ -2164,6 +2169,13 @@ paths:
                     - percent
                     - used
                     - free
+                    type: object
+                  server:
+                    properties:
+                      memory:
+                        type: integer
+                    required:
+                    - memory
                     type: object
                 required:
                 - memory

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -651,12 +651,18 @@ export interface paths {
               cpu: {
                 percent: number;
               };
+              kernel?: {
+                memory?: number;
+              };
               memory: {
                 available: number;
                 free: number;
                 percent: number;
                 total: number;
                 used: number;
+              };
+              server?: {
+                memory: number;
               };
             };
           };

--- a/tests/_server/api/endpoints/test_health.py
+++ b/tests/_server/api/endpoints/test_health.py
@@ -55,3 +55,8 @@ def test_memory(client: TestClient) -> None:
     assert memory["free"] > 0
     cpu = response.json()["cpu"]
     assert cpu["percent"] >= 0
+    computer = response.json()["server"]
+    assert computer["memory"] > 0
+    # None, no active session
+    computer = response.json()["kernel"]
+    assert computer["memory"] is None


### PR DESCRIPTION
## 📝 Summary

Add server memory (the whole `marimo edit`) and kernel memory (just the current session), to the footer

<img width="373" alt="image" src="https://github.com/marimo-team/marimo/assets/2753772/50194019-f4ff-451a-bb17-13fad7e1f688">
