### PR TITLE
fix: run all stale button

### DIFF
--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -895,7 +895,10 @@ export function staleCellIds(state: NotebookState) {
     (cellId) =>
       isUninstantiated(
         autoInstantiate,
-        cellData[cellId].lastExecutionTime,
+        // runElapstedTimeMs is what we've seen in this session
+        cellRuntime[cellId].runElapsedTimeMs ??
+          // lastExecutionTime is what was seen on session start/resume
+          cellData[cellId].lastExecutionTime,
         cellRuntime[cellId].status,
         cellRuntime[cellId].errored,
         cellRuntime[cellId].interrupted,

--- a/frontend/src/core/cells/types.ts
+++ b/frontend/src/core/cells/types.ts
@@ -67,7 +67,7 @@ export interface CellData {
   edited: boolean;
   /** snapshot of code that was last run */
   lastCodeRun: string | null;
-  /** last execution time */
+  /** execution time on session start / resume */
   lastExecutionTime: number | null;
   /** cell configuration */
   config: CellConfig;


### PR DESCRIPTION
Fixes a bug in which the run all stale button would always indicate staleness when autorun on startup was disabled.

Fixes #1656 