### PR TITLE
feat: support for Azure OpenAI with AI Assistant

### DIFF
--- a/marimo/_ai/llm.py
+++ b/marimo/_ai/llm.py
@@ -117,16 +117,18 @@ class openai(ChatModel):
         # Azure OpenAI clients are instantiated slightly differently
         # To check if we're using Azure, we check the base_url for the format
         # https://[subdomain].openai.azure.com/openai/deployments/[model]/chat/completions?api-version=[api_version]
-        parsed_base_url = urlparse(self.base_url)
-        if parsed_base_url.hostname and parsed_base_url.hostname.endswith(
+        parsed_url = urlparse(self.base_url)
+        if parsed_url.hostname and cast(str, parsed_url.hostname).endswith(
             "openai.azure.com"
         ):
-            self.model = parsed_base_url.path.split("/")[3]
-            api_version = parse_qs(parsed_base_url.query)["api-version"][0]
-            client = AzureOpenAI(
+            self.model = cast(str, parsed_url.path).split("/")[3]
+            api_version = parse_qs(cast(str, parsed_url.query))["api-version"][
+                0
+            ]
+            client: AzureOpenAI | OpenAI = AzureOpenAI(
                 api_key=self._require_api_key,
                 api_version=api_version,
-                azure_endpoint=f"{parsed_base_url.scheme}://{parsed_base_url.hostname}",
+                azure_endpoint=f"{cast(str,parsed_url.scheme)}://{cast(str,parsed_url.hostname)}",
             )
         else:
             client = OpenAI(

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -97,17 +97,17 @@ def get_openai_client(config: MarimoConfig) -> "OpenAI":
     # Azure OpenAI clients are instantiated slightly differently
     # To check if we're using Azure, we check the base_url for the format
     # https://[subdomain].openai.azure.com/openai/deployments/[model]/chat/completions?api-version=[api_version]
-    parsed_base_url = urlparse(base_url)
-    if parsed_base_url.hostname and parsed_base_url.hostname.endswith(
+    parsed_url = urlparse(base_url)
+    if parsed_url.hostname and cast(str, parsed_url.hostname).endswith(
         "openai.azure.com"
     ):
-        deployment_model = parsed_base_url.path.split("/")[3]
-        api_version = parse_qs(parsed_base_url.query)["api-version"][0]
+        deployment_model = cast(str, parsed_url.path).split("/")[3]
+        api_version = parse_qs(cast(str, parsed_url.query))["api-version"][0]
         return AzureOpenAI(
             api_key=key,
             api_version=api_version,
             azure_deployment=deployment_model,
-            azure_endpoint=f"{parsed_base_url.scheme}://{parsed_base_url.hostname}",
+            azure_endpoint=f"{cast(str,parsed_url.scheme)}://{cast(str,parsed_url.hostname)}",
         )
     else:
         return OpenAI(


### PR DESCRIPTION
## 📝 Summary

Resolves marimo-team/marimo#3117

## 🔍 Description of Changes

As discussed in marimo-team/marimo#3117, I'm inferring whether to instantiate an AzureOpenAI client or a regular OpenAI client based on the format of the base url. I made this change consistently in two places: once for the AI assistant and one for the `llm` class in Chat. 

Note one other change: when streaming, the first response for the "choices" array can sometimes be empty (not sure if this is an Azure thing, or in general). So this also includes a one-line change to handle that case.  

I have verified locally that this change allows the AI assistant to work, as well as the [openai example](https://github.com/marimo-team/marimo/blob/main/examples/ai/chat/openai_example.py) assuming you pass in the same base url. 

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
