### PR TITLE
fix: formatting for proxied url

### DIFF
--- a/marimo/_server/print.py
+++ b/marimo/_server/print.py
@@ -77,8 +77,13 @@ def _colorized_url(url_string: str) -> str:
     else:
         query = ""
 
+    url_string = f"{url.scheme}://{url.hostname}"
+    # raw https and http urls do not have a port to parse
+    if url.port:
+        url_string += f":{url.port}"
+
     return bold(
-        f"{url.scheme}://{url.hostname}:{url.port}{url.path}{query}",
+        f"{url_string}{url.path}{query}",
     )
 
 


### PR DESCRIPTION
nit: just a little thing that was bothering me

Changes
```
 ➜  URL: https://example.tld:None?access_token=token
```

to 

```
 ➜  URL: https://example.tld?access_token=token
```