### PR TITLE
support tqdm.notebook

### DIFF
--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -21,6 +21,7 @@ from marimo._output.formatters.pandas_formatters import PandasFormatter
 from marimo._output.formatters.plotly_formatters import PlotlyFormatter
 from marimo._output.formatters.seaborn_formatters import SeabornFormatter
 from marimo._output.formatters.structures import StructuresFormatter
+from marimo._output.formatters.tqdm_formatters import TqdmFormatter
 
 # Map from formatter factory's package name to formatter, for third-party
 # modules. These formatters will be registered if and when their associated
@@ -38,6 +39,7 @@ THIRD_PARTY_FACTORIES: dict[str, FormatterFactory] = {
     HoloViewsFormatter.package_name(): HoloViewsFormatter(),
     IPythonFormatter.package_name(): IPythonFormatter(),
     AnyWidgetFormatter.package_name(): AnyWidgetFormatter(),
+    TqdmFormatter.package_name(): TqdmFormatter(),
 }
 
 # Formatters for builtin types and other things that don't require a

--- a/marimo/_output/formatters/tqdm_formatters.py
+++ b/marimo/_output/formatters/tqdm_formatters.py
@@ -15,7 +15,7 @@ class TqdmFormatter(FormatterFactory):
 
     def register(self) -> None:
         if running_in_notebook():
-            import tqdm.notebook  # type: ignore [import-not-found]
+            import tqdm.notebook  # type: ignore [import-not-found,import-untyped] # noqa: E501
 
             def tqdm_to_progress_bar(
                 *args: Any, **kwargs: Any

--- a/marimo/_output/formatters/tqdm_formatters.py
+++ b/marimo/_output/formatters/tqdm_formatters.py
@@ -1,0 +1,41 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import Any
+
+from marimo._output.formatters.formatter_factory import FormatterFactory
+from marimo._plugins.stateless.status._progress import progress_bar
+from marimo._runtime.context.utils import running_in_notebook
+
+
+class TqdmFormatter(FormatterFactory):
+    @staticmethod
+    def package_name() -> str:
+        return "tqdm"
+
+    def register(self) -> None:
+        if running_in_notebook():
+            import tqdm.notebook  # type: ignore [import-not-found]
+
+            def tqdm_to_progress_bar(
+                *args: Any, **kwargs: Any
+            ) -> progress_bar:
+                # Partial translation from tqdm to our native progress bar;
+                # uses API of tqdm v4.66.4, likely backward compatible.
+                iterable: Any = kwargs.get("iterable", None)
+                desc: str | None = kwargs.get("desc", None)
+                total: int | None = kwargs.get("total", None)
+
+                # In case args were used
+                if args:
+                    iterable = args[0]
+                if len(args) >= 2:
+                    desc = args[1]
+                if len(args) >= 3:
+                    total = args[2]
+
+                return progress_bar(
+                    collection=iterable, title=desc, total=total
+                )
+
+            tqdm.notebook.tqdm = tqdm_to_progress_bar

--- a/marimo/_smoke_tests/tqdm_notebook.py
+++ b/marimo/_smoke_tests/tqdm_notebook.py
@@ -1,0 +1,24 @@
+# Copyright 2024 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.7.13"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    from tqdm.notebook import tqdm
+
+    import time
+    return time, tqdm
+
+
+@app.cell
+def __(time, tqdm):
+    for i in tqdm(range(10)):
+        time.sleep(0.1)
+    return i,
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
monkey patch tqdm.notebook, translating it to mo.status.progress_bar.

Will likely work for >90% of tqdm.notebook use cases, but won't work for power users since we don't support all of tqdm's options (we just drop unsupported options).

![image](https://github.com/user-attachments/assets/b2527dba-5d90-4d45-a46d-a638bd60fcc8)