### PR TITLE
perf: use pyodide lockfiles

### DIFF
--- a/frontend/islands/vite.config.mts
+++ b/frontend/islands/vite.config.mts
@@ -31,6 +31,7 @@ export default defineConfig({
     dedupe: ["react", "react-dom", "@emotion/react", "@emotion/cache"],
   },
   worker: {
+    format: "es",
     plugins: () => [tsconfigPaths()],
   },
   define: {

--- a/frontend/src/core/islands/worker/worker.tsx
+++ b/frontend/src/core/islands/worker/worker.tsx
@@ -18,10 +18,7 @@ import { ReadonlyWasmController } from "./controller";
 import type { OperationMessage } from "@/core/kernel/messages";
 import type { JsonString } from "@/utils/json/base64";
 import { Logger } from "@/utils/Logger";
-import {
-  getPyodideVersion,
-  importPyodide,
-} from "@/core/wasm/worker/getPyodideVersion";
+import { getPyodideVersion } from "@/core/wasm/worker/getPyodideVersion";
 
 declare const self: Window & {
   pyodide: PyodideInterface;
@@ -32,7 +29,6 @@ declare const self: Window & {
 async function loadPyodideAndPackages() {
   const marimoVersion = getMarimoVersion();
   const pyodideVersion = getPyodideVersion(marimoVersion);
-  await importPyodide(marimoVersion);
   try {
     self.controller = new ReadonlyWasmController();
     self.pyodide = await self.controller.bootstrap({

--- a/frontend/src/core/wasm/store.ts
+++ b/frontend/src/core/wasm/store.ts
@@ -54,6 +54,10 @@ const remoteDefaultFileStore: FileStore = {
     // Do nothing
   },
   readFile() {
+    // Only do this on the marimo playground (https://marimo.app)
+    if (window.location.hostname !== "marimo.app") {
+      return null;
+    }
     const baseURI = document.baseURI;
     return fetch(`${baseURI}files/wasm-intro.py`)
       .then((res) => (res.ok ? res.text() : null))

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { type PyodideInterface, loadPyodide } from "pyodide";
+import { loadPyodide, type PyodideInterface } from "pyodide";
 import { WasmFileSystem } from "./fs";
 import { Logger } from "../../../utils/Logger";
 import type { SerializedBridge, WasmController } from "./types";

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -1,19 +1,15 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import type { PyodideInterface } from "pyodide";
+import { type PyodideInterface, loadPyodide } from "pyodide";
 import { WasmFileSystem } from "./fs";
 import { Logger } from "../../../utils/Logger";
 import type { SerializedBridge, WasmController } from "./types";
 import { invariant } from "../../../utils/invariant";
 import type { UserConfig } from "@/core/config/config-schema";
-import { getMarimoWheel } from "./getMarimoWheel";
 import type { OperationMessage } from "@/core/kernel/messages";
 import type { JsonString } from "@/utils/json/base64";
 import { t } from "./tracer";
 
-declare let loadPyodide: (opts: {
-  packages: string[];
-  indexURL: string;
-}) => Promise<PyodideInterface>;
+const MAKE_SNAPSHOT = false;
 
 // This class initializes the wasm environment
 // We would like this initialization to be parallelizable
@@ -37,91 +33,50 @@ export class DefaultWasmController implements WasmController {
     version: string;
     pyodideVersion: string;
   }): Promise<PyodideInterface> {
-    const pyodide = await this.loadPyodideAndPackages(opts.pyodideVersion);
+    const pyodide = await this.loadPyodideAndPackages(opts);
 
-    const { version } = opts;
-
-    // If is a dev release, we need to install from test.pypi.org
-    if (version.includes("dev")) {
-      await this.installDevMarimoAndDeps(pyodide, version);
-      return pyodide;
+    if (MAKE_SNAPSHOT) {
+      const snapshot = pyodide.makeMemorySnapshot();
+      Logger.log("Snapshot size (mb):", snapshot.byteLength / 1024 / 1024);
     }
-
-    await this.installMarimoAndDeps(pyodide, version);
 
     return pyodide;
   }
 
-  private async loadPyodideAndPackages(
-    pyodideVersion: string,
-  ): Promise<PyodideInterface> {
+  private async loadPyodideAndPackages(opts: {
+    version: string;
+    pyodideVersion: string;
+  }): Promise<PyodideInterface> {
     if (!loadPyodide) {
       throw new Error("loadPyodide is not defined");
     }
     // Load pyodide and packages
     const span = t.startSpan("loadPyodide");
-    const pyodide = await loadPyodide({
-      // Perf: These get loaded while pyodide is being bootstrapped
-      packages: ["micropip"],
-      // Without this, this fails in Firefox with
-      // `Could not extract indexURL path from pyodide module`
-      // This fixes for Firefox and does not break Chrome/others
-      indexURL: `https://cdn.jsdelivr.net/pyodide/${pyodideVersion}/full/`,
-    });
-    this.pyodide = pyodide;
-    span.end("ok");
-    return pyodide;
-  }
-
-  private async installDevMarimoAndDeps(
-    pyodide: PyodideInterface,
-    version: string,
-  ) {
-    const span = t.startSpan("installDevMarimoAndDeps");
-    await Promise.all([
-      pyodide.runPythonAsync(`
-      import micropip
-      await micropip.install(
-        [
-          "${getMarimoWheel(version)}",
+    try {
+      const pyodide = await loadPyodide({
+        // Perf: These get loaded while pyodide is being bootstrapped
+        packages: [
+          "micropip",
+          "marimo-base",
+          "Markdown",
+          "pymdown-extensions",
+          "narwhals",
+          "packaging",
         ],
-        deps=False,
-        index_urls="https://test.pypi.org/pypi/{package_name}/json"
-        );
-      `),
-      pyodide.runPythonAsync(`
-      import micropip
-      await micropip.install(
-        [
-          "Markdown==3.6",
-          "pymdown-extensions==10.8.1",
-          "narwhals==1.9.2",
-        ],
-        deps=False,
-        );
-      `),
-    ]);
-    span.end("ok");
-  }
-
-  private async installMarimoAndDeps(
-    pyodide: PyodideInterface,
-    version: string,
-  ) {
-    const span = t.startSpan("installMarimoAndDeps");
-    await pyodide.runPythonAsync(`
-      import micropip
-      await micropip.install(
-        [
-          "${getMarimoWheel(version)}",
-          "Markdown==3.6",
-          "pymdown-extensions==10.8.1",
-          "narwhals==1.9.2",
-        ],
-        deps=False,
-      );
-    `);
-    span.end("ok");
+        _makeSnapshot: MAKE_SNAPSHOT,
+        lockFileURL: `https://wasm.marimo.app/pyodide-lock.json?v=${opts.version}&pyodide=${opts.pyodideVersion}`,
+        // Without this, this fails in Firefox with
+        // `Could not extract indexURL path from pyodide module`
+        // This fixes for Firefox and does not break Chrome/others
+        indexURL: `https://cdn.jsdelivr.net/pyodide/${opts.pyodideVersion}/full/`,
+      });
+      this.pyodide = pyodide;
+      span.end("ok");
+      return pyodide;
+    } catch (error) {
+      Logger.error("Failed to load Pyodide", error);
+      throw error;
+    }
   }
 
   async mountFilesystem(opts: { code: string; filename: string | null }) {

--- a/frontend/src/core/wasm/worker/getPyodideVersion.ts
+++ b/frontend/src/core/wasm/worker/getPyodideVersion.ts
@@ -1,17 +1,10 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { version as pyodideVersion } from "pyodide";
+
 const ALLOW_DEV_VERSIONS = false;
 
 export function getPyodideVersion(marimoVersion: string) {
   return marimoVersion.includes("dev") && ALLOW_DEV_VERSIONS
     ? "dev"
-    : "v0.26.2";
-}
-
-export async function importPyodide(marimoVersion: string) {
-  // Vite does not like imports with dynamic urls
-  return marimoVersion.includes("dev") && ALLOW_DEV_VERSIONS
-    ? // @ts-expect-error typescript does not like
-      await import("https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js")
-    : // @ts-expect-error typescript does not like
-      await import("https://cdn.jsdelivr.net/pyodide/v0.26.2/full/pyodide.js");
+    : `v${pyodideVersion}`;
 }

--- a/frontend/src/core/wasm/worker/save-worker.ts
+++ b/frontend/src/core/wasm/worker/save-worker.ts
@@ -11,7 +11,7 @@ import {
 import type { ParentSchema } from "../rpc";
 import { Logger } from "../../../utils/Logger";
 import { TRANSPORT_ID } from "./constants";
-import { getPyodideVersion, importPyodide } from "./getPyodideVersion";
+import { getPyodideVersion } from "./getPyodideVersion";
 import type { SaveNotebookRequest } from "@/core/network/types";
 import { WasmFileSystem } from "./fs";
 import { getController } from "./getController";
@@ -30,7 +30,6 @@ async function loadPyodideAndPackages() {
     // Import pyodide
     const marimoVersion = getMarimoVersion();
     const pyodideVersion = getPyodideVersion(marimoVersion);
-    await importPyodide(marimoVersion);
 
     // Bootstrap the controller
     const controller = await getController(marimoVersion);

--- a/frontend/src/core/wasm/worker/worker.ts
+++ b/frontend/src/core/wasm/worker/worker.ts
@@ -19,7 +19,7 @@ import { invariant } from "../../../utils/invariant";
 import type { OperationMessage } from "@/core/kernel/messages";
 import type { JsonString } from "@/utils/json/base64";
 import type { UserConfig } from "@/core/config/config-schema";
-import { getPyodideVersion, importPyodide } from "./getPyodideVersion";
+import { getPyodideVersion } from "./getPyodideVersion";
 import { t } from "./tracer";
 import { once } from "@/utils/once";
 import { getController } from "./getController";
@@ -44,7 +44,6 @@ async function loadPyodideAndPackages() {
   try {
     const marimoVersion = getMarimoVersion();
     const pyodideVersion = getPyodideVersion(marimoVersion);
-    await t.wrapAsync(importPyodide)(marimoVersion);
     const controller = await t.wrapAsync(getController)(marimoVersion);
     self.controller = controller;
     rpc.send.initializingMessage({

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -228,6 +228,7 @@ export default defineConfig({
     dedupe: ["react", "react-dom", "@emotion/react", "@emotion/cache"],
   },
   worker: {
+    format: "es",
     plugins: () => [tsconfigPaths()],
   },
   plugins: [

--- a/marimo/_cli/upgrade.py
+++ b/marimo/_cli/upgrade.py
@@ -8,8 +8,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Dict, Optional
 
-from packaging import version
-
 from marimo import __version__ as current_version
 from marimo._cli.print import echo, green, orange
 from marimo._server.api.status import HTTPException
@@ -43,6 +41,8 @@ def check_for_updates(on_update: Callable[[str, str], None]) -> None:
 
 
 def _check_for_updates_internal(on_update: Callable[[str, str], None]) -> None:
+    from packaging import version
+
     config_reader = ConfigReader.for_filename("state.toml")
     if not config_reader:
         # Couldn't find home directory, so do nothing

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -7,8 +7,6 @@ import shutil
 import sys
 from dataclasses import dataclass
 
-from packaging import version
-
 
 @dataclass
 class Dependency:
@@ -115,6 +113,8 @@ def _version_check(
 ) -> bool:
     if min_v is None and max_v is None:
         return True
+
+    from packaging import version
 
     parsed_min_version = version.parse(min_v) if min_v else None
     parsed_max_version = version.parse(max_v) if max_v else None

--- a/marimo/_server/api/auth.py
+++ b/marimo/_server/api/auth.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import starlette
 import starlette.status as status
-from packaging import version
 from starlette.datastructures import Secret
 from starlette.exceptions import HTTPException
 from starlette.middleware.sessions import SessionMiddleware
@@ -168,6 +167,8 @@ class CustomSessionMiddleware(SessionMiddleware):
         https_only: bool = False,
         domain: typing.Optional[str] = None,
     ) -> None:
+        from packaging import version
+
         # We can't update the cookie here since
         # we don't have access to the app state
 

--- a/marimo/_server/uvicorn_utils.py
+++ b/marimo/_server/uvicorn_utils.py
@@ -1,11 +1,12 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import asyncio
 import signal
 import sys
 from typing import Any
 
 import uvicorn
-from packaging import version
 
 from marimo import _loggers
 
@@ -13,6 +14,8 @@ LOGGER = _loggers.marimo_logger()
 
 
 def initialize_signals() -> None:
+    from packaging import version
+
     # 0.29.0 changed how uvicorn handles signals
     #
     # https://github.com/encode/uvicorn/pull/1600
@@ -33,6 +36,8 @@ def initialize_signals() -> None:
 
 
 def close_uvicorn(server: uvicorn.Server) -> None:
+    from packaging import version
+
     LOGGER.debug("Shutting down uvicorn")
 
     # Tried using sys.exit(0) to quit instead, but that ends up not being


### PR DESCRIPTION
We now host lockfiles for pyodide at https://wasm.marimo.app/pyodide-lock.json. This allows us resolve marimo packages and deps much faster than before (no waterfalls, and no looking at pypi for the file urls or deps)

Other improvements: 
* don't load the initial `pyodide.js`, we bundle this in
* don't initialize the save worker until the main worker is done -> we can benefit from a cache hit 
* lazily import `packages`