### PR TITLE
fix: don't render dataframes in mo.ui.table if they contain nested datastructures

### DIFF
--- a/marimo/_output/formatters/df_formatters.py
+++ b/marimo/_output/formatters/df_formatters.py
@@ -20,6 +20,15 @@ class PolarsFormatter(FormatterFactory):
         def _show_marimo_dataframe(
             df: pl.DataFrame,
         ) -> tuple[KnownMimeType, str]:
+            # If has structured don't display in the table
+            for col in df.get_columns():
+                if (
+                    col.dtype == pl.Struct
+                    or col.dtype == pl.List
+                    or col.dtype == pl.Array
+                ):
+                    return ("text/html", df._repr_html_())
+
             return table(df, selection=None, pagination=True)._mime_()
 
 

--- a/marimo/_smoke_tests/bugs/1706.py
+++ b/marimo/_smoke_tests/bugs/1706.py
@@ -1,0 +1,33 @@
+import marimo
+
+__generated_with = "0.6.25"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import polars as pl
+    import numpy as np
+
+    df = pl.DataFrame(
+        {"a": [np.zeros(5) for i in range(5)]}, schema={"a": pl.Array(pl.Float64, 5)}
+    )
+    df
+    return df, mo, np, pl
+
+
+@app.cell
+def __(df, mo):
+    mo.plain(df)
+    return
+
+
+@app.cell
+def __(df):
+    df.get_columns()[0].dtype
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #1706 