### PR TITLE
Auto apply theme to mo.ui.data_explorer based on the notebook display theme

### DIFF
--- a/frontend/src/plugins/impl/data-explorer/ConnectedDataExplorerComponent.tsx
+++ b/frontend/src/plugins/impl/data-explorer/ConnectedDataExplorerComponent.tsx
@@ -23,6 +23,7 @@ import { ColumnSummary } from "./components/column-summary";
 import type { VegaLiteProps } from "react-vega/lib/VegaLite";
 import { useOnMount } from "@/hooks/useLifecycle";
 import type { ChartSpec } from "./state/types";
+import { useTheme } from "@/theme/useTheme"; // P7a34
 
 /**
  * @param label - a label of the table
@@ -104,6 +105,7 @@ export const DataExplorerComponent = ({
 
   const { mark } = useAtomValue(chartSpecAtom);
   const charts = useAtomValue(relatedChartSpecsAtom);
+  const { theme } = useTheme();
 
   if (error) {
     return <ErrorBanner error={error} />;
@@ -133,6 +135,7 @@ export const DataExplorerComponent = ({
           padding={PADDING}
           actions={ACTIONS}
           spec={makeResponsive(mainPlot.spec)}
+          theme={theme === "dark" ? "dark" : undefined}
         />
       </div>
     );
@@ -207,6 +210,7 @@ export const DataExplorerComponent = ({
                 key={idx}
                 actions={false}
                 spec={plot.spec}
+                theme={theme === "dark" ? "dark" : undefined}
               />
             </HorizontalCarouselItem>
           ))}


### PR DESCRIPTION
Fixes #2228

Update `ConnectedDataExplorerComponent` to apply dark theme based on the current display theme.

* **Import `useTheme` hook:**
  - Import `useTheme` from `frontend/src/theme/useTheme.ts`.

* **Apply dark theme:**
  - Use the `useTheme` hook to get the current theme.
  - Apply the dark theme to the `VegaLite` component if the current theme is dark.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/marimo-team/marimo/issues/2228?shareId=XXXX-XXXX-XXXX-XXXX).