### PR TITLE
[wip] improvement: autocomplete functions

### DIFF
--- a/frontend/src/core/codemirror/completion/Autocompleter.ts
+++ b/frontend/src/core/codemirror/completion/Autocompleter.ts
@@ -60,6 +60,7 @@ export const Autocompleter = {
           info: () => constructCompletionInfoNode(option.completion_info),
         };
       }),
+      validFor: /^\w+$/,
     };
   },
 

--- a/frontend/src/core/codemirror/completion/Autocompleter.ts
+++ b/frontend/src/core/codemirror/completion/Autocompleter.ts
@@ -60,7 +60,6 @@ export const Autocompleter = {
           info: () => constructCompletionInfoNode(option.completion_info),
         };
       }),
-      validFor: /^[\w.]*$/,
     };
   },
 

--- a/frontend/src/core/codemirror/completion/Autocompleter.ts
+++ b/frontend/src/core/codemirror/completion/Autocompleter.ts
@@ -60,7 +60,7 @@ export const Autocompleter = {
           info: () => constructCompletionInfoNode(option.completion_info),
         };
       }),
-      validFor: /^\w*$/,
+      validFor: /^[\w.]*$/,
     };
   },
 

--- a/frontend/src/core/codemirror/completion/completer.ts
+++ b/frontend/src/core/codemirror/completion/completer.ts
@@ -47,9 +47,6 @@ export async function completer(
       documentation: tooltip.html ?? null,
     });
   }
-  if (tooltip) {
-    return null;
-  }
 
   return Autocompleter.asCompletionResult(context.pos, result);
 }

--- a/frontend/src/core/codemirror/completion/completer.ts
+++ b/frontend/src/core/codemirror/completion/completer.ts
@@ -36,7 +36,7 @@ export async function completer(
     return null;
   }
 
-  // If it is a tooltip, show it as a Tooltip instead of a completion
+  // If it is a tooltip, set it in the documentation panel
   const tooltip = Autocompleter.asHoverTooltip({
     position: context.pos,
     message: result,

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -313,7 +313,7 @@ def complete(
     glbls: dict[str, Any],
     glbls_lock: threading.RLock,
     stream: Stream,
-    docstrings_limit: int = 80,
+    docstrings_limit: int = 100,
     timeout: float | None = None,
     prefer_interpreter_completion: bool = False,
 ) -> None:


### PR DESCRIPTION
## 📝 Summary
<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #2877 
- increase docstring limit so complete docstring hints would show up more often
- remove regex as it doesn't recognize certain inputs. (I'm worried about responsiveness but it's okay locally)
- allow hints to appear in a bracket `def abc(# <---- when the cursor is  here`

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

There are still some odd / inconsistent behaviours, so this fix isn't foolproof.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
