### PR TITLE
fix: fix browser freezing when rendering large dataframes

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -625,22 +625,24 @@ export const UserConfigForm: React.FC = () => {
             disabled={isWasmRuntime}
             name="ai.open_ai.model"
             render={({ field }) => (
-              <FormItem className={formItemClasses}>
-                <FormLabel>Model</FormLabel>
-                <FormControl>
-                  <Input
-                    data-testid="ai-model-input"
-                    className="m-0 inline-flex"
-                    placeholder="gpt-4-turbo"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
+              <div className="flex flex-col space-y-1">
+                <FormItem className={formItemClasses}>
+                  <FormLabel>Model</FormLabel>
+                  <FormControl>
+                    <Input
+                      data-testid="ai-model-input"
+                      className="m-0 inline-flex"
+                      placeholder="gpt-4-turbo"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
                 <FormDescription>
                   If the model starts with "claude-", we will use your Anthropic
                   API key. Otherwise, we will use your OpenAI API key.
                 </FormDescription>
-              </FormItem>
+              </div>
             )}
           />
         </SettingGroup>

--- a/frontend/src/components/data-table/pagination.tsx
+++ b/frontend/src/components/data-table/pagination.tsx
@@ -83,6 +83,14 @@ export const DataTablePagination = <TData,>({
   );
   const totalPages = table.getPageCount();
 
+  const renderOption = (i: number) => {
+    return (
+      <option key={i} value={i + 1}>
+        {i + 1}
+      </option>
+    );
+  };
+
   return (
     <div className="flex flex-1 items-center justify-between px-2">
       <div className="text-sm text-muted-foreground">{renderTotal()}</div>
@@ -117,11 +125,27 @@ export const DataTablePagination = <TData,>({
             data-testid="page-select"
             onChange={(e) => table.setPageIndex(Number(e.target.value) - 1)}
           >
-            {Array.from({ length: totalPages }, (_, i) => (
-              <option key={i} value={i + 1}>
-                {i + 1}
-              </option>
-            ))}
+            {/* If this is too large, this can cause the browser to hang. */}
+            {totalPages <= 100 ? (
+              Array.from({ length: totalPages }, (_, i) => renderOption(i))
+            ) : (
+              // Show the first 10 pages, the middle 10 pages, and the last 10 pages.
+              <>
+                {Array.from({ length: 10 }, (_, i) => renderOption(i))}
+                <option disabled={true} value="__1__">
+                  ...
+                </option>
+                {Array.from({ length: 10 }, (_, i) =>
+                  renderOption(Math.floor(totalPages / 2) - 5 + i),
+                )}
+                <option disabled={true} value="__2__">
+                  ...
+                </option>
+                {Array.from({ length: 10 }, (_, i) =>
+                  renderOption(totalPages - 10 + i),
+                )}
+              </>
+            )}
           </select>
           <span className="flex-shrink-0">of {prettyNumber(totalPages)}</span>
         </div>

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -80,37 +80,33 @@ export const ScratchPad: React.FC = () => {
       className="flex flex-col h-full overflow-hidden divide-y"
       id={HTMLCellId.create(cellId)}
     >
-      <div className="flex justify-start items-center flex-shrink-0">
-        <div className="flex items-center">
-          <Tooltip content={renderShortcut("cell.run")}>
-            <Button
-              data-testid="scratchpad-run-button"
-              onClick={handleRun}
-              variant="text"
-              // className="bg-[var(--grass-3)] hover:bg-[var(--grass-4)] rounded-none"
-              size="xs"
-            >
-              <PlayIcon color="var(--grass-11)" size={16} />
+      <div className="flex items-center flex-shrink-0">
+        <Tooltip content={renderShortcut("cell.run")}>
+          <Button
+            data-testid="scratchpad-run-button"
+            onClick={handleRun}
+            variant="text"
+            // className="bg-[var(--grass-3)] hover:bg-[var(--grass-4)] rounded-none"
+            size="xs"
+          >
+            <PlayIcon color="var(--grass-11)" size={16} />
+          </Button>
+        </Tooltip>
+        <Tooltip content="Clear code and outputs">
+          <Button size="xs" variant="text" onClick={handleClearCode}>
+            <EraserIcon size={16} />
+          </Button>
+        </Tooltip>
+        <HideInKioskMode>
+          <Tooltip content="Insert code">
+            <Button size="xs" variant="text" onClick={handleInsertCode}>
+              <BetweenHorizontalStartIcon size={16} />
             </Button>
           </Tooltip>
-          {(status === "running" || status === "queued") && (
-            <Spinner className="inline" size="small" />
-          )}
-        </div>
-        <div>
-          <Tooltip content="Clear code and outputs">
-            <Button size="xs" variant="text" onClick={handleClearCode}>
-              <EraserIcon size={16} />
-            </Button>
-          </Tooltip>
-          <HideInKioskMode>
-            <Tooltip content="Insert code">
-              <Button size="xs" variant="text" onClick={handleInsertCode}>
-                <BetweenHorizontalStartIcon size={16} />
-              </Button>
-            </Tooltip>
-          </HideInKioskMode>
-        </div>
+        </HideInKioskMode>
+        {(status === "running" || status === "queued") && (
+          <Spinner className="inline" size="small" />
+        )}
       </div>
       <div className="overflow-auto flex-shrink-0 max-h-[40%]">
         <CellEditor


### PR DESCRIPTION
In the DataTablePagination component, the rendering of page options was improved to prevent browser hanging when there are a large number of pages. Now, only the first 10 pages, the middle 10 pages, and the last 10 pages are shown, with ellipsis indicating the skipped pages.
