### PR TITLE
fix: cloning UI elements

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -437,14 +437,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         Composite UIElement may need to override this method to run
         their own side-effects.
         """
-        # context is not deepcopy-able because it has a thread lock;
-        # temporarily unset it during the clone.
-        ctx = self._ctx
-        try:
-            self._ctx = None
-            duplicate = copy.deepcopy(self)
-            duplicate._ctx = ctx
-            duplicate._initialize(*self._args)
-        finally:
-            self._ctx = ctx
+        duplicate = copy.copy(self)
+        # Generates a new UI element ID, function namespace
+        duplicate._initialize(*self._args)
         return duplicate

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -438,9 +438,7 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         result = cls.__new__(cls)
         memo[id(self)] = result
         for k, v in self.__dict__.items():
-            if isinstance(v, UIElement):
-                setattr(result, k, v._clone())
-            elif isinstance(v, RuntimeContext):
+            if isinstance(v, RuntimeContext):
                 setattr(result, k, v)
             else:
                 setattr(result, k, copy.deepcopy(v, memo))

--- a/marimo/_smoke_tests/bugs/1816.py
+++ b/marimo/_smoke_tests/bugs/1816.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.6"

--- a/marimo/_smoke_tests/bugs/1816.py
+++ b/marimo/_smoke_tests/bugs/1816.py
@@ -1,0 +1,28 @@
+import marimo
+
+__generated_with = "0.7.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    dict1={"hello": mo.ui.text(label="world")}
+    dict2=mo.ui.dictionary({k: v.form() for k, v in dict1.items()})
+    dict2
+    return dict1, dict2
+
+
+@app.cell
+def __(dict2):
+    dict2.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -426,6 +426,13 @@ def test_form_in_array_retains_on_change() -> None:
     assert array[0]._on_change == on_change
 
 
+def test_form_in_dictionary_allowed() -> None:
+    checkbox = ui.checkbox()
+    form = checkbox.form()
+    d = ui.dictionary({"form": form})
+    assert checkbox._id != d["form"].element._id
+
+
 # TODO(akshayka): test file
 
 


### PR DESCRIPTION
This PR fixes the logic for cloning composite UI elements to exclude the runtime context, which is not deep-clonable.

Fixes #1816 