### PR TITLE
improvement: generate unique function names to work with linting

### DIFF
--- a/frontend/src/core/cells/__tests__/names.test.ts
+++ b/frontend/src/core/cells/__tests__/names.test.ts
@@ -51,7 +51,6 @@ describe("getValidName", () => {
 describe("displayCellName", () => {
   it("should return the name if it is not the default cell name", () => {
     expect(displayCellName("custom_name", 1)).toBe("custom_name");
-    expect(displayCellName("__custom_name", 1)).toBe("__custom_name");
   });
 
   it("should return the HTML cell ID if the name is the default cell name", () => {
@@ -59,5 +58,6 @@ describe("displayCellName", () => {
     expect(displayCellName(DEFAULT_CELL_NAME, 1)).toBe("cell-1");
     expect(displayCellName("__abcd", 0)).toBe("cell-0");
     expect(displayCellName("__1234", 0)).toBe("cell-0");
+    expect(displayCellName("__custom_name", 1)).toBe("cell-1");
   });
 });

--- a/frontend/src/core/cells/__tests__/names.test.ts
+++ b/frontend/src/core/cells/__tests__/names.test.ts
@@ -51,10 +51,13 @@ describe("getValidName", () => {
 describe("displayCellName", () => {
   it("should return the name if it is not the default cell name", () => {
     expect(displayCellName("custom_name", 1)).toBe("custom_name");
+    expect(displayCellName("__custom_name", 1)).toBe("__custom_name");
   });
 
   it("should return the HTML cell ID if the name is the default cell name", () => {
     expect(displayCellName(DEFAULT_CELL_NAME, 0)).toBe("cell-0");
     expect(displayCellName(DEFAULT_CELL_NAME, 1)).toBe("cell-1");
+    expect(displayCellName("__1", 0)).toBe("cell-0");
+    expect(displayCellName("__2", 0)).toBe("cell-0");
   });
 });

--- a/frontend/src/core/cells/__tests__/names.test.ts
+++ b/frontend/src/core/cells/__tests__/names.test.ts
@@ -57,7 +57,7 @@ describe("displayCellName", () => {
   it("should return the HTML cell ID if the name is the default cell name", () => {
     expect(displayCellName(DEFAULT_CELL_NAME, 0)).toBe("cell-0");
     expect(displayCellName(DEFAULT_CELL_NAME, 1)).toBe("cell-1");
-    expect(displayCellName("__1", 0)).toBe("cell-0");
-    expect(displayCellName("__2", 0)).toBe("cell-0");
+    expect(displayCellName("__abcd", 0)).toBe("cell-0");
+    expect(displayCellName("__1234", 0)).toBe("cell-0");
   });
 });

--- a/frontend/src/core/cells/names.ts
+++ b/frontend/src/core/cells/names.ts
@@ -96,14 +96,10 @@ export function displayCellName(name: string, cellIndex: number): string {
   return name;
 }
 
-// Default cell names look like "__" or "__{idx}"
+// Default cell names look like "__" or "__{4char_hash}"
 function isDefaultCellName(name: string): boolean {
   return (
     name === DEFAULT_CELL_NAME ||
-    (name.startsWith(DEFAULT_CELL_NAME) && isInteger(name.slice(2)))
+    (name.startsWith(DEFAULT_CELL_NAME) && name.slice(2).length === 4)
   );
-}
-
-function isInteger(name: string): boolean {
-  return !Number.isNaN(Number.parseInt(name));
 }

--- a/frontend/src/core/cells/names.ts
+++ b/frontend/src/core/cells/names.ts
@@ -90,16 +90,13 @@ export function getValidName(name: string, existingNames: string[]): string {
  * Print the cell name if differs from DEFAULT_CELL_NAME
  */
 export function displayCellName(name: string, cellIndex: number): string {
-  if (isDefaultCellName(name)) {
+  if (isInternalCellName(name)) {
     return `cell-${cellIndex}`;
   }
   return name;
 }
 
-// Default cell names look like "__" or "__{4char_hash}"
-function isDefaultCellName(name: string): boolean {
-  return (
-    name === DEFAULT_CELL_NAME ||
-    (name.startsWith(DEFAULT_CELL_NAME) && name.slice(2).length === 4)
-  );
+// Default cell names look like "__" or "__{some_hash}"
+function isInternalCellName(name: string): boolean {
+  return name.startsWith(DEFAULT_CELL_NAME);
 }

--- a/frontend/src/core/cells/names.ts
+++ b/frontend/src/core/cells/names.ts
@@ -90,8 +90,20 @@ export function getValidName(name: string, existingNames: string[]): string {
  * Print the cell name if differs from DEFAULT_CELL_NAME
  */
 export function displayCellName(name: string, cellIndex: number): string {
-  if (name !== DEFAULT_CELL_NAME) {
-    return name;
+  if (isDefaultCellName(name)) {
+    return `cell-${cellIndex}`;
   }
-  return `cell-${cellIndex}`;
+  return name;
+}
+
+// Default cell names look like "__" or "__{idx}"
+function isDefaultCellName(name: string): boolean {
+  return (
+    name === DEFAULT_CELL_NAME ||
+    (name.startsWith(DEFAULT_CELL_NAME) && isInteger(name.slice(2)))
+  );
+}
+
+function isInteger(name: string): boolean {
+  return !Number.isNaN(Number.parseInt(name));
 }

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -27,6 +27,7 @@ from marimo._ast.errors import (
     MultipleDefinitionError,
     UnparsableError,
 )
+from marimo._ast.names import DEFAULT_CELL_NAME
 from marimo._config.config import WidthType
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._output.hypertext import Html
@@ -51,12 +52,6 @@ if TYPE_CHECKING:
     from marimo._runtime.context.types import ExecutionContext
 
 LOGGER = _loggers.marimo_logger()
-
-DEFAULT_CELL_NAME = "__"
-
-
-def is_default_cell_name(name: str) -> bool:
-    return name == DEFAULT_CELL_NAME
 
 
 @dataclass

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -12,7 +12,10 @@ from marimo import __version__
 from marimo._ast.app import App, _AppConfig
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
-from marimo._ast.names import default_cell_name_from_code, is_default_cell_name
+from marimo._ast.names import (
+    default_cell_name_from_code,
+    is_internal_cell_name,
+)
 from marimo._ast.visitor import Name
 
 if TYPE_CHECKING:
@@ -176,9 +179,9 @@ def generate_filecontents(
     unshadowed_builtins = set(builtins.__dict__.keys()) - defs
     fndefs: list[str] = []
 
-    # Update default names to be __{4char_hash}
+    # Canonicalize internal names to __{some_hash}
     for idx, name in enumerate(names):
-        if is_default_cell_name(name):
+        if is_internal_cell_name(name):
             names[idx] = default_cell_name_from_code(codes[idx])
 
     for data, name in zip(cell_data, names):

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -12,6 +12,7 @@ from marimo import __version__
 from marimo._ast.app import App, _AppConfig
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
+from marimo._ast.names import is_default_cell_name
 from marimo._ast.visitor import Name
 
 if TYPE_CHECKING:
@@ -174,6 +175,12 @@ def generate_filecontents(
 
     unshadowed_builtins = set(builtins.__dict__.keys()) - defs
     fndefs: list[str] = []
+
+    # Update default names to be __{idx}
+    for idx, name in enumerate(names):
+        if is_default_cell_name(name):
+            names[idx] = f"__{idx + 1}"
+
     for data, name in zip(cell_data, names):
         if isinstance(data, CellImpl):
             fndefs.append(to_functiondef(data, name, unshadowed_builtins))

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -12,7 +12,7 @@ from marimo import __version__
 from marimo._ast.app import App, _AppConfig
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
-from marimo._ast.names import is_default_cell_name
+from marimo._ast.names import default_cell_name_from_code, is_default_cell_name
 from marimo._ast.visitor import Name
 
 if TYPE_CHECKING:
@@ -176,10 +176,10 @@ def generate_filecontents(
     unshadowed_builtins = set(builtins.__dict__.keys()) - defs
     fndefs: list[str] = []
 
-    # Update default names to be __{idx}
+    # Update default names to be __{4char_hash}
     for idx, name in enumerate(names):
         if is_default_cell_name(name):
-            names[idx] = f"__{idx + 1}"
+            names[idx] = default_cell_name_from_code(codes[idx])
 
     for data, name in zip(cell_data, names):
         if isinstance(data, CellImpl):

--- a/marimo/_ast/names.py
+++ b/marimo/_ast/names.py
@@ -3,11 +3,12 @@ import hashlib
 DEFAULT_CELL_NAME = "__"
 
 
-def is_default_cell_name(name: str) -> bool:
+def is_internal_cell_name(name: str) -> bool:
     return name.startswith("__") and (name == "__" or len(name) == 6)
 
 
+NUMBER_OF_HASH_CHARS = 6
+
+
 def default_cell_name_from_code(code: str) -> str:
-    return (
-        f"{DEFAULT_CELL_NAME}{hashlib.sha256(code.encode()).hexdigest()[:4]}"
-    )
+    return f"{DEFAULT_CELL_NAME}{hashlib.sha256(code.encode()).hexdigest()[:NUMBER_OF_HASH_CHARS]}"

--- a/marimo/_ast/names.py
+++ b/marimo/_ast/names.py
@@ -1,0 +1,5 @@
+DEFAULT_CELL_NAME = "__"
+
+
+def is_default_cell_name(name: str) -> bool:
+    return name.startswith("__") and (name == "__" or name[2:].isdigit())

--- a/marimo/_ast/names.py
+++ b/marimo/_ast/names.py
@@ -1,5 +1,13 @@
+import hashlib
+
 DEFAULT_CELL_NAME = "__"
 
 
 def is_default_cell_name(name: str) -> bool:
-    return name.startswith("__") and (name == "__" or name[2:].isdigit())
+    return name.startswith("__") and (name == "__" or len(name) == 6)
+
+
+def default_cell_name_from_code(code: str) -> str:
+    return (
+        f"{DEFAULT_CELL_NAME}{hashlib.sha256(code.encode()).hexdigest()[:4]}"
+    )

--- a/marimo/_ast/names.py
+++ b/marimo/_ast/names.py
@@ -4,7 +4,7 @@ DEFAULT_CELL_NAME = "__"
 
 
 def is_internal_cell_name(name: str) -> bool:
-    return name.startswith("__") and (name == "__" or len(name) == 6)
+    return name.startswith(DEFAULT_CELL_NAME)
 
 
 NUMBER_OF_HASH_CHARS = 6

--- a/marimo/_cli/convert/markdown.py
+++ b/marimo/_cli/convert/markdown.py
@@ -26,6 +26,7 @@ from marimo._ast import codegen
 from marimo._ast.app import App, InternalApp, _AppConfig
 from marimo._ast.cell import Cell, CellConfig
 from marimo._ast.compiler import compile_cell
+from marimo._ast.names import DEFAULT_CELL_NAME
 from marimo._convert.utils import markdown_to_marimo
 
 MARIMO_MD = "marimo-md"
@@ -110,7 +111,7 @@ def _tree_to_app_obj(root: Element) -> SafeWrap:
     app = InternalApp(App(**app_config.asdict()))
 
     for child in root:
-        name = child.get("name", "__")
+        name = child.get("name", DEFAULT_CELL_NAME)
         # Default to hiding markdown cells.
         cell_config = get_cell_config_from_tag(
             child, hide_code=child.tag == MARIMO_MD
@@ -134,7 +135,7 @@ def _tree_to_app_obj(root: Element) -> SafeWrap:
                 cell_id=cell_id,
                 code=source,
                 config=cell_config,
-                name=name or "__",
+                name=name or DEFAULT_CELL_NAME,
                 cell=None,
             )
 
@@ -148,7 +149,7 @@ def _tree_to_app(root: Element) -> str:
     names: list[str] = []
     cell_config: list[CellConfig] = []
     for child in root:
-        names.append(child.get("name", "__"))
+        names.append(child.get("name", DEFAULT_CELL_NAME))
         cell_config.append(get_cell_config_from_tag(child))
         sources.append(get_source_from_tag(child))
 

--- a/marimo/_convert/utils.py
+++ b/marimo/_convert/utils.py
@@ -6,6 +6,7 @@ from typing import Optional
 from marimo._ast import codegen
 from marimo._ast.app import _AppConfig
 from marimo._ast.cell import CellConfig
+from marimo._ast.names import DEFAULT_CELL_NAME
 
 
 def markdown_to_marimo(source: str) -> str:
@@ -33,7 +34,7 @@ def generate_from_sources(
     """
     return codegen.generate_filecontents(
         sources,
-        ["__" for _ in sources],
+        [DEFAULT_CELL_NAME for _ in sources],
         [CellConfig() for _ in range(len(sources))],
         config=config,
         header_comments=header_comments,

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 from marimo import __version__
 from marimo._ast.cell import Cell, CellConfig, CellImpl
-from marimo._ast.names import is_default_cell_name
+from marimo._ast.names import DEFAULT_CELL_NAME, is_default_cell_name
 from marimo._config.config import (
     DEFAULT_CONFIG,
     DisplayConfig,
@@ -257,7 +257,7 @@ class Exporter:
             # Config values are opt in, so only include if they are set.
             attributes = cell_data.config.asdict()
             attributes = {k: "true" for k, v in attributes.items() if v}
-            if cell_data.name != "__":
+            if not is_default_cell_name(cell_data.name):
                 attributes["name"] = cell_data.name
             # No "cell" typically means not parseable. However newly added
             # cells require compilation before cell is set.
@@ -353,7 +353,7 @@ def _create_notebook_cell(
     import nbformat  # ignore
 
     markdown_string = get_markdown_from_cell(
-        Cell(_name="__", _cell=cell), cell.code
+        Cell(_name=DEFAULT_CELL_NAME, _cell=cell), cell.code
     )
     if markdown_string is not None:
         return nbformat.v4.new_markdown_cell(markdown_string, id=cell.cell_id)

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -8,8 +8,8 @@ import os
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 from marimo import __version__
-from marimo._ast.app import is_default_cell_name
 from marimo._ast.cell import Cell, CellConfig, CellImpl
+from marimo._ast.names import is_default_cell_name
 from marimo._config.config import (
     DEFAULT_CONFIG,
     DisplayConfig,

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 from marimo import __version__
 from marimo._ast.cell import Cell, CellConfig, CellImpl
-from marimo._ast.names import DEFAULT_CELL_NAME, is_default_cell_name
+from marimo._ast.names import DEFAULT_CELL_NAME, is_internal_cell_name
 from marimo._config.config import (
     DEFAULT_CONFIG,
     DisplayConfig,
@@ -189,7 +189,7 @@ class Exporter:
                     cell.config.asdict_without_defaults()
                 )
             name = file_manager.app.cell_manager.cell_name(cid)
-            if not is_default_cell_name(name):
+            if not is_internal_cell_name(name):
                 marimo_metadata["name"] = name
             if marimo_metadata:
                 notebook_cell["metadata"]["marimo"] = marimo_metadata
@@ -257,7 +257,7 @@ class Exporter:
             # Config values are opt in, so only include if they are set.
             attributes = cell_data.config.asdict()
             attributes = {k: "true" for k, v in attributes.items() if v}
-            if not is_default_cell_name(cell_data.name):
+            if not is_internal_cell_name(cell_data.name):
                 attributes["name"] = cell_data.name
             # No "cell" typically means not parseable. However newly added
             # cells require compilation before cell is set.

--- a/tests/_ast/codegen_data/test_generate_filecontents_with_syntax_error.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_with_syntax_error.py
@@ -19,7 +19,7 @@ app._unparsable_cell(
 
 
 @app.cell
-def __():
+def __3():
     'all good'
     return
 
@@ -31,7 +31,7 @@ app._unparsable_cell(
 
         \t
     """,
-    name="__"
+    name="__4"
 )
 
 

--- a/tests/_ast/codegen_data/test_generate_filecontents_with_syntax_error.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_with_syntax_error.py
@@ -19,7 +19,7 @@ app._unparsable_cell(
 
 
 @app.cell
-def __1f24():
+def __1f2440():
     'all good'
     return
 
@@ -31,7 +31,7 @@ app._unparsable_cell(
 
         \t
     """,
-    name="__1d37"
+    name="__1d37f2"
 )
 
 

--- a/tests/_ast/codegen_data/test_generate_filecontents_with_syntax_error.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_with_syntax_error.py
@@ -19,7 +19,7 @@ app._unparsable_cell(
 
 
 @app.cell
-def __3():
+def __1f24():
     'all good'
     return
 
@@ -31,7 +31,7 @@ app._unparsable_cell(
 
         \t
     """,
-    name="__4"
+    name="__1d37"
 )
 
 

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -16,6 +16,7 @@ from marimo import __version__
 from marimo._ast import codegen, compiler
 from marimo._ast.app import App, InternalApp, _AppConfig
 from marimo._ast.cell import CellConfig
+from marimo._ast.names import is_default_cell_name
 
 compile_cell = partial(compiler.compile_cell, cell_id="0")
 
@@ -263,6 +264,21 @@ class TestGeneration:
         result = codegen.generate_app_constructor(config)
         assert result == 'app = marimo.App(auto_download=["html"])'
 
+    @staticmethod
+    def test_generate_file_contents_overwrite_default_cell_names() -> None:
+        contents = wrap_generate_filecontents(
+            ["import numpy as np", "x = 0", "y = x + 1", "print(x)"],
+            ["is_named", "__9", "__10", "__foo"],
+        )
+        # __9 and __10 are overwritten by the default names
+        assert "is_named" in contents
+        assert "__foo" in contents
+        assert "__2" in contents
+        assert "__3" in contents
+
+        assert "__9" not in contents
+        assert "__10" not in contents
+
 
 class TestGetCodes:
     @staticmethod
@@ -394,7 +410,7 @@ class TestGetCodes:
         )
         assert app is not None
         cell_manager = app._cell_manager
-        assert list(cell_manager.names()) == ["one", "two", "__", "__"]
+        assert list(cell_manager.names()) == ["one", "two", "__3", "__4"]
         assert list(cell_manager.codes()) == [
             "import numpy as np",
             "_ error",
@@ -620,3 +636,10 @@ def test_sqls() -> None:
     cell = compile_cell(code)
     sqls = cell.sqls
     assert sqls == ["SELECT * FROM foo", "ATTACH TABLE bar"]
+
+
+def test_is_default_cell_name() -> None:
+    assert is_default_cell_name("__")
+    assert is_default_cell_name("__1")
+    assert not is_default_cell_name("__foo")
+    assert not is_default_cell_name("foo")

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -267,17 +267,14 @@ class TestGeneration:
     @staticmethod
     def test_generate_file_contents_overwrite_default_cell_names() -> None:
         contents = wrap_generate_filecontents(
-            ["import numpy as np", "x = 0", "y = x + 1", "print(x)"],
-            ["is_named", "__9", "__10", "__foo"],
+            ["import numpy as np", "x = 0", "y = x + 1"],
+            ["is_named", "__1234", "__abcd"],
         )
         # __9 and __10 are overwritten by the default names
         assert "is_named" in contents
-        assert "__foo" in contents
-        assert "__2" in contents
-        assert "__3" in contents
 
-        assert "__9" not in contents
-        assert "__10" not in contents
+        assert "__1234" not in contents
+        assert "__abcd" not in contents
 
 
 class TestGetCodes:
@@ -410,7 +407,7 @@ class TestGetCodes:
         )
         assert app is not None
         cell_manager = app._cell_manager
-        assert list(cell_manager.names()) == ["one", "two", "__3", "__4"]
+        assert list(cell_manager.names()) == ["one", "two", "__1f24", "__1d37"]
         assert list(cell_manager.codes()) == [
             "import numpy as np",
             "_ error",
@@ -640,6 +637,6 @@ def test_sqls() -> None:
 
 def test_is_default_cell_name() -> None:
     assert is_default_cell_name("__")
-    assert is_default_cell_name("__1")
+    assert is_default_cell_name("__1213")
     assert not is_default_cell_name("__foo")
     assert not is_default_cell_name("foo")

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -17,10 +17,13 @@ from marimo._ast import codegen, compiler
 from marimo._ast.app import App, InternalApp, _AppConfig
 from marimo._ast.cell import CellConfig
 from marimo._ast.names import is_internal_cell_name
+from tests.mocks import snapshotter
 
 compile_cell = partial(compiler.compile_cell, cell_id="0")
 
 DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+
+snapshot = snapshotter(__file__)
 
 
 def get_expected_filecontents(name: str) -> str:
@@ -407,7 +410,12 @@ class TestGetCodes:
         )
         assert app is not None
         cell_manager = app._cell_manager
-        assert list(cell_manager.names()) == ["one", "two", "__1f24", "__1d37"]
+        assert list(cell_manager.names()) == [
+            "one",
+            "two",
+            "__1f2440",
+            "__1d37f2",
+        ]
         assert list(cell_manager.codes()) == [
             "import numpy as np",
             "_ error",

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -16,7 +16,7 @@ from marimo import __version__
 from marimo._ast import codegen, compiler
 from marimo._ast.app import App, InternalApp, _AppConfig
 from marimo._ast.cell import CellConfig
-from marimo._ast.names import is_default_cell_name
+from marimo._ast.names import is_internal_cell_name
 
 compile_cell = partial(compiler.compile_cell, cell_id="0")
 
@@ -635,8 +635,8 @@ def test_sqls() -> None:
     assert sqls == ["SELECT * FROM foo", "ATTACH TABLE bar"]
 
 
-def test_is_default_cell_name() -> None:
-    assert is_default_cell_name("__")
-    assert is_default_cell_name("__1213")
-    assert not is_default_cell_name("__foo")
-    assert not is_default_cell_name("foo")
+def test_is_internal_cell_name() -> None:
+    assert is_internal_cell_name("__")
+    assert is_internal_cell_name("__1213123123")
+    assert is_internal_cell_name("__foo")
+    assert not is_internal_cell_name("foo")

--- a/tests/_cli/snapshots/converted_arithmetic.py.txt
+++ b/tests/_cli/snapshots/converted_arithmetic.py.txt
@@ -4,14 +4,14 @@ app = marimo.App()
 
 
 @app.cell
-def __():
+def __1():
     x = 0
     x
     return (x,)
 
 
 @app.cell
-def __(x):
+def __2(x):
     x + 1
     return
 

--- a/tests/_cli/snapshots/converted_arithmetic.py.txt
+++ b/tests/_cli/snapshots/converted_arithmetic.py.txt
@@ -4,14 +4,14 @@ app = marimo.App()
 
 
 @app.cell
-def __1886():
+def __188665():
     x = 0
     x
     return (x,)
 
 
 @app.cell
-def __ab69(x):
+def __ab6998(x):
     x + 1
     return
 

--- a/tests/_cli/snapshots/converted_arithmetic.py.txt
+++ b/tests/_cli/snapshots/converted_arithmetic.py.txt
@@ -4,14 +4,14 @@ app = marimo.App()
 
 
 @app.cell
-def __1():
+def __1886():
     x = 0
     x
     return (x,)
 
 
 @app.cell
-def __2(x):
+def __ab69(x):
     x + 1
     return
 

--- a/tests/_cli/snapshots/converted_blank.py.txt
+++ b/tests/_cli/snapshots/converted_blank.py.txt
@@ -4,7 +4,7 @@ app = marimo.App()
 
 
 @app.cell
-def __():
+def __1():
     return
 
 

--- a/tests/_cli/snapshots/converted_blank.py.txt
+++ b/tests/_cli/snapshots/converted_blank.py.txt
@@ -4,7 +4,7 @@ app = marimo.App()
 
 
 @app.cell
-def __e3b0():
+def __e3b0c4():
     return
 
 

--- a/tests/_cli/snapshots/converted_blank.py.txt
+++ b/tests/_cli/snapshots/converted_blank.py.txt
@@ -4,7 +4,7 @@ app = marimo.App()
 
 
 @app.cell
-def __1():
+def __e3b0():
     return
 
 

--- a/tests/_cli/snapshots/converted_juv.py.txt
+++ b/tests/_cli/snapshots/converted_juv.py.txt
@@ -11,7 +11,7 @@ app = marimo.App()
 
 
 @app.cell
-def __e3b0():
+def __e3b0c4():
     return
 
 

--- a/tests/_cli/snapshots/converted_juv.py.txt
+++ b/tests/_cli/snapshots/converted_juv.py.txt
@@ -11,7 +11,7 @@ app = marimo.App()
 
 
 @app.cell
-def __():
+def __1():
     return
 
 

--- a/tests/_cli/snapshots/converted_juv.py.txt
+++ b/tests/_cli/snapshots/converted_juv.py.txt
@@ -11,7 +11,7 @@ app = marimo.App()
 
 
 @app.cell
-def __1():
+def __e3b0():
     return
 
 

--- a/tests/_cli/snapshots/converted_markdown.py.txt
+++ b/tests/_cli/snapshots/converted_markdown.py.txt
@@ -4,7 +4,7 @@ app = marimo.App()
 
 
 @app.cell
-def __e4fa(mo):
+def __e4fa05(mo):
     mo.md(
         r"""
         # Hello, markdown
@@ -19,7 +19,7 @@ def __e4fa(mo):
 
 
 @app.cell
-def __2721(mo):
+def __2721a7(mo):
     mo.md(
         r"""
         Here is some math
@@ -31,7 +31,7 @@ def __2721(mo):
 
 
 @app.cell
-def __f649():
+def __f649a0():
     import marimo as mo
     return (mo,)
 

--- a/tests/_cli/snapshots/converted_markdown.py.txt
+++ b/tests/_cli/snapshots/converted_markdown.py.txt
@@ -4,7 +4,7 @@ app = marimo.App()
 
 
 @app.cell
-def __(mo):
+def __1(mo):
     mo.md(
         r"""
         # Hello, markdown
@@ -19,7 +19,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def __2(mo):
     mo.md(
         r"""
         Here is some math
@@ -31,7 +31,7 @@ def __(mo):
 
 
 @app.cell
-def __():
+def __3():
     import marimo as mo
     return (mo,)
 

--- a/tests/_cli/snapshots/converted_markdown.py.txt
+++ b/tests/_cli/snapshots/converted_markdown.py.txt
@@ -4,7 +4,7 @@ app = marimo.App()
 
 
 @app.cell
-def __1(mo):
+def __e4fa(mo):
     mo.md(
         r"""
         # Hello, markdown
@@ -19,7 +19,7 @@ def __1(mo):
 
 
 @app.cell
-def __2(mo):
+def __2721(mo):
     mo.md(
         r"""
         Here is some math
@@ -31,7 +31,7 @@ def __2(mo):
 
 
 @app.cell
-def __3():
+def __f649():
     import marimo as mo
     return (mo,)
 

--- a/tests/_cli/snapshots/converted_multiple_defs.py.txt
+++ b/tests/_cli/snapshots/converted_multiple_defs.py.txt
@@ -4,46 +4,46 @@ app = marimo.App()
 
 
 @app.cell
-def __():
+def __1():
     _x = 0
     _x
     return
 
 
 @app.cell
-def __():
+def __2():
     _x = 1
     _x
     return
 
 
 @app.cell
-def __():
+def __3():
     y = 0
     return (y,)
 
 
 @app.cell
-def __():
+def __4():
     y_1 = 1
     return (y_1,)
 
 
 @app.cell
-def __(y_1):
+def __5(y_1):
     y_1
     return
 
 
 @app.cell
-def __():
+def __6():
     for _i in range(3):
         print(_i)
     return
 
 
 @app.cell
-def __():
+def __7():
     for _i in range(4):
         print(_i)
     return

--- a/tests/_cli/snapshots/converted_multiple_defs.py.txt
+++ b/tests/_cli/snapshots/converted_multiple_defs.py.txt
@@ -4,46 +4,46 @@ app = marimo.App()
 
 
 @app.cell
-def __ec85():
+def __ec850d():
     _x = 0
     _x
     return
 
 
 @app.cell
-def __32a1():
+def __32a1ec():
     _x = 1
     _x
     return
 
 
 @app.cell
-def __b735():
+def __b73587():
     y = 0
     return (y,)
 
 
 @app.cell
-def __b39a():
+def __b39ab0():
     y_1 = 1
     return (y_1,)
 
 
 @app.cell
-def __c887(y_1):
+def __c887b3(y_1):
     y_1
     return
 
 
 @app.cell
-def __c331():
+def __c331ef():
     for _i in range(3):
         print(_i)
     return
 
 
 @app.cell
-def __742a():
+def __742ace():
     for _i in range(4):
         print(_i)
     return

--- a/tests/_cli/snapshots/converted_multiple_defs.py.txt
+++ b/tests/_cli/snapshots/converted_multiple_defs.py.txt
@@ -4,46 +4,46 @@ app = marimo.App()
 
 
 @app.cell
-def __1():
+def __ec85():
     _x = 0
     _x
     return
 
 
 @app.cell
-def __2():
+def __32a1():
     _x = 1
     _x
     return
 
 
 @app.cell
-def __3():
+def __b735():
     y = 0
     return (y,)
 
 
 @app.cell
-def __4():
+def __b39a():
     y_1 = 1
     return (y_1,)
 
 
 @app.cell
-def __5(y_1):
+def __c887(y_1):
     y_1
     return
 
 
 @app.cell
-def __6():
+def __c331():
     for _i in range(3):
         print(_i)
     return
 
 
 @app.cell
-def __7():
+def __742a():
     for _i in range(4):
         print(_i)
     return

--- a/tests/_cli/snapshots/converted_unparsable.py.txt
+++ b/tests/_cli/snapshots/converted_unparsable.py.txt
@@ -9,12 +9,12 @@ app._unparsable_cell(
 
     x = 0
     """,
-    name="__1"
+    name="__3675"
 )
 
 
 @app.cell
-def __2(x):
+def __2d71(x):
     x
     return
 

--- a/tests/_cli/snapshots/converted_unparsable.py.txt
+++ b/tests/_cli/snapshots/converted_unparsable.py.txt
@@ -9,12 +9,12 @@ app._unparsable_cell(
 
     x = 0
     """,
-    name="__"
+    name="__1"
 )
 
 
 @app.cell
-def __(x):
+def __2(x):
     x
     return
 

--- a/tests/_cli/snapshots/converted_unparsable.py.txt
+++ b/tests/_cli/snapshots/converted_unparsable.py.txt
@@ -9,12 +9,12 @@ app._unparsable_cell(
 
     x = 0
     """,
-    name="__3675"
+    name="__367526"
 )
 
 
 @app.cell
-def __2d71(x):
+def __2d7116(x):
     x
     return
 

--- a/tests/_cli/snapshots/frontmatter-test.py.txt
+++ b/tests/_cli/snapshots/frontmatter-test.py.txt
@@ -5,7 +5,7 @@ app = marimo.App(app_title="My Title")
 
 
 @app.cell
-def __b5b5(mo):
+def __b5b56f(mo):
     mo.md(
         r"""
         # Notebook
@@ -15,7 +15,7 @@ def __b5b5(mo):
 
 
 @app.cell
-def __cf60():
+def __cf603e():
     print("Hello, World!")
     return
 

--- a/tests/_cli/snapshots/frontmatter-test.py.txt
+++ b/tests/_cli/snapshots/frontmatter-test.py.txt
@@ -5,7 +5,7 @@ app = marimo.App(app_title="My Title")
 
 
 @app.cell
-def __(mo):
+def __1(mo):
     mo.md(
         r"""
         # Notebook
@@ -15,7 +15,7 @@ def __(mo):
 
 
 @app.cell
-def __():
+def __2():
     print("Hello, World!")
     return
 

--- a/tests/_cli/snapshots/frontmatter-test.py.txt
+++ b/tests/_cli/snapshots/frontmatter-test.py.txt
@@ -5,7 +5,7 @@ app = marimo.App(app_title="My Title")
 
 
 @app.cell
-def __1(mo):
+def __b5b5(mo):
     mo.md(
         r"""
         # Notebook
@@ -15,7 +15,7 @@ def __1(mo):
 
 
 @app.cell
-def __2():
+def __cf60():
     print("Hello, World!")
     return
 

--- a/tests/_cli/snapshots/ipynb_to_marimo.txt
+++ b/tests/_cli/snapshots/ipynb_to_marimo.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __2b33():
+def __2b3321():
     print('Hello, World!')
     return
 

--- a/tests/_cli/snapshots/ipynb_to_marimo.txt
+++ b/tests/_cli/snapshots/ipynb_to_marimo.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __():
+def __1():
     print('Hello, World!')
     return
 

--- a/tests/_cli/snapshots/ipynb_to_marimo.txt
+++ b/tests/_cli/snapshots/ipynb_to_marimo.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __1():
+def __2b33():
     print('Hello, World!')
     return
 

--- a/tests/_cli/snapshots/ipynb_to_marimo_with_output.txt
+++ b/tests/_cli/snapshots/ipynb_to_marimo_with_output.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __5827():
+def __582721():
     print('Hello, Output!')
     return
 

--- a/tests/_cli/snapshots/ipynb_to_marimo_with_output.txt
+++ b/tests/_cli/snapshots/ipynb_to_marimo_with_output.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __1():
+def __5827():
     print('Hello, Output!')
     return
 

--- a/tests/_cli/snapshots/ipynb_to_marimo_with_output.txt
+++ b/tests/_cli/snapshots/ipynb_to_marimo_with_output.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __():
+def __1():
     print('Hello, Output!')
     return
 

--- a/tests/_cli/snapshots/markdown_to_marimo.txt
+++ b/tests/_cli/snapshots/markdown_to_marimo.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __(mo):
+def __1(mo):
     mo.md(
         r"""
         # Test Markdown

--- a/tests/_cli/snapshots/markdown_to_marimo.txt
+++ b/tests/_cli/snapshots/markdown_to_marimo.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __1(mo):
+def __0095(mo):
     mo.md(
         r"""
         # Test Markdown

--- a/tests/_cli/snapshots/markdown_to_marimo.txt
+++ b/tests/_cli/snapshots/markdown_to_marimo.txt
@@ -5,7 +5,7 @@ app = marimo.App()
 
 
 @app.cell
-def __0095(mo):
+def __009519(mo):
     mo.md(
         r"""
         # Test Markdown

--- a/tests/_cli/snapshots/unsafe-app.py.txt
+++ b/tests/_cli/snapshots/unsafe-app.py.txt
@@ -5,13 +5,13 @@ app = marimo.App(app_title="Test Notebook")
 
 
 @app.cell
-def __1():
+def __f649():
     import marimo as mo
     return (mo,)
 
 
 @app.cell
-def __2(mo):
+def __1bb6(mo):
     mo.md("""
         # Code blocks in code blocks
         Output code for Hello World!
@@ -27,7 +27,7 @@ def __2(mo):
 
 
 @app.cell
-def __3(mo):
+def __b4fd(mo):
     mo.md(f"""
         with f-string too!
         ```{{python}}
@@ -38,7 +38,7 @@ def __3(mo):
 
 
 @app.cell
-def __4(mo):
+def __d6c4(mo):
     mo.md(f"""
         Not markdown
         ```{{python}}
@@ -49,7 +49,7 @@ def __4(mo):
 
 
 @app.cell
-def __5(mo):
+def __893b(mo):
     mo.md(
         r"""
         Nested fence
@@ -63,7 +63,7 @@ def __5(mo):
 
 
 @app.cell
-def __6():
+def __a42b():
     """
     ```
     """
@@ -71,7 +71,7 @@ def __6():
 
 
 @app.cell
-def __7(mo):
+def __987c(mo):
     mo.md("""
         Cross cell injection
         ```python
@@ -80,13 +80,13 @@ def __7(mo):
 
 
 @app.cell
-def __8():
+def __72fc():
     1 + 1
     return
 
 
 @app.cell
-def __9():
+def __5370():
     # Actual print
     print("Hello World")
     return

--- a/tests/_cli/snapshots/unsafe-app.py.txt
+++ b/tests/_cli/snapshots/unsafe-app.py.txt
@@ -5,13 +5,13 @@ app = marimo.App(app_title="Test Notebook")
 
 
 @app.cell
-def __():
+def __1():
     import marimo as mo
     return (mo,)
 
 
 @app.cell
-def __(mo):
+def __2(mo):
     mo.md("""
         # Code blocks in code blocks
         Output code for Hello World!
@@ -27,7 +27,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def __3(mo):
     mo.md(f"""
         with f-string too!
         ```{{python}}
@@ -38,7 +38,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def __4(mo):
     mo.md(f"""
         Not markdown
         ```{{python}}
@@ -49,7 +49,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def __5(mo):
     mo.md(
         r"""
         Nested fence
@@ -63,7 +63,7 @@ def __(mo):
 
 
 @app.cell
-def __():
+def __6():
     """
     ```
     """
@@ -71,7 +71,7 @@ def __():
 
 
 @app.cell
-def __(mo):
+def __7(mo):
     mo.md("""
         Cross cell injection
         ```python
@@ -80,13 +80,13 @@ def __(mo):
 
 
 @app.cell
-def __():
+def __8():
     1 + 1
     return
 
 
 @app.cell
-def __():
+def __9():
     # Actual print
     print("Hello World")
     return

--- a/tests/_cli/snapshots/unsafe-app.py.txt
+++ b/tests/_cli/snapshots/unsafe-app.py.txt
@@ -5,13 +5,13 @@ app = marimo.App(app_title="Test Notebook")
 
 
 @app.cell
-def __f649():
+def __f649a0():
     import marimo as mo
     return (mo,)
 
 
 @app.cell
-def __1bb6(mo):
+def __1bb65d(mo):
     mo.md("""
         # Code blocks in code blocks
         Output code for Hello World!
@@ -27,7 +27,7 @@ def __1bb6(mo):
 
 
 @app.cell
-def __b4fd(mo):
+def __b4fdfb(mo):
     mo.md(f"""
         with f-string too!
         ```{{python}}
@@ -38,7 +38,7 @@ def __b4fd(mo):
 
 
 @app.cell
-def __d6c4(mo):
+def __d6c40e(mo):
     mo.md(f"""
         Not markdown
         ```{{python}}
@@ -49,7 +49,7 @@ def __d6c4(mo):
 
 
 @app.cell
-def __893b(mo):
+def __893b5e(mo):
     mo.md(
         r"""
         Nested fence
@@ -63,7 +63,7 @@ def __893b(mo):
 
 
 @app.cell
-def __a42b():
+def __a42bb6():
     """
     ```
     """
@@ -71,7 +71,7 @@ def __a42b():
 
 
 @app.cell
-def __987c(mo):
+def __987ce4(mo):
     mo.md("""
         Cross cell injection
         ```python
@@ -80,13 +80,13 @@ def __987c(mo):
 
 
 @app.cell
-def __72fc():
+def __72fce5():
     1 + 1
     return
 
 
 @app.cell
-def __5370():
+def __537086():
     # Actual print
     print("Hello World")
     return

--- a/tests/_cli/snapshots/unsafe-doc.py.txt
+++ b/tests/_cli/snapshots/unsafe-doc.py.txt
@@ -5,7 +5,7 @@ app = marimo.App(app_title="Casually malicious md")
 
 
 @app.cell
-def __(mo):
+def __1(mo):
     mo.md(
         r"""
         What happens if I just leave a \"\"\"
@@ -20,13 +20,13 @@ def __(mo):
 
 
 @app.cell
-def __():
+def __2():
     print("Hello, World!")
     return
 
 
 @app.cell
-def __(mo):
+def __3(mo):
     mo.md(
         r"""
         -->
@@ -41,12 +41,12 @@ app._unparsable_cell(
     r"""
     it's an unparsable cell
     """,
-    name="__"
+    name="__4"
 )
 
 
 @app.cell
-def __(mo):
+def __5(mo):
     mo.md(
         r"""
         <!-- Actually markdown -->
@@ -60,13 +60,13 @@ def __(mo):
 
 
 @app.cell(disabled=True)
-def __():
+def __6():
     1 + 1
     return
 
 
 @app.cell
-def __(mo):
+def __7(mo):
     mo.md(
         r"""
         <!-- Hidden code block -->
@@ -76,13 +76,13 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __():
+def __8():
     1 + 1
     return
 
 
 @app.cell
-def __(mo):
+def __9(mo):
     mo.md(
         r"""
         <!-- Empty code block -->
@@ -92,12 +92,12 @@ def __(mo):
 
 
 @app.cell
-def __():
+def __10():
     return
 
 
 @app.cell
-def __(mo):
+def __11(mo):
     mo.md(
         r"""
         <!-- Improperly nested code block -->
@@ -112,12 +112,12 @@ app._unparsable_cell(
     ```{python}
     print(\"Hello, World!\")
     """,
-    name="__"
+    name="__12"
 )
 
 
 @app.cell
-def __(mo):
+def __13(mo):
     mo.md(
         r"""
         \"\"\"
@@ -139,7 +139,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def __14(mo):
     mo.md("""
       This is a markdown cell with an execution block in it
       ```{python}
@@ -150,7 +150,7 @@ def __(mo):
 
 
 @app.cell
-def __():
+def __15():
     return
 
 

--- a/tests/_cli/snapshots/unsafe-doc.py.txt
+++ b/tests/_cli/snapshots/unsafe-doc.py.txt
@@ -5,7 +5,7 @@ app = marimo.App(app_title="Casually malicious md")
 
 
 @app.cell
-def __4683(mo):
+def __468353(mo):
     mo.md(
         r"""
         What happens if I just leave a \"\"\"
@@ -20,13 +20,13 @@ def __4683(mo):
 
 
 @app.cell
-def __cf60():
+def __cf603e():
     print("Hello, World!")
     return
 
 
 @app.cell
-def __abfb(mo):
+def __abfb7a(mo):
     mo.md(
         r"""
         -->
@@ -41,12 +41,12 @@ app._unparsable_cell(
     r"""
     it's an unparsable cell
     """,
-    name="__b628"
+    name="__b62866"
 )
 
 
 @app.cell
-def __682f(mo):
+def __682fdb(mo):
     mo.md(
         r"""
         <!-- Actually markdown -->
@@ -60,13 +60,13 @@ def __682f(mo):
 
 
 @app.cell(disabled=True)
-def __72fc():
+def __72fce5():
     1 + 1
     return
 
 
 @app.cell
-def __8b85(mo):
+def __8b8517(mo):
     mo.md(
         r"""
         <!-- Hidden code block -->
@@ -76,13 +76,13 @@ def __8b85(mo):
 
 
 @app.cell(hide_code=True)
-def __72fc():
+def __72fce5():
     1 + 1
     return
 
 
 @app.cell
-def __86ad(mo):
+def __86ad6f(mo):
     mo.md(
         r"""
         <!-- Empty code block -->
@@ -92,12 +92,12 @@ def __86ad(mo):
 
 
 @app.cell
-def __e3b0():
+def __e3b0c4():
     return
 
 
 @app.cell
-def __2444(mo):
+def __2444f9(mo):
     mo.md(
         r"""
         <!-- Improperly nested code block -->
@@ -112,12 +112,12 @@ app._unparsable_cell(
     ```{python}
     print(\"Hello, World!\")
     """,
-    name="__e389"
+    name="__e38943"
 )
 
 
 @app.cell
-def __11e6(mo):
+def __11e62b(mo):
     mo.md(
         r"""
         \"\"\"
@@ -139,7 +139,7 @@ def __11e6(mo):
 
 
 @app.cell
-def __1c22(mo):
+def __1c2229(mo):
     mo.md("""
       This is a markdown cell with an execution block in it
       ```{python}
@@ -150,7 +150,7 @@ def __1c22(mo):
 
 
 @app.cell
-def __e3b0():
+def __e3b0c4():
     return
 
 

--- a/tests/_cli/snapshots/unsafe-doc.py.txt
+++ b/tests/_cli/snapshots/unsafe-doc.py.txt
@@ -5,7 +5,7 @@ app = marimo.App(app_title="Casually malicious md")
 
 
 @app.cell
-def __1(mo):
+def __4683(mo):
     mo.md(
         r"""
         What happens if I just leave a \"\"\"
@@ -20,13 +20,13 @@ def __1(mo):
 
 
 @app.cell
-def __2():
+def __cf60():
     print("Hello, World!")
     return
 
 
 @app.cell
-def __3(mo):
+def __abfb(mo):
     mo.md(
         r"""
         -->
@@ -41,12 +41,12 @@ app._unparsable_cell(
     r"""
     it's an unparsable cell
     """,
-    name="__4"
+    name="__b628"
 )
 
 
 @app.cell
-def __5(mo):
+def __682f(mo):
     mo.md(
         r"""
         <!-- Actually markdown -->
@@ -60,13 +60,13 @@ def __5(mo):
 
 
 @app.cell(disabled=True)
-def __6():
+def __72fc():
     1 + 1
     return
 
 
 @app.cell
-def __7(mo):
+def __8b85(mo):
     mo.md(
         r"""
         <!-- Hidden code block -->
@@ -76,13 +76,13 @@ def __7(mo):
 
 
 @app.cell(hide_code=True)
-def __8():
+def __72fc():
     1 + 1
     return
 
 
 @app.cell
-def __9(mo):
+def __86ad(mo):
     mo.md(
         r"""
         <!-- Empty code block -->
@@ -92,12 +92,12 @@ def __9(mo):
 
 
 @app.cell
-def __10():
+def __e3b0():
     return
 
 
 @app.cell
-def __11(mo):
+def __2444(mo):
     mo.md(
         r"""
         <!-- Improperly nested code block -->
@@ -112,12 +112,12 @@ app._unparsable_cell(
     ```{python}
     print(\"Hello, World!\")
     """,
-    name="__12"
+    name="__e389"
 )
 
 
 @app.cell
-def __13(mo):
+def __11e6(mo):
     mo.md(
         r"""
         \"\"\"
@@ -139,7 +139,7 @@ def __13(mo):
 
 
 @app.cell
-def __14(mo):
+def __1c22(mo):
     mo.md("""
       This is a markdown cell with an execution block in it
       ```{python}
@@ -150,7 +150,7 @@ def __14(mo):
 
 
 @app.cell
-def __15():
+def __e3b0():
     return
 
 

--- a/tests/_convert/test_convert_utils.py
+++ b/tests/_convert/test_convert_utils.py
@@ -37,13 +37,13 @@ app = marimo.App()
 
 
 @app.cell
-def __():
+def __1():
     print('Hello')
     return
 
 
 @app.cell
-def __():
+def __2():
     x = 5
     return (x,)
 

--- a/tests/_convert/test_convert_utils.py
+++ b/tests/_convert/test_convert_utils.py
@@ -37,13 +37,13 @@ app = marimo.App()
 
 
 @app.cell
-def __1():
+def __0d4b():
     print('Hello')
     return
 
 
 @app.cell
-def __2():
+def __b203():
     x = 5
     return (x,)
 

--- a/tests/_convert/test_convert_utils.py
+++ b/tests/_convert/test_convert_utils.py
@@ -37,13 +37,13 @@ app = marimo.App()
 
 
 @app.cell
-def __0d4b():
+def __0d4b93():
     print('Hello')
     return
 
 
 @app.cell
-def __b203():
+def __b203e5():
     x = 5
     return (x,)
 

--- a/tests/_server/test_file_manager.py
+++ b/tests/_server/test_file_manager.py
@@ -239,7 +239,7 @@ def test_to_code(app_file_manager: AppFileManager) -> None:
             "",
             "",
             "@app.cell",
-            "def __1():",
+            "def __f649():",
             "    import marimo as mo",
             "    return (mo,)",
             "",

--- a/tests/_server/test_file_manager.py
+++ b/tests/_server/test_file_manager.py
@@ -239,7 +239,7 @@ def test_to_code(app_file_manager: AppFileManager) -> None:
             "",
             "",
             "@app.cell",
-            "def __():",
+            "def __1():",
             "    import marimo as mo",
             "    return (mo,)",
             "",

--- a/tests/_server/test_file_manager.py
+++ b/tests/_server/test_file_manager.py
@@ -239,7 +239,7 @@ def test_to_code(app_file_manager: AppFileManager) -> None:
             "",
             "",
             "@app.cell",
-            "def __f649():",
+            "def __f649a0():",
             "    import marimo as mo",
             "    return (mo,)",
             "",


### PR DESCRIPTION
This change makes the code-generation output the cell `def` names as their ~~positions~~ code cell hashes, in order to be unique. 

It doesnt actually matter what gets read, they only update on write.

Fixes #1954, #2325