### PR TITLE
improvement: make ui-element ids deterministic across runs

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import abc
 import base64
 import copy
+import random
 import sys
 import types
 import uuid
@@ -111,6 +112,8 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
     _value_frontend: S
     _value: T
 
+    _random_seed = random.Random(42)
+
     def __init__(
         self,
         component_name: str,
@@ -194,7 +197,11 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         # element will trigger a re-render and reset it to its initial value.
         # We need this to ensure that the element on the page is synchronized
         # with the element in the kernel.
-        self._random_id = str(uuid.uuid4())
+        # We use a fixed seed so that we can reproduce the same random ids
+        # across multiple runs (useful when exporting as html or in tests)
+        self._random_id = str(
+            uuid.UUID(int=self._random_seed.getrandbits(128))
+        )
 
         # Stable ID
         #

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -16,6 +16,7 @@ from marimo._runtime.requests import (
     SetUIElementValueRequest,
 )
 from marimo._runtime.runner import cell_runner
+from marimo._server.model import SessionMode
 
 if TYPE_CHECKING:
     from marimo._ast.app import InternalApp
@@ -85,6 +86,7 @@ class AppKernelRunner:
             stdout=None,
             stderr=None,
             virtual_files_supported=True,
+            mode=SessionMode.EDIT,
             parent=ctx,
         )
         ctx.add_child(self._runtime_context)

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -122,12 +122,13 @@ class KernelRuntimeContext(RuntimeContext):
 
 
 def create_kernel_context(
+    *,
     kernel: Kernel,
     stream: Stream,
     stdout: Stdout | None,
     stderr: Stderr | None,
-    virtual_files_supported: bool = True,
-    mode: SessionMode = SessionMode.EDIT,
+    virtual_files_supported: bool,
+    mode: SessionMode,
     app: InternalApp | None = None,
     parent: KernelRuntimeContext | None = None,
 ) -> KernelRuntimeContext:
@@ -155,12 +156,13 @@ def create_kernel_context(
 
 
 def initialize_kernel_context(
+    *,
     kernel: Kernel,
     stream: Stream,
     stdout: Stdout | None,
     stderr: Stderr | None,
-    virtual_files_supported: bool = True,
-    mode: SessionMode = SessionMode.EDIT,
+    virtual_files_supported: bool,
+    mode: SessionMode,
 ) -> None:
     """Initializes thread-local/session-specific context.
 
@@ -168,11 +170,11 @@ def initialize_kernel_context(
     """
     initialize_context(
         runtime_context=create_kernel_context(
-            kernel,
-            stream,
-            stdout,
-            stderr,
-            virtual_files_supported,
-            mode,
+            kernel=kernel,
+            stream=stream,
+            stdout=stdout,
+            stderr=stderr,
+            virtual_files_supported=virtual_files_supported,
+            mode=mode,
         )
     )

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -415,7 +415,7 @@ class Session:
         app_file_manager: AppFileManager,
         user_config_manager: UserConfigManager,
         virtual_files_supported: bool,
-        redirect_console_to_browser: bool = False,
+        redirect_console_to_browser: bool,
     ) -> Session:
         """
         Create a new session.

--- a/tests/_plugins/ui/_core/test_ui_element.py
+++ b/tests/_plugins/ui/_core/test_ui_element.py
@@ -51,3 +51,28 @@ def test_bool_ui_element() -> None:
         res = not element
         del res
         assert buf.getvalue() == expected_warning
+
+
+def test_ui_element_random_id() -> None:
+    element1 = Element()
+    element2 = Element()
+
+    assert element1._random_id != element2._random_id
+
+    class AnotherElement(UIElement[int, int]):
+        _name: str = "another_element"
+
+        def __init__(self) -> None:
+            super().__init__(
+                component_name=AnotherElement._name,
+                initial_value=0,
+                label=None,
+                args={},
+                on_change=None,
+            )
+
+        def _convert_value(self, value: int) -> int:
+            return value
+
+    another_element = AnotherElement()
+    assert element1._random_id != another_element._random_id

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -37,6 +37,7 @@ from marimo._runtime.requests import (
 )
 from marimo._runtime.runtime import Kernel
 from marimo._runtime.scratch import SCRATCH_CELL_ID
+from marimo._server.model import SessionMode
 from marimo._utils.parse_dataclass import parse_raw
 from tests.conftest import ExecReqProvider, MockedKernel
 
@@ -920,6 +921,8 @@ class TestExecution:
                 stream=k.stream,
                 stdout=k.stdout,
                 stderr=k.stderr,
+                virtual_files_supported=True,
+                mode=SessionMode.EDIT,
             )
 
             await k.run(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from marimo._runtime.input_override import input_override
 from marimo._runtime.marimo_pdb import MarimoPdb
 from marimo._runtime.requests import AppMetadata, ExecutionRequest
 from marimo._runtime.runtime import Kernel
+from marimo._server.model import SessionMode
 
 # register import hooks for third-party module formatters
 register_formatters()
@@ -128,6 +129,8 @@ class MockedKernel:
             stream=self.stream,  # type: ignore
             stdout=self.stdout,  # type: ignore
             stderr=self.stderr,  # type: ignore
+            virtual_files_supported=True,
+            mode=SessionMode.EDIT,
         )
 
     def teardown(self) -> None:


### PR DESCRIPTION
This helps when committing generated marimo files (html/ipynb) that they don't cause unnecessary diffs.

html files still have some changes from the timestamps in the outputs