### PR TITLE
example: attach to persistent duckdb db

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,13 @@ comment. Here are the steps to open an example notebook:
 
 1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
 2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+3. Open an example with `marimo edit --sandbox <notebook-url>`.
+
+For example:
+
+```bash
+marimo edit --sandbox https://github.com/marimo-team/marimo/blob/main/examples/ui/reactive_plots.py
+```
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,

--- a/examples/sql/README.md
+++ b/examples/sql/README.md
@@ -9,6 +9,7 @@ analytical database.
 - `read_csv.py` shows hows to read CSV data into duckdb
 - `read_json.py` shows hows to read JSON data into duckdb
 - `read_parquet.py` shows hows to read parquet data into duckdb
+- `connect_to_persistent_db.py` shows hows to connect to a duckdb persistent database
 - `connect_to_sqlite.py` shows hows to connect to a SQLite database
 - `connect_to_postgres.py` shows hows to connect to a PostgreSQL database
 - `connect_to_motherduck.py` shows hows to connect to [motherduck](https://motherduck.com)
@@ -29,7 +30,8 @@ comment. Here are the steps to open an example notebook:
 
 1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
 2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+3. Open an example with `marimo edit --sandbox <notebook-url>`.
+
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,

--- a/examples/sql/connect_to_persistent_db.py
+++ b/examples/sql/connect_to_persistent_db.py
@@ -1,0 +1,41 @@
+import marimo
+
+__generated_with = "0.9.16"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def __(mo):
+    mo.md("""Connect to duckdb [persistent storage](https://duckdb.org/docs/connect/overview.html#persistent-database) using the `ATTACH` command:""")
+    return
+
+
+@app.cell
+def __(mo):
+    _df = mo.sql(
+        f"""
+        ATTACH 'test.db' as test;
+        SHOW ALL TABLES;
+        """
+    )
+    return (test,)
+
+
+@app.cell
+def __(mo, test, test_table):
+    _df = mo.sql(
+        f"""
+        SELECT * FROM test.test_table;
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
A very small example on how to connect to a local `duckdb` file.

Additionally, update readme to let users know about run via URL.