### PR TITLE
improvement: always allow converting cell to markdown from python

### DIFF
--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -205,14 +205,16 @@ export function useCellActionButtons({ cell }: Props) {
         icon: <MarkdownIcon />,
         label: "View as Markdown",
         hotkey: "cell.viewAsMarkdown",
-        hidden: !canToggleToLanguage(editorView, "markdown"),
+        // We allow them to toggle to markdown in Python
+        // even if its not wrapped in a mo.md
+        hidden: getCurrentLanguageAdapter(editorView) !== "python",
         handle: () => {
           if (!editorView) {
             return;
           }
           maybeAddMarimoImport(autoInstantiate, createCell);
 
-          toggleToLanguage(editorView, "markdown");
+          toggleToLanguage(editorView, "markdown", { force: true });
         },
       },
       {

--- a/frontend/src/core/codemirror/extensions.ts
+++ b/frontend/src/core/codemirror/extensions.ts
@@ -39,7 +39,9 @@ export function formatKeymapExtension(
         }
         const destinationLanguage =
           currentLanguage === "python" ? "markdown" : "python";
-        const response = toggleToLanguage(ev, destinationLanguage);
+        const response = toggleToLanguage(ev, destinationLanguage, {
+          force: true,
+        });
         if (response === "markdown") {
           afterToggleMarkdown();
         }

--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -40,11 +40,14 @@ describe("MarkdownLanguageAdapter", () => {
       expect(offset).toBe(9);
     });
 
-    it("should throw if no markdown is detected", () => {
+    it("should still transform if no markdown is detected", () => {
       const pythonCode = 'print("Hello, World!")';
-      expect(() =>
-        adapter.transformIn(pythonCode),
-      ).toThrowErrorMatchingInlineSnapshot(`[Error: Not supported]`);
+      expect(adapter.transformIn(pythonCode)).toMatchInlineSnapshot(`
+        [
+          "print("Hello, World!")",
+          0,
+        ]
+      `);
     });
 
     it("should handle an empty string", () => {
@@ -91,11 +94,11 @@ describe("MarkdownLanguageAdapter", () => {
       expect(offset).toBe('mo.md("""'.length);
     });
 
-    it("should return the original string if no markdown delimiters are present", () => {
+    it("should convert to markdown anyways", () => {
       const pythonCode = 'print("No markdown here")';
-      expect(() =>
-        adapter.transformIn(pythonCode),
-      ).toThrowErrorMatchingInlineSnapshot(`[Error: Not supported]`);
+      const [innerCode, offset] = adapter.transformIn(pythonCode);
+      expect(innerCode).toBe(`print("No markdown here")`);
+      expect(offset).toBe(0);
     });
 
     it("should handle multiple markdown blocks in a single string", () => {

--- a/frontend/src/core/codemirror/language/commands.ts
+++ b/frontend/src/core/codemirror/language/commands.ts
@@ -37,9 +37,10 @@ export function canToggleToLanguage(
 export function toggleToLanguage(
   editorView: EditorView,
   language: LanguageAdapterType,
+  opts: { force?: boolean } = {},
 ): LanguageAdapterType | false {
   // Check if the language can be toggled
-  if (!canToggleToLanguage(editorView, language)) {
+  if (!opts.force && !canToggleToLanguage(editorView, language)) {
     return false;
   }
 

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -54,10 +54,6 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
   lastQuotePrefix: QuotePrefixKind = "";
 
   transformIn(pythonCode: string): [string, number] {
-    if (!this.isSupported(pythonCode)) {
-      throw new Error("Not supported");
-    }
-
     pythonCode = pythonCode.trim();
 
     // empty string
@@ -82,6 +78,7 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
       }
     }
 
+    // no match
     return [pythonCode, 0];
   }
 


### PR DESCRIPTION
This allow converting any python to markdown, even if its not in the valid markdown syntax `mo.md(...)`