### PR TITLE
fix: ai prompt context from sql tables with periods

### DIFF
--- a/frontend/src/components/editor/ai/__tests__/completion-utils.test.ts
+++ b/frontend/src/components/editor/ai/__tests__/completion-utils.test.ts
@@ -112,4 +112,45 @@ describe("getAICompletionBody", () => {
       code: "",
     });
   });
+
+  it("should handle dataset names with dots", () => {
+    // Set up test data in the Jotai store
+    const testDatasets = [
+      {
+        name: "dataset.with.dots",
+        columns: [
+          { name: "col1", type: "number" },
+          { name: "col2", type: "string" },
+        ],
+      },
+      {
+        name: "regular_dataset",
+        columns: [{ name: "col3", type: "boolean" }],
+      },
+    ];
+    store.set(datasetsAtom, { tables: testDatasets } as DatasetsState);
+
+    const input = "Use @dataset.with.dots and @regular_dataset for analysis";
+    const result = getAICompletionBody(input);
+
+    expect(result).toEqual({
+      includeOtherCode: "// Some other code",
+      context: {
+        schema: [
+          {
+            name: "dataset.with.dots",
+            columns: [
+              { name: "col1", type: "number" },
+              { name: "col2", type: "string" },
+            ],
+          },
+          {
+            name: "regular_dataset",
+            columns: [{ name: "col3", type: "boolean" }],
+          },
+        ],
+      },
+      code: "",
+    });
+  });
 });

--- a/frontend/src/components/editor/ai/completion-utils.ts
+++ b/frontend/src/components/editor/ai/completion-utils.ts
@@ -40,7 +40,7 @@ function extractDatasets(input: string): DataTable[] {
   const existingDatasets = Maps.keyBy(datasets, (dataset) => dataset.name);
 
   // Extract dataset mentions from the input
-  const mentionedDatasets = input.match(/@(\w+)/g) || [];
+  const mentionedDatasets = input.match(/@([\w.]+)/g) || [];
 
   // Filter to only include datasets that exist
   return mentionedDatasets

--- a/frontend/src/components/editor/chrome/panels/datasources-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/datasources-panel.tsx
@@ -494,7 +494,7 @@ const DatasetColumnPreview: React.FC<{
         size="icon"
         className="z-10 bg-background absolute right-1 -top-1"
         onClick={Events.stopPropagation(() => {
-          const code = `_df = mo.sql(f"SELECT '${column.name}' FROM ${table.name} LIMIT 100")`;
+          const code = `_df = mo.sql(f'SELECT "${column.name}" FROM ${table.name} LIMIT 100')`;
           onAddColumnChart(code);
         })}
       >

--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -308,7 +308,7 @@ export const EditApp: React.FC<AppProps> = ({ userConfig, appConfig }) => {
         <AppHeader
           connection={connection}
           className={cn(
-            "pt-4 sm:pt-12 pb-2 mb-4 print:hidden",
+            "pt-4 sm:pt-12 pb-2 mb-4 print:hidden z-50",
             // Keep the header sticky when scrolling horizontally, for column mode
             "sticky left-0",
           )}

--- a/marimo/_data/preview_column.py
+++ b/marimo/_data/preview_column.py
@@ -45,7 +45,9 @@ def get_column_preview_dataframe(
         # Get the summary of the column
         try:
             summary = table.get_summary(column_name)
-        except Exception as e:
+        except BaseException as e:
+            # Catch-all: some libraries like Polars have bugs and raise
+            # BaseExceptions, which shouldn't crash the kernel
             LOGGER.warning(
                 "Failed to get summary for column %s in table %s",
                 column_name,

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -430,18 +430,23 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
         # Get column summaries
         summaries: List[ColumnSummary] = []
         for column in self._manager.get_column_names():
-            summary = self._searched_manager.get_summary(column)
-            summaries.append(
-                ColumnSummary(
-                    column=column,
-                    nulls=summary.nulls,
-                    min=summary.min,
-                    max=summary.max,
-                    unique=summary.unique,
-                    true=summary.true,
-                    false=summary.false,
+            try:
+                summary = self._searched_manager.get_summary(column)
+                summaries.append(
+                    ColumnSummary(
+                        column=column,
+                        nulls=summary.nulls,
+                        min=summary.min,
+                        max=summary.max,
+                        unique=summary.unique,
+                        true=summary.true,
+                        false=summary.false,
+                    )
                 )
-            )
+            except BaseException:
+                # Catch-all: some libraries like Polars have bugs and raise
+                # BaseExceptions, which shouldn't crash the kernel
+                LOGGER.warning("Failed to get summary for column %s", column)
 
         # If we are above the limit to show charts,
         # we don't return the chart data


### PR DESCRIPTION
Couple fixes

* catch errors from polars panics
* fix sql table context not being added if they have a `.`