### PR TITLE
fix: typings of marimo config, fix typedict to openapi cases

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -194,7 +194,7 @@ const CellEditorInternal = ({
       completionConfig: userConfig.completion,
       keymapConfig: userConfig.keymap,
       theme,
-      hotkeys: new OverridingHotkeyProvider(userConfig.keymap.overrides),
+      hotkeys: new OverridingHotkeyProvider(userConfig.keymap.overrides ?? {}),
     });
 
     extensions.push(
@@ -268,7 +268,7 @@ const CellEditorInternal = ({
             reconfigureLanguageEffect(
               editorViewRef.current,
               userConfig.completion,
-              new OverridingHotkeyProvider(userConfig.keymap.overrides),
+              new OverridingHotkeyProvider(userConfig.keymap.overrides ?? {}),
             ),
           ],
         });

--- a/frontend/src/core/config/config.ts
+++ b/frontend/src/core/config/config.ts
@@ -19,7 +19,7 @@ export const autoInstantiateAtom = atom((get) => {
 });
 
 export const hotkeyOverridesAtom = atom((get) => {
-  return get(userConfigAtom).keymap.overrides;
+  return get(userConfigAtom).keymap.overrides ?? {};
 });
 
 export const hotkeysAtom = atom((get) => {

--- a/frontend/src/core/config/feature-flag.tsx
+++ b/frontend/src/core/config/feature-flag.tsx
@@ -33,6 +33,7 @@ function setFeatureFlag(
   value: boolean,
 ) {
   const userConfig = getUserConfig();
+  userConfig.experimental = userConfig.experimental ?? {};
   userConfig.experimental[feature] = value;
   saveUserConfig({ config: userConfig });
 }

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
+from typing import TypeVar
 
 if sys.version_info < (3, 11):
     from typing_extensions import NotRequired
@@ -54,7 +55,7 @@ class SaveConfig(TypedDict):
 
 @mddoc
 @dataclass
-class KeymapConfig(TypedDict, total=False):
+class KeymapConfig(TypedDict):
     """Configuration for keymaps.
 
     **Keys.**
@@ -64,7 +65,7 @@ class KeymapConfig(TypedDict, total=False):
     """
 
     preset: Literal["default", "vim"]
-    overrides: Dict[str, str]
+    overrides: NotRequired[Dict[str, str]]
 
 
 OnCellChangeType = Literal["lazy", "autorun"]
@@ -166,7 +167,7 @@ class PackageManagementConfig(TypedDict):
 
 
 @dataclass
-class AiConfig(TypedDict):
+class AiConfig(TypedDict, total=False):
     """Configuration options for AI.
 
     **Keys.**
@@ -182,7 +183,7 @@ class AiConfig(TypedDict):
 
 
 @dataclass
-class OpenAiConfig(TypedDict):
+class OpenAiConfig(TypedDict, total=False):
     """Configuration options for OpenAI or OpenAI-compatible services.
 
     **Keys.**
@@ -199,7 +200,7 @@ class OpenAiConfig(TypedDict):
 
 
 @dataclass
-class AnthropicConfig(TypedDict):
+class AnthropicConfig(TypedDict, total=False):
     """Configuration options for Anthropic.
 
     **Keys.**
@@ -211,7 +212,7 @@ class AnthropicConfig(TypedDict):
 
 
 @dataclass
-class GoogleAiConfig(TypedDict):
+class GoogleAiConfig(TypedDict, total=False):
     """Configuration options for Google AI.
 
     **Keys.**
@@ -226,6 +227,23 @@ class GoogleAiConfig(TypedDict):
 @dataclass
 class MarimoConfig(TypedDict):
     """Configuration for the marimo editor"""
+
+    completion: CompletionConfig
+    display: DisplayConfig
+    formatting: FormattingConfig
+    keymap: KeymapConfig
+    runtime: RuntimeConfig
+    save: SaveConfig
+    server: ServerConfig
+    package_management: PackageManagementConfig
+    ai: NotRequired[AiConfig]
+    experimental: NotRequired[Dict[str, Any]]
+
+
+@mddoc
+@dataclass
+class PartialMarimoConfig(TypedDict, total=False):
+    """Partial configuration for the marimo editor"""
 
     completion: CompletionConfig
     display: DisplayConfig
@@ -268,13 +286,15 @@ DEFAULT_CONFIG: MarimoConfig = {
 }
 
 
-def merge_default_config(config: MarimoConfig) -> MarimoConfig:
+def merge_default_config(
+    config: PartialMarimoConfig | MarimoConfig,
+) -> MarimoConfig:
     """Merge a user configuration with the default configuration."""
     return merge_config(DEFAULT_CONFIG, config)
 
 
 def merge_config(
-    config: MarimoConfig, new_config: MarimoConfig
+    config: MarimoConfig, new_config: PartialMarimoConfig | MarimoConfig
 ) -> MarimoConfig:
     """Merge a user configuration with a new configuration."""
     # Remove the keymap overrides from the incoming config,
@@ -319,7 +339,7 @@ def _deep_copy(obj: Any) -> Any:
 SECRET_PLACEHOLDER = "********"
 
 
-def mask_secrets(config: MarimoConfig) -> MarimoConfig:
+def mask_secrets(config: MarimoConfig | PartialMarimoConfig) -> MarimoConfig:
     def deep_remove_from_path(path: list[str], obj: Dict[str, Any]) -> None:
         key = path[0]
         if key not in obj:
@@ -343,7 +363,10 @@ def mask_secrets(config: MarimoConfig) -> MarimoConfig:
     return new_config  # type: ignore
 
 
-def remove_secret_placeholders(config: MarimoConfig) -> MarimoConfig:
+T = TypeVar("T")
+
+
+def remove_secret_placeholders(config: T) -> T:
     def deep_remove(obj: Any) -> Any:
         if isinstance(obj, dict):
             # Filter all keys with value SECRET_PLACEHOLDER

--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -6,6 +6,7 @@ from typing import Optional
 from marimo import _loggers
 from marimo._config.config import (
     MarimoConfig,
+    PartialMarimoConfig,
     mask_secrets,
     merge_config,
     merge_default_config,
@@ -24,7 +25,9 @@ class UserConfigManager:
         self._config_path = config_path
         self.config = load_config()
 
-    def save_config(self, config: MarimoConfig) -> MarimoConfig:
+    def save_config(
+        self, config: MarimoConfig | PartialMarimoConfig
+    ) -> MarimoConfig:
         import tomlkit
 
         config_path = self.get_config_path()

--- a/marimo/_config/utils.py
+++ b/marimo/_config/utils.py
@@ -8,6 +8,7 @@ from marimo import _loggers
 from marimo._config.config import (
     DEFAULT_CONFIG,
     MarimoConfig,
+    PartialMarimoConfig,
     merge_default_config,
 )
 
@@ -139,7 +140,7 @@ def load_config() -> MarimoConfig:
             LOGGER.error("Failed to read user config at %s", path)
             LOGGER.error(str(e))
             return DEFAULT_CONFIG
-        return merge_default_config(cast(MarimoConfig, user_config))
+        return merge_default_config(cast(PartialMarimoConfig, user_config))
     else:
         LOGGER.debug("No config found; loading default settings.")
     return DEFAULT_CONFIG

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1034,15 +1034,11 @@ components:
               properties:
                 api_key:
                   type: string
-              required:
-              - api_key
               type: object
             google:
               properties:
                 api_key:
                   type: string
-              required:
-              - api_key
               type: object
             open_ai:
               properties:
@@ -1052,15 +1048,7 @@ components:
                   type: string
                 model:
                   type: string
-              required:
-              - api_key
-              - model
-              - base_url
               type: object
-          required:
-          - open_ai
-          - anthropic
-          - google
           type: object
         completion:
           properties:
@@ -1137,7 +1125,6 @@ components:
               type: string
           required:
           - preset
-          - overrides
           type: object
         package_management:
           properties:
@@ -1211,8 +1198,6 @@ components:
       - save
       - server
       - package_management
-      - ai
-      - experimental
       type: object
     MarimoExceptionRaisedError:
       properties:
@@ -1919,7 +1904,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.8.22
+  version: 0.9.1
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2385,17 +2385,17 @@ export interface components {
       type: "ancestor-stopped";
     };
     MarimoConfig: {
-      ai: {
-        anthropic: {
-          api_key: string;
+      ai?: {
+        anthropic?: {
+          api_key?: string;
         };
-        google: {
-          api_key: string;
+        google?: {
+          api_key?: string;
         };
-        open_ai: {
-          api_key: string;
-          base_url: string;
-          model: string;
+        open_ai?: {
+          api_key?: string;
+          base_url?: string;
+          model?: string;
         };
       };
       completion: {
@@ -2414,14 +2414,14 @@ export interface components {
         /** @enum {string} */
         theme: "light" | "dark" | "system";
       };
-      experimental: {
+      experimental?: {
         [key: string]: unknown;
       };
       formatting: {
         line_length: number;
       };
       keymap: {
-        overrides: {
+        overrides?: {
           [key: string]: string;
         };
         /** @enum {string} */

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import unittest
 from functools import wraps
 from typing import Any, Callable, TypeVar
 from unittest.mock import patch
 
-from marimo._config.config import merge_default_config
-from marimo._config.manager import MarimoConfig, UserConfigManager
+from marimo._config.config import PartialMarimoConfig, merge_default_config
+from marimo._config.manager import UserConfigManager
 from marimo._config.utils import load_config
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -28,7 +30,7 @@ class TestUserConfigManager(unittest.TestCase):
     @patch("tomlkit.dump")
     @patch("marimo._config.manager.load_config")
     def test_save_config(self, mock_load: Any, mock_dump: Any) -> None:
-        mock_config = merge_default_config(MarimoConfig())
+        mock_config = merge_default_config(PartialMarimoConfig())
         mock_load.return_value = mock_config
         manager = UserConfigManager()
 
@@ -43,13 +45,15 @@ class TestUserConfigManager(unittest.TestCase):
     @patch("tomlkit.dump")
     @patch("marimo._config.manager.load_config")
     def test_can_save_secrets(self, mock_load: Any, mock_dump: Any) -> None:
-        mock_config = merge_default_config(MarimoConfig())
+        mock_config = merge_default_config(PartialMarimoConfig())
         mock_load.return_value = mock_config
         manager = UserConfigManager()
 
         manager.save_config(
             merge_default_config(
-                MarimoConfig(ai={"open_ai": {"api_key": "super_secret"}})
+                PartialMarimoConfig(
+                    ai={"open_ai": {"api_key": "super_secret"}}
+                )
             )
         )
 
@@ -61,7 +65,7 @@ class TestUserConfigManager(unittest.TestCase):
         # Do not overwrite secrets
         manager.save_config(
             merge_default_config(
-                MarimoConfig(ai={"open_ai": {"api_key": "********"}})
+                PartialMarimoConfig(ai={"open_ai": {"api_key": "********"}})
             )
         )
         assert (
@@ -73,7 +77,7 @@ class TestUserConfigManager(unittest.TestCase):
     @patch("marimo._config.manager.load_config")
     def test_can_read_secrets(self, mock_load: Any) -> None:
         mock_config = merge_default_config(
-            MarimoConfig(ai={"open_ai": {"api_key": "super_secret"}})
+            PartialMarimoConfig(ai={"open_ai": {"api_key": "super_secret"}})
         )
         mock_load.return_value = mock_config
         manager = UserConfigManager()
@@ -87,7 +91,7 @@ class TestUserConfigManager(unittest.TestCase):
     @restore_config
     @patch("marimo._config.manager.load_config")
     def test_get_config(self, mock_load: Any) -> None:
-        mock_config = merge_default_config(MarimoConfig())
+        mock_config = merge_default_config(PartialMarimoConfig())
         mock_load.return_value = mock_config
         manager = UserConfigManager()
 


### PR DESCRIPTION
Improve typings for `PartialMarimoConfig` and handle NotRequired from TypedDict