### PR TITLE
fix: table selection when being cleared

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -267,26 +267,32 @@ export const LoadingDataTableComponent = memo(
       }
 
       // If we have sort/search/filter, use the search function
-      if (!shouldSkipSearch) {
-        const searchResults = await search<T>({
-          sort:
-            sorting.length > 0
-              ? {
-                  by: sorting[0].id,
-                  descending: sorting[0].desc,
-                }
-              : undefined,
-          query: searchQuery,
-          page_number: paginationState.pageIndex,
-          page_size: paginationState.pageSize,
-          filters: filters.flatMap((filter) => {
-            return filterToFilterCondition(
-              filter.id,
-              filter.value as ColumnFilterValue,
-            );
-          }),
-        });
+      const searchResultsPromise = search<T>({
+        sort:
+          sorting.length > 0
+            ? {
+                by: sorting[0].id,
+                descending: sorting[0].desc,
+              }
+            : undefined,
+        query: searchQuery,
+        page_number: paginationState.pageIndex,
+        page_size: paginationState.pageSize,
+        filters: filters.flatMap((filter) => {
+          return filterToFilterCondition(
+            filter.id,
+            filter.value as ColumnFilterValue,
+          );
+        }),
+      });
 
+      if (shouldSkipSearch) {
+        // We still want to run the search,
+        // so the backend knows the current state for selection
+        // see https://github.com/marimo-team/marimo/issues/2756
+        void searchResultsPromise;
+      } else {
+        const searchResults = await searchResultsPromise;
         tableData = searchResults.data;
         totalRows = searchResults.total_rows;
       }

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -255,8 +255,9 @@ export const LoadingDataTableComponent = memo(
       let tableData = props.data;
       let totalRows = props.totalRows;
 
-      // First page and no search query
-      const shouldSkipSearch =
+      // If it is just the first page and no search query,
+      // we can show the initial page.
+      const canShowInitialPage =
         searchQuery === "" &&
         paginationState.pageIndex === 0 &&
         filters.length === 0 &&
@@ -286,7 +287,7 @@ export const LoadingDataTableComponent = memo(
         }),
       });
 
-      if (shouldSkipSearch) {
+      if (canShowInitialPage) {
         // We still want to run the search,
         // so the backend knows the current state for selection
         // see https://github.com/marimo-team/marimo/issues/2756


### PR DESCRIPTION
Fixes #2756

There is a subtle bug when clearing table sort/filter, we reverted back to the initial page but we did not tell the backend, so the was an inconsistency in state. This fixes it while still showing the initial state when possible.