### PR TITLE
Fixed setting filetypes to None, causing the parameter not to work

### DIFF
--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -1360,7 +1360,6 @@ class file_browser(UIElement[List[Dict[str, Any]], Sequence[FileInfo]]):
                 + "Must be either 'file' or 'directory'."
             )
         else:
-            self.filetypes = None
             self.selection_mode = selection_mode
 
         if not initial_path:


### PR DESCRIPTION
## 📝 Summary

There is a stale override that sets `filetypes` always to None. This causes extension filtering not to work.

## 🔍 Description of Changes

Removing the `self.filetypes = None` allows the set filetypes to propagate. Before this change, the if statement either throws an exception or it sets `filetypes` to None. Both outcomes are undesirable. Therefore, removing the override is the best way forward.

To reproduce:

The code below also shows files that don't have the extension "pdf". With this PR, it will hide other files.

```py
mo.ui.file_browser(
    multiple=True,
    selection_mode="file",
    filetypes=[".pdf"],
)
```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
