### PR TITLE
Add str in conversion to stop toml.type from being encoded and breaking markdown mode

### DIFF
--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -183,7 +183,7 @@ class Exporter:
         # as long as it isn't the default.
         metadata.update(
             {
-                k: v
+                k: str(v)
                 for k, v in file_manager.app.config.asdict().items()
                 if k not in ignored_keys and v != _AppConfig.__dict__[k]
             }


### PR DESCRIPTION
## 📝 Summary

Saving a new markdown file with a user specified default width, causes breakage since `tomlkit` loads wrapped types as opposed to raw python types. The result of saving or creating a new md notebook gives something like:

```md
---
title: Example
marimo-version: 0.6.22
width: !!python/object/apply:tomlkit.items.String
- !!python/object/apply:tomlkit.items.StringType
  - '"'
- medium
- medium
- !!python/object:tomlkit.items.Trivia
  indent: ''
  comment_ws: ''
  comment: ''
  trail: '

    '
---
```

Ideally, you might consider casting config loads to be the raw python values.

To replicate, set your default to something that is not "compact".
Then do `marimo edit example.md` (assuming example.md doesn't exist). Make a change, and try to save. View the raw file.

## 🔍 Description of Changes

Just run str on frontmatter inputs, this is safer, even if the toml config is properly converted. 

## 📜 Reviewers

@akshayka OR @mscolnick
