### PR TITLE
fix: don't reprompt docker when running in sandbox

### DIFF
--- a/marimo/_cli/run_docker.py
+++ b/marimo/_cli/run_docker.py
@@ -19,6 +19,8 @@ LOGGER = _loggers.marimo_logger()
 def prompt_run_in_docker_container(name: str | None) -> bool:
     if GLOBAL_SETTINGS.IN_SECURE_ENVIRONMENT:
         return False
+    if GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA:
+        return False
 
     # Only prompt for remote files
     if name is None:


### PR DESCRIPTION
This prevents re-prompting the user to run in a docker container when running in a package sandbox.