### PR TITLE
feat: markdown caption support, tabs, critic, emoji, magic links

### DIFF
--- a/frontend/src/css/globals.css
+++ b/frontend/src/css/globals.css
@@ -8,6 +8,8 @@
 @import url("@radix-ui/colors/red-dark.css");
 @import url("@radix-ui/colors/sky.css");
 @import url("@radix-ui/colors/sky-dark.css");
+@import url("@radix-ui/colors/orange.css");
+@import url("@radix-ui/colors/orange-dark.css");
 @import url("@radix-ui/colors/cyan.css");
 @import url("@radix-ui/colors/cyan-dark.css");
 @import url("@radix-ui/colors/slate.css");

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -183,16 +183,16 @@ button .prose.prose {
   border-radius: 3px;
   border-style: solid;
   border-width: 1px;
-  padding-top: 0.1em;
-  padding-bottom: 0.1em;
+  padding-top: 0.1rem;
+  padding-bottom: 0.1rem;
   text-decoration: none;
 }
 
 .prose .critic:before,
 .prose .critic:after {
   content: "\00a0";
-  padding-top: 0.1em;
-  padding-bottom: 0.1em;
+  padding-top: 0.1rem;
+  padding-bottom: 0.1rem;
   font-size: initial;
 }
 
@@ -284,7 +284,7 @@ button .prose.prose {
 
 .prose .block {
   display: block;
-  padding: 0.02em;
+  padding: 0.02rem;
 }
 
 /* Keys */

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -109,3 +109,186 @@ button .prose.prose {
   margin: 0 0.5rem 0.25rem -1.6rem;
   vertical-align: middle;
 }
+
+/* Tabs */
+
+.tabbed-set {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  border-radius: var(--radius);
+}
+
+.tabbed-set > input {
+  display: none;
+}
+
+.tabbed-set label {
+  width: auto;
+  padding: 0.2rem 1rem;
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  border-top-left-radius: var(--radius);
+  border-top-right-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color var(--transition), color var(--transition);
+  color: var(--muted-foreground);
+}
+
+.tabbed-set .tabbed-content {
+  width: 100%;
+  display: none;
+  box-shadow: 0 -1px var(--border);
+  background-color: var(--background);
+  padding: 0.5rem 1rem;
+}
+
+.tabbed-set input {
+  position: absolute;
+  opacity: 0;
+}
+
+.tabbed-set input:checked:nth-child(n + 1) + label {
+  color: var(--foreground);
+  border-color: var(--primary);
+  background-color: var(--background);
+}
+
+.tabbed-set label:hover {
+  color: var(--foreground);
+  background-color: var(--accent);
+}
+
+@media screen {
+  .tabbed-set input:nth-child(n + 1):checked + label + .tabbed-content {
+    order: 99;
+    display: block;
+  }
+}
+
+@media print {
+  .tabbed-content {
+    display: contents;
+  }
+}
+
+/* Critic Markup */
+
+.prose .critic {
+  font-family: inherit;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  padding-top: 0.1em;
+  padding-bottom: 0.1em;
+  text-decoration: none;
+}
+
+.prose .critic:before,
+.prose .critic:after {
+  content: "\00a0";
+  padding-top: 0.1em;
+  padding-bottom: 0.1em;
+  font-size: initial;
+}
+
+.prose .block:before,
+.prose .block:after {
+  content: "";
+}
+.prose mark.critic {
+  border-color: var(--orange-9);
+  background: var(--orange-3);
+}
+
+.prose ins.critic {
+  border-color: var(--grass-9);
+  background: var(--grass-3);
+}
+
+.prose del.critic {
+  border-color: var(--red-9);
+  background: var(--red-3);
+}
+
+.prose ins.break,
+.prose del.break {
+  font-size: 0;
+  border: none;
+}
+
+.prose ins.break:before,
+.prose del.break:before {
+  content: "\00a0\b6\00a0";
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+}
+
+.prose ins.after,
+.prose del.after {
+  content: "";
+}
+
+.prose ins.break:before {
+  color: var(--green-9);
+  border: 1px solid var(--green-9);
+  background: var(--green-3);
+}
+
+.prose del.break:before {
+  color: var(--red-9);
+  border: 1px solid var(--red-9);
+  background: var(--red-3);
+}
+
+.prose span.critic {
+  background: var(--blue-3);
+  border: 0;
+  border-top: 1px solid var(--blue-9);
+  border-bottom: 1px solid var(--blue-9);
+}
+
+.prose span.critic:before,
+.prose span.critic:after {
+  font-size: inherit;
+  background: var(--blue-3);
+  border: 1px solid var(--blue-9);
+}
+
+.prose span.critic:before {
+  content: "\00a0\bb";
+  border-right: none;
+  -webkit-border-top-left-radius: 3px;
+  -moz-border-top-left-radius: 3px;
+  border-top-left-radius: 3px;
+  -webkit-border-bottom-left-radius: 3px;
+  -moz-border-bottom-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+
+.prose span.critic:after {
+  content: "\ab\00a0";
+  border-left: none;
+  -webkit-border-top-right-radius: 3px;
+  -moz-border-top-right-radius: 3px;
+  border-top-right-radius: 3px;
+  -webkit-border-bottom-right-radius: 3px;
+  -moz-border-bottom-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+
+.prose .block {
+  display: block;
+  padding: 0.02em;
+}
+
+/* Keys */
+
+.prose .keys {
+  @apply space-x-1;
+}

--- a/marimo/_output/md.py
+++ b/marimo/_output/md.py
@@ -56,12 +56,12 @@ class _md(Html):
         self._markdown_text = text
 
         # Lazily add mo.notebook_dir() as the bas64 base path
-        if "pymdownx.b64" not in extension_configs:
-            from marimo._runtime.runtime import notebook_dir
+        # if "pymdownx.b64" not in extension_configs:
+        #     from marimo._runtime.runtime import notebook_dir
 
-            extension_configs["pymdownx.b64"] = {
-                "base_path": str(notebook_dir()),
-            }
+        #     extension_configs["pymdownx.b64"] = {
+        #         "base_path": str(notebook_dir()),
+        #     }
 
         # markdown.markdown appends a newline, hence strip
         html_text = markdown.markdown(
@@ -73,8 +73,9 @@ class _md(Html):
                 "tables",
                 # LaTeX
                 "pymdownx.arithmatex",
-                # Base64 images - allows embedding images in markdown
-                "pymdownx.b64",
+                # Base64 is not enabled, since app users could potentially
+                # use it to grab files they shouldn't have access to.
+                # "pymdownx.b64",
                 # Subscripts and strikethrough
                 "pymdownx.tilde",
                 # Better code blocks

--- a/marimo/_output/md.py
+++ b/marimo/_output/md.py
@@ -5,6 +5,7 @@ from inspect import cleandoc
 from typing import Literal, Optional
 
 import markdown  # type: ignore
+import pymdownx.emoji  # type: ignore
 
 from marimo._output.hypertext import Html
 from marimo._output.md_extensions.external_links import ExternalLinksExtension
@@ -28,6 +29,11 @@ extension_configs = {
         "disable_indented_code_blocks": True,
         "css_class": "codehilite",
     },
+    "pymdownx.emoji": {
+        # This uses native emoji characters,
+        # instead of loading from a CDN
+        "emoji_generator": pymdownx.emoji.to_alt,
+    },
     "footnotes": {
         "UNIQUE_IDS": True,
     },
@@ -49,6 +55,14 @@ class _md(Html):
         text = cleandoc(text)
         self._markdown_text = text
 
+        # Lazily add mo.notebook_dir() as the bas64 base path
+        if "pymdownx.b64" not in extension_configs:
+            from marimo._runtime.runtime import notebook_dir
+
+            extension_configs["pymdownx.b64"] = {
+                "base_path": str(notebook_dir()),
+            }
+
         # markdown.markdown appends a newline, hence strip
         html_text = markdown.markdown(
             text,
@@ -59,12 +73,26 @@ class _md(Html):
                 "tables",
                 # LaTeX
                 "pymdownx.arithmatex",
+                # Base64 images - allows embedding images in markdown
+                "pymdownx.b64",
                 # Subscripts and strikethrough
                 "pymdownx.tilde",
                 # Better code blocks
                 "pymdownx.superfences",
                 # Task lists
                 "pymdownx.tasklist",
+                # Caption
+                "pymdownx.blocks.caption",
+                # Tabs
+                "pymdownx.blocks.tab",
+                # Critic - color-coded markup
+                "pymdownx.critic",
+                # Emoji - :emoji:
+                "pymdownx.emoji",
+                # Keys - <kbd> support
+                "pymdownx.keys",
+                # Magic links - auto-link URLs
+                "pymdownx.magiclink",
                 # Table of contents
                 # This adds ids to the HTML headers
                 "toc",

--- a/marimo/_smoke_tests/markdown_pymdownx.py
+++ b/marimo/_smoke_tests/markdown_pymdownx.py
@@ -8,7 +8,7 @@ app = marimo.App(width="medium")
 def _(mo):
     mo.md(
         r"""
-        Task List
+        ## Task List
 
         - item
         -   [X] item 1
@@ -22,6 +22,184 @@ def _(mo):
             *   non item
         -   [ ] item 2
         -   [ ] item 3
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Base 64
+
+        ![picture](../../docs/_static/docs-settings.png)
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Admonitions
+
+        !!! important ""
+            This is an admonition box without a title.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Caption
+
+        Fruit      | Amount
+        ---------- | ------
+        Apple      | 20
+        Peach      | 10
+        Banana     | 3
+        Watermelon | 1
+
+        /// caption
+        Fruit Count
+        ///
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Tabs
+
+        /// tab | Tab 1 title
+        Tab 1 content
+        ///
+
+        /// tab | Tab 2 title
+        Tab 2 content
+        ///
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Nested em
+
+        This * won't emphasize *
+
+        This *will emphasize*
+
+        ***I'm italic and bold* I am just bold.**
+
+        ***I'm bold and italic!** I am just italic.*
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Critic
+
+        Here is some {--*incorrect*--} Markdown.  I am adding this{++ here++}.  Here is some more {--text
+         that I am removing--}text.  And here is even more {++text that I 
+         am ++}adding.{~~
+
+        ~>  ~~}Paragraph was deleted and replaced with some spaces.{~~  ~>
+
+        ~~}Spaces were removed and a paragraph was added.
+
+        And here is a comment on {==some
+         text==}{>>This works quite well. I just wanted to comment on it.<<}. Substitutions {~~is~>are~~} great!
+
+        General block handling.
+
+        {--
+
+        * test remove
+        * test remove
+        * test remove
+            * test remove
+        * test remove
+
+        --}
+
+        {++
+
+        * test add
+        * test add
+        * test add
+            * test add
+        * test add
+
+        ++}
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Emoji
+
+        :smile: :heart: :thumbsup:
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Keys
+
+        ++ctrl+alt+delete++
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Magic link
+
+        - Just paste links directly in the document like this: https://google.com.
+        - Or even an email address: fake.email@email.com.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## Subscripts and strikethrough
+
+        ~~Delete me~~
+
+        CH~3~CH~2~OH
+
+        text~a\ subscript~
         """
     )
     return


### PR DESCRIPTION
Enable more markdown features. 

base64 is not enabled (but the code is there as a reference) until we come up with a better approach for it. e.g only allow files in a public/ or assets/ directory

![markdown_pymdownx](https://github.com/user-attachments/assets/f948ea74-69b9-4916-9c30-21291b31710e)
