### PR TITLE
Update AutoExporter directory to __marimo__

### DIFF
--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -8,6 +8,9 @@ marimo export
 
 ## Export to static HTML
 
+
+### Export from a running notebook
+
 Export the current view your notebook to static HTML via the notebook
 menu:
 
@@ -18,7 +21,13 @@ menu:
 </figure>
 </div>
 
-You can also export to HTML at the command-line:
+Additionally, you can configure individual notebooks to automatically
+save as HTML through the notebook menu. These automatic snapshots are
+saved to a folder called `__marimo__` in the notebook directory.
+
+### Export from the command line
+
+Export to HTML at the command line:
 
 ```bash
 marimo export html notebook.py -o notebook.html
@@ -29,6 +38,9 @@ or watch the notebook for changes and automatically export to HTML:
 ```bash
 marimo export html notebook.py -o notebook.html --watch
 ```
+
+When you export from the command line, marimo runs your notebook to produce
+its visual outputs before saving as HTML.
 
 ## Export to a Python script
 

--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -188,7 +188,7 @@ export const AppConfigForm: React.FC = () => {
               </FormItem>
               <FormDescription>
                 When enabled, marimo will periodically save this notebook as
-                HTML to a folder <Kbd className="inline">.marimo</Kbd> in the
+                HTML to a folder <Kbd className="inline">__marimo__</Kbd> in the
                 notebook's directory.
               </FormDescription>
             </div>

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -265,7 +265,7 @@ class Exporter:
 
 
 class AutoExporter:
-    EXPORT_DIR = ".marimo"
+    EXPORT_DIR = "__marimo__"
 
     def save_html(self, file_manager: AppFileManager, html: str) -> None:
         # get filename

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -170,7 +170,6 @@ def test_other_exports_dont_work_in_read(client: TestClient) -> None:
 def test_auto_export_html(client: TestClient, temp_marimo_file: str) -> None:
     session = get_session_manager(client).get_session(SESSION_ID)
     assert session
-    print(temp_marimo_file)
     assert temp_marimo_file is not None
     session.app_file_manager.filename = temp_marimo_file
 
@@ -198,9 +197,9 @@ def test_auto_export_html(client: TestClient, temp_marimo_file: str) -> None:
     # Not modified response
     assert response.status_code == 304
 
-    # Assert .marimo file is created
+    # Assert __marimo__ directory is created
     assert os.path.exists(
-        os.path.join(os.path.dirname(temp_marimo_file), ".marimo")
+        os.path.join(os.path.dirname(temp_marimo_file), "__marimo__")
     )
 
 
@@ -236,9 +235,9 @@ def test_auto_export_html_no_code(
     # Not modified response
     assert response.status_code == 304
 
-    # Assert .marimo file is created
+    # Assert __marimo__ file is created
     assert os.path.exists(
-        os.path.join(os.path.dirname(temp_marimo_file), ".marimo")
+        os.path.join(os.path.dirname(temp_marimo_file), "__marimo__")
     )
 
 
@@ -270,7 +269,7 @@ def test_auto_export_markdown(
     # Not modified response
     assert response.status_code == 304
 
-    # Assert .marimo file is created
+    # Assert __marimo__ file is created
     assert os.path.exists(
-        os.path.join(os.path.dirname(temp_marimo_file), ".marimo")
+        os.path.join(os.path.dirname(temp_marimo_file), "__marimo__")
     )


### PR DESCRIPTION
To be the same as where the cache is saved (caches are saved under `__marimo__/cache` and can be selectively git-ignored).