### PR TITLE
fix: status transitions should not be repeated

### DIFF
--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -172,6 +172,7 @@ class CellImpl:
     def set_status(
         self, status: CellStatusType, stream: Stream | None = None
     ) -> None:
+        """Set execution status and broadcast to frontends."""
         from marimo._messaging.ops import CellOp
         from marimo._runtime.context import (
             ContextNotInitializedError,

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -238,7 +238,6 @@ class CellOp(Op):
         data: Sequence[Error],
         clear_console: bool,
         cell_id: CellId_t,
-        status: Optional[CellStatusType],
     ) -> None:
         console: Optional[list[CellOutput]] = [] if clear_console else None
         CellOp(
@@ -249,7 +248,7 @@ class CellOp(Op):
                 data=data,
             ),
             console=console,
-            status=status,
+            status=None,
         ).broadcast()
 
     @staticmethod

--- a/marimo/_runtime/runner/execution_hooks.py
+++ b/marimo/_runtime/runner/execution_hooks.py
@@ -1,4 +1,0 @@
-# Copyright 2024 Marimo. All rights reserved.
-from marimo import _loggers
-
-LOGGER = _loggers.marimo_logger()

--- a/marimo/_runtime/runner/hooks_on_finish.py
+++ b/marimo/_runtime/runner/hooks_on_finish.py
@@ -28,7 +28,6 @@ def _send_interrupt_errors(runner: cell_runner.Runner) -> None:
                 # reflect a previous run and should be cleared
                 clear_console=True,
                 cell_id=cid,
-                status="idle",
             )
 
 
@@ -36,7 +35,12 @@ def _send_cancellation_errors(runner: cell_runner.Runner) -> None:
     for raising_cell in runner.cells_cancelled:
         for cid in runner.cells_cancelled[raising_cell]:
             # `cid` was not run
-            runner.graph.cells[cid].set_status("idle")
+            cell = runner.graph.cells[cid]
+            if cell.status != "idle":
+                # the cell raising an exception will already be
+                # idle, but its descendants won't be.
+                cell.set_status("idle")
+
             exception = runner.exceptions[raising_cell]
             data: Error
             if isinstance(exception, MarimoStopError):
@@ -74,7 +78,6 @@ def _send_cancellation_errors(runner: cell_runner.Runner) -> None:
                 # reflect a previous run and should be cleared
                 clear_console=True,
                 cell_id=cid,
-                status="idle",
             )
 
 

--- a/marimo/_runtime/runner/hooks_post_execution.py
+++ b/marimo/_runtime/runner/hooks_post_execution.py
@@ -128,7 +128,7 @@ def _broadcast_outputs(
             mimetype=formatted_output.mimetype,
             data=formatted_output.data,
             cell_id=cell.cell_id,
-            status=cell.status,
+            status=None,
         )
     elif isinstance(run_result.exception, MarimoStrictExecutionError):
         LOGGER.debug("Cell %s raised a strict error", cell.cell_id)
@@ -137,7 +137,6 @@ def _broadcast_outputs(
             data=[run_result.output],
             clear_console=True,
             cell_id=cell.cell_id,
-            status=cell.status,
         )
     elif isinstance(run_result.exception, MarimoInterrupt):
         LOGGER.debug("Cell %s was interrupted", cell.cell_id)
@@ -147,7 +146,6 @@ def _broadcast_outputs(
             data=[MarimoInterruptionError()],
             clear_console=False,
             cell_id=cell.cell_id,
-            status=cell.status,
         )
     elif run_result.exception is not None:
         LOGGER.debug(
@@ -176,7 +174,6 @@ def _broadcast_outputs(
             ],
             clear_console=False,
             cell_id=cell.cell_id,
-            status=cell.status,
         )
 
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -838,7 +838,6 @@ class Kernel:
                 data=self.errors[cid],
                 clear_console=True,
                 cell_id=cid,
-                status=None,
             )
 
         Variables(

--- a/tests/_plugins/ui/_impl/test_run_button.py
+++ b/tests/_plugins/ui/_impl/test_run_button.py
@@ -1,0 +1,52 @@
+from marimo._plugins import ui
+from marimo._runtime.requests import SetUIElementValueRequest
+from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider
+
+
+def test_run_button_initial_value():
+    run_button = ui.run_button()
+    assert not run_button.value
+
+
+async def test_run_button_set_to_true_on_click(
+    any_kernel: Kernel, exec_req: ExecReqProvider
+):
+    k = any_kernel
+    await k.run(
+        [
+            exec_req.get("import marimo as mo"),
+            exec_req.get("b = mo.ui.run_button()"),
+            er := exec_req.get(
+                """
+                if b.value:
+                    x = 1
+                else:
+                    x = 0
+                """
+            ),
+        ]
+    )
+
+    run_button = k.globals["b"]
+    assert not run_button.value
+
+    await k.set_ui_element_value(
+        SetUIElementValueRequest([run_button._id], [1])
+    )
+
+    if not k.lazy():
+        assert k.globals["x"] == 1
+        assert not run_button.value
+    else:
+        # value is updated ...
+        assert run_button.value
+        # ... but we haven't run its descendants yet
+        assert k.globals["x"] == 0
+
+        await k.run([er])
+
+        assert k.globals["x"] == 1
+        # in lazy kernels, run button's value is not set to False, since
+        # we don't know when its descendants have run
+        assert run_button.value


### PR DESCRIPTION
Cleans up hooks so that state transitions aren't repeated. The
semantics in cell-op are that a field is non-None if and only if the
field's value has changed.

Also sneaks in a unit test that I forgot to include in a previous PR.