### PR TITLE
feat: mo.Thread

### DIFF
--- a/docs/api/miscellaneous.md
+++ b/docs/api/miscellaneous.md
@@ -15,3 +15,7 @@
 ```{eval-rst}
 .. autofunction:: marimo.notebook_dir
 ```
+
+```{eval-rst}
+.. autoclass:: marimo.Thread
+```

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "create_asgi_app",
     "MarimoIslandGenerator",
     "MarimoStopError",
+    "Thread",
     # Other namespaces
     "ai",
     "ui",
@@ -130,6 +131,7 @@ from marimo._runtime.runtime import (
     refs,
 )
 from marimo._runtime.state import state
+from marimo._runtime.threads import Thread
 from marimo._save.save import cache, lru_cache, persistent_cache
 from marimo._server.asgi import create_asgi_app
 from marimo._sql.sql import sql

--- a/marimo/_cli/run_docker.py
+++ b/marimo/_cli/run_docker.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 import subprocess

--- a/marimo/_data/sql_summaries.py
+++ b/marimo/_data/sql_summaries.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 from typing import List, Tuple

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -1,6 +1,11 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import threading
+from typing import Any
 
 from marimo._runtime.context.types import (
+    RuntimeContext,
     get_context,
     initialize_context,
     runtime_context_installed,
@@ -15,15 +20,15 @@ class Thread(threading.Thread):
     frontend, whereas `threading.Thread` can't.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+
+        self._marimo_ctx: RuntimeContext | None = None
 
         if runtime_context_installed():
             self._marimo_ctx = get_context()
-        else:
-            self._marimo_ctx = None
 
-    def run(self):
+    def run(self) -> None:
         if self._marimo_ctx is not None:
             initialize_context(self._marimo_ctx)
         super().run()

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -1,0 +1,29 @@
+import threading
+
+from marimo._runtime.context.types import (
+    get_context,
+    initialize_context,
+    runtime_context_installed,
+)
+
+
+class Thread(threading.Thread):
+    """A Thread subclass that is aware of marimo internals.
+
+    `mo.Thread` has the same API as threading.Thread,
+    but `mo.Thread`s are able to communicate with the marimo
+    frontend, whereas `threading.Thread` can't.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        if runtime_context_installed():
+            self._marimo_ctx = get_context()
+        else:
+            self._marimo_ctx = None
+
+    def run(self):
+        if self._marimo_ctx is not None:
+            initialize_context(self._marimo_ctx)
+        super().run()

--- a/marimo/_smoke_tests/threads.py
+++ b/marimo/_smoke_tests/threads.py
@@ -1,0 +1,41 @@
+import marimo
+
+__generated_with = "0.9.10"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def __():
+    def foo():
+        print("hi")
+    return (foo,)
+
+
+@app.cell
+def __():
+    import threading
+    return (threading,)
+
+
+@app.cell
+def __(foo, mo, threading):
+    with mo.redirect_stdout():
+        threading.Thread(target=foo).start()
+    return
+
+
+@app.cell
+def __(foo, mo):
+    with mo.redirect_stdout():
+        mo.Thread(target=foo).start()
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_utils/narwhals_utils.py
+++ b/marimo/_utils/narwhals_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 import sys

--- a/tests/_runtime/test_threads.py
+++ b/tests/_runtime/test_threads.py
@@ -1,0 +1,36 @@
+import time
+
+from marimo._runtime.runtime import Kernel
+
+from tests.conftest import ExecReqProvider
+
+
+async def test_set_ui_element_value_lensed(
+    any_kernel: Kernel, exec_req: ExecReqProvider
+) -> None:
+    """Test setting the value of a lensed element.
+
+    Make sure reactivity flows through its parent, and that its on_change
+    handler is called exactly once.
+    """
+    k = any_kernel
+
+    await k.run(
+        [
+            exec_req.get("import marimo as mo"),
+            exec_req.get("ctx_main = mo._runtime.context.get_context()"),
+            exec_req.get(
+                """
+                ctx_thread = None
+                def target():
+                    global ctx_thread
+                    ctx_thread = mo._runtime.context.get_context()
+                mo.Thread(target=target).start().join()
+                """
+            ),
+        ]
+    )
+
+    # thread run should be basically instantaneous, but sleep just in case ...
+    time.sleep(0.01)
+    assert k.globals["ctx_main"] == k.globals["ctx_thread"]

--- a/tests/_runtime/test_threads.py
+++ b/tests/_runtime/test_threads.py
@@ -31,5 +31,5 @@ async def test_set_ui_element_value_lensed(
     )
 
     # thread run should be basically instantaneous, but sleep just in case ...
-    time.sleep(0.01)
+    time.sleep(0.01)  # noqa: ASYNC251
     assert k.globals["ctx_main"] == k.globals["ctx_thread"]

--- a/tests/_runtime/test_threads.py
+++ b/tests/_runtime/test_threads.py
@@ -1,7 +1,6 @@
 import time
 
 from marimo._runtime.runtime import Kernel
-
 from tests.conftest import ExecReqProvider
 
 


### PR DESCRIPTION
This change adds a new public API, `mo.Thread`, which is exactly the same as `threading.Thread` except it inherits the "parent" thread's runtime context. This allows it to communicate to the parent's session.

Users can optionally choose to monkey patch `threading.Thread` with `mo.Thread` to redirect third-party library logs to the appropriate session, ie

```python
import threading

import marimo as mo

threading.Thread = mo.Thread
```

Fixes #2642 as best we can.