### PR TITLE
release marimo-base to test pypi

### DIFF
--- a/.github/workflows/dev-release-marimo-base.yml
+++ b/.github/workflows/dev-release-marimo-base.yml
@@ -1,4 +1,4 @@
-name: Publish dev release
+name: Publish marimo-base dev release
 
 # Publish development release to test pypi on pushes to main
 on:

--- a/.github/workflows/dev-release-marimo-base.yml
+++ b/.github/workflows/dev-release-marimo-base.yml
@@ -1,0 +1,71 @@
+name: Publish dev release
+
+# Publish development release to test pypi on pushes to main
+on:
+  push:
+    branches:
+      - main
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: marimo
+
+jobs:
+  publish_dev_release:
+    name: 📤 Publish dev release for marimo-base
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+        with:
+          # get tag history for version number
+          fetch-depth: 0
+
+      - name: 🥚 Install Hatch
+        uses: pypa/hatch@install
+
+      # Python build tools generally only allow building one project
+      # per Python project. This modifies the pyproject.toml
+      # to build marimo-base, a slimmed down marimo distribution with
+      # no static artifacts.
+      # 
+      # Adapted from https://github.com/cvxpy/cvxpy/blob/297278e2a88db3c0084750052a16e60672074da3/.github/workflows/build.yml#L169C1-L180C1
+      - name: Adapt pyproject.toml to build marimo-base
+        run: |
+          # Mac has a different syntax for sed -i, this works across oses
+          sed -i.bak -e 's/name = "marimo"/name = "marimo-base"/g' pyproject.toml
+          # Remove static artifacts
+          sed -i.bak '/artifacts = /d' pyproject.toml
+          rm -rf pyproject.toml.bak
+
+      # patch __init__.py version to be of the form
+      # X.Y.<Z+1>-dev{n-commits-since-last-tag}
+      - name: 🔨 Patch version number
+        run: |
+          # Get the version number and increment patch
+          # - assumes version is on a line of the form __version__ == "x.y.z"
+          incremented_version=`grep '__version__' marimo/__init__.py | awk '{print $3}' | awk -F. '{printf "%d.%d.%d", $1, $2, $3+1}'`
+          # Get the number of commits since last tag
+          n_commits=`git rev-list $(git describe --tags --abbrev=0)..HEAD --count`
+          # Form the new version, which is one patch ahead of the last version
+          # so installing from Test PyPI does the right thing
+          MARIMO_VERSION="${incremented_version}-dev${n_commits}"
+          # Set the version in the environment for later steps
+          echo "MARIMO_VERSION=$MARIMO_VERSION" >> $GITHUB_ENV
+          sed -i "s/__version__ = \".*\"/__version__ = \"$MARIMO_VERSION\"/" marimo/__init__.py
+
+      - name: 📦 Build marimo
+        run: hatch build
+
+      - name: 📤 Upload to TestPyPI
+        env:
+          HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_USER }}
+          HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_PASSWORD }}
+        run: hatch publish --repo test


### PR DESCRIPTION
This change adds a workflow that releases a marimo-base package to TestPyPI.

marimo-base is marimo without static artifacts, which are not needed when running on WASM.

Because Python build tools only allow one project per pyproject.toml, it is not possible to do this by adding a build rule to hatch. Instead, marimo-base is built by adapting the pyproject.toml in CI (this is what CVXPY does).

With this change, the wheel size is reduced from `15M` to `614k`. 