### PR TITLE
fix: mo.ui.table does not render in HTML export on Windows Chrome/Edge

### DIFF
--- a/frontend/src/core/static/__tests__/files.test.ts
+++ b/frontend/src/core/static/__tests__/files.test.ts
@@ -60,6 +60,28 @@ describe("patchFetch", () => {
     );
     expect(text).toBe("Remote content");
   });
+
+  it("should handle @file/ URLs and set content type", async () => {
+    const virtualFiles = {
+      "/@file/data.csv":
+        "data:text/csv;base64,aGVsbG8sd29ybGQK" as DataURLString,
+    };
+
+    patchFetch(virtualFiles);
+
+    // Test with both formats of @file URLs
+    const responses = await Promise.all([
+      window.fetch("/@file/data.csv"),
+      window.fetch("./@file/data.csv"),
+      window.fetch("http://example.com/@file/data.csv"),
+    ]);
+
+    for (const response of responses) {
+      expect(response.headers.get("Content-Type")).toBe("text/csv");
+      const text = await response.text();
+      expect(text).toBe("hello,world\n");
+    }
+  });
 });
 
 describe("patchVegaLoader", () => {


### PR DESCRIPTION
Fixes #1884

Fixes mo.ui.table does not render in HTML export on Windows Chrome/Edge, by adding `ContentType` to the response and use `fetch` for base64 conversion