### PR TITLE
fix: vega charts with special characters

### DIFF
--- a/frontend/src/components/data-table/__test__/chart-spec-model.test.ts
+++ b/frontend/src/components/data-table/__test__/chart-spec-model.test.ts
@@ -1,0 +1,94 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, it, expect } from "vitest";
+import { ColumnChartSpecModel } from "../chart-spec-model";
+import type { ColumnHeaderSummary, FieldTypes } from "../types";
+
+describe("ColumnChartSpecModel", () => {
+  const mockData = "http://example.com/data.json";
+  const mockFieldTypes: FieldTypes = {
+    date: "date",
+    number: "number",
+    integer: "integer",
+    boolean: "boolean",
+    string: "string",
+  };
+  const mockSummaries: ColumnHeaderSummary[] = [
+    { column: "date", min: "2023-01-01", max: "2023-12-31" },
+    { column: "number", min: 0, max: 100 },
+    { column: "integer", min: 1, max: 10 },
+    { column: "boolean", true: 5, false: 5 },
+    { column: "string", unique: 20 },
+  ];
+
+  it("should create an instance", () => {
+    const model = new ColumnChartSpecModel(
+      mockData,
+      mockFieldTypes,
+      mockSummaries,
+      { includeCharts: true },
+    );
+    expect(model).toBeInstanceOf(ColumnChartSpecModel);
+  });
+
+  it("should return EMPTY for static EMPTY property", () => {
+    expect(ColumnChartSpecModel.EMPTY).toBeInstanceOf(ColumnChartSpecModel);
+    expect(ColumnChartSpecModel.EMPTY.summaries).toEqual([]);
+  });
+
+  it("should return header summary with spec when includeCharts is true", () => {
+    const model = new ColumnChartSpecModel(
+      mockData,
+      mockFieldTypes,
+      mockSummaries,
+      { includeCharts: true },
+    );
+    const dateSummary = model.getHeaderSummary("date");
+    expect(dateSummary.summary).toEqual(mockSummaries[0]);
+    expect(dateSummary.type).toBe("date");
+    expect(dateSummary.spec).toBeDefined();
+  });
+
+  it("should return header summary without spec when includeCharts is false", () => {
+    const model = new ColumnChartSpecModel(
+      mockData,
+      mockFieldTypes,
+      mockSummaries,
+      { includeCharts: false },
+    );
+    const numberSummary = model.getHeaderSummary("number");
+    expect(numberSummary.summary).toEqual(mockSummaries[1]);
+    expect(numberSummary.type).toBe("number");
+    expect(numberSummary.spec).toBeUndefined();
+  });
+
+  it("should return null spec for string and unknown types", () => {
+    const model = new ColumnChartSpecModel(
+      mockData,
+      mockFieldTypes,
+      mockSummaries,
+      { includeCharts: true },
+    );
+    const stringSummary = model.getHeaderSummary("string");
+    expect(stringSummary.spec).toBeNull();
+  });
+
+  it("should handle special characters in column names", () => {
+    const specialFieldTypes: FieldTypes = {
+      "column.with[special:chars]": "number",
+    };
+    const specialSummaries: ColumnHeaderSummary[] = [
+      { column: "column.with[special:chars]", min: 0, max: 100 },
+    ];
+    const model = new ColumnChartSpecModel(
+      mockData,
+      specialFieldTypes,
+      specialSummaries,
+      { includeCharts: true },
+    );
+    const summary = model.getHeaderSummary("column.with[special:chars]");
+    expect(summary.spec).toBeDefined();
+    expect((summary.spec?.encoding?.x as { field: string })?.field).toBe(
+      "column\\.with\\[special\\:chars\\]",
+    );
+  });
+});

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -69,6 +69,14 @@ export class ColumnChartSpecModel<T> {
     };
     const type = this.fieldTypes[column];
 
+    // https://github.com/vega/altair/blob/32990a597af7c09586904f40b3f5e6787f752fa5/doc/user_guide/encodings/index.rst#escaping-special-characters-in-column-names
+    // escape periods in column names
+    column = column.replaceAll(".", "\\.");
+    // escape brackets in column names
+    column = column.replaceAll("[", "\\[").replaceAll("]", "\\]");
+    // escape colons in column names
+    column = column.replaceAll(":", "\\:");
+
     switch (type) {
       case "date":
         return {

--- a/marimo/_smoke_tests/bugs/2315.py
+++ b/marimo/_smoke_tests/bugs/2315.py
@@ -1,0 +1,49 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo",
+#     "polars",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.8.15"
+app = marimo.App(width="full")
+
+
+@app.cell
+def __():
+    import polars as pl
+    import altair as alt
+
+    # https://github.com/vega/altair/blob/32990a597af7c09586904f40b3f5e6787f752fa5/doc/user_guide/encodings/index.rst#escaping-special-characters-in-column-names
+
+    df1 = pl.DataFrame(
+        {
+            "a": [0.0, 0.0, 0.2, 0.2],
+            "b": [True, False, False, False],
+            "c": [True, False, False, False],
+            "d": [True, False, False, False],
+        }
+    )
+    df1
+    return alt, df1, pl
+
+
+@app.cell
+def __(pl):
+    df2 = pl.DataFrame(
+        {
+            "i.a": [0.0, 0.0, 0.2, 0.2],
+            "i.b": [True, False, False, False],
+            "i[c]": [True, False, False, False],
+            "i:d": [True, False, False, False],
+        }
+    )
+    df2
+    return df2,
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #2315

per https://github.com/vega/altair/blob/32990a597af7c09586904f40b3f5e6787f752fa5/doc/user_guide/encodings/index.rst#escaping-special-characters-in-column-names