### PR TITLE
feat: attachment support in mo.ui.chat

### DIFF
--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -111,6 +111,24 @@ mo.ui.chat(rag_model)
 This example demonstrates how you can implement a Retrieval-Augmented
 Generation (RAG) model within the chat interface.
 
+## Templated Prompts
+
+You can pass sample prompts to `mo.ui.chat` to allow users to select from a
+list of predefined prompts. By including a `{{var}}` in the prompt, you can
+dynamically insert values into the prompt; a form will be generated to allow
+users to fill in the variables.
+
+```python
+mo.ui.chat(
+    mo.ai.llm.openai("gpt-4o"),
+    prompts=[
+        "What is the capital of France?",
+        "What is the capital of Germany?",
+        "What is the capital of {{country}}?",
+    ],
+)
+```
+
 ## Including Attachments
 
 You can allow users to upload attachments to their messages by passing an

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -81,7 +81,7 @@ chat.value
 ```
 
 This returns a list of [`ChatMessage`](#marimo.ai.ChatMessage) objects, each
-containing `role` and `content` attributes.
+containing `role`, `content`, and optional `attachments` attributes.
 
 ```{eval-rst}
 .. autoclass:: ChatMessage
@@ -110,6 +110,20 @@ mo.ui.chat(rag_model)
 
 This example demonstrates how you can implement a Retrieval-Augmented
 Generation (RAG) model within the chat interface.
+
+## Including Attachments
+
+You can allow users to upload attachments to their messages by passing an
+`allow_attachments` parameter to `mo.ui.chat`.
+
+```python
+mo.ui.chat(
+    rag_model,
+    allow_attachments=["image/png", "image/jpeg"],
+    # or True for any attachment type
+    # allow_attachments=True,
+)
+```
 
 ## Built-in Models
 

--- a/examples/ai/chat/anthropic_example.py
+++ b/examples/ai/chat/anthropic_example.py
@@ -58,6 +58,10 @@ def __(key, mo):
             system_message="You are a helpful assistant.",
             api_key=key,
         ),
+        allow_attachments=[
+            "image/png",
+            "image/jpeg"
+        ],
         prompts=[
             "Hello",
             "How are you?",

--- a/examples/ai/chat/openai_example.py
+++ b/examples/ai/chat/openai_example.py
@@ -57,6 +57,10 @@ def __(mo, openai_key):
             "gpt-4o",
             system_message="You are a helpful assistant.",
             api_key=openai_key,
+            allow_attachments=[
+            "image/png",
+            "image/jpeg"
+        ],
        ),
         prompts=[
             "Hello",

--- a/frontend/src/plugins/impl/chat/ChatPlugin.tsx
+++ b/frontend/src/plugins/impl/chat/ChatPlugin.tsx
@@ -26,6 +26,7 @@ export const ChatPlugin = createPlugin<ChatMessage[]>("marimo-chatbot")
         frequencyPenalty: z.number().default(0),
         presencePenalty: z.number().default(0),
       }),
+      allowAttachments: z.union([z.boolean(), z.string().array()]),
     }),
   )
   .withFunctions<PluginFunctions>({
@@ -46,6 +47,15 @@ export const ChatPlugin = createPlugin<ChatMessage[]>("marimo-chatbot")
             z.object({
               role: z.enum(["system", "user", "assistant"]),
               content: z.string(),
+              attachments: z
+                .array(
+                  z.object({
+                    name: z.string().optional(),
+                    contentType: z.string().optional(),
+                    url: z.string(),
+                  }),
+                )
+                .optional(),
             }),
           ),
           config: z.object({
@@ -65,6 +75,7 @@ export const ChatPlugin = createPlugin<ChatMessage[]>("marimo-chatbot")
       <Chatbot
         prompts={props.data.prompts}
         showConfigurationControls={props.data.showConfigurationControls}
+        allowAttachments={props.data.allowAttachments}
         config={props.data.config}
         sendPrompt={props.functions.send_prompt}
         value={props.value || Arrays.EMPTY}

--- a/frontend/src/plugins/impl/chat/types.ts
+++ b/frontend/src/plugins/impl/chat/types.ts
@@ -1,7 +1,16 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+export type ChatRole = "system" | "user" | "assistant";
+
 export interface ChatMessage {
-  role: "system" | "user" | "assistant";
+  role: ChatRole;
   content: string;
+  attachments?: ChatAttachment[];
+}
+
+export interface ChatAttachment {
+  name?: string;
+  contentType?: string;
+  url: string;
 }
 
 export interface SendMessageRequest {

--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -53,6 +53,9 @@ class LocalFileReader(FileReader):
         return not is_url(name)
 
     def read(self, name: str) -> Tuple[str, str]:
+        # Is directory
+        if os.path.isdir(name):
+            return "", os.path.basename(name)
         with open(name, "r") as f:
             content = f.read()
         return content, os.path.basename(name)

--- a/marimo/_plugins/ui/_impl/chat/chat.py
+++ b/marimo/_plugins/ui/_impl/chat/chat.py
@@ -93,6 +93,17 @@ class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
     )
     ```
 
+    You can also allow the user to include attachments in their messages.
+
+    ```python
+    chat = mo.ui.chat(
+        mo.ai.llm.openai(
+            "gpt-4o",
+        ),
+        allow_attachments=["image/png", "image/jpeg"],
+    )
+    ```
+
     **Attributes.**
 
     - `value`: the current chat history, a list of `ChatMessage` objects.

--- a/marimo/_plugins/ui/_impl/chat/chat.py
+++ b/marimo/_plugins/ui/_impl/chat/chat.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Final, List, Optional, cast
+from typing import Any, Callable, Dict, Final, List, Optional, Union, cast
 
 from marimo._output.formatting import as_html
 from marimo._output.rich_help import mddoc
@@ -112,6 +112,8 @@ class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
         - `top_k`
         - `frequency_penalty`
         - `presence_penalty`
+    - `allow_attachments`: (bool | List[str]) allow attachments. True for any
+        attachments types, or pass a list of mime types
     """
 
     _name: Final[str] = "marimo-chatbot"
@@ -124,6 +126,7 @@ class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
         on_message: Optional[Callable[[List[ChatMessage]], None]] = None,
         show_configuration_controls: bool = False,
         config: Optional[ChatModelConfigDict] = None,
+        allow_attachments: Union[bool, List[str]] = False,
     ) -> None:
         self._model = model
         self._chat_history: List[ChatMessage] = []
@@ -137,6 +140,7 @@ class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
                 "prompts": prompts,
                 "show-configuration-controls": show_configuration_controls,
                 "config": cast(JSONType, config or {}),
+                "allow-attachments": allow_attachments,
             },
             functions=(
                 Function(

--- a/marimo/_plugins/ui/_impl/chat/types.py
+++ b/marimo/_plugins/ui/_impl/chat/types.py
@@ -45,7 +45,7 @@ class ChatAttachment:
     # By default, it's extracted from the pathname's extension.
     content_type: Optional[str] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.content_type is None:
             self.content_type = mimetypes.guess_type(self.url)[0]
 

--- a/marimo/_plugins/ui/_impl/chat/types.py
+++ b/marimo/_plugins/ui/_impl/chat/types.py
@@ -2,14 +2,15 @@
 from __future__ import annotations
 
 import abc
+import mimetypes
 from dataclasses import dataclass
 from typing import List, Literal, Optional, TypedDict
 
 
 class ChatAttachmentDict(TypedDict):
-    name: str
-    content_type: str
     url: str
+    content_type: Optional[str]
+    name: Optional[str]
 
 
 class ChatMessageDict(TypedDict):
@@ -33,16 +34,20 @@ class ChatModelConfigDict(TypedDict, total=False):
 
 @dataclass
 class ChatAttachment:
-    # The name of the attachment, usually the file name.
-    name: str
-
-    # A string indicating the [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type).
-    # By default, it's extracted from the pathname's extension.
-    content_type: str
-
     # The URL of the attachment. It can either be a URL to a hosted file or a
     # [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
     url: str
+
+    # The name of the attachment, usually the file name.
+    name: str = "attachment"
+
+    # A string indicating the [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type).
+    # By default, it's extracted from the pathname's extension.
+    content_type: Optional[str] = None
+
+    def __post_init__(self):
+        if self.content_type is None:
+            self.content_type = mimetypes.guess_type(self.url)[0]
 
 
 @dataclass

--- a/marimo/_plugins/ui/_impl/chat/utils.py
+++ b/marimo/_plugins/ui/_impl/chat/utils.py
@@ -19,7 +19,7 @@ def from_chat_message_dict(d: ChatMessageDict) -> ChatMessage:
     if attachments_dict is not None:
         attachments = [
             ChatAttachment(
-                name=attachment["name"],
+                name=attachment["name"] or "attachment",
                 content_type=attachment["content_type"],
                 url=attachment["url"],
             )

--- a/tests/_plugins/ui/_impl/chat/test_chat_convert.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat_convert.py
@@ -27,7 +27,7 @@ def sample_messages() -> List[ChatMessage]:
                 ChatAttachment(
                     name="image.png",
                     content_type="image/png",
-                    url=f"data:image/png;base64,{base64.b64encode("hello".encode())}",
+                    url=f"data:image/png;base64,{base64.b64encode('hello'.encode())}",
                 ),
                 ChatAttachment(
                     name="text.txt",


### PR DESCRIPTION
Add opt-in support for file attachments.

You can opt in all attachment types or specific content-types.

<img width="1222" alt="Screenshot 2024-10-04 at 8 50 24 AM" src="https://github.com/user-attachments/assets/4f6ffddb-09df-4dee-846f-87c869e7df89">