### PR TITLE
Update Makefile for ".[dev]"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ marimo/_lsp: $(shell find lsp)
 .PHONY: py
 # editable python install; only need to run once
 py:
-	pip install -e .[dev]
+	pip install -e ".[dev]"
 
 .PHONY: check
 # run all checks


### PR DESCRIPTION
## 📝 Summary

Totally a minor update this one. This PR changes a `pip install -e .[dev]` into `pip install -e ".[dev]"` command in the `Makefile`. 

## 🔍 Description of Changes

The reason I did this is because some shells (Zshell mainly, but maybe others too) seem to have trouble parsing the command in the Makefile. Gives me this error:

```
zsh: no matches found: .[dev]
```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
