### PR TITLE
docs: add community themes section to theming guide

### DIFF
--- a/docs/guides/configuration/theming.md
+++ b/docs/guides/configuration/theming.md
@@ -43,6 +43,17 @@ Here is an example of a custom CSS file that changes the font of the notebook:
 }
 ```
 
+## Community Themes
+
+The marimo community maintains a [library of custom themes](https://github.com/metaboulie/marimo-themes) that you can use in your notebooks. The library includes various themes like "coldme", "nord", "mininini", and "wigwam", each supporting both light and dark modes.
+
+You can:
+- Browse and download existing themes
+- Use them in your own notebooks
+- Contribute your own themes to share with the community
+
+Visit the [marimo-themes repository](https://github.com/metaboulie/marimo-themes) to explore available themes and learn how to contribute your own.
+
 ## More customizations
 
 We want to hear from you! If you have any suggestions for more theming options, please let us know on [GitHub](https://github.com/marimo-team/marimo/discussions)


### PR DESCRIPTION
docs: add community themes section to theming guide

- Add new section highlighting the marimo-themes repository
- Inform users about available themes and contribution opportunities
- Include direct link to the community theme library
- List example themes like coldme, nord, mininini, and wigwam

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://discord.gg/JE7nhX6mD8), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!-- 
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
@akshayka OR @mscolnick
