### PR TITLE
fix: loosen docutils lower bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
     "websockets >= 10.0.0,<13.0.0",
     # python <=3.10 compatibility
     "typing_extensions>=4.4.0; python_version < \"3.11\"",
-    # for rst parsing
-    "docutils>=0.17.0",
+    # for rst parsing; lowerbound determined by awscli requiring < 0.17,
+    "docutils>=0.16.0",
     # to show RAM, CPU usage, other system utilities
     "psutil>=5.0",
     # required dependency in Starlette for SessionMiddleware support


### PR DESCRIPTION
It was incompatible with awscli. Fixes #1693 
