### PR TITLE
improvement: add dtype to mo.ui.table and dataset sidebar

### DIFF
--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -1,8 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { TopLevelFacetedUnitSpec } from "@/plugins/impl/data-explorer/queries/types";
-import { DataType } from "@/plugins/impl/vega/vega-loader";
 import { mint, orange, slate } from "@radix-ui/colors";
-import { ColumnHeaderSummary } from "./types";
+import { ColumnHeaderSummary, FieldTypes } from "./types";
 
 export class ColumnChartSpecModel<T> {
   private columnSummaries = new Map<string | number, ColumnHeaderSummary>();
@@ -13,7 +12,7 @@ export class ColumnChartSpecModel<T> {
 
   constructor(
     private readonly data: T[],
-    private readonly fieldTypes: Record<string, DataType>,
+    private readonly fieldTypes: FieldTypes,
     readonly summaries: ColumnHeaderSummary[],
     private readonly opts: {
       includeCharts: boolean;

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -77,6 +77,8 @@ export const DataTableColumnHeader = <TData, TValue>({
     );
   };
 
+  const dtype = column.columnDef.meta?.dtype;
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild={true}>
@@ -106,6 +108,12 @@ export const DataTableColumnHeader = <TData, TValue>({
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
+        {dtype && (
+          <div className="flex-1 px-2 text-xs text-muted-foreground font-bold">
+            {dtype}
+          </div>
+        )}
+        <DropdownMenuSeparator />
         {renderSorts()}
         <DropdownMenuItem
           onClick={() =>

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -10,6 +10,7 @@ import { uniformSample } from "./uniformSample";
 import { DataType } from "@/core/kernel/messages";
 import { TableColumnSummary } from "./column-summary";
 import { FilterType } from "./filters";
+import { FieldTypesWithExternalType } from "./types";
 
 interface ColumnInfo {
   key: string;
@@ -74,7 +75,7 @@ export function generateColumns<T>({
   rowHeaders: string[];
   selection: "single" | "multi" | null;
   showColumnSummaries: boolean;
-  fieldTypes?: Record<string, DataType>;
+  fieldTypes?: FieldTypesWithExternalType;
 }): Array<ColumnDef<T>> {
   const columnInfo = getColumnInfo(items);
   const rowHeadersSet = new Set(rowHeaders);
@@ -130,7 +131,8 @@ export function generateColumns<T>({
       meta: {
         type: info.type,
         rowHeader: rowHeadersSet.has(info.key),
-        filterType: getFilterTypeForFieldType(fieldTypes?.[info.key]),
+        filterType: getFilterTypeForFieldType(fieldTypes?.[info.key]?.[0]),
+        dtype: fieldTypes?.[info.key]?.[1],
       },
     }),
   );

--- a/frontend/src/components/data-table/filters.ts
+++ b/frontend/src/components/data-table/filters.ts
@@ -10,6 +10,7 @@ declare module "@tanstack/react-table" {
   interface ColumnMeta<TData extends RowData, TValue> {
     type?: "primitive" | "mime";
     rowHeader?: boolean;
+    dtype?: string;
     filterType?: FilterType;
   }
 }

--- a/frontend/src/components/data-table/types.ts
+++ b/frontend/src/components/data-table/types.ts
@@ -1,4 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+
+import { DataType } from "@/core/kernel/messages";
+
 export interface ColumnHeaderSummary {
   column: string | number;
   min?: number | string | undefined | null;
@@ -8,3 +11,9 @@ export interface ColumnHeaderSummary {
   true?: number | null;
   false?: number | null;
 }
+
+export type FieldTypesWithExternalType = Record<
+  string,
+  [DataType, externalType: string]
+>;
+export type FieldTypes = Record<string, DataType>;

--- a/frontend/src/components/editor/chrome/panels/datasources-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/datasources-panel.tsx
@@ -305,6 +305,9 @@ const DatasetColumnItem: React.FC<{
           />
         </Button>
       </Tooltip>
+      <span className="text-xs text-muted-foreground">
+        {column.external_type}
+      </span>
     </CommandItem>
   );
 };

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -21,7 +21,6 @@ import { DelayMount } from "@/components/utils/delay-mount";
 import {
   ColumnHeaderSummary,
   FieldTypesWithExternalType,
-  FieldTypesWithExternalType,
 } from "@/components/data-table/types";
 import {
   ColumnFiltersState,

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -9,7 +9,6 @@ import { Alert, AlertTitle } from "@/components/ui/alert";
 import { rpc } from "../core/rpc";
 import { createPlugin } from "../core/builder";
 import { vegaLoadData } from "./vega/loader";
-import { DataType } from "./vega/vega-loader";
 import { getVegaFieldTypes } from "./vega/utils";
 import { Arrays } from "@/utils/arrays";
 import { Banner } from "./common/error-banner";
@@ -19,7 +18,11 @@ import { ColumnChartContext } from "@/components/data-table/column-summary";
 import { Logger } from "@/utils/Logger";
 import { LoadingTable } from "@/components/data-table/loading-table";
 import { DelayMount } from "@/components/utils/delay-mount";
-import { ColumnHeaderSummary } from "@/components/data-table/types";
+import {
+  ColumnHeaderSummary,
+  FieldTypesWithExternalType,
+  FieldTypesWithExternalType,
+} from "@/components/data-table/types";
 import {
   ColumnFiltersState,
   OnChangeFn,
@@ -34,6 +37,7 @@ import {
   ColumnFilterValue,
   filterToFilterCondition,
 } from "@/components/data-table/filters";
+import { Objects } from "@/utils/objects";
 
 type CsvURL = string;
 type TableData<T> = T[] | CsvURL;
@@ -56,7 +60,7 @@ interface Data<T> {
   showFilters: boolean;
   showColumnSummaries: boolean;
   rowHeaders: string[];
-  fieldTypes?: Record<string, DataType> | null;
+  fieldTypes?: FieldTypesWithExternalType | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -94,7 +98,17 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
       rowHeaders: z.array(z.string()),
       fieldTypes: z
         .record(
-          z.enum(["boolean", "integer", "number", "date", "string", "unknown"]),
+          z.tuple([
+            z.enum([
+              "boolean",
+              "integer",
+              "number",
+              "date",
+              "string",
+              "unknown",
+            ]),
+            z.string(),
+          ]),
         )
         .nullish(),
     }),
@@ -223,10 +237,15 @@ export const LoadingDataTableComponent = memo(
         return tableData;
       }
 
+      const withoutExternalTypes = Objects.mapValues(
+        props.fieldTypes ?? {},
+        ([type]) => type,
+      );
+
       // Otherwise, load the data from the URL
       return vegaLoadData(
         tableData,
-        { type: "csv", parse: getVegaFieldTypes(props.fieldTypes) },
+        { type: "csv", parse: getVegaFieldTypes(withoutExternalTypes) },
         { handleBigInt: true },
       );
     }, [sorting, search, filters, searchQuery, props.fieldTypes, props.data]);
@@ -324,9 +343,18 @@ const DataTableComponent = ({
     if (!fieldTypes || !data || !columnSummaries) {
       return ColumnChartSpecModel.EMPTY;
     }
-    return new ColumnChartSpecModel(data, fieldTypes, columnSummaries, {
-      includeCharts: !resultsAreClipped,
-    });
+    const fieldTypesWithoutExternalTypes = Objects.mapValues(
+      fieldTypes,
+      ([type]) => type,
+    );
+    return new ColumnChartSpecModel(
+      data,
+      fieldTypesWithoutExternalTypes,
+      columnSummaries,
+      {
+        includeCharts: !resultsAreClipped,
+      },
+    );
   }, [data, fieldTypes, columnSummaries, resultsAreClipped]);
 
   const columns = useMemo(

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -6,7 +6,7 @@ import { TransformPanel } from "./panel";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Code2Icon, FunctionSquareIcon } from "lucide-react";
 import { CodePanel } from "./python/code-panel";
-import { ColumnDataTypes, RawColumnDataTypes } from "./types";
+import { ColumnDataTypes, ColumnId } from "./types";
 import { createPlugin } from "@/plugins/core/builder";
 import { rpc } from "@/plugins/core/rpc";
 import { useAsyncData } from "@/hooks/useAsyncData";
@@ -59,8 +59,12 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
       dataframeName: z.string(),
       pageSize: z.number().default(5),
       columns: z
-        .array(z.tuple([z.string().or(z.number()), z.string()]))
-        .transform((value) => new Map(value as RawColumnDataTypes)),
+        .array(z.tuple([z.string().or(z.number()), z.string(), z.string()]))
+        .transform((value) => {
+          const map = new Map<ColumnId, string>();
+          value.forEach(([key, dtype]) => map.set(key as ColumnId, dtype));
+          return map;
+        }),
     }),
   )
   .withFunctions<PluginFunctions>({

--- a/frontend/src/plugins/impl/data-frames/types.ts
+++ b/frontend/src/plugins/impl/data-frames/types.ts
@@ -15,7 +15,7 @@ export type NumPyType = string;
  *
  * We cannot use a js map, since maps don't preserve keys as ints (e.g. "1" and 1 are the same key)
  */
-export type RawColumnDataTypes = Array<[ColumnId, NumPyType]>;
+export type RawColumnDataTypes = Array<[ColumnId, [DataType, NumPyType]]>;
 /**
  * Map of column Id and their data types
  * ES6 maps preserve keys as ints (e.g. "1" and 1 are different keys)

--- a/marimo/_data/get_datasets.py
+++ b/marimo/_data/get_datasets.py
@@ -29,7 +29,11 @@ def _get_data_table(value: object, variable_name: str) -> Optional[DataTable]:
             return None
 
         columns = [
-            DataTableColumn(name=column_name, type=column_type)
+            DataTableColumn(
+                name=column_name,
+                type=column_type[0],
+                external_type=column_type[1],
+            )
             for column_name, column_type in table.get_field_types().items()
         ]
         return DataTable(

--- a/marimo/_data/models.py
+++ b/marimo/_data/models.py
@@ -7,7 +7,9 @@ from decimal import Decimal
 from typing import List, Literal, Optional, Union
 
 DataType = Literal["string", "boolean", "integer", "number", "date", "unknown"]
-NumpyType = str
+# This is the data type based on the source library
+# e.g. polars, pandas, numpy, etc.
+ExternalDataType = str
 
 
 @dataclass
@@ -22,6 +24,7 @@ class DataTableColumn:
 
     name: str
     type: DataType
+    external_type: ExternalDataType
 
 
 @dataclass

--- a/marimo/_data/preview_column.py
+++ b/marimo/_data/preview_column.py
@@ -123,7 +123,9 @@ def _get_altair_chart(
         MaxRowsError,
     )
 
-    column_type = table.get_field_types()[request.column_name]
+    (column_type, _external_type) = table.get_field_types()[
+        request.column_name
+    ]
 
     # For categorical columns with more than 10 unique values,
     # we limit the chart to 10 items

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -168,7 +168,7 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
 
     def _get_column_types(self) -> List[List[Union[str, int]]]:
         return [
-            [name, dtype]
+            [name, dtype[0], dtype[1]]
             for name, dtype in self._manager.get_field_types().items()
         ]
 

--- a/marimo/_plugins/ui/_impl/tables/df_protocol_table.py
+++ b/marimo/_plugins/ui/_impl/tables/df_protocol_table.py
@@ -1,9 +1,9 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
-from marimo._data.models import ColumnSummary
+from marimo._data.models import ColumnSummary, ExternalDataType
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._plugins.ui._impl.tables.dataframe_protocol import (
     Column,
@@ -122,24 +122,24 @@ class DataFrameProtocolTableManager(TableManager[DataFrameLike]):
         return self._ensure_delegate().sort_values(by, descending)
 
     @staticmethod
-    def _get_field_type(column: Column) -> FieldType:
+    def _get_field_type(column: Column) -> Tuple[FieldType, ExternalDataType]:
         kind = column.dtype[0]
         if kind == DtypeKind.BOOL:
-            return "boolean"
+            return ("boolean", "BOOL")
         elif kind == DtypeKind.INT:
-            return "integer"
+            return ("integer", "INT")
         elif kind == DtypeKind.UINT:
-            return "integer"
+            return ("integer", "UINT")
         elif kind == DtypeKind.FLOAT:
-            return "number"
+            return ("number", "FLOAT")
         elif kind == DtypeKind.STRING:
-            return "string"
+            return ("string", "STRING")
         elif kind == DtypeKind.DATETIME:
-            return "date"
+            return ("date", "DATETIME")
         elif kind == DtypeKind.CATEGORICAL:
-            return "string"
+            return ("string", "CATEGORICAL")
         else:
-            return "unknown"
+            return ("unknown", "UNKNOWN")
 
 
 # Copied from Altair

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -1,9 +1,9 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Tuple
 
-from marimo._data.models import ColumnSummary
+from marimo._data.models import ColumnSummary, ExternalDataType
 from marimo._plugins.ui._impl.tables.table_manager import (
     ColumnName,
     FieldType,
@@ -107,7 +107,7 @@ class PandasTableManagerFactory(TableManagerFactory):
             @staticmethod
             def _get_field_type(
                 series: pd.Series[Any] | pd.DataFrame,
-            ) -> FieldType:
+            ) -> Tuple[FieldType, ExternalDataType]:
                 # If a df has duplicate columns, it won't be a series, but
                 # a dataframe. In this case, we take the dtype of the columns
                 if isinstance(series, pd.DataFrame):
@@ -116,24 +116,24 @@ class PandasTableManagerFactory(TableManagerFactory):
                     dtype = str(series.dtype)
 
                 if dtype.startswith("interval"):
-                    return "string"
+                    return ("string", dtype)
                 if dtype.startswith("int") or dtype.startswith("uint"):
-                    return "integer"
+                    return ("integer", dtype)
                 if dtype.startswith("float"):
-                    return "number"
+                    return ("number", dtype)
                 if dtype == "object":
-                    return "string"
+                    return ("string", dtype)
                 if dtype == "bool":
-                    return "boolean"
+                    return ("boolean", dtype)
                 if dtype == "datetime64[ns]":
-                    return "date"
+                    return ("date", dtype)
                 if dtype == "timedelta64[ns]":
-                    return "string"
+                    return ("string", dtype)
                 if dtype == "category":
-                    return "string"
+                    return ("string", dtype)
                 if dtype.startswith("complex"):
-                    return "unknown"
-                return "unknown"
+                    return ("unknown", dtype)
+                return ("unknown", dtype)
 
             def get_summary(self, column: str) -> ColumnSummary:
                 # If column is not in the dataframe, return an empty summary

--- a/marimo/_plugins/ui/_impl/tables/polars_table.py
+++ b/marimo/_plugins/ui/_impl/tables/polars_table.py
@@ -1,9 +1,13 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Tuple, cast
 
-from marimo._data.models import ColumnSummary, NonNestedLiteral
+from marimo._data.models import (
+    ColumnSummary,
+    ExternalDataType,
+    NonNestedLiteral,
+)
 from marimo._plugins.ui._impl.tables.table_manager import (
     ColumnName,
     FieldType,
@@ -149,18 +153,21 @@ class PolarsTableManagerFactory(TableManagerFactory):
                 return PolarsTableManager(sorted_data)
 
             @staticmethod
-            def _get_field_type(column: pl.Series) -> FieldType:
+            def _get_field_type(
+                column: pl.Series,
+            ) -> Tuple[FieldType, ExternalDataType]:
+                dtype_string = column.dtype._string_repr()
                 if column.dtype == pl.String:
-                    return "string"
+                    return ("string", dtype_string)
                 elif column.dtype == pl.Boolean:
-                    return "boolean"
+                    return ("boolean", dtype_string)
                 elif column.dtype.is_integer():
-                    return "integer"
+                    return ("integer", dtype_string)
                 elif column.dtype.is_float() or column.dtype.is_numeric():
-                    return "number"
+                    return ("number", dtype_string)
                 elif column.dtype.is_temporal():
-                    return "date"
+                    return ("date", dtype_string)
                 else:
-                    return "unknown"
+                    return ("unknown", dtype_string)
 
         return PolarsTableManager

--- a/marimo/_plugins/ui/_impl/tables/pyarrow_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pyarrow_table.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import io
-from typing import Any, Union, cast
+from typing import Any, Tuple, Union, cast
 
-from marimo._data.models import ColumnSummary
+from marimo._data.models import ColumnSummary, ExternalDataType
 from marimo._plugins.ui._impl.tables.table_manager import (
     ColumnName,
     FieldType,
@@ -127,7 +127,7 @@ class PyArrowTableManagerFactory(TableManagerFactory):
                 idx = self.data.schema.get_field_index(column)
                 col: Any = self.data.column(idx)
 
-                field_type = self._get_field_type(col)
+                field_type = self._get_field_type(col)[0]
                 if field_type == "unknown":
                     return ColumnSummary()
                 if field_type == "string":
@@ -197,24 +197,27 @@ class PyArrowTableManagerFactory(TableManagerFactory):
                 return PyArrowTableManager(sorted_data)
 
             @staticmethod
-            def _get_field_type(column: pa.Array[Any, Any]) -> FieldType:
+            def _get_field_type(
+                column: pa.Array[Any, Any],
+            ) -> Tuple[FieldType, ExternalDataType]:
+                dtype_string = str(column.type)
                 if isinstance(column, pa.NullArray):
-                    return "unknown"
+                    return ("unknown", dtype_string)
                 elif pa.types.is_string(column.type):
-                    return "string"
+                    return ("string", dtype_string)
                 elif pa.types.is_boolean(column.type):
-                    return "boolean"
+                    return ("boolean", dtype_string)
                 elif pa.types.is_integer(column.type):
-                    return "integer"
+                    return ("integer", dtype_string)
                 elif pa.types.is_floating(column.type) or pa.types.is_decimal(
                     column.type
                 ):
-                    return "number"
+                    return ("number", dtype_string)
                 elif pa.types.is_date(column.type) or pa.types.is_timestamp(
                     column.type
                 ):
-                    return "date"
+                    return ("date", dtype_string)
                 else:
-                    return "unknown"
+                    return ("unknown", dtype_string)
 
         return PyArrowTableManager

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -2,18 +2,17 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Dict, Generic, Optional, TypeVar
+from typing import Any, Dict, Generic, Optional, Tuple, TypeVar
 
 import marimo._output.data.data as mo_data
-from marimo._data.models import ColumnSummary, DataType, NumpyType
+from marimo._data.models import ColumnSummary, DataType, ExternalDataType
 from marimo._plugins.core.web_component import JSONType
 
 T = TypeVar("T")
 
 ColumnName = str
 FieldType = DataType
-FieldTypes = Dict[ColumnName, FieldType]
-NumpyTypes = Dict[ColumnName, NumpyType]
+FieldTypes = Dict[ColumnName, Tuple[FieldType, ExternalDataType]]
 
 
 class TableManager(abc.ABC, Generic[T]):

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -363,6 +363,8 @@ components:
       type: object
     DataTableColumn:
       properties:
+        external_type:
+          type: string
         name:
           type: string
         type:
@@ -370,6 +372,7 @@ components:
       required:
       - name
       - type
+      - external_type
       type: object
     DataType:
       enum:
@@ -884,6 +887,7 @@ components:
     MarimoAncestorPreventedError:
       properties:
         blamed_cell:
+          nullable: true
           type: string
         msg:
           type: string
@@ -896,7 +900,6 @@ components:
       required:
       - msg
       - raising_cell
-      - blamed_cell
       - type
       type: object
     MarimoAncestorStoppedError:
@@ -1121,6 +1124,7 @@ components:
     MarimoStrictExecutionError:
       properties:
         blamed_cell:
+          nullable: true
           type: string
         msg:
           type: string
@@ -1133,7 +1137,6 @@ components:
       required:
       - msg
       - ref
-      - blamed_cell
       - type
       type: object
     MarimoSyntaxError:
@@ -1661,7 +1664,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.6.19
+  version: 0.6.23
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -879,6 +879,7 @@ export interface components {
       variable_name?: string | null;
     };
     DataTableColumn: {
+      external_type: string;
       name: string;
       type: components["schemas"]["DataType"];
     };
@@ -1094,7 +1095,7 @@ export interface components {
     };
     MIME: Record<string, never>;
     MarimoAncestorPreventedError: {
-      blamed_cell: string;
+      blamed_cell?: string | null;
       msg: string;
       raising_cell: string;
       /** @enum {string} */
@@ -1181,7 +1182,7 @@ export interface components {
       type: "interruption";
     };
     MarimoStrictExecutionError: {
-      blamed_cell: string;
+      blamed_cell?: string | null;
       msg: string;
       ref: string;
       /** @enum {string} */

--- a/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
@@ -44,8 +44,11 @@ class TestDataframes:
 
         assert subject.value is df
         assert subject._component_args["columns"] == [
-            ["A", "integer"],
-            ["B", "string"],
+            ["A", "integer", "i64"],
+            ["B", "string", "str"],
+        ] or subject._component_args["columns"] == [
+            ["A", "integer", "int64"],
+            ["B", "string", "object"],
         ]
         assert subject.get_column_values(
             GetColumnValuesArgs(column="A")
@@ -71,8 +74,8 @@ class TestDataframes:
 
         assert subject.value is df
         assert subject._component_args["columns"] == [
-            [1, "integer"],
-            [2, "string"],
+            [1, "integer", "int64"],
+            [2, "string", "object"],
         ]
 
         assert subject.get_column_values(

--- a/tests/_plugins/ui/_impl/tables/test_df_protocol.py
+++ b/tests/_plugins/ui/_impl/tables/test_df_protocol.py
@@ -77,11 +77,11 @@ class TestDataFrameProtocolTableManager(unittest.TestCase):
         import pyarrow as pa
 
         expected_field_types = {
-            "A": "integer",
-            "B": "string",
-            "C": "number",
-            "D": "boolean",
-            "E": "date",
+            "A": ("integer", "INT"),
+            "B": ("string", "STRING"),
+            "C": ("number", "FLOAT"),
+            "D": ("boolean", "BOOL"),
+            "E": ("date", "DATETIME"),
         }
         assert self.manager.get_field_types() == expected_field_types
 
@@ -94,10 +94,10 @@ class TestDataFrameProtocolTableManager(unittest.TestCase):
             }  # type: ignore
         )
         expected_field_types = {
-            "A": "integer",
-            "B": "string",
-            "C": "number",
-            "D": "boolean",
+            "A": ("integer", "INT"),
+            "B": ("string", "STRING"),
+            "C": ("number", "FLOAT"),
+            "D": ("boolean", "BOOL"),
         }
         assert (
             DataFrameProtocolTableManager(

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -129,12 +129,12 @@ class TestPandasTableManager(unittest.TestCase):
         import pandas as pd
 
         expected_field_types = {
-            "A": "integer",
-            "B": "string",
-            "C": "number",
-            "D": "boolean",
-            "E": "date",
-            "F": "string",
+            "A": ("integer", "int64"),
+            "B": ("string", "object"),
+            "C": ("number", "float64"),
+            "D": ("boolean", "bool"),
+            "E": ("date", "datetime64[ns]"),
+            "F": ("string", "object"),
         }
         assert self.manager.get_field_types() == expected_field_types
 
@@ -165,16 +165,16 @@ class TestPandasTableManager(unittest.TestCase):
             }
         )
         expected_field_types = {
-            "A": "integer",
-            "B": "string",
-            "C": "number",
-            "D": "boolean",
-            "E": "unknown",
-            "F": "string",
-            "G": "string",
-            "H": "date",
-            "I": "string",
-            "J": "string",
+            "A": ("integer", "int64"),
+            "B": ("string", "object"),
+            "C": ("number", "float64"),
+            "D": ("boolean", "bool"),
+            "E": ("unknown", "complex128"),
+            "F": ("string", "object"),
+            "G": ("string", "object"),
+            "H": ("date", "datetime64[ns]"),
+            "I": ("string", "timedelta64[ns]"),
+            "J": ("string", "interval[int64, right]"),
         }
         assert (
             self.factory.create()(complex_data).get_field_types()
@@ -193,7 +193,7 @@ class TestPandasTableManager(unittest.TestCase):
         )
         data = data.rename(columns={"A": "B"})
         expected_field_types = {
-            "B": "string",
+            "B": ("string", "object"),
         }
         assert (
             self.factory.create()(data).get_field_types()
@@ -209,7 +209,7 @@ class TestPandasTableManager(unittest.TestCase):
         )
         data = data.rename(columns={"A": "B"})
         expected_field_types = {
-            "B": "string",
+            "B": ("string", "object"),
         }
         assert (
             self.factory.create()(data).get_field_types()
@@ -225,7 +225,7 @@ class TestPandasTableManager(unittest.TestCase):
         )
         data = data.rename(columns={"A": "B"})
         expected_field_types = {
-            "B": "string",
+            "B": ("string", "object"),
         }
         assert (
             self.factory.create()(data).get_field_types()

--- a/tests/_plugins/ui/_impl/tables/test_polars_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_polars_table.py
@@ -78,11 +78,11 @@ class TestPolarsTableManagerFactory(unittest.TestCase):
         import polars as pl
 
         expected_field_types = {
-            "A": "integer",
-            "B": "string",
-            "C": "number",
-            "D": "boolean",
-            "E": "date",
+            "A": ("integer", "i64"),
+            "B": ("string", "str"),
+            "C": ("number", "f64"),
+            "D": ("boolean", "bool"),
+            "E": ("date", "datetime[μs]"),
         }
         assert self.manager.get_field_types() == expected_field_types
 
@@ -113,16 +113,16 @@ class TestPolarsTableManagerFactory(unittest.TestCase):
             }
         )
         expected_field_types = {
-            "A": "integer",
-            "B": "string",
-            "C": "number",
-            "D": "boolean",
-            "E": "unknown",
-            "F": "unknown",
-            "G": "unknown",
-            "H": "date",
-            "I": "string",
-            "J": "string",
+            "A": ("integer", "i64"),
+            "B": ("string", "str"),
+            "C": ("number", "f64"),
+            "D": ("boolean", "bool"),
+            "E": ("unknown", "object"),
+            "F": ("unknown", "null"),
+            "G": ("unknown", "object"),
+            "H": ("date", "datetime[μs]"),
+            "I": ("string", "str"),
+            "J": ("string", "str"),
         }
         assert (
             self.factory.create()(complex_data).get_field_types()

--- a/tests/_plugins/ui/_impl/tables/test_pyarrow.py
+++ b/tests/_plugins/ui/_impl/tables/test_pyarrow.py
@@ -77,11 +77,11 @@ class TestPyArrowTableManagerFactory(unittest.TestCase):
         import pyarrow as pa
 
         expected_field_types = {
-            "A": "integer",
-            "B": "string",
-            "C": "number",
-            "D": "boolean",
-            "E": "date",
+            "A": ("integer", "int64"),
+            "B": ("string", "string"),
+            "C": ("number", "double"),
+            "D": ("boolean", "bool"),
+            "E": ("date", "timestamp[us]"),
         }
         assert self.manager.get_field_types() == expected_field_types
 
@@ -95,11 +95,11 @@ class TestPyArrowTableManagerFactory(unittest.TestCase):
             }  # type: ignore
         )
         expected_field_types = {
-            "A": "integer",
-            "B": "string",
-            "C": "number",
-            "D": "boolean",
-            "E": "unknown",
+            "A": ("integer", "int64"),
+            "B": ("string", "string"),
+            "C": ("number", "double"),
+            "D": ("boolean", "bool"),
+            "E": ("unknown", "null"),
         }
         assert (
             self.factory.create()(complex_data).get_field_types()

--- a/tests/_server/session/test_session_view.py
+++ b/tests/_server/session/test_session_view.py
@@ -38,7 +38,7 @@ updated_output = CellOutput(
     mimetype="text/plain",
 )
 
-initial_status = "running"
+initial_status: CellStatusType = "running"
 updated_status: CellStatusType = "running"
 
 
@@ -243,7 +243,13 @@ def test_add_datasets() -> None:
                     DataTable(
                         source="Local",
                         name="table1",
-                        columns=[DataTableColumn(name="col1", type="boolean")],
+                        columns=[
+                            DataTableColumn(
+                                name="col1",
+                                type="boolean",
+                                external_type="BOOL",
+                            )
+                        ],
                         num_rows=1,
                         num_columns=1,
                         variable_name="df1",
@@ -251,7 +257,13 @@ def test_add_datasets() -> None:
                     DataTable(
                         source="Local",
                         name="table2",
-                        columns=[DataTableColumn(name="col2", type="integer")],
+                        columns=[
+                            DataTableColumn(
+                                name="col2",
+                                type="integer",
+                                external_type="BOOL",
+                            )
+                        ],
                         num_rows=2,
                         num_columns=2,
                         variable_name="df2",
@@ -276,7 +288,11 @@ def test_add_datasets() -> None:
                         source="Local",
                         name="table2",
                         columns=[
-                            DataTableColumn(name="new_col", type="boolean")
+                            DataTableColumn(
+                                name="new_col",
+                                type="boolean",
+                                external_type="BOOL",
+                            )
                         ],
                         num_rows=20,
                         num_columns=20,


### PR DESCRIPTION
Add the external datatypes that come from pandas/arrow/polars. These don't conform to the same types or names, so they are just strings used as display. 

* adds it to the table dropdown
* adds it to the dataset sidebar 

<img width="526" alt="Screenshot 2024-06-27 at 10 25 49 PM" src="https://github.com/marimo-team/marimo/assets/2753772/69bc36c5-55dc-4916-8315-0318575a5632">
<img width="260" alt="Screenshot 2024-06-27 at 10 25 40 PM" src="https://github.com/marimo-team/marimo/assets/2753772/f9d51b3e-d8fd-4ede-823e-34063a23a994">
<img width="1236" alt="Screenshot 2024-06-27 at 10 25 33 PM" src="https://github.com/marimo-team/marimo/assets/2753772/7d8e6259-10a0-4301-85eb-bc3e847c6dc9">
