### PR TITLE
fix: higher-order components should call `on_update_completion()`

### DIFF
--- a/marimo/_config/reader.py
+++ b/marimo/_config/reader.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from pathlib import Path
 from typing import Any, Dict, Optional, Union, cast
 

--- a/marimo/_config/secrets.py
+++ b/marimo/_config/secrets.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from typing import Any, Dict, TypeVar, Union, cast
 
 from marimo._config.config import MarimoConfig, PartialMarimoConfig

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -461,9 +461,12 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         if self._on_change is not None:
             self._on_change(self._value)
 
-    def _on_update_completion(self) -> None:
-        """Callback to run after the kernel has processed a value update."""
-        return
+    def _on_update_completion(self) -> bool:
+        """Callback to run after the kernel has processed a value update.
+
+        Return true if the value of the component has changed, false otherwise
+        """
+        return False
 
     def __deepcopy__(self, memo: dict[int, Any]) -> UIElement[S, T]:
         # Custom deepcopy that excludes elements that can't be deepcopied

--- a/marimo/_plugins/ui/_impl/array.py
+++ b/marimo/_plugins/ui/_impl/array.py
@@ -124,6 +124,12 @@ class array(UIElement[Dict[str, JSONType], Sequence[object]]):
                     element._update(v)
         return [e._value for e in self._elements]
 
+    def _on_update_completion(self) -> None:
+        any_updated = False
+        for element in self._elements:
+            any_updated |= element._on_update_completion()
+        self._value = [e._value for e in self._elements]
+
     def _clone(self) -> array:
         return array(
             elements=self.elements,

--- a/marimo/_plugins/ui/_impl/batch.py
+++ b/marimo/_plugins/ui/_impl/batch.py
@@ -96,6 +96,17 @@ class _batch_base(UIElement[Dict[str, JSONType], Dict[str, object]]):
             for key, wrapped_element in self._elements.items()
         }
 
+    def _on_update_completion(self) -> None:
+        any_updated = False
+        for element in self._elements.values():
+            any_updated |= element._on_update_completion()
+
+        if any_updated or True:
+            self._value = {
+                key: wrapped_element._value
+                for key, wrapped_element in self._elements.items()
+            }
+
 
 @mddoc
 class batch(_batch_base):

--- a/marimo/_plugins/ui/_impl/run_button.py
+++ b/marimo/_plugins/ui/_impl/run_button.py
@@ -96,7 +96,7 @@ class run_button(UIElement[Any, Any]):
         else:
             return True
 
-    def _on_update_completion(self) -> None:
+    def _on_update_completion(self) -> bool:
         from marimo._runtime.context import get_context
         from marimo._runtime.context.kernel_context import KernelRuntimeContext
 
@@ -104,7 +104,7 @@ class run_button(UIElement[Any, Any]):
             ctx = get_context()
         except ContextNotInitializedError:
             self._value = False
-            return
+            return True
 
         if isinstance(ctx, KernelRuntimeContext) and ctx.lazy:
             # Resetting to False in lazy kernels makes the button pointless,
@@ -114,6 +114,7 @@ class run_button(UIElement[Any, Any]):
             # The right thing to do would be to somehow set to False after
             # all cells that were marked stale because of the update were run,
             # but that's too complicated.
-            return
-        else:
-            self._value = False
+            return False
+
+        self._value = False
+        return True

--- a/marimo/_smoke_tests/issues/3141_update_completion.py
+++ b/marimo/_smoke_tests/issues/3141_update_completion.py
@@ -1,0 +1,64 @@
+import marimo
+
+__generated_with = "0.9.34"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    from time import time
+    return mo, time
+
+
+@app.cell
+def __(mo):
+    d = mo.ui.dictionary(
+        {
+            "run_button1": mo.ui.run_button(label="run button 1"),
+            "run_button2": mo.ui.run_button(label="run button 2"),
+        }
+    )
+    return (d,)
+
+
+@app.cell
+def __(d):
+    d
+    return
+
+
+@app.cell
+def __(d, time):
+    d.value, time()
+    return
+
+
+@app.cell
+def __(d, time):
+    _t = time()
+    for name, button in d.items():
+        if button.value:
+            print(f"Clicked: at {_t}", name)
+    for n, b in d.items():
+        print(button.value, n)
+    d.value
+    return b, button, n, name
+
+
+@app.cell
+def __(mo):
+    run_button = mo.ui.run_button(label="single run button")
+    run_button
+    return (run_button,)
+
+
+@app.cell
+def __(run_button, time):
+    if run_button.value:
+        print("Clicked run button at time ", time())
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_plugins/ui/_impl/test_run_button.py
+++ b/tests/_plugins/ui/_impl/test_run_button.py
@@ -50,3 +50,43 @@ async def test_run_button_set_to_true_on_click(
         # in lazy kernels, run button's value is not set to False, since
         # we don't know when its descendants have run
         assert run_button.value
+
+
+async def test_run_buttons_in_array(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    await k.run(
+        [
+            exec_req.get("import marimo as mo"),
+            exec_req.get(
+                "arr = mo.ui.array([mo.ui.run_button(), mo.ui.run_button()])"
+            ),
+            exec_req.get("count = [0]"),
+            exec_req.get(
+                """
+                for b in arr:
+                    if b.value:
+                        count[0] += 1
+                """
+            ),
+        ]
+    )
+
+    arr = k.globals["arr"]
+    count = k.globals["count"]
+    assert not arr.value[0]
+    assert not arr.value[1]
+    # No buttons yet pushed
+    assert count[0] == 0
+
+    # Just one button pushed
+    await k.set_ui_element_value(SetUIElementValueRequest([arr[0]._id], [1]))
+    assert count[0] == 1
+    assert not arr.value[0]
+    assert not arr.value[1]
+    # Push another button, first button's value should be false, so just an
+    # increment by 1
+    await k.set_ui_element_value(SetUIElementValueRequest([arr[1]._id], [1]))
+    assert count[0] == 2
+    assert not arr.value[0]
+    assert not arr.value[1]


### PR DESCRIPTION
Higher order components like dicts and arrays need to call their children's completion hooks after their value is updated.

Fixes #3141