### PR TITLE
tests: check schema drift from openapi schema

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -861,6 +861,13 @@ components:
             app_title:
               nullable: true
               type: string
+            auto_download:
+              items:
+                enum:
+                - html
+                - markdown
+                type: string
+              type: array
             css_file:
               nullable: true
               type: string
@@ -876,6 +883,7 @@ components:
               type: string
           required:
           - width
+          - auto_download
           type: object
         capabilities:
           properties:
@@ -1855,7 +1863,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.8.14
+  version: 0.8.15
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2203,6 +2203,7 @@ export interface components {
     KernelReady: {
       app_config: {
         app_title?: string | null;
+        auto_download: ("html" | "markdown")[];
         css_file?: string | null;
         layout_file?: string | null;
         /** @enum {string} */

--- a/tests/_cli/test_cli_development.py
+++ b/tests/_cli/test_cli_development.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import subprocess
 
+import yaml
+
 
 def test_cli_development_openapi() -> None:
     p = subprocess.run(
@@ -12,3 +14,25 @@ def test_cli_development_openapi() -> None:
     assert p.returncode == 0
     # Check a random endpoint
     assert "/api/export/html" in p.stdout.decode()
+
+
+def test_openapi_up_to_date() -> None:
+    with open("openapi/api.yaml", "r") as f:
+        current_content = yaml.safe_load(f)
+
+    result = subprocess.run(
+        ["marimo", "development", "openapi"], capture_output=True, text=True
+    )
+    generated_content = yaml.safe_load(result.stdout)
+
+    # Remove the version from both contents
+    # we don't care about the version for this comparison
+    if "info" in current_content:
+        del current_content["info"]["version"]
+    if "info" in generated_content:
+        del generated_content["info"]["version"]
+
+    cmd = "marimo development openapi > openapi/api.yaml && make fe-codegen"
+    assert (
+        current_content == generated_content
+    ), f"openapi/api.yaml is not up to date. Run '{cmd}' to update it."


### PR DESCRIPTION
Tests to check that marimo's backend is up-to-date with the open-api schema (minus the version)