### PR TITLE
Add `Groq` for `mo.ui.chat`

### DIFF
--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -207,6 +207,13 @@ mo.ui.chat(
 )
 ```
 
+```{eval-rst}
+.. autoclass:: marimo.ai.llm.google
+  :members:
+
+  .. autoclasstoc:: marimo._plugins.ui._impl.chat.llm.google
+```
+
 ## Types
 
 Chatbots can be implemented with a function that receives a list of

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -214,6 +214,28 @@ mo.ui.chat(
   .. autoclasstoc:: marimo._plugins.ui._impl.chat.llm.google
 ```
 
+### Groq
+
+```python
+import marimo as mo
+
+mo.ui.chat(
+    mo.ai.llm.groq(
+        "llama-3.1-70b-versatile",
+        system_message="You are a helpful assistant.",
+        api_key="gsk-...",
+    ),
+    show_configuration_controls=True
+)
+```
+
+```{eval-rst}
+.. autoclass:: marimo.ai.llm.groq
+  :members:
+
+  .. autoclasstoc:: marimo._plugins.ui._impl.chat.llm.groq
+```
+
 ## Types
 
 Chatbots can be implemented with a function that receives a list of

--- a/examples/ai/chat/anthropic_example.py
+++ b/examples/ai/chat/anthropic_example.py
@@ -75,7 +75,7 @@ def __(key, mo):
 
 @app.cell
 def __(mo):
-    mo.md("""Access the chatbot's historical messages with `chatbot.value`.""")
+    mo.md("""Access the chatbot's historical messages with [`chatbot.value`](https://docs.marimo.io/api/inputs/chat.html#accessing-chat-history).""")
     return
 
 

--- a/examples/ai/chat/gemini.py
+++ b/examples/ai/chat/gemini.py
@@ -71,7 +71,7 @@ def __(key, mo):
 
 @app.cell(hide_code=True)
 def __(mo):
-    mo.md("""Access the chatbot's historical messages with `chatbot.value`.""")
+    mo.md("""Access the chatbot's historical messages with [`chatbot.value`](https://docs.marimo.io/api/inputs/chat.html#accessing-chat-history).""")
     return
 
 

--- a/examples/ai/chat/groq-example.py
+++ b/examples/ai/chat/groq-example.py
@@ -1,0 +1,104 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "groq==0.11.0",
+#     "anthropic==0.37.1",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.9.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def __(mo):
+    mo.md(
+        r"""
+        # Using Groq
+
+        This example shows how to use [`mo.ui.chat`](https://docs.marimo.io/api/inputs/chat.html#marimo.ui.chat) to make a chatbot backed by [Groq](https://groq.com/).
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def __(mo):
+    # Hyperlinking the groq as it is mentioned here - https://console.groq.com/docs/badge
+    mo.md(
+        r"""
+        <a href="https://groq.com" target="_blank" rel="noopener noreferrer">
+          <img
+            src="https://groq.com/wp-content/uploads/2024/03/PBG-mark1-color.svg"
+            alt="Powered by Groq for fast inference."
+            width="80" height="800"
+          />
+        </a>
+        """
+    ).right()
+    return
+
+
+@app.cell
+def __(mo):
+    import os
+
+    os_key = os.environ.get("GROQ_AI_API_KEY")
+    input_key = mo.ui.text(label="Groq AI API key", kind="password")
+    input_key if not os_key else None
+    return input_key, os, os_key
+
+
+@app.cell
+def __(input_key, mo, os_key):
+    key = os_key or input_key.value
+
+    mo.stop(
+        not key,
+        mo.md("Please provide your Groq AI API key in the input field."),
+    )
+    return (key,)
+
+
+@app.cell
+def __(key, mo):
+    chatbot = mo.ui.chat(
+       mo.ai.llm.groq(
+           model="llama-3.1-70b-versatile",
+           system_message="You are a helpful assistant.",
+           api_key=key,
+       ),
+        prompts=[
+            "Hello",
+            "How are you?",
+            "I'm doing great, how about you?",
+        ],
+    )
+    chatbot
+    return (chatbot,)
+
+
+@app.cell(hide_code=True)
+def __(mo):
+    mo.md("""Access the chatbot's historical messages with [`chatbot.value`](https://docs.marimo.io/api/inputs/chat.html#accessing-chat-history).""")
+    return
+
+
+@app.cell
+def __(chatbot):
+    # chatbot.value is the list of chat messages
+    chatbot.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/ai/chat/openai_example.py
+++ b/examples/ai/chat/openai_example.py
@@ -74,7 +74,7 @@ def __(mo, openai_key):
 
 @app.cell
 def __(mo):
-    mo.md("""Access the chatbot's historical messages with `chatbot.value`.""")
+    mo.md("""Access the chatbot's historical messages with [`chatbot.value`](https://docs.marimo.io/api/inputs/chat.html#accessing-chat-history).""")
     return
 
 

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -165,6 +165,7 @@ class DependencyManager:
     opentelemetry = Dependency("opentelemetry")
     anthropic = Dependency("anthropic")
     google_ai = Dependency("google.generativeai")
+    groq = Dependency("groq")
     panel = Dependency("panel")
 
     @staticmethod

--- a/marimo/_plugins/ui/_impl/chat/convert.py
+++ b/marimo/_plugins/ui/_impl/chat/convert.py
@@ -82,6 +82,32 @@ def convert_to_anthropic_messages(
     return anthropic_messages
 
 
+def convert_to_groq_messages(
+    messages: List[ChatMessage],
+) -> List[Dict[Any, Any]]:
+    groq_messages: List[Dict[Any, Any]] = []
+
+    for message in messages:
+        # Currently only supports text content
+        if message.attachments:
+            # Convert attachments to text if possible
+            text_content = message.content
+            for attachment in message.attachments:
+                content_type = attachment.content_type or "text/plain"
+                if content_type.startswith("text"):
+                    text_content += "\n" + _extract_text(attachment.url)
+
+            groq_messages.append(
+                {"role": message.role, "content": text_content}
+            )
+        else:
+            groq_messages.append(
+                {"role": message.role, "content": message.content}
+            )
+
+    return groq_messages
+
+
 # Matches from google.generativeai.types import content_types
 class BlobDict(TypedDict):
     mime_type: str

--- a/marimo/_plugins/ui/_impl/chat/convert.py
+++ b/marimo/_plugins/ui/_impl/chat/convert.py
@@ -88,10 +88,11 @@ def convert_to_groq_messages(
     groq_messages: List[Dict[Any, Any]] = []
 
     for message in messages:
-        # Currently only supports text content
+        # Currently only supports text content (Llava is deprecated now)
+        # See here - https://console.groq.com/docs/deprecations
         if message.attachments:
             # Convert attachments to text if possible
-            text_content = message.content
+            text_content = str(message.content)  # Explicitly convert to string
             for attachment in message.attachments:
                 content_type = attachment.content_type or "text/plain"
                 if content_type.startswith("text"):
@@ -102,7 +103,12 @@ def convert_to_groq_messages(
             )
         else:
             groq_messages.append(
-                {"role": message.role, "content": message.content}
+                {
+                    "role": message.role,
+                    "content": str(
+                        message.content
+                    ),  # Explicitly convert to string
+                }
             )
 
     return groq_messages

--- a/marimo/_plugins/ui/_impl/chat/llm.py
+++ b/marimo/_plugins/ui/_impl/chat/llm.py
@@ -351,15 +351,16 @@ class groq(ChatModel):
         if env_key is not None:
             return env_key
 
-        # Then check the user's config
-        try:
-            from marimo._runtime.context.types import get_context
-
-            api_key = get_context().user_config["ai"]["groq"]["api_key"]
-            if api_key:
-                return api_key
-        except Exception:
-            pass
+        # TODO(haleshot): Add config support later
+        # # Then check the user's config
+        # try:
+        #     from marimo._runtime.context.types import get_context
+        #
+        #     api_key = get_context().user_config["ai"]["groq"]["api_key"]
+        #     if api_key:
+        #         return api_key
+        # except Exception:
+        #     pass
 
         raise ValueError(
             "groq api key not provided. Pass it as an argument or "

--- a/marimo/_plugins/ui/_impl/chat/llm.py
+++ b/marimo/_plugins/ui/_impl/chat/llm.py
@@ -140,6 +140,7 @@ class anthropic(ChatModel):
     **Args:**
 
     - model: The model to use.
+        Can be found on the [Anthropic models page](https://docs.anthropic.com/en/docs/about-claude/models)
     - system_message: The system message to use
     - api_key: The API key to use.
         If not provided, the API key will be retrieved
@@ -237,6 +238,7 @@ class google(ChatModel):
     **Args:**
 
     - model: The model to use.
+        Can be found on the [Gemini models page](https://ai.google.dev/gemini-api/docs/models/gemini)
     - system_message: The system message to use
     - api_key: The API key to use.
         If not provided, the API key will be retrieved

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -53,7 +53,7 @@ def get_openai_client(config: MarimoConfig) -> "OpenAI":
     except ImportError:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
-            detail="OpenAI not installed. Run `pip install openai`",
+            detail="OpenAI not installed. Add 'openai' using the package installer in the sidebar.",
         ) from None
 
     if "ai" not in config:
@@ -91,7 +91,7 @@ def get_anthropic_client(config: MarimoConfig) -> "Client":
     except ImportError:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
-            detail="Anthropic not installed. Run `pip install anthropic`",
+            detail="Anthropic not installed. Add 'anthropic' using the package installer in the sidebar.",
         ) from None
 
     if "ai" not in config:
@@ -217,7 +217,7 @@ def get_google_client(config: MarimoConfig, model: str) -> "GenerativeModel":
             status_code=HTTPStatus.BAD_REQUEST,
             detail=(
                 "Google AI not installed. "
-                "Run `pip install google-generativeai`"
+                "Add 'google-generativeai' using the package installer in the sidebar."
             ),
         ) from None
 

--- a/marimo/_smoke_tests/chat/chatbot.py
+++ b/marimo/_smoke_tests/chat/chatbot.py
@@ -11,17 +11,23 @@
 
 import marimo
 
-__generated_with = "0.8.20"
+__generated_with = "0.9.14"
 app = marimo.App(width="medium")
 
 
-@app.cell
+@app.cell(hide_code=True)
+def __():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
 def __(mo):
     mo.md(r"""# Built-in chatbots""")
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md(r"""## OpenAI""")
     return
@@ -43,7 +49,7 @@ def __(mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md(r"""## Anthropic""")
     return
@@ -63,13 +69,27 @@ def __(mo):
     return
 
 
-@app.cell
-def __():
-    import marimo as mo
-    return (mo,)
+@app.cell(hide_code=True)
+def __(mo):
+    mo.md(r"""## Google Gemini""")
+    return
 
 
 @app.cell
+def __(mo):
+    mo.ui.chat(
+        mo.ai.llm.google("gemini-1.5-pro-001"),
+        show_configuration_controls=True,
+        prompts=[
+            "Tell me a joke",
+            "What is the meaning of life?",
+            "What is 2 + {{number}}",
+        ],
+    )
+    return
+
+
+@app.cell(hide_code=True)
 def __(mo):
     mo.md(r"""# Custom chatbots""")
     return
@@ -107,7 +127,7 @@ def __(mo, openai_key):
     return client, ell, openai
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md(r"""## Simple""")
     return
@@ -125,7 +145,7 @@ def __(client, ell, mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def __(mo):
     mo.md(r"""## Complex""")
     return

--- a/tests/_plugins/ui/_impl/chat/test_chat_convert.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat_convert.py
@@ -142,14 +142,34 @@ def test_convert_to_groq_messages(sample_messages: List[ChatMessage]):
 
     # Check user message
     assert result[0]["role"] == "user"
-    assert result[0]["content"] == "Hello, I have a question."
+    assert len(result[0]["content"]) == 3
+    assert result[0]["content"][0] == {
+        "type": "text",
+        "text": "Hello, I have a question.",
+    }
+
+    # Commenting out the following till multi-modal models
+    # are added to groq models to test them
+    # assert result[0]["content"][1] == {
+    #     "type": "image",
+    #     "source": {
+    #         "data": "b'aGVsbG8='",
+    #         "media_type": "image/png",
+    #         "type": "base64",
+    #     },
+    # }
+    assert result[0]["content"][2] == {
+        "type": "text",
+        "text": "A\n1\n2\n3\n",
+    }
 
     # Check assistant message
     assert result[1]["role"] == "assistant"
-    assert (
-        result[1]["content"]
-        == "Sure, I'd be happy to help. What's your question?"
-    )
+    assert len(result[1]["content"]) == 1
+    assert result[1]["content"][0] == {
+        "type": "text",
+        "text": "Sure, I'd be happy to help. What's your question?",
+    }
 
 
 def test_empty_messages():

--- a/tests/_plugins/ui/_impl/chat/test_chat_convert.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat_convert.py
@@ -8,6 +8,7 @@ import pytest
 from marimo._plugins.ui._impl.chat.convert import (
     convert_to_anthropic_messages,
     convert_to_google_messages,
+    convert_to_groq_messages,
     convert_to_openai_messages,
 )
 from marimo._plugins.ui._impl.chat.types import (
@@ -134,11 +135,42 @@ def test_convert_to_google_messages(sample_messages: List[ChatMessage]):
     ]
 
 
+def test_convert_to_groq_messages(sample_messages: List[ChatMessage]):
+    result = convert_to_groq_messages(sample_messages)
+
+    assert len(result) == 2
+
+    # Check user message
+    assert result[0]["role"] == "user"
+    assert len(result[0]["content"]) == 3
+    assert result[0]["content"][0] == {
+        "type": "text",
+        "text": "Hello, I have a question.",
+    }
+    assert result[0]["content"][1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,b'aGVsbG8='"},
+    }
+    assert result[0]["content"][2] == {
+        "type": "text",
+        "text": "A\n1\n2\n3\n",
+    }
+
+    # Check assistant message
+    assert result[1]["role"] == "assistant"
+    assert len(result[1]["content"]) == 1
+    assert result[1]["content"][0] == {
+        "type": "text",
+        "text": "Sure, I'd be happy to help. What's your question?",
+    }
+
+
 def test_empty_messages():
     empty_messages = []
     assert convert_to_openai_messages(empty_messages) == []
     assert convert_to_anthropic_messages(empty_messages) == []
     assert convert_to_google_messages(empty_messages) == []
+    assert convert_to_groq_messages(empty_messages) == []
 
 
 def test_message_without_attachments():
@@ -170,6 +202,15 @@ def test_message_without_attachments():
     assert len(google_result) == 1
     assert google_result[0]["role"] == "user"
     assert google_result[0]["parts"] == ["Just a simple message"]
+
+    groq_result = convert_to_groq_messages(messages)
+    assert len(groq_result) == 1
+    assert groq_result[0]["role"] == "user"
+    assert len(groq_result[0]["content"]) == 1
+    assert groq_result[0]["content"][0] == {
+        "type": "text",
+        "text": "Just a simple message",
+    }
 
 
 def test_from_chat_message_dict():

--- a/tests/_plugins/ui/_impl/chat/test_chat_convert.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat_convert.py
@@ -140,36 +140,16 @@ def test_convert_to_groq_messages(sample_messages: List[ChatMessage]):
 
     assert len(result) == 2
 
-    # Check user message
+    # Check user message with text attachment
     assert result[0]["role"] == "user"
-    assert len(result[0]["content"]) == 3
-    assert result[0]["content"][0] == {
-        "type": "text",
-        "text": "Hello, I have a question.",
-    }
-
-    # Commenting out the following till multi-modal models
-    # are added to groq models to test them
-    # assert result[0]["content"][1] == {
-    #     "type": "image",
-    #     "source": {
-    #         "data": "b'aGVsbG8='",
-    #         "media_type": "image/png",
-    #         "type": "base64",
-    #     },
-    # }
-    assert result[0]["content"][2] == {
-        "type": "text",
-        "text": "A\n1\n2\n3\n",
-    }
+    assert result[0]["content"] == "Hello, I have a question.\nA\n1\n2\n3\n"
 
     # Check assistant message
     assert result[1]["role"] == "assistant"
-    assert len(result[1]["content"]) == 1
-    assert result[1]["content"][0] == {
-        "type": "text",
-        "text": "Sure, I'd be happy to help. What's your question?",
-    }
+    assert (
+        result[1]["content"]
+        == "Sure, I'd be happy to help. What's your question?"
+    )
 
 
 def test_empty_messages():

--- a/tests/_plugins/ui/_impl/chat/test_chat_convert.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat_convert.py
@@ -142,27 +142,14 @@ def test_convert_to_groq_messages(sample_messages: List[ChatMessage]):
 
     # Check user message
     assert result[0]["role"] == "user"
-    assert len(result[0]["content"]) == 3
-    assert result[0]["content"][0] == {
-        "type": "text",
-        "text": "Hello, I have a question.",
-    }
-    assert result[0]["content"][1] == {
-        "type": "image_url",
-        "image_url": {"url": "data:image/png;base64,b'aGVsbG8='"},
-    }
-    assert result[0]["content"][2] == {
-        "type": "text",
-        "text": "A\n1\n2\n3\n",
-    }
+    assert result[0]["content"] == "Hello, I have a question."
 
     # Check assistant message
     assert result[1]["role"] == "assistant"
-    assert len(result[1]["content"]) == 1
-    assert result[1]["content"][0] == {
-        "type": "text",
-        "text": "Sure, I'd be happy to help. What's your question?",
-    }
+    assert (
+        result[1]["content"]
+        == "Sure, I'd be happy to help. What's your question?"
+    )
 
 
 def test_empty_messages():

--- a/tests/_plugins/ui/_impl/chat/test_chat_convert.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat_convert.py
@@ -193,11 +193,7 @@ def test_message_without_attachments():
     groq_result = convert_to_groq_messages(messages)
     assert len(groq_result) == 1
     assert groq_result[0]["role"] == "user"
-    assert len(groq_result[0]["content"]) == 1
-    assert groq_result[0]["content"][0] == {
-        "type": "text",
-        "text": "Just a simple message",
-    }
+    assert groq_result[0]["content"] == "Just a simple message"
 
 
 def test_from_chat_message_dict():


### PR DESCRIPTION
## 📝 Summary

Adding `GROQ` in `mo.ai.llm` inside [`mo.ui.chat`](https://docs.marimo.io/api/inputs/chat.html#chat) integration to extend Marimo's AI capabilities alongside existing support for OpenAI, Gemini, and Anthropic. This addition introduces GROQ support for AI completions and chat interactions. Also fixes a documentation display issue for the `iframe` function.

## 🔍 Description of Changes

### GROQ API Integration
1. **Implementation**: Added `groq` as a model option in `marimo/_plugins/ui/_impl/chat/llm.py`.
2. **Documentation**: Minor docs touchups.
3. **Examples**: Created a GROQ chatbot example in `examples/ai/chat`.

### Additional Context
Reference PR includes [#2398](https://github.com/marimo-team/marimo/pull/2479) and issue includes https://github.com/marimo-team/marimo/issues/2505.

### Issues Encountered
Encountering `AttributeError` when testing GROQ in `examples/ai/chat/groq-example.py`, despite successful autocomplete detection. Suggested by [@Myles](https://github.com/mscolnick) to avoid `--sandbox` for local dev tests.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, this was discussed/approved via [community discussions](https://github.com/marimo-team/marimo/discussions) or Discord.
- [x] Added tests for new functionality.
- [x] Verified functionality locally.

## 📜 Reviewers

@akshayka, @mscolnick