### PR TITLE
fix: pyodide dependency

### DIFF
--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -220,7 +220,7 @@ export class DefaultWasmController implements WasmController {
     // to `foundImports`:
     // https://pyodide.org/en/stable/usage/packages-in-pyodide.html
     code = `import docutils\n${code}`;
-    code = `import Pygments\n${code}`;
+    code = `import pygments\n${code}`;
     code = `import jedi\n${code}`;
     code = `import pyodide_http\n${code}`;
 


### PR DESCRIPTION
import pygments not Pygments

fixes broken handling of tracebacks on WASM