### PR TITLE
feat: Support anywidget lifecycle hooks

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,6 @@
     "dist"
   ],
   "dependencies": {
-    "@anywidget/types": "^0.1.9",
     "@codemirror/autocomplete": "^6.16.3",
     "@codemirror/commands": "^6.6.0",
     "@codemirror/lang-markdown": "^6.2.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "dist"
   ],
   "dependencies": {
+    "@anywidget/types": "^0.1.9",
     "@codemirror/autocomplete": "^6.16.3",
     "@codemirror/commands": "^6.6.0",
     "@codemirror/lang-markdown": "^6.2.5",

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -1,7 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from "zod";
-import type { AnyWidget, AnyModel, Initialize, Render } from "@anywidget/types";
 
 import type { IPluginProps } from "@/plugins/types";
 import { useEffect, useRef } from "react";
@@ -12,7 +11,7 @@ import { useDeepCompareMemoize } from "@/hooks/useDeepCompareMemoize";
 import { ErrorBanner } from "../common/error-banner";
 import { createPlugin } from "@/plugins/core/builder";
 import { rpc } from "@/plugins/core/rpc";
-import type { EventHandler } from "./types";
+import type { AnyModel, AnyWidget, EventHandler, Experimental } from "./types";
 import { Logger } from "@/utils/Logger";
 import { useEventListener } from "@/hooks/useEventListener";
 import { MarimoIncomingMessageEvent } from "@/core/dom/events";
@@ -104,10 +103,18 @@ async function runAnyWidgetModule(
   model: Model<T>,
   el: HTMLElement,
 ) {
+  const experimental: Experimental = {
+    invoke: async (name, msg, options) => {
+      const message =
+        "anywidget.invoke not supported in marimo. Please file an issue at https://github.com/marimo-team/marimo/issues";
+      Logger.warn(message);
+      throw new Error(message);
+    },
+  };
   const widget =
     typeof widgetDef === "function" ? await widgetDef() : widgetDef;
-  await widget.initialize?.({ model });
-  await widget.render?.({ model, el });
+  await widget.initialize?.({ model, experimental });
+  await widget.render?.({ model, el, experimental });
 }
 
 function isAnyWidgetModule(mod: any): mod is { default: AnyWidget } {

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -99,8 +99,13 @@ const AnyWidgetSlot = (props: Props) => {
  * @param widgetDef - The anywidget definition
  * @param model - The model to pass to the widget
  */
-async function runAnyWidgetModule(widgetDef: AnyWidget, model: Model<T>, el: HTMLElement) {
-  const widget = typeof widgetDef === "function" ? await widgetDef() : widgetDef;
+async function runAnyWidgetModule(
+  widgetDef: AnyWidget,
+  model: Model<T>,
+  el: HTMLElement,
+) {
+  const widget =
+    typeof widgetDef === "function" ? await widgetDef() : widgetDef;
   await widget.initialize?.({ model });
   await widget.render?.({ model, el });
 }
@@ -155,7 +160,7 @@ class Model<T extends Record<string, any>> implements AnyModel<T> {
     private send_to_widget: (req: { content?: any }) => Promise<
       null | undefined
     >,
-  ) { }
+  ) {}
 
   off(eventName?: string | null, callback?: EventHandler | null): void {
     if (!eventName) {

--- a/frontend/src/plugins/impl/anywidget/types.ts
+++ b/frontend/src/plugins/impl/anywidget/types.ts
@@ -1,10 +1,13 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-invalid-void-type */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 // Copied from https://github.com/manzt/anywidget/blob/main/packages/types/index.ts
 // with slight modifications
 // - removed widget_manager
+// We copy this for now since `@anywidget/types` pulls in jquery and backbone, which we don't need
 
+type Awaitable<T> = T | Promise<T>;
 export type EventHandler = (...args: any[]) => void;
 type ObjectHash = Record<string, any>;
 export type ChangeEventHandler<Payload> = (_: unknown, value: Payload) => void;
@@ -36,3 +39,37 @@ export interface AnyModel<T extends ObjectHash = ObjectHash> {
   ): void;
   widget_manager: {};
 }
+
+export interface Experimental {
+  invoke: <T>(
+    name: string,
+    msg?: any,
+    options?: {
+      buffers?: DataView[];
+      signal?: AbortSignal;
+    },
+  ) => Promise<[T, DataView[]]>;
+}
+export interface RenderProps<T extends ObjectHash = ObjectHash> {
+  model: AnyModel<T>;
+  el: HTMLElement;
+  experimental: Experimental;
+}
+export type Render<T extends ObjectHash = ObjectHash> = (
+  props: RenderProps<T>,
+) => Awaitable<void | (() => Awaitable<void>)>;
+export interface InitializeProps<T extends ObjectHash = ObjectHash> {
+  model: AnyModel<T>;
+  experimental: Experimental;
+}
+
+export type Initialize<T extends ObjectHash = ObjectHash> = (
+  props: InitializeProps<T>,
+) => Awaitable<void | (() => Awaitable<void>)>;
+interface WidgetDef<T extends ObjectHash = ObjectHash> {
+  initialize?: Initialize<T>;
+  render?: Render<T>;
+}
+export type AnyWidget<T extends ObjectHash = ObjectHash> =
+  | WidgetDef<T>
+  | (() => Awaitable<WidgetDef<T>>);

--- a/marimo/_smoke_tests/quak-demo.py
+++ b/marimo/_smoke_tests/quak-demo.py
@@ -1,0 +1,37 @@
+import marimo
+
+__generated_with = "0.7.12"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import polars as pl
+    import quak
+    from vega_datasets import data
+    return data, mo, pl, quak
+
+
+@app.cell
+def __(data):
+    df = data.cars()
+    return df,
+
+
+@app.cell
+def __(df, mo, quak):
+    qwidget = quak.Widget(df)
+    w = mo.ui.anywidget(qwidget)
+    w
+    return qwidget, w
+
+
+@app.cell
+def __():
+    # w.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## 📝 Summary

Related to https://github.com/manzt/quak/issues/25

Sorry I probably won't have the time to test further but hopefully this is useful! Widgets can export and object or a function that returns a (promise) for an object with `initialize` and `render` [lifecycle hooks](https://anywidget.dev/blog/a-year-with-anywidget/#introducing-widget-lifecycle-hooks).

quak exports a default function (to intialize some initial state).

<!-- 
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123). 
-->

## 🔍 Description of Changes

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
