### PR TITLE
Add Additional 'unclonables'

### DIFF
--- a/marimo/_runtime/executor.py
+++ b/marimo/_runtime/executor.py
@@ -28,7 +28,13 @@ UNCLONABLE_TYPES = [
     "marimo._runtime.state.SetFunctor",
 ]
 
-UNCLONABLE_MODULES = ["_asyncio", "marimo._ast", "marimo._plugins.ui"]
+UNCLONABLE_MODULES = set([
+    "_asyncio",
+    "_io",
+    "marimo._ast",
+    "marimo._plugins.ui",
+    "numpy.lib.npyio",
+])
 PRIMITIVES = (weakref.ref, str, numbers.Number, type(None))
 
 EXECUTION_TYPES: dict[str, Type[Executor]] = {}

--- a/marimo/_runtime/executor.py
+++ b/marimo/_runtime/executor.py
@@ -28,13 +28,15 @@ UNCLONABLE_TYPES = [
     "marimo._runtime.state.SetFunctor",
 ]
 
-UNCLONABLE_MODULES = set([
-    "_asyncio",
-    "_io",
-    "marimo._ast",
-    "marimo._plugins.ui",
-    "numpy.lib.npyio",
-])
+UNCLONABLE_MODULES = set(
+    [
+        "_asyncio",
+        "_io",
+        "marimo._ast",
+        "marimo._plugins.ui",
+        "numpy.lib.npyio",
+    ]
+)
 PRIMITIVES = (weakref.ref, str, numbers.Number, type(None))
 
 EXECUTION_TYPES: dict[str, Type[Executor]] = {}


### PR DESCRIPTION
## 📝 Summary

Came across these during my research, quick fix for common unclonable types

## 🔍 Description of Changes

Strict mode should not clone _io objects or wrapped numpy objects by default

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
