### PR TITLE
fix: unit test for markdown export

### DIFF
--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest pytest-asyncio
 
       - name: Download wheel
         uses: actions/download-artifact@v3

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -340,7 +340,7 @@ class TestExportMarkdown:
         snapshot("markdown.txt", output)
 
     @staticmethod
-    def test_export_script_async(temp_async_marimo_file: str) -> None:
+    def test_export_markdown_async(temp_async_marimo_file: str) -> None:
         p = subprocess.run(
             ["marimo", "export", "md", temp_async_marimo_file],
             capture_output=True,
@@ -351,7 +351,7 @@ class TestExportMarkdown:
         snapshot("async.txt", output)
 
     @staticmethod
-    def test_export_broken(temp_unparsable_marimo_file: str) -> None:
+    def test_export_markdown_broken(temp_unparsable_marimo_file: str) -> None:
         p = subprocess.run(
             ["marimo", "export", "md", temp_unparsable_marimo_file],
             capture_output=True,
@@ -365,8 +365,8 @@ class TestExportMarkdown:
         condition=DependencyManager.has_watchdog(),
         reason="hangs when watchdog is installed",
     )
-    async def test_export_watch_script(self, temp_marimo_file: str) -> None:
-        temp_out_file = temp_marimo_file.replace(".md", ".script.md")
+    async def test_export_watch_markdown(self, temp_marimo_file: str) -> None:
+        temp_out_file = temp_marimo_file.replace(".py", ".md")
         p = subprocess.Popen(  # noqa: ASYNC101 ASYNC220
             [
                 "marimo",
@@ -409,7 +409,7 @@ class TestExportMarkdown:
         condition=DependencyManager.has_watchdog(),
         reason="hangs when watchdog is installed",
     )
-    def test_export_watch_script_no_out_dir(
+    def test_export_watch_markdown_no_out_dir(
         self, temp_marimo_file: str
     ) -> None:
         p = subprocess.Popen(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import os
 import sys
 import textwrap
 from tempfile import TemporaryDirectory
@@ -188,7 +189,7 @@ def executing_kernel() -> Generator[Kernel, None, None]:
 @pytest.fixture
 def temp_marimo_file() -> Generator[str, None, None]:
     tmp_dir = TemporaryDirectory()
-    tmp_file = tmp_dir.name + "/notebook.py"
+    tmp_file = os.path.join(tmp_dir.name, "notebook.py")
     content = inspect.cleandoc(
         """
         import marimo
@@ -220,7 +221,7 @@ def temp_marimo_file() -> Generator[str, None, None]:
 @pytest.fixture
 def temp_async_marimo_file() -> Generator[str, None, None]:
     tmp_dir = TemporaryDirectory()
-    tmp_file = tmp_dir.name + "/notebook.py"
+    tmp_file = os.path.join(tmp_dir.name, "notebook.py")
     content = inspect.cleandoc(
         """
         import marimo
@@ -249,7 +250,7 @@ def temp_async_marimo_file() -> Generator[str, None, None]:
 @pytest.fixture
 def temp_unparsable_marimo_file() -> Generator[str, None, None]:
     tmp_dir = TemporaryDirectory()
-    tmp_file = tmp_dir.name + "/notebook.py"
+    tmp_file = os.path.join(tmp_dir.name, "notebook.py")
     content = inspect.cleandoc(
         """
         import marimo
@@ -291,7 +292,7 @@ def temp_unparsable_marimo_file() -> Generator[str, None, None]:
 @pytest.fixture
 def temp_marimo_file_with_md() -> Generator[str, None, None]:
     tmp_dir = TemporaryDirectory()
-    tmp_file = tmp_dir.name + "/notebook.py"
+    tmp_file = os.path.join(tmp_dir.name, "notebook.py")
     content = inspect.cleandoc(
         """
         import marimo
@@ -331,7 +332,7 @@ def temp_marimo_file_with_md() -> Generator[str, None, None]:
 @pytest.fixture
 def temp_md_marimo_file() -> Generator[str, None, None]:
     tmp_dir = TemporaryDirectory()
-    tmp_file = tmp_dir.name + "/notebook.md"
+    tmp_file = os.path.join(tmp_dir.name, "notebook.md")
     content = inspect.cleandoc(
         """
         ---


### PR DESCRIPTION
## 📝 Summary

The unit test `TestExportMarkdown::test_export_watch_script` should expect a .py file and convert it into a .md file, so the following line is incorrect:

https://github.com/marimo-team/marimo/blob/fd0f67b10963403a213eaeec4f605a943a7b0c47/tests/_cli/test_cli_export.py#L368-L369

The above unit test fails when runing `pytest tests/_cli/test_cli_export.py`. However, the test failure is not catched by CI because the test requires `pytest-asyncio` which is not installed: https://github.com/marimo-team/marimo/actions/runs/10220369751/job/28280651187#step:8:71

## 🔍 Description of Changes

- Corrected the file extension in test `TestExportMarkdown::test_export_watch_script`
- Renamed the unit test functions in `TestExportMarkdown` from `script` to `markdown` (Looks like that most functions in `TestExportMarkdown` are copied from `TestExportScript`, and the function name is kept as-is. They shoud be renamed to `markdown`.)
- Install `pytest-asyncio` in CLI test workflow (Maybe we should try another way to install test dependencies, as it is actually listed in `pyproject.toml`. But I'm not very familiar with it.)

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] (Not applicable) For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] (Not applicable) I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
