### PR TITLE
feat(cli): add --sandbox flag to `marimo export html` command

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -328,6 +328,17 @@ Requires nbformat to be installed.
     type=bool,
     help="Run the notebook and include outputs in the exported ipynb file.",
 )
+@click.option(
+    "--sandbox",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    type=bool,
+    help=(
+        "Run the command in an isolated virtual environment using "
+        "`uv run --isolated`. Requires `uv`."
+    ),
+)
 @click.argument(
     "name",
     required=True,
@@ -339,6 +350,7 @@ def ipynb(
     watch: bool,
     sort: Literal["top-down", "topological"],
     include_outputs: bool,
+    sandbox: bool,
 ) -> None:
     """
     Export a marimo notebook as a Jupyter notebook in topological order.
@@ -346,6 +358,16 @@ def ipynb(
     DependencyManager.nbformat.require(
         why="to convert marimo notebooks to ipynb"
     )
+
+    import sys
+
+    from marimo._cli.sandbox import prompt_run_in_sandbox
+
+    if include_outputs and (sandbox or prompt_run_in_sandbox(name)):
+        from marimo._cli.sandbox import run_in_sandbox
+
+        run_in_sandbox(sys.argv[1:], name)
+        return
 
     def export_callback(file_path: MarimoPath) -> ExportResult:
         if include_outputs:

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -133,6 +133,14 @@ Optionally pass CLI args to the notebook:
         "If not provided, the HTML will be printed to stdout."
     ),
 )
+@click.option(
+    "--sandbox",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    type=bool,
+    help="Run the command in an isolated virtual environment using `uv run --isolated`. Requires `uv`.",
+)
 @click.argument("name", required=True, callback=validators.is_file_path)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def html(
@@ -140,11 +148,19 @@ def html(
     include_code: bool,
     output: str,
     watch: bool,
+    sandbox: bool,
     args: tuple[str],
 ) -> None:
-    """
-    Run a notebook and export it as an HTML file.
-    """
+    """Run a notebook and export it as an HTML file."""
+    import sys
+
+    from marimo._cli.sandbox import prompt_run_in_sandbox
+
+    if sandbox or prompt_run_in_sandbox(name):
+        from marimo._cli.sandbox import run_in_sandbox
+
+        run_in_sandbox(sys.argv[1:], name)
+        return
 
     cli_args = parse_args(args)
 

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -139,7 +139,10 @@ Optionally pass CLI args to the notebook:
     default=False,
     show_default=True,
     type=bool,
-    help="Run the command in an isolated virtual environment using `uv run --isolated`. Requires `uv`.",
+    help=(
+        "Run the command in an isolated virtual environment using "
+        "`uv run --isolated`. Requires `uv`."
+    ),
 )
 @click.argument("name", required=True, callback=validators.is_file_path)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)


### PR DESCRIPTION
# Add sandbox support to HTML exports

Fixes #3233

## 📝 Summary

Adds a `--sandbox` flag to the `marimo export html` command that allows running exports in an isolated virtual environment using `uv`. This is particularly useful when:

- Exporting notebooks with specific package dependencies
- Wanting to avoid polluting the global Python environment
- Ensuring reproducible exports by using the exact package versions specified in the notebook

## Implementation Details

- Added `--sandbox` flag to HTML export command with same behavior as existing sandbox commands

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
