### PR TITLE
improve: temporarily show code

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -108,27 +108,27 @@ const CellEditorInternal = ({
 
   const createBelow = useCallback(
     () => createNewCell({ cellId, before: false }),
-    [cellId, createNewCell]
+    [cellId, createNewCell],
   );
   const createAbove = useCallback(
     () => createNewCell({ cellId, before: true }),
-    [cellId, createNewCell]
+    [cellId, createNewCell],
   );
   const moveDown = useCallback(
     () => moveCell({ cellId, before: false }),
-    [cellId, moveCell]
+    [cellId, moveCell],
   );
   const moveUp = useCallback(
     () => moveCell({ cellId, before: true }),
-    [cellId, moveCell]
+    [cellId, moveCell],
   );
   const focusDown = useCallback(
     () => focusCell({ cellId, before: false }),
-    [cellId, focusCell]
+    [cellId, focusCell],
   );
   const focusUp = useCallback(
     () => focusCell({ cellId, before: true }),
-    [cellId, focusCell]
+    [cellId, focusCell],
   );
 
   const toggleHideCode = useEvent(() => {
@@ -202,7 +202,7 @@ const CellEditorInternal = ({
             setLanguageAdapter(languageAdapter.type);
           },
         };
-      })
+      }),
     );
 
     return extensions;
@@ -249,7 +249,7 @@ const CellEditorInternal = ({
         // Initialize the language adapter
         switchLanguage(
           editorViewRef.current,
-          getInitialLanguageAdapter(editorViewRef.current.state).type
+          getInitialLanguageAdapter(editorViewRef.current.state).type,
         );
       } else {
         editorViewRef.current.dispatch({
@@ -258,7 +258,7 @@ const CellEditorInternal = ({
             reconfigureLanguageEffect(
               editorViewRef.current,
               userConfig.completion,
-              new OverridingHotkeyProvider(userConfig.keymap.overrides)
+              new OverridingHotkeyProvider(userConfig.keymap.overrides),
             ),
           ],
         });
@@ -272,13 +272,13 @@ const CellEditorInternal = ({
             doc: code,
             extensions: extensions,
           },
-          { history: historyField }
+          { history: historyField },
         ),
       });
       // Initialize the language adapter
       switchLanguage(
         editorViewRef.current,
-        getInitialLanguageAdapter(editorViewRef.current.state).type
+        getInitialLanguageAdapter(editorViewRef.current.state).type,
       );
       shouldFocus = true;
       // Clear the serialized state so that we don't re-create the editor next time
@@ -332,7 +332,7 @@ const CellEditorInternal = ({
       editorViewRef.current?.contentDOM.addEventListener(
         "blur",
         () => updateCellConfig({ cellId, config: { hide_code: true } }),
-        { once: true }
+        { once: true },
       );
     }
   };
@@ -399,7 +399,7 @@ const CellCodeMirrorEditor = React.forwardRef(
       className?: string;
       editorView: EditorView | null;
     },
-    ref: React.Ref<HTMLDivElement>
+    ref: React.Ref<HTMLDivElement>,
   ) => {
     const { className, editorView } = props;
     const internalRef = useRef<HTMLDivElement>(null);
@@ -425,7 +425,7 @@ const CellCodeMirrorEditor = React.forwardRef(
         data-testid="cell-editor"
       />
     );
-  }
+  },
 );
 CellCodeMirrorEditor.displayName = "CellCodeMirrorEditor";
 

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -108,27 +108,27 @@ const CellEditorInternal = ({
 
   const createBelow = useCallback(
     () => createNewCell({ cellId, before: false }),
-    [cellId, createNewCell],
+    [cellId, createNewCell]
   );
   const createAbove = useCallback(
     () => createNewCell({ cellId, before: true }),
-    [cellId, createNewCell],
+    [cellId, createNewCell]
   );
   const moveDown = useCallback(
     () => moveCell({ cellId, before: false }),
-    [cellId, moveCell],
+    [cellId, moveCell]
   );
   const moveUp = useCallback(
     () => moveCell({ cellId, before: true }),
-    [cellId, moveCell],
+    [cellId, moveCell]
   );
   const focusDown = useCallback(
     () => focusCell({ cellId, before: false }),
-    [cellId, focusCell],
+    [cellId, focusCell]
   );
   const focusUp = useCallback(
     () => focusCell({ cellId, before: true }),
-    [cellId, focusCell],
+    [cellId, focusCell]
   );
 
   const toggleHideCode = useEvent(() => {
@@ -202,7 +202,7 @@ const CellEditorInternal = ({
             setLanguageAdapter(languageAdapter.type);
           },
         };
-      }),
+      })
     );
 
     return extensions;
@@ -249,7 +249,7 @@ const CellEditorInternal = ({
         // Initialize the language adapter
         switchLanguage(
           editorViewRef.current,
-          getInitialLanguageAdapter(editorViewRef.current.state).type,
+          getInitialLanguageAdapter(editorViewRef.current.state).type
         );
       } else {
         editorViewRef.current.dispatch({
@@ -258,7 +258,7 @@ const CellEditorInternal = ({
             reconfigureLanguageEffect(
               editorViewRef.current,
               userConfig.completion,
-              new OverridingHotkeyProvider(userConfig.keymap.overrides),
+              new OverridingHotkeyProvider(userConfig.keymap.overrides)
             ),
           ],
         });
@@ -272,13 +272,13 @@ const CellEditorInternal = ({
             doc: code,
             extensions: extensions,
           },
-          { history: historyField },
+          { history: historyField }
         ),
       });
       // Initialize the language adapter
       switchLanguage(
         editorViewRef.current,
-        getInitialLanguageAdapter(editorViewRef.current.state).type,
+        getInitialLanguageAdapter(editorViewRef.current.state).type
       );
       shouldFocus = true;
       // Clear the serialized state so that we don't re-create the editor next time
@@ -325,12 +325,15 @@ const CellEditorInternal = ({
     };
   }, [editorViewRef]);
 
-  const showCode = async () => {
+  const temporarilyShowCode = async () => {
     if (hidden) {
-      await saveCellConfig({ configs: { [cellId]: { hide_code: false } } });
       updateCellConfig({ cellId, config: { hide_code: false } });
-      // Focus on the editor view
       editorViewRef.current?.focus();
+      editorViewRef.current?.contentDOM.addEventListener(
+        "blur",
+        () => updateCellConfig({ cellId, config: { hide_code: true } }),
+        { once: true }
+      );
     }
   };
 
@@ -369,7 +372,7 @@ const CellEditorInternal = ({
         className="relative w-full"
         onFocus={() => setLastFocusedCellId(cellId)}
       >
-        {hidden && <HideCodeButton onClick={showCode} />}
+        {hidden && <HideCodeButton onClick={temporarilyShowCode} />}
         <CellCodeMirrorEditor
           className={cn(hidden && "opacity-20 h-8 overflow-hidden")}
           editorView={editorViewRef.current}
@@ -396,7 +399,7 @@ const CellCodeMirrorEditor = React.forwardRef(
       className?: string;
       editorView: EditorView | null;
     },
-    ref: React.Ref<HTMLDivElement>,
+    ref: React.Ref<HTMLDivElement>
   ) => {
     const { className, editorView } = props;
     const internalRef = useRef<HTMLDivElement>(null);
@@ -422,7 +425,7 @@ const CellCodeMirrorEditor = React.forwardRef(
         data-testid="cell-editor"
       />
     );
-  },
+  }
 );
 CellCodeMirrorEditor.displayName = "CellCodeMirrorEditor";
 


### PR DESCRIPTION
This PR improves the UX of working with hidden cells. When code is hidden, clicking on the eye icon will now temporarily show the code as long as the editor is focused, and hide it again once the editor is blurred.

In this way users can, for example, hide markdown code and later edit it without permanently unhiding it.

To permanently unhide code, users can use the cell action menu or the keyboard shortcut, as before.

This change is based on user feedback, and it also happens to match the behavior in Observable notebooks.

Interactions with changing the cell config to `show code` while temporarily focused still works, since the user must first click the cell action menu which blurs the editor.