### PR TITLE
sandbox mode supports named and editable local packages, related dev …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,14 @@ or [on Discord](https://discord.gg/JE7nhX6mD8).
 To build marimo from source, you'll need to have Node.js, pnpm, GNU make, and
 Python (>=3.8) installed.
 
+- Install dev dependencies
+  - `pip install -e '.[dev]'`
 - Install [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-version-manager-to-install-nodejs-and-npm) >= 18
   - We use Node.js version 20
 - Install [pnpm](https://github.com/pnpm/pnpm) == 8.x
   - `npm install -g pnpm@8`
+- Install [typos](https://github.com/crate-ci/typos?tab=readme-ov-file#install)
+  - `brew install typos-cli` or `cargo install typos-cli`
 - Install [GNU Make](https://www.gnu.org/software/make/) (you may already have it installed)
 - Install [Python](https://www.python.org/) >= 3.8. (You may already it installed. To see your version, use `python -V` at the command line.)
 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,24 @@ help:
 	@# https://stackoverflow.com/a/35730928
 	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' Makefile | column -s: -t
 
+.PHONY: required-build-tools
+expect-tools:
+	@if ! /usr/bin/which -s pnpm typos pytest2; then \
+		echo "📦 pnpm, pytest, typos-cli required to build and test."; \
+		if ! /usr/bin/which -s pnpm; then \
+		    echo "💡 Please perform 'npm install -g pnpm@8' or use your preferred package manager."; \
+        fi; \
+		if ! /usr/bin/which -s pytest; then \
+		    echo "💡 Please perform 'pip install -e .[dev]' to add pytest and other dev requirements."; \
+        fi; \
+		if ! /usr/bin/which -s typos; then \
+		  echo "💡 Please perform 'brew install typos-cli', 'cargo install typos-cli' or use your preferred package manager."; \
+	    fi; \
+	fi
+
 # package frontend into marimo/
 .PHONY: fe
-fe: marimo/_static marimo/_lsp
+fe: expect-tools marimo/_static marimo/_lsp
 
 # install/build frontend if anything under frontend/src or (top-level)
 # frontend/ has changed
@@ -68,7 +83,7 @@ py-check:
 
 .PHONY: py-test
 # test python
-py-test:
+py-test: expect-tools
 	cd marimo && typos && cd - && pytest;
 
 .PHONY: py-snapshots

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from marimo._cli.sandbox import _get_dependencies
 
 
@@ -37,3 +39,35 @@ __generated_with = "0.8.2"
 app = marimo.App(width="medium")
 """
     assert _get_dependencies(SCRIPT) == []
+
+
+def test_get_local_package_dependencies():
+    SCRIPT = """
+# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pandas @ ~/local/path1",
+#     "numpy @ /local/abs/path2",
+#     "polars",
+#     "-e ~/foo/package1",
+#     "--editable ~/bar/package2",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.8.2"
+app = marimo.App(width="medium")
+"""
+    parsed_deps = _get_dependencies(SCRIPT)
+    home_dir = os.path.expanduser("~")
+    # test home dirs are expanded
+    assert parsed_deps[0].endswith(f"{home_dir}/local/path1")
+    # test that abs paths are left alone
+    assert parsed_deps[1].endswith("/local/abs/path2")
+    # assert that standard pypi package names remain intact
+    assert parsed_deps[2] == "polars"
+    # check -e and --editable package paths
+    assert parsed_deps[3].endswith(f"{home_dir}/foo/package1")
+    assert parsed_deps[4].endswith(f"{home_dir}/bar/package2")


### PR DESCRIPTION
## 📝 Summary

These scenarios are common in work settings where private packages are running off of `git clone`s of teammates' branches, or packages are distributed as-is via private CI to prod without publishing to PyPi.

1. Support local named packages via `pyproject.toml`'s `package @ some/local/path` spec
1. Support installation of local editable packages (libraries in development, or otherwise not available in PyPi index for any reason) via the use of `uv run`'s `--with-editable` flag.

```sh
Usage: uv run [OPTIONS] <COMMAND>

Options:
      --with-editable <WITH_EDITABLE>          Run with the given packages installed as
```

3. dev ux improvement: when running `make` targets, if expected tools are missing because user skipped reading `CONTRIBUTING.md`, print helpful message about expectations and remediation commands.

## 🔍 Description of Changes

- `marimo/_cli/sandbox.py` is edited to parse for local paths
- `tests/_cli/sandbox.py` adds test to cover all the path parsing and alterations
- `Makefile` gets new `expect-tools` phony target for `pnpm`, `pytest`, `typos`, and added as a target dependency to `make fe` and `make py-test`
- `CONTRIBUTING.md` gets mentions of dev requirements and `typos-cli` install

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

### known issues?

There are 4 tests far away from my change that are not passing, and I think either I didn't set the right flags or these are known issues.

```
FAILED tests/_runtime/packages/test_pypi_package_manager.py::test_install - AssertionError: Expected 'run' to be called once. Called 0 times.
FAILED tests/_runtime/packages/test_pypi_package_manager.py::test_uninstall - AssertionError: Expected 'run' to be called once. Called 0 times.
FAILED tests/_runtime/packages/test_pypi_package_manager.py::test_list_packages - AssertionError: Expected 'run' to be called once. Called 0 times.
FAILED tests/_server/api/endpoints/test_ws.py::test_query_params - OSError: [Errno 24] Too many open files
```

## 📜 Reviewers

for review by @akshayka - who implemented the sandbox just days ago
