### PR TITLE
fix: ignore not implmented sync-cell-ids

### DIFF
--- a/frontend/src/components/dependency-graph/panels.tsx
+++ b/frontend/src/components/dependency-graph/panels.tsx
@@ -253,8 +253,8 @@ export const GraphSelectionPanel: React.FC<{
   };
 
   return (
-    <Panel position="bottom-left">
-      <div className="min-h-[100px] shadow-md rounded-md border max-w-[550px] border-primary/40 my-4 min-w-[240px] bg-[var(--slate-1)] text-muted-foreground/80 flex flex-col">
+    <Panel position="bottom-left" className="max-h-[90%] flex flex-col">
+      <div className="min-h-[100px] shadow-md rounded-md border max-w-[550px] border-primary/40 my-4 min-w-[240px] bg-[var(--slate-1)] text-muted-foreground/80 flex flex-col overflow-y-auto">
         {renderSelection()}
       </div>
     </Panel>

--- a/frontend/src/components/editor/chrome/panels/datasources-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/datasources-panel.tsx
@@ -289,7 +289,7 @@ const DatasetColumnItem: React.FC<{
       onSelect={() => onExpandColumn(table, column)}
     >
       <div className="flex flex-row gap-2 items-center pl-6 flex-1">
-        <Icon className="h-3 w-3" strokeWidth={1.5} />
+        <Icon className="flex-shrink-0 h-3 w-3" strokeWidth={1.5} />
         <span>{column.name}</span>
       </div>
       <Tooltip content="Copy column name" delayDuration={400}>

--- a/frontend/src/core/pyodide/bridge.ts
+++ b/frontend/src/core/pyodide/bridge.ts
@@ -405,7 +405,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
     await this.putControlRequest(request);
     return null;
   };
-  syncCellIds = throwNotImplemented;
+  syncCellIds = () => Promise.resolve(null);
   getUsageStats = throwNotImplemented;
   getRecentFiles = throwNotImplemented;
   getWorkspaceFiles = throwNotImplemented;


### PR DESCRIPTION
This gets emitted in WASM, but rather than throwing an error, we should just ignore it