### PR TITLE
improvement: simplify inline metadata config, turn on only in --sandbox

### DIFF
--- a/docs/guides/editor_features/package_management.md
+++ b/docs/guides/editor_features/package_management.md
@@ -36,4 +36,4 @@ For example, whenever you add or remove a package, marimo will automatically upd
 # ///
 ```
 
-This means your notebook file is a completing self-contained artifact with all the necessary information to run.
+This means your notebook file is a completely self-contained artifact with all the necessary information to run.

--- a/docs/guides/editor_features/package_management.md
+++ b/docs/guides/editor_features/package_management.md
@@ -10,11 +10,21 @@ Once the module is installed, all cells that depend on the module will be rerun.
 We use some heuristic for guessing the package name in your registry (e.g. PyPI) from the module name. It is possible that the package name is different from the module name. If you encounter an error, please file an issue or help us by adding your mapping [directly to the codebase](https://github.com/marimo-team/marimo/blob/main/marimo/_runtime/packages/module_name_to_pypi_name.py).
 ```
 
-## Auto-add inline script metadata (`uv` only)
+## Running `marimo` in a sandbox environment (`uv` only)
 
-When using [uv](https://docs.astral.sh/uv), marimo can automatically update the package name metadata in your notebook file, per [PEP 723](https://peps.python.org/pep-0723/). This metadata is used to manage the notebook's dependencies and Python version.
+If you want to run marimo in a sandbox environment, you can use the `--sandbox` flag. This will create an isolated virtual environment (using [uv](https://docs.astral.sh/uv)) and install any packages listed in the script metadata, per [PEP 723](https://peps.python.org/pep-0723/). If there is no package metadata in the script, marimo will still prompt you to install any missing packages.
 
-For example, say you start marimo in a new virtual environment and spin up a new notebook. Whenever you add a new package, marimo will automatically add script metadata that looks like this:
+This is useful when you want to run marimo in a clean environment without affecting your global environment.
+
+```bash
+marimo edit --sandbox notebook.py
+```
+
+### Auto-tracking inline script metadata
+
+When running with `--sandbox`, marimo will automatically track the package name metadata in your notebook file, per [PEP 723](https://peps.python.org/pep-0723/). This metadata is used to manage the notebook's dependencies and Python version.
+
+For example, whenever you add or remove a package, marimo will automatically update the script metadata in your notebook file:
 
 ```python
 # /// script
@@ -26,13 +36,4 @@ For example, say you start marimo in a new virtual environment and spin up a new
 # ///
 ```
 
-## Running `marimo` in a sandbox environment (`uv` only)
-
-If you want to run marimo in a sandbox environment, you can use the `--sandbox` flag. This will create a new virtual environment (using [uv](https://docs.astral.sh/uv)) and install any packages listed in the script metadata, per [PEP 723](https://peps.python.org/pep-0723/).
-This is useful when you want to run marimo in a clean environment without affecting your global environment.
-
-```bash
-marimo edit --sandbox notebook.py
-```
-
-If there is not package metadata in the script, marimo will still prompt you to install any missing packages.
+This means your notebook file is a completing self-contained artifact with all the necessary information to run.

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -458,47 +458,6 @@ export const UserConfigForm: React.FC = () => {
               </FormItem>
             )}
           />
-          <FormField
-            control={form.control}
-            disabled={isWasmRuntime}
-            name="package_management.add_script_metadata"
-            render={({ field }) => {
-              if (form.getValues("package_management.manager") !== "uv") {
-                return <div />;
-              }
-
-              return (
-                <div className="flex flex-col gap-y-1">
-                  <FormItem className={formItemClasses}>
-                    <FormLabel className="font-normal">
-                      Auto-add script metadata
-                    </FormLabel>
-                    <FormControl>
-                      <Checkbox
-                        data-testid="auto-instantiate-checkbox"
-                        disabled={field.disabled}
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                  </FormItem>
-                  <FormDescription>
-                    Whether marimo should automatically add package metadata to
-                    scripts. See more about{" "}
-                    <a
-                      href="https://docs.marimo.io/guides/editor_features/package_management.html"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-link hover:underline"
-                    >
-                      package metadata
-                    </a>
-                    .
-                  </FormDescription>
-                </div>
-              );
-            }}
-          />
         </SettingGroup>
         <SettingGroup title="Runtime">
           <FormField

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -49,7 +49,6 @@ test("default UserConfig - empty", () => {
         "preset": "default",
       },
       "package_management": {
-        "add_script_metadata": false,
         "manager": "pip",
       },
       "runtime": {
@@ -100,7 +99,6 @@ test("default UserConfig - one level", () => {
         "preset": "default",
       },
       "package_management": {
-        "add_script_metadata": false,
         "manager": "pip",
       },
       "runtime": {

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -90,7 +90,6 @@ export const UserConfigSchema = z
     package_management: z
       .object({
         manager: z.enum(PackageManagerNames).default("pip"),
-        add_script_metadata: z.boolean().default(false),
       })
       .default({ manager: "pip" }),
     ai: z

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -61,7 +61,10 @@ def run_in_sandbox(
 
     click.echo(f"Running in a sandbox: {' '.join(cmd)}")
 
-    process = subprocess.Popen(cmd)
+    env = os.environ.copy()
+    env["MARIMO_MANAGE_SCRIPT_METADATA"] = "true"
+
+    process = subprocess.Popen(cmd, env=env)
 
     def handler(sig: int, frame: Any) -> None:
         del sig

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -160,12 +160,9 @@ class PackageManagementConfig(TypedDict):
     **Keys.**
 
     - `manager`: the package manager to use
-    - `add_script_metadata`: if true, add script metadata to the notebook
-        Currently only supports `uv`
     """
 
     manager: Literal["pip", "rye", "uv", "poetry", "pixi"]
-    add_script_metadata: bool
 
 
 @dataclass
@@ -249,7 +246,7 @@ DEFAULT_CONFIG: MarimoConfig = {
         "autosave_delay": 1000,
         "format_on_save": False,
     },
-    "package_management": {"manager": "pip", "add_script_metadata": False},
+    "package_management": {"manager": "pip"},
     "server": {
         "browser": "default",
         "follow_symlink": False,

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -14,6 +14,9 @@ class GlobalSettings:
     TRACING: bool = os.getenv("MARIMO_TRACING", "false") in ("true", "1")
     PROFILE_DIR: str | None = None
     LOG_LEVEL: int = logging.WARNING
+    MANAGE_SCRIPT_METADATA: bool = os.getenv(
+        "MARIMO_MANAGE_SCRIPT_METADATA", "false"
+    ) in ("true", "1")
 
 
 GLOBAL_SETTINGS = GlobalSettings()

--- a/marimo/_pyodide/bootstrap.py
+++ b/marimo/_pyodide/bootstrap.py
@@ -25,6 +25,12 @@ if TYPE_CHECKING:
 
 
 def instantiate(session: PyodideSession) -> None:
+    """
+    Instantiate the marimo app in the session.
+
+    This function is called by the WebAssembly frontend.
+    """
+
     app = session.app_manager.app
     execution_requests = tuple(
         ExecutionRequest(cell_id=cell_data.cell_id, code=cell_data.code)
@@ -47,6 +53,22 @@ def create_session(
     message_callback: Callable[[str], None],
     user_config: MarimoConfig,
 ) -> tuple[PyodideSession, PyodideBridge]:
+    """
+    Create a session with the given filename and query parameters.
+
+    Args:
+        filename: The filename of the app.
+        query_params: The query parameters from the URL.
+        message_callback: A callback that can be used to send messages to the
+            frontend.
+        user_config: The user configuration.
+
+    Returns:
+        A tuple of (session, bridge)
+
+    This function is called by the WebAssembly frontend.
+    """
+
     def write_kernel_message(op: KernelMessage) -> None:
         message_callback(
             json.dumps({"op": op[0], "data": op[1]}, cls=WebComponentEncoder)
@@ -105,6 +127,15 @@ def save_file(
     request: str,
     filename: str,
 ) -> None:
+    """
+    Save the app to the given filename.
+
+    Args:
+        request: serialized/stringified SaveNotebookRequest
+        filename: the filename of the app
+
+    This function is called by the WebAssembly frontend.
+    """
     parsed = parse_raw(json.loads(request), SaveNotebookRequest)
     app_file_manager = AppFileManager(filename=filename)
     app_file_manager.save(parsed)

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -122,7 +122,7 @@ class PyodideSession:
             consumer(msg)
 
     async def start(self) -> None:
-        self.kernel_task = launch_pyodide_kernel(
+        self.kernel_task = _launch_pyodide_kernel(
             control_queue=self._queue_manager.control_queue,
             set_ui_element_queue=self._queue_manager.set_ui_element_queue,
             completion_queue=self._queue_manager.completion_queue,
@@ -297,7 +297,7 @@ class PyodideBridge:
         return json.dumps(md)
 
 
-def launch_pyodide_kernel(
+def _launch_pyodide_kernel(
     control_queue: asyncio.Queue[ControlRequest],
     set_ui_element_queue: asyncio.Queue[SetUIElementValueRequest],
     completion_queue: asyncio.Queue[CodeCompletionRequest],

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1104,8 +1104,6 @@ components:
           type: object
         package_management:
           properties:
-            add_script_metadata:
-              type: boolean
             manager:
               enum:
               - pip
@@ -1116,7 +1114,6 @@ components:
               type: string
           required:
           - manager
-          - add_script_metadata
           type: object
         runtime:
           properties:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2302,7 +2302,6 @@ export interface components {
         preset: "default" | "vim";
       };
       package_management: {
-        add_script_metadata: boolean;
         /** @enum {string} */
         manager: "pip" | "rye" | "uv" | "poetry" | "pixi";
       };

--- a/tests/_config/test_config.py
+++ b/tests/_config/test_config.py
@@ -32,7 +32,6 @@ def test_configure_full() -> None:
             keymap={"preset": "vim", "overrides": {}},
             package_management={
                 "manager": "pip",
-                "add_script_metadata": False,
             },
         )
     )

--- a/tests/_runtime/test_manage_script_metadata.py
+++ b/tests/_runtime/test_manage_script_metadata.py
@@ -8,6 +8,7 @@ import pytest
 from marimo._config.config import (
     merge_default_config,
 )
+from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._dependencies.dependencies import DependencyManager
 from tests.conftest import MockedKernel
 
@@ -18,9 +19,10 @@ HAS_UV = DependencyManager.which("uv")
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv not installed")
-async def test_add_script_metadata_uv(
+async def test_manage_script_metadata_uv(
     tmp_path: pathlib.Path, mocked_kernel: MockedKernel
 ) -> None:
+    GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA = True
     filename = str(tmp_path / "notebook.py")
     # Create empty file
     with open(filename, "w") as f:  # noqa: ASYNC230
@@ -33,12 +35,10 @@ async def test_add_script_metadata_uv(
             {
                 "package_management": {
                     "manager": "uv",
-                    "add_script_metadata": True,
                 }
             },
         )
     )
-
     # Add marimo, skip os
     k._maybe_register_cell("0", "import marimo as mo\nimport os")
 
@@ -67,9 +67,10 @@ async def test_add_script_metadata_uv(
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv not installed")
-async def test_add_script_metadata_uv_deletion(
+async def test_manage_script_metadata_uv_deletion(
     tmp_path: pathlib.Path, mocked_kernel: MockedKernel
 ) -> None:
+    GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA = True
     filename = str(tmp_path / "notebook.py")
     # Create empty file
     with open(filename, "w") as f:  # noqa: ASYNC230
@@ -82,7 +83,6 @@ async def test_add_script_metadata_uv_deletion(
             {
                 "package_management": {
                     "manager": "uv",
-                    "add_script_metadata": True,
                 }
             },
         )
@@ -125,9 +125,10 @@ async def test_add_script_metadata_uv_deletion(
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv not installed")
-async def test_add_script_metadata_uv_off(
+async def test_manage_script_metadata_uv_off(
     tmp_path: pathlib.Path, mocked_kernel: MockedKernel
 ) -> None:
+    GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA = False
     filename = str(tmp_path / "notebook.py")
     # Create empty file
     with open(filename, "w") as f:  # noqa: ASYNC230
@@ -140,7 +141,6 @@ async def test_add_script_metadata_uv_off(
             {
                 "package_management": {
                     "manager": "uv",
-                    "add_script_metadata": False,
                 }
             },
         )
@@ -154,9 +154,10 @@ async def test_add_script_metadata_uv_off(
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv not installed")
-async def test_add_script_metadata_uv_no_filename(
+async def test_manage_script_metadata_uv_no_filename(
     tmp_path: pathlib.Path, mocked_kernel: MockedKernel
 ) -> None:
+    GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA = True
     filename = str(tmp_path / "notebook.py")
     # Create empty file
     with open(filename, "w") as f:  # noqa: ASYNC230
@@ -168,7 +169,6 @@ async def test_add_script_metadata_uv_no_filename(
             {
                 "package_management": {
                     "manager": "uv",
-                    "add_script_metadata": True,
                 }
             },
         )
@@ -181,9 +181,10 @@ async def test_add_script_metadata_uv_no_filename(
         assert "" == f.read()
 
 
-async def test_add_script_metadata_pip_noop(
+async def test_manage_script_metadata_pip_noop(
     tmp_path: pathlib.Path, mocked_kernel: MockedKernel
 ) -> None:
+    GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA = True
     filename = str(tmp_path / "notebook.py")
     # Create empty file
     with open(filename, "w") as f:  # noqa: ASYNC230
@@ -196,7 +197,6 @@ async def test_add_script_metadata_pip_noop(
             {
                 "package_management": {
                     "manager": "pip",
-                    "add_script_metadata": True,
                 }
             },
         )

--- a/tests/_server/templates/snapshots/export1.txt
+++ b/tests/_server/templates/snapshots/export1.txt
@@ -25,7 +25,7 @@
     <script data-marimo="true">
       function __resizeIframe(obj) {
         var scrollbarHeight = 20; // Max between windows, mac, and linux
-        
+
         function setHeight() {
           var element = obj.contentWindow.document.documentElement;
           // If there is no vertical scrollbar, we don't need to resize the iframe
@@ -45,7 +45,7 @@
 
         // Resize the iframe to the height of the content and bottom scrollbar height
         setHeight();
-        
+
         // Resize the iframe when the content changes
         const resizeObserver = new ResizeObserver((entries) => {
           setHeight();
@@ -56,13 +56,13 @@
     <marimo-filename hidden>notebook.py</marimo-filename>
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
-    <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "package_management": {"add_script_metadata": false, "manager": "pip"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}}' hidden></marimo-user-config>
+    <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "package_management": {"manager": "pip"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}}' hidden></marimo-user-config>
     <marimo-app-config data-config='{"width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
-  
+
 <script data-marimo="true">
     window.__MARIMO_STATIC__ = {};
     window.__MARIMO_STATIC__.version = "0.0.0";
@@ -73,7 +73,7 @@
 </head>
   <body>
     <div id="root"></div>
-  
+
     <marimo-code hidden="">
         print('Hello%2C%20World!')
     </marimo-code>

--- a/tests/_server/templates/snapshots/export1.txt
+++ b/tests/_server/templates/snapshots/export1.txt
@@ -25,7 +25,7 @@
     <script data-marimo="true">
       function __resizeIframe(obj) {
         var scrollbarHeight = 20; // Max between windows, mac, and linux
-
+        
         function setHeight() {
           var element = obj.contentWindow.document.documentElement;
           // If there is no vertical scrollbar, we don't need to resize the iframe
@@ -45,7 +45,7 @@
 
         // Resize the iframe to the height of the content and bottom scrollbar height
         setHeight();
-
+        
         // Resize the iframe when the content changes
         const resizeObserver = new ResizeObserver((entries) => {
           setHeight();
@@ -62,7 +62,7 @@
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
-
+  
 <script data-marimo="true">
     window.__MARIMO_STATIC__ = {};
     window.__MARIMO_STATIC__.version = "0.0.0";
@@ -73,7 +73,7 @@
 </head>
   <body>
     <div id="root"></div>
-
+  
     <marimo-code hidden="">
         print('Hello%2C%20World!')
     </marimo-code>

--- a/tests/_server/templates/snapshots/export2.txt
+++ b/tests/_server/templates/snapshots/export2.txt
@@ -25,7 +25,7 @@
     <script data-marimo="true">
       function __resizeIframe(obj) {
         var scrollbarHeight = 20; // Max between windows, mac, and linux
-
+        
         function setHeight() {
           var element = obj.contentWindow.document.documentElement;
           // If there is no vertical scrollbar, we don't need to resize the iframe
@@ -45,7 +45,7 @@
 
         // Resize the iframe to the height of the content and bottom scrollbar height
         setHeight();
-
+        
         // Resize the iframe when the content changes
         const resizeObserver = new ResizeObserver((entries) => {
           setHeight();
@@ -62,7 +62,7 @@
     <title>marimo</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
-
+  
 <script data-marimo="true">
     window.__MARIMO_STATIC__ = {};
     window.__MARIMO_STATIC__.version = "0.0.0";
@@ -73,7 +73,7 @@
 </head>
   <body>
     <div id="root"></div>
-
+  
     <marimo-code hidden="">
         print('Hello%2C%20World!')
     </marimo-code>

--- a/tests/_server/templates/snapshots/export2.txt
+++ b/tests/_server/templates/snapshots/export2.txt
@@ -25,7 +25,7 @@
     <script data-marimo="true">
       function __resizeIframe(obj) {
         var scrollbarHeight = 20; // Max between windows, mac, and linux
-        
+
         function setHeight() {
           var element = obj.contentWindow.document.documentElement;
           // If there is no vertical scrollbar, we don't need to resize the iframe
@@ -45,7 +45,7 @@
 
         // Resize the iframe to the height of the content and bottom scrollbar height
         setHeight();
-        
+
         // Resize the iframe when the content changes
         const resizeObserver = new ResizeObserver((entries) => {
           setHeight();
@@ -56,13 +56,13 @@
     <marimo-filename hidden></marimo-filename>
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
-    <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "package_management": {"add_script_metadata": false, "manager": "pip"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}}' hidden></marimo-user-config>
+    <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "package_management": {"manager": "pip"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}}' hidden></marimo-user-config>
     <marimo-app-config data-config='{"width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>marimo</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
-  
+
 <script data-marimo="true">
     window.__MARIMO_STATIC__ = {};
     window.__MARIMO_STATIC__.version = "0.0.0";
@@ -73,7 +73,7 @@
 </head>
   <body>
     <div id="root"></div>
-  
+
     <marimo-code hidden="">
         print('Hello%2C%20World!')
     </marimo-code>

--- a/tests/_server/templates/snapshots/export3.txt
+++ b/tests/_server/templates/snapshots/export3.txt
@@ -25,7 +25,7 @@
     <script data-marimo="true">
       function __resizeIframe(obj) {
         var scrollbarHeight = 20; // Max between windows, mac, and linux
-
+        
         function setHeight() {
           var element = obj.contentWindow.document.documentElement;
           // If there is no vertical scrollbar, we don't need to resize the iframe
@@ -45,7 +45,7 @@
 
         // Resize the iframe to the height of the content and bottom scrollbar height
         setHeight();
-
+        
         // Resize the iframe when the content changes
         const resizeObserver = new ResizeObserver((entries) => {
           setHeight();
@@ -62,7 +62,7 @@
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
-
+  
 <script data-marimo="true">
     window.__MARIMO_STATIC__ = {};
     window.__MARIMO_STATIC__.version = "0.0.0";

--- a/tests/_server/templates/snapshots/export3.txt
+++ b/tests/_server/templates/snapshots/export3.txt
@@ -25,7 +25,7 @@
     <script data-marimo="true">
       function __resizeIframe(obj) {
         var scrollbarHeight = 20; // Max between windows, mac, and linux
-        
+
         function setHeight() {
           var element = obj.contentWindow.document.documentElement;
           // If there is no vertical scrollbar, we don't need to resize the iframe
@@ -45,7 +45,7 @@
 
         // Resize the iframe to the height of the content and bottom scrollbar height
         setHeight();
-        
+
         // Resize the iframe when the content changes
         const resizeObserver = new ResizeObserver((entries) => {
           setHeight();
@@ -56,13 +56,13 @@
     <marimo-filename hidden>notebook.py</marimo-filename>
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
-    <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "package_management": {"add_script_metadata": false, "manager": "pip"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}}' hidden></marimo-user-config>
+    <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "package_management": {"manager": "pip"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}}' hidden></marimo-user-config>
     <marimo-app-config data-config='{"width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
-  
+
 <script data-marimo="true">
     window.__MARIMO_STATIC__ = {};
     window.__MARIMO_STATIC__.version = "0.0.0";

--- a/tests/_server/templates/snapshots/export4.txt
+++ b/tests/_server/templates/snapshots/export4.txt
@@ -25,7 +25,7 @@
     <script data-marimo="true">
       function __resizeIframe(obj) {
         var scrollbarHeight = 20; // Max between windows, mac, and linux
-
+        
         function setHeight() {
           var element = obj.contentWindow.document.documentElement;
           // If there is no vertical scrollbar, we don't need to resize the iframe
@@ -45,7 +45,7 @@
 
         // Resize the iframe to the height of the content and bottom scrollbar height
         setHeight();
-
+        
         // Resize the iframe when the content changes
         const resizeObserver = new ResizeObserver((entries) => {
           setHeight();
@@ -62,7 +62,7 @@
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
-
+  
 <script data-marimo="true">
     window.__MARIMO_STATIC__ = {};
     window.__MARIMO_STATIC__.version = "0.0.0";

--- a/tests/_server/templates/snapshots/export4.txt
+++ b/tests/_server/templates/snapshots/export4.txt
@@ -25,7 +25,7 @@
     <script data-marimo="true">
       function __resizeIframe(obj) {
         var scrollbarHeight = 20; // Max between windows, mac, and linux
-        
+
         function setHeight() {
           var element = obj.contentWindow.document.documentElement;
           // If there is no vertical scrollbar, we don't need to resize the iframe
@@ -45,7 +45,7 @@
 
         // Resize the iframe to the height of the content and bottom scrollbar height
         setHeight();
-        
+
         // Resize the iframe when the content changes
         const resizeObserver = new ResizeObserver((entries) => {
           setHeight();
@@ -56,13 +56,13 @@
     <marimo-filename hidden>notebook.py</marimo-filename>
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
-    <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "package_management": {"add_script_metadata": false, "manager": "pip"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}}' hidden></marimo-user-config>
+    <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "package_management": {"manager": "pip"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}}' hidden></marimo-user-config>
     <marimo-app-config data-config='{"css_file": "custom.css", "width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
-  
+
 <script data-marimo="true">
     window.__MARIMO_STATIC__ = {};
     window.__MARIMO_STATIC__.version = "0.0.0";


### PR DESCRIPTION
This removes the config `add_script_metadata` and just auto-adds it whenever we do `--sandbox`