### PR TITLE
fix: skip gracefully when virtual file is not found

### DIFF
--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -73,8 +73,16 @@ class Exporter:
         for filename_and_length in request.files:
             if filename_and_length.startswith("/@file/"):
                 filename = filename_and_length[7:]
-            byte_length, basename = filename.split("-", 1)
-            buffer_contents = read_virtual_file(basename, int(byte_length))
+            try:
+                byte_length, basename = filename.split("-", 1)
+                buffer_contents = read_virtual_file(basename, int(byte_length))
+            except Exception as e:
+                LOGGER.warning(
+                    "File not found in export: %s. Error: %s",
+                    filename_and_length,
+                    e,
+                )
+                continue
             mime_type, _ = mimetypes.guess_type(basename) or (
                 "text/plain",
                 None,

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -86,6 +86,24 @@ def test_export_html_no_code(client: TestClient) -> None:
     assert CODE not in body
 
 
+@with_session(SESSION_ID)
+def test_export_html_file_not_found(client: TestClient) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.filename = "test.py"
+    response = client.post(
+        "/api/export/html",
+        headers=HEADERS,
+        json={
+            "download": False,
+            "files": ["/test-10.csv"],
+            "include_code": True,
+        },
+    )
+    assert response.status_code == 200
+    assert "<marimo-code hidden=" in response.text
+
+
 # Read session forces empty code
 @with_read_session(SESSION_ID)
 def test_export_html_no_code_in_read(client: TestClient) -> None:


### PR DESCRIPTION
It's possible the file is not longer in the virtual memory, but this is ok as the export should be valid.

Fixes #3235 