### PR TITLE
feat: slides

### DIFF
--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -53,12 +53,24 @@ grid to arrange them on the page.
 Enable the grid editor in the app preview, via a dropdown:
 
 <div align="center">
-<figure>
-<blockquote class="twitter-tweet" data-media-max-width="560"><p lang="en" dir="ltr">New feature! Drag-and-drop notebook outputs to build an app using our grid editor.<br><br>Shipping in our next release — stay tuned! <a href="https://t.co/DQpstGAmKh">pic.twitter.com/DQpstGAmKh</a></p>&mdash; marimo (@marimo_io) <a href="https://twitter.com/marimo_io/status/1762595771504116221?ref_src=twsrc%5Etfw">February 27, 2024</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-</figure>
-<figcaption>Grid layout lets you drag and drop outputs to construct your app</figcaption>
+  <figure>
+    <blockquote class="twitter-tweet" data-media-max-width="560">
+      <p lang="en" dir="ltr">
+        <a href="https://t.co/DQpstGAmKh">pic.twitter.com/DQpstGAmKh</a>
+      </p>&mdash; marimo (@marimo_io)
+      <a href="https://twitter.com/marimo_io/status/1762595771504116221?ref_src=twsrc%5Etfw">February 27, 2024</a>
+    </blockquote>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  </figure>
+  <figcaption>Grid layout lets you drag and drop outputs to construct your app</figcaption>
 </div>
 
 marimo saves metadata about your constructed layout in a `layouts` folder;
 make sure to include this folder when sharing your notebook so that others
 can reconstruct your layout.
+
+### Slides layout
+
+If you prefer a slideshow-like experience, you can use the slides layout.
+
+Enable the slides layout in the app preview, via the same dropdown as above.

--- a/frontend/src/components/editor/renderers/layout-select.tsx
+++ b/frontend/src/components/editor/renderers/layout-select.tsx
@@ -10,14 +10,20 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { LayoutType } from "./types";
-import { SquareIcon, Grid3x3Icon, ListIcon } from "lucide-react";
+import {
+  SquareIcon,
+  Grid3x3Icon,
+  ListIcon,
+  PresentationIcon,
+} from "lucide-react";
 import { isPyodide } from "@/core/pyodide/utils";
 import { useLayoutActions, useLayoutState } from "@/core/layout/layout";
+import { logNever } from "@/utils/assertNever";
 
 export const LayoutSelect: React.FC = () => {
   const { selectedLayout } = useLayoutState();
   const { setLayoutView } = useLayoutActions();
-  const layouts: LayoutType[] = ["vertical", "grid"];
+  const layouts: LayoutType[] = ["vertical", "grid", "slides"];
 
   // Layouts are not supported in Pyodide
   if (isPyodide()) {
@@ -59,7 +65,10 @@ function renderIcon(layoutType: LayoutType) {
       return <ListIcon className="h-4 w-4" />;
     case "grid":
       return <Grid3x3Icon className="h-4 w-4" />;
+    case "slides":
+      return <PresentationIcon className="h-4 w-4" />;
     default:
+      logNever(layoutType);
       return <SquareIcon className="h-4 w-4" />;
   }
 }
@@ -70,7 +79,10 @@ function displayName(layoutType: LayoutType) {
       return "Vertical";
     case "grid":
       return "Grid";
+    case "slides":
+      return "Slides";
     default:
+      logNever(layoutType);
       return "Unknown";
   }
 }

--- a/frontend/src/components/editor/renderers/plugins.ts
+++ b/frontend/src/components/editor/renderers/plugins.ts
@@ -3,11 +3,13 @@ import { GridLayoutPlugin } from "./grid-layout/plugin";
 import { ICellRendererPlugin, LayoutType } from "./types";
 import { CellData } from "@/core/cells/types";
 import { VerticalLayoutPlugin } from "./vertical-layout/vertical-layout";
+import { SlidesLayoutPlugin } from "./slides-layout/plugin";
 
 // If more renderers are added, we may want to consider lazy loading them.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const cellRendererPlugins: Array<ICellRendererPlugin<any, any>> = [
   GridLayoutPlugin,
+  SlidesLayoutPlugin,
   VerticalLayoutPlugin,
 ];
 

--- a/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
@@ -1,0 +1,30 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { ICellRendererPlugin } from "../types";
+import { SlidesLayout } from "./types";
+import { z } from "zod";
+import { SlidesLayoutRenderer } from "./slides-layout";
+
+/**
+ * Plugin definition for the slides layout.
+ */
+export const SlidesLayoutPlugin: ICellRendererPlugin<
+  SlidesLayout,
+  SlidesLayout
+> = {
+  type: "slides",
+  name: "Slides",
+
+  validator: z.object({}),
+
+  deserializeLayout: (_serialized, _cells): SlidesLayout => {
+    return {};
+  },
+
+  serializeLayout: (_layout, _cells): SlidesLayout => {
+    return {};
+  },
+
+  Component: SlidesLayoutRenderer,
+
+  getInitialLayout: () => ({}),
+};

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -1,0 +1,73 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import React, { memo } from "react";
+import { ICellRendererProps } from "../types";
+import { SlidesLayout } from "./types";
+
+import { CellId } from "@/core/cells/ids";
+import { CellRuntimeState } from "@/core/cells/types";
+import { AppMode } from "@/core/mode";
+import { OutputArea } from "../../Output";
+
+type Props = ICellRendererProps<SlidesLayout>;
+
+const LazySlidesComponent = React.lazy(
+  () => import("../../../slides/slides-component"),
+);
+
+export const SlidesLayoutRenderer: React.FC<Props> = ({
+  // Currently we don't have layout config
+  // layout,
+  // setLayout,
+  cells,
+  mode,
+}) => {
+  const isReading = mode === "read";
+
+  const slides = (
+    <LazySlidesComponent forceKeyboardNavigation={true}>
+      {cells.map((cell) => {
+        const isOutputEmpty = cell.output == null || cell.output.data === "";
+        if (isOutputEmpty) {
+          return null;
+        }
+        return (
+          <Slide
+            key={cell.id}
+            cellId={cell.id}
+            code={cell.code}
+            status={cell.status}
+            output={cell.output}
+            mode={mode}
+          />
+        );
+      })}
+    </LazySlidesComponent>
+  );
+
+  if (isReading) {
+    return <div className="p-4">{slides}</div>;
+  }
+
+  return <div className="pr-9">{slides}</div>;
+};
+
+interface SlideProps extends Pick<CellRuntimeState, "output" | "status"> {
+  className?: string;
+  code: string;
+  cellId: CellId;
+  mode: AppMode;
+}
+
+const Slide = memo(({ output, cellId, status }: SlideProps) => {
+  const loading = status === "running" || status === "queued";
+  return (
+    <OutputArea
+      className="contents"
+      allowExpand={false}
+      output={output}
+      cellId={cellId}
+      stale={loading}
+    />
+  );
+});
+Slide.displayName = "Slide";

--- a/frontend/src/components/editor/renderers/slides-layout/types.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/types.ts
@@ -1,0 +1,14 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+/**
+ * The serialized form of a slides layout.
+ * This must be backwards-compatible as it is stored on the user's disk.
+ */
+export interface SerializedSlidesLayout {
+  // No additional properties for now
+}
+
+export interface SlidesLayout extends SerializedSlidesLayout {
+  // No additional properties for now
+}

--- a/frontend/src/components/editor/renderers/types.ts
+++ b/frontend/src/components/editor/renderers/types.ts
@@ -36,7 +36,7 @@ export interface ICellRendererProps<L> {
   setLayout: (layout: L) => void;
 }
 
-export type LayoutType = "grid" | "vertical";
+export type LayoutType = "grid" | "vertical" | "slides";
 
 /**
  * A cell renderer plugin.

--- a/frontend/src/components/slides/slides-component.tsx
+++ b/frontend/src/components/slides/slides-component.tsx
@@ -1,7 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import "./carousel.css";
-
 import React, { PropsWithChildren, useEffect } from "react";
 import { Swiper, SwiperSlide, SwiperRef } from "swiper/react";
 import {
@@ -15,14 +13,27 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/utils/cn";
 import { useEventListener } from "@/hooks/useEventListener";
 
-interface CarouselComponentProps {
+import "./slides.css";
+import "swiper/css";
+import "swiper/css/virtual";
+import "swiper/css/keyboard";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import "swiper/css/scrollbar";
+
+interface SlidesComponentProps {
+  className?: string;
+  forceKeyboardNavigation?: boolean;
   index?: string | null;
   height?: string | number | null;
 }
-const CarouselComponent = ({
+
+const SlidesComponent = ({
+  className,
   children,
   height,
-}: PropsWithChildren<CarouselComponentProps>): JSX.Element => {
+  forceKeyboardNavigation = false,
+}: PropsWithChildren<SlidesComponentProps>): JSX.Element => {
   const el = React.useRef<SwiperRef>(null);
   const [isFullscreen, setIsFullscreen] = React.useState(false);
 
@@ -44,7 +55,10 @@ const CarouselComponent = ({
   return (
     <Swiper
       ref={el}
-      className="relative w-full border rounded bg-background mo-carousel"
+      className={cn(
+        "relative w-full border rounded bg-background mo-slides-theme",
+        className,
+      )}
       spaceBetween={50}
       style={{
         height: isFullscreen ? "100%" : height || "550px",
@@ -58,7 +72,7 @@ const CarouselComponent = ({
       simulateTouch={false}
       keyboard={{
         // Only enable keyboard controls when in fullscreen
-        enabled: isFullscreen,
+        enabled: isFullscreen || forceKeyboardNavigation,
       }}
       navigation={true}
       pagination={{
@@ -67,6 +81,9 @@ const CarouselComponent = ({
       virtual={true}
     >
       {React.Children.map(children, (child, index) => {
+        if (child == null) {
+          return null;
+        }
         return (
           <SwiperSlide key={index}>
             <div
@@ -92,7 +109,7 @@ const CarouselComponent = ({
       <Button
         variant="link"
         size="sm"
-        data-testid="marimo-plugin-carousel-fullscreen"
+        data-testid="marimo-plugin-slides-fullscreen"
         onClick={async () => {
           if (!el.current) {
             return;
@@ -115,4 +132,4 @@ const CarouselComponent = ({
   );
 };
 
-export default CarouselComponent;
+export default SlidesComponent;

--- a/frontend/src/components/slides/slides.css
+++ b/frontend/src/components/slides/slides.css
@@ -1,4 +1,4 @@
-.mo-carousel {
+.mo-slides-theme {
   --swiper-theme-color: hsl(var(--primary));
   --swiper-pagination-color: var(--swiper-theme-color);
   --swiper-pagination-left: auto;
@@ -17,6 +17,30 @@
   --swiper-pagination-bullet-opacity: 1;
   --swiper-pagination-bullet-horizontal-gap: 4px;
   --swiper-pagination-bullet-vertical-gap: 6px;
+
+  .swiper-button-prev,
+  .swiper-button-next {
+    height: 100%;
+    top: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.1);
+    opacity: 0;
+    padding: 0 15px;
+    transition: opacity 0.3s;
+    font-weight: 900;
+    margin-top: 0;
+
+    --swiper-navigation-sides-offset: 0;
+    --swiper-navigation-size: 20px;
+
+    &.swiper-button-disabled {
+      opacity: 0;
+    }
+
+    &:hover:not(.swiper-button-disabled) {
+      opacity: 1;
+    }
+  }
 }
 
 @font-face {
@@ -24,28 +48,4 @@
   src: url("data:application/font-woff;charset=utf-8;base64, d09GRgABAAAAAAZgABAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAAGRAAAABoAAAAci6qHkUdERUYAAAWgAAAAIwAAACQAYABXR1BPUwAABhQAAAAuAAAANuAY7+xHU1VCAAAFxAAAAFAAAABm2fPczU9TLzIAAAHcAAAASgAAAGBP9V5RY21hcAAAAkQAAACIAAABYt6F0cBjdnQgAAACzAAAAAQAAAAEABEBRGdhc3AAAAWYAAAACAAAAAj//wADZ2x5ZgAAAywAAADMAAAD2MHtryVoZWFkAAABbAAAADAAAAA2E2+eoWhoZWEAAAGcAAAAHwAAACQC9gDzaG10eAAAAigAAAAZAAAArgJkABFsb2NhAAAC0AAAAFoAAABaFQAUGG1heHAAAAG8AAAAHwAAACAAcABAbmFtZQAAA/gAAAE5AAACXvFdBwlwb3N0AAAFNAAAAGIAAACE5s74hXjaY2BkYGAAYpf5Hu/j+W2+MnAzMYDAzaX6QjD6/4//Bxj5GA8AuRwMYGkAPywL13jaY2BkYGA88P8Agx4j+/8fQDYfA1AEBWgDAIB2BOoAeNpjYGRgYNBh4GdgYgABEMnIABJzYNADCQAACWgAsQB42mNgYfzCOIGBlYGB0YcxjYGBwR1Kf2WQZGhhYGBiYGVmgAFGBiQQkOaawtDAoMBQxXjg/wEGPcYDDA4wNUA2CCgwsAAAO4EL6gAAeNpj2M0gyAACqxgGNWBkZ2D4/wMA+xkDdgAAAHjaY2BgYGaAYBkGRgYQiAHyGMF8FgYHIM3DwMHABGQrMOgyWDLEM1T9/w8UBfEMgLzE////P/5//f/V/xv+r4eaAAeMbAxwIUYmIMHEgKYAYjUcsDAwsLKxc3BycfPw8jEQA/gZBASFhEVExcQlJKWkZWTl5BUUlZRVVNXUNTQZBgMAAMR+E+gAEQFEAAAAKgAqACoANAA+AEgAUgBcAGYAcAB6AIQAjgCYAKIArAC2AMAAygDUAN4A6ADyAPwBBgEQARoBJAEuATgBQgFMAVYBYAFqAXQBfgGIAZIBnAGmAbIBzgHsAAB42u2NMQ6CUAyGW568x9AneYYgm4MJbhKFaExIOAVX8ApewSt4Bic4AfeAid3VOBixDxfPYEza5O+Xfi04YADggiUIULCuEJK8VhO4bSvpdnktHI5QCYtdi2sl8ZnXaHlqUrNKzdKcT8cjlq+rwZSvIVczNiezsfnP/uznmfPFBNODM2K7MTQ45YEAZqGP81AmGGcF3iPqOop0r1SPTaTbVkfUe4HXj97wYE+yNwWYxwWu4v1ugWHgo3S1XdZEVqWM7ET0cfnLGxWfkgR42o2PvWrDMBSFj/IHLaF0zKjRgdiVMwScNRAoWUoH78Y2icB/yIY09An6AH2Bdu/UB+yxopYshQiEvnvu0dURgDt8QeC8PDw7Fpji3fEA4z/PEJ6YOB5hKh4dj3EvXhxPqH/SKUY3rJ7srZ4FZnh1PMAtPhwP6fl2PMJMPDgeQ4rY8YT6Gzao0eAEA409DuggmTnFnOcSCiEiLMgxCiTI6Cq5DZUd3Qmp10vO0LaLTd2cjN4fOumlc7lUYbSQcZFkutRG7g6JKZKy0RmdLY680CDnEJ+UMkpFFe1RN7nxdVpXrC4aTtnaurOnYercZg2YVmLN/d/gczfEimrE/fs/bOuq29Zmn8tloORaXgZgGa78yO9/cnXm2BpaGvq25Dv9S4E9+5SIc9PqupJKhYFSSl47+Qcr1mYNAAAAeNptw0cKwkAAAMDZJA8Q7OUJvkLsPfZ6zFVERPy8qHh2YER+3i/BP83vIBLLySsoKimrqKqpa2hp6+jq6RsYGhmbmJqZSy0sraxtbO3sHRydnEMU4uR6yx7JJXveP7WrDycAAAAAAAH//wACeNpjYGRgYOABYhkgZgJCZgZNBkYGLQZtIJsFLMYAAAw3ALgAeNolizEKgDAQBCchRbC2sFER0YD6qVQiBCv/H9ezGI6Z5XBAw8CBK/m5iQQVauVbXLnOrMZv2oLdKFa8Pjuru2hJzGabmOSLzNMzvutpB3N42mNgZGBg4GKQYzBhYMxJLMlj4GBgAYow/P/PAJJhLM6sSoWKfWCAAwDAjgbRAAB42mNgYGBkAIIbCZo5IPrmUn0hGA0AO8EFTQAA");
   font-weight: 400;
   font-style: normal;
-}
-
-.swiper-button-prev,
-.swiper-button-next {
-  height: 100%;
-  top: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.1);
-  opacity: 0;
-  padding: 0 15px;
-  transition: opacity 0.3s;
-  font-weight: 900;
-  margin-top: 0;
-
-  --swiper-navigation-sides-offset: 0;
-  --swiper-navigation-size: 20px;
-
-  &.swiper-button-disabled {
-    opacity: 0;
-  }
-
-  &:hover:not(.swiper-button-disabled) {
-    opacity: 1;
-  }
 }

--- a/frontend/src/plugins/layout/carousel/CarouselPlugin.tsx
+++ b/frontend/src/plugins/layout/carousel/CarouselPlugin.tsx
@@ -38,11 +38,13 @@ export class CarouselPlugin implements IStatelessPlugin<Data> {
 
   render(props: IStatelessPluginProps<Data>): JSX.Element {
     return (
-      <LazyCarouselComponent {...props.data}>
+      <LazySlidesComponent {...props.data}>
         {props.children}
-      </LazyCarouselComponent>
+      </LazySlidesComponent>
     );
   }
 }
 
-const LazyCarouselComponent = React.lazy(() => import("./CarouselComponent"));
+const LazySlidesComponent = React.lazy(
+  () => import("../../../components/slides/slides-component"),
+);

--- a/marimo/_smoke_tests/layouts/slides.slides.json
+++ b/marimo/_smoke_tests/layouts/slides.slides.json
@@ -1,0 +1,4 @@
+{
+  "type": "slides",
+  "data": {}
+}

--- a/marimo/_smoke_tests/slides.py
+++ b/marimo/_smoke_tests/slides.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Marimo. All rights reserved.
+
+import marimo
+
+__generated_with = "0.7.1"
+app = marimo.App(layout_file="layouts/slides.slides.json")
+
+
+@app.cell
+def __(mo):
+    mo.md("# A Presentation on Iris Data")
+    return
+
+
+@app.cell
+def __():
+    "By the marimo team"
+    return
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import pandas as pd
+    import altair as alt
+    return alt, mo, pd
+
+
+@app.cell
+def __(pd):
+    df = pd.read_csv(
+        "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv"
+    )
+    return df,
+
+
+@app.cell
+def __(df, mo):
+    table = mo.ui.table(df, label="Iris Data in a table")
+    table
+    return table,
+
+
+@app.cell
+def __(alt, df, mo):
+    chart = mo.ui.altair_chart(
+        alt.Chart(df)
+        .mark_point()
+        .encode(x="sepal_length", y="sepal_width", color="species"),
+        label="Iris Data in chart",
+    )
+    chart
+    return chart,
+
+
+@app.cell
+def __(mo):
+    mo.md("# Thank you!")
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
This PR adds Slides as a layout plugin. Code was fairly small given the abstractions of the `LayoutRenderer` and the already existing `mo.carousel` ui element. 

```
marimo run marimo/_smoke_tests/slides.py
marimo edit marimo/_smoke_tests/slides.py
```