### PR TITLE
improvement: fullscreen outputs

### DIFF
--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -257,7 +257,10 @@ const ExpandableOutput = React.memo(
           </div>
           <div
             {...props}
-            className={cn("relative fullscreen:bg-background", props.className)}
+            className={cn(
+              "relative fullscreen:bg-background fullscreen:flex fullscreen:items-center fullscreen:justify-center",
+              props.className,
+            )}
             ref={containerRef}
             style={isExpanded ? { maxHeight: "none" } : undefined}
           >

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -1,5 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import React, { memo, useEffect, useMemo, useRef, useState } from "react";
+import React from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 
 import type { OutputMessage } from "@/core/kernel/messages";
 
@@ -16,7 +17,11 @@ import { ErrorBoundary } from "./boundary/ErrorBoundary";
 
 import "./output/Outputs.css";
 import { Button } from "../ui/button";
-import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react";
+import {
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  ExpandIcon,
+} from "lucide-react";
 import { Tooltip } from "../ui/tooltip";
 import { useExpandedOutput } from "@/core/cells/outputs";
 import { invariant } from "@/utils/invariant";
@@ -140,29 +145,30 @@ export const OutputArea = React.memo(
   ({ output, cellId, stale, allowExpand, className }: OutputAreaProps) => {
     if (output === null) {
       return null;
-    } else if (output.channel === "output" && output.data === "") {
-      return null;
-    } else {
-      // TODO(akshayka): More descriptive title
-      // 1. This output is stale (this cell has been edited but not run)
-      // 2. This output is stale (this cell is queued to run)
-      // 3. This output is stale (its inputs have changed)
-      const title = stale ? "This output is stale" : undefined;
-      const Container = allowExpand ? ExpandableOutput : Div;
-
-      return (
-        <ErrorBoundary>
-          <Container
-            title={title}
-            cellId={cellId}
-            id={`output-${cellId}`}
-            className={cn(stale && "marimo-output-stale", className)}
-          >
-            <OutputRenderer message={output} />
-          </Container>
-        </ErrorBoundary>
-      );
     }
+    if (output.channel === "output" && output.data === "") {
+      return null;
+    }
+
+    // TODO(akshayka): More descriptive title
+    // 1. This output is stale (this cell has been edited but not run)
+    // 2. This output is stale (this cell is queued to run)
+    // 3. This output is stale (its inputs have changed)
+    const title = stale ? "This output is stale" : undefined;
+    const Container = allowExpand ? ExpandableOutput : Div;
+
+    return (
+      <ErrorBoundary>
+        <Container
+          title={title}
+          cellId={cellId}
+          id={`output-${cellId}`}
+          className={cn(stale && "marimo-output-stale", className)}
+        >
+          <OutputRenderer message={output} />
+        </Container>
+      </ErrorBoundary>
+    );
   },
 );
 OutputArea.displayName = "OutputArea";
@@ -210,34 +216,48 @@ const ExpandableOutput = React.memo(
     return (
       <>
         <div>
-          {(isOverflowing || isExpanded) && (
-            <div className="relative print:hidden">
-              <Button
-                data-testid="expand-output-button"
-                className={cn(
-                  "absolute top-6 -right-12 z-10",
-                  // Force show button if expanded
-                  !isExpanded && "hover-action",
-                )}
-                onClick={() => setIsExpanded(!isExpanded)}
-                size="xs"
-                variant="text"
-              >
-                {isExpanded ? (
-                  <Tooltip content="Collapse output" side="left">
-                    <ChevronsDownUpIcon className="h-4 w-4" />
-                  </Tooltip>
-                ) : (
-                  <Tooltip content="Expand output" side="left">
-                    <ChevronsUpDownIcon className="h-4 w-4" />
-                  </Tooltip>
-                )}
-              </Button>
+          <div className="relative print:hidden">
+            <div className="absolute top-6 -right-11 z-10 flex flex-col gap-1">
+              <Tooltip content="Fullscreen" side="left">
+                <Button
+                  data-testid="fullscreen-output-button"
+                  className="hover-action hover:bg-muted"
+                  onClick={async () => {
+                    await containerRef.current?.requestFullscreen();
+                  }}
+                  size="xs"
+                  variant="text"
+                >
+                  <ExpandIcon className="h-4 w-4" />
+                </Button>
+              </Tooltip>
+              {(isOverflowing || isExpanded) && (
+                <Button
+                  data-testid="expand-output-button"
+                  className={cn(
+                    // Force show button if expanded
+                    !isExpanded && "hover-action hover:bg-muted",
+                  )}
+                  onClick={() => setIsExpanded(!isExpanded)}
+                  size="xs"
+                  variant="text"
+                >
+                  {isExpanded ? (
+                    <Tooltip content="Collapse output" side="left">
+                      <ChevronsDownUpIcon className="h-4 w-4" />
+                    </Tooltip>
+                  ) : (
+                    <Tooltip content="Expand output" side="left">
+                      <ChevronsUpDownIcon className="h-4 w-4" />
+                    </Tooltip>
+                  )}
+                </Button>
+              )}
             </div>
-          )}
+          </div>
           <div
             {...props}
-            className={cn("relative", props.className)}
+            className={cn("relative fullscreen:bg-background", props.className)}
             ref={containerRef}
             style={isExpanded ? { maxHeight: "none" } : undefined}
           >

--- a/frontend/src/core/MarimoApp.tsx
+++ b/frontend/src/core/MarimoApp.tsx
@@ -84,7 +84,7 @@ const Providers = memo(({ children }: PropsWithChildren) => {
   return (
     <ErrorBoundary>
       <Suspense>
-        <TooltipProvider>
+        <TooltipProvider delayDuration={400}>
           <DayPickerProvider initialProps={{}}>
             <SlotzProvider controller={slotsController}>
               <ModalProvider>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -169,7 +169,7 @@ module.exports = {
   plugins: [
     require("tailwindcss-animate"),
     require("@tailwindcss/typography"),
-    plugin(({ addUtilities }) => {
+    plugin(({ addUtilities, addVariant }) => {
       const newUtilities = {
         ".increase-pointer-area-x": {
           border: "none",
@@ -193,6 +193,7 @@ module.exports = {
         },
       };
 
+      addVariant("fullscreen", "&:fullscreen");
       addUtilities(newUtilities);
     }),
   ],


### PR DESCRIPTION
_doesnt need to be merged / open to discurss_

this adds a Fullscreen button to expand any output to fullscreen.

<img width="1529" alt="image" src="https://github.com/user-attachments/assets/f7f816d1-f252-4d42-be38-445665050d0a">
