### PR TITLE
improve: Move highlighted code to newly created cells

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -239,12 +239,22 @@ const CellComponent = (
 
   const createBelow = useCallback(
     (opts: { code?: string } = {}) =>
-      createNewCell({ cellId, before: false, ...opts }),
+      createNewCell({
+        cellId,
+        before: false,
+        ...opts,
+        includeSelectionAsInitialCode: true,
+      }),
     [cellId, createNewCell],
   );
   const createAbove = useCallback(
     (opts: { code?: string } = {}) =>
-      createNewCell({ cellId, before: true, ...opts }),
+      createNewCell({
+        cellId,
+        before: true,
+        ...opts,
+        includeSelectionAsInitialCode: true,
+      }),
     [cellId, createNewCell],
   );
 

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -107,11 +107,21 @@ const CellEditorInternal = ({
   });
 
   const createBelow = useCallback(
-    () => createNewCell({ cellId, before: false }),
+    () =>
+      createNewCell({
+        cellId,
+        before: false,
+        includeSelectionAsInitialCode: true,
+      }),
     [cellId, createNewCell],
   );
   const createAbove = useCallback(
-    () => createNewCell({ cellId, before: true }),
+    () =>
+      createNewCell({
+        cellId,
+        before: true,
+        includeSelectionAsInitialCode: true,
+      }),
     [cellId, createNewCell],
   );
   const moveDown = useCallback(

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -220,6 +220,7 @@ const {
     const cellEditorView = getCellEditorView(cellId as CellId);
     if (cellEditorView) {
       cellContents = extractHighlightedCode(cellEditorView);
+      state.cellData[cellId as CellId].edited = true;
     }
 
     return {
@@ -232,7 +233,7 @@ const {
           code: cellContents,
           lastCodeRun,
           lastExecutionTime,
-          edited: Boolean(code) && code !== lastCodeRun,
+          edited: true,
         }),
       },
       cellRuntime: {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -224,8 +224,9 @@ const {
       const id = cellId as CellId;
       const editorView = state.cellHandles[id].current?.editorView;
       if (editorView) {
-        const [highlighted, leftover] = extractHighlightedCode(editorView);
-        if (highlighted.length > 0) {
+        const result = extractHighlightedCode(editorView);
+        if (result != null) {
+          const [highlighted, leftover] = result;
           newCellCode = highlighted === "" ? code : highlighted;
           updateEditorCodeFromPython(editorView, leftover);
           state.cellData = {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -222,7 +222,7 @@ const {
 
     if (includeSelectionAsInitialCode) {
       const id = cellId as CellId;
-      const editorView = getCellEditorView(id);
+      const editorView = state.cellHandles[id].current?.editorView;
       if (editorView) {
         const [highlighted, leftover] = extractHighlightedCode(editorView);
         if (highlighted.length > 0) {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -153,7 +153,7 @@ function initialNotebookState(): NotebookState {
         output: outputMessage,
         outline: parseOutline(outputMessage),
         consoleOutputs: outputs.map((output) =>
-          deserializeJson(deserializeBase64(output)),
+          deserializeJson(deserializeBase64(output))
         ),
       };
     }
@@ -199,7 +199,7 @@ const {
       lastExecutionTime?: number;
       newCellId?: CellId;
       autoFocus?: boolean;
-    },
+    }
   ) => {
     const {
       cellId,
@@ -447,7 +447,7 @@ const {
        * if so, the 'edited' state will be handled differently.
        */
       formattingChange: boolean;
-    },
+    }
   ) => {
     const { cellId, code, formattingChange } = action;
     if (!state.cellData[cellId]) {
@@ -481,7 +481,7 @@ const {
   },
   updateCellConfig: (
     state,
-    action: { cellId: CellId; config: Partial<CellConfig> },
+    action: { cellId: CellId; config: Partial<CellConfig> }
   ) => {
     const { cellId, config } = action;
     return updateCellData(state, cellId, (cell) => {
@@ -543,7 +543,7 @@ const {
   setCellCodes: (state, action: { codes: string[]; ids: CellId[] }) => {
     invariant(
       action.codes.length === action.ids.length,
-      "Expected codes and ids to have the same length",
+      "Expected codes and ids to have the same length"
     );
 
     for (let i = 0; i < action.codes.length; i++) {
@@ -564,7 +564,7 @@ const {
   },
   setStdinResponse: (
     state,
-    action: { cellId: CellId; response: string; outputIndex: number },
+    action: { cellId: CellId; response: string; outputIndex: number }
   ) => {
     const { cellId, response, outputIndex } = action;
     return updateCellRuntimeState(state, cellId, (cell) => {
@@ -594,7 +594,7 @@ const {
     const cellData = Object.fromEntries(cells.map((cell) => [cell.id, cell]));
 
     const cellRuntime = Object.fromEntries(
-      cells.map((cell) => [cell.id, createCellRuntimeState()]),
+      cells.map((cell) => [cell.id, createCellRuntimeState()])
     );
 
     return withScratchCell({
@@ -603,7 +603,7 @@ const {
       cellData: cellData,
       cellRuntime: cellRuntime,
       cellHandles: Object.fromEntries(
-        cells.map((cell) => [cell.id, createRef()]),
+        cells.map((cell) => [cell.id, createRef()])
       ),
     });
   },
@@ -618,7 +618,7 @@ const {
    */
   moveToNextCell: (
     state,
-    action: { cellId: CellId; before: boolean; noCreate?: boolean },
+    action: { cellId: CellId; before: boolean; noCreate?: boolean }
   ) => {
     const { cellId, before, noCreate = false } = action;
     const index = state.cellIds.indexOfOrThrow(cellId);
@@ -710,14 +710,14 @@ const {
   },
   foldAll: (state) => {
     const targets = Object.values(state.cellHandles).map(
-      (handle) => handle.current?.editorView,
+      (handle) => handle.current?.editorView
     );
     foldAllBulk(targets);
     return state;
   },
   unfoldAll: (state) => {
     const targets = Object.values(state.cellHandles).map(
-      (handle) => handle.current?.editorView,
+      (handle) => handle.current?.editorView
     );
     unfoldAllBulk(targets);
     return state;
@@ -785,7 +785,7 @@ const {
     }
 
     const { beforeCursorCode, afterCursorCode } = splitEditor(
-      cellHandle.editorView,
+      cellHandle.editorView
     );
 
     updateEditorCodeFromPython(cellHandle.editorView, beforeCursorCode);
@@ -870,7 +870,7 @@ const {
 function updateCellRuntimeState(
   state: NotebookState,
   cellId: CellId,
-  cellReducer: ReducerWithoutAction<CellRuntimeState>,
+  cellReducer: ReducerWithoutAction<CellRuntimeState>
 ) {
   if (!(cellId in state.cellRuntime)) {
     Logger.warn(`Cell ${cellId} not found in state`);
@@ -888,7 +888,7 @@ function updateCellRuntimeState(
 function updateCellData(
   state: NotebookState,
   cellId: CellId,
-  cellReducer: ReducerWithoutAction<CellData>,
+  cellReducer: ReducerWithoutAction<CellData>
 ) {
   if (!(cellId in state.cellData)) {
     Logger.warn(`Cell ${cellId} not found in state`);
@@ -928,7 +928,7 @@ const cellErrorsAtom = atom((get) => {
         // but nothing the user can take action on.
         invariant(Array.isArray(cell.output.data), "Expected array data");
         const nonAncestorErrors = cell.output.data.filter(
-          (error) => !error.type.includes("ancestor"),
+          (error) => !error.type.includes("ancestor")
         );
 
         if (nonAncestorErrors.length > 0) {
@@ -951,7 +951,7 @@ export const notebookHasCellsAtom = atom((get) => get(cellIdsAtom).length > 0);
 export const notebookOutline = atom((get) => {
   const { cellIds, cellRuntime } = get(notebookAtom);
   const outlines = cellIds.inOrderIds.map(
-    (cellId) => cellRuntime[cellId].outline,
+    (cellId) => cellRuntime[cellId].outline
   );
   return mergeOutlines(outlines);
 });
@@ -961,7 +961,7 @@ export const cellErrorCount = atom((get) => get(cellErrorsAtom).length);
 export const cellIdToNamesMap = atom((get) => {
   const { cellIds, cellData } = get(notebookAtom);
   const names: Record<CellId, string | undefined> = Objects.fromEntries(
-    cellIds.inOrderIds.map((cellId) => [cellId, cellData[cellId]?.name]),
+    cellIds.inOrderIds.map((cellId) => [cellId, cellData[cellId]?.name])
   );
   return names;
 });
@@ -1015,16 +1015,16 @@ export const getCellNames = () => {
 
 const cellDataAtoms = splitAtom(
   selectAtom(notebookAtom, (cells) =>
-    cells.cellIds.inOrderIds.map((id) => cells.cellData[id]),
-  ),
+    cells.cellIds.inOrderIds.map((id) => cells.cellData[id])
+  )
 );
 export const useCellDataAtoms = () => useAtom(cellDataAtoms);
 
 export const notebookIsRunningAtom = atom((get) =>
-  notebookIsRunning(get(notebookAtom)),
+  notebookIsRunning(get(notebookAtom))
 );
 export const notebookQueuedOrRunningCountAtom = atom((get) =>
-  notebookQueueOrRunningCount(get(notebookAtom)),
+  notebookQueueOrRunningCount(get(notebookAtom))
 );
 
 /**
@@ -1039,7 +1039,11 @@ export const getAllEditorViews = () => {
 
 export const getCellEditorView = (cellId: CellId): EditorView | undefined => {
   const { cellHandles } = store.get(notebookAtom);
-  return cellHandles[cellId].current?.editorView;
+  const cellHandle = cellHandles[cellId];
+  if (!cellHandle) {
+    return;
+  }
+  return cellHandle.current?.editorView;
 };
 
 export function isUninstantiated(
@@ -1048,7 +1052,7 @@ export function isUninstantiated(
   status: RuntimeState,
   errored: boolean,
   interrupted: boolean,
-  stopped: boolean,
+  stopped: boolean
 ) {
   return (
     // autorun on startup is off ...
@@ -1081,7 +1085,7 @@ export function staleCellIds(state: NotebookState) {
         cellRuntime[cellId].status,
         cellRuntime[cellId].errored,
         cellRuntime[cellId].interrupted,
-        cellRuntime[cellId].stopped,
+        cellRuntime[cellId].stopped
       ) ||
       cellData[cellId].edited ||
       cellRuntime[cellId].interrupted ||
@@ -1090,12 +1094,12 @@ export function staleCellIds(state: NotebookState) {
         !(
           cellRuntime[cellId].status === "disabled-transitively" ||
           cellData[cellId].config.disabled
-        )),
+        ))
   );
 }
 
 export function flattenTopLevelNotebookCells(
-  state: NotebookState,
+  state: NotebookState
 ): Array<CellData & CellRuntimeState> {
   const { cellIds, cellData, cellRuntime } = state;
   return cellIds.topLevelIds.map((cellId) => ({
@@ -1120,7 +1124,7 @@ export type CellActions = ReturnType<typeof createActions>;
 export const CellEffects = {
   onCellIdsChange: (
     cellIds: CollapsibleTree<CellId>,
-    prevCellIds: CollapsibleTree<CellId>,
+    prevCellIds: CollapsibleTree<CellId>
   ) => {
     const kioskMode = store.get(kioskModeAtom);
     if (kioskMode) {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -153,7 +153,7 @@ function initialNotebookState(): NotebookState {
         output: outputMessage,
         outline: parseOutline(outputMessage),
         consoleOutputs: outputs.map((output) =>
-          deserializeJson(deserializeBase64(output))
+          deserializeJson(deserializeBase64(output)),
         ),
       };
     }
@@ -199,7 +199,7 @@ const {
       lastExecutionTime?: number;
       newCellId?: CellId;
       autoFocus?: boolean;
-    }
+    },
   ) => {
     const {
       cellId,
@@ -447,7 +447,7 @@ const {
        * if so, the 'edited' state will be handled differently.
        */
       formattingChange: boolean;
-    }
+    },
   ) => {
     const { cellId, code, formattingChange } = action;
     if (!state.cellData[cellId]) {
@@ -481,7 +481,7 @@ const {
   },
   updateCellConfig: (
     state,
-    action: { cellId: CellId; config: Partial<CellConfig> }
+    action: { cellId: CellId; config: Partial<CellConfig> },
   ) => {
     const { cellId, config } = action;
     return updateCellData(state, cellId, (cell) => {
@@ -543,7 +543,7 @@ const {
   setCellCodes: (state, action: { codes: string[]; ids: CellId[] }) => {
     invariant(
       action.codes.length === action.ids.length,
-      "Expected codes and ids to have the same length"
+      "Expected codes and ids to have the same length",
     );
 
     for (let i = 0; i < action.codes.length; i++) {
@@ -564,7 +564,7 @@ const {
   },
   setStdinResponse: (
     state,
-    action: { cellId: CellId; response: string; outputIndex: number }
+    action: { cellId: CellId; response: string; outputIndex: number },
   ) => {
     const { cellId, response, outputIndex } = action;
     return updateCellRuntimeState(state, cellId, (cell) => {
@@ -594,7 +594,7 @@ const {
     const cellData = Object.fromEntries(cells.map((cell) => [cell.id, cell]));
 
     const cellRuntime = Object.fromEntries(
-      cells.map((cell) => [cell.id, createCellRuntimeState()])
+      cells.map((cell) => [cell.id, createCellRuntimeState()]),
     );
 
     return withScratchCell({
@@ -603,7 +603,7 @@ const {
       cellData: cellData,
       cellRuntime: cellRuntime,
       cellHandles: Object.fromEntries(
-        cells.map((cell) => [cell.id, createRef()])
+        cells.map((cell) => [cell.id, createRef()]),
       ),
     });
   },
@@ -618,7 +618,7 @@ const {
    */
   moveToNextCell: (
     state,
-    action: { cellId: CellId; before: boolean; noCreate?: boolean }
+    action: { cellId: CellId; before: boolean; noCreate?: boolean },
   ) => {
     const { cellId, before, noCreate = false } = action;
     const index = state.cellIds.indexOfOrThrow(cellId);
@@ -710,14 +710,14 @@ const {
   },
   foldAll: (state) => {
     const targets = Object.values(state.cellHandles).map(
-      (handle) => handle.current?.editorView
+      (handle) => handle.current?.editorView,
     );
     foldAllBulk(targets);
     return state;
   },
   unfoldAll: (state) => {
     const targets = Object.values(state.cellHandles).map(
-      (handle) => handle.current?.editorView
+      (handle) => handle.current?.editorView,
     );
     unfoldAllBulk(targets);
     return state;
@@ -785,7 +785,7 @@ const {
     }
 
     const { beforeCursorCode, afterCursorCode } = splitEditor(
-      cellHandle.editorView
+      cellHandle.editorView,
     );
 
     updateEditorCodeFromPython(cellHandle.editorView, beforeCursorCode);
@@ -870,7 +870,7 @@ const {
 function updateCellRuntimeState(
   state: NotebookState,
   cellId: CellId,
-  cellReducer: ReducerWithoutAction<CellRuntimeState>
+  cellReducer: ReducerWithoutAction<CellRuntimeState>,
 ) {
   if (!(cellId in state.cellRuntime)) {
     Logger.warn(`Cell ${cellId} not found in state`);
@@ -888,7 +888,7 @@ function updateCellRuntimeState(
 function updateCellData(
   state: NotebookState,
   cellId: CellId,
-  cellReducer: ReducerWithoutAction<CellData>
+  cellReducer: ReducerWithoutAction<CellData>,
 ) {
   if (!(cellId in state.cellData)) {
     Logger.warn(`Cell ${cellId} not found in state`);
@@ -928,7 +928,7 @@ const cellErrorsAtom = atom((get) => {
         // but nothing the user can take action on.
         invariant(Array.isArray(cell.output.data), "Expected array data");
         const nonAncestorErrors = cell.output.data.filter(
-          (error) => !error.type.includes("ancestor")
+          (error) => !error.type.includes("ancestor"),
         );
 
         if (nonAncestorErrors.length > 0) {
@@ -951,7 +951,7 @@ export const notebookHasCellsAtom = atom((get) => get(cellIdsAtom).length > 0);
 export const notebookOutline = atom((get) => {
   const { cellIds, cellRuntime } = get(notebookAtom);
   const outlines = cellIds.inOrderIds.map(
-    (cellId) => cellRuntime[cellId].outline
+    (cellId) => cellRuntime[cellId].outline,
   );
   return mergeOutlines(outlines);
 });
@@ -961,7 +961,7 @@ export const cellErrorCount = atom((get) => get(cellErrorsAtom).length);
 export const cellIdToNamesMap = atom((get) => {
   const { cellIds, cellData } = get(notebookAtom);
   const names: Record<CellId, string | undefined> = Objects.fromEntries(
-    cellIds.inOrderIds.map((cellId) => [cellId, cellData[cellId]?.name])
+    cellIds.inOrderIds.map((cellId) => [cellId, cellData[cellId]?.name]),
   );
   return names;
 });
@@ -1015,16 +1015,16 @@ export const getCellNames = () => {
 
 const cellDataAtoms = splitAtom(
   selectAtom(notebookAtom, (cells) =>
-    cells.cellIds.inOrderIds.map((id) => cells.cellData[id])
-  )
+    cells.cellIds.inOrderIds.map((id) => cells.cellData[id]),
+  ),
 );
 export const useCellDataAtoms = () => useAtom(cellDataAtoms);
 
 export const notebookIsRunningAtom = atom((get) =>
-  notebookIsRunning(get(notebookAtom))
+  notebookIsRunning(get(notebookAtom)),
 );
 export const notebookQueuedOrRunningCountAtom = atom((get) =>
-  notebookQueueOrRunningCount(get(notebookAtom))
+  notebookQueueOrRunningCount(get(notebookAtom)),
 );
 
 /**
@@ -1052,7 +1052,7 @@ export function isUninstantiated(
   status: RuntimeState,
   errored: boolean,
   interrupted: boolean,
-  stopped: boolean
+  stopped: boolean,
 ) {
   return (
     // autorun on startup is off ...
@@ -1085,7 +1085,7 @@ export function staleCellIds(state: NotebookState) {
         cellRuntime[cellId].status,
         cellRuntime[cellId].errored,
         cellRuntime[cellId].interrupted,
-        cellRuntime[cellId].stopped
+        cellRuntime[cellId].stopped,
       ) ||
       cellData[cellId].edited ||
       cellRuntime[cellId].interrupted ||
@@ -1094,12 +1094,12 @@ export function staleCellIds(state: NotebookState) {
         !(
           cellRuntime[cellId].status === "disabled-transitively" ||
           cellData[cellId].config.disabled
-        ))
+        )),
   );
 }
 
 export function flattenTopLevelNotebookCells(
-  state: NotebookState
+  state: NotebookState,
 ): Array<CellData & CellRuntimeState> {
   const { cellIds, cellData, cellRuntime } = state;
   return cellIds.topLevelIds.map((cellId) => ({
@@ -1124,7 +1124,7 @@ export type CellActions = ReturnType<typeof createActions>;
 export const CellEffects = {
   onCellIdsChange: (
     cellIds: CollapsibleTree<CellId>,
-    prevCellIds: CollapsibleTree<CellId>
+    prevCellIds: CollapsibleTree<CellId>,
   ) => {
     const kioskMode = store.get(kioskModeAtom);
     if (kioskMode) {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -199,6 +199,7 @@ const {
       lastExecutionTime?: number;
       newCellId?: CellId;
       autoFocus?: boolean;
+      includeSelectionAsInitialCode?: boolean;
     },
   ) => {
     const {
@@ -208,6 +209,7 @@ const {
       lastCodeRun = null,
       lastExecutionTime = null,
       autoFocus = true,
+      includeSelectionAsInitialCode,
     } = action;
     const newCellId = action.newCellId || CellId.create();
     const index =
@@ -217,10 +219,16 @@ const {
     const insertionIndex = before ? index : index + 1;
 
     let cellContents = code;
-    const cellEditorView = getCellEditorView(cellId as CellId);
-    if (cellEditorView) {
-      cellContents = extractHighlightedCode(cellEditorView);
-      state.cellData[cellId as CellId].edited = true;
+
+    if (includeSelectionAsInitialCode) {
+      const id = cellId as CellId;
+      const cellEditorView = getCellEditorView(id);
+      if (cellEditorView) {
+        const [highlighted, leftover] = extractHighlightedCode(cellEditorView);
+        cellContents = highlighted;
+        state.cellData[id].code = leftover;
+        state.cellData[id].edited = true;
+      }
     }
 
     return {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -218,16 +218,25 @@ const {
         : state.cellIds.topLevelIds.indexOf(cellId);
     const insertionIndex = before ? index : index + 1;
 
-    let cellContents = code;
+    let newCellCode = code;
 
     if (includeSelectionAsInitialCode) {
       const id = cellId as CellId;
-      const cellEditorView = getCellEditorView(id);
-      if (cellEditorView) {
-        const [highlighted, leftover] = extractHighlightedCode(cellEditorView);
-        cellContents = highlighted;
-        state.cellData[id].code = leftover;
-        state.cellData[id].edited = true;
+      const editorView = getCellEditorView(id);
+      if (editorView) {
+        const [highlighted, leftover] = extractHighlightedCode(editorView);
+        if (highlighted.length > 0) {
+          newCellCode = highlighted === "" ? code : highlighted;
+          updateEditorCodeFromPython(editorView, leftover);
+          state.cellData = {
+            ...state.cellData,
+            [id]: {
+              ...state.cellData[id],
+              code: leftover,
+              edited: true,
+            },
+          };
+        }
       }
     }
 
@@ -238,10 +247,10 @@ const {
         ...state.cellData,
         [newCellId]: createCell({
           id: newCellId,
-          code: cellContents,
+          code: newCellCode,
           lastCodeRun,
           lastExecutionTime,
-          edited: Boolean(cellContents) && cellContents !== lastCodeRun,
+          edited: Boolean(newCellCode) && newCellCode !== lastCodeRun,
         }),
       },
       cellRuntime: {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -233,7 +233,7 @@ const {
           code: cellContents,
           lastCodeRun,
           lastExecutionTime,
-          edited: true,
+          edited: Boolean(cellContents) && cellContents !== lastCodeRun,
         }),
       },
       cellRuntime: {

--- a/frontend/src/core/codemirror/language/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/utils.test.ts
@@ -150,52 +150,196 @@ describe("splitEditor", () => {
 });
 
 describe("extractHighlightedCode", () => {
-  const firstLine = "import marimo as mo";
-  const secondLine = "import pandas as pd";
-  const thirdLine = "import numpy as np";
+  const pyLineOne = "import marimo as mo";
+  const pyLineTwo = "import pandas as pd";
+  const pyLineThree = "import numpy as np";
+  const pythonCode = `${pyLineOne}\n${pyLineTwo}\n${pyLineThree}`;
 
-  it("extracts highlighted code at start", () => {
-    const mockEditor = createEditor(
-      `${firstLine}\n${secondLine}\n${thirdLine}`,
-    );
+  const sqlLineOne = "SELECT * FROM table";
+  const sqlLineTwo = "WHERE column = 'value'";
+  const sqlLineThree = "ORDER BY column";
+  const sqlCode = `df = mo.sql('${sqlLineOne}\n${sqlLineTwo}\n${sqlLineThree}')`;
+
+  const mdLineOne = "Hello, World!";
+  const mdLineTwo = "Goodbye, World!";
+  const mdLineThree = "Hello, Goodbye!";
+  const markdownCode = `mo.md('${mdLineOne}\n${mdLineTwo}\n${mdLineThree}')`;
+
+  function getExtraction(editor: EditorView) {
+    const result = extractHighlightedCode(editor);
+    if (!result) {
+      throw new Error("Result is null");
+    }
+    return result;
+  }
+
+  it("extracts highlighted Python code at start", () => {
+    const mockEditor = createEditor(pythonCode);
     mockEditor.dispatch({
       selection: {
         anchor: mockEditor.state.doc.line(1).from,
         head: mockEditor.state.doc.line(2).to,
       },
     });
-    const [highlighted, leftover] = extractHighlightedCode(mockEditor);
-    expect(highlighted).toEqual(`${firstLine}\n${secondLine}`);
-    expect(leftover).toEqual(`\n${thirdLine}`);
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual(`${pyLineOne}\n${pyLineTwo}`);
+    expect(leftover).toEqual(`\n${pyLineThree}`);
   });
 
-  it("extracts highlighted code in middle", () => {
-    const mockEditor = createEditor(
-      `${firstLine}\n${secondLine}\n${thirdLine}`,
-    );
+  it("extracts highlighted Python code in middle", () => {
+    const mockEditor = createEditor(pythonCode);
     mockEditor.dispatch({
       selection: {
         anchor: mockEditor.state.doc.line(2).from,
         head: mockEditor.state.doc.line(2).to,
       },
     });
-    const [highlighted, leftover] = extractHighlightedCode(mockEditor);
-    expect(highlighted).toEqual(secondLine);
-    expect(leftover).toEqual(`${firstLine}\n${thirdLine}`);
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual(pyLineTwo);
+    expect(leftover).toEqual(`${pyLineOne}\n${pyLineThree}`);
   });
 
-  it("extracts highlighted code at end", () => {
-    const mockEditor = createEditor(
-      `${firstLine}\n${secondLine}\n${thirdLine}`,
-    );
+  it("extracts highlighted Python code at end", () => {
+    const mockEditor = createEditor(pythonCode);
     mockEditor.dispatch({
       selection: {
         anchor: mockEditor.state.doc.line(3).from,
         head: mockEditor.state.doc.line(3).to,
       },
     });
-    const [highlighted, leftover] = extractHighlightedCode(mockEditor);
-    expect(highlighted).toEqual(thirdLine);
-    expect(leftover).toEqual(`${firstLine}\n${secondLine}`);
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual(pyLineThree);
+    expect(leftover).toEqual(`${pyLineOne}\n${pyLineTwo}`);
+  });
+
+  it("extracts no highlighted Python code if none", () => {
+    const mockEditor = createEditor(pythonCode);
+    mockEditor.dispatch({ selection: { anchor: 0, head: 0 } });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual("");
+    expect(leftover).toEqual(pythonCode);
+  });
+
+  it("extracts highlighted SQL code at start", () => {
+    const mockEditor = createEditor(sqlCode);
+    switchLanguage(mockEditor, "sql");
+    mockEditor.dispatch({
+      selection: {
+        anchor: mockEditor.state.doc.line(1).from,
+        head: mockEditor.state.doc.line(2).to,
+      },
+    });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual(`${sqlLineOne}\n${sqlLineTwo}`);
+    expect(leftover).toEqual(`\n${sqlLineThree}`);
+  });
+
+  it("extracts highlighted SQL code in middle", () => {
+    const mockEditor = createEditor(sqlCode);
+    switchLanguage(mockEditor, "sql");
+    mockEditor.dispatch({
+      selection: {
+        anchor: mockEditor.state.doc.line(2).from,
+        head: mockEditor.state.doc.line(2).to,
+      },
+    });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual(sqlLineTwo);
+    expect(leftover).toEqual(`${sqlLineOne}\n${sqlLineThree}`);
+  });
+
+  it("extracts highlighted SQL code at end", () => {
+    const mockEditor = createEditor(sqlCode);
+    switchLanguage(mockEditor, "sql");
+    mockEditor.dispatch({
+      selection: {
+        anchor: mockEditor.state.doc.line(3).from,
+        head: mockEditor.state.doc.line(3).to,
+      },
+    });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual(sqlLineThree);
+    expect(leftover).toEqual(`${sqlLineOne}\n${sqlLineTwo}`);
+  });
+
+  it("extracts no highlighted SQL code if none", () => {
+    const mockEditor = createEditor(sqlCode);
+    switchLanguage(mockEditor, "sql");
+    mockEditor.dispatch({ selection: { anchor: 0, head: 0 } });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual("");
+    expect(leftover).toEqual(sqlCode);
+  });
+
+  it("extracts highlighted Markdown code at start", () => {
+    const mockEditor = createEditor(markdownCode);
+    switchLanguage(mockEditor, "markdown");
+    mockEditor.dispatch({
+      selection: {
+        anchor: mockEditor.state.doc.line(1).from,
+        head: mockEditor.state.doc.line(2).to,
+      },
+    });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(leftover).toEqual(`mo.md(
+    """
+
+    ${mdLineThree}
+    """\n)`);
+    expect(highlighted).toEqual(`mo.md(
+    """
+    ${mdLineOne}
+    ${mdLineTwo}
+    """\n)`);
+  });
+
+  it("extracts highlighted Markdown code in middle", () => {
+    const mockEditor = createEditor(markdownCode);
+    switchLanguage(mockEditor, "markdown");
+    mockEditor.dispatch({
+      selection: {
+        anchor: mockEditor.state.doc.line(2).from,
+        head: mockEditor.state.doc.line(2).to,
+      },
+    });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual(`mo.md("""${mdLineTwo}""")`);
+    expect(leftover).toEqual(`mo.md(
+    """
+    ${mdLineOne}
+    ${mdLineThree}
+    """\n)`);
+  });
+
+  it("extracts highlighted Markdown code at end", () => {
+    const mockEditor = createEditor(markdownCode);
+    switchLanguage(mockEditor, "markdown");
+    mockEditor.dispatch({
+      selection: {
+        anchor: mockEditor.state.doc.line(3).from,
+        head: mockEditor.state.doc.line(3).to,
+      },
+    });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual(`mo.md("""${mdLineThree}""")`);
+    expect(leftover).toEqual(`mo.md(
+    """
+    ${mdLineOne}
+    ${mdLineTwo}
+    """\n)`);
+  });
+
+  it("extracts no highlighted Markdown code if none", () => {
+    const mockEditor = createEditor(markdownCode);
+    switchLanguage(mockEditor, "markdown");
+    mockEditor.dispatch({ selection: { anchor: 0, head: 0 } });
+    const [highlighted, leftover] = getExtraction(mockEditor);
+    expect(highlighted).toEqual('mo.md(""" """)');
+    expect(leftover).toEqual(`mo.md(
+    """
+    Hello, World!
+    Goodbye, World!
+    Hello, Goodbye!
+    """\n)`);
   });
 });

--- a/frontend/src/core/codemirror/language/utils.ts
+++ b/frontend/src/core/codemirror/language/utils.ts
@@ -81,5 +81,6 @@ export function extractHighlightedCode(editor: EditorView) {
     changes: { from, to, insert: "" },
   });
 
-  return highlighted;
+  const leftover = editor.state.doc.toString();
+  return [highlighted, leftover];
 }

--- a/frontend/src/core/codemirror/language/utils.ts
+++ b/frontend/src/core/codemirror/language/utils.ts
@@ -73,6 +73,9 @@ export function splitEditor(editor: EditorView) {
 export function extractHighlightedCode(editor: EditorView) {
   const code = editor.state.doc.toString();
   let { from, to } = editor.state.selection.main;
+  if (from === to) {
+    return null;
+  }
   const highlighted = getEditorCodeAsPython(editor, from, to);
 
   from = code[from - 1] === "\n" ? from - 1 : from;

--- a/frontend/src/core/codemirror/language/utils.ts
+++ b/frontend/src/core/codemirror/language/utils.ts
@@ -71,12 +71,12 @@ export function splitEditor(editor: EditorView) {
 }
 
 export function extractHighlightedCode(editor: EditorView) {
-  const code = editor.state.doc;
+  const code = editor.state.doc.toString();
   let { from, to } = editor.state.selection.main;
   const highlighted = getEditorCodeAsPython(editor, from, to);
 
-  from = code.toString()[from - 1] === "\n" ? from - 1 : from;
-  to = code.toString()[to + 1] === "\n" ? to + 1 : to;
+  from = code[from - 1] === "\n" ? from - 1 : from;
+  to = code[to + 1] === "\n" ? to + 1 : to;
   editor.dispatch({
     changes: { from, to, insert: "" },
   });

--- a/frontend/src/core/codemirror/language/utils.ts
+++ b/frontend/src/core/codemirror/language/utils.ts
@@ -73,7 +73,7 @@ export function splitEditor(editor: EditorView) {
 export function extractHighlightedCode(editor: EditorView) {
   const code = editor.state.doc;
   let { from, to } = editor.state.selection.main;
-  const highlighted = code.sliceString(from, to);
+  const highlighted = getEditorCodeAsPython(editor, from, to);
 
   from = code.toString()[from - 1] === "\n" ? from - 1 : from;
   to = code.toString()[to + 1] === "\n" ? to + 1 : to;
@@ -81,6 +81,6 @@ export function extractHighlightedCode(editor: EditorView) {
     changes: { from, to, insert: "" },
   });
 
-  const leftover = editor.state.doc.toString();
+  const leftover = getEditorCodeAsPython(editor);
   return [highlighted, leftover];
 }

--- a/frontend/src/core/codemirror/language/utils.ts
+++ b/frontend/src/core/codemirror/language/utils.ts
@@ -69,3 +69,17 @@ export function splitEditor(editor: EditorView) {
     afterCursorCode,
   };
 }
+
+export function extractHighlightedCode(editor: EditorView) {
+  const code = editor.state.doc;
+  let { from, to } = editor.state.selection.main;
+  const highlighted = code.sliceString(from, to);
+
+  from = code.toString()[from - 1] === "\n" ? from - 1 : from;
+  to = code.toString()[to + 1] === "\n" ? to + 1 : to;
+  editor.dispatch({
+    changes: { from, to, insert: "" },
+  });
+
+  return highlighted;
+}


### PR DESCRIPTION
## 📝 Summary

Implements #2474.

## 🔍 Description of Changes

When a new cell is created, any highlighted code is cut from the original cell and pasted into the new cell.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
