### PR TITLE
docs: fix example for marimo.ui.file_browser

### DIFF
--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -1295,13 +1295,15 @@ class file_browser(UIElement[List[Dict[str, Any]], Sequence[FileInfo]]):
     Selecting multiple files:
 
     ```python
-    file_browser = mo.ui.file_browser(path="path/to/dir", multiple=True)
+    file_browser = mo.ui.file_browser(
+        initial_path="path/to/dir", multiple=True
+    )
 
     # Access the selected file path(s):
-    file_browser.value[index]
-
-    # Or:
     file_browser.path(index)
+
+    # Get name of selected file(s)
+    file_browser.name(index)
     ```
 
     **Attributes.**


### PR DESCRIPTION
## 📝 Summary

Small changes to update documentation of `marimo.ui.file_browser()`.

Fixes #1752 

## 🔍 Description of Changes

In addition to the wrong name of the argument (that was `path` instead of `initial_path`), I noticed that the other examples were not accurate: `file_browser.value[index]` does not return the path of the selected file, but a `FileInfo` object. Given that its attributes are not so useful, I have proposed to give instead a second example using another dedicated method of the `file_browser` class.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
