### PR TITLE
feat: add Auto-export to markdown or html from the marimo editor

### DIFF
--- a/frontend/src/components/editor/actions/types.ts
+++ b/frontend/src/components/editor/actions/types.ts
@@ -7,7 +7,9 @@ import type { HotkeyAction } from "@/core/hotkeys/hotkeys";
  */
 export interface ActionButton {
   label: string;
-  variant?: "danger";
+  labelElement?: React.ReactNode;
+  description?: string;
+  variant?: "danger" | "muted" | "disabled";
   disableClick?: boolean;
   icon?: React.ReactElement;
   hidden?: boolean;
@@ -37,6 +39,10 @@ export function flattenActions(
   prevLabel = "",
 ): ActionButton[] {
   return actions.flatMap((action) => {
+    // If label is empty, hide
+    if (!action.label) {
+      return [];
+    }
     if (isParentAction(action)) {
       return flattenActions(action.dropdown, `${prevLabel + action.label} > `);
     }

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -30,6 +30,7 @@ import {
   EditIcon,
   LayoutTemplateIcon,
   Files,
+  FolderSyncIcon,
 } from "lucide-react";
 import { commandPaletteAtom } from "../controls/command-palette";
 import { useCellActions, useNotebook } from "@/core/cells/cells";
@@ -64,6 +65,11 @@ import { useLayoutState, useLayoutActions } from "@/core/layout/layout";
 import { useTogglePresenting } from "@/core/layout/useTogglePresenting";
 import { useCopyNotebook } from "./useCopyNotebook";
 import { isWasm } from "@/core/wasm/utils";
+import {
+  autoExportHTMLAtom,
+  autoExportMarkdownAtom,
+} from "@/core/export/state";
+import { Kbd } from "@/components/ui/kbd";
 
 const NOOP_HANDLER = (event?: Event) => {
   event?.preventDefault();
@@ -90,6 +96,16 @@ export function useNotebookActions() {
   const { selectedLayout } = useLayoutState();
   const { setLayoutView } = useLayoutActions();
   const togglePresenting = useTogglePresenting();
+  const [autoExportHTML, setAutoExportHTML] = useAtom(autoExportHTMLAtom);
+  const [autoExportMarkdown, setAutoExportMarkdown] = useAtom(
+    autoExportMarkdownAtom,
+  );
+
+  const renderCheckboxElement = (checked: boolean) => (
+    <div className="w-8 flex justify-end">
+      {checked && <CheckIcon size={14} />}
+    </div>
+  );
 
   const actions: ActionButton[] = [
     {
@@ -216,6 +232,65 @@ export function useNotebookActions() {
     },
 
     {
+      icon: <FolderSyncIcon size={14} strokeWidth={1.5} />,
+      label: "Auto-export",
+      hidden: isWasm(),
+      handle: NOOP_HANDLER,
+      dropdown: [
+        {
+          label: "",
+          labelElement: (
+            <span className="text-muted-foreground text-sm block w-[18rem]">
+              When enabled, the notebook will automatically export to HTML or
+              Markdown to a folder <Kbd className="inline">.marimo</Kbd> in the
+              notebook's directory.
+            </span>
+          ),
+          variant: "disabled",
+          handle: NOOP_HANDLER,
+          disableClick: true,
+        },
+        {
+          divider: true,
+          icon: <FolderDownIcon size={14} strokeWidth={1.5} />,
+          label: "Auto Export HTML on changes",
+          rightElement: renderCheckboxElement(autoExportHTML),
+          handle: async () => {
+            if (!filename) {
+              toast({
+                variant: "danger",
+                title: "Error",
+                description: "Notebooks must be named to be exported.",
+              });
+              return;
+            }
+
+            setAutoExportHTML((val) => !val);
+          },
+        },
+        {
+          icon: (
+            <MarkdownIcon strokeWidth={1.5} style={{ width: 14, height: 14 }} />
+          ),
+          label: "Auto Export Markdown on changes",
+          rightElement: renderCheckboxElement(autoExportMarkdown),
+          handle: async () => {
+            if (!filename) {
+              toast({
+                variant: "danger",
+                title: "Error",
+                description: "Notebooks must be named to be exported.",
+              });
+              return;
+            }
+
+            setAutoExportMarkdown((val) => !val);
+          },
+        },
+      ],
+    },
+
+    {
       divider: true,
       icon: <PanelLeftIcon size={14} strokeWidth={1.5} />,
       label: "Helper panel",
@@ -226,11 +301,7 @@ export function useNotebookActions() {
         }
         return {
           label: startCase(type),
-          rightElement: (
-            <div className="w-8 flex justify-end">
-              {selectedPanel === type && <CheckIcon size={14} />}
-            </div>
-          ),
+          rightElement: renderCheckboxElement(selectedPanel === type),
           icon: <Icon size={14} strokeWidth={1.5} />,
           handle: () => openApplication(type),
         };

--- a/frontend/src/components/editor/controls/notebook-menu-dropdown.tsx
+++ b/frontend/src/components/editor/controls/notebook-menu-dropdown.tsx
@@ -38,7 +38,7 @@ export const NotebookMenuDropdown: React.FC = () => {
     return (
       <>
         {action.icon && <span className="flex-0 mr-2">{action.icon}</span>}
-        <span className="flex-1">{action.label}</span>
+        <span className="flex-1">{action.labelElement || action.label}</span>
         {action.hotkey && (
           <MinimalShortcut shortcut={action.hotkey} className="ml-4" />
         )}

--- a/frontend/src/components/ui/menu-items.tsx
+++ b/frontend/src/components/ui/menu-items.tsx
@@ -70,6 +70,7 @@ export const menuItemVariants = cva(
           "focus:bg-muted/70 focus:text-muted-foreground aria-selected:bg-muted/70 aria-selected:text-muted-foreground",
         success:
           "focus:bg-[var(--grass-3)] focus:text-[var(--grass-11)] aria-selected:bg-[var(--grass-3)] aria-selected:text-[var(--grass-11)]",
+        disabled: "text-muted-foreground",
       },
     },
     defaultVariants: {

--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -62,6 +62,7 @@ import { useJotaiEffect } from "./state/jotai";
 import { Paths } from "@/utils/paths";
 import { KnownQueryParams } from "./constants";
 import { useTogglePresenting } from "./layout/useTogglePresenting";
+import { useAutoExport } from "./export/hooks";
 
 interface AppProps {
   userConfig: UserConfig;
@@ -225,6 +226,7 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
     config: userConfig,
     kioskMode: kioskMode,
   });
+  useAutoExport();
 
   useEventListener(window, "beforeunload", (e: BeforeUnloadEvent) => {
     if (isStaticNotebook()) {

--- a/frontend/src/core/export/hooks.ts
+++ b/frontend/src/core/export/hooks.ts
@@ -1,0 +1,43 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { useAtomValue } from "jotai";
+import { autoExportHTMLAtom, autoExportMarkdownAtom } from "./state";
+import { useInterval } from "@/hooks/useInterval";
+import { autoExportAsHTML, autoExportAsMarkdown } from "../network/requests";
+import { VirtualFileTracker } from "../static/virtual-file-tracker";
+import { connectionAtom } from "../network/connection";
+import { WebSocketState } from "../websocket/types";
+
+const DELAY = 5000; // 5 seconds;
+
+export function useAutoExport() {
+  const markdownEnabled = useAtomValue(autoExportMarkdownAtom);
+  const htmlEnabled = useAtomValue(autoExportHTMLAtom);
+  const { state } = useAtomValue(connectionAtom);
+
+  const markdownDisabled = !markdownEnabled || state !== WebSocketState.OPEN;
+  const htmlDisabled = !htmlEnabled || state !== WebSocketState.OPEN;
+
+  useInterval(
+    async () => {
+      await autoExportAsMarkdown({
+        download: false,
+      });
+    },
+    // Run every 5 seconds, or when the document becomes visible
+    // Ignore if the document is not visible
+    { delayMs: DELAY, whenVisible: true, disabled: markdownDisabled },
+  );
+
+  useInterval(
+    async () => {
+      await autoExportAsHTML({
+        download: false,
+        includeCode: true,
+        files: VirtualFileTracker.INSTANCE.filenames(),
+      });
+    },
+    // Run every 5 seconds, or when the document becomes visible
+    // Ignore if the document is not visible
+    { delayMs: DELAY, whenVisible: true, disabled: htmlDisabled },
+  );
+}

--- a/frontend/src/core/export/state.ts
+++ b/frontend/src/core/export/state.ts
@@ -1,0 +1,6 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { atom } from "jotai";
+
+export const autoExportMarkdownAtom = atom(false);
+export const autoExportHTMLAtom = atom(false);

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -152,6 +152,8 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   openTutorial = throwNotImplemented;
   exportAsHTML = throwNotImplemented;
   exportAsMarkdown = throwNotImplemented;
+  autoExportAsHTML = throwNotImplemented;
+  autoExportAsMarkdown = throwNotImplemented;
   getRecentFiles = throwNotImplemented;
   getWorkspaceFiles = throwNotImplemented;
   getRunningNotebooks = throwNotImplemented;

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -266,5 +266,19 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         })
         .then(handleResponse);
     },
+    autoExportAsHTML: async (request) => {
+      return marimoClient
+        .POST("/api/export/auto_export/html", {
+          body: request,
+        })
+        .then(handleResponseReturnNull);
+    },
+    autoExportAsMarkdown: async (request) => {
+      return marimoClient
+        .POST("/api/export/auto_export/markdown", {
+          body: request,
+        })
+        .then(handleResponseReturnNull);
+    },
   };
 }

--- a/frontend/src/core/network/requests-static.ts
+++ b/frontend/src/core/network/requests-static.ts
@@ -66,5 +66,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     shutdownSession: throwNotInEditMode,
     exportAsHTML: throwNotInEditMode,
     exportAsMarkdown: throwNotInEditMode,
+    autoExportAsHTML: throwNotInEditMode,
+    autoExportAsMarkdown: throwNotInEditMode,
   };
 }

--- a/frontend/src/core/network/requests-toasting.ts
+++ b/frontend/src/core/network/requests-toasting.ts
@@ -32,7 +32,7 @@ export function createErrorToastingRequests(
     readSnippets: "Failed to fetch snippets",
     previewDatasetColumn: "Failed to fetch data sources",
     openFile: "Failed to open file",
-    getUsageStats: "", // Empty string because we don't show a toast for this
+    getUsageStats: "", // No toast
     sendListFiles: "Failed to list files",
     sendCreateFileOrFolder: "Failed to create file or folder",
     sendDeleteFileOrFolder: "Failed to delete file or folder",
@@ -47,6 +47,8 @@ export function createErrorToastingRequests(
     shutdownSession: "Failed to shutdown session",
     exportAsHTML: "Failed to export HTML",
     exportAsMarkdown: "Failed to export Markdown",
+    autoExportAsHTML: "", // No toast
+    autoExportAsMarkdown: "", // No toast
   };
 
   const handlers = {} as EditRequests & RunRequests;

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -64,4 +64,6 @@ export const {
   shutdownSession,
   exportAsHTML,
   exportAsMarkdown,
+  autoExportAsHTML,
+  autoExportAsMarkdown,
 } = getRequest();

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -143,6 +143,8 @@ export interface EditRequests {
   ) => Promise<RunningNotebooksResponse>;
   exportAsHTML: (request: ExportAsHTMLRequest) => Promise<string>;
   exportAsMarkdown: (request: ExportAsMarkdownRequest) => Promise<string>;
+  autoExportAsHTML: (request: ExportAsHTMLRequest) => Promise<null>;
+  autoExportAsMarkdown: (request: ExportAsMarkdownRequest) => Promise<null>;
 }
 
 export type RequestKey = keyof (EditRequests & RunRequests);

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -424,6 +424,8 @@ export class PyodideBridge implements RunRequests, EditRequests {
   getWorkspaceFiles = throwNotImplemented;
   getRunningNotebooks = throwNotImplemented;
   shutdownSession = throwNotImplemented;
+  autoExportAsHTML = throwNotImplemented;
+  autoExportAsMarkdown = throwNotImplemented;
 
   private async putControlRequest(operation: object) {
     await this.rpc.proxy.request.bridge({

--- a/frontend/src/hooks/useInterval.ts
+++ b/frontend/src/hooks/useInterval.ts
@@ -10,9 +10,10 @@ export function useInterval(
   opts: {
     delayMs: number | null;
     whenVisible: boolean;
+    disabled?: boolean;
   },
 ) {
-  const { delayMs, whenVisible } = opts;
+  const { delayMs, whenVisible, disabled = false } = opts;
   const savedCallback = useRef<() => void>();
 
   // Store the callback
@@ -22,7 +23,7 @@ export function useInterval(
 
   // Run the interval
   useEffect(() => {
-    if (delayMs === null) {
+    if (delayMs === null || disabled) {
       return;
     }
 
@@ -35,11 +36,11 @@ export function useInterval(
     }, delayMs);
 
     return () => clearInterval(id);
-  }, [delayMs, whenVisible]);
+  }, [delayMs, whenVisible, disabled]);
 
   // When the document becomes visible, run the callback
   useEventListener(document, "visibilitychange", () => {
-    if (document.visibilityState === "visible" && whenVisible) {
+    if (document.visibilityState === "visible" && whenVisible && !disabled) {
       savedCallback.current?.();
     }
   });

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -5,19 +5,20 @@ from typing import TYPE_CHECKING
 
 from starlette.authentication import requires
 from starlette.exceptions import HTTPException
-from starlette.responses import HTMLResponse, PlainTextResponse
+from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
 from marimo import _loggers
 from marimo._server.api.deps import AppState
 from marimo._server.api.status import HTTPStatus
 from marimo._server.api.utils import parse_request
-from marimo._server.export.exporter import Exporter
+from marimo._server.export.exporter import AutoExporter, Exporter
 from marimo._server.model import SessionMode
 from marimo._server.models.export import (
     ExportAsHTMLRequest,
     ExportAsMarkdownRequest,
     ExportAsScriptRequest,
 )
+from marimo._server.models.models import SuccessResponse
 from marimo._server.router import APIRouter
 
 if TYPE_CHECKING:
@@ -78,6 +79,63 @@ async def export_as_html(
         content=html,
         headers=headers,
     )
+
+
+@router.post("/auto_export/html")
+@requires("edit")
+async def auto_export_as_html(
+    *,
+    request: Request,
+) -> SuccessResponse | JSONResponse:
+    """
+    requestBody:
+        content:
+            application/json:
+                schema:
+                    $ref: "#/components/schemas/ExportAsHTMLRequest"
+    responses:
+        200:
+            description: Export the notebook as HTML
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/SuccessResponse"
+        400:
+            description: File must be saved before downloading
+    """
+    app_state = AppState(request)
+    body = await parse_request(request, cls=ExportAsHTMLRequest)
+    session = app_state.require_current_session()
+    session_view = session.session_view
+
+    # If we have already exported to HTML, don't do it again
+    if session_view.has_auto_exported_html:
+        LOGGER.debug("Already auto-exported to HTML")
+        return JSONResponse(
+            status_code=HTTPStatus.NOT_MODIFIED,
+            content={},
+        )
+
+    # Reload the file manager to get the latest state
+    session.app_file_manager.reload()
+
+    html, _filename = Exporter().export_as_html(
+        file_manager=session.app_file_manager,
+        session_view=session_view,
+        display_config=app_state.session_manager.user_config_manager.get_config()[
+            "display"
+        ],
+        request=body,
+    )
+
+    # Save the HTML file to disk, at `.marimo/<filename>.html`
+    AutoExporter().save_html(
+        file_manager=session.app_file_manager,
+        html=html,
+    )
+    session_view.mark_auto_export_html()
+
+    return SuccessResponse()
 
 
 @router.post("/script")
@@ -170,3 +228,54 @@ async def export_as_markdown(
         content=markdown,
         headers=headers,
     )
+
+
+@router.post("/auto_export/markdown")
+@requires("edit")
+async def auto_export_as_markdown(
+    *,
+    request: Request,
+) -> SuccessResponse | JSONResponse:
+    """
+    requestBody:
+        content:
+            application/json:
+                schema:
+                    $ref: "#/components/schemas/ExportAsMarkdownRequest"
+    responses:
+        200:
+            description: Export the notebook as a markdown
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/SuccessResponse"
+        400:
+            description: File must be saved before downloading
+    """
+    app_state = AppState(request)
+    session = app_state.require_current_session()
+    session_view = session.session_view
+
+    # If we have already exported to Markdown, don't do it again
+    if session_view.has_auto_exported_md:
+        LOGGER.debug("Already auto-exported to Markdown")
+        return JSONResponse(
+            status_code=HTTPStatus.NOT_MODIFIED,
+            content={},
+        )
+
+    # Reload the file manager to get the latest state
+    session.app_file_manager.reload()
+
+    markdown, _filename = Exporter().export_as_md(
+        file_manager=session.app_file_manager,
+    )
+
+    # Save the Markdown file to disk, at `.marimo/<filename>.md`
+    AutoExporter().save_md(
+        file_manager=session.app_file_manager,
+        markdown=markdown,
+    )
+    session_view.mark_auto_export_md()
+
+    return SuccessResponse()

--- a/marimo/_server/api/status.py
+++ b/marimo/_server/api/status.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 class HTTPStatus(IntEnum):
     OK = 200
+    NOT_MODIFIED = 304
     BAD_REQUEST = 400
     FORBIDDEN = 403
     NOT_FOUND = 404

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -248,3 +248,43 @@ class Exporter:
 
         download_filename = get_download_filename(file_manager, ".md")
         return "\n".join(document).strip(), download_filename
+
+
+class AutoExporter:
+    EXPORT_DIR = ".marimo"
+
+    def save_html(self, file_manager: AppFileManager, html: str) -> None:
+        # get filename
+        directory = os.path.dirname(get_filename(file_manager))
+        filename = get_download_filename(file_manager, "html")
+
+        # make directory if it doesn't exist
+        self._make_export_dir(directory)
+        filepath = os.path.join(directory, self.EXPORT_DIR, filename)
+
+        # save html to .marimo directory
+        with open(filepath, "w") as f:
+            f.write(html)
+
+    def save_md(self, file_manager: AppFileManager, markdown: str) -> None:
+        # get filename
+        directory = os.path.dirname(get_filename(file_manager))
+        filename = get_download_filename(file_manager, "md")
+
+        # make directory if it doesn't exist
+        self._make_export_dir(directory)
+        filepath = os.path.join(directory, self.EXPORT_DIR, filename)
+
+        # save md to .marimo directory
+        with open(filepath, "w") as f:
+            f.write(markdown)
+
+    def _make_export_dir(self, directory: str) -> None:
+        # make .marimo dir if it doesn't exist
+        # don't make the other directories
+        if not os.path.exists(directory):
+            raise FileNotFoundError(f"Directory {directory} does not exist")
+
+        export_dir = os.path.join(directory, self.EXPORT_DIR)
+        if not os.path.exists(export_dir):
+            os.mkdir(export_dir)

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -4,6 +4,34 @@ components:
       properties:
         code:
           type: string
+        context:
+          nullable: true
+          properties:
+            schema:
+              items:
+                properties:
+                  columns:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                required:
+                - name
+                - columns
+                type: object
+              type: array
+          required:
+          - schema
+          type: object
         includeOtherCode:
           type: string
         language:
@@ -274,6 +302,16 @@ components:
       - prefix_length
       - options
       - name
+      type: object
+    CopyNotebookRequest:
+      properties:
+        destination:
+          type: string
+        source:
+          type: string
+      required:
+      - source
+      - destination
       type: object
     CreationRequest:
       properties:
@@ -1816,7 +1854,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.8.4
+  version: 0.8.14
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:
@@ -1877,6 +1915,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/Snippets'
           description: Load the snippets for the documentation page
+  /api/export/auto_export/html:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportAsHTMLRequest'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+          description: Export the notebook as HTML
+        400:
+          description: File must be saved before downloading
+  /api/export/auto_export/markdown:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportAsMarkdownRequest'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+          description: Export the notebook as a markdown
+        400:
+          description: File must be saved before downloading
   /api/export/html:
     post:
       requestBody:
@@ -2083,6 +2153,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
           description: Complete a code fragment
+  /api/kernel/copy:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CopyNotebookRequest'
+      responses:
+        200:
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Copy notebook
   /api/kernel/delete:
     post:
       requestBody:
@@ -2241,20 +2325,6 @@ paths:
               schema:
                 type: string
           description: Save the current app
-  /api/kernel/copy:
-    post:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CopyNotebookRequest'
-      responses:
-        200:
-          content:
-            text/plain:
-              schema:
-                type: string
-          description: Copy notebook
   /api/kernel/save_app_config:
     post:
       requestBody:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -165,6 +165,98 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/export/auto_export/html": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ExportAsHTMLRequest"];
+        };
+      };
+      responses: {
+        /** @description Export the notebook as HTML */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/export/auto_export/markdown": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ExportAsMarkdownRequest"];
+        };
+      };
+      responses: {
+        /** @description Export the notebook as a markdown */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/export/html": {
     parameters: {
       query?: never;
@@ -763,6 +855,45 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/kernel/copy": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["CopyNotebookRequest"];
+        };
+      };
+      responses: {
+        /** @description Copy notebook */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/plain": string;
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/kernel/delete": {
     parameters: {
       query?: never;
@@ -1217,45 +1348,6 @@ export interface paths {
       };
       responses: {
         /** @description Save the current app */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/plain": string;
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/copy": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["CopyNotebookRequest"];
-        };
-      };
-      responses: {
-        /** @description Save the app as a new file */
         200: {
           headers: {
             [name: string]: unknown;
@@ -1768,6 +1860,15 @@ export interface components {
   schemas: {
     AiCompletionRequest: {
       code: string;
+      context?: {
+        schema: {
+          columns: {
+            name: string;
+            type: string;
+          }[];
+          name: string;
+        }[];
+      } | null;
       includeOtherCode: string;
       /** @enum {string} */
       language: "python" | "markdown" | "sql";
@@ -1881,6 +1982,10 @@ export interface components {
         type: string;
       }[];
       prefix_length: number;
+    };
+    CopyNotebookRequest: {
+      destination: string;
+      source: string;
     };
     CreationRequest: {
       executionRequests: components["schemas"]["ExecutionRequest"][];
@@ -2405,10 +2510,6 @@ export interface components {
       } | null;
       names: string[];
       persist: boolean;
-    };
-    CopyNotebookRequest: {
-      source: string;
-      destination: string;
     };
     SaveUserConfigurationRequest: {
       config: components["schemas"]["MarimoConfig"];

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from marimo import __version__
@@ -163,3 +164,116 @@ def test_other_exports_dont_work_in_read(client: TestClient) -> None:
         },
     )
     assert response.status_code == 401
+
+
+@with_session(SESSION_ID)
+def test_auto_export_html(client: TestClient, temp_marimo_file: str) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    print(temp_marimo_file)
+    assert temp_marimo_file is not None
+    session.app_file_manager.filename = temp_marimo_file
+
+    response = client.post(
+        "/api/export/auto_export/html",
+        headers=HEADERS,
+        json={
+            "download": False,
+            "files": [],
+            "include_code": True,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+
+    response = client.post(
+        "/api/export/auto_export/html",
+        headers=HEADERS,
+        json={
+            "download": False,
+            "files": [],
+            "include_code": True,
+        },
+    )
+    # Not modified response
+    assert response.status_code == 304
+    assert response.json() == {}
+
+    # Assert .marimo file is created
+    assert os.path.exists(
+        os.path.join(os.path.dirname(temp_marimo_file), ".marimo")
+    )
+
+
+@with_session(SESSION_ID)
+def test_auto_export_html_no_code(
+    client: TestClient, temp_marimo_file: str
+) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.filename = temp_marimo_file
+
+    response = client.post(
+        "/api/export/auto_export/html",
+        headers=HEADERS,
+        json={
+            "download": False,
+            "files": [],
+            "include_code": False,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+
+    response = client.post(
+        "/api/export/auto_export/html",
+        headers=HEADERS,
+        json={
+            "download": False,
+            "files": [],
+            "include_code": False,
+        },
+    )
+    # Not modified response
+    assert response.status_code == 304
+    assert response.json() == {}
+
+    # Assert .marimo file is created
+    assert os.path.exists(
+        os.path.join(os.path.dirname(temp_marimo_file), ".marimo")
+    )
+
+
+@with_session(SESSION_ID)
+def test_auto_export_markdown(
+    client: TestClient, *, temp_marimo_file: str
+) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.filename = temp_marimo_file
+
+    response = client.post(
+        "/api/export/auto_export/markdown",
+        headers=HEADERS,
+        json={
+            "download": False,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+
+    response = client.post(
+        "/api/export/auto_export/markdown",
+        headers=HEADERS,
+        json={
+            "download": False,
+        },
+    )
+    # Not modified response
+    assert response.status_code == 304
+    assert response.json() == {}
+
+    # Assert .marimo file is created
+    assert os.path.exists(
+        os.path.join(os.path.dirname(temp_marimo_file), ".marimo")
+    )

--- a/tests/_server/session/test_session_view.py
+++ b/tests/_server/session/test_session_view.py
@@ -604,3 +604,31 @@ def test_get_cell_console_outputs(time_mock: Any) -> None:
         cell_id: [CellOutput.stdout("one"), CellOutput.stdout("two")],
         cell_2_id: [CellOutput.stdout("two")],
     }
+
+
+def test_mark_auto_export():
+    session_view = SessionView()
+    assert not session_view.has_auto_exported_html
+    assert not session_view.has_auto_exported_md
+
+    session_view.mark_auto_export_html()
+    assert session_view.has_auto_exported_html
+
+    session_view.mark_auto_export_md()
+    assert session_view.has_auto_exported_md
+
+    session_view._touch()
+    assert not session_view.has_auto_exported_html
+    assert not session_view.has_auto_exported_md
+
+    session_view.mark_auto_export_html()
+    session_view.mark_auto_export_md()
+    session_view.add_operation(
+        CellOp(
+            cell_id=cell_id,
+            output=initial_output,
+            status=initial_status,
+        ),
+    )
+    assert not session_view.has_auto_exported_html
+    assert not session_view.has_auto_exported_md


### PR DESCRIPTION
This adds a new notebook action to turn on "Auto-export to markdown/html" which does so every 5 seconds **only if there are changes**.

<img width="869" alt="Screenshot 2024-09-10 at 2 03 37 PM" src="https://github.com/user-attachments/assets/8451dcdd-66df-4521-b351-2ab53c137686">


cc @patrick-kidger - I figure you might be the first to want to try this. Once this releases, and if you do try it, could you give us some feedback on the ergonomics. I'd like to figure out if it should be per session (as it is today), CLI arg, User Config, App Config, etc.