### PR TITLE
feat: add column wrapping

### DIFF
--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -9,6 +9,8 @@ import {
   FilterX,
   MinusIcon,
   SearchIcon,
+  WrapTextIcon,
+  AlignJustifyIcon,
 } from "lucide-react";
 
 import { cn } from "@/utils/cn";
@@ -79,6 +81,35 @@ export const DataTableColumnHeader = <TData, TValue>({
 
   const dtype = column.columnDef.meta?.dtype;
 
+  const renderColumnWrapping = () => {
+    if (!column.getCanWrap?.() || !column.getColumnWrapping) {
+      return null;
+    }
+
+    const wrap = column.getColumnWrapping();
+    if (wrap === "wrap") {
+      return (
+        <DropdownMenuItem
+          onClick={() => column.toggleColumnWrapping("nowrap")}
+          className="flex items-center"
+        >
+          <AlignJustifyIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+          No wrap text
+        </DropdownMenuItem>
+      );
+    }
+
+    return (
+      <DropdownMenuItem
+        onClick={() => column.toggleColumnWrapping("wrap")}
+        className="flex items-center"
+      >
+        <WrapTextIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+        Wrap text
+      </DropdownMenuItem>
+    );
+  };
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild={true}>
@@ -125,6 +156,7 @@ export const DataTableColumnHeader = <TData, TValue>({
           <CopyIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
           Copy column name
         </DropdownMenuItem>
+        {renderColumnWrapping()}
         <DropdownMenuItemFilter column={column} />
       </DropdownMenuContent>
     </DropdownMenu>

--- a/frontend/src/components/data-table/column-wrapping/feature.ts
+++ b/frontend/src/components/data-table/column-wrapping/feature.ts
@@ -1,0 +1,62 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import {
+  TableFeature,
+  RowData,
+  makeStateUpdater,
+  Table,
+  Column,
+  Updater,
+} from "@tanstack/react-table";
+import {
+  ColumnWrappingTableState,
+  ColumnWrappingOptions,
+  ColumnWrappingState,
+} from "./types";
+
+export const ColumnWrappingFeature: TableFeature = {
+  getInitialState: (state): ColumnWrappingTableState => {
+    return {
+      columnWrapping: {},
+      ...state,
+    };
+  },
+
+  getDefaultOptions: <TData extends RowData>(
+    table: Table<TData>,
+  ): ColumnWrappingOptions => {
+    return {
+      enableColumnWrapping: true,
+      onColumnWrappingChange: makeStateUpdater("columnWrapping", table),
+    } as ColumnWrappingOptions;
+  },
+
+  createColumn: <TData extends RowData>(
+    column: Column<TData>,
+    table: Table<TData>,
+  ) => {
+    column.getColumnWrapping = () => {
+      return table.getState().columnWrapping[column.id] || "nowrap";
+    };
+
+    column.getCanWrap = () => {
+      return table.options.enableColumnWrapping ?? false;
+    };
+
+    column.toggleColumnWrapping = (value?: "nowrap" | "wrap") => {
+      const safeUpdater: Updater<ColumnWrappingState> = (old) => {
+        const prevValue = old[column.id] || "nowrap";
+        if (value) {
+          return {
+            ...old,
+            [column.id]: value,
+          };
+        }
+        return {
+          ...old,
+          [column.id]: prevValue === "nowrap" ? "wrap" : "nowrap",
+        };
+      };
+      table.options.onColumnWrappingChange?.(safeUpdater);
+    };
+  },
+};

--- a/frontend/src/components/data-table/column-wrapping/types.ts
+++ b/frontend/src/components/data-table/column-wrapping/types.ts
@@ -1,0 +1,29 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import { OnChangeFn, RowData } from "@tanstack/react-table";
+
+export type ColumnWrappingState = Record<string, "nowrap" | "wrap" | undefined>;
+export interface ColumnWrappingTableState {
+  columnWrapping: ColumnWrappingState;
+}
+
+export interface ColumnWrappingOptions {
+  enableColumnWrapping?: boolean;
+  onColumnWrappingChange?: OnChangeFn<ColumnWrappingState>;
+}
+
+export interface ColumnWrappingInstance {
+  toggleColumnWrapping: (value?: "nowrap" | "wrap") => void;
+  getColumnWrapping?: () => "nowrap" | "wrap";
+  getCanWrap?: () => boolean;
+}
+
+// Use declaration merging to add our new feature APIs
+declare module "@tanstack/react-table" {
+  interface TableState extends ColumnWrappingTableState {}
+
+  interface TableOptionsResolved<TData extends RowData>
+    extends ColumnWrappingOptions {}
+
+  interface Column<TData extends RowData> extends ColumnWrappingInstance {}
+}

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -33,6 +33,7 @@ import useEvent from "react-use-event-hook";
 import { Tooltip } from "../ui/tooltip";
 import { Spinner } from "../icons/spinner";
 import { FilterPills } from "./filter-pills";
+import { ColumnWrappingFeature } from "./column-wrapping/feature";
 
 interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   wrapperClassName?: string;
@@ -92,6 +93,7 @@ const DataTableInternal = <TData,>({
   }, [pageSize, paginationState.pageSize]);
 
   const table = useReactTable({
+    _features: [ColumnWrappingFeature],
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -178,7 +180,12 @@ const DataTableInternal = <TData,>({
                   {row.getVisibleCells().map((cell) => (
                     <TableCell
                       key={cell.id}
-                      className="whitespace-nowrap truncate max-w-[300px]"
+                      className={cn(
+                        "whitespace-nowrap truncate max-w-[300px]",
+                        cell.column.getColumnWrapping &&
+                          cell.column.getColumnWrapping() === "wrap" &&
+                          "whitespace-normal min-w-[200px]",
+                      )}
                       title={String(cell.getValue())}
                     >
                       {flexRender(


### PR DESCRIPTION
Adds column wrapping to the header. This is only frontend state rather than putting it in the python plugin. 