### PR TITLE
improvement: toast user for new marimo versions

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -20,7 +20,8 @@ from marimo._cli.export.commands import export
 from marimo._cli.file_path import validate_name
 from marimo._cli.parse_args import parse_args
 from marimo._cli.print import red
-from marimo._cli.upgrade import check_for_updates
+from marimo._cli.upgrade import check_for_updates, print_latest_version
+from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._server.file_router import AppFileRouter
 from marimo._server.model import SessionMode
 from marimo._server.start import start
@@ -32,9 +33,6 @@ from marimo._tutorials import (
     tutorial_order,
 )
 from marimo._utils.marimo_path import MarimoPath
-
-DEVELOPMENT_MODE = False
-QUIET = False
 
 
 def helpful_usage_error(self: Any, file: Any = None) -> None:
@@ -169,10 +167,8 @@ def main(log_level: str, quiet: bool, development_mode: bool) -> None:
     log_level = "DEBUG" if development_mode else log_level
     _loggers.set_level(log_level)
 
-    global DEVELOPMENT_MODE
-    global QUIET
-    DEVELOPMENT_MODE = development_mode
-    QUIET = quiet
+    GLOBAL_SETTINGS.DEVELOPMENT_MODE = development_mode
+    GLOBAL_SETTINGS.QUIET = quiet
 
 
 edit_help_msg = "\n".join(
@@ -274,8 +270,9 @@ def edit(
     args: tuple[str, ...],
 ) -> None:
     if not skip_update_check and os.getenv("MARIMO_SKIP_UPDATE_CHECK") != "1":
+        GLOBAL_SETTINGS.CHECK_STATUS_UPDATE = True
         # Check for version updates
-        check_for_updates()
+        check_for_updates(print_latest_version)
 
     if name is not None:
         # Validate name, or download from URL
@@ -308,8 +305,8 @@ def edit(
 
     start(
         file_router=AppFileRouter.infer(name),
-        development_mode=DEVELOPMENT_MODE,
-        quiet=QUIET,
+        development_mode=GLOBAL_SETTINGS.DEVELOPMENT_MODE,
+        quiet=GLOBAL_SETTINGS.QUIET,
         host=host,
         port=port,
         proxy=proxy,
@@ -388,8 +385,8 @@ def new(
 ) -> None:
     start(
         file_router=AppFileRouter.new_file(),
-        development_mode=DEVELOPMENT_MODE,
-        quiet=QUIET,
+        development_mode=GLOBAL_SETTINGS.DEVELOPMENT_MODE,
+        quiet=GLOBAL_SETTINGS.QUIET,
         host=host,
         port=port,
         proxy=proxy,
@@ -528,8 +525,8 @@ def run(
 
     start(
         file_router=AppFileRouter.from_filename(MarimoPath(name)),
-        development_mode=DEVELOPMENT_MODE,
-        quiet=QUIET,
+        development_mode=GLOBAL_SETTINGS.DEVELOPMENT_MODE,
+        quiet=GLOBAL_SETTINGS.QUIET,
         host=host,
         port=port,
         proxy=proxy,
@@ -640,8 +637,8 @@ def tutorial(
 
     start(
         file_router=AppFileRouter.from_filename(path),
-        development_mode=DEVELOPMENT_MODE,
-        quiet=QUIET,
+        development_mode=GLOBAL_SETTINGS.DEVELOPMENT_MODE,
+        quiet=GLOBAL_SETTINGS.QUIET,
         host=host,
         port=port,
         proxy=proxy,

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GlobalSettings:
+    DEVELOPMENT_MODE: bool = False
+    QUIET: bool = False
+    CHECK_STATUS_UPDATE: bool = False
+
+
+GLOBAL_SETTINGS = GlobalSettings()

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -569,7 +569,11 @@ class WebsocketHandler(SessionConsumer):
         return self.status
 
     def _check_status_update(self) -> None:
-        if not GLOBAL_SETTINGS.CHECK_STATUS_UPDATE:
+        # Only check for updates if we're in edit mode
+        if (
+            not GLOBAL_SETTINGS.CHECK_STATUS_UPDATE
+            or self.mode != SessionMode.EDIT
+        ):
             return
 
         def on_update(current_version: str, latest_version: str) -> None:

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -10,6 +10,8 @@ from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from marimo import _loggers
 from marimo._ast.cell import CellConfig, CellId_t
+from marimo._cli.upgrade import check_for_updates
+from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._messaging.ops import (
     Alert,
     Banner,
@@ -512,6 +514,7 @@ class WebsocketHandler(SessionConsumer):
 
         async def listen_for_disconnect() -> None:
             try:
+                self._check_status_update()
                 await self.websocket.receive_text()
             except WebSocketDisconnect as e:
                 self._on_disconnect(
@@ -564,3 +567,28 @@ class WebsocketHandler(SessionConsumer):
 
     def connection_state(self) -> ConnectionState:
         return self.status
+
+    def _check_status_update(self) -> None:
+        if not GLOBAL_SETTINGS.CHECK_STATUS_UPDATE:
+            return
+
+        def on_update(current_version: str, latest_version: str) -> None:
+            # Let's only toast once per marimo server
+            # so we can just store this in memory.
+            # We still want to check for updates (which are debounced 24 hours)
+            # but don't keep toasting.
+            global HAS_TOASTED
+            if HAS_TOASTED:
+                return
+
+            HAS_TOASTED = True
+
+            title = f"Update available {current_version} → {latest_version}"
+            release_url = "https://github.com/marimo-team/marimo/releases"
+            description = f"Check out the <a class='underline' target='_blank' href='{release_url}'>latest release on GitHub.</a>"  # noqa: E501
+            self.write_operation(Alert(title=title, description=description))
+
+        check_for_updates(on_update)
+
+
+HAS_TOASTED = False

--- a/marimo/_tutorials/plots.py
+++ b/marimo/_tutorials/plots.py
@@ -1,13 +1,14 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.1.69"
+__generated_with = "0.8.0"
 app = marimo.App()
 
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("# Plotting")
+    mo.md("""# Plotting""")
     return
 
 
@@ -33,7 +34,7 @@ def __(mo):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## Matplotlib")
+    mo.md("""## Matplotlib""")
     return
 
 
@@ -203,7 +204,7 @@ def __(exponent, mo, plt, x):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## Other libraries")
+    mo.md("""## Other libraries""")
     return
 
 

--- a/tests/_cli/test_upgrade.py
+++ b/tests/_cli/test_upgrade.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any
 from unittest.mock import mock_open, patch
@@ -7,6 +9,7 @@ from marimo._cli.upgrade import (
     MarimoCLIState,
     _update_with_latest_version,
     check_for_updates,
+    print_latest_version,
 )
 
 
@@ -34,7 +37,7 @@ def test_check_for_updates(
     mock_open_file.side_effect = FileNotFoundError()
 
     # Call the function to test
-    check_for_updates()
+    check_for_updates(print_latest_version)
 
     # Assert that the makedirs function was not called
     mock_makedirs.assert_not_called()


### PR DESCRIPTION
For users who don't look at their terminal (or use vscode), this will toast the status update once per-marimo startup.

Later we can add a small indicator to the UI for future sessions. 