### PR TITLE
fix: boolean charts in table headers for pandas 

### DIFF
--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -137,7 +137,8 @@ export class ColumnChartSpecModel<T> {
               field: column,
               type: "nominal",
               axis: {
-                labelExpr: "datum.label === 'true' ? 'True' : 'False'",
+                labelExpr:
+                  "datum.label === 'true' || datum.label === 'True'  ? 'True' : 'False'",
                 tickWidth: 0,
                 title: null,
                 labelColor: slate.slate9,
@@ -150,7 +151,7 @@ export class ColumnChartSpecModel<T> {
               scale: { type: "linear" },
             },
             tooltip: [
-              { field: column, type: "nominal", format: ",d", title: "Value" },
+              { field: column, type: "nominal", title: "Value" },
               {
                 aggregate: "count",
                 type: "quantitative",

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -4,6 +4,8 @@ import { mint, orange, slate } from "@radix-ui/colors";
 import type { ColumnHeaderSummary, FieldTypes } from "./types";
 import { asURL } from "@/utils/url";
 
+const MAX_BAR_HEIGHT = 24; // px
+
 export class ColumnChartSpecModel<T> {
   private columnSummaries = new Map<string | number, ColumnHeaderSummary>();
 
@@ -162,7 +164,11 @@ export class ColumnChartSpecModel<T> {
           },
           layer: [
             {
-              mark: { type: "bar", color: mint.mint11 },
+              mark: {
+                type: "bar",
+                color: mint.mint11,
+                height: MAX_BAR_HEIGHT,
+              },
             },
             {
               mark: {

--- a/marimo/_smoke_tests/tables/booleans.py
+++ b/marimo/_smoke_tests/tables/booleans.py
@@ -15,22 +15,33 @@ app = marimo.App(width="medium")
 @app.cell
 def __():
     import marimo as mo
-    return mo,
+    import pandas as pd
+    import polars as pl
+    return mo, pd, pl
 
 
 @app.cell
-def __():
-    import pandas as pd
-
+def __(pd):
     data = {
         "A": [True, True, True],
         "B": [False, False, False],
         "C": [True, True, False],
     }
 
-    df = pd.DataFrame(data)
-    df
-    return data, df, pd
+    pd.DataFrame(data)
+    return data,
+
+
+@app.cell
+def __(data, pl):
+    pl.DataFrame(data)
+    return
+
+
+@app.cell
+def __(data, mo):
+    mo.ui.table(data)
+    return
 
 
 if __name__ == "__main__":

--- a/marimo/_smoke_tests/tables/booleans.py
+++ b/marimo/_smoke_tests/tables/booleans.py
@@ -1,0 +1,37 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "pandas",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.8.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __():
+    import pandas as pd
+
+    data = {
+        "A": [True, True, True],
+        "B": [False, False, False],
+        "C": [True, True, False],
+    }
+
+    df = pd.DataFrame(data)
+    df
+    return data, df, pd
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Pandas serializes to `True` (unlike polars)

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/69822db5-9da6-4307-ac80-7b369a30080d">
