### PR TITLE
Fix `mo.ui.tabs` UI Component Documentation Example

### DIFF
--- a/marimo/_plugins/stateless/tabs.py
+++ b/marimo/_plugins/stateless/tabs.py
@@ -19,9 +19,9 @@ def tabs(tabs: dict[str, object]) -> Html:
 
     ```python
     tab1 = mo.vstack([
-        "slider": mo.ui.slider(1, 10),
-        "text": mo.ui.text(),
-        "date": mo.ui.date()
+        mo.ui.slider(1, 10),
+        mo.ui.text(),
+        mo.ui.date()
     ]);
     tab2 = mo.vstack([{
         "slider": mo.ui.slider(1, 10),


### PR DESCRIPTION
## 📝 Summary
This PR fixes incorrect notation in the UI component documentation (in docstrings - came across this when referring to the live docs in the siderbar panel in marimo itself). It removes misleading string keys and colons from the examples, ensuring that the documentation accurately reflects the proper usage of the framework's UI components.

Fixes #1915 

## 🔍 Description of Changes
This pull request addresses a documentation error in our UI component usage examples. The current documentation incorrectly shows UI components being used with string keys and colons, which could lead to implementation errors and developer confusion.

### Before:
```python
"slider": mo.ui.slider(1, 10),
"text": mo.ui.text(),
"date": mo.ui.date()
```

![image](https://github.com/user-attachments/assets/2e0621cc-3d61-4c29-9191-212935da41be)


### After:
```python
mo.ui.slider(1, 10),
mo.ui.text(),
mo.ui.date()
```

![image](https://github.com/user-attachments/assets/3b8cffcb-6f83-402b-b7ef-7d137e6ba1e6)

## 📋 Checklist
- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers
@akshayka OR @mscolnick