### PR TITLE
Introducing marimo Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 <a href="https://discord.gg/JE7nhX6mD8"><img src="https://shields.io/discord/1059888774789730424" alt="discord" /></a>
 <a href="https://static.pepy.tech/badge/marimo"><img src="https://static.pepy.tech/badge/marimo" alt="downloads" /></a>
 <a href="https://github.com/marimo-team/marimo/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/marimo" /></a>
+<a href="https://gurubase.io/g/marimo"><img src="https://img.shields.io/badge/Gurubase-Ask%20marimo%20Guru-006BFF" alt="Gurubase" /></a>
 </p>
 
 **marimo** is a reactive Python notebook: run a cell or interact with a UI


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [marimo Guru](https://gurubase.io/g/marimo) to Gurubase. marimo Guru uses the data from this repo and data from the [docs](https://docs.marimo.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "marimo Guru", which highlights that marimo now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable marimo Guru in Gurubase, just let me know that's totally fine.
