### PR TITLE
allow --global-session for marimo run

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -354,6 +354,7 @@ def edit(
         base_url=base_url,
         allow_origins=allow_origins,
         redirect_console_to_browser=True,
+        global_session=True,
     )
 
 
@@ -551,6 +552,17 @@ Example:
     help="Redirect console logs to the browser console.",
 )
 @click.option(
+    "--global-session",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    type=bool,
+    help="""
+    Run a single session and reconnect when the connection is lost,
+    similar to edit mode
+    """,
+)
+@click.option(
     "--sandbox",
     is_flag=True,
     default=False,
@@ -575,6 +587,7 @@ def run(
     base_url: str,
     allow_origins: tuple[str, ...],
     redirect_console_to_browser: bool,
+    global_session: bool,
     sandbox: bool,
     name: str,
     args: tuple[str, ...],
@@ -612,6 +625,7 @@ def run(
         cli_args=parse_args(args),
         auth_token=_resolve_token(token, token_password),
         redirect_console_to_browser=redirect_console_to_browser,
+        global_session=global_session,
     )
 
 

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -661,6 +661,7 @@ class SessionManager:
         cli_args: SerializedCLIArgs,
         auth_token: Optional[AuthToken],
         redirect_console_to_browser: bool = False,
+        global_session: bool = False,
     ) -> None:
         self.file_router = file_router
         self.mode = mode
@@ -674,6 +675,7 @@ class SessionManager:
         self.user_config_manager = user_config_manager
         self.cli_args = cli_args
         self.redirect_console_to_browser = redirect_console_to_browser
+        self.global_session = global_session
 
         # Auth token and Skew-protection token
         if auth_token is not None:
@@ -772,9 +774,10 @@ class SessionManager:
         If it is resumable, return the session and update the session id.
         """
 
-        # If in run mode, only resume the session if it is orphaned and has
-        # the same session id, otherwise we want to create a new session
-        if self.mode == SessionMode.RUN:
+        # If we dont have a global session, only resume the session if it
+        # is orphaned and has the same session id,
+        # otherwise we want to create a new session
+        if not self.global_session:
             maybe_session = self.get_session(new_session_id)
             if (
                 maybe_session

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -81,6 +81,7 @@ def start(
     allow_origins: Optional[tuple[str, ...]] = None,
     auth_token: Optional[AuthToken],
     redirect_console_to_browser: bool,
+    global_session: bool,
 ) -> None:
     """
     Start the server.
@@ -102,6 +103,7 @@ def start(
         cli_args=cli_args,
         auth_token=auth_token,
         redirect_console_to_browser=redirect_console_to_browser,
+        global_session=global_session,
     )
 
     log_level = "info" if development_mode else "error"


### PR DESCRIPTION
## 📝 Summary

I encountered this use-case here: https://github.com/marimo-team/marimo/issues/2488

When doing large computations running entirely locally, especially with non-coder users, it is often important to be able to resume the session when the browser refreshes, or tabs wake up from sleep, especially when loading large files into memory.

In my case, a customer has refreshed their browser, causing a large model to load in memory twice. We don't run marimo on a server but locally, so there's no need for unique sessions.

This feature lets you add `--global-session` to your `marimo run` command, sharing the session even when refreshing, asserting the same session behaviour as `marimo edit`.

For the rest, default behaviour stays, so after this PR, everyone still gets unique sessions in `marimo run`, except if they provide the argument.

This is a living PR, and certainly not perfect yet - I assume that we have to add some e2e tests, but I'm not familiar enough to make this work yet, and need some guidance.

<!-- 
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123). 
-->

## 🔍 Description of Changes

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made. 
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
