### PR TITLE
fix: handle escaped table names in SQL statements

### DIFF
--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -86,6 +86,9 @@ class TokenExtractor:
             end = sql_statement.find('"', start + 1) + 1
         elif sql_statement[start] == "'":
             end = sql_statement.find("'", start + 1) + 1
+        elif sql_statement[start:].startswith("e'"):
+            start += 1
+            end = sql_statement.find("'", start + 1) + 1
         else:
             # For non-quoted tokens, find until space or comment
             maybe_end = re.search(r"[\s\-/]", sql_statement[start:])

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -710,16 +710,27 @@ class Kernel:
 
                 # We only drop in-memory tables: we don't want to drop tables
                 # on databases!
-                duckdb.execute(f"DROP TABLE IF EXISTS memory.main.{name}")
+                try:
+                    duckdb.execute(f"DROP TABLE IF EXISTS memory.main.{name}")
+                except Exception as e:
+                    LOGGER.warning("Failed to drop table %s: %s", name, str(e))
             elif variable.kind == "view" and DependencyManager.duckdb.has():
                 import duckdb
 
                 # We only drop in-memory views for the same reason.
-                duckdb.execute(f"DROP VIEW IF EXISTS memory.main.{name}")
+                try:
+                    duckdb.execute(f"DROP VIEW IF EXISTS memory.main.{name}")
+                except Exception as e:
+                    LOGGER.warning("Failed to drop view %s: %s", name, str(e))
             elif variable.kind == "schema" and DependencyManager.duckdb.has():
                 import duckdb
 
-                duckdb.execute(f"DETACH DATABASE IF EXISTS {name}")
+                try:
+                    duckdb.execute(f"DETACH DATABASE IF EXISTS {name}")
+                except Exception as e:
+                    LOGGER.warning(
+                        "Failed to detach schema %s: %s", name, str(e)
+                    )
             else:
                 if name in self.globals:
                     del self.globals[name]

--- a/tests/_ast/test_sql_visitor.py
+++ b/tests/_ast/test_sql_visitor.py
@@ -345,7 +345,7 @@ class TestFindCreatedTables:
 
     @staticmethod
     def test_find_sql_defs_weird_names() -> None:
-        sql = """
+        sql = r"""
         CREATE TABLE "my--table" (
             "column/*with*/comment" INT,
             "another--column" VARCHAR
@@ -362,6 +362,9 @@ class TestFindCreatedTables:
         CREATE TABLE "my/*weird*/table" (id INT);
 
         CREATE TABLE "with a space" (id INT);
+
+        CREATE TABLE 'single-quotes' (id INT);
+        CREATE TABLE e'escaped\ntable' (id INT);
         """
         assert find_sql_defs(sql) == SQLDefs(
             [
@@ -369,6 +372,8 @@ class TestFindCreatedTables:
                 "my_table_with_select",
                 "my/*weird*/table",
                 "with a space",
+                "single-quotes",
+                r"escaped\ntable",
             ],
             [],
             [],


### PR DESCRIPTION
The code changes in `sql_visitor.py` handle the case where SQL statements have escaped table names. This is done by checking if the statement starts with `e'` and adjusting the start and end indices accordingly. This ensures that the correct table name is extracted.
