### PR TITLE
fix: Preserve language in cell actions undo/redo stack

### DIFF
--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -173,7 +173,7 @@ describe("cell reducer", () => {
     `);
   });
 
-  it("can delete a cell", () => {
+  it("can delete a Python cell and undo delete", () => {
     actions.createNewCell({
       cellId: firstCellId,
       before: false,
@@ -196,6 +196,63 @@ describe("cell reducer", () => {
 
       key: 1
       code: ''"
+    `);
+  });
+
+  it("can delete a SQL cell and undo delete", () => {
+    actions.createNewCell({
+      cellId: firstCellId,
+      before: false,
+      code: `df = mo.sql("""SELECT * FROM table""")`,
+    });
+    const newCellId = state.cellIds.atOrThrow(1);
+    actions.deleteCell({
+      cellId: newCellId,
+    });
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      key: 0
+      code: ''"
+    `);
+
+    // undo
+    actions.undoDeleteCell();
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      key: 0
+      code: ''
+
+      key: 2
+      code: 'df = mo.sql("""SELECT * FROM table""")'"
+    `);
+  });
+
+  it("can delete a Markdown cell and undo delete", () => {
+    const text = "The quick brown fox jumps over the lazy dog.";
+    actions.createNewCell({
+      cellId: firstCellId,
+      before: false,
+      code: `mo.md(r"""${text}""")`,
+    });
+    const newCellId = state.cellIds.atOrThrow(1);
+    actions.deleteCell({
+      cellId: newCellId,
+    });
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      key: 0
+      code: ''"
+    `);
+
+    // undo
+    actions.undoDeleteCell();
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      key: 0
+      code: ''
+
+      key: 2
+      code: 'mo.md(r"""${text}""")'"
     `);
   });
 


### PR DESCRIPTION
## 📝 Summary

Fixes #2509.

## 🔍 Description of Changes

Added `language: LanguageAdapterType` to `state.history`, and use this in `deleteCell` and `undoDeleteCell` handlers to bring back SQL/Markdown cells appropriately.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
