### PR TITLE
fix: don't show errors in run mode when re-running

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -52,6 +52,7 @@ import type { CellConfig, RuntimeState } from "@/core/network/types";
 import { MoreHorizontalIcon } from "lucide-react";
 import { Toolbar, ToolbarItem } from "@/components/editor/cell/toolbar";
 import { cn } from "@/utils/cn";
+import { isErrorMime } from "@/core/mime";
 
 /**
  * Imperative interface of the cell.
@@ -417,8 +418,12 @@ const CellComponent = (
   });
 
   if (!editing) {
-    const hidden = errored || interrupted || stopped;
-    return hidden ? null : (
+    const outputIsError = isErrorMime(output?.mimetype);
+    const hidden = errored || interrupted || stopped || outputIsError;
+    if (hidden) {
+      return null;
+    }
+    return (
       <div tabIndex={-1} id={HTMLId} ref={cellRef} className={className}>
         {outputArea}
       </div>

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -38,6 +38,7 @@ import { FloatingOutline } from "../../chrome/panels/outline/floating-outline";
 import { KnownQueryParams } from "@/core/constants";
 import { useUserConfig } from "@/core/config/config";
 import { MarkdownLanguageAdapter } from "@/core/codemirror/language/markdown";
+import { isErrorMime } from "@/core/mime";
 
 type VerticalLayout = null;
 type VerticalLayoutProps = ICellRendererProps<VerticalLayout>;
@@ -294,9 +295,13 @@ const VerticalCell = memo(
       );
     }
 
-    const hidden = errored || interrupted || stopped;
+    const outputIsError = isErrorMime(output?.mimetype);
+    const hidden = errored || interrupted || stopped || outputIsError;
+    if (hidden) {
+      return null;
+    }
 
-    return hidden ? null : (
+    return (
       <div tabIndex={-1} id={HTMLId} ref={cellRef} className={className}>
         <OutputArea
           allowExpand={mode === "edit"}

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -49,6 +49,7 @@ import {
   MultiColumn,
 } from "@/utils/id-tree";
 import { isEqual } from "lodash-es";
+import { isErrorMime } from "../mime";
 
 export const SCRATCH_CELL_ID = "__scratch__" as CellId;
 
@@ -1153,7 +1154,7 @@ const cellErrorsAtom = atom((get) => {
     .map((cellId) => {
       const cell = cellRuntime[cellId];
       const { name } = cellData[cellId];
-      if (cell.output?.mimetype === "application/vnd.marimo+error") {
+      if (isErrorMime(cell.output?.mimetype)) {
         // Filter out ancestor-stopped errors
         // These are errors that are caused by a cell that was stopped,
         // but nothing the user can take action on.

--- a/frontend/src/core/mime.ts
+++ b/frontend/src/core/mime.ts
@@ -1,0 +1,9 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import type { OutputMessage } from "./kernel/messages";
+
+export function isErrorMime(mime: OutputMessage["mimetype"] | undefined) {
+  return (
+    mime === "application/vnd.marimo+error" ||
+    mime === "application/vnd.marimo+traceback"
+  );
+}


### PR DESCRIPTION
* Don't show errors in run mode when re-running. This can happen when a cell errors (not shown yet) and then is re-running (is in a queued/running state) so we end up showing the error briefly.
* Since we do send these errors to the frontend anyways, I now log it to the console for developers.