### PR TITLE
fix: sql case with function

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -6,11 +6,12 @@ import itertools
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Callable, Literal, Optional, Union
+from typing import Callable, Literal, Optional, Set, Union
 from uuid import uuid4
 
 from marimo import _loggers
 from marimo._ast.sql_visitor import (
+    SQLDefs,
     find_sql_defs,
     find_sql_refs,
     normalize_sql_f_string,
@@ -489,20 +490,28 @@ class ScopedVisitor(ast.NodeVisitor):
                     return node
 
                 for statement in statements:
+                    tables: Set[str] = set()
+                    from_targets: list[str] = []
                     # Parse the refs and defs of each statement
                     try:
                         tables = duckdb.get_table_names(statement.query)
+                    except (duckdb.ProgrammingError, duckdb.IOException):
+                        LOGGER.debug(
+                            "Error parsing SQL statement: %s", statement.query
+                        )
+                    except BaseException as e:
+                        LOGGER.warning("Unexpected duckdb error %s", e)
+                    try:
                         # TODO(akshayka): more comprehensive parsing
                         # of the statement -- schemas can show up in
                         # joins, queries, ...
                         from_targets = find_sql_refs(statement.query)
                     except (duckdb.ProgrammingError, duckdb.IOException):
-                        self.generic_visit(node)
-                        continue
+                        LOGGER.debug(
+                            "Error parsing SQL statement: %s", statement.query
+                        )
                     except BaseException as e:
                         LOGGER.warning("Unexpected duckdb error %s", e)
-                        self.generic_visit(node)
-                        continue
 
                     for name in itertools.chain(tables, from_targets):
                         # Name (table, db) may be a URL or something else that
@@ -514,12 +523,10 @@ class ScopedVisitor(ast.NodeVisitor):
                     try:
                         sql_defs = find_sql_defs(sql)
                     except duckdb.ProgrammingError:
-                        self.generic_visit(node)
-                        continue
+                        sql_defs = SQLDefs()
                     except BaseException as e:
                         LOGGER.warning("Unexpected duckdb error %s", e)
-                        self.generic_visit(node)
-                        continue
+                        sql_defs = SQLDefs()
 
                     for _table in sql_defs.tables:
                         self._define(None, _table, VariableData("table"))

--- a/tests/_ast/test_sql_visitor.py
+++ b/tests/_ast/test_sql_visitor.py
@@ -485,6 +485,23 @@ class TestFindSQLRefs:
         assert find_sql_refs(sql) == ["table1", "table2"]
 
     @staticmethod
+    def test_find_sql_refs_without_duplicates() -> None:
+        sql = """
+        SELECT * FROM table1;
+        SELECT * FROM table2;
+        SELECT * FROM table1;
+        """
+        assert find_sql_refs(sql) == ["table1", "table2"]
+
+    @staticmethod
+    def test_find_sql_refs_with_function() -> None:
+        sql = """
+        SELECT *, embedding(text) as text_embedding
+        FROM prompts;
+        """
+        assert find_sql_refs(sql) == ["prompts"]
+
+    @staticmethod
     def test_find_sql_refs_with_schema() -> None:
         sql = "SELECT * FROM my_schema.my_table;"
         assert find_sql_refs(sql) == ["my_schema", "my_table"]

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import ast
 from inspect import cleandoc
+from textwrap import dedent
 
 import pytest
 
@@ -1096,6 +1097,23 @@ def test_sql_statement_with_url() -> None:
     assert v.defs == set(["cars"])
     assert v.variable_data == {"cars": [VariableData("table")]}
     assert v.refs == set(["mo"])
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="Requires duckdb")
+def test_sql_statement_with_function() -> None:
+    code = dedent('''
+    prompt_embeddings = mo.sql(
+        f"""
+        SELECT *, embedding(text) as text_embedding
+        FROM prompts;
+        """
+    )
+    ''')
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == set(["prompt_embeddings"])
+    assert v.refs == set(["mo", "prompts"])
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="Requires duckdb")


### PR DESCRIPTION
`duckdb.get_table_names` fails for unknown (or unloaded) functions. so we don't want to fail everything if that fails