### PR TITLE
fix: don't import tomlkit top-level

### DIFF
--- a/marimo/_cli/config/commands.py
+++ b/marimo/_cli/config/commands.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import click
-import tomlkit
 
 from marimo._cli.config.utils import highlight_toml_headers
 from marimo._cli.print import green
@@ -22,6 +21,8 @@ def show() -> None:
 
         marimo config show
     """
+    import tomlkit
+
     config_manager = UserConfigManager()
     click.echo(f"User config from {green(config_manager.get_config_path())}\n")
     toml_string = tomlkit.dumps(config_manager.get_config())

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -4,7 +4,6 @@ from dataclasses import asdict
 from tempfile import TemporaryDirectory
 from typing import Any, Optional, Type, TypeVar
 
-import tomlkit
 
 from marimo._utils.parse_dataclass import parse_raw
 
@@ -30,6 +29,8 @@ class ConfigReader:
         return ConfigReader(filepath)
 
     def read_toml(self, cls: Type[T], *, fallback: T) -> T:
+        import tomlkit
+
         try:
             with open(self.filepath, "r") as file:
                 data = tomlkit.parse(file.read())
@@ -38,6 +39,8 @@ class ConfigReader:
             return fallback
 
     def write_toml(self, data: Any) -> None:
+        import tomlkit
+
         _maybe_create_directory(self.filepath)
         with open(self.filepath, "w") as file:
             tomlkit.dump(asdict(data), file)

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -4,7 +4,6 @@ from dataclasses import asdict
 from tempfile import TemporaryDirectory
 from typing import Any, Optional, Type, TypeVar
 
-
 from marimo._utils.parse_dataclass import parse_raw
 
 ROOT_DIR = ".marimo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,7 +260,7 @@ docstring-code-format = true
 ban-relative-imports = "all"
 # Ban certain modules from being imported at module level, instead requiring
 # that they're imported lazily (e.g., within a function definition).
-banned-module-level-imports = ["numpy", "pandas"]
+banned-module-level-imports = ["numpy", "pandas", "tomlkit"]
 
 [tool.ruff.lint.flake8-pytest-style]
 mark-parentheses = false

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -20,7 +20,6 @@ import urllib.request
 from typing import Any, Callable, Iterator, Optional
 
 import pytest
-import tomlkit
 
 from marimo import __version__
 from marimo._ast import codegen
@@ -138,6 +137,8 @@ def _get_port() -> int:
 
 
 def _read_toml(filepath: str) -> Optional[dict]:
+    import tomlkit
+
     if not os.path.exists(filepath):
         return None
     with open(filepath, "r") as file:


### PR DESCRIPTION
We don't install tomlkit when running under wasm (and don't need to). This was breaking marimo wasm.