### PR TITLE
feat: prioritize ruff over black in formatter, requirements, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ statically analyzing your code.
 prevent them from automatically running, or configure the runtime to be
 lazy and mark affected stales as stale instead of automatically running them.
 
-**Batteries-included.** marimo comes with GitHub Copilot, Black code
+**Batteries-included.** marimo comes with GitHub Copilot, Ruff code
 formatting, HTML export, fast code completion, a [VS Code
 extension](https://marketplace.visualstudio.com/items?itemName=marimo-team.vscode-marimo),
 and many more quality-of-life features.

--- a/frontend/public/files/wasm-intro.py
+++ b/frontend/public/files/wasm-intro.py
@@ -463,8 +463,8 @@ def __():
         ),
         "Code Formatting": (
             """
-            If you have [black](https://github.com/psf/black) installed, you can format a cell with
-            the keyboard shortcut `Ctrl/Cmd+b`.
+            If you have [ruff](https://github.com/astral-sh/ruff) installed,
+            you can format a cell with the keyboard shortcut `Ctrl/Cmd+b`.
             """
         ),
         "Command Palette": (

--- a/marimo/_tutorials/fileformat.py
+++ b/marimo/_tutorials/fileformat.py
@@ -195,7 +195,7 @@ def __():
         the generated code. For example, whitespace, line breaks, and so on are
         all preserved exactly. This means that you can touch up formatting in
         your text editor, either manually or using automated formatters like 
-        Black, and be confident that your changes will be preserved.
+        Ruff, and be confident that your changes will be preserved.
         """,
         "Cell functions can have names": """
         If you want to, you can replace the default names for cell functions 

--- a/marimo/_tutorials/intro.py
+++ b/marimo/_tutorials/intro.py
@@ -436,8 +436,8 @@ def __():
         ),
         "Code Formatting": (
             """
-            If you have [black](https://github.com/psf/black) installed, you can format a cell with
-            the keyboard shortcut `Ctrl/Cmd+b`.
+            If you have [ruff](https://github.com/astral-sh/ruff) installed,
+            you can format a cell with the keyboard shortcut `Ctrl/Cmd+b`.
             """
         ),
         "Command Palette": (

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -22,24 +22,32 @@ class Formatter:
 
 class DefaultFormatter(Formatter):
     """
-    Tries black, then ruff, then no formatting.
+    Tries ruff, then black, then no formatting.
     """
 
     def format(self, codes: CellCodes) -> CellCodes:
-        if DependencyManager.has("black"):
-            return BlackFormatter(self.line_length).format(codes)
-        elif DependencyManager.has("ruff"):
+        if DependencyManager.has("ruff"):
             return RuffFormatter(self.line_length).format(codes)
+        elif DependencyManager.has("black"):
+            return BlackFormatter(self.line_length).format(codes)
         else:
             LOGGER.warning(
-                "To enable code formatting, install black (pip install black) "
-                "or ruff (pip install ruff)"
+                "To enable code formatting, install ruff (pip install ruff) "
+                "or black (pip install black)"
             )
             return {}
 
 
 class RuffFormatter(Formatter):
     def format(self, codes: CellCodes) -> CellCodes:
+        try:
+            process = subprocess.run("ruff", capture_output=True)
+        except FileNotFoundError:
+            LOGGER.warning(
+                "To enable code formatting, install ruff (pip install ruff)"
+            )
+            return {}
+
         formatted_codes: CellCodes = {}
         for key, code in codes.items():
             try:
@@ -74,7 +82,8 @@ class BlackFormatter(Formatter):
             import black
         except ModuleNotFoundError:
             LOGGER.warning(
-                "To enable code formatting, install black (pip install black)"
+                "To enable code formatting, install ruff (pip install ruff) "
+                "or black (pip install black)"
             )
             return {}
 

--- a/marimo/_utils/health.py
+++ b/marimo/_utils/health.py
@@ -36,7 +36,7 @@ def get_required_modules_list() -> dict[str, str]:
         "starlette",
         "websockets",
         "typing-extensions",
-        "black",
+        "ruff",
     ]
 
     package_versions: dict[str, str] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "itsdangerous>=2.0.0",
     # for cell formatting; if user version is not compatible, no-op
     # so no lower bound needed
-    "black",
+    "ruff",
 ]
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## 📝 Summary

prioritize ruff over black in formatter, requirements, and documentation

## 🔍 Description of Changes

as discussed in this [discord thread](https://discord.com/channels/1059888774789730424/1260236862862266564), changes were made to prioritize ruff over black.

- ecd1279fb85eee7c4bbfd9b4dbce79dbd4a17d12 `formatter.py` prefers ruff over black. warnings updated to reflect this.
- 7d01256a79af5c42016482973e4e504251ca101e ruff required instead of black
- a3747e22e58a9d17ee18a3cf8dd61a91633a9e20 readme and tutorials mention ruff instead of black

tested changes with environments ± ruff and ± black, and an editable install and custom ruff configuration.

### ♾️ Limitations 

`marimo/_utils/format_signature.py` and `frontend/src/core/pyodide/worker/worker.ts` not updated

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
