### PR TITLE
fix: sort only when column exists

### DIFF
--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -268,7 +268,7 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
         if query:
             result = result.search(query)
 
-        if sort:
+        if sort and sort.by in result.get_column_names():
             result = result.sort_values(sort.by, sort.descending)
 
         return result

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -547,7 +547,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
         if query:
             result = result.search(query)
 
-        if sort:
+        if sort and sort.by in result.get_column_names():
             result = result.sort_values(sort.by, sort.descending)
 
         return result

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -366,6 +366,22 @@ def test_value_with_search_then_selection_dfs(df: Any) -> None:
     assert nw.from_native(value)["a"][0] == "baz"
 
 
+def test_search_sort_nonexistent_columns() -> None:
+    data = ["banana", "apple", "cherry", "date", "elderberry"]
+    table = ui.table(data)
+
+    # no error raised
+    table.search(
+        SearchTableArgs(
+            sort=SortArgs("missing_column", descending=False),
+            page_size=10,
+            page_number=0,
+        )
+    )
+
+    assert table._convert_value(["0"]) == ["banana"]
+
+
 def test_table_with_too_many_columns_passes() -> None:
     data = {str(i): [1] for i in range(101)}
     assert ui.table(data) is not None


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #3017 . Checks if sorted column exists before sorting.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Added some tests, let me know if I should add more sort tests to the dataframe component.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
