### PR TITLE
fix: allow un-hiding code when temporarily shown, show delete button

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -110,7 +110,10 @@ export interface CellProps
   showPlaceholder: boolean;
   mode: AppMode;
   appClosed: boolean;
-  showDeleteButton: boolean;
+  /**
+   * False only when there is only one cell in the notebook.
+   */
+  canDelete: boolean;
   /**
    * If true, the cell is allowed to be focus on.
    * This is false when the app is initially loading.
@@ -144,7 +147,7 @@ const CellComponent = (
     mode,
     debuggerActive,
     appClosed,
-    showDeleteButton,
+    canDelete,
     updateCellCode,
     prepareForRun,
     createNewCell,
@@ -345,6 +348,8 @@ const CellComponent = (
 
   const HTMLId = HTMLCellId.create(cellId);
 
+  const isCellCodeShown = !cellConfig.hide_code || temporarilyVisible;
+
   // Register hotkeys on the cell instead of the code editor
   // This is in case the code editor is hidden
   useHotkeysOnElement(editing ? cellRef.current : null, {
@@ -411,7 +416,7 @@ const CellComponent = (
     },
     // only register j/k movement if the cell is hidden, so as to not
     // interfere with editing
-    ...(userConfig.keymap.preset === "vim" && cellConfig.hide_code
+    ...(userConfig.keymap.preset === "vim" && isCellCodeShown
       ? {
           j: () => {
             moveToNextCell({ cellId, before: false, noCreate: true });
@@ -511,6 +516,7 @@ const CellComponent = (
               allowFocus={allowFocus}
               id={cellId}
               code={code}
+              config={cellConfig}
               status={status}
               serializedEditorState={serializedEditorState}
               runCell={handleRun}
@@ -524,7 +530,7 @@ const CellComponent = (
               clearSerializedEditorState={clearSerializedEditorState}
               userConfig={userConfig}
               editorViewRef={editorView}
-              hidden={cellConfig.hide_code && !temporarilyVisible}
+              hidden={!isCellCodeShown}
               setTemporarilyVisible={setTemporarilyVisible}
             />
             <div className="shoulder-right z-20">
@@ -544,7 +550,7 @@ const CellComponent = (
               </div>
             </div>
             <div className="shoulder-bottom hover-action">
-              {showDeleteButton ? (
+              {canDelete && isCellCodeShown && (
                 <DeleteButton
                   appClosed={appClosed}
                   status={status}
@@ -554,7 +560,7 @@ const CellComponent = (
                     }
                   }}
                 />
-              ) : null}
+              )}
             </div>
           </div>
           {userConfig.display.cell_output === "below" && outputArea}

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -40,7 +40,7 @@ import { useSplitCellCallback } from "../useSplitCell";
 
 export interface CellEditorProps
   extends Pick<CellRuntimeState, "status">,
-    Pick<CellData, "id" | "code" | "serializedEditorState">,
+    Pick<CellData, "id" | "code" | "serializedEditorState" | "config">,
     Pick<
       CellActions,
       | "updateCellCode"
@@ -62,6 +62,10 @@ export interface CellEditorProps
    */
   allowFocus: boolean;
   userConfig: UserConfig;
+  /**
+   * If true, the cell code is hidden.
+   * This is different from cellConfig.hide_code, since it may be temporarily shown.
+   */
   hidden?: boolean;
   /**
    * Not used by scratchpad.
@@ -74,6 +78,7 @@ const CellEditorInternal = ({
   showPlaceholder,
   allowFocus,
   id: cellId,
+  config: cellConfig,
   code,
   status,
   serializedEditorState,
@@ -137,7 +142,8 @@ const CellEditorInternal = ({
   );
 
   const toggleHideCode = useEvent(() => {
-    const nextHidden = !hidden;
+    // Use cellConfig.hide_code instead of hidden, since it may be temporarily shown
+    const nextHidden = !cellConfig.hide_code;
     // Fire-and-forget save
     void saveCellConfig({ configs: { [cellId]: { hide_code: nextHidden } } });
     updateCellConfig({ cellId, config: { hide_code: nextHidden } });

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -167,9 +167,7 @@ export const CellArray: React.FC<CellArrayProps> = ({
                             (cellData.lastExecutionTime as Milliseconds)
                           }
                           serializedEditorState={cellData.serializedEditorState}
-                          showDeleteButton={
-                            !hasOnlyOneCell && !cellData.config.hide_code
-                          }
+                          canDelete={!hasOnlyOneCell}
                           mode={mode}
                           appClosed={connStatus.state !== WebSocketState.OPEN}
                           ref={notebook.cellHandles[cellId]}

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -37,6 +37,12 @@ import {
 } from "./scratchpad-history";
 import AnyLanguageCodeMirror from "@/plugins/impl/code/any-language-editor";
 import { cn } from "@/utils/cn";
+import type { CellConfig } from "@/core/network/types";
+
+const scratchpadCellConfig: CellConfig = {
+  hide_code: false,
+  disabled: false,
+};
 
 export const ScratchPad: React.FC = () => {
   const notebookState = useNotebook();
@@ -124,6 +130,7 @@ export const ScratchPad: React.FC = () => {
             showPlaceholder={false}
             id={cellId}
             code={code}
+            config={scratchpadCellConfig}
             status="idle"
             serializedEditorState={null}
             runCell={handleRun}

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -37,7 +37,7 @@ const props: CellProps = {
   mode: "edit",
   name: "cell_1",
   appClosed: false,
-  showDeleteButton: true,
+  canDelete: true,
   allowFocus: false,
   debuggerActive: false,
   isCollapsed: false,


### PR DESCRIPTION
Fixes 2 subtle bugs: 
- allow deleting a cell when hidden, but temporarily shown
- allow un-hiding a cell when hidden, but temporarily shown