### PR TITLE
improvement: allow python files with just deps or no cells

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -538,6 +538,15 @@ class CellManager:
             cell=None,
         )
 
+    def ensure_one_cell(self) -> None:
+        if not self._cell_data:
+            cell_id = self.create_cell_id()
+            self.register_cell(
+                cell_id=cell_id,
+                code="",
+                config=CellConfig(),
+            )
+
     def cell_name(self, cell_id: CellId_t) -> str:
         return self._cell_data[cell_id].name
 

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -223,6 +223,17 @@ def get_app(filename: Optional[str]) -> Optional[App]:
 
         return convert_from_md_to_app(contents)
 
+    # Below assumes it's a Python file
+
+    # This means it could have only the package dependencies
+    # but no actual code yet.
+    has_only_comments = all(
+        not line.strip() or line.strip().startswith("#")
+        for line in contents.splitlines()
+    )
+    if has_only_comments:
+        return None
+
     spec = importlib.util.spec_from_file_location("marimo_app", filename)
     if spec is None:
         raise RuntimeError("Failed to load module spec")

--- a/marimo/_server/file_manager.py
+++ b/marimo/_server/file_manager.py
@@ -153,7 +153,10 @@ class AppFileManager:
                 config=CellConfig(),
             )
             return empty_app
-        return InternalApp(app)
+        result = InternalApp(app)
+        # Ensure at least one cell
+        result.cell_manager.ensure_one_cell()
+        return result
 
     def rename(self, new_filename: str) -> None:
         """Rename the file."""

--- a/tests/_ast/codegen_data/test_app_with_no_cells.py
+++ b/tests/_ast/codegen_data/test_app_with_no_cells.py
@@ -1,0 +1,3 @@
+import marimo
+
+app = marimo.App()

--- a/tests/_ast/codegen_data/test_app_with_only_comments.py
+++ b/tests/_ast/codegen_data/test_app_with_only_comments.py
@@ -1,0 +1,8 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "altair==5.4.1",
+#     "duckdb==1.1.3",
+#     "marimo",
+# ]
+# ///

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -402,6 +402,19 @@ class TestGetCodes:
             '_ another_error\n_ and """another"""\n\n    \\t',
         ]
 
+    @staticmethod
+    def test_get_codes_app_with_only_comments() -> None:
+        app = codegen.get_app(get_filepath("test_app_with_only_comments"))
+        assert app is None
+
+    @staticmethod
+    def test_get_codes_app_with_no_cells() -> None:
+        app = codegen.get_app(get_filepath("test_app_with_no_cells"))
+        assert app is not None
+        app._cell_manager.ensure_one_cell()
+        assert app._cell_manager.names() == ["__"]
+        assert app._cell_manager.codes() == [""]
+
 
 @pytest.fixture
 def marimo_app() -> App:

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -412,8 +412,8 @@ class TestGetCodes:
         app = codegen.get_app(get_filepath("test_app_with_no_cells"))
         assert app is not None
         app._cell_manager.ensure_one_cell()
-        assert app._cell_manager.names() == ["__"]
-        assert app._cell_manager.codes() == [""]
+        assert list(app._cell_manager.names()) == ["__"]
+        assert list(app._cell_manager.codes()) == [""]
 
 
 @pytest.fixture


### PR DESCRIPTION
This change makes blogs or tutorials easier since you can give the user a starting file that installs the deps, for sandboxed environments. 