### PR TITLE
fix: prevent more buttons from stealing focus

### DIFF
--- a/frontend/src/components/dependency-graph/dependency-graph-tree.tsx
+++ b/frontend/src/components/dependency-graph/dependency-graph-tree.tsx
@@ -37,6 +37,7 @@ import { MapPinIcon } from "lucide-react";
 import { store } from "@/core/state/jotai";
 import { lastFocusedCellIdAtom } from "@/core/cells/focus";
 import { Tooltip } from "../ui/tooltip";
+import { Events } from "@/utils/events";
 
 interface Props {
   cellIds: CellId[];
@@ -143,10 +144,7 @@ export const DependencyGraphTree: React.FC<PropsWithChildren<Props>> = ({
             asChild={false}
           >
             <ControlButton
-              onMouseDown={(e) => {
-                // Prevent focus moving to the control button
-                e.preventDefault();
-              }}
+              onMouseDown={Events.preventFocus}
               onClick={() => {
                 const lastFocusedCell = store.get(lastFocusedCellIdAtom);
                 // Zoom the graph to the last focused cell

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -34,6 +34,7 @@ import type { TopLevelFacetedUnitSpec } from "@/plugins/impl/data-explorer/queri
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Objects } from "@/utils/objects";
 import { renderMimeIcon } from "./renderMimeIcon";
+import { Events } from "@/utils/events";
 
 const LazyVegaLite = React.lazy(() =>
   import("react-vega").then((m) => ({ default: m.VegaLite })),
@@ -338,6 +339,7 @@ const ExpandableOutput = React.memo(
                   onClick={async () => {
                     await containerRef.current?.requestFullscreen();
                   }}
+                  onMouseDown={Events.preventFocus}
                   size="xs"
                   variant="text"
                 >

--- a/frontend/src/components/editor/SortableCell.tsx
+++ b/frontend/src/components/editor/SortableCell.tsx
@@ -6,6 +6,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { GripVerticalIcon } from "lucide-react";
 import type { CellId } from "@/core/cells/ids";
 import { cn } from "@/utils/cn";
+import { Events } from "@/utils/events";
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   cellId: CellId;
@@ -72,6 +73,7 @@ const SortableCellInternal = React.forwardRef(
         data-is-dragging={isDragging}
         className={cn(props.className, isMoving && "is-moving")}
         style={style}
+        onMouseDown={Events.preventFocus}
       >
         <DragHandleSlot.Provider value={dragHandle}>
           {props.children}

--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -12,6 +12,7 @@ import { MarkdownLanguageAdapter } from "@/core/codemirror/language/markdown";
 import { MarkdownIcon, PythonIcon } from "./code/icons";
 import { SQLLanguageAdapter } from "@/core/codemirror/language/sql";
 import { cn } from "@/utils/cn";
+import { Events } from "@/utils/events";
 
 export const CreateCellButton = ({
   appClosed,
@@ -31,6 +32,7 @@ export const CreateCellButton = ({
             "shoulder-button hover-action",
             appClosed && " inactive-button",
           )}
+          onMouseDown={Events.preventFocus}
           shape="circle"
           size="small"
           color="hint-green"

--- a/frontend/src/components/editor/cell/DeleteButton.tsx
+++ b/frontend/src/components/editor/cell/DeleteButton.tsx
@@ -4,6 +4,7 @@ import type { RuntimeState } from "@/core/network/types";
 import { Tooltip } from "../../ui/tooltip";
 import { Button } from "../../ui/button";
 import { cn } from "@/utils/cn";
+import { Events } from "@/utils/events";
 
 export const DeleteButton = (props: {
   status: RuntimeState;
@@ -32,12 +33,10 @@ export const DeleteButton = (props: {
         size="icon"
         onClick={onClick}
         data-testid="delete-button"
-        onMouseDown={(evt) => {
-          // Prevent stealing focus
-          // This is needed to delete cells when the cell editor
-          // is shown temporarily (e.g. when set to `hidden`)
-          evt.preventDefault();
-        }}
+        // Prevent stealing focus
+        // This is needed to delete cells when the cell editor
+        // is shown temporarily (e.g. when set to `hidden`)
+        onMouseDown={Events.preventFocus}
         className={cn(
           "hover:bg-transparent text-destructive/60 hover:text-destructive",
           (appClosed || loading) && "inactive-button",

--- a/frontend/src/components/editor/cell/toolbar.tsx
+++ b/frontend/src/components/editor/cell/toolbar.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/utils/cn";
 import { Toolbar as ReactAriaToolbar } from "react-aria-components";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Events } from "@/utils/events";
 
 const toolbarItemVariants = cva(
   "rounded-full shadow-xsSolid border p-[5px] transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 [&>svg]:size-3 active:shadow-none bg-background",
@@ -45,14 +46,11 @@ export const ToolbarItem: React.FC<ToolbarItemProps> = ({
       {...rest}
       onClick={(evt) => {
         if (!disabled) {
-          // evt.preventDefault();
           rest.onClick?.(evt);
         }
       }}
-      onMouseDown={(evt) => {
-        // Prevent focus on the toolbar after clicking
-        evt.preventDefault();
-      }}
+      // Prevent focus on the toolbar after clicking
+      onMouseDown={Events.preventFocus}
       className={cn(toolbarItemVariants({ variant }), rest.className)}
     >
       {children}

--- a/frontend/src/utils/events.ts
+++ b/frontend/src/utils/events.ts
@@ -21,4 +21,15 @@ export const Events = {
       }
     };
   },
+  /**
+   * This is used when we are focused in a code-editor,
+   * but don't want pressing a button to move focus to that
+   * button and instead stay in the code editor.
+   *
+   * This should only be placed on the onMouseDown callback
+   */
+  preventFocus: (e: React.MouseEvent) => {
+    // Prevent focus moving to the button on click
+    e.preventDefault();
+  },
 };


### PR DESCRIPTION
Fixes #2589

Prevent buttons from stealing focus;

This is used when we are focused in a code-editor, but don't want pressing a button to move focus to that button and instead stay in the code editor.