### PR TITLE
fix: staleness in mo.ui.table() when using UI elements

### DIFF
--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -12,6 +12,7 @@ import { TableColumnSummary } from "./column-summary";
 import type { FilterType } from "./filters";
 import type { FieldTypesWithExternalType } from "./types";
 import { UrlDetector } from "./url-detector";
+import { Arrays } from "@/utils/arrays";
 
 interface ColumnInfo {
   key: string;
@@ -21,12 +22,12 @@ interface ColumnInfo {
 function getColumnInfo<T>(items: T[]): ColumnInfo[] {
   // No items
   if (items.length === 0) {
-    return [];
+    return Arrays.EMPTY;
   }
 
   // Not an object
   if (typeof items[0] !== "object") {
-    return [];
+    return Arrays.EMPTY;
   }
 
   const keys = new Map<string, ColumnInfo>();
@@ -71,13 +72,11 @@ export function generateColumns<T>({
   items,
   rowHeaders,
   selection,
-  showColumnSummaries,
   fieldTypes,
 }: {
   items: T[];
   rowHeaders: string[];
   selection: "single" | "multi" | null;
-  showColumnSummaries: boolean;
   fieldTypes?: FieldTypesWithExternalType;
 }): Array<ColumnDef<T>> {
   const columnInfo = getColumnInfo(items);
@@ -107,12 +106,6 @@ export function generateColumns<T>({
 
         // Row headers have no summaries
         if (rowHeadersSet.has(info.key)) {
-          return (
-            <DataTableColumnHeader header={headerWithType} column={column} />
-          );
-        }
-
-        if (!showColumnSummaries) {
           return (
             <DataTableColumnHeader header={headerWithType} column={column} />
           );

--- a/frontend/src/components/editor/file-tree/renderers.tsx
+++ b/frontend/src/components/editor/file-tree/renderers.tsx
@@ -7,6 +7,7 @@ import type React from "react";
 import { useMemo, useState } from "react";
 import { type Base64String, base64ToDataURL } from "@/utils/json/base64";
 import type { PaginationState } from "@tanstack/react-table";
+import { Arrays } from "@/utils/arrays";
 
 const PAGE_SIZE = 25;
 
@@ -20,9 +21,8 @@ export const CsvViewer: React.FC<{ contents: string }> = ({ contents }) => {
     () =>
       generateColumns({
         items: data,
-        rowHeaders: [],
+        rowHeaders: Arrays.EMPTY,
         selection: null,
-        showColumnSummaries: false,
       }),
     [data],
   );

--- a/frontend/src/hooks/debug.ts
+++ b/frontend/src/hooks/debug.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 /* eslint-disable react-hooks/rules-of-hooks */
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useMemo } from "react";
 import { dequal } from "dequal";
 import { Logger } from "@/utils/Logger";
 
@@ -65,4 +65,50 @@ export function usePropsDidChange(
 
     prevProps.current = props;
   });
+}
+
+/**
+ * Like useMemo, but logs when the value changes.
+ */
+export function useMemoDebugChanges<T>(
+  name: string,
+  fn: () => T,
+  deps: unknown[],
+) {
+  if (process.env.NODE_ENV !== "development") {
+    return fn();
+  }
+
+  const previousDeps = useRef<unknown[]>([]);
+
+  return useMemo(() => {
+    if (previousDeps.current.length === 0) {
+      previousDeps.current = deps;
+      return fn();
+    }
+
+    const changedIndices: number[] = [];
+    const changedDeps = deps.filter((dep, idx) => {
+      if (!dequal(dep, previousDeps.current[idx])) {
+        changedIndices.push(idx);
+        return true;
+      }
+      return false;
+    });
+
+    if (changedDeps.length > 0) {
+      Logger.debug(
+        `[${name}] Memo deps changed at indices: ${changedIndices}`,
+        {
+          previous: previousDeps.current,
+          current: deps,
+        },
+      );
+    }
+
+    previousDeps.current = deps;
+
+    return fn();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
 }

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -4,19 +4,16 @@ import { z } from "zod";
 import { DataTable } from "../../components/data-table/data-table";
 import { generateColumns } from "../../components/data-table/columns";
 import { Labeled } from "./common/labeled";
-import { useAsyncData } from "@/hooks/useAsyncData";
 import { Alert, AlertTitle } from "@/components/ui/alert";
 import { rpc } from "../core/rpc";
 import { createPlugin } from "../core/builder";
 import { vegaLoadData } from "./vega/loader";
 import { getVegaFieldTypes } from "./vega/utils";
-import { Arrays } from "@/utils/arrays";
 import { Banner } from "./common/error-banner";
 import { ColumnChartSpecModel } from "@/components/data-table/chart-spec-model";
 import { ColumnChartContext } from "@/components/data-table/column-summary";
 import { Logger } from "@/utils/Logger";
-import { LoadingTable } from "@/components/data-table/loading-table";
-import { DelayMount } from "@/components/utils/delay-mount";
+
 import type {
   ColumnHeaderSummary,
   FieldTypesWithExternalType,
@@ -28,7 +25,6 @@ import type {
   RowSelectionState,
   SortingState,
 } from "@tanstack/react-table";
-import { TooltipProvider } from "@radix-ui/react-tooltip";
 import useEvent from "react-use-event-hook";
 import { Functions } from "@/utils/functions";
 import { ConditionSchema, type ConditionType } from "./data-frames/schema";
@@ -38,7 +34,12 @@ import {
 } from "@/components/data-table/filters";
 import { Objects } from "@/utils/objects";
 import React from "react";
-
+import { TooltipProvider } from "@radix-ui/react-tooltip";
+import { Arrays } from "@/utils/arrays";
+import { LoadingTable } from "@/components/data-table/loading-table";
+import { useAsyncData } from "@/hooks/useAsyncData";
+import { useDeepCompareMemoize } from "@/hooks/useDeepCompareMemoize";
+import { DelayMount } from "@/components/utils/delay-mount";
 type CsvURL = string;
 type TableData<T> = T[] | CsvURL;
 interface ColumnSummaries<T = unknown> {
@@ -253,7 +254,7 @@ export const LoadingDataTableComponent = memo(
     }>(async () => {
       // If there is no data, return an empty array
       if (props.totalRows === 0) {
-        return { rows: [], totalRows: 0 };
+        return { rows: Arrays.EMPTY, totalRows: 0 };
       }
 
       // Table data is a url string or an array of objects
@@ -384,7 +385,7 @@ export const LoadingDataTableComponent = memo(
         {errorComponent}
         <DataTableComponent
           {...props}
-          data={data?.rows || Arrays.EMPTY}
+          data={data?.rows ?? Arrays.EMPTY}
           columnSummaries={columnSummaries}
           sorting={sorting}
           setSorting={setSorting}
@@ -413,7 +414,6 @@ const DataTableComponent = ({
   showFilters,
   showDownload,
   rowHeaders,
-  showColumnSummaries,
   fieldTypes,
   paginationState,
   setPaginationState,
@@ -463,13 +463,16 @@ const DataTableComponent = ({
         items: data,
         rowHeaders: rowHeaders,
         selection,
-        showColumnSummaries: showColumnSummaries,
         fieldTypes: fieldTypes ?? {},
       }),
-    [data, selection, fieldTypes, rowHeaders, showColumnSummaries],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [data, useDeepCompareMemoize([selection, fieldTypes, rowHeaders])],
   );
 
-  const rowSelection = Object.fromEntries((value || []).map((v) => [v, true]));
+  const rowSelection = useMemo(
+    () => Object.fromEntries((value || []).map((v) => [v, true])),
+    [value],
+  );
 
   const handleRowSelectionChange: OnChangeFn<RowSelectionState> = useEvent(
     (updater) => {

--- a/marimo/_smoke_tests/bugs/2327_table_staleness.py
+++ b/marimo/_smoke_tests/bugs/2327_table_staleness.py
@@ -1,0 +1,82 @@
+
+
+import marimo
+
+__generated_with = "0.8.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import datetime
+    return datetime, mo
+
+
+@app.cell
+def __():
+    initial_data = [{"x": 1, "y": -1}]
+    return initial_data,
+
+
+@app.cell
+def __(initial_data, mo):
+    get_data, set_data = mo.state(initial_data)
+    return get_data, set_data
+
+
+@app.cell
+def __(datetime, get_data, mo, set_data):
+    _data = get_data()
+    print("Creating new table list", datetime.datetime.utcnow())
+    def on_change_wrapper(i, k):    
+        def on_change(value):
+            print("setting")
+            _data = get_data()
+            _data[i][k] = value
+            set_data(_data)
+        return on_change
+
+    table_list = [{k: mo.ui.number(value=v, start=-100, stop=100, on_change=on_change_wrapper(i, k)) for k, v in d.items()} for i, d in enumerate(_data)]
+    return on_change_wrapper, table_list
+
+
+@app.cell
+def __(mo, table_list):
+    table = mo.ui.table(table_list)
+    return table,
+
+
+@app.cell
+def __(get_data, mo, set_data):
+    def on_click(*value):
+        rows = get_data()
+        rows.append({"x": 0, "y": 0})
+        set_data(rows)
+
+
+
+    add_row = mo.ui.button(label="add row", on_click=on_click)
+    return add_row, on_click
+
+
+@app.cell
+def __(add_row, mo, table):
+    mo.vstack([table, add_row])
+    return
+
+
+@app.cell
+def __(get_data):
+    get_data()
+    return
+
+
+@app.cell
+def __(table_list):
+    table_list[0]["x"].value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/bugs/2403_table_ui_staleness.py
+++ b/marimo/_smoke_tests/bugs/2403_table_ui_staleness.py
@@ -1,0 +1,44 @@
+
+
+import marimo
+
+__generated_with = "0.8.20"
+app = marimo.App(width="full")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def __():
+    keys_1 = [f"123_{x}" for x in range(20)]
+    keys_2 = [f"abc_{x}" for x in range(20)]
+    return keys_1, keys_2
+
+
+@app.cell
+def __(mo):
+    # Toggling this switch should change the keys in the tables and the initial value in the text inputs
+    switch = mo.ui.switch()
+    switch
+    return (switch,)
+
+
+@app.cell
+def button(keys_1, keys_2, switch):
+    keys = keys_1 if switch.value else keys_2
+    return (keys,)
+
+
+@app.cell
+def display(keys, mo):
+    table = mo.ui.table({str(k): mo.ui.text(value=k) for k in keys})
+    table
+    return (table,)
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #2403
Fixes #2327

There is a subtle bug that when the table is not properly memoized, it can mount stale data when re-mounting. 

There is likely a better long-term fix as this can pop-up again unknowingly by not preventing re-renders, which I plan to look into in a followup. 