### PR TITLE
fix: treat special variable "__" as local variable

### DIFF
--- a/marimo/_utils/variables.py
+++ b/marimo/_utils/variables.py
@@ -12,4 +12,4 @@ def is_mangled_local(name: str, cell_id: CellId_t) -> bool:
 
 
 def is_local(name: str) -> bool:
-    return name.startswith("_") and not name.startswith("__")
+    return name == "__" or (name.startswith("_") and not name.startswith("__"))

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -276,6 +276,25 @@ class TestApp:
         app.run()
 
     @staticmethod
+    def test_dunder_rewritten_as_local() -> None:
+        app = App()
+
+        @app.cell
+        def _() -> None:
+            __ = 1  # noqa: F841
+            return
+
+        @app.cell
+        def _() -> None:
+            __  # type: ignore
+            return
+
+        with pytest.raises(NameError) as e:
+            app.run()
+
+        assert "'__' is not defined" in str(e.value)
+
+    @staticmethod
     def test_app_width_config() -> None:
         app = App(width="full")
         assert app._config.width == "full"


### PR DESCRIPTION
## 📝 Summary

<!-- 
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123). 
-->

Fixes #1675 

## 🔍 Description of Changes

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

This change has the method `is_local` returning true for the special variable name `__`.

Here is a screenshot showing that `__` is treated as a local variable. It can be redefined across multiple cells, but it cannot be referenced as if it were a global variable.

![Screenshot from 2024-07-09 23-12-06](https://github.com/marimo-team/marimo/assets/82607723/cdfc0e83-bfbf-4757-9207-5e1f98e92825)

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] ~For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).~
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@dmadisetti
