### PR TITLE
improvement: proxy attributes for `mo.ui.anywidget`

### DIFF
--- a/docs/api/inputs/anywidget.md
+++ b/docs/api/inputs/anywidget.md
@@ -51,6 +51,9 @@ widget = mo.ui.anywidget(CounterWidget())
 
 # In another cell, you can access the widget's value
 widget.value
+
+# You can also access the widget's specific properties
+widget.count
 ```
 
 ## Importing a widget
@@ -63,6 +66,10 @@ widget = mo.ui.anywidget(ScatterWidget())
 
 # In another cell, you can access the widget's value
 widget.value
+
+# You can also access the widget's specific properties
+widget.data
+widget.data_as_polars
 ```
 
 ---

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import weakref
 from typing import TYPE_CHECKING, Any, Dict
 
@@ -31,6 +33,7 @@ T = Dict[str, Any]
 class anywidget(UIElement[T, T]):
     """
     Create a UIElement from an AnyWidget.
+    This proxies all the widget's attributes and methods.
 
     **Example.**
 
@@ -38,10 +41,16 @@ class anywidget(UIElement[T, T]):
     from drawdata import ScatterWidget
     import marimo as mo
 
-    widget = mo.ui.anywidget(ScatterWidget())
+    scatter = ScatterWidget()
+    scatter = mo.ui.anywidget(scatter)
 
     # In another cell, access its value
-    widget.value
+    # This works for all widgets
+    scatter.value
+
+    # Or attributes specifically on the ScatterWidget
+    scatter.data_as_pandas
+    scatter.data_as_polars
     ```
 
     **Attributes.**
@@ -93,3 +102,7 @@ class anywidget(UIElement[T, T]):
 
     def _convert_value(self, value: T) -> T:
         return value
+
+    # Proxy all the widget's attributes
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.widget, name)

--- a/tests/_plugins/ui/_impl/test_anywidget.py
+++ b/tests/_plugins/ui/_impl/test_anywidget.py
@@ -60,12 +60,14 @@ base_widget = CounterWidget()
 are_same = mo.as_html(base_widget).text == mo.as_html(base_widget).text
 are_different = mo.as_html(CounterWidget()) is not mo.as_html(CounterWidget())
 as_marimo_element = mo.ui.anywidget(base_widget)
+x = as_marimo_element.count
 """
                 )
             ]
         )
         assert k.globals["are_same"] is True
         assert k.globals["are_different"] is True
+        assert k.globals["x"] == 10
         assert isinstance(k.globals["base_widget"], _anywidget.AnyWidget)
         assert "marimo-anywidget" in k.globals["as_marimo_element"].text
 
@@ -101,9 +103,11 @@ as_marimo_element = mo.ui.anywidget(base_widget)
                 exec_req.get(
                     """
                     w_value = w.value
+                    w_count = w.count
                     """
                 ),
             ]
         )
         assert isinstance(k.globals["w"], anywidget)
         assert k.globals["w_value"]["count"] == 10
+        assert k.globals["w_count"] == 10


### PR DESCRIPTION
This allows you to access attributes directly on the original widget
```python
from drawdata import ScatterWidget
import marimo as mo

scatter = ScatterWidget()
scatter = mo.ui.anywidget(scatter)

# In another cell, access its value
# This works for all widgets
scatter.value

# Or attributes specifically on the ScatterWidget
scatter.data_as_pandas
scatter.data_as_polars
```