### PR TITLE
fix: pagination and sort in csv viewer in the file-explorer panel

### DIFF
--- a/frontend/src/components/editor/file-tree/renderers.tsx
+++ b/frontend/src/components/editor/file-tree/renderers.tsx
@@ -4,11 +4,18 @@ import { DataTable } from "@/components/data-table/data-table";
 import { parseCsvData } from "@/plugins/impl/vega/loader";
 import { Objects } from "@/utils/objects";
 import type React from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { type Base64String, base64ToDataURL } from "@/utils/json/base64";
+import type { PaginationState } from "@tanstack/react-table";
+
+const PAGE_SIZE = 25;
 
 export const CsvViewer: React.FC<{ contents: string }> = ({ contents }) => {
   const data = useMemo(() => parseCsvData(contents), [contents]);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: PAGE_SIZE,
+  });
   const columns = useMemo(
     () =>
       generateColumns({
@@ -25,6 +32,9 @@ export const CsvViewer: React.FC<{ contents: string }> = ({ contents }) => {
       data={data}
       totalRows={data.length}
       columns={columns}
+      manualPagination={false}
+      paginationState={pagination}
+      setPaginationState={setPagination}
       wrapperClassName="h-full justify-between pb-1 px-1"
       pagination={true}
       className="rounded-none border-b flex overflow-hidden"

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -231,12 +231,20 @@ export const LoadingDataTableComponent = memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.setValue, filters, searchQuery, sorting]);
 
-    // If pageSize changes, reset pageSize
+    // If pageSize changes, reset pagination state
     useEffect(() => {
       if (paginationState.pageSize !== props.pageSize) {
-        setPaginationState((state) => ({ ...state, pageSize: props.pageSize }));
+        setPaginationState({
+          pageIndex: 0,
+          pageSize: props.pageSize,
+        });
       }
     }, [props.pageSize, paginationState.pageSize]);
+
+    // If total rows change, reset pageIndex
+    useEffect(() => {
+      setPaginationState((state) => ({ ...state, pageIndex: 0 }));
+    }, [props.totalRows]);
 
     // Data loading
     const { data, loading, error } = useAsyncData<{
@@ -502,8 +510,10 @@ const DataTableComponent = ({
             className={className}
             sorting={sorting}
             totalRows={totalRows}
+            manualSorting={true}
             setSorting={setSorting}
             pagination={pagination}
+            manualPagination={true}
             paginationState={paginationState}
             setPaginationState={setPaginationState}
             rowSelection={rowSelection}


### PR DESCRIPTION
- fix pagination and sort in csv viewer in the file-explorer panel
- reset pagination state whenever the total rows changes or pageSize changes (go back to the first page)