### PR TITLE
fix: strict execution single cell reference error

### DIFF
--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -142,7 +142,7 @@ export const MarimoErrorOutput = ({
           </div>
         );
       case "strict-exception":
-        return error.blamed_cell === null ? (
+        return error.blamed_cell == null ? (
           <Fragment key={idx}>
             <p>{error.msg}</p>
             <Tip>
@@ -166,7 +166,7 @@ export const MarimoErrorOutput = ({
         titleContents = "Ancestor prevented from running";
         alertVariant = "default";
         textColor = "text-secondary-foreground";
-        return error.blamed_cell === null ? (
+        return error.blamed_cell == null ? (
           <div key={idx}>
             {error.msg}
             (<CellLinkError cellId={error.raising_cell as CellId} />)

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -142,7 +142,7 @@ export const MarimoErrorOutput = ({
           </div>
         );
       case "strict-exception":
-        return error.blamed_cell == null ? (
+        return error.blamed_cell === null ? (
           <Fragment key={idx}>
             <p>{error.msg}</p>
             <Tip>
@@ -157,7 +157,7 @@ export const MarimoErrorOutput = ({
             <Tip>
               Ensure that&nbsp;
               <CellLinkError cellId={error.blamed_cell as CellId} />
-              &nbsp;defines the variable {error.ref}, or turn off strict
+              &nbsp;defines the variable `{error.ref}`, or turn off strict
               execution.
             </Tip>
           </div>
@@ -166,7 +166,12 @@ export const MarimoErrorOutput = ({
         titleContents = "Ancestor prevented from running";
         alertVariant = "default";
         textColor = "text-secondary-foreground";
-        return (
+        return error.blamed_cell === null ? (
+          <div key={idx}>
+            {error.msg}
+            (<CellLinkError cellId={error.raising_cell as CellId} />)
+          </div>
+        ) : (
           <div key={idx}>
             {error.msg}
             (<CellLinkError cellId={error.raising_cell as CellId} />

--- a/marimo/_messaging/errors.py
+++ b/marimo/_messaging/errors.py
@@ -37,7 +37,7 @@ class MarimoInterruptionError:
 class MarimoAncestorPreventedError:
     msg: str
     raising_cell: CellId_t
-    blamed_cell: CellId_t
+    blamed_cell: Optional[CellId_t]
     type: Literal["ancestor-prevented"] = "ancestor-prevented"
 
 
@@ -73,7 +73,7 @@ class UnknownError:
 class MarimoStrictExecutionError:
     msg: str
     ref: str
-    blamed_cell: CellId_t
+    blamed_cell: Optional[CellId_t]
     type: Literal["strict-exception"] = "strict-exception"
 
 

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -362,7 +362,7 @@ class DirectedGraph:
                                 processed.add(maybe_private)
 
         if inclusive:
-            return processed
+            return processed | refs
         return processed - refs
 
 

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -350,8 +350,8 @@ class Runner:
             try:
                 (blamed_cell, *_) = self.graph.get_defining_cells(e.ref)
             except KeyError:
-                # This should never happen, but just in case
-                blamed_cell = e.ref
+                # The reference is not found anywhere else in the graph
+                blamed_cell = None
 
             output = MarimoStrictExecutionError(
                 f"marimo was unable to resolve "


### PR DESCRIPTION
## 📝 Summary

fix: If a cell references a variable that no other cell potentially produces, strict mode is supposed to create an error.

## 🔍 Description of Changes

A small bug in `transitive_references` (dataflow.py) stopped the expected behavior from happening, but then I realized the error UI was slightly wrong (MarimoErrorOutput.tsx, cell_runner.py, errors.py).

So, I added a unit test (test_runtime.py), and realized that Strict Errors should probably be promoted to kernel level errors (runtime.py).

## 📜 Reviewers

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
