### PR TITLE
Remove 3.8 support

### DIFF
--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -38,12 +38,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         dependencies: ['core', 'core,optional']
-        python-version: ['3.8']
+        python-version: ['3.9']
         include:
           - os: ubuntu-latest
-            python-version: '3.9'
-            dependencies: 'core'
-          - os: ubuntu-latest
             python-version: '3.10'
             dependencies: 'core'
           - os: ubuntu-latest
@@ -63,6 +60,9 @@ jobs:
             dependencies: 'core,optional'
           - os: ubuntu-latest
             python-version: '3.12'
+            dependencies: 'core,optional'
+          - os: ubuntu-latest
+            python-version: '3.13'
             dependencies: 'core,optional'
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -38,11 +38,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         dependencies: ['core', 'core,optional']
-        python-version: ['3.8']
+        python-version: ['3.9']
         include:
-          - os: ubuntu-latest
-            python-version: '3.9'
-            dependencies: 'core'
           - os: ubuntu-latest
             python-version: '3.10'
             dependencies: 'core'

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -38,8 +38,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         dependencies: ['core', 'core,optional']
-        python-version: ['3.9']
+        python-version: ['3.8']
         include:
+          - os: ubuntu-latest
+            python-version: '3.9'
+            dependencies: 'core'
           - os: ubuntu-latest
             python-version: '3.10'
             dependencies: 'core'
@@ -60,9 +63,6 @@ jobs:
             dependencies: 'core,optional'
           - os: ubuntu-latest
             python-version: '3.12'
-            dependencies: 'core,optional'
-          - os: ubuntu-latest
-            python-version: '3.13'
             dependencies: 'core,optional'
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/marimo/_convert/ipynb.py
+++ b/marimo/_convert/ipynb.py
@@ -26,10 +26,6 @@ def transform_fixup_multiple_definitions(sources: List[str]) -> List[str]:
     This only takes effect if the declaration and reference are in
     the same cell.
     """
-    if sys.version_info < (3, 9):
-        # ast.unparse not available in Python 3.8
-        return sources
-
     try:
         cells = [
             compile_cell(source, cell_id=str(i))
@@ -355,10 +351,6 @@ class Renamer:
 
 
 def _transform_aug_assign(sources: List[str]) -> List[str]:
-    if sys.version_info < (3, 9):
-        # ast.unparse unavailable
-        return sources
-
     new_sources = sources.copy()
     for i, source in enumerate(sources):
         try:
@@ -433,9 +425,6 @@ def transform_duplicate_definitions(sources: List[str]) -> List[str]:
     print(a_2)
     ```
     """
-    if sys.version_info < (3, 9):
-        # ast.unparse not available in Python 3.8
-        return sources
 
     # Find all definitions in the AST
     def find_definitions(node: ast.AST) -> List[str]:

--- a/marimo/_plugins/ui/_impl/batch.py
+++ b/marimo/_plugins/ui/_impl/batch.py
@@ -1,13 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import sys
-
-if sys.version_info < (3, 9):
-    from typing import ItemsView, ValuesView
-else:
-    pass
-
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/marimo/_runtime/copy.py
+++ b/marimo/_runtime/copy.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import inspect
-import sys
 import weakref
 from copy import copy
 from typing import (
@@ -16,11 +15,7 @@ from typing import (
 )
 
 T = TypeVar("T")
-if sys.version_info < (3, 9):
-    # Future does not seem to work for this in CI.
-    Ref = Union["weakref.ReferenceType[T]", Callable[[], T]]
-else:
-    Ref = Union[weakref.ReferenceType[T], Callable[[], T]]
+Ref = Union[weakref.ReferenceType[T], Callable[[], T]]
 
 
 class CloneError(Exception):

--- a/marimo/_runtime/primitives.py
+++ b/marimo/_runtime/primitives.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import inspect
 import numbers
-import sys
 import weakref
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
@@ -18,11 +17,7 @@ PRIMITIVES: tuple[type, ...] = (bytes, str, numbers.Number, type(None))
 # reference.
 CLONE_PRIMITIVES = (weakref.ref,) + PRIMITIVES
 
-if sys.version_info < (3, 9):
-    # Future does not seem to work for this in CI.
-    FN_CACHE_TYPE = Optional["dict[Union[Callable[..., Any], type], bool]"]
-else:
-    FN_CACHE_TYPE = Optional[dict[Union[Callable[..., Any], type], bool]]
+FN_CACHE_TYPE = Optional[dict[Union[Callable[..., Any], type], bool]]
 
 
 def is_external(value: Any) -> bool:

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -522,12 +522,15 @@ class Kernel:
         self.execution_context = ExecutionContext(
             cell_id, setting_element_value
         )
-        with get_context().provide_ui_ids(str(cell_id)), redirect_streams(
-            cell_id,
-            stream=self.stream,
-            stdout=self.stdout,
-            stderr=self.stderr,
-            stdin=self.stdin,
+        with (
+            get_context().provide_ui_ids(str(cell_id)),
+            redirect_streams(
+                cell_id,
+                stream=self.stream,
+                stdout=self.stdout,
+                stderr=self.stderr,
+                stdin=self.stdin,
+            ),
         ):
             modules = None
             try:
@@ -1590,9 +1593,10 @@ class Kernel:
         else:
             found = True
             LOGGER.debug("Executing RPC %s", request)
-            with self._install_execution_context(
-                cell_id=function.cell_id
-            ), ctx.provide_ui_ids(str(uuid4())):
+            with (
+                self._install_execution_context(cell_id=function.cell_id),
+                ctx.provide_ui_ids(str(uuid4())),
+            ):
                 # Usually UI element IDs are deterministic, based on
                 # cell id, so that element values can be matched up
                 # with objects on notebook/app re-connection.

--- a/marimo/_server/api/lifespans.py
+++ b/marimo/_server/api/lifespans.py
@@ -5,24 +5,15 @@ import asyncio
 import contextlib
 import socket
 import sys
+from collections.abc import AsyncIterator, Callable, Sequence
+from contextlib import AbstractAsyncContextManager
+
+from starlette.applications import Starlette
 
 from marimo._server.api.deps import AppState, AppStateBase
 from marimo._server.file_router import AppFileRouter
 from marimo._server.sessions import SessionManager
 from marimo._server.tokens import AuthToken
-
-if sys.version_info < (3, 9):
-    from typing import (
-        AsyncContextManager as AbstractAsyncContextManager,
-        AsyncIterator,
-        Callable,
-        Sequence,
-    )
-else:
-    from collections.abc import AsyncIterator, Callable, Sequence
-    from contextlib import AbstractAsyncContextManager
-
-from starlette.applications import Starlette
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias

--- a/marimo/_utils/paths.py
+++ b/marimo/_utils/paths.py
@@ -2,15 +2,11 @@
 from __future__ import annotations
 
 import os
-import sys
 from typing import Any
 
 
 def import_files(filename: str) -> Any:
-    if sys.version_info < (3, 9):
-        from importlib_resources import files as importlib_files
-    else:
-        from importlib.resources import files as importlib_files
+    from importlib.resources import files as importlib_files
 
     return importlib_files(filename)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ dynamic = ["version"]
 dependencies = [
     # For maintainable cli
     "click>=8.0,<9",
-    # For python 3.8 compatibility
-    "importlib_resources>=5.10.2; python_version < \"3.9\"",
     # code completion
     "jedi>=0.18.0",
     # compile markdown to html
@@ -51,7 +49,7 @@ dependencies = [
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Operating System :: OS Independent",
     "License :: OSI Approved :: Apache Software License",
@@ -61,10 +59,10 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Education",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Operating System :: OS Independent",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Operating System :: OS Independent",
     "License :: OSI Approved :: Apache Software License",

--- a/tests/_cli/test_file_path.py
+++ b/tests/_cli/test_file_path.py
@@ -165,17 +165,15 @@ def test_generic_url_reader() -> None:
 def test_file_content_reader() -> None:
     reader = FileContentReader()
 
-    with patch.object(
-        LocalFileReader, "read"
-    ) as mock_local_read, patch.object(
-        GitHubIssueReader, "read"
-    ) as mock_github_issue_read, patch.object(
-        StaticNotebookReader, "read"
-    ) as mock_static_notebook_read, patch.object(
-        GitHubSourceReader, "read"
-    ) as mock_github_source_read, patch.object(
-        GenericURLReader, "read"
-    ) as mock_generic_url_read:
+    with (
+        patch.object(LocalFileReader, "read") as mock_local_read,
+        patch.object(GitHubIssueReader, "read") as mock_github_issue_read,
+        patch.object(
+            StaticNotebookReader, "read"
+        ) as mock_static_notebook_read,
+        patch.object(GitHubSourceReader, "read") as mock_github_source_read,
+        patch.object(GenericURLReader, "read") as mock_generic_url_read,
+    ):
         mock_local_read.return_value = ("local content", "local.py")
         mock_github_issue_read.return_value = ("issue content", "issue.py")
         mock_static_notebook_read.return_value = (
@@ -337,8 +335,9 @@ def test_validate_name_with_relative_and_absolute_paths():
     relative_path = "relative/path/file.py"
     absolute_path = "/absolute/path/file.py"
 
-    with patch("os.path.exists", return_value=True), patch(
-        "pathlib.Path.is_file", return_value=True
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("pathlib.Path.is_file", return_value=True),
     ):
         assert (
             validate_name(

--- a/tests/_runtime/test_trace.py
+++ b/tests/_runtime/test_trace.py
@@ -72,7 +72,7 @@ class TestScriptTrace:
             os.path.normpath(
                 "tests/_runtime/script_data/script_exception_with_imported_function.py"  # noqa: E501
             )
-            + ", line 11"
+            + '", line 11'
             in result
         )
         assert "y = y / x" in result

--- a/tests/_runtime/test_trace.py
+++ b/tests/_runtime/test_trace.py
@@ -69,7 +69,9 @@ class TestScriptTrace:
         assert f'{file_path}", line 3' in result
 
         assert (
-            'tests/_runtime/script_data/script_exception_with_imported_function.py"'
+            os.path.normpath(
+                "tests/_runtime/script_data/script_exception_with_imported_function.py"  # noqa: E501
+            )
             + ", line 11"
             in result
         )

--- a/tests/_runtime/test_trace.py
+++ b/tests/_runtime/test_trace.py
@@ -22,10 +22,7 @@ class TestScriptTrace:
 
         result = p.stderr.decode()
         assert "NameError: name 'y' is not defined" in result
-        assert (
-            'tests/_runtime/script_data/script_exception.py", line 10'
-            in result
-        )
+        assert 'script_exception.py", line 10' in result
         assert "y = y / x" in result
         # Test col_offset
         # Expected output:
@@ -50,10 +47,7 @@ class TestScriptTrace:
 
         result = p.stderr.decode()
         assert "ZeroDivisionError: division by zero" in result
-        assert (
-            'tests/_runtime/script_data/script_exception_with_output.py"'
-            ", line 11"
-        ) in result
+        assert ('script_exception_with_output.py"' ", line 11") in result
         assert "y / x" in result
 
     @staticmethod


### PR DESCRIPTION
This PR drops support for Python 3.8, which has reached its end-of-life.