### PR TITLE
improvement: errors should stay internal in marimo run and logged to console

### DIFF
--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -156,6 +156,10 @@ export const MarimoErrorOutput = ({
             </Tip>
           </div>
         );
+      case "internal":
+        titleContents = "An internal error occurred";
+        return <p key={idx}>{error.msg}</p>;
+
       case "ancestor-prevented":
         titleContents = "Ancestor prevented from running";
         alertVariant = "default";

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -15,7 +15,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:w-fit md:max-w-[420px]",
       className,
     )}
     {...props}

--- a/frontend/src/core/cells/logs.ts
+++ b/frontend/src/core/cells/logs.ts
@@ -60,14 +60,16 @@ export function getCellLogsForMessage(cell: CellMessage): CellLog[] {
       });
     });
 
-    if (!didAlreadyToastError) {
+    const shouldToast = cell.output.data.some(
+      (error) => error.type === "internal",
+    );
+    if (!didAlreadyToastError && shouldToast) {
       didAlreadyToastError = true;
       toast({
         title: "An internal error occurred",
         description: "See console for details.",
         className:
           "text-xs text-background bg-[var(--red-10)] py-2 pl-3 [&>*]:flex [&>*]:gap-3",
-        duration: 70_000,
       });
     }
   }

--- a/frontend/src/core/cells/logs.ts
+++ b/frontend/src/core/cells/logs.ts
@@ -4,6 +4,7 @@ import type { CellMessage, OutputMessage } from "../kernel/messages";
 import type { CellId } from "./ids";
 import { fromUnixTime } from "date-fns";
 import { isErrorMime } from "../mime";
+import { toast } from "@/components/ui/use-toast";
 
 export interface CellLog {
   timestamp: number;
@@ -11,6 +12,8 @@ export interface CellLog {
   message: string;
   cellId: CellId;
 }
+
+let didAlreadyToastError = false;
 
 export function getCellLogsForMessage(cell: CellMessage): CellLog[] {
   const logs: CellLog[] = [];
@@ -56,6 +59,17 @@ export function getCellLogsForMessage(cell: CellMessage): CellLog[] {
         message: JSON.stringify(error),
       });
     });
+
+    if (!didAlreadyToastError) {
+      didAlreadyToastError = true;
+      toast({
+        title: "An internal error occurred",
+        description: "See console for details.",
+        className:
+          "text-xs text-background bg-[var(--red-10)] py-2 pl-3 [&>*]:flex [&>*]:gap-3",
+        duration: 70_000,
+      });
+    }
   }
 
   return logs;

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -59,6 +59,7 @@ def _generate_schema() -> dict[str, Any]:
         errors.MultipleDefinitionError,
         errors.DeleteNonlocalError,
         errors.MarimoInterruptionError,
+        errors.MarimoInternalError,
         errors.MarimoAncestorStoppedError,
         errors.MarimoAncestorPreventedError,
         errors.MarimoStrictExecutionError,

--- a/marimo/_messaging/errors.py
+++ b/marimo/_messaging/errors.py
@@ -107,6 +107,50 @@ class MarimoStrictExecutionError:
         return self.msg
 
 
+@dataclass
+class MarimoInternalError:
+    """
+    An internal error that should be hidden from the user.
+    The error is logged to the console and then a new error is broadcasted
+    such that the data is hidden.
+
+    They can be linked back to the original error by the error_id.
+    """
+
+    error_id: str
+    type: Literal["internal"] = "internal"
+    msg: str = ""
+
+    def __post_init__(self) -> None:
+        self.msg = f"An internal error occurred: {self.error_id}"
+
+    def describe(self) -> str:
+        return self.msg
+
+
+def is_unexpected_error(error: Error) -> bool:
+    """
+    These errors are unexpected, in that they are not intentional.
+    mo.stop and interrupt are intentional.
+    """
+    return error.type not in [
+        "ancestor-prevented",
+        "ancestor-stopped",
+        "interruption",
+    ]
+
+
+def is_sensitive_error(error: Error) -> bool:
+    """
+    These errors are sensitive, in that they are intentional.
+    """
+    return error.type not in [
+        "ancestor-prevented",
+        "ancestor-stopped",
+        "internal",
+    ]
+
+
 Error = Union[
     CycleError,
     MultipleDefinitionError,
@@ -117,5 +161,6 @@ Error = Union[
     MarimoStrictExecutionError,
     MarimoInterruptionError,
     MarimoSyntaxError,
+    MarimoInternalError,
     UnknownError,
 ]

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -257,7 +257,7 @@ class CellOp(Op):
 
         # In run mode, we don't want to broadcast the error. Instead we want to print the error to the console
         # and then broadcast a new error such that the data is hidden.
-        safe_errors: Sequence[Error] = []
+        safe_errors: list[Error] = []
         if get_mode() == "run":
             for error in data:
                 # Skip non-sensitive errors
@@ -272,7 +272,7 @@ class CellOp(Op):
                 )
                 safe_errors.append(MarimoInternalError(error_id=str(error_id)))
         else:
-            safe_errors = data
+            safe_errors = list(data)
 
         CellOp(
             cell_id=cell_id,

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -23,6 +23,7 @@ from typing import (
     Union,
     cast,
 )
+from uuid import uuid4
 
 from marimo import _loggers as loggers
 from marimo._ast.app import _AppConfig
@@ -31,7 +32,11 @@ from marimo._data.models import ColumnSummary, DataTable, DataTableSource
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.completion_option import CompletionOption
-from marimo._messaging.errors import Error
+from marimo._messaging.errors import (
+    Error,
+    MarimoInternalError,
+    is_sensitive_error,
+)
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._messaging.streams import OUTPUT_MAX_BYTES
 from marimo._messaging.types import Stream
@@ -41,6 +46,7 @@ from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._plugins.ui._impl.tables.utils import get_table_manager_or_none
 from marimo._runtime.context import get_context
+from marimo._runtime.context.utils import get_mode
 from marimo._runtime.layout.layout import LayoutConfig
 from marimo._utils.platform import is_pyodide, is_windows
 
@@ -248,12 +254,32 @@ class CellOp(Op):
         cell_id: CellId_t,
     ) -> None:
         console: Optional[list[CellOutput]] = [] if clear_console else None
+
+        # In run mode, we don't want to broadcast the error. Instead we want to print the error to the console
+        # and then broadcast a new error such that the data is hidden.
+        safe_errors: Sequence[Error] = []
+        if get_mode() == "run":
+            for error in data:
+                # Skip non-sensitive errors
+                if not is_sensitive_error(error):
+                    safe_errors.append(error)
+                    continue
+
+                error_id = uuid4()
+                LOGGER.error(
+                    f"(error_id={error_id}) {error.describe()}",
+                    extra={"error_id": error_id},
+                )
+                safe_errors.append(MarimoInternalError(error_id=str(error_id)))
+        else:
+            safe_errors = data
+
         CellOp(
             cell_id=cell_id,
             output=CellOutput(
                 channel=CellChannel.MARIMO_ERROR,
                 mimetype="application/vnd.marimo+error",
-                data=data,
+                data=safe_errors,
             ),
             console=console,
             status=None,

--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -501,6 +501,7 @@ def create_asgi_app(
                 # to each application
                 cli_args={},
                 auth_token=auth_token,
+                redirect_console_to_browser=False,
             )
             app = create_starlette_app(
                 base_url="",

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -164,7 +164,7 @@ class KernelManager:
         app_metadata: AppMetadata,
         user_config_manager: MarimoConfigReader,
         virtual_files_supported: bool,
-        redirect_console_to_browser: bool = False,
+        redirect_console_to_browser: bool,
     ) -> None:
         self.kernel_task: Optional[threading.Thread] | Optional[mp.Process]
         self.queue_manager = queue_manager
@@ -661,7 +661,7 @@ class SessionManager:
         user_config_manager: MarimoConfigReader,
         cli_args: SerializedCLIArgs,
         auth_token: Optional[AuthToken],
-        redirect_console_to_browser: bool = False,
+        redirect_console_to_browser: bool,
     ) -> None:
         self.file_router = file_router
         self.mode = mode

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -505,6 +505,7 @@ components:
       - $ref: '#/components/schemas/MarimoStrictExecutionError'
       - $ref: '#/components/schemas/MarimoInterruptionError'
       - $ref: '#/components/schemas/MarimoSyntaxError'
+      - $ref: '#/components/schemas/MarimoInternalError'
       - $ref: '#/components/schemas/UnknownError'
     ExecuteMultipleRequest:
       properties:
@@ -1268,6 +1269,21 @@ components:
       required:
       - name
       - path
+      type: object
+    MarimoInternalError:
+      properties:
+        error_id:
+          type: string
+        msg:
+          type: string
+        type:
+          enum:
+          - internal
+          type: string
+      required:
+      - error_id
+      - type
+      - msg
       type: object
     MarimoInterruptionError:
       properties:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2249,6 +2249,7 @@ export interface components {
       | components["schemas"]["MarimoStrictExecutionError"]
       | components["schemas"]["MarimoInterruptionError"]
       | components["schemas"]["MarimoSyntaxError"]
+      | components["schemas"]["MarimoInternalError"]
       | components["schemas"]["UnknownError"];
     ExecuteMultipleRequest: {
       cellIds: string[];
@@ -2554,6 +2555,12 @@ export interface components {
       name: string;
       path: string;
       sessionId?: string | null;
+    };
+    MarimoInternalError: {
+      error_id: string;
+      msg: string;
+      /** @enum {string} */
+      type: "internal";
     };
     MarimoInterruptionError: {
       /** @enum {string} */

--- a/tests/_runtime/test_app_mode.py
+++ b/tests/_runtime/test_app_mode.py
@@ -8,12 +8,13 @@ from marimo._runtime.context import (
 from marimo._runtime.context.kernel_context import KernelRuntimeContext
 from marimo._runtime.context.script_context import ScriptRuntimeContext
 from marimo._runtime.context.utils import get_mode
+from marimo._server.model import SessionMode
 
 
 def test_get_mode_kernel_run():
     """Test get_mode() returns 'run' when in kernel run mode"""
     mock_context = Mock(spec=KernelRuntimeContext)
-    mock_context.session_mode = "run"
+    mock_context.session_mode = SessionMode.RUN
 
     with patch(
         "marimo._runtime.context.utils.get_context", return_value=mock_context
@@ -24,7 +25,7 @@ def test_get_mode_kernel_run():
 def test_get_mode_kernel_edit():
     """Test get_mode() returns 'edit' when in kernel edit mode"""
     mock_context = Mock(spec=KernelRuntimeContext)
-    mock_context.session_mode = "edit"
+    mock_context.session_mode = SessionMode.EDIT
 
     with patch(
         "marimo._runtime.context.utils.get_context", return_value=mock_context

--- a/tests/_server/export/snapshots/run_until_completion_with_stack_trace.txt
+++ b/tests/_server/export/snapshots/run_until_completion_with_stack_trace.txt
@@ -1,0 +1,30 @@
+[
+  {
+    "output": "",
+    "console": [
+      "running internal tests\n"
+    ],
+    "status": "idle"
+  },
+  {
+    "output": "<pre style='font-size: 12px'>15</pre>",
+    "console": [
+      "internal error\n"
+    ],
+    "status": "idle"
+  },
+  {
+    "output": [
+      {
+        "msg": "This cell raised an exception: Exception('Failed to authenticate. The correct password is 's3cret'.')",
+        "exception_type": "Exception",
+        "raising_cell": null,
+        "type": "exception"
+      }
+    ],
+    "console": [
+      "<span class=\"codehilite\"><div class=\"highlight\"><pre><span></span><span class=\"gt\">Traceback (most recent call last):</span>\n  &quot;</span>, line <span class=\"m\">3</span>, in <span class=\"n\">&lt;module&gt;</span>\n<span class=\"w\">    </span><span class=\"k\">raise</span> <span class=\"ne\">Exception</span><span class=\"p\">(</span>\n<span class=\"gr\">Exception</span>: <span class=\"n\">Failed to authenticate. The correct password is &#39;s3cret&#39;.</span>\n</pre></div>\n</span>"
+    ],
+    "status": "idle"
+  }
+]

--- a/tests/_server/export/snapshots/run_until_completion_with_stack_trace.txt
+++ b/tests/_server/export/snapshots/run_until_completion_with_stack_trace.txt
@@ -16,14 +16,14 @@
   {
     "output": [
       {
-        "msg": "This cell raised an exception: Exception('Failed to authenticate. The correct password is 's3cret'.')",
-        "exception_type": "Exception",
+        "msg": "This cell raised an exception: ValueError('Failed to authenticate. The correct password is 's3cret'.')",
+        "exception_type": "ValueError",
         "raising_cell": null,
         "type": "exception"
       }
     ],
     "console": [
-      "<span class=\"codehilite\"><div class=\"highlight\"><pre><span></span><span class=\"gt\">Traceback (most recent call last):</span>\n  &quot;</span>, line <span class=\"m\">3</span>, in <span class=\"n\">&lt;module&gt;</span>\n<span class=\"w\">    </span><span class=\"k\">raise</span> <span class=\"ne\">Exception</span><span class=\"p\">(</span>\n<span class=\"gr\">Exception</span>: <span class=\"n\">Failed to authenticate. The correct password is &#39;s3cret&#39;.</span>\n</pre></div>\n</span>"
+      "<span class=\"codehilite\"><div class=\"highlight\"><pre><span></span><span class=\"gt\">Traceback (most recent call last):</span>\n  &quot;</span>, line <span class=\"m\">3</span>, in <span class=\"n\">&lt;module&gt;</span>\n<span class=\"w\">    </span><span class=\"k\">raise</span> <span class=\"ne\">ValueError</span><span class=\"p\">(</span>\n<span class=\"gr\">ValueError</span>: <span class=\"n\">Failed to authenticate. The correct password is &#39;s3cret&#39;.</span>\n</pre></div>\n</span>"
     ],
     "status": "idle"
   }

--- a/tests/_server/export/snapshots/run_until_completion_with_stop.txt
+++ b/tests/_server/export/snapshots/run_until_completion_with_stop.txt
@@ -1,1 +1,23 @@
-["", "", [{"msg": "This cell wasn't run because an ancestor was stopped with `mo.stop`: ", "raising_cell": "MJUe", "type": "ancestor-stopped"}]]
+[
+  {
+    "output": "",
+    "console": [],
+    "status": "idle"
+  },
+  {
+    "output": "",
+    "console": [],
+    "status": "idle"
+  },
+  {
+    "output": [
+      {
+        "msg": "This cell wasn't run because an ancestor was stopped with `mo.stop`: ",
+        "raising_cell": "MJUe",
+        "type": "ancestor-stopped"
+      }
+    ],
+    "console": [],
+    "status": "idle"
+  }
+]

--- a/tests/_server/mocks.py
+++ b/tests/_server/mocks.py
@@ -56,6 +56,7 @@ if __name__ == "__main__":
         user_config_manager=get_default_config_manager(current_path=None),
         cli_args={},
         auth_token=AuthToken("fake-token"),
+        redirect_console_to_browser=False,
     )
     sm.skew_protection_token = SkewProtectionToken("skew-id-1")
     return sm

--- a/tests/_server/test_session_manager.py
+++ b/tests/_server/test_session_manager.py
@@ -37,6 +37,7 @@ def session_manager():
         user_config_manager=get_default_config_manager(current_path=None),
         cli_args={},
         auth_token=None,
+        redirect_console_to_browser=False,
     )
 
 

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -76,6 +76,7 @@ def test_kernel_manager_run_mode() -> None:
         app_metadata,
         get_default_config_manager(current_path=None),
         virtual_files_supported=True,
+        redirect_console_to_browser=False,
     )
 
     kernel_manager.start_kernel()
@@ -108,6 +109,7 @@ def test_kernel_manager_edit_mode() -> None:
         app_metadata,
         get_default_config_manager(current_path=None),
         virtual_files_supported=True,
+        redirect_console_to_browser=False,
     )
 
     kernel_manager.start_kernel()
@@ -139,6 +141,7 @@ def test_kernel_manager_interrupt(tmp_path) -> None:
         app_metadata,
         get_default_config_manager(current_path=None),
         virtual_files_supported=True,
+        redirect_console_to_browser=False,
     )
 
     # Assert startup
@@ -224,6 +227,7 @@ def test_session() -> None:
         app_metadata,
         get_default_config_manager(current_path=None),
         virtual_files_supported=True,
+        redirect_console_to_browser=False,
     )
 
     # Instantiate a Session
@@ -268,6 +272,7 @@ def test_session_disconnect_reconnect() -> None:
         AppMetadata(query_params={}, cli_args={}),
         get_default_config_manager(current_path=None),
         virtual_files_supported=True,
+        redirect_console_to_browser=False,
     )
 
     # Instantiate a Session
@@ -323,6 +328,7 @@ def test_session_with_kiosk_consumers() -> None:
         app_metadata,
         get_default_config_manager(current_path=None),
         virtual_files_supported=True,
+        redirect_console_to_browser=False,
     )
 
     # Instantiate a Session


### PR DESCRIPTION
This hides stack traces when in run mode, and instead propagates up an `error_id` that can be used to grep the server logs.

![Screenshot 2024-12-12 at 4 39 47 PM](https://github.com/user-attachments/assets/4cab2683-b839-4695-afab-dc3e6bcae237)

![Screenshot 2024-12-12 at 4 39 39 PM](https://github.com/user-attachments/assets/00827b0c-131f-4fa6-9f30-e7e83f380a55)

![Screenshot 2024-12-12 at 5 06 01 PM](https://github.com/user-attachments/assets/a7ddeb5a-3b69-40be-b4ba-b7643691adec)