### PR TITLE
improvement: Extract and lift inline script metadata in `marimo convert`

### DIFF
--- a/marimo/_convert/utils.py
+++ b/marimo/_convert/utils.py
@@ -23,7 +23,9 @@ def markdown_to_marimo(source: str) -> str:
 
 
 def generate_from_sources(
-    sources: list[str], config: Optional[_AppConfig] = None
+    sources: list[str],
+    config: Optional[_AppConfig] = None,
+    header_comments: Optional[str] = None,
 ) -> str:
     """
     Given a list of Python source code,
@@ -34,4 +36,5 @@ def generate_from_sources(
         ["__" for _ in sources],
         [CellConfig() for _ in range(len(sources))],
         config=config,
+        header_comments=header_comments,
     )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Adds support for extracting inline script metadata from notebook cells, and lifting the comment block to the top of the converted marimo Python script.

This allows for nice interchange between a tool like juv and marimo:

```sh
juv init
juv add Untitled.ipynb anywidget polars
marimo convert Untitled.ipynb > Untitled.py
marimo edit Untitled.py
```

## 🔍 Description of Changes

Adds regex to extract metadata from inline script comments, and lifts the comment block to the top of the converted marimo Python script.

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
