### PR TITLE
fix: don't include trailing quotes in completions

### DIFF
--- a/marimo/_messaging/completion_option.py
+++ b/marimo/_messaging/completion_option.py
@@ -17,5 +17,5 @@ class CompletionOption:
     completion_info: Optional[str]
 
     def __post_init__(self) -> None:
-        # Remove trailing quotes because frontends may automatically add quotes.
+        # Remove trailing quotes because frontends may automatically add quotes
         self.name = self.name.rstrip('"').rstrip("'")

--- a/marimo/_messaging/completion_option.py
+++ b/marimo/_messaging/completion_option.py
@@ -15,3 +15,7 @@ class CompletionOption:
     type: str
     # docstring, type hint, or other info
     completion_info: Optional[str]
+
+    def __post_init__(self) -> None:
+        # Remove trailing quotes because frontends may automatically add quotes.
+        self.name = self.name.rstrip('"').rstrip("'")


### PR DESCRIPTION
Small fix for something that a few users have mentioned.