### PR TITLE
improvement: clamp tables at 50 columnns by default

### DIFF
--- a/frontend/src/components/data-table/TableActions.tsx
+++ b/frontend/src/components/data-table/TableActions.tsx
@@ -15,6 +15,7 @@ interface TableActionsProps<TData> {
   isSearchEnabled: boolean;
   setIsSearchEnabled: React.Dispatch<React.SetStateAction<boolean>>;
   pagination: boolean;
+  totalColumns: number;
   selection?: "single" | "multi" | null;
   onRowSelectionChange?: (value: RowSelectionState) => void;
   table: Table<TData>;
@@ -27,6 +28,7 @@ export const TableActions = <TData,>({
   isSearchEnabled,
   setIsSearchEnabled,
   pagination,
+  totalColumns,
   selection,
   onRowSelectionChange,
   table,
@@ -48,6 +50,7 @@ export const TableActions = <TData,>({
       )}
       {pagination ? (
         <DataTablePagination
+          totalColumns={totalColumns}
           selection={selection}
           onSelectAllRowsChange={
             onRowSelectionChange

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -32,6 +32,8 @@ export const TableColumnSummary = <TData, TValue>({
     chart = (
       <DelayMount
         milliseconds={200}
+        visibility={true}
+        rootMargin="200px"
         fallback={<ChartSkeleton seed={columnId} width={130} height={60} />}
       >
         <LazyVegaLite

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -41,6 +41,7 @@ interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   setSorting?: OnChangeFn<SortingState>; // controlled sorting
   // Pagination
   totalRows: number | "too_many";
+  totalColumns: number;
   pagination?: boolean;
   manualPagination?: boolean; // server-side pagination
   paginationState?: PaginationState; // controlled pagination
@@ -68,6 +69,7 @@ const DataTableInternal = <TData,>({
   columns,
   data,
   selection,
+  totalColumns,
   totalRows,
   manualSorting = false,
   sorting,
@@ -168,6 +170,7 @@ const DataTableInternal = <TData,>({
       </div>
       <TableActions
         enableSearch={enableSearch}
+        totalColumns={totalColumns}
         onSearchQueryChange={onSearchQueryChange}
         isSearchEnabled={isSearchEnabled}
         setIsSearchEnabled={setIsSearchEnabled}

--- a/frontend/src/components/data-table/pagination.tsx
+++ b/frontend/src/components/data-table/pagination.tsx
@@ -16,6 +16,7 @@ import { range } from "lodash-es";
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;
   selection?: "single" | "multi" | null;
+  totalColumns: number;
   onSelectAllRowsChange?: (value: boolean) => void;
 }
 
@@ -23,6 +24,7 @@ export const DataTablePagination = <TData,>({
   table,
   selection,
   onSelectAllRowsChange,
+  totalColumns,
 }: DataTablePaginationProps<TData>) => {
   const renderTotal = () => {
     const selected = Object.keys(table.getState().rowSelection).length;
@@ -76,13 +78,8 @@ export const DataTablePagination = <TData,>({
       );
     }
 
-    let numColumns = table.getAllColumns().length;
-    // If we have a selection column, subtract one from the total columns
-    if (selection != null) {
-      numColumns -= 1;
-    }
     const rowsLabel = `${prettyNumber(numRows)} ${new PluralWord("row").pluralize(numRows)}`;
-    const columnsLabel = `${prettyNumber(numColumns)} ${new PluralWord("column").pluralize(numColumns)}`;
+    const columnsLabel = `${prettyNumber(totalColumns)} ${new PluralWord("column").pluralize(totalColumns)}`;
 
     return <span>{[rowsLabel, columnsLabel].join(", ")}</span>;
   };

--- a/frontend/src/components/editor/file-tree/renderers.tsx
+++ b/frontend/src/components/editor/file-tree/renderers.tsx
@@ -36,6 +36,7 @@ export const CsvViewer: React.FC<{ contents: string }> = ({ contents }) => {
       data={data}
       totalRows={data.length}
       columns={columns}
+      totalColumns={columns.length}
       manualPagination={false}
       paginationState={pagination}
       setPaginationState={setPagination}

--- a/frontend/src/components/utils/delay-mount.tsx
+++ b/frontend/src/components/utils/delay-mount.tsx
@@ -1,16 +1,66 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import React from "react";
+import { useIntersectionObserver } from "@uidotdev/usehooks";
+import React, { useEffect, useState } from "react";
 
 interface Props {
+  /**
+   * The delay in milliseconds before mounting the children.
+   */
   milliseconds: number;
+
+  /**
+   * The content to be rendered after the delay.
+   */
   children: React.ReactNode;
+
+  /**
+   * The content to be rendered while waiting for the delay or visibility condition.
+   */
   fallback?: React.ReactNode;
+
+  /**
+   * If true, the children will only be rendered if the component has been visible in the viewport at least once.
+   */
+  visibility?: boolean;
+
+  /**
+   * The threshold at which the visibility is considered. A number between 0 and 1.
+   */
+  threshold?: number;
+
+  /**
+   * The root margin for the intersection observer.
+   */
+  rootMargin?: string;
 }
 
-export const DelayMount = ({ milliseconds, children, fallback }: Props) => {
-  const [mounted, setMounted] = React.useState(false);
+/**
+ * DelayMount component delays the rendering of its children until a specified time has passed.
+ * It can also conditionally render based on the visibility of the component in the viewport.
+ */
+export const DelayMount = ({
+  milliseconds,
+  children,
+  fallback,
+  visibility = false,
+  threshold = 0,
+  rootMargin = "0px",
+}: Props) => {
+  const [mounted, setMounted] = useState(false);
+  const [hasBeenVisible, setHasBeenVisible] = useState(false);
+  const [ref, entry] = useIntersectionObserver({
+    threshold,
+    root: null,
+    rootMargin,
+  });
 
-  React.useEffect(() => {
+  useEffect(() => {
+    if (entry?.isIntersecting) {
+      setHasBeenVisible(true);
+    }
+  }, [entry?.isIntersecting]);
+
+  useEffect(() => {
     const timeout = setTimeout(() => {
       setMounted(true);
     }, milliseconds);
@@ -20,5 +70,12 @@ export const DelayMount = ({ milliseconds, children, fallback }: Props) => {
     };
   }, [milliseconds]);
 
-  return mounted ? children : fallback;
+  // Determine if the children should be shown
+  // If visibility is true, only show the children if the component has been visible in the viewport at least once.
+  // If visibility is false, always show the children after the delay.
+  const shouldShow = visibility && !hasBeenVisible ? false : mounted;
+
+  return (
+    <div ref={visibility ? ref : null}>{shouldShow ? children : fallback}</div>
+  );
 };

--- a/frontend/src/plugins/impl/DataEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/DataEditorPlugin.tsx
@@ -48,7 +48,12 @@ export const DataEditorPlugin = createPlugin<Edits>("marimo-data-editor")
       pagination: z.boolean().default(false),
       pageSize: z.number().default(10),
       fieldTypes: z
-        .array(z.tuple([z.string(), z.tuple([z.enum(DATA_TYPES), z.string()])]))
+        .array(
+          z.tuple([
+            z.coerce.string(),
+            z.tuple([z.enum(DATA_TYPES), z.string()]),
+          ]),
+        )
         .nullish(),
     }),
   )

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -263,6 +263,7 @@ export const DataFrameComponent = memo(
           className="rounded-b border-x border-b"
           data={url || ""}
           totalRows={total_rows ?? 0}
+          totalColumns={Object.keys(columns).length}
           pageSize={pageSize}
           pagination={true}
           fieldTypes={field_types}

--- a/frontend/src/stories/data-table.stories.tsx
+++ b/frontend/src/stories/data-table.stories.tsx
@@ -15,6 +15,7 @@ export const Default = {
   render: () => (
     <DataTable
       totalRows={100}
+      totalColumns={2}
       paginationState={{ pageIndex: 0, pageSize: 10 }}
       setPaginationState={Functions.NOOP}
       data={[

--- a/frontend/src/stories/data-table.stories.tsx
+++ b/frontend/src/stories/data-table.stories.tsx
@@ -52,6 +52,7 @@ export const Empty1 = {
   render: () => (
     <DataTable
       totalRows={100}
+      totalColumns={2}
       paginationState={{ pageIndex: 0, pageSize: 10 }}
       setPaginationState={Functions.NOOP}
       data={[]}
@@ -79,6 +80,7 @@ export const Empty2 = {
   render: () => (
     <DataTable
       totalRows={100}
+      totalColumns={2}
       paginationState={{ pageIndex: 0, pageSize: 10 }}
       setPaginationState={Functions.NOOP}
       data={[]}
@@ -92,6 +94,7 @@ export const Pagination = {
   render: () => (
     <DataTable
       totalRows={100}
+      totalColumns={2}
       paginationState={{ pageIndex: 0, pageSize: 10 }}
       setPaginationState={Functions.NOOP}
       data={[

--- a/marimo/_smoke_tests/issues/2991-df-columns.py
+++ b/marimo/_smoke_tests/issues/2991-df-columns.py
@@ -1,0 +1,94 @@
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo",
+#     "numpy==2.1.3",
+#     "pandas==2.2.3",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.9.27"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import pandas as pd
+    import marimo as mo
+    import numpy as np
+    return mo, np, pd
+
+
+@app.cell
+def __(mo):
+    mo.md(r"""## Lots of columns""")
+    return
+
+
+@app.cell(hide_code=True)
+def __(mo):
+    mo.md("""Set cols to 10000 to crash the frontend. Number of rows appears to have no effect.""")
+    return
+
+
+@app.cell
+def __(mo):
+    rows = mo.ui.number(start=1, value=10, label="rows")
+    columns = mo.ui.number(start=1, value=50, label="cols")
+
+    mo.hstack([rows, columns], justify="start")
+    return columns, rows
+
+
+@app.cell
+def __(columns, np, rows):
+    data = np.zeros((rows.value, columns.value))
+    return (data,)
+
+
+@app.cell
+def __(data, pd):
+    df = pd.DataFrame(data, columns=[str(i) for i in range(1, data.shape[1] + 1)])
+    return (df,)
+
+
+@app.cell
+def __(df):
+    df
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        ## 20k rows, 40 columns 
+
+        This is the default max to show column summaries
+        """
+    )
+    return
+
+
+@app.cell
+def __(np, pd):
+    _data = np.random.rand(20000, 40)
+    column_names = [f"col{i}" for i in range(40)]
+    large_df = pd.DataFrame(
+        {col: _data[:, i] for i, col in enumerate(column_names)}
+    )
+    large_df
+    return column_names, large_df
+
+
+@app.cell
+def __():
+    # mo.ui.table(df, max_columns=None)
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #2996
Fixes #2991

- clamp tables at 50 columnns by default
- delay render of charts until they are visible, this also delays parsing/aggregating the data for the chart