### PR TITLE
fix: dont autoinstall pkgs we already tried installing

### DIFF
--- a/marimo/_runtime/packages/conda_package_manager.py
+++ b/marimo/_runtime/packages/conda_package_manager.py
@@ -17,5 +17,5 @@ class CondaPackageManager(CanonicalizingPackageManager):
 class PixiPackageManager(CondaPackageManager):
     name = "pixi"
 
-    async def install(self, package: str) -> bool:
+    async def _install(self, package: str) -> bool:
         return self.run(["pixi", "add", package])

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -18,7 +18,7 @@ class PypiPackageManager(CanonicalizingPackageManager):
 class PipPackageManager(PypiPackageManager):
     name = "pip"
 
-    async def install(self, package: str) -> bool:
+    async def _install(self, package: str) -> bool:
         return self.run(["pip", "install", package])
 
 
@@ -31,7 +31,7 @@ class MicropipPackageManager(PypiPackageManager):
     def is_manager_installed(self) -> bool:
         return is_pyodide()
 
-    async def install(self, package: str) -> bool:
+    async def _install(self, package: str) -> bool:
         assert is_pyodide()
         import micropip  # type: ignore
 
@@ -45,19 +45,19 @@ class MicropipPackageManager(PypiPackageManager):
 class UvPackageManager(PypiPackageManager):
     name = "uv"
 
-    async def install(self, package: str) -> bool:
+    async def _install(self, package: str) -> bool:
         return self.run(["uv", "pip", "install", package])
 
 
 class RyePackageManager(PypiPackageManager):
     name = "rye"
 
-    async def install(self, package: str) -> bool:
+    async def _install(self, package: str) -> bool:
         return self.run(["rye", "add", package])
 
 
 class PoetryPackageManager(PypiPackageManager):
     name = "poetry"
 
-    async def install(self, package: str) -> bool:
+    async def _install(self, package: str) -> bool:
         return self.run(["poetry", "add", package])


### PR DESCRIPTION
Fixes an issue that is related to #1736 (infinite loop when installing a package that doesn't have an importable module — found this when importing an empty package).  I am unsure if this fixes the problem in #1736, since that involved packages that should be importable.
