### PR TITLE
improvement: better loading indicator while pyodide is bootstrapping

### DIFF
--- a/frontend/src/components/icons/large-spinner.tsx
+++ b/frontend/src/components/icons/large-spinner.tsx
@@ -1,15 +1,36 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { cn } from "@/utils/cn";
 import { Loader2Icon } from "lucide-react";
+import { useState, useEffect } from "react";
 
-export const LargeSpinner = () => {
+export const LargeSpinner = ({ title }: { title?: string }) => {
+  const [currentTitle, setCurrentTitle] = useState(title);
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    if (title !== currentTitle) {
+      setIsVisible(false);
+      const timer = setTimeout(() => {
+        setCurrentTitle(title);
+        setIsVisible(true);
+      }, 300); // Wait for fade out animation to complete
+      return () => clearTimeout(timer);
+    }
+  }, [title, currentTitle]);
+
   return (
     <div className="flex flex-col h-full flex-1 items-center justify-center p-4">
       <Loader2Icon
         className="size-20 animate-spin text-primary"
         strokeWidth={1}
       />
-      <div className="mt-2 text-muted-foreground font-semibold text-lg">
-        Initializing...
+      <div
+        className={cn(
+          "mt-2 text-muted-foreground font-semibold text-lg transition-opacity duration-300",
+          isVisible ? "opacity-100" : "opacity-0",
+        )}
+      >
+        {currentTitle}
       </div>
     </div>
   );

--- a/frontend/src/core/wasm/PyodideLoader.tsx
+++ b/frontend/src/core/wasm/PyodideLoader.tsx
@@ -5,6 +5,11 @@ import { useAsyncData } from "@/hooks/useAsyncData";
 import { isWasm } from "./utils";
 import { PyodideBridge } from "./bridge";
 import { LargeSpinner } from "@/components/icons/large-spinner";
+import { useAtomValue } from "jotai";
+import { hasAnyOutputAtom, wasmInitializationAtom } from "./state";
+import { initialMode } from "../mode";
+import { hasQueryParam } from "@/utils/urls";
+import { KnownQueryParams } from "../constants";
 
 /**
  * HOC to load Pyodide before rendering children, if necessary.
@@ -21,8 +26,24 @@ export const PyodideLoader: React.FC<PropsWithChildren> = ({ children }) => {
     return true;
   }, []);
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const hasOutput = useAtomValue(hasAnyOutputAtom);
+
   if (loading) {
-    return <LargeSpinner />;
+    return <WasmSpinner />;
+  }
+
+  // If we:
+  // - are in read mode
+  // - we are not showing the code
+  // - and there is no output
+  // then show the spinner
+  if (
+    !hasOutput &&
+    initialMode === "read" &&
+    hasQueryParam(KnownQueryParams.showCode, "false")
+  ) {
+    return <WasmSpinner />;
   }
 
   // Propagate back up to our error boundary
@@ -31,4 +52,10 @@ export const PyodideLoader: React.FC<PropsWithChildren> = ({ children }) => {
   }
 
   return children;
+};
+
+export const WasmSpinner: React.FC<PropsWithChildren> = ({ children }) => {
+  const wasmInitialization = useAtomValue(wasmInitializationAtom);
+
+  return <LargeSpinner title={wasmInitialization} />;
 };

--- a/frontend/src/core/wasm/state.ts
+++ b/frontend/src/core/wasm/state.ts
@@ -1,0 +1,12 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { atom } from "jotai";
+import { notebookAtom } from "../cells/cells";
+
+export const wasmInitializationAtom = atom<string>("Initializing...");
+
+export const hasAnyOutputAtom = atom<boolean>((get) => {
+  const notebook = get(notebookAtom);
+  return Object.values(notebook.cellRuntime).some((runtime) =>
+    Boolean(runtime.output),
+  );
+});

--- a/frontend/src/core/wasm/worker/worker.ts
+++ b/frontend/src/core/wasm/worker/worker.ts
@@ -113,7 +113,6 @@ const requestHandler = createRPCRequestHandler({
           messageBuffer.push(msg);
         },
       });
-      initializeOnce();
       bridgeReady.resolve(bridge);
       workerInitSpan.end("ok");
     } catch (error) {
@@ -246,7 +245,7 @@ export type WorkerSchema = RPCSchema<
       kernelMessage: { message: JsonString<OperationMessage> };
       // Emitted when the Pyodide is initialized
       initialized: {};
-      // Emitted when the Pyodide is initializing
+      // Emitted when the Pyodide is initializing, with new messages
       initializingMessage: { message: string };
       // Emitted when the Pyodide fails to initialize
       initializedError: { error: string };

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -4,3 +4,16 @@ export function updateQueryParams(updater: (params: URLSearchParams) => void) {
   updater(url.searchParams);
   window.history.replaceState({}, "", url.toString());
 }
+
+export function hasQueryParam(key: string, value?: string): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const urlParams = new URLSearchParams(window.location.search);
+
+  if (value === undefined) {
+    return urlParams.has(key);
+  }
+
+  return urlParams.get(key) === value;
+}


### PR DESCRIPTION
- show ongoing messages as pyodide loads
- if we are not showing the code cells, keep showing the loading indicator until _some_ output is shown
- don't initialize the save-rpc webworker when running in read mode