### PR TITLE
Adds SymPy expression rendering support (#1412)

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -134,6 +134,7 @@ def _version_check(
 class DependencyManager:
     """Utilities for checking the status of dependencies."""
 
+    sympy = Dependency("sympy")
     pandas = Dependency("pandas")
     polars = Dependency("polars")
     ibis = Dependency("ibis")

--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -25,6 +25,7 @@ from marimo._output.formatters.plotly_formatters import PlotlyFormatter
 from marimo._output.formatters.seaborn_formatters import SeabornFormatter
 from marimo._output.formatters.structures import StructuresFormatter
 from marimo._output.formatters.tqdm_formatters import TqdmFormatter
+from marimo._output.formatters.sympy_formatters import SympyFormatter
 
 # Map from formatter factory's package name to formatter, for third-party
 # modules. These formatters will be registered if and when their associated
@@ -45,6 +46,7 @@ THIRD_PARTY_FACTORIES: dict[str, FormatterFactory] = {
     AnyWidgetFormatter.package_name(): AnyWidgetFormatter(),
     TqdmFormatter.package_name(): TqdmFormatter(),
     LetsPlotFormatter.package_name(): LetsPlotFormatter(),
+    SympyFormatter.package_name(): SympyFormatter(),
 }
 
 # Formatters for builtin types and other things that don't require a

--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -24,8 +24,8 @@ from marimo._output.formatters.pandas_formatters import PandasFormatter
 from marimo._output.formatters.plotly_formatters import PlotlyFormatter
 from marimo._output.formatters.seaborn_formatters import SeabornFormatter
 from marimo._output.formatters.structures import StructuresFormatter
-from marimo._output.formatters.tqdm_formatters import TqdmFormatter
 from marimo._output.formatters.sympy_formatters import SympyFormatter
+from marimo._output.formatters.tqdm_formatters import TqdmFormatter
 
 # Map from formatter factory's package name to formatter, for third-party
 # modules. These formatters will be registered if and when their associated

--- a/marimo/_output/formatters/sympy_formatters.py
+++ b/marimo/_output/formatters/sympy_formatters.py
@@ -1,0 +1,65 @@
+from marimo._output.formatters.formatter_factory import FormatterFactory
+from marimo._plugins.ui._impl.anywidget.init import init_marimo_widget
+
+
+from marimo._output.formatters.formatter_factory import FormatterFactory
+#import marimo as mo
+
+#print("LOADING SIMPY")
+#from sympy import latex
+def patch_sympy(*objs):
+    import marimo as mo
+    """adds the _mime_() method to the sympy objects
+    e.g.
+    Symbol._mime_ = sympy_html
+    example:
+    patch_sympy(Symbol, Integral)
+    """
+    from sympy import latex
+    for obj in objs:
+        #print("Monkey-Patching", obj)
+        # the lambda below is our sympy_html 
+        obj._mime_ = lambda obj: ("text/html", mo.md(f"""\\[{latex(obj)}\\]""").text)
+        #obj._mime_ = lambda obj: ("text/html", mo.md(f"""{latex(obj)}""").text)
+
+
+def sympy_as_md(obj):
+    import marimo as mo
+    from sympy import latex
+    """adds the _mime_() method to the sympy objects
+    e.g.
+    Symbol._mime_ = sympy_html
+    example:
+    patch_sympy(Symbol, Integral)
+    """
+    return ("text/html", mo.md(f"""\\[{latex(obj)}\\]""").text)
+
+
+class SympyFormatter(FormatterFactory):
+    @staticmethod
+    def package_name() -> str:
+        return "sympy"
+
+    def register(self) -> None:
+        print("SYMPY FORMMATER REGISTARTION")
+        import sympy  # type:ignore
+        #from sympy import Symbol, Integral, Derivative, Pow, Matrix, Mul, Add, Piecewise
+        from sympy.core.basic import Basic
+        from sympy.core.basic import Printable
+
+        #from sympy.physics.quantum.state import Wavefunction
+        #monkey patching Symbol, Derivative, Pow etc
+        #monkey patch the printable class so anything that can produce output with
+        # latex(expr) e.g. latex(x**2) --> x^{2}
+        patch_sympy(Printable)
+        #patch_sympy(Symbol, Derivative, Pow, Matrix, Integral, Mul, 
+        #            Add, Piecewise)
+
+
+        #from sympy import symbols, Matrix, latex
+
+        #from marimo._output import formatting
+        # @formatting.formatter(Integral)
+        #def _show_integral(integral: Integral) -> tuple[str, str]:
+        #    return sympy_as_md(integral)
+

--- a/marimo/_output/formatters/sympy_formatters.py
+++ b/marimo/_output/formatters/sympy_formatters.py
@@ -49,7 +49,7 @@ class SympyFormatter(FormatterFactory):
         from sympy.core.basic import Printable  # type: ignore
 
         # We will monkey-patch the Printable class so most Sympy constructs
-        # that can be "pretty-printed" that with sympy.latex
+        # that can be "pretty-printed" with sympy.latex
         # can also be rendered in marimo.
         # One way to test if an expression is supported is
         # with latex(expr)

--- a/marimo/_output/formatters/sympy_formatters.py
+++ b/marimo/_output/formatters/sympy_formatters.py
@@ -3,10 +3,7 @@ from marimo._plugins.ui._impl.anywidget.init import init_marimo_widget
 
 
 from marimo._output.formatters.formatter_factory import FormatterFactory
-#import marimo as mo
 
-#print("LOADING SIMPY")
-#from sympy import latex
 def patch_sympy(*objs):
     import marimo as mo
     """adds the _mime_() method to the sympy objects
@@ -17,10 +14,8 @@ def patch_sympy(*objs):
     """
     from sympy import latex
     for obj in objs:
-        #print("Monkey-Patching", obj)
         # the lambda below is our sympy_html 
         obj._mime_ = lambda obj: ("text/html", mo.md(f"""\\[{latex(obj)}\\]""").text)
-        #obj._mime_ = lambda obj: ("text/html", mo.md(f"""{latex(obj)}""").text)
 
 
 def sympy_as_md(obj):
@@ -41,22 +36,16 @@ class SympyFormatter(FormatterFactory):
         return "sympy"
 
     def register(self) -> None:
-        print("SYMPY FORMMATER REGISTARTION")
         import sympy  # type:ignore
-        #from sympy import Symbol, Integral, Derivative, Pow, Matrix, Mul, Add, Piecewise
-        from sympy.core.basic import Basic
         from sympy.core.basic import Printable
 
-        #from sympy.physics.quantum.state import Wavefunction
-        #monkey patching Symbol, Derivative, Pow etc
-        #monkey patch the printable class so anything that can produce output with
-        # latex(expr) e.g. latex(x**2) --> x^{2}
+        # We will monkey-patch the Printable class so most Sympy constructs
+        # that can be "pretty-printed" that with sympy.latex
+        # can also be rendered in marimo.
+        # One way to test if an experssion is supported is
+        # with latex(expr) 
+        # e.g. latex(x**2) --> x^{2}
         patch_sympy(Printable)
-        #patch_sympy(Symbol, Derivative, Pow, Matrix, Integral, Mul, 
-        #            Add, Piecewise)
-
-
-        #from sympy import symbols, Matrix, latex
 
         #from marimo._output import formatting
         # @formatting.formatter(Integral)

--- a/marimo/_output/formatters/sympy_formatters.py
+++ b/marimo/_output/formatters/sympy_formatters.py
@@ -1,27 +1,41 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import Any
+
+from marimo._messaging.mimetypes import KnownMimeType
 from marimo._output.formatters.formatter_factory import FormatterFactory
 
-def patch_sympy(*objs):
+
+def patch_sympy(*objs: Any) -> None:
     import marimo as mo
-    """adds the _mime_() method to the sympy objects
+
+    """adds the _mime_() method to sympy objects
     e.g.
     Symbol._mime_ = sympy_html
     example:
     patch_sympy(Symbol, Integral)
     """
-    from sympy import latex
+    from sympy import latex  # type: ignore
+
     for obj in objs:
-        # the lambda below is our sympy_html 
-        obj._mime_ = lambda obj: ("text/html", mo.md(f"""\\[{latex(obj)}\\]""").text)
+        # the lambda below is our sympy_html
+        obj._mime_ = lambda obj: (
+            "text/html",
+            mo.md(f"""\\[{latex(obj)}\\]""").text,
+        )
 
 
-def sympy_as_md(obj):
-    import marimo as mo
+def sympy_as_html(obj: Any) -> tuple[KnownMimeType, str]:
     from sympy import latex
-    """adds the _mime_() method to the sympy objects
+
+    import marimo as mo
+
+    """creates HTML output from a Printable Sympy object
     e.g.
-    Symbol._mime_ = sympy_html
     example:
-    patch_sympy(Symbol, Integral)
+    integral = Integral(x**2, x)
+    sympy_as_html(integral)
     """
     return ("text/html", mo.md(f"""\\[{latex(obj)}\\]""").text)
 
@@ -32,19 +46,17 @@ class SympyFormatter(FormatterFactory):
         return "sympy"
 
     def register(self) -> None:
-        import sympy  # type:ignore
-        from sympy.core.basic import Printable
+        from sympy.core.basic import Printable  # type: ignore
 
         # We will monkey-patch the Printable class so most Sympy constructs
         # that can be "pretty-printed" that with sympy.latex
         # can also be rendered in marimo.
-        # One way to test if an experssion is supported is
-        # with latex(expr) 
+        # One way to test if an expression is supported is
+        # with latex(expr)
         # e.g. latex(x**2) --> x^{2}
         patch_sympy(Printable)
 
-        #from marimo._output import formatting
+        # from marimo._output import formatting
         # @formatting.formatter(Integral)
-        #def _show_integral(integral: Integral) -> tuple[str, str]:
-        #    return sympy_as_md(integral)
-
+        # def _show_integral(integral: Integral) -> tuple[KnownMimeType, str]:
+        #    return sympy_as_html(integral)

--- a/marimo/_output/formatters/sympy_formatters.py
+++ b/marimo/_output/formatters/sympy_formatters.py
@@ -1,8 +1,4 @@
 from marimo._output.formatters.formatter_factory import FormatterFactory
-from marimo._plugins.ui._impl.anywidget.init import init_marimo_widget
-
-
-from marimo._output.formatters.formatter_factory import FormatterFactory
 
 def patch_sympy(*objs):
     import marimo as mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ testoptional = [
     "anthropic==0.34.1",
     # exporting as ipynb
     "nbformat >=5.10.4",
+    "sympy>=1.13.2",
 ]
 
 [project.urls]

--- a/tests/_output/formatters/test_sympy.py
+++ b/tests/_output/formatters/test_sympy.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._output.formatters.formatters import register_formatters
+from marimo._output.formatting import (
+    get_formatter,
+)
+
+HAS_DEPS = DependencyManager.sympy.has()
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_sympy_formatters_basic_symbols() -> None:
+    register_formatters()
+
+    from sympy import symbols
+
+    x, y = symbols("x y")
+
+    # x Symbol
+    formatter = get_formatter(x, include_opinionated=False)
+    assert formatter
+    mime, content = formatter(x)
+    assert mime == "text/html"
+    assert content.find(r"||[x||]") > 0
+
+    # y Symbol
+    formatter = get_formatter(y, include_opinionated=False)
+    assert formatter
+    mime, content = formatter(y)
+    assert mime == "text/html"
+    assert content.find(r"||[y||]") > 0
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_sympy_formatters_addition() -> None:
+    register_formatters()
+
+    from sympy import symbols
+
+    x, y, z = symbols("x y z")
+    out_exp = x + y + z
+    # x + y + z
+    formatter = get_formatter(out_exp, include_opinionated=False)
+    assert formatter
+    mime, content = formatter(out_exp)
+    assert mime == "text/html"
+    assert content.find("||[x + y + z||]") > 0
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_sympy_formatters_power() -> None:
+    register_formatters()
+
+    from sympy import symbols
+
+    x, y, z = symbols("x y z")
+    x_squared = x**2
+
+    # x^2
+    formatter = get_formatter(x_squared, include_opinionated=False)
+    assert formatter
+    mime, content = formatter(x_squared)
+    assert mime == "text/html"
+    assert content.find("||[x^{2}||]") > 0
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_sympy_formatters_matrix() -> None:
+    register_formatters()
+
+    from sympy import Matrix, symbols
+
+    x, y, z = symbols("x y z")
+
+    # numeric matrix
+    M = Matrix([[1, 2], [3, 4]])
+    B = Matrix([[1 * x, 2 * y], [z, 4]])
+
+    # numeric matrix
+    formatter = get_formatter(M, include_opinionated=False)
+    assert formatter
+    mime, content = formatter(M)
+    assert mime == "text/html"
+    assert (
+        content.find(
+            r"||[\left[\begin{matrix}1 &amp; 2\\3 &amp; 4\end{matrix}\right]||]"  # noqa: E501
+        )
+        > 0
+    )
+    # symbolic matrix
+    formatter = get_formatter(B, include_opinionated=False)
+    assert formatter
+    mime, content = formatter(B)
+    assert mime == "text/html"
+    assert (
+        content.find(
+            r"||[\left[\begin{matrix}x &amp; 2 y\\z &amp; 4\end{matrix}\right]||]"  # noqa: E501
+        )
+        > 0
+    )
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_sympy_formatters_Integral() -> None:
+    register_formatters()
+
+    from sympy import Integral, sqrt, symbols
+
+    x, y, z = symbols("x y z")
+    out_exp = Integral(sqrt(1 / x), x)
+
+    # symbolic integral
+    formatter = get_formatter(out_exp, include_opinionated=False)
+    assert formatter
+    mime, content = formatter(out_exp)
+    assert mime == "text/html"
+    assert content.find(r"||[\int \sqrt{\frac{1}{x}}\, dx||]") > 0


### PR DESCRIPTION
## 📝 Summary
Adds SymPy expression rendering support, with output similar to Jupyter's notebooks. Fixes #1412 

## 🔍 Description of Changes
An analog to Jupyter lab pretty-printing of sympy expressions is missing from marimo. This code aims to solve that problem.

The codes adds an output formatter that applies a patch to Sympy `Printable` base class. This class is used in all the sympy printable expressions. The code  adds a `__mime__` attribute to the `Printable` with a function pointing to the sympy -> html marimo md formatter.

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers
@mscolnick
