### PR TITLE
fix: only add borderless css when not published

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -421,7 +421,7 @@ const CellComponent = (
     stopped: stopped,
     disabled: cellConfig.disabled,
     stale: status === "disabled-transitively",
-    borderless: isMarkdownCodeHidden,
+    borderless: isMarkdownCodeHidden && editing,
   });
 
   const HTMLId = HTMLCellId.create(cellId);

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -261,7 +261,7 @@ const VerticalCell = memo(
     const isPureMarkdown = new MarkdownLanguageAdapter().isSupported(code);
     const published = !showCode && !kioskFull;
     const className = cn("Cell", "hover-actions-parent empty:invisible", {
-      published: !showCode && !kioskFull,
+      published: published,
       interactive: mode === "edit",
       "has-error": errored,
       stopped: stopped,

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -259,12 +259,13 @@ const VerticalCell = memo(
     const kioskFull = kiosk && mode !== "present";
 
     const isPureMarkdown = new MarkdownLanguageAdapter().isSupported(code);
+    const published = !showCode && !kioskFull;
     const className = cn("Cell", "hover-actions-parent empty:invisible", {
       published: !showCode && !kioskFull,
       interactive: mode === "edit",
       "has-error": errored,
       stopped: stopped,
-      borderless: isPureMarkdown,
+      borderless: isPureMarkdown && !published,
     });
 
     const HTMLId = HTMLCellId.create(cellId);


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

There is a bad bug when you're in app view, since the borders are removed, so hovering over the cell will cause borders to be re-added. Borderless view is not needed in 'present' or 'view' mode.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
