### PR TITLE
docs: marimo.ui.dictionary

### DIFF
--- a/examples/ui/arrays_and_dicts.py
+++ b/examples/ui/arrays_and_dicts.py
@@ -7,7 +7,7 @@
 
 import marimo
 
-__generated_with = "0.8.19"
+__generated_with = "0.9.14"
 app = marimo.App()
 
 
@@ -76,6 +76,55 @@ def __(mo):
 def __(array, dictionary, mo):
     mo.hstack([array.value, dictionary.value], justify="space-around")
     return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        Fundamental difference between marimo dict and standard python dict.
+
+        The UI elements in marimo dict are clones of the original: interacting with the marimo dictionary will not update the original elements, and vice versa.
+
+        This allows you to reuse multiple UI components (e.g., sliders, text inputs, or date pickers) independently, ensuring they don’t interfere with each other when managed through marimo dict.
+
+        However, if you use a regular python dict, all references remain synchronized, and changes to one element propagate across all linked instances.
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def __(create, mo):
+    create
+
+    slider = mo.ui.slider(1, 10, show_value=True)
+    text = mo.ui.text()
+    date = mo.ui.date()
+
+    mo_d = mo.ui.dictionary(
+        {
+            "slider": slider,
+            "text": text,
+            "date": date,
+        }
+    )
+
+    py_d = {
+        "slider": slider,
+        "text": text,
+        "date": date,
+    }
+
+    mo.hstack(
+        [
+            mo.vstack(["marimo dict", mo_d]),
+            mo.vstack(["original elements", mo.vstack([slider, text, date])]),
+            mo.vstack(["python dict", py_d]),
+        ],
+        justify="space-around",
+    )
+    return date, mo_d, py_d, slider, text
 
 
 @app.cell

--- a/marimo/_plugins/ui/_impl/dictionary.py
+++ b/marimo/_plugins/ui/_impl/dictionary.py
@@ -59,16 +59,29 @@ class dictionary(_batch_base):
     Access and output a UI element in the array:
 
     ```python
-    mo.md(f"This is a slider: d['slider']")
+    mo.md(f"This is a slider: {d['slider']}")
     ```
 
     Some number of UI elements, determined at runtime:
 
     ```python
-    mo.ui.dictionary({
-        f"option {i}": mo.ui.slider(1, 10)
-        for i in range random.randint(4, 8)
-    })
+    mo.ui.dictionary(
+        {
+            f"option {i}": mo.ui.slider(1, 10)
+            for i in range(random.randint(4, 8))
+        }
+    )
+    ```
+
+    Quick layouts of UI elements:
+
+    ```python
+    mo.ui.dictionary(
+        {
+            f"option {i}": mo.ui.slider(1, 10)
+            for i in range(random.randint(4, 8))
+        }
+    ).vstack()  # Can also use `hstack`, `callout`, `center`, etc.
     ```
 
     **Attributes.**

--- a/marimo/_plugins/ui/_impl/dictionary.py
+++ b/marimo/_plugins/ui/_impl/dictionary.py
@@ -34,6 +34,14 @@ class dictionary(_batch_base):
     elements: interacting with the dictionary will _not_ update the original
     elements, and vice versa.
 
+    This allows you to reuse multiple UI components (e.g., sliders, text
+    inputs, or date pickers) independently, ensuring they don’t interfere with
+    each other when managed through `mo.ui.dictionary`.
+
+    However, if you use a regular Python dictionary, all references remain
+    synchronized, and changes to one element propagate across all linked
+    instances.
+
     **Examples.**
 
     A heterogeneous collection of UI elements:


### PR DESCRIPTION
Improve documentation for dictionary UI element

- Fix f-string syntax in example: `d['slider']` to `{d['slider']}`
- Fix range syntax in example: `for i in range random.randint(4, 8)` to `for i in range(random.randint(4, 8))`
- [Add interpretation for difference between marimo.ui.dictionary and python dictionary](https://discord.com/channels/1059888774789730424/1298939811268264016)
- Add example in doc for quick layouts using `.vstack()`
- Update example for marimo dictionary

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
