### PR TITLE
fix: resolve relative URL for old browsers

### DIFF
--- a/frontend/src/components/terminal/terminal.tsx
+++ b/frontend/src/components/terminal/terminal.tsx
@@ -5,6 +5,7 @@ import { AttachAddon } from "@xterm/addon-attach";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import "./xterm.css";
+import { resolveToWsUrl } from "@/core/websocket/createWsUrl";
 
 const TerminalComponent: React.FC<{
   visible: boolean;
@@ -27,7 +28,7 @@ const TerminalComponent: React.FC<{
       return;
     }
 
-    const socket = new WebSocket("terminal/ws");
+    const socket = new WebSocket(resolveToWsUrl("terminal/ws"));
     const attachAddon = new AttachAddon(socket);
     terminal.loadAddon(attachAddon);
 

--- a/frontend/src/core/codemirror/copilot/client.ts
+++ b/frontend/src/core/codemirror/copilot/client.ts
@@ -7,6 +7,7 @@ import { Transport } from "@open-rpc/client-js/build/transports/Transport";
 import type { JSONRPCRequestData } from "@open-rpc/client-js/build/Request";
 import { waitForEnabledCopilot } from "./state";
 import { waitForWs } from "@/utils/waitForWs";
+import { resolveToWsUrl } from "@/core/websocket/createWsUrl";
 
 // Dummy file for the copilot language server
 export const COPILOT_FILENAME = "/marimo.py";
@@ -80,5 +81,5 @@ export function copilotServer() {
 }
 
 export function createWsUrl(): string {
-  return "/lsp/copilot";
+  return resolveToWsUrl("lsp/copilot");
 }

--- a/frontend/src/core/websocket/__tests__/createWsUrl.test.ts
+++ b/frontend/src/core/websocket/__tests__/createWsUrl.test.ts
@@ -15,7 +15,7 @@ describe("createWsUrl", () => {
     const sessionId = "1234";
     const result = createWsUrl(sessionId);
     const url = new URL(result, document.baseURI);
-    expect(url.toString()).toBe("https://marimo.app/ws?session_id=1234");
+    expect(url.toString()).toBe("wss://marimo.app/ws?session_id=1234");
     expect(url.searchParams.get(KnownQueryParams.sessionId)).toBe(sessionId);
   });
 
@@ -29,7 +29,7 @@ describe("createWsUrl", () => {
     const sessionId = "1234";
     const result = createWsUrl(sessionId);
     const url = new URL(result, document.baseURI);
-    expect(url.toString()).toBe("http://marimo.app/ws?session_id=1234");
+    expect(url.toString()).toBe("ws://marimo.app/ws?session_id=1234");
     expect(url.searchParams.get(KnownQueryParams.sessionId)).toBe(sessionId);
   });
 
@@ -43,7 +43,7 @@ describe("createWsUrl", () => {
     const sessionId = "1234";
     const result = createWsUrl(sessionId);
     const url = new URL(result, document.baseURI);
-    expect(url.toString()).toBe("http://marimo.app/nested/ws?session_id=1234");
+    expect(url.toString()).toBe("ws://marimo.app/nested/ws?session_id=1234");
     expect(url.searchParams.get(KnownQueryParams.sessionId)).toBe(sessionId);
   });
 
@@ -62,7 +62,7 @@ describe("createWsUrl", () => {
     const result = createWsUrl(sessionId);
     const url = new URL(result, document.baseURI);
     expect(url.toString()).toBe(
-      "http://marimo.app/nested/ws?foo=bar&session_id=1234",
+      "ws://marimo.app/nested/ws?foo=bar&session_id=1234",
     );
     expect(url.searchParams.get(KnownQueryParams.sessionId)).toBe(sessionId);
   });

--- a/frontend/src/core/websocket/createWsUrl.ts
+++ b/frontend/src/core/websocket/createWsUrl.ts
@@ -13,8 +13,9 @@ export function resolveToWsUrl(relativeUrl: string): string {
   if (relativeUrl.startsWith("ws:") || relativeUrl.startsWith("wss:")) {
     return relativeUrl;
   }
-  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-  const host = window.location.host;
-  const pathname = new URL(document.baseURI).pathname;
-  return `${protocol}//${host}/${Strings.withoutTrailingSlash(pathname)}/${relativeUrl}`;
+  const baseUri = new URL(document.baseURI);
+  const protocol = baseUri.protocol === "https:" ? "wss:" : "ws:";
+  const host = baseUri.host;
+  const pathname = baseUri.pathname;
+  return `${protocol}//${host}${Strings.withoutTrailingSlash(pathname)}/${Strings.withoutLeadingSlash(relativeUrl)}`;
 }

--- a/frontend/src/core/websocket/createWsUrl.ts
+++ b/frontend/src/core/websocket/createWsUrl.ts
@@ -1,9 +1,20 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { Strings } from "@/utils/strings";
 import { KnownQueryParams } from "../constants";
 
 export function createWsUrl(sessionId: string): string {
   const searchParams = new URLSearchParams(window.location.search);
   searchParams.set(KnownQueryParams.sessionId, sessionId);
 
-  return `ws?${searchParams.toString()}`;
+  return resolveToWsUrl(`ws?${searchParams.toString()}`);
+}
+
+export function resolveToWsUrl(relativeUrl: string): string {
+  if (relativeUrl.startsWith("ws:") || relativeUrl.startsWith("wss:")) {
+    return relativeUrl;
+  }
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const host = window.location.host;
+  const pathname = new URL(document.baseURI).pathname;
+  return `${protocol}//${host}/${Strings.withoutTrailingSlash(pathname)}/${relativeUrl}`;
 }

--- a/frontend/src/utils/strings.ts
+++ b/frontend/src/utils/strings.ts
@@ -40,4 +40,7 @@ export const Strings = {
   withoutTrailingSlash(url: string): string {
     return url.endsWith("/") ? url.slice(0, -1) : url;
   },
+  withoutLeadingSlash(url: string): string {
+    return url.startsWith("/") ? url.slice(1) : url;
+  },
 };


### PR DESCRIPTION
Some older browsers don't support relative websocket urls so we need to resolve them ourselves

Fixes #3167 