### PR TITLE
Add `zenodo` badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <a href="https://pypi.org/project/marimo/"><img src="https://img.shields.io/pypi/v/marimo?color=%2334D058&label=pypi" /></a>
 <a href="https://anaconda.org/conda-forge/marimo"><img src="https://img.shields.io/conda/vn/conda-forge/marimo.svg"/></a>
 <a href="https://marimo.io/discord?ref=readme"><img src="https://shields.io/discord/1059888774789730424" alt="discord" /></a>
-<a href="https://doi.org/10.5281/zenodo.14058595"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14058595.svg" alt="DOI"/></a>
+<a href="https://doi.org/10.5281/zenodo.12735329"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14511438.svg" alt="DOI"/></a>
 <img alt="Pepy Total Downloads" src="https://img.shields.io/pepy/dt/marimo?label=pypi%20%7C%20downloads"/>
 <img alt="Conda Downloads" src="https://img.shields.io/conda/d/conda-forge/marimo" />
 <a href="https://github.com/marimo-team/marimo/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/marimo" /></a>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 <a href="https://pypi.org/project/marimo/"><img src="https://img.shields.io/pypi/v/marimo?color=%2334D058&label=pypi" /></a>
 <a href="https://anaconda.org/conda-forge/marimo"><img src="https://img.shields.io/conda/vn/conda-forge/marimo.svg"/></a>
 <a href="https://marimo.io/discord?ref=readme"><img src="https://shields.io/discord/1059888774789730424" alt="discord" /></a>
+<a href="https://doi.org/10.5281/zenodo.14058595"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14058595.svg" alt="DOI"/></a>
 <img alt="Pepy Total Downloads" src="https://img.shields.io/pepy/dt/marimo?label=pypi%20%7C%20downloads"/>
 <img alt="Conda Downloads" src="https://img.shields.io/conda/d/conda-forge/marimo" />
 <a href="https://github.com/marimo-team/marimo/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/marimo" /></a>

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -20,7 +20,7 @@
 <a href="https://pypi.org/project/marimo/"><img src="https://img.shields.io/pypi/v/marimo?color=%2334D058&label=pypi" /></a>
 <a href="https://anaconda.org/conda-forge/marimo"><img src="https://img.shields.io/conda/vn/conda-forge/marimo.svg"/></a>
 <a href="https://marimo.io/discord?ref=readme"><img src="https://shields.io/discord/1059888774789730424" alt="discord" /></a>
-<a href="https://doi.org/10.5281/zenodo.14058595"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14058595.svg" alt="DOI"/></a>
+<a href="https://doi.org/10.5281/zenodo.12735329"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14511438.svg" alt="DOI"/></a>
 <img alt="Pepy Total Downloads" src="https://img.shields.io/pepy/dt/marimo?label=pypi%20%7C%20downloads"/>
 <img alt="Conda Downloads" src="https://img.shields.io/conda/d/conda-forge/marimo" />
 <a href="https://github.com/marimo-team/marimo/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/marimo" /></a>

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -18,8 +18,11 @@
 
 <p align="center">
 <a href="https://pypi.org/project/marimo/"><img src="https://img.shields.io/pypi/v/marimo?color=%2334D058&label=pypi" /></a>
-<a href="https://doi.org/10.5281/zenodo.14058595"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14058595.svg" alt="DOI"/></a>
 <a href="https://anaconda.org/conda-forge/marimo"><img src="https://img.shields.io/conda/vn/conda-forge/marimo.svg"/></a>
+<a href="https://marimo.io/discord?ref=readme"><img src="https://shields.io/discord/1059888774789730424" alt="discord" /></a>
+<a href="https://doi.org/10.5281/zenodo.14058595"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14058595.svg" alt="DOI"/></a>
+<img alt="Pepy Total Downloads" src="https://img.shields.io/pepy/dt/marimo?label=pypi%20%7C%20downloads"/>
+<img alt="Conda Downloads" src="https://img.shields.io/conda/d/conda-forge/marimo" />
 <a href="https://github.com/marimo-team/marimo/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/marimo" /></a>
 </p>
 

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -18,6 +18,7 @@
 
 <p align="center">
 <a href="https://pypi.org/project/marimo/"><img src="https://img.shields.io/pypi/v/marimo?color=%2334D058&label=pypi" /></a>
+<a href="https://doi.org/10.5281/zenodo.14058595"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.14058595.svg" alt="DOI"/></a>
 <a href="https://anaconda.org/conda-forge/marimo"><img src="https://img.shields.io/conda/vn/conda-forge/marimo.svg"/></a>
 <a href="https://github.com/marimo-team/marimo/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/marimo" /></a>
 </p>


### PR DESCRIPTION
## 📝 Summary

Add relevant Zenodo badge pointing to appropriate releases (latest) as and when it gets pulled/updated on their site. Felt it would be nice to have a zenodo badge if that makes sense.

## 🔍 Description of Changes

Updated both:
- Root (English) README with zenodo badge.
- Chinese README with more/matching badges as primary file (conda, discord, PyPi).

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
