### PR TITLE
fix: Altair 5.5 compat

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -54,6 +54,10 @@ class NarwhalsTableManager(
         format_mapping: Optional[FormatMapping] = None,
     ) -> bytes:
         _data = self.apply_formatting(format_mapping).as_frame()
+        if nw.get_level(_data) == "interchange":
+            # `write_csv` isn't supported by interchange-level-only
+            # DataFrames, so we convert to PyArrow in this case
+            _data = _data.to_arrow()
         csv_str = _data.write_csv()
         if isinstance(csv_str, str):
             return csv_str.encode("utf-8")

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -57,8 +57,11 @@ class NarwhalsTableManager(
         if nw.get_level(_data) == "interchange":
             # `write_csv` isn't supported by interchange-level-only
             # DataFrames, so we convert to PyArrow in this case
-            _data = _data.to_arrow()
-        csv_str = _data.write_csv()
+            csv_str = nw.from_native(
+                _data.to_arrow(), eager_only=True
+            ).write_csv()
+        else:
+            csv_str = _data.write_csv()
         if isinstance(csv_str, str):
             return csv_str.encode("utf-8")
         return cast(bytes, csv_str)


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Currently, `tests/_plugins/ui/_impl/test_altair_chart.py` is failing for DuckDB input, because:
- previously `_data` has already been converted to PyArrow Table
- now, `_data` is still a DuckDB PyRelation, which for now only has "interchange" level support in Narwhals. So, in that case, we convert to PyArrow. We plan to greatly improve DuckDB support next year: https://github.com/narwhals-dev/narwhals/discussions/1370

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
