### PR TITLE
Fix: expose port via os to allow mpl to work in docker

### DIFF
--- a/docs/guides/deploying/deploying_docker.md
+++ b/docs/guides/deploying/deploying_docker.md
@@ -75,6 +75,18 @@ docker run -p 8080:8080 -it my_app
 
 After verifying that your application runs without errors, you can use these files to deploy your application on your preferred cloud provider that supports dockerized applications.
 
+### Using Interactive Matplotlib Plots in Docker
+
+If your notebook uses `mo.mpl.interactive()` for interactive matplotlib plots, you'll need to make some additional configurations in your Dockerfile:
+
+```Dockerfile
+# Add these lines before the CMD instruction
+ENV MARIMO_MPL_HOST="0.0.0.0" # same as main host from `marimo run`.
+EXPOSE 10000  # In addition to your main application port
+```
+
+This exposes the additional CSS and JavaScript required.
+
 ## Health checks
 
 You can add a health check to your Dockerfile to ensure that your application is running as expected. This is especially useful when deploying to a cloud provider.

--- a/docs/guides/deploying/deploying_docker.md
+++ b/docs/guides/deploying/deploying_docker.md
@@ -82,7 +82,8 @@ If your notebook uses `mo.mpl.interactive()` for interactive matplotlib plots, y
 ```Dockerfile
 # Add these lines before the CMD instruction
 ENV MARIMO_MPL_HOST="0.0.0.0" # same as main host from `marimo run`.
-EXPOSE 10000  # In addition to your main application port
+ENV MARIMO_MPL_SECURE=true # if you are running on https
+EXPOSE 10000  # Expose in addition to your main application port
 ```
 
 This exposes the additional CSS and JavaScript required.

--- a/docs/guides/working_with_data/plotting.md
+++ b/docs/guides/working_with_data/plotting.md
@@ -283,5 +283,6 @@ If you want to output the plot in the console area, use `plt.show()` or
 ### Interactive plots
 
 To make matplotlib plots interactive, use
-[mo.mpl.interactive](../api/plotting.md#marimo.mpl.interactive).
+[mo.mpl.interactive](/api/plotting.md#marimo.mpl.interactive).
 (Matplotlib plots are not yet reactive.)
+For additional instructions when deploying an interactive matplotlib plot in Docker, see [Interactive Matplotlib Plots in Docker](/guides/deploying/deploying_docker.md#using-interactive-matplotlib-plots-in-docker)

--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -58,6 +58,7 @@ class FigureManagers:
 
 figure_managers = FigureManagers()
 
+
 def _get_host() -> str:
     """
     Get the host from environment variable or fall back to localhost.
@@ -70,14 +71,13 @@ def _get_host() -> str:
             f"Invalid host '{host}': should not include protocol (http:// or https://)"
         )
     if "/" in host:
-        raise ValueError(
-            f"Invalid host '{host}': should not include paths"
-        )
+        raise ValueError(f"Invalid host '{host}': should not include paths")
     if ":" in host:
         raise ValueError(
             f"Invalid host '{host}': should not include port numbers"
         )
     return host
+
 
 def _get_secure() -> bool:
     """
@@ -96,12 +96,8 @@ def _get_secure() -> bool:
         f"Invalid secure value '{secure}': should be 'true' or 'false'"
     )
 
-def _template(
-    host: str,
-    port: int,
-    fig_id: str,
-    secure: bool = False
-) -> str:
+
+def _template(host: str, port: int, fig_id: str, secure: bool = False) -> str:
     ws_protocol = "wss" if secure else "ws"
     http_protocol = "https" if secure else "http"
 
@@ -240,7 +236,7 @@ _app: Optional[Starlette] = None
 def get_or_create_application(
     app_host: Optional[str] = None,
     free_port: Optional[int] = None,
-    secure_host: Optional[bool] = None
+    secure_host: Optional[bool] = None,
 ) -> Starlette:
     global _app
 


### PR DESCRIPTION
## 📝 Summary

1. Gets the host from an environment variable, if specified, for the mpl plugin.
2. Adds checks to make sure the host name is valid. Throws an error on `marimo run` if failure.
3. Exposes host and port variables through the main create application function for simpler configuration in the future, hopefully when spawning the process instead of being specified by the user.

Unfortunately this spawns a new error that I really don't understand. I'm submitting this to see if it's an easy fix or if the approach should be thrown away altogether and the process should be proxied through the main server.

## 🔍 Description of Changes

See: https://github.com/marimo-team/marimo/issues/2848

I only saw integration tests for marimo.mpl And those all pass. I did not add additional testing for this.

I did run manual tests:
- Validating that it works in Docker local (on http, works, did not validate https)
- The checks fail when appropriate
- That it works on Fly.io (http fails due to mixed content in iframe, https throws following error:)

<img width="598" alt="Screenshot 2024-11-12 at 2 47 23 PM" src="https://github.com/user-attachments/assets/327bd38c-3f7d-4f8b-8ee7-77724819681d">

I also added documentation to the matplotlib plotting area and the docker deployment areas where appropriate.

Screenshot of _intended_ failure when setting host incorrectly.
<img width="791" alt="Screenshot 2024-11-12 at 1 33 21 PM" src="https://github.com/user-attachments/assets/728563fd-facf-46f6-999d-c587134e3c57">

## 📋 Checklist

- [ x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) -- see GitHub issue linked above. This doesn't really affect the API, but that's where the context lives.
- [ ] I have added tests for the changes made.
- [x ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick Per out discussion. Thank you for the point in the right direction.  Longer term, it will make more sense to have this all go through port 8080. 

I'm curious to get your feedback as to the error I'm encountering now. If it's an easy fix or we should just throw this PR away altogether.