### PR TITLE
fix: dont show tables with many columns

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -161,7 +161,7 @@ class FormattedOutput:
     exception: BaseException | None = None
 
 
-def try_format(obj: Any, include_opinionated=True) -> FormattedOutput:
+def try_format(obj: Any, include_opinionated: bool = True) -> FormattedOutput:
     obj = "" if obj is None else obj
     if (
         formatter := get_formatter(

--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -158,20 +158,26 @@ class FormattedOutput:
     mimetype: KnownMimeType
     data: str
     traceback: Optional[str] = None
+    exception: BaseException | None = None
 
 
-def try_format(obj: Any) -> FormattedOutput:
+def try_format(obj: Any, include_opinionated=True) -> FormattedOutput:
     obj = "" if obj is None else obj
-    if (formatter := get_formatter(obj)) is not None:
+    if (
+        formatter := get_formatter(
+            obj, include_opinionated=include_opinionated
+        )
+    ) is not None:
         try:
             mimetype, data = formatter(obj)
             return FormattedOutput(mimetype=mimetype, data=data)
-        except BaseException:  # noqa: E722
+        except BaseException as e:  # noqa: E722
             # Catching base exception so we're robust to bugs in libraries
             return FormattedOutput(
                 mimetype="text/plain",
                 data="",
                 traceback=traceback.format_exc(),
+                exception=e,
             )
 
     from marimo._runtime.context import ContextNotInitializedError, get_context

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -206,11 +206,22 @@ class table(
         # Holds the data after selection and filtering
         self._selected_manager: Optional[TableManager[Any]] = None
 
+        if (
+            total_cols := self._manager.get_num_columns()
+        ) > TableManager.DEFAULT_COL_LIMIT:
+            raise ValueError(
+                f"Your table has {total_cols} columns, "
+                "which is greater than the maximum allowed columns of "
+                f"{TableManager.DEFAULT_COL_LIMIT} for mo.ui.table(). "
+                "If this is a problem, please open a GitHub issue: "
+                "https://github.com/marimo-team/marimo/issues"
+            )
+
         totalRows = self._manager.get_num_rows(force=True) or 0
-        hasMore = totalRows > TableManager.DEFAULT_LIMIT
+        hasMore = totalRows > TableManager.DEFAULT_ROW_LIMIT
         if hasMore:
             self._filtered_manager = self._filtered_manager.limit(
-                TableManager.DEFAULT_LIMIT
+                TableManager.DEFAULT_ROW_LIMIT
             )
 
         # pagination defaults to True if there are more than 10 rows
@@ -334,4 +345,4 @@ class table(
             result = result.sort_values(args.sort.by, args.sort.descending)
         # Save the manager to be used for selection
         self._filtered_manager = result
-        return result.limit(TableManager.DEFAULT_LIMIT).to_data()
+        return result.limit(TableManager.DEFAULT_ROW_LIMIT).to_data()

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -16,7 +16,8 @@ FieldTypes = Dict[ColumnName, Tuple[FieldType, ExternalDataType]]
 
 
 class TableManager(abc.ABC, Generic[T]):
-    DEFAULT_LIMIT = 20_000
+    DEFAULT_ROW_LIMIT = 20_000
+    DEFAULT_COL_LIMIT = 100
     type: str = ""
 
     def __init__(self, data: T) -> None:

--- a/marimo/_runtime/runner/hooks_post_execution.py
+++ b/marimo/_runtime/runner/hooks_post_execution.py
@@ -154,6 +154,13 @@ def _broadcast_outputs(
 
         def format_output() -> formatting.FormattedOutput:
             formatted_output = formatting.try_format(run_result.output)
+
+            if formatted_output.exception is not None:
+                # Try a plain formatter; maybe an opinionated one failed.
+                formatted_output = formatting.try_format(
+                    run_result.output, include_opinionated=False
+                )
+
             if formatted_output.traceback is not None:
                 write_traceback(formatted_output.traceback)
             return formatted_output

--- a/marimo/_server/api/endpoints/terminal.py
+++ b/marimo/_server/api/endpoints/terminal.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 import asyncio

--- a/marimo/_smoke_tests/polars/polars_to_csv.py
+++ b/marimo/_smoke_tests/polars/polars_to_csv.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.8"

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -257,3 +257,11 @@ def test_value_with_search_then_selection():
     # empty search
     table.search(SearchTableArgs())
     assert list(table._convert_value(["2"])) == [{"value": "cherry"}]
+
+
+def test_table_with_too_many_columns_fails():
+    data = {str(i): [1] for i in range(101)}
+    with pytest.raises(ValueError) as e:
+        ui.table(data)
+
+    assert "greater than the maximum allowed columns" in str(e)


### PR DESCRIPTION
Refuse to show tables with > 100 columns as a heuristic to prevent the frontend from crashing.

Can handle this more gracefully in the future if needed.

Fixes #1846 