### PR TITLE
fix: consolidate shadows to be easily overriden

### DIFF
--- a/frontend/src/components/editor/header/filename-input.css
+++ b/frontend/src/components/editor/header/filename-input.css
@@ -1,15 +1,11 @@
 .missing-filename {
   text-align: center;
-  box-shadow: var(--light-shadow-stale);
+  @apply shadow-mdSolid shadow-stale;
 }
 
 .missing-filename:hover,
 .missing-filename:focus {
-  box-shadow: var(--medium-shadow-stale);
-}
-
-.missing-filename:focus {
-  border-radius: 4px 4px 0 0;
+  @apply shadow-lgSolid shadow-stale;
 }
 
 .filename {
@@ -19,9 +15,5 @@
 
 .filename:hover,
 .filename:focus {
-  box-shadow: var(--medium-shadow);
-}
-
-.filename:focus {
-  border-radius: 4px 4px 0 0;
+  @apply border shadow-lgSolid;
 }

--- a/frontend/src/components/pages/home-page.tsx
+++ b/frontend/src/components/pages/home-page.tsx
@@ -502,7 +502,7 @@ const CreateNewNotebook: React.FC = () => {
   return (
     <a
       className="relative rounded-lg p-6 group
-      text-primary hover:bg-[var(--blue-2)] shadow-smAccent border
+      text-primary hover:bg-[var(--blue-2)] shadow-mdSolid shadow-accent border
       transition-all duration-300 cursor-pointer
       "
       href={asURL(`?file=${initializationId}`).toString()}

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -30,7 +30,7 @@ const toastVariants = cva(
       variant: {
         default: "bg-background border",
         danger:
-          "group destructive text-error border-destructive bg-[var(--red-1)] shadow-smError",
+          "group destructive text-error border-destructive bg-[var(--red-1)] shadow-mdSolid shadow-error",
       },
     },
     defaultVariants: {

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -10,10 +10,9 @@
   border-radius: 10px;
   max-width: inherit;
   width: 100%;
-  border: 1px solid transparent;
-  box-shadow: var(--light-shadow);
+  border: 1px solid var(--gray-4);
 
-  @apply divide-y divide-[var(--gray-5)];
+  @apply divide-y divide-[var(--gray-5)] shadow-smSolid shadow-shade;
 
   &:focus-visible {
     /* focus-visible outlines the entire cell body in black, but the cell's
@@ -54,14 +53,14 @@
     }
 
     &:hover {
-      box-shadow: var(--medium-shadow);
+      @apply shadow-mdSolid shadow-shade;
     }
 
     &:focus-within {
       border: 1px solid var(--gray-5);
 
       /* a sharp box shadow with a slight blur to outline the element */
-      box-shadow: var(--heavy-shadow);
+      @apply shadow-lgSolid shadow-shade;
 
       /* a little bit of motion
       *
@@ -97,10 +96,10 @@
   &.disabled.has-error,
   &.disabled:hover,
   &.disabled.has-error:hover {
-    box-shadow: var(--light-shadow);
+    @apply shadow-smSolid shadow-shade;
 
     &:focus-within {
-      box-shadow: var(--heavy-shadow);
+      @apply shadow-lgSolid shadow-shade;
     }
 
     .output-area,
@@ -113,17 +112,15 @@
 
   /* Needs Run */
   &.needs-run {
-    box-shadow: var(--light-shadow-stale);
-
-    @apply divide-[var(--stale-color)];
+    @apply divide-stale shadow-mdSolid shadow-stale;
 
     &:hover {
-      box-shadow: var(--medium-shadow-stale);
+      @apply shadow-lgSolid shadow-stale;
     }
 
     &:focus-within:hover,
     &:focus-within {
-      box-shadow: var(--heavy-shadow-stale);
+      @apply shadow-xlSolid shadow-stale;
     }
 
     &:focus-within .cm-editor {
@@ -140,16 +137,16 @@
   &.has-error,
   &.error-outline {
     outline: 1px solid var(--red-4);
-    box-shadow: var(--light-shadow-error);
+    @apply shadow-mdSolid shadow-[var(--red-8)];
   }
 
   &.has-error:hover {
-    box-shadow: var(--medium-shadow-error);
+    @apply shadow-lgSolid shadow-[var(--red-8)];
   }
 
   &.has-error:focus-within,
   &.has-error:focus-within:hover {
-    box-shadow: var(--heavy-shadow-error);
+    @apply shadow-xlSolid shadow-[var(--red-8)];
   }
 
   &.error-outline,
@@ -164,11 +161,7 @@
     border-color: var(--blue-8) !important;
 
     /* custom shadow until our theme overrides can support colored shadow */
-    --tw-shadow: 0 4px 0px -1px var(--blue-8), 0 2px 4px -2px var(--blue-8) !important;
-
-    box-shadow: var(--tw-shadow) !important;
-
-    @apply shadow-lg;
+    @apply shadow-lg shadow-[var(--blue-8)];
   }
 
   /* Published - when its just the output */

--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -31,10 +31,9 @@
 
 #root .cm-tooltip {
   border: none;
-  box-shadow: var(--light-shadow);
   border-radius: 4px;
 
-  @apply bg-popover;
+  @apply bg-popover shadow-smSolid shadow-shade;
 }
 
 /*
@@ -109,23 +108,23 @@
 }
 
 .cm .cm-completionIcon-function::after {
-  content: "λ";
+  content: 'λ';
 }
 
 .cm .cm-completionIcon-class::after {
-  content: "τ";
+  content: 'τ';
 }
 
 .cm .cm-completionIcon-module::after {
-  content: "μ";
+  content: 'μ';
 }
 
 .cm .cm-completionIcon-statement::after {
-  content: "χ";
+  content: 'χ';
 }
 
 .cm .cm-completionIcon-keyword::after {
-  content: "κ";
+  content: 'κ';
 }
 
 /* -- Panels -- */

--- a/frontend/src/css/globals.css
+++ b/frontend/src/css/globals.css
@@ -63,31 +63,13 @@
     --action-foreground: hsl(42deg 100% 29%);
     --link: hsl(211deg 90% 42%); /* blue-11 */
     --link-visited: hsl(272deg 51% 54%); /* purple-9 */
+    --stale: hsl(42deg 56% 44% / 25%);
     --ring: hsl(215deg 20.2% 65.1%);
     --radius: 8px;
+
     --base-shadow: hsl(0deg 0% 85% / 40%);
     --base-shadow-darker: hsl(0deg 0% 50% / 40%);
-
-    /* Fuzzy shadows. */
-    --shadow-xxs: 0px 0px 2px 0px var(--base-shadow-darker);
-    --shadow-xs: 1px 1px 2px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 25% / 5%);
-    --shadow-sm: 2px 2px 2px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 25% / 5%);
-    --shadow-md: 4px 4px 4px 0px var(--base-shadow), 0 0px 4px 0px hsl(0deg 0% 60% / 5%);
-    --shadow-lg: 5px 6px 4px 0px var(--base-shadow), 0 0px 4px 0px hsl(0deg 0% 75% / 5%);
-    --shadow-xl: 8px 9px 4px 0px var(--base-shadow), 0 0px 6px 0px hsl(0deg 0% 85% / 5%);
-
-    /* Shadow states. */
-    --stale-color: hsl(42deg 56% 44% / 25%);
-    --light-shadow: 2px 2px 0px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 25% / 50%);
-    --light-shadow-stale: 4px 4px 0px 0px var(--stale-color), 0px 0px 4px 0px var(--stale-color);
-    --medium-shadow: 4px 4px 0px 0px var(--base-shadow), 0px 0px 4px 0px hsl(0deg 0% 60% / 50%);
-    --medium-shadow-stale: 6px 6px 0px 0px var(--stale-color), 0px 0px 4px 0px var(--stale-color);
-    --light-shadow-error: 4px 4px 0px 0px var(--red-8), 0px 0px 2px 0px var(--red-8);
-    --medium-shadow-error: 6px 6px 0px 0px var(--red-8), 0px 0px 2px 0px var(--red-8);
-    --heavy-shadow: 5px 6px 0px 0px var(--base-shadow), 0px 0px 4px 0px hsl(0deg 0% 75% / 50%);
-    --heavy-shadow-stale: 7px 8px 0px 0px var(--stale-color), 0px 0px 4px 0px var(--stale-color);
-    --heavy-shadow-error: 7px 8px 0px 0px var(--red-8), 0px 0px 2px 0px var(--red-8);
-    --light-shadow-accent: 4px 4px 0px 0px var(--accent), 0px 0px 2px 0px var(--accent);
+    --base-shadow-opacity: 5%;
   }
 
   .dark,
@@ -114,33 +96,14 @@
     --destructive-foreground: hsl(210deg 40% 98%); /* red-1 */
     --accent: hsl(192deg 56.6% 26.5%); /* cyan-7 */
     --accent-foreground: hsl(190deg 80% 84%); /* cyan-12 */
+    --stale: hsl(42deg 56% 44% / 25%);
     --link: hsl(211deg 90% 62%); /* blue-11 */
     --link-visited: hsl(272deg 51% 74%); /* purple-9 */
 
     /* Base shadows. */
-    --base-shadow: hsl(0deg 0% 15% / 60%);
+    --base-shadow: hsla(0 0% 36% / 60%);
     --base-shadow-darker: hsl(0deg 0% 50% / 60%);
-
-    /* Fuzzy shadows. */
-    --shadow-xxs: 0px 0px 2px 0px var(--base-shadow-darker);
-    --shadow-xs: 1px 1px 2px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 75% / 50%);
-    --shadow-sm: 2px 2px 2px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 75% / 50%);
-    --shadow-md: 4px 4px 4px 0px var(--base-shadow), 0 0px 4px 0px hsl(0deg 0% 40% / 50%);
-    --shadow-lg: 5px 6px 4px 0px var(--base-shadow), 0 0px 4px 0px hsl(0deg 0% 25% / 50%);
-    --shadow-xl: 8px 9px 4px 0px var(--base-shadow), 0 0px 6px 0px hsl(0deg 0% 15% / 50%);
-
-    /* Shadow states. */
-    --stale-color: hsl(42deg 56% 44% / 75%);
-    --light-shadow: 2px 2px 0px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 75% / 50%);
-    --light-shadow-stale: 4px 4px 0px 0px var(--stale-color), 0px 0px 4px 0px var(--stale-color);
-    --medium-shadow: 4px 4px 0px 0px var(--base-shadow), 0px 0px 4px 0px hsl(0deg 0% 100% / 50%);
-    --medium-shadow-stale: 6px 6px 0px 0px var(--stale-color), 0px 0px 4px 0px var(--stale-color);
-    --light-shadow-error: 4px 4px 0px 0px var(--red-5), 0px 0px 2px 0px var(--red-5);
-    --medium-shadow-error: 6px 6px 0px 0px var(--red-5), 0px 0px 2px 0px var(--red-5);
-    --heavy-shadow: 5px 6px 0px 0px var(--base-shadow), 0px 0px 4px 0px hsl(0deg 0% 100% / 50%);
-    --heavy-shadow-stale: 7px 8px 0px 0px var(--stale-color), 0px 0px 4px 0px var(--stale-color);
-    --heavy-shadow-error: 7px 8px 0px 0px var(--red-5), 0px 0px 2px 0px var(--red-5);
-    --light-shadow-accent: 4px 4px 0px 0px var(--accent), 0px 0px 2px 0px var(--accent);
+    --base-shadow-opacity: 85%;
   }
 }
 

--- a/frontend/src/plugins/impl/common/error-banner.tsx
+++ b/frontend/src/plugins/impl/common/error-banner.tsx
@@ -62,8 +62,8 @@ const bannerStyle = cva("text-sm p-2 border whitespace-pre-wrap", {
   variants: {
     kind: {
       danger:
-        "text-error border-[var(--red-6)] shadow-smError bg-[var(--red-1)]",
-      info: "text-primary border-[var(--blue-6)] shadow-smAccent bg-[var(--blue-1)]",
+        "text-error border-[var(--red-6)] shadow-mdSolid shadow-error bg-[var(--red-1)]",
+      info: "text-primary border-[var(--blue-6)] shadow-mdSolid shadow-accent bg-[var(--blue-1)]",
       warn: "text-warning border-[var(--yellow-6)] bg-[var(--yellow-2)]",
     },
     clickable: {

--- a/frontend/src/stories/colors.stories.tsx
+++ b/frontend/src/stories/colors.stories.tsx
@@ -100,6 +100,17 @@ const SHADOWS = [
   "shadow-inner",
   "shadow-none",
 ];
+
+const COLORED_SHADOWS = [
+  "shadow-xs shadow-blue-500",
+  "shadow-sm shadow-blue-500",
+  "shadow-md shadow-blue-500",
+  "shadow-lg shadow-blue-500",
+  "shadow-xl shadow-blue-500",
+  "shadow-2xl shadow-blue-500",
+  "shadow-inner shadow-blue-500",
+];
+
 const SOLID_SHADOWS = [
   "shadow-xsSolid",
   "shadow-smSolid",
@@ -107,6 +118,13 @@ const SOLID_SHADOWS = [
   "shadow-lgSolid",
   "shadow-xlSolid",
   "shadow-2xlSolid",
+];
+
+const MISC = [
+  "shadow-smSolid shadow-accent",
+  "shadow-mdSolid shadow-accent",
+  "shadow-smSolid shadow-error",
+  "shadow-mdSolid shadow-error",
 ];
 
 export const Shadows: StoryObj = {
@@ -129,7 +147,9 @@ export const Shadows: StoryObj = {
     return (
       <div className="flex flex-col">
         {renderShadows(SHADOWS)}
+        {renderShadows(COLORED_SHADOWS)}
         {renderShadows(SOLID_SHADOWS)}
+        {renderShadows(MISC)}
       </div>
     );
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -59,8 +59,8 @@ module.exports = {
           "color-mix(in srgb, var(--background), transparent calc((1 - <alpha-value>) * 100%))",
         foreground:
           "color-mix(in srgb, var(--foreground), transparent calc((1 - <alpha-value>) * 100%))",
-        link: "color-mix(in srgb, var(--link))",
-        "link-visited": "color-mix(in srgb, var(--link-visited))",
+        link: "var(--link)",
+        "link-visited": "var(--link-visited)",
         primary: {
           DEFAULT:
             "color-mix(in srgb, var(--primary), transparent calc((1 - <alpha-value>) * 100%))",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -19,31 +19,27 @@ module.exports = {
       boxShadow: {
         none: "none",
         // fuzzy shadows
-        xxs: "var(--shadow-xxs)",
-        xs: "var(--shadow-xs)",
-        sm: "var(--shadow-sm)",
-        md: "var(--shadow-md)",
-        lg: "var(--shadow-lg)",
-        xl: "var(--shadow-xl)",
-        // solid shadows
+        xxs: "0px 0px 2px 0px var(--base-shadow-darker)",
+        xs: "1px 1px 2px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 25% / var(--base-shadow-opacity))",
+        sm: "2px 2px 2px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 25% / var(--base-shadow-opacity))",
+        md: "4px 4px 4px 0px var(--base-shadow), 0 0px 4px 0px hsl(0deg 0% 60% / var(--base-shadow-opacity))",
+        lg: "5px 6px 4px 0px var(--base-shadow), 0 0px 4px 0px hsl(0deg 0% 75% / var(--base-shadow-opacity))",
+        xl: "8px 9px 4px 0px var(--base-shadow), 0 0px 6px 0px hsl(0deg 0% 85% / var(--base-shadow-opacity))",
+        "2xl":
+          "10px 12px 10px 0px var(--base-shadow), 0 0px 8px 0px hsl(0deg 0% 90% / var(--base-shadow-opacity))",
+
         xsSolid:
-          "1px 1px 0px 0px var(--tw-shadow-color, var(--base-shadow-darker)), 0px 0px 2px 0px hsl(0deg 0% 25% / 5%)",
+          "1px 1px 0px 0px var(--base-shadow-darker), 0px 0px 2px 0px hsl(0deg 0% 50% / 20%)",
         smSolid:
-          "2px 2px 0px 0px var(--tw-shadow-color, var(--base-shadow-darker)), 0px 0px 2px 0px hsl(0deg 0% 25% / 5%)",
+          "2px 2px 0px 0px var(--base-shadow-darker), 0px 0px 2px 0px hsl(0deg 0% 50% / 20%)",
         mdSolid:
-          "4px 4px 0px 0px var(--tw-shadow-color, var(--base-shadow-darker)), 0 0px 4px 0px hsl(0deg 0% 60% / 5%)",
+          "4px 4px 0px 0px var(--base-shadow-darker), 0 0px 2px 0px hsl(0deg 0% 60% / 50%)",
         lgSolid:
-          "5px 6px 0px 0px var(--tw-shadow-color, var(--base-shadow-darker)), 0 0px 4px 0px hsl(0deg 0% 75% / 5%)",
+          "5px 6px 0px 0px var(--base-shadow-darker), 0 0px 4px 0px hsl(0deg 0% 75% / 50%)",
         xlSolid:
-          "8px 9px 0px 0px var(--tw-shadow-color, var(--base-shadow-darker)), 0 0px 6px 0px hsl(0deg 0% 85% / 5%)",
-        // neutral shadows (used for cells, ...)
-        // TODO(akshayka): clean these up to use tw-shadow-color
-        smNeutral: "var(--light-shadow)",
-        mdNeutral: "var(--medium-shadow)",
-        lgNeutral: "var(--heavy-shadow)",
-        // accent/error shadows
-        smError: "var(--light-shadow-error)",
-        smAccent: "var(--light-shadow-accent)",
+          "7px 8px 0px 0px var(--base-shadow-darker), 0 0px 4px 0px hsl(0deg 0% 85% / 50%)",
+        "2xlSolid":
+          "10px 12px 0px 0px var(--base-shadow-darker), 0 0px 8px 0px hsl(0deg 0% 90% / 50%)",
       },
       maxWidth: {
         contentWidth: "var(--content-width)",
@@ -55,6 +51,7 @@ module.exports = {
       colors: {
         border:
           "color-mix(in srgb, var(--border), transparent calc((1 - <alpha-value>) * 100%))",
+        shade: "var(--base-shadow)",
         input:
           "color-mix(in srgb, var(--input), transparent calc((1 - <alpha-value>) * 100%))",
         ring: "color-mix(in srgb, var(--ring), transparent calc((1 - <alpha-value>) * 100%))",
@@ -88,6 +85,7 @@ module.exports = {
           foreground:
             "color-mix(in srgb, var(--error-foreground), transparent calc((1 - <alpha-value>) * 100%))",
         },
+        stale: "var(--stale)",
         muted: {
           DEFAULT:
             "color-mix(in srgb, var(--muted), transparent calc((1 - <alpha-value>) * 100%))",


### PR DESCRIPTION
Reduces some of the extra variables for shadows. They can be more easily created by overriding the colors. 

Can view "Shadows" and "Cell" states here: https://marimo-storybook-git-ms-consolidate-shadows-marimo.vercel.app/