### PR TITLE
improvement: prevent uncessary rerenders in plugins

### DIFF
--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -42,6 +42,7 @@ import { Functions } from "@/utils/functions";
 import { StyleNamespace } from "@/theme/namespace";
 import { UIElementRegistry } from "@/core/dom/uiregistry";
 import { useEventListener } from "@/hooks/useEventListener";
+import { shallowCompare } from "@/utils/shallow-compare";
 
 export interface PluginSlotHandle {
   /**
@@ -134,6 +135,12 @@ function PluginSlotInternal<T>(
     setValue((prevValue) => {
       const updater = Functions.asUpdater(value);
       const nextValue = updater(prevValue);
+      // Shallow compare the values
+      // If the value hasn't changed, we don't need to send an input event
+      if (shallowCompare(nextValue, prevValue)) {
+        return nextValue;
+      }
+
       hostElement.dispatchEvent(createInputEvent(nextValue, hostElement));
       return nextValue;
     });

--- a/frontend/src/plugins/impl/plotly/PlotlyPlugin.tsx
+++ b/frontend/src/plugins/impl/plotly/PlotlyPlugin.tsx
@@ -186,13 +186,20 @@ export const PlotlyComponent = memo(
               ? figure.layout.selections
               : [];
           if (selections.length === 0) {
-            setValue((prev) => ({
-              ...prev,
-              selections: selections,
-              points: [],
-              indices: [],
-              range: undefined,
-            }));
+            setValue((prev) => {
+              const prevSelections = prev?.selections ?? [];
+              if (prevSelections.length === 0) {
+                return prev;
+              }
+
+              return {
+                ...prev,
+                selections: selections,
+                points: [],
+                indices: [],
+                range: undefined,
+              };
+            });
           }
         }}
         config={plotlyConfig}

--- a/frontend/src/utils/__tests__/shallow-compare.test.ts
+++ b/frontend/src/utils/__tests__/shallow-compare.test.ts
@@ -1,0 +1,55 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, test, expect } from "vitest";
+import { shallowCompare } from "../shallow-compare";
+
+describe("shallowCompare", () => {
+  test("compares primitive values", () => {
+    expect(shallowCompare(1, 1)).toBe(true);
+    expect(shallowCompare("a", "a")).toBe(true);
+    expect(shallowCompare(true, true)).toBe(true);
+    expect(shallowCompare(null, null)).toBe(true);
+    expect(shallowCompare(undefined, undefined)).toBe(true);
+
+    expect(shallowCompare(1, 2)).toBe(false);
+    expect(shallowCompare("a", "b")).toBe(false);
+    expect(shallowCompare(true, false)).toBe(false);
+    expect(shallowCompare(null, undefined)).toBe(false);
+  });
+
+  test("compares arrays", () => {
+    expect(shallowCompare([], [])).toBe(true);
+    expect(shallowCompare([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(shallowCompare(["a", "b"], ["a", "b"])).toBe(true);
+
+    expect(shallowCompare([1, 2, 3], [1, 2, 4])).toBe(false);
+    expect(shallowCompare([1, 2], [1, 2, 3])).toBe(false);
+    expect(shallowCompare(["a", "b"], ["b", "a"])).toBe(false);
+  });
+
+  test("compares objects", () => {
+    expect(shallowCompare({}, {})).toBe(true);
+    expect(shallowCompare({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+    expect(shallowCompare({ a: "x", b: "y" }, { a: "x", b: "y" })).toBe(true);
+
+    expect(shallowCompare({ a: 1, b: 2 }, { a: 1, b: 3 })).toBe(false);
+    expect(shallowCompare({ a: 1, b: 2 }, { a: 1, c: 2 })).toBe(false);
+    expect(shallowCompare({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  test("compares nested structures", () => {
+    const subObj1 = { c: 2 };
+    const obj1 = { a: 1, b: subObj1 };
+    const obj2 = { a: 1, b: subObj1 };
+    const obj3 = { a: 1, b: { c: 2 } };
+
+    expect(shallowCompare(obj1, obj2)).toBe(true);
+    expect(shallowCompare(obj1, obj3)).toBe(false);
+
+    const arr1 = [1, subObj1];
+    const arr2 = [1, subObj1];
+    const arr3 = [1, { c: 2 }];
+
+    expect(shallowCompare(arr1, arr2)).toBe(true);
+    expect(shallowCompare(arr1, arr3)).toBe(false);
+  });
+});

--- a/frontend/src/utils/shallow-compare.ts
+++ b/frontend/src/utils/shallow-compare.ts
@@ -1,0 +1,30 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { arrayShallowEquals } from "./arrays";
+import { Objects } from "./objects";
+
+export function shallowCompare<T>(a: T, b: T): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (a == null || b == null) {
+    return false;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return arrayShallowEquals(a, b);
+  }
+
+  if (typeof a === "object" && typeof b === "object") {
+    return shallowCompareObjects(a, b);
+  }
+
+  return false;
+}
+
+function shallowCompareObjects<T extends object>(a: T, b: T): boolean {
+  return (
+    Object.keys(a).length === Object.keys(b).length &&
+    Objects.keys(a).every((key) => a[key] === b[key])
+  );
+}


### PR DESCRIPTION
This commit optimizes setting state by plugins by using a newly added shallowCompare utility function. This helps improve performance by avoiding unnecessary rerenders when the value hasn't really changed.
