### PR TITLE
fix: nested ModuleNotFound

### DIFF
--- a/examples/third_party/anywidget/reactive_quak.py
+++ b/examples/third_party/anywidget/reactive_quak.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "altair",
-#     "polars",
+#     "altair==5.5.0",
+#     "polars==1.17.1",
 #     "marimo",
-#     "quak",
+#     "quak==0.2.1",
 #     "pandas",
 # ]
 # ///

--- a/frontend/src/components/editor/package-alert.tsx
+++ b/frontend/src/components/editor/package-alert.tsx
@@ -116,6 +116,7 @@ export const PackageAlert: React.FC = () => {
                 <>
                   <InstallPackagesButton
                     manager={userConfig.package_management.manager}
+                    packages={packageAlert.packages}
                     versions={desiredPackageVersions}
                     clearPackageAlert={() => clearPackageAlert(packageAlert.id)}
                   />
@@ -270,10 +271,12 @@ const ProgressIcon = ({
 
 const InstallPackagesButton = ({
   manager,
+  packages,
   versions,
   clearPackageAlert,
 }: {
   manager: PackageManagerName;
+  packages: string[];
   versions: Record<string, string>;
   clearPackageAlert: () => void;
 }) => {
@@ -284,11 +287,19 @@ const InstallPackagesButton = ({
       size="sm"
       onClick={async () => {
         clearPackageAlert();
-        await sendInstallMissingPackages({ manager, versions }).catch(
-          (error) => {
-            Logger.error(error);
-          },
-        );
+
+        // Empty version implies latest
+        const completePackages = { ...versions };
+        for (const pkg of packages) {
+          completePackages[pkg] = completePackages[pkg] ?? "";
+        }
+
+        await sendInstallMissingPackages({
+          manager,
+          versions: completePackages,
+        }).catch((error) => {
+          Logger.error(error);
+        });
       }}
     >
       <DownloadCloudIcon className="w-4 h-4 mr-2" />

--- a/marimo/_runtime/packages/module_registry.py
+++ b/marimo/_runtime/packages/module_registry.py
@@ -30,7 +30,7 @@ class ModuleRegistry:
     ) -> None:
         self.graph = graph
         # modules that do not have corresponding packages on package index
-        self.excluded_modules = (
+        self.excluded_modules: set[str] = (
             excluded_modules if excluded_modules is not None else set()
         )
 


### PR DESCRIPTION
Fixes #3164

`polars` and `pandas` have a lot of optional deps that throw `ModuleNotFound` errors (e.g. with `pyarrow`). Our auto-installation does not work with nested `ModuleNotFound` this fixes it, however it is not reactive (but you can easily run the offending cells).

```python
import marimo as mo
import polars as pl
df = pl.read_parquet(
      "https://github.com/uwdata/mosaic/raw/main/data/athletes.parquet"
  ).to_pandas()
```