### PR TITLE
tidy: Tweaks to enable pytest on marimo nbs

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import functools
 import inspect
 import random
 import string
@@ -464,6 +465,8 @@ class CellManager:
             )
             cell._cell.configure(cell_config)
             self._register_cell(cell, app=app)
+            # NB. in place metadata update.
+            functools.wraps(func)(cell)
             return cell
 
         if func is None:

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -362,6 +362,7 @@ class Cell:
         """The definitions made by this cell"""
         return self._cell.defs
 
+    @property
     def _is_coroutine(self) -> bool:
         """Whether this cell is a coroutine function.
 
@@ -379,15 +380,15 @@ class Cell:
         from marimo._output.formatting import as_html
         from marimo._output.md import md
 
-        signature_prefix = "Async " if self._is_coroutine() else ""
+        signature_prefix = "Async " if self._is_coroutine else ""
         execute_str_refs = (
             f"output, defs = await {self.name}.run(**refs)"
-            if self._is_coroutine()
+            if self._is_coroutine
             else f"output, defs = {self.name}.run(**refs)"
         )
         execute_str_no_refs = (
             f"output, defs = await {self.name}.run()"
-            if self._is_coroutine()
+            if self._is_coroutine
             else f"output, defs = {self.name}.run()"
         )
 
@@ -524,7 +525,7 @@ class Cell:
                 from the cell's defined names to their values.
         """
         assert self._app is not None
-        if self._is_coroutine():
+        if self._is_coroutine:
             return self._app.run_cell_async(cell=self, kwargs=refs)
         else:
             return self._app.run_cell_sync(cell=self, kwargs=refs)
@@ -532,7 +533,7 @@ class Cell:
     def __call__(self, *args: Any, **kwargs: Any) -> None:
         del args
         del kwargs
-        if self._is_coroutine():
+        if self._is_coroutine:
             call_str = f"`outputs, defs = await {self.name}.run()`"
         else:
             call_str = f"`outputs, defs = {self.name}.run()`"

--- a/marimo/_runtime/app/script_runner.py
+++ b/marimo/_runtime/app/script_runner.py
@@ -50,7 +50,7 @@ class AppScriptRunner:
                     "please raise an issue."
                 )
 
-            if cell._is_coroutine():
+            if cell._is_coroutine:
                 is_async = True
                 break
 

--- a/marimo/_runtime/executor.py
+++ b/marimo/_runtime/executor.py
@@ -246,9 +246,9 @@ class StrictExecutor(Executor):
                     except TypeError as e:
                         raise CloneError(
                             f"Could not clone reference `{ref}` of type "
-                            f"{getattr(glbls[ref], '__module__', '<module>')}."
-                            f"{glbls[ref].__class__.__name__}"
-                            " try wrapping the object in a `zero_copy`"
+                            f"{getattr(glbls[ref], '__module__', '<module>')}. "
+                            f"{glbls[ref].__class__.__name__} "
+                            "try wrapping the object in a `zero_copy` "
                             "call. If this is a common object type, consider "
                             "making an issue on the marimo GitHub "
                             "repository to never deepcopy."

--- a/marimo/_runtime/primitives.py
+++ b/marimo/_runtime/primitives.py
@@ -7,6 +7,7 @@ import weakref
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from marimo._ast.visitor import Name, VariableData
+from marimo._ast.cell import Cell
 
 if TYPE_CHECKING:
     from marimo._runtime.dataflow import DirectedGraph
@@ -130,6 +131,9 @@ def is_instance_by_name(obj: object, name: str) -> bool:
 
 
 def is_unclonable_type(obj: object) -> bool:
+    # Cell objects in particular are hidden by functools.wraps.
+    if isinstance(obj, Cell):
+        return True
     return any([is_instance_by_name(obj, name) for name in UNCLONABLE_TYPES])
 
 

--- a/marimo/_runtime/primitives.py
+++ b/marimo/_runtime/primitives.py
@@ -6,8 +6,8 @@ import numbers
 import weakref
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
-from marimo._ast.visitor import Name, VariableData
 from marimo._ast.cell import Cell
+from marimo._ast.visitor import Name, VariableData
 
 if TYPE_CHECKING:
     from marimo._runtime.dataflow import DirectedGraph

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -137,7 +137,7 @@ class Exporter:
         for cell in file_manager.app.cell_manager.cells():
             if not cell:
                 continue
-            if cell._is_coroutine():
+            if cell._is_coroutine:
                 from click import UsageError
 
                 raise UsageError(

--- a/tests/_ast/test_cell.py
+++ b/tests/_ast/test_cell.py
@@ -22,7 +22,7 @@ class TestCellRun:
         assert cell.name == "f"
         assert not cell.refs
         assert cell.defs == set(["x"])
-        assert not cell._is_coroutine()
+        assert not cell._is_coroutine
         assert cell.run() == ("output", {"x": 4})
 
     @staticmethod
@@ -39,7 +39,7 @@ class TestCellRun:
         assert cell.name == "f"
         assert cell.refs == {"asyncio"}
         assert cell.defs == {"x"}
-        assert cell._is_coroutine()
+        assert cell._is_coroutine
 
         import asyncio
 
@@ -118,10 +118,10 @@ class TestCellRun:
             y = x
             return (y,)
 
-        assert g._is_coroutine()
+        assert g._is_coroutine
         # h is a coroutine because it depends on the execution of an async
         # function
-        assert h._is_coroutine()
+        assert h._is_coroutine
 
     @staticmethod
     def test_async_chain() -> None:
@@ -143,9 +143,9 @@ class TestCellRun:
             z = y
             return (z,)
 
-        assert f._is_coroutine()
-        assert g._is_coroutine()
-        assert h._is_coroutine()
+        assert f._is_coroutine
+        assert g._is_coroutine
+        assert h._is_coroutine
 
     @staticmethod
     def test_empty_cell() -> None:

--- a/tests/_runtime/test_pytest.py
+++ b/tests/_runtime/test_pytest.py
@@ -10,7 +10,7 @@ app = marimo.App()
     reason=(
         "Invoking a cell is not directly supported, and as such should fail "
         "until #2293. However, the decorated function _should_ be picked up "
-        "by pytest. A hook in conftest.py should esnure this."
+        "by pytest. The hook in conftest.py ensures this."
     ),
     raises=RuntimeError,
     strict=True,

--- a/tests/_runtime/test_pytest.py
+++ b/tests/_runtime/test_pytest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+import marimo
+
+app = marimo.App()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Invoking a cell is not directly supported, and as such should fail "
+        "until #2293. However, the decorated function _should_ be picked up "
+        "by pytest. A hook in conftest.py should esnure this."
+    ),
+    raises=RuntimeError,
+    strict=True,
+)
+@app.cell
+def test_cell_is_invoked():
+    assert True

--- a/tests/_runtime/test_pytest.py
+++ b/tests/_runtime/test_pytest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 import marimo
 
 app = marimo.App()


### PR DESCRIPTION
I was really interested in having tests in notebooks (re discussion yesterday), so I played around with it a tiny bit this afternoon. As is, pytest does not work out of the box since:
 1. the wrapped functions become Cell instances
 2. coroutine detection through the `_is_coroutine` spec should be as an attribute

This change enables both of these minor adjustments. Now, pytest will pick up
marimo `test_*` functions, but they will fail since directly invoking a cell is
currently not allowed. I put in a little unit test to fight against a possible
regression until such time when a top level fn spec is enabled (see #2293).

@akshayka OR @mscolnick