### PR TITLE
feat: sql support in wasm

### DIFF
--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -41,7 +41,6 @@ import { MarkdownLanguageAdapter } from "@/core/codemirror/language/markdown";
 import { capabilitiesAtom } from "@/core/config/capabilities";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Kbd } from "@/components/ui/kbd";
-import { isWasm } from "@/core/wasm/utils";
 
 interface CellArrayProps {
   notebook: NotebookState;

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -187,44 +187,42 @@ const AddCellButtons: React.FC = () => {
           <SquareMIcon className="mr-2 size-4 flex-shrink-0" />
           Markdown
         </Button>
-        {!isWasm() && (
-          <Tooltip
-            content={
-              sqlCapabilities ? null : (
-                <div className="flex flex-col">
-                  <span>
-                    Requires duckdb:{" "}
-                    <Kbd className="inline">pip install duckdb</Kbd>.
-                  </span>
-                  <span>
-                    You will need to restart the notebook after installing.
-                  </span>
-                </div>
-              )
-            }
-            delayDuration={100}
-            asChild={false}
-          >
-            <Button
-              className={buttonClass}
-              variant="text"
-              size="sm"
-              disabled={!sqlCapabilities}
-              onClick={() => {
-                maybeAddMarimoImport(autoInstantiate, createNewCell);
+        <Tooltip
+          content={
+            sqlCapabilities ? null : (
+              <div className="flex flex-col">
+                <span>
+                  Requires duckdb:{" "}
+                  <Kbd className="inline">pip install duckdb</Kbd>.
+                </span>
+                <span>
+                  You will need to restart the notebook after installing.
+                </span>
+              </div>
+            )
+          }
+          delayDuration={100}
+          asChild={false}
+        >
+          <Button
+            className={buttonClass}
+            variant="text"
+            size="sm"
+            disabled={!sqlCapabilities}
+            onClick={() => {
+              maybeAddMarimoImport(autoInstantiate, createNewCell);
 
-                createNewCell({
-                  cellId: "__end__",
-                  before: false,
-                  code: new SQLLanguageAdapter().defaultCode,
-                });
-              }}
-            >
-              <DatabaseIcon className="mr-2 size-4 flex-shrink-0" />
-              SQL
-            </Button>
-          </Tooltip>
-        )}
+              createNewCell({
+                cellId: "__end__",
+                before: false,
+                code: new SQLLanguageAdapter().defaultCode,
+              });
+            }}
+          >
+            <DatabaseIcon className="mr-2 size-4 flex-shrink-0" />
+            SQL
+          </Button>
+        </Tooltip>
         <Tooltip
           content={
             aiEnabled ? null : <span>Enable via settings under AI Assist</span>

--- a/frontend/src/core/islands/worker/worker.tsx
+++ b/frontend/src/core/islands/worker/worker.tsx
@@ -86,10 +86,16 @@ const requestHandler = createRPCRequestHandler({
   /**
    * Load packages
    */
-  loadPackages: async (packages: string) => {
+  loadPackages: async (code: string) => {
     await pyodideReadyPromise; // Make sure loading is done
 
-    await self.pyodide.loadPackagesFromImports(packages, {
+    if (code.includes("mo.sql")) {
+      // Add pandas and duckdb to the code
+      code = `import pandas\n${code}`;
+      code = `import duckdb\n${code}`;
+    }
+
+    await self.pyodide.loadPackagesFromImports(code, {
       messageCallback: Logger.log,
       errorCallback: Logger.error,
     });

--- a/frontend/src/core/kernel/handlers.ts
+++ b/frontend/src/core/kernel/handlers.ts
@@ -2,14 +2,23 @@
 import { deserializeLayout } from "@/components/editor/renderers/plugins";
 import { Objects } from "@/utils/objects";
 import { UI_ELEMENT_REGISTRY } from "../dom/uiregistry";
-import { LayoutData, LayoutState, initialLayoutState } from "../layout/layout";
+import {
+  type LayoutData,
+  type LayoutState,
+  initialLayoutState,
+} from "../layout/layout";
 import { sendInstantiate } from "../network/requests";
-import { Capabilities, CellMessage, OperationMessageData } from "./messages";
-import { LayoutType } from "@/components/editor/renderers/types";
-import { AppConfig } from "../config/config-schema";
-import { CellData, createCell } from "../cells/types";
+import type {
+  Capabilities,
+  CellMessage,
+  OperationMessageData,
+} from "./messages";
+import type { LayoutType } from "@/components/editor/renderers/types";
+import type { AppConfig } from "../config/config-schema";
+import { type CellData, createCell } from "../cells/types";
 import { VirtualFileTracker } from "../static/virtual-file-tracker";
-import { CellId, UIElementId } from "../cells/ids";
+import type { CellId, UIElementId } from "../cells/ids";
+import { isWasm } from "../wasm/utils";
 
 export function handleKernelReady(
   data: OperationMessageData<"kernel-ready">,
@@ -89,7 +98,11 @@ export function handleKernelReady(
   setAppConfig({
     ...app_config,
   } as AppConfig);
-  setCapabilities(capabilities);
+  setCapabilities({
+    ...capabilities,
+    // always enable sql if wasm
+    sql: capabilities.sql || isWasm(),
+  });
 
   // If resumed, we don't need to instantiate the UI elements,
   // and we should read in th existing values from the kernel.

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -2,12 +2,12 @@
 import type { PyodideInterface } from "pyodide";
 import { WasmFileSystem } from "./fs";
 import { Logger } from "../../../utils/Logger";
-import { SerializedBridge, WasmController } from "./types";
+import type { SerializedBridge, WasmController } from "./types";
 import { invariant } from "../../../utils/invariant";
-import { UserConfig } from "@/core/config/config-schema";
+import type { UserConfig } from "@/core/config/config-schema";
 import { getMarimoWheel } from "./getMarimoWheel";
-import { OperationMessage } from "@/core/kernel/messages";
-import { JsonString } from "@/utils/json/base64";
+import type { OperationMessage } from "@/core/kernel/messages";
+import type { JsonString } from "@/utils/json/base64";
 import { t } from "./tracer";
 
 declare let loadPyodide: (opts: {
@@ -32,8 +32,9 @@ export class DefaultWasmController implements WasmController {
     const { version } = opts;
 
     // If is a dev release, we need to install from test.pypi.org
-    if (version.includes("dev")) {
-      await this.installDevMarimo(pyodide, version);
+    if (version.includes("dev") || 4) {
+      await this.installDevMarimoAndDeps(pyodide, version);
+      return pyodide;
     }
 
     await this.installMarimoAndDeps(pyodide, version);
@@ -63,11 +64,14 @@ export class DefaultWasmController implements WasmController {
     return pyodide;
   }
 
-  private async installDevMarimo(pyodide: PyodideInterface, version: string) {
+  private async installDevMarimoAndDeps(
+    pyodide: PyodideInterface,
+    version: string,
+  ) {
     const span = t.startSpan("installDevMarimo");
-    await pyodide.runPythonAsync(`
+    await Promise.all([
+      pyodide.runPythonAsync(`
       import micropip
-
       await micropip.install(
         [
           "${getMarimoWheel(version)}",
@@ -75,7 +79,19 @@ export class DefaultWasmController implements WasmController {
         deps=False,
         index_urls="https://test.pypi.org/pypi/{package_name}/json"
         );
-      `);
+      `),
+      pyodide.runPythonAsync(`
+      import micropip
+      await micropip.install(
+        [
+          "Markdown==3.6",
+          "pymdown-extensions==10.8.1",
+          "duckdb==1.0.0",
+        ],
+        deps=False,
+        );
+      `),
+    ]);
     span.end("ok");
   }
 
@@ -86,12 +102,12 @@ export class DefaultWasmController implements WasmController {
     const span = t.startSpan("installMarimoAndDeps");
     await pyodide.runPythonAsync(`
       import micropip
-
       await micropip.install(
         [
           "${getMarimoWheel(version)}",
           "Markdown==3.6",
-          "pymdown-extensions==10.8.1"
+          "pymdown-extensions==10.8.1",
+          "duckdb==1.0.0",
         ],
         deps=False,
       );


### PR DESCRIPTION
Add sql support to wasm. `pandas` and `duckdb` aren't loaded until the first `mo.sql` call