### PR TITLE
fix: disable pdf export while editing

### DIFF
--- a/frontend/src/components/editor/actions/types.ts
+++ b/frontend/src/components/editor/actions/types.ts
@@ -9,6 +9,8 @@ export interface ActionButton {
   label: string;
   labelElement?: React.ReactNode;
   description?: string;
+  disabled?: boolean;
+  tooltip?: React.ReactNode;
   variant?: "danger" | "muted" | "disabled";
   disableClick?: boolean;
   icon?: React.ReactElement;

--- a/frontend/src/components/editor/controls/command-palette.tsx
+++ b/frontend/src/components/editor/controls/command-palette.tsx
@@ -66,7 +66,7 @@ export const CommandPalette = () => {
     shortcut: HotkeyAction,
     props: {
       disabled?: boolean;
-      tooltip?: string;
+      tooltip?: React.ReactNode;
     },
   ) => {
     const action = registeredActions[shortcut];
@@ -103,7 +103,7 @@ export const CommandPalette = () => {
   const renderCommandItem = (
     label: string,
     handle: () => void,
-    props: { disabled?: boolean; tooltip?: string } = {},
+    props: { disabled?: boolean; tooltip?: React.ReactNode } = {},
     hotkey?: HotkeyAction,
   ) => {
     return (

--- a/frontend/src/components/editor/controls/notebook-menu-dropdown.tsx
+++ b/frontend/src/components/editor/controls/notebook-menu-dropdown.tsx
@@ -17,6 +17,7 @@ import { MinimalShortcut } from "../../shortcuts/renderShortcut";
 import { useNotebookActions } from "../actions/useNotebookActions";
 import type { ActionButton } from "../actions/types";
 import { getMarimoVersion } from "@/core/dom/marimo-tag";
+import { Tooltip } from "@/components/ui/tooltip";
 
 export const NotebookMenuDropdown: React.FC = () => {
   const actions = useNotebookActions();
@@ -48,16 +49,32 @@ export const NotebookMenuDropdown: React.FC = () => {
   };
 
   const renderLeafAction = (action: ActionButton) => {
-    return (
+    const item = (
       <DropdownMenuItem
         key={action.label}
         variant={action.variant}
+        disabled={action.disabled}
         onSelect={(evt) => action.handle(evt)}
         data-testid={`notebook-menu-dropdown-${action.label}`}
       >
         {renderLabel(action)}
       </DropdownMenuItem>
     );
+
+    if (action.tooltip) {
+      return (
+        <Tooltip
+          content={action.tooltip}
+          key={action.label}
+          side="left"
+          delayDuration={100}
+        >
+          <span>{item}</span>
+        </Tooltip>
+      );
+    }
+
+    return item;
   };
 
   return (

--- a/frontend/src/components/shortcuts/renderShortcut.tsx
+++ b/frontend/src/components/shortcuts/renderShortcut.tsx
@@ -8,17 +8,20 @@ import { hotkeysAtom } from "@/core/config/config";
 import { useAtomValue } from "jotai";
 import { cn } from "@/utils/cn";
 
-export function renderShortcut(shortcut: HotkeyAction) {
-  return <Shortcut shortcut={shortcut} />;
+export function renderShortcut(shortcut: HotkeyAction, includeName = true) {
+  return <Shortcut shortcut={shortcut} includeName={includeName} />;
 }
 
-const Shortcut: React.FC<{ shortcut: HotkeyAction }> = ({ shortcut }) => {
+const Shortcut: React.FC<{ shortcut: HotkeyAction; includeName?: boolean }> = ({
+  shortcut,
+  includeName = true,
+}) => {
   const hotkeys = useAtomValue(hotkeysAtom);
   const hotkey = hotkeys.getHotkey(shortcut);
 
   return (
-    <span className="flex">
-      <span className="mr-2">{hotkey.name}</span>
+    <span className="inline-flex">
+      {includeName && <span className="mr-2">{hotkey.name}</span>}
       <KeyboardHotkeys shortcut={hotkey.key} />
     </span>
   );

--- a/marimo/_smoke_tests/third_party/plotly_example.py
+++ b/marimo/_smoke_tests/third_party/plotly_example.py
@@ -1,14 +1,15 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "plotly",
-#     "pandas",
+#     "plotly==5.24.1",
+#     "pandas==2.2.3",
+#     "marimo",
 # ]
 # ///
 
 import marimo
 
-__generated_with = "0.8.14"
+__generated_with = "0.8.18"
 app = marimo.App(width="full")
 
 
@@ -20,10 +21,16 @@ def __(mo):
 
 @app.cell
 def __():
+    import ibis
+    return (ibis,)
+
+
+@app.cell
+def __():
     import plotly.express as px
 
     px.scatter(x=[0, 1, 2, 3, 4], y=[0, 1, 4, 9, 16])
-    return px,
+    return (px,)
 
 
 @app.cell
@@ -37,7 +44,7 @@ def __(mo, px):
             plot,
         ]
     )
-    return plot,
+    return (plot,)
 
 
 @app.cell
@@ -145,7 +152,7 @@ def __():
 def __(cars, mo):
     sample_size = mo.ui.slider(label="Sample", start=100, stop=len(cars), step=100)
     sample_size
-    return sample_size,
+    return (sample_size,)
 
 
 @app.cell
@@ -162,7 +169,7 @@ def __(cars, mo, px, sample_size):
     _fig
     plot3 = mo.ui.plotly(_fig)
     plot3
-    return plot3,
+    return (plot3,)
 
 
 @app.cell

--- a/marimo/_smoke_tests/third_party/plotly_example.py
+++ b/marimo/_smoke_tests/third_party/plotly_example.py
@@ -21,12 +21,6 @@ def __(mo):
 
 @app.cell
 def __():
-    import ibis
-    return (ibis,)
-
-
-@app.cell
-def __():
     import plotly.express as px
 
     px.scatter(x=[0, 1, 2, 3, 4], y=[0, 1, 4, 9, 16])


### PR DESCRIPTION
Fixes #2376

Rather than trying to switch to app-view and waiting some time, we just disable the action and let the user do it. 
1. this is more correct / less error-prone
2. the user may want to set up the view a bit more before exporting (expanding accordions, setting a correct tab, etc)

![Screenshot 2024-09-23 at 11 00 57 AM](https://github.com/user-attachments/assets/ea4f13af-d4e0-45a5-94cd-7b32dda7348a)

