### PR TITLE
fix: actually fix copilot stale requests

### DIFF
--- a/frontend/src/core/codemirror/copilot/extension.ts
+++ b/frontend/src/core/codemirror/copilot/extension.ts
@@ -109,7 +109,7 @@ function getCopilotRequest(
       indentSize: 1,
       insertSpaces: true,
       path: COPILOT_FILENAME,
-      version: 0,
+      version: "replace_me" as unknown as number,
       uri: `file://${COPILOT_FILENAME}`,
       relativePath: COPILOT_FILENAME,
       languageId: LANGUAGE_ID,
@@ -134,14 +134,8 @@ function getSuggestion(
   const startOffset = completionPosition.character - userPosition.character;
 
   // If startOffset is negative, we need to trim the beginning of displayText
-  const trimmedDisplayText =
-    startOffset < 0 ? displayText.slice(-startOffset) : displayText;
-
-  // If startOffset is positive, we need to prepend spaces
   const resultText =
-    startOffset > 0
-      ? " ".repeat(startOffset) + trimmedDisplayText
-      : trimmedDisplayText;
+    startOffset < 0 ? displayText.slice(-startOffset) : displayText;
 
   // If the end of the suggestion already exists next in the document, we should trim it,
   // for example closing quotes, brackets, etc.

--- a/frontend/src/core/codemirror/copilot/types.ts
+++ b/frontend/src/core/codemirror/copilot/types.ts
@@ -58,6 +58,7 @@ export interface CopilotGetCompletionsParams {
 export interface CopilotGetCompletionsResult {
   completions: Array<{
     text: string;
+    docVersion: number;
     position: {
       line: number;
       character: number;


### PR DESCRIPTION
This actually fixes the stale requests. When comparing the version, it was always `0` since we werent using `this.documentVersion`