### PR TITLE
fix: islands render_html() head needs marimo tags

### DIFF
--- a/marimo/_islands/island_generator.py
+++ b/marimo/_islands/island_generator.py
@@ -284,7 +284,7 @@ class MarimoIslandGenerator:
         self,
         *,
         version_override: str = __version__,
-        _development_url: Union[str | bool] = False,
+        _development_url: Union[str, bool] = False,
     ) -> str:
         """
         Render the header for the app.
@@ -341,6 +341,11 @@ class MarimoIslandGenerator:
                 """
             ).strip()
 
+        marimo_tags = f"""
+        <marimo-filename hidden></>
+        <marimo-mode data-mode='read' hidden></marimo-mode>
+        """.strip()
+
         return dedent(
             f"""
             <script type="module" src="{base_url}/dist/main.js"></script>
@@ -350,6 +355,7 @@ class MarimoIslandGenerator:
                 crossorigin="anonymous"
             />
             {fonts}
+            {marimo_tags}
             """
         ).strip()
 
@@ -455,7 +461,7 @@ class MarimoIslandGenerator:
         self,
         *,
         version_override: str = __version__,
-        _development_url: Union[str | bool] = False,
+        _development_url: Union[str, bool] = False,
         include_init_island: bool = True,
         max_width: Optional[str] = None,
         margin: Optional[str] = None,

--- a/tests/_islands/snapshots/header.txt
+++ b/tests/_islands/snapshots/header.txt
@@ -1,19 +1,21 @@
 <script type="module" src="https://cdn.jsdelivr.net/npm/@marimo-team/islands@0.0.0/dist/main.js"></script>
-<link
-    href="https://cdn.jsdelivr.net/npm/@marimo-team/islands@0.0.0/dist/style.css"
-    rel="stylesheet"
-    crossorigin="anonymous"
-/>
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link
-    rel="preconnect"
-    href="https://fonts.gstatic.com"
-    crossorigin
-/>
-<link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&amp;family=Lora&amp;family=PT+Sans:wght@400;700&amp;display=swap" rel="stylesheet" />
-<link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css"
-    integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww"
-    crossorigin="anonymous"
-/>
+    <link
+        href="https://cdn.jsdelivr.net/npm/@marimo-team/islands@0.0.0/dist/style.css"
+        rel="stylesheet"
+        crossorigin="anonymous"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+        rel="preconnect"
+        href="https://fonts.gstatic.com"
+        crossorigin
+    />
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&amp;family=Lora&amp;family=PT+Sans:wght@400;700&amp;display=swap" rel="stylesheet" />
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css"
+        integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww"
+        crossorigin="anonymous"
+    />
+    <marimo-filename hidden></>
+<marimo-mode data-mode='read' hidden></marimo-mode>


### PR DESCRIPTION
HTML generated with `MarimoIslandGenerator.from_file().render_html()` was failing to render because the frontend expects marimo-filename and marimo-mode tags to be present.