### PR TITLE
feat: support iconfify icons in markdown with ::lucide:rocket:: syntax

### DIFF
--- a/docs/api/markdown.md
+++ b/docs/api/markdown.md
@@ -10,7 +10,11 @@ elements.
 
 ## Icons
 
-You can render icons from [Iconify](https://icon-sets.iconify.design/) with `mo.icon`.
+We support rendering icons from [Iconify](https://icon-sets.iconify.design/).
+
+When in inside markdown, you can render an icon with the syntax `::iconset:icon-name::` for example `::lucide:rocket::` or `::mdi:home::`. This is useful for quickly adding an icon, however, it does not support advanced configuration such as size, color, and rotation.
+
+For other advanced features, use `mo.icon()` such as `mo.icon("lucide:rocket", size=20)` or `mo.icon("mdi:home", color="blue")`.
 
 ```{eval-rst}
 .. autofunction:: marimo.icon

--- a/docs/api/markdown.md
+++ b/docs/api/markdown.md
@@ -12,7 +12,7 @@ elements.
 
 We support rendering icons from [Iconify](https://icon-sets.iconify.design/).
 
-When in inside markdown, you can render an icon with the syntax `::iconset:icon-name::` for example `::lucide:rocket::` or `::mdi:home::`. This is useful for quickly adding an icon, however, it does not support advanced configuration such as size, color, and rotation.
+When is inside markdown, you can render an icon with the syntax `::iconset:icon-name::` for example `::lucide:rocket::` or `::mdi:home::`. This is useful for quickly adding an icon, however, it does not support advanced configuration such as size, color, and rotation.
 
 For other advanced features, use `mo.icon()` such as `mo.icon("lucide:rocket", size=20)` or `mo.icon("mdi:home", color="blue")`.
 

--- a/marimo/_output/md.py
+++ b/marimo/_output/md.py
@@ -8,6 +8,7 @@ import markdown  # type: ignore
 
 from marimo._output.hypertext import Html
 from marimo._output.md_extensions.external_links import ExternalLinksExtension
+from marimo._output.md_extensions.iconify import IconifyExtension
 from marimo._output.rich_help import mddoc
 
 extension_configs = {
@@ -66,6 +67,8 @@ def _md(
             "admonition",
             # Links
             ExternalLinksExtension(),
+            # Iconify
+            IconifyExtension(),
         ],
         extension_configs=extension_configs,  # type: ignore[arg-type]
     ).strip()

--- a/marimo/_output/md_extensions/iconify.py
+++ b/marimo/_output/md_extensions/iconify.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from xml.etree.ElementTree import Element
 
-from markdown import Extension, Markdown, inlinepatterns  # type: ignore
+from markdown import Extension, Markdown, inlinepatterns
 
 if TYPE_CHECKING:
     import re
@@ -18,7 +18,7 @@ class IconifyPattern(inlinepatterns.InlineProcessor):
     def __init__(self, pattern: str, md: Markdown) -> None:
         super().__init__(pattern, md)
 
-    def handleMatch(
+    def handleMatch(  # type: ignore
         self, m: re.Match[str], data: str
     ) -> tuple[Element, int, int]:
         del data

--- a/marimo/_output/md_extensions/iconify.py
+++ b/marimo/_output/md_extensions/iconify.py
@@ -1,0 +1,41 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from xml.etree.ElementTree import Element
+
+from markdown import Extension, Markdown, inlinepatterns  # type: ignore
+
+if TYPE_CHECKING:
+    import re
+
+
+class IconifyPattern(inlinepatterns.InlineProcessor):
+    """
+    Converts ::icon-set:icon-name:: to an iconify-icon element.
+    """
+
+    def __init__(self, pattern: str, md: Markdown) -> None:
+        super().__init__(pattern, md)
+
+    def handleMatch(
+        self, m: re.Match[str], data: str
+    ) -> tuple[Element, int, int]:
+        del data
+        icon_name = m.group(1)
+        return (
+            Element("iconify-icon", {"icon": icon_name, "inline": ""}),
+            m.start(0),
+            m.end(0),
+        )
+
+
+class IconifyExtension(Extension):
+    def extendMarkdown(self, md: Markdown) -> None:
+        # Add IconifyPattern with high priority (200) to
+        # handle it before other inline patterns
+        md.inlinePatterns.register(
+            IconifyPattern(r"::([a-zA-Z0-9-]+:[a-zA-Z0-9-]+)::", md),
+            "iconify",
+            200,
+        )

--- a/marimo/_smoke_tests/icons.py
+++ b/marimo/_smoke_tests/icons.py
@@ -5,33 +5,26 @@
 # ]
 # ///
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.1.79"
+__generated_with = "0.9.7"
 app = marimo.App()
 
 
 @app.cell
 def __():
     import marimo as mo
-    return mo,
+    return (mo,)
 
 
 @app.cell
 def __(mo):
-    mo.hstack(
-        [
-            mo.md("Icon sets"),
-            mo.icon("lucide:leaf", size=20),
-            mo.icon("material-symbols:rocket-launch", size=20),
-            mo.icon("ic:twotone-rocket-launch", size=20),
-        ],
-        justify="start",
-    )
+    mo.md(r"""::lucide:alarm-clock::""")
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.hstack(
         [
@@ -85,12 +78,11 @@ def __(mo):
             mo.ui.button(
                 label=f"{mo.icon('material-symbols:rocket-launch')} Launch"
             ),
-            mo.ui.button(
-                label=f"Clear {mo.icon('material-symbols:close-rounded')}"
-            ),
+            mo.ui.button(label=f"::material-symbols:rocket-launch:: Launch"),
+            mo.ui.button(label=f"Clear ::material-symbols:close-rounded::"),
             # Left and right
             mo.ui.button(
-                label=f"{mo.icon('material-symbols:download')} Download {mo.icon('material-symbols:csv')}"
+                label=f"::material-symbols:download:: Download ::material-symbols:csv::"
             ),
         ],
         justify="start",

--- a/tests/_output/test_md.py
+++ b/tests/_output/test_md.py
@@ -57,3 +57,25 @@ def test_md_footnotes() -> None:
     assert _md(footnote_input, apply_markdown_class=False).text == (
         expected_output
     )
+
+
+def test_md_iconify() -> None:
+    # Test iconify conversion
+    iconify_input = "This is an icon: ::lucide:user::"
+    expected_output = '<span class="paragraph">This is an icon: <iconify-icon icon="lucide:user" inline=""></iconify-icon></span>'  # noqa: E501
+    assert (
+        _md(iconify_input, apply_markdown_class=False).text == expected_output
+    )
+
+    # Test multiple icons
+    multiple_icons_input = "Icons: ::mdi:home:: ::fa:car:: ::lucide:settings::"
+    expected_output = '<span class="paragraph">Icons: <iconify-icon icon="mdi:home" inline=""></iconify-icon> <iconify-icon icon="fa:car" inline=""></iconify-icon> <iconify-icon icon="lucide:settings" inline=""></iconify-icon></span>'  ## noqa: E501
+    assert (
+        _md(multiple_icons_input, apply_markdown_class=False).text
+        == expected_output
+    )
+
+    # Test icon within other markdown elements
+    mixed_input = "# Header with ::lucide:star:: icon\n\n**Bold text with ::mdi:alert:: icon**"  # noqa: E501
+    expected_output = '<h1 id="header-with-icon">Header with <iconify-icon icon="lucide:star" inline=""></iconify-icon> icon</h1>\n<span class="paragraph"><strong>Bold text with <iconify-icon icon="mdi:alert" inline=""></iconify-icon> icon</strong></span>'  # noqa: E501
+    assert _md(mixed_input, apply_markdown_class=False).text == expected_output


### PR DESCRIPTION
<img width="308" alt="image" src="https://github.com/user-attachments/assets/e97dbf2d-9517-479f-a9e9-df0ba991b756">
