### PR TITLE
fix: patching vegaloader when rendering static content

### DIFF
--- a/frontend/src/core/static/__tests__/files.test.ts
+++ b/frontend/src/core/static/__tests__/files.test.ts
@@ -70,9 +70,9 @@ describe("patchVegaLoader", () => {
     };
 
     const loader = createLoader();
-    patchVegaLoader(loader, virtualFiles);
-
+    const unpatch = patchVegaLoader(loader, virtualFiles);
     const content = await loader.http("virtual-file.json");
+    unpatch();
     expect(content).toBe('{"key": "value"}');
   });
 
@@ -84,5 +84,15 @@ describe("patchVegaLoader", () => {
     unpatch(); // Restore the original http function
 
     expect(content).toBe("Remote content");
+  });
+
+  it("should work with data URIs", async () => {
+    const loader = createLoader();
+    const unpatch = patchVegaLoader(loader, {});
+    const content = await loader.http(
+      "data:application/json;base64,eyJrZXkiOiAidmFsdWUifQ==",
+    );
+    unpatch();
+    expect(content).toBe('{"key": "value"}');
   });
 });

--- a/frontend/src/core/static/files.ts
+++ b/frontend/src/core/static/files.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { StaticVirtualFiles } from "./types";
+import type { StaticVirtualFiles } from "./types";
 import { deserializeBlob } from "@/utils/blob";
 import { getStaticVirtualFiles } from "./static-state";
 
@@ -45,7 +45,8 @@ export function patchVegaLoader(
   },
   files: StaticVirtualFiles = getStaticVirtualFiles(),
 ) {
-  const originalHttp = loader.http;
+  // const originalHttp = loader.http.bind(loader);
+  const originalHttp = loader.http.bind(loader);
 
   loader.http = async (url: string) => {
     if (files[url]) {

--- a/frontend/src/plugins/impl/vega/vega-loader.ts
+++ b/frontend/src/plugins/impl/vega/vega-loader.ts
@@ -1,8 +1,8 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 // @ts-expect-error - no types
 import * as vl from "vega-loader";
-import { DataFormat } from "./types";
-import { DataType } from "@/core/kernel/messages";
+import type { DataFormat } from "./types";
+import type { DataType } from "@/core/kernel/messages";
 
 // Re-export the vega-loader functions to add TypeScript types
 


### PR DESCRIPTION
Fixes #1768

fix: patching vegaloader when rendering static content.

Was missing a `.bind` which fails for http calls and handle when it fails with for data-uris