### PR TITLE
doc: add period to Plotly docstring

### DIFF
--- a/marimo/_plugins/ui/_impl/plotly.py
+++ b/marimo/_plugins/ui/_impl/plotly.py
@@ -86,7 +86,7 @@ class plotly(UIElement[PlotlySelection, List[Dict[str, Any]]]):
     **Initialization Args.**
 
     - `figure`: A `plotly.graph_objects.Figure`
-    - `config`: optional configuration for the plot
+    - `config`: optional configuration for the plot.
         This is a dictionary that is passed directly to the plotly.
         See the plotly documentation for more information:
         https://plotly.com/javascript/configuration-options/


### PR DESCRIPTION
Adds a period to the `plotly` docstring. [In the docs](https://docs.marimo.io/guides/working_with_data/plotting.html#plotly) it ends up looking like a typo:
<img width="764" alt="Screenshot 2024-10-29 at 9 52 33 AM" src="https://github.com/user-attachments/assets/9fba38ce-9975-442d-b084-7c197de2d666">

Looks like convention is to end each param definition without a period, though, so I haven't added periods where the description is only one sentence.

I have read the CLA Document and I hereby sign the CLA