### PR TITLE
feat: support skipping update check in `marimo edit`

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -250,6 +250,14 @@ edit_help_msg = "\n".join(
     multiple=True,
     help="Allowed origins for CORS. Can be repeated. Use * for all origins.",
 )
+@click.option(
+    "--skip-update-check",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    type=bool,
+    help="Skip update check before starting.",
+)
 @click.argument("name", required=False)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def edit(
@@ -261,11 +269,13 @@ def edit(
     token_password: Optional[str],
     base_url: str,
     allow_origins: Optional[tuple[str, ...]],
+    skip_update_check: bool,
     name: Optional[str],
     args: tuple[str, ...],
 ) -> None:
-    # Check for version updates
-    check_for_updates()
+    if not skip_update_check:
+        # Check for version updates
+        check_for_updates()
 
     if name is not None:
         # Validate name, or download from URL

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -256,7 +256,7 @@ edit_help_msg = "\n".join(
     default=False,
     show_default=True,
     type=bool,
-    help="Skip update check before starting.",
+    help="Don't check if a new version of marimo is available for download.",
 )
 @click.argument("name", required=False)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)

--- a/marimo/_cli/upgrade.py
+++ b/marimo/_cli/upgrade.py
@@ -12,6 +12,8 @@ from marimo._cli.print import green, orange
 from marimo._server.api.status import HTTPException
 from marimo._utils.config.config import ConfigReader
 
+FETCH_TIMEOUT = 5
+
 
 @dataclass
 class MarimoCLIState:
@@ -90,7 +92,7 @@ def _update_with_latest_version(state: MarimoCLIState) -> MarimoCLIState:
 
 
 def _fetch_data_from_url(url: str) -> Dict[str, Any]:
-    with urllib.request.urlopen(url) as response:
+    with urllib.request.urlopen(url, timeout=FETCH_TIMEOUT) as response:
         status = response.status
         if status == 200:
             data = response.read()

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -46,8 +46,13 @@ class ConfigReader:
     def _get_home_directory() -> str:
         # If in pytest, we want to set a temporary directory
         if os.environ.get("PYTEST_CURRENT_TEST"):
-            tmpdir = TemporaryDirectory()
-            return tmpdir.name
+            # If the home directory is given by test, take it
+            home_dir = os.environ.get("MARIMO_PYTEST_HOME_DIR")
+            if home_dir is not None:
+                return home_dir
+            else:
+                tmpdir = TemporaryDirectory()
+                return tmpdir.name
         else:
             return os.path.expanduser("~")
 

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -264,10 +264,8 @@ def test_cli_edit_update_check() -> None:
         state_contents = _read_toml(
             os.path.join(tempdir, CONFIG_ROOT_DIR, "state.toml")
         )
-        assert (
-            state_contents is not None
-            and state_contents.get("last_checked_at") is not None
-        )
+        assert state_contents is not None
+        assert state_contents.get("last_checked_at") is not None
 
 
 @pytest.mark.skipif(

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -270,7 +270,7 @@ def test_cli_edit_update_check() -> None:
 
 @pytest.mark.skipif(
     condition=not _can_access_pypi(),
-    reason="update check won't work without access to pypi",
+    reason="update check skip is only detectable if pypi is accessible",
 )
 def test_cli_edit_skip_update_check() -> None:
     with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
## 📝 Summary

Let `marimo edit` work under Internet-restricted environments by adding a `--skip-update-check` command-line argument, and a default update check timeout.

Fixes #1936.

PS: In issue #1936 I proposed adding a new configuration item, but I found it quite cumbersome. Doing it will require changing the backend, the frontend and even the public API. I think this feature doesn't worth such a big code change. The code is kept for reference in https://github.com/mutongx/marimo/commit/9a583e7ab71fa0fab3accd09f96a6afa2643a81d for anyone interested.

## 🔍 Description of Changes

- Add `--skip-update-check` command-line argument to `marimo edit`
- Add a default timeout (which is 5 seconds) to update check's `urlopen()` call
- Support setting the `.marimo` configuration directory in unit test, so we can test on the update check behavior

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] (Not applicable) For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
