### PR TITLE
Revert "improve: Hide code by default for Markdown cells (#2507)"

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -37,7 +37,6 @@ import { autoInstantiateAtom, isAiEnabled } from "@/core/config/config";
 import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import { OverridingHotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { useSplitCellCallback } from "../useSplitCell";
-import { MarkdownLanguageAdapter } from "@/core/codemirror/language/markdown";
 
 export interface CellEditorProps
   extends Pick<CellRuntimeState, "status">,
@@ -326,7 +325,7 @@ const CellEditorInternal = ({
     };
   }, [editorViewRef]);
 
-  const temporarilyShowCode = useCallback(async () => {
+  const temporarilyShowCode = async () => {
     if (hidden) {
       updateCellConfig({ cellId, config: { hide_code: false } });
       editorViewRef.current?.focus();
@@ -351,17 +350,7 @@ const CellEditorInternal = ({
         { signal: abortController.signal },
       );
     }
-  }, [hidden, cellId, updateCellConfig, editorViewRef]);
-
-  // For a newly created Markdown cell, which defaults to
-  // hidden code, we temporarily show the code editor
-  useEffect(() => {
-    if (code === new MarkdownLanguageAdapter().defaultCode) {
-      return;
-    }
-    temporarilyShowCode();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [code]);
+  };
 
   return (
     <AiCompletionEditor

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -29,11 +29,7 @@ import { deserializeBase64, deserializeJson } from "@/utils/json/base64";
 import { historyField } from "@codemirror/commands";
 import { clamp } from "@/utils/math";
 import type { LayoutState } from "../layout/layout";
-import {
-  isMarkdown,
-  notebookIsRunning,
-  notebookQueueOrRunningCount,
-} from "./utils";
+import { notebookIsRunning, notebookQueueOrRunningCount } from "./utils";
 import {
   splitEditor,
   updateEditorCodeFromPython,
@@ -256,10 +252,6 @@ const {
           lastCodeRun,
           lastExecutionTime,
           edited: Boolean(code) && code !== lastCodeRun,
-          config: {
-            disabled: false,
-            hide_code: isMarkdown(code),
-          },
         }),
       },
       cellRuntime: {

--- a/frontend/src/core/cells/utils.ts
+++ b/frontend/src/core/cells/utils.ts
@@ -10,7 +10,6 @@ import {
   type LastSavedNotebook,
   staleCellIds,
 } from "./cells";
-import { LanguageAdapters } from "../codemirror/language/LanguageAdapters";
 
 export function notebookIsRunning(state: NotebookState) {
   return Object.values(state.cellRuntime).some(
@@ -103,10 +102,4 @@ export function getDescendantsStatus(state: NotebookState, cellId: CellId) {
     errored,
     runningOrQueued,
   };
-}
-
-export function isMarkdown(code: string | undefined) {
-  return code && code !== ""
-    ? LanguageAdapters.markdown().isSupported(code)
-    : false;
 }


### PR DESCRIPTION
This reverts commit 9a674dcb5900a4f4204cba548697b85c395b0c00.

The logic for temporarily showing code for markdown cells is incorrect and causing all hidden cells to not render as hidden.

We can fix and restore in a follow up