### PR TITLE
improvement: Wrap output for lists and dictionaries

### DIFF
--- a/frontend/src/components/editor/output/JsonOutput.tsx
+++ b/frontend/src/components/editor/output/JsonOutput.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { memo } from "react";
+import { memo, useState } from "react";
 import {
   type DataType,
   JsonViewer,
@@ -14,6 +14,8 @@ import { TextOutput } from "./TextOutput";
 import { VideoOutput } from "./VideoOutput";
 import { logNever } from "../../../utils/assertNever";
 import { useTheme } from "../../../theme/useTheme";
+import { Labeled } from "@/plugins/impl/common/labeled";
+import { Switch } from "@/components/ui/switch";
 
 interface Props {
   /**
@@ -40,26 +42,44 @@ export const JsonOutput: React.FC<Props> = memo(
     if (format === "auto") {
       format = inferBestFormat(data);
     }
+    const [wrapText, setWrapText] = useState(false);
 
     switch (format) {
       case "tree":
         return (
-          <JsonViewer
-            className={"marimo-json-output"}
-            rootName={name}
-            theme={theme}
-            value={data}
-            style={{
-              backgroundColor: "transparent",
-            }}
-            valueTypes={VALUE_TYPE}
-            // disable array grouping (it's misleading) by using a large value
-            groupArraysAfterLength={1_000_000}
-            // TODO(akshayka): disable clipboard until we have a better
-            // solution: copies raw values, shifts content; can use onCopy prop
-            // to override what is copied to clipboard
-            enableClipboard={false}
-          />
+          <>
+            <div className="grid justify-items-end">
+              <Labeled label="Wrap text" align="right" labelClassName="ml-1">
+                <Switch
+                  id="json-wrap-text-switch"
+                  size="sm"
+                  checked={wrapText}
+                  onCheckedChange={setWrapText}
+                  className="data-[state=unchecked]:hover:bg-input/80 mb-0"
+                />
+              </Labeled>
+            </div>
+            <JsonViewer
+              className={
+                wrapText
+                  ? "marimo-json-output marimo-json-output-wrapped"
+                  : "marimo-json-output"
+              }
+              rootName={name}
+              theme={theme}
+              value={data}
+              style={{
+                backgroundColor: "transparent",
+              }}
+              valueTypes={VALUE_TYPE}
+              // disable array grouping (it's misleading) by using a large value
+              groupArraysAfterLength={1_000_000}
+              // TODO(akshayka): disable clipboard until we have a better
+              // solution: copies raw values, shifts content; can use onCopy prop
+              // to override what is copied to clipboard
+              enableClipboard={false}
+            />
+          </>
         );
       case "raw":
         return <pre className={className}>{JSON.stringify(data, null, 2)}</pre>;

--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -68,6 +68,11 @@
   @apply text-xs;
 }
 
+.marimo-json-output-wrapped span {
+  text-wrap: wrap;
+  word-break: break-word;
+}
+
 .marimo-json-output .data-key-pair:not(:last-child) {
   margin-top: 0.2rem;
   margin-bottom: 0.2rem;


### PR DESCRIPTION
## 📝 Summary

Completes #2977.

## 🔍 Description of Changes

Add switch to wrap text for list and dictionary (JSON) outputs.

Before:

<img width="847" alt="Screenshot 2024-11-27 at 10 25 32 PM" src="https://github.com/user-attachments/assets/b6d4c7e2-8293-4e5d-ad18-b220b83751a5">

After:

<img width="836" alt="Screenshot 2024-11-27 at 10 25 16 PM" src="https://github.com/user-attachments/assets/e0cba359-a9a0-4b8a-b68b-a23175464a9b">

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
