### PR TITLE
Find ruff when it's not on PATH

### DIFF
--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from typing import Dict
 
 from marimo import _loggers
@@ -43,7 +44,7 @@ class DefaultFormatter(Formatter):
 class RuffFormatter(Formatter):
     def format(self, codes: CellCodes) -> CellCodes:
         try:
-            process = subprocess.run("ruff", capture_output=True)
+            process = subprocess.run(f"{sys.prefix}/ruff", capture_output=True)
         except FileNotFoundError:
             LOGGER.warning(
                 "To enable code formatting, install ruff (pip install ruff)"
@@ -55,7 +56,7 @@ class RuffFormatter(Formatter):
             try:
                 process = subprocess.run(
                     [
-                        "ruff",
+                        f"{sys.prefix}/ruff",
                         "format",
                         "--line-length",
                         str(self.line_length),

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -50,10 +50,10 @@ class RuffFormatter(Formatter):
         if platform.system() == "Windows":
             ruff_path = ruff_path.with_suffix(".exe")
         if ruff_path.exists():
-            # fall back to ruff on PATH
-            ruff_cmd = "ruff"
-        else:
             ruff_cmd = ruff_path.as_posix()
+        else:
+            # fall back to ruff on PATH (how it was before #2980)
+            ruff_cmd = "ruff"
         try:
             process = subprocess.run(ruff_cmd, capture_output=True)
         except FileNotFoundError:

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -44,7 +44,7 @@ class DefaultFormatter(Formatter):
 class RuffFormatter(Formatter):
     def format(self, codes: CellCodes) -> CellCodes:
         ruff_cmd = [sys.executable, "-m", "ruff"]
-        process = subprocess.run([*ruff_cmd, "--help"])
+        process = subprocess.run([*ruff_cmd, "--help"], capture_output=True)
         if process.returncode != 0:
             LOGGER.warning(
                 "To enable code formatting, install ruff (pip install ruff)"

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
 from typing import Dict
 
 from marimo import _loggers
@@ -43,8 +44,13 @@ class DefaultFormatter(Formatter):
 
 class RuffFormatter(Formatter):
     def format(self, codes: CellCodes) -> CellCodes:
+        # first look for ruff next to sys.executable
+        ruff_path = Path(sys.prefix) / "ruff"
+        if not ruff_path.exists():
+            # fall back to ruff on PATH
+            ruff_path = "ruff"
         try:
-            process = subprocess.run(f"{sys.prefix}/ruff", capture_output=True)
+            process = subprocess.run(ruff_path.as_posix(), capture_output=True)
         except FileNotFoundError:
             LOGGER.warning(
                 "To enable code formatting, install ruff (pip install ruff)"
@@ -56,7 +62,7 @@ class RuffFormatter(Formatter):
             try:
                 process = subprocess.run(
                     [
-                        f"{sys.prefix}/ruff",
+                        ruff_path.as_posix(),
                         "format",
                         "--line-length",
                         str(self.line_length),

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -1,10 +1,8 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import platform
 import subprocess
 import sys
-from pathlib import Path
 from typing import Dict
 
 from marimo import _loggers
@@ -45,15 +43,7 @@ class DefaultFormatter(Formatter):
 
 class RuffFormatter(Formatter):
     def format(self, codes: CellCodes) -> CellCodes:
-        # first look for ruff next to sys.executable
-        ruff_path = Path(sys.prefix) / "ruff"
-        if platform.system() == "Windows":
-            ruff_path = ruff_path.with_suffix(".exe")
-        if ruff_path.exists():
-            ruff_cmd = ruff_path.as_posix()
-        else:
-            # fall back to ruff on PATH (how it was before #2980)
-            ruff_cmd = "ruff"
+        ruff_cmd = [sys.executable, "-m", "ruff"]
         try:
             process = subprocess.run(ruff_cmd, capture_output=True)
         except FileNotFoundError:
@@ -67,7 +57,7 @@ class RuffFormatter(Formatter):
             try:
                 process = subprocess.run(
                     [
-                        ruff_cmd,
+                        *ruff_cmd,
                         "format",
                         "--line-length",
                         str(self.line_length),

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -44,9 +44,8 @@ class DefaultFormatter(Formatter):
 class RuffFormatter(Formatter):
     def format(self, codes: CellCodes) -> CellCodes:
         ruff_cmd = [sys.executable, "-m", "ruff"]
-        try:
-            process = subprocess.run(ruff_cmd, capture_output=True)
-        except FileNotFoundError:
+        process = subprocess.run([*ruff_cmd, "--help"])
+        if process.returncode != 0:
             LOGGER.warning(
                 "To enable code formatting, install ruff (pip install ruff)"
             )


### PR DESCRIPTION
## 📝 Summary

Ruff doesn't always go on PATH; if marimo is launched directly via `.venv/bin/marimo`, ruff that sits at `.venv/bin/ruff` will not be found.

## 🔍 Description of Changes

Call ruff using `f"{sys.prefix}/ruff"`

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
