### PR TITLE
Fix iframe documentation display

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -417,7 +417,7 @@ def iframe(html: str, *, width: str = "100%", height: str = "400px") -> Html:
     Embed an HTML string in an iframe.
 
     Scripts by default are not executed using `mo.as_html` or `mo.Html`,
-    so if you have a script tag (written as "<script></script>"),
+    so if you have a `<script/>` tag,
     you can use `mo.iframe` for scripts to be executed.
 
     You may also want to use this function to display HTML content


### PR DESCRIPTION
Fix issue in incorrect documentation rendering introduced at #2559 
![image](https://github.com/user-attachments/assets/2e9ac4c7-8b71-4306-a7cb-ccd43480fea5)

Sorry for this; not sure why I didn't catch this earlier.