### PR TITLE
fix: support dates in data-editor

### DIFF
--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -40,6 +40,10 @@ class WebComponentEncoder(JSONEncoder):
         if isinstance(o, (datetime.datetime, datetime.date, datetime.time)):
             return o.isoformat()
 
+        # Handle timedelta
+        if isinstance(o, datetime.timedelta):
+            return str(o)
+
         # Handle UUID
         if isinstance(o, UUID):
             return str(o)

--- a/marimo/_smoke_tests/editable_df.py
+++ b/marimo/_smoke_tests/editable_df.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.9.4"
+__generated_with = "0.9.9"
 app = marimo.App(width="medium")
 
 
@@ -91,17 +91,28 @@ def __(mo):
 
 @app.cell
 def __(pd):
+    import datetime
+
     large_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 
     varying_data = {
         "strings": ["a", "b", "c", large_text],
         "numbers": [1, 2, 3, 4],
         "bools": [True, False, True, False],
-        "dates": [pd.Timestamp("2021-01-01") for _ in range(4)],
+        "timestamps": [pd.Timestamp("2021-01-01") for _ in range(4)],
+        "dates": [datetime.date(2021, 1, 1) for _ in range(4)],
+        "datetimes": [datetime.datetime(2021, 1, 1, 1, 1, 1) for _ in range(4)],
+        "duration": [datetime.timedelta(days=2, seconds=13500) for _ in range(4)],
         "none": [None for _ in range(4)],
         "lists": [[1, 2], [3, 4], [5, 6], [7, 8]],
     }
-    return large_text, varying_data
+    return datetime, large_text, varying_data
+
+
+@app.cell
+def __(pl, varying_data):
+    pl.DataFrame(varying_data).schema
+    return
 
 
 @app.cell

--- a/tests/_plugins/core/test_json_encoder.py
+++ b/tests/_plugins/core/test_json_encoder.py
@@ -324,6 +324,14 @@ def test_date_time_encoding() -> None:
     assert encoded_datetime == '"2023-01-01T12:30:45"'
 
 
+def test_timedelta_encoding() -> None:
+    import datetime
+
+    timedelta_obj = datetime.timedelta(days=1, seconds=2, microseconds=3)
+    encoded = json.dumps(timedelta_obj, cls=WebComponentEncoder)
+    assert encoded == '"1 day, 0:00:02.000003"'
+
+
 def test_enum_encoding() -> None:
     from enum import Enum
 

--- a/tests/_plugins/ui/_impl/test_data_editor.py
+++ b/tests/_plugins/ui/_impl/test_data_editor.py
@@ -1,8 +1,10 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import datetime
 from typing import Any
 
+import narwhals.stable.v1 as nw
 import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
@@ -84,6 +86,225 @@ def test_apply_edits_new_row():
         {"A": 1, "B": "a"},
         {"A": 2, "B": "b"},
         {"A": 3, "B": None},
+    ]
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
+def test_apply_edits_ints_floats():
+    data = [{"A": 1, "B": 2.5}, {"A": 3, "B": 4.7}]
+    edits = {
+        "edits": [
+            {"rowIdx": 0, "columnId": "A", "value": "2"},
+            {"rowIdx": 1, "columnId": "B", "value": "5.8"},
+        ]
+    }
+    result = apply_edits(data, edits)
+    assert result == [{"A": 2, "B": 2.5}, {"A": 3, "B": 5.8}]
+
+    # With dtypes
+    result = apply_edits(
+        data, edits, schema=nw.Schema({"A": nw.Float32(), "B": nw.Float32()})
+    )
+    assert result == [{"A": 2.0, "B": 2.5}, {"A": 3.0, "B": 5.8}]
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
+def test_apply_edits_booleans():
+    data = [{"A": True, "B": False}, {"A": False, "B": True}]
+    edits = {
+        "edits": [
+            {"rowIdx": 0, "columnId": "A", "value": False},
+            {"rowIdx": 1, "columnId": "B", "value": False},
+        ]
+    }
+    result = apply_edits(data, edits)
+    assert result == [{"A": False, "B": False}, {"A": False, "B": False}]
+
+    # With dtypes
+    result = apply_edits(
+        data, edits, schema=nw.Schema({"A": nw.Boolean(), "B": nw.Boolean()})
+    )
+    assert result == [{"A": False, "B": False}, {"A": False, "B": False}]
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
+def test_apply_edits_dates():
+    data = [
+        {"date": datetime.date(2023, 1, 1)},
+        {"date": datetime.date(2023, 2, 1)},
+    ]
+    edits = {
+        "edits": [
+            {"rowIdx": 0, "columnId": "date", "value": "2023-03-15"},
+            {"rowIdx": 1, "columnId": "date", "value": "2023-04-20"},
+        ]
+    }
+    result = apply_edits(data, edits)
+    assert result == [
+        {"date": datetime.date(2023, 3, 15)},
+        {"date": datetime.date(2023, 4, 20)},
+    ]
+
+    # With dtypes
+    result = apply_edits(data, edits, schema=nw.Schema({"date": nw.Date()}))
+    assert result == [
+        {"date": datetime.date(2023, 3, 15)},
+        {"date": datetime.date(2023, 4, 20)},
+    ]
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
+def test_apply_edits_lists():
+    data = [{"list": [1, 2, 3]}, {"list": [4, 5, 6]}]
+    edits = {
+        "edits": [
+            {"rowIdx": 0, "columnId": "list", "value": "[1, 2, 3, 4]"},
+            {"rowIdx": 1, "columnId": "list", "value": "7,8"},
+        ]
+    }
+    result = apply_edits(data, edits)
+    assert result == [{"list": [1, 2, 3, 4]}, {"list": [7, 8]}]
+
+    # With dtypes
+    result = apply_edits(data, edits, schema=nw.Schema({"list": nw.List()}))
+    assert result == [{"list": [1, 2, 3, 4]}, {"list": [7, 8]}]
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
+def test_apply_edits_various_datatypes():
+    data = [
+        {
+            "int": 1,
+            "float": 1.5,
+            "str": "hello",
+            "bool": True,
+            "datetime": datetime.datetime(2023, 1, 1, 12, 0),
+            "date": datetime.date(2023, 1, 1),
+            "duration": datetime.timedelta(days=1, hours=2, minutes=30),
+            "list": [1, 2, 3],
+        },
+        {
+            "int": 2,
+            "float": 2.5,
+            "str": "world",
+            "bool": False,
+            "datetime": datetime.datetime(2023, 2, 1, 12, 0),
+            "date": datetime.date(2023, 2, 1),
+            "duration": datetime.timedelta(days=2, hours=4, minutes=45),
+            "list": [4, 5, 6],
+        },
+    ]
+    edits = {
+        "edits": [
+            {"rowIdx": 0, "columnId": "int", "value": "3"},
+            {"rowIdx": 0, "columnId": "float", "value": "3.14"},
+            {"rowIdx": 0, "columnId": "str", "value": "updated"},
+            {"rowIdx": 0, "columnId": "bool", "value": False},
+            {
+                "rowIdx": 0,
+                "columnId": "datetime",
+                "value": "2023-03-15T15:30:00",
+            },
+            {"rowIdx": 0, "columnId": "date", "value": "2023-03-15"},
+            {"rowIdx": 0, "columnId": "duration", "value": "186300000000"},
+            {"rowIdx": 0, "columnId": "list", "value": "[7, 8, 9]"},
+            {"rowIdx": 1, "columnId": "int", "value": "4"},
+            {"rowIdx": 1, "columnId": "float", "value": "4.5"},
+            {"rowIdx": 1, "columnId": "str", "value": "updated2"},
+            {"rowIdx": 1, "columnId": "bool", "value": True},
+            {
+                "rowIdx": 1,
+                "columnId": "datetime",
+                "value": "2023-04-20T10:00:00",
+            },
+            {"rowIdx": 1, "columnId": "date", "value": "2023-04-20"},
+            {"rowIdx": 1, "columnId": "duration", "value": 186300000000},
+            {"rowIdx": 1, "columnId": "list", "value": "10,11,12"},
+        ]
+    }
+    result = apply_edits(data, edits)
+    assert result == [
+        {
+            "int": 3,
+            "float": 3.14,
+            "str": "updated",
+            "bool": False,
+            "datetime": datetime.datetime(2023, 1, 1, 12, 0),
+            "date": datetime.date(2023, 3, 15),
+            "duration": datetime.timedelta(days=2, seconds=13500),
+            "list": [7, 8, 9],
+        },
+        {
+            "int": 4,
+            "float": 4.5,
+            "str": "updated2",
+            "bool": True,
+            "datetime": datetime.datetime(2023, 1, 1, 12, 0),
+            "date": datetime.date(2023, 4, 20),
+            "duration": datetime.timedelta(days=2, seconds=13500),
+            "list": [10, 11, 12],
+        },
+    ]
+
+    # Test with explicit dtypes
+    dtypes = nw.Schema(
+        {
+            "int": nw.Int64(),
+            "float": nw.Float64(),
+            "str": nw.String(),
+            "bool": nw.Boolean(),
+            "datetime": nw.Datetime(),
+            "date": nw.Date(),
+            "duration": nw.Duration(),
+            "list": nw.List(),
+        }
+    )
+    result_with_dtypes = apply_edits(data, edits, schema=dtypes)
+    assert result_with_dtypes == result
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
+def test_apply_edits_edge_cases():
+    data = [
+        {
+            "empty_to_value": None,
+            "value_to_empty": "hello",
+            "zero_length_list": [],
+        },
+        {
+            "empty_to_value": None,
+            "value_to_empty": "world",
+            "zero_length_list": [],
+        },
+    ]
+    edits = {
+        "edits": [
+            {"rowIdx": 0, "columnId": "empty_to_value", "value": "filled"},
+            {"rowIdx": 1, "columnId": "value_to_empty", "value": ""},
+            {"rowIdx": 0, "columnId": "zero_length_list", "value": "[1]"},
+            {"rowIdx": 1, "columnId": "zero_length_list", "value": "[]"},
+        ]
+    }
+    result = apply_edits(data, edits)
+    assert result == [
+        {
+            "empty_to_value": "filled",
+            "value_to_empty": "hello",
+            "zero_length_list": [1],
+        },
+        {"empty_to_value": None, "value_to_empty": "", "zero_length_list": []},
     ]
 
 

--- a/tests/_plugins/ui/_impl/test_data_editor.py
+++ b/tests/_plugins/ui/_impl/test_data_editor.py
@@ -174,7 +174,9 @@ def test_apply_edits_lists():
     assert result == [{"list": [1, 2, 3, 4]}, {"list": [7, 8]}]
 
     # With dtypes
-    result = apply_edits(data, edits, schema=nw.Schema({"list": nw.List()}))
+    result = apply_edits(
+        data, edits, schema=nw.Schema({"list": nw.List(nw.Int64())})
+    )
     assert result == [{"list": [1, 2, 3, 4]}, {"list": [7, 8]}]
 
 
@@ -266,7 +268,7 @@ def test_apply_edits_various_datatypes():
             "datetime": nw.Datetime(),
             "date": nw.Date(),
             "duration": nw.Duration(),
-            "list": nw.List(),
+            "list": nw.List(nw.Int64()),
         }
     )
     result_with_dtypes = apply_edits(data, edits, schema=dtypes)


### PR DESCRIPTION
Fixes #2617

Support date/datetime/duration conversion in the data-editor plugin. The frontend is still a string instead of a date-input, but this fixes backend support. 