### PR TITLE
improvement: allow taking control of an existing session if in edit mode

### DIFF
--- a/frontend/src/components/editor/Disconnected.tsx
+++ b/frontend/src/components/editor/Disconnected.tsx
@@ -1,9 +1,42 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { API } from "@/core/network/api";
+import { Button } from "../ui/button";
+import { toast } from "../ui/use-toast";
+import { prettyError } from "@/utils/errors";
 
-export const Disconnected = (props: { reason: string }) => {
+interface DisconnectedProps {
+  reason: string;
+  canTakeover: boolean | undefined;
+}
+
+export const Disconnected = ({
+  reason,
+  canTakeover = false,
+}: DisconnectedProps) => {
+  const handleTakeover = async () => {
+    try {
+      const searchParams = new URL(window.location.href).searchParams;
+      await API.post(`/kernel/takeover?${searchParams.toString()}`, {});
+
+      // Refresh the page to reconnect
+      window.location.reload();
+    } catch (error) {
+      toast({
+        title: "Failed to take over session",
+        description: prettyError(error),
+        variant: "danger",
+      });
+    }
+  };
+
   return (
     <div id="Disconnected">
-      <p>{props.reason}</p>
+      <p>{reason}</p>
+      {canTakeover && (
+        <Button onClick={handleTakeover} variant="secondary" className="mt-2">
+          Take over session
+        </Button>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/editor/Disconnected.tsx
+++ b/frontend/src/components/editor/Disconnected.tsx
@@ -3,6 +3,7 @@ import { API } from "@/core/network/api";
 import { Button } from "../ui/button";
 import { toast } from "../ui/use-toast";
 import { prettyError } from "@/utils/errors";
+import { reloadSafe } from "@/utils/reload-safe";
 
 interface DisconnectedProps {
   reason: string;
@@ -19,7 +20,7 @@ export const Disconnected = ({
       await API.post(`/kernel/takeover?${searchParams.toString()}`, {});
 
       // Refresh the page to reconnect
-      window.location.reload();
+      reloadSafe();
     } catch (error) {
       toast({
         title: "Failed to take over session",

--- a/frontend/src/components/editor/actions/useRestartKernel.tsx
+++ b/frontend/src/components/editor/actions/useRestartKernel.tsx
@@ -4,6 +4,7 @@ import { AlertDialogDestructiveAction } from "@/components/ui/alert-dialog";
 import { connectionAtom } from "@/core/network/connection";
 import { sendRestart } from "@/core/network/requests";
 import { WebSocketState } from "@/core/websocket/types";
+import { reloadSafe } from "@/utils/reload-safe";
 import { useSetAtom } from "jotai";
 
 export function useRestartKernel() {
@@ -21,7 +22,7 @@ export function useRestartKernel() {
           onClick={async () => {
             setConnection({ state: WebSocketState.CLOSING });
             await sendRestart();
-            window.location.reload();
+            reloadSafe();
           }}
           aria-label="Confirm Restart"
         >

--- a/frontend/src/components/editor/header/app-header.tsx
+++ b/frontend/src/components/editor/header/app-header.tsx
@@ -17,7 +17,10 @@ export const AppHeader: React.FC<PropsWithChildren<Props>> = ({
     <div className={className}>
       {children}
       {connection.state === WebSocketState.CLOSED && (
-        <Disconnected reason={connection.reason} />
+        <Disconnected
+          reason={connection.reason}
+          canTakeover={connection.canTakeover}
+        />
       )}
     </div>
   );

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -1,4 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { reloadSafe } from "@/utils/reload-safe";
 import { API, marimoClient } from "./api";
 import type { RunRequests, EditRequests } from "./types";
 
@@ -167,7 +168,7 @@ export function createNetworkRequests(): EditRequests & RunRequests {
       await marimoClient
         .POST("/api/kernel/restart_session")
         .then(handleResponseReturnNull);
-      window.location.reload();
+      reloadSafe();
       return null;
     },
     getUsageStats: () => {

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -35,6 +35,7 @@ import { store } from "../state/jotai";
 import { notebookIsRunningAtom } from "../cells/cells";
 import { getInitialAppMode, initialMode } from "../mode";
 import { wasmInitializationAtom } from "./state";
+import { reloadSafe } from "@/utils/reload-safe";
 
 type SaveWorker = ReturnType<
   typeof getWorkerRPC<SaveWorkerSchema>
@@ -310,7 +311,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
       notebookFileStore.saveFile(code.contents);
       fallbackFileStore.saveFile(code.contents);
     }
-    window.location.reload();
+    reloadSafe();
     return null;
   };
 

--- a/frontend/src/core/websocket/types.ts
+++ b/frontend/src/core/websocket/types.ts
@@ -23,6 +23,11 @@ export type ConnectionStatus =
        * Human-readable reason for closing the connection.
        */
       reason: string;
+      /**
+       * Whether the current session can be taken over by another session,
+       * since we only allow single-user editing.
+       */
+      canTakeover?: boolean;
     }
   | {
       state:

--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -253,6 +253,7 @@ export function useMarimoWebSocket(opts: {
             state: WebSocketState.CLOSED,
             code: WebSocketClosedReason.ALREADY_RUNNING,
             reason: "another browser tab is already connected to the kernel",
+            canTakeover: true,
           });
           ws.close(); // close to prevent reconnecting
           return;

--- a/frontend/src/core/websocket/useMarimoWebSocket.tsx
+++ b/frontend/src/core/websocket/useMarimoWebSocket.tsx
@@ -39,6 +39,7 @@ import { kioskModeAtom } from "../mode";
 import { focusAndScrollCellOutputIntoView } from "../cells/scrollCellIntoView";
 import { capabilitiesAtom } from "../config/capabilities";
 import { UI_ELEMENT_REGISTRY } from "../dom/uiregistry";
+import { reloadSafe } from "@/utils/reload-safe";
 
 /**
  * WebSocket that connects to the Marimo kernel and handles incoming messages.
@@ -69,7 +70,7 @@ export function useMarimoWebSocket(opts: {
     const msg = jsonParseWithSpecialChar(e.data);
     switch (msg.op) {
       case "reload":
-        window.location.reload();
+        reloadSafe();
         return;
       case "kernel-ready":
         handleKernelReady(msg.data, {

--- a/frontend/src/utils/reload-safe.ts
+++ b/frontend/src/utils/reload-safe.ts
@@ -1,0 +1,15 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { toast } from "@/components/ui/use-toast";
+import { Logger } from "./Logger";
+
+export function reloadSafe() {
+  try {
+    window.location.reload();
+  } catch (error) {
+    Logger.error("Failed to reload page", error);
+    toast({
+      title: "Failed to reload page",
+      description: "Please refresh the page manually.",
+    });
+  }
+}

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -1,18 +1,23 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Optional
 from uuid import uuid4
 
 from starlette.authentication import requires
+from starlette.responses import JSONResponse
 
 from marimo import _loggers
+from marimo._messaging.ops import Alert
 from marimo._runtime.requests import (
     FunctionCallRequest,
     SetUIElementValueRequest,
 )
 from marimo._server.api.deps import AppState
+from marimo._server.api.endpoints.ws import FILE_QUERY_PARAM_KEY
 from marimo._server.api.utils import parse_request
+from marimo._server.file_router import MarimoFileKey
 from marimo._server.models.models import (
     BaseResponse,
     InstantiateRequest,
@@ -261,3 +266,52 @@ async def shutdown(
         shutdown_server()
 
     return SuccessResponse()
+
+
+@router.post("/takeover")
+@requires("edit")
+async def takeover_endpoint(
+    *,
+    request: Request,
+) -> JSONResponse:
+    """Force close any existing sessions for the current file.
+
+    responses:
+        200:
+            description: Successfully closed existing sessions
+        403:
+            description: Not allowed to take over in this mode
+    """
+    app_state = AppState(request)
+
+    file_key: Optional[MarimoFileKey] = (
+        app_state.query_params(FILE_QUERY_PARAM_KEY)
+        or app_state.session_manager.file_router.get_unique_file_key()
+    )
+    if file_key is None:
+        LOGGER.error("No file key provided")
+        return JSONResponse(
+            status_code=400,
+            content={"error": "Cannot take over session."},
+        )
+
+    # Find and close any existing sessions for this file
+    existing_session = app_state.session_manager.get_session_by_file_key(
+        file_key
+    )
+    if existing_session is not None:
+        # Send a disconnect message to the client
+        existing_session.write_operation(
+            Alert(
+                title="Session taken over",
+                description="Another user has taken over this session.",
+                variant="danger",
+            )
+        )
+        # Wait 100ms to ensure the client has received the message
+        await asyncio.sleep(0.1)
+        existing_session.maybe_disconnect_consumer()
+    else:
+        LOGGER.warning("No existing session found for file key %s", file_key)
+
+    return JSONResponse(status_code=200, content={"status": "ok"})

--- a/tests/_server/api/endpoints/test_execution.py
+++ b/tests/_server/api/endpoints/test_execution.py
@@ -116,6 +116,28 @@ class TestExecutionRoutes_EditMode:
         assert response.headers["content-type"] == "application/json"
         assert "success" in response.json()
 
+    @staticmethod
+    @with_session(SESSION_ID)
+    def test_takeover_no_file_key(client: TestClient) -> None:
+        response = client.post(
+            "/api/kernel/takeover",
+            headers=HEADERS,
+        )
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"] == "application/json"
+        assert response.json()["status"] == "ok"
+
+    @staticmethod
+    @with_session(SESSION_ID)
+    def test_takeover_file_key(client: TestClient) -> None:
+        response = client.post(
+            "/api/kernel/takeover?file=test.py",
+            headers=HEADERS,
+        )
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"] == "application/json"
+        assert response.json()["status"] == "ok"
+
 
 class TestExecutionRoutes_RunMode:
     @staticmethod
@@ -198,4 +220,10 @@ class TestExecutionRoutes_RunMode:
             headers=HEADERS,
             json={"code": "print('Hello, scratchpad')"},
         )
+        assert response.status_code == 401, response.text
+
+    @staticmethod
+    @with_read_session(SESSION_ID)
+    def test_takeover_no_file_key(client: TestClient) -> None:
+        response = client.post("/api/kernel/takeover", headers=HEADERS)
         assert response.status_code == 401, response.text


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/603e836b-30b9-4b26-81ba-214d712d03ab)

This will disconnect the other session and refresh your page (and resume where the other session left off). This should also help with vscode connections that sometimes seem to hold onto websocket connections even though the vscode browser was closed.