### PR TITLE
fix: portal menus when in fullscreen

### DIFF
--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -5,20 +5,20 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 import { cn } from "@/utils/cn";
 import { buttonVariants } from "@/components/ui/button";
 import { useRestoreFocus } from "./use-restore-focus";
+import { withFullScreenAsRoot } from "./fullscreen";
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
 const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = ({
-  children,
-  ...props
-}: AlertDialogPrimitive.AlertDialogPortalProps) => (
-  <AlertDialogPrimitive.Portal {...props}>
-    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-start sm:top-[15%]">
-      {children}
-    </div>
-  </AlertDialogPrimitive.Portal>
+const AlertDialogPortal = withFullScreenAsRoot(
+  ({ children, ...props }: AlertDialogPrimitive.AlertDialogPortalProps) => (
+    <AlertDialogPrimitive.Portal {...props}>
+      <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-start sm:top-[15%]">
+        {children}
+      </div>
+    </AlertDialogPrimitive.Portal>
+  ),
 );
 AlertDialogPortal.displayName = AlertDialogPrimitive.Portal.displayName;
 

--- a/frontend/src/components/ui/context-menu.tsx
+++ b/frontend/src/components/ui/context-menu.tsx
@@ -17,12 +17,13 @@ import {
   menuSeparatorVariants,
   menuSubTriggerVariants,
 } from "./menu-items";
-import { VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
+import { withFullScreenAsRoot } from "./fullscreen";
 
 const ContextMenu = ContextMenuPrimitive.Root;
 const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
 const ContextMenuGroup = ContextMenuPrimitive.Group;
-const ContextMenuPortal = ContextMenuPrimitive.Portal;
+const ContextMenuPortal = withFullScreenAsRoot(ContextMenuPrimitive.Portal);
 const ContextMenuSub = ContextMenuPrimitive.Sub;
 const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
 
@@ -66,13 +67,13 @@ const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
 >(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Portal>
+  <ContextMenuPortal>
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(menuContentCommon(), contentCommon, className)}
       {...props}
     />
-  </ContextMenuPrimitive.Portal>
+  </ContextMenuPortal>
 ));
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
 

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -5,26 +5,29 @@ import { X } from "lucide-react";
 
 import { cn } from "@/utils/cn";
 import { useRestoreFocus } from "./use-restore-focus";
+import { withFullScreenAsRoot } from "./fullscreen";
 
 const Dialog = DialogPrimitive.Root;
 
 const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = ({
-  className,
-  children,
-  ...props
-}: DialogPrimitive.DialogPortalProps & { className?: string }) => (
-  <DialogPrimitive.Portal {...props}>
-    <div
-      className={cn(
-        "fixed inset-0 z-50 flex items-start justify-center sm:items-start sm:top-[15%]",
-        className,
-      )}
-    >
-      {children}
-    </div>
-  </DialogPrimitive.Portal>
+const DialogPortal = withFullScreenAsRoot(
+  ({
+    className,
+    children,
+    ...props
+  }: DialogPrimitive.DialogPortalProps & { className?: string }) => (
+    <DialogPrimitive.Portal {...props}>
+      <div
+        className={cn(
+          "fixed inset-0 z-50 flex items-start justify-center sm:items-start sm:top-[15%]",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </DialogPrimitive.Portal>
+  ),
 );
 DialogPortal.displayName = DialogPrimitive.Portal.displayName;
 

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -13,12 +13,13 @@ import {
 import { cn } from "@/utils/cn";
 import React from "react";
 import { Check, ChevronRight, Circle } from "lucide-react";
-import { VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
+import { withFullScreenAsRoot } from "./fullscreen";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuPortal = withFullScreenAsRoot(DropdownMenuPrimitive.Portal);
 const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
@@ -61,7 +62,7 @@ const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
+  <DropdownMenuPortal>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
@@ -72,7 +73,7 @@ const DropdownMenuContent = React.forwardRef<
       )}
       {...props}
     />
-  </DropdownMenuPrimitive.Portal>
+  </DropdownMenuPortal>
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 

--- a/frontend/src/components/ui/fullscreen.tsx
+++ b/frontend/src/components/ui/fullscreen.tsx
@@ -1,0 +1,36 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { useEventListener } from "@/hooks/useEventListener";
+import type { PortalProps } from "@radix-ui/react-popover";
+import { useState } from "react";
+
+/**
+ * Get the full screen element if we are in full screen mode
+ */
+export function useFullScreenElement() {
+  const [fullScreenElement, setFullScreenElement] = useState<Element | null>(
+    document.fullscreenElement,
+  );
+  useEventListener(document, "fullscreenchange", () => {
+    setFullScreenElement(document.fullscreenElement);
+  });
+  return fullScreenElement;
+}
+
+/**
+ * HOC wrapping a Portal component to use the
+ * full screen element as the container if we are in full screen mode
+ */
+export function withFullScreenAsRoot<T extends PortalProps>(
+  Component: React.ComponentType<PortalProps>,
+) {
+  const Comp = (props: T) => {
+    const fullScreenElement = useFullScreenElement();
+    if (!fullScreenElement) {
+      return <Component {...props} />;
+    }
+    return <Component {...props} container={fullScreenElement} />;
+  };
+
+  Comp.displayName = Component.displayName;
+  return Comp;
+}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -4,10 +4,12 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 
 import { cn } from "@/utils/cn";
 import { StyleNamespace } from "@/theme/namespace";
+import { withFullScreenAsRoot } from "./fullscreen";
 
 const Popover = PopoverPrimitive.Root;
 
 const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverPortal = withFullScreenAsRoot(PopoverPrimitive.Portal);
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
@@ -34,7 +36,7 @@ const PopoverContent = React.forwardRef<
       </StyleNamespace>
     );
     if (portal) {
-      return <PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>;
+      return <PopoverPortal>{content}</PopoverPortal>;
     }
 
     return content;

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -11,11 +11,13 @@ import {
 
 import { cn } from "@/utils/cn";
 import { selectStyles } from "./native-select";
-import { VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
+import { withFullScreenAsRoot } from "./fullscreen";
 
 const Select = SelectPrimitive.Root;
 
 const SelectGroup = SelectPrimitive.Group;
+const SelectPortal = withFullScreenAsRoot(SelectPrimitive.Portal);
 
 const SelectValue = SelectPrimitive.Value;
 
@@ -60,7 +62,7 @@ const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
+  <SelectPortal>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
@@ -90,7 +92,7 @@ const SelectContent = React.forwardRef<
         <ChevronDownIcon className="h-4 w-4 opacity-50" />
       </SelectPrimitive.ScrollDownButton>
     </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
+  </SelectPortal>
 ));
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -4,6 +4,7 @@ import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
+import { withFullScreenAsRoot } from "./fullscreen";
 
 const Sheet = SheetPrimitive.Root;
 
@@ -11,7 +12,7 @@ const SheetTrigger = SheetPrimitive.Trigger;
 
 const SheetClose = SheetPrimitive.Close;
 
-const SheetPortal = SheetPrimitive.Portal;
+const SheetPortal = withFullScreenAsRoot(SheetPrimitive.Portal);
 
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,


### PR DESCRIPTION
This makes the fullscreen component the root of the portal when in fullscreenmode