### PR TITLE
AI Completion: Send api-key header for OpenAI endpoints

### DIFF
--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -84,7 +84,7 @@ def get_openai_client(config: MarimoConfig) -> "OpenAI":
 
     return OpenAI(
         default_headers={"api-key": key},
-        api_key=key, 
+        api_key=key,
         base_url=base_url,
     )
 

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -82,7 +82,11 @@ def get_openai_client(config: MarimoConfig) -> "OpenAI":
     if not base_url:
         base_url = None
 
-    return OpenAI(api_key=key, base_url=base_url)
+    return OpenAI(
+        default_headers={"api-key": key},
+        api_key=key, 
+        base_url=base_url,
+    )
 
 
 def get_anthropic_client(config: MarimoConfig) -> "Client":


### PR DESCRIPTION
## 📝 Summary

Some OpenAI-compatible endpoints appear to need the API key sent in the header,
this change makes it work.
Without it, I'm getting an error 401.
(I don't actually know which specific endpoint provider/product I am using.)

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

Set `default_headers` in the OpenAI instance.

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
