### PR TITLE
improve: text label -> markdown label

### DIFF
--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -338,7 +338,7 @@ class altair_chart(UIElement[ChartSelection, ChartDataType]):
     - `legend_selection`: optional list of legend fields (columns) for which to
         enable selection, `True` to enable selection for all fields, or
         `False` to disable selection entirely
-    - `label`: optional text label for the element
+    - `label`: optional markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 

--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -73,7 +73,7 @@ class date(UIElement[str, dt.date]):
           current day;
         - else if `None` and `start` is not `None`, defaults to `start`;
         - else if `None` and `stop` is not `None`, defaults to `stop`
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -193,7 +193,7 @@ class datetime(UIElement[Optional[str], Optional[dt.datetime]]):
     - `start`: the minimum selectable datetime (default: minimum datetime)
     - `stop`: the maximum selectable datetime (default: maximum datetime)
     - `value`: default value
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of
       its container
@@ -322,7 +322,7 @@ class date_range(UIElement[Tuple[str, str], Tuple[dt.date, dt.date]]):
     - `start`: the minimum selectable date (default: minimum date)
     - `stop`: the maximum selectable date (default: maximum date)
     - `value`: default value (tuple of two dates)
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
       container

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -78,7 +78,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     - `value`: default value
     - `debounce`: whether to debounce (rate-limit) value
         updates from the frontend
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -181,7 +181,7 @@ class slider(UIElement[Numeric, Numeric]):
     - `show_value`: whether to display the current value of the slider
     - `steps`: list of steps to customize the slider, mutually exclusive
         with `start`, `stop`, and `step`
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -365,7 +365,7 @@ class range_slider(UIElement[List[Numeric], Sequence[Numeric]]):
     - `show_value`: whether to display the current value of the slider
     - `steps`: list of steps to customize the slider, mutually exclusive
         with `start`, `stop`, and `step`
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -543,7 +543,7 @@ class checkbox(UIElement[bool, bool]):
     **Initialization Args.**
 
     - `value`: default value, True or False
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -605,7 +605,7 @@ class radio(UIElement[Optional[str], Any]):
     - `options`: sequence of text options, or dict mapping option name
                  to option value
     - `value`: default option name, if None, starts with nothing checked
-    - `label`: optional text label for the element
+    - `label`: optional markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -674,7 +674,7 @@ class text(UIElement[str, str]):
     - `debounce`: whether the input is debounced. If number, debounce by
         that many milliseconds. If True, then value is only emitted on Enter
         or when the input loses focus.
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -739,7 +739,7 @@ class text_area(UIElement[str, str]):
         many milliseconds. If True, then value is only emitted on Ctrl+Enter
         or when the input loses focus.
     - `rows`: number of rows of text to display
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -805,7 +805,7 @@ class code_editor(UIElement[str, str]):
     - `disabled`: whether the input is disabled
     - `min_height`: minimum height of the code editor in pixels
     - `max_height`: maximum height of the code editor in pixels
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -893,7 +893,7 @@ class dropdown(UIElement[List[str], Any]):
     - `allow_select_none`: whether to include special option (`"--"`) for a
                            `None` value; when `None`, defaults to `True` when
                            `value` is `None`
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -1007,7 +1007,7 @@ class multiselect(UIElement[List[str], List[object]]):
     - `options`: sequence of text options, or dict mapping option name
                  to option value
     - `value`: a list of initially selected options
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -1113,7 +1113,7 @@ class button(UIElement[Any, Any]):
     - `value`: an initial value for the button
     - `kind`: 'neutral', 'success', 'warn', or 'danger'
     - `disabled`: whether the button is disabled
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
@@ -1247,7 +1247,7 @@ class file(UIElement[List[Tuple[str, str]], Sequence[FileUploadResults]]):
        or `"image/*"` to accept any audio, video, or image file.
     - `multiple`: if True, allow the user to upload multiple files
     - `kind`: `"button"` or `"area"`
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -1343,7 +1343,7 @@ class file_browser(UIElement[List[Dict[str, Any]], Sequence[FileInfo]]):
     - `multiple`: if True, allow the user to select multiple files.
     - `restrict_navigation`: if True, prevent the user from navigating
        any level above the given path.
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 
@@ -1537,7 +1537,7 @@ class form(UIElement[Optional[JSONTypeBound], Optional[T]]):
     - `clear_button_tooltip`: the tooltip of the clear button
     - `validate`: a function that takes the form's value and returns an error
         message if the value is invalid, or `None` if the value is valid
-    - `label`: text label for the form
+    - `label`: markdown label for the form
     - `on_change`: optional callback to run when this element's value changes
     """
 

--- a/marimo/_plugins/ui/_impl/microphone.py
+++ b/marimo/_plugins/ui/_impl/microphone.py
@@ -33,7 +33,7 @@ class microphone(UIElement[str, io.BytesIO]):
 
     **Initialization Args.**
 
-    - `label`: optional text label for the element
+    - `label`: optional markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 

--- a/marimo/_plugins/ui/_impl/plotly.py
+++ b/marimo/_plugins/ui/_impl/plotly.py
@@ -94,7 +94,7 @@ class plotly(UIElement[PlotlySelection, List[Dict[str, Any]]]):
     - `renderer_name`: optional renderer to use for the plot.
         If this is not provided, the default renderer (pio.renderers.default)
         is used.
-    - `label`: optional text label for the element
+    - `label`: optional markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 

--- a/marimo/_plugins/ui/_impl/refresh.py
+++ b/marimo/_plugins/ui/_impl/refresh.py
@@ -47,7 +47,7 @@ class refresh(UIElement[int, int]):
     If no options are provided and default_interval is not provided,
     the refresh button will not be displayed with a dropdown for auto-refresh.
     - `default_interval`: The default value of the refresh interval.
-    - `label`: optional text label for the element
+    - `label`: optional markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 

--- a/marimo/_plugins/ui/_impl/run_button.py
+++ b/marimo/_plugins/ui/_impl/run_button.py
@@ -51,7 +51,7 @@ class run_button(UIElement[Any, Any]):
     - `kind`: 'neutral', 'success', 'warn', or 'danger'
     - `disabled`: whether the button is disabled
     - `tooltip`: a tooltip to display for the button
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container

--- a/marimo/_plugins/ui/_impl/switch.py
+++ b/marimo/_plugins/ui/_impl/switch.py
@@ -25,7 +25,7 @@ class switch(UIElement[bool, bool]):
     **Initialization Args.**
 
     - `value`: default value, True or False
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -203,7 +203,7 @@ class table(
     or functions
     - `freeze_columns_left`: list of column names to freeze on the left
     - `freeze_columns_right`: list of column names to freeze on the right
-    - `label`: text label for the element
+    - `label`: markdown label for the element
     - `on_change`: optional callback to run when this element's value changes
     """
 


### PR DESCRIPTION
marimo expects labels to be markdown; update docstrings to make this explicit.

cc @fuenfundachtzig , thanks for the suggestion.