### PR TITLE
improvement: allow <script src/> in html

### DIFF
--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -39,10 +39,29 @@ const replaceValidIframes = (domNode: DOMNode) => {
   }
 };
 
+const replaceSrcScripts = (domNode: DOMNode): JSX.Element | undefined => {
+  if (domNode instanceof Element && domNode.name === "script") {
+    // Missing src, we don't handle inline scripts
+    const src = domNode.attribs.src;
+    if (!src) {
+      return;
+    }
+    // Check if script already exists
+    if (!document.querySelector(`script[src="${src}"]`)) {
+      const script = document.createElement("script");
+      script.src = src;
+      document.head.append(script);
+    }
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <></>;
+  }
+};
+
 export const renderHTML = ({ html, additionalReplacements = [] }: Options) => {
   const renderFunctions: ReplacementFn = [
     replaceValidTags,
     replaceValidIframes,
+    replaceSrcScripts,
     ...additionalReplacements,
   ];
 

--- a/marimo/_smoke_tests/third_party/mohtml_example.py
+++ b/marimo/_smoke_tests/third_party/mohtml_example.py
@@ -1,0 +1,35 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "mohtml==0.1.2",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.9.21"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    # You can import any HTML element this way
+    from mohtml import a, p, div, script, h1
+
+    div(
+        script(src="https://cdn.tailwindcss.com"),
+        h1(
+            "Testing",
+            klass="font-bold text-xl border-yellow-600 border-2 px-2 border-dashed",
+        ),
+    )
+    return a, div, h1, p, script
+
+
+@app.cell
+def __():
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
This allows `<script src/>` tags to be properly created. This doesn't open up a new attack vector since this is already possible today with anywidget (running javascript)

cc @koaning 