### PR TITLE
fix: marimo edit with absolute path to directory

### DIFF
--- a/frontend/src/components/pages/home-page.tsx
+++ b/frontend/src/components/pages/home-page.tsx
@@ -62,6 +62,7 @@ import {
 } from "../home/state";
 import { Maps } from "@/utils/maps";
 import { Input } from "../ui/input";
+import { Paths } from "@/utils/paths";
 
 function tabTarget(path: string) {
   // Consistent tab target so we open in the same tab when clicking on the same notebook
@@ -262,6 +263,7 @@ const Node = ({ node, style }: NodeRendererProps<FileInfo>) => {
 
   const Icon = FILE_TYPE_ICONS[fileType];
   const iconEl = <Icon className="w-5 h-5 flex-shrink-0" strokeWidth={1.5} />;
+  const root = useContext(RunningNotebooksContext).root;
 
   const renderItem = () => {
     const itemClassName =
@@ -275,21 +277,25 @@ const Node = ({ node, style }: NodeRendererProps<FileInfo>) => {
       );
     }
 
-    const path = node.data.path;
-    const isMarkdown = path.endsWith(".md");
+    const relativePath =
+      node.data.path.startsWith(root) && Paths.isAbsolute(node.data.path)
+        ? node.data.path.slice(root.length + 1)
+        : node.data.path;
+
+    const isMarkdown = relativePath.endsWith(".md");
 
     return (
       <a
         className={itemClassName}
-        href={asURL(`?file=${path}`).toString()}
-        target={tabTarget(path)}
+        href={asURL(`?file=${relativePath}`).toString()}
+        target={tabTarget(relativePath)}
       >
         {iconEl}
         <span className="flex-1 overflow-hidden text-ellipsis">
           {node.data.name}
           {isMarkdown && <MarkdownIcon className="ml-2 inline opacity-80" />}
         </span>
-        <SessionShutdownButton filePath={path} />
+        <SessionShutdownButton filePath={relativePath} />
         <ExternalLinkIcon
           size={20}
           className="group-hover:opacity-100 opacity-0 text-primary"

--- a/frontend/src/components/pages/home-page.tsx
+++ b/frontend/src/components/pages/home-page.tsx
@@ -62,7 +62,6 @@ import {
 } from "../home/state";
 import { Maps } from "@/utils/maps";
 import { Input } from "../ui/input";
-import { Paths } from "@/utils/paths";
 
 function tabTarget(path: string) {
   // Consistent tab target so we open in the same tab when clicking on the same notebook
@@ -263,7 +262,6 @@ const Node = ({ node, style }: NodeRendererProps<FileInfo>) => {
 
   const Icon = FILE_TYPE_ICONS[fileType];
   const iconEl = <Icon className="w-5 h-5 flex-shrink-0" strokeWidth={1.5} />;
-  const root = useContext(RunningNotebooksContext).root;
 
   const renderItem = () => {
     const itemClassName =
@@ -277,25 +275,21 @@ const Node = ({ node, style }: NodeRendererProps<FileInfo>) => {
       );
     }
 
-    const relativePath =
-      node.data.path.startsWith(root) && Paths.isAbsolute(node.data.path)
-        ? node.data.path.slice(root.length + 1)
-        : node.data.path;
-
-    const isMarkdown = relativePath.endsWith(".md");
+    const path = node.data.path;
+    const isMarkdown = path.endsWith(".md");
 
     return (
       <a
         className={itemClassName}
-        href={asURL(`?file=${relativePath}`).toString()}
-        target={tabTarget(relativePath)}
+        href={asURL(`?file=${path}`).toString()}
+        target={tabTarget(path)}
       >
         {iconEl}
         <span className="flex-1 overflow-hidden text-ellipsis">
           {node.data.name}
           {isMarkdown && <MarkdownIcon className="ml-2 inline opacity-80" />}
         </span>
-        <SessionShutdownButton filePath={relativePath} />
+        <SessionShutdownButton filePath={path} />
         <ExternalLinkIcon
           size={20}
           className="group-hover:opacity-100 opacity-0 text-primary"

--- a/frontend/src/components/pages/home-page.tsx
+++ b/frontend/src/components/pages/home-page.tsx
@@ -279,7 +279,7 @@ const Node = ({ node, style }: NodeRendererProps<FileInfo>) => {
 
     const relativePath =
       node.data.path.startsWith(root) && Paths.isAbsolute(node.data.path)
-        ? node.data.path.slice(root.length + 1)
+        ? Paths.rest(node.data.path, root)
         : node.data.path;
 
     const isMarkdown = relativePath.endsWith(".md");

--- a/frontend/src/utils/__tests__/path.test.ts
+++ b/frontend/src/utils/__tests__/path.test.ts
@@ -48,6 +48,38 @@ describe("Paths", () => {
       expect(Paths.basename("C:\\user\\docs\\Letter.txt")).toBe("Letter.txt");
     });
   });
+
+  describe("rest", () => {
+    it("should return the suffix of a path", () => {
+      expect(Paths.rest("/user/docs/Letter.txt", "/user/docs")).toBe(
+        "Letter.txt",
+      );
+      expect(Paths.rest("/user/docs/Letter.txt", "/user/docs/")).toBe(
+        "Letter.txt",
+      );
+      expect(Paths.rest("/user/docs/Letter.txt", "/user")).toBe(
+        "docs/Letter.txt",
+      );
+      expect(Paths.rest("/user/docs/Letter.txt", "/user/")).toBe(
+        "docs/Letter.txt",
+      );
+    });
+
+    it("should handle windows-style paths", () => {
+      expect(Paths.rest("C:\\user\\docs\\Letter.txt", "C:\\user\\docs")).toBe(
+        "Letter.txt",
+      );
+      expect(Paths.rest("C:\\user\\docs\\Letter.txt", "C:\\user\\docs\\")).toBe(
+        "Letter.txt",
+      );
+      expect(Paths.rest("C:\\user\\docs\\Letter.txt", "C:\\user")).toBe(
+        "docs\\Letter.txt",
+      );
+      expect(Paths.rest("C:\\user\\docs\\Letter.txt", "C:\\user\\")).toBe(
+        "docs\\Letter.txt",
+      );
+    });
+  });
 });
 
 describe("PathBuilder", () => {

--- a/frontend/src/utils/paths.ts
+++ b/frontend/src/utils/paths.ts
@@ -16,6 +16,12 @@ export const Paths = {
   basename: (path: string) => {
     return PathBuilder.guessDeliminator(path).basename(path as FilePath);
   },
+  rest: (path: string, root: string) => {
+    return PathBuilder.guessDeliminator(path).rest(
+      path as FilePath,
+      root as FilePath,
+    );
+  },
   extension: (filename: string): string => {
     const parts = filename.split(".");
     if (parts.length === 1) {
@@ -39,6 +45,18 @@ export class PathBuilder {
   basename(path: FilePath): FilePath {
     const parts = path.split(this.deliminator);
     return (parts.pop() ?? "") as FilePath;
+  }
+
+  rest(path: FilePath, root: FilePath): FilePath {
+    const pathParts = path.split(this.deliminator);
+    const rootParts = root.split(this.deliminator);
+    let i = 0;
+    for (; i < pathParts.length && i < rootParts.length; ++i) {
+      if (pathParts[i] !== rootParts[i]) {
+        break;
+      }
+    }
+    return pathParts.slice(i).join(this.deliminator) as FilePath;
   }
 
   dirname(path: FilePath): FilePath {

--- a/tests/_server/test_file_router.py
+++ b/tests/_server/test_file_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -46,7 +47,7 @@ class TestAppFileRouter(unittest.TestCase):
         os.unlink(self.test_file1.name)
         os.unlink(self.test_file2.name)
         os.unlink(self.test_file_3.name)
-        os.rmdir(self.test_dir)
+        shutil.rmtree(self.test_dir)
 
     def test_infer_file(self):
         # Test infer method with a file path
@@ -118,3 +119,11 @@ class TestAppFileRouter(unittest.TestCase):
         router = router.toggle_markdown(True)
         files = router.files
         assert len(files) == 3
+
+    def test_lazy_list_of_get_app_file_manager(self):
+        router = LazyListOfFilesAppFileRouter(
+            self.test_dir, include_markdown=False
+        )
+        basename = os.path.basename(self.test_file1.name)
+        file_manager = router.get_file_manager(key=basename)
+        assert file_manager.filename == os.path.join(self.test_dir, basename)


### PR DESCRIPTION
Fixes a bug in which marimo edit /abs/path/ would fail to open notebooks due to incorrect slicing.

Fixes a bug in which marimo edit /abs/path/ or /abs/path would fail when run in a directory other than /abs/path

Fixes #1895.