### PR TITLE
fix: encoding table elements when passed through RPC calls

### DIFF
--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -58,7 +58,7 @@ def serialize(datacls: Any) -> Dict[str, JSONType]:
         # If that fails, try to serialize using the WebComponentEncoder
         return cast(
             Dict[str, JSONType],
-            json.loads(json.dumps(datacls, cls=WebComponentEncoder)),
+            json.loads(WebComponentEncoder.json_dumps(datacls)),
         )
 
 
@@ -286,7 +286,7 @@ class FunctionCallResult(Op):
         # We want to serialize the return_value using our custom JSON encoder
         try:
             self.return_value = json.loads(
-                json.dumps(self.return_value, cls=WebComponentEncoder)
+                WebComponentEncoder.json_dumps(self.return_value)
             )
         except Exception as e:
             LOGGER.exception(

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -282,6 +282,19 @@ class FunctionCallResult(Op):
     return_value: JSONType
     status: HumanReadableStatus
 
+    def __post_init__(self) -> None:
+        # We want to serialize the return_value using our custom JSON encoder
+        try:
+            self.return_value = json.loads(
+                json.dumps(self.return_value, cls=WebComponentEncoder)
+            )
+        except Exception as e:
+            LOGGER.exception(
+                "Error serializing function call result %s: %s",
+                self.__class__.__name__,
+                e,
+            )
+
     def serialize(self) -> dict[str, Any]:
         try:
             return serialize(self)

--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -4,93 +4,138 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import json
+from enum import Enum
 from json import JSONEncoder
 from typing import Any
+from uuid import UUID
 
 from marimo._dependencies.dependencies import DependencyManager
 
 
 class WebComponentEncoder(JSONEncoder):
-    """Custom JSON encoder for WebComponents"""
+    @staticmethod
+    def json_dumps(o: Any) -> Any:
+        """Serialize an object to JSON."""
+        return json.dumps(o, cls=WebComponentEncoder)
 
     def default(self, o: Any) -> Any:
         """Override default method to handle additional types."""
-        return self._default_internal(o)
+        return self._convert_to_json(o)
 
-    def _default_internal(self, o: Any) -> Any:
-        obj = o
+    def _convert_to_json(self, o: Any) -> Any:
+        """Convert various types to JSON serializable format."""
+        # Primitives (most common case first for performance)
+        if isinstance(o, (str, int, float, bool, type(None))):
+            return o
+
+        # Handle bytes objects
+        if isinstance(o, bytes):
+            return o.decode("utf-8")
+
+        # Handle datetime objects
+        if isinstance(o, (datetime.datetime, datetime.date, datetime.time)):
+            return o.isoformat()
+
+        # Handle UUID
+        if isinstance(o, UUID):
+            return str(o)
+
+        # Handle enum
+        if isinstance(o, Enum):
+            return o.name
+
+        # Handle complex numbers
+        if isinstance(o, complex):
+            return str(o)
+
+        # Handle iterable objects
+        if isinstance(o, (set, frozenset)):
+            return list(o)
+
+        # If handled by default encoder
+        if isinstance(o, (dict, list)):
+            return o
+
+        # Handle MIME objects
+        if hasattr(o, "_mime_"):
+            mimetype, data = o._mime_()
+            return {"mimetype": mimetype, "data": data}
+
+        # Handle dataclasses
+        # Must come after MIME objects
+        if dataclasses.is_dataclass(o):
+            # We cannot use asdict since we need to recursively encode
+            # the values
+            return {
+                field.name: self._convert_to_json(getattr(o, field.name))
+                for field in dataclasses.fields(o)
+            }
+
         # Handle numpy objects
         if DependencyManager.numpy.imported():
             import numpy as np
 
-            dtypes = (np.datetime64, np.complexfloating)
-            if isinstance(obj, dtypes):
-                return str(obj)
-            elif isinstance(obj, np.integer):
-                return int(obj)
-            elif isinstance(obj, np.floating):
-                return float(obj)
-            elif isinstance(obj, np.ndarray):
-                if any([np.issubdtype(obj.dtype, i) for i in dtypes]):
-                    return obj.astype(str).tolist()
-                return str(obj.tolist())
-            elif isinstance(obj, np.dtype):
-                return str(obj)
+            if isinstance(o, (np.datetime64, np.complexfloating)):
+                return str(o)
+            if isinstance(o, np.integer):
+                return int(o)
+            if isinstance(o, np.floating):
+                return float(o)
+            if isinstance(o, np.ndarray):
+                if any(
+                    np.issubdtype(o.dtype, dtype)
+                    for dtype in (np.datetime64, np.complexfloating)
+                ):
+                    return o.astype(str).tolist()
+                return o.tolist()
+            if isinstance(o, np.dtype):
+                return str(o)
 
         # Handle pandas objects
         if DependencyManager.pandas.imported():
             import pandas as pd
 
-            # Opinionated or known types
-            if isinstance(obj, pd.DataFrame):
-                return obj.to_dict("records")
-            elif isinstance(obj, pd.Series):
-                return obj.to_list()
-            elif isinstance(obj, pd.Categorical):
-                return obj.tolist()
-            elif isinstance(obj, pd.CategoricalDtype):
-                return str(obj)
-            elif isinstance(obj, pd.Timestamp):
-                return str(obj)
-            elif isinstance(obj, pd.Timedelta):
-                return str(obj)
-            elif isinstance(obj, pd.Interval):
-                return str(obj)
-            elif isinstance(obj, pd.TimedeltaIndex):
-                return str(obj.astype(str).tolist())
+            if isinstance(o, pd.DataFrame):
+                return o.to_dict("records")
+            if isinstance(o, pd.Series):
+                return o.to_list()
+            if isinstance(o, pd.Categorical):
+                return o.tolist()
+            if isinstance(
+                o,
+                (pd.CategoricalDtype, pd.Timestamp, pd.Timedelta, pd.Interval),
+            ):
+                return str(o)
+            if isinstance(o, pd.TimedeltaIndex):
+                return o.astype(str).tolist()
 
             # Catch-all for other pandas objects
             try:
-                if isinstance(obj, pd.core.base.PandasObject):  # type: ignore
-                    return json.loads(obj.to_json(date_format="iso"))
+                if isinstance(o, pd.core.base.PandasObject):  # type: ignore
+                    return json.loads(o.to_json(date_format="iso"))
             except AttributeError:
                 pass
 
-        # Handle MIME objects
-        if hasattr(obj, "_mime_"):
-            (mimetype, data) = obj._mime_()
-            return {"mimetype": mimetype, "data": data}
-
-        # Must come after MIME objects
-        if dataclasses.is_dataclass(obj):
-            # We cannot use asdict since we need to recursively encode
-            # the values
+        # Handle named tuples
+        if isinstance(o, tuple) and hasattr(o, "_fields"):
             return {
-                field.name: self._default_internal(getattr(obj, field.name))
-                for field in dataclasses.fields(obj)
+                field: self._convert_to_json(getattr(o, field))
+                for field in o._fields  # type: ignore
             }
 
-        # Handle bytes objects
-        if isinstance(obj, bytes):
-            return obj.decode("utf-8")
+        # Handle objects with __slots__
+        if hasattr(o, "__slots__"):
+            return {
+                slot: self._convert_to_json(getattr(o, slot))
+                for slot in o.__slots__  # type: ignore
+                if hasattr(o, slot)
+            }
 
-        # Handle iterable objects
-        if isinstance(obj, (set, frozenset)):
-            return list(obj)
-
-        # Handle datetime objects
-        if isinstance(obj, datetime.datetime):
-            return obj.isoformat()
-
+        # Handle custom objects with __dict__
+        if hasattr(o, "__dict__"):
+            return {
+                key: self._convert_to_json(value)
+                for key, value in o.__dict__.items()
+            }
         # Fallthrough to default encoder
-        return obj
+        return JSONEncoder.default(self, o)

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import json
 import weakref
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional
@@ -113,10 +112,13 @@ class anywidget(UIElement[T, T]):
         for k, v in args.items():
             try:
                 # Try to see if it is json-serializable
-                json.dumps(v, cls=WebComponentEncoder)
+                WebComponentEncoder.json_dumps(v)
                 # Just add the plain value, it will be json-serialized later
                 json_args[k] = v
             except TypeError:
+                pass
+            except ValueError:
+                # Handle circular dependencies
                 pass
 
         def on_change(change: T) -> None:

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -93,6 +93,7 @@ class anywidget(UIElement[T, T]):
             "_esm",
             "_css",
             "_anywidget_id",
+            "_msg_callbacks",
             "_dom_classes",
             "_model_module",
             "_model_module_version",

--- a/marimo/_pyodide/bootstrap.py
+++ b/marimo/_pyodide/bootstrap.py
@@ -71,7 +71,7 @@ def create_session(
 
     def write_kernel_message(op: KernelMessage) -> None:
         message_callback(
-            json.dumps({"op": op[0], "data": op[1]}, cls=WebComponentEncoder)
+            WebComponentEncoder.json_dumps({"op": op[0], "data": op[1]})
         )
 
     # Lazy import to decrease startup time

--- a/marimo/_smoke_tests/bugs/2357-table-ui-elements.py
+++ b/marimo/_smoke_tests/bugs/2357-table-ui-elements.py
@@ -1,0 +1,28 @@
+
+
+import marimo
+
+__generated_with = "0.8.17"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def __(mo):
+    data = [{"x": 1, "y": "a", "c": mo.ui.button(label="hello")}, {"x": 2, "y": "b", "c": mo.ui.button(label="world")}]
+    return (data,)
+
+
+@app.cell
+def __(data, mo):
+    mo.ui.table(data)
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
`asdict` does not encode our UI elements properly and should be used sparingly 