### PR TITLE
improvement: support AnyWidget.send, mosaic_widget example

### DIFF
--- a/frontend/src/core/dom/events.ts
+++ b/frontend/src/core/dom/events.ts
@@ -1,22 +1,53 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { UIElementId } from "../cells/ids";
+import type { UIElementId } from "../cells/ids";
+
+export function defineCustomEvent<T extends string>(eventName: T) {
+  return <D>() => ({
+    TYPE: eventName,
+    is(event: Event): event is CustomEvent<D> {
+      return event.type === eventName;
+    },
+    create(init: CustomEventInit<D>) {
+      return new CustomEvent(eventName, init);
+    },
+  });
+}
 
 export type ValueType = unknown;
 
-export type MarimoValueInputEventType = CustomEvent<{
+export const MarimoValueInputEvent = defineCustomEvent("marimo-value-input")<{
   value: ValueType;
   element: HTMLElement;
-}>;
-export const marimoValueInputEvent = "marimo-value-input";
+}>();
+export type MarimoValueInputEventType = ReturnType<
+  typeof MarimoValueInputEvent.create
+>;
 
-export type MarimoValueUpdateEventType = CustomEvent<{
+export const MarimoValueUpdateEvent = defineCustomEvent("marimo-value-update")<{
   value: ValueType;
   element: HTMLElement;
-}>;
-export const marimoValueUpdateEvent = "marimo-value-update";
+}>();
+export type MarimoValueUpdateEventType = ReturnType<
+  typeof MarimoValueUpdateEvent.create
+>;
 
-export type MarimoValueReadyEventType = CustomEvent<{ objectId: UIElementId }>;
-export const marimoValueReadyEvent = "marimo-value-ready";
+export const MarimoValueReadyEvent = defineCustomEvent("marimo-value-ready")<{
+  objectId: UIElementId;
+}>();
+export type MarimoValueReadyEventType = ReturnType<
+  typeof MarimoValueReadyEvent.create
+>;
+
+export const MarimoIncomingMessageEvent = defineCustomEvent(
+  "marimo-incoming-message",
+)<{
+  objectId: UIElementId;
+  message: unknown;
+  buffers: DataView[] | undefined;
+}>();
+export type MarimoIncomingMessageEventType = ReturnType<
+  typeof MarimoIncomingMessageEvent.create
+>;
 
 /**
  * Create a custom event to communicate a change in value
@@ -38,7 +69,7 @@ export function createInputEvent(
   value: ValueType,
   element: HTMLElement,
 ): MarimoValueInputEventType {
-  return new CustomEvent(marimoValueInputEvent, {
+  return MarimoValueInputEvent.create({
     bubbles: true, // bubble to tell marimo that a value has changed
     composed: true,
     detail: { value: value, element: element },
@@ -48,14 +79,16 @@ export function createInputEvent(
 // Augment the global namespace to include the custom events
 declare global {
   interface HTMLElementEventMap {
-    "marimo-value-input": MarimoValueInputEventType;
-    "marimo-value-update": MarimoValueUpdateEventType;
-    "marimo-value-ready": MarimoValueReadyEventType;
+    [MarimoValueInputEvent.TYPE]: MarimoValueInputEventType;
+    [MarimoValueUpdateEvent.TYPE]: MarimoValueUpdateEventType;
+    [MarimoValueReadyEvent.TYPE]: MarimoValueReadyEventType;
+    [MarimoIncomingMessageEvent.TYPE]: MarimoIncomingMessageEventType;
   }
 
   interface DocumentEventMap {
-    "marimo-value-input": MarimoValueInputEventType;
-    "marimo-value-update": MarimoValueUpdateEventType;
-    "marimo-value-ready": MarimoValueReadyEventType;
+    [MarimoValueInputEvent.TYPE]: MarimoValueInputEventType;
+    [MarimoValueUpdateEvent.TYPE]: MarimoValueUpdateEventType;
+    [MarimoValueReadyEvent.TYPE]: MarimoValueReadyEventType;
+    [MarimoIncomingMessageEvent.TYPE]: MarimoIncomingMessageEventType;
   }
 }

--- a/frontend/src/core/dom/ui-element.ts
+++ b/frontend/src/core/dom/ui-element.ts
@@ -4,7 +4,10 @@ import { Logger } from "../../utils/Logger";
 import { Functions } from "../../utils/functions";
 import { UIElementId } from "../cells/ids";
 import { defineCustomElement } from "./defineCustomElement";
-import { MarimoValueInputEventType, marimoValueInputEvent } from "./events";
+import {
+  MarimoValueInputEvent,
+  type MarimoValueInputEventType,
+} from "./events";
 import { UI_ELEMENT_REGISTRY } from "./uiregistry";
 
 import "./ui-element.css";
@@ -68,11 +71,11 @@ export function initializeUIElement() {
    * COMMUNICATION
    * Communication between marimo and the child of a UIElement is facilitated
    * by two events:
-   *   1. marimoValueInputEvent: the child publishes its value by dispatching
-   *      a marimoValueInputEvent, with `detail` set to
+   *   1. MarimoValueInputEvent: the child publishes its value by dispatching
+   *      a MarimoValueInputEvent, with `detail` set to
    *      `{ value: <the new value> }`;
-   *   2. marimoValueUpdateEvent: the UIElement node broadcasts a
-   *      marimoValueUpdateEvent to every element registered under its
+   *   2. MarimoValueUpdateEvent: the UIElement node broadcasts a
+   *      MarimoValueUpdateEvent to every element registered under its
    *      objectId when a new value is available; the targets of these
    *      events (i.e., the child node of each UIElement in the equivalence
    *      class of the objectId) are responsible for listening to these
@@ -136,14 +139,20 @@ export function initializeUIElement() {
 
         // Listen to marimo input events provided by the child element: these
         // events are signals to this UIElement that our value should change.
-        document.addEventListener(marimoValueInputEvent, this.inputListener);
+        document.addEventListener(
+          MarimoValueInputEvent.TYPE,
+          this.inputListener,
+        );
       }
     }
 
     disconnectedCallback() {
       if (this.initialized) {
         // Unregister everything
-        document.removeEventListener(marimoValueInputEvent, this.inputListener);
+        document.removeEventListener(
+          MarimoValueInputEvent.TYPE,
+          this.inputListener,
+        );
         const objectId = UIElementId.parseOrThrow(this);
         UI_ELEMENT_REGISTRY.removeInstance(
           objectId,

--- a/frontend/src/core/islands/main.ts
+++ b/frontend/src/core/islands/main.ts
@@ -27,7 +27,9 @@ import { defineCustomElement } from "../dom/defineCustomElement";
 import { MarimoIslandElement } from "./components/web-components";
 import { RuntimeState } from "../kernel/RuntimeState";
 import { sendComponentValues } from "../network/requests";
-import { RequestId } from "../network/DeferredRequestRegistry";
+import type { RequestId } from "../network/DeferredRequestRegistry";
+import { UI_ELEMENT_REGISTRY } from "../dom/uiregistry";
+import type { UIElementId } from "../cells/ids";
 
 /**
  * Main entry point for the js bundle for embedded marimo apps.
@@ -93,6 +95,14 @@ export async function initialize() {
         return;
       case "interrupted":
         return;
+      case "send-ui-element-message":
+        UI_ELEMENT_REGISTRY.broadcastMessage(
+          msg.data.ui_element as UIElementId,
+          msg.data.message,
+          msg.data.buffers,
+        );
+        return;
+
       case "remove-ui-elements":
         handleRemoveUIElements(msg.data);
         return;

--- a/frontend/src/core/kernel/RuntimeState.ts
+++ b/frontend/src/core/kernel/RuntimeState.ts
@@ -1,10 +1,10 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import {
-  marimoValueReadyEvent,
-  MarimoValueReadyEventType,
+  MarimoValueReadyEvent,
+  type MarimoValueReadyEventType,
 } from "../dom/events";
-import { UI_ELEMENT_REGISTRY, UIElementRegistry } from "../dom/uiregistry";
-import { RunRequests } from "../network/types";
+import { UI_ELEMENT_REGISTRY, type UIElementRegistry } from "../dom/uiregistry";
+import type { RunRequests } from "../network/types";
 import { Logger } from "@/utils/Logger";
 
 /**
@@ -47,7 +47,10 @@ export class RuntimeState {
       return;
     }
     this._sendComponentValues = sendComponentValues;
-    document.addEventListener(marimoValueReadyEvent, this.handleReadyEvent);
+    document.addEventListener(
+      MarimoValueReadyEvent.TYPE,
+      this.handleReadyEvent,
+    );
     this.hasStarted = true;
   }
 
@@ -59,7 +62,10 @@ export class RuntimeState {
       Logger.warn("RuntimeState already stopped");
       return;
     }
-    document.removeEventListener(marimoValueReadyEvent, this.handleReadyEvent);
+    document.removeEventListener(
+      MarimoValueReadyEvent.TYPE,
+      this.handleReadyEvent,
+    );
     this.hasStarted = false;
   }
 

--- a/frontend/src/core/kernel/__tests__/RuntimeState.test.ts
+++ b/frontend/src/core/kernel/__tests__/RuntimeState.test.ts
@@ -1,9 +1,16 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { marimoValueReadyEvent } from "@/core/dom/events";
 import { UIElementRegistry } from "@/core/dom/uiregistry";
-import { describe, beforeEach, expect, vi, test, MockedFunction } from "vitest";
+import {
+  describe,
+  beforeEach,
+  expect,
+  vi,
+  test,
+  type MockedFunction,
+} from "vitest";
 import { RuntimeState } from "../RuntimeState";
-import { RunRequests } from "@/core/network/types";
+import type { RunRequests } from "@/core/network/types";
+import { MarimoValueReadyEvent } from "@/core/dom/events";
 
 const addEventListenerSpy = vi.spyOn(document, "addEventListener");
 const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
@@ -27,7 +34,7 @@ describe("RuntimeState", () => {
   test("start should register event listener", () => {
     runtimeState.start(mockSendComponentValues);
     expect(addEventListenerSpy).toHaveBeenCalledWith(
-      marimoValueReadyEvent,
+      MarimoValueReadyEvent.TYPE,
       expect.any(Function),
     );
   });
@@ -42,7 +49,7 @@ describe("RuntimeState", () => {
     runtimeState.start(mockSendComponentValues);
     runtimeState.stop();
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
-      marimoValueReadyEvent,
+      MarimoValueReadyEvent.TYPE,
       expect.any(Function),
     );
   });

--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -32,12 +32,13 @@ import {
 import { queryParamHandlers } from "../kernel/queryParamHandlers";
 import type { JsonString } from "@/utils/json/base64";
 import { useDatasetsActions } from "../datasets/state";
-import { RequestId } from "../network/DeferredRequestRegistry";
-import { VariableName } from "../variables/types";
-import { CellId } from "../cells/ids";
+import type { RequestId } from "../network/DeferredRequestRegistry";
+import type { VariableName } from "../variables/types";
+import type { CellId, UIElementId } from "../cells/ids";
 import { kioskModeAtom } from "../mode";
 import { focusAndScrollCellOutputIntoView } from "../cells/scrollCellIntoView";
 import { capabilitiesAtom } from "../config/capabilities";
+import { UI_ELEMENT_REGISTRY } from "../dom/uiregistry";
 
 /**
  * WebSocket that connects to the Marimo kernel and handles incoming messages.
@@ -85,6 +86,14 @@ export function useMarimoWebSocket(opts: {
       case "completed-run":
         return;
       case "interrupted":
+        return;
+
+      case "send-ui-element-message":
+        UI_ELEMENT_REGISTRY.broadcastMessage(
+          msg.data.ui_element as UIElementId,
+          msg.data.message,
+          msg.data.buffers,
+        );
         return;
 
       case "remove-ui-elements":

--- a/frontend/src/plugins/impl/DictPlugin.tsx
+++ b/frontend/src/plugins/impl/DictPlugin.tsx
@@ -4,10 +4,10 @@ import { z } from "zod";
 
 import { getUIElementObjectId } from "../../core/dom/ui-element";
 import {
-  marimoValueInputEvent,
-  MarimoValueInputEventType,
+  MarimoValueInputEvent,
+  type MarimoValueInputEventType,
 } from "../../core/dom/events";
-import { IPlugin, IPluginProps, Setter } from "../types";
+import type { IPlugin, IPluginProps, Setter } from "../types";
 
 // key => value updates
 type T = Record<string, unknown> | null;
@@ -71,9 +71,9 @@ const Dict = ({
         return nextValue;
       });
     };
-    document.addEventListener(marimoValueInputEvent, handleUpdate);
+    document.addEventListener(MarimoValueInputEvent.TYPE, handleUpdate);
     return () => {
-      document.removeEventListener(marimoValueInputEvent, handleUpdate);
+      document.removeEventListener(MarimoValueInputEvent.TYPE, handleUpdate);
     };
   }, [elementIds, setValue]);
 

--- a/frontend/src/plugins/impl/FormPlugin.tsx
+++ b/frontend/src/plugins/impl/FormPlugin.tsx
@@ -4,10 +4,10 @@ import { z } from "zod";
 
 import { getUIElementObjectId, isUIElement } from "../../core/dom/ui-element";
 import {
-  marimoValueInputEvent,
-  MarimoValueInputEventType,
+  MarimoValueInputEvent,
+  type MarimoValueInputEventType,
 } from "@/core/dom/events";
-import { Setter } from "../types";
+import type { Setter } from "../types";
 import { Button } from "../../components/ui/button";
 import { UI_ELEMENT_REGISTRY } from "@/core/dom/uiregistry";
 import { cn } from "../../utils/cn";
@@ -247,9 +247,9 @@ const Form = ({
         setInternalValue(e.detail.value);
       }
     };
-    document.addEventListener(marimoValueInputEvent, handleUpdate);
+    document.addEventListener(MarimoValueInputEvent.TYPE, handleUpdate);
     return () => {
-      document.removeEventListener(marimoValueInputEvent, handleUpdate);
+      document.removeEventListener(MarimoValueInputEvent.TYPE, handleUpdate);
     };
   }, [elementId, setValue]);
 

--- a/frontend/src/plugins/impl/anywidget/types.ts
+++ b/frontend/src/plugins/impl/anywidget/types.ts
@@ -1,0 +1,38 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Copied from https://github.com/manzt/anywidget/blob/main/packages/types/index.ts
+// with slight modifications
+// - removed widget_manager
+
+export type EventHandler = (...args: any[]) => void;
+type ObjectHash = Record<string, any>;
+export type ChangeEventHandler<Payload> = (_: unknown, value: Payload) => void;
+type LiteralUnion<T, U = string> = T | (U & {});
+
+export interface AnyModel<T extends ObjectHash = ObjectHash> {
+  get<K extends keyof T>(key: K): T[K];
+  set<K extends keyof T>(key: K, value: T[K]): void;
+  off<K extends keyof T>(
+    eventName?: LiteralUnion<`change:${K & string}` | "msg:custom"> | null,
+    callback?: EventHandler | null,
+  ): void;
+  on(
+    eventName: "msg:custom",
+    callback: (msg: any, buffers: DataView[]) => void,
+  ): void;
+  on<K extends `change:${keyof T & string}`>(
+    eventName: K,
+    callback: K extends `change:${infer Key}`
+      ? ChangeEventHandler<T[Key]>
+      : never,
+  ): void;
+  on(eventName: string, callback: EventHandler): void;
+  save_changes(): void;
+  send(
+    content: any,
+    callbacks?: any,
+    buffers?: ArrayBuffer[] | ArrayBufferView[],
+  ): void;
+  widget_manager: {};
+}

--- a/frontend/src/plugins/plugins.ts
+++ b/frontend/src/plugins/plugins.ts
@@ -18,9 +18,9 @@ import { SliderPlugin } from "./impl/SliderPlugin";
 import { SwitchPlugin } from "./impl/SwitchPlugin";
 import { TextInputPlugin } from "./impl/TextInputPlugin";
 import { TextAreaPlugin } from "./impl/TextAreaPlugin";
-import { IPlugin } from "./types";
+import type { IPlugin } from "./types";
 import { DataTablePlugin } from "./impl/DataTablePlugin";
-import { IStatelessPlugin } from "./stateless-plugin";
+import type { IStatelessPlugin } from "./stateless-plugin";
 import { AccordionPlugin } from "./layout/AccordionPlugin";
 import { CalloutPlugin } from "./layout/CalloutPlugin";
 import { JsonOutputPlugin } from "./layout/JsonOutputPlugin";
@@ -72,7 +72,7 @@ export const UI_PLUGINS: Array<IPlugin<any, unknown>> = [
   DataExplorerPlugin,
   DataFramePlugin,
   LazyPlugin,
-  new AnyWidgetPlugin(),
+  AnyWidgetPlugin,
 ];
 
 // List of output / layout plugins

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -64,6 +64,7 @@ def _generate_schema() -> dict[str, Any]:
         ops.CellOp,
         ops.HumanReadableStatus,
         ops.FunctionCallResult,
+        ops.SendUIElementMessage,
         ops.RemoveUIElements,
         ops.Interrupted,
         ops.CompletedRun,

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -309,6 +309,16 @@ class RemoveUIElements(Op):
 
 
 @dataclass
+class SendUIElementMessage(Op):
+    """Send a message to a UI element."""
+
+    name: ClassVar[str] = "send-ui-element-message"
+    ui_element: str
+    message: JSONType
+    buffers: Optional[Sequence[str]]
+
+
+@dataclass
 class Interrupted(Op):
     """Written when the kernel is interrupted by the user."""
 
@@ -568,6 +578,7 @@ MessageOperation = Union[
     # Cell operations
     CellOp,
     FunctionCallResult,
+    SendUIElementMessage,
     RemoveUIElements,
     # Notebook operations
     Reload,

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import abc
+import base64
 import copy
 import uuid
 import weakref
@@ -12,6 +13,7 @@ from typing import (
     Callable,
     Generic,
     Optional,
+    Sequence,
     TypeVar,
     cast,
 )
@@ -388,6 +390,24 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
             validate=validate,
             on_change=on_change,
         )
+
+    def send_message(
+        self, message: JSONType, buffers: Optional[Sequence[bytes]]
+    ) -> None:
+        """
+        Send a message to the element rendered on the frontend
+        from the backend.
+        """
+
+        from marimo._messaging.ops import SendUIElementMessage
+
+        SendUIElementMessage(
+            ui_element=self._id,
+            message=message,
+            buffers=[
+                base64.b64encode(buffer).decode() for buffer in (buffers or [])
+            ],
+        ).broadcast()
 
     def _update(self, value: S) -> None:
         """Update value, given a value from the frontend

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -100,7 +100,7 @@ class anywidget(UIElement[T, T]):
         js: str = widget._esm if hasattr(widget, "_esm") else ""  # type: ignore [unused-ignore]  # noqa: E501
         css: str = widget._css if hasattr(widget, "_css") else ""  # type: ignore [unused-ignore]  # noqa: E501
 
-        self.widget.comm = maybe_create_comm(self)
+        self.widget.comm = _maybe_create_comm(self)
 
         super().__init__(
             component_name="marimo-anywidget",
@@ -115,17 +115,17 @@ class anywidget(UIElement[T, T]):
                 Function(
                     name="send_to_widget",
                     arg_cls=SendToWidgetArgs,
-                    function=self.receive_from_frontend,
+                    function=self._receive_from_frontend,
                 ),
             ),
         )
 
-    def send_to_frontend(
+    def _send_to_frontend(
         self, value: T, buffers: Optional[Any] = None
     ) -> None:
         self.send_message(value, buffers)
 
-    def receive_from_frontend(self, args: SendToWidgetArgs) -> None:
+    def _receive_from_frontend(self, args: SendToWidgetArgs) -> None:
         self.widget._handle_custom_msg(args.content, args.buffers)
 
     def _convert_value(self, value: T) -> T:
@@ -136,7 +136,7 @@ class anywidget(UIElement[T, T]):
         return getattr(self.widget, name)
 
 
-def maybe_create_comm(widget: "anywidget") -> Any:
+def _maybe_create_comm(widget: "anywidget") -> Any:
     try:
         from comm.base_comm import BaseComm  # type: ignore
 
@@ -157,7 +157,7 @@ def maybe_create_comm(widget: "anywidget") -> Any:
                     and data["method"] == "custom"
                 ):
                     if "content" in data:
-                        widget.send_to_frontend(data["content"], buffers)
+                        widget._send_to_frontend(data["content"], buffers)
                     else:
                         LOGGER.warning("No content in custom message")
 

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -138,9 +138,9 @@ class anywidget(UIElement[T, T]):
 
 def maybe_create_comm(widget: "anywidget") -> Any:
     try:
-        from comm.base_comm import BaseComm
+        from comm.base_comm import BaseComm  # type: ignore
 
-        class MarimoComm(BaseComm):
+        class MarimoComm(BaseComm):  # type: ignore
             def publish_msg(
                 self,
                 msg_type: str,

--- a/marimo/_smoke_tests/anywidget/maplibre.py
+++ b/marimo/_smoke_tests/anywidget/maplibre.py
@@ -1,0 +1,98 @@
+import marimo
+
+__generated_with = "0.7.2"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import functools
+    return functools, mo
+
+
+@app.cell
+def __():
+    from maplibre.controls import NavigationControl, ScaleControl
+    from maplibre.ipywidget import MapOptions, MapWidget
+    return MapOptions, MapWidget, NavigationControl, ScaleControl
+
+
+@app.cell
+def __():
+    deck_grid_layer = {
+        "@@type": "GridLayer",
+        "id": "GridLayer",
+        "data": "https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/sf-bike-parking.json",
+        "extruded": True,
+        "getPosition": "@@=COORDINATES",
+        "getColorWeight": "@@=SPACES",
+        "getElevationWeight": "@@=SPACES",
+        "elevationScale": 4,
+        "cellSize": 200,
+        "pickable": True,
+    }
+    return deck_grid_layer,
+
+
+@app.cell
+def __(MapOptions):
+    map_options = MapOptions(
+        center=(-122.4, 37.74),
+        zoom=12,
+        hash=True,
+        pitch=40,
+    )
+    return map_options,
+
+
+@app.cell
+def __(MapWidget, NavigationControl, deck_grid_layer, map_options, mo):
+    m = MapWidget(map_options)
+    m.use_message_queue(False)
+    m.add_control(NavigationControl())
+    m.add_deck_layers([deck_grid_layer])
+    m = mo.ui.anywidget(m)
+    m
+    return m,
+
+
+@app.cell
+def __(mo):
+    add_control_button = mo.ui.run_button(label="add scale control")
+    add_control_button
+    return add_control_button,
+
+
+@app.cell
+def __(ScaleControl, add_control_button, m):
+    if add_control_button.value:
+        m.add_control(ScaleControl())
+    return
+
+
+@app.cell
+def __(m):
+    m.clicked
+    return
+
+
+@app.cell
+def __(m):
+    m.zoom
+    return
+
+
+@app.cell
+def __(m):
+    m.center
+    return
+
+
+@app.cell
+def __():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/anywidget/maplibre.py
+++ b/marimo/_smoke_tests/anywidget/maplibre.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.2"

--- a/marimo/_smoke_tests/anywidget/mosaic.py
+++ b/marimo/_smoke_tests/anywidget/mosaic.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.2"

--- a/marimo/_smoke_tests/anywidget/mosaic.py
+++ b/marimo/_smoke_tests/anywidget/mosaic.py
@@ -1,0 +1,40 @@
+import marimo
+
+__generated_with = "0.7.2"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __(__file__):
+    import pandas as pd
+    import marimo as mo
+    import os
+    import yaml
+
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+
+    from mosaic_widget import MosaicWidget
+
+    weather = pd.read_csv(
+        "https://uwdata.github.io/mosaic-datasets/data/seattle-weather.csv",
+        parse_dates=["date"],
+    )
+
+    # Load weather spec, remove data key to ensure load from Pandas
+    with open(dir_path + "/weather.yaml") as f:
+        spec = yaml.safe_load(f)
+        spec.pop("data")
+
+    w = mo.ui.anywidget(MosaicWidget(spec, data={"weather": weather}))
+    return MosaicWidget, dir_path, f, mo, os, pd, spec, w, weather, yaml
+
+
+@app.cell
+def __(w):
+    w
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/anywidget/weather.yaml
+++ b/marimo/_smoke_tests/anywidget/weather.yaml
@@ -1,0 +1,55 @@
+data:
+  weather: { file: data/seattle-weather.parquet }
+params:
+  click: { select: single }
+  domain: [sun, fog, drizzle, rain, snow]
+  colors: ['#e7ba52', '#a7a7a7', '#aec7e8', '#1f77b4', '#9467bd']
+vconcat:
+- hconcat:
+  - plot:
+    - mark: dot
+      data: { from: weather, filterBy: $click }
+      x: { dateMonthDay: date }
+      y: temp_max
+      fill: weather
+      r: precipitation
+      fillOpacity: 0.7
+    - select: intervalX
+      as: $range
+      brush: { fill: none, stroke: '#888' }
+    - select: highlight
+      by: $range
+      fill: '#ccc'
+      fillOpacity: 0.2
+    - legend: color
+      as: $click
+      columns: 1
+    xyDomain: Fixed
+    colorDomain: $domain
+    colorRange: $colors
+    rDomain: Fixed
+    rRange: [2, 10]
+    width: 680
+    height: 300
+- plot:
+  - mark: barX
+    data: { from: weather }
+    x: { count: }
+    y: weather
+    fill: '#ccc'
+    fillOpacity: 0.2
+  - mark: barX
+    data: { from: weather, filterBy: $range }
+    x: { count: }
+    y: weather
+    fill: weather
+  - select: toggleY
+    as: $click
+  - select: highlight
+    by: $click
+  xDomain: Fixed
+  yDomain: $domain
+  yLabel: null
+  colorDomain: $domain
+  colorRange: $colors
+  width: 680

--- a/marimo/_smoke_tests/bugs/1710.py
+++ b/marimo/_smoke_tests/bugs/1710.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.6.25"

--- a/marimo/_smoke_tests/bugs/1711.py
+++ b/marimo/_smoke_tests/bugs/1711.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.6.25"

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -30,15 +30,15 @@ def sql(query: str) -> Any:
     import duckdb  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
 
     if DependencyManager.has_polars():
-        df = duckdb.execute(query=query).pl()
-        t = table.table(df, selection=None, page_size=5, pagination=True)
+        pl_df = duckdb.execute(query=query).pl()
+        t = table.table(pl_df, selection=None, page_size=5, pagination=True)
         output.replace(t)
-        return df
+        return pl_df
     if DependencyManager.has_pandas():
-        df = duckdb.execute(query=query).df()
-        t = table.table(df, selection=None, page_size=5, pagination=True)
+        pd_df = duckdb.execute(query=query).df()
+        t = table.table(pd_df, selection=None, page_size=5, pagination=True)
         output.replace(t)
-        return df
+        return pd_df
 
     raise ModuleNotFoundError(
         "pandas or polars is required to execute sql. "

--- a/marimo/_tutorials/sql.py
+++ b/marimo/_tutorials/sql.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.1"

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1178,6 +1178,7 @@ components:
       oneOf:
       - $ref: '#/components/schemas/CellOp'
       - $ref: '#/components/schemas/FunctionCallResult'
+      - $ref: '#/components/schemas/SendUIElementMessage'
       - $ref: '#/components/schemas/RemoveUIElements'
       - $ref: '#/components/schemas/Reload'
       - $ref: '#/components/schemas/Reconnected'
@@ -1471,6 +1472,25 @@ components:
       required:
       - config
       type: object
+    SendUIElementMessage:
+      properties:
+        buffers:
+          items:
+            type: string
+          nullable: true
+          type: array
+        message:
+          $ref: '#/components/schemas/JSONType'
+        name:
+          enum:
+          - send-ui-element-message
+          type: string
+        ui_element:
+          type: string
+      required:
+      - ui_element
+      - name
+      type: object
     SetCellConfigRequest:
       properties:
         configs:
@@ -1699,7 +1719,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.7.1
+  version: 0.7.2
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -1202,6 +1202,7 @@ export interface components {
     MessageOperation:
       | components["schemas"]["CellOp"]
       | components["schemas"]["FunctionCallResult"]
+      | components["schemas"]["SendUIElementMessage"]
       | components["schemas"]["RemoveUIElements"]
       | components["schemas"]["Reload"]
       | components["schemas"]["Reconnected"]
@@ -1331,6 +1332,13 @@ export interface components {
     };
     SaveUserConfigurationRequest: {
       config: components["schemas"]["MarimoConfig"];
+    };
+    SendUIElementMessage: {
+      buffers?: string[] | null;
+      message?: components["schemas"]["JSONType"];
+      /** @enum {string} */
+      name: "send-ui-element-message";
+      ui_element: string;
     };
     SetCellConfigRequest: {
       configs: {


### PR DESCRIPTION
This adds a new `MarimoIncomingMessageEvent` frontend UI element event and a backend `SendUIElementMessage` to allow the backend plugins/ui-elements to push messages to UI elements

Fixes #1690 