### PR TITLE
improvement: add typoegraphy setting for slides

### DIFF
--- a/frontend/src/components/slides/slides-component.tsx
+++ b/frontend/src/components/slides/slides-component.tsx
@@ -56,7 +56,7 @@ const SlidesComponent = ({
     <Swiper
       ref={el}
       className={cn(
-        "relative w-full border rounded bg-background mo-slides-theme",
+        "relative w-full border rounded bg-background mo-slides-theme prose-slides",
         className,
       )}
       spaceBetween={50}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -184,6 +184,80 @@ module.exports = {
             },
           },
         },
+        slides: {
+          // This aims to match Google Slides' typography
+          // h1 -> 52pts (70px)
+          // h2 -> 36pts (48px)
+          // h3 -> 28pts (37.33px)
+          // h4 -> 25pts (33.33px)
+          // p -> 18pts (24px)
+          // code -> 18pts (24px)
+          css: {
+            h1: {
+              fontSize: `${70 / 16}rem`,
+              lineHeight: 1.2,
+            },
+            "h1 code": {
+              fontSize: `${70 / 16}rem`,
+            },
+            h2: {
+              fontSize: `${48 / 16}rem`,
+              lineHeight: 1.3,
+            },
+            "h2 code": {
+              fontSize: `${48 / 16}rem`,
+            },
+            h3: {
+              fontSize: `${37 / 16}rem`,
+              lineHeight: 1.4,
+            },
+            "h3 code": {
+              fontSize: `${37 / 16}rem`,
+            },
+            h4: {
+              fontSize: `${33 / 16}rem`,
+              lineHeight: 1.5,
+            },
+            "h4 code": {
+              fontSize: `${33 / 16}rem`,
+            },
+            h5: {
+              fontSize: `${24 / 16}rem`,
+              lineHeight: 1.5,
+            },
+            "h5 code": {
+              fontSize: `${24 / 16}rem`,
+            },
+            h6: {
+              fontSize: `${20 / 16}rem`,
+              lineHeight: 1.5,
+            },
+            "h6 code": {
+              fontSize: `${20 / 16}rem`,
+            },
+            p: {
+              fontSize: `${24 / 16}rem`,
+              lineHeight: 1.5,
+            },
+            li: {
+              fontSize: `${24 / 16}rem`,
+              lineHeight: 1.5,
+            },
+            ".paragraph": {
+              fontSize: `${24 / 16}rem`,
+              lineHeight: 1.5,
+            },
+            ".markdown > span.paragraph": {
+              fontSize: `${24 / 16}rem`,
+              lineHeight: 1.5,
+            },
+            // Set default font size for prose content
+            ".prose": {
+              fontSize: `${24 / 16}rem`,
+              lineHeight: 1.5,
+            },
+          },
+        },
       },
     },
   },

--- a/marimo/_plugins/core/web_component.py
+++ b/marimo/_plugins/core/web_component.py
@@ -82,7 +82,7 @@ def build_ui_plugin(
 
     attrs: list[str] = [_build_attr("initial-value", initial_value)]
     if label is not None and label:
-        attrs.append(_build_attr("label", _md(label, size="sm").text))
+        attrs.append(_build_attr("label", _md(label).text))
     else:
         attrs.append(_build_attr("label", None))
 

--- a/marimo/_smoke_tests/slides.py
+++ b/marimo/_smoke_tests/slides.py
@@ -1,20 +1,28 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "altair",
+#     "pandas",
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo
 
-__generated_with = "0.7.1"
+__generated_with = "0.8.11"
 app = marimo.App(layout_file="layouts/slides.slides.json")
 
 
 @app.cell
 def __(mo):
-    mo.md("# A Presentation on Iris Data")
+    mo.md("""# A Presentation on `Iris` Data""")
     return
 
 
 @app.cell
-def __():
-    "By the marimo team"
+def __(mo):
+    mo.md("""## By the marimo team (`@marimo_io`)""")
     return
 
 
@@ -55,7 +63,83 @@ def __(alt, df, mo):
 
 @app.cell
 def __(mo):
-    mo.md("# Thank you!")
+    mo.md("""# Thank you!""")
+    return
+
+
+@app.cell
+def __():
+    # Some markdown testing
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        # H1 (`H1`)
+        ## H2 (`H2`)
+        ### H3 (`H3`)
+        #### H4 (`H4`)
+        ##### H5 (`H5`)
+        ###### H6 (`H6`)
+        """
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        - Item 1
+        - `Item 2`
+        - **Item 3**
+        - _Item 4_
+        """
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        !!! note "Callouts"
+            This is a callout
+        """
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.callout("""
+    This is another callout
+    """)
+    return
+
+
+@app.cell
+def __():
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(r"""## Items that don't quite work in slides""")
+    return
+
+
+@app.cell
+def __(mo):
+    mo.accordion({"Accodrions too small": mo.md("Content")})
+    return
+
+
+@app.cell
+def __(mo):
+    mo.ui.tabs({"Tabs to small": mo.md("Content")})
     return
 
 


### PR DESCRIPTION
Add `prose-slides` to make all typography elements larger. 

![Screenshot 2024-09-06 at 10 10 06 AM](https://github.com/user-attachments/assets/8788fa02-64af-4550-aea0-c2833b34a80d)
![image](https://github.com/user-attachments/assets/642b33c1-099f-42b5-b692-a6da7cdb763c)

This should help with #2125 

Some ui elements are harder to override and may need another pass:
- accordion 
- tabs