### PR TITLE
improvement: add hash to html export

### DIFF
--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -87,6 +87,9 @@ class Exporter:
             configs = [CellConfig() for _ in cell_ids]
             console_outputs = {}
 
+        # We include the code hash regardless of whether we include the code
+        code_hash = hash_code(file_manager.to_code())
+
         html = static_notebook_template(
             html=index_html,
             user_config=config,
@@ -94,6 +97,7 @@ class Exporter:
             app_config=file_manager.app.config,
             filename=file_manager.filename,
             code=code,
+            code_hash=code_hash,
             cell_ids=cell_ids,
             cell_names=list(file_manager.app.cell_manager.names()),
             cell_codes=list(codes),
@@ -298,3 +302,9 @@ class AutoExporter:
         export_dir = os.path.join(directory, self.EXPORT_DIR)
         if not os.path.exists(export_dir):
             os.mkdir(export_dir)
+
+
+def hash_code(code: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(code.encode("utf-8")).hexdigest()

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -83,6 +83,7 @@ def static_notebook_template(
     app_config: _AppConfig,
     filename: Optional[str],
     code: str,
+    code_hash: str,
     cell_ids: list[str],
     cell_names: list[str],
     cell_codes: list[str],
@@ -159,13 +160,18 @@ def static_notebook_template(
             </style>
             """)
 
-    code_block = f"""
+    code_block = dedent(f"""
     <marimo-code hidden="">
         {uri_encode_component(code)}
     </marimo-code>
-    """
+    """)
     if not code:
         code_block = '<marimo-code hidden=""></marimo-code>'
+
+    # Add a 256-bit hash of the code, for cache busting or CI checks
+    code_block += (
+        f'\n<marimo-code-hash hidden="">{code_hash}</marimo-code-hash>\n'
+    )
 
     # Replace all relative href and src with absolute URL
     html = (

--- a/tests/_server/templates/snapshots/export1.txt
+++ b/tests/_server/templates/snapshots/export1.txt
@@ -74,8 +74,10 @@
   <body>
     <div id="root"></div>
   
-    <marimo-code hidden="">
-        print('Hello%2C%20World!')
-    </marimo-code>
-    </body>
+<marimo-code hidden="">
+    print('Hello%2C%20World!')
+</marimo-code>
+
+<marimo-code-hash hidden="">2b33215fadf3c54926d5c4100348afc158dbff4c94b15044e3a7fe804f80ed2d</marimo-code-hash>
+</body>
 </html>

--- a/tests/_server/templates/snapshots/export2.txt
+++ b/tests/_server/templates/snapshots/export2.txt
@@ -74,8 +74,10 @@
   <body>
     <div id="root"></div>
   
-    <marimo-code hidden="">
-        print('Hello%2C%20World!')
-    </marimo-code>
-    </body>
+<marimo-code hidden="">
+    print('Hello%2C%20World!')
+</marimo-code>
+
+<marimo-code-hash hidden="">2b33215fadf3c54926d5c4100348afc158dbff4c94b15044e3a7fe804f80ed2d</marimo-code-hash>
+</body>
 </html>

--- a/tests/_server/templates/snapshots/export3.txt
+++ b/tests/_server/templates/snapshots/export3.txt
@@ -73,5 +73,7 @@
 </head>
   <body>
     <div id="root"></div>
-  <marimo-code hidden=""></marimo-code></body>
+  <marimo-code hidden=""></marimo-code>
+<marimo-code-hash hidden="">2b33215fadf3c54926d5c4100348afc158dbff4c94b15044e3a7fe804f80ed2d</marimo-code-hash>
+</body>
 </html>

--- a/tests/_server/templates/snapshots/export4.txt
+++ b/tests/_server/templates/snapshots/export4.txt
@@ -77,5 +77,7 @@
 </head>
   <body>
     <div id="root"></div>
-  <marimo-code hidden=""></marimo-code></body>
+  <marimo-code hidden=""></marimo-code>
+<marimo-code-hash hidden="">2b33215fadf3c54926d5c4100348afc158dbff4c94b15044e3a7fe804f80ed2d</marimo-code-hash>
+</body>
 </html>

--- a/tests/_server/templates/test_templates.py
+++ b/tests/_server/templates/test_templates.py
@@ -8,6 +8,7 @@ from marimo._ast.app import _AppConfig
 from marimo._ast.cell import CellConfig
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._server.export.exporter import hash_code
 from marimo._server.model import SessionMode
 from marimo._server.templates import templates
 from marimo._server.tokens import SkewProtectionToken
@@ -188,6 +189,7 @@ class TestStaticNotebookTemplate(unittest.TestCase):
             self.app_config,
             self.filename,
             self.code,
+            hash_code(self.code),
             self.cell_ids,
             self.cell_names,
             self.cell_codes,
@@ -207,6 +209,7 @@ class TestStaticNotebookTemplate(unittest.TestCase):
             self.app_config,
             None,
             self.code,
+            hash_code(self.code),
             self.cell_ids,
             self.cell_names,
             self.cell_codes,
@@ -226,6 +229,7 @@ class TestStaticNotebookTemplate(unittest.TestCase):
             self.app_config,
             self.filename,
             "",
+            hash_code(self.code),
             [],
             [],
             [],
@@ -253,6 +257,7 @@ class TestStaticNotebookTemplate(unittest.TestCase):
                 _AppConfig(css_file="custom.css"),
                 self.filename,
                 "",
+                hash_code(self.code),
                 [],
                 [],
                 [],


### PR DESCRIPTION
Fixes #2346

Includes a 256 bit has regardless if the code is included, as a cache bust / integrity for the html export