### PR TITLE
fix: resetting pagination after filtering

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -241,11 +241,6 @@ export const LoadingDataTableComponent = memo(
       }
     }, [props.pageSize, paginationState.pageSize]);
 
-    // If total rows change, reset pageIndex
-    useEffect(() => {
-      setPaginationState((state) => ({ ...state, pageIndex: 0 }));
-    }, [props.totalRows]);
-
     // Data loading
     const { data, loading, error } = useAsyncData<{
       rows: T[];
@@ -334,6 +329,11 @@ export const LoadingDataTableComponent = memo(
       paginationState.pageSize,
       paginationState.pageIndex,
     ]);
+
+    // If total rows change, reset pageIndex
+    useEffect(() => {
+      setPaginationState((state) => ({ ...state, pageIndex: 0 }));
+    }, [data?.totalRows]);
 
     // Column summaries
     const { data: columnSummaries, error: columnSummariesError } = useAsyncData<

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -332,7 +332,9 @@ export const LoadingDataTableComponent = memo(
 
     // If total rows change, reset pageIndex
     useEffect(() => {
-      setPaginationState((state) => ({ ...state, pageIndex: 0 }));
+      setPaginationState((state) =>
+        state.pageIndex === 0 ? state : { ...state, pageIndex: 0 },
+      );
     }, [data?.totalRows]);
 
     // Column summaries


### PR DESCRIPTION
Fix #2967 

We were checking the original totalRows, not the filtered totalRows.