### PR TITLE
fix: robust websocket disconnect, nonblocking usage stats

### DIFF
--- a/frontend/src/core/websocket/useWebSocket.tsx
+++ b/frontend/src/core/websocket/useWebSocket.tsx
@@ -35,6 +35,9 @@ export function useWebSocket(options: UseWebSocketOptions) {
             maxRetries: 10,
             debug: false,
             startClosed: true,
+            // long timeout -- the server can become slow when many notebooks
+            // are open.
+            connectionTimeout: 60_000,
           });
 
     onOpen && socket.addEventListener("open", onOpen);

--- a/marimo/_server/api/auth.py
+++ b/marimo/_server/api/auth.py
@@ -34,6 +34,7 @@ TOKEN_QUERY_PARAM = "access_token"
 def validate_auth(
     conn: HTTPConnection, form_dict: Optional[dict[str, str]] = None
 ) -> bool:
+    LOGGER.debug("Validating auth")
     state = AppState.from_app(conn.app)
     auth_token = str(state.session_manager.auth_token)
 

--- a/marimo/_server/api/endpoints/health.py
+++ b/marimo/_server/api/endpoints/health.py
@@ -156,7 +156,9 @@ async def usage(request: Request) -> JSONResponse:
     import psutil
 
     memory = psutil.virtual_memory()
-    cpu = psutil.cpu_percent(interval=1)
+    # interval=None is nonblocking; first value is meaningless but after
+    # that it's useful.
+    cpu = psutil.cpu_percent(interval=None)
 
     # Server memory (and children)
     main_process = psutil.Process()

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -366,13 +366,18 @@ class Session:
 
     def disconnect_consumer(self) -> None:
         """Stop the session consumer but keep the kernel running"""
-        assert (
-            self.session_consumer is not None
-        ), "Expecting a session consumer to pause"
+        if self.session_consumer is None:
+            LOGGER.debug(
+                "Expecting a session consumer to pause, but none found"
+            )
+            return
+
         LOGGER.debug("Disconnecting session consumer")
-        self.session_consumer.on_stop()
-        self.unsubscribe_consumer()
-        self.session_consumer = None
+        try:
+            self.session_consumer.on_stop()
+        finally:
+            self.unsubscribe_consumer()
+            self.session_consumer = None
 
     def maybe_disconnect_consumer(self) -> None:
         if self.session_consumer is not None:

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -302,7 +302,11 @@ class Room:
             self.main_consumer = consumer
 
     def remove_consumer(self, consumer: SessionConsumer) -> None:
-        assert consumer in self.consumers, "Consumer not in room"
+        if consumer not in self.consumers:
+            LOGGER.debug(
+                "Attempted to remove a consumer that was not in room."
+            )
+            return
 
         if consumer == self.main_consumer:
             self.main_consumer = None


### PR DESCRIPTION
1. When multiple notebooks are open in marimo edit, we sometimes get unexpected `WebSocketDisconnect`s. This change makes the server more robust to those errors — one can at least continue working with notebooks that failed to connect by refreshing —  without solving the root problem.

2. Make usage endpoint's CPU measurement nonblocking. This was slowing down the server.

Fixes #1653 
Fixes #1622