### PR TITLE
fix: mo.ui.dataframe filtering

### DIFF
--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -1,12 +1,12 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { z } from "zod";
 
-import { Transformations } from "./schema";
+import type { Transformations } from "./schema";
 import { TransformPanel } from "./panel";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Code2Icon, FunctionSquareIcon } from "lucide-react";
 import { CodePanel } from "./python/code-panel";
-import { ColumnDataTypes, ColumnId } from "./types";
+import type { ColumnDataTypes, ColumnId } from "./types";
 import { createPlugin } from "@/plugins/core/builder";
 import { rpc } from "@/plugins/core/rpc";
 import { useAsyncData } from "@/hooks/useAsyncData";
@@ -16,6 +16,7 @@ import { Arrays } from "@/utils/arrays";
 import { memo, useState } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Banner, ErrorBanner } from "../common/error-banner";
+import type { DataType } from "../vega/vega-loader";
 
 /**
  * Arguments for a data table
@@ -62,7 +63,9 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
         .array(z.tuple([z.string().or(z.number()), z.string(), z.string()]))
         .transform((value) => {
           const map = new Map<ColumnId, string>();
-          value.forEach(([key, dtype]) => map.set(key as ColumnId, dtype));
+          value.forEach(([key, dataType]) =>
+            map.set(key as ColumnId, dataType as DataType),
+          );
           return map;
         }),
     }),

--- a/frontend/src/plugins/impl/data-frames/types.ts
+++ b/frontend/src/plugins/impl/data-frames/types.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { DataType } from "@/core/kernel/messages";
+import type { DataType } from "@/core/kernel/messages";
 import { logNever } from "@/utils/assertNever";
 
 /**

--- a/frontend/src/plugins/impl/data-frames/utils/__tests__/operators.test.ts
+++ b/frontend/src/plugins/impl/data-frames/utils/__tests__/operators.test.ts
@@ -14,10 +14,16 @@ import {
 describe("getOperatorForDtype", () => {
   it('should return BOOLEAN_OPERATORS for "bool"', () => {
     expect(getOperatorForDtype("bool")).toEqual(Object.keys(BOOLEAN_OPERATORS));
+    expect(getOperatorForDtype("boolean")).toEqual(
+      Object.keys(BOOLEAN_OPERATORS),
+    );
   });
 
   it('should return NUMERIC_OPERATORS for "int" and "float"', () => {
     expect(getOperatorForDtype("int")).toEqual(Object.keys(NUMERIC_OPERATORS));
+    expect(getOperatorForDtype("number")).toEqual(
+      Object.keys(NUMERIC_OPERATORS),
+    );
     expect(getOperatorForDtype("float")).toEqual(
       Object.keys(NUMERIC_OPERATORS),
     );
@@ -25,6 +31,10 @@ describe("getOperatorForDtype", () => {
 
   it('should return DATE_OPERATORS for "datetime64[ns]"', () => {
     expect(getOperatorForDtype("datetime64[ns]")).toEqual(
+      Object.keys(DATE_OPERATORS),
+    );
+    expect(getOperatorForDtype("date")).toEqual(Object.keys(DATE_OPERATORS));
+    expect(getOperatorForDtype("datetime")).toEqual(
       Object.keys(DATE_OPERATORS),
     );
   });
@@ -38,6 +48,13 @@ describe("getOperatorForDtype", () => {
     );
   });
 
+  it("should return empty array for bool", () => {
+    expect(getOperatorForDtype("bool")).toEqual(Object.keys(BOOLEAN_OPERATORS));
+    expect(getOperatorForDtype("boolean")).toEqual(
+      Object.keys(BOOLEAN_OPERATORS),
+    );
+  });
+
   it("should return empty array for unknown dtype", () => {
     expect(getOperatorForDtype("unknown")).toEqual([]);
   });
@@ -48,10 +65,17 @@ describe("getSchemaForOperator", () => {
     expect(getSchemaForOperator("bool", "is true")).toEqual(
       BOOLEAN_OPERATORS.is_true,
     );
+    expect(getSchemaForOperator("boolean", "is true")).toEqual(
+      BOOLEAN_OPERATORS.is_true,
+    );
     expect(getSchemaForOperator("int", "==")).toEqual(NUMERIC_OPERATORS["=="]);
+    expect(getSchemaForOperator("number", "==")).toEqual(
+      NUMERIC_OPERATORS["=="],
+    );
     expect(getSchemaForOperator("datetime64[ns]", "!=")).toEqual(
       DATE_OPERATORS["!="],
     );
+    expect(getSchemaForOperator("date", "!=")).toEqual(DATE_OPERATORS["!="]);
     expect(getSchemaForOperator("string", "contains")).toEqual(
       STRING_OPERATORS.contains,
     );

--- a/frontend/src/plugins/impl/data-frames/utils/operators.ts
+++ b/frontend/src/plugins/impl/data-frames/utils/operators.ts
@@ -1,6 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { z } from "zod";
 import { FieldOptions } from "../forms/options";
+import type { DataType } from "@/core/kernel/messages";
 
 const Schema = {
   number: z.coerce.number().describe(FieldOptions.of({ label: "Value" })),
@@ -65,6 +66,43 @@ export const ALL_OPERATORS = {
 
 export type OperatorType = keyof typeof ALL_OPERATORS;
 
+function numpyTypeToDataType(type: string): DataType {
+  if (!type) {
+    return "unknown";
+  }
+
+  if (type.startsWith("int")) {
+    return "integer";
+  }
+
+  if (
+    type.startsWith("float") ||
+    type.startsWith("uint") ||
+    type.startsWith("number") ||
+    type.startsWith("complex")
+  ) {
+    return "number";
+  }
+
+  if (
+    type.startsWith("string") ||
+    type.startsWith("object") ||
+    type.startsWith("utf8")
+  ) {
+    return "string";
+  }
+
+  if (type.startsWith("date") || type.startsWith("time")) {
+    return "date";
+  }
+
+  if (type.startsWith("bool")) {
+    return "boolean";
+  }
+
+  return "unknown";
+}
+
 export function getOperatorForDtype(
   dtype: string | undefined,
 ): readonly string[] {
@@ -72,16 +110,21 @@ export function getOperatorForDtype(
     return [];
   }
 
-  if (dtype === "bool") {
-    return Object.keys(BOOLEAN_OPERATORS);
-  } else if (dtype.startsWith("int") || dtype.startsWith("float")) {
-    return Object.keys(NUMERIC_OPERATORS);
-  } else if (dtype === "datetime64[ns]") {
-    return Object.keys(DATE_OPERATORS);
-  } else if (dtype === "object" || dtype === "string") {
-    return Object.keys(STRING_OPERATORS);
-  } else {
-    return [];
+  const dataType = numpyTypeToDataType(dtype);
+
+  switch (dataType) {
+    case "integer":
+      return Object.keys(NUMERIC_OPERATORS);
+    case "number":
+      return Object.keys(NUMERIC_OPERATORS);
+    case "string":
+      return Object.keys(STRING_OPERATORS);
+    case "date":
+      return Object.keys(DATE_OPERATORS);
+    case "boolean":
+      return Object.keys(BOOLEAN_OPERATORS);
+    case "unknown":
+      return [];
   }
 }
 
@@ -93,16 +136,21 @@ export function getSchemaForOperator(
     return [];
   }
 
-  if (dtype === "bool") {
-    return safeGet(BOOLEAN_OPERATORS, operator);
-  } else if (dtype.startsWith("int") || dtype.startsWith("float")) {
-    return safeGet(NUMERIC_OPERATORS, operator);
-  } else if (dtype === "datetime64[ns]") {
-    return safeGet(DATE_OPERATORS, operator);
-  } else if (dtype === "object" || dtype === "string") {
-    return safeGet(STRING_OPERATORS, operator);
-  } else {
-    return [];
+  const dataType = numpyTypeToDataType(dtype);
+
+  switch (dataType) {
+    case "integer":
+      return safeGet(NUMERIC_OPERATORS, operator);
+    case "number":
+      return safeGet(NUMERIC_OPERATORS, operator);
+    case "string":
+      return safeGet(STRING_OPERATORS, operator);
+    case "date":
+      return safeGet(DATE_OPERATORS, operator);
+    case "boolean":
+      return safeGet(BOOLEAN_OPERATORS, operator);
+    case "unknown":
+      return [];
   }
 }
 

--- a/marimo/_smoke_tests/dataframe.py
+++ b/marimo/_smoke_tests/dataframe.py
@@ -2,13 +2,13 @@
 
 import marimo
 
-__generated_with = "0.6.18"
+__generated_with = "0.7.12"
 app = marimo.App(width="full")
 
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("# 🤖 Lists/Dicts")
+    mo.md("""# 🤖 Lists/Dicts""")
     return
 
 
@@ -63,13 +63,13 @@ def __(as_primitives):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("# 🐼 Pandas")
+    mo.md("""# 🐼 Pandas""")
     return
 
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## mo.ui.dataframe")
+    mo.md("""## mo.ui.dataframe""")
     return
 
 
@@ -82,7 +82,7 @@ def __(cars, mo):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## mo.ui.table")
+    mo.md("""## mo.ui.table""")
     return
 
 
@@ -94,7 +94,7 @@ def __(dataframe, mo):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## .value")
+    mo.md("""## .value""")
     return
 
 
@@ -112,7 +112,7 @@ def __(dataframe):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## mo.ui.data_explorer")
+    mo.md("""## mo.ui.data_explorer""")
     return
 
 
@@ -124,13 +124,13 @@ def __(mo, pl_dataframe):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("# 🐻‍❄️ Polars")
+    mo.md("""# 🐻‍❄️ Polars""")
     return
 
 
 @app.cell
 def __(mo):
-    mo.md("## mo.ui.dataframe")
+    mo.md("""## mo.ui.dataframe""")
     return
 
 
@@ -149,7 +149,7 @@ def __(pl_dataframe_prime):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## mo.ui.table")
+    mo.md("""## mo.ui.table""")
     return
 
 
@@ -162,7 +162,7 @@ def __(cars, mo, pl):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## mo.ui.data_explorer")
+    mo.md("""## mo.ui.data_explorer""")
     return
 
 
@@ -174,7 +174,7 @@ def __(mo, pl_dataframe):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("# 🏹 Arrow")
+    mo.md("""# 🏹 Arrow""")
     return
 
 
@@ -187,7 +187,7 @@ def __(cars, mo, pa):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## mo.ui.table")
+    mo.md("""## mo.ui.table""")
     return
 
 
@@ -200,7 +200,7 @@ def __(arrow_table, mo):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## .value")
+    mo.md("""## .value""")
     return
 
 


### PR DESCRIPTION
When we added polars support, we moved away from numpy types and instead created our own types. So i accidentally regressed the filtering chooser. 

Fixes #1880