### PR TITLE
fix: support duckdb 1.1.0, update globals() for scanning

### DIFF
--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -50,8 +50,8 @@ def sql(
     original_globals: Optional[dict[str, Any]] = None
     try:
         ctx = get_context()
-        globals().update(ctx.globals)
         original_globals = dict(globals())
+        globals().update(ctx.globals)
     except ContextNotInitializedError:
         pass
 
@@ -60,6 +60,7 @@ def sql(
     finally:
         # Restore the original globals
         if original_globals is not None:
+            globals().clear()
             globals().update(original_globals)
 
     if not relation:

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -46,23 +46,17 @@ def sql(
     # the kernel globals, it just returns this module's global namespace.
     #
     # However, duckdb needs access to the kernel's globals. For this reason,
-    # we temporarily update globals() to include the context globals so that
-    # the query can scan the global namespace for dataframes.
-    original_globals: Optional[dict[str, Any]] = None
+    # we manually exec duckdb and provide it with the kernel's globals.
     try:
         ctx = get_context()
     except ContextNotInitializedError:
-        pass
-    else:
-        original_globals = dict(globals())
-        globals().update(ctx.globals)
-
-    try:
         relation = duckdb.sql(query=query)
-    finally:
-        if original_globals is not None:
-            globals().clear()
-            globals().update(original_globals)
+    else:
+        relation = eval(
+            "duckdb.sql(query=query)",
+            ctx.globals,
+            {"query": query, "duckdb": duckdb},
+        )
 
     if not relation:
         return None

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -19,10 +19,6 @@ def get_default_result_limit() -> Optional[int]:
     return int(limit) if limit is not None else None
 
 
-# if "duckdb" not in globals():
-#     import duckdb
-
-
 @mddoc
 def sql(
     query: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dev = [
     # For server testing
     "httpx~=0.27.0",
     # For SQL
-    "duckdb~=1.0.0",
+    "duckdb~=1.1.0",
     # For testing mo.ui.chart, dataframes, tables
     "pandas>=1.5.3",
     "pandas-stubs>=1.5.3.230321",


### PR DESCRIPTION
`duckdb`s scanning must have changed in 1.1.0 such that we need to augment the default `globals()` with the notebook `globals()`. this feels more correct, but I am unsure why this worked previously. 

Fixes #2277 #2272