### PR TITLE
added python executable to pip and uv

### DIFF
--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from typing import List
 
 from marimo._runtime.packages.module_name_to_pypi_name import (
@@ -14,6 +15,8 @@ from marimo._runtime.packages.package_manager import (
 )
 from marimo._runtime.packages.utils import split_packages
 from marimo._utils.platform import is_pyodide
+
+PY_EXE = sys.executable
 
 
 class PypiPackageManager(CanonicalizingPackageManager):
@@ -43,13 +46,23 @@ class PipPackageManager(PypiPackageManager):
     docs_url = "https://pip.pypa.io/"
 
     async def _install(self, package: str) -> bool:
-        return self.run(["pip", "install", *split_packages(package)])
+        return self.run(
+            ["pip", f"--python {PY_EXE}", "install", *split_packages(package)]
+        )
 
     async def uninstall(self, package: str) -> bool:
-        return self.run(["pip", "uninstall", "-y", *split_packages(package)])
+        return self.run(
+            [
+                "pip",
+                f"--python {PY_EXE}",
+                "uninstall",
+                "-y",
+                *split_packages(package),
+            ]
+        )
 
     def list_packages(self) -> List[PackageDescription]:
-        cmd = ["pip", "list", "--format=json"]
+        cmd = ["pip", f"--python {PY_EXE}", "list", "--format=json"]
         return self._list_packages_from_cmd(cmd)
 
 
@@ -103,7 +116,9 @@ class UvPackageManager(PypiPackageManager):
     docs_url = "https://docs.astral.sh/uv/"
 
     async def _install(self, package: str) -> bool:
-        return self.run(["uv", "pip", "install", *split_packages(package)])
+        return self.run(
+            ["uv", "pip", "install", *split_packages(package), f"-p {PY_EXE}"]
+        )
 
     def update_notebook_script_metadata(
         self,
@@ -159,10 +174,18 @@ class UvPackageManager(PypiPackageManager):
         return {pkg.name: pkg.version for pkg in packages}
 
     async def uninstall(self, package: str) -> bool:
-        return self.run(["uv", "pip", "uninstall", *split_packages(package)])
+        return self.run(
+            [
+                "uv",
+                "pip",
+                "uninstall",
+                *split_packages(package),
+                f"-p {PY_EXE}",
+            ]
+        )
 
     def list_packages(self) -> List[PackageDescription]:
-        cmd = ["uv", "pip", "list", "--format=json"]
+        cmd = ["uv", "pip", "list", "--format=json", f"-p {PY_EXE}"]
         return self._list_packages_from_cmd(cmd)
 
 

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -47,14 +47,15 @@ class PipPackageManager(PypiPackageManager):
 
     async def _install(self, package: str) -> bool:
         return self.run(
-            ["pip", f"--python {PY_EXE}", "install", *split_packages(package)]
+            ["pip", "--python", PY_EXE, "install", *split_packages(package)]
         )
 
     async def uninstall(self, package: str) -> bool:
         return self.run(
             [
                 "pip",
-                f"--python {PY_EXE}",
+                "--python",
+                PY_EXE,
                 "uninstall",
                 "-y",
                 *split_packages(package),
@@ -62,7 +63,7 @@ class PipPackageManager(PypiPackageManager):
         )
 
     def list_packages(self) -> List[PackageDescription]:
-        cmd = ["pip", f"--python {PY_EXE}", "list", "--format=json"]
+        cmd = ["pip", "--python", PY_EXE, "list", "--format=json"]
         return self._list_packages_from_cmd(cmd)
 
 
@@ -117,7 +118,7 @@ class UvPackageManager(PypiPackageManager):
 
     async def _install(self, package: str) -> bool:
         return self.run(
-            ["uv", "pip", "install", *split_packages(package), f"-p {PY_EXE}"]
+            ["uv", "pip", "install", *split_packages(package), "-p", PY_EXE]
         )
 
     def update_notebook_script_metadata(
@@ -175,17 +176,11 @@ class UvPackageManager(PypiPackageManager):
 
     async def uninstall(self, package: str) -> bool:
         return self.run(
-            [
-                "uv",
-                "pip",
-                "uninstall",
-                *split_packages(package),
-                f"-p {PY_EXE}",
-            ]
+            ["uv", "pip", "uninstall", *split_packages(package), "-p", PY_EXE]
         )
 
     def list_packages(self) -> List[PackageDescription]:
-        cmd = ["uv", "pip", "list", "--format=json", f"-p {PY_EXE}"]
+        cmd = ["uv", "pip", "list", "--format=json", "-p", PY_EXE]
         return self._list_packages_from_cmd(cmd)
 
 

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from functools import partial
 from unittest.mock import MagicMock, patch
 
@@ -11,6 +12,8 @@ from marimo._runtime.packages.pypi_package_manager import (
 )
 
 parse_cell = partial(compiler.compile_cell, cell_id="0")
+
+PY_EXE = sys.executable
 
 
 def test_module_to_package() -> None:
@@ -43,7 +46,7 @@ async def test_install(mock_run: MagicMock):
     result = await manager._install("package1 package2")
 
     mock_run.assert_called_once_with(
-        ["pip", "install", "package1", "package2"],
+        ["pip", f"--python {PY_EXE}", "install", "package1", "package2"],
     )
     assert result is True
 
@@ -64,7 +67,14 @@ async def test_uninstall(mock_run: MagicMock):
     result = await manager.uninstall("package1 package2")
 
     mock_run.assert_called_once_with(
-        ["pip", "uninstall", "-y", "package1", "package2"],
+        [
+            "pip",
+            f"--python {PY_EXE}",
+            "uninstall",
+            "-y",
+            "package1",
+            "package2",
+        ],
     )
     assert result is True
 
@@ -82,7 +92,9 @@ def test_list_packages(mock_run: MagicMock):
     packages = manager.list_packages()
 
     mock_run.assert_called_once_with(
-        ["pip", "list", "--format=json"], capture_output=True, text=True
+        ["pip", f"--python {PY_EXE}", "list", "--format=json"],
+        capture_output=True,
+        text=True,
     )
     assert len(packages) == 2
     assert packages[0] == PackageDescription(name="package1", version="1.0.0")

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -46,7 +46,7 @@ async def test_install(mock_run: MagicMock):
     result = await manager._install("package1 package2")
 
     mock_run.assert_called_once_with(
-        ["pip", f"--python {PY_EXE}", "install", "package1", "package2"],
+        ["pip", "--python", PY_EXE, "install", "package1", "package2"],
     )
     assert result is True
 
@@ -69,7 +69,8 @@ async def test_uninstall(mock_run: MagicMock):
     mock_run.assert_called_once_with(
         [
             "pip",
-            f"--python {PY_EXE}",
+            "--python",
+            PY_EXE,
             "uninstall",
             "-y",
             "package1",
@@ -92,7 +93,7 @@ def test_list_packages(mock_run: MagicMock):
     packages = manager.list_packages()
 
     mock_run.assert_called_once_with(
-        ["pip", f"--python {PY_EXE}", "list", "--format=json"],
+        ["pip", "--python", PY_EXE, "list", "--format=json"],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## 📝 Summary

fixes #2465

## 🔍 Description of Changes

Pointers to runtime python executable were added:
1) pip:
- `pip --python {PY_EXE} install ...`
- `pip --python {PY_EXE} uninstall ...`
- `pip --python {PY_EXE} list`

For pip, the --python option must be placed before the pip subcommand name

2) uv:
- `uv pip install ... -p {PY_EXE} `
- `uv pip uninstall ... -p {PY_EXE} `
- `uv pip list -p {PY_EXE} `

UV allows -p/--python at the end.
