### PR TITLE
improvement: Add "Hide outputs" to sql cells

### DIFF
--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -11,43 +11,72 @@ export const LanguagePanelComponent: React.FC<{
   const languageAdapter = view.state.field(languageAdapterState);
   const { spanProps, inputProps } = useAutoGrowInputProps({ minWidth: 50 });
   let actions: React.ReactNode = <div />;
+  let showDivider = false;
 
   if (languageAdapter instanceof SQLLanguageAdapter) {
+    showDivider = true;
     actions = (
-      <div className="flex gap-2 relative">
-        Output variable:{" "}
-        <input
-          {...inputProps}
-          defaultValue={languageAdapter.dataframeName}
-          onChange={(e) => {
-            languageAdapter.dataframeName = e.target.value;
-            inputProps.onChange?.(e);
-          }}
-          onBlur={(e) => {
-            // Normalize the name to a valid variable name
-            const name = normalizeName(e.target.value, false);
-            languageAdapter.dataframeName = name;
-            e.target.value = name;
+      <div className="flex flex-1 gap-2 relative items-center justify-between">
+        <div className="flex gap-2 items-center">
+          <label htmlFor="dataframeName" className="select-none">
+            Output variable:{" "}
+          </label>
+          <input
+            id="dataframeName"
+            {...inputProps}
+            defaultValue={languageAdapter.dataframeName}
+            onChange={(e) => {
+              languageAdapter.dataframeName = e.target.value;
+              inputProps.onChange?.(e);
+            }}
+            onBlur={(e) => {
+              // Normalize the name to a valid variable name
+              const name = normalizeName(e.target.value, false);
+              languageAdapter.dataframeName = name;
+              e.target.value = name;
 
-            // Send noop update code event, which will trigger an update to the new output variable name
-            view.dispatch({
-              changes: {
-                from: 0,
-                to: view.state.doc.length,
-                insert: view.state.doc.toString(),
-              },
-            });
-          }}
-          className="min-w-14 w-auto border border-border rounded px-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        />
-        <span {...spanProps} />
+              // Send noop update code event, which will trigger an update to the new output variable name
+              view.dispatch({
+                changes: {
+                  from: 0,
+                  to: view.state.doc.length,
+                  insert: view.state.doc.toString(),
+                },
+              });
+            }}
+            className="min-w-14 w-auto border border-border rounded px-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          />
+          <span {...spanProps} />
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="hideOutput"
+            onChange={(e) => {
+              languageAdapter.showOutput = !e.target.checked;
+              // Trigger an update to reflect the change
+              view.dispatch({
+                changes: {
+                  from: 0,
+                  to: view.state.doc.length,
+                  insert: view.state.doc.toString(),
+                },
+              });
+            }}
+            checked={!languageAdapter.showOutput}
+          />
+          <label className="select-none" htmlFor="hideOutput">
+            Hide output
+          </label>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="flex justify-between px-2 pt-2">
+    <div className="flex justify-between items-center gap-4 px-2 pt-2">
       {actions}
+      {showDivider && <div className="h-4 border-r border-border" />}
       {languageAdapter.type}
     </div>
   );

--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -17,12 +17,9 @@ export const LanguagePanelComponent: React.FC<{
     showDivider = true;
     actions = (
       <div className="flex flex-1 gap-2 relative items-center justify-between">
-        <div className="flex gap-2 items-center">
-          <label htmlFor="dataframeName" className="select-none">
-            Output variable:{" "}
-          </label>
+        <label className="flex gap-2 items-center">
+          <span className="select-none">Output variable: </span>
           <input
-            id="dataframeName"
             {...inputProps}
             defaultValue={languageAdapter.dataframeName}
             onChange={(e) => {
@@ -47,11 +44,10 @@ export const LanguagePanelComponent: React.FC<{
             className="min-w-14 w-auto border border-border rounded px-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           />
           <span {...spanProps} />
-        </div>
-        <div className="flex items-center gap-2">
+        </label>
+        <label className="flex items-center gap-2">
           <input
             type="checkbox"
-            id="hideOutput"
             onChange={(e) => {
               languageAdapter.showOutput = !e.target.checked;
               // Trigger an update to reflect the change
@@ -65,10 +61,8 @@ export const LanguagePanelComponent: React.FC<{
             }}
             checked={!languageAdapter.showOutput}
           />
-          <label className="select-none" htmlFor="hideOutput">
-            Hide output
-          </label>
-        </div>
+          <span className="select-none">Hide output</span>
+        </label>
       </div>
     );
   }

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -7,11 +7,11 @@ from typing import Any, Literal, Optional, cast
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._impl import table
-from marimo._runtime import output
 from marimo._runtime.context.types import (
     ContextNotInitializedError,
     get_context,
 )
+from marimo._runtime.output import replace
 
 
 def get_default_result_limit() -> Optional[int]:
@@ -22,6 +22,7 @@ def get_default_result_limit() -> Optional[int]:
 @mddoc
 def sql(
     query: str,
+    output: bool = True,
 ) -> Any:
     """
     Execute a SQL query.
@@ -29,10 +30,11 @@ def sql(
     This uses duckdb to execute the query. Any dataframes in the global
     namespace can be used inside the query.
 
-    The result of the query is displayed in the UI.
+    The result of the query is displayed in the UI if output is True.
 
     Args:
         query: The SQL query to execute.
+        output: Whether to display the result in the UI. Defaults to True.
 
     Returns:
         The result of the query.
@@ -101,14 +103,15 @@ def sql(
             + "You can install them with 'pip install pandas polars'"
         )
 
-    t = table.table(
-        df,
-        selection=None,
-        page_size=5,
-        pagination=True,
-        _internal_total_rows=custom_total_count,
-    )
-    output.replace(t)
+    if output:
+        t = table.table(
+            df,
+            selection=None,
+            page_size=5,
+            pagination=True,
+            _internal_total_rows=custom_total_count,
+        )
+        replace(t)
     return df
 
 


### PR DESCRIPTION
Fixes #2266

Adds "Hide output" to the sql. This serializes to `mo.sql("...", output=False)`

Note: Since this changes the code, it does mark the cell as stale, instead of actually hiding the output at the time. 
We could auto-run this cell afterwards, but that could create undesirable. 

<img width="831" alt="image" src="https://github.com/user-attachments/assets/b5c63c95-243e-4af0-8f66-aabd44755631">
