### PR TITLE
docs: Populating form - HTML escape

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -398,7 +398,7 @@ form.value
 ### Populating form with pre-defined examples
 
 **Use cases.** To give examples of how a filled form looks like.  Useful for illustrating complex API requests or database queries.
-The form can also be populated from [URL query parameters](https://docs.marimo.io/api/query_params.html) ([example](https://marimo.app/l/w21a3x?t1=query&t2=params)).
+The form can also be populated from [URL query parameters](https://docs.marimo.io/api/query_params.html) (<a href="https://marimo.app/l/w21a3x?t1=query&t2=params">notebook example</a>).
 
 **Recipe.**
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -395,6 +395,65 @@ form
 form.value
 ```
 
+### Populating form with pre-defined examples
+
+**Use cases.** To give examples of how a filled form looks like.  Useful for illustrating complex API requests or database queries.
+The form can also be populated from [URL query parameters](https://docs.marimo.io/api/query_params.html) ([example](https://marimo.app/l/w21a3x?t1=query&t2=params)).
+
+**Recipe.**
+
+1. Import packages
+
+```python
+import marimo as mo
+```
+
+2. Create dropdown of examples
+
+```python
+query_params = mo.query_params().to_dict()
+examples = mo.ui.dropdown(
+    options={
+        "ex 1": {"t1": "hello", "t2": "world"},
+        "ex 2": {"t1": "marimo", "t2": "notebook"},
+    },
+    value="ex 1",
+    label="examples",
+)
+```
+3. Create form from examples.
+
+```
+form = (
+    mo.md(
+        """
+    ### Your form
+
+    {t1}
+    {t2}
+"""
+    )
+    .batch(
+        t1=mo.ui.text(label="enter text", value=examples.value.get("t1", "")),
+        t2=mo.ui.text(label="more text", value=examples.value.get("t2", "")),
+    )
+    .form(
+        submit_button_label="go"
+    )
+)
+```
+
+4. Run pre-populated from or recompute with new input.
+
+```python
+output = (
+    " ".join(form.value.values()).upper()
+    if form.value is not None
+    else " ".join(examples.value.values()).upper()
+)
+examples, form, output
+```
+
 ## Working with buttons
 
 ### Create a button that triggers computation when clicked

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -411,7 +411,6 @@ import marimo as mo
 2. Create dropdown of examples
 
 ```python
-query_params = mo.query_params().to_dict()
 examples = mo.ui.dropdown(
     options={
         "ex 1": {"t1": "hello", "t2": "world"},


### PR DESCRIPTION
## 📝 Summary

 https://github.com/marimo-team/marimo/pull/2979#issuecomment-2501998832 After checking the updated website, noticed that the query parameter in the link to notebook got reformatted to `https://marimo.app/l/w21a3x?t1=query&amp;t2=params` - which breaks the notebook.

## 🔍 Description of Changes

try HTML instead of Markdown link

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers
 @mscolnick
