### PR TITLE
fix: arrow key navigation taking precedence in inputs

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -480,11 +480,17 @@ const CellComponent = (
   });
 
   useKeydownOnElement(editing ? cellRef : null, {
-    ArrowDown: () => {
+    ArrowDown: (evt) => {
+      if (evt && Events.fromInput(evt)) {
+        return false;
+      }
       moveToNextCell({ cellId, before: false, noCreate: true });
       return true;
     },
-    ArrowUp: () => {
+    ArrowUp: (evt) => {
+      if (evt && Events.fromInput(evt)) {
+        return false;
+      }
       moveToNextCell({ cellId, before: true, noCreate: true });
       return true;
     },


### PR DESCRIPTION
Similar to #3220 but for arrow keys. Discovered interacting with a date input.