### PR TITLE
improvement: add 'jump to focused cell' in the dependency viewer

### DIFF
--- a/frontend/src/components/dependency-graph/dependency-graph-tree.tsx
+++ b/frontend/src/components/dependency-graph/dependency-graph-tree.tsx
@@ -160,6 +160,7 @@ export const DependencyGraphTree: React.FC<PropsWithChildren<Props>> = ({
                       duration: 600,
                       nodes: [node],
                     });
+                    setSelection({ type: "node", id: lastFocusedCell });
                   }
                 }
               }}

--- a/frontend/src/components/dependency-graph/panels.tsx
+++ b/frontend/src/components/dependency-graph/panels.tsx
@@ -253,7 +253,10 @@ export const GraphSelectionPanel: React.FC<{
   };
 
   return (
-    <Panel position="bottom-left" className="max-h-[90%] flex flex-col">
+    <Panel
+      position="bottom-left"
+      className="max-h-[90%] flex flex-col w-[calc(100%-5rem)]"
+    >
       <div className="min-h-[100px] shadow-md rounded-md border max-w-[550px] border-primary/40 my-4 min-w-[240px] bg-[var(--slate-1)] text-muted-foreground/80 flex flex-col overflow-y-auto">
         {renderSelection()}
       </div>

--- a/frontend/src/core/cells/focus.ts
+++ b/frontend/src/core/cells/focus.ts
@@ -8,7 +8,7 @@ import type { CellConfig, RuntimeState } from "../network/types";
 /**
  * Holds state for the last focused cell.
  */
-const lastFocusedCellIdAtom = atom<CellId | null>(null);
+export const lastFocusedCellIdAtom = atom<CellId | null>(null);
 
 export function useLastFocusedCellId() {
   return useAtomValue(lastFocusedCellIdAtom);


### PR DESCRIPTION
Fixes https://github.com/marimo-team/marimo/issues/2576

Add a control button to jump to the focused cell. 

![Screenshot 2024-10-10 at 11 36 31 AM](https://github.com/user-attachments/assets/97abfcd8-4966-48ea-88d0-77857bd71160)
