### PR TITLE
fix: publish docker containers for arm64 (mac compat)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           target: slim
+          platforms: linux/amd64,linux/arm64
           build-args: |
             marimo_version=${{ needs.publish_release.outputs.marimo_version }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -195,6 +196,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}-data
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-data
           target: data
+          platforms: linux/amd64,linux/arm64
           build-args: |
             marimo_version=${{ needs.publish_release.outputs.marimo_version }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -211,6 +213,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}-sql
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-sql
           target: sql
+          platforms: linux/amd64,linux/arm64
           build-args: |
             marimo_version=${{ needs.publish_release.outputs.marimo_version }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add mac support.

Linux works: `docker run -p 8080:8080 -it ghcr.io/marimo-team/marimo:latest-sql`