### PR TITLE
perf: lazy imports when checking for datasets

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -38,6 +38,9 @@ class Dependency:
             max_v=max_version,
         )
 
+    def imported(self) -> bool:
+        return self.pkg in sys.modules
+
     def require(self, why: str) -> None:
         """
         Raise an ModuleNotFoundError if the package is not installed.
@@ -162,6 +165,14 @@ class DependencyManager:
     def has(pkg: str) -> bool:
         """Return True if any lib is installed."""
         return Dependency(pkg).has()
+
+    @staticmethod
+    def imported(pkg: str) -> bool:
+        """Return True if the lib has been imported.
+
+        Can be much faster than 'has'.
+        """
+        return Dependency(pkg).imported()
 
     @staticmethod
     def which(pkg: str) -> bool:

--- a/marimo/_plugins/ui/_impl/tables/utils.py
+++ b/marimo/_plugins/ui/_impl/tables/utils.py
@@ -42,13 +42,16 @@ def get_table_manager_or_none(data: Any) -> TableManager[Any] | None:
 
     # Try to find a manager specifically for the data type
     for manager_factory in MANAGERS:
-        if DependencyManager.has(manager_factory.package_name()):
+        # We use `imported` instead of `has()` because `has()` can be very
+        # slow. If a variable created by a package is in memory, then the
+        # module will have been imported.
+        if DependencyManager.imported(manager_factory.package_name()):
             manager = manager_factory.create()
             if manager.is_type(data):
                 return manager(data)
 
     # Unpack narwhal dataframe wrapper
-    if DependencyManager.narwhals.has():
+    if DependencyManager.narwhals.imported():
         import narwhals  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
 
         if isinstance(data, narwhals.DataFrame):

--- a/tests/_dependencies/test_dependencies.py
+++ b/tests/_dependencies/test_dependencies.py
@@ -16,12 +16,16 @@ def test_dependencies() -> None:
 
         assert altair is not None
         DependencyManager.altair.require("for testing")
+        assert DependencyManager.altair.imported()
+        assert DependencyManager.imported("altair")
 
     if DependencyManager.pandas.has():
         import pandas
 
         assert pandas is not None
         DependencyManager.pandas.require("for testing")
+        assert DependencyManager.pandas.imported()
+        assert DependencyManager.imported("pandas")
 
 
 def test_without_dependencies() -> None:


### PR DESCRIPTION
This change adds an `imported()` method to the DependencyManager that checks whether a module has been imported, and updates the broadcast-datasets codepath to use this check instead of DependencyManager.has().

Previously, running an arbitrary line of code (eg import marimo as mo) could take 10+ seconds, as our table libraries (such as pandas) were all being eagerly imported in order to check if a variable was of a table type. Instead, this change only does the import and instance check if the module has already been imported, which should be the case if an instance of it is in memory.

With this change, import marimo as mo takes just ms.

The bottleneck was discovered with cProfile using the --profile-dir development CLI arg:

```
marimo edit --profile-dir profiles/ notebook.py
```

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/3692b1c3-c452-44d9-908a-7e84457af01b">


