### PR TITLE
fix: allow mo.status.spinner and mo.state.progress to noop outside marimo

### DIFF
--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
 
 from marimo._ast.cell import CellId_t
 from marimo._messaging.cell_output import CellChannel
@@ -8,6 +9,7 @@ from marimo._output import formatting
 from marimo._output.rich_help import mddoc
 from marimo._plugins.stateless.flex import vstack
 from marimo._runtime.context import get_context
+from marimo._runtime.context.types import ContextNotInitializedError
 
 
 def write_internal(cell_id: CellId_t, value: object) -> None:
@@ -34,7 +36,11 @@ def replace(value: object) -> None:
 
     - `value`: object to output
     """
-    ctx = get_context()
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        return
+
     if ctx.execution_context is None:
         return
     elif value is None:
@@ -57,7 +63,11 @@ def replace_at_index(value: object, idx: int) -> None:
     - `idx`: index of output to replace
     """
 
-    ctx = get_context()
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        return
+
     if ctx.execution_context is None or ctx.execution_context.output is None:
         return
     elif idx > len(ctx.execution_context.output):
@@ -85,7 +95,11 @@ def append(value: object) -> None:
 
     - `value`: object to output
     """
-    ctx = get_context()
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        return
+
     if ctx.execution_context is None:
         return
 
@@ -107,7 +121,11 @@ def clear() -> None:
 
 def flush() -> None:
     """Internal function to re-render the cell's output."""
-    ctx = get_context()
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        return
+
     if ctx.execution_context is None:
         return
 
@@ -120,7 +138,11 @@ def flush() -> None:
 
 def remove(value: object) -> None:
     """Internal function to remove an object from a cell's output."""
-    ctx = get_context()
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        return
+
     if ctx.execution_context is None or ctx.execution_context.output is None:
         return
     output = [

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -1,11 +1,18 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import time
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 
-from marimo._plugins.stateless.status._progress import _Progress
+from marimo._plugins.stateless.status._progress import (
+    _Progress,
+    progress_bar,
+    spinner,
+)
+from marimo._runtime.context.types import runtime_context_installed
 
 
 # Test initialization
@@ -98,3 +105,26 @@ def test_update_progress_closed(mock_flush: Any) -> None:
     with pytest.raises(RuntimeError):
         progress.update_progress()
     mock_flush.assert_called_once()
+
+
+def test_spinner_without_context():
+    assert runtime_context_installed() is False
+
+    with spinner("Test"):
+        assert True
+
+    with spinner(subtitle="Loading data ...") as _spinner:
+        assert spinner
+        _spinner.update(subtitle="Crunching numbers ...")
+
+
+def test_progress_without_context():
+    assert runtime_context_installed() is False
+
+    for i in progress_bar(range(10)):
+        assert i is not None
+
+    with progress_bar(total=10) as bar:
+        for _ in range(10):
+            assert bar
+            bar.update()

--- a/tests/_runtime/output/test_output.py
+++ b/tests/_runtime/output/test_output.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+from marimo._runtime import output
 from tests.conftest import ExecReqProvider, MockedKernel
 
 
@@ -88,3 +89,20 @@ async def test_nested_output(
             outputs.append(msg[1]["output"]["data"])
     assert len(outputs) == 1
     assert outputs[0] == "['hi', [...], [...], [...], [...], [...]]"
+
+
+def test_without_context():
+    from marimo._runtime.context import get_context
+    from marimo._runtime.context.types import ContextNotInitializedError
+
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        ctx = None
+
+    assert ctx is None
+    output.replace("test")
+    output.replace_at_index("test", 0)
+    output.append("test")
+    output.clear()
+    assert True  # No exceptions should be raised


### PR DESCRIPTION
This lets `mo.status.spinner` and `mo.state.progress` be used outside marimo, for example if you export to a pure script if you want to run something on it. This just noops the output updates
For example:
`marimo export script notebook.py -o notebook_test.py; python -m doctest notebook_test.py `

Unblocks https://github.com/marimo-team/marimo/issues/2191