### PR TITLE
Restrict CORS allow origins to localhost; add CLI flag to specify allowed origins

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -244,6 +244,12 @@ edit_help_msg = "\n".join(
     help="Base URL for the server. Should start with a /.",
     callback=validators.base_url,
 )
+@click.option(
+    "--allow-origins",
+    default=None,
+    multiple=True,
+    help="Allowed origins for CORS. Can be repeated. Use * for all origins.",
+)
 @click.argument("name", required=False)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def edit(
@@ -254,8 +260,9 @@ def edit(
     token: bool,
     token_password: Optional[str],
     base_url: str,
+    allow_origins: Optional[tuple[str, ...]],
     name: Optional[str],
-    args: tuple[str],
+    args: tuple[str, ...],
 ) -> None:
     # Check for version updates
     check_for_updates()
@@ -297,6 +304,7 @@ def edit(
         cli_args=parse_args(args),
         auth_token=_resolve_token(token, token_password),
         base_url=base_url,
+        allow_origins=allow_origins,
     )
 
 
@@ -460,6 +468,12 @@ Example:
     help="Base URL for the server. Should start with a /.",
     callback=validators.base_url,
 )
+@click.option(
+    "--allow-origins",
+    default=None,
+    multiple=True,
+    help="Allowed origins for CORS. Can be repeated.",
+)
 @click.argument("name", required=True)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def run(
@@ -472,8 +486,9 @@ def run(
     include_code: bool,
     watch: bool,
     base_url: str,
+    allow_origins: tuple[str, ...],
     name: str,
-    args: tuple[str],
+    args: tuple[str, ...],
 ) -> None:
     # Validate name, or download from URL
     # The second return value is an optional temporary directory. It is unused,
@@ -496,6 +511,7 @@ def run(
         include_code=include_code,
         watch=watch,
         base_url=base_url,
+        allow_origins=allow_origins,
         cli_args=parse_args(args),
         auth_token=_resolve_token(token, token_password),
     )

--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -153,6 +153,7 @@ def create_asgi_app(
                     ]
                 ),
                 enable_auth=not AuthToken.is_empty(auth_token),
+                allow_origins=("*",),
             )
             app.state.session_manager = session_manager
             app.state.base_url = path

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -68,6 +68,7 @@ async def handle_error(request: Request, response: Any) -> Any:
 def create_starlette_app(
     *,
     base_url: str,
+    host: Optional[str] = None,
     middleware: Optional[List[Middleware]] = None,
     lifespan: Optional[Lifespan[Starlette]] = None,
     enable_auth: bool = True,
@@ -75,9 +76,11 @@ def create_starlette_app(
 ) -> Starlette:
     final_middlewares: List[Middleware] = []
 
-    allow_origins = (
-        ("localhost", "127.0.0.1") if allow_origins is None else allow_origins
-    )
+    if allow_origins is None:
+        allow_origins = ("localhost", "127.0.0.1") + (
+            (host,) if host is not None else ()
+        )
+
     if enable_auth:
         final_middlewares.extend(
             [

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -71,9 +71,13 @@ def create_starlette_app(
     middleware: Optional[List[Middleware]] = None,
     lifespan: Optional[Lifespan[Starlette]] = None,
     enable_auth: bool = True,
+    allow_origins: Optional[tuple[str, ...]] = None,
 ) -> Starlette:
     final_middlewares: List[Middleware] = []
 
+    allow_origins = (
+        ("localhost", "127.0.0.1") if allow_origins is None else allow_origins
+    )
     if enable_auth:
         final_middlewares.extend(
             [
@@ -93,7 +97,7 @@ def create_starlette_app(
             ),
             Middleware(
                 CORSMiddleware,
-                allow_origins=["*"],
+                allow_origins=allow_origins,
                 allow_credentials=True,
                 allow_methods=["*"],
                 allow_headers=["*"],

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -104,8 +104,10 @@ def start(
 
     log_level = "info" if development_mode else "error"
 
+    (external_port, external_host) = _resolve_proxy(port, host, proxy)
     app = create_starlette_app(
         base_url=base_url,
+        host=external_host,
         lifespan=lifespans.Lifespans(
             [
                 lifespans.lsp,
@@ -120,7 +122,6 @@ def start(
         enable_auth=not AuthToken.is_empty(session_manager.auth_token),
     )
 
-    (external_port, external_host) = _resolve_proxy(port, host, proxy)
     app.state.port = external_port
     app.state.host = external_host
 

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -78,6 +78,7 @@ def start(
     watch: bool,
     cli_args: SerializedCLIArgs,
     base_url: str = "",
+    allow_origins: Optional[tuple[str, ...]] = None,
     auth_token: Optional[AuthToken],
 ) -> None:
     """
@@ -115,11 +116,11 @@ def start(
                 lifespans.open_browser,
             ]
         ),
+        allow_origins=allow_origins,
         enable_auth=not AuthToken.is_empty(session_manager.auth_token),
     )
 
     (external_port, external_host) = _resolve_proxy(port, host, proxy)
-
     app.state.port = external_port
     app.state.host = external_host
 


### PR DESCRIPTION
Restrict CORS allowed origins to localhost. Can be overriden by a CLI flag.