### PR TITLE
fix: allow table selection in full screen

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -192,7 +192,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       collapsedSize={0}
       collapsible={true}
       className={cn(
-        "dark:bg-[var(--slate-1)] no-print print:hidden fullscreen:hidden",
+        "dark:bg-[var(--slate-1)] no-print print:hidden hide-on-fullscreen",
         isTerminalOpen && "border-[var(--slate-7)]",
       )}
       minSize={10}

--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -162,7 +162,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       collapsedSize={0}
       collapsible={true}
       className={cn(
-        "dark:bg-[var(--slate-1)] no-print print:hidden",
+        "dark:bg-[var(--slate-1)] no-print print:hidden hide-on-fullscreen",
         isSidebarOpen && "border-r border-l border-[var(--slate-7)]",
       )}
       minSize={10}
@@ -192,7 +192,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       collapsedSize={0}
       collapsible={true}
       className={cn(
-        "dark:bg-[var(--slate-1)] no-print print:hidden",
+        "dark:bg-[var(--slate-1)] no-print print:hidden fullscreen:hidden",
         isTerminalOpen && "border-[var(--slate-7)]",
       )}
       minSize={10}

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -48,7 +48,7 @@ export const Footer: React.FC = () => {
   });
 
   return (
-    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md pl-1 pr-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50 print:hidden">
+    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md pl-1 pr-4 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50 print:hidden hide-on-fullscreen">
       <FooterItem
         tooltip={errorPanel.tooltip}
         selected={selectedPanel === errorPanel.type}

--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -23,7 +23,7 @@ export const Sidebar: React.FC = () => {
   );
 
   return (
-    <div className="h-full pt-4 pb-1 px-1 flex flex-col items-start text-muted-foreground text-md select-none no-print text-sm z-50 dark:bg-background print:hidden">
+    <div className="h-full pt-4 pb-1 px-1 flex flex-col items-start text-muted-foreground text-md select-none no-print text-sm z-50 dark:bg-background print:hidden hide-on-fullscreen">
       {sidebarItems.map((p) => (
         <SidebarItem
           key={p.type}

--- a/frontend/src/css/common.css
+++ b/frontend/src/css/common.css
@@ -27,3 +27,8 @@
 .hover-actions-parent:has([data-state="open"]) .hover-action {
   display: inline-flex !important;
 }
+
+/* When any element is fullscreen, hide the element with this class */
+:root:has(:fullscreen) .hide-on-fullscreen {
+  display: none !important;
+}


### PR DESCRIPTION
This hides some elements that were causing click conflicts with the table when in fullscreen 

Fixes #1971 