### PR TITLE
chore: add internal tracing for debugging

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -150,7 +150,7 @@ jobs:
           fi
           ruff check marimo/
       - name: Typecheck
-        if: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.11' || matrix.python-version == '3.12' }}
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
             source marimo-dev-env\\Scripts\\activate

--- a/development_docs/traces.md
+++ b/development_docs/traces.md
@@ -1,11 +1,6 @@
 # Server Telemetry
 
-For debugging purposes, we emit OpenTelemetry traces from the server. We emit traces to:
-
-- `~/.marimo/traces/server.json`
-- `~/.marimo/traces/kernel.json`
-
-We don't emit any sensitive information in the traces, and these traces stay local to your machine. The traces get wiped on each sever restart.
+For debugging purposes, we emit OpenTelemetry traces from the server. We emit traces to `~/.marimo/traces/trace.jsonl`. We don't emit any sensitive information in the traces, and these traces stay local to your machine. The traces get wiped on each sever restart.
 
 You can analyze the traces using tools like Jaeger or Zipkin, or our marimo notebook:
 

--- a/development_docs/traces.md
+++ b/development_docs/traces.md
@@ -1,0 +1,14 @@
+# Server Telemetry
+
+For debugging purposes, we emit OpenTelemetry traces from the server. We emit traces to:
+
+- `~/.marimo/traces/server.json`
+- `~/.marimo/traces/kernel.json`
+
+We don't emit any sensitive information in the traces, and these traces stay local to your machine. The traces get wiped on each sever restart.
+
+You can analyze the traces using tools like Jaeger or Zipkin, or our marimo notebook:
+
+```bash
+marimo edit scripts/analyze_traces.py
+```

--- a/development_docs/traces.md
+++ b/development_docs/traces.md
@@ -1,9 +1,17 @@
 # Server Telemetry
 
-For debugging purposes, we emit OpenTelemetry traces from the server. We emit traces to `~/.marimo/traces/traces.jsonl`. We don't emit any sensitive information in the traces, and these traces stay local to your machine. The traces get wiped on each sever restart.
+For debugging purposes, we emit OpenTelemetry traces from the server. We emit traces to `~/.marimo/traces/spans.jsonl`. We don't emit any sensitive information in the traces, and these traces stay local to your machine. The traces get wiped on each sever restart.
 
 You can analyze the traces using tools like Jaeger or Zipkin, or our marimo notebook:
 
 ```bash
 marimo edit scripts/analyze_traces.py
+```
+
+## Enable Traces
+
+To enable traces, set the `MARIMO_TRACING` environment variable to `true`:
+
+```bash
+MARIMO_TRACING=true ./your_server_command
 ```

--- a/development_docs/traces.md
+++ b/development_docs/traces.md
@@ -1,6 +1,6 @@
 # Server Telemetry
 
-For debugging purposes, we emit OpenTelemetry traces from the server. We emit traces to `~/.marimo/traces/trace.jsonl`. We don't emit any sensitive information in the traces, and these traces stay local to your machine. The traces get wiped on each sever restart.
+For debugging purposes, we emit OpenTelemetry traces from the server. We emit traces to `~/.marimo/traces/traces.jsonl`. We don't emit any sensitive information in the traces, and these traces stay local to your machine. The traces get wiped on each sever restart.
 
 You can analyze the traces using tools like Jaeger or Zipkin, or our marimo notebook:
 

--- a/marimo/_cli/upgrade.py
+++ b/marimo/_cli/upgrade.py
@@ -13,6 +13,7 @@ from packaging import version
 from marimo import __version__ as current_version
 from marimo._cli.print import green, orange
 from marimo._server.api.status import HTTPException
+from marimo._tracer import server_tracer
 from marimo._utils.config.config import ConfigReader
 
 FETCH_TIMEOUT = 5
@@ -31,6 +32,7 @@ def print_latest_version(current_version: str, latest_version: str) -> None:
     print()
 
 
+@server_tracer.start_as_current_span("check_for_updates")
 def check_for_updates(on_update: Callable[[str, str], None]) -> None:
     try:
         _check_for_updates_internal(on_update)

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -9,9 +9,7 @@ class GlobalSettings:
     DEVELOPMENT_MODE: bool = False
     QUIET: bool = False
     CHECK_STATUS_UPDATE: bool = False
-    CAPTURE_TRACES: bool = (
-        os.getenv("MARIMO_CAPTURE_TRACES", "false") == "true"
-    )
+    TRACING: bool = os.getenv("MARIMO_TRACING", "false") in ("true", "1")
 
 
 GLOBAL_SETTINGS = GlobalSettings()

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 
@@ -8,6 +9,9 @@ class GlobalSettings:
     DEVELOPMENT_MODE: bool = False
     QUIET: bool = False
     CHECK_STATUS_UPDATE: bool = False
+    CAPTURE_TRACES: bool = (
+        os.getenv("MARIMO_CAPTURE_TRACES", "false") == "true"
+    )
 
 
 GLOBAL_SETTINGS = GlobalSettings()

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 import os

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -152,6 +152,7 @@ class DependencyManager:
     narwhals = Dependency("narwhals")
     ruff = Dependency("ruff")
     black = Dependency("black")
+    opentelemetry = Dependency("opentelemetry")
 
     @staticmethod
     def has(pkg: str) -> bool:

--- a/marimo/_plugins/ui/_impl/anywidget/comm.py
+++ b/marimo/_plugins/ui/_impl/anywidget/comm.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 import base64

--- a/marimo/_plugins/ui/_impl/anywidget/init.py
+++ b/marimo/_plugins/ui/_impl/anywidget/init.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast

--- a/marimo/_runtime/runner/hooks_on_finish.py
+++ b/marimo/_runtime/runner/hooks_on_finish.py
@@ -15,12 +15,14 @@ from marimo._messaging.errors import (
 from marimo._messaging.ops import CellOp
 from marimo._runtime.control_flow import MarimoStopError
 from marimo._runtime.runner import cell_runner
+from marimo._tracer import kernel_tracer
 
 LOGGER = _loggers.marimo_logger()
 
 OnFinishHookType = Callable[[cell_runner.Runner], None]
 
 
+@kernel_tracer.start_as_current_span("send_interrupt_errors")
 def _send_interrupt_errors(runner: cell_runner.Runner) -> None:
     if runner.cells_to_run:
         assert runner.interrupted
@@ -37,6 +39,7 @@ def _send_interrupt_errors(runner: cell_runner.Runner) -> None:
             )
 
 
+@kernel_tracer.start_as_current_span("send_cancellation_errors")
 def _send_cancellation_errors(runner: cell_runner.Runner) -> None:
     for raising_cell in runner.cells_cancelled:
         for cid in runner.cells_cancelled[raising_cell]:

--- a/marimo/_runtime/runner/hooks_post_execution.py
+++ b/marimo/_runtime/runner/hooks_post_execution.py
@@ -29,6 +29,7 @@ from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._runtime.context.types import get_global_context
 from marimo._runtime.control_flow import MarimoInterrupt, MarimoStopError
 from marimo._runtime.runner import cell_runner
+from marimo._tracer import kernel_tracer
 from marimo._utils.flatten import contains_instance
 
 LOGGER = _loggers.marimo_logger()
@@ -38,6 +39,7 @@ PostExecutionHookType = Callable[
 ]
 
 
+@kernel_tracer.start_as_current_span("set_imported_defs")
 def _set_imported_defs(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -51,6 +53,7 @@ def _set_imported_defs(
             )
 
 
+@kernel_tracer.start_as_current_span("set_status_idle")
 def _set_status_idle(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -61,6 +64,7 @@ def _set_status_idle(
     cell.set_runtime_state(status="idle")
 
 
+@kernel_tracer.start_as_current_span("set_run_result_status")
 def _set_run_result_status(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -76,6 +80,7 @@ def _set_run_result_status(
         cell.set_run_result_status("success")
 
 
+@kernel_tracer.start_as_current_span("broadcast_variables")
 def _broadcast_variables(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -95,6 +100,7 @@ def _broadcast_variables(
         VariableValues(variables=values).broadcast()
 
 
+@kernel_tracer.start_as_current_span("broadcast_datasets")
 def _broadcast_datasets(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -112,6 +118,7 @@ def _broadcast_datasets(
         Datasets(tables=tables).broadcast()
 
 
+@kernel_tracer.start_as_current_span("broadcast_duckdb_tables")
 def _broadcast_duckdb_tables(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -141,6 +148,7 @@ def _broadcast_duckdb_tables(
         return
 
 
+@kernel_tracer.start_as_current_span("store_reference_to_output")
 def _store_reference_to_output(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -157,6 +165,7 @@ def _store_reference_to_output(
             cell.set_output(run_result.output)
 
 
+@kernel_tracer.start_as_current_span("broadcast_outputs")
 def _broadcast_outputs(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -258,6 +267,7 @@ def _broadcast_outputs(
         )
 
 
+@kernel_tracer.start_as_current_span("reset_matplotlib_context")
 def _reset_matplotlib_context(
     cell: CellImpl,
     runner: cell_runner.Runner,

--- a/marimo/_runtime/runner/hooks_pre_execution.py
+++ b/marimo/_runtime/runner/hooks_pre_execution.py
@@ -5,10 +5,12 @@ from typing import Callable
 
 from marimo._ast.cell import CellImpl
 from marimo._runtime.runner import cell_runner
+from marimo._tracer import kernel_tracer
 
 PreExecutionHookType = Callable[[CellImpl, cell_runner.Runner], None]
 
 
+@kernel_tracer.start_as_current_span("set_staleness")
 def _set_staleness(
     cell: CellImpl,
     runner: cell_runner.Runner,
@@ -25,6 +27,7 @@ def _set_staleness(
         cell.set_stale(stale=False)
 
 
+@kernel_tracer.start_as_current_span("set_status_to_running")
 def _set_status_to_running(
     cell: CellImpl,
     runner: cell_runner.Runner,

--- a/marimo/_runtime/runner/hooks_preparation.py
+++ b/marimo/_runtime/runner/hooks_preparation.py
@@ -6,10 +6,12 @@ from typing import Callable
 from marimo._runtime import dataflow
 from marimo._runtime.dataflow import import_block_relatives
 from marimo._runtime.runner import cell_runner
+from marimo._tracer import kernel_tracer
 
 PreparationHookType = Callable[[cell_runner.Runner], None]
 
 
+@kernel_tracer.start_as_current_span("update_stale_statuses")
 def _update_stale_statuses(runner: cell_runner.Runner) -> None:
     graph = runner.graph
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -122,6 +122,7 @@ from marimo._runtime.utils.set_ui_element_request_manager import (
 from marimo._runtime.validate_graph import check_for_errors
 from marimo._runtime.win32_interrupt_handler import Win32InterruptHandler
 from marimo._server.types import QueueType
+from marimo._tracer import kernel_tracer
 from marimo._utils.assert_never import assert_never
 from marimo._utils.platform import is_pyodide
 from marimo._utils.signals import restore_signals
@@ -478,6 +479,7 @@ class Kernel:
         ).start()
         self._completion_worker_started = True
 
+    @kernel_tracer.start_as_current_span("code_completion")
     def code_completion(
         self, request: CodeCompletionRequest, docstrings_limit: int
     ) -> None:
@@ -1102,7 +1104,8 @@ class Kernel:
         # TODO(akshayka): Send VariableValues message for any globals
         # bound to this state object (just like UI elements)
 
-    async def delete(self, request: DeleteCellRequest) -> None:
+    @kernel_tracer.start_as_current_span("delete_cell")
+    async def delete_cell(self, request: DeleteCellRequest) -> None:
         """Delete a cell from kernel and graph."""
         cell_id = request.cell_id
         if cell_id in self.graph.cells:
@@ -1112,6 +1115,7 @@ class Kernel:
                 )
             )
 
+    @kernel_tracer.start_as_current_span("run")
     async def run(
         self, execution_requests: Sequence[ExecutionRequest]
     ) -> None:
@@ -1154,6 +1158,7 @@ class Kernel:
             self.mutate_graph(filtered_requests, deletion_requests=[])
         )
 
+    @kernel_tracer.start_as_current_span("rename_file")
     async def rename_file(self, filename: str) -> None:
         self.globals["__file__"] = filename
         roots = set()
@@ -1162,6 +1167,7 @@ class Kernel:
                 roots.add(cell.cell_id)
         await self._if_autorun_then_run_cells(roots)
 
+    @kernel_tracer.start_as_current_span("run_scratchpad")
     async def run_scratchpad(self, code: str) -> None:
         roots = {SCRATCH_CELL_ID}
 
@@ -1202,6 +1208,7 @@ class Kernel:
 
         await runner.run_all()
 
+    @kernel_tracer.start_as_current_span("run_stale_cells")
     async def run_stale_cells(self) -> None:
         cells_to_run: set[CellId_t] = set()
         for cid, cell_impl in self.graph.cells.items():
@@ -1217,6 +1224,7 @@ class Kernel:
         if self.module_watcher is not None:
             self.module_watcher.run_is_processed.set()
 
+    @kernel_tracer.start_as_current_span("set_cell_config")
     async def set_cell_config(self, request: SetCellConfigRequest) -> None:
         """Update cell configs.
 
@@ -1241,9 +1249,11 @@ class Kernel:
         if stale_cells and self.reactive_execution_mode == "autorun":
             await self._run_cells(stale_cells)
 
+    @kernel_tracer.start_as_current_span("set_user_config")
     def set_user_config(self, request: SetUserConfigRequest) -> None:
         self._update_runtime_from_user_config(request.config)
 
+    @kernel_tracer.start_as_current_span("set_ui_element_value")
     async def set_ui_element_value(
         self, request: SetUIElementValueRequest
     ) -> bool:
@@ -1435,6 +1445,7 @@ class Kernel:
     def reset_ui_initializers(self) -> None:
         self.ui_initializers = {}
 
+    @kernel_tracer.start_as_current_span("function_call_request")
     async def function_call_request(
         self, request: FunctionCallRequest
     ) -> tuple[HumanReadableStatus, JSONType, bool]:
@@ -1527,6 +1538,7 @@ class Kernel:
             found,
         )
 
+    @kernel_tracer.start_as_current_span("instantiate")
     async def instantiate(self, request: CreationRequest) -> None:
         """Instantiate the kernel with cells and UIElement initial values
 
@@ -1607,6 +1619,7 @@ class Kernel:
         if cells_to_run:
             await self._if_autorun_then_run_cells(cells_to_run)
 
+    @kernel_tracer.start_as_current_span("preview_dataset_column")
     async def preview_dataset_column(
         self, request: PreviewDatasetColumnRequest
     ) -> None:
@@ -1682,7 +1695,7 @@ class Kernel:
                 ).broadcast()
                 CompletedRun().broadcast()
             elif isinstance(request, DeleteCellRequest):
-                await self.delete(request)
+                await self.delete_cell(request)
             elif isinstance(request, InstallMissingPackagesRequest):
                 await self.install_missing_packages(request)
                 CompletedRun().broadcast()

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -18,6 +18,7 @@ from marimo._server.api.auth import (
 )
 from marimo._server.api.middleware import (
     AuthBackend,
+    OpenTelemetryMiddleware,
     SkewProtectionMiddleware,
 )
 from marimo._server.api.router import build_routes
@@ -93,6 +94,7 @@ def create_starlette_app(
 
     final_middlewares.extend(
         [
+            Middleware(OpenTelemetryMiddleware),
             Middleware(
                 AuthenticationMiddleware,
                 backend=AuthBackend(should_authenticate=enable_auth),

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -63,6 +63,7 @@ from marimo._server.session.session_view import SessionView
 from marimo._server.tokens import AuthToken, SkewProtectionToken
 from marimo._server.types import QueueType
 from marimo._server.utils import print_tabbed
+from marimo._tracer import server_tracer
 from marimo._utils.disposable import Disposable
 from marimo._utils.distributor import Distributor
 from marimo._utils.file_watcher import FileWatcher
@@ -847,6 +848,7 @@ class LspServer:
         self.port = port
         self.process: Optional[subprocess.Popen[bytes]] = None
 
+    @server_tracer.start_as_current_span("lsp_server.start")
     def start(self) -> Optional[Alert]:
         if self.process is not None:
             LOGGER.debug("LSP server already started")

--- a/marimo/_smoke_tests/bugs/2070-latex-slides.py
+++ b/marimo/_smoke_tests/bugs/2070-latex-slides.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.8.0"

--- a/marimo/_smoke_tests/quak-demo.py
+++ b/marimo/_smoke_tests/quak-demo.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -64,7 +64,7 @@ class MockSpan:
 
 class MockTracer:
     @contextmanager
-    def span(self, *args: Any, **kwargs: Any) -> Any:
+    def start_span(self, *args: Any, **kwargs: Any) -> Any:
         del args, kwargs
 
         return MockSpan()
@@ -75,11 +75,11 @@ class MockTracer:
         yield MockSpan()
 
 
-TRACE_FILENAME = os.path.join("traces", "traces.jsonl")
+TRACE_FILENAME = os.path.join("traces", "spans.jsonl")
 
 
 def _set_tracer_provider() -> None:
-    if is_pyodide() or GLOBAL_SETTINGS.CAPTURE_TRACES is False:
+    if is_pyodide() or GLOBAL_SETTINGS.TRACING is False:
         return
 
     from opentelemetry import trace
@@ -145,7 +145,7 @@ def create_tracer(trace_name: str) -> "trace.Tracer":
     """
 
     # Don't load opentelemetry if we're in a Pyodide environment.
-    if is_pyodide() or GLOBAL_SETTINGS.CAPTURE_TRACES is False:
+    if is_pyodide() or GLOBAL_SETTINGS.TRACING is False:
         return cast(Any, MockTracer())
 
     from opentelemetry import trace

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 import os
@@ -146,7 +147,7 @@ def create_tracer(trace_name: str) -> "trace.Tracer":
 
     # Don't load opentelemetry if we're in a Pyodide environment.
     if is_pyodide() or GLOBAL_SETTINGS.TRACING is False:
-        return cast(Any, MockTracer())
+        return cast(Any, MockTracer())  # type: ignore[no-any-return]
 
     from opentelemetry import trace
 

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Sequence, cast
@@ -104,7 +103,7 @@ def _set_tracer_provider() -> None:
             try:
                 with open(self.file_path, "a") as f:
                     for span in spans:
-                        json.dump(span.to_json(), f)
+                        f.write(span.to_json(cast(Any, None)))
                         f.write("\n")
                 return SpanExportResult.SUCCESS
             except Exception as e:

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -167,7 +167,7 @@ def create_tracer(trace_name: str) -> "trace.Tracer":
     except Exception as e:
         LOGGER.debug("Failed to create tracer: %s", e)
 
-    return cast(Any, MockTracer())
+    return cast(Any, MockTracer())  # type: ignore[no-any-return]
 
 
 try:

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Sequence, cast
+
+from marimo import _loggers
+from marimo._utils.config.config import ConfigReader
+from marimo._utils.platform import is_pyodide
+
+LOGGER = _loggers.marimo_logger()
+
+if TYPE_CHECKING:
+    from opentelemetry import trace
+
+
+class MockSpan:
+    @contextmanager
+    def as_current_span(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield self
+
+    @contextmanager
+    def set_attribute(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield
+
+    @contextmanager
+    def set_status(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield
+
+    @contextmanager
+    def update_name(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield
+
+    @contextmanager
+    def end(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield
+
+    @contextmanager
+    def add_event(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield
+
+    @contextmanager
+    def add_link(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield
+
+    @contextmanager
+    def set_attributes(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield
+
+    @contextmanager
+    def record_exception(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield
+
+
+class MockTracer:
+    @contextmanager
+    def span(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+
+        return MockSpan()
+
+    @contextmanager
+    def start_as_current_span(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        yield MockSpan()
+
+
+TRACE_FILENAME = os.path.join("traces", "trace.jsonl")
+
+
+def _set_tracer_provider() -> None:
+    if is_pyodide():
+        return
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        SpanExporter,
+        SpanExportResult,
+    )
+
+    # If one already exists, return
+    try:
+        trace.get_tracer_provider()
+    except Exception:
+        return
+
+    class FileExporter(SpanExporter):
+        def __init__(self, file_path: str) -> None:
+            self.file_path: str = file_path
+
+        def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+            try:
+                with open(self.file_path, "a") as f:
+                    for span in spans:
+                        json.dump(span.to_json(), f)
+                        f.write("\n")
+                return SpanExportResult.SUCCESS
+            except Exception as e:
+                LOGGER.exception(e)
+                return SpanExportResult.FAILURE
+
+        def shutdown(self) -> None:
+            pass
+
+    # Create a directory for logs if it doesn't exist
+    config_ready = ConfigReader.for_filename(TRACE_FILENAME)
+    if config_ready is None:
+        raise FileNotFoundError(
+            f"Could not local config file {TRACE_FILENAME}"
+        )
+
+    filepath = config_ready.filepath
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
+    # Create a file exporter
+    file_exporter: FileExporter = FileExporter(filepath)
+
+    provider = TracerProvider()
+    processor = BatchSpanProcessor(file_exporter)
+    provider.add_span_processor(processor)
+
+    # Sets the global default tracer provider
+    trace.set_tracer_provider(provider)
+
+
+def create_tracer(trace_name: str) -> "trace.Tracer":
+    """
+    Creates a tracer that logs to a file.
+
+    This lazily loads opentelemetry.
+    """
+
+    # Don't load opentelemetry if we're in a Pyodide environment.
+    if is_pyodide():
+        return cast(Any, MockTracer())
+
+    from opentelemetry import trace
+
+    return trace.get_tracer(
+        trace_name,
+        attributes={
+            "service.name": trace_name,
+        },
+    )
+
+
+_set_tracer_provider()
+server_tracer = create_tracer("marimo.server")
+kernel_tracer = create_tracer("marimo.kernel")

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -75,7 +75,7 @@ class MockTracer:
         yield MockSpan()
 
 
-TRACE_FILENAME = os.path.join("traces", "trace.jsonl")
+TRACE_FILENAME = os.path.join("traces", "traces.jsonl")
 
 
 def _set_tracer_provider() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ dev = [
     "pandas-stubs>=1.5.3.230321",
     "pyarrow>=15.0.2,<16",
     "pyarrow-stubs>=10.0.1.9",
+    # For tracing debugging
+    "opentelemetry-api~=1.26.0",
+    "opentelemetry-sdk~=1.26.0",
     # For testing mo.image
     "pillow~=10.4.0",
     "types-Pillow~=10.2.0.20240520",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ include = ["marimo*"]
 line-length=79
 exclude = [
     "examples",
-    "scripts/print_banned_cell_names.py",
+    "scripts",
     "marimo/_tutorials",
     "marimo/_snippets/data",
     "marimo/_smoke_tests",

--- a/scripts/analyze_traces.py
+++ b/scripts/analyze_traces.py
@@ -6,93 +6,299 @@ app = marimo.App(width="medium")
 
 @app.cell
 def __():
+    from opentelemetry import trace
+    import altair as alt
     import json
+    import marimo as mo
+    import os
+    import numpy as np
 
+    import dataclasses
     import matplotlib.pyplot as plt
     import pandas as pd
+    return alt, dataclasses, json, mo, np, os, pd, plt, trace
 
 
+@app.cell
+def __():
+    from pydantic import BaseModel, Field, computed_field
+    from typing import List, Dict, Optional, Any
+    from datetime import datetime
+
+
+    class Context(BaseModel):
+        trace_id: str
+        span_id: str
+        trace_state: str
+
+
+    class Status(BaseModel):
+        status_code: str
+
+
+    class ResourceAttributes(BaseModel):
+        telemetry_sdk_language: str = Field(alias="telemetry.sdk.language")
+        telemetry_sdk_name: str = Field(alias="telemetry.sdk.name")
+        telemetry_sdk_version: str = Field(alias="telemetry.sdk.version")
+        service_name: str = Field(alias="service.name")
+
+
+    class Resource(BaseModel):
+        attributes: ResourceAttributes
+        schema_url: str
+
+
+    class Span(BaseModel):
+        name: str
+        context: Context
+        kind: str
+        parent_id: Optional[str]
+        start_time: datetime
+        end_time: datetime
+        status: Status
+        attributes: Dict[str, Any]
+        events: List = []
+        links: List = []
+        resource: Resource
+        relative_start: Optional[datetime] = None
+        depth: Optional[int] = 0
+
+        @computed_field
+        @property
+        def duration_ms(self) -> float:
+            return (self.end_time - self.start_time).microseconds / 1000
+
+        @classmethod
+        def parse(cls, data: Dict) -> "Span":
+            # Convert string timestamps to datetime objects
+            data["start_time"] = datetime.fromisoformat(
+                data["start_time"].rstrip("Z")
+            )
+            data["end_time"] = datetime.fromisoformat(data["end_time"].rstrip("Z"))
+
+            # Parse the nested Resource structure
+            resource_data = data["resource"]
+            resource_data["attributes"] = ResourceAttributes(
+                **resource_data["attributes"]
+            )
+            data["resource"] = Resource(**resource_data)
+
+            # Handle the trace_state as a string
+            if isinstance(data["context"]["trace_state"], list):
+                data["context"]["trace_state"] = str(
+                    data["context"]["trace_state"]
+                )
+
+            return cls(**data)
+    return (
+        Any,
+        BaseModel,
+        Context,
+        Dict,
+        Field,
+        List,
+        Optional,
+        Resource,
+        ResourceAttributes,
+        Span,
+        Status,
+        computed_field,
+        datetime,
+    )
+
+
+@app.cell
+def __(Dict, List, Span, json):
     def parse_jsonl(file_path):
-        traces = []
+        spans = []
         with open(file_path, "r") as file:
             for line in file:
-                traces.append(json.loads(line))
-        return traces
+                spans.append(Span.parse(json.loads(line)))
+        return spans
 
 
-    def create_dataframe(traces):
-        df = pd.json_normalize(traces)
-        df["duration"] = (
-            df["end_time"] - df["start_time"]
-        ) / 1e9  # Convert to seconds
-        df["timestamp"] = pd.to_datetime(df["start_time"], unit="ns")
+    def populate_depth(spans: List[Span]) -> List[Span]:
+        # Sort spans by start_time
+        sorted_spans = sorted(spans, key=lambda span: span.start_time)
 
-        # Extract HTTP method, path, and status code from attributes
-        df["http_method"] = df["attributes"].apply(
-            lambda x: x[0] if isinstance(x, list) and len(x) > 0 else None
-        )
-        df["http_path"] = df["attributes"].apply(
-            lambda x: x[1] if isinstance(x, list) and len(x) > 1 else None
-        )
-        df["http_status"] = df["attributes"].apply(
-            lambda x: x[2] if isinstance(x, list) and len(x) > 2 else None
-        )
+        # Create a dictionary to store spans by their ID
+        span_dict: Dict[str, Span] = {
+            span.context.span_id: span for span in sorted_spans
+        }
 
-        return df
-    return create_dataframe, json, parse_jsonl, pd, plt
+        # Function to recursively calculate depth
+        def calculate_depth(span: Span, current_depth: int = 0) -> int:
+            if span.depth is not None:
+                return span.depth
+
+            span.depth = current_depth
+
+            # If this span has a parent, calculate the parent's depth first
+            if span.parent_id and span.parent_id in span_dict:
+                parent_span = span_dict[span.parent_id]
+                parent_depth = calculate_depth(parent_span, current_depth)
+                span.depth = parent_depth + 1
+
+            return span.depth
+
+        # Calculate depth for all spans
+        for span in sorted_spans:
+            calculate_depth(span)
+        return sorted_spans
+    return parse_jsonl, populate_depth
 
 
 @app.cell
-def __(parse_jsonl):
-    import os
-
+def __(os, parse_jsonl, populate_depth):
     file_path = "~/.marimo/traces/traces.jsonl"
-    traces = parse_jsonl(os.path.expanduser(file_path))
-    return file_path, os, traces
+    spans = parse_jsonl(os.path.expanduser(file_path))
+    spans = populate_depth(spans)
+    len(spans)
+    return file_path, spans
 
 
 @app.cell
-def __(create_dataframe, traces):
-    df = create_dataframe(traces)
+def __(spans):
+    json_spans = [trace.model_dump(mode="serialization") for trace in spans]
+    return json_spans,
+
+
+@app.cell
+def __(json_spans, mo):
+    mo.ui.table(json_spans)
+    return
+
+
+@app.cell
+def __(Span, pd):
+    def spans_to_dataframe(spans: Span):
+        data = []
+        for span in spans:
+            row = {
+                "name": span.name,
+                "kind": span.kind,
+                "parent_id": span.parent_id,
+                "start_time": span.start_time,
+                "end_time": span.end_time,
+                "status": span.status.status_code,
+                "duration_ms": span.duration_ms,
+                "depth": span.depth,
+                "service_name": span.resource.attributes.service_name,
+            }
+            data.append(row)
+
+        return pd.DataFrame(data)
+    return spans_to_dataframe
+
+
+@app.cell
+def __(spans, spans_to_dataframe):
+    df = spans_to_dataframe(spans)
+    df
     return df,
 
 
-@app.cell
-def __(df):
-    df
-    return
-
-
-@app.cell
-def __(df):
-    print(f"Total traces: {len(df)}")
-    print(f"Average duration: {df['duration'].mean():.6f} seconds")
-    return
-
-
 @app.cell(hide_code=True)
-def __(df):
-    print("\nEndpoint distribution:")
-    print(df["name"].value_counts())
+def __(spans):
+    total_duration = (
+        max(span.end_time for span in spans)
+        - min(span.start_time for span in spans)
+    ).total_seconds() * 1000
+    total_duration
+    return total_duration,
 
-    print("\nStatus code distribution:")
-    print(df["http_status"].value_counts())
 
-    print("\nTop 10 slowest requests:")
-    slowest = df.nlargest(10, "duration")
-    print(
-        slowest[
-            [
-                "name",
-                "duration",
-                "context.trace_id",
-                "http_method",
-                "http_path",
-                "http_status",
-            ]
-        ]
+@app.cell
+def __(alt, df):
+    duration_chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .interactive()
+        .encode(
+            x=alt.X("duration_ms:Q", bin=True, title="Duration (ms)"),
+            y="count()",
+            color="service_name:N",
+        )
+        .properties(
+            title="Span Duration Distribution by Service", width=600, height=400
+        )
     )
-    return slowest,
+
+    duration_chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .interactive()
+        .encode(
+            x=alt.X("duration_ms:Q", bin=True, title="Duration (ms)"),
+            y="count()",
+            color="service_name:N",
+        )
+        .properties(
+            title="Span Duration Distribution by Service", width=600, height=400
+        )
+    )
+
+    service_count_chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .interactive()
+        .encode(x="service_name:N", y="count()", color="service_name:N")
+        .properties(title="Span Count by Service", width=600, height=400)
+    )
+
+    timeline_chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .encode(
+            x=alt.X("start_time:T", title="Time"),
+            x2="end_time:T",
+            y="name:N",
+            color="service_name:N",
+            tooltip=["name", "duration_ms", "service_name"],
+        )
+        .properties(title="Span Timeline", width=800, height=400)
+    )
+
+    status_chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .interactive()
+        .encode(x="status:N", y="count()", color="status:N")
+        .properties(title="Span Status Distribution", width=400, height=300)
+    )
+
+    depth_chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .interactive()
+        .encode(x="depth:O", y="count()", color="depth:O")
+        .properties(title="Span Depth Distribution", width=400, height=300)
+    )
+    return (
+        depth_chart,
+        duration_chart,
+        service_count_chart,
+        status_chart,
+        timeline_chart,
+    )
+
+
+@app.cell
+def __(duration_chart):
+    duration_chart
+    return
+
+
+@app.cell
+def __(timeline_chart):
+    timeline_chart
+    return
+
+
+@app.cell
+def __(depth_chart, status_chart):
+    status_chart | depth_chart
+    return
 
 
 if __name__ == "__main__":

--- a/scripts/analyze_traces.py
+++ b/scripts/analyze_traces.py
@@ -1,0 +1,99 @@
+import marimo
+
+__generated_with = "0.8.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import json
+
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+
+    def parse_jsonl(file_path):
+        traces = []
+        with open(file_path, "r") as file:
+            for line in file:
+                traces.append(json.loads(line))
+        return traces
+
+
+    def create_dataframe(traces):
+        df = pd.json_normalize(traces)
+        df["duration"] = (
+            df["end_time"] - df["start_time"]
+        ) / 1e9  # Convert to seconds
+        df["timestamp"] = pd.to_datetime(df["start_time"], unit="ns")
+
+        # Extract HTTP method, path, and status code from attributes
+        df["http_method"] = df["attributes"].apply(
+            lambda x: x[0] if isinstance(x, list) and len(x) > 0 else None
+        )
+        df["http_path"] = df["attributes"].apply(
+            lambda x: x[1] if isinstance(x, list) and len(x) > 1 else None
+        )
+        df["http_status"] = df["attributes"].apply(
+            lambda x: x[2] if isinstance(x, list) and len(x) > 2 else None
+        )
+
+        return df
+    return create_dataframe, json, parse_jsonl, pd, plt
+
+
+@app.cell
+def __(parse_jsonl):
+    import os
+
+    file_path = "~/.marimo/traces/trace.jsonl"
+    traces = parse_jsonl(os.path.expanduser(file_path))
+    return file_path, os, traces
+
+
+@app.cell
+def __(create_dataframe, traces):
+    df = create_dataframe(traces)
+    return df,
+
+
+@app.cell
+def __(df):
+    df
+    return
+
+
+@app.cell
+def __(df):
+    print(f"Total traces: {len(df)}")
+    print(f"Average duration: {df['duration'].mean():.6f} seconds")
+    return
+
+
+@app.cell(hide_code=True)
+def __(df):
+    print("\nEndpoint distribution:")
+    print(df["name"].value_counts())
+
+    print("\nStatus code distribution:")
+    print(df["http_status"].value_counts())
+
+    print("\nTop 10 slowest requests:")
+    slowest = df.nlargest(10, "duration")
+    print(
+        slowest[
+            [
+                "name",
+                "duration",
+                "context.trace_id",
+                "http_method",
+                "http_path",
+                "http_status",
+            ]
+        ]
+    )
+    return slowest,
+
+
+if __name__ == "__main__":
+    app.run()

--- a/scripts/analyze_traces.py
+++ b/scripts/analyze_traces.py
@@ -46,7 +46,7 @@ def __():
 def __(parse_jsonl):
     import os
 
-    file_path = "~/.marimo/traces/trace.jsonl"
+    file_path = "~/.marimo/traces/traces.jsonl"
     traces = parse_jsonl(os.path.expanduser(file_path))
     return file_path, os, traces
 

--- a/scripts/analyze_traces.py
+++ b/scripts/analyze_traces.py
@@ -19,7 +19,7 @@ def __():
     return alt, dataclasses, json, mo, np, os, pd, plt, trace
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __():
     from pydantic import BaseModel, Field, computed_field
     from typing import List, Dict, Optional, Any
@@ -150,7 +150,7 @@ def __(Dict, List, Span, json):
 
 @app.cell
 def __(os, parse_jsonl, populate_depth):
-    file_path = "~/.marimo/traces/traces.jsonl"
+    file_path = "~/.marimo/traces/spans.jsonl"
     spans = parse_jsonl(os.path.expanduser(file_path))
     spans = populate_depth(spans)
     len(spans)
@@ -188,7 +188,7 @@ def __(Span, pd):
             data.append(row)
 
         return pd.DataFrame(data)
-    return spans_to_dataframe
+    return spans_to_dataframe,
 
 
 @app.cell

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -116,7 +116,7 @@ class TestExecution:
             await k.run([er2])
         assert k.globals["z"] == 2
 
-        await k.delete(DeleteCellRequest(cell_id="1"))
+        await k.delete_cell(DeleteCellRequest(cell_id="1"))
         assert k.globals["x"] == 2
         assert "y" not in k.globals
         if k.lazy():
@@ -124,7 +124,7 @@ class TestExecution:
             await k.run([er2])
         assert "z" not in k.globals
 
-        await k.delete(DeleteCellRequest(cell_id="0"))
+        await k.delete_cell(DeleteCellRequest(cell_id="0"))
         assert "x" not in k.globals
         assert "y" not in k.globals
         assert "z" not in k.globals
@@ -413,7 +413,7 @@ class TestExecution:
         assert k.errors["1"] == (MultipleDefinitionError("x", ("0",)),)
 
         # issue delete request for cell 1 to clear error and run cell 0
-        await k.delete(DeleteCellRequest(cell_id="1"))
+        await k.delete_cell(DeleteCellRequest(cell_id="1"))
         if k.lazy():
             assert k.graph.cells[er.cell_id].stale
             await k.run([er])
@@ -500,7 +500,7 @@ class TestExecution:
         _check_edges(k.errors["0"][0], [("0", ["x"], "1"), ("1", ["y"], "0")])
 
         # break cycle by deleting cell
-        await k.delete(DeleteCellRequest(cell_id="1"))
+        await k.delete_cell(DeleteCellRequest(cell_id="1"))
         if k.execution_type == "strict":
             # Still invalid in strict mode because y is missing.
             assert set(k.errors.keys()) == {"0"}
@@ -551,7 +551,7 @@ class TestExecution:
 
         # Delete the cell that defines x. There shouldn't be any more errors
         # because x no longer exists.
-        await k.delete(DeleteCellRequest(cell_id="0"))
+        await k.delete_cell(DeleteCellRequest(cell_id="0"))
         if k.execution_type != "strict":
             assert not k.errors
 
@@ -1348,7 +1348,7 @@ class TestImports:
         )
         assert "x" not in k.globals
 
-        await k.delete(DeleteCellRequest(cell_id=er.cell_id))
+        await k.delete_cell(DeleteCellRequest(cell_id=er.cell_id))
         assert "x" in k.globals
 
     async def test_different_import_same_def(

--- a/tests/_runtime/test_virtual_file.py
+++ b/tests/_runtime/test_virtual_file.py
@@ -48,7 +48,7 @@ async def test_virtual_file_deletion(
     for fname, _ in get_context().virtual_file_registry.registry.items():
         assert fname.endswith(".pdf")
 
-    await k.delete(DeleteCellRequest(cell_id=er.cell_id))
+    await k.delete_cell(DeleteCellRequest(cell_id=er.cell_id))
     assert not get_context().virtual_file_registry.registry
 
 
@@ -89,8 +89,8 @@ async def test_cached_virtual_file_not_deleted(
     assert len(get_context().virtual_file_registry.registry) == 2
 
     # Remove the cells that create the vfiles
-    await k.delete(DeleteCellRequest(cell_id=create_vfile_1.cell_id))
-    await k.delete(DeleteCellRequest(cell_id=create_vfile_2.cell_id))
+    await k.delete_cell(DeleteCellRequest(cell_id=create_vfile_1.cell_id))
+    await k.delete_cell(DeleteCellRequest(cell_id=create_vfile_2.cell_id))
 
     # Reset the vfile cache
     await k.run([vfile_cache])
@@ -124,7 +124,7 @@ async def test_cell_deletion_clears_vfiles(
     assert len(get_context().virtual_file_registry.registry) == 1
 
     # Delete the vfile cache: virtual file registry should be empty
-    await k.delete(DeleteCellRequest(cell_id=vfile_cache.cell_id))
+    await k.delete_cell(DeleteCellRequest(cell_id=vfile_cache.cell_id))
     assert len(get_context().virtual_file_registry.registry) == 0
 
 

--- a/tests/_server/api/test_auth.py
+++ b/tests/_server/api/test_auth.py
@@ -19,7 +19,9 @@ from tests._server.mocks import get_mock_session_manager
 
 
 async def mock_receive() -> Any:
-    return {}
+    return {
+        "type": "http.disconnect",
+    }
 
 
 async def mock_send(message: Any) -> None:


### PR DESCRIPTION
This adds local-only open telemetry that gets output `~/.marimo/traces/traces.jsonl` that can be later analyzed. This should help debug slow parts of marimo when working with users. 