### PR TITLE
improvement: batch the same url requests to avoid additional download / parsing

### DIFF
--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -8,6 +8,7 @@ import { DelayMount } from "../utils/delay-mount";
 import { ChartSkeleton } from "../charts/chart-skeleton";
 import { logNever } from "@/utils/assertNever";
 import { DatePopover } from "./date-popover";
+import { createBatchedLoader } from "@/plugins/impl/vega/debounced";
 
 export const ColumnChartContext = React.createContext<
   ColumnChartSpecModel<unknown>
@@ -20,6 +21,10 @@ interface Props<TData, TValue> {
 const LazyVegaLite = React.lazy(() =>
   import("react-vega").then((m) => ({ default: m.VegaLite })),
 );
+
+// We batch multiple calls to the same URL returning the same promise
+// for all calls with the same key.
+const batchedLoader = createBatchedLoader();
 
 export const TableColumnSummary = <TData, TValue>({
   columnId,
@@ -38,6 +43,8 @@ export const TableColumnSummary = <TData, TValue>({
           spec={spec}
           width={120}
           height={50}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          loader={batchedLoader as any}
           style={{ minWidth: "unset", maxHeight: "60px" }}
           actions={false}
           theme={theme === "dark" ? "dark" : "vox"}

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -8,7 +8,7 @@ import { DelayMount } from "../utils/delay-mount";
 import { ChartSkeleton } from "../charts/chart-skeleton";
 import { logNever } from "@/utils/assertNever";
 import { DatePopover } from "./date-popover";
-import { createBatchedLoader } from "@/plugins/impl/vega/debounced";
+import { createBatchedLoader } from "@/plugins/impl/vega/batched";
 
 export const ColumnChartContext = React.createContext<
   ColumnChartSpecModel<unknown>

--- a/frontend/src/core/static/files.ts
+++ b/frontend/src/core/static/files.ts
@@ -46,7 +46,6 @@ export function patchVegaLoader(
   },
   files: StaticVirtualFiles = getStaticVirtualFiles(),
 ) {
-  // const originalHttp = loader.http.bind(loader);
   const originalHttp = loader.http.bind(loader);
 
   loader.http = async (url: string) => {

--- a/frontend/src/plugins/impl/vega/__tests__/resolve-data.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/resolve-data.test.ts
@@ -1,4 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/unbound-method */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { vegaLoader } from "../loader";
 import { resolveVegaSpecData } from "../resolve-data";

--- a/frontend/src/plugins/impl/vega/batched.ts
+++ b/frontend/src/plugins/impl/vega/batched.ts
@@ -1,0 +1,15 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { batch } from "@/utils/batch-requests";
+import { createLoader, type Loader } from "./vega-loader";
+
+export function createBatchedLoader(): Loader {
+  const loader = createLoader();
+  const toKey = (request: unknown) => JSON.stringify(request);
+  return {
+    load: batch(loader.load.bind(loader) as any, toKey),
+    sanitize: batch(loader.sanitize.bind(loader) as any, toKey),
+    http: batch(loader.http.bind(loader) as any, toKey),
+    file: batch(loader.file.bind(loader) as any, toKey),
+  };
+}

--- a/frontend/src/plugins/impl/vega/batched.ts
+++ b/frontend/src/plugins/impl/vega/batched.ts
@@ -10,6 +10,6 @@ export function createBatchedLoader(): Loader {
     load: batch(loader.load.bind(loader) as any, toKey),
     sanitize: batch(loader.sanitize.bind(loader) as any, toKey),
     http: batch(loader.http.bind(loader) as any, toKey),
-    file: batch(loader.file.bind(loader) as any, toKey),
+    file: batch(loader.file.bind(loader), toKey),
   };
 }

--- a/frontend/src/plugins/impl/vega/vega-loader.ts
+++ b/frontend/src/plugins/impl/vega/vega-loader.ts
@@ -24,15 +24,13 @@ export function read<T = object>(
 }
 
 export interface Loader {
-  load: (
+  load(
     uri: string,
     options?: unknown,
-  ) => Promise<
-    string | Record<string, unknown> | Array<Record<string, unknown>>
-  >;
-  sanitize: (uri: string, options: unknown) => Promise<{ href: string }>;
-  http: (uri: string, options: unknown) => Promise<string>;
-  file: (filename: string) => Promise<string>;
+  ): Promise<string | Record<string, unknown> | Array<Record<string, unknown>>>;
+  sanitize(uri: string, options?: unknown): Promise<{ href: string }>;
+  http(uri: string, options?: unknown): Promise<string>;
+  file(filename: string): Promise<string>;
 }
 
 export function createLoader(): Loader {

--- a/frontend/src/plugins/impl/vega/vega-loader.ts
+++ b/frontend/src/plugins/impl/vega/vega-loader.ts
@@ -23,14 +23,19 @@ export function read<T = object>(
   return vl.read(data, format);
 }
 
-export function createLoader(): {
+export interface Loader {
   load: (
-    url: string,
+    uri: string,
+    options?: unknown,
   ) => Promise<
     string | Record<string, unknown> | Array<Record<string, unknown>>
   >;
-  http: (url: string) => Promise<string>;
-} {
+  sanitize: (uri: string, options: unknown) => Promise<{ href: string }>;
+  http: (uri: string, options: unknown) => Promise<string>;
+  file: (filename: string) => Promise<string>;
+}
+
+export function createLoader(): Loader {
   return vl.loader();
 }
 

--- a/frontend/src/utils/__tests__/batch-requests.test.ts
+++ b/frontend/src/utils/__tests__/batch-requests.test.ts
@@ -1,0 +1,60 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, it, expect, vi } from "vitest";
+import { batch } from "../batch-requests";
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("batch", () => {
+  it("should return the same promise for calls with the same key", async () => {
+    const loader = vi.fn().mockImplementation(async (arg) => {
+      await sleep(10);
+      return "response";
+    });
+    const batchedLoader = batch(loader, JSON.stringify);
+
+    const promise1 = batchedLoader("arg1");
+    const promise2 = batchedLoader("arg1");
+
+    expect(promise1).toBe(promise2);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    const result = await promise1;
+    expect(result).toBe("response");
+  });
+
+  it("should call loader again after the first promise resolves", async () => {
+    const loader = vi.fn().mockImplementation(async (arg) => {
+      await sleep(10);
+      return "response";
+    });
+    const batchedLoader = batch(loader, JSON.stringify);
+
+    const promise1 = batchedLoader("arg1");
+    await promise1;
+
+    const promise2 = batchedLoader("arg1");
+    expect(promise1).not.toBe(promise2);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("should handle different keys separately", async () => {
+    const loader = vi.fn().mockImplementation(async (arg) => {
+      await sleep(10);
+      return "response";
+    });
+    const batchedLoader = batch(loader, JSON.stringify);
+
+    const promise1 = batchedLoader("arg1");
+    const promise2 = batchedLoader("arg2");
+
+    expect(promise1).not.toBe(promise2);
+    expect(loader).toHaveBeenCalledTimes(2);
+
+    const result1 = await promise1;
+    const result2 = await promise2;
+    expect(result1).toBe("response");
+    expect(result2).toBe("response");
+  });
+});

--- a/frontend/src/utils/batch-requests.ts
+++ b/frontend/src/utils/batch-requests.ts
@@ -1,0 +1,28 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Debounces multiple calls to a loader function, returning the same promise for
+ * all calls with the same key.
+ */
+export function batch<T, REQ extends unknown[]>(
+  loader: (...args: REQ) => Promise<T>,
+  toKey: (...args: REQ) => string,
+) {
+  const requestCache = new Map<string, Promise<T>>();
+
+  return (...args: REQ): Promise<T> => {
+    const key = toKey(...args);
+    if (requestCache.has(key)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return requestCache.get(key)!;
+    }
+
+    const requestPromise = loader(...args).finally(() => {
+      requestCache.delete(key);
+    });
+
+    requestCache.set(key, requestPromise);
+    return requestPromise;
+  };
+}


### PR DESCRIPTION
Helps https://github.com/marimo-team/marimo/issues/2996, https://github.com/marimo-team/marimo/issues/2991, but not fixed until https://github.com/marimo-team/marimo/pull/3000

This shared promises with inflight requests (e.g. when they are shot off at the same time), and then clears the share cache, because (in this case) can fall back to browser cache. 