### PR TITLE
feat: max_height argument for ui.code_editor

### DIFF
--- a/frontend/src/plugins/impl/CodeEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/CodeEditorPlugin.tsx
@@ -15,6 +15,7 @@ interface Data {
   label: string | null;
   disabled?: boolean;
   minHeight?: number;
+  maxHeight?: number;
 }
 
 export class CodeEditorPlugin implements IPlugin<T, Data> {
@@ -28,6 +29,7 @@ export class CodeEditorPlugin implements IPlugin<T, Data> {
     label: z.string().nullable(),
     disabled: z.boolean().optional(),
     minHeight: z.number().optional(),
+    maxHeight: z.number().optional(),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -50,6 +52,7 @@ const CodeEditorComponent = (props: CodeEditorComponentProps) => {
   const { theme } = useTheme();
   const finalTheme = props.theme || theme;
   const minHeight = props.minHeight ? `${props.minHeight}px` : "70px";
+  const maxHeight = props.maxHeight ? `${props.maxHeight}px` : undefined;
 
   return (
     <Labeled label={props.label} align="top" fullWidth={true}>
@@ -57,6 +60,7 @@ const CodeEditorComponent = (props: CodeEditorComponentProps) => {
         className={`cm [&>*]:outline-none border rounded overflow-hidden ${finalTheme}`}
         theme={finalTheme === "dark" ? "dark" : "light"}
         minHeight={minHeight}
+        maxHeight={maxHeight}
         placeholder={props.placeholder}
         editable={!props.disabled}
         value={props.value}

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -787,6 +787,7 @@ class code_editor(UIElement[str, str]):
     - `theme`: theme of the code editor, defaults to the editor's default
     - `disabled`: whether the input is disabled
     - `min_height`: minimum height of the code editor in pixels
+    - `max_height`: maximum height of the code editor in pixels
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
@@ -801,10 +802,20 @@ class code_editor(UIElement[str, str]):
         theme: Optional[Literal["light", "dark"]] = None,
         disabled: bool = False,
         min_height: Optional[int] = None,
+        max_height: Optional[int] = None,
         *,
         label: str = "",
         on_change: Optional[Callable[[str], None]] = None,
     ) -> None:
+        if (
+            min_height is not None
+            and max_height is not None
+            and min_height > max_height
+        ):
+            raise ValueError(
+                f"min_height ({min_height}) must be <= max_height {max_height}"
+            )
+
         super().__init__(
             component_name=code_editor._name,
             initial_value=value,
@@ -815,6 +826,7 @@ class code_editor(UIElement[str, str]):
                 "theme": theme,
                 "disabled": disabled,
                 "min-height": min_height,
+                "max-height": max_height,
             },
             on_change=on_change,
         )

--- a/marimo/_smoke_tests/bugs/1851.py
+++ b/marimo/_smoke_tests/bugs/1851.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.9"

--- a/marimo/_smoke_tests/markdown_quotes.py
+++ b/marimo/_smoke_tests/markdown_quotes.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.9"


### PR DESCRIPTION
Optional argument to impose a max height in pixels for ui.code_editor. The editor scrolls if height > max_height. This is useful for embedding code editors with a lot of code in slides.