### PR TITLE
fix(mo.ui.table): implement row count limit on column summaries; various bug fixes

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -67,6 +67,7 @@ type Functions = {
   download_as: (req: { format: "csv" | "json" }) => Promise<string>;
   get_column_summaries: (opts: {}) => Promise<{
     summaries: ColumnHeaderSummary[];
+    is_disabled?: boolean;
   }>;
   search: <T>(req: {
     sort?: {
@@ -129,6 +130,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
             false: z.number().nullish(),
           }),
         ),
+        is_disabled: z.boolean().optional(),
       }),
     ),
     search: rpc
@@ -291,6 +293,7 @@ export const LoadingDataTableComponent = memo(
           {...props}
           data={data || Arrays.EMPTY}
           columnSummaries={columnSummaries?.summaries}
+          columnSummariesDisabled={columnSummaries?.is_disabled}
           sorting={sorting}
           setSorting={setSorting}
           searchQuery={searchQuery}
@@ -321,6 +324,7 @@ const DataTableComponent = ({
   fieldTypes,
   download_as: downloadAs,
   columnSummaries,
+  columnSummariesDisabled,
   className,
   setValue,
   sorting,
@@ -335,6 +339,7 @@ const DataTableComponent = ({
   DataTableSearchProps & {
     data: unknown[];
     columnSummaries?: ColumnHeaderSummary[];
+    columnSummariesDisabled?: boolean;
   }): JSX.Element => {
   const resultsAreClipped =
     hasMore && (totalRows === "too_many" || totalRows > 0);
@@ -407,6 +412,12 @@ const DataTableComponent = ({
       {hasMore && totalRows === "too_many" && (
         <Banner className="mb-2 rounded">
           Result clipped. If no LIMIT is given, we only show the first 300 rows.
+        </Banner>
+      )}
+      {columnSummariesDisabled && (
+        <Banner className="mb-2 rounded">
+          Column summaries are unavailable. Filter your data to fewer than
+          1,000,000 rows.
         </Banner>
       )}
       <ColumnChartContext.Provider value={chartSpecModel}>

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -419,6 +419,9 @@ const DataTableComponent = ({
         </Banner>
       )}
       {columnSummaries?.is_disabled && (
+        // Note: Keep the text in sync with the constant defined in table_manager.py
+        //       This hard-code can be removed when Functions can pass structural
+        //       error information from the backend
         <Banner className="mb-2 rounded">
           Column summaries are unavailable. Filter your data to fewer than
           1,000,000 rows.

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -341,6 +341,7 @@ class table(
     def get_column_summaries(self, args: EmptyArgs) -> ColumnSummaries:
         del args
 
+        # Avoid expensive column summaries calculation by setting a upper limit
         if (
             self._filtered_manager.get_num_rows(force=True) or 0
         ) > TableManager.DEFAULT_SUMMARY_ROW_LIMIT:

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -339,6 +339,7 @@ class table(
         manager = (
             self._selected_manager
             if self._selected_manager and self._has_any_selection
+            # use _searched_manager here to download the full data
             else self._searched_manager
         )
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -329,7 +329,7 @@ class table(
         self, value: list[str]
     ) -> Union[List[JSONType], "pd.DataFrame", "pl.DataFrame"]:
         indices = [int(v) for v in value]
-        self._selected_manager = self._searched_manager.select_rows(indices)
+        self._selected_manager = self._limited_manager.select_rows(indices)
         self._has_any_selection = len(indices) > 0
         return self._selected_manager.data  # type: ignore[no-any-return]
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -68,6 +68,7 @@ class ColumnSummary:
 @dataclass
 class ColumnSummaries:
     summaries: List[ColumnSummary]
+    is_disabled: Optional[bool] = None
 
 
 @dataclass
@@ -339,6 +340,12 @@ class table(
 
     def get_column_summaries(self, args: EmptyArgs) -> ColumnSummaries:
         del args
+
+        if (
+            self._filtered_manager.get_num_rows(force=True) or 0
+        ) > TableManager.DEFAULT_SUMMARY_ROW_LIMIT:
+            return ColumnSummaries([], is_disabled=True)
+
         summaries: List[ColumnSummary] = []
         for column in self._filtered_manager.get_column_names():
             summary = self._filtered_manager.get_summary(column)
@@ -354,7 +361,7 @@ class table(
                 )
             )
 
-        return ColumnSummaries(summaries)
+        return ColumnSummaries(summaries, is_disabled=False)
 
     def search(self, args: SearchTableArgs) -> Union[JSONType, str]:
         # Start with the original manager, then filter

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -28,6 +28,7 @@ class TableManager(abc.ABC, Generic[T]):
     DEFAULT_ROW_LIMIT = 20_000
     DEFAULT_COL_LIMIT = 100
     # Upper limit for column summaries to avoid hanging up the kernel
+    # Note: Keep this value in sync with DataTablePlugin's banner text
     DEFAULT_SUMMARY_ROW_LIMIT = 1_000_000
 
     type: str = ""

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -26,6 +26,8 @@ FieldTypes = Dict[ColumnName, Tuple[FieldType, ExternalDataType]]
 class TableManager(abc.ABC, Generic[T]):
     DEFAULT_ROW_LIMIT = 20_000
     DEFAULT_COL_LIMIT = 100
+    DEFAULT_SUMMARY_ROW_LIMIT = 1_000_000
+
     type: str = ""
 
     def __init__(self, data: T) -> None:

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -24,8 +24,10 @@ FieldTypes = Dict[ColumnName, Tuple[FieldType, ExternalDataType]]
 
 
 class TableManager(abc.ABC, Generic[T]):
+    # Upper limit for frontend table component to ensure browser performance
     DEFAULT_ROW_LIMIT = 20_000
     DEFAULT_COL_LIMIT = 100
+    # Upper limit for column summaries to avoid hanging up the kernel
     DEFAULT_SUMMARY_ROW_LIMIT = 1_000_000
 
     type: str = ""

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -9,7 +9,6 @@ import pytest
 from marimo._plugins import ui
 from marimo._plugins.ui._impl.table import SearchTableArgs, SortArgs
 from marimo._plugins.ui._impl.tables.default_table import DefaultTableManager
-from marimo._plugins.ui._impl.tables.table_manager import TableManager
 from marimo._plugins.ui._impl.utils.dataframe import TableData
 from marimo._runtime.functions import EmptyArgs
 from marimo._runtime.runtime import Kernel
@@ -312,10 +311,7 @@ def test_table_with_too_many_rows_unknown_total():
 
 
 def test_table_with_too_many_rows_column_summaries_disabled():
-    # The row limit is only applied when calling get_column_summaries, so we
-    # don't have something like _internal_row_limit. Allocating a list of 1m
-    # should be fine on most machines.
-    data = {"a": list(range(TableManager.DEFAULT_SUMMARY_ROW_LIMIT + 1))}
-    table = ui.table(data)
+    data = {"a": list(range(20))}
+    table = ui.table(data, _internal_summary_row_limit=10)
     summaries = table.get_column_summaries(EmptyArgs())
     assert summaries.is_disabled is True

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -9,7 +9,9 @@ import pytest
 from marimo._plugins import ui
 from marimo._plugins.ui._impl.table import SearchTableArgs, SortArgs
 from marimo._plugins.ui._impl.tables.default_table import DefaultTableManager
+from marimo._plugins.ui._impl.tables.table_manager import TableManager
 from marimo._plugins.ui._impl.utils.dataframe import TableData
+from marimo._runtime.functions import EmptyArgs
 from marimo._runtime.runtime import Kernel
 
 
@@ -307,3 +309,13 @@ def test_table_with_too_many_rows_unknown_total():
     assert table._component_args["has-more"] is True
     assert table._component_args["total-rows"] == "too_many"
     assert len(table._component_args["data"]) == 30
+
+
+def test_table_with_too_many_rows_column_summaries_disabled():
+    # The row limit is only applied when calling get_column_summaries, so we
+    # don't have something like _internal_row_limit. Allocating a list of 1m
+    # should be fine on most machines.
+    data = {"a": list(range(TableManager.DEFAULT_SUMMARY_ROW_LIMIT + 1))}
+    table = ui.table(data)
+    summaries = table.get_column_summaries(EmptyArgs())
+    assert summaries.is_disabled is True

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -313,5 +313,11 @@ def test_table_with_too_many_rows_unknown_total():
 def test_table_with_too_many_rows_column_summaries_disabled():
     data = {"a": list(range(20))}
     table = ui.table(data, _internal_summary_row_limit=10)
-    summaries = table.get_column_summaries(EmptyArgs())
-    assert summaries.is_disabled is True
+
+    summaries_disabled = table.get_column_summaries(EmptyArgs())
+    assert summaries_disabled.is_disabled is True
+
+    # search results are 2 and 12
+    table.search(SearchTableArgs(query="2"))
+    summaries_enabled = table.get_column_summaries(EmptyArgs())
+    assert summaries_enabled.is_disabled is False


### PR DESCRIPTION
## 📝 Summary

1. Add a hard-coded row count upper limit on table's column summaries feature.
2. Update column summaries after changing search/filter criteria
3. Fix the inconsistency of table filtering and row count limiting
4. Some code reorganization

Fixes #1979.
Fixes #2016.

## 🔍 Description of Changes

- Add a `is_disabled` field to `ColumnSummaries` so it can indicate itself being disabled
    - I tried to use exceptions, but I found Function objects only propagates human-readable error messages. So it's unfeasible.
- Add a hard-coded 1,000,000 row count limit to the column summaries feature
    - marimo already imposes a column count limit, so I think limiting only rows here should be OK for most situations
- Make column summaries react to filter/search criteria changes, so the summaries gets updated after such operations
- Separate the `table._filtered_manager` to `table._searched_manager` and `table._limited_manager`
    - The `_searched_manager` holds the full data after search (query, filter and sort), and the `_limited_manager` holds the first 20000 rows of `_searched_manager`
- Reorganized the code in `table.__init__()` for better clarity

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] (Not applicable) For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
