### PR TITLE
fix: macOS logging

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -169,6 +169,7 @@ def main(log_level: str, quiet: bool, development_mode: bool) -> None:
 
     GLOBAL_SETTINGS.DEVELOPMENT_MODE = development_mode
     GLOBAL_SETTINGS.QUIET = quiet
+    GLOBAL_SETTINGS.LOG_LEVEL = _loggers.log_level_string_to_int(log_level)
 
 
 edit_help_msg = "\n".join(

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 
@@ -12,6 +13,7 @@ class GlobalSettings:
     CHECK_STATUS_UPDATE: bool = False
     TRACING: bool = os.getenv("MARIMO_TRACING", "false") in ("true", "1")
     PROFILE_DIR: str | None = None
+    LOG_LEVEL: int = logging.WARNING
 
 
 GLOBAL_SETTINGS = GlobalSettings()

--- a/marimo/_loggers.py
+++ b/marimo/_loggers.py
@@ -16,22 +16,26 @@ _LOG_FORMATTER = LogFormatter()
 _LOGGERS: dict[str, logging.Logger] = {}
 
 
+def log_level_string_to_int(level: str) -> int:
+    level = level.upper()
+    if level == "DEBUG":
+        return logging.DEBUG
+    elif level == "INFO":
+        return logging.INFO
+    elif level == "WARN":
+        return logging.WARNING
+    elif level == "ERROR":
+        return logging.ERROR
+    elif level == "CRITICAL":
+        return logging.CRITICAL
+    else:
+        raise ValueError("Unrecognized log level %s" % level)
+
+
 def set_level(level: str | int = logging.WARNING) -> None:
     global _LOG_LEVEL
     if isinstance(level, str):
-        level = level.upper()
-        if level == "DEBUG":
-            _LOG_LEVEL = logging.DEBUG
-        elif level == "INFO":
-            _LOG_LEVEL = logging.INFO
-        elif level == "WARN":
-            _LOG_LEVEL = logging.WARNING
-        elif level == "ERROR":
-            _LOG_LEVEL = logging.ERROR
-        elif level == "CRITICAL":
-            _LOG_LEVEL = logging.CRITICAL
-        else:
-            raise ValueError("Unrecognized log level %s" % level)
+        _LOG_LEVEL = log_level_string_to_int(level)
     elif level not in [
         logging.DEBUG,
         logging.INFO,
@@ -65,4 +69,5 @@ def get_logger(name: str, level: Optional[int] = None) -> logging.Logger:
 
 
 def marimo_logger() -> logging.Logger:
-    return get_logger("marimo")
+    name = "marimo"
+    return get_logger(name)

--- a/marimo/_loggers.py
+++ b/marimo/_loggers.py
@@ -24,6 +24,8 @@ def log_level_string_to_int(level: str) -> int:
         return logging.INFO
     elif level == "WARN":
         return logging.WARNING
+    elif level == "WARNING":
+        return logging.WARNING
     elif level == "ERROR":
         return logging.ERROR
     elif level == "CRITICAL":

--- a/marimo/_loggers.py
+++ b/marimo/_loggers.py
@@ -69,5 +69,4 @@ def get_logger(name: str, level: Optional[int] = None) -> logging.Logger:
 
 
 def marimo_logger() -> logging.Logger:
-    name = "marimo"
-    return get_logger(name)
+    return get_logger("marimo")

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1723,7 +1723,10 @@ def launch_kernel(
     redirect_console_to_browser: bool,
     interrupt_queue: QueueType[bool] | None = None,
     profile_path: Optional[str] = None,
+    log_level: int | None = None,
 ) -> None:
+    if log_level is not None:
+        _loggers.set_level(log_level)
     LOGGER.debug("Launching kernel")
     if is_edit_mode:
         restore_signals()

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -193,6 +193,7 @@ class KernelManager:
                     self.redirect_console_to_browser,
                     self.queue_manager.win32_interrupt_queue,
                     self.profile_path,
+                    GLOBAL_SETTINGS.LOG_LEVEL,
                 ),
                 # The process can't be a daemon, because daemonic processes
                 # can't create children
@@ -236,6 +237,8 @@ class KernelManager:
                     None,
                     # profile path
                     None,
+                    # log level
+                    GLOBAL_SETTINGS.LOG_LEVEL,
                 ),
                 # daemon threads can create child processes, unlike
                 # daemon processes

--- a/marimo/_smoke_tests/tooltips.py
+++ b/marimo/_smoke_tests/tooltips.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.8.0"


### PR DESCRIPTION
can't rely on fork() process start, reinitialize log level