### PR TITLE
chore: add recommended deps

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -86,43 +86,6 @@ Having installation issues? Reach out to us [at GitHub](https://github.com/marim
 marimo tutorial --help
 ```
 
-## Enable more features with optional dependencies
-
-Some features require additional dependencies, which are not installed by default. This includes:
-
-- [SQL cells](/guides/working_with_data/sql.md)
-- Charts in the datasource viewer
-- [AI features](/guides/editor_features/ai_completion.md)
-- Format on save
-
-To install the optional dependencies, run:
-
-::::{tab-set}
-:::{tab-item} install with pip
-
-```bash
-pip install "marimo[recommended]"
-```
-
-:::
-:::{tab-item} install with uv
-
-```bash
-uv pip install "marimo[recommended]"
-```
-
-:::
-:::{tab-item} install with conda
-
-```bash
-conda install -c conda-forge marimo duckdb altair polars openai ruff
-```
-
-:::
-::::
-
-This will install: `duckdb`, `altair`, `polars`, `openai`, and `ruff`.
-
 ## Edit notebooks
 
 Create and edit notebooks with `marimo edit`.
@@ -179,6 +142,43 @@ auto_instantiate = false
 ```
 
 :::
+
+## Enable more features with optional dependencies
+
+Some features require additional dependencies, which are not installed by default. This includes:
+
+- [SQL cells](/guides/working_with_data/sql.md)
+- Charts in the datasource viewer
+- [AI features](/guides/editor_features/ai_completion.md)
+- Format on save
+
+To install the optional dependencies, run:
+
+::::{tab-set}
+:::{tab-item} install with pip
+
+```bash
+pip install "marimo[recommended]"
+```
+
+:::
+:::{tab-item} install with uv
+
+```bash
+uv pip install "marimo[recommended]"
+```
+
+:::
+:::{tab-item} install with conda
+
+```bash
+conda install -c conda-forge marimo duckdb altair polars openai ruff
+```
+
+:::
+::::
+
+This will install: `duckdb`, `altair`, `polars`, `openai`, and `ruff`.
 
 ## GitHub Copilot and AI Assistant
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -86,6 +86,43 @@ Having installation issues? Reach out to us [at GitHub](https://github.com/marim
 marimo tutorial --help
 ```
 
+## Enable more features with optional dependencies
+
+Some features require additional dependencies, which are not installed by default. This includes:
+
+- [SQL cells](/guides/working_with_data/sql.md)
+- Charts in the datasource viewer
+- [AI features](/guides/editor_features/ai_completion.md)
+- Format on save
+
+To install the optional dependencies, run:
+
+::::{tab-set}
+:::{tab-item} install with pip
+
+```bash
+pip install "marimo[recommended]"
+```
+
+:::
+:::{tab-item} install with uv
+
+```bash
+uv pip install "marimo[recommended]"
+```
+
+:::
+:::{tab-item} install with conda
+
+```bash
+conda install -c conda-forge marimo duckdb altair polars openai ruff
+```
+
+:::
+::::
+
+This will install: `duckdb`, `altair`, `polars`, `openai`, and `ruff`.
+
 ## Edit notebooks
 
 Create and edit notebooks with `marimo edit`.

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -7,9 +7,29 @@ the query result back as a Python dataframe.
 To create a SQL cell, you first need to install additional dependencies,
 including [duckdb](https://duckdb.org/):
 
+::::{tab-set}
+:::{tab-item} install with pip
+
 ```bash
-pip install 'marimo[sql]'
+pip install "marimo[sql]"
 ```
+
+:::
+:::{tab-item} install with uv
+
+```bash
+uv pip install "marimo[sql]"
+```
+
+:::
+:::{tab-item} install with conda
+
+```bash
+conda install -c conda-forge marimo duckdb polars
+```
+
+:::
+::::
 
 ```{admonition} Examples
 :class: tip
@@ -17,7 +37,6 @@ pip install 'marimo[sql]'
 For example notebooks, check out
 [`examples/sql/` on GitHub](https://github.com/marimo-team/marimo/tree/main/examples/sql/).
 ```
-
 
 ## Example
 

--- a/docs/integrations/motherduck.md
+++ b/docs/integrations/motherduck.md
@@ -24,7 +24,7 @@ uv pip install "marimo[sql]"
 :::{tab-item} install with conda
 
 ```bash
-conda install -c conda-forge marimo duckdb
+conda install -c conda-forge marimo duckdb polars
 ```
 
 :::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,19 @@ marimo = "marimo._cli.cli:main"
 homepage = "https://github.com/marimo-team/marimo"
 
 [project.optional-dependencies]
-sql = ["duckdb >= 1.0.0"]
+sql = [
+    "duckdb >= 1.0.0",
+    "polars >= 1.9.0",
+]
+# List of deps that are recommended for most users
+# in order to unlock all features in marimo
+recommended = [
+    "duckdb>=1.1.0", # SQL cells
+    "altair>=5.4.0", # Plotting in datasource viewer
+    "polars>=1.9.0", # SQL output back in Python
+    "openai>=1.41.1", # AI features
+    "ruff", # Formatting
+]
 
 dev = [
     "click <8.1.4",  # https://github.com/pallets/click/issues/2558


### PR DESCRIPTION
1. Add `pip install "marimo[recommended]"` which unlocks all the features. I did not want to go with `all` as there are more deps that we could add in future that we may not need in recommended (`vegafusion`, `duckdb` extensions, `anthropic`0
2. This also add polars to the sql deps, since we require one of pandas and polars, and this helps them get started without an initial error when starting from a clean venv