### PR TITLE
mpl proxy for matplotlib process

### DIFF
--- a/docs/guides/deploying/deploying_docker.md
+++ b/docs/guides/deploying/deploying_docker.md
@@ -75,19 +75,6 @@ docker run -p 8080:8080 -it my_app
 
 After verifying that your application runs without errors, you can use these files to deploy your application on your preferred cloud provider that supports dockerized applications.
 
-### Using Interactive Matplotlib Plots in Docker
-
-If your notebook uses `mo.mpl.interactive()` for interactive matplotlib plots, you'll need to make some additional configurations in your Dockerfile:
-
-```Dockerfile
-# Add these lines before the CMD instruction
-ENV MARIMO_MPL_HOST="0.0.0.0" # same as main host from `marimo run`.
-ENV MARIMO_MPL_SECURE=true # if you are running on https
-EXPOSE 10000  # Expose in addition to your main application port
-```
-
-This exposes the additional CSS and JavaScript required.
-
 ## Health checks
 
 You can add a health check to your Dockerfile to ensure that your application is running as expected. This is especially useful when deploying to a cloud provider.

--- a/docs/guides/working_with_data/plotting.md
+++ b/docs/guides/working_with_data/plotting.md
@@ -285,4 +285,3 @@ If you want to output the plot in the console area, use `plt.show()` or
 To make matplotlib plots interactive, use
 [mo.mpl.interactive](/api/plotting.md#marimo.mpl.interactive).
 (Matplotlib plots are not yet reactive.)
-For additional instructions when deploying an interactive matplotlib plot in Docker, see [Interactive Matplotlib Plots in Docker](/guides/deploying/deploying_docker.md#using-interactive-matplotlib-plots-in-docker)

--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from starlette.applications import Starlette
     from starlette.requests import Request
-    from starlette.websockets import WebSocket
+    from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 
 class FigureManagers:
@@ -148,19 +148,33 @@ def create_application() -> Starlette:
 
     async def websocket_endpoint(websocket: WebSocket) -> None:
         await websocket.accept()
-
-        queue = asyncio.Queue[Tuple[Any, str]]()
+        queue: asyncio.Queue[Tuple[Any, str]] = asyncio.Queue()
 
         class SyncWebSocket:
             def send_json(self, content: str) -> None:
                 queue.put_nowait((content, "json"))
-
             def send_binary(self, blob: Any) -> None:
                 queue.put_nowait((blob, "binary"))
 
         figure_id = websocket.query_params.get("figure")
-        assert figure_id is not None
-        figure_manager = figure_managers.get(figure_id)
+        if not figure_id:
+            await websocket.send_json({
+                "type": "error",
+                "message": "No figure ID provided"
+            })
+            await websocket.close()
+            return
+
+        try:
+            figure_manager = figure_managers.get(figure_id)
+        except RuntimeError as e:
+            await websocket.send_json({
+                "type": "error",
+                "message": f"Figure with id '{figure_id}' not found"
+            })
+            await websocket.close()
+            return
+
         figure_manager.add_web_socket(SyncWebSocket())  # type: ignore[no-untyped-call]
 
         async def receive() -> None:
@@ -174,11 +188,15 @@ def create_application() -> Starlette:
                         pass
                     else:
                         figure_manager.handle_json(data)  # type: ignore[no-untyped-call]
-            except Exception:
+            except WebSocketDisconnect:
                 pass
+            except Exception as e:
+                if websocket.application_state != WebSocketState.DISCONNECTED:
+                    await websocket.send_json({
+                        "type": "error",
+                        "message": str(e)
+                    })
             finally:
-                from starlette.websockets import WebSocketState
-
                 if websocket.application_state != WebSocketState.DISCONNECTED:
                     await websocket.close()
 
@@ -190,15 +208,28 @@ def create_application() -> Starlette:
                         await websocket.send_json(data)
                     else:
                         await websocket.send_bytes(data)
-            except Exception:
+            except WebSocketDisconnect:
+                # Client disconnected normally
                 pass
+            except Exception as e:
+                if websocket.application_state != WebSocketState.DISCONNECTED:
+                    await websocket.send_json({
+                        "type": "error",
+                        "message": str(e)
+                    })
             finally:
-                from starlette.websockets import WebSocketState
-
                 if websocket.application_state != WebSocketState.DISCONNECTED:
                     await websocket.close()
 
-        await asyncio.gather(receive(), send())
+        try:
+            await asyncio.gather(receive(), send())
+        except Exception as e:
+            if websocket.application_state != WebSocketState.DISCONNECTED:
+                await websocket.send_json({
+                    "type": "error",
+                    "message": str(e)
+                })
+                await websocket.close()
 
     return Starlette(
         routes=[

--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -37,7 +37,11 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from starlette.applications import Starlette
     from starlette.requests import Request
-    from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
+    from starlette.websockets import (
+        WebSocket,
+        WebSocketDisconnect,
+        WebSocketState,
+    )
 
 
 class FigureManagers:
@@ -167,7 +171,7 @@ def create_application() -> Starlette:
 
         try:
             figure_manager = figure_managers.get(figure_id)
-        except RuntimeError as e:
+        except RuntimeError:
             await websocket.send_json({
                 "type": "error",
                 "message": f"Figure with id '{figure_id}' not found"

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
-from http.client import HTTPConnection, HTTPSConnection, HTTPResponse
+from http.client import HTTPConnection, HTTPResponse, HTTPSConnection
+from typing import TYPE_CHECKING, Any, AsyncIterable, Dict, Optional
 from urllib.parse import urljoin, urlparse
 
 import starlette.status as status
@@ -31,7 +32,6 @@ from marimo._server.api.auth import validate_auth
 from marimo._server.api.deps import AppState, AppStateBase
 from marimo._server.model import SessionMode
 from marimo._tracer import server_tracer
-from typing import Any, Dict, Optional, AsyncIterable, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from starlette.requests import HTTPConnection
@@ -173,7 +173,7 @@ class AsyncHTTPResponse:
                 if not chunk:
                     break
                 yield chunk
-        except Exception as e:
+        except Exception:
             raise
         finally:
             await self.aclose()
@@ -223,7 +223,7 @@ class AsyncHTTPClient:
                             else:
                                 chunks.append(chunk)
                         return b''.join(chunks)
-                    except Exception as e:
+                    except Exception:
                         raise
                 if isinstance(request.data, str):
                     return request.data.encode()
@@ -236,11 +236,11 @@ class AsyncHTTPClient:
 
         try:
             body = await collect_body()
-        except Exception as e:
+        except Exception:
             raise
 
         def _send():
-            from http.client import HTTPSConnection, HTTPConnection
+            from http.client import HTTPConnection
             parsed_url = urlparse(request.full_url)
             path_and_query = parsed_url.path
             if parsed_url.query:
@@ -260,7 +260,7 @@ class AsyncHTTPClient:
                 )
                 resp = conn.getresponse()
                 return resp
-            except Exception as e:
+            except Exception:
                 raise
 
         response = await loop.run_in_executor(None, _send)
@@ -346,9 +346,9 @@ class ProxyMiddleware:
                             await ws_client.send(msg["text"])
                         elif "bytes" in msg:
                             await ws_client.send(msg["bytes"])
-                except ConnectionClosed as e:
+                except ConnectionClosed:
                     return
-                except Exception as e_2:
+                except Exception:
                     await websocket.close()
                     return
 
@@ -361,9 +361,9 @@ class ProxyMiddleware:
                             await websocket.send_bytes(msg)
                         else:
                             await websocket.send_text(msg)
-                except ConnectionClosed as e:
+                except ConnectionClosed:
                     return
-                except Exception as e_2:
+                except Exception:
 
                     await websocket.close()
 

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -176,6 +176,7 @@ class AsyncHTTPResponse:
         except Exception as e:
             raise
         finally:
+            await self.aclose()
 
     async def aclose(self):
         self.raw_response.close()

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Optional
-from urllib.parse import urljoin
+from functools import partial
+from http.client import HTTPConnection, HTTPSConnection, HTTPResponse
+from urllib.parse import urljoin, urlparse
 
-import httpx
 import starlette.status as status
 from starlette.authentication import (
     AuthCredentials,
@@ -31,6 +31,7 @@ from marimo._server.api.auth import validate_auth
 from marimo._server.api.deps import AppState, AppStateBase
 from marimo._server.model import SessionMode
 from marimo._tracer import server_tracer
+from typing import Any, Dict, Optional, AsyncIterable, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from starlette.requests import HTTPConnection
@@ -152,22 +153,132 @@ class OpenTelemetryMiddleware(BaseHTTPMiddleware):
                 raise
             return response
 
+class URLRequest:
+    def __init__(self, url, method, headers, data):
+        self.full_url = url
+        self.method = method
+        self.headers = headers
+        self.data = data
+
+class AsyncHTTPResponse:
+    def __init__(self, response: HTTPResponse):
+        self.raw_response = response
+        self.status_code = response.status
+        self.headers = {k.lower(): v for k, v in response.getheaders()}
+
+    async def aiter_raw(self):
+        try:
+            while True:
+                chunk = self.raw_response.read(8192)
+                if not chunk:
+                    break
+                yield chunk
+        except Exception as e:
+            raise
+        finally:
+
+    async def aclose(self):
+        self.raw_response.close()
+
+class AsyncHTTPClient:
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+        parsed = urlparse(base_url)
+        self.host = parsed.netloc
+        self.is_https = parsed.scheme == "https"
+
+    def build_request(self, method: str, url: Any, headers: Dict[str, str], content: Any) -> URLRequest:
+        # Combine base_url with path and query to form a full URL
+        full_url = f"{self.base_url}{url.path}"
+        if hasattr(url, 'query') and url.query:
+            full_url += f"?{url.query.decode('utf-8')}"
+
+        headers = dict(headers)
+        headers['host'] = self.host
+
+        request = URLRequest(
+            full_url,  # Use the full URL here
+            method=method,
+            headers=headers,
+            data=content
+        )
+
+        request.method = method
+        return request
+
+    async def send(self, request: URLRequest, stream: bool = False) -> AsyncHTTPResponse:
+        loop = asyncio.get_event_loop()
+
+        async def collect_body() -> bytes:
+            if hasattr(request, 'data'):
+                if request.data is None:
+                    return b''
+                if isinstance(request.data, AsyncIterable):
+                    chunks: list[bytes] = []
+                    try:
+                        async for chunk in request.data:
+                            if isinstance(chunk, str):
+                                chunks.append(chunk.encode())
+                            else:
+                                chunks.append(chunk)
+                        return b''.join(chunks)
+                    except Exception as e:
+                        raise
+                if isinstance(request.data, str):
+                    return request.data.encode()
+                if isinstance(request.data, bytes):
+                    return request.data
+                if hasattr(request.data, 'read'):
+                    return request.data.read()  # type: ignore
+                raise ValueError(f"Unsupported request data type: {type(request.data)}")
+            return b''
+
+        try:
+            body = await collect_body()
+        except Exception as e:
+            raise
+
+        def _send():
+            from http.client import HTTPSConnection, HTTPConnection
+            parsed_url = urlparse(request.full_url)
+            path_and_query = parsed_url.path
+            if parsed_url.query:
+                path_and_query += f"?{parsed_url.query}"
+
+            conn_class = HTTPSConnection if self.is_https else HTTPConnection
+            conn = conn_class(self.host)
+
+            method = request.method if request.method is not None else "GET"
+
+            try:
+                conn.request(
+                    method=method,
+                    url=path_and_query,  # Only path and query
+                    body=body,
+                    headers=request.headers
+                )
+                resp = conn.getresponse()
+                return resp
+            except Exception as e:
+                raise
+
+        response = await loop.run_in_executor(None, _send)
+        return AsyncHTTPResponse(response)
+
 
 class ProxyMiddleware:
     def __init__(self, app: ASGIApp, proxy_path: str, target_url: str) -> None:
         self.app = app
         self.path = proxy_path.rstrip("/")
         self.target = target_url.rstrip("/")
-        self.client = httpx.AsyncClient(base_url=self.target)
+        self.client = AsyncHTTPClient(base_url=self.target)
 
-    async def __call__(
-        self, scope: Scope, receive: Receive, send: Send
-    ) -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "websocket":
             if not scope["path"].startswith(self.path):
                 return await self.app(scope, receive, send)
 
-            # Connect to target websocket
+            # WebSocket handling remains unchanged
             ws_url = urljoin(self.target, scope["path"])
             if scope["scheme"] in ("http", "ws"):
                 ws_url = ws_url.replace("http", "ws", 1)
@@ -185,15 +296,24 @@ class ProxyMiddleware:
             await self.app(scope, receive, send)
             return
 
-        url = httpx.URL(
-            path=request.url.path, query=request.url.query.encode("utf-8")
-        )
+        target_path = request.url.path
+        target_query = request.url.query.encode('utf-8')
+
+        # Construct the URL object with path and query
+        url = type('URL', (), {
+            'path': target_path,
+            'query': target_query
+        })()
+
+        headers = {k.decode(): v.decode() for k, v in request.headers.raw}
+
         rp_req = self.client.build_request(
             request.method,
             url,
-            headers=request.headers.raw,
+            headers=headers,
             content=request.stream(),
         )
+
         rp_resp = await self.client.send(rp_req, stream=True)
         response = StreamingResponse(
             rp_resp.aiter_raw(),
@@ -201,18 +321,17 @@ class ProxyMiddleware:
             headers=rp_resp.headers,
             background=BackgroundTask(rp_resp.aclose),
         )
-
         await response(scope, receive, send)
 
-    # TODO: this does not work, but the correct answer probably lies
-    # in here: https://github.com/valohai/asgiproxy/blob/master/asgiproxy/proxies/websocket.py
     async def _proxy_websocket(
         self, scope: Scope, receive: Receive, send: Send, ws_url: str
     ) -> None:
         websocket = WebSocket(scope, receive=receive, send=send)
+        original_params = websocket.query_params
+        if original_params:
+            ws_url = f"{ws_url}?{'&'.join(f'{k}={v}' for k,v in original_params.items())}"
         await websocket.accept()
 
-        print("[debug] CONNECTING TO", ws_url)
         async with connect(ws_url) as ws_client:
 
             async def client_to_upstream() -> None:
@@ -227,9 +346,11 @@ class ProxyMiddleware:
                         elif "bytes" in msg:
                             await ws_client.send(msg["bytes"])
                 except ConnectionClosed as e:
-                    await websocket.close()
-                    print("[debug] CLIENT CLOSED", e)
                     return
+                except Exception as e_2:
+                    await websocket.close()
+                    return
+
 
             async def upstream_to_client() -> None:
                 try:
@@ -240,9 +361,11 @@ class ProxyMiddleware:
                         else:
                             await websocket.send_text(msg)
                 except ConnectionClosed as e:
-                    await websocket.close()
-                    print("[debug] UPSTREAM CLOSED", e)
                     return
+                except Exception as e_2:
+
+                    await websocket.close()
+
 
             # Run both relay loops concurrently
             relay_tasks = [
@@ -251,25 +374,11 @@ class ProxyMiddleware:
             ]
 
             try:
-                # Wait for either task to complete
-                done, pending = await asyncio.wait(
-                    relay_tasks, return_when=asyncio.FIRST_COMPLETED
-                )
-
-                # Cancel pending tasks
-                for task in pending:
-                    task.cancel()
-
-                # Check for exceptions
-                for task in done:
-                    try:
-                        task.result()
-                    except Exception:
-                        pass
-
+                await asyncio.gather(*relay_tasks)
+            except Exception as e:
+                raise e
             finally:
-                # Ensure websocket is closed
                 try:
                     await websocket.close()
-                except Exception:
-                    pass
+                except Exception as e:
+                    raise e

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -154,10 +154,10 @@ class OpenTelemetryMiddleware(BaseHTTPMiddleware):
 
 
 class ProxyMiddleware:
-    def __init__(self, app: ASGIApp, path: str, target: str) -> None:
+    def __init__(self, app: ASGIApp, proxy_path: str, target_url: str) -> None:
         self.app = app
-        self.path = path.rstrip("/")
-        self.target = target.rstrip("/")
+        self.path = proxy_path.rstrip("/")
+        self.target = target_url.rstrip("/")
         self.client = httpx.AsyncClient(base_url=self.target)
 
     async def __call__(

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -114,8 +114,8 @@ def create_starlette_app(
             Middleware(
                 # TODO: use correct url/host
                 ProxyMiddleware,
-                path="/mpl",
-                target="http://localhost:10000",
+                proxy_path="/mpl",
+                target_url="http://localhost:10000",
             ),
         ]
     )

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -112,7 +112,6 @@ def create_starlette_app(
             ),
             Middleware(SkewProtectionMiddleware),
             Middleware(
-                # TODO: use correct url/host
                 ProxyMiddleware,
                 proxy_path="/mpl",
                 target_url="http://localhost:10000",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,22 +75,19 @@ marimo = "marimo._cli.cli:main"
 homepage = "https://github.com/marimo-team/marimo"
 
 [project.optional-dependencies]
-sql = [
-    "duckdb >= 1.0.0",
-    "polars >= 1.9.0",
-]
+sql = ["duckdb >= 1.0.0", "polars >= 1.9.0"]
 # List of deps that are recommended for most users
 # in order to unlock all features in marimo
 recommended = [
-    "duckdb>=1.1.0", # SQL cells
-    "altair>=5.4.0", # Plotting in datasource viewer
-    "polars>=1.9.0", # SQL output back in Python
+    "duckdb>=1.1.0",  # SQL cells
+    "altair>=5.4.0",  # Plotting in datasource viewer
+    "polars>=1.9.0",  # SQL output back in Python
     "openai>=1.41.1", # AI features
-    "ruff", # Formatting
+    "ruff",           # Formatting
 ]
 
 dev = [
-    "click <8.1.4",  # https://github.com/pallets/click/issues/2558
+    "click <8.1.4",   # https://github.com/pallets/click/issues/2558
     "black~=23.12.1",
     # For tracing debugging
     "opentelemetry-api~=1.26.0",
@@ -114,7 +111,7 @@ docs = [
     "sphinx-design~=0.5.0",
     "sphinx-autobuild~=2024.10.3",
     "myst_parser~=3.0.1",
-    "furo==2024.8.6"
+    "furo==2024.8.6",
 ]
 
 [tool.hatch]
@@ -125,12 +122,22 @@ path = "marimo/__init__.py"
 
 [tool.hatch.build.targets.sdist]
 include = ["/marimo"]
-artifacts = ["marimo/_static/", "marimo/_lsp/", "third_party.txt", "third_party_licenses.txt"]
+artifacts = [
+    "marimo/_static/",
+    "marimo/_lsp/",
+    "third_party.txt",
+    "third_party_licenses.txt",
+]
 exclude = ["marimo/_smoke_tests"]
 
 [tool.hatch.build.targets.wheel]
 include = ["/marimo"]
-artifacts = ["marimo/_static/", "marimo/_lsp/", "third_party.txt", "third_party_licenses.txt"]
+artifacts = [
+    "marimo/_static/",
+    "marimo/_lsp/",
+    "third_party.txt",
+    "third_party_licenses.txt",
+]
 exclude = ["marimo/_smoke_tests"]
 
 # Override the default uv version to use the latest version
@@ -179,6 +186,7 @@ extra-dependencies = [
     "hypothesis~=6.102.1",
     # For server testing
     "httpx~=0.27.0",
+    "matplotlib~=3.9.2",
     "pytest~=8.3.2",
     "pytest-timeout~=2.3.1",
     "pytest-codecov~=0.5.1",
@@ -186,7 +194,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9","3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.scripts]
 test = "pytest{env:HATCH_TEST_ARGS:} {args:tests}"
@@ -206,12 +214,12 @@ template = "test"
 extra-dependencies = [
     "hypothesis~=6.102.1",
     "httpx~=0.27.0",
+    "matplotlib~=3.9.2",
     "pytest~=8.3.2",
     "pytest-timeout~=2.3.1",
     "pytest-codecov~=0.5.1",
     "pytest-asyncio~=0.23.8",
     # For testing mo.ui.chart, table, ...
-    "matplotlib",
     "vl-convert-python",
     "pyarrow",
     "pyarrow_hotfix",
@@ -239,7 +247,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.test-optional.matrix]]
-python = ["3.9","3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.docs]
 features = ["docs"]
@@ -250,7 +258,7 @@ autobuild = "sphinx-autobuild {args:docs/ docs/_build}"
 clean = "cd docs && make clean"
 
 [tool.ruff]
-line-length=79
+line-length = 79
 include = ["marimo/**/*.py", "tests/**/*.py", "dagger/**/*.py"]
 exclude = [
     "examples",
@@ -275,12 +283,12 @@ exclude = [
 
 [tool.ruff.lint]
 ignore = [
-    "G004", # Logging statement uses f-string
+    "G004",   # Logging statement uses f-string
     "TCH001", # Move application import into a type-checking block
-    "D301", # Use r""" if any backslashes in a docstring
+    "D301",   # Use r""" if any backslashes in a docstring
     # TODO: we should fix these, and enable this rule
     "PT011", # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
-    "E501", # Line too long, we still trim
+    "E501",  # Line too long, we still trim
 ]
 extend-select = [
     # pyflakes
@@ -307,10 +315,10 @@ extend-select = [
     "I001",
     # Enable entire ruff rule section
     "ASYNC", # subset of flake8-async rules
-    "TCH", # Rules around TYPE_CHECKING blocks
-    "G", # flake8-logging-format rules
-    "LOG", # flake8-logging rules, most of them autofixable
-    "PT", # flake8-pytest-style rules
+    "TCH",   # Rules around TYPE_CHECKING blocks
+    "G",     # flake8-logging-format rules
+    "LOG",   # flake8-logging rules, most of them autofixable
+    "PT",    # flake8-pytest-style rules
     "TID25", # flake8-tidy-imports rules
     # Per rule enables
     # "RUF100", # Unused noqa (auto-fixable)
@@ -325,13 +333,13 @@ extend-select = [
     "D403",
     "D412",
     "D419",
-    "PGH004",  # Use specific rule codes when using noqa
+    "PGH004", # Use specific rule codes when using noqa
     "PGH005", # Invalid unittest.mock.Mock methods/attributes/properties
     # "S101", # Checks use `assert` outside the test cases, test cases should be added into the exclusions
-    "B004", # Checks for use of hasattr(x, "__call__") and replaces it with callable(x)
-    "B006", # Checks for uses of mutable objects as function argument defaults.
-    "B017", # Checks for pytest.raises context managers that catch Exception or BaseException.
-    "B019", # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
+    "B004",   # Checks for use of hasattr(x, "__call__") and replaces it with callable(x)
+    "B006",   # Checks for uses of mutable objects as function argument defaults.
+    "B017",   # Checks for pytest.raises context managers that catch Exception or BaseException.
+    "B019",   # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
     "TRY002", # Prohibit use of `raise Exception`, use specific exceptions instead.
 ]
 
@@ -357,7 +365,16 @@ docstring-code-format = true
 ban-relative-imports = "all"
 # Ban certain modules from being imported at module level, instead requiring
 # that they're imported lazily (e.g., within a function definition).
-banned-module-level-imports = ["numpy", "pandas", "tomlkit", "polars", "altair", "ipython", "anywidget", "packaging"]
+banned-module-level-imports = [
+    "numpy",
+    "pandas",
+    "tomlkit",
+    "polars",
+    "altair",
+    "ipython",
+    "anywidget",
+    "packaging",
+]
 
 [tool.ruff.lint.flake8-pytest-style]
 mark-parentheses = false
@@ -377,22 +394,20 @@ exclude = [
     'marimo/_snippets/data/',
     'marimo/_smoke_tests/',
 ]
-warn_unused_ignores=false
+warn_unused_ignores = false
 
 # tutorials shouldn't be type-checked (should be excluded), but they
 # get included anyway, maybe due to import following; this is coarse but works
 [[tool.mypy.overrides]]
-module= "marimo._tutorials.*"
+module = "marimo._tutorials.*"
 ignore_errors = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q -v --ignore tests/_cli/ipynb_data --ignore tests/_ast/codegen_data --ignore tests/_ast/app_data"
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]
 asyncio_mode = "auto"
-timeout = 30 # seconds, per test
+timeout = 30                                                                                                       # seconds, per test
 
 [tool.coverage.run]
 omit = ["marimo/_tutorials/*"]
@@ -402,9 +417,9 @@ extend-ignore-re = ["[0-9a-zA-Z]{43}"]
 
 [tool.typos.default.extend-words]
 wheres = "wheres"
-Ue = "Ue" # Used in one of the cell IDs
-Nd = "Nd" # Confused with And
-pn = "pn" # Panel
+Ue = "Ue"         # Used in one of the cell IDs
+Nd = "Nd"         # Confused with And
+pn = "pn"         # Panel
 
 [tool.typos.files]
 extend-exclude = [

--- a/tests/_server/api/test_middleware.py
+++ b/tests/_server/api/test_middleware.py
@@ -1,28 +1,31 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Tuple
 
 import pytest
 import uvicorn
 from uvicorn import Config, Server
 from starlette.testclient import TestClient
-from starlette.responses import Response
+from starlette.responses import Response, FileResponse
 from starlette.websockets import WebSocketDisconnect, WebSocket
+from starlette.middleware import Middleware
+from starlette.routing import Route
 
 from marimo._config.manager import UserConfigManager
 from marimo._server.main import create_starlette_app
 from marimo._server.model import SessionMode
 from marimo._server.tokens import AuthToken
-from marimo._server.api.middleware import ProxyMiddleware
+from marimo._server.api.middleware import ProxyMiddleware, AsyncHTTPClient, AsyncHTTPResponse, URLRequest
+from marimo._server.utils import find_free_port
 from multiprocessing import Process
+from starlette.applications import Starlette
 from tests._server.mocks import get_mock_session_manager, token_header
-import httpx
 import time
 import json
+import io
 
 if TYPE_CHECKING:
-    from starlette.applications import Starlette
     from starlette.types import ASGIApp
 
 
@@ -248,7 +251,6 @@ class TestNoAuth:
         assert response.headers.get("Set-Cookie") is None
 
 
-# Define the target server app at the module level
 async def target_app(scope, receive, send):
     if scope["type"] == "http":
         response = Response(
@@ -259,8 +261,13 @@ async def target_app(scope, receive, send):
     elif scope["type"] == "websocket":
         websocket = WebSocket(scope, receive=receive, send=send)
         await websocket.accept()
-        await websocket.send_json({"message": "ws response from proxied app"})
-        await websocket.close()
+        try:
+            while True:
+                data = await websocket.receive_json()
+                await websocket.send_json({"message": "ws response from proxied app"})
+        except WebSocketDisconnect:
+            print("Client disconnected")
+            return
 
 def run_target_server():
     """Runs the target app with uvicorn."""
@@ -268,9 +275,47 @@ def run_target_server():
     server = Server(config)
     server.run()
 
+def run_mpl_server(host: str, port: int):
+    """Runs the matplotlib plugin server.
+    Defined at module level so it can be pickled."""
+    from marimo._plugins.stateless.mpl._mpl import create_application  # Import here to avoid circular imports
+    app = create_application()
+    app.state.host = host
+    app.state.port = port
+    app.state.secure = False
+    config = Config(app=app, host=host, port=port, log_level="info")
+    server = Server(config)
+    server.run()
+
+async def serve_static(request):
+    content = "body { color: red; }"
+    return Response(
+        content=content,
+        media_type="text/css"
+    )
+
+async def serve_large_file(request):
+    content = "x" * 1024 * 1024  # 1MB of 'x' characters
+    return Response(
+        content=content,
+        media_type="text/plain"
+    )
+
+target_static_app = Starlette(routes=[
+    Route("/_static/css/page.css", serve_static),
+    Route("/_static/large-file.txt", serve_large_file),
+])
+
+def run_static_server():
+    """Runs the static file server with uvicorn."""
+    config = Config(app=target_static_app, host="127.0.0.1", port=8766, log_level="info")
+    server = Server(config)
+    server.run()
+
+
 class TestProxyMiddleware:
     @pytest.fixture(scope="module")
-    def target_server(self) -> None:
+    def target_server(self):
         """Start a separate `uvicorn` server for the target app."""
         process = Process(target=run_target_server, daemon=True)
         process.start()
@@ -288,6 +333,170 @@ class TestProxyMiddleware:
             target_url="http://127.0.0.1:8765",
         )
         return edit_app
+
+    @pytest.fixture(scope="module")
+    def mpl_server(self):
+        """Start the matplotlib plugin server in a separate process."""
+        host = '127.0.0.1'
+        port = 10_000
+
+        process = Process(
+            target=run_mpl_server,
+            args=(host, port),
+            daemon=True
+        )
+        process.start()
+        time.sleep(1)
+        yield host, port
+        process.terminate()
+        process.join()
+
+    @pytest.fixture
+    def app_with_mpl_proxy(self, edit_app: Starlette, mpl_server: Tuple[str, int]) -> ASGIApp:
+        """Create the app with ProxyMiddleware targeting the matplotlib plugin server."""
+        host, port = mpl_server
+        target_url = f"http://{host}:{port}"
+        edit_app.add_middleware(
+            ProxyMiddleware,
+            proxy_path="/mpl",
+            target_url=target_url,
+        )
+        return edit_app
+
+    @pytest.fixture(scope="module")
+    def static_server(self):
+        """Start a separate server for static files."""
+        process = Process(target=run_static_server, daemon=True)
+        process.start()
+        time.sleep(1)  # Ensure the server has started
+        yield
+        process.terminate()
+        process.join()
+
+    @pytest.fixture
+    def app_with_static_proxy(self, edit_app: Starlette, static_server: None, tmp_path) -> ASGIApp:
+        """Create the app with ProxyMiddleware targeting the static server."""
+        # Create test static files
+        css_dir = tmp_path / "static" / "css"
+        css_dir.mkdir(parents=True)
+        css_file = css_dir / "page.css"
+        css_file.write_text("body { color: red; }")
+
+        large_file = tmp_path / "static" / "large-file.txt"
+        large_file.write_text("x" * 1024 * 1024)  # 1MB file
+
+        edit_app.add_middleware(
+            ProxyMiddleware,
+            proxy_path="/_static",
+            target_url="http://127.0.0.1:8766",
+        )
+        return edit_app
+
+    def test_proxy_static_file(self, app_with_static_proxy):
+        client = TestClient(app_with_static_proxy)
+        response = client.get("/_static/css/page.css")
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith('text/css')
+        assert "body { color: red; }" in response.text
+
+    def test_proxy_large_static_file(self, app_with_static_proxy):
+        client = TestClient(app_with_static_proxy)
+        response = client.get("/_static/large-file.txt")
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith("text/plain")
+        assert len(response.content) == 1024 * 1024  # Check full content length
+
+    def test_proxy_static_file_streaming(self, app_with_static_proxy):
+        client = TestClient(app_with_static_proxy)
+        with client.stream("GET", "/_static/large-file.txt") as response:
+            assert response.status_code == 200, response.text
+            content_length = 0
+            for chunk in response.iter_bytes():
+                content_length += len(chunk)
+            assert content_length == 1024 * 1024
+
+
+    @pytest.mark.asyncio
+    async def test_http_client_streaming(self, app_with_proxy: Starlette) -> None:
+        client = AsyncHTTPClient(base_url="http://127.0.0.1:8765")
+
+        request = URLRequest(
+            "http://127.0.0.1:8765/test",
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            data=b"test string"
+        )
+        response = await client.send(request, stream=True)
+        assert response.status_code == 200
+        chunks = [chunk async for chunk in response.aiter_raw()]
+        assert len(chunks) > 0
+        await response.aclose()
+
+    @pytest.mark.asyncio
+    async def test_http_client_body_types(self, app_with_proxy: Starlette) -> None:
+        client = AsyncHTTPClient(base_url="http://127.0.0.1:8765")
+
+        # Test with bytes data
+        request = URLRequest(
+            "http://127.0.0.1:8765/test",
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            data=b'{"test": "data"}'
+        )
+        response = await client.send(request)
+        assert response.status_code == 200
+        await response.aclose()
+
+        # Test with iterable of bytes using a file-like object
+        class BytesBuffer(io.BytesIO):
+            def read(self, size: int | None = -1) -> bytes:
+                return super().read(size)
+
+        buffer = BytesBuffer(b'{"test": "data"}')
+        request = URLRequest(
+            "http://127.0.0.1:8765/test",
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            data=buffer
+        )
+        response = await client.send(request)
+        assert response.status_code == 200
+        await response.aclose()
+
+    @pytest.mark.asyncio
+    async def test_http_client_headers(self, app_with_proxy: Starlette) -> None:
+        client = AsyncHTTPClient(base_url="http://127.0.0.1:8765")
+
+        custom_headers = {
+            "X-Test-Header": "test-value",
+            "Content-Type": "application/json"
+        }
+        request = URLRequest(
+            "http://127.0.0.1:8765/test",
+            method="GET",
+            headers=custom_headers,
+            data=None  # Explicitly set to None for GET request
+        )
+        response = await client.send(request)
+        assert response.headers.get("content-type") == "application/json"
+        await response.aclose()
+
+    def test_http_client_url_building(self) -> None:
+        client = AsyncHTTPClient(base_url="http://127.0.0.1:8765")
+
+        url = type('URL', (), {
+            'path': '/test/path',
+            'query': b'param=value'
+        })()
+
+        request = client.build_request(
+            "GET",
+            url,
+            headers={},
+            content=None
+        )
+        assert request.full_url == "http://127.0.0.1:8765/test/path?param=value"
+        assert "host" in request.headers
 
     @pytest.mark.parametrize("method, payload", [
         ("GET", None),
@@ -316,9 +525,24 @@ class TestProxyMiddleware:
         assert response.headers.get("Set-Cookie") is None
 
     @pytest.mark.asyncio
-    async def test_proxy_websocket_with_session(self, app_with_proxy: Starlette) -> None:
+    async def test_proxy_websocket(self, app_with_proxy: Starlette) -> None:
         client = TestClient(app_with_proxy)
         with client.websocket_connect("/proxy/ws") as websocket:
             websocket.send_json({"message": "hello there"})
             response = websocket.receive_json()
             assert response['message'] == "ws response from proxied app"
+            websocket.send_json({"message": "hello there again"})
+            response_2 = websocket.receive_json()
+            assert response_2['message'] == "ws response from proxied app"
+            websocket.send_json({"message": "hello there again"})
+            response_3 = websocket.receive_json()
+            assert response_3['message'] == "ws response from proxied app"
+
+    def test_proxy_websocket_with_invalid_id(self, app_with_mpl_proxy: Starlette) -> None:
+        client = TestClient(app_with_mpl_proxy)
+        with client.websocket_connect("/mpl/ws?figure=invalid_id") as websocket:
+            websocket.send_json({"type": "supports_binary", "value": True})
+            message = websocket.receive_json()
+            assert message["type"] == "error"
+            assert "invalid" in message["message"].lower()
+    # Could be good to go on to test the happy path for mpl but we're already doing that with the test client above so leaving just this invalid ID test for

--- a/tests/_server/api/test_middleware.py
+++ b/tests/_server/api/test_middleware.py
@@ -1,29 +1,34 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import io
+import json
+import time
+from multiprocessing import Process
 from typing import TYPE_CHECKING, Any, Tuple
 
 import pytest
 import uvicorn
-from uvicorn import Config, Server
-from starlette.testclient import TestClient
-from starlette.responses import Response, FileResponse
-from starlette.websockets import WebSocketDisconnect, WebSocket
+from starlette.applications import Starlette
 from starlette.middleware import Middleware
+from starlette.responses import FileResponse, Response
 from starlette.routing import Route
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocket, WebSocketDisconnect
+from uvicorn import Config, Server
 
 from marimo._config.manager import UserConfigManager
+from marimo._server.api.middleware import (
+    AsyncHTTPClient,
+    AsyncHTTPResponse,
+    ProxyMiddleware,
+    URLRequest,
+)
 from marimo._server.main import create_starlette_app
 from marimo._server.model import SessionMode
 from marimo._server.tokens import AuthToken
-from marimo._server.api.middleware import ProxyMiddleware, AsyncHTTPClient, AsyncHTTPResponse, URLRequest
 from marimo._server.utils import find_free_port
-from multiprocessing import Process
-from starlette.applications import Starlette
 from tests._server.mocks import get_mock_session_manager, token_header
-import time
-import json
-import io
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp
@@ -278,7 +283,9 @@ def run_target_server():
 def run_mpl_server(host: str, port: int):
     """Runs the matplotlib plugin server.
     Defined at module level so it can be pickled."""
-    from marimo._plugins.stateless.mpl._mpl import create_application  # Import here to avoid circular imports
+    from marimo._plugins.stateless.mpl._mpl import (
+        create_application,  # Import here to avoid circular imports
+    )
     app = create_application()
     app.state.host = host
     app.state.port = port


### PR DESCRIPTION
## 📝 Summary

This represents the matplotlib fix to create a proxy middleware which connects the main starlette process to the mpl starlette process.

Using this mapplotlib can be used in production on Docker for any kind of interactive stuff.

See my demo app here, which is finally working: https://causal-quartets.fly.dev/

I left the environmental variables in the codebase so that you could customize the port or hosts for some reason in the future, but I removed references to them from the documentation since I think that would be more of a developer-facing thing anyway.

## 🔍 Description of Changes

1. Creates AsyncHTTPClient class to manage HTTP responses between the two starlette processes without any dependencies (i.e., no httpx)
2. Fixes The WebSocket handling from the original implementation of the proxy class. There were two things wrong: The websocket proxy was dropping the figure url params required for matplotlib to find the figure. There was also a bare Exception that was silently catching the assertion failure in _mpl, which made diagnosis difficult.
3. adds 9 tests which successfully simulate and range the gamut across all of the issues we were seeing and make sure that all of the HTTP and WebSocket methods we're talking about work correctly as well as testing it directly with the mpl middleware.


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.


## 📜 Reviewers


@mscolnick - finally ready for you
