### PR TITLE
Set status to idle after formatters run, not before

### DIFF
--- a/marimo/_runtime/runner/hooks_post_execution.py
+++ b/marimo/_runtime/runner/hooks_post_execution.py
@@ -170,6 +170,7 @@ def _broadcast_outputs(
                 formatted_output = format_output()
         else:
             formatted_output = format_output()
+
         CellOp.broadcast_output(
             channel=CellChannel.OUTPUT,
             mimetype=formatted_output.mimetype,
@@ -237,11 +238,14 @@ def _reset_matplotlib_context(
 
 
 POST_EXECUTION_HOOKS: list[PostExecutionHookType] = [
-    _set_status_idle,
     _store_reference_to_output,
     _broadcast_variables,
     _broadcast_datasets,
     _broadcast_duckdb_tables,
     _broadcast_outputs,
     _reset_matplotlib_context,
+    # set status to idle after all post-processing is done, in case the
+    # other hooks take a long time (broadcast outputs can take a long time
+    # if a formatter is slow).
+    _set_status_idle,
 ]

--- a/marimo/_smoke_tests/bugs/1851.py
+++ b/marimo/_smoke_tests/bugs/1851.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.9"

--- a/marimo/_smoke_tests/markdown_quotes.py
+++ b/marimo/_smoke_tests/markdown_quotes.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.9"

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -881,7 +881,7 @@ class TestExecution:
         assert all(m[1]["cell_id"] == SCRATCH_CELL_ID for m in messages)
         assert m1[1]["status"] == "queued"
         assert m2[1]["status"] == "running"
-        assert m3[1]["status"] == None
+        assert m3[1]["status"] is None
         assert (
             m3[1]["output"]["data"] == "<pre style='font-size: 12px'>1</pre>"
         )

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -881,11 +881,11 @@ class TestExecution:
         assert all(m[1]["cell_id"] == SCRATCH_CELL_ID for m in messages)
         assert m1[1]["status"] == "queued"
         assert m2[1]["status"] == "running"
-        assert m3[1]["status"] == "idle"
-        assert m4[1]["status"] is None
+        assert m3[1]["status"] == None
         assert (
-            m4[1]["output"]["data"] == "<pre style='font-size: 12px'>1</pre>"
+            m3[1]["output"]["data"] == "<pre style='font-size: 12px'>1</pre>"
         )
+        assert m4[1]["status"] == "idle"
         # Does not pollute globals
         assert "x" not in k.globals
 
@@ -908,9 +908,9 @@ class TestExecution:
         # Has no errors
         assert not k.errors
         messages = mocked_kernel.stream.messages
-        last_message = messages[-1]
+        output_message = messages[-2]
         assert (
-            last_message[1]["output"]["data"]
+            output_message[1]["output"]["data"]
             == "<pre style='font-size: 12px'>20</pre>"
         )
         assert "z" in k.globals
@@ -936,9 +936,9 @@ class TestExecution:
         # Has no errors
         assert not k.errors
         messages = mocked_kernel.stream.messages
-        last_message = messages[-1]
+        output_message = messages[-2]
         assert (
-            last_message[1]["output"]["data"]
+            output_message[1]["output"]["data"]
             == "<pre style='font-size: 12px'>20</pre>"
         )
         assert "z" in k.globals


### PR DESCRIPTION
This PR modifies the cell state machine to count the cell as "running" when output formatters are running.

Sometimes formatters can take a very long time — today, this happens when outputting a very large list or dict. Before this change, formatters that took a long time would lock the kernel without any UI indication in the frontend, making the notebook appear to be broken. 

This has the side-effect of making a formatter interruptible, which is helpful if the formatter is taking a very long time to run.

Re: lists/dicts formatting, we should probably lists/dicts/tuples when outputting very large ones, to avoid locking the kernel, but can handle that in another PR.

Draft because haven't tested thoroughly.