### PR TITLE
fix: duckdb lowerbound

### DIFF
--- a/docs/guides/sql.md
+++ b/docs/guides/sql.md
@@ -1,12 +1,18 @@
 # SQL
 
-With marimo, you can mix-and-match both **Python and SQL**. To create a SQL cell, you first need to install our SQL query engine of choice: [duckdb](https://duckdb.org/).
+With marimo, you can mix-and-match both **Python and SQL**. To create a SQL
+cell, you first need to install additional dependencies, including
+[duckdb](https://duckdb.org/). Install dependencies with
 
 ```bash
-pip install duckdb
+pip install marimo[sql]
 ```
 
-This will enable SQL cells in your notebook. Once you've installed `duckdb`, you can create a SQL cell by right-clicking an **Add Cell** button and choosing "SQL cell", by converting an empty cell to SQL via the cell context menu, or via the SQL button that appears when you mouse hover at the bottom of your notebook.
+This will enable SQL cells in your notebook. Once you've installed
+the dependencies, you can create a SQL cell by right-clicking an **Add Cell**
+button and choosing "SQL cell", by converting an empty cell to SQL via the cell
+context menu, or via the SQL button that appears when you mouse hover at the
+bottom of your notebook.
 
 <div align="center">
   <figure>

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -193,8 +193,8 @@ const AddCellButtons: React.FC = () => {
             sqlCapabilities ? null : (
               <div className="flex flex-col">
                 <span>
-                  Requires duckdb:{" "}
-                  <Kbd className="inline">pip install duckdb</Kbd>.
+                  Additional dependencies required:
+                  <Kbd className="inline">pip install marimo[sql]</Kbd>.
                 </span>
                 <span>
                   You will need to restart the notebook after installing.

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -6,6 +6,7 @@ Messages that the kernel sends to the frontend.
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import sys
 import time
@@ -23,6 +24,8 @@ from typing import (
     Union,
     cast,
 )
+
+from packaging import version
 
 from marimo import _loggers as loggers
 from marimo._ast.app import _AppConfig
@@ -339,7 +342,12 @@ class KernelCapabilities:
     terminal: bool = False
 
     def __post_init__(self) -> None:
-        self.sql = DependencyManager.has_duckdb()
+        if DependencyManager.has_duckdb():
+            self.sql = version.parse(
+                importlib.metadata.version("duckdb")
+            ) >= version.parse("1.0.0")
+        else:
+            self.sql = False
         # Only available in mac/linux
         self.terminal = not is_windows() and not is_pyodide()
 

--- a/marimo/_tutorials/sql.py
+++ b/marimo/_tutorials/sql.py
@@ -22,13 +22,13 @@ def __(mo):
 def __(mo):
     mo.md(
         r"""
-        With marimo, you can mix-and-match both **Python and SQL**. To create a SQL cell, you first need to install our SQL query engine of choice: [duckdb](https://duckdb.org/).
+        With marimo, you can mix-and-match both **Python and SQL**. To create a
+        SQL cell, you first need to install some additional dependencies,
+        including [duckdb](https://duckdb.org/). Obtain these dependencies with
 
         ```bash
-        pip install duckdb
+        pip install marimo[sql]
         ```
-
-        Or if you `import duckdb` in any SQL cell, marimo will automatically install it for you.
         """
     )
     return
@@ -96,18 +96,25 @@ def __(has_duckdb_installed, mo):
 def __(mo):
     mo.md(
         r"""
-        Once duckdb is installed, you can create SQL cells by either right clicking the **Add Cell** buttons on the left of a cell, or click the **Add SQL Cell** at the bottom of the page. 
+        Once the required dependencies are installed, you can create SQL cells
+        by either right clicking the **Add Cell** buttons on the left of a
+        cell, or click the **Add SQL Cell** at the bottom of the page.
 
-        marimo is still just Python, even when using SQL. Here is an example of how marimo
-        embeds SQL in Python in its file format:
+        marimo is still just Python, even when using SQL. Here is an example of
+        how marimo embeds SQL in Python in its file format:
 
         ```python
         output_df = mo.sql(f"SELECT * FROM my_table LIMIT {max_rows.value}")
         ```
 
-        Notice that we have an **`output_df`** variable in the cell. This is a resulting Polars DataFrame (if you have `polars` installed) or a Pandas DataFrame (if you don't). One of them must be installed in order to interact with the SQL result.
+        Notice that we have an **`output_df`** variable in the cell. This is a
+        resulting Polars DataFrame (if you have `polars` installed) or a Pandas
+        DataFrame (if you don't). One of them must be installed in order to
+        interact with the SQL result.
 
-        The SQL statement itself is an formatted string (f-string), so this means they can contain any valid Python code, such as the values of UI elements. This means your SQL statement and results can be reactive! 🚀
+        The SQL statement itself is an formatted string (f-string), so this
+        means they can contain any valid Python code, such as the values of UI
+        elements. This means your SQL statement and results can be reactive! 🚀
         """
     )
     return
@@ -214,7 +221,7 @@ def __(df, mo, token_prefix):
     result = mo.sql(
         f"""
         -- Change the dropdown to see the SQL query filter itself!
-        -- 
+        --
         -- Here we use a duckdb function called `starts_with`:
         SELECT * FROM df WHERE starts_with(token, '{token_prefix.value}')
 
@@ -255,7 +262,7 @@ def __(charting_library, mo, render_chart, token_prefix):
         f"""
         We can re-use the dropdown from above: {token_prefix}
 
-        Now we have a histogram visualizing the token count distribution of tokens starting 
+        Now we have a histogram visualizing the token count distribution of tokens starting
         with {token_prefix.value}, powered by your SQL query and UI element.
         """
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ classifiers = [
 marimo = "marimo._cli.cli:main"
 
 [project.optional-dependencies]
+sql = [
+    "duckdb >= 1.0.0",
+]
+
 dev = [
     "click < 8.1.4",  # https://github.com/pallets/click/issues/2558
     "black~=23.3.0",


### PR DESCRIPTION
Add an optional [sql] section to the pyproject.toml which enumerates our SQL dependencies with lower bounds, currently only `duckdb >= 1.0`.

Tell users to obtain SQL dependencies with pip install marimo[sql] instead of pip install duckdb, to ensure they get the correct versions.

Update the kernel capabilities check for SQL to check duckdb verison.

Fixes a bug in which we'd enable SQL support even though users were using incompatible versions of duckdb, causing the kernel to crash.