### PR TITLE
fix: apply format_mapping to None values in table formatting

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/format.py
+++ b/marimo/_plugins/ui/_impl/tables/format.py
@@ -14,16 +14,21 @@ def format_value(
     # Return None if the format mapping is None
     if format_mapping is None:
         return value
-    # Return None if the value is None
-    if value is None:
-        return None
-    # Apply formatting logic based on column and value
+
     if col in format_mapping:
         formatter = format_mapping[col]
-        if isinstance(formatter, str):
-            return formatter.format(value)
-        if callable(formatter):
-            return formatter(value)
+        try:
+            if isinstance(formatter, str):
+                return formatter.format(value)
+            if callable(formatter):
+                return formatter(value)
+        except Exception as e:
+            import logging
+
+            logging.warning(
+                f"Error formatting for value {value} in column {col}: {str(e)}"
+            )
+            return value
     return value
 
 

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -629,7 +629,7 @@ class TestPandasTableManager(unittest.TestCase):
                     [4, 5, 6],
                     [7, 8, 9],
                 ],  # No formatting applied
-                "G": [None, "text", "3.14"],
+                "G": ["None", "text", "3.14"],
             }
         )
         assert_frame_equal(formatted_data, expected_data)
@@ -753,8 +753,34 @@ class TestPandasTableManager(unittest.TestCase):
                     [4, 5, 6],
                     [7, 8, 9],
                 ],  # No formatting applied
-                "G": [None, "text", "3.14"],
+                "G": ["None", "text", "3.14"],
                 "H": [2.23606797749979, 5.0, 7.810249675906654],
+            }
+        )
+        assert_frame_equal(formatted_data, expected_data)
+
+    def test_apply_formatting_with_none_values(self) -> None:
+        data = pd.DataFrame(
+            {
+                "A": [1, None, 3],
+                "B": [None, "text", None],
+                "C": [1.0, 2.0, None],
+            }
+        )
+        manager = self.factory.create()(data)
+
+        format_mapping: FormatMapping = {
+            "A": lambda x: "N/A" if pd.isna(x) else x * 2,
+            "B": lambda x: "Missing" if pd.isna(x) else x.upper(),
+            "C": lambda x: "---" if pd.isna(x) else f"{x:.2f}",
+        }
+
+        formatted_data = manager.apply_formatting(format_mapping).data
+        expected_data = pd.DataFrame(
+            {
+                "A": [2, "N/A", 6],
+                "B": ["Missing", "TEXT", "Missing"],
+                "C": ["1.00", "2.00", "---"],
             }
         )
         assert_frame_equal(formatted_data, expected_data)

--- a/tests/_plugins/ui/_impl/tables/test_polars_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_polars_table.py
@@ -676,6 +676,50 @@ class TestPolarsTableManagerFactory(unittest.TestCase):
         )
         assert_frame_equal(formatted_data, expected_data)
 
+    def test_apply_formatting_with_none_values(self) -> None:
+        import polars as pl
+
+        # Create test data with None values in different types of columns
+        data = pl.DataFrame(
+            {
+                "strings": ["a", None, "c"],
+                "integers": [1, None, 3],
+                "floats": [1.5, None, 3.5],
+                "booleans": [True, None, False],
+                "dates": [
+                    datetime.date(2021, 1, 1),
+                    None,
+                    datetime.date(2021, 1, 3),
+                ],
+                "lists": [[1, 2], None, [5, 6]],
+            },
+        )
+        manager = self.factory.create()(data)
+
+        format_mapping: FormatMapping = {
+            "strings": lambda x: "MISSING" if x is None else x.upper(),
+            "integers": lambda x: -100 if x is None else x * 2,
+            "floats": lambda x: "---" if x is None else f"{x:.1f}",
+            "booleans": lambda x: "MISSING" if x is None else str(x).upper(),
+            "dates": lambda x: "No Date"
+            if x is None
+            else x.strftime("%Y-%m-%d"),
+            "lists": lambda x: "Empty" if x is None else f"List({len(x)})",
+        }
+
+        formatted_data = manager.apply_formatting(format_mapping).data
+        expected_data = pl.DataFrame(
+            {
+                "strings": ["A", "MISSING", "C"],
+                "integers": [2, -100, 6],
+                "floats": ["1.5", "---", "3.5"],
+                "booleans": ["TRUE", "MISSING", "FALSE"],
+                "dates": ["2021-01-01", "No Date", "2021-01-03"],
+                "lists": ["List(2)", "Empty", "List(2)"],
+            }
+        )
+        assert_frame_equal(formatted_data, expected_data)
+
     def test_empty_dataframe(self) -> None:
         import polars as pl
 

--- a/tests/_plugins/ui/_impl/tables/test_table_utils.py
+++ b/tests/_plugins/ui/_impl/tables/test_table_utils.py
@@ -36,6 +36,10 @@ def test_format_value():
     format_mapping = {"col1": lambda x: f"{x:.2f} units"}
     assert format_value("col1", 123.456, format_mapping) == "123.46 units"
 
+    # Test with None formatter
+    format_mapping = {"col1": lambda x: "None value" if x is None else x}
+    assert format_value("col1", None, format_mapping) == "None value"
+
 
 def test_format_row():
     # Test with string formatter
@@ -77,6 +81,15 @@ def test_format_row():
     expected = {"col1": None, "col2": "78.9"}
     assert format_row(row, format_mapping) == expected
 
+    # Test with None formatter
+    format_mapping = {
+        "col1": lambda x: "None value" if x is None else x,
+        "col2": lambda x: "N/A" if x is None else x,
+    }
+    row = {"col1": None, "col2": None}
+    expected = {"col1": "None value", "col2": "N/A"}
+    assert format_row(row, format_mapping) == expected
+
 
 def test_format_column():
     # Test with string formatter
@@ -113,4 +126,10 @@ def test_format_column():
     format_mapping = {"col1": "{:.2f}"}
     values = []
     expected = []
+    assert format_column("col1", values, format_mapping) == expected
+
+    # Test with None formatter
+    format_mapping = {"col1": lambda x: "Missing" if x is None else x}
+    values = [123.456, None, 78.9]
+    expected = [123.456, "Missing", 78.9]
     assert format_column("col1", values, format_mapping) == expected


### PR DESCRIPTION
fix: apply format_mapping to None values in table formatting

Previously, format_mapping functions were not being called when the value was None,
causing inconsistent formatting behavior. This change ensures that:

1. None values are passed through to format_mapping functions rather than being
   skipped
2. Format functions can handle None values explicitly and transform them as needed

before:
<img width="755" alt="Screenshot 2024-12-18 at 13 10 56" src="https://github.com/user-attachments/assets/6582eb53-67dc-4655-b45a-4d49b2640a00" />
now:
<img width="753" alt="Screenshot 2024-12-18 at 13 10 29" src="https://github.com/user-attachments/assets/5deb4978-586e-406d-813d-d501807cf46c" />

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
