### PR TITLE
fix: empty tables total rows

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -289,7 +289,8 @@ class table(
         if _internal_total_rows is not None:
             total_rows = _internal_total_rows
         else:
-            total_rows = self._manager.get_num_rows(force=True) or "too_many"
+            total_rows = self._manager.get_num_rows(force=True)
+            total_rows = total_rows if total_rows is not None else "too_many"
 
         if pagination is False and total_rows != "too_many":
             page_size = total_rows

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -289,8 +289,8 @@ class table(
         if _internal_total_rows is not None:
             total_rows = _internal_total_rows
         else:
-            total_rows = self._manager.get_num_rows(force=True)
-            total_rows = total_rows if total_rows is not None else "too_many"
+            num_rows = self._manager.get_num_rows(force=True)
+            total_rows = num_rows if num_rows is not None else "too_many"
 
         if pagination is False and total_rows != "too_many":
             page_size = total_rows

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -372,6 +372,11 @@ def test_table_with_too_many_rows_unknown_total():
     assert len(table._component_args["data"]) == 10
 
 
+def test_empty_table():
+    table = ui.table([])
+    assert table._component_args["total-rows"] == 0
+
+
 def test_table_with_too_many_rows_column_summaries_disabled():
     data = {"a": list(range(20))}
     table = ui.table(data, _internal_summary_row_limit=10)


### PR DESCRIPTION
Total rows is 0 for empty tables, not too_many. Previously empty tables showed a results clipped warning on the frontend.
