### PR TITLE
improvement: add validate callback to asgi with_dynamic_directory

### DIFF
--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -18,6 +18,12 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info < (3, 10):
+        from typing_extensions import TypeAlias
+    else:
+        from typing import TypeAlias
     from starlette.requests import Request
     from starlette.responses import Response
     from starlette.types import ASGIApp, Receive, Scope, Send

--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -13,7 +13,6 @@ from typing import (
     List,
     Optional,
     Tuple,
-    TypeAlias,
     Union,
 )
 


### PR DESCRIPTION
Adds a validate callback that can be used in the programmatic ASGI app to check for authN or authZ.

```
            validate_callback (Optional[ValidateCallback]): A callback function to validate the application path.
                This is useful to plug in authentication or authorization checks.
                The validate_callback receives the application path and the scope,
                and returns a boolean indicating whether the application is valid.
                You may also raise an exception for a custom error message.
```