### PR TITLE
fix: json encoding of png binary

### DIFF
--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -30,7 +30,11 @@ class WebComponentEncoder(JSONEncoder):
 
         # Handle bytes objects
         if isinstance(o, bytes):
-            return o.decode("utf-8")
+            try:
+                return o.decode("utf-8")
+            except UnicodeDecodeError:
+                # Fallback to latin1
+                return o.decode("latin1")
 
         # Handle datetime objects
         if isinstance(o, (datetime.datetime, datetime.date, datetime.time)):

--- a/marimo/_smoke_tests/bugs/2506_anywidget_buffer_paths.py
+++ b/marimo/_smoke_tests/bugs/2506_anywidget_buffer_paths.py
@@ -1,0 +1,61 @@
+import marimo
+
+__generated_with = "0.9.1"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    # binary data is a png image of a small purple square
+    CONTENT = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x14\x00\x00\x00\x14\x08\x02\x00\x00\x00\x02\xeb\x8aZ\x00\x00\x00\tpHYs\x00\x00.#\x00\x00.#\x01x\xa5?v\x00\x00\x00\x1dIDAT8\xcbc\xac\x11\xa9g \x1701P\x00F5\x8fj\x1e\xd5<\xaa\x99r\xcd\x00m\xba\x017\xd3\x00\xdf\xcb\x00\x00\x00\x00IEND\xaeB`\x82'
+    return (CONTENT,)
+
+
+@app.cell
+def __(CONTENT):
+    import anywidget
+    import traitlets
+
+    class BytesWidget(anywidget.AnyWidget):
+        _esm = """
+        function render({ model, el }) {
+            let value = model.get("value");
+            const isDataView = document.createElement("div");
+            isDataView.innerText = `Is  DataView: ${value instanceof DataView}`;
+            el.appendChild(isDataView);
+
+            const image = document.createElement("img");
+            image.src = URL.createObjectURL(new Blob([value]));
+            el.appendChild(image);
+        }
+        export default { render };
+        """
+        value = traitlets.Bytes().tag(sync=True)
+
+    # binary data is a png image of a small purple square
+    BytesWidget(value=CONTENT)
+    return BytesWidget, anywidget, traitlets
+
+
+@app.cell
+def __(CONTENT, mo):
+    # Not lossy
+    mo.image(CONTENT.decode("latin1").encode("latin1"))
+    return
+
+
+@app.cell
+def __(CONTENT, mo):
+    # Is lossy
+    mo.image(CONTENT.decode("utf-8", errors="replace").encode("utf-8"))
+    return
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_plugins/core/test_json_encoder.py
+++ b/tests/_plugins/core/test_json_encoder.py
@@ -377,3 +377,9 @@ def test_complex_nested_structure():
     assert decoded["dict"] == {"b": [5, 6], "c": {"d": 7}}
     assert set(decoded["set"]) == {8, 9, 10}
     assert decoded["tuple"] == [11, [12, 13], {"e": 14}]
+
+
+def test_png_encoding() -> None:
+    purple_square = "b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x14\x00\x00\x00\x14\x08\x02\x00\x00\x00\x02\xeb\x8aZ\x00\x00\x00\tpHYs\x00\x00.#\x00\x00.#\x01x\xa5?v\x00\x00\x00\x1dIDAT8\xcbc\xac\x11\xa9g \x1701P\x00F5\x8fj\x1e\xd5<\xaa\x99r\xcd\x00m\xba\x017\xd3\x00\xdf\xcb\x00\x00\x00\x00IEND\xaeB`\x82'"  # noqa: E501
+    encoded = json.dumps(purple_square, cls=WebComponentEncoder)
+    assert isinstance(encoded, str)


### PR DESCRIPTION
Fixes #2506

We failed to decode when bytes are not utf-8 decodable, so instead we should fallback to latin1 (for cases such as png). 

![image](https://github.com/user-attachments/assets/a879b0e5-d467-449c-8cc4-57e17acf5542)
