### PR TITLE
improvement: track duckdb.sql and duckdb.execute SQL statements in dep graph

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -378,16 +378,21 @@ class ScopedVisitor(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> None:
         # If the call name is sql and has one argument, and the argument is
         # a string literal, then it's likely to be a SQL query.
-        # It must also come from the `mo` module.
+        # It must also come from the `mo` or `duckdb` module.
         #
         # This check is brittle, since we can't detect at parse time whether
         # 'mo'/'marimo' actually refer to the marimo library, but it gets
         # the job done.
+        valid_sql_calls = [
+            "marimo.sql",
+            "mo.sql",
+            "duckdb.execute",
+            "duckdb.sql",
+        ]
         if (
             isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
-            and (node.func.value.id == "mo" or node.func.value.id == "marimo")
-            and node.func.attr == "sql"
+            and f"{node.func.value.id}.{node.func.attr}" in valid_sql_calls
             and len(node.args) == 1
         ):
             self.language = "sql"

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -273,6 +273,40 @@ class TestParseSQLCell:
         assert cell.language == "sql"
         assert not cell.variable_data
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        "code",
+        [
+            'duckdb.sql("CREATE TABLE t1 (i INTEGER, j INTEGER)")',
+            'duckdb.execute("CREATE TABLE t1 (i INTEGER, j INTEGER)")',
+        ],
+    )
+    def test_table_definition_duckdb(code: str) -> None:
+        cell = compile_cell(code)
+        assert cell.key == hash(code)
+        assert cell.code == code
+        assert cell.defs == set(["t1"])
+        assert cell.refs == set(["duckdb"])
+        assert cell.language == "sql"
+        assert cell.variable_data == {"t1": [VariableData("table")]}
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "code",
+        [
+            'duckdb.sql("SELECT * from t1")',
+            'duckdb.execute("SELECT * from t1")',
+        ],
+    )
+    def test_table_reference_duckdb(code: str) -> None:
+        cell = compile_cell(code)
+        assert cell.key == hash(code)
+        assert cell.code == code
+        assert not cell.defs
+        assert cell.refs == set(["duckdb", "t1"])
+        assert cell.language == "sql"
+        assert not cell.variable_data
+
 
 class TestCellFactory:
     @staticmethod

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -927,6 +927,22 @@ def test_sql_statement_with_marimo_sql() -> None:
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="Requires duckdb")
+@pytest.mark.parametrize(
+    "code",
+    [
+        "df = duckdb.sql('select * from cars')",
+        "df = duckdb.execute('select * from cars')",
+    ],
+)
+def test_sql_statement_with_duckdb_sql(code: str) -> None:
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == set(["df"])
+    assert v.refs == set(["cars", "duckdb"])
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="Requires duckdb")
 def test_sql_statement_with_f_string() -> None:
     code = "\n".join(
         [
@@ -974,16 +990,22 @@ def test_print_f_string() -> None:
 
 @pytest.mark.skipif(not HAS_DEPS, reason="Requires duckdb")
 def test_sql_empty_statement() -> None:
-    code = "\n".join(
-        [
-            "mo.sql('')",
-        ]
-    )
+    code = "mo.sql('')"
     v = visitor.ScopedVisitor()
     mod = ast.parse(code)
     v.visit(mod)
     assert v.defs == set([])
     assert v.refs == set(["mo"])
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="Requires duckdb")
+def test_sql_empty_statement_duckdb() -> None:
+    code = "duckdb.sql('')"
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == set([])
+    assert v.refs == set(["duckdb"])
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="Requires duckdb")


### PR DESCRIPTION
Came across a few notebooks that use plain `duckdb.sql` instead of `mo.sql`. We should still track the dependencies. 