### PR TITLE
fix: add ref handling for useEventListener

### DIFF
--- a/frontend/src/components/debugger/debugger-code.tsx
+++ b/frontend/src/components/debugger/debugger-code.tsx
@@ -79,7 +79,7 @@ const DebuggerInput: React.FC<{
   const ref = React.useRef<HTMLDivElement>(null);
 
   // Capture some events to prevent default behavior
-  useKeydownOnElement(ref.current, {
+  useKeydownOnElement(ref, {
     ArrowUp: Functions.NOOP,
     ArrowDown: Functions.NOOP,
   });

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -352,7 +352,7 @@ const CellComponent = (
 
   // Register hotkeys on the cell instead of the code editor
   // This is in case the code editor is hidden
-  useHotkeysOnElement(editing ? cellRef.current : null, {
+  useHotkeysOnElement(editing ? cellRef : null, {
     "cell.run": handleRun,
     "cell.runAndNewBelow": () => {
       handleRun();

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -405,7 +405,7 @@ const CellComponent = (
     },
   });
 
-  useKeydownOnElement(editing ? cellRef.current : null, {
+  useKeydownOnElement(editing ? cellRef : null, {
     ArrowDown: () => {
       moveToNextCell({ cellId, before: false, noCreate: true });
       return true;

--- a/frontend/src/hooks/__tests__/useEventListener.test.tsx
+++ b/frontend/src/hooks/__tests__/useEventListener.test.tsx
@@ -1,0 +1,24 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { expect, describe, it } from "vitest";
+import { renderHook } from "@testing-library/react-hooks";
+import { useRef } from "react";
+import { isRefObject } from "../useEventListener";
+
+describe("isRefObject", () => {
+  it("should return true for React ref objects", () => {
+    const { result } = renderHook(() => useRef(null));
+    expect(isRefObject(result)).toBe(true);
+  });
+
+  it("should return false for non-ref values", () => {
+    expect(isRefObject(null)).toBe(false);
+    expect(isRefObject(123)).toBe(false);
+    expect(isRefObject(document.createElement("div"))).toBe(false);
+    expect(isRefObject(document)).toBe(false);
+    expect(isRefObject(window)).toBe(false);
+  });
+
+  it("should return true for objects with 'current' property", () => {
+    expect(isRefObject({ current: document.createElement("div") })).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useEventListener.ts
+++ b/frontend/src/hooks/useEventListener.ts
@@ -17,7 +17,7 @@ function isRefObject<T>(target: T | RefObject<T>): target is RefObject<T> {
 }
 
 export function useEventListener<T extends Target, K extends keyof EventMap<T>>(
-  targetValue: Target | TargetRef,
+  targetValue: T | TargetRef,
   type: K & string,
   listener: (ev: EventMap<T>[K]) => unknown,
   options?: boolean | AddEventListenerOptions,

--- a/frontend/src/hooks/useEventListener.ts
+++ b/frontend/src/hooks/useEventListener.ts
@@ -12,7 +12,9 @@ type EventMap<T extends Target> = T extends Document
       ? WindowEventMap
       : never;
 
-function isRefObject<T>(target: T | RefObject<T>): target is RefObject<T> {
+export function isRefObject<T>(
+  target: T | RefObject<T>,
+): target is RefObject<T> {
   return target !== null && typeof target === "object" && "current" in target;
 }
 

--- a/frontend/src/hooks/useEventListener.ts
+++ b/frontend/src/hooks/useEventListener.ts
@@ -1,7 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, type RefObject } from "react";
 
 type Target = Document | HTMLElement | Window | null;
+type TargetRef = RefObject<Target>;
+type TargetValue = Target | TargetRef;
 type EventMap<T extends Target> = T extends Document
   ? DocumentEventMap
   : T extends HTMLElement
@@ -10,8 +12,12 @@ type EventMap<T extends Target> = T extends Document
       ? WindowEventMap
       : never;
 
+function isRefObject<T>(target: T | RefObject<T>): target is RefObject<T> {
+  return target !== null && typeof target === "object" && "current" in target;
+}
+
 export function useEventListener<T extends Target, K extends keyof EventMap<T>>(
-  target: T,
+  targetValue: TargetValue,
   type: K & string,
   listener: (ev: EventMap<T>[K]) => unknown,
   options?: boolean | AddEventListenerOptions,
@@ -23,6 +29,9 @@ export function useEventListener<T extends Target, K extends keyof EventMap<T>>(
   }, [listener]);
 
   useEffect(() => {
+    // Get the actual target, whether it's from a ref or direct value
+    // We get ref.current inside the effect instead of during render because changes to ref.current will not trigger a re-render
+    const target = isRefObject(targetValue) ? targetValue.current : targetValue;
     if (!target) {
       return;
     }
@@ -34,5 +43,5 @@ export function useEventListener<T extends Target, K extends keyof EventMap<T>>(
     return () => {
       target.removeEventListener(type, eventListener, options);
     };
-  }, [type, target, options]);
+  }, [type, targetValue, options]);
 }

--- a/frontend/src/hooks/useEventListener.ts
+++ b/frontend/src/hooks/useEventListener.ts
@@ -3,7 +3,7 @@ import { useRef, useEffect, type RefObject } from "react";
 
 type Target = Document | HTMLElement | Window | null;
 type TargetRef = RefObject<Target>;
-type TargetValue = Target | TargetRef;
+
 type EventMap<T extends Target> = T extends Document
   ? DocumentEventMap
   : T extends HTMLElement
@@ -17,7 +17,7 @@ function isRefObject<T>(target: T | RefObject<T>): target is RefObject<T> {
 }
 
 export function useEventListener<T extends Target, K extends keyof EventMap<T>>(
-  targetValue: TargetValue,
+  targetValue: Target | TargetRef,
   type: K & string,
   listener: (ev: EventMap<T>[K]) => unknown,
   options?: boolean | AddEventListenerOptions,

--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { useEffect } from "react";
+import { type RefObject, useEffect } from "react";
 
 import { parseShortcut } from "../core/hotkeys/shortcuts";
 import { useEventListener } from "./useEventListener";
@@ -57,7 +57,7 @@ export function useHotkey(shortcut: HotkeyAction, callback: HotkeyHandler) {
  * Registers a hotkey listener on a given element.
  */
 export function useHotkeysOnElement<T extends HotkeyAction>(
-  element: HTMLElement | null,
+  element: HTMLElement | RefObject<HTMLElement> | null,
   handlers: Record<T, HotkeyHandler>,
 ) {
   const hotkeys = useAtomValue(hotkeysAtom);
@@ -81,7 +81,7 @@ export function useHotkeysOnElement<T extends HotkeyAction>(
  * Registers a hotkey listener on a given element.
  */
 export function useKeydownOnElement(
-  element: HTMLElement | null,
+  element: HTMLElement | RefObject<HTMLElement> | null,
   handlers: Record<string, HotkeyHandler>,
 ) {
   useEventListener(element, "keydown", (e) => {

--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -54,7 +54,7 @@ export function useHotkey(shortcut: HotkeyAction, callback: HotkeyHandler) {
 }
 
 /**
- * Registers a hotkey listener on a given element.
+ * Registers a hotkey listener on a given element or ref to an element.
  */
 export function useHotkeysOnElement<T extends HotkeyAction>(
   element: HTMLElement | RefObject<HTMLElement> | null,
@@ -78,7 +78,7 @@ export function useHotkeysOnElement<T extends HotkeyAction>(
 }
 
 /**
- * Registers a hotkey listener on a given element.
+ * Registers a hotkey listener on a given element or ref to an element.
  */
 export function useKeydownOnElement(
   element: HTMLElement | RefObject<HTMLElement> | null,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
useEventListener wasn't working properly when you passed in ref.current. For example, the `ArrowUp` & `ArrowDown` keys to move between cells. This is because changes to ref.current will not trigger a re-render.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
useEventListener lets you pass in a ref object instead of ref.current and ensure it re-renders correctly when ref.current is no longer null.

Stumbled upon this as I was trying to add new eventListeners. Shoutout to Claude for helping me understand & write 😅.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
