### PR TITLE
fix: drop index for data-explorer

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -83,7 +83,7 @@ const categories = [
     id: "labs",
     label: "Labs",
     Icon: FlaskConicalIcon,
-    className: "bg-[var(--yellow-4)]",
+    className: "bg-[var(--slate-4)]",
   },
 ] as const;
 

--- a/marimo/_plugins/ui/_impl/data_explorer.py
+++ b/marimo/_plugins/ui/_impl/data_explorer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable, Dict, Final, Optional
 
 import marimo._output.data.data as mo_data
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._plugins.ui._impl.tables.utils import get_table_manager
@@ -39,6 +40,8 @@ class data_explorer(UIElement[Dict[str, Any], Dict[str, Any]]):
         df: IntoDataFrame,
         on_change: Optional[Callable[[Dict[str, Any]], None]] = None,
     ) -> None:
+        # Drop the index since empty column names break the data explorer
+        df = _drop_index(df)
         self._data = df
 
         manager = get_table_manager(df)
@@ -55,3 +58,12 @@ class data_explorer(UIElement[Dict[str, Any], Dict[str, Any]]):
 
     def _convert_value(self, value: Dict[str, Any]) -> Dict[str, Any]:
         return value
+
+
+def _drop_index(df: IntoDataFrame) -> IntoDataFrame:
+    if DependencyManager.pandas.imported():
+        import pandas as pd
+
+        if isinstance(df, pd.DataFrame):
+            return df.reset_index(drop=True)
+    return df

--- a/tests/_plugins/ui/_impl/test_data_explorer.py
+++ b/tests/_plugins/ui/_impl/test_data_explorer.py
@@ -24,7 +24,7 @@ def test_data_explorer(df: Any) -> None:
 
 
 @pytest.mark.skipif(
-    not HAS_DEPS and is_windows(),
+    not HAS_DEPS or is_windows(),
     reason="optional dependencies not installed or windows",
 )
 def test_data_explorer_index() -> None:

--- a/tests/_plugins/ui/_impl/test_data_explorer.py
+++ b/tests/_plugins/ui/_impl/test_data_explorer.py
@@ -1,23 +1,49 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
+from marimo._output.data.data import from_data_uri
 from marimo._plugins.ui._impl import data_explorer
-from marimo._runtime.runtime import Kernel
+from marimo._utils.platform import is_windows
+from tests._data.mocks import create_dataframes
 
 HAS_DEPS = DependencyManager.pandas.has()
 
 
-@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
-def test_data_explorer(executing_kernel: Kernel) -> None:
-    # unused, except for the side effect of giving the kernel an execution
-    # context
-    del executing_kernel
+@pytest.mark.parametrize(
+    "df",
+    create_dataframes({"A": [1, 2, 3], "B": [4, 5, 6]}, exclude=["duckdb"]),
+)
+def test_data_explorer(df: Any) -> None:
+    explorer = data_explorer.data_explorer(df)
+    assert explorer
 
+
+@pytest.mark.skipif(
+    not HAS_DEPS and is_windows(),
+    reason="optional dependencies not installed or windows",
+)
+def test_data_explorer_index() -> None:
     import pandas as pd
 
-    data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    explorer = data_explorer.data_explorer(data)
-    assert explorer
+    # With index
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["a", "b", "c"])
+    explorer = data_explorer.data_explorer(df)
+    data = explorer._component_args["data"]
+    assert from_data_uri(data)[1] == b"A,B\n1,4\n2,5\n3,6\n"
+
+    # Reset index beforehand
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["a", "b", "c"])
+    explorer = data_explorer.data_explorer(df.reset_index(drop=False))
+    data = explorer._component_args["data"]
+    assert from_data_uri(data)[1] == b"index,A,B\na,1,4\nb,2,5\nc,3,6\n"
+
+    # No index
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    explorer = data_explorer.data_explorer(df)
+    data = explorer._component_args["data"]
+    assert from_data_uri(data)[1] == b"A,B\n1,4\n2,5\n3,6\n"


### PR DESCRIPTION
If the index is there, pandas will add an empty column name in the csv, which breaks the data-explorer. 