### PR TITLE
fix: do not require plotly or bokeh when holoviews is used

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -141,6 +141,7 @@ class DependencyManager:
     duckdb = Dependency("duckdb")
     pillow = Dependency("PIL")
     plotly = Dependency("plotly")
+    bokeh = Dependency("bokeh")
     pyarrow = Dependency("pyarrow")
     openai = Dependency("openai")
     matplotlib = Dependency("matplotlib")

--- a/marimo/_output/formatters/holoviews_formatters.py
+++ b/marimo/_output/formatters/holoviews_formatters.py
@@ -58,9 +58,11 @@ class HoloViewsFormatter(FormatterFactory):
     def apply_theme(self, theme: Theme) -> None:
         import holoviews as hv  # type: ignore
 
-        hv.renderer("bokeh").theme = (
-            "dark_minimal" if theme == "dark" else None
-        )
-        hv.renderer("plotly").theme = (
-            "plotly_dark" if theme == "dark" else "plotly"
-        )
+        if DependencyManager.bokeh.has():
+            hv.renderer("bokeh").theme = (
+                "dark_minimal" if theme == "dark" else None
+            )
+        if DependencyManager.plotly.has():
+            hv.renderer("plotly").theme = (
+                "plotly_dark" if theme == "dark" else "plotly"
+            )


### PR DESCRIPTION
## 📝 Summary

Verifies that plotly or bokeh is installed when using holoviews

Fixes #2198 

## 🔍 Description of Changes

Importing `holoviews` was failing of plotly or bokeh was not installed. 

In holoviews formatter, only apply theme for plotly or bokeh when they are installed.

It also adds bokeh in `DependencyManager`

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@mscolnick
