### PR TITLE
fix: consistent value for no column in config

### DIFF
--- a/frontend/src/core/cells/__tests__/__snapshots__/cells.test.ts.snap
+++ b/frontend/src/core/cells/__tests__/__snapshots__/cells.test.ts.snap
@@ -4,6 +4,7 @@ exports[`cell reducer > can initialize stdin 1`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -31,6 +32,7 @@ exports[`cell reducer > can initialize stdin 2`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -58,6 +60,7 @@ exports[`cell reducer > can initialize stdin 3`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -85,6 +88,7 @@ exports[`cell reducer > can initialize stdin 4`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -112,6 +116,7 @@ exports[`cell reducer > can initialize stdin 5`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -146,6 +151,7 @@ exports[`cell reducer > can initialize stdin 6`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -180,6 +186,7 @@ exports[`cell reducer > can initialize stdin 7`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -220,6 +227,7 @@ exports[`cell reducer > can initialize stdin 8`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -261,6 +269,7 @@ exports[`cell reducer > can initialize stdin 9`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -308,6 +317,7 @@ exports[`cell reducer > can receive console when the cell is idle and will clear
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -335,6 +345,7 @@ exports[`cell reducer > can receive console when the cell is idle and will clear
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -369,6 +380,7 @@ exports[`cell reducer > can receive console when the cell is idle and will clear
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -403,6 +415,7 @@ exports[`cell reducer > can receive console when the cell is idle and will clear
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -430,6 +443,7 @@ exports[`cell reducer > can receive console when the cell is idle and will clear
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -464,6 +478,7 @@ exports[`cell reducer > can run a stale cell 1`] = `
 {
   "code": "mo.slider()",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -491,6 +506,7 @@ exports[`cell reducer > can run a stale cell 2`] = `
 {
   "code": "mo.slider()",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -518,6 +534,7 @@ exports[`cell reducer > can run a stopped cell 1`] = `
 {
   "code": "mo.md('This has an ancestor that was stopped')",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -545,6 +562,7 @@ exports[`cell reducer > can run a stopped cell 2`] = `
 {
   "code": "mo.md('This has an ancestor that was stopped')",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -572,6 +590,7 @@ exports[`cell reducer > can run a stopped cell 3`] = `
 {
   "code": "mo.md('This has an ancestor that was stopped')",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -610,6 +629,7 @@ exports[`cell reducer > can run a stopped cell 4`] = `
 {
   "code": "mo.md('This has an ancestor that was stopped')",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -648,6 +668,7 @@ exports[`cell reducer > can run a stopped cell 5`] = `
 {
   "code": "mo.md('This has an ancestor that was stopped')",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -675,6 +696,7 @@ exports[`cell reducer > can run cell and receive cell messages 1`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -702,6 +724,7 @@ exports[`cell reducer > can run cell and receive cell messages 2`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -729,6 +752,7 @@ exports[`cell reducer > can run cell and receive cell messages 3`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -756,6 +780,7 @@ exports[`cell reducer > can run cell and receive cell messages 4`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -783,6 +808,7 @@ exports[`cell reducer > can run cell and receive cell messages 5`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -810,6 +836,7 @@ exports[`cell reducer > can run cell and receive cell messages 6`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -844,6 +871,7 @@ exports[`cell reducer > can run cell and receive cell messages 7`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -884,6 +912,7 @@ exports[`cell reducer > can run cell and receive cell messages 8`] = `
   "code": "import marimo as mo
 import numpy",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -923,6 +952,7 @@ exports[`cell reducer > can run cell and receive cell messages 9`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -963,6 +993,7 @@ exports[`cell reducer > can run cell and receive cell messages 10`] = `
   "code": "import marimo as mo
 import numpy",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -1003,6 +1034,7 @@ exports[`cell reducer > can run cell and receive cell messages 11`] = `
   "code": "import marimo as mo
 import numpy",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -1050,6 +1082,7 @@ exports[`cell reducer > can run cell and receive cell messages 12`] = `
   "code": "import marimo as mo
 import numpy",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -1094,6 +1127,7 @@ exports[`cell reducer > errors reset status to idle 1`] = `
 {
   "code": "",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -1121,6 +1155,7 @@ exports[`cell reducer > errors reset status to idle 2`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -1148,6 +1183,7 @@ exports[`cell reducer > errors reset status to idle 3`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },
@@ -1175,6 +1211,7 @@ exports[`cell reducer > errors reset status to idle 4`] = `
 {
   "code": "import marimo as mo",
   "config": {
+    "column": null,
     "disabled": false,
     "hide_code": false,
   },

--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -812,6 +812,7 @@ describe("cell reducer", () => {
     expect(cell.config).toEqual({
       disabled: false,
       hide_code: false,
+      column: null,
     });
 
     actions.updateCellConfig({

--- a/frontend/src/core/cells/__tests__/utils.test.ts
+++ b/frontend/src/core/cells/__tests__/utils.test.ts
@@ -94,7 +94,9 @@ describe("getCellConfigs", () => {
     };
 
     const result = getCellConfigs(mockState);
-    expect(result).toEqual([{ hide_code: false, disabled: false }]);
+    expect(result).toEqual([
+      { hide_code: false, disabled: false, column: null },
+    ]);
   });
 
   it("should handle empty notebook state", () => {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1109,7 +1109,7 @@ export function getCellConfigs(state: NotebookState): CellConfig[] {
       return column.inOrderIds.map((cellId) => {
         return {
           ...cells[cellId].config,
-          column: undefined,
+          column: null,
         };
       });
     });

--- a/frontend/src/core/cells/types.ts
+++ b/frontend/src/core/cells/types.ts
@@ -25,6 +25,7 @@ export function createCell({
     config: config || {
       hide_code: false,
       disabled: false,
+      column: null,
     },
     name: name,
     code: code,

--- a/frontend/src/core/cells/utils.ts
+++ b/frontend/src/core/cells/utils.ts
@@ -37,8 +37,8 @@ export function notebookNeedsSave(
   const names = data.map((d) => d.name);
   return (
     !arrayShallowEquals(codes, lastSavedNotebook.codes) ||
-    !arrayShallowEquals(configs, lastSavedNotebook.configs) ||
     !arrayShallowEquals(names, lastSavedNotebook.names) ||
+    !isEqual(configs, lastSavedNotebook.configs) ||
     !isEqual(layout.selectedLayout, lastSavedNotebook.layout.selectedLayout) ||
     !isEqual(layout.layoutData, lastSavedNotebook.layout.layoutData)
   );


### PR DESCRIPTION
Previously, the value for column in a single-column notebook was sometimes null, sometimes undefined. This led to false positives on notebookNeedsSave. This PR changes it so that when a column is not set, the corresponding config value is `null` (which corresponds to `None` in Python).

Without this fix, if you opened a notebook and saved it with or without making any changes (experimental multi-column was disabled), the notebook was marked as needing to be save for the remainder of the session, no matter how many times you clicked "save".

I found that I also had to change arrayShallowEquals to lodash isEquals for the equality check on config objects to work.