### PR TITLE
improvement: support sunburst and treemap plotly selection

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -218,5 +218,10 @@
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.6.0"
   },
-  "packageManager": "pnpm@9.8.0"
+  "packageManager": "pnpm@9.8.0",
+  "pnpm": {
+    "patchedDependencies": {
+      "react-plotly.js": "patches/react-plotly.js.patch"
+    }
+  }
 }

--- a/frontend/patches/react-plotly.js.patch
+++ b/frontend/patches/react-plotly.js.patch
@@ -1,0 +1,15 @@
+diff --git a/factory.js b/factory.js
+index 40f3edccbebc45b491dd3488ed619ec9208be8d9..f88f451588d656805d1ae76ce4184a486a179eb1 100644
+--- a/factory.js
++++ b/factory.js
+@@ -40,8 +40,8 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.g
+ // The naming convention is:
+ //   - events are attached as `'plotly_' + eventName.toLowerCase()`
+ //   - react props are `'on' + eventName`
+-var eventNames = ['AfterExport', 'AfterPlot', 'Animated', 'AnimatingFrame', 'AnimationInterrupted', 'AutoSize', 'BeforeExport', 'BeforeHover', 'ButtonClicked', 'Click', 'ClickAnnotation', 'Deselect', 'DoubleClick', 'Framework', 'Hover', 'LegendClick', 'LegendDoubleClick', 'Relayout', 'Relayouting', 'Restyle', 'Redraw', 'Selected', 'Selecting', 'SliderChange', 'SliderEnd', 'SliderStart', 'SunburstClick', 'Transitioning', 'TransitionInterrupted', 'Unhover', 'WebGlContextLost'];
+-var updateEvents = ['plotly_restyle', 'plotly_redraw', 'plotly_relayout', 'plotly_relayouting', 'plotly_doubleclick', 'plotly_animated', 'plotly_sunburstclick']; // Check if a window is available since SSR (server-side rendering)
++var eventNames = ['AfterExport', 'AfterPlot', 'Animated', 'AnimatingFrame', 'AnimationInterrupted', 'AutoSize', 'BeforeExport', 'BeforeHover', 'ButtonClicked', 'Click', 'ClickAnnotation', 'Deselect', 'DoubleClick', 'Framework', 'Hover', 'LegendClick', 'LegendDoubleClick', 'Relayout', 'Relayouting', 'Restyle', 'Redraw', 'Selected', 'Selecting', 'SliderChange', 'SliderEnd', 'SliderStart', 'SunburstClick', 'TreemapClick', 'Transitioning', 'TransitionInterrupted', 'Unhover', 'WebGlContextLost'];
++var updateEvents = ['plotly_restyle', 'plotly_redraw', 'plotly_relayout', 'plotly_relayouting', 'plotly_doubleclick', 'plotly_animated', 'plotly_sunburstclick', 'plotly_treemapclick']; // Check if a window is available since SSR (server-side rendering)
+ // breaks unnecessarily if you try to use it server-side.
+ 
+ var isBrowser = typeof window !== 'undefined';

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -6,6 +6,11 @@ settings:
 
 pnpmfileChecksum: eqzj7c6t3bs5v7xcjer2wfwkp4
 
+patchedDependencies:
+  react-plotly.js:
+    hash: bpeex744nmt6722etqry6essaq
+    path: patches/react-plotly.js.patch
+
 importers:
 
   .:
@@ -330,7 +335,7 @@ importers:
         version: 7.52.2(react@18.3.1)
       react-plotly.js:
         specifier: ^2.6.0
-        version: 2.6.0(plotly.js@2.34.0(mapbox-gl@1.13.3))(react@18.3.1)
+        version: 2.6.0(patch_hash=bpeex744nmt6722etqry6essaq)(plotly.js@2.34.0(mapbox-gl@1.13.3))(react@18.3.1)
       react-resizable-panels:
         specifier: 2.0.19
         version: 2.0.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -19530,7 +19535,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-plotly.js@2.6.0(plotly.js@2.34.0(mapbox-gl@1.13.3))(react@18.3.1):
+  react-plotly.js@2.6.0(patch_hash=bpeex744nmt6722etqry6essaq)(plotly.js@2.34.0(mapbox-gl@1.13.3))(react@18.3.1):
     dependencies:
       plotly.js: 2.34.0(mapbox-gl@1.13.3)
       prop-types: 15.8.1

--- a/marimo/_smoke_tests/bugs/2457-plotly-section.py
+++ b/marimo/_smoke_tests/bugs/2457-plotly-section.py
@@ -1,0 +1,69 @@
+
+
+import marimo
+
+__generated_with = "0.8.22"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import plotly.express as px
+
+    df = px.data.tips()
+    mo.md("# Plotly Selection")
+    return df, mo, px
+
+
+@app.cell
+def __(df):
+    df
+    return
+
+
+@app.cell
+def __(df, mo, px):
+    _fig = px.treemap(df, path=[px.Constant("all"), 'day', 'time', 'sex'], values='total_bill')
+    plot = mo.ui.plotly(_fig)
+    return (plot,)
+
+
+@app.cell
+def __(mo, plot):
+    mo.vstack([plot], align="stretch")
+    return
+
+
+@app.cell
+def __(plot):
+    plot.value
+    return
+
+
+@app.cell
+def __(mo, px):
+    _data = dict(
+        character=["Eve", "Cain", "Seth", "Enos", "Noam", "Abel", "Awan", "Enoch", "Azura"],
+        parent=["", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve" ],
+        value=[10, 14, 12, 10, 2, 6, 6, 4, 4])
+
+    sunburst = mo.ui.plotly(px.sunburst(
+        _data,
+        names='character',
+        parents='parent',
+        values='value',
+    ))
+
+    sunburst
+    return (sunburst,)
+
+
+@app.cell
+def __(sunburst):
+    sunburst.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #2457

Support sunburst and treemap selection. react-plotly does not have a callback for treemap, so I had to add a patch. I will try to commit this upstream, so later remove the patch. 