### PR TITLE
fix: allow backslashes in app config (file format)

### DIFF
--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -124,7 +124,9 @@ def generate_unparsable_cell(
 def generate_app_constructor(config: Optional[_AppConfig]) -> str:
     def _format_arg(arg: Any) -> str:
         if isinstance(arg, str):
-            return f'"{arg}"'
+            # Serialize string arguments as r-strings to handle backslashes
+            # in file paths
+            return f'r"{arg}"'
         else:
             return str(arg)
 

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -124,9 +124,7 @@ def generate_unparsable_cell(
 def generate_app_constructor(config: Optional[_AppConfig]) -> str:
     def _format_arg(arg: Any) -> str:
         if isinstance(arg, str):
-            # Serialize string arguments as r-strings to handle backslashes
-            # in file paths
-            return f'r"{arg}"'
+            return f'"{arg}"'.replace("\\", "\\\\")
         else:
             return str(arg)
 

--- a/tests/_ast/codegen_data/test_generate_filecontents_empty_with_config.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_empty_with_config.py
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "0.4.6"
-app = marimo.App(width=r"full", app_title=r"test_title", css_file=r"a\b.css")
+app = marimo.App(width="full", app_title="test_title", css_file="a\\b.css")
 
 
 

--- a/tests/_ast/codegen_data/test_generate_filecontents_empty_with_config.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_empty_with_config.py
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "0.4.6"
-app = marimo.App(width="full", app_title="test_title")
+app = marimo.App(width=r"full", app_title=r"test_title", css_file=r"a\b.css")
 
 
 

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -71,7 +71,9 @@ class TestGeneration:
 
     @staticmethod
     def test_generate_filecontents_empty_with_config() -> None:
-        config = _AppConfig(app_title="test_title", width="full")
+        config = _AppConfig(
+            app_title="test_title", width="full", css_file=r"a\b.css"
+        )
         contents = wrap_generate_filecontents([], [], config=config)
         assert contents == get_expected_filecontents(
             "test_generate_filecontents_empty_with_config"


### PR DESCRIPTION
Escape backslashes in app config strings.

Fixes #2202 