### PR TITLE
fix: latex mime, exlclude text/plain, depcheck perf

### DIFF
--- a/marimo/_data/series.py
+++ b/marimo/_data/series.py
@@ -61,7 +61,7 @@ def get_number_series_info(series: Any) -> NumberSeriesInfo:
             raise ValueError("Expected a number. Got: " + str(type(value)))
         return value
 
-    if DependencyManager.pandas.has():
+    if DependencyManager.pandas.imported():
         import pandas as pd
 
         if isinstance(series, pd.Series):
@@ -71,7 +71,7 @@ def get_number_series_info(series: Any) -> NumberSeriesInfo:
                 label=_get_name(series),
             )
 
-    if DependencyManager.polars.has():
+    if DependencyManager.polars.imported():
         import polars as pl
 
         if isinstance(series, pl.Series):
@@ -88,7 +88,7 @@ def get_category_series_info(series: Any) -> CategorySeriesInfo:
     """
     Get the summary of a categorical series.
     """
-    if DependencyManager.pandas.has():
+    if DependencyManager.pandas.imported():
         import pandas as pd
 
         if isinstance(series, pd.Series):
@@ -97,7 +97,7 @@ def get_category_series_info(series: Any) -> CategorySeriesInfo:
                 label=_get_name(series),
             )
 
-    if DependencyManager.polars.has():
+    if DependencyManager.polars.imported():
         import polars as pl
 
         if isinstance(series, pl.Series):
@@ -119,7 +119,7 @@ def get_date_series_info(series: Any) -> DateSeriesInfo:
             raise ValueError("Expected a date. Got: " + str(type(value)))
         return value.strftime("%Y-%m-%d")
 
-    if DependencyManager.pandas.has():
+    if DependencyManager.pandas.imported():
         import pandas as pd
 
         if isinstance(series, pd.Series):
@@ -129,7 +129,7 @@ def get_date_series_info(series: Any) -> DateSeriesInfo:
                 label=_get_name(series),
             )
 
-    if DependencyManager.polars.has():
+    if DependencyManager.polars.imported():
         import polars as pl
 
         if isinstance(series, pl.Series):
@@ -156,7 +156,7 @@ def get_datetime_series_info(series: Any) -> DateSeriesInfo:
             return value.strftime("%Y-%m-%d")
         raise ValueError("Expected a datetime. Got: " + str(type(value)))
 
-    if DependencyManager.pandas.has():
+    if DependencyManager.pandas.imported():
         import pandas as pd
 
         if isinstance(series, pd.Series):
@@ -166,7 +166,7 @@ def get_datetime_series_info(series: Any) -> DateSeriesInfo:
                 label=_get_name(series),
             )
 
-    if DependencyManager.polars.has():
+    if DependencyManager.polars.imported():
         import polars as pl
 
         if isinstance(series, pl.Series):

--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -16,7 +16,7 @@ class WebComponentEncoder(JSONEncoder):
     def default(self, o: Any) -> Any:
         obj = o
         # Handle numpy objects
-        if DependencyManager.numpy.has():
+        if DependencyManager.numpy.imported():
             import numpy as np
 
             dtypes = (np.datetime64, np.complexfloating)
@@ -34,7 +34,7 @@ class WebComponentEncoder(JSONEncoder):
                 return str(obj)
 
         # Handle pandas objects
-        if DependencyManager.pandas.has():
+        if DependencyManager.pandas.imported():
             import pandas as pd
 
             # Opinionated or known types

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/apply.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/apply.py
@@ -65,18 +65,18 @@ def get_handler_for_dataframe(
 
     raises ValueError if the dataframe type is not supported.
     """
-    if DependencyManager.pandas.has():
+    if DependencyManager.pandas.imported():
         import pandas as pd
 
         if isinstance(df, pd.DataFrame):
             return PandasTransformHandler()
-    if DependencyManager.polars.has():
+    if DependencyManager.polars.imported():
         import polars as pl
 
         if isinstance(df, pl.DataFrame):
             return PolarsTransformHandler()
 
-    if DependencyManager.ibis.has():
+    if DependencyManager.ibis.imported():
         import ibis  # type: ignore
 
         if isinstance(df, ibis.Table):

--- a/marimo/_smoke_tests/admonitions.py
+++ b/marimo/_smoke_tests/admonitions.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo

--- a/marimo/_smoke_tests/altair/altair_brush.py
+++ b/marimo/_smoke_tests/altair/altair_brush.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pandas",
+#     "altair",
+#     "marimo",
+#     "numpy",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo

--- a/marimo/_smoke_tests/altair/altair_charts.py
+++ b/marimo/_smoke_tests/altair/altair_charts.py
@@ -1,8 +1,17 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "pandas",
+#     "numpy",
+#     "vega-datasets",
+#     "altair",
+# ]
+# ///
 
 import marimo
 
-__generated_with = "0.8.2"
+__generated_with = "0.8.14"
 app = marimo.App(width="full")
 
 
@@ -221,7 +230,7 @@ def __(mo):
 
 @app.cell
 def __(chart3, mo):
-    mo.hstack([chart3, chart3.value.head(10)])
+    mo.hstack([chart3, chart3.value.head(10)], widths="equal")
     return
 
 

--- a/marimo/_smoke_tests/altair/altair_geoshape.py
+++ b/marimo/_smoke_tests/altair/altair_geoshape.py
@@ -1,7 +1,16 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "altair",
+#     "vega-datasets",
+#     "geopandas",
+# ]
+# ///
+
 import marimo
 
-__generated_with = "0.7.20"
+__generated_with = "0.8.14"
 app = marimo.App(width="medium")
 
 
@@ -42,6 +51,12 @@ def __(alt, gdf_sel):
 @app.cell
 def __(chart):
     chart
+    return
+
+
+@app.cell
+def __(chart):
+    chart.mark.type
     return
 
 

--- a/marimo/_smoke_tests/altair/altair_polars.py
+++ b/marimo/_smoke_tests/altair/altair_polars.py
@@ -1,4 +1,11 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "altair",
+#     "polars",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.8.2"

--- a/marimo/_smoke_tests/ansi.py
+++ b/marimo/_smoke_tests/ansi.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo

--- a/marimo/_smoke_tests/anywidget/maplibre_example.py
+++ b/marimo/_smoke_tests/anywidget/maplibre_example.py
@@ -1,4 +1,10 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "maplibre",
+# ]
+# ///
 
 import marimo
 

--- a/marimo/_smoke_tests/anywidget/mosaic_example.py
+++ b/marimo/_smoke_tests/anywidget/mosaic_example.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pandas",
+#     "mosaic-widget",
+#     "marimo",
+#     "pyyaml",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/anywidget_compat.py
+++ b/marimo/_smoke_tests/anywidget_compat.py
@@ -1,4 +1,14 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "traitlets",
+#     "anywidget",
+#     "pandas",
+#     "altair",
+#     "drawdata",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.2.13"

--- a/marimo/_smoke_tests/arrays_and_dicts.py
+++ b/marimo/_smoke_tests/arrays_and_dicts.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/buttons.py
+++ b/marimo/_smoke_tests/buttons.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/carousel.py
+++ b/marimo/_smoke_tests/carousel.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "altair",
+#     "pandas",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/charts/1mil_flights.py
+++ b/marimo/_smoke_tests/charts/1mil_flights.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "vega-datasets",
+#     "altair",
+#     "pandas",
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/cli_args.py
+++ b/marimo/_smoke_tests/cli_args.py
@@ -1,7 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.4.0"
+__generated_with = "0.8.14"
 app = marimo.App()
 
 
@@ -13,13 +20,15 @@ def __():
 
 @app.cell
 def __(mo):
-    mo.md("""
-    Re-run this with notebook with the following command line:
+    mo.md(
+        """
+        Re-run this with notebook with the following command line:
 
-    ```bash
-    marimo edit marimo/_smoke_tests/cli_args.py -- -a foo --b=bar -d 10 -d 20 -d false
-    ```
-    """)
+        ```bash
+        marimo edit marimo/_smoke_tests/cli_args.py -- -a foo --b=bar -d 10 -d 20 -d false
+        ```
+        """
+    )
     return
 
 

--- a/marimo/_smoke_tests/code_editor.py
+++ b/marimo/_smoke_tests/code_editor.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/data_explorer.py
+++ b/marimo/_smoke_tests/data_explorer.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "vega-datasets",
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo

--- a/marimo/_smoke_tests/dataframe.py
+++ b/marimo/_smoke_tests/dataframe.py
@@ -8,12 +8,13 @@
 #     "pyarrow",
 #     "marimo",
 #     "pandas",
+#     "ibis",
 # ]
 # ///
 
 import marimo
 
-__generated_with = "0.8.7"
+__generated_with = "0.8.14"
 app = marimo.App(width="full")
 
 
@@ -305,24 +306,6 @@ def __():
 
     cars = vega_datasets.data.cars()
     return alt, cars, mo, pa, pd, pl, vega_datasets
-
-
-app._unparsable_cell(
-    r"""
-    SELECT * FROM cars WHERE Cylinders > 6;
-    """,
-    name="__"
-)
-
-
-@app.cell
-def __(mo):
-    _df = mo.sql(
-        f"""
-        SELECT * FROM
-        """
-    )
-    return
 
 
 @app.cell

--- a/marimo/_smoke_tests/from_series.py
+++ b/marimo/_smoke_tests/from_series.py
@@ -1,4 +1,11 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "vega-datasets",
+#     "marimo",
+#     "polars",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.6.23"

--- a/marimo/_smoke_tests/full_width.py
+++ b/marimo/_smoke_tests/full_width.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/grid.py
+++ b/marimo/_smoke_tests/grid.py
@@ -1,7 +1,8 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.1.8"
+__generated_with = "0.8.14"
 app = marimo.App(layout_file="layouts/grid.grid.json")
 
 
@@ -24,7 +25,7 @@ def __(mo):
 
 @app.cell
 def __(mo):
-    mo.md("# Horizontal Stack: `hstack`")
+    mo.md("""# Horizontal Stack: `hstack`""")
     return
 
 
@@ -42,7 +43,7 @@ def __(align, boxes, gap, justify, mo, wrap):
 
 @app.cell
 def __(mo):
-    mo.md("# Vertical Stack: `vstack`")
+    mo.md("""# Vertical Stack: `vstack`""")
     return
 
 

--- a/marimo/_smoke_tests/icons.py
+++ b/marimo/_smoke_tests/icons.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/layout.py
+++ b/marimo/_smoke_tests/layout.py
@@ -1,7 +1,8 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.1.3"
+__generated_with = "0.8.14"
 app = marimo.App()
 
 
@@ -24,7 +25,7 @@ def __(mo):
 
 @app.cell
 def __(mo):
-    mo.md("# Horizontal Stack: `hstack`")
+    mo.md("""# Horizontal Stack: `hstack`""")
     return
 
 
@@ -42,7 +43,7 @@ def __(align, boxes, gap, justify, mo, wrap):
 
 @app.cell
 def __(mo):
-    mo.md("# Vertical Stack: `vstack`")
+    mo.md("""# Vertical Stack: `vstack`""")
     return
 
 

--- a/marimo/_smoke_tests/md.py
+++ b/marimo/_smoke_tests/md.py
@@ -1,7 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.2.1"
+__generated_with = "0.8.14"
 app = marimo.App()
 
 
@@ -13,7 +20,7 @@ def __():
 
 @app.cell
 def __(mo):
-    mo.md("# Tables")
+    mo.md("""# Tables""")
     return
 
 
@@ -46,7 +53,7 @@ def __(mo):
 
 @app.cell
 def __(mo):
-    mo.md("# Footnotes")
+    mo.md("""# Footnotes""")
     return
 
 
@@ -72,7 +79,7 @@ def __(mo):
 
 @app.cell
 def __(mo):
-    mo.md("# External links")
+    mo.md("""# External links""")
     return
 
 

--- a/marimo/_smoke_tests/nav_menus.py
+++ b/marimo/_smoke_tests/nav_menus.py
@@ -2,13 +2,13 @@
 
 import marimo
 
-__generated_with = "0.5.0"
+__generated_with = "0.8.14"
 app = marimo.App()
 
 
 @app.cell
 def __(mo):
-    mo.md("# Horizontal")
+    mo.md("""# Horizontal""")
     return
 
 
@@ -26,7 +26,7 @@ def __(mo):
 
 @app.cell
 def __(mo):
-    mo.md("-----")
+    mo.md("""-----""")
     return
 
 
@@ -58,7 +58,7 @@ def __(mo):
 
 @app.cell
 def __(mo):
-    mo.md("# Vertical")
+    mo.md("""# Vertical""")
     return
 
 
@@ -77,7 +77,7 @@ def __(mo):
 
 @app.cell
 def __(mo):
-    mo.md("-----")
+    mo.md("""-----""")
     return
 
 

--- a/marimo/_smoke_tests/output.py
+++ b/marimo/_smoke_tests/output.py
@@ -2,7 +2,7 @@
 
 import marimo
 
-__generated_with = "0.6.0"
+__generated_with = "0.8.14"
 app = marimo.App()
 
 
@@ -34,7 +34,7 @@ def __(mo, time):
 
 @app.cell
 def __(mo):
-    mo.md("### Replace")
+    mo.md("""### Replace""")
     return
 
 
@@ -54,7 +54,7 @@ def __(loop_replace, mo):
 
 @app.cell
 def __(mo):
-    mo.md("### Append")
+    mo.md("""### Append""")
     return
 
 
@@ -74,7 +74,7 @@ def __(loop_append, mo):
 
 @app.cell
 def __(mo):
-    mo.md("### Clear")
+    mo.md("""### Clear""")
     return
 
 
@@ -96,7 +96,7 @@ def __(loop_append, mo):
 
 @app.cell
 def __(mo):
-    mo.md("### Sleep (stale)")
+    mo.md("""### Sleep (stale)""")
     return
 
 
@@ -111,6 +111,7 @@ def __(time):
 def __(mo):
     mo.output.append(mo.md("To be replaced."))
     mo.output.replace_at_index(mo.md("Replaced at index"), 0)
+    return
 
 
 if __name__ == "__main__":

--- a/marimo/_smoke_tests/plain.py
+++ b/marimo/_smoke_tests/plain.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "vega-datasets",
+#     "marimo",
+#     "polars",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/pyg_walker.py
+++ b/marimo/_smoke_tests/pyg_walker.py
@@ -1,7 +1,16 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pandas",
+#     "pygwalker",
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.7.5"
+__generated_with = "0.8.14"
 app = marimo.App(width="medium")
 
 

--- a/marimo/_smoke_tests/query_params.py
+++ b/marimo/_smoke_tests/query_params.py
@@ -1,7 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.3.4"
+__generated_with = "0.8.14"
 app = marimo.App()
 
 
@@ -68,11 +75,7 @@ def __(mo, query_params):
 
 @app.cell
 def __(mo):
-    mo.md(
-        """
-    You can also initialized with query params. Open this URL [/?foo=1&bar=2&bar=3&baz=4](/?foo=1&bar=2&bar=3&baz=4) and restart the kernel
-    """
-    )
+    mo.md("""You can also initialized with query params. Open this URL [/?foo=1&bar=2&bar=3&baz=4](/?foo=1&bar=2&bar=3&baz=4) and restart the kernel""")
     return
 
 

--- a/marimo/_smoke_tests/routes.py
+++ b/marimo/_smoke_tests/routes.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo

--- a/marimo/_smoke_tests/run_button.py
+++ b/marimo/_smoke_tests/run_button.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo

--- a/marimo/_smoke_tests/scale.py
+++ b/marimo/_smoke_tests/scale.py
@@ -1,13 +1,20 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.1.0"
+__generated_with = "0.8.14"
 app = marimo.App()
 
 
 @app.cell
 def __(mo):
-    mo.md("# Scale")
+    mo.md("""# Scale""")
     return
 
 
@@ -134,36 +141,36 @@ def __():
 def __(mo):
     mo.md(
         """
-    ---
+        ---
 
-    # h1 Heading
-    ## h2 Heading
-    ### h3 Heading
-    #### h4 Heading
-    ##### h5 Heading
-    ###### h6 Heading
-
-
-    ## Emphasis
-
-    **This is bold text**
-
-    __This is bold text__
-
-    *This is italic text*
-
-    _This is italic text_
-
-    ~~Strikethrough~~
+        # h1 Heading
+        ## h2 Heading
+        ### h3 Heading
+        #### h4 Heading
+        ##### h5 Heading
+        ###### h6 Heading
 
 
-    ## Blockquotes
+        ## Emphasis
+
+        **This is bold text**
+
+        __This is bold text__
+
+        *This is italic text*
+
+        _This is italic text_
+
+        ~~Strikethrough~~
 
 
-    > Blockquotes can also be nested...
-    >> ...by using additional greater-than signs right next to each other...
-    > > > ...or with spaces between arrows.
-    """
+        ## Blockquotes
+
+
+        > Blockquotes can also be nested...
+        >> ...by using additional greater-than signs right next to each other...
+        > > > ...or with spaces between arrows.
+        """
     )
     return
 

--- a/marimo/_smoke_tests/scripting.py
+++ b/marimo/_smoke_tests/scripting.py
@@ -1,8 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo
 
-__generated_with = "0.6.0"
+__generated_with = "0.8.14"
 app = marimo.App()
 
 
@@ -14,7 +20,7 @@ def __():
 
 @app.cell
 def __(mo):
-    mo.md("hello")
+    mo.md("""hello""")
     return
 
 

--- a/marimo/_smoke_tests/sql.py
+++ b/marimo/_smoke_tests/sql.py
@@ -1,8 +1,17 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "duckdb",
+#     "vega-datasets",
+#     "marimo",
+#     "altair",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo
 
-__generated_with = "0.6.25"
+__generated_with = "0.8.14"
 app = marimo.App(width="medium")
 
 
@@ -17,7 +26,7 @@ def __():
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## Cars")
+    mo.md("""## Cars""")
     return
 
 
@@ -56,7 +65,7 @@ def __(alt, df, mo):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("## Airports")
+    mo.md("""## Airports""")
     return
 
 
@@ -84,7 +93,7 @@ def __(less_airports):
 
 @app.cell
 def __(mo):
-    mo.md("## Google Sheets")
+    mo.md("""## Google Sheets""")
     return
 
 
@@ -126,7 +135,7 @@ def __(job_title, mo, sheet):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("Debug")
+    mo.md("""Debug""")
     return
 
 

--- a/marimo/_smoke_tests/sql/duckdb_tokenize.py
+++ b/marimo/_smoke_tests/sql/duckdb_tokenize.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "duckdb",
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/sql/limits.py
+++ b/marimo/_smoke_tests/sql/limits.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/state.py
+++ b/marimo/_smoke_tests/state.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/status.py
+++ b/marimo/_smoke_tests/status.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo

--- a/marimo/_smoke_tests/stdin.py
+++ b/marimo/_smoke_tests/stdin.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/stop.py
+++ b/marimo/_smoke_tests/stop.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/table_urls.py
+++ b/marimo/_smoke_tests/table_urls.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/tables/booleans.py
+++ b/marimo/_smoke_tests/tables/booleans.py
@@ -3,6 +3,7 @@
 # dependencies = [
 #     "marimo",
 #     "pandas",
+#     "polars",
 # ]
 # ///
 

--- a/marimo/_smoke_tests/tables/dictionary_table.py
+++ b/marimo/_smoke_tests/tables/dictionary_table.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/tables/server_pagination.py
+++ b/marimo/_smoke_tests/tables/server_pagination.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "vega-datasets",
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 
 import marimo

--- a/marimo/_smoke_tests/theming/altair_theme.py
+++ b/marimo/_smoke_tests/theming/altair_theme.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "altair",
+#     "marimo",
 # ]
 # ///
 

--- a/marimo/_smoke_tests/theming/apply_theme.py
+++ b/marimo/_smoke_tests/theming/apply_theme.py
@@ -1,3 +1,18 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "seaborn",
+#     "matplotlib",
+#     "holoviews",
+#     "bokeh",
+#     "vega-datasets",
+#     "altair",
+#     "plotly",
+#     "marimo",
+#     "pandas",
+#     "numpy",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.8.3"

--- a/marimo/_smoke_tests/third_party/altair_example.py
+++ b/marimo/_smoke_tests/third_party/altair_example.py
@@ -1,4 +1,11 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "vega-datasets",
+#     "altair",
+# ]
+# ///
 
 import marimo
 

--- a/marimo/_smoke_tests/third_party/holoviews_example.py
+++ b/marimo/_smoke_tests/third_party/holoviews_example.py
@@ -1,4 +1,15 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "holoviews",
+#     "pandas",
+#     "marimo",
+#     "hvplot",
+#     "bokeh",
+#     "polars",
+# ]
+# ///
 
 import marimo
 

--- a/marimo/_smoke_tests/third_party/ipython_display.py
+++ b/marimo/_smoke_tests/third_party/ipython_display.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "ipython",
+#     "marimo",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/marimo/_smoke_tests/third_party/pandas_example.py
+++ b/marimo/_smoke_tests/third_party/pandas_example.py
@@ -1,4 +1,10 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pandas",
+#     "numpy",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.1.0"

--- a/marimo/_smoke_tests/third_party/plotly_example.py
+++ b/marimo/_smoke_tests/third_party/plotly_example.py
@@ -1,13 +1,20 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "plotly",
+#     "pandas",
+# ]
+# ///
+
 import marimo
 
-__generated_with = "0.1.51"
+__generated_with = "0.8.14"
 app = marimo.App(width="full")
 
 
 @app.cell
 def __(mo):
-    mo.md("# Plotly Express Chart")
+    mo.md("""# Plotly Express Chart""")
     return
 
 
@@ -59,7 +66,7 @@ def __(mo, plot):
 
 @app.cell
 def __(mo):
-    mo.md("# Plotly Graph Objects Chart")
+    mo.md("""# Plotly Graph Objects Chart""")
     return
 
 
@@ -121,7 +128,7 @@ def __(mo, plot2):
 
 @app.cell
 def __(mo):
-    mo.md("# Re-rendering Chart")
+    mo.md("""# Re-rendering Chart""")
     return
 
 
@@ -166,7 +173,7 @@ def __(mo, plot3):
 
 @app.cell
 def __(mo):
-    mo.md("# 3D Chart")
+    mo.md("""# 3D Chart""")
     return
 
 

--- a/marimo/_smoke_tests/third_party/rich_example.py
+++ b/marimo/_smoke_tests/third_party/rich_example.py
@@ -1,4 +1,10 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "rich",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.1.88"

--- a/marimo/_smoke_tests/third_party/seaborn_example.py
+++ b/marimo/_smoke_tests/third_party/seaborn_example.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "seaborn",
+# ]
+# ///
 # Copyright 2024 Marimo. All rights reserved.
 import marimo
 

--- a/tests/_output/formatters/test_formatters.py
+++ b/tests/_output/formatters/test_formatters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import os.path
 import sys
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -158,6 +159,7 @@ def test_repr_markdown():
     )
 
 
+@pytest.mark.skip
 def test_repr_latex():
     class ReprLatex:
         def _repr_latex_(self):
@@ -274,7 +276,21 @@ def test_repr_mimebundle():
     assert formatter
     mime, content = formatter(obj)
     assert mime == "application/vnd.marimo+mimebundle"
-    assert content == {
-        "application/json": {"message": "Hello, World!"},
-        "text/plain": "Hello, World!",
-    }
+    assert content == {"application/json": {"message": "Hello, World!"}}
+
+
+def test_repr_mimebundle_with_exclude():
+    class ReprMimeBundle:
+        def _repr_mimebundle_(self, include: Any = None, exclude: Any = None):
+            del include, exclude
+            return {
+                "application/json": {"message": "Hello, World!"},
+                "text/plain": "Hello, World!",
+            }
+
+    obj = ReprMimeBundle()
+    formatter = get_formatter(obj)
+    assert formatter
+    mime, content = formatter(obj)
+    assert mime == "application/vnd.marimo+mimebundle"
+    assert content == {"application/json": {"message": "Hello, World!"}}


### PR DESCRIPTION
Some mime fixes:

- ignore `_repr_latex_`, this breaks pandas
- exlclude `text/plain` from mimebundle, since ibis includes this as well as html, and we dont need both
- depcheck: change `has()` to `imported()`
- bugfix for the empty value of `altair_chart`
