### PR TITLE
improvement: make it clearer/possible to convert to SQL and markdown

### DIFF
--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -66,7 +66,7 @@ const CreateCellButtonContextMenu = (props: {
             onClick({ code: "" });
           }}
         >
-          <div className="mr-3">
+          <div className="mr-3 text-muted-foreground">
             <PythonIcon />
           </div>
           Python cell
@@ -79,7 +79,7 @@ const CreateCellButtonContextMenu = (props: {
             onClick({ code: new MarkdownLanguageAdapter().defaultCode });
           }}
         >
-          <div className="mr-3">
+          <div className="mr-3 text-muted-foreground">
             <MarkdownIcon />
           </div>
           Markdown cell
@@ -91,7 +91,7 @@ const CreateCellButtonContextMenu = (props: {
             onClick({ code: new SQLLanguageAdapter().defaultCode });
           }}
         >
-          <div className="mr-3">
+          <div className="mr-3 text-muted-foreground">
             <DatabaseIcon size={13} strokeWidth={1.5} />
           </div>
           SQL cell

--- a/frontend/src/components/editor/cell/cell-actions.tsx
+++ b/frontend/src/components/editor/cell/cell-actions.tsx
@@ -87,7 +87,9 @@ const CellActionsDropdownInternal = (
                     >
                       <div className="flex items-center flex-1">
                         {action.icon && (
-                          <div className="mr-2 w-5">{action.icon}</div>
+                          <div className="mr-2 w-5 text-muted-foreground">
+                            {action.icon}
+                          </div>
                         )}
                         <div className="flex-1">{action.label}</div>
                         <div className="flex-shrink-0 text-sm">

--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -127,7 +127,9 @@ export const CellActionsContextMenu = ({ children, ...props }: Props) => {
                 >
                   <div className="flex items-center flex-1">
                     {action.icon && (
-                      <div className="mr-2 w-5">{action.icon}</div>
+                      <div className="mr-2 w-5 text-muted-foreground">
+                        {action.icon}
+                      </div>
                     )}
                     <div className="flex-1">{action.label}</div>
                     <div className="flex-shrink-0 text-sm">

--- a/frontend/src/components/editor/cell/code/icons.tsx
+++ b/frontend/src/components/editor/cell/code/icons.tsx
@@ -7,6 +7,7 @@ export const PythonIcon = (props: SVGProps<SVGSVGElement>) => (
     xmlns="http://www.w3.org/2000/svg"
     width="1em"
     height="1em"
+    fill="currentColor"
     viewBox="0 0 448 512"
     {...props}
   >

--- a/frontend/src/components/editor/cell/code/language-toggle.tsx
+++ b/frontend/src/components/editor/cell/code/language-toggle.tsx
@@ -26,23 +26,20 @@ export const LanguageToggles: React.FC<LanguageTogglesProps> = ({
   onAfterToggle,
 }) => {
   const canUseMarkdown = useMemo(
-    () => new MarkdownLanguageAdapter().isSupported(code),
+    () => new MarkdownLanguageAdapter().isSupported(code) || code.trim() === "",
     [code],
   );
   const canUseSQL = useMemo(
-    () => new SQLLanguageAdapter().isSupported(code),
+    () => new SQLLanguageAdapter().isSupported(code) || code.trim() === "",
     [code],
   );
 
   return (
-    <div className="absolute right-2 top-2 z-20 flex hover-action">
+    <div className="absolute right-3 top-2 z-20 flex hover-action gap-1">
       <LanguageToggle
         editorView={editorView}
         currentLanguageAdapter={currentLanguageAdapter}
-        // Prefer showing markdown over SQL when both are supported
-        canSwitchToLanguage={
-          canUseSQL && currentLanguageAdapter === "python" && !canUseMarkdown
-        }
+        canSwitchToLanguage={canUseSQL && currentLanguageAdapter === "python"}
         icon={
           <DatabaseIcon
             color={"var(--sky-11)"}

--- a/frontend/src/components/icons/multi-icon.tsx
+++ b/frontend/src/components/icons/multi-icon.tsx
@@ -17,8 +17,8 @@ export const MultiIcon = ({
 }: PropsWithChildren<MultiIconProps>) => {
   const [first, second] = React.Children.toArray(children);
   const positioning = layerTop
-    ? "top-[-1px] left-[-1px]"
-    : "bottom-[-1px] right-[-1px]";
+    ? "top-[-2px] left-[-2px]"
+    : "bottom-[-2px] right-[-2px]";
   return (
     <div className="multi-icon relative w-fit">
       {first}

--- a/frontend/src/core/codemirror/language/__tests__/extension.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/extension.test.ts
@@ -3,14 +3,17 @@ import { beforeAll, describe, expect, it } from "vitest";
 import {
   adaptiveLanguageConfiguration,
   getInitialLanguageAdapter,
+  languageAdapterState,
+  switchLanguage,
 } from "../extension";
 import { EditorState } from "@codemirror/state";
 import { OverridingHotkeyProvider } from "@/core/hotkeys/hotkeys";
 import type { MovementCallbacks } from "../../cells/extensions";
 import { store } from "@/core/state/jotai";
 import { capabilitiesAtom } from "@/core/config/capabilities";
+import { EditorView } from "@codemirror/view";
 
-function createState(content: string) {
+function createState(content: string, selection?: { anchor: number }) {
   const state = EditorState.create({
     doc: content,
     extensions: [
@@ -26,6 +29,7 @@ function createState(content: string) {
         cellMovementCallbacks: {} as MovementCallbacks,
       }),
     ],
+    selection,
   });
 
   return state;
@@ -55,5 +59,121 @@ describe("getInitialLanguageAdapter", () => {
   it("should return sql", () => {
     const state = createState("df = mo.sql('hello')");
     expect(getInitialLanguageAdapter(state).type).toBe("sql");
+  });
+});
+
+describe("switchLanguage", () => {
+  it("handles keepCodeAsIs is true", () => {
+    const state = createState("print('Hello')\nprint('Goodbye')", {
+      anchor: 2,
+    });
+    const mockEditor = new EditorView({ state });
+    switchLanguage(mockEditor, "python", { keepCodeAsIs: true });
+    expect(mockEditor.state.field(languageAdapterState).type).toBe("python");
+    expect(mockEditor.state.doc.toString()).toEqual(
+      "print('Hello')\nprint('Goodbye')",
+    );
+
+    // Check that the cursor position is maintained
+    expect(mockEditor.state.selection.main.from).toEqual(2);
+
+    // Check that the language adapter is updated
+    expect(getInitialLanguageAdapter(mockEditor.state).type).toBe("python");
+
+    // Switch to markdown
+    switchLanguage(mockEditor, "markdown", { keepCodeAsIs: true });
+    expect(mockEditor.state.field(languageAdapterState).type).toBe("markdown");
+    expect(mockEditor.state.doc.toString()).toEqual(
+      "print('Hello')\nprint('Goodbye')",
+    );
+
+    // Switch back to python
+    switchLanguage(mockEditor, "python", { keepCodeAsIs: true });
+    expect(mockEditor.state.field(languageAdapterState).type).toBe("python");
+    expect(mockEditor.state.doc.toString()).toEqual(
+      "print('Hello')\nprint('Goodbye')",
+    );
+
+    // Check that the cursor position is maintained
+    expect(mockEditor.state.selection.main.from).toEqual(2);
+
+    // Switch to sql
+    switchLanguage(mockEditor, "sql", { keepCodeAsIs: true });
+    expect(mockEditor.state.field(languageAdapterState).type).toBe("sql");
+    expect(mockEditor.state.doc.toString()).toEqual(
+      "print('Hello')\nprint('Goodbye')",
+    );
+
+    // Check that the cursor position is maintained
+    expect(mockEditor.state.selection.main.from).toEqual(2);
+
+    // Switch back to python
+    switchLanguage(mockEditor, "python", { keepCodeAsIs: true });
+    expect(mockEditor.state.field(languageAdapterState).type).toBe("python");
+    expect(mockEditor.state.doc.toString()).toEqual(
+      "print('Hello')\nprint('Goodbye')",
+    );
+
+    // Check that the cursor position is maintained
+    expect(mockEditor.state.selection.main.from).toEqual(2);
+  });
+
+  it("handles keepCodeAsIs is false", () => {
+    const state = createState("print('Hello')\nprint('Goodbye')", {
+      anchor: 2,
+    });
+    const mockEditor = new EditorView({ state });
+    switchLanguage(mockEditor, "python", { keepCodeAsIs: false });
+    expect(mockEditor.state.doc.toString()).toEqual(
+      "print('Hello')\nprint('Goodbye')",
+    );
+
+    // Check that the cursor position is maintained
+    expect(mockEditor.state.selection.main.from).toEqual(2);
+
+    // Switch to markdown
+    switchLanguage(mockEditor, "markdown", { keepCodeAsIs: false });
+    expect(mockEditor.state.doc.toString()).toEqual(
+      "print('Hello')\nprint('Goodbye')",
+    );
+
+    // Switch back to python
+    switchLanguage(mockEditor, "python", { keepCodeAsIs: false });
+    expect(mockEditor.state.doc.toString()).toMatchInlineSnapshot(`
+      "mo.md(
+          """
+          print('Hello')
+          print('Goodbye')
+          """
+      )"
+    `);
+
+    // Check that the cursor position is shifted
+    expect(mockEditor.state.selection.main.from).toEqual(18);
+
+    // Switch to sql
+    switchLanguage(mockEditor, "sql", { keepCodeAsIs: false });
+    expect(mockEditor.state.doc.toString()).toMatchInlineSnapshot(`
+      "print('Hello')
+      print('Goodbye')"
+    `);
+
+    // Check that the cursor position is shifted
+    expect(mockEditor.state.selection.main.from).toEqual(18);
+
+    // Switch back to python
+    switchLanguage(mockEditor, "python", { keepCodeAsIs: false });
+    expect(mockEditor.state.doc.toString()).toMatchInlineSnapshot(`
+      "_df = mo.sql(
+          f"""
+          mo.md(
+              \\"""
+              print('Hello')
+              print('Goodbye')
+              \\"""
+          )
+          """
+      )"
+    `);
   });
 });

--- a/frontend/src/core/codemirror/language/commands.ts
+++ b/frontend/src/core/codemirror/language/commands.ts
@@ -29,6 +29,11 @@ export function canToggleToLanguage(
     return false;
   }
 
+  // If there is no code, we can always toggle to any language
+  if (editorView.state.doc.toString().trim() === "") {
+    return true;
+  }
+
   return LanguageAdapters[language]().isSupported(
     getEditorCodeAsPython(editorView),
   );

--- a/frontend/src/core/codemirror/language/sql.ts
+++ b/frontend/src/core/codemirror/language/sql.ts
@@ -19,6 +19,7 @@ import {
   upgradePrefixKind,
 } from "./utils/quotes";
 import { capabilitiesAtom } from "@/core/config/capabilities";
+import { MarkdownLanguageAdapter } from "./markdown";
 
 const quoteKinds = [
   ['"""', '"""'],
@@ -59,7 +60,11 @@ export class SQLLanguageAdapter implements LanguageAdapter {
 
   transformIn(pythonCode: string): [string, number] {
     if (!this.isSupported(pythonCode)) {
-      throw new Error("Not supported");
+      // Attempt to remove any markdown wrappers
+      const [transformedCode, offset] =
+        new MarkdownLanguageAdapter().transformIn(pythonCode);
+      // Just return the original code
+      return [transformedCode, offset];
     }
 
     pythonCode = pythonCode.trim();

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -102,7 +102,7 @@ if confirm "Push changes to remote?"; then
 fi
 
 # Create and push tag
-if confirm "Create and push tag v$NEW_VERSION?"; then
+if confirm "Create and push tag $NEW_VERSION?"; then
   git tag -a "$NEW_VERSION" -m "release: $NEW_VERSION"
   git push origin --tags
   echo -e "${GREEN}✓ Tag pushed successfully${NC}"
@@ -110,3 +110,6 @@ fi
 
 # Final success message
 echo -e "\n${BOLD}${GREEN}🎉 Release $NEW_VERSION completed successfully! 🎉${NC}\n"
+echo -e "${YELLOW}Don't forget to:${NC}"
+echo "  1. Monitor the release: https://github.com/marimo-team/marimo/actions/workflows/release.yml"
+echo "  2. Draft the release notes: https://github.com/marimo-team/marimo/releases/new?tag=$NEW_VERSION"


### PR DESCRIPTION
* Allow converting to SQL on an empty cell
* Update the cell action to "Convert to SQL" and "Convert to Markdown", which is clearer and doesn't carry over the `mo.md` and `mo.sql`. Python is still "toggle"