### PR TITLE
fix: make scratchpad scrollable

### DIFF
--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -125,7 +125,7 @@ export const ScratchPad: React.FC = () => {
     // We overlay the history on top of the body, instead of removing it,
     // so we don't have to re-render the entire editor and outputs.
     return (
-      <div className="absolute overflow-auto h-full w-full">
+      <>
         <div className="overflow-auto flex-shrink-0 max-h-[40%]">
           <CellEditor
             theme={theme}
@@ -156,7 +156,7 @@ export const ScratchPad: React.FC = () => {
             setLanguageAdapter={setLanguageAdapter}
           />
         </div>
-        <div className="flex-1 overflow-auto flex-shrink-0 max-h-[35%]">
+        <div className="flex-1 overflow-auto flex-shrink-0">
           <OutputArea
             allowExpand={false}
             output={output}
@@ -176,7 +176,7 @@ export const ScratchPad: React.FC = () => {
             debuggerActive={false}
           />
         </div>
-      </div>
+      </>
     );
   };
 
@@ -269,7 +269,7 @@ export const ScratchPad: React.FC = () => {
           </Button>
         </Tooltip>
       </div>
-      <div className="flex-1 divide-y relative">
+      <div className="flex-1 divide-y relative overflow-hidden flex flex-col">
         {renderBody()}
         {renderHistory()}
       </div>

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -125,7 +125,7 @@ export const ScratchPad: React.FC = () => {
     // We overlay the history on top of the body, instead of removing it,
     // so we don't have to re-render the entire editor and outputs.
     return (
-      <>
+      <div className="absolute overflow-auto h-full w-full">
         <div className="overflow-auto flex-shrink-0 max-h-[40%]">
           <CellEditor
             theme={theme}
@@ -156,7 +156,7 @@ export const ScratchPad: React.FC = () => {
             setLanguageAdapter={setLanguageAdapter}
           />
         </div>
-        <div className="flex-1 overflow-auto flex-shrink-0">
+        <div className="flex-1 overflow-auto flex-shrink-0 max-h-[35%]">
           <OutputArea
             allowExpand={false}
             output={output}
@@ -176,7 +176,7 @@ export const ScratchPad: React.FC = () => {
             debuggerActive={false}
           />
         </div>
-      </>
+      </div>
     );
   };
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #3073 . Each individual part can be scrolled (code editor, output area, console output) and the whole scratchpad can be scrolled too. I think it maintains the feel of scratchpad while handling long inputs / outputs.

I'm not sure if it breaks anything else, so plan to test it locally a while.

<img width="300" alt="Screenshot 2024-12-06 at 7 26 57 PM" src="https://github.com/user-attachments/assets/0c777a17-8eca-4070-8ce2-bb5d7bf181ef">

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
