### PR TITLE
fix: recursive outputs

### DIFF
--- a/marimo/_runtime/runner/hooks_post_execution.py
+++ b/marimo/_runtime/runner/hooks_post_execution.py
@@ -29,7 +29,7 @@ from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._runtime.context.types import get_global_context
 from marimo._runtime.control_flow import MarimoInterrupt, MarimoStopError
 from marimo._runtime.runner import cell_runner
-from marimo._utils.flatten import flatten
+from marimo._utils.flatten import contains_instance
 
 LOGGER = _loggers.marimo_logger()
 
@@ -125,8 +125,7 @@ def _store_reference_to_output(
     if isinstance(run_result.output, UIElement):
         cell.set_output(run_result.output)
     elif run_result.output is not None:
-        flattened, _ = flatten(run_result.output)
-        if any(isinstance(v, UIElement) for v in flattened):
+        if contains_instance(run_result.output, UIElement):
             cell.set_output(run_result.output)
 
 

--- a/marimo/_smoke_tests/bugs/1927.py
+++ b/marimo/_smoke_tests/bugs/1927.py
@@ -1,0 +1,17 @@
+import marimo
+
+__generated_with = "0.7.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    breaker = []
+    for i in range(5):
+        breaker.append(breaker)
+    breaker
+    return breaker, i
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_utils/flatten.py
+++ b/marimo/_utils/flatten.py
@@ -182,12 +182,15 @@ def flatten(value: Any, json_compat_keys: bool = False) -> FLATTEN_RET_TYPE:
     the flattened structure.
 
     Usage:
-        value = [1, [2, 3], {"4": [5, 6]}, []]
-        flattened, unflattener = flatten(value)
-        # apply a map or other processing to each value of flattened ...
-        # ...
-        # packed_as_value has same nesting structure as value
-        packed_as_value = unflattener(processed_flattened)
+
+    ```python
+    value = [1, [2, 3], {"4": [5, 6]}, []]
+    flattened, unflattener = flatten(value)
+    # apply a map or other processing to each value of flattened ...
+    # ...
+    # packed_as_value has same nesting structure as value
+    packed_as_value = unflattener(processed_flattened)
+    ```
 
     Args:
     ----
@@ -220,3 +223,25 @@ def flatten(value: Any, json_compat_keys: bool = False) -> FLATTEN_RET_TYPE:
         return u(vector)
 
     return flattened, unflatten_with_validation
+
+
+def contains_instance(value: Any, instance: Any) -> bool:
+    """
+    Recursively checks if value contains the given instance
+    """
+
+    seen: set[int] = set()
+
+    def _contains_instance(value: Any) -> bool:
+        if id(value) in seen:
+            return False
+        seen.add(id(value))
+
+        if isinstance(value, (tuple, list)):
+            return any(_contains_instance(v) for v in value)
+        elif isinstance(value, dict):
+            return any(_contains_instance(v) for v in value.values())
+        else:
+            return isinstance(value, instance)
+
+    return _contains_instance(value)

--- a/tests/_utils/test_flatten.py
+++ b/tests/_utils/test_flatten.py
@@ -5,7 +5,11 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
-from marimo._utils.flatten import CyclicStructureError, flatten
+from marimo._utils.flatten import (
+    CyclicStructureError,
+    contains_instance,
+    flatten,
+)
 
 L = List[Any]
 T = Tuple[Any, ...]
@@ -201,3 +205,38 @@ def test_flatten_custom_list() -> None:
     v, u = flatten(custom_list)
     assert v == []
     assert u(v) == []
+
+
+def test_contains_instance() -> None:
+    class A:
+        pass
+
+    class B:
+        pass
+
+    assert contains_instance([], A) is False
+    assert contains_instance([B()], A) is False
+    assert contains_instance([B(), A()], A) is True
+
+
+def test_contains_instance_nested() -> None:
+    class A:
+        pass
+
+    class B:
+        pass
+
+    assert contains_instance([{}], A) is False
+    assert contains_instance({"key": B()}, A) is False
+    assert contains_instance({"key": B()}, B) is True
+    assert contains_instance({"key": [B(), (B(), A())]}, A) is True
+
+
+def test_contains_instance_recursive() -> None:
+    class A:
+        pass
+
+    value: Any = [A()]
+    for _ in range(5):
+        value.append(value)
+    assert contains_instance(value, A) is True


### PR DESCRIPTION
Fixes #1927 

Fixes recursive outputs.

Replaces `flatten` with `contains_instance` which is slightly cheaper and easier to test/follow