### PR TITLE
Update feedback dialog

### DIFF
--- a/frontend/src/components/editor/chrome/components/feedback-button.tsx
+++ b/frontend/src/components/editor/chrome/components/feedback-button.tsx
@@ -66,7 +66,18 @@ const FeedbackModal: React.FC<{
         <DialogHeader>
           <DialogTitle>Send Feedback</DialogTitle>
           <DialogDescription>
-            Let us know what you think about marimo! If you have a bug that you
+            Help us improve marimo by taking our{" "}
+            <a
+              href={Constants.feedbackForm}
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              two-minute survey!
+            </a>
+          </DialogDescription>
+          <DialogDescription>
+            If you have a bug that you
             would like to report, please use the{" "}
             <a
               href={Constants.issuesPage}
@@ -74,9 +85,9 @@ const FeedbackModal: React.FC<{
               rel="noreferrer"
               className="underline"
             >
-              GitHub issue tracker
+              GitHub issue tracker 
             </a>
-            .
+            {" "}instead .
           </DialogDescription>
           <DialogDescription>
             Your feedback is anonymous and will help us improve marimo. Thank

--- a/frontend/src/components/editor/chrome/components/feedback-button.tsx
+++ b/frontend/src/components/editor/chrome/components/feedback-button.tsx
@@ -66,82 +66,53 @@ const FeedbackModal: React.FC<{
         <DialogHeader>
           <DialogTitle>Send Feedback</DialogTitle>
           <DialogDescription>
-            Help us improve marimo by taking our{" "}
-            <a
-              href={Constants.feedbackForm}
-              target="_blank"
-              rel="noreferrer"
-              className="underline"
-            >
-              two-minute survey!
-            </a>
-          </DialogDescription>
-          <DialogDescription>
-            If you have a bug that you
-            would like to report, please use the{" "}
-            <a
-              href={Constants.issuesPage}
-              target="_blank"
-              rel="noreferrer"
-              className="underline"
-            >
-              GitHub issue tracker 
-            </a>
-            {" "}instead .
-          </DialogDescription>
-          <DialogDescription>
-            Your feedback is anonymous and will help us improve marimo. Thank
-            you!
+            <p className="my-2 prose">
+              We want to hear from <span className="font-bold">you</span>: from
+              minor bug reports to wishlist features and everything in between.
+              Here are some ways you can get in touch:
+            </p>
+            <ul className="list-disc ml-8 my-2 prose">
+              <li className="my-0">
+                Take our{" "}
+                <a
+                  href={Constants.feedbackForm}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  two-minute survey.
+                </a>
+              </li>
+              <li className="my-0">
+                File a{" "}
+                <a
+                  href={Constants.issuesPage}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  GitHub issue.
+                </a>
+              </li>
+              <li className="my-0">
+                Chat with us on{" "}
+                <a
+                  href={Constants.discordLink}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  Discord.
+                </a>
+              </li>
+            </ul>
+            <p className="my-2 prose">
+              We're excited you're here as we discover and build the future of
+              Python data tooling together. Thanks for being part of our
+              community!
+            </p>
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-6 py-4">
-          <div className="flex gap-5 justify-center">
-            {Object.entries(EmojiToRating).map(([emoji, rating]) => (
-              <label
-                key={emoji}
-                className="flex flex-col items-center select-none"
-              >
-                <input
-                  key={emoji}
-                  type="radio"
-                  className="peer hidden"
-                  name="rating"
-                  value={rating}
-                  aria-label={emoji}
-                />
-                <span className="text-4xl peer-checked:opacity-100 opacity-40 cursor-pointer">
-                  {emoji}
-                </span>
-              </label>
-            ))}
-          </div>
-          <Textarea
-            id="message"
-            name="message"
-            autoFocus={true}
-            placeholder="Your feedback; if you'd like us to respond, please include your email!"
-            rows={5}
-            required={true}
-            autoComplete="off"
-          />
-        </div>
-        <DialogFooter>
-          <Button
-            data-testid="feedback-cancel-button"
-            variant="secondary"
-            onClick={onClose}
-          >
-            Cancel
-          </Button>
-          <Button
-            data-testid="feedback-send-button"
-            aria-label="Save"
-            variant="default"
-            type="submit"
-          >
-            Send
-          </Button>
-        </DialogFooter>
       </form>
     </DialogContent>
   );

--- a/frontend/src/components/editor/chrome/components/feedback-button.tsx
+++ b/frontend/src/components/editor/chrome/components/feedback-button.tsx
@@ -1,7 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { useImperativeModal } from "@/components/modal/ImperativeModal";
 import {
-  DialogFooter,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -9,8 +8,6 @@ import {
 } from "@/components/ui/dialog";
 import { Slot } from "@radix-ui/react-slot";
 import React, { type PropsWithChildren } from "react";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/use-toast";
 import { Constants } from "@/core/constants";
 
@@ -22,14 +19,6 @@ export const FeedbackButton: React.FC<PropsWithChildren> = ({ children }) => {
       {children}
     </Slot>
   );
-};
-
-const EmojiToRating: Record<string, number> = {
-  "😡": 1,
-  "🙁": 2,
-  "😐": 3,
-  "🙂": 4,
-  "😍": 5,
 };
 
 const FeedbackModal: React.FC<{

--- a/frontend/src/components/editor/chrome/components/feedback-button.tsx
+++ b/frontend/src/components/editor/chrome/components/feedback-button.tsx
@@ -55,12 +55,12 @@ const FeedbackModal: React.FC<{
         <DialogHeader>
           <DialogTitle>Send Feedback</DialogTitle>
           <DialogDescription>
-            <p className="my-2 prose">
-              We want to hear from <span className="font-bold">you</span>: from
-              minor bug reports to wishlist features and everything in between.
-              Here are some ways you can get in touch:
+            <p className="my-2 prose dark:prose-invert">
+              We want to hear from you — from minor bug reports to wishlist
+              features and everything in between. Here are some ways you can get
+              in touch:
             </p>
-            <ul className="list-disc ml-8 my-2 prose">
+            <ul className="list-disc ml-8 my-2 prose dark:prose-invert">
               <li className="my-0">
                 Take our{" "}
                 <a
@@ -95,10 +95,9 @@ const FeedbackModal: React.FC<{
                 </a>
               </li>
             </ul>
-            <p className="my-2 prose">
-              We're excited you're here as we build the future of
-              Python data tooling. Thanks for being part of our
-              community!
+            <p className="my-2 prose dark:prose-invert">
+              We're excited you're here as we build the future of Python data
+              tooling. Thanks for being part of our community!
             </p>
           </DialogDescription>
         </DialogHeader>

--- a/frontend/src/components/editor/chrome/components/feedback-button.tsx
+++ b/frontend/src/components/editor/chrome/components/feedback-button.tsx
@@ -96,8 +96,8 @@ const FeedbackModal: React.FC<{
               </li>
             </ul>
             <p className="my-2 prose">
-              We're excited you're here as we discover and build the future of
-              Python data tooling together. Thanks for being part of our
+              We're excited you're here as we build the future of
+              Python data tooling. Thanks for being part of our
               community!
             </p>
           </DialogDescription>

--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -2,6 +2,7 @@
 export const Constants = {
   githubPage: "https://github.com/marimo-team/marimo",
   issuesPage: "https://github.com/marimo-team/marimo/issues",
+  feedbackForm: "https://marimo.io/feedback",
 };
 
 export const KnownQueryParams = {

--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -3,6 +3,7 @@ export const Constants = {
   githubPage: "https://github.com/marimo-team/marimo",
   issuesPage: "https://github.com/marimo-team/marimo/issues",
   feedbackForm: "https://marimo.io/feedback",
+  discordLink: "https://marimo.io/discord?ref=notebook",
 };
 
 export const KnownQueryParams = {


### PR DESCRIPTION
This PR updates the feedback panel to highlight three channels:

1. Our [survey](https://marimo.io/feedback)
2. GitHub issues
3. Discord

It removes the free-form feedback text input.

![image](https://github.com/user-attachments/assets/963c783a-bb3f-40ec-a070-fa29c167e2b3)

