### PR TITLE
fix: mpl.interactive should not hang when running as a script

### DIFF
--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -19,17 +19,21 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from starlette.websockets import WebSocketState
 
+from marimo import _loggers
 from marimo._output.builder import h
+from marimo._output.formatting import as_html
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
 from marimo._runtime.context import (
-    ContextNotInitializedError,
     RuntimeContext,
     get_context,
 )
+from marimo._runtime.context.kernel_context import KernelRuntimeContext
 from marimo._server.utils import find_free_port
 from marimo._utils.signals import get_signals
+
+LOGGER = _loggers.marimo_logger()
 
 if TYPE_CHECKING:
     from starlette.applications import Starlette
@@ -259,12 +263,13 @@ def interactive(figure: "Figure | Axes") -> Html:  # type: ignore[name-defined] 
     if isinstance(figure, Axes):
         figure = figure.get_figure()
 
-    try:
-        ctx = get_context()
-    except ContextNotInitializedError as err:
-        raise RuntimeError(
-            "marimo.mpl.interactive can't be used when running as a script."
-        ) from err
+    ctx = get_context()
+    if not isinstance(ctx, KernelRuntimeContext):
+        LOGGER.warning(
+            "mo.mpl.interactive is not supported when running as a script; "
+            "rendering a static plot instead."
+        )
+        return as_html(figure)
 
     # Figure Manager, Any type because matplotlib doesn't have typings
     figure_manager = new_figure_manager_given_figure(id(figure), figure)

--- a/marimo/_smoke_tests/bugs/1851.py
+++ b/marimo/_smoke_tests/bugs/1851.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.9"

--- a/marimo/_smoke_tests/markdown_quotes.py
+++ b/marimo/_smoke_tests/markdown_quotes.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.9"


### PR DESCRIPTION
Fixes #1869 — makes `mpl.interactive` return a static plot in script mode instead.