### PR TITLE
feat: add keyboard shortcut to buttons

### DIFF
--- a/frontend/e2e-tests/py/components.py
+++ b/frontend/e2e-tests/py/components.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.5.2"
+__generated_with = "0.9.15"
 app = marimo.App()
 
 
@@ -14,7 +14,7 @@ def __(mo):
 def __(basic_ui_elements, mo):
     mo.md(
         f"""### Basic elements
-
+                                    
         {basic_ui_elements}
         """
     )
@@ -25,7 +25,7 @@ def __(basic_ui_elements, mo):
 def __(basic_ui_elements, construct_element, show_element):
     selected_element = construct_element(basic_ui_elements.value)
     show_element(selected_element)
-    return selected_element,
+    return (selected_element,)
 
 
 @app.cell
@@ -49,7 +49,7 @@ def __(composite_elements, mo):
 def __(composite_elements, construct_element, show_element):
     composite_element = construct_element(composite_elements.value)
     show_element(composite_element)
-    return composite_element,
+    return (composite_element,)
 
 
 @app.cell
@@ -70,7 +70,7 @@ def __(mo):
             'reused-in-json': 'reused-in-json',
         }.items())),
     )
-    return composite_elements,
+    return (composite_elements,)
 
 
 @app.cell
@@ -117,7 +117,7 @@ def __(file_area, file_button, mo):
             ).batch(name=mo.ui.text(), date=mo.ui.date())
         elif value == mo.ui.button:
             return mo.ui.button(
-                value=0, label="click me", on_click=lambda value: value + 1
+                value=0, label="click me", on_click=lambda value: value + 1, keyboard_shortcut="Cmd-l"
             )
         elif value == mo.ui.checkbox:
             return mo.ui.checkbox(label="check me")
@@ -181,7 +181,7 @@ def __(file_area, file_button, mo):
         elif value == mo.ui.text_area:
             return mo.ui.text_area()
         return None
-    return construct_element,
+    return (construct_element,)
 
 
 @app.cell
@@ -189,7 +189,7 @@ def __(mo):
     def show_element(element):
         if element is not None:
           return mo.hstack([element], justify="center")
-    return show_element,
+    return (show_element,)
 
 
 @app.cell
@@ -213,13 +213,13 @@ def __(mo):
                 The element's current value is {printed_value}
                 """
             )
-    return value,
+    return (value,)
 
 
 @app.cell
 def __():
     import marimo as mo
-    return mo,
+    return (mo,)
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps, cva } from "class-variance-authority";
 
 import { cn } from "@/utils/cn";
-import { isShortcutPressed } from "@/core/hotkeys/shortcuts";
+import { parseShortcut } from "@/core/hotkeys/shortcuts";
 import { useEventListener } from "@/hooks/useEventListener";
 
 const activeCommon = "active:shadow-xsSolid";
@@ -113,7 +113,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         if (!keyboardShortcut) {
           return;
         }
-        if (isShortcutPressed(keyboardShortcut, e)) {
+        if (parseShortcut(keyboardShortcut)(e)) {
           e.preventDefault();
           e.stopPropagation();
           if (buttonRef?.current && !buttonRef.current.disabled) {

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps, cva } from "class-variance-authority";
 
 import { cn } from "@/utils/cn";
-import { parseShortcut } from "@/core/hotkeys/shortcuts";
+import { isShortcutPressed } from "@/core/hotkeys/shortcuts";
 import { useEventListener } from "@/hooks/useEventListener";
 
 const activeCommon = "active:shadow-xsSolid";
@@ -113,7 +113,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         if (!keyboardShortcut) {
           return;
         }
-        if (parseShortcut(keyboardShortcut)(e)) {
+        if (isShortcutPressed(keyboardShortcut, e)) {
           e.preventDefault();
           e.stopPropagation();
           if (buttonRef?.current && !buttonRef.current.disabled) {

--- a/frontend/src/core/hotkeys/__tests__/shortcuts.test.ts
+++ b/frontend/src/core/hotkeys/__tests__/shortcuts.test.ts
@@ -27,6 +27,12 @@ describe("parseShortcut", () => {
     expect(shortcut(event)).toBe(true);
   });
 
+  it("should recognize Arrow key shortcuts", () => {
+    const shortcut = parseShortcut("ArrowRight");
+    const event = new KeyboardEvent("keydown", { key: "ArrowRight" });
+    expect(shortcut(event)).toBe(true);
+  });
+
   it("should recognize Space key shortcuts", () => {
     const shortcut = parseShortcut("Space");
     const event = new KeyboardEvent("keydown", { code: "Space" });

--- a/frontend/src/core/hotkeys/__tests__/shortcuts.test.ts
+++ b/frontend/src/core/hotkeys/__tests__/shortcuts.test.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { expect, describe, it } from "vitest";
-import { parseShortcut, isShortcutPressed } from "../shortcuts";
+import { parseShortcut } from "../shortcuts";
 
 describe("parseShortcut", () => {
   it("should recognize single key shortcuts", () => {
@@ -99,99 +99,32 @@ describe("parseShortcut", () => {
     expect(parseShortcut("Shift-Enter")(event)).toBe(false);
     expect(parseShortcut("Alt-Shift-Enter")(event)).toBe(true);
   });
-});
 
-describe("isShortcutPressed", () => {
-  it("should recognize single key shortcuts", () => {
-    const event = new KeyboardEvent("keydown", { key: "a" });
-    expect(isShortcutPressed("a", event)).toBe(true);
-  });
-
-  it("should recognize incorrect single key shortcuts", () => {
-    const event = new KeyboardEvent("keydown", { key: "b" });
-    expect(isShortcutPressed("a", event)).toBe(false);
-  });
-
-  it("should recognize combined Ctrl key shortcuts", () => {
-    const event = new KeyboardEvent("keydown", { key: "a", ctrlKey: true });
-    expect(isShortcutPressed("Ctrl-a", event)).toBe(true);
-  });
-
-  it("should recognize combined Shift key shortcuts", () => {
-    const event = new KeyboardEvent("keydown", { key: "a", shiftKey: true });
-    expect(isShortcutPressed("Shift-a", event)).toBe(true);
-  });
-
-  it("should recognize combined Cmd key shortcuts", () => {
-    const event = new KeyboardEvent("keydown", { key: "a", metaKey: true });
-    expect(isShortcutPressed("Cmd-a", event)).toBe(true);
-  });
-
-  it("should recognize Space key shortcuts", () => {
-    const event = new KeyboardEvent("keydown", { code: "Space" });
-    expect(isShortcutPressed("Space", event)).toBe(true);
-  });
-
-  it("should recognize arrow key shortcuts", () => {
-    const event = new KeyboardEvent("keydown", { key: "ArrowUp" });
-    expect(isShortcutPressed("ArrowUp", event)).toBe(true);
-  });
-
-  it("should recognize keyboard hotkeys", () => {
-    const event = new KeyboardEvent("keydown", { key: "F12" });
-    expect(isShortcutPressed("F12", event)).toBe(true);
-  });
-
-  it("should not recognize incorrect combined key shortcuts", () => {
-    const event = new KeyboardEvent("keydown", { key: "a" });
-    expect(isShortcutPressed("Ctrl-a", event)).toBe(false);
-  });
-
-  it("should not recognize shortcuts with additional keys pressed", () => {
-    const event = new KeyboardEvent("keydown", { key: "a", shiftKey: true });
-    expect(isShortcutPressed("a", event)).toBe(false);
-  });
-
-  it("should not recognize shortcuts when Shift is not part of the shortcut but is pressed", () => {
-    const event = new KeyboardEvent("keydown", {
+  it("should not recognize shortcuts when one part is missing", () => {
+    const missingShift = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+    });
+    const missingCtrl = new KeyboardEvent("keydown", {
+      key: "a",
+      shiftKey: true,
+    });
+    const missingSpecial = new KeyboardEvent("keydown", { key: "a" });
+    const missingLetter = new KeyboardEvent("keydown", {
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    const correctEvent = new KeyboardEvent("keydown", {
       key: "a",
       ctrlKey: true,
       shiftKey: true,
     });
-    expect(isShortcutPressed("Ctrl-a", event)).toBe(false);
-  });
 
-  it("should not recognize shortcuts when Ctrl is not part of the shortcut but is pressed", () => {
-    const event = new KeyboardEvent("keydown", {
-      key: "Enter",
-      shiftKey: true,
-      ctrlKey: true,
-    });
-
-    expect(isShortcutPressed("Shift-Enter", event)).toBe(false);
-    expect(isShortcutPressed("Ctrl-Shift-Enter", event)).toBe(true);
-  });
-
-  it("should not recognize shortcuts when Cmd is not part of the shortcut but is pressed", () => {
-    const event = new KeyboardEvent("keydown", {
-      key: "Enter",
-      shiftKey: true,
-      metaKey: true,
-    });
-
-    expect(isShortcutPressed("Shift-Enter", event)).toBe(false);
-    expect(isShortcutPressed("Cmd-Shift-Enter", event)).toBe(true);
-  });
-
-  it("should not recognize shortcuts when Alt is not part of the shortcut but is pressed", () => {
-    const event = new KeyboardEvent("keydown", {
-      key: "Enter",
-      shiftKey: true,
-      altKey: true,
-    });
-
-    expect(isShortcutPressed("Shift-Enter", event)).toBe(false);
-    expect(isShortcutPressed("Alt-Shift-Enter", event)).toBe(true);
+    expect(parseShortcut("Ctrl-Shift-A")(missingShift)).toBe(false);
+    expect(parseShortcut("Ctrl-Shift-A")(missingCtrl)).toBe(false);
+    expect(parseShortcut("Ctrl-Shift-A")(missingSpecial)).toBe(false);
+    expect(parseShortcut("Ctrl-Shift-A")(missingLetter)).toBe(false);
+    expect(parseShortcut("Ctrl-Shift-A")(correctEvent)).toBe(true);
   });
 
   it("should recognize + as a separator", () => {
@@ -200,6 +133,8 @@ describe("isShortcutPressed", () => {
       ctrlKey: true,
       shiftKey: true,
     });
-    expect(isShortcutPressed("Ctrl+Shift+a", event)).toBe(true);
+
+    expect(parseShortcut("Ctrl+Shift+a")(event)).toBe(true);
+    expect(parseShortcut("Ctrl+A")(event)).toBe(false);
   });
 });

--- a/frontend/src/core/hotkeys/__tests__/shortcuts.test.ts
+++ b/frontend/src/core/hotkeys/__tests__/shortcuts.test.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { expect, describe, it } from "vitest";
-import { parseShortcut } from "../shortcuts";
+import { parseShortcut, isShortcutPressed } from "../shortcuts";
 
 describe("parseShortcut", () => {
   it("should recognize single key shortcuts", () => {
@@ -98,5 +98,108 @@ describe("parseShortcut", () => {
 
     expect(parseShortcut("Shift-Enter")(event)).toBe(false);
     expect(parseShortcut("Alt-Shift-Enter")(event)).toBe(true);
+  });
+});
+
+describe("isShortcutPressed", () => {
+  it("should recognize single key shortcuts", () => {
+    const event = new KeyboardEvent("keydown", { key: "a" });
+    expect(isShortcutPressed("a", event)).toBe(true);
+  });
+
+  it("should recognize incorrect single key shortcuts", () => {
+    const event = new KeyboardEvent("keydown", { key: "b" });
+    expect(isShortcutPressed("a", event)).toBe(false);
+  });
+
+  it("should recognize combined Ctrl key shortcuts", () => {
+    const event = new KeyboardEvent("keydown", { key: "a", ctrlKey: true });
+    expect(isShortcutPressed("Ctrl-a", event)).toBe(true);
+  });
+
+  it("should recognize combined Shift key shortcuts", () => {
+    const event = new KeyboardEvent("keydown", { key: "a", shiftKey: true });
+    expect(isShortcutPressed("Shift-a", event)).toBe(true);
+  });
+
+  it("should recognize combined Cmd key shortcuts", () => {
+    const event = new KeyboardEvent("keydown", { key: "a", metaKey: true });
+    expect(isShortcutPressed("Cmd-a", event)).toBe(true);
+  });
+
+  it("should recognize Space key shortcuts", () => {
+    const event = new KeyboardEvent("keydown", { code: "Space" });
+    expect(isShortcutPressed("Space", event)).toBe(true);
+  });
+
+  it("should recognize arrow key shortcuts", () => {
+    const event = new KeyboardEvent("keydown", { key: "ArrowUp" });
+    expect(isShortcutPressed("ArrowUp", event)).toBe(true);
+  });
+
+  it("should recognize keyboard hotkeys", () => {
+    const event = new KeyboardEvent("keydown", { key: "F12" });
+    expect(isShortcutPressed("F12", event)).toBe(true);
+  });
+
+  it("should not recognize incorrect combined key shortcuts", () => {
+    const event = new KeyboardEvent("keydown", { key: "a" });
+    expect(isShortcutPressed("Ctrl-a", event)).toBe(false);
+  });
+
+  it("should not recognize shortcuts with additional keys pressed", () => {
+    const event = new KeyboardEvent("keydown", { key: "a", shiftKey: true });
+    expect(isShortcutPressed("a", event)).toBe(false);
+  });
+
+  it("should not recognize shortcuts when Shift is not part of the shortcut but is pressed", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    expect(isShortcutPressed("Ctrl-a", event)).toBe(false);
+  });
+
+  it("should not recognize shortcuts when Ctrl is not part of the shortcut but is pressed", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      ctrlKey: true,
+    });
+
+    expect(isShortcutPressed("Shift-Enter", event)).toBe(false);
+    expect(isShortcutPressed("Ctrl-Shift-Enter", event)).toBe(true);
+  });
+
+  it("should not recognize shortcuts when Cmd is not part of the shortcut but is pressed", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      metaKey: true,
+    });
+
+    expect(isShortcutPressed("Shift-Enter", event)).toBe(false);
+    expect(isShortcutPressed("Cmd-Shift-Enter", event)).toBe(true);
+  });
+
+  it("should not recognize shortcuts when Alt is not part of the shortcut but is pressed", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      altKey: true,
+    });
+
+    expect(isShortcutPressed("Shift-Enter", event)).toBe(false);
+    expect(isShortcutPressed("Alt-Shift-Enter", event)).toBe(true);
+  });
+
+  it("should recognize + as a separator", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    expect(isShortcutPressed("Ctrl+Shift+a", event)).toBe(true);
   });
 });

--- a/frontend/src/core/hotkeys/shortcuts.ts
+++ b/frontend/src/core/hotkeys/shortcuts.ts
@@ -65,3 +65,63 @@ export function parseShortcut(shortcut: string): (e: KeyboardEvent) => boolean {
     return satisfied;
   };
 }
+
+function normalizeKey(key: string): string {
+  const specialKeys: { [key: string]: string } = {
+    control: "ctrl",
+    command: "meta",
+    cmd: "meta",
+    option: "alt",
+    return: "enter",
+    " ": "space",
+  };
+  return specialKeys[key.toLowerCase()] || key.toLowerCase();
+}
+
+export function isShortcutPressed(shortcut: string, e: KeyboardEvent): boolean {
+  const separator = shortcut.includes("+") ? "+" : "-";
+  const keys = shortcut.split(separator).map(normalizeKey);
+
+  let satisfied = true;
+  for (const key of keys) {
+    switch (key) {
+      case "ctrl":
+        satisfied &&= e.ctrlKey;
+        break;
+      case "meta":
+        satisfied &&= e.metaKey;
+        break;
+      case "shift":
+        satisfied &&= e.shiftKey;
+        break;
+      case "alt":
+        satisfied &&= e.altKey;
+        break;
+      case "space":
+        satisfied &&= e.code === "Space";
+        break;
+      default:
+        satisfied &&= e.key.toLowerCase() === key;
+        break;
+    }
+
+    if (!satisfied) {
+      return false;
+    }
+  }
+
+  if (!keys.includes("shift")) {
+    satisfied &&= !e.shiftKey;
+  }
+  if (!keys.includes("ctrl")) {
+    satisfied &&= !e.ctrlKey;
+  }
+  if (!keys.includes("meta")) {
+    satisfied &&= !e.metaKey;
+  }
+  if (!keys.includes("alt")) {
+    satisfied &&= !e.altKey;
+  }
+
+  return satisfied;
+}

--- a/frontend/src/core/hotkeys/shortcuts.ts
+++ b/frontend/src/core/hotkeys/shortcuts.ts
@@ -20,68 +20,7 @@ export function isPlatformMac() {
   return /mac/i.test(platform);
 }
 
-export function parseShortcut(shortcut: string): (e: KeyboardEvent) => boolean {
-  const keys = shortcut.split("-");
-  return (e: KeyboardEvent) => {
-    let satisfied = true;
-    for (const character of keys) {
-      switch (character) {
-        case "Ctrl":
-          satisfied &&= e.ctrlKey;
-          break;
-        case "Cmd":
-          satisfied &&= e.metaKey;
-          break;
-        case "Shift":
-          satisfied &&= e.shiftKey;
-          break;
-        case "Alt":
-          satisfied &&= e.altKey;
-          break;
-        case "Space":
-          satisfied &&= e.code === "Space";
-          break;
-        default:
-          satisfied &&= e.key.toLowerCase() === character.toLowerCase();
-          break;
-      }
-
-      if (!satisfied) {
-        return false;
-      }
-    }
-    if (!keys.includes("Shift")) {
-      satisfied &&= !e.shiftKey;
-    }
-    if (!keys.includes("Ctrl")) {
-      satisfied &&= !e.ctrlKey;
-    }
-    if (!keys.includes("Cmd")) {
-      satisfied &&= !e.metaKey;
-    }
-    if (!keys.includes("Alt")) {
-      satisfied &&= !e.altKey;
-    }
-    return satisfied;
-  };
-}
-
-function normalizeKey(key: string): string {
-  const specialKeys: { [key: string]: string } = {
-    control: "ctrl",
-    command: "meta",
-    cmd: "meta",
-    option: "alt",
-    return: "enter",
-    " ": "space",
-  };
-  return specialKeys[key.toLowerCase()] || key.toLowerCase();
-}
-
-export function isShortcutPressed(shortcut: string, e: KeyboardEvent): boolean {
-  const separator = shortcut.includes("+") ? "+" : "-";
-  const keys = shortcut.split(separator).map(normalizeKey);
-
+function areKeysPressed(keys: string[], e: KeyboardEvent): boolean {
   let satisfied = true;
   for (const key of keys) {
     switch (key) {
@@ -124,4 +63,21 @@ export function isShortcutPressed(shortcut: string, e: KeyboardEvent): boolean {
   }
 
   return satisfied;
+}
+
+function normalizeKey(key: string): string {
+  const specialKeys: { [key: string]: string } = {
+    control: "ctrl",
+    command: "meta",
+    cmd: "meta",
+    option: "alt",
+    return: "enter",
+  };
+  return specialKeys[key.toLowerCase()] || key.toLowerCase();
+}
+
+export function parseShortcut(shortcut: string): (e: KeyboardEvent) => boolean {
+  const separator = shortcut.includes("+") ? "+" : "-";
+  const keys = shortcut.split(separator).map(normalizeKey);
+  return (e: KeyboardEvent) => areKeysPressed(keys, e);
 }

--- a/frontend/src/plugins/impl/ButtonPlugin.tsx
+++ b/frontend/src/plugins/impl/ButtonPlugin.tsx
@@ -7,6 +7,7 @@ import { renderHTML } from "../core/RenderHTML";
 import { type Intent, zodIntent } from "./common/intent";
 import { cn } from "@/utils/cn";
 import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
+import { KeyboardHotkeys } from "@/components/shortcuts/renderShortcut";
 
 interface Data {
   label: string;
@@ -57,10 +58,21 @@ export class ButtonPlugin implements IPlugin<number, Data> {
       </Button>
     );
 
-    if (tooltip) {
+    let tooltipContent: string | JSX.Element | undefined;
+
+    // eslint-disable-next-line unicorn/prefer-ternary
+    if (keyboardShortcut && !tooltip) {
+      tooltipContent = <KeyboardHotkeys shortcut={keyboardShortcut} />;
+    } else {
+      tooltipContent = tooltip;
+    }
+
+    if (tooltipContent) {
       return (
         <TooltipProvider>
-          <Tooltip content={tooltip}>{button}</Tooltip>
+          <Tooltip content={tooltipContent} delayDuration={200}>
+            {button}
+          </Tooltip>
         </TooltipProvider>
       );
     }

--- a/frontend/src/plugins/impl/ButtonPlugin.tsx
+++ b/frontend/src/plugins/impl/ButtonPlugin.tsx
@@ -58,14 +58,12 @@ export class ButtonPlugin implements IPlugin<number, Data> {
       </Button>
     );
 
-    let tooltipContent: string | JSX.Element | undefined;
-
-    // eslint-disable-next-line unicorn/prefer-ternary
-    if (keyboardShortcut && !tooltip) {
-      tooltipContent = <KeyboardHotkeys shortcut={keyboardShortcut} />;
-    } else {
-      tooltipContent = tooltip;
-    }
+    const tooltipContent =
+      keyboardShortcut && !tooltip ? (
+        <KeyboardHotkeys shortcut={keyboardShortcut} />
+      ) : (
+        tooltip
+      );
 
     if (tooltipContent) {
       return (

--- a/frontend/src/plugins/impl/ButtonPlugin.tsx
+++ b/frontend/src/plugins/impl/ButtonPlugin.tsx
@@ -14,6 +14,7 @@ interface Data {
   disabled: boolean;
   fullWidth: boolean;
   tooltip?: string;
+  keyboardShortcut?: string;
 }
 
 export class ButtonPlugin implements IPlugin<number, Data> {
@@ -25,11 +26,12 @@ export class ButtonPlugin implements IPlugin<number, Data> {
     disabled: z.boolean().default(false),
     fullWidth: z.boolean().default(false),
     tooltip: z.string().optional(),
+    keyboardShortcut: z.string().optional(),
   });
 
   render(props: IPluginProps<number, Data>): JSX.Element {
     const {
-      data: { disabled, kind, label, fullWidth, tooltip },
+      data: { disabled, kind, label, fullWidth, tooltip, keyboardShortcut },
     } = props;
     // value counts number of times button was clicked
     const button = (
@@ -38,6 +40,7 @@ export class ButtonPlugin implements IPlugin<number, Data> {
         variant={kindToButtonVariant(kind)}
         disabled={disabled}
         size="xs"
+        keyboardShortcut={keyboardShortcut}
         className={cn({
           "w-full": fullWidth,
         })}

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -1117,7 +1117,7 @@ class button(UIElement[Any, Any]):
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
-    - `keyboard_shortcut`: keyboard shortcut to trigger the button (e.g. 'Ctrl+Shift+K')
+    - `keyboard_shortcut`: keyboard shortcut to trigger the button (e.g. 'Ctrl-L')
     """
 
     _name: Final[str] = "marimo-button"
@@ -1137,7 +1137,6 @@ class button(UIElement[Any, Any]):
     ) -> None:
         self._on_click = (lambda _: value) if on_click is None else on_click
         self._initial_value = value
-        tooltip = keyboard_shortcut if tooltip is None else tooltip
         # This should be kept in sync with mo.ui.run_button()
         super().__init__(
             component_name=button._name,

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -1117,6 +1117,7 @@ class button(UIElement[Any, Any]):
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
+    - `keyboard_shortcut`: keyboard shortcut to trigger the button (e.g. 'Ctrl+Shift+K')
     """
 
     _name: Final[str] = "marimo-button"
@@ -1132,9 +1133,11 @@ class button(UIElement[Any, Any]):
         label: str = "click here",
         on_change: Optional[Callable[[Any], None]] = None,
         full_width: bool = False,
+        keyboard_shortcut: Optional[str] = None,
     ) -> None:
         self._on_click = (lambda _: value) if on_click is None else on_click
         self._initial_value = value
+        tooltip = keyboard_shortcut if tooltip is None else tooltip
         # This should be kept in sync with mo.ui.run_button()
         super().__init__(
             component_name=button._name,
@@ -1146,6 +1149,7 @@ class button(UIElement[Any, Any]):
                 "disabled": disabled,
                 "tooltip": tooltip,
                 "full-width": full_width,
+                "keyboard-shortcut": keyboard_shortcut,
             },
             on_change=on_change,
         )

--- a/marimo/_plugins/ui/_impl/run_button.py
+++ b/marimo/_plugins/ui/_impl/run_button.py
@@ -55,6 +55,7 @@ class run_button(UIElement[Any, Any]):
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
+    - `keyboard_shortcut`: keyboard shortcut to trigger the button (e.g. 'Ctrl+Shift+K')
     """
 
     # We reuse the button plugin on the frontend, UI/logic are the same
@@ -69,8 +70,10 @@ class run_button(UIElement[Any, Any]):
         label: str = "click to run",
         on_change: Optional[Callable[[Any], None]] = None,
         full_width: bool = False,
+        keyboard_shortcut: Optional[str] = None,
     ) -> None:
         self._initial_value = False
+        tooltip = keyboard_shortcut if tooltip is None else tooltip
         super().__init__(
             component_name=button._name,
             # frontend's value is a counter
@@ -81,6 +84,7 @@ class run_button(UIElement[Any, Any]):
                 "disabled": disabled,
                 "tooltip": tooltip,
                 "full-width": full_width,
+                "keyboard-shortcut": keyboard_shortcut,
             },
             on_change=on_change,
         )

--- a/marimo/_plugins/ui/_impl/run_button.py
+++ b/marimo/_plugins/ui/_impl/run_button.py
@@ -55,7 +55,7 @@ class run_button(UIElement[Any, Any]):
     - `on_change`: optional callback to run when this element's value changes
     - `full_width`: whether the input should take up the full width of its
         container
-    - `keyboard_shortcut`: keyboard shortcut to trigger the button (e.g. 'Ctrl+Shift+K')
+    - `keyboard_shortcut`: keyboard shortcut to trigger the button (e.g. 'Ctrl-L')
     """
 
     # We reuse the button plugin on the frontend, UI/logic are the same
@@ -73,7 +73,6 @@ class run_button(UIElement[Any, Any]):
         keyboard_shortcut: Optional[str] = None,
     ) -> None:
         self._initial_value = False
-        tooltip = keyboard_shortcut if tooltip is None else tooltip
         super().__init__(
             component_name=button._name,
             # frontend's value is a counter


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
<img width="1191" alt="Screenshot 2024-11-08 at 10 44 00 PM" src="https://github.com/user-attachments/assets/0e4e7633-1e3c-4a26-b438-cb8925d94f41">

Fixes #633 . Buttons can now have shortcuts by declaring them
`mo.ui.button(label='Add', value=0, on_click=lambda x: x + 1, keyboard_shortcut="Cmd-L")`

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Adds a global listener for keyboard shortcuts when declared on a button, prevents default action
- Uses the default hotkeys parsing
- Adds a default tooltip for the keyboard shortcut

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
