### PR TITLE
chore: add narwhals test command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,15 @@ python = ["3.9","3.10", "3.11", "3.12"]
 [tool.hatch.envs.test.scripts]
 test = "pytest{env:HATCH_TEST_ARGS:} {args:tests}"
 default = "pytest{env:HATCH_TEST_ARGS:} {args:tests}"
+# This is used externally from the narwhals repo to run our tests from their repo.
+# This should include any tests that may use narwhals. 
+# It is ok if we test more than narwhals here, but we should not test less.
+test-narwhals = """
+    pytest{env:HATCH_TEST_ARGS:} \
+        tests/_data/ \
+        tests/_plugins/ui/_impl/ \
+        tests/_utils/test_narwhals_utils.py
+"""
 
 [tool.hatch.envs.test-optional]
 template = "test"

--- a/tests/_plugins/ui/_impl/tables/snapshots/narwhals.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/narwhals.field_types.json
@@ -4,7 +4,7 @@
   "int": ["integer", "Int64"],
   "float": ["number", "Float64"],
   "datetime": ["date", "Datetime(time_unit='us', time_zone=None)"],
-  "struct": ["unknown", "Struct"],
+  "struct": ["unknown", "Struct({'a': Int64, 'b': Int64})"],
   "list": ["unknown", "List(Int64)"],
   "array": ["unknown", "List(Int64)"],
   "nulls": ["string", "String"],

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -52,14 +52,14 @@ def snapshotter(current_file: str) -> Callable[[str, str], None]:
         if is_json:
             import json
 
-            expected = json.loads(expected)
-            result = json.loads(result)
+            expected_json = json.loads(expected)
+            result_json = json.loads(result)
 
-            if expected != result:
+            if expected_json != result_json:
                 write_result()
                 print("Snapshot updated")
 
-            assert expected == result
+            assert expected_json == result_json
         else:
             text_diff = "\n".join(
                 list(


### PR DESCRIPTION
can run with:
```bash
hatch run +py=3.12 test-optional:test-narwhals
```

cc @MarcoGorelli this should be the only command you need to run (i dont think there is benefit with `test:test-narwhals`)