### PR TITLE
Change the copilot server script name

### DIFF
--- a/lsp/index.ts
+++ b/lsp/index.ts
@@ -17,7 +17,10 @@ if (argv.help) {
 let serverPort: number = parseInt(argv.port) || 3000;
 
 let languageServers: Record<string, string[]> = {
-  copilot: ["node", path.join(__dirname, "copilot", "dist", "language-server.js")],
+  copilot: [
+    "node",
+    path.join(__dirname, "copilot", "dist", "language-server.js"),
+  ],
 };
 
 const wss = new WebSocketServer(

--- a/lsp/index.ts
+++ b/lsp/index.ts
@@ -17,7 +17,7 @@ if (argv.help) {
 let serverPort: number = parseInt(argv.port) || 3000;
 
 let languageServers: Record<string, string[]> = {
-  copilot: ["node", path.join(__dirname, "copilot", "dist", "agent.js")],
+  copilot: ["node", path.join(__dirname, "copilot", "dist", "language-server.js")],
 };
 
 const wss = new WebSocketServer(


### PR DESCRIPTION
## 📝 Summary

On enabling Github copilot in a Marimo notebook, the LSP server tries to initialize the Copilot language server. The script to run has since changed, from "agent.js" to "language-server.js". 

Discord discussion - https://discord.com/channels/1059888774789730424/1258708018397184031

## 🔍 Description of Changes

Changed name of the script. Similar change in Rstudio repo - https://github.com/rstudio/rstudio/pull/14808

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
