### PR TITLE
docs: add CLI to the docs, reformat CLI so renders propperly

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,12 @@
+<style>
+  td code {
+    white-space: nowrap;
+  }
+</style>
+
+::: mkdocs-click
+    :module: marimo._cli.cli
+    :command: main
+    :prog_name: marimo
+    :depth: 0
+    :style: table

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - navigation
+---
+
 # FAQ
 
 - [Choosing marimo](#choosing-marimo)

--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -9,47 +9,7 @@ grid editor; you can also choose to include code in the app view.
 
 ## CLI
 
-```
-Usage: marimo run [OPTIONS] NAME [ARGS]...
-
-  Run a notebook as an app in read-only mode.
-
-  If NAME is a url, the notebook will be downloaded to a temporary file.
-
-  Example:
-
-      * marimo run notebook.py
-
-Options:
-  -p, --port INTEGER             Port to attach to.
-  --host TEXT                    Host to attach to.  [default: 127.0.0.1]
-  --proxy TEXT                   Address of reverse proxy.
-  --headless                     Don't launch a browser.
-  --token / --no-token           Use a token for authentication. This enables
-                                 session-based authentication. A random token
-                                 will be generated if --token-password is not
-                                 set.
-
-                                 If --no-token is set, session-based
-                                 authentication will not be used.  [default:
-                                 no-token]
-  --token-password TEXT          Use a specific token for authentication. This
-                                 enables session-based authentication. A
-                                 random token will be generated if not set.
-  --include-code                 Include notebook code in the app.
-  --watch                        Watch the file for changes and reload the
-                                 app. If watchdog is installed, it will be
-                                 used to watch the file. Otherwise, file
-                                 watcher will poll the file every 1s.
-  --base-url TEXT                Base URL for the server. Should start with a
-                                 /.
-  --allow-origins TEXT           Allowed origins for CORS. Can be repeated.
-  --redirect-console-to-browser  Redirect console logs to the browser console.
-  --sandbox                      Run the command in an isolated virtual
-                                 environment using 'uv run --isolated'.
-                                 Requires `uv`.
-  --help                         Show this message and exit.
-```
+View the CLI [documentation here](../api/cli.md#marimo-run).
 
 ## Layout
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -57,7 +57,7 @@ click.exceptions.UsageError.show = helpful_usage_error  # type: ignore
 
 def _key_value_bullets(items: list[tuple[str, str]]) -> str:
     max_length = max(len(item[0]) for item in items)
-    lines = []
+    lines: list[str] = []
 
     def _sep(desc: str) -> str:
         return ":" if desc else ""
@@ -93,13 +93,16 @@ main_help_msg = "\n".join(
         "Welcome to marimo!",
         "\b",
         "Getting started:",
+        "",
         _key_value_bullets(
             [
                 ("marimo tutorial intro", ""),
             ]
         ),
         "\b",
+        "",
         "Example usage:",
+        "",
         _key_value_bullets(
             [
                 (
@@ -123,19 +126,23 @@ main_help_msg = "\n".join(
     ]
 )
 
-token_message = """
-    Use a token for authentication.
-    This enables session-based authentication.
-    A random token will be generated if --token-password is not set.
+token_message = (
+    "Use a token for authentication. "
+    "This enables session-based authentication. "
+    "A random token will be generated if --token-password is not set. "
+    "If --no-token is set, session-based authentication will not be used. "
+)
 
-    If --no-token is set, session-based authentication will not be used.
-    """
+token_password_message = (
+    "Use a specific token for authentication. "
+    "This enables session-based authentication. "
+    "A random token will be generated if not set. "
+)
 
-token_password_message = """
-    Use a specific token for authentication.
-    This enables session-based authentication.
-    A random token will be generated if not set.
-    """
+sandbox_message = (
+    "Run the command in an isolated virtual environment using "
+    "`uv run --isolated`. Requires `uv`."
+)
 
 
 @click.group(help=main_help_msg)
@@ -190,6 +197,7 @@ edit_help_msg = "\n".join(
     [
         "\b",
         "Create or edit notebooks.",
+        "",
         _key_value_bullets(
             [
                 (
@@ -275,10 +283,7 @@ edit_help_msg = "\n".join(
     default=False,
     show_default=True,
     type=bool,
-    help="""
-    Run the command in an isolated virtual environment using
-    'uv run --isolated'. Requires 'uv'.
-    """,
+    help=sandbox_message,
 )
 @click.option("--profile-dir", default=None, type=str, hidden=True)
 @click.argument("name", required=False)
@@ -431,10 +436,7 @@ def edit(
     default=False,
     show_default=True,
     type=bool,
-    help="""
-    Run the command in an isolated virtual environment using
-    'uv run --isolated'. Requires `uv`.
-    """,
+    help=sandbox_message,
 )
 def new(
     port: Optional[int],
@@ -477,8 +479,7 @@ If NAME is a url, the notebook will be downloaded to a temporary file.
 
 Example:
 
-  \b
-  * marimo run notebook.py
+    marimo run notebook.py
 """
 )
 @click.option(
@@ -538,11 +539,11 @@ Example:
     default=False,
     show_default=True,
     type=bool,
-    help="""
-    Watch the file for changes and reload the app.
-    If watchdog is installed, it will be used to watch the file.
-    Otherwise, file watcher will poll the file every 1s.
-    """,
+    help=(
+        "Watch the file for changes and reload the app. "
+        "If watchdog is installed, it will be used to watch the file. "
+        "Otherwise, file watcher will poll the file every 1s."
+    ),
 )
 @click.option(
     "--base-url",
@@ -572,10 +573,7 @@ Example:
     default=False,
     show_default=True,
     type=bool,
-    help="""
-    Run the command in an isolated virtual environment using
-    'uv run --isolated'. Requires `uv`.
-    """,
+    help=sandbox_message,
 )
 @click.argument("name", required=True)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
@@ -752,12 +750,7 @@ def tutorial(
 
 @main.command()
 def env() -> None:
-    """Print out environment information for debugging purposes.
-
-    Example usage:
-
-        marimo env
-    """
+    """Print out environment information for debugging purposes."""
     click.echo(json.dumps(get_system_info(), indent=2))
 
 

--- a/marimo/_cli/config/commands.py
+++ b/marimo/_cli/config/commands.py
@@ -19,7 +19,7 @@ def config() -> None:
     pass
 
 
-@click.command(help="""Show the marimo config""")
+@click.command(help="""Show the marimo config.""")
 def show() -> None:
     """
     Print out marimo config information.
@@ -51,7 +51,7 @@ def show() -> None:
     echo(highlight_toml_headers(tomlkit.dumps(user_config)))
 
 
-@click.command(help="""Describe the marimo config""")
+@click.command(help="""Describe the marimo config.""")
 def describe() -> None:
     """Print documentation for all config options."""
     import inspect

--- a/marimo/_cli/convert/commands.py
+++ b/marimo/_cli/convert/commands.py
@@ -18,10 +18,10 @@ from marimo._utils.paths import maybe_make_dirs
     "--output",
     type=str,
     default=None,
-    help="""
-    Output file to save the converted notebook to.
-    If not provided, the converted notebook will be printed to stdout.
-    """,
+    help=(
+        "Output file to save the converted notebook to. "
+        "If not provided, the converted notebook will be printed to stdout."
+    ),
 )
 def convert(
     filename: str,
@@ -41,7 +41,7 @@ def convert(
         marimo convert your_nb.md -o your_nb.py
 
     Jupyter notebook conversion will strip out all outputs. Markdown cell
-    conversion with occur on the presence of `\`\`\`{python}` code blocks.
+    conversion with occur on the presence of `{python}` code fences.
     After conversion, you can open the notebook in the editor:
 
         marimo edit your_nb.py

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -29,6 +29,12 @@ from marimo._utils.paths import maybe_make_dirs
 if TYPE_CHECKING:
     from pathlib import Path
 
+_watch_message = (
+    "Watch notebook for changes and regenerate the output on modification. "
+    "If watchdog is installed, it will be used to watch the file. "
+    "Otherwise, file watcher will poll the file every 1s."
+)
+
 
 @click.group(help="""Export a notebook to various formats.""")
 def export() -> None:
@@ -96,13 +102,11 @@ def watch_and_export(
 
 Example:
 
-  \b
-  * marimo export html notebook.py -o notebook.html
+    marimo export html notebook.py -o notebook.html
 
 Optionally pass CLI args to the notebook:
 
-  \b
-  * marimo export html notebook.py -o notebook.html -- -arg1 foo -arg2 bar
+    marimo export html notebook.py -o notebook.html -- -arg1 foo -arg2 bar
 """
 )
 @click.option(
@@ -117,21 +121,17 @@ Optionally pass CLI args to the notebook:
     default=False,
     show_default=True,
     type=bool,
-    help="""
-    Watch notebook for changes and regenerate HTML on modification.
-    If watchdog is installed, it will be used to watch the file.
-    Otherwise, file watcher will poll the file every 1s.
-    """,
+    help=_watch_message,
 )
 @click.option(
     "-o",
     "--output",
     type=str,
     default=None,
-    help="""
-    Output file to save the HTML to.
-    If not provided, the HTML will be printed to stdout.
-    """,
+    help=(
+        "Output file to save the HTML to. "
+        "If not provided, the HTML will be printed to stdout."
+    ),
 )
 @click.argument("name", required=True, callback=validators.is_file_path)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
@@ -166,13 +166,11 @@ Export a marimo notebook as a flat script, in topological order.
 
 Example:
 
-    \b
-    * marimo export script notebook.py -o notebook.script.py
+    marimo export script notebook.py -o notebook.script.py
 
 Watch for changes and regenerate the script on modification:
 
-    \b
-    * marimo export script notebook.py -o notebook.script.py --watch
+    marimo export script notebook.py -o notebook.script.py --watch
 """
 )
 @click.option(
@@ -180,21 +178,17 @@ Watch for changes and regenerate the script on modification:
     default=False,
     show_default=True,
     type=bool,
-    help="""
-    Watch notebook for changes and regenerate the script on modification.
-    If watchdog is installed, it will be used to watch the file.
-    Otherwise, file watcher will poll the file every 1s.
-    """,
+    help=_watch_message,
 )
 @click.option(
     "-o",
     "--output",
     type=str,
     default=None,
-    help="""
-    Output file to save the script to.
-    If not provided, the script will be printed to stdout.
-    """,
+    help=(
+        "Output file to save the script to. "
+        "If not provided, the script will be printed to stdout."
+    ),
 )
 @click.argument("name", required=True, callback=validators.is_file_path)
 def script(
@@ -218,13 +212,11 @@ Export a marimo notebook as a code fenced Markdown file.
 
 Example:
 
-    \b
-    * marimo export md notebook.py -o notebook.md
+    marimo export md notebook.py -o notebook.md
 
 Watch for changes and regenerate the script on modification:
 
-    \b
-    * marimo export md notebook.py -o notebook.md --watch
+    marimo export md notebook.py -o notebook.md --watch
 """
 )
 @click.option(
@@ -232,21 +224,17 @@ Watch for changes and regenerate the script on modification:
     default=False,
     show_default=True,
     type=bool,
-    help="""
-    Watch notebook for changes and regenerate the script on modification.
-    If watchdog is installed, it will be used to watch the file.
-    Otherwise, file watcher will poll the file every 1s.
-    """,
+    help=_watch_message,
 )
 @click.option(
     "-o",
     "--output",
     type=str,
     default=None,
-    help="""
-    Output file to save the script to.
-    If not provided, markdown will be printed to stdout.
-    """,
+    help=(
+        "Output file to save the markdown to. "
+        "If not provided, markdown will be printed to stdout."
+    ),
 )
 @click.argument("name", required=True, callback=validators.is_file_path)
 def md(
@@ -270,13 +258,11 @@ Export a marimo notebook as a Jupyter notebook in topological order.
 
 Example:
 
-    \b
-    * marimo export ipynb notebook.py -o notebook.ipynb
+    marimo export ipynb notebook.py -o notebook.ipynb
 
 Watch for changes and regenerate the script on modification:
 
-    \b
-    * marimo export ipynb notebook.py -o notebook.ipynb --watch
+    marimo export ipynb notebook.py -o notebook.ipynb --watch
 
 Requires nbformat to be installed.
 """
@@ -293,21 +279,17 @@ Requires nbformat to be installed.
     default=False,
     show_default=True,
     type=bool,
-    help="""
-    Watch notebook for changes and regenerate the ipynb on modification.
-    If watchdog is installed, it will be used to watch the file.
-    Otherwise, file watcher will poll the file every 1s.
-    """,
+    help=_watch_message,
 )
 @click.option(
     "-o",
     "--output",
     type=str,
     default=None,
-    help="""
-    Output file to save the ipynb file to. If not provided, the ipynb contents
-    will be printed to stdout.
-    """,
+    help=(
+        "Output file to save the ipynb file to. "
+        "If not provided, the ipynb contents will be printed to stdout."
+    ),
 )
 @click.option(
     "--include-outputs/--no-include-outputs",
@@ -348,8 +330,7 @@ def ipynb(
 
 Example:
 
-  \b
-  * marimo export html-wasm notebook.py -o notebook.wasm.html
+    marimo export html-wasm notebook.py -o notebook.wasm.html
 
 The exported HTML file will run the notebook using WebAssembly, making it
 completely self-contained and executable in the browser. This lets you
@@ -369,7 +350,7 @@ and cannot be opened directly from the file system (e.g. file://).
     "--output",
     type=str,
     required=True,
-    help="""Output directory to save the HTML to.""",
+    help="Output directory to save the HTML to.",
 )
 @click.option(
     "--mode",

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -39,14 +39,17 @@ config = (
     .get("server", {})
 )
 
-router.mount(
-    "/assets",
-    app=StaticFiles(
-        directory=os.path.join(root, "assets"),
-        follow_symlink=config.get("follow_symlink", False),
-    ),
-    name="assets",
-)
+try:
+    router.mount(
+        "/assets",
+        app=StaticFiles(
+            directory=os.path.join(root, "assets"),
+            follow_symlink=config.get("follow_symlink", False),
+        ),
+        name="assets",
+    )
+except RuntimeError:
+    LOGGER.error("Static files not found, skipping mount")
 
 FILE_QUERY_PARAM_KEY = "file"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.tilde
   - blocks:MarimoBlocksExtension
+  - mkdocs-click
 nav:
   - Marimo: index.md
   - Getting Started:
@@ -187,6 +188,7 @@ nav:
       - App: api/app.md
       - Cell: api/cell.md
       - Miscellaneous: api/miscellaneous.md
+      - CLI: api/cli.md
   - Examples:
       - Notebooks: examples.md
       - Recipes: recipes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ docs = [
     "mkdocs-glightbox>=0.3.7",
     "mkdocs-macros-plugin>=1.3.0",
     "mkdocs-redirects>=1.0.0",
+    "mkdocs-click>=0.8.1",
     "mike>=2.0.0",  # for versioning
     "pillow>=10.2.0",  # for social cards
     "cairosvg>=2.7.1",  # for social cards


### PR DESCRIPTION
This adds our CLI docs to docs.marimo.io. 

I needed to reformat our CLI so that they get rendered as markdown properly 