### PR TITLE
improvement: sync vim mode

### DIFF
--- a/frontend/src/core/codemirror/keymaps/keymaps.ts
+++ b/frontend/src/core/codemirror/keymaps/keymaps.ts
@@ -1,9 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { KeymapConfig } from "@/core/config/config-schema";
+import type { KeymapConfig } from "@/core/config/config-schema";
 import { logNever } from "@/utils/assertNever";
 import { defaultKeymap } from "@codemirror/commands";
-import { Extension, Prec } from "@codemirror/state";
-import { EditorView, keymap } from "@codemirror/view";
+import { type Extension, Prec } from "@codemirror/state";
+import { type EditorView, keymap } from "@codemirror/view";
 import { vim, Vim } from "@replit/codemirror-vim";
 import { vimKeymapExtension } from "./vim";
 
@@ -38,7 +38,6 @@ export function keymapBundle(
         callbacks.deleteCell();
       });
       return [
-        vimKeymapExtension(callbacks),
         // delete the cell on double press of "d", if the cell is empty
         Prec.highest(
           doubleCharacterListener(
@@ -54,6 +53,8 @@ export function keymapBundle(
           ),
         ),
         vim({ status: false }),
+        // Needs to come after the vim extension
+        vimKeymapExtension(callbacks),
         keymap.of(defaultKeymap),
       ];
     default:

--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -121,22 +121,31 @@ class CodeMirrorVimSync {
         const vim = cm.state.vim;
         if (!vim) {
           Logger.warn("Expected CodeMirror instance to have Vim state");
+          continue;
         }
 
         switch (mode) {
           case "normal":
-            if (vim?.insertMode) {
+            // Only exit insert mode if we're in it
+            if (vim.insertMode) {
               Vim.exitInsertMode(cm, true);
             }
-            if (vim?.visualMode) {
+            // Only exit visual mode if we're in it
+            if (vim.visualMode) {
               Vim.exitVisualMode(cm, true);
             }
             break;
           case "insert":
-            Vim.handleKey(cm, "i", "");
+            // Only enter insert mode if we're not already in it
+            if (!vim.insertMode) {
+              Vim.handleKey(cm, "i", "");
+            }
             break;
           case "visual":
-            Vim.handleKey(cm, "v", "");
+            // Only enter visual mode if we're not already in it
+            if (!vim.visualMode) {
+              Vim.handleKey(cm, "v", "");
+            }
             break;
         }
 

--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -142,10 +142,7 @@ class CodeMirrorVimSync {
             }
             break;
           case "visual":
-            // Only enter visual mode if we're not already in it
-            if (!vim.visualMode) {
-              Vim.handleKey(cm, "v", "");
-            }
+            // We don't switch to visual mode across instances
             break;
         }
 

--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -1,16 +1,37 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { keymap } from "@codemirror/view";
+import { getCM, Vim } from "@replit/codemirror-vim";
+import { type EditorView, keymap, ViewPlugin } from "@codemirror/view";
 import {
   isAtEndOfEditor,
   isAtStartOfEditor,
   isInVimNormalMode,
 } from "../utils";
+import { invariant } from "@/utils/invariant";
+import type { Extension } from "@codemirror/state";
+
+console.log(Vim);
+invariant(
+  "exitInsertMode" in Vim,
+  "Vim does not have an exitInsertMode method",
+);
+// invariant(
+// 	"enterInsertMode" in Vim,
+// 	"Vim does not have an enterInsertMode method",
+// );
+// invariant(
+// 	"enterVisualMode" in Vim,
+// 	"Vim does not have an enterVisualMode method",
+// );
+invariant(
+  "exitVisualMode" in Vim,
+  "Vim does not have an exitVisualMode method",
+);
 
 export function vimKeymapExtension(callbacks: {
   focusUp: () => void;
   focusDown: () => void;
-}) {
+}): Extension[] {
   return [
     keymap.of([
       {
@@ -36,5 +57,101 @@ export function vimKeymapExtension(callbacks: {
         },
       },
     ]),
+    ViewPlugin.define((view) => {
+      console.log(view);
+      CodeMirrorSync.INSTANCES.addInstance(view);
+      return {
+        destroy() {
+          CodeMirrorSync.INSTANCES.removeInstance(view);
+        },
+      };
+    }),
   ];
+}
+
+class CodeMirrorSync {
+  private instances = new Set<EditorView>();
+  private isBroadcasting = false;
+
+  public static INSTANCES: CodeMirrorSync = new CodeMirrorSync();
+
+  private constructor() {
+    // noop
+  }
+
+  addInstance(instance: EditorView) {
+    console.log("addInstance", getCM(instance));
+    getCM(instance)?.on("vim-mode-change", (e: { mode: string }) => {
+      if (this.isBroadcasting) {
+        return;
+      }
+      invariant("mode" in e, 'Expected event to have a "mode" property');
+      console.log("mode changed");
+      console.log(e);
+      const mode = e.mode;
+      this.isBroadcasting = true;
+      // trap focus
+      const handleTrapAllFocus = (e: FocusEvent) => {
+        console.log("focaus");
+        e.preventDefault();
+      };
+      const handleTrapScroll = (e: WheelEvent) => {
+        e.preventDefault();
+      };
+
+      document.addEventListener("focus", handleTrapAllFocus, true);
+      document.addEventListener("focusin", handleTrapAllFocus);
+      document.addEventListener("focusout", handleTrapAllFocus);
+      document.addEventListener("blur", handleTrapAllFocus);
+      document.addEventListener("wheel", handleTrapScroll, { passive: false });
+      const app = document.querySelector<HTMLElement>("#App");
+      // get scroll of app
+      const appScrollTop = app?.scrollTop ?? 0;
+      console.log(appScrollTop);
+      this.broadcastModeChange(instance, mode);
+      // reset scroll
+      app?.scrollTo(0, appScrollTop);
+      console.log(appScrollTop);
+      const cm = getCM(instance)?.focus();
+      document.removeEventListener("focus", handleTrapAllFocus, true);
+      document.removeEventListener("focusin", handleTrapAllFocus);
+      document.removeEventListener("focusout", handleTrapAllFocus);
+      document.removeEventListener("blur", handleTrapAllFocus);
+      document.removeEventListener("wheel", handleTrapScroll);
+      document.removeEventListener("wheel", handleTrapScroll);
+      document.removeEventListener("focus", handleTrapAllFocus, true);
+      // restore focus
+
+      this.isBroadcasting = false;
+    });
+    this.instances.add(instance);
+  }
+
+  removeInstance(instance: EditorView) {
+    this.instances.delete(instance);
+  }
+
+  broadcastModeChange(originInstance: EditorView, mode: string) {
+    for (const instance of this.instances) {
+      if (instance !== originInstance) {
+        // const cm = getCM(instance);
+        // cm.focus = () => {
+        // 	// do nothing
+        // 	console.log("focus");
+        // };
+        switch (mode) {
+          case "normal":
+            console.log("leaving vim mode");
+            Vim.handleKey(getCM(instance), "<Esc>");
+            break;
+          case "insert":
+            Vim.handleKey(getCM(instance), "i");
+            break;
+          case "visual":
+            Vim.handleKey(getCM(instance), "v");
+            break;
+        }
+      }
+    }
+  }
 }

--- a/frontend/src/css/common.css
+++ b/frontend/src/css/common.css
@@ -8,14 +8,12 @@
 }
 
 .hover-action:hover,
-.hover-action:focus,
-.hover-action:focus-within {
+.hover-action:focus {
   display: inline-flex !important;
 }
 
 .hover-actions-parent:hover .hover-action,
-.hover-actions-parent:focus .hover-action,
-.hover-actions-parent:focus-within .hover-action {
+.hover-actions-parent:focus .hover-action {
   display: inline-flex !important;
 }
 


### PR DESCRIPTION
This PR adds some hooks into the codemirror vim plugin to keep the vim-mode (normal, insert, visual) in sync with other editors. This includes a bit of hacks in order to get into the internal of the vim plugin. 

Fixes #915