### PR TITLE
improvement: Debounce mo.ui.text and text_area

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -59,12 +59,12 @@ export const DebouncedInput = React.forwardRef<
   InputProps & {
     value: string;
     onValueChange: (value: string) => void;
+    delay?: number;
   }
 >(({ className, onValueChange, ...props }, ref) => {
-  // Create a debounced value of 200
   const { value, onChange } = useDebounceControlledState<string>({
     initialValue: props.value,
-    delay: 200,
+    delay: props.delay,
     onChange: onValueChange,
   });
 
@@ -154,5 +154,32 @@ export const SearchInput = React.forwardRef<
   );
 });
 SearchInput.displayName = "SearchInput";
+
+export const OnBlurredInput = React.forwardRef<
+  HTMLInputElement,
+  InputProps & {
+    value: string;
+    onValueChange: (value: string) => void;
+  }
+>(({ className, onValueChange, ...props }, ref) => {
+  const [internalValue, setInternalValue] = React.useState(props.value);
+  return (
+    <Input
+      ref={ref}
+      className={className}
+      {...props}
+      onChange={(event) => setInternalValue(event.target.value)}
+      onBlur={() => onValueChange(internalValue)}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter") {
+          return;
+        }
+        onValueChange(internalValue);
+      }}
+      value={internalValue}
+    />
+  );
+});
+OnBlurredInput.displayName = "OnBlurredInput";
 
 export { Input };

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -9,6 +9,7 @@ import {
   type NumberFieldProps,
 } from "@/components/ui/number-field";
 import { SearchIcon, XIcon } from "lucide-react";
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   icon?: React.ReactNode;
@@ -163,20 +164,31 @@ export const OnBlurredInput = React.forwardRef<
   }
 >(({ className, onValueChange, ...props }, ref) => {
   const [internalValue, setInternalValue] = React.useState(props.value);
+
+  const [value, setValue] = useControllableState<string>({
+    prop: props.value,
+    defaultProp: props.value,
+    onChange: onValueChange,
+  });
+
+  React.useEffect(() => {
+    setInternalValue(value || "");
+  }, [value]);
+
   return (
     <Input
       ref={ref}
       className={className}
       {...props}
+      value={internalValue}
       onChange={(event) => setInternalValue(event.target.value)}
-      onBlur={() => onValueChange(internalValue)}
+      onBlur={() => setValue(internalValue || "")}
       onKeyDown={(event) => {
         if (event.key !== "Enter") {
           return;
         }
-        onValueChange(internalValue);
+        setValue(internalValue || "");
       }}
-      value={internalValue}
     />
   );
 });

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -167,7 +167,7 @@ export const OnBlurredInput = React.forwardRef<
 
   const [value, setValue] = useControllableState<string>({
     prop: props.value,
-    defaultProp: props.value,
+    defaultProp: internalValue,
     onChange: onValueChange,
   });
 

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
 import { useDebounceControlledState } from "@/hooks/useDebounce";
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -69,21 +70,32 @@ export const OnBlurredTextarea = React.forwardRef<
   }
 >(({ className, onValueChange, ...props }, ref) => {
   const [internalValue, setInternalValue] = React.useState(props.value);
+
+  const [value, setValue] = useControllableState<string>({
+    prop: props.value,
+    defaultProp: props.value,
+    onChange: onValueChange,
+  });
+
+  React.useEffect(() => {
+    setInternalValue(value || "");
+  }, [value]);
+
   return (
     <Textarea
       ref={ref}
       className={className}
       {...props}
+      value={internalValue}
       onChange={(event) => setInternalValue(event.target.value)}
-      onBlur={() => onValueChange(internalValue)}
+      onBlur={() => setValue(internalValue)}
       onKeyDown={(event) => {
         if (!(event.ctrlKey && event.key === "Enter")) {
           return;
         }
         event.preventDefault();
-        onValueChange(internalValue);
+        setValue(internalValue);
       }}
-      value={internalValue}
     />
   );
 });

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
+import { useDebounceControlledState } from "@/hooks/useDebounce";
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -33,5 +34,59 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   },
 );
 Textarea.displayName = "Textarea";
+
+export const DebouncedTextarea = React.forwardRef<
+  HTMLTextAreaElement,
+  TextareaProps & {
+    value: string;
+    onValueChange: (value: string) => void;
+    delay?: number;
+  }
+>(({ className, onValueChange, ...props }, ref) => {
+  const { value, onChange } = useDebounceControlledState<string>({
+    initialValue: props.value,
+    delay: props.delay,
+    onChange: onValueChange,
+  });
+
+  return (
+    <Textarea
+      ref={ref}
+      className={className}
+      {...props}
+      onChange={(evt) => onChange(evt.target.value)}
+      value={value}
+    />
+  );
+});
+DebouncedTextarea.displayName = "DebouncedTextarea";
+
+export const OnBlurredTextarea = React.forwardRef<
+  HTMLTextAreaElement,
+  TextareaProps & {
+    value: string;
+    onValueChange: (value: string) => void;
+  }
+>(({ className, onValueChange, ...props }, ref) => {
+  const [internalValue, setInternalValue] = React.useState(props.value);
+  return (
+    <Textarea
+      ref={ref}
+      className={className}
+      {...props}
+      onChange={(event) => setInternalValue(event.target.value)}
+      onBlur={() => onValueChange(internalValue)}
+      onKeyDown={(event) => {
+        if (!(event.ctrlKey && event.key === "Enter")) {
+          return;
+        }
+        event.preventDefault();
+        onValueChange(internalValue);
+      }}
+      value={internalValue}
+    />
+  );
+});
+OnBlurredTextarea.displayName = "OnBlurredTextarea";
 
 export { Textarea };

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -73,7 +73,7 @@ export const OnBlurredTextarea = React.forwardRef<
 
   const [value, setValue] = useControllableState<string>({
     prop: props.value,
-    defaultProp: props.value,
+    defaultProp: internalValue,
     onChange: onValueChange,
   });
 

--- a/frontend/src/plugins/impl/TextAreaPlugin.tsx
+++ b/frontend/src/plugins/impl/TextAreaPlugin.tsx
@@ -2,7 +2,11 @@
 import { z } from "zod";
 import type { IPlugin, IPluginProps, Setter } from "../types";
 
-import { Textarea } from "../../components/ui/textarea";
+import {
+  DebouncedTextarea,
+  OnBlurredTextarea,
+  Textarea,
+} from "../../components/ui/textarea";
 import { Labeled } from "./common/labeled";
 import { cn } from "@/utils/cn";
 
@@ -14,6 +18,7 @@ interface Data {
   maxLength?: number;
   minLength?: number;
   disabled?: boolean;
+  debounce?: boolean | number;
   rows: number;
   fullWidth: boolean;
 }
@@ -28,6 +33,7 @@ export class TextAreaPlugin implements IPlugin<T, Data> {
     maxLength: z.number().optional(),
     minLength: z.number().optional(),
     disabled: z.boolean().optional(),
+    debounce: z.optional(z.union([z.boolean(), z.number()])),
     rows: z.number().default(4),
     fullWidth: z.boolean().default(false),
   });
@@ -54,6 +60,51 @@ const TextAreaComponent = (props: TextAreaComponentProps) => {
       {props.value.length}/{props.maxLength}
     </span>
   ) : null;
+
+  if (props.debounce === true) {
+    return (
+      <Labeled label={props.label} align="top" fullWidth={props.fullWidth}>
+        <OnBlurredTextarea
+          className={cn("font-code", {
+            "w-full": props.fullWidth,
+          })}
+          rows={props.rows}
+          cols={33}
+          maxLength={props.maxLength}
+          minLength={props.minLength}
+          required={props.minLength != null && props.minLength > 0}
+          disabled={props.disabled}
+          bottomAdornment={bottomAdornment}
+          value={props.value}
+          onValueChange={props.setValue}
+          placeholder={props.placeholder}
+        />
+      </Labeled>
+    );
+  }
+
+  if (typeof props.debounce === "number") {
+    return (
+      <Labeled label={props.label} align="top" fullWidth={props.fullWidth}>
+        <DebouncedTextarea
+          className={cn("font-code", {
+            "w-full": props.fullWidth,
+          })}
+          rows={props.rows}
+          cols={33}
+          maxLength={props.maxLength}
+          minLength={props.minLength}
+          required={props.minLength != null && props.minLength > 0}
+          disabled={props.disabled}
+          bottomAdornment={bottomAdornment}
+          value={props.value}
+          onValueChange={props.setValue}
+          placeholder={props.placeholder}
+          delay={props.debounce}
+        />
+      </Labeled>
+    );
+  }
 
   return (
     <Labeled label={props.label} align="top" fullWidth={props.fullWidth}>

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -665,7 +665,8 @@ class text(UIElement[str, str]):
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
     - `debounce`: whether the input is debounced. If number, debounce by
-        that many milliseconds. If True, then value is only emitted on Enter.
+        that many milliseconds. If True, then value is only emitted on Enter 
+        or when the input loses focus.
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
@@ -728,7 +729,8 @@ class text_area(UIElement[str, str]):
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
     - `debounce`: whether the input is debounced. If number, debounce by that
-        many milliseconds. If True, then value is only emitted on Ctrl+Enter.
+        many milliseconds. If True, then value is only emitted on Ctrl+Enter 
+        or when the input loses focus.
     - `rows`: number of rows of text to display
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -665,7 +665,7 @@ class text(UIElement[str, str]):
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
     - `debounce`: whether the input is debounced. If number, debounce by
-        that many milliseconds. If True, then value is only emitted on Enter 
+        that many milliseconds. If True, then value is only emitted on Enter
         or when the input loses focus.
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
@@ -729,7 +729,7 @@ class text_area(UIElement[str, str]):
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
     - `debounce`: whether the input is debounced. If number, debounce by that
-        many milliseconds. If True, then value is only emitted on Ctrl+Enter 
+        many milliseconds. If True, then value is only emitted on Ctrl+Enter
         or when the input loses focus.
     - `rows`: number of rows of text to display
     - `label`: text label for the element

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -664,6 +664,8 @@ class text(UIElement[str, str]):
         defaults to `"text"`
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
+    - `debounce`: whether the input is debounced. If number, debounce by
+        that many milliseconds. If True, then value is only emitted on Enter.
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
@@ -679,6 +681,7 @@ class text(UIElement[str, str]):
         kind: Literal["text", "password", "email", "url"] = "text",
         max_length: Optional[int] = None,
         disabled: bool = False,
+        debounce: bool | int = True,
         *,
         label: str = "",
         on_change: Optional[Callable[[str], None]] = None,
@@ -694,6 +697,7 @@ class text(UIElement[str, str]):
                 "max-length": max_length,
                 "full-width": full_width,
                 "disabled": disabled,
+                "debounce": debounce,
             },
             on_change=on_change,
         )
@@ -723,6 +727,8 @@ class text_area(UIElement[str, str]):
     - `placeholder`: placeholder text to display when the text area is empty
     - `max_length`: maximum length of input
     - `disabled`: whether the input is disabled
+    - `debounce`: whether the input is debounced. If number, debounce by that
+        many milliseconds. If True, then value is only emitted on Ctrl+Enter.
     - `rows`: number of rows of text to display
     - `label`: text label for the element
     - `on_change`: optional callback to run when this element's value changes
@@ -738,6 +744,7 @@ class text_area(UIElement[str, str]):
         placeholder: str = "",
         max_length: Optional[int] = None,
         disabled: bool = False,
+        debounce: bool | int = True,
         rows: Optional[int] = None,
         *,
         label: str = "",
@@ -752,6 +759,7 @@ class text_area(UIElement[str, str]):
                 "placeholder": placeholder,
                 "max-length": max_length,
                 "disabled": disabled,
+                "debounce": debounce,
                 "full-width": full_width,
                 "rows": rows,
             },

--- a/marimo/_smoke_tests/debounce_input.py
+++ b/marimo/_smoke_tests/debounce_input.py
@@ -15,13 +15,13 @@ def __(debounce, debounce_options, mo):
     name_input = mo.ui.text(
         label="Enter your name for the greeting of a lifetime:", debounce=debounce
     )
-    mo.vstack([debounce_options, name_input])
+    mo.vstack([debounce_options, name_input, name_input])
     return name_input,
 
 
 @app.cell
 def __(name_input):
-    if len(name_input.value) > 1:
+    if len(name_input.value) > 0:
         print(f"Hello {name_input.value}!")
     return
 
@@ -31,13 +31,14 @@ def __(debounce, debounce_options, mo):
     story_input = mo.ui.text_area(
         label="Now tell me a story from your childhood:", debounce=debounce
     )
-    mo.vstack([debounce_options, story_input])
+    mo.vstack([debounce_options, mo.hstack([story_input, story_input])])
     return story_input,
 
 
 @app.cell
 def __(story_input):
-    print(story_input.value)
+    if (len(story_input.value) > 0):
+        print(story_input.value)
     return
 
 

--- a/marimo/_smoke_tests/debounce_input.py
+++ b/marimo/_smoke_tests/debounce_input.py
@@ -1,0 +1,71 @@
+import marimo
+
+__generated_with = "0.8.15"
+app = marimo.App()
+
+
+@app.cell
+def __(mo):
+    mo.md(r"""[Debounce mo.ui.text and mo.ui.text_area #2218](https://github.com/marimo-team/marimo/issues/2218)""")
+    return
+
+
+@app.cell
+def __(debounce, debounce_options, mo):
+    name_input = mo.ui.text(
+        label="Enter your name for the greeting of a lifetime:", debounce=debounce
+    )
+    mo.vstack([debounce_options, name_input])
+    return name_input,
+
+
+@app.cell
+def __(name_input):
+    if len(name_input.value) > 1:
+        print(f"Hello {name_input.value}!")
+    return
+
+
+@app.cell
+def __(debounce, debounce_options, mo):
+    story_input = mo.ui.text_area(
+        label="Now tell me a story from your childhood:", debounce=debounce
+    )
+    mo.vstack([debounce_options, story_input])
+    return story_input,
+
+
+@app.cell
+def __(story_input):
+    print(story_input.value)
+    return
+
+
+@app.cell
+def __(mo):
+    debounce_options = mo.ui.dropdown(
+        label="Choose debounce option",
+        options=["True", "500", "1000", "False"],
+        value="True",
+    )
+    return debounce_options,
+
+
+@app.cell
+def __(debounce_options):
+    debounce = debounce_options.value
+    debounce = (
+        int(debounce) if debounce != "True" and debounce != "False" else debounce
+    )
+    debounce = debounce == "True" if isinstance(debounce, str) else debounce
+    return debounce,
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## 📝 Summary

Debounce `mo.ui.text` and `mo.ui.text_area` either until Enter is pressed (or Ctrl+Enter for text area), or by a given number of milliseconds. Completes #2218.

## 🔍 Description of Changes

- If `debounce === true`, then only emit values on Enter key down (Ctrl + Enter for text area)
- If `typeof debounce === "number"`, then delay emit by that value in milliseconds
- Both `mo.ui.text` and `mo.ui.text_area` have `debounce` set to `True` by default now

Feel free to check out the example notebook in the `_smoke_tests` directory. When `debounce === False`, noticed some flickering when the value from an input/textarea is printed in a different cell; may need to address in a separate issue.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
