### PR TITLE
faster CLI

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional, get_args
 
 import click
 
+import marimo._cli.cli_validators as validators
 from marimo._cli.config.commands import config
 from marimo._cli.convert.commands import convert
 from marimo._cli.development.commands import development
@@ -22,17 +23,6 @@ from marimo._tutorials import (
 
 if TYPE_CHECKING:
     from marimo._server.tokens import AuthToken
-
-
-def base_url(ctx: Any, param: Any, value: Optional[str]) -> str:
-    del ctx
-    del param
-    if value is None or value == "":
-        return ""
-
-    if not value.startswith("/"):
-        raise click.BadParameter("Must start with /")
-    return value
 
 
 def helpful_usage_error(self: Any, file: Any = None) -> None:
@@ -246,7 +236,7 @@ edit_help_msg = "\n".join(
     show_default=True,
     type=str,
     help="Base URL for the server. Should start with a /.",
-    callback=base_url,
+    callback=validators.base_url,
 )
 @click.option(
     "--allow-origins",
@@ -392,7 +382,7 @@ def edit(
     show_default=True,
     type=str,
     help="Base URL for the server. Should start with a /.",
-    callback=base_url,
+    callback=validators.base_url,
 )
 def new(
     port: Optional[int],
@@ -506,7 +496,7 @@ Example:
     show_default=True,
     type=str,
     help="Base URL for the server. Should start with a /.",
-    callback=base_url,
+    callback=validators.base_url,
 )
 @click.option(
     "--allow-origins",

--- a/marimo/_cli/config/commands.py
+++ b/marimo/_cli/config/commands.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 
 import click
 
-from marimo._cli.config.utils import highlight_toml_headers
-from marimo._cli.print import green
-from marimo._config.manager import UserConfigManager
-
 
 @click.group(help="""Various commands for the marimo config.""")
 def config() -> None:
@@ -22,6 +18,10 @@ def show() -> None:
         marimo config show
     """
     import tomlkit
+
+    from marimo._cli.config.utils import highlight_toml_headers
+    from marimo._cli.print import green
+    from marimo._config.manager import UserConfigManager
 
     config_manager = UserConfigManager()
     click.echo(f"User config from {green(config_manager.get_config_path())}\n")

--- a/marimo/_cli/convert/commands.py
+++ b/marimo/_cli/convert/commands.py
@@ -5,10 +5,6 @@ from pathlib import Path
 
 import click
 
-from marimo._cli.convert.ipynb import convert_from_ipynb
-from marimo._cli.convert.markdown import convert_from_md
-from marimo._cli.convert.utils import load_external_file
-
 
 @click.argument("filename", required=True)
 def convert(
@@ -37,6 +33,10 @@ def convert(
     you may need to fix errors like multiple definition errors or cycle
     errors.
     """
+    from marimo._cli.convert.ipynb import convert_from_ipynb
+    from marimo._cli.convert.markdown import convert_from_md
+    from marimo._cli.convert.utils import load_external_file
+
     ext = Path(filename).suffix
     if ext not in (".ipynb", ".md", ".qmd"):
         raise click.UsageError("File must be an .ipynb or .md file")

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -10,38 +10,33 @@ from typing import TYPE_CHECKING, Any, Dict
 import click
 from starlette.schemas import SchemaGenerator
 
-import marimo._data.models as data
-import marimo._messaging.errors as errors
-import marimo._messaging.ops as ops
-import marimo._runtime.requests as requests
-import marimo._server.models.completion as completion
-import marimo._server.models.export as export
-import marimo._server.models.files as files
-import marimo._server.models.home as home
-import marimo._server.models.models as models
-import marimo._snippets.snippets as snippets
-from marimo import __version__
-from marimo._ast.cell import CellConfig, RuntimeStateType
-from marimo._cli.print import orange
-from marimo._config.config import MarimoConfig
-from marimo._dependencies.dependencies import DependencyManager
-from marimo._messaging.cell_output import CellChannel, CellOutput
-from marimo._messaging.mimetypes import KnownMimeType
-from marimo._output.mime import MIME
-from marimo._plugins.core.web_component import JSONType
-from marimo._runtime.packages.module_name_to_pypi_name import (
-    module_name_to_pypi_name,
-)
-from marimo._server.api.router import build_routes
-from marimo._utils.dataclass_to_openapi import (
-    PythonTypeToOpenAPI,
-)
-
 if TYPE_CHECKING:
     import psutil
 
 
 def _generate_schema() -> dict[str, Any]:
+    import marimo._data.models as data
+    import marimo._messaging.errors as errors
+    import marimo._messaging.ops as ops
+    import marimo._runtime.requests as requests
+    import marimo._server.models.completion as completion
+    import marimo._server.models.export as export
+    import marimo._server.models.files as files
+    import marimo._server.models.home as home
+    import marimo._server.models.models as models
+    import marimo._snippets.snippets as snippets
+    from marimo import __version__
+    from marimo._ast.cell import CellConfig, RuntimeStateType
+    from marimo._config.config import MarimoConfig
+    from marimo._messaging.cell_output import CellChannel, CellOutput
+    from marimo._messaging.mimetypes import KnownMimeType
+    from marimo._output.mime import MIME
+    from marimo._plugins.core.web_component import JSONType
+    from marimo._server.api.router import build_routes
+    from marimo._utils.dataclass_to_openapi import (
+        PythonTypeToOpenAPI,
+    )
+
     # dataclass components used in websocket messages
     # these are always snake_case
     MESSAGES = [
@@ -301,6 +296,8 @@ def list_processes() -> None:
 
         marimo development ps list
     """
+    from marimo._cli.print import orange
+
     # pretty print processes
     result = get_marimo_processes()
     for proc in result:
@@ -348,6 +345,12 @@ def inline_packages(
     """
 
     # Validate uv is installed
+
+    from marimo._dependencies.dependencies import DependencyManager
+    from marimo._runtime.packages.module_name_to_pypi_name import (
+        module_name_to_pypi_name,
+    )
+
     if not DependencyManager.which("uv"):
         raise click.UsageError(
             "uv is not installed. See https://docs.astral.sh/uv/getting-started/installation/"

--- a/marimo/_cli/envinfo.py
+++ b/marimo/_cli/envinfo.py
@@ -5,13 +5,6 @@ import platform
 import sys
 from typing import Any, Union, cast
 
-from marimo import __version__
-from marimo._utils.health import (
-    get_chrome_version,
-    get_node_version,
-    get_required_modules_list,
-)
-
 
 def is_win11() -> bool:
     """
@@ -26,6 +19,13 @@ def is_win11() -> bool:
 
 
 def get_system_info() -> dict[str, Union[str, dict[str, str]]]:
+    from marimo import __version__
+    from marimo._utils.health import (
+        get_chrome_version,
+        get_node_version,
+        get_required_modules_list,
+    )
+
     os_version = platform.release()
     if platform.system() == "Windows" and is_win11():
         os_version = "11"

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -7,21 +7,10 @@ from typing import TYPE_CHECKING, Callable
 
 import click
 
-from marimo._cli.parse_args import parse_args
-from marimo._cli.print import green
-from marimo._server.export import (
-    export_as_ipynb,
-    export_as_md,
-    export_as_script,
-    run_app_then_export_as_html,
-)
-from marimo._server.utils import asyncio_run
-from marimo._utils.file_watcher import FileWatcher
-from marimo._utils.marimo_path import MarimoPath
-from marimo._utils.paths import maybe_make_dirs
-
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from marimo._utils.marimo_path import MarimoPath
 
 
 @click.group(help="""Export a notebook to various formats.""")
@@ -35,6 +24,12 @@ def watch_and_export(
     watch: bool,
     export_callback: Callable[[MarimoPath], str],
 ) -> None:
+    from marimo._cli.print import green
+    from marimo._server.utils import asyncio_run
+    from marimo._utils.file_watcher import FileWatcher
+    from marimo._utils.marimo_path import MarimoPath
+    from marimo._utils.paths import maybe_make_dirs
+
     if watch and not output:
         raise click.UsageError(
             "Cannot use --watch without providing "
@@ -136,6 +131,12 @@ def html(
     """
     Run a notebook and export it as an HTML file.
     """
+    from marimo._cli.parse_args import parse_args
+    from marimo._server.export import (
+        run_app_then_export_as_html,
+    )
+    from marimo._server.utils import asyncio_run
+    from marimo._utils.marimo_path import MarimoPath
 
     cli_args = parse_args(args)
 
@@ -195,6 +196,10 @@ def script(
     """
     Export a marimo notebook as a flat script, in topological order.
     """
+    from marimo._server.export import (
+        export_as_script,
+    )
+    from marimo._utils.marimo_path import MarimoPath
 
     def export_callback(file_path: MarimoPath) -> str:
         return export_as_script(file_path)[0]
@@ -247,6 +252,10 @@ def md(
     """
     Export a marimo notebook as a code fenced markdown document.
     """
+    from marimo._server.export import (
+        export_as_md,
+    )
+    from marimo._utils.marimo_path import MarimoPath
 
     def export_callback(file_path: MarimoPath) -> str:
         return export_as_md(file_path)[0]
@@ -301,6 +310,10 @@ def ipynb(
     """
     Export a marimo notebook as a Jupyter notebook in topological order.
     """
+    from marimo._server.export import (
+        export_as_ipynb,
+    )
+    from marimo._utils.marimo_path import MarimoPath
 
     def export_callback(file_path: MarimoPath) -> str:
         return export_as_ipynb(file_path)[0]

--- a/marimo/_smoke_tests/theming/bokeh_theme.py
+++ b/marimo/_smoke_tests/theming/bokeh_theme.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.8.3"

--- a/marimo/_smoke_tests/theming/custom_css.py
+++ b/marimo/_smoke_tests/theming/custom_css.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import marimo
 
 __generated_with = "0.8.3"


### PR DESCRIPTION
By my measurements `marimo --help` is 20% faster with these changes, which make several imports lazy. Not all of these imports need to be lazy, just the ones not hit by `marimo.__init__.py` ...

Not sure the complexity is worth the speed-up, but putting the PR up in case anyone else has ideas.