### PR TITLE
Force asyncio in edit mode

### DIFF
--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -168,6 +168,11 @@ def start(
             # close the websocket if we don't receive a pong after 60 seconds
             ws_ping_timeout=60,
             timeout_graceful_shutdown=1,
+            # Under uvloop, reading the socket we monitor under add_reader()
+            # occassionally throws BlockingIOError (errno 11, or errno 35,
+            # ...). RUN mode no longer uses a socket (it has no IPC) but EDIT
+            # does, so force asyncio.
+            loop="asyncio" if mode == SessionMode.EDIT else "auto",
         )
     )
     app.state.server = server

--- a/tests/_convert/test_convert_utils.py
+++ b/tests/_convert/test_convert_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from textwrap import dedent
 
 from marimo._convert import utils
@@ -25,12 +26,13 @@ def test_generate_from_sources():
     # Test with basic sources
     sources = ["print('Hello')", "x = 5"]
     result = utils.generate_from_sources(sources)
+    result = re.sub(r"__generated_with = .*", "", result)
 
     assert result == dedent(
         """
 import marimo
 
-__generated_with = "0.8.20"
+
 app = marimo.App()
 
 


### PR DESCRIPTION
Under uvloop, reading the socket we monitor under `add_reader()` occasionally throws BlockingIOError (errno 11), even though our socket is blocking and doesn't have a receive timeout

RUN mode no longer uses a socket (it has no IPC) but EDIT does, so this PR forces `asyncio` in `uvicorn`.

Not 100% sure the issue was due to `uvloop`, but did notice it in the stack trace in #1568, and also found a few similar issues (https://github.com/ipython/ipython/issues/12563).

Hopefully fixes the edit mode counterpart of #1568 
