### PR TITLE
fix: don't allow install/uninstall if package manager doesn't exist, better warnings

### DIFF
--- a/marimo/_runtime/packages/conda_package_manager.py
+++ b/marimo/_runtime/packages/conda_package_manager.py
@@ -13,6 +13,9 @@ from marimo._runtime.packages.package_manager import (
 
 
 class CondaPackageManager(CanonicalizingPackageManager):
+    name = "conda"
+    docs_url = "https://docs.conda.io/projects/conda/"
+
     def _construct_module_name_mapping(self) -> dict[str, str]:
         return module_name_to_conda_name()
 
@@ -29,6 +32,9 @@ class PixiPackageManager(CondaPackageManager):
     def list_packages(self) -> List[PackageDescription]:
         import json
         import subprocess
+
+        if not self.is_manager_installed():
+            return []
 
         try:
             proc = subprocess.run(

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -22,6 +22,8 @@ class PypiPackageManager(CanonicalizingPackageManager):
     def _list_packages_from_cmd(
         self, cmd: List[str]
     ) -> List[PackageDescription]:
+        if not self.is_manager_installed():
+            return []
         proc = subprocess.run(cmd, capture_output=True, text=True)
         if proc.returncode != 0:
             return []
@@ -37,6 +39,7 @@ class PypiPackageManager(CanonicalizingPackageManager):
 
 class PipPackageManager(PypiPackageManager):
     name = "pip"
+    docs_url = "https://pip.pypa.io/"
 
     async def _install(self, package: str) -> bool:
         return self.run(["pip", "install", package])
@@ -51,6 +54,7 @@ class PipPackageManager(PypiPackageManager):
 
 class MicropipPackageManager(PypiPackageManager):
     name = "micropip"
+    docs_url = "https://micropip.pyodide.org/"
 
     def should_auto_install(self) -> bool:
         return True
@@ -89,9 +93,13 @@ class MicropipPackageManager(PypiPackageManager):
         # micropip doesn't sort the packages
         return sorted(packages, key=lambda pkg: pkg.name)
 
+    def check_available(self) -> bool:
+        return is_pyodide()
+
 
 class UvPackageManager(PypiPackageManager):
     name = "uv"
+    docs_url = "https://docs.astral.sh/uv/"
 
     async def _install(self, package: str) -> bool:
         return self.run(["uv", "pip", "install", package])
@@ -159,6 +167,7 @@ class UvPackageManager(PypiPackageManager):
 
 class RyePackageManager(PypiPackageManager):
     name = "rye"
+    docs_url = "https://rye.astral.sh/"
 
     async def _install(self, package: str) -> bool:
         return self.run(["rye", "add", package])
@@ -173,6 +182,7 @@ class RyePackageManager(PypiPackageManager):
 
 class PoetryPackageManager(PypiPackageManager):
     name = "poetry"
+    docs_url = "https://python-poetry.org/docs/"
 
     async def _install(self, package: str) -> bool:
         return self.run(["poetry", "add", "--no-interaction", package])

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -36,7 +36,6 @@ from marimo._messaging.errors import (
     UnknownError,
 )
 from marimo._messaging.ops import (
-    Alert,
     CellOp,
     CompletedRun,
     DataColumnPreview,
@@ -1673,13 +1672,7 @@ class Kernel:
             self.package_manager = create_package_manager(request.manager)
 
         if not self.package_manager.is_manager_installed():
-            Alert(
-                title="Package manager not installed",
-                description=(
-                    f"{request.manager} is not available on your machine."
-                ),
-                variant="danger",
-            ).broadcast()
+            self.package_manager.alert_not_installed()
             return
 
         # Package manager operates on module names

--- a/marimo/_server/api/endpoints/packages.py
+++ b/marimo/_server/api/endpoints/packages.py
@@ -45,6 +45,13 @@ async def install_package(request: Request) -> PackageOperationResponse:
     body = await parse_request(request, cls=AddPackageRequest)
 
     package_manager = _get_package_manager(request)
+    if not package_manager.is_manager_installed():
+        package_manager.alert_not_installed()
+        return PackageOperationResponse.of_failure(
+            f"{package_manager.name} is not available. "
+            f"Check out the docs for installation instructions: {package_manager.docs_url}"  # noqa: E501
+        )
+
     success = await package_manager.install(body.package, version=None)
 
     # Update the script metadata
@@ -84,6 +91,13 @@ async def uninstall_package(request: Request) -> PackageOperationResponse:
     body = await parse_request(request, cls=RemovePackageRequest)
 
     package_manager = _get_package_manager(request)
+    if not package_manager.is_manager_installed():
+        package_manager.alert_not_installed()
+        return PackageOperationResponse.of_failure(
+            f"{package_manager.name} is not available. "
+            f"Check out the docs for installation instructions: {package_manager.docs_url}"  # noqa: E501
+        )
+
     success = await package_manager.uninstall(body.package)
 
     # Update the script metadata
@@ -116,6 +130,10 @@ async def list_packages(request: Request) -> ListPackagesResponse:
                         $ref: "#/components/schemas/ListPackagesResponse"
     """
     package_manager = _get_package_manager(request)
+    if not package_manager.is_manager_installed():
+        package_manager.alert_not_installed()
+        return ListPackagesResponse(packages=[])
+
     packages = package_manager.list_packages()
 
     return ListPackagesResponse(packages=packages)


### PR DESCRIPTION
Fixes #2425

Improve the warnings and better error handling when a user does not have the package manager installed. 