### PR TITLE
fix: support microseconds in mo.ui.table, (but not nanoseconds)

### DIFF
--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -2,7 +2,6 @@
 "use no memo";
 
 import type { ColumnDef } from "@tanstack/react-table";
-import { format as formatDate } from "date-fns";
 import {
   DataTableColumnHeader,
   DataTableColumnHeaderWithSummary,
@@ -19,6 +18,7 @@ import { uniformSample } from "./uniformSample";
 import { DatePopover } from "./date-popover";
 import { Objects } from "@/utils/objects";
 import { Maps } from "@/utils/maps";
+import { exactDateTime } from "@/utils/dates";
 
 function inferDataType(value: unknown): [type: DataType, displayType: string] {
   if (typeof value === "string") {
@@ -201,7 +201,7 @@ export function generateColumns<T>({
           return (
             <div className={getCellStyleClass(justify, wrapped)}>
               <DatePopover date={value} type={type}>
-                {formatDate(value, "yyyy-MM-dd HH:mm:ss")}
+                {exactDateTime(value)}
               </DatePopover>
             </div>
           );

--- a/frontend/src/components/data-table/date-popover.tsx
+++ b/frontend/src/components/data-table/date-popover.tsx
@@ -60,6 +60,33 @@ export const DatePopover: React.FC<DatePopoverProps> = ({
 
 function getTimezones(date: Date) {
   const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const hasSubSeconds = date.getUTCMilliseconds() !== 0;
+  if (hasSubSeconds) {
+    return {
+      UTC: new Intl.DateTimeFormat("en-US", {
+        timeZone: "UTC",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        fractionalSecondDigits: 3,
+      }).format(date),
+      [localTimezone]: new Intl.DateTimeFormat("en-US", {
+        timeZone: localTimezone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        fractionalSecondDigits: 3,
+      }).format(date),
+    };
+  }
+
   return {
     UTC: new Intl.DateTimeFormat("en-US", {
       timeZone: "UTC",

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -1,4 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { formatDate } from "date-fns";
 import { Logger } from "./Logger";
 
 export function prettyDate(
@@ -27,6 +28,18 @@ export function prettyDate(
     Logger.warn("Failed to parse date", error);
     return value.toString();
   }
+}
+
+/**
+ * If the date has sub-second precision, it should say "2024-10-07 17:15:00.123".
+ * Otherwise, it should say "2024-10-07 17:15:00".
+ */
+export function exactDateTime(value: Date): string {
+  const hasSubSeconds = value.getUTCMilliseconds() !== 0;
+  if (hasSubSeconds) {
+    return formatDate(value, "yyyy-MM-dd HH:mm:ss.SSS");
+  }
+  return formatDate(value, "yyyy-MM-dd HH:mm:ss");
 }
 
 /**

--- a/marimo/_smoke_tests/tables/subseconds.py
+++ b/marimo/_smoke_tests/tables/subseconds.py
@@ -1,0 +1,94 @@
+
+
+import marimo
+
+__generated_with = "0.9.27"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import datetime
+
+    import marimo as mo
+    import pandas as pd
+    return datetime, mo, pd
+
+
+@app.cell
+def __(mo):
+    mo.md(r"""## Datetime""")
+    return
+
+
+@app.cell
+def __(datetime, pd):
+    _start = datetime.datetime(2024, 11, 27, 16)
+    _slice = datetime.timedelta(days=1)
+    pd.DataFrame(
+        data={
+            "timestamp": [_start + n * _slice for n in range(5)],
+        }
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(r"""## Seconds""")
+    return
+
+
+@app.cell
+def __(datetime, pd):
+    _start = datetime.datetime(2024, 11, 27, 16, 17, 7)
+    _slice = datetime.timedelta(seconds=1)
+    pd.DataFrame(
+        data={
+            "timestamp": [_start + n * _slice for n in range(5)],
+        }
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(r"""## Milliseconds""")
+    return
+
+
+@app.cell
+def __(datetime, pd):
+    _start = datetime.datetime(2024, 11, 27, 16, 17, 7, 742951)
+    _slice = datetime.timedelta(microseconds=123456)
+    test_df = pd.DataFrame(
+        data={
+            "timestamp": [_start + n * _slice for n in range(5)],
+        }
+    )
+    return (test_df,)
+
+
+@app.cell
+def __(mo, test_df):
+    # Nanoseconds are still missing, because JavaScript (browsers) don't support nanoseconds.
+    mo.hstack([mo.plain(test_df), test_df])
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(r"""## Nanoseconds""")
+    return
+
+
+@app.cell
+def __(test_df):
+    nano_df = test_df.copy()
+    nano_df["timestamp"] = nano_df["timestamp"].astype(str)
+    nano_df
+    return (nano_df,)
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #3007 

This adds microsecond support to the table. 

It does not handle nanoseconds since browser `Dates` do not handle nanoseconds. So the workaround is to cast the column as a string.

```python
    _start = datetime.datetime(2024, 11, 27, 16, 17, 7, 742951)
    _slice = datetime.timedelta(microseconds=123456)
    test_df = pd.DataFrame(
        data={
            "timestamp": [_start + n * _slice for n in range(5)],
        }
    )
    nano_df = test_df.copy()
    nano_df["timestamp"] = nano_df["timestamp"].astype(str)
    nano_df
```