### PR TITLE
no f-strings in md viewer

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -56,7 +56,7 @@ export const UserConfigForm: React.FC = () => {
 
   const renderCopilotProvider = () => {
     const copilot = form.getValues("completion.copilot");
-    if (copilot === false) {
+    if (!copilot) {
       return null;
     }
     if (copilot === "codeium") {
@@ -590,11 +590,11 @@ export const UserConfigForm: React.FC = () => {
                         }
                       }}
                       value={
-                        field.value === true
+                        field.value
                           ? "github"
-                          : field.value === false
-                            ? "none"
-                            : field.value
+                          : field.value
+                            ? field.value
+                            : "none"
                       }
                       disabled={field.disabled}
                       className="inline-flex mr-2"

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -56,7 +56,7 @@ export const UserConfigForm: React.FC = () => {
 
   const renderCopilotProvider = () => {
     const copilot = form.getValues("completion.copilot");
-    if (!copilot) {
+    if (copilot === false) {
       return null;
     }
     if (copilot === "codeium") {
@@ -590,11 +590,11 @@ export const UserConfigForm: React.FC = () => {
                         }
                       }}
                       value={
-                        field.value
+                        field.value === true
                           ? "github"
-                          : field.value
-                            ? field.value
-                            : "none"
+                          : field.value === false
+                            ? "none"
+                            : field.value
                       }
                       disabled={field.disabled}
                       className="inline-flex mr-2"

--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -55,12 +55,6 @@ describe("MarkdownLanguageAdapter", () => {
     });
 
     it("should unescape code blocks", () => {
-      // f"""
-      const pythonCode = String.raw`mo.md(f"""This is some \"""content\"""!""")`;
-      const [innerCode, offset] = adapter.transformIn(pythonCode);
-      expect(innerCode).toBe(`This is some """content"""!`);
-      expect(offset).toBe(10);
-
       // """
       const pythonCode2 = String.raw`mo.md("""This is some \"""content\"""!""")`;
       const [innerCode2, offset2] = adapter.transformIn(pythonCode2);
@@ -202,22 +196,6 @@ describe("MarkdownLanguageAdapter", () => {
       expect(offset).toBe(9);
     });
 
-    it("should not downgrade a f-string", () => {
-      const code = "Normal markdown";
-      adapter.lastQuotePrefix = "f";
-      const [wrappedCode, offset] = adapter.transformOut(code);
-      expect(wrappedCode).toBe('mo.md(f"Normal markdown")');
-      expect(offset).toBe(8);
-    });
-
-    it("should not downgrade a rf-string", () => {
-      const code = "Normal markdown";
-      adapter.lastQuotePrefix = "rf";
-      const [wrappedCode, offset] = adapter.transformOut(code);
-      expect(wrappedCode).toBe('mo.md(rf"Normal markdown")');
-      expect(offset).toBe(9);
-    });
-
     it("should preserve r strings", () => {
       const code = String.raw`$\nu = \mathllap{}\cdot\mathllap{\alpha}$`;
       adapter.lastQuotePrefix = "r";
@@ -235,6 +213,11 @@ describe("MarkdownLanguageAdapter", () => {
       expect(adapter.isSupported("mo.md()")).toBe(true);
       expect(adapter.isSupported("mo.md('')")).toBe(true);
       expect(adapter.isSupported('mo.md("")')).toBe(true);
+    });
+
+    it("should return false for unsupported markdown string formats", () => {
+      expect(adapter.isSupported("mo.md(f'hello world')")).toBe(false);
+      expect(adapter.isSupported('mo.md(f"hello world")')).toBe(false);
     });
 
     it("should return false for unsupported string formats", () => {

--- a/frontend/src/core/codemirror/language/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/utils.test.ts
@@ -132,7 +132,8 @@ describe("splitEditor", () => {
     expect(result.afterCursorCode).toEqual('mo.md(" World!")');
   });
 
-  it("handles markdown with variables", () => {
+  // f-strings not currently supported
+  it.skip("handles markdown with variables", () => {
     const mockEditor = createEditor('mo.md(f"""{a}\n{b}!""")');
     // Set to markdown
     switchLanguage(mockEditor, "markdown");

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -32,7 +32,7 @@ const quoteKinds = [
 // f-strings are not yet supported due to bad interactions with
 // string escaping, LaTeX, and loss of Python syntax highlighting
 const pairs = ["", "r"].flatMap((prefix) =>
-  quoteKinds.map(([start, end]) => [prefix + start, end])
+  quoteKinds.map(([start, end]) => [prefix + start, end]),
 );
 
 const regexes = pairs.map(
@@ -41,7 +41,7 @@ const regexes = pairs.map(
     [
       start,
       new RegExp(`^mo\\.md\\(\\s*${start}(.*)${end}\\s*\\)$`, "s"),
-    ] as const
+    ] as const,
 );
 
 /**
@@ -131,7 +131,7 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
 
   getExtension(
     _completionConfig: CompletionConfig,
-    hotkeys: HotkeyProvider
+    hotkeys: HotkeyProvider,
   ): Extension[] {
     return [
       markdown({
@@ -196,7 +196,7 @@ const emojiCompletionSource: CompletionSource = async (context) => {
 // everything works fine, except for autocompletion of emojis
 const getEmojiList = once(async (): Promise<Completion[]> => {
   const emojiList = await fetch(
-    "https://unpkg.com/emojilib@3.0.11/dist/emoji-en-US.json"
+    "https://unpkg.com/emojilib@3.0.11/dist/emoji-en-US.json",
   )
     .then((res) => {
       if (!res.ok) {

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -16,11 +16,7 @@ import { enhancedMarkdownExtension } from "../markdown/extension";
 import { CompletionConfig } from "@/core/config/config-schema";
 import { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { indentOneTab } from "./utils/indentOneTab";
-import {
-  QuotePrefixKind,
-  QUOTE_PREFIX_KINDS,
-  splitQuotePrefix,
-} from "./utils/quotes";
+import { QuotePrefixKind, splitQuotePrefix } from "./utils/quotes";
 
 const quoteKinds = [
   ['"""', '"""'],
@@ -28,9 +24,15 @@ const quoteKinds = [
   ['"', '"'],
   ["'", "'"],
 ];
+
 // explode into all combinations
-const pairs = QUOTE_PREFIX_KINDS.flatMap((prefix) =>
-  quoteKinds.map(([start, end]) => [prefix + start, end]),
+//
+// A note on f-strings:
+//
+// f-strings are not yet supported due to bad interactions with
+// string escaping, LaTeX, and loss of Python syntax highlighting
+const pairs = ["", "r"].flatMap((prefix) =>
+  quoteKinds.map(([start, end]) => [prefix + start, end])
 );
 
 const regexes = pairs.map(
@@ -39,7 +41,7 @@ const regexes = pairs.map(
     [
       start,
       new RegExp(`^mo\\.md\\(\\s*${start}(.*)${end}\\s*\\)$`, "s"),
-    ] as const,
+    ] as const
 );
 
 /**
@@ -89,7 +91,10 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
 
     const isOneLine = !code.includes("\n");
     if (isOneLine) {
-      const escapedCode = code.replaceAll('"', String.raw`\"`);
+      // This logic breaks f-strings:
+      //
+      // https://github.com/marimo-team/marimo/issues/1727
+      const escapedCode = code.replaceAll('"', '\\"');
       const start = `mo.md(${prefix}"`;
       const end = `")`;
       return [start + escapedCode + end, start.length];
@@ -126,7 +131,7 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
 
   getExtension(
     _completionConfig: CompletionConfig,
-    hotkeys: HotkeyProvider,
+    hotkeys: HotkeyProvider
   ): Extension[] {
     return [
       markdown({
@@ -191,7 +196,7 @@ const emojiCompletionSource: CompletionSource = async (context) => {
 // everything works fine, except for autocompletion of emojis
 const getEmojiList = once(async (): Promise<Completion[]> => {
   const emojiList = await fetch(
-    "https://unpkg.com/emojilib@3.0.11/dist/emoji-en-US.json",
+    "https://unpkg.com/emojilib@3.0.11/dist/emoji-en-US.json"
   )
     .then((res) => {
       if (!res.ok) {


### PR DESCRIPTION
There are too many edge cases to handle with f-strings in markdown (latex, escaping rules, syntax highlighting). This change changes the markdown viewer to no longer parse f strings.

Closes #1727  #1684 