### PR TITLE
disable lint keymap

### DIFF
--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -20,7 +20,6 @@ import {
   indentUnit,
   syntaxHighlighting,
 } from "@codemirror/language";
-import { lintKeymap } from "@codemirror/lint";
 import {
   drawSelection,
   dropCursor,

--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -143,7 +143,7 @@ export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
     indentOnInput(),
     indentUnit.of("    "),
     syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-    keymap.of([...foldKeymap, ...lintKeymap]),
+    keymap.of(foldKeymap),
 
     ///// Language Support
     adaptiveLanguageConfiguration(opts),


### PR DESCRIPTION
The lint diagnostic keymap (ctrl-shift-m) interferes with the view as markdown keymap.

I don't think we use the functionality provided by the lint keymap anyway: https://codemirror.net/docs/ref/#lint.lintKeymap

Addresses an issue mentioned in #1737 (markdown keymap not working)