### PR TITLE
feat: add anthropic support

### DIFF
--- a/docs/guides/editor_features/ai_completion.md
+++ b/docs/guides/editor_features/ai_completion.md
@@ -63,6 +63,22 @@ cell. This will open an input to modify the cell using AI.
 </figure>
 </div>
 
+### Using Anthropic
+
+To use Anthropic with marimo:
+
+1. Sign up for an account at [Anthropic](https://console.anthropic.com/) and grab your [Anthropic Key](https://console.anthropic.com/settings/keys).
+2. Add the following to your `~/.marimo.toml`:
+
+```toml
+[ai.open_ai]
+model = "claude-3-5-sonnet-20240620"
+# or any model from https://docs.anthropic.com/en/docs/about-claude/models
+
+[ai.anthropic]
+api_key = "sk-..."
+```
+
 ### Using other AI providers
 
 marimo supports OpenAI's GPT-3.5 API by default. If your provider is compatible with OpenAI's API, you can use it by changing the `base_url` in the configuration.

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -636,6 +636,10 @@ export const UserConfigForm: React.FC = () => {
                   />
                 </FormControl>
                 <FormMessage />
+                <FormDescription>
+                  If the model starts with "claude-", we will use your Anthropic
+                  API key. Otherwise, we will use your OpenAI API key.
+                </FormDescription>
               </FormItem>
             )}
           />

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -33,7 +33,7 @@ import { aiCompletionCellAtom } from "@/core/ai/state";
 import { mergeRefs } from "@/utils/mergeRefs";
 import { useSetLastFocusedCellId } from "@/core/cells/focus";
 import type { LanguageAdapterType } from "@/core/codemirror/language/types";
-import { autoInstantiateAtom } from "@/core/config/config";
+import { autoInstantiateAtom, isAiEnabled } from "@/core/config/config";
 import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import { OverridingHotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { useSplitCellCallback } from "../useSplitCell";
@@ -143,11 +143,13 @@ const CellEditorInternal = ({
     maybeAddMarimoImport(autoInstantiate, createNewCell);
   });
 
+  const aiEnabled = isAiEnabled(userConfig);
+
   const extensions = useMemo(() => {
     const extensions = setupCodeMirror({
       cellId,
       showPlaceholder,
-      enableAI: Boolean(userConfig.ai.open_ai?.api_key),
+      enableAI: aiEnabled,
       cellCodeCallbacks: {
         updateCellCode,
         afterToggleMarkdown,
@@ -208,7 +210,7 @@ const CellEditorInternal = ({
     cellId,
     userConfig.keymap,
     userConfig.completion,
-    userConfig.ai.open_ai?.api_key,
+    aiEnabled,
     theme,
     showPlaceholder,
     createAbove,

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -102,6 +102,11 @@ export const UserConfigSchema = z
             model: z.string().optional(),
           })
           .optional(),
+        anthropic: z
+          .object({
+            api_key: z.string().optional(),
+          })
+          .optional(),
       })
       .default({}),
     experimental: z

--- a/frontend/src/core/config/config.ts
+++ b/frontend/src/core/config/config.ts
@@ -39,8 +39,14 @@ export function getUserConfig() {
 }
 
 export const aiEnabledAtom = atom<boolean>((get) => {
-  return Boolean(get(userConfigAtom).ai.open_ai?.api_key);
+  return isAiEnabled(get(userConfigAtom));
 });
+
+export function isAiEnabled(config: UserConfig) {
+  return (
+    Boolean(config.ai.open_ai?.api_key) || Boolean(config.ai.anthropic?.api_key)
+  );
+}
 
 /**
  * Atom for storing the app config.

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -174,9 +174,11 @@ class AiConfig(TypedDict):
     **Keys.**
 
     - `open_ai`: the OpenAI config
+    - `anthropic`: the Anthropic config
     """
 
     open_ai: OpenAiConfig
+    anthropic: AnthropicConfig
 
 
 @dataclass
@@ -186,13 +188,26 @@ class OpenAiConfig(TypedDict):
     **Keys.**
 
     - `api_key`: the OpenAI API key
-    - `model`: the model to use
+    - `model`: the model to use.
+        if model starts with `claude-` we use the AnthropicConfig
     - `base_url`: the base URL for the API
     """
 
     api_key: str
     model: NotRequired[str]
     base_url: NotRequired[str]
+
+
+@dataclass
+class AnthropicConfig(TypedDict):
+    """Configuration options for Anthropic.
+
+    **Keys.**
+
+    - `api_key`: the Anthropic
+    """
+
+    api_key: str
 
 
 @mddoc
@@ -303,7 +318,7 @@ def mask_secrets(config: MarimoConfig) -> MarimoConfig:
         else:
             deep_remove_from_path(path[1:], cast(Dict[str, Any], obj[key]))
 
-    secrets = [["ai", "open_ai", "api_key"]]
+    secrets = [["ai", "open_ai", "api_key"], ["ai", "anthropic", "api_key"]]
 
     new_config = _deep_copy(config)
     for secret in secrets:

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -128,7 +128,7 @@ def get_content(
     response: RawMessageStreamEvent | ChatCompletionChunk,
 ) -> str | None:
     if hasattr(response, "choices"):
-        return response.choices[0].delta.content  # type: ignore[attr-defined][no-any-return]
+        return response.choices[0].delta.content  # type: ignore
 
     from anthropic.types import (
         RawContentBlockDeltaEvent,
@@ -137,7 +137,7 @@ def get_content(
 
     if isinstance(response, RawContentBlockDeltaEvent):
         if isinstance(response.delta, TextDelta):
-            return response.delta.text  # type: ignore[attr-defined][no-any-return]
+            return response.delta.text  # type: ignore
 
     return None
 

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
         Client,
         Stream as AnthropicStream,
     )
-    from anthropic.types import (
-        RawMessageStreamEvent,  # type: ignore[import-not-found]
+    from anthropic.types import (  # type: ignore[import-not-found]
+        RawMessageStreamEvent,
     )
     from openai import (  # type: ignore[import-not-found]
         OpenAI,
@@ -128,7 +128,7 @@ def get_content(
     response: RawMessageStreamEvent | ChatCompletionChunk,
 ) -> str | None:
     if hasattr(response, "choices"):
-        return response.choices[0].delta.content  # type: ignore[attr-defined]
+        return response.choices[0].delta.content  # type: ignore[attr-defined][no-any-return]
 
     from anthropic.types import (
         RawContentBlockDeltaEvent,
@@ -137,7 +137,7 @@ def get_content(
 
     if isinstance(response, RawContentBlockDeltaEvent):
         if isinstance(response.delta, TextDelta):
-            return response.delta.text
+            return response.delta.text  # type: ignore[attr-defined][no-any-return]
 
     return None
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -823,6 +823,9 @@ components:
             app_title:
               nullable: true
               type: string
+            css_file:
+              nullable: true
+              type: string
             layout_file:
               nullable: true
               type: string
@@ -960,6 +963,13 @@ components:
       properties:
         ai:
           properties:
+            anthropic:
+              properties:
+                api_key:
+                  type: string
+              required:
+              - api_key
+              type: object
             open_ai:
               properties:
                 api_key:
@@ -975,6 +985,7 @@ components:
               type: object
           required:
           - open_ai
+          - anthropic
           type: object
         completion:
           properties:
@@ -1784,7 +1795,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.8.2
+  version: 0.8.3
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2020,6 +2020,7 @@ export interface components {
     KernelReady: {
       app_config: {
         app_title?: string | null;
+        css_file?: string | null;
         layout_file?: string | null;
         /** @enum {string} */
         width: "normal" | "compact" | "medium" | "full";
@@ -2079,6 +2080,9 @@ export interface components {
     };
     MarimoConfig: {
       ai: {
+        anthropic: {
+          api_key: string;
+        };
         open_ai: {
           api_key: string;
           base_url: string;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ testoptional = [
     "anywidget~=0.9.13",
     "ipython~=8.12.3",
     "openai~=1.41.1",
+    "anthropic==0.34.1",
     # exporting as ipynb
     "nbformat >=5.10.4",
 ]

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -293,7 +293,9 @@ class TestAiEndpoints:
 def openai_config(config: UserConfigManager):
     prev_config = config.get_config()
     try:
-        config.save_config({"ai": {"open_ai": {"api_key": "fake-api"}}})
+        config.save_config(
+            {"ai": {"open_ai": {"api_key": "fake-api", "model": ""}}}
+        )
         yield
     finally:
         config.save_config(prev_config)
@@ -328,6 +330,7 @@ def openai_config_custom_base_url(config: UserConfigManager):
                     "open_ai": {
                         "api_key": "fake-api",
                         "base_url": "https://my-openai-instance.com",
+                        "model": "",
                     }
                 }
             }
@@ -341,7 +344,7 @@ def openai_config_custom_base_url(config: UserConfigManager):
 def no_openai_config(config: UserConfigManager):
     prev_config = config.get_config()
     try:
-        config.save_config({"ai": {"open_ai": {"api_key": ""}}})
+        config.save_config({"ai": {"open_ai": {"api_key": "", "model": ""}}})
         yield
     finally:
         config.save_config(prev_config)

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -27,16 +27,31 @@ HEADERS = {
 HAS_DEPS = DependencyManager.openai.has()
 
 
+# Anthropic
+@dataclass
+class TextDelta:
+    text: str
+
+
+# Anthropic
+@dataclass
+class RawContentBlockDeltaEvent:
+    delta: TextDelta
+
+
+# OpenAI
 @dataclass
 class Delta:
     content: str
 
 
+# OpenAI
 @dataclass
 class Choice:
     delta: Delta
 
 
+# OpenAI
 @dataclass
 class FakeChoices:
     choices: List[Choice]
@@ -65,6 +80,30 @@ class TestAiEndpoints:
             )
         assert response.status_code == 400, response.text
         assert response.json() == {"detail": "OpenAI API key not configured"}
+
+    @staticmethod
+    @with_session(SESSION_ID)
+    @patch("anthropic.Client")
+    def test_anthropic_completion_without_token(
+        client: TestClient, anthropic_mock: Any
+    ) -> None:
+        del anthropic_mock
+        user_config_manager = get_user_config_manager(client)
+
+        with no_anthropic_config(user_config_manager):
+            response = client.post(
+                "/api/ai/completion",
+                headers=HEADERS,
+                json={
+                    "prompt": "Help me create a dataframe",
+                    "include_other_code": "",
+                    "code": "",
+                },
+            )
+        assert response.status_code == 400, response.text
+        assert response.json() == {
+            "detail": "Anthropic API key not configured"
+        }
 
     @staticmethod
     @with_session(SESSION_ID)
@@ -138,6 +177,43 @@ class TestAiEndpoints:
             prompt = oaiclient.chat.completions.create.call_args.kwargs[
                 "messages"
             ][1]["content"]
+            assert prompt == (
+                "Help me create a dataframe\n\nCurrent code:\nimport pandas as pd"  # noqa: E501
+            )
+
+    @staticmethod
+    @with_session(SESSION_ID)
+    @pytest.mark.skipif(
+        not HAS_DEPS, reason="optional dependencies not installed"
+    )
+    @patch("anthropic.Client")
+    def test_anthropic_completion_with_code(
+        client: TestClient, anthropic_mock: Any
+    ) -> None:
+        user_config_manager = get_user_config_manager(client)
+
+        anthropic_client = MagicMock()
+        anthropic_mock.return_value = anthropic_client
+
+        anthropic_client.messages.create.return_value = [
+            RawContentBlockDeltaEvent(TextDelta("import pandas as pd"))
+        ]
+
+        with anthropic_config(user_config_manager):
+            response = client.post(
+                "/api/ai/completion",
+                headers=HEADERS,
+                json={
+                    "prompt": "Help me create a dataframe",
+                    "code": "import pandas as pd",
+                    "include_other_code": "",
+                },
+            )
+            assert response.status_code == 200, response.text
+            # Assert the prompt it was called with
+            prompt: str = anthropic_client.messages.create.call_args.kwargs[
+                "messages"
+            ][0]["content"]
             assert prompt == (
                 "Help me create a dataframe\n\nCurrent code:\nimport pandas as pd"  # noqa: E501
             )
@@ -266,6 +342,40 @@ def no_openai_config(config: UserConfigManager):
     prev_config = config.get_config()
     try:
         config.save_config({"ai": {"open_ai": {"api_key": ""}}})
+        yield
+    finally:
+        config.save_config(prev_config)
+
+
+@contextmanager
+def no_anthropic_config(config: UserConfigManager):
+    prev_config = config.get_config()
+    try:
+        config.save_config(
+            {
+                "ai": {
+                    "open_ai": {"model": "claude-3.5"},
+                    "anthropic": {"api_key": ""},
+                }
+            }
+        )
+        yield
+    finally:
+        config.save_config(prev_config)
+
+
+@contextmanager
+def anthropic_config(config: UserConfigManager):
+    prev_config = config.get_config()
+    try:
+        config.save_config(
+            {
+                "ai": {
+                    "open_ai": {"model": "claude-3.5"},
+                    "anthropic": {"api_key": "fake-key"},
+                }
+            }
+        )
         yield
     finally:
         config.save_config(prev_config)


### PR DESCRIPTION
Fixes #2141 

This adds Claude (anthropic) support:

-----------

### Using Anthropic

To use Anthropic with marimo:

1. Sign up for an account at [Anthropic](https://console.anthropic.com/) and grab your [Anthropic Key](https://console.anthropic.com/settings/keys).
2. Add the following to your `~/.marimo.toml`:

```toml
[ai.open_ai]
model = "claude-3-5-sonnet-20240620"
# or any model from https://docs.anthropic.com/en/docs/about-claude/models

[ai.anthropic]
api_key = "sk-..."
```