### PR TITLE
fix: vim j/k keys

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -416,7 +416,7 @@ const CellComponent = (
     },
     // only register j/k movement if the cell is hidden, so as to not
     // interfere with editing
-    ...(userConfig.keymap.preset === "vim" && isCellCodeShown
+    ...(userConfig.keymap.preset === "vim" && !isCellCodeShown
       ? {
           j: () => {
             moveToNextCell({ cellId, before: false, noCreate: true });


### PR DESCRIPTION
Fixes #2822

A flipped boolean made j/k not work in any cells