### PR TITLE
chore: workaround runtime warning in pandas table column summary

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -204,13 +204,17 @@ class PandasTableManagerFactory(TableManagerFactory):
                         p95=col.quantile(0.95),
                     )
 
+                import numpy as np
+
                 return ColumnSummary(
                     total=col.count(),
                     nulls=col.isnull().sum(),
                     min=col.min(),
                     max=col.max(),
                     mean=col.mean(),
-                    median=col.median(),
+                    # Pandas prints an unhelpful RuntimeWarning when taking
+                    # the median of an all nan column
+                    median=col.median() if not col.isna().all() else np.nan,
                     std=col.std(),
                     p5=col.quantile(0.05),
                     p25=col.quantile(0.25),

--- a/marimo/_smoke_tests/tables/pandas_nan.py
+++ b/marimo/_smoke_tests/tables/pandas_nan.py
@@ -1,0 +1,29 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo",
+#     "numpy",
+#     "pandas",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.8.11"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import pandas as pd
+    import numpy as np
+
+    # This shouldn't print a runtime warning
+    df = pd.DataFrame({"a": [1,2,3], "b": [np.nan, np.nan, np.nan]})
+    df
+    return df, mo, np, pd
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Pandas doesn't like it when you take the median of an empty column