### PR TITLE
Update outdated import of Gcf in mpl.py

### DIFF
--- a/marimo/_output/mpl.py
+++ b/marimo/_output/mpl.py
@@ -17,11 +17,11 @@ import io
 from typing import Optional
 
 import matplotlib.pyplot as plt  # type: ignore
+from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (  # type: ignore
     FigureCanvasBase,
     FigureManagerBase,
 )
-from matplotlib._pylab_helpers import Gcf
 from matplotlib.backends.backend_agg import FigureCanvasAgg  # type: ignore
 
 from marimo._messaging.cell_output import CellChannel

--- a/marimo/_output/mpl.py
+++ b/marimo/_output/mpl.py
@@ -17,7 +17,7 @@ import io
 from typing import Optional
 
 import matplotlib.pyplot as plt  # type: ignore
-from matplotlib._pylab_helpers import Gcf
+from matplotlib._pylab_helpers import Gcf  # type: ignore
 from matplotlib.backend_bases import (  # type: ignore
     FigureCanvasBase,
     FigureManagerBase,

--- a/marimo/_output/mpl.py
+++ b/marimo/_output/mpl.py
@@ -20,8 +20,8 @@ import matplotlib.pyplot as plt  # type: ignore
 from matplotlib.backend_bases import (  # type: ignore
     FigureCanvasBase,
     FigureManagerBase,
-    Gcf,
 )
+from matplotlib._pylab_helpers import Gcf
 from matplotlib.backends.backend_agg import FigureCanvasAgg  # type: ignore
 
 from marimo._messaging.cell_output import CellChannel


### PR DESCRIPTION
## 📝 Summary
Update outdated import of `Gcf` in `mpl.py`

Fixes #1741 

## 🔍 Description of Changes
This pull request addresses an outdated import statement in the `mpl.py` file located in `marimo\_output\mpl.py`. The current import of `Gcf` is from an obsolete location in the Matplotlib library.

Changes made:
- Updated the import statement for `Gcf` to reflect the current Matplotlib structure.

Before:
```python
from matplotlib.backend_bases import Gcf
```

After:
```python
from matplotlib._pylab_helpers import Gcf
```

This change aligns our code with the current Matplotlib implementation, as seen in their [backend_template.py](https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/backends/backend_template.py).

The update resolves potential compatibility issues or errors that could occur when using newer versions of Matplotlib.

## 📋 Checklist
- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers
@akshayka OR @mscolnick