### PR TITLE
fix: support import doctest; doctest.testmod()

### DIFF
--- a/marimo/_runtime/marimo_pdb.py
+++ b/marimo/_runtime/marimo_pdb.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import inspect
 import sys
 from pdb import Pdb
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from marimo import _loggers
 from marimo._messaging.types import Stdin, Stdout
@@ -16,8 +16,24 @@ LOGGER = _loggers.marimo_logger()
 
 
 class MarimoPdb(Pdb):
-    def __init__(self, stdout: Stdout | None, stdin: Stdin | None):
-        super().__init__(stdout=stdout, stdin=stdin)  # type: ignore[arg-type]
+    # Because we are patching Pdb, we need copy the exact constructor signature
+    def __init__(
+        self,
+        completekey: str = "tab",
+        stdout: Stdout | None = None,
+        stdin: Stdin | None = None,
+        skip: Any = None,
+        nosigint: bool = False,
+        readrc: bool = True,
+    ):
+        super().__init__(
+            completekey=completekey,
+            stdout=stdout,  # type: ignore[arg-type]
+            stdin=stdin,  # type: ignore[arg-type]
+            skip=skip,
+            nosigint=nosigint,
+            readrc=readrc,
+        )  # type: ignore[arg-type]
         # it's fine to use input() since marimo overrides it, but disable
         # it anyway -- stdin is fine too ...
         self.use_rawinput = stdin is None

--- a/marimo/_smoke_tests/doctests.py
+++ b/marimo/_smoke_tests/doctests.py
@@ -1,0 +1,69 @@
+import marimo
+
+__generated_with = "0.8.17"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return mo,
+
+
+@app.cell
+def __():
+    def euclid_mcd(a: int, b: int) -> int:
+        """Return the MCD between positive a, b.
+
+        >>> euclid_mcd(42, 24)
+        6
+        >>> euclid_mcd(24, 42)
+        6
+        >>> euclid_mcd(42, 42)
+        42
+        """
+        assert a > 0
+        assert b > 0
+        if a < b:
+            a, b = b, a
+        if (a != b):
+            r = a - b
+            return euclid_mcd(b, r)
+        return a
+    return euclid_mcd,
+
+
+@app.cell
+def __(euclid_mcd):
+    euclid_mcd(42, 42)
+    return
+
+
+@app.cell
+def __():
+    def bad_multiply_by_2(a: int) -> int:
+        """Multiply a by 2 and return the result.
+
+        >>> bad_multiply_by_2(2)
+        4
+        >>> bad_multiply_by_2(3)
+        6
+        """
+        return a + 2
+    return bad_multiply_by_2,
+
+
+@app.cell
+def __(bad_multiply_by_2, euclid_mcd, mo):
+    # Including these make this doctest reactive
+    euclid_mcd
+    bad_multiply_by_2
+
+    import doctest
+    failures, success = doctest.testmod(verbose=True)
+    mo.md(f"Success: {success}, Failures: {failures}")
+    return doctest, failures, success
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #2191

Fixes the signature of `pdb` which unlocks
```python
import doctest; doctest.testmod()
```
Which will run doctests from marimo (and reactively if you reference the function), great for education!

```python
# cell 1
def euclid_mcd(a: int, b: int) -> int:
    """Return the MCD between positive a, b.
    >>> euclid_mcd(42, 24)
    6
    >>> euclid_mcd(24, 42)
    6
    >>> euclid_mcd(42, 42)
    42
    """
    assert a > 0
    assert b > 0
    if a < b:
        a, b = b, a
    if (a != b):
        r = a - b
        return euclid_mcd(b, r)
    return a

# cell 2
# Including these make this doctest reactive
euclid_mcd

import doctest
failures, success = doctest.testmod(verbose=True)
mo.md(f"Success: {success}, Failures: {failures}")
```