### PR TITLE
Parameterize fastapi-github example with environment vars

### DIFF
--- a/examples/frameworks/fastapi-github/main.py
+++ b/examples/frameworks/fastapi-github/main.py
@@ -23,8 +23,8 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Constants
-GITHUB_REPO = "marimo-team/marimo"
-ROOT_DIR = "examples/ui"
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "marimo-team/marimo")
+ROOT_DIR = os.environ.get("ROOT_DIR", "examples/ui")
 templates_dir = os.path.join(os.path.dirname(__file__), "templates")
 
 # Set up templates


### PR DESCRIPTION
## 📝 Summary

Detects `GITHUB_REPO` and `REPO_ROOT` environment variables if set,
falling back to default in marimo.

(I believe this is the desired behavior of the script)

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

Just detects `GITHUB_REPO` and `REPO_ROOT` environment variables if set.

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
