### PR TITLE
ignore project when running in a sandbox

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -55,6 +55,9 @@ def run_in_sandbox(
         "uv",
         "run",
         "--isolated",
+        # sandboxed notebook shouldn't pick up existing pyproject.toml,
+        # which may conflict with the sandbox requirements
+        "--no-project",
         "--with-requirements",
         temp_file_path,
     ] + cmd


### PR DESCRIPTION
Without this change, running `marimo edit --sandbox notebook.py` in a directory with a pyproject.toml (such as the marimo repo itself) very often fails because the notebook's requirements conflict with the project's requirements, which defeats the purpose of "sandboxing" the notebook. This change makes the notebook actually self-contained.