### PR TITLE
fix: hidden cell blur on parent, not editorview

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -339,7 +339,7 @@ const CellEditorInternal = ({
     if (hidden) {
       updateCellConfig({ cellId, config: { hide_code: false } });
       editorViewRef.current?.focus();
-      editorViewRef.current?.contentDOM.addEventListener(
+      editorViewParentRef.current?.addEventListener(
         "blur",
         () => updateCellConfig({ cellId, config: { hide_code: true } }),
         { once: true },


### PR DESCRIPTION
When re-hiding a cell, process blur on the parent of the editor view, not the editorview itself, so things like the delete button, language toggle, and codemirror folds are still clickable.

cc @wasimsandhu 