### PR TITLE
Fix rendering of ui.date_range embedded example

### DIFF
--- a/docs/api/inputs/dates.md
+++ b/docs/api/inputs/dates.md
@@ -46,9 +46,6 @@
 
 ## Date range
 
-````{eval-rst}
-
-
 ```{eval-rst}
 .. marimo-embed::
     @app.cell


### PR DESCRIPTION
## 📝 Summary

<!-- 
Provide a concise summary of what this pull request is addressing.
As pointed out in #2621, there is no interactive example of `mo.ui.date_range`
-->

The embedded interactive example of `marimo.ui.date_range` is not rendering correctly as pointed out in #2621.

Currently, it looks like this:
![image](https://github.com/user-attachments/assets/9d98a110-3ffb-49cb-8bb6-558b5cc49393)

It seems that the error is due to double lines of 

    [``](https://docs.marimo.io/api/inputs/dates.html#id1)[`](https://docs.marimo.io/api/inputs/dates.html#id3){eval-rst} .. marimo-embed:


## 🔍 Description of Changes

<!-- 
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
