### PR TITLE
docs: add quotation marks for marimo[sql] commands

### DIFF
--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -8,7 +8,7 @@ To create a SQL cell, you first need to install additional dependencies,
 including [duckdb](https://duckdb.org/):
 
 ```bash
-pip install marimo[sql]
+pip install 'marimo[sql]'
 ```
 
 ```{admonition} Examples

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -254,7 +254,7 @@ const AddCellButtons: React.FC<{
               <div className="flex flex-col">
                 <span>
                   Additional dependencies required:
-                  <Kbd className="inline">pip install marimo[sql]</Kbd>.
+                  <Kbd className="inline">pip install 'marimo[sql]'</Kbd>.
                 </span>
                 <span>
                   You will need to restart the notebook after installing.

--- a/marimo/_tutorials/sql.py
+++ b/marimo/_tutorials/sql.py
@@ -27,7 +27,7 @@ def __(mo):
         including [duckdb](https://duckdb.org/). Obtain these dependencies with
 
         ```bash
-        pip install marimo[sql]
+        pip install 'marimo[sql]'
         ```
         """
     )


### PR DESCRIPTION
## 📝 Summary

Add a quotation mark for the pip install command for `marimo[sql]`. I was confused why it didn't work when I ran this command. You would get a `zsh: no matches found` error by default.

This is just a small QoL improvement.
<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
