### PR TITLE
Revert "improvement: cleanup markdown, use prose (#1892)"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,6 @@
     "@react-aria/focus": "^3.17.1",
     "@replit/codemirror-vim": "^6.2.1",
     "@storybook/addon-styling": "^1.3.7",
-    "@tailwindcss/typography": "^0.5.13",
     "@tanstack/react-table": "^8.19.2",
     "@textea/json-viewer": "^3.4.1",
     "@types/humanize-duration": "^3.27.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -170,9 +170,6 @@ dependencies:
   '@storybook/addon-styling':
     specifier: ^1.3.7
     version: 1.3.7(@types/react-dom@18.3.0)(@types/react@18.3.3)(less@4.2.0)(postcss@8.4.39)(react-dom@18.3.1)(react@18.3.1)(webpack@5.91.0)
-  '@tailwindcss/typography':
-    specifier: ^0.5.13
-    version: 0.5.13(tailwindcss@3.4.4)
   '@tanstack/react-table':
     specifier: ^8.19.2
     version: 8.19.2(react-dom@18.3.1)(react@18.3.1)
@@ -8292,18 +8289,6 @@ packages:
       '@swc/counter': 0.1.3
     dev: true
 
-  /@tailwindcss/typography@0.5.13(tailwindcss@3.4.4):
-    resolution: {integrity: sha512-ADGcJ8dX21dVVHIwTRgzrcunY6YY9uSlAHHGVKvkA+vLc5qLwEszvKts40lx7z0qc4clpjclwLeK5rVCV2P/uw==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders'
-    dependencies:
-      lodash.castarray: 4.4.0
-      lodash.isplainobject: 4.0.6
-      lodash.merge: 4.6.2
-      postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.4
-    dev: false
-
   /@tanstack/react-table@8.19.2(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-itoSIAkA/Vsg+bjY23FSemcTyPhc5/1YjYyaMsr9QSH/cdbZnQxHVWrpWn0Sp2BWN71qkzR7e5ye8WuMmwyOjg==}
     engines: {node: '>=12'}
@@ -14493,17 +14478,9 @@ packages:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
     dev: false
 
-  /lodash.castarray@4.4.0:
-    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
-    dev: false
-
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
-
-  /lodash.isplainobject@4.0.6:
-    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
-    dev: false
 
   /lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -16188,14 +16165,6 @@ packages:
     dependencies:
       postcss: 8.4.39
     dev: true
-
-  /postcss-selector-parser@6.0.10:
-    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
-    engines: {node: '>=4'}
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-    dev: false
 
   /postcss-selector-parser@6.1.0:
     resolution: {integrity: sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==}

--- a/frontend/src/components/editor/output/JsonOutput.tsx
+++ b/frontend/src/components/editor/output/JsonOutput.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { memo } from "react";
-import { type DataType, JsonViewer } from "@textea/json-viewer";
+import { DataType, JsonViewer } from "@textea/json-viewer";
 
 import { HtmlOutput } from "./HtmlOutput";
 import { ImageOutput } from "./ImageOutput";

--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -64,8 +64,6 @@
   /* Coarse hack to stop children from overflowing; doesn't seem to affect
    * margin collapse. */
   overflow: auto;
-
-  @apply text-xs;
 }
 
 .marimo-json-output .data-key-pair:not(:last-child) {

--- a/frontend/src/core/MarimoApp.tsx
+++ b/frontend/src/core/MarimoApp.tsx
@@ -18,11 +18,6 @@ import { Provider as SlotzProvider } from "@marimo-team/react-slotz";
 import { slotsController } from "./slots/slots";
 import { reactLazyWithPreload } from "@/utils/lazy";
 
-// Force tailwind classnames
-// tailwind only creates css for classnames that exist the FE files
-export const FORCE_TW_CLASSES =
-  "prose prose-sm prose-base prose-lg prose-xl prose-2xl";
-
 // Lazy imports
 const LazyHomePage = reactLazyWithPreload(
   () => import("@/components/pages/home-page"),

--- a/frontend/src/css/app/reset.css
+++ b/frontend/src/css/app/reset.css
@@ -1,4 +1,15 @@
+html {
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
 body {
+  margin: 0;
   font-family: var(--text-font);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -13,4 +24,9 @@ body {
 
 code {
   font-family: var(--monospace-font);
+}
+
+button {
+  padding: 0;
+  margin: 0;
 }

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -1,34 +1,89 @@
+.markdown p,
+.markdown .paragraph,
+.markdown ol,
+.markdown ul,
+.markdown span:not(code *, .MuiBox-root) {
+  /* the not selector makes sure we don't change katex/LaTeX styles */
+  line-height: 1.5rem;
+  font-family: var(--text-font);
+}
+
 .markdown p:first-child,
 .markdown .paragraph:first-child {
-  /* This is needed when markdown is used inside buttons or labels  */
   margin-block-start: 0;
 }
 
 .markdown p:last-child,
-/* This is needed when markdown is used inside buttons or labels  */
 .markdown .paragraph:last-child {
   margin-block-end: 0;
 }
 
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+  font-weight: normal;
+}
 
 .markdown h1 {
+  /* provide by the browser, but removed from 'reset' */
+  display: block;
+  font-size: 2rem;
+  margin-block-end: 0.67rem;
+  margin-inline: 0 0;
   text-align: center;
 }
 
 .config-width-full .markdown h1 {
-  /* In full-width display, we left-align the title */
+  /* In full-width display, centered headings look odd */
   text-align: start;
 }
 
+.markdown h2 {
+  /* provide by the browser, but removed from 'reset' */
+  display: block;
+  font-size: 1.5rem;
+  margin-block-end: 0.83rem;
+  margin-inline: 0 0;
+}
 
+.markdown h3 {
+  /* provide by the browser, but removed from 'reset' */
+  display: block;
+  font-size: 1.17rem;
+  margin-block-end: 1rem;
+  margin-inline: 0 0;
+}
+
+.markdown p,
 .markdown .paragraph {
-  /*
-  we convert <p> to span.paragraph to support nesting,
-  so we need to apply the same formatting
-  */
+  /* provide by the browser, but removed from 'reset' */
   display: block;
   margin-block: 1rem 1rem;
   margin-inline: 0 0;
+}
+
+.markdown ul {
+  /* provide by the browser, but removed from 'reset' */
+  display: block;
+  list-style-type: disc;
+  margin-block: 1rem 1rem;
+  margin-inline: 0 0;
+  padding-inline-start: 40px;
+}
+
+.markdown ol {
+  /* provide by the browser, but removed from 'reset' */
+  display: block;
+  list-style-type: decimal;
+  margin-block: 1rem 1rem;
+  margin-inline: 0 0;
+  padding-inline-start: 40px;
+}
+
+.markdown li {
+  /* provided by the browser, but removed from 'reset' */
+  display: list-itrem;
+  text-align: -webkit-match-parent;
 }
 
 .markdown h1,
@@ -37,13 +92,39 @@
 .markdown h4,
 .markdown h5,
 .markdown h6 {
-  font-weight: inherit;
   font-family: var(--heading-font);
+}
+
+.markdown pre {
+  /* source code */
+  margin: 30px;
+  line-height: 1.8rem;
+  font-family: var(--monospace-font);
+  overflow: auto;
+  white-space: pre;
+}
+
+.markdown p code,
+.markdown .paragraph code,
+.markdown pre code,
+.markdown li code {
+  font-size: 0.875rem;
+  scroll-margin:;
+}
+
+.markdown sup,
+.markdown sub {
+  vertical-align: baseline;
+  position: relative;
+  top: -0.4rem;
+}
+
+.markdown sub {
+  top: 0.4rem;
 }
 
 .markdown a {
   cursor: pointer;
-  text-decoration: inherit;
 
   @apply text-link;
 }
@@ -57,11 +138,17 @@
   @apply text-link-visited;
 }
 
+.markdown blockquote {
+  padding: 0 1rem;
+
+  @apply border-l-4;
+  @apply text-muted-foreground;
+}
+
 .mo-label .markdown p,
 .mo-label-block .markdown p,
 .mo-label .markdown .paragraph,
 .mo-label-block .markdown .paragraph {
-  /* This is needed when markdown is used inside labels  */
   padding: 0;
   margin: 0;
 }

--- a/frontend/src/css/table.css
+++ b/frontend/src/css/table.css
@@ -1,5 +1,10 @@
 .markdown table,
 table.dataframe {
+  border: none;
+  border-collapse: collapse;
+  border-spacing: 0;
+  table-layout: fixed;
+  font-size: 0.9375rem;
   display: block;
   max-width: 100%;
   overflow: auto;
@@ -7,9 +12,10 @@ table.dataframe {
 
 .markdown table thead,
 table.dataframe thead {
+  border-bottom: 1px solid;
   vertical-align: bottom;
 
-  @apply border-input;
+  @apply border-foreground;
 }
 
 .markdown table tbody tr:nth-child(odd),
@@ -24,7 +30,7 @@ table.dataframe tbody tr:nth-child(even) {
 
 .markdown table tbody tr:hover,
 table.dataframe tbody tr:hover {
-  background: var(--yellow-4);
+  background: var(--yellow-5);
 }
 
 .markdown table tr,
@@ -35,8 +41,15 @@ table.dataframe th,
 table.dataframe td {
   text-align: right;
   vertical-align: middle;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding: 0.5rem;
   line-height: normal;
+  white-space: normal;
+  max-width: none;
   border: none;
+  font-size: 0.875rem;
+}
+
+.markdown table th,
+table.dataframe th {
+  font-weight: bold;
 }

--- a/frontend/src/plugins/layout/AccordionPlugin.tsx
+++ b/frontend/src/plugins/layout/AccordionPlugin.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import React, { type PropsWithChildren } from "react";
+import React, { PropsWithChildren } from "react";
 
 import {
   Accordion,
@@ -8,10 +8,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { z } from "zod";
-import type {
-  IStatelessPlugin,
-  IStatelessPluginProps,
-} from "../stateless-plugin";
+import { IStatelessPlugin, IStatelessPluginProps } from "../stateless-plugin";
 import { renderHTML } from "../core/RenderHTML";
 
 interface Data {
@@ -51,7 +48,11 @@ const AccordionComponent = ({
     <Accordion type={type} className="text-muted-foreground" collapsible={true}>
       {React.Children.map(children, (child, index) => {
         return (
-          <AccordionItem key={index} value={index.toString()}>
+          <AccordionItem
+            key={index}
+            value={index.toString()}
+            className="border-muted-foreground-20"
+          >
             <AccordionTrigger className="py-2 text-md">
               {renderHTML({ html: labels[index] })}
             </AccordionTrigger>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -137,38 +137,10 @@ module.exports = {
         "2-fit": "repeat(2, minmax(0, max-content))",
         "3-fit": "repeat(3, minmax(0, max-content))",
       },
-      typography: {
-        DEFAULT: {
-          css: {
-            fontFamily: "var(--text-font)",
-            color: "inherit",
-            pre: {
-              color: "inherit",
-              background: "inherit",
-            },
-            "code::before": {
-              content: "",
-            },
-            "code::after": {
-              content: "",
-            },
-            code: {
-              fontWeight: 500,
-            },
-            "ul > li::marker": {
-              color: "hsl(var(--muted-foreground))",
-            },
-            "ol > li::marker": {
-              color: "hsl(var(--muted-foreground))",
-            },
-          },
-        },
-      },
     },
   },
   plugins: [
     require("tailwindcss-animate"),
-    require("@tailwindcss/typography"),
     plugin(({ addUtilities, addVariant }) => {
       const newUtilities = {
         ".increase-pointer-area-x": {

--- a/marimo/_output/md.py
+++ b/marimo/_output/md.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from inspect import cleandoc
-from typing import Literal, Optional
 
 import markdown  # type: ignore
 
@@ -32,14 +31,8 @@ extension_configs = {
     },
 }
 
-MarkdownSize = Literal["sm", "base", "lg", "xl", "2xl"]
 
-
-def _md(
-    text: str,
-    apply_markdown_class: bool = True,
-    size: Optional[MarkdownSize] = None,
-) -> Html:
+def _md(text: str, apply_markdown_class: bool = True) -> Html:
     # cleandoc uniformly strips leading whitespace; useful for
     # indented multiline strings
     text = cleandoc(text)
@@ -75,10 +68,7 @@ def _md(
     )
 
     if apply_markdown_class:
-        classes = ["markdown", "prose"]
-        if size is not None:
-            classes.append(f"prose-{size}")
-        return Html(f'<span class="{" ".join(classes)}">{html_text}</span>')
+        return Html('<span class="markdown">' + html_text + "</span>")
     else:
         return Html(html_text)
 

--- a/marimo/_plugins/core/web_component.py
+++ b/marimo/_plugins/core/web_component.py
@@ -82,7 +82,7 @@ def build_ui_plugin(
 
     attrs: list[str] = [_build_attr("initial-value", initial_value)]
     if label is not None and label:
-        attrs.append(_build_attr("label", _md(label, size="sm").text))
+        attrs.append(_build_attr("label", _md(label).text))
     else:
         attrs.append(_build_attr("label", None))
 

--- a/tests/_islands/snapshots/island-no-code.txt
+++ b/tests/_islands/snapshots/island-no-code.txt
@@ -4,7 +4,7 @@
     data-reactive="true"
 >
     <marimo-cell-output>
-    <span class="markdown prose"><span class="paragraph">Hello, islands!</span></span>
+    <span class="markdown"><span class="paragraph">Hello, islands!</span></span>
     </marimo-cell-output>
     <marimo-cell-code hidden>mo.md('Hello%2C%20islands!')</marimo-cell-code>
 </marimo-island>

--- a/tests/_islands/snapshots/island.txt
+++ b/tests/_islands/snapshots/island.txt
@@ -4,7 +4,7 @@
     data-reactive="true"
 >
     <marimo-cell-output>
-    <span class="markdown prose"><span class="paragraph">Hello, islands!</span></span>
+    <span class="markdown"><span class="paragraph">Hello, islands!</span></span>
     </marimo-cell-output>
     <marimo-cell-code hidden>mo.md('Hello%2C%20islands!')</marimo-cell-code>
 </marimo-island>

--- a/tests/_output/test_md.py
+++ b/tests/_output/test_md.py
@@ -1,12 +1,10 @@
-from __future__ import annotations
-
 from marimo._output.md import _md
 
 
 def test_md() -> None:
     # Test basic markdown conversion
     input_text = "This is **bold** and this is _italic_."
-    expected_output = '<span class="markdown prose"><span class="paragraph">This is <strong>bold</strong> and this is <em>italic</em>.</span></span>'  # noqa: E501
+    expected_output = '<span class="markdown"><span class="paragraph">This is <strong>bold</strong> and this is <em>italic</em>.</span></span>'  # noqa: E501
     assert _md(input_text).text == expected_output
 
     # Test disabling markdown class
@@ -15,12 +13,6 @@ def test_md() -> None:
         _md(input_text, apply_markdown_class=False).text
         == expected_output_no_class
     )
-
-
-# def test_md_size() -> None:
-#     input_text = "This is **bold** and this is _italic_."
-#     expected_output = '<span class="markdown prose prose-lg"><span class="paragraph">This is <strong>bold</strong> and this is <em>italic</em>.</span></span>'  # noqa: E501
-#     assert _md(input_text, size="lg").text == expected_output
 
 
 def test_md_code_blocks() -> None:


### PR DESCRIPTION
This reverts commit 15fa75a7a4deaf98c905179f46ae454c7ab044d9.

Tailwind prose broke dark mode colors. This PR reverts the associated change so that dark mode users can enjoy the other new features and bug fixes in 0.7.14-0.7.16. We can bring it back when the styling bug is fixed (the revert was easy).

Fixes #1949 