### PR TITLE
fix: handle altair usermeta embed_options manually

### DIFF
--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -20,7 +20,8 @@ env:
 
 jobs:
   test_python:
-    name: Tests on ${{ matrix.os }}, Python ${{ matrix.python-version }} with ${{ matrix.dependencies }} dependencies
+    # short name otherwise GitHub Actions will truncate it
+    name: ${{ matrix.os }} / Py ${{ matrix.python-version }} / ${{ matrix.dependencies }} deps
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     defaults:

--- a/marimo/_smoke_tests/altair/embed_options.py
+++ b/marimo/_smoke_tests/altair/embed_options.py
@@ -1,0 +1,32 @@
+import marimo
+
+__generated_with = "0.8.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import altair as alt
+    import pandas as pd
+
+    data = pd.DataFrame({"x": range(10), "y": range(10)})
+
+    alt.renderers.set_embed_options(actions=False)
+    # altair.renderers.set_embed_options(actions=True)
+
+    # Plain chart
+    chart = alt.Chart(data).mark_line().encode(x="x", y="y")
+    chart
+    return alt, chart, data, mo, pd
+
+
+@app.cell
+def __(chart, mo):
+    # Wrapped chart
+    mo.ui.altair_chart(chart)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_output/formatters/test_altair.py
+++ b/tests/_output/formatters/test_altair.py
@@ -49,6 +49,55 @@ async def test_altair(
 
 
 @pytest.mark.skipif(
+    not HAS_ALTAIR, reason="optional dependencies not installed"
+)
+async def test_altair_with_embed_options(
+    executing_kernel: Kernel, exec_req: ExecReqProvider
+) -> None:
+    from marimo._output.formatters.formatters import register_formatters
+
+    register_formatters()
+
+    await executing_kernel.run(
+        [
+            exec_req.get(
+                """
+                import altair as alt
+                import pandas as pd
+                from marimo._output.formatting import get_formatter
+
+                data = pd.DataFrame({"a": ["A", "B"], "b": [28, 55]})
+                chart = alt.Chart(data).mark_bar().encode(x="a", y="b")
+                formatter = get_formatter(chart)
+
+                before_options_result = formatter(chart)
+                alt.renderers.set_embed_options(actions=False)
+                after_options_result = formatter(chart)
+                """
+            )
+        ]
+    )
+
+    result = executing_kernel.globals["before_options_result"]
+    assert result is not None
+    assert result[0] == "application/vnd.vegalite.v5+json"
+    json_result = json.loads(result[1])
+    assert json_result["usermeta"] == {
+        "embedOptions": {},
+    }
+
+    result = executing_kernel.globals["after_options_result"]
+    assert result is not None
+    assert result[0] == "application/vnd.vegalite.v5+json"
+    json_result = json.loads(result[1])
+    assert json_result["usermeta"] == {
+        "embedOptions": {
+            "actions": False,
+        },
+    }
+
+
+@pytest.mark.skipif(
     not HAS_ALTAIR or not HAS_VL_CONVERT,
     reason="optional dependencies not installed and fails on mac",
 )


### PR DESCRIPTION
Fixes #2302 

User's can set `embed_options` globally with altair. However these embedoptions were missing from the final chart spec.
I am surprised this is not handled by altair internally, but we can handle this ourselves.