### PR TITLE
fix: ignore mo.stop() 'errors' in marimo export

### DIFF
--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -196,11 +196,16 @@ async def run_app_until_completion(
 
                         for err in errors:
                             parsed = parse_raw({"error": err}, Container)
-                            echo(
-                                f"{parsed.error.__class__.__name__}: {parsed.error.describe()}",
-                                file=sys.stderr,
-                            )
-                        self.did_error = True
+                            # Not all errors are fatal
+                            if parsed.error.type not in [
+                                "ancestor-prevented",
+                                "ancestor-stopped",
+                            ]:
+                                echo(
+                                    f"{parsed.error.__class__.__name__}: {parsed.error.describe()}",
+                                    file=sys.stderr,
+                                )
+                                self.did_error = True
                 if message[0] == "completed-run":
                     instantiated_event.set()
 

--- a/tests/_server/export/snapshots/run_until_completion_with_stop.txt
+++ b/tests/_server/export/snapshots/run_until_completion_with_stop.txt
@@ -1,0 +1,1 @@
+["", "", [{"msg": "This cell wasn't run because an ancestor was stopped with `mo.stop`: ", "raising_cell": "MJUe", "type": "ancestor-stopped"}]]


### PR DESCRIPTION
We recently propagated errors from `marimo export`, but we should ignore `mo.stop()` as errors since they are intentional and should fail the export