### PR TITLE
improvement: tie-break topological sort by top-down order

### DIFF
--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -489,32 +489,36 @@ def get_cycles(
 def topological_sort(
     graph: DirectedGraph, cell_ids: Collection[CellId_t]
 ) -> list[CellId_t]:
-    """Sort `cell_ids` in a topological order.
+    """Sort `cell_ids` in a topological order using a heap queue.
 
     When multiple cells have the same parents (including no parents), the tie is broken by
     registration order - cells registered earlier are processed first.
     """
+    from heapq import heappop, heappush
+
     parents, children = induced_subgraph(graph, cell_ids)
+    # Use registration order as tiebreaker
     top_down_keys = {
         key: index for index, key in enumerate(graph.cells.keys())
     }
 
-    # Group cells by their parents and sort within each group by registration order
-    roots = sorted(
-        [cid for cid in cell_ids if not parents[cid]],
-        key=lambda x: top_down_keys[x],
-    )
+    # Initialize heap with roots (nodes with no parents)
+    heap: list[tuple[int, CellId_t]] = []
+    for cid in cell_ids:
+        if not parents[cid]:
+            # Use tuple with registration order as first element for heap ordering
+            heappush(heap, (top_down_keys[cid], cid))
+
     sorted_cell_ids: list[CellId_t] = []
-    while roots:
-        # Within each level, process cells in registration order
-        roots.sort(key=lambda x: top_down_keys[x])
-        cid = roots.pop(0)
+    while heap:
+        _, cid = heappop(heap)
         sorted_cell_ids.append(cid)
+
         for child in children[cid]:
             parents[child].remove(cid)
             if not parents[child]:
-                roots.append(child)
-    # TODO make sure parents for each id is empty, otherwise cycle
+                heappush(heap, (top_down_keys[child], child))
+
     return sorted_cell_ids
 
 


### PR DESCRIPTION
This is useful to keep markdown elements (which may not have a dependency) in the same order that they are created, when exporting to a script or ipynb.

This also renders markdown from top to bottom which is less jerky on startup. 