### PR TITLE
fix: remove upper bound on websockets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # - starlette 0.36.0 introduced a bug
     "starlette>=0.26.1,!=0.36.0",
     # websockets for use with starlette
-    "websockets >= 10.0.0,<13.0.0",
+    "websockets >= 10.0.0",
     # python <=3.10 compatibility
     "typing_extensions>=4.4.0; python_version < '3.11'",
     # for rst parsing; lowerbound determined by awscli requiring < 0.17,


### PR DESCRIPTION
`websockets` is required by uvicorn, which does not set an upperbound: https://github.com/encode/uvicorn/blob/master/pyproject.toml#L47

Fixes #2890 