### PR TITLE
fix: register cell as queued on run

### DIFF
--- a/frontend/src/core/cells/__tests__/__snapshots__/cells.test.ts.snap
+++ b/frontend/src/core/cells/__tests__/__snapshots__/cells.test.ts.snap
@@ -49,7 +49,7 @@ exports[`cell reducer > can initialize stdin 2`] = `
   "runStartTimestamp": null,
   "serializedEditorState": null,
   "staleInputs": false,
-  "status": "idle",
+  "status": "queued",
   "stopped": false,
 }
 `;
@@ -360,7 +360,7 @@ exports[`cell reducer > can receive console when the cell is idle and will clear
   "runStartTimestamp": null,
   "serializedEditorState": null,
   "staleInputs": false,
-  "status": "idle",
+  "status": "queued",
   "stopped": false,
 }
 `;
@@ -747,7 +747,7 @@ exports[`cell reducer > can run cell and receive cell messages 3`] = `
   "runStartTimestamp": null,
   "serializedEditorState": null,
   "staleInputs": false,
-  "status": "idle",
+  "status": "queued",
   "stopped": false,
 }
 `;

--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -266,7 +266,7 @@ describe("cell reducer", () => {
       cellId: firstCellId,
     });
     cell = cells[0];
-    expect(cell.status).toBe("idle");
+    expect(cell.status).toBe("queued");
     expect(cell.lastCodeRun).toBe("import marimo as mo");
     expect(cell.edited).toBe(false);
     expect(cell).toMatchSnapshot(); // snapshot everything as a catch all
@@ -767,7 +767,7 @@ describe("cell reducer", () => {
       cellId: firstCellId,
     });
     cell = cells[0];
-    expect(cell.status).toBe("idle");
+    expect(cell.status).toBe("queued");
     expect(cell.consoleOutputs).toEqual([]);
     expect(cell).toMatchSnapshot(); // snapshot everything as a catch all
 
@@ -922,7 +922,7 @@ describe("cell reducer", () => {
       cellId: firstCellId,
     });
     cell = cells[0];
-    expect(cell.status).toBe("idle");
+    expect(cell.status).toBe("queued");
     expect(cell.consoleOutputs).toEqual([OLD_STDOUT]); // Old stays there until it starts running
     expect(cell).toMatchSnapshot(); // snapshot everything as a catch all
 

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -142,6 +142,7 @@ export function prepareCellForExecution(
 ): CellRuntimeState {
   const nextCell = { ...cell };
 
+  nextCell.status = "queued";
   nextCell.interrupted = false;
   nextCell.errored = false;
   nextCell.runElapsedTimeMs = null;


### PR DESCRIPTION
When preparing to run a cell, register a cell as queued. This is only on the FE, and doesn't solve the deeper problem of deduping execution requests on the BE, but it does as a stopgap fix the problem in #1788 from the user's perspective.

We already clear its interrupted status, etc on run in the FE, so thought it could be okay to set the status too. 