### PR TITLE
fix: gracefully close dead sessions in edit mode

### DIFF
--- a/marimo/_ast/names.py
+++ b/marimo/_ast/names.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 DEFAULT_CELL_NAME = "_"
 
 

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -97,7 +97,7 @@ class QueueManager:
         # requests.
         self.set_ui_element_queue: QueueType[
             requests.SetUIElementValueRequest
-        ] = context.Queue() if context is not None else queue.Queue()
+        ] = (context.Queue() if context is not None else queue.Queue())
 
         # Code completion requests are sent through a separate queue
         self.completion_queue: QueueType[requests.CodeCompletionRequest] = (
@@ -488,12 +488,22 @@ class Session:
     def _start_heartbeat(self) -> None:
         def _check_alive() -> None:
             if not self.kernel_manager.is_alive():
-                LOGGER.debug("Closing session because kernel died")
+                LOGGER.debug(
+                    "Closing session %s because kernel died",
+                    self.initialization_id,
+                )
                 self.close()
                 print_()
-                print_tabbed(red("The Python kernel died unexpectedly."))
+                print_tabbed(
+                    red(
+                        "A Python kernel for file "
+                        f"{self.app_file_manager.filename} died unexpectedly."
+                    )
+                )
                 print_()
-                sys.exit()
+                print("calling close")
+                self.close()
+                #sys.exit()
 
         # Start a heartbeat task, which checks if the kernel is alive
         # every second

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -803,7 +803,8 @@ class SessionManager:
                 return maybe_session
             return None
 
-        # Cleanup sessions with dead kernels
+        # Cleanup sessions with dead kernels; materializing as a list because
+        # close_sessions mutates self.sessions
         for session_id, session in list(self.sessions.items()):
             task = session.kernel_manager.kernel_task
             if task is not None and not task.is_alive():

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -496,14 +496,12 @@ class Session:
                 print_()
                 print_tabbed(
                     red(
-                        "A Python kernel for file "
+                        "The Python kernel for file "
                         f"{self.app_file_manager.filename} died unexpectedly."
                     )
                 )
                 print_()
-                print("calling close")
                 self.close()
-                #sys.exit()
 
         # Start a heartbeat task, which checks if the kernel is alive
         # every second
@@ -609,6 +607,9 @@ class Session:
 
         This will close the session consumer, kernel, and all kiosk consumers.
         """
+        if self._closed:
+            return
+
         self._closed = True
         # Close the room
         self.room.close()
@@ -801,6 +802,12 @@ class SessionManager:
                 )
                 return maybe_session
             return None
+
+        # Cleanup sessions with dead kernels
+        for session_id, session in list(self.sessions.items()):
+            task = session.kernel_manager.kernel_task
+            if task is not None and not task.is_alive():
+                self.close_session(session_id)
 
         # Should only return an orphaned session
         sessions_with_the_same_file: dict[SessionId, Session] = {

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -97,7 +97,7 @@ class QueueManager:
         # requests.
         self.set_ui_element_queue: QueueType[
             requests.SetUIElementValueRequest
-        ] = (context.Queue() if context is not None else queue.Queue())
+        ] = context.Queue() if context is not None else queue.Queue()
 
         # Code completion requests are sent through a separate queue
         self.completion_queue: QueueType[requests.CodeCompletionRequest] = (

--- a/marimo/_smoke_tests/issues/3187_kernel_dies.py
+++ b/marimo/_smoke_tests/issues/3187_kernel_dies.py
@@ -1,0 +1,32 @@
+import marimo
+
+__generated_with = "0.10.4"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import sys
+    return (sys,)
+
+
+@app.cell
+def _(sys):
+    sys.exit()
+    return
+
+
+@app.cell
+def _():
+    import os
+    return (os,)
+
+
+@app.cell
+def _(os):
+    os._exit(1)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_server/test_session_manager.py
+++ b/tests/_server/test_session_manager.py
@@ -8,7 +8,12 @@ from marimo._config.manager import get_default_config_manager
 from marimo._server.file_manager import AppFileManager
 from marimo._server.file_router import AppFileRouter
 from marimo._server.model import ConnectionState, SessionConsumer, SessionMode
-from marimo._server.sessions import LspServer, Session, SessionManager
+from marimo._server.sessions import (
+    KernelManager,
+    LspServer,
+    Session,
+    SessionManager,
+)
 
 
 @pytest.fixture
@@ -22,6 +27,8 @@ def mock_session_consumer():
 def mock_session():
     session = Mock(spec=Session)
     session.connection_state.return_value = ConnectionState.OPEN
+    session.kernel_manager = Mock(spec=KernelManager)
+    session.kernel_manager.kernel_task = None
     return session
 
 
@@ -81,7 +88,8 @@ async def test_create_session_absolute_url(
 
 
 def test_maybe_resume_session_for_new_file(
-    session_manager: SessionManager, mock_session: Session
+    session_manager: SessionManager,
+    mock_session: Session,
 ) -> None:
     session_id = "test_session_id"
     mock_session.connection_state.return_value = ConnectionState.ORPHANED


### PR DESCRIPTION
Fixes #3187.

Previously we brought down the whole edit server if an edit-mode kernel died unexpectedly. This used to make sense when marimo was 1 server, 1 notebook, but it no longer makes sense today, as it causes the user to lose all their work in other notebooks opened by the server too.

Instead, this change makes it so that the session is closed (and removed from the manager), but the server is still kept alive.