### PR TITLE
fix: table pagination for next page

### DIFF
--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import base64
 import io
 from typing import Union
@@ -171,3 +173,13 @@ def any_data(data: Union[str, bytes, io.BytesIO], ext: str) -> VirtualFile:
         return item.virtual_file
 
     raise ValueError(f"Unsupported data type: {type(data)}")
+
+
+# Format: data:mime_type;base64,data
+def from_data_uri(data: str) -> tuple[str, bytes]:
+    assert isinstance(data, str)
+    assert data.startswith("data:")
+    mime_type, data = data.split(",", 1)
+    # strip data: and ;base64
+    mime_type = mime_type.split(";")[0][5:]
+    return mime_type, base64.b64decode(data)

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -127,7 +127,7 @@ class NarwhalsTableManager(
             raise ValueError("Count must be a positive integer")
         if offset < 0:
             raise ValueError("Offset must be a non-negative integer")
-        return self.with_new_data(self.data[offset:count])
+        return self.with_new_data(self.data[offset : offset + count])
 
     def search(self, query: str) -> TableManager[Any]:
         query = query.lower()

--- a/tests/_plugins/ui/_impl/tables/test_narwhals.py
+++ b/tests/_plugins/ui/_impl/tables/test_narwhals.py
@@ -240,6 +240,24 @@ class TestNarwhalsTableManagerFactory(unittest.TestCase):
         expected_data = self.data.head(1)
         assert_frame_equal(limited_manager.data, expected_data)
 
+    def test_take(self) -> None:
+        assert self.manager.take(1, 0).data["A"].to_list() == [1]
+        assert self.manager.take(2, 0).data["A"].to_list() == [1, 2]
+        assert self.manager.take(2, 1).data["A"].to_list() == [2, 3]
+        assert self.manager.take(2, 2).data["A"].to_list() == [3]
+
+    def test_take_zero(self) -> None:
+        limited_manager = self.manager.take(0, 0)
+        assert limited_manager.data.is_empty()
+
+    def test_take_negative(self) -> None:
+        with pytest.raises(ValueError):
+            self.manager.take(-1, 0)
+
+    def test_take_negative_offset(self) -> None:
+        with pytest.raises(ValueError):
+            self.manager.take(1, -1)
+
     def test_take_out_of_bounds(self) -> None:
         # Too large of page
         assert len(self.manager.take(10, 0).data) == 3

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -318,6 +318,24 @@ class TestPandasTableManager(unittest.TestCase):
         expected_data = self.data.head(limit)
         assert_frame_equal(limited_manager.data, expected_data)
 
+    def test_take(self) -> None:
+        assert self.manager.take(1, 0).data["A"].to_list() == [1]
+        assert self.manager.take(2, 0).data["A"].to_list() == [1, 2]
+        assert self.manager.take(2, 1).data["A"].to_list() == [2, 3]
+        assert self.manager.take(2, 2).data["A"].to_list() == [3]
+
+    def test_take_zero(self) -> None:
+        limited_manager = self.manager.take(0, 0)
+        assert limited_manager.data.is_empty()
+
+    def test_take_negative(self) -> None:
+        with pytest.raises(ValueError):
+            self.manager.take(-1, 0)
+
+    def test_take_negative_offset(self) -> None:
+        with pytest.raises(ValueError):
+            self.manager.take(1, -1)
+
     def test_take_out_of_bounds(self) -> None:
         # Too large of page
         assert len(self.manager.take(10, 0).data) == 3

--- a/tests/_plugins/ui/_impl/tables/test_polars_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_polars_table.py
@@ -265,6 +265,24 @@ class TestPolarsTableManagerFactory(unittest.TestCase):
         assert "PolarsTableManager" in str(type(limited_manager))
         assert assert_frame_equal(limited_manager.data, expected_data)
 
+    def test_take(self) -> None:
+        assert self.manager.take(1, 0).data["A"].to_list() == [1]
+        assert self.manager.take(2, 0).data["A"].to_list() == [1, 2]
+        assert self.manager.take(2, 1).data["A"].to_list() == [2, 3]
+        assert self.manager.take(2, 2).data["A"].to_list() == [3]
+
+    def test_take_zero(self) -> None:
+        limited_manager = self.manager.take(0, 0)
+        assert limited_manager.data.is_empty()
+
+    def test_take_negative(self) -> None:
+        with pytest.raises(ValueError):
+            self.manager.take(-1, 0)
+
+    def test_take_negative_offset(self) -> None:
+        with pytest.raises(ValueError):
+            self.manager.take(1, -1)
+
     def test_take_out_of_bounds(self) -> None:
         # Too large of page
         assert len(self.manager.take(10, 0).data) == 3


### PR DESCRIPTION
Regression when moving to narwhals, pagination offset logic was incorrect. This fixes it and adds a test