### PR TITLE
improvement: include cell config and name in ipynb metadata

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -52,6 +52,12 @@ if TYPE_CHECKING:
 
 LOGGER = _loggers.marimo_logger()
 
+DEFAULT_CELL_NAME = "__"
+
+
+def is_default_cell_name(name: str) -> bool:
+    return name == DEFAULT_CELL_NAME
+
 
 @dataclass
 class _AppConfig:
@@ -495,7 +501,7 @@ class CellManager:
         cell_id: Optional[CellId_t],
         code: str,
         config: Optional[CellConfig],
-        name: str = "__",
+        name: str = DEFAULT_CELL_NAME,
         cell: Optional[Cell] = None,
     ) -> None:
         if cell_id is None:
@@ -528,9 +534,12 @@ class CellManager:
             cell_id=self.create_cell_id(),
             code=code,
             config=cell_config,
-            name=name or "__",
+            name=name or DEFAULT_CELL_NAME,
             cell=None,
         )
+
+    def cell_name(self, cell_id: CellId_t) -> str:
+        return self._cell_data[cell_id].name
 
     def names(self) -> Iterable[str]:
         for cell_data in self._cell_data.values():

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -39,6 +39,16 @@ class CellConfig:
     def asdict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
 
+    def asdict_without_defaults(self) -> dict[str, Any]:
+        return {
+            k: v
+            for k, v in self.asdict().items()
+            if v != getattr(CellConfig(), k)
+        }
+
+    def is_different_from_default(self) -> bool:
+        return self != CellConfig()
+
     def configure(self, update: dict[str, Any] | CellConfig) -> None:
         """Update the config in-place.
 

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -183,7 +183,7 @@ class Exporter:
 
             notebook_cell = _create_notebook_cell(cell, outputs)
             # Add metadata to the cell
-            marimo_metadata = {}
+            marimo_metadata: dict[str, Any] = {}
             if cell.config.is_different_from_default():
                 marimo_metadata["config"] = (
                     cell.config.asdict_without_defaults()

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -8,6 +8,7 @@ import os
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 from marimo import __version__
+from marimo._ast.app import is_default_cell_name
 from marimo._ast.cell import Cell, CellConfig, CellImpl
 from marimo._config.config import (
     DEFAULT_CONFIG,
@@ -181,6 +182,17 @@ class Exporter:
                 )
 
             notebook_cell = _create_notebook_cell(cell, outputs)
+            # Add metadata to the cell
+            marimo_metadata = {}
+            if cell.config.is_different_from_default():
+                marimo_metadata["config"] = (
+                    cell.config.asdict_without_defaults()
+                )
+            name = file_manager.app.cell_manager.cell_name(cid)
+            if not is_default_cell_name(name):
+                marimo_metadata["name"] = name
+            if marimo_metadata:
+                notebook_cell["metadata"]["marimo"] = marimo_metadata
             notebook["cells"].append(notebook_cell)
 
         # notebook.metadata["marimo-version"] = __version__

--- a/tests/_ast/test_cell.py
+++ b/tests/_ast/test_cell.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable
 import pytest
 
 from marimo._ast.app import App
+from marimo._ast.cell import CellConfig
 
 
 class TestCellRun:
@@ -201,3 +202,22 @@ def help_smoke() -> None:
 
     assert "Async" in f._help().text
     assert "Async" not in g._help().text
+
+
+def test_cell_config_asdict_without_defaults():
+    config = CellConfig()
+    assert config.asdict_without_defaults() == {}
+
+    config = CellConfig(hide_code=True)
+    assert config.asdict_without_defaults() == {"hide_code": True}
+
+    config = CellConfig(hide_code=False)
+    assert config.asdict_without_defaults() == {}
+
+
+def test_is_different_from_default():
+    config = CellConfig(hide_code=True)
+    assert config.is_different_from_default()
+
+    config = CellConfig(hide_code=False)
+    assert not config.is_different_from_default()

--- a/tests/_server/export/snapshots/notebook_top_down.ipynb.txt
+++ b/tests/_server/export/snapshots/notebook_top_down.ipynb.txt
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "Hbol",
-   "metadata": {},
+   "metadata": {
+    "marimo": {
+     "name": "result"
+    }
+   },
    "outputs": [],
    "source": [
     "z = x + y"

--- a/tests/_server/export/snapshots/notebook_topological.ipynb.txt
+++ b/tests/_server/export/snapshots/notebook_topological.ipynb.txt
@@ -24,7 +24,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "Hbol",
-   "metadata": {},
+   "metadata": {
+    "marimo": {
+     "name": "result"
+    }
+   },
    "outputs": [],
    "source": [
     "z = x + y"

--- a/tests/_server/export/snapshots/notebook_with_cells.ipynb.txt
+++ b/tests/_server/export/snapshots/notebook_with_cells.ipynb.txt
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "Hbol",
-   "metadata": {},
+   "metadata": {
+    "marimo": {
+     "name": "cell_1"
+    }
+   },
    "outputs": [],
    "source": [
     "print(\"hello\")"

--- a/tests/_server/export/snapshots/notebook_with_outputs.ipynb.txt
+++ b/tests/_server/export/snapshots/notebook_with_outputs.ipynb.txt
@@ -22,7 +22,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "MJUe",
-   "metadata": {},
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "name": "cell_4"
+    }
+   },
    "outputs": [],
    "source": [
     "x = 10"
@@ -32,7 +39,27 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "vblA",
-   "metadata": {},
+   "metadata": {
+    "marimo": {
+     "config": {
+      "disabled": true
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(\"disabled\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bkHC",
+   "metadata": {
+    "marimo": {
+     "name": "cell_5"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -52,8 +79,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bkHC",
-   "metadata": {},
+   "id": "lEQa",
+   "metadata": {
+    "marimo": {
+     "name": "cell_6"
+    }
+   },
    "outputs": [],
    "source": [
     "import marimo as mo"
@@ -61,8 +92,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lEQa",
-   "metadata": {},
+   "id": "PKri",
+   "metadata": {
+    "marimo": {
+     "name": "cell_7"
+    }
+   },
    "source": [
     "hello"
    ]
@@ -70,8 +105,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "PKri",
-   "metadata": {},
+   "id": "Xref",
+   "metadata": {
+    "marimo": {
+     "name": "cell_8"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -90,8 +129,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Xref",
-   "metadata": {},
+   "id": "SFPL",
+   "metadata": {
+    "marimo": {
+     "name": "cell_11"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -110,8 +153,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "SFPL",
-   "metadata": {},
+   "id": "BYtC",
+   "metadata": {
+    "marimo": {
+     "name": "cell_12"
+    }
+   },
    "outputs": [
     {
      "data": {

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -94,9 +94,9 @@ async def test_export_ipynb_with_outputs():
 
     # stdout
     @app.cell()
-    def cell_1():
+    def __():
         print("hello")
-        return ()
+        return
 
     # # stdout
     # @app.cell()
@@ -120,10 +120,16 @@ async def test_export_ipynb_with_outputs():
     #     return ()
 
     # display
-    @app.cell()
+    @app.cell(hide_code=True)
     def cell_4():
         x = 10
         return (x,)
+
+    # disabled
+    @app.cell(disabled=True)
+    def __():
+        print("disabled")
+        return
 
     # dependency
     @app.cell()


### PR DESCRIPTION
Fixes #2960 

Last bit for #2960. This scopes everything under a `"marimo"` config to it won't conflict with any other future or existing configs