### PR TITLE
improvement: add .from_series to many mo.ui inputs

### DIFF
--- a/marimo/_data/series.py
+++ b/marimo/_data/series.py
@@ -46,6 +46,10 @@ class DateSeriesInfo:
     label: str
 
 
+def _get_name(series: DataFrameSeries) -> str:
+    return str(series.name) if series.name is not None else ""
+
+
 def get_number_series_info(series: Any) -> NumberSeriesInfo:
     """
     Get the summary of a numeric series.
@@ -64,7 +68,7 @@ def get_number_series_info(series: Any) -> NumberSeriesInfo:
             return NumberSeriesInfo(
                 min=validate_number(series.min()),
                 max=validate_number(series.max()),
-                label=str(series.name),
+                label=_get_name(series),
             )
 
     if DependencyManager.has_polars():
@@ -74,7 +78,7 @@ def get_number_series_info(series: Any) -> NumberSeriesInfo:
             return NumberSeriesInfo(
                 min=validate_number(series.min()),
                 max=validate_number(series.max()),
-                label=str(series.name),
+                label=_get_name(series),
             )
 
     raise ValueError("Unsupported series type. Expected pandas or polars.")
@@ -90,7 +94,7 @@ def get_category_series_info(series: Any) -> CategorySeriesInfo:
         if isinstance(series, pd.Series):
             return CategorySeriesInfo(
                 categories=sorted(series.unique().tolist()),
-                label=str(series.name),
+                label=_get_name(series),
             )
 
     if DependencyManager.has_polars():
@@ -99,7 +103,7 @@ def get_category_series_info(series: Any) -> CategorySeriesInfo:
         if isinstance(series, pl.Series):
             return CategorySeriesInfo(
                 categories=sorted(series.unique().to_list()),
-                label=str(series.name),
+                label=_get_name(series),
             )
 
     raise ValueError("Unsupported series type. Expected pandas or polars.")
@@ -122,7 +126,7 @@ def get_date_series_info(series: Any) -> DateSeriesInfo:
             return DateSeriesInfo(
                 min=validate_date(series.min()),
                 max=validate_date(series.max()),
-                label=str(series.name),
+                label=_get_name(series),
             )
 
     if DependencyManager.has_polars():
@@ -132,7 +136,7 @@ def get_date_series_info(series: Any) -> DateSeriesInfo:
             return DateSeriesInfo(
                 min=validate_date(series.min()),
                 max=validate_date(series.max()),
-                label=str(series.name),
+                label=_get_name(series),
             )
 
     raise ValueError("Unsupported series type. Expected pandas or polars.")

--- a/marimo/_data/series.py
+++ b/marimo/_data/series.py
@@ -1,0 +1,138 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Union
+
+from marimo._dependencies.dependencies import DependencyManager
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import polars as pl
+
+DataFrameSeries = Union["pd.Series[Any]", "pl.Series"]
+
+
+@dataclass
+class NumberSeriesInfo:
+    """
+    Represents a summary of a numeric series.
+    """
+
+    min: float
+    max: float
+    label: str
+
+
+@dataclass
+class CategorySeriesInfo:
+    """
+    Represents a summary of a categorical series.
+    """
+
+    categories: list[str]
+    label: str
+
+
+@dataclass
+class DateSeriesInfo:
+    """
+    Represents a summary of a date series.
+    """
+
+    min: str
+    max: str
+    label: str
+
+
+def get_number_series_info(series: Any) -> NumberSeriesInfo:
+    """
+    Get the summary of a numeric series.
+    """
+
+    def validate_number(value: Any) -> float:
+        value = float(value)
+        if not isinstance(value, (int, float)):
+            raise ValueError("Expected a number. Got: " + str(type(value)))
+        return value
+
+    if DependencyManager.has_pandas():
+        import pandas as pd
+
+        if isinstance(series, pd.Series):
+            return NumberSeriesInfo(
+                min=validate_number(series.min()),
+                max=validate_number(series.max()),
+                label=str(series.name),
+            )
+
+    if DependencyManager.has_polars():
+        import polars as pl
+
+        if isinstance(series, pl.Series):
+            return NumberSeriesInfo(
+                min=validate_number(series.min()),
+                max=validate_number(series.max()),
+                label=str(series.name),
+            )
+
+    raise ValueError("Unsupported series type. Expected pandas or polars.")
+
+
+def get_category_series_info(series: Any) -> CategorySeriesInfo:
+    """
+    Get the summary of a categorical series.
+    """
+    if DependencyManager.has_pandas():
+        import pandas as pd
+
+        if isinstance(series, pd.Series):
+            return CategorySeriesInfo(
+                categories=sorted(series.unique().tolist()),
+                label=str(series.name),
+            )
+
+    if DependencyManager.has_polars():
+        import polars as pl
+
+        if isinstance(series, pl.Series):
+            return CategorySeriesInfo(
+                categories=sorted(series.unique().to_list()),
+                label=str(series.name),
+            )
+
+    raise ValueError("Unsupported series type. Expected pandas or polars.")
+
+
+def get_date_series_info(series: Any) -> DateSeriesInfo:
+    """
+    Get the summary of a date series.
+    """
+
+    def validate_date(value: Any) -> str:
+        if not isinstance(value, datetime.date):
+            raise ValueError("Expected a date. Got: " + str(type(value)))
+        return value.strftime("%Y-%m-%d")
+
+    if DependencyManager.has_pandas():
+        import pandas as pd
+
+        if isinstance(series, pd.Series):
+            return DateSeriesInfo(
+                min=validate_date(series.min()),
+                max=validate_date(series.max()),
+                label=str(series.name),
+            )
+
+    if DependencyManager.has_polars():
+        import polars as pl
+
+        if isinstance(series, pl.Series):
+            return DateSeriesInfo(
+                min=validate_date(series.min()),
+                max=validate_date(series.max()),
+                label=str(series.name),
+            )
+
+    raise ValueError("Unsupported series type. Expected pandas or polars.")

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -52,6 +52,12 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     number = mo.ui.number(start=1, stop=10, step=2)
     ```
 
+    Or from a dataframe series:
+
+    ```python
+    number = mo.ui.number.from_series(df["column_name"])
+    ```
+
     **Attributes.**
 
     - `value`: the value of the number, possibly `None`
@@ -141,6 +147,12 @@ class slider(UIElement[Numeric, Numeric]):
 
     ```python
     slider = mo.ui.slider(start=1, stop=10, step=2)
+    ```
+
+    Or from a dataframe series:
+
+    ```python
+    slider = mo.ui.slider.from_series(df["column_name"])
     ```
 
     **Attributes.**
@@ -317,6 +329,12 @@ class range_slider(UIElement[List[Numeric], Sequence[Numeric]]):
 
     ```python
     range_slider = mo.ui.range_slider(start=1, stop=10, step=2, value=[2, 6])
+    ```
+
+    Or from a dataframe series:
+
+    ```python
+    range_slider = mo.ui.range_slider.from_series(df["column_name"])
     ```
 
     **Attributes.**
@@ -560,6 +578,12 @@ class radio(UIElement[Optional[str], Any]):
         value="one",
         label="pick a number",
     )
+    ```
+
+    Or from a dataframe series:
+
+    ```python
+    radiogroup = mo.ui.radio.from_series(df["column_name"])
     ```
 
     **Attributes.**
@@ -820,6 +844,12 @@ class dropdown(UIElement[List[str], Any]):
     )
     ```
 
+    Or from a dataframe series:
+
+    ```python
+    dropdown = mo.ui.dropdown.from_series(df["column_name"])
+    ```
+
     **Attributes.**
 
     - `value`: the selected value, or `None` if no selection
@@ -932,6 +962,12 @@ class multiselect(UIElement[List[str], List[object]]):
     multiselect = mo.ui.multiselect(
         options=["a", "b", "c"], label="choose some options"
     )
+    ```
+
+    Or from a dataframe series:
+
+    ```python
+    multiselect = mo.ui.multiselect.from_series(df["column_name"])
     ```
 
     **Attributes.**
@@ -1408,6 +1444,12 @@ class date(UIElement[str, dt.date]):
         start="2022-01-01",
         stop="2022-12-31",
     )
+    ```
+
+    Or from a dataframe series:
+
+    ```python
+    date = mo.ui.date.from_series(df["column_name"])
     ```
 
     **Attributes.**

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -23,6 +23,12 @@ from typing import (
 )
 
 from marimo import _loggers
+from marimo._data.series import (
+    DataFrameSeries,
+    get_category_series_info,
+    get_date_series_info,
+    get_number_series_info,
+)
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import S as JSONTypeBound, UIElement
@@ -111,6 +117,14 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
                 "full-width": full_width,
             },
             on_change=on_change,
+        )
+
+    @staticmethod
+    def from_series(series: DataFrameSeries, **kwargs: Any) -> "number":
+        """Create a number picker from a dataframe series."""
+        info = get_number_series_info(series)
+        return number(
+            start=info.min, stop=info.max, label=info.label, **kwargs
         )
 
     def _convert_value(self, value: Optional[Numeric]) -> Optional[Numeric]:
@@ -280,6 +294,14 @@ class slider(UIElement[Numeric, Numeric]):
                 on_change=on_change,
             )
 
+    @staticmethod
+    def from_series(series: DataFrameSeries, **kwargs: Any) -> "slider":
+        """Create a slider from a dataframe series."""
+        info = get_number_series_info(series)
+        return slider(
+            start=info.min, stop=info.max, label=info.label, **kwargs
+        )
+
     def _convert_value(self, value: Numeric) -> Numeric:
         if self._mapping is not None:
             return cast(Numeric, self._dtype(self._mapping[int(value)]))
@@ -446,6 +468,14 @@ class range_slider(UIElement[List[Numeric], Sequence[Numeric]]):
                 on_change=on_change,
             )
 
+    @staticmethod
+    def from_series(series: DataFrameSeries, **kwargs: Any) -> "range_slider":
+        """Create a range slider from a dataframe series."""
+        info = get_number_series_info(series)
+        return range_slider(
+            start=info.min, stop=info.max, label=info.label, **kwargs
+        )
+
     def _convert_value(self, value: List[Numeric]) -> Sequence[Numeric]:
         if self._mapping is not None:
             return cast(
@@ -571,6 +601,16 @@ class radio(UIElement[Optional[str], Any]):
                 "inline": inline,
             },
             on_change=on_change,
+        )
+
+    @staticmethod
+    def from_series(series: DataFrameSeries, **kwargs: Any) -> "radio":
+        """Create a radio group from a dataframe series."""
+        info = get_category_series_info(series)
+        return radio(
+            options=info.categories,
+            label=info.label,
+            **kwargs,
         )
 
     def _convert_value(self, value: Optional[str]) -> Any:
@@ -856,6 +896,16 @@ class dropdown(UIElement[List[str], Any]):
             on_change=on_change,
         )
 
+    @staticmethod
+    def from_series(series: DataFrameSeries, **kwargs: Any) -> "dropdown":
+        """Create a dropdown from a dataframe series."""
+        info = get_category_series_info(series)
+        return dropdown(
+            options=info.categories,
+            label=info.label,
+            **kwargs,
+        )
+
     def _convert_value(self, value: list[str]) -> Any:
         if value:
             assert len(value) == 1
@@ -949,6 +999,16 @@ class multiselect(UIElement[List[str], List[object]]):
                 "max-selections": max_selections,
             },
             on_change=on_change,
+        )
+
+    @staticmethod
+    def from_series(series: DataFrameSeries, **kwargs: Any) -> "multiselect":
+        """Create a multiselect from a dataframe series."""
+        info = get_category_series_info(series)
+        return multiselect(
+            options=info.categories,
+            label=info.label,
+            **kwargs,
         )
 
     def _convert_value(self, value: list[str]) -> list[object]:
@@ -1426,6 +1486,17 @@ class date(UIElement[str, dt.date]):
                 "full-width": full_width,
             },
             on_change=on_change,
+        )
+
+    @staticmethod
+    def from_series(series: DataFrameSeries, **kwargs: Any) -> "date":
+        """Create a date picker from a dataframe series."""
+        info = get_date_series_info(series)
+        return date(
+            start=info.min,
+            stop=info.max,
+            label=info.label,
+            **kwargs,
         )
 
     def _convert_value(self, value: str) -> dt.date:

--- a/marimo/_smoke_tests/from_series.py
+++ b/marimo/_smoke_tests/from_series.py
@@ -1,0 +1,78 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.6.23"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    from vega_datasets import data
+    return data, mo
+
+
+@app.cell
+def __(data):
+    import polars as pl
+    polars_df = pl.from_pandas(data.cars())
+    return pl, polars_df
+
+
+@app.cell
+def __(mo, polars_df):
+    mo.ui.slider.from_series(polars_df["Cylinders"])
+    return
+
+
+@app.cell
+def __(mo, polars_df):
+    mo.ui.number.from_series(polars_df["Cylinders"])
+    return
+
+
+@app.cell
+def __(mo, polars_df):
+    mo.ui.radio.from_series(polars_df["Origin"])
+    return
+
+
+@app.cell
+def __(mo, polars_df):
+    mo.ui.dropdown.from_series(polars_df["Origin"])
+    return
+
+
+@app.cell
+def __(mo, polars_df):
+    mo.ui.multiselect.from_series(polars_df["Origin"])
+    return
+
+
+@app.cell
+def __(mo, polars_df):
+    mo.ui.date.from_series(polars_df["Year"])
+    return
+
+
+@app.cell
+def __(data, mo):
+    pandas_df = data.cars()
+    [
+        mo.ui.slider.from_series(pandas_df["Cylinders"]),
+        mo.ui.number.from_series(pandas_df["Cylinders"]),
+        mo.ui.radio.from_series(pandas_df["Origin"]),
+        mo.ui.dropdown.from_series(pandas_df["Origin"]),
+        mo.ui.multiselect.from_series(pandas_df["Origin"]),
+        mo.ui.date.from_series(pandas_df["Year"])
+    ]
+    return pandas_df,
+
+
+@app.cell
+def __():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_data/test_series.py
+++ b/tests/_data/test_series.py
@@ -48,6 +48,12 @@ def test_number_series(
         response = get_number_series_info(df["B"])
 
 
+def test_get_with_no_name() -> None:
+    series = pd.Series([1, 2, 3])
+    series.name = None
+    assert get_number_series_info(series).label == ""
+
+
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 @pytest.mark.parametrize(
     "df",

--- a/tests/_data/test_series.py
+++ b/tests/_data/test_series.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from marimo._data.series import (
+    get_category_series_info,
+    get_date_series_info,
+    get_number_series_info,
+)
+from marimo._dependencies.dependencies import DependencyManager
+
+HAS_DEPS = (
+    DependencyManager.has_pandas()
+    and DependencyManager.has_numpy()
+    and DependencyManager.has_polars()
+)
+
+if HAS_DEPS:
+    import pandas as pd
+    import polars as pl
+else:
+    pd = Mock()
+    pl = Mock()
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+@pytest.mark.parametrize(
+    "df",
+    [
+        pd.DataFrame({"A": [1, 2, 3], "B": ["a", "a", "a"]}),
+        pl.DataFrame({"A": [1, 2, 3], "B": ["a", "a", "a"]}),
+    ],
+)
+def test_number_series(
+    df: Any,
+) -> None:
+    response = get_number_series_info(df["A"])
+
+    assert response.min == 1
+    assert response.max == 3
+    assert response.label == "A"
+
+    with pytest.raises(ValueError):
+        response = get_number_series_info(df["B"])
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+@pytest.mark.parametrize(
+    "df",
+    [
+        pd.DataFrame({"A": [1, 2, 3], "B": ["a", "b", "b"]}),
+        pl.DataFrame({"A": [1, 2, 3], "B": ["a", "b", "b"]}),
+    ],
+)
+def test_categorical_series(df: Any) -> None:
+    response = get_category_series_info(df["B"])
+
+    assert response.categories == ["a", "b"]
+    assert response.label == "B"
+
+    response = get_category_series_info(df["A"])
+    assert response.categories == [1, 2, 3]
+    assert response.label == "A"
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+@pytest.mark.parametrize(
+    "df",
+    [
+        pd.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": ["a", "b", "b"],
+                "C": [
+                    datetime(2024, 1, 1),
+                    datetime(2024, 1, 2),
+                    datetime(2024, 1, 3),
+                ],
+            }
+        ),
+        pl.DataFrame(
+            {
+                "A": [1, 2, 3],
+                "B": ["a", "b", "b"],
+                "C": [
+                    datetime(2024, 1, 1),
+                    datetime(2024, 1, 2),
+                    datetime(2024, 1, 3),
+                ],
+            }
+        ),
+    ],
+)
+def test_date_series(df: Any) -> None:
+    response = get_date_series_info(df["C"])
+
+    assert response.min == "2024-01-01"
+    assert response.max == "2024-01-03"
+    assert response.label == "C"
+
+    with pytest.raises(ValueError):
+        response = get_date_series_info(df["B"])
+    with pytest.raises(ValueError):
+        response = get_date_series_info(df["A"])

--- a/tests/_data/test_series.py
+++ b/tests/_data/test_series.py
@@ -48,6 +48,7 @@ def test_number_series(
         response = get_number_series_info(df["B"])
 
 
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 def test_get_with_no_name() -> None:
     series = pd.Series([1, 2, 3])
     series.name = None


### PR DESCRIPTION
Add `.from_series` to many mo.ui inputs.

```python
number = mo.ui.number.from_series(df["column_name"])
slider = mo.ui.slider.from_series(df["column_name"])
range_slider = mo.ui.range_slider.from_series(df["column_name"])
radiogroup = mo.ui.radio.from_series(df["column_name"])
dropdown = mo.ui.dropdown.from_series(df["column_name"])
multiselect = mo.ui.multiselect.from_series(df["column_name"])
date = mo.ui.date.from_series(df["column_name"])
```

<img width="1283" alt="Screenshot 2024-06-26 at 9 47 08 PM" src="https://github.com/marimo-team/marimo/assets/2753772/c930cd8e-0c1b-4ec5-b8d1-b787dc7d3d8d">
