### PR TITLE
development: marimo development inline-packages

### DIFF
--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -397,10 +397,7 @@ def inline_packages(
 
     click.echo(f"Inlining packages: {pypi_names}")
     click.echo(f"into script: {name}")
-
-    # run: uv add {pypi_names} --script {name}
-    for pypi_name in pypi_names:
-        subprocess.run(["uv", "add", pypi_name, "--script", name])
+    subprocess.run(["uv", "add", "--script", name, " ".join(pypi_names)])
 
 
 development.add_command(inline_packages)

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -397,7 +397,15 @@ def inline_packages(
 
     click.echo(f"Inlining packages: {pypi_names}")
     click.echo(f"into script: {name}")
-    subprocess.run(["uv", "add", "--script", name, " ".join(pypi_names)])
+    subprocess.run(
+        [
+            "uv",
+            "add",
+            "--script",
+            name,
+        ]
+        + pypi_names
+    )
 
 
 development.add_command(inline_packages)

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -359,6 +359,9 @@ def inline_packages(
 
     # Validate >=3.10 for sys.stdlib_module_names
     if sys.version_info < (3, 10):
+        # TOD: add support for < 3.10
+        # We can use https://github.com/omnilib/stdlibs
+        # to get the stdlib module names
         raise click.UsageError("Requires Python >=3.10")
 
     package_names = module_name_to_pypi_name()

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import importlib.util
+import shutil
 import sys
 from dataclasses import dataclass
 
@@ -156,3 +157,10 @@ class DependencyManager:
     def has(pkg: str) -> bool:
         """Return True if any lib is installed."""
         return Dependency(pkg).has()
+
+    @staticmethod
+    def which(pkg: str) -> bool:
+        """
+        Checks if a CLI command is installed.
+        """
+        return shutil.which(pkg) is not None

--- a/marimo/_smoke_tests/quak-demo.py
+++ b/marimo/_smoke_tests/quak-demo.py
@@ -1,4 +1,12 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "polars",
+#     "marimo",
+#     "quak",
+#     "vega-datasets",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.7.12"


### PR DESCRIPTION
Just an experimental util behind the `marimo development` CLI. 

This automatically adds the inline package metadata per PEP 723 using `uv`.