### PR TITLE
fix: column summaries in wasm

### DIFF
--- a/frontend/src/components/data-table/__test__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__test__/__snapshots__/chart-spec-model.test.ts.snap
@@ -1,0 +1,307 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ColumnChartSpecModel > snapshot > array 1`] = `
+{
+  "background": "transparent",
+  "config": {
+    "axis": {
+      "domain": false,
+    },
+    "view": {
+      "stroke": "transparent",
+    },
+  },
+  "data": {
+    "values": [
+      "a",
+      "b",
+      "c",
+    ],
+  },
+  "encoding": {
+    "color": {
+      "condition": {
+        "test": "datum["bin_maxbins_10_a_range"] === "null"",
+        "value": "#cc4e00",
+      },
+      "value": "#027864",
+    },
+    "tooltip": [
+      {
+        "bin": true,
+        "field": "a",
+        "format": ".2f",
+        "title": "a",
+        "type": "nominal",
+      },
+      {
+        "aggregate": "count",
+        "format": ",d",
+        "title": "Count",
+        "type": "quantitative",
+      },
+    ],
+    "x": {
+      "axis": null,
+      "bin": true,
+      "field": "a",
+      "scale": {
+        "align": 0,
+        "paddingInner": 0,
+        "paddingOuter": {
+          "expr": "length(data('source_0')) == 2 ? 1 : length(data('source_0')) == 3 ? 0.5 : length(data('source_0')) == 4 ? 0 : 0",
+        },
+      },
+      "type": "nominal",
+    },
+    "y": {
+      "aggregate": "count",
+      "axis": null,
+      "scale": {
+        "type": "linear",
+      },
+      "type": "quantitative",
+    },
+  },
+  "height": 100,
+  "mark": {
+    "align": "right",
+    "color": "#027864",
+    "size": {
+      "expr": "min(28, 120 / length(data('source_0')) - 1)",
+    },
+    "type": "bar",
+  },
+}
+`;
+
+exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
+{
+  "background": "transparent",
+  "config": {
+    "axis": {
+      "domain": false,
+    },
+    "view": {
+      "stroke": "transparent",
+    },
+  },
+  "data": {
+    "values": [
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      },
+      {
+        "a": 4,
+        "b": 5,
+        "c": 6,
+      },
+    ],
+  },
+  "encoding": {
+    "color": {
+      "condition": {
+        "test": "datum["bin_maxbins_10_a_range"] === "null"",
+        "value": "#cc4e00",
+      },
+      "value": "#027864",
+    },
+    "tooltip": [
+      {
+        "bin": true,
+        "field": "a",
+        "format": ".2f",
+        "title": "a",
+        "type": "nominal",
+      },
+      {
+        "aggregate": "count",
+        "format": ",d",
+        "title": "Count",
+        "type": "quantitative",
+      },
+    ],
+    "x": {
+      "axis": null,
+      "bin": true,
+      "field": "a",
+      "scale": {
+        "align": 0,
+        "paddingInner": 0,
+        "paddingOuter": {
+          "expr": "length(data('data_0')) == 2 ? 1 : length(data('data_0')) == 3 ? 0.5 : length(data('data_0')) == 4 ? 0 : 0",
+        },
+      },
+      "type": "nominal",
+    },
+    "y": {
+      "aggregate": "count",
+      "axis": null,
+      "scale": {
+        "type": "linear",
+      },
+      "type": "quantitative",
+    },
+  },
+  "height": 100,
+  "mark": {
+    "align": "right",
+    "color": "#027864",
+    "size": {
+      "expr": "min(28, 120 / length(data('data_0')) - 1)",
+    },
+    "type": "bar",
+  },
+}
+`;
+
+exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
+{
+  "background": "transparent",
+  "config": {
+    "axis": {
+      "domain": false,
+    },
+    "view": {
+      "stroke": "transparent",
+    },
+  },
+  "data": {
+    "values": [
+      {
+        "a": 1,
+        "b": 2,
+        "c": 3,
+      },
+      {
+        "a": 4,
+        "b": 5,
+        "c": 6,
+      },
+    ],
+  },
+  "encoding": {
+    "color": {
+      "condition": {
+        "test": "datum["bin_maxbins_10_a_range"] === "null"",
+        "value": "#cc4e00",
+      },
+      "value": "#027864",
+    },
+    "tooltip": [
+      {
+        "bin": true,
+        "field": "a",
+        "format": ".2f",
+        "title": "a",
+        "type": "nominal",
+      },
+      {
+        "aggregate": "count",
+        "format": ",d",
+        "title": "Count",
+        "type": "quantitative",
+      },
+    ],
+    "x": {
+      "axis": null,
+      "bin": true,
+      "field": "a",
+      "scale": {
+        "align": 0,
+        "paddingInner": 0,
+        "paddingOuter": {
+          "expr": "length(data('data_0')) == 2 ? 1 : length(data('data_0')) == 3 ? 0.5 : length(data('data_0')) == 4 ? 0 : 0",
+        },
+      },
+      "type": "nominal",
+    },
+    "y": {
+      "aggregate": "count",
+      "axis": null,
+      "scale": {
+        "type": "linear",
+      },
+      "type": "quantitative",
+    },
+  },
+  "height": 100,
+  "mark": {
+    "align": "right",
+    "color": "#027864",
+    "size": {
+      "expr": "min(28, 120 / length(data('data_0')) - 1)",
+    },
+    "type": "bar",
+  },
+}
+`;
+
+exports[`ColumnChartSpecModel > snapshot > url data 1`] = `
+{
+  "background": "transparent",
+  "config": {
+    "axis": {
+      "domain": false,
+    },
+    "view": {
+      "stroke": "transparent",
+    },
+  },
+  "data": {
+    "values": [],
+  },
+  "encoding": {
+    "color": {
+      "condition": {
+        "test": "datum["bin_maxbins_10_date_range"] === "null"",
+        "value": "#cc4e00",
+      },
+      "value": "#027864",
+    },
+    "tooltip": [
+      {
+        "bin": true,
+        "field": "date",
+        "format": "%Y-%m-%d",
+        "title": "date",
+        "type": "temporal",
+      },
+      {
+        "aggregate": "count",
+        "format": ",d",
+        "title": "Count",
+        "type": "quantitative",
+      },
+    ],
+    "x": {
+      "axis": null,
+      "bin": true,
+      "field": "date",
+      "scale": {
+        "align": 0,
+        "paddingInner": 0,
+        "paddingOuter": {
+          "expr": "length(data('data_0')) == 2 ? 1 : length(data('data_0')) == 3 ? 0.5 : length(data('data_0')) == 4 ? 0 : 0",
+        },
+      },
+      "type": "temporal",
+    },
+    "y": {
+      "aggregate": "count",
+      "axis": null,
+      "type": "quantitative",
+    },
+  },
+  "height": 100,
+  "mark": {
+    "color": "#027864",
+    "type": "bar",
+    "width": {
+      "expr": "min(28, 120 / length(data('data_0')) - 1)",
+    },
+  },
+}
+`;

--- a/frontend/src/components/data-table/__test__/chart-spec-model.test.ts
+++ b/frontend/src/components/data-table/__test__/chart-spec-model.test.ts
@@ -91,4 +91,51 @@ describe("ColumnChartSpecModel", () => {
       "column\\.with\\[special\\:chars\\]",
     );
   });
+
+  describe("snapshot", () => {
+    const fieldTypes: FieldTypes = {
+      ...mockFieldTypes,
+      a: "number",
+    };
+
+    it("url data", () => {
+      const model = new ColumnChartSpecModel(
+        mockData,
+        fieldTypes,
+        mockSummaries,
+        { includeCharts: true },
+      );
+      expect(model.getHeaderSummary("date").spec).toMatchSnapshot();
+    });
+
+    it("csv data", () => {
+      const model = new ColumnChartSpecModel(
+        `data:text/csv;base64,${btoa("a,b,c\n1,2,3\n4,5,6")}`,
+        fieldTypes,
+        mockSummaries,
+        { includeCharts: true },
+      );
+      expect(model.getHeaderSummary("a").spec).toMatchSnapshot();
+    });
+
+    it("csv string", () => {
+      const model = new ColumnChartSpecModel(
+        "a,b,c\n1,2,3\n4,5,6",
+        fieldTypes,
+        mockSummaries,
+        { includeCharts: true },
+      );
+      expect(model.getHeaderSummary("a").spec).toMatchSnapshot();
+    });
+
+    it("array", () => {
+      const model = new ColumnChartSpecModel(
+        ["a", "b", "c"],
+        fieldTypes,
+        mockSummaries,
+        { includeCharts: true },
+      );
+      expect(model.getHeaderSummary("a").spec).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
Column summaries in wasm come in as data-uris. This handles that case and adds some snapshot tests to make sure we don't change it