### PR TITLE
docs: add integer-only example for number input

### DIFF
--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -57,6 +57,12 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     number = mo.ui.number(start=1, stop=10, step=2)
     ```
 
+    Or for integer-only values:
+
+    ```python
+    number = mo.ui.number(step=1)
+    ```
+
     Or from a dataframe series:
 
     ```python


### PR DESCRIPTION
## 📝 Summary

Add documentation example showing how to create a number input that only accepts integer values using `step=1` parameter.


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
