### PR TITLE
improvement: add action to Clear Cell Outputs / Clear All Outputs

### DIFF
--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -26,6 +26,7 @@ import {
   SparklesIcon,
   DatabaseIcon,
   Columns2Icon,
+  XCircleIcon,
 } from "lucide-react";
 import type { ActionButton } from "./types";
 import { MultiIcon } from "@/components/icons/multi-icon";
@@ -78,6 +79,7 @@ export function useCellActionButtons({ cell }: Props) {
     sendToTop,
     sendToBottom,
     addColumnBreakpoint,
+    clearCellOutput,
   } = useCellActions();
   const runCell = useRunCell(cell?.cellId);
   const hasOnlyOneCell = useAtomValue(hasOnlyOneCellAtom);
@@ -231,6 +233,14 @@ export function useCellActionButtons({ cell }: Props) {
           />
         ),
         handle: toggleDisabled,
+      },
+      {
+        icon: <XCircleIcon size={13} strokeWidth={1.5} />,
+        label: "Clear output",
+        hidden: !hasOutput,
+        handle: () => {
+          clearCellOutput({ cellId });
+        },
       },
     ],
 

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -27,6 +27,7 @@ import {
   LayoutTemplateIcon,
   Files,
   SettingsIcon,
+  XCircleIcon,
 } from "lucide-react";
 import { commandPaletteAtom } from "../controls/command-palette";
 import { useCellActions, useNotebook } from "@/core/cells/cells";
@@ -79,7 +80,8 @@ export function useNotebookActions() {
   const kioskMode = useAtomValue(kioskModeAtom);
 
   const notebook = useNotebook();
-  const { updateCellConfig, undoDeleteCell } = useCellActions();
+  const { updateCellConfig, undoDeleteCell, clearAllCellOutputs } =
+    useCellActions();
   const restartKernel = useRestartKernel();
   const copyNotebook = useCopyNotebook(filename);
   const setCommandPaletteOpen = useSetAtom(commandPaletteAtom);
@@ -340,6 +342,13 @@ export function useNotebookActions() {
         for (const cellId of ids) {
           updateCellConfig({ cellId, config: { disabled: true } });
         }
+      },
+    },
+    {
+      icon: <XCircleIcon size={14} strokeWidth={1.5} />,
+      label: "Clear all outputs",
+      handle: () => {
+        clearAllCellOutputs();
       },
     },
     {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1057,6 +1057,28 @@ const {
       },
     };
   },
+  clearCellOutput: (state, action: { cellId: CellId }) => {
+    const { cellId } = action;
+    return updateCellRuntimeState(state, cellId, (cell) => ({
+      ...cell,
+      output: null,
+      consoleOutputs: [],
+    }));
+  },
+  clearAllCellOutputs: (state) => {
+    const newCellRuntime = { ...state.cellRuntime };
+    for (const cellId of state.cellIds.inOrderIds) {
+      newCellRuntime[cellId] = {
+        ...newCellRuntime[cellId],
+        output: null,
+        consoleOutputs: [],
+      };
+    }
+    return {
+      ...state,
+      cellRuntime: newCellRuntime,
+    };
+  },
 });
 
 // Helper function to update a cell in the array


### PR DESCRIPTION
Add an option to clear cell outputs. This can be useful if you are rendering a lot of graphs and they start to bog down the browser ([feedback from here](https://github.com/marimo-team/marimo/discussions/2899#discussioncomment-11371867)).