### PR TITLE
fix: remove any need for tornado in matplotlib.interactive

### DIFF
--- a/marimo/_output/mpl.py
+++ b/marimo/_output/mpl.py
@@ -16,13 +16,13 @@ import base64
 import io
 from typing import Optional
 
-import matplotlib.pyplot as plt  # type: ignore
-from matplotlib._pylab_helpers import Gcf  # type: ignore
-from matplotlib.backend_bases import (  # type: ignore
+import matplotlib.pyplot as plt
+from matplotlib._pylab_helpers import Gcf
+from matplotlib.backend_bases import (
     FigureCanvasBase,
     FigureManagerBase,
 )
-from matplotlib.backends.backend_agg import FigureCanvasAgg  # type: ignore
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.mimetypes import KnownMimeType
@@ -40,7 +40,7 @@ def close_figures() -> None:
 def _internal_show(canvas: FigureCanvasBase) -> None:
     buf = io.BytesIO()
     buf.seek(0)
-    canvas.figure.savefig(buf, format="png", bbox_inches="tight")
+    canvas.figure.savefig(buf, format="png", bbox_inches="tight")  # type: ignore[attr-defined]
     plt.close(canvas.figure)
     mimetype: KnownMimeType = "image/png"
     plot_bytes = base64.b64encode(buf.getvalue())
@@ -53,7 +53,7 @@ def _internal_show(canvas: FigureCanvasBase) -> None:
     )
 
 
-class FigureManager(FigureManagerBase):  # type: ignore
+class FigureManager(FigureManagerBase):
     def show(self) -> None:
         _internal_show(self.canvas)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ dependencies = [
     # Types for mypy
     "polars~=1.9.0",
     "narwhals>=1.9.0",
+    "matplotlib>=3.8.0",
     "pyarrow-stubs>=17.0",
     "pandas-stubs>=1.5.3.230321",
     "types-Pillow~=10.2.0.20240520",

--- a/tests/_plugins/stateless/test_mpl.py
+++ b/tests/_plugins/stateless/test_mpl.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._output.hypertext import Html
+from marimo._runtime.requests import DeleteCellRequest
+from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider
+
+
+@pytest.mark.skipif(
+    not DependencyManager.matplotlib.has(),
+    reason="matplotlib is not installed",
+)
+async def test_mpl_interactive(k: Kernel, exec_req: ExecReqProvider) -> None:
+    from threading import Thread
+
+    # This tests that the interactive figure is correctly displayed
+    # and does not crash when tornado is not installed.
+
+    with patch.object(Thread, "start", lambda self: None):  # noqa: ARG005
+        await k.run(
+            [
+                cell := exec_req.get(
+                    """
+                    # remove tornado from sys.modules
+                    import sys
+                    sys.modules.pop("tornado", None)
+
+                    import marimo as mo
+                    import matplotlib.pyplot as plt
+                    plt.plot([1, 2])
+                    try:
+                        interactive = mo.mpl.interactive(plt.gcf())
+                    except Exception as e:
+                        interactive = str(e)
+                    """
+                ),
+            ]
+        )
+
+        interactive = k.globals["interactive"]
+        assert isinstance(interactive, Html)
+        assert interactive.text.startswith("<iframe srcdoc=")
+        await k.delete_cell(DeleteCellRequest(cell_id=cell.cell_id))
+
+
+@pytest.mark.skipif(
+    not DependencyManager.matplotlib.has(),
+    reason="matplotlib is not installed",
+)
+async def test_mpl_show(k: Kernel, exec_req: ExecReqProvider) -> None:
+    await k.run(
+        [
+            exec_req.get(
+                """
+                import matplotlib.pyplot as plt
+                plt.plot([1, 2])
+                plt.show()
+                """
+            )
+        ]
+    )


### PR DESCRIPTION
Fixes #2713

We don't actually use tornado (we moved it to Starlette at some point), but an import still uses tornado