### PR TITLE
Nitpick: prefer --directory flag over cdUpdate commands.py

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -412,7 +412,7 @@ def html_wasm(
 
     echo(
         "To run the exported notebook, use:\n"
-        f"  cd {output} && python -m http.server\n"
+        f"  python -m http.server --directory {output}\n"
         "Then open the URL that is printed to your terminal."
     )
 


### PR DESCRIPTION
## 📝 Summary

Right now when you export to html-wasm this line is shown: 

```
To run the exported notebook, use:
  cd docs/index.html && python -m http.server
```

It works, but the `cd` is a side effect. Might be nice to be able to do without it? 

## 🔍 Description of Changes

You can use a `--directory` flag for `python -m http.server` instead. Might be preferable? 

## 📜 Reviewers


@akshayka OR @mscolnick
