### PR TITLE
fix: mangle node.asname for imports

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -189,7 +189,9 @@ class ScopedVisitor(ast.NodeVisitor):
             return name
 
     def _get_alias_name(self, node: ast.alias) -> str:
-        """Get the string name of an imported alias
+        """Get the string name of an imported alias.
+
+        Mangles the "as" name if it's a local variable.
 
         NB: We disallow `import *` because Python only allows
         star imports at module-level, but we store cells as functions.
@@ -214,7 +216,8 @@ class ScopedVisitor(ast.NodeVisitor):
                 )
             return basename
         else:
-            return self._if_local_then_mangle(node.asname)
+            node.asname = self._if_local_then_mangle(node.asname)
+            return node.asname
 
     def _is_defined(self, identifier: str) -> bool:
         """Check if `identifier` is defined in any block."""

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -541,6 +541,23 @@ class TestExecution:
         assert k.globals["z"] == 2
         assert not k.errors
 
+    async def test_import_module_as_local_var(
+        self, any_kernel: Kernel
+    ) -> None:
+        # Tests that imported names are mangled but still usable
+        k = any_kernel
+        await k.run(
+            [
+                ExecutionRequest(
+                    cell_id="0",
+                    code="import sys as _sys; msize = _sys.maxsize",
+                ),
+            ]
+        )
+        # _sys mangled, should not be in globals
+        assert "_sys" not in k.globals
+        assert k.globals["msize"] == sys.maxsize
+
     async def test_defs_with_no_definers_are_removed_from_cell(
         self, any_kernel: Kernel
     ) -> None:


### PR DESCRIPTION
Fixes a bug in which `as` imports weren't mangled, making it impossible to use modules imported as local variables.