### PR TITLE
fix: handle exit code in terminal, auto-close terminal

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -208,7 +208,10 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
     >
       {terminalResizeHandle}
       <LazyMount isOpen={isTerminalOpen}>
-        <LazyTerminal />
+        <LazyTerminal
+          visible={isTerminalOpen}
+          onClose={() => setIsTerminalOpen(false)}
+        />
       </LazyMount>
     </Panel>
   );


### PR DESCRIPTION
Handles writing `exit` in the terminal 

Fixes #1872