### PR TITLE
fix: Undo split cell with code snapshot

### DIFF
--- a/frontend/src/components/editor/cell/useSplitCell.tsx
+++ b/frontend/src/components/editor/cell/useSplitCell.tsx
@@ -1,7 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { UndoButton } from "@/components/buttons/undo-button";
 import { toast } from "@/components/ui/use-toast";
-import { useCellActions } from "@/core/cells/cells";
+import { getCellEditorView, useCellActions } from "@/core/cells/cells";
 import { CellId } from "@/core/cells/ids";
 import useEvent from "react-use-event-hook";
 
@@ -9,6 +9,10 @@ export function useSplitCellCallback() {
   const { splitCell, undoSplitCell } = useCellActions();
 
   return useEvent((opts: { cellId: CellId }) => {
+    // Save snapshot of code for undo
+    const cellEditorView = getCellEditorView(opts.cellId);
+    const code = cellEditorView?.state.doc.toString() ?? "";
+
     // Optimistic update
     splitCell(opts);
 
@@ -20,7 +24,7 @@ export function useSplitCellCallback() {
           size="sm"
           variant="outline"
           onClick={() => {
-            undoSplitCell(opts);
+            undoSplitCell({ ...opts, snapshot: code });
             dismiss();
           }}
         >


### PR DESCRIPTION
## 📝 Summary

Follow up to #2018 that addresses an edge case. 

Originally, split cell undo was done by triggering an undo in the original cell. However, if the user were to split a cell, edit the original cell, and then undo the split cell, this would not undo the cell action correctly.

## 🔍 Description of Changes

In `useSplitCellCallback`, save the original cell's code in a variable before cell split, and then pass it to `undoSplitCell()` if the user undoes the split.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
