### PR TITLE
docs: add support for model providers with usage examples

### DIFF
--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -339,3 +339,4 @@ configuration with a dictionary conforming to the config.
 
 ```{eval-rst}
 .. autoclass:: marimo.ai.ChatAttachment
+```

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -75,7 +75,7 @@ chatbot
 ::::
 
 ```{note}
-We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). Cerebras, as of today, offers the fastest inferencing of the Llama3.2 model, and GROQ is also competitive in this space.
+We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). Cerebras, as of today, offers the fastest inferencing of the Llama3.1 70B model and GROQ is also competitive in this space.
 ```
 
 ### Finding the Right Endpoint URLs

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -297,7 +297,7 @@ chatbot
 ::::
 
 ```{note}
-We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). Cerebras, as of today, offers the fastest inferencing of the Llama3.1 70B model and GROQ is also competitive in this space.
+We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). You can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion in marimo](/guides/editor_features/ai_completion#ai-completion).
 ```
 
 ### Finding the Right Endpoint URLs
@@ -316,8 +316,6 @@ chatbot = mo.ui.chat(
 )
 chatbot
 ```
-
-We recommend using free providers like [GROQ](https://groq.com/) and [Cerebras](https://cerebras.ai/), as you can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion documentation in marimo](https://docs.marimo.io/guides/editor_features/ai_completion.html#ai-completion).
 
 If you want more examples for model providers and their endpoints listed, please submit a [feature request](https://github.com/marimo-team/marimo/issues/new?template=documentation.yaml).
 

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -37,88 +37,6 @@ AI models from popular providers or custom functions.
 
 ## Basic Usage
 
-## Supported Model Providers
-
-You can refer to the [LiteLLM page](https://litellm.vercel.app/docs/providers) for a list of OpenAI API supported providers. If you want any specific provider added explicitly (ones that don't abide by the standard OpenAI API format), you can file a [feature request](https://github.com/marimo-team/marimo/issues/new?template=feature_request.yaml).
-
-Normally, overriding the `base_url` parameter should work. Here are some examples:
-
-::::{tab-set}
-:::{tab-item} Cerebras
-
-```python
-chatbot = mo.ui.chat(
-   mo.ai.llm.openai(
-       model="llama3.1-8b",
-       api_key="csk-...", # insert your key here,
-       base_url="https://api.cerebras.ai/v1/",
-   ),
-)
-chatbot
-```
-
-:::
-:::{tab-item} Groq
-
-```python
-chatbot = mo.ui.chat(
-   mo.ai.llm.openai(
-       model="llama-3.1-70b-versatile",
-       api_key="gsk_...", # insert your key here,
-       base_url="https://api.groq.com/openai/v1/",
-   ),
-)
-chatbot
-```
-
-:::
-::::
-
-```{note}
-We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). Cerebras, as of today, offers the fastest inferencing of the Llama3.1 70B model and GROQ is also competitive in this space.
-```
-
-### Finding the Right Endpoint URLs
-
-While the [LiteLLM page](https://litellm.vercel.app/docs/providers) provides a list of OpenAI API supported providers, the endpoints mentioned there are for chat completion and are not suitable for the `base_url` parameter. You need to do your research on the documentation websites of the model providers you select and find the right endpoint URL for normal inferencing (can usually be found in the curl commands).
-
-For example, here is how you can override the `base_url` and specify the endpoint for Cerebras:
-
-```python
-chatbot = mo.ui.chat(
-   mo.ai.llm.openai(
-       model="llama3.1-8b",
-       api_key=key,
-       base_url="https://api.cerebras.ai/v1/",
-   ),
-)
-chatbot
-```
-
-We recommend using free providers like [GROQ](https://groq.com/) and [Cerebras](https://cerebras.ai/), as you can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion documentation in marimo](https://docs.marimo.io/guides/editor_features/ai_completion.html#ai-completion).
-
-If you want more examples for model providers and their endpoints listed, please submit a [feature request](https://github.com/marimo-team/marimo/issues/new?template=documentation.yaml).
-
-### Example Usage
-
-```python
-import marimo as mo
-chatbot = mo.ui.chat(
-   mo.ai.llm.openai(
-       model="llama3.1-8b",
-       system_message="You are a helpful assistant.",
-       api_key="csk-...", # insert your key here
-       base_url="https://api.cerebras.ai/v1/",
-   ),
-    prompts=[
-        "Hello",
-        "How are you?",
-        "I'm doing great, how about you?",
-    ],
-)
-chatbot
-```
-
 Here's a simple example using a custom echo model:
 
 ```python
@@ -339,4 +257,86 @@ configuration with a dictionary conforming to the config.
 
 ```{eval-rst}
 .. autoclass:: marimo.ai.ChatAttachment
+```
+
+## Supported Model Providers
+
+You can refer to the [LiteLLM page](https://litellm.vercel.app/docs/providers) for a list of OpenAI API supported providers. If you want any specific provider added explicitly (ones that don't abide by the standard OpenAI API format), you can file a [feature request](https://github.com/marimo-team/marimo/issues/new?template=feature_request.yaml).
+
+Normally, overriding the `base_url` parameter should work. Here are some examples:
+
+::::{tab-set}
+:::{tab-item} Cerebras
+
+```python
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="llama3.1-8b",
+       api_key="csk-...", # insert your key here,
+       base_url="https://api.cerebras.ai/v1/",
+   ),
+)
+chatbot
+```
+
+:::
+:::{tab-item} Groq
+
+```python
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="llama-3.1-70b-versatile",
+       api_key="gsk_...", # insert your key here,
+       base_url="https://api.groq.com/openai/v1/",
+   ),
+)
+chatbot
+```
+
+:::
+::::
+
+```{note}
+We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). Cerebras, as of today, offers the fastest inferencing of the Llama3.1 70B model and GROQ is also competitive in this space.
+```
+
+### Finding the Right Endpoint URLs
+
+While the [LiteLLM page](https://litellm.vercel.app/docs/providers) provides a list of OpenAI API supported providers, the endpoints mentioned there are for chat completion and are not suitable for the `base_url` parameter. You need to do your research on the documentation websites of the model providers you select and find the right endpoint URL for normal inferencing (can usually be found in the curl commands).
+
+For example, here is how you can override the `base_url` and specify the endpoint for Cerebras:
+
+```python
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="llama3.1-8b",
+       api_key=key,
+       base_url="https://api.cerebras.ai/v1/",
+   ),
+)
+chatbot
+```
+
+We recommend using free providers like [GROQ](https://groq.com/) and [Cerebras](https://cerebras.ai/), as you can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion documentation in marimo](https://docs.marimo.io/guides/editor_features/ai_completion.html#ai-completion).
+
+If you want more examples for model providers and their endpoints listed, please submit a [feature request](https://github.com/marimo-team/marimo/issues/new?template=documentation.yaml).
+
+### Example Usage
+
+```python
+import marimo as mo
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="llama3.1-8b",
+       system_message="You are a helpful assistant.",
+       api_key="csk-...", # insert your key here
+       base_url="https://api.cerebras.ai/v1/",
+   ),
+    prompts=[
+        "Hello",
+        "How are you?",
+        "I'm doing great, how about you?",
+    ],
+)
+chatbot
 ```

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -261,7 +261,7 @@ configuration with a dictionary conforming to the config.
 
 ## Supported Model Providers
 
-You can refer to the [LiteLLM page](https://litellm.vercel.app/docs/providers) for a list of OpenAI API supported providers. If you want any specific provider added explicitly (ones that don't abide by the standard OpenAI API format), you can file a [feature request](https://github.com/marimo-team/marimo/issues/new?template=feature_request.yaml).
+We support any OpenAI-compatible endpoint. If you want any specific provider added explicitly (ones that don't abide by the standard OpenAI API format), you can file a [feature request](https://github.com/marimo-team/marimo/issues/new?template=feature_request.yaml).
 
 Normally, overriding the `base_url` parameter should work. Here are some examples:
 
@@ -272,7 +272,7 @@ Normally, overriding the `base_url` parameter should work. Here are some example
 chatbot = mo.ui.chat(
    mo.ai.llm.openai(
        model="llama3.1-8b",
-       api_key="csk-...", # insert your key here,
+       api_key="csk-...", # insert your key here
        base_url="https://api.cerebras.ai/v1/",
    ),
 )
@@ -286,8 +286,22 @@ chatbot
 chatbot = mo.ui.chat(
    mo.ai.llm.openai(
        model="llama-3.1-70b-versatile",
-       api_key="gsk_...", # insert your key here,
+       api_key="gsk_...", # insert your key here
        base_url="https://api.groq.com/openai/v1/",
+   ),
+)
+chatbot
+```
+
+:::
+:::{tab-item} xAI
+
+```python
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="grok-beta",
+       api_key=key, # insert your key here
+       base_url="https://api.x.ai/v1",
    ),
 )
 chatbot
@@ -297,44 +311,5 @@ chatbot
 ::::
 
 ```{note}
-We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). You can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion in marimo](/guides/editor_features/ai_completion).
-```
-
-### Finding the Right Endpoint URLs
-
-While the [LiteLLM page](https://litellm.vercel.app/docs/providers) provides a list of OpenAI API supported providers, the endpoints mentioned there are for chat completion and are not suitable for the `base_url` parameter. You need to do your research on the documentation websites of the model providers you select and find the right endpoint URL for normal inferencing (can usually be found in the curl commands).
-
-For example, here is how you can override the `base_url` and specify the endpoint for Cerebras:
-
-```python
-chatbot = mo.ui.chat(
-   mo.ai.llm.openai(
-       model="llama3.1-8b",
-       api_key=key,
-       base_url="https://api.cerebras.ai/v1/",
-   ),
-)
-chatbot
-```
-
-If you want more examples for model providers and their endpoints listed, please submit a [feature request](https://github.com/marimo-team/marimo/issues/new?template=documentation.yaml).
-
-### Example Usage
-
-```python
-import marimo as mo
-chatbot = mo.ui.chat(
-   mo.ai.llm.openai(
-       model="llama3.1-8b",
-       system_message="You are a helpful assistant.",
-       api_key="csk-...", # insert your key here
-       base_url="https://api.cerebras.ai/v1/",
-   ),
-    prompts=[
-        "Hello",
-        "How are you?",
-        "I'm doing great, how about you?",
-    ],
-)
-chatbot
+We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). You can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion documentation in marimo](/guides/editor_features/ai_completion).
 ```

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -297,7 +297,7 @@ chatbot
 ::::
 
 ```{note}
-We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). You can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion in marimo](/guides/editor_features/ai_completion#ai-completion).
+We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). You can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion in marimo](/guides/editor_features/ai_completion).
 ```
 
 ### Finding the Right Endpoint URLs

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -37,6 +37,88 @@ AI models from popular providers or custom functions.
 
 ## Basic Usage
 
+## Supported Model Providers
+
+You can refer to the [LiteLLM page](https://litellm.vercel.app/docs/providers) for a list of OpenAI API supported providers. If you want any specific provider added explicitly (ones that don't abide by the standard OpenAI API format), you can file a [feature request](https://github.com/marimo-team/marimo/issues/new?template=feature_request.yaml).
+
+Normally, overriding the `base_url` parameter should work. Here are some examples:
+
+::::{tab-set}
+:::{tab-item} Cerebras
+
+```python
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="llama3.1-8b",
+       api_key=key,
+       base_url="https://api.cerebras.ai/v1/",
+   ),
+)
+chatbot
+```
+
+:::
+:::{tab-item} Groq
+
+```python
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="llama-3.1-70b-versatile",
+       api_key=key,
+       base_url="https://api.groq.com/openai/v1/",
+   ),
+)
+chatbot
+```
+
+:::
+::::
+
+```{note}
+We have added examples for GROQ and Cerebras. These providers offer free API keys and are great for trying out Llama models (from Meta). Cerebras, as of today, offers the fastest inferencing of the Llama3.2 model, and GROQ is also competitive in this space.
+```
+
+### Finding the Right Endpoint URLs
+
+While the [LiteLLM page](https://litellm.vercel.app/docs/providers) provides a list of OpenAI API supported providers, the endpoints mentioned there are for chat completion and are not suitable for the `base_url` parameter. You need to do your research on the documentation websites of the model providers you select and find the right endpoint URL for normal inferencing (can usually be found in the curl commands).
+
+For example, here is how you can override the `base_url` and specify the endpoint for Cerebras:
+
+```python
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="llama3.1-8b",
+       api_key=key,
+       base_url="https://api.cerebras.ai/v1/",
+   ),
+)
+chatbot
+```
+
+We recommend using free providers like [GROQ](https://groq.com/) and [Cerebras](https://cerebras.ai/), as you can sign up on their platforms and integrate with various AI integrations in marimo easily. For more information, refer to the [AI completion documentation in marimo](https://docs.marimo.io/guides/editor_features/ai_completion.html#ai-completion).
+
+If you want more examples for model providers and their endpoints listed, please submit a [feature request](https://github.com/marimo-team/marimo/issues/new?template=documentation.yaml).
+
+### Example Usage
+
+```python
+import marimo as mo
+chatbot = mo.ui.chat(
+   mo.ai.llm.openai(
+       model="llama3.1-8b",
+       system_message="You are a helpful assistant.",
+       api_key="csk-...", # insert your key here
+       base_url="https://api.cerebras.ai/v1/",
+   ),
+    prompts=[
+        "Hello",
+        "How are you?",
+        "I'm doing great, how about you?",
+    ],
+)
+chatbot
+```
+
 Here's a simple example using a custom echo model:
 
 ```python
@@ -257,4 +339,3 @@ configuration with a dictionary conforming to the config.
 
 ```{eval-rst}
 .. autoclass:: marimo.ai.ChatAttachment
-```

--- a/docs/api/inputs/chat.md
+++ b/docs/api/inputs/chat.md
@@ -50,7 +50,7 @@ Normally, overriding the `base_url` parameter should work. Here are some example
 chatbot = mo.ui.chat(
    mo.ai.llm.openai(
        model="llama3.1-8b",
-       api_key=key,
+       api_key="csk-...", # insert your key here,
        base_url="https://api.cerebras.ai/v1/",
    ),
 )
@@ -64,7 +64,7 @@ chatbot
 chatbot = mo.ui.chat(
    mo.ai.llm.openai(
        model="llama-3.1-70b-versatile",
-       api_key=key,
+       api_key="gsk_...", # insert your key here,
        base_url="https://api.groq.com/openai/v1/",
    ),
 )


### PR DESCRIPTION
## 📝 Summary

Update the `chat.md` file to include examples for GROQ and Cerebras model providers (while also linking the [LiteLLM page](https://litellm.vercel.app/docs/providers) to showcase various other model providers).
Address comment - https://github.com/marimo-team/marimo/issues/2773#issuecomment-2455326251

## 🔍 Description of Changes

- Added examples for GROQ and Cerebras model providers.
- Included a note about the availability of free API keys for GROQ and Cerebras.
- Provided guidance on finding the correct endpoint URLs for model providers (refer to docs; usually found in the curl commands).

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers
@akshayka OR @mscolnick
