### PR TITLE
fix: allow grid controls to be edited

### DIFF
--- a/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
@@ -402,7 +402,7 @@ const GridControls: React.FC<{
   setIsLocked: (isLocked: boolean) => void;
 }> = ({ layout, setLayout, isLocked, setIsLocked }) => {
   return (
-    <div className="flex flex-row absolute pl-5 top-8 gap-4 w-full justify-end pr-[350px] pb-3 border-b z-20">
+    <div className="flex flex-row absolute pl-5 top-8 gap-4 w-full justify-end pr-[350px] pb-3 border-b z-50">
       <div className="flex flex-row items-center gap-2">
         <Label htmlFor="columns">Columns</Label>
         <NumberField


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #3074. Adjusts z-index of grid-controls to be the same as app header like below:

```.tsx
<AppHeader
    connection={connection}
    className={cn(
      "pt-4 sm:pt-12 pb-2 mb-4 print:hidden z-50",
      // Keep the header sticky when scrolling horizontally, for column mode
      "sticky left-0",
    )}
  >
```

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
