### PR TITLE
fix: preserve whitespace in data table

### DIFF
--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -127,13 +127,15 @@ const DataTableInternal = <TData,>({
       return;
     }
 
+    // whitespace-pre so that strings with different whitespace look
+    // different
     return table.getHeaderGroups().map((headerGroup) => (
       <TableRow key={headerGroup.id}>
         {headerGroup.headers.map((header) => {
           return (
             <TableHead
               key={header.id}
-              className="h-auto min-h-10 whitespace-nowrap align-baseline"
+              className="h-auto min-h-10 whitespace-pre align-baseline"
             >
               {header.isPlaceholder
                 ? null
@@ -181,7 +183,7 @@ const DataTableInternal = <TData,>({
                     <TableCell
                       key={cell.id}
                       className={cn(
-                        "whitespace-nowrap truncate max-w-[300px]",
+                        "whitespace-pre truncate max-w-[300px]",
                         cell.column.getColumnWrapping &&
                           cell.column.getColumnWrapping() === "wrap" &&
                           "whitespace-pre-wrap min-w-[200px]",

--- a/marimo/_smoke_tests/markdown_size.py
+++ b/marimo/_smoke_tests/markdown_size.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.7.12"

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -25,7 +25,7 @@ class TestPandasTableManager(unittest.TestCase):
                 # Integer
                 "A": [1, 2, 3],
                 # String
-                "B": ["a", "b", "c"],
+                "B": ["a", "b", " b"],
                 # Float
                 "C": [1.0, 2.0, 3.0],
                 # Boolean
@@ -345,7 +345,11 @@ class TestPandasTableManager(unittest.TestCase):
 
     def test_get_unique_column_values(self) -> None:
         column = "B"
-        assert self.manager.get_unique_column_values(column) == ["a", "b", "c"]
+        assert self.manager.get_unique_column_values(column) == [
+            "a",
+            "b",
+            " b",
+        ]
 
     def test_search(self) -> None:
         import pandas as pd


### PR DESCRIPTION
So NLP-ers and data scientists can see true underlying data.

![image](https://github.com/user-attachments/assets/41329be0-35d2-4b02-a171-c97fe87630d3)

Before this change, the two rows looked identical -- saw an NLP-er bang their head against this for a while (they incorrectly thought their data had dupes based on what they saw).
