### PR TITLE
Add formatter for lets-plot figures.

### DIFF
--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -17,6 +17,7 @@ from marimo._output.formatters.holoviews_formatters import HoloViewsFormatter
 from marimo._output.formatters.ipython_formatters import IPythonFormatter
 from marimo._output.formatters.ipywidgets_formatters import IPyWidgetsFormatter
 from marimo._output.formatters.leafmap_formatters import LeafmapFormatter
+from marimo._output.formatters.lets_plot_formatters import LetsPlotFormatter
 from marimo._output.formatters.matplotlib_formatters import MatplotlibFormatter
 from marimo._output.formatters.pandas_formatters import PandasFormatter
 from marimo._output.formatters.plotly_formatters import PlotlyFormatter
@@ -42,6 +43,7 @@ THIRD_PARTY_FACTORIES: dict[str, FormatterFactory] = {
     IPyWidgetsFormatter.package_name(): IPyWidgetsFormatter(),
     AnyWidgetFormatter.package_name(): AnyWidgetFormatter(),
     TqdmFormatter.package_name(): TqdmFormatter(),
+    LetsPlotFormatter.package_name(): LetsPlotFormatter(),
 }
 
 # Formatters for builtin types and other things that don't require a

--- a/marimo/_output/formatters/lets_plot_formatters.py
+++ b/marimo/_output/formatters/lets_plot_formatters.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._messaging.mimetypes import KnownMimeType
+from marimo._output.formatters.formatter_factory import FormatterFactory
+
+
+class LetsPlotFormatter(FormatterFactory):
+    @staticmethod
+    def package_name() -> str:
+        return "lets_plot"
+
+    def register(self) -> None:
+        import lets_plot.plot.core  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        import lets_plot.plot.subplots  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+
+        from marimo._output import formatting
+
+        @formatting.formatter(lets_plot.plot.core.PlotSpec)
+        def _html_from_plot_spec(
+            fig: lets_plot.plot.core.PlotSpec,
+        ) -> tuple[KnownMimeType, str]:
+            html_str: str = fig.to_html(iframe=True)
+            return ("text/html", html_str)
+
+        @formatting.formatter(lets_plot.plot.subplots.SupPlotsSpec)
+        def _html_from_subplot_spec(
+            fig: lets_plot.plot.subplots.SupPlotsSpec,
+        ) -> tuple[KnownMimeType, str]:
+            html_str: str = fig.to_html(iframe=True)
+            return ("text/html", html_str)


### PR DESCRIPTION
## 📝 Summary

Register formatters for 'plot' objects produced by the Lets-Plot plotting library: https://lets-plot.org

## 🔍 Description of Changes

Added `LetsPlotFormatter` class (marimo/_output/formatters/lets_plot_formatters.py) implementing formatters associated with the 'lets_plot' package.

Demo code:
```
import numpy as np
from lets_plot import ggplot, geom_point, aes, gggrid, ggsize, geom_livemap

x = np.random.rand(100)
y = 2 * x + 1 + np.random.normal(0, 0.1, 100)

data = dict(x = x, y = y)

p = ggplot(data) + geom_point(aes('x', 'y'))
p
---------

gggrid([p, p]) + ggsize(1000, 300)
---------

ggplot() + geom_livemap()
```

## 📋 Checklist

- [x ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
