### PR TITLE
fix: upperbound on duckdb 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ marimo = "marimo._cli.cli:main"
 
 [project.optional-dependencies]
 sql = [
-    "duckdb >= 1.0.0",
+    "duckdb>=1.0.0,<1.1.0",
 ]
 
 dev = [


### PR DESCRIPTION
While we investigate why duckdb 1.1.0 breaks in marimo, we should pin an upper bound:

Fixes #2277 
Related to #2272