### PR TITLE
Fix with inline tag

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -417,8 +417,8 @@ def iframe(html: str, *, width: str = "100%", height: str = "400px") -> Html:
     Embed an HTML string in an iframe.
 
     Scripts by default are not executed using `mo.as_html` or `mo.Html`,
-    so if you have a <script/> tag, you can use `mo.iframe` for
-    scripts to be executed.
+    so if you have a script tag (written as "<script></script>"),
+    you can use `mo.iframe` for scripts to be executed.
 
     You may also want to use this function to display HTML content
     that may contain styles that could interfere with the rest of the


### PR DESCRIPTION
## 📝 Summary

This pull request addresses an issue with the `iframe` documentation, where content was being cut off in the section `docs/api/html.html#marimo.iframe`. The issue was related to improper handling of the `<script>` tag in the documentation, resulting in incomplete display of the text. Addresses #2558 
![iframe-doc](https://github.com/user-attachments/assets/78ad6822-9533-4faf-aac3-735bf39208e6)

## 🔍 Description of Changes

1. Fixed the display issue in the `iframe` documentation by wrapping the `<script>` tag using inline highlighting to prevent it from being rendered incorrectly.
2. Identified and modified `marimo/_output/formatting.py` to address the root cause, which was introduced in PR #2398.
3. Built off the earlier PR #2505 as suggested.

Before: Documentation content for `iframe` was cut off, making it confusing for users.
After: Full content is displayed properly, improving clarity and completeness.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] This change was discussed and branched off PR #2505. 
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick