### PR TITLE
Add `frameworks` in README list; fix typo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ This folder contains example marimo notebooks.
 - 🤖 [`ai/`](ai/): AI-related examples
 - 📦 [`third_party/`](third_party/): using popular third-party packages in marimo
 - ☁️  [`cloud/`](cloud/): using various cloud providers
+- 🧩 [`frameworks/`](frameworks/): integrating with different frameworks (web/ASGI)
 - ✨ [`misc/`](misc/): miscellenous topical examples
 
 > [!TIP]

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ This folder contains example marimo notebooks.
 - 📦 [`third_party/`](third_party/): using popular third-party packages in marimo
 - ☁️  [`cloud/`](cloud/): using various cloud providers
 - 🧩 [`frameworks/`](frameworks/): integrating with different frameworks (web/ASGI)
-- ✨ [`misc/`](misc/): miscellenous topical examples
+- ✨ [`misc/`](misc/): miscellaneous topical examples
 
 > [!TIP]
 > New to marimo? Run `marimo tutorial ui` at the command line first!


### PR DESCRIPTION
## 📝 Summary

Add frameworks subfolder in README listing; fix small typo

## 🔍 Description of Changes
Add [`frameworks`](https://github.com/marimo-team/marimo/tree/main/examples/frameworks) to [`README`](https://github.com/marimo-team/marimo/blob/main/examples/README.md); fix typo [here](https://github.com/marimo-team/marimo/blame/076514328aa92fb7d0a75f023253d44bee1e3f64/examples/README.md#L11)

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
