### PR TITLE
chore: add stricter types for useEventListener

### DIFF
--- a/frontend/src/hooks/__tests__/useEventListener.test.tsx
+++ b/frontend/src/hooks/__tests__/useEventListener.test.tsx
@@ -1,8 +1,12 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { expect, describe, it } from "vitest";
+import { expect, describe, it, beforeEach, vi } from "vitest";
 import { renderHook } from "@testing-library/react-hooks";
 import { useRef } from "react";
-import { isRefObject } from "../useEventListener";
+import {
+  type HTMLElementNotDerivedFromRef,
+  isRefObject,
+  useEventListener,
+} from "../useEventListener";
 
 describe("isRefObject", () => {
   it("should return true for React ref objects", () => {
@@ -20,5 +24,124 @@ describe("isRefObject", () => {
 
   it("should return true for objects with 'current' property", () => {
     expect(isRefObject({ current: document.createElement("div") })).toBe(true);
+  });
+});
+
+describe("useEventListener", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should attach event listener to document", () => {
+    const listener = vi.fn();
+    const addSpy = vi.spyOn(document, "addEventListener");
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() =>
+      useEventListener(document, "click", listener),
+    );
+
+    // Verify listener was attached
+    expect(addSpy).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function),
+      undefined,
+    );
+
+    // Simulate click
+    document.dispatchEvent(new Event("click"));
+    expect(listener).toHaveBeenCalled();
+
+    // Cleanup
+    unmount();
+    expect(removeSpy).toHaveBeenCalled();
+  });
+
+  it("should attach event listener to window", () => {
+    const listener = vi.fn();
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    renderHook(() => useEventListener(window, "resize", listener));
+
+    expect(addSpy).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("should attach event listener to HTML element", () => {
+    const element = document.createElement("div");
+    const listener = vi.fn();
+    const addSpy = vi.spyOn(element, "addEventListener");
+
+    renderHook(() =>
+      useEventListener(
+        element as HTMLElementNotDerivedFromRef<HTMLDivElement>,
+        "click",
+        listener,
+      ),
+    );
+
+    expect(addSpy).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("should attach event listener to ref", () => {
+    const element = document.createElement("div");
+    const ref = { current: element };
+    const listener = vi.fn();
+    const addSpy = vi.spyOn(element, "addEventListener");
+
+    renderHook(() => useEventListener(ref, "click", listener));
+
+    expect(addSpy).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it("should not attach listener if target is null", () => {
+    const listener = vi.fn();
+    const ref = { current: null };
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    renderHook(() => useEventListener(ref, "click", listener));
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it("should update listener when callback changes", () => {
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ cb }) => useEventListener(document, "click", cb),
+      { initialProps: { cb: listener1 } },
+    );
+
+    document.dispatchEvent(new Event("click"));
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener2).not.toHaveBeenCalled();
+
+    rerender({ cb: listener2 });
+
+    document.dispatchEvent(new Event("click"));
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener2).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle options parameter", () => {
+    const listener = vi.fn();
+    const options = { capture: true };
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    renderHook(() => useEventListener(document, "click", listener, options));
+
+    expect(addSpy).toHaveBeenCalledWith("click", expect.any(Function), options);
   });
 });

--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -57,7 +57,7 @@ export function useHotkey(shortcut: HotkeyAction, callback: HotkeyHandler) {
  * Registers a hotkey listener on a given element or ref to an element.
  */
 export function useHotkeysOnElement<T extends HotkeyAction>(
-  element: HTMLElement | RefObject<HTMLElement> | null,
+  element: RefObject<HTMLElement> | null,
   handlers: Record<T, HotkeyHandler>,
 ) {
   const hotkeys = useAtomValue(hotkeysAtom);
@@ -81,7 +81,7 @@ export function useHotkeysOnElement<T extends HotkeyAction>(
  * Registers a hotkey listener on a given element or ref to an element.
  */
 export function useKeydownOnElement(
-  element: HTMLElement | RefObject<HTMLElement> | null,
+  element: RefObject<HTMLElement> | null,
   handlers: Record<string, HotkeyHandler>,
 ) {
   useEventListener(element, "keydown", (e) => {

--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -41,7 +41,10 @@ import useEvent from "react-use-event-hook";
 import { Functions } from "@/utils/functions";
 import { StyleNamespace } from "@/theme/namespace";
 import { UIElementRegistry } from "@/core/dom/uiregistry";
-import { useEventListener } from "@/hooks/useEventListener";
+import {
+  type HTMLElementNotDerivedFromRef,
+  useEventListener,
+} from "@/hooks/useEventListener";
 import { shallowCompare } from "@/utils/shallow-compare";
 
 export interface PluginSlotHandle {
@@ -99,11 +102,15 @@ function PluginSlotInternal<T>(
   }));
 
   // Listen to value updates
-  useEventListener(hostElement, MarimoValueUpdateEvent.TYPE, (e) => {
-    if (e.detail.element === hostElement) {
-      setValue(e.detail.value as T);
-    }
-  });
+  useEventListener(
+    hostElement as HTMLElementNotDerivedFromRef,
+    MarimoValueUpdateEvent.TYPE,
+    (e) => {
+      if (e.detail.element === hostElement) {
+        setValue(e.detail.value as T);
+      }
+    },
+  );
 
   // We create a mutation observer to listen for changes to the host element's attributes
   // and update the plugin's data accordingly

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -13,7 +13,10 @@ import { createPlugin } from "@/plugins/core/builder";
 import { rpc } from "@/plugins/core/rpc";
 import type { AnyModel, AnyWidget, EventHandler, Experimental } from "./types";
 import { Logger } from "@/utils/Logger";
-import { useEventListener } from "@/hooks/useEventListener";
+import {
+  type HTMLElementNotDerivedFromRef,
+  useEventListener,
+} from "@/hooks/useEventListener";
 import { MarimoIncomingMessageEvent } from "@/core/dom/events";
 import { updateBufferPaths } from "@/utils/date-views";
 
@@ -148,9 +151,13 @@ const LoadedSlot = ({
   );
 
   // Listen to incoming messages
-  useEventListener(host, MarimoIncomingMessageEvent.TYPE, (e) => {
-    model.current.receiveCustomMessage(e.detail.message, e.detail.buffers);
-  });
+  useEventListener(
+    host as HTMLElementNotDerivedFromRef,
+    MarimoIncomingMessageEvent.TYPE,
+    (e) => {
+      model.current.receiveCustomMessage(e.detail.message, e.detail.buffers);
+    },
+  );
 
   useOnMount(() => {
     if (!ref.current) {


### PR DESCRIPTION
This does't change any runtime code but adds stricter types so that we can enforce the correct practice that @Light2Dark pointed out (pass the Ref, not the HTMLElement)

cc @Light2Dark 