### PR TITLE
fix: don't unhide when markdown is empty

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -378,21 +378,6 @@ const CellComponent = (
 
   const hasOutput = !isOutputEmpty(output);
 
-  const unhideCode = useEvent(() => {
-    // Fire-and-forget save
-    void saveCellConfig({ configs: { [cellId]: { hide_code: false } } });
-    updateCellConfig({ cellId, config: { hide_code: false } });
-
-    // focus the editor
-    editorView.current?.focus();
-    return false;
-  });
-
-  // When markdown cell is hidden & output is cleared, show the code editor
-  if (isMarkdownCodeHidden && !hasOutput) {
-    unhideCode();
-  }
-
   const outputArea = hasOutput && (
     <div className="relative" onDoubleClick={showHiddenMarkdownCode}>
       <div className="absolute top-5 -left-8 z-10 print:hidden">


### PR DESCRIPTION
Don't unhide the markdown if empty since it may start empty (before any rendering)