### PR TITLE
fix: Open destination path on notebook copy

### DIFF
--- a/frontend/src/components/editor/actions/useCopyNotebook.tsx
+++ b/frontend/src/components/editor/actions/useCopyNotebook.tsx
@@ -20,10 +20,11 @@ export function useCopyNotebook(source: string | null) {
       defaultValue: `_${filename}`,
       confirmText: "Copy notebook",
       spellCheck: false,
-      onConfirm: (destination: string) => {
+      onConfirm: (filename: string) => {
+        const destination = pathBuilder.join(Paths.dirname(source), filename);
         sendCopy({
           source: source,
-          destination: pathBuilder.join(Paths.dirname(source), destination),
+          destination: destination,
         }).then(() => {
           closeModal();
           toast({


### PR DESCRIPTION
## 📝 Summary

Use the destination path to open the new notebook copy, not its filename. Small fix for #2307. 🙂

## 🔍 Description of Changes

In `useNotebookCopy.tsx`, the `destination` variable was set to the new copy's filename, not the full file path.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka
