### PR TITLE
improve: Keyboard shortcut to toggle terminal

### DIFF
--- a/docs/guides/editor_features/hotkeys.md
+++ b/docs/guides/editor_features/hotkeys.md
@@ -45,6 +45,7 @@ You can find a list of available hotkeys below:
 | `global.save`               |
 | `global.showHelp`           |
 | `global.toggleLanguage`     |
+| `global.toggleTerminal`     |
 | `global.toggleSidebar`      |
 | `global.unfoldCode`         |
 | `markdown.blockquote`       |

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ChevronDownIcon } from "lucide-react";
 import { FooterItem } from "./footer-item";
+import { useHotkey } from "@/hooks/useHotkey";
 
 export const Footer: React.FC = () => {
   const { selectedPanel, isTerminalOpen } = useChromeState();
@@ -40,6 +41,10 @@ export const Footer: React.FC = () => {
 
   const errorPanel = PANELS.find((p) => p.type === "errors");
   invariant(errorPanel, "Error panel not found");
+
+  useHotkey("global.toggleTerminal", () => {
+    toggleTerminal();
+  });
 
   return (
     <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md pl-1 pr-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50 print:hidden">

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -289,6 +289,11 @@ const DEFAULT_HOT_KEY = {
     group: "Editing",
     key: "F4",
   },
+  "global.toggleTerminal": {
+    name: "Toggle terminal",
+    group: "Other",
+    key: "Ctrl-`",
+  },
 
   // Global Navigation
   "global.focusTop": {


### PR DESCRIPTION
## 📝 Summary

Toggle terminal with Ctrl + ` just as in vscode. Completes #2608.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
