### PR TITLE
improvement: keep rich objects in mo.ui.chat contents, convert strings to markdown

### DIFF
--- a/marimo/_plugins/ui/_impl/chat/chat.py
+++ b/marimo/_plugins/ui/_impl/chat/chat.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Final, List, Optional, Union, cast
 
 from marimo._output.formatting import as_html
+from marimo._output.md import md
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import UIElement
@@ -205,14 +206,8 @@ class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
                 pass
             response = latest_response
 
-        content = (
-            as_html(response).text  # convert to html if not a string
-            if not isinstance(response, str)
-            else response
-        )
-        self._chat_history = messages + [
-            ChatMessage(role="assistant", content=content)
-        ]
+        response_message = ChatMessage(role="assistant", content=response)
+        self._chat_history = messages + [response_message]
 
         from marimo._runtime.context import get_context
 
@@ -234,7 +229,11 @@ class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
                     )
                 )
 
-        return content
+        # Return the response as HTML
+        # If the response is a string, convert it to markdown
+        if isinstance(response, str):
+            return md(response).text
+        return as_html(response).text
 
     def _convert_value(self, value: Dict[str, Any]) -> List[ChatMessage]:
         if not isinstance(value, dict) or "messages" not in value:

--- a/marimo/_plugins/ui/_impl/chat/convert.py
+++ b/marimo/_plugins/ui/_impl/chat/convert.py
@@ -94,7 +94,7 @@ def convert_to_google_messages(
     google_messages: List[Dict[Any, Any]] = []
 
     for message in messages:
-        parts: List[str | BlobDict] = [message.content]
+        parts: List[str | BlobDict] = [str(message.content)]
         if message.attachments:
             for attachment in message.attachments:
                 content_type = attachment.content_type or "text/plain"

--- a/marimo/_plugins/ui/_impl/chat/llm.py
+++ b/marimo/_plugins/ui/_impl/chat/llm.py
@@ -39,7 +39,7 @@ class simple(ChatModel):
         self, messages: List[ChatMessage], config: ChatModelConfig
     ) -> object:
         del config
-        prompt = messages[-1].content
+        prompt = str(messages[-1].content)
         return self.delegate(prompt)
 
 

--- a/marimo/_plugins/ui/_impl/chat/types.py
+++ b/marimo/_plugins/ui/_impl/chat/types.py
@@ -60,7 +60,7 @@ class ChatMessage:
     role: Literal["user", "assistant", "system"]
 
     # The content of the message.
-    content: str
+    content: object
 
     # Optional attachments to the message.
     attachments: Optional[List[ChatAttachment]] = None

--- a/tests/_plugins/ui/_impl/chat/test_chat.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat.py
@@ -6,6 +6,7 @@ from typing import AsyncIterator, Dict, List
 
 import pytest
 
+from marimo._output.md import md
 from marimo._plugins import ui
 from marimo._plugins.ui._impl.chat.chat import SendMessageRequest
 from marimo._plugins.ui._impl.chat.types import (
@@ -70,7 +71,7 @@ async def test_chat_send_prompt():
     )
     response: str = await chat._send_prompt(request)
 
-    assert response == "Response to: Hello"
+    assert response == md("Response to: Hello").text
     assert len(chat._chat_history) == 2
     assert chat._chat_history[0].role == "user"
     assert chat._chat_history[0].content == "Hello"
@@ -93,7 +94,7 @@ async def test_chat_send_prompt_async_function():
     )
     response: str = await chat._send_prompt(request)
 
-    assert response == "Response to: Hello"
+    assert response == md("Response to: Hello").text
     assert len(chat._chat_history) == 2
     assert chat._chat_history[0].role == "user"
     assert chat._chat_history[0].content == "Hello"
@@ -119,7 +120,7 @@ async def test_chat_send_prompt_async_generator():
     response: str = await chat._send_prompt(request)
 
     # the last yielded value is the response
-    assert response == "2"
+    assert response == md("2").text
     assert len(chat._chat_history) == 2
     assert chat._chat_history[0].role == "user"
     assert chat._chat_history[0].content == "Hello"


### PR DESCRIPTION
- keep rich objects in mo.ui.chat contents, so they can be used later if desired
- convert strings to markdown by default (most LLMs return markdown)