### PR TITLE
Ensure binary messages are serialized to base64 in Panel Comm layer

### DIFF
--- a/frontend/src/plugins/impl/panel/utils.ts
+++ b/frontend/src/plugins/impl/panel/utils.ts
@@ -30,10 +30,9 @@ export function extractBuffers(
     }
     return result;
   }
-  if (value instanceof ArrayBuffer) {
-    // TODO: this does not seem correct
+  if (value.to_base64 !== undefined) {
     const id = buffers.length;
-    buffers.push(value);
+    buffers.push(value.to_base64());
     return { id };
   }
   if (typeof value === "object" && value !== null) {

--- a/marimo/_plugins/ui/_impl/from_panel.py
+++ b/marimo/_plugins/ui/_impl/from_panel.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import base64
 import sys
 from dataclasses import dataclass
 from typing import (
@@ -65,7 +66,8 @@ def _get_comm_class() -> Type[Any]:
         @classmethod
         def decode(cls, msg: SendToWidgetArgs) -> dict[str, Any]:
             buffers: Dict[int, Any] = {
-                i: v for i, v in enumerate(msg.buffers or [])
+                i: memoryview(base64.b64decode(v))
+                for i, v in enumerate(msg.buffers or [])
             }
             return dict(msg.message, _buffers=buffers)
 


### PR DESCRIPTION
## 📝 Summary

Ensures binary messages sent from the frontend to Python are serialized from binary ArrayBuffers to base64 strings.

## 🔍 Description of Changes

Adds code on the frontend to convert Bokeh `Buffer` objects to base64 and convert the base64 buffers arriving in Python into `memoryview` objects expected by the Bokeh protocol  

## 📋 Checklist

- [x] Fixes https://github.com/marimo-team/marimo/issues/979
- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick please review.

I wasn't aware that binary transport was not supported at all. Is there any chance this could be enabled? Panel applications often push a lot of data across the websocket and base64 encoding/decoding adds major overhead.
