### PR TITLE
improvement: add copy/paste to json viewer, support urls

### DIFF
--- a/frontend/src/components/data-table/url-detector.tsx
+++ b/frontend/src/components/data-table/url-detector.tsx
@@ -1,9 +1,8 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { Events } from "@/utils/events";
 
+const urlRegex = /(https?:\/\/\S+)/g;
 export const UrlDetector = ({ text }: { text: string }) => {
-  const urlRegex = /(https?:\/\/\S+)/g;
-
   const createMarkup = (text: string) => {
     const parts = text.split(urlRegex);
 

--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -63,11 +63,11 @@
    * margin collapse. */
   overflow: auto;
   @apply text-xs;
-}
 
-.marimo-json-output .data-key-pair:not(:last-child) {
-  margin-top: 0.2rem;
-  margin-bottom: 0.2rem;
+  .data-key-pair:not(:last-child) {
+    margin-top: 0.2rem;
+    margin-bottom: 0.2rem;
+  }
 }
 
 .traceback-cell-link {

--- a/frontend/src/components/editor/output/__tests__/json-output.test.ts
+++ b/frontend/src/components/editor/output/__tests__/json-output.test.ts
@@ -1,0 +1,158 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, it, expect } from "vitest";
+import { getCopyValue } from "../JsonOutput";
+
+describe("getCopyValue", () => {
+  it("should handle strings without MIME prefixes", () => {
+    const value = "simple string";
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`""simple string""`);
+  });
+
+  it("should handle strings with MIME prefixes", () => {
+    const value = "text/plain:Hello, World!";
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`""Hello, World!""`);
+  });
+
+  it("should handle booleans", () => {
+    expect(getCopyValue(true)).toMatchInlineSnapshot(`"True"`);
+    expect(getCopyValue(false)).toMatchInlineSnapshot(`"False"`);
+  });
+
+  it("should handle null and undefined", () => {
+    expect(getCopyValue(null)).toMatchInlineSnapshot(`"None"`);
+    expect(getCopyValue(undefined)).toMatchInlineSnapshot(`"None"`);
+  });
+
+  it("should handle arrays", () => {
+    const value = ["text/plain:Hello", true, null];
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`"["Hello",True,None]"`);
+  });
+
+  it("should handle objects", () => {
+    const value = {
+      key1: "text/plain:Hello",
+      key2: false,
+      key3: null,
+    };
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(
+      `"{"key1":"Hello","key2":False,"key3":None}"`,
+    );
+  });
+
+  it("should handle a string called true and None", () => {
+    const value = {
+      true: "true",
+      None: "none",
+      null: "null",
+      sentence: "something true none null something",
+    };
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(
+      `"{"true":"true","None":"none","null":"null","sentence":"something true none null something"}"`,
+    );
+  });
+
+  it("should handle nested objects", () => {
+    const value = {
+      key1: {
+        nestedKey1: "text/plain:Nested Hello",
+        nestedKey2: true,
+      },
+      key2: false,
+    };
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(
+      `"{"key1":{"nestedKey1":"Nested Hello","nestedKey2":True},"key2":False}"`,
+    );
+  });
+
+  it("should handle nested arrays", () => {
+    const value = ["text/plain:Hello", [true, null, "text/plain:World"]];
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`"["Hello",[True,None,"World"]]"`);
+  });
+
+  it("should handle empty objects", () => {
+    const value = {};
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`"{}"`);
+  });
+
+  it("should handle empty arrays", () => {
+    const value: string[] = [];
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`"[]"`);
+  });
+
+  it("should handle numbers", () => {
+    const value = 42;
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`"42"`);
+  });
+
+  it("should handle special characters in strings", () => {
+    const value = "text/plain:Hello, \nWorld!";
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`""Hello, \\nWorld!""`);
+  });
+
+  it("should handle mixed types in arrays", () => {
+    const value = [42, "text/plain:Hello", true, null];
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`"[42,"Hello",True,None]"`);
+  });
+
+  it("should handle mixed types in objects", () => {
+    const value = {
+      key1: 42,
+      key2: "text/plain:Hello",
+      key3: true,
+      key4: null,
+      key5: "text/plain+float:1.23",
+    };
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(
+      `"{"key1":42,"key2":"Hello","key3":True,"key4":None,"key5":1.23}"`,
+    );
+  });
+
+  it("should handle sets", () => {
+    const value = "text/plain+set:[1,2,3]";
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`"{1,2,3}"`);
+  });
+
+  it("should handle sets in mixed types", () => {
+    const value = {
+      key1: 42,
+      key2: "text/plain+set:[1,2,3]",
+      key3: true,
+    };
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(
+      `"{"key1":42,"key2":{1,2,3},"key3":True}"`,
+    );
+  });
+
+  it("should handle tuples", () => {
+    const value = "text/plain+tuple:[1,2,3]";
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(`"(1,2,3)"`);
+  });
+
+  it("should handle tuples in mixed types", () => {
+    const value = {
+      key1: 42,
+      key2: "text/plain+tuple:[1,2,3]",
+      key3: true,
+    };
+    const result = getCopyValue(value);
+    expect(result).toMatchInlineSnapshot(
+      `"{"key1":42,"key2":(1,2,3),"key3":True}"`,
+    );
+  });
+});

--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -26,3 +26,8 @@ export function newNotebookURL() {
   const initializationId = `__new__${sessionId}`;
   return asURL(`?file=${initializationId}`).toString();
 }
+
+const urlRegex = /(https?:\/\/\S+)/g;
+export function isUrl(value: unknown): boolean {
+  return typeof value === "string" && urlRegex.test(value);
+}

--- a/marimo/_output/formatters/structures.py
+++ b/marimo/_output/formatters/structures.py
@@ -29,6 +29,10 @@ def _leaf_formatter(value: object) -> bool | None | str | int:
         return f"text/plain+float:{value}"
     if value is None:
         return value
+    if isinstance(value, set):
+        return f"text/plain+set:{str(value)}"
+    if isinstance(value, tuple):
+        return f"text/plain+tuple:{json.dumps(value)}"
 
     try:
         return f"text/plain:{json.dumps(value)}"

--- a/marimo/_smoke_tests/structures.py
+++ b/marimo/_smoke_tests/structures.py
@@ -1,11 +1,11 @@
 import marimo
 
-__generated_with = "0.9.29"
+__generated_with = "0.9.30"
 app = marimo.App(width="medium")
 
 
 @app.cell
-def __():
+def __(mo):
     [
         {
             "a": 1,
@@ -13,6 +13,13 @@ def __():
             "c": "foo",
             "d": True,
             "e": False,
+            "e": mo.ui.slider(0, 10),
+            "f": "bar" * 1000,
+            "url": "https://www.google.com",
+            "g": [1, 2, 3],
+            "h": (1, 2, 3),
+            "i": {1, 2, 3},
+            "j": {"a": 1, "b": 2},
         }
     ]
     return

--- a/tests/_output/formatters/test_structures.py
+++ b/tests/_output/formatters/test_structures.py
@@ -218,3 +218,13 @@ def test_format_structure_subclasses_with_different_built_in_repr() -> None:
     assert get_and_format(sys.version_info)[1].startswith(
         "<pre style='font-size: 12px'>sys.version_info(major=3"
     )
+
+
+def test_format_structure_set() -> None:
+    test_set = {1, 2, 3}
+    assert format_structure([test_set]) == (["text/plain+set:{1, 2, 3}"])
+
+
+def test_format_structure_tuple() -> None:
+    test_tuple = (1, 2, 3)
+    assert format_structure(test_tuple) == (1, 2, 3)


### PR DESCRIPTION
This adds copy/paste support for floats/sets/lists/dictionaries. This also adds a URL renderer.

**It does not yet support tuples** since those get converted to lists on `json.dump` and not sure I want to make that change yet. 