### PR TITLE
Update dropdown.md to show of dict options and selected_key

### DIFF
--- a/docs/api/inputs/dropdown.md
+++ b/docs/api/inputs/dropdown.md
@@ -4,13 +4,17 @@
 .. marimo-embed::
     @app.cell
     def __():
-        options = ["Apples", "Oranges", "Pears"]
-        dropdown = mo.ui.dropdown(options=options)
+        dropdown = mo.ui.dropdown(options=["Apples", "Oranges", "Pears"], label="choose fruit")
+        dropdown_dict = mo.ui.dropdown(options={"Apples":1, "Oranges":2, "Pears":3}, 
+                               value="Apples", # initial value
+                               label="choose fruit with dict options")
         return
 
     @app.cell
     def __():
-        mo.hstack([dropdown, mo.md(f"Has value: {dropdown.value}")])
+        mo.vstack([mo.hstack([dropdown, mo.md(f"Has value: {dropdown.value}")]),
+        mo.hstack([dropdown_dict, mo.md(f"Has value: {dropdown_dict.value} and selected_key {dropdown_dict.selected_key}")]),
+                    ])
         return
 ```
 


### PR DESCRIPTION

## 📝 Summary

I had to read the docs like 8 times to figure out what `selected_key` does, at first I thought it was a vestigal name for `value`. So here is an update to the interactive example (so cool) that shows off more features.

Also the name `value` for the argument to pick the default choice of the dropdown takes the key from the options dict, so the name is misleading.

## 🔍 Description of Changes

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
