### PR TITLE
feat: app comp

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -280,6 +280,8 @@ class App:
 
         return (self._flatten_outputs(outputs), self._cached_defs)
 
+    # should be kept synchronized with _run_async
+    # TODO(akshayka): DRY these functions
     def _run_sync(
         self,
         post_execute_hooks: list[Callable[..., Any]],
@@ -300,10 +302,13 @@ class App:
                     assert self._cached_defs is not None
                     assert self._cached_outputs is not None
                     outputs[cid] = self._cached_outputs[cid]
-                    glbls |= {
-                        name: self._cached_defs[name]
-                        for name in cell.defs
-                        if name in self._cached_defs
+                    glbls = {
+                        **glbls,
+                        **{
+                            name: self._cached_defs[name]
+                            for name in cell.defs
+                            if name in self._cached_defs
+                        },
                     }
                     continue
 
@@ -337,10 +342,13 @@ class App:
                     assert self._cached_defs is not None
                     assert self._cached_outputs is not None
                     outputs[cid] = self._cached_outputs[cid]
-                    glbls |= {
-                        name: self._cached_defs[name]
-                        for name in cell.defs
-                        if name in self._cached_defs
+                    glbls = {
+                        **glbls,
+                        **{
+                            name: self._cached_defs[name]
+                            for name in cell.defs
+                            if name in self._cached_defs
+                        },
                     }
                     continue
 

--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 10):
 else:
     from typing import TypeAlias
 
-from marimo._ast.app import _Namespace
+from marimo._ast.app import App, _Namespace
 from marimo._ast.cell import CellId_t
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._runtime.context import get_context
@@ -92,6 +92,16 @@ class UIElementRegistry:
             elif isinstance(
                 value, _Namespace
             ) and self._find_bindings_in_namespace(object_id, value):
+                bindings.add(name)
+            elif (
+                isinstance(value, App)
+                and value._cached_defs is not None
+                and self._find_bindings_in_namespace(
+                    object_id, value._cached_defs
+                )
+            ):
+                # app composition -- only one level of nesting is currently
+                # supported
                 bindings.add(name)
         return bindings
 

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -84,6 +84,21 @@ class KernelRuntimeContext(RuntimeContext):
     def register_state_update(self, state: State[Any]) -> None:
         return self._kernel.register_state_update(state)
 
+    @contextmanager
+    def with_cell_id(self, cell_id: CellId_t) -> Iterator[None]:
+        old = self.execution_context
+        try:
+            if old is not None:
+                setting_element_value = old.setting_element_value
+            else:
+                setting_element_value = False
+            self._kernel.execution_context = ExecutionContext(
+                cell_id=cell_id, setting_element_value=setting_element_value
+            )
+            yield
+        finally:
+            self._kernel.execution_context = old
+
 
 def initialize_kernel_context(
     kernel: Kernel,

--- a/marimo/_runtime/context/script_context.py
+++ b/marimo/_runtime/context/script_context.py
@@ -82,6 +82,24 @@ class ScriptRuntimeContext(RuntimeContext):
         del state
         return
 
+    @contextmanager
+    def with_cell_id(self, cell_id: CellId_t) -> Iterator[None]:
+        old = self.execution_context
+        try:
+            if old is not None:
+                setting_element_value = old.setting_element_value
+            else:
+                setting_element_value = False
+            self._app.set_execution_context(
+                ExecutionContext(
+                    cell_id=cell_id,
+                    setting_element_value=setting_element_value,
+                )
+            )
+            yield
+        finally:
+            self._app.set_execution_context(old)
+
 
 def initialize_script_context(app: InternalApp, stream: Stream) -> None:
     """Initializes thread-local/session-specific context.

--- a/marimo/_runtime/context/types.py
+++ b/marimo/_runtime/context/types.py
@@ -117,6 +117,11 @@ class RuntimeContext(abc.ABC):
     def register_state_update(self, state: State[Any]) -> None:
         pass
 
+    @contextmanager
+    @abc.abstractmethod
+    def with_cell_id(self, cell_id: CellId_t) -> Iterator[None]:
+        pass
+
 
 class _ThreadLocalContext(threading.local):
     """Thread-local container that holds thread/session-specific state."""

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, cast
 from uuid import uuid4
 
 from marimo import _loggers
+from marimo._ast.app import App
 from marimo._ast.cell import CellConfig, CellId_t
 from marimo._ast.compiler import compile_cell
 from marimo._ast.visitor import Name
@@ -1126,12 +1127,19 @@ class Kernel:
 
             variable_values: list[VariableValue] = []
             for name in bound_names:
-                # subtracting self.graph.definitions[name]: never rerun the
-                # cell that created the name
+                # TODO update variable values even for namespaces? lenses? etc
                 variable_values.append(
                     VariableValue(name=name, value=component)
                 )
+                if name in self.globals and isinstance(
+                    self.globals[name], App
+                ):
+                    self.globals[name]._register_ui_element_update(
+                        value=component
+                    )
                 try:
+                    # subtracting self.graph.definitions[name]: never rerun the
+                    # cell that created the name
                     referring_cells.update(
                         self.graph.get_referring_cells(name)
                         - self.graph.get_defining_cells(name)
@@ -1238,6 +1246,9 @@ class Kernel:
                 # elements associated with its owning cell. But that
                 # means we won't be able to restore their values
                 # on reconnection.
+                #
+                # TODO(akshayka): Do UI elements created in function calls
+                # get cleared from the FE registry? This could be a leak.
                 try:
                     response = function(request.args)
                     if asyncio.iscoroutine(response):

--- a/marimo/_smoke_tests/appcomp/inner.py
+++ b/marimo/_smoke_tests/appcomp/inner.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.6.22"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def __(mo):
+    x = mo.ui.number(1, 10)
+    return (x,)
+
+
+@app.cell
+def __(x):
+    x
+    return
+
+
+@app.cell
+def __(mo):
+    y = mo.ui.number(1, 10)
+    return (y,)
+
+
+@app.cell
+def __(y):
+    y
+    return
+
+
+@app.cell
+def __(x, y):
+    x.value + y.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/appcomp/make_table.py
+++ b/marimo/_smoke_tests/appcomp/make_table.py
@@ -1,0 +1,26 @@
+import marimo
+
+__generated_with = "0.6.22"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    t = mo.ui.table({"a": [1, 2, 3], "b": [4, 5, 6]})
+    return t,
+
+
+@app.cell
+def __(t):
+    t
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/appcomp/make_table.py
+++ b/marimo/_smoke_tests/appcomp/make_table.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.6.22"

--- a/marimo/_smoke_tests/appcomp/outer.py
+++ b/marimo/_smoke_tests/appcomp/outer.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
 __generated_with = "0.6.22"
@@ -39,6 +40,24 @@ def __(mo):
 def __(app, mo):
     tabs = mo.ui.tabs({"🧮": app, "📝": mo.md("Hello world")}); tabs
     return tabs,
+
+
+@app.cell
+def __(mo):
+    mo.md(rf"## Render an app that uses function calls")
+    return
+
+
+@app.cell
+def __():
+    from make_table import app as table_app
+    return table_app,
+
+
+@app.cell
+def __(table_app):
+    table_app
+    return
 
 
 @app.cell

--- a/marimo/_smoke_tests/appcomp/outer.py
+++ b/marimo/_smoke_tests/appcomp/outer.py
@@ -1,0 +1,51 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.6.22"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    from inner import app
+    return app,
+
+
+@app.cell(hide_code=True)
+def __(mo):
+    mo.md("## Render the same app multiple times")
+    return
+
+
+@app.cell
+def __(app):
+    app
+    return
+
+
+@app.cell
+def __(app):
+    app
+    return
+
+
+@app.cell(hide_code=True)
+def __(mo):
+    mo.md("## Render an app inside tabs")
+    return
+
+
+@app.cell
+def __(app, mo):
+    tabs = mo.ui.tabs({"🧮": app, "📝": mo.md("Hello world")}); tabs
+    return tabs,
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ exclude = [
     "tests/_ast/cell_data",
     "tests/_cli/ipynb_data",
     "tests/_runtime/runtime_data",
+    "tests/_ast/test_app.py",
     "frontend",
     "docs",
     "build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ exclude = [
     "marimo/_test_utils/codegen_data",
     "marimo/_test_utils/_tutorials",
     "marimo/_static/files/wasm-intro.py",
+    "tests/_ast/app_data",
     "tests/_ast/codegen_data",
     "tests/_ast/cell_data",
     "tests/_cli/ipynb_data",
@@ -263,6 +264,7 @@ fixture-parentheses = false
 strict = true
 exclude = [
     'examples',
+    'tests/_ast/app_data',
     'tests/_ast/codegen_data',
     'tests/_ast/cell_data',
     'tests/_cli/ipynb_data',
@@ -281,7 +283,7 @@ ignore_errors = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra -q -v --ignore tests/_cli/ipynb_data --ignore tests/_ast/codegen_data"
+addopts = "-ra -q -v --ignore tests/_cli/ipynb_data --ignore tests/_ast/codegen_data --ignore tests/_ast/app_data"
 testpaths = [
     "tests",
 ]

--- a/tests/_ast/app_data/calculator.py
+++ b/tests/_ast/app_data/calculator.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.6.22"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def __(mo):
+    x = mo.ui.number(1, 10)
+    return (x,)
+
+
+@app.cell
+def __(x):
+    x
+    return
+
+
+@app.cell
+def __(mo):
+    y = mo.ui.number(1, 10)
+    return (y,)
+
+
+@app.cell
+def __(y):
+    y
+    return
+
+
+@app.cell
+def __(x, y):
+    x.value + y.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_ast/app_data/ui_element_dropdown.py
+++ b/tests/_ast/app_data/ui_element_dropdown.py
@@ -1,0 +1,32 @@
+import marimo
+
+__generated_with = "0.6.22"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    d = mo.ui.dropdown(["first", "second"], value="first")
+    return d,
+
+
+@app.cell
+def __(d):
+    d
+    return
+
+
+@app.cell
+def __(d):
+    "value is " + d.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -578,10 +578,12 @@ class TestAppComposition:
                 [(dropdown_element._id, ["second"])]
             )
         )
+        assert token != k.globals["token"]
+        assert not app._pending_ui_element_updates
+
         # make sure ui element value updated
         assert dropdown_element.value == "second"
         # make sure cell referencing app re-ran
-        assert token != k.globals["token"]
 
         html = as_html(app).text
         assert "value is first" not in html

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -17,6 +17,9 @@ from marimo._ast.errors import (
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.formatting import as_html
 from marimo._plugins.stateless.flex import vstack
+from marimo._runtime.requests import SetUIElementValueRequest
+from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider
 
 if TYPE_CHECKING:
     import pathlib
@@ -523,3 +526,104 @@ class TestAppComposition:
         app_html = as_html(app).text
         # None shouldn't show up in output
         assert app_html == vstack(["hello", "world"]).text
+
+    def test_app_as_html_is_cached(self) -> None:
+        app = App()
+
+        @app.cell
+        def __() -> None:
+            import random
+
+            random.randint(0, 10000)
+
+        # the app should only run once
+        assert as_html(app).text == as_html(app).text
+
+    async def test_app_comp_basic(
+        self, k: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        await k.run(
+            [
+                exec_req.get(
+                    """
+                    from app_data.ui_element_dropdown import app
+                    """
+                ),
+                exec_req.get(
+                    """
+                    import random
+
+                    token = random.randint(0, 10000)
+                    app
+                    """
+                ),
+            ]
+        )
+        assert not k.errors
+
+        # store the token value now, so we can make sure it changes later,
+        # ie can make sure cell re-ran
+        token = k.globals["token"]
+        app = k.globals["app"]
+        # dropdown has name d in app
+        dropdown_element = app._cached_defs["d"]
+        assert dropdown_element.value == "first"
+
+        html = as_html(app).text
+        assert "value is first" in html
+        assert "value is second" not in html
+
+        await k.set_ui_element_value(
+            SetUIElementValueRequest.from_ids_and_values(
+                [(dropdown_element._id, ["second"])]
+            )
+        )
+        # make sure ui element value updated
+        assert dropdown_element.value == "second"
+        # make sure cell referencing app re-ran
+        assert token != k.globals["token"]
+
+        html = as_html(app).text
+        assert "value is first" not in html
+        assert "value is second" in html
+
+    async def test_app_comp_multiple_ui_elements(
+        self, k: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        await k.run(
+            [
+                exec_req.get(
+                    """
+                    from app_data.calculator import app
+                    """
+                ),
+                exec_req.get(
+                    """
+                    app
+                    """
+                ),
+            ]
+        )
+        assert not k.errors
+
+        app = k.globals["app"]
+        # two number inputs: x and y
+        x = app._cached_defs["x"]
+        y = app._cached_defs["y"]
+        assert x.value == 1
+        assert y.value == 1
+
+        # testing that only descendants of the updated UI elements run,
+        # and that the other UI element is not reset
+        await k.set_ui_element_value(
+            SetUIElementValueRequest.from_ids_and_values([(x._id, 2)])
+        )
+        assert x.value == 2
+        assert y.value == 1
+
+        await k.set_ui_element_value(
+            SetUIElementValueRequest.from_ids_and_values([(y._id, 3)])
+        )
+
+        assert x.value == 2
+        assert y.value == 3


### PR DESCRIPTION
Embed notebooks in other notebooks.

This change makes it possible to embed a notebook as an output in another notebook. The embedded notebook is rendered as a `vstack` of its non-None outputs, and is reactive with respect to UI element value updates.

This lets you make a more complex notebook out of smaller building-block notebooks.

Enhancements left for the future:

1. Multiple levels of composition. Right now, reactivity wrt to UI elements only allows for 1 level of nesting.
2. API for passing references to the app, or for otherwise injecting/overriding args into the embedded app.

![image](https://github.com/marimo-team/marimo/assets/1994308/6028275b-0dff-466a-8cae-1c64d7346adc)

![image](https://github.com/marimo-team/marimo/assets/1994308/218de8a2-7a93-4cf4-8741-5ecbcafbe140)
