### PR TITLE
fix: accordion max-width styling

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -48,14 +48,28 @@ export const Sidebar: React.FC = () => {
 const QueuedOrRunningStack = () => {
   const count = useAtomValue(notebookQueuedOrRunningCountAtom);
   return (
-    <div className="flex flex-col-reverse gap-[1px] overflow-hidden">
-      {Array.from({ length: count }).map((_, index) => (
-        <div
-          key={index.toString()}
-          className="flex-shrink-0 h-1 w-2 bg-[var(--grass-6)] border border-[var(--grass-7)]"
-        />
-      ))}
-    </div>
+    <Tooltip
+      content={
+        count > 0 ? (
+          <span>
+            {count} cell{count > 1 ? "s" : ""} queued or running
+          </span>
+        ) : (
+          "No cells queued or running"
+        )
+      }
+      side="right"
+      delayDuration={200}
+    >
+      <div className="flex flex-col-reverse gap-[1px] overflow-hidden">
+        {Array.from({ length: count }).map((_, index) => (
+          <div
+            key={index.toString()}
+            className="flex-shrink-0 h-1 w-2 bg-[var(--grass-6)] border border-[var(--grass-7)]"
+          />
+        ))}
+      </div>
+    </Tooltip>
   );
 };
 

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -10,7 +10,6 @@
   margin-block-end: 0;
 }
 
-
 .markdown h1 {
   text-align: center;
 }
@@ -19,7 +18,6 @@
   /* In full-width display, we left-align the title */
   text-align: start;
 }
-
 
 .markdown .paragraph {
   /*
@@ -90,3 +88,11 @@ button .markdown .paragraph {
 }
 
 /* stylelint-enable unit-allowed-list */
+
+/*
+Disable max-width for prose in buttons
+This change includes accordions https://github.com/marimo-team/marimo/issues/2217
+*/
+button .prose.prose {
+  max-width: none;
+}

--- a/marimo/_smoke_tests/bugs/2216-accordions.py
+++ b/marimo/_smoke_tests/bugs/2216-accordions.py
@@ -1,0 +1,53 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.8.11"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __(mo):
+    mo.accordion(
+        {
+            """**e)** Diria que o trabalho, a educação e a idade explicam muita da variação no sono? Que outros fatores poderiam afetar o tempo passado a dormir? Estarão esses fatores provavelmente correlacionados com o trabalho?""": """
+        - O $R^2 = 0.113$ é reduzido
+        - Só 11.3% da variabilidade do sono é explicada pelas variáveis explicativas escolhidas para o modelo
+        - Há fatores que ficaram de fora do modelo que podem influenciar o sono. Exemplos:
+            - _Stress_
+            - Idade dos filhos
+            - Profissão
+        """
+        }
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.accordion(
+        {
+            r"""**a)** Estime os coeficientes da regressão de $Y$ sobre $X_1$, bem como o error padrão da regressão e o $R^2$. O que pensa da estimativa de $\beta_1$?""": mo.md(
+                """
+                - Introduzindo o commando `regress Y X1` obtemos a estimação abaixo
+                - A estimativa para $\beta_1$ é inesperada, pois contradiz a teoria económica de que existe uma relação negativa entre o preço e as vendas.
+                """
+            )
+        }
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/datasources.py
+++ b/marimo/_smoke_tests/datasources.py
@@ -1,4 +1,13 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pandas",
+#     "vega-datasets",
+#     "marimo",
+#     "polars",
+#     "pyarrow",
+# ]
+# ///
 
 import marimo
 


### PR DESCRIPTION
Fixes #2217
Fixes #2216

Unset the max-width for buttons that is added by `.prose`

Small drive-by to add a tooltip to the running cell's indicator

![image](https://github.com/user-attachments/assets/be107885-3bf3-49c4-a3fc-cb7966c64e2c)
