### PR TITLE
chore: format tuple in return to match ruff/black

### DIFF
--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -85,7 +85,7 @@ def to_functiondef(
         defs = tuple(name for name in sorted(cell.defs))
         returns = INDENT + "return "
         if len(cell.defs) == 1:
-            returns += f"{defs[0]},"
+            returns += f"({defs[0]},)"
         else:
             returns += ", ".join(defs)
         fndef += (

--- a/tests/_ast/codegen_data/test_generate_filecontents.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents.py
@@ -7,7 +7,7 @@ app = marimo.App()
 @app.cell
 def one():
     import numpy as np
-    return np,
+    return (np,)
 
 
 @app.cell
@@ -20,14 +20,14 @@ def two():
 @app.cell
 def three(x):
     y = x + 1
-    return y,
+    return (y,)
 
 
 @app.cell
 def four(np, x, y):
     # comment
     z = np.array(x + y)
-    return z,
+    return (z,)
 
 
 @app.cell

--- a/tests/_ast/codegen_data/test_generate_filecontents_async_long_signature.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_async_long_signature.py
@@ -40,7 +40,7 @@ async def two(
     async for data_point in client("test", "ws://localhost:8000"):
         print(data_point)
     data_point
-    return data_point,
+    return (data_point,)
 
 
 if __name__ == "__main__":

--- a/tests/_ast/codegen_data/test_generate_filecontents_shadowed_builtin.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_shadowed_builtin.py
@@ -7,7 +7,7 @@ app = marimo.App()
 @app.cell
 def one():
     type = 1
-    return type,
+    return (type,)
 
 
 @app.cell

--- a/tests/_ast/codegen_data/test_generate_filecontents_single_cell.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_single_cell.py
@@ -7,7 +7,7 @@ app = marimo.App()
 @app.cell
 def one():
     import numpy as np
-    return np,
+    return (np,)
 
 
 if __name__ == "__main__":

--- a/tests/_ast/codegen_data/test_generate_filecontents_with_syntax_error.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_with_syntax_error.py
@@ -7,7 +7,7 @@ app = marimo.App()
 @app.cell
 def one():
     import numpy as np
-    return np,
+    return (np,)
 
 
 app._unparsable_cell(

--- a/tests/_ast/codegen_data/test_get_codes_messy.py
+++ b/tests/_ast/codegen_data/test_get_codes_messy.py
@@ -14,7 +14,7 @@ def __(a,
 
     # yet another comment
     x = 0 + a + b + c + d
-    return x,
+    return (x,)
 
 
 if __name__ == "__main__":

--- a/tests/_ast/codegen_data/test_get_codes_multiline_fndef.py
+++ b/tests/_ast/codegen_data/test_get_codes_multiline_fndef.py
@@ -9,7 +9,7 @@ def one(a,
         b,      c,d) -> int:
     # comment
     x = 0 + a + b + c + d
-    return x,
+    return (x,)
 
 
 if __name__ == "__main__":

--- a/tests/_ast/codegen_data/test_get_codes_multiline_string.py
+++ b/tests/_ast/codegen_data/test_get_codes_multiline_string.py
@@ -6,7 +6,7 @@ app = marimo.App()
 
 @app.cell
 def one(): c = """
-  a, b"""; return c,
+  a, b"""; return (c,)
 
 
 if __name__ == "__main__":

--- a/tests/_ast/codegen_data/test_get_codes_single_line_fn.py
+++ b/tests/_ast/codegen_data/test_get_codes_single_line_fn.py
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def one(a: int, b: int) -> None: c = a + b; print(c); return c,
+def one(a: int, b: int) -> None: c = a + b; print(c); return (c,)
 
 
 if __name__ == "__main__":

--- a/tests/_ast/codegen_data/test_get_codes_with_incorrect_args_rets.py
+++ b/tests/_ast/codegen_data/test_get_codes_with_incorrect_args_rets.py
@@ -13,7 +13,7 @@ def one():
 def two():
     x = 0
     xx = 1
-    return x,
+    return (x,)
 
 
 @app.cell
@@ -25,7 +25,7 @@ def three():
 def four(y):
     # comment
     z = np.array(x + y)
-    return z,
+    return (z,)
 
 
 @app.cell

--- a/tests/_ast/codegen_data/test_long_line_in_main.py
+++ b/tests/_ast/codegen_data/test_long_line_in_main.py
@@ -23,7 +23,7 @@ def two(
     yet_another_very_long_name,
 ):
     z = i_am_a_very_long_name + i_am_another_very_long_name + yet_another_very_long_name
-    return z,
+    return (z,)
 
 
 if __name__ == "__main__":

--- a/tests/_ast/codegen_data/test_main.py
+++ b/tests/_ast/codegen_data/test_main.py
@@ -9,21 +9,21 @@ app = marimo.App()
 @app.cell
 def one() -> Tuple[Any]:
     x = 0
-    return x,
+    return (x,)
 
 
 @app.cell
 def two(x: Any) -> Tuple[Any, Any]:
     y = x + 1
     z = y + 1
-    'z'
+    "z"
     return y, z
 
 
 @app.cell
 def three(x: Any, y: Any) -> Tuple[Any]:
     a = x + y
-    return a,
+    return (a,)
 
 
 if __name__ == "__main__":

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -431,7 +431,7 @@ class TestToFunctionDef:
         cell = compile_cell(code)
         fndef = codegen.to_functiondef(cell, "foo")
         expected = "\n".join(
-            ["@app.cell", "def foo():", "    x = 0", "    return x,"]
+            ["@app.cell", "def foo():", "    x = 0", "    return (x,)"]
         )
         assert fndef == expected
 
@@ -491,7 +491,7 @@ class TestToFunctionDef:
         cell = cell.configure(CellConfig())
         fndef = codegen.to_functiondef(cell, "foo")
         expected = "\n".join(
-            ["@app.cell", "def foo():", "    x = 0", "    return x,"]
+            ["@app.cell", "def foo():", "    x = 0", "    return (x,)"]
         )
         assert fndef == expected
 
@@ -505,7 +505,7 @@ class TestToFunctionDef:
                 "@app.cell(disabled=True)",
                 "def foo():",
                 "    x = 0",
-                "    return x,",
+                "    return (x,)",
             ]
         )
         assert fndef == expected
@@ -520,7 +520,7 @@ class TestToFunctionDef:
                 "@app.cell(disabled=True, hide_code=True)",
                 "def foo():",
                 "    x = 0",
-                "    return x,",
+                "    return (x,)",
             ]
         )
         assert fndef == expected
@@ -535,7 +535,7 @@ class TestToFunctionDef:
                 "@app.cell",
                 "def foo():",
                 "    x = 0",
-                "    return x,",
+                "    return (x,)",
             ]
         )
         assert fndef == expected

--- a/tests/_cli/snapshots/unsafe-app.py.txt
+++ b/tests/_cli/snapshots/unsafe-app.py.txt
@@ -7,7 +7,7 @@ app = marimo.App(app_title="Test Notebook")
 @app.cell
 def __():
     import marimo as mo
-    return mo,
+    return (mo,)
 
 
 @app.cell

--- a/tests/_server/test_file_manager.py
+++ b/tests/_server/test_file_manager.py
@@ -241,7 +241,7 @@ def test_to_code(app_file_manager: AppFileManager) -> None:
             "@app.cell",
             "def __():",
             "    import marimo as mo",
-            "    return mo,",
+            "    return (mo,)",
             "",
             "",
             'if __name__ == "__main__":',


### PR DESCRIPTION
formats single-element tuples in return statements to match ruff/black to prevent unnecessary git diffs for ruff/black users