### PR TITLE
fix: always use triple quotes to prevent escaping single quotes

### DIFF
--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -13,8 +13,8 @@ describe("MarkdownLanguageAdapter", () => {
       const out = adapter.transformOut(innerCode);
       expect(out).toMatchInlineSnapshot(`
         [
-          "mo.md(r"")",
-          8,
+          "mo.md(r""" """)",
+          10,
         ]
       `);
     });
@@ -158,6 +158,50 @@ describe("MarkdownLanguageAdapter", () => {
   });
 
   describe("transformOut", () => {
+    it("empty string", () => {
+      const code = "";
+      adapter.lastQuotePrefix = "";
+      const [wrappedCode, offset] = adapter.transformOut(code);
+      expect(wrappedCode).toBe(`mo.md(""" """)`);
+      expect(offset).toBe(9);
+    });
+
+    it("single line", () => {
+      const code = "Hello world";
+      adapter.lastQuotePrefix = "";
+      const [wrappedCode, offset] = adapter.transformOut(code);
+      expect(wrappedCode).toBe(`mo.md("""Hello world""")`);
+      expect(offset).toBe(9);
+    });
+
+    it("starts with quote", () => {
+      const code = '"Hello" world';
+      adapter.lastQuotePrefix = "";
+      const [wrappedCode, offset] = adapter.transformOut(code);
+      expect(wrappedCode).toMatchInlineSnapshot(`
+        "mo.md(
+            """
+            "Hello" world
+            """
+        )"
+      `);
+      expect(offset).toBe(16);
+    });
+
+    it("ends with quote", () => {
+      const code = 'Hello "world"';
+      adapter.lastQuotePrefix = "";
+      const [wrappedCode, offset] = adapter.transformOut(code);
+      expect(wrappedCode).toMatchInlineSnapshot(`
+        "mo.md(
+            """
+            Hello "world"
+            """
+        )"
+      `);
+      expect(offset).toBe(16);
+    });
+
     it("should wrap Markdown code with triple double-quoted string format", () => {
       const code = "# Markdown Title\n\nSome content here.";
       adapter.lastQuotePrefix = "";
@@ -179,9 +223,9 @@ describe("MarkdownLanguageAdapter", () => {
       adapter.lastQuotePrefix = "";
       const [wrappedCode, offset] = adapter.transformOut(code);
       expect(wrappedCode).toBe(
-        `mo.md("Markdown with an escaped \\"\\"\\"quote\\"\\"\\"!!")`,
+        `mo.md("""Markdown with an escaped \\"""quote\\"""!!""")`,
       );
-      expect(offset).toBe(7);
+      expect(offset).toBe(9);
     });
 
     it.skip("should upgrade to an f-string if the code contains {}", () => {
@@ -203,9 +247,9 @@ describe("MarkdownLanguageAdapter", () => {
       const code = String.raw`$\nu = \mathllap{}\cdot\mathllap{\alpha}$`;
       adapter.lastQuotePrefix = "r";
       const [wrappedCode, offset] = adapter.transformOut(code);
-      const pythonCode = `mo.md(r"$\\nu = \\mathllap{}\\cdot\\mathllap{\\alpha}$")`;
+      const pythonCode = `mo.md(r"""$\\nu = \\mathllap{}\\cdot\\mathllap{\\alpha}$""")`;
       expect(wrappedCode).toBe(pythonCode);
-      expect(offset).toBe(8);
+      expect(offset).toBe(10);
     });
   });
 

--- a/frontend/src/core/codemirror/language/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/utils.test.ts
@@ -128,8 +128,8 @@ describe("splitEditor", () => {
       selection: { anchor: "Hello,".length },
     });
     const result = splitEditor(mockEditor);
-    expect(result.beforeCursorCode).toEqual('mo.md("Hello,")');
-    expect(result.afterCursorCode).toEqual('mo.md(" World!")');
+    expect(result.beforeCursorCode).toEqual('mo.md("""Hello,""")');
+    expect(result.afterCursorCode).toEqual('mo.md(""" World!""")');
   });
 
   // f-strings not currently supported
@@ -142,7 +142,7 @@ describe("splitEditor", () => {
       selection: { anchor: "{a}\n".length },
     });
     const result = splitEditor(mockEditor);
-    expect(result.beforeCursorCode).toEqual('mo.md(f"{a}")');
-    expect(result.afterCursorCode).toEqual('mo.md(f"{b}!")');
+    expect(result.beforeCursorCode).toEqual('mo.md(f"""{a}""")');
+    expect(result.afterCursorCode).toEqual('mo.md(f"""{b}!""")');
   });
 });

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -86,20 +86,27 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
     // Get the quote type from the last transformIn
     const prefix = this.lastQuotePrefix;
 
+    // Empty string
+    if (code === "") {
+      // Need at least a space, otherwise the output will be 6 quotes
+      code = " ";
+    }
+
+    // We always transform back with triple quotes, as to avoid needing to
+    // escape single quotes.
+    const escapedCode = code.replaceAll('"""', String.raw`\"""`);
+
+    // If its one line and not bounded by quotes, write it as single line
     const isOneLine = !code.includes("\n");
-    if (isOneLine) {
-      // This logic breaks f-strings:
-      //
-      // https://github.com/marimo-team/marimo/issues/1727
-      const escapedCode = code.replaceAll('"', '\\"');
-      const start = `mo.md(${prefix}"`;
-      const end = `")`;
+    const boundedByQuote = code.startsWith('"') || code.endsWith('"');
+    if (isOneLine && !boundedByQuote) {
+      const start = `mo.md(${prefix}"""`;
+      const end = `""")`;
       return [start + escapedCode + end, start.length];
     }
 
     // Multiline code
     const start = `mo.md(\n    ${prefix}"""\n`;
-    const escapedCode = code.replaceAll('"""', String.raw`\"""`);
     const end = `\n    """\n)`;
     return [start + indentOneTab(escapedCode) + end, start.length + 1];
   }

--- a/marimo/_smoke_tests/markdown_quotes.py
+++ b/marimo/_smoke_tests/markdown_quotes.py
@@ -1,0 +1,64 @@
+import marimo
+
+__generated_with = "0.7.9"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __(mo):
+    mo.md("""Markdown""")
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(r"""Markdown with an escaped \"""quote\"""!!""")
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        """
+        Markdown with a trailing "quote"
+        """
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        """
+        "Markdown" with a leading quote
+        """
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md("""Markdown with a trailing 'single quote'""")
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md("""'Markdown' with a leading single quote""")
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md("""Markdown with an triple-single '''quote'''!!""")
+    return
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #1832

We now always force triple quote (in some cases we keep a single line; others we make it multi-line). This is so that single quotes (which can be more common) don't need to be escaped.

If the user wants triple-quotes not escaped, they will need to remove the `r-string` (which is the default to latex works properly) for a normal string or f-string.