### PR TITLE
improve: parse google-style attributes in docstrings

### DIFF
--- a/docs/api/inputs/dates.md
+++ b/docs/api/inputs/dates.md
@@ -2,6 +2,8 @@
 
 ## Single date
 
+/// marimo-embed
+
 ```python
     @app.cell
     def __():
@@ -14,6 +16,8 @@
         return
 
 ```
+
+///
 
 ::: marimo.ui.date
   :members:
@@ -37,6 +41,8 @@
 
 ## Date range
 
+/// marimo-embed
+
 ```python
     @app.cell
     def __():
@@ -48,6 +54,8 @@
         mo.hstack([date_range, mo.md(f"Has value: {date_range.value}")])
         return
 ```
+
+///
 
 ::: marimo.ui.date_range
   :members:

--- a/marimo/_plugins/__init__.py
+++ b/marimo/_plugins/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2024 Marimo. All rights reserved.

--- a/marimo/_plugins/ui/_impl/chat/__init__.py
+++ b/marimo/_plugins/ui/_impl/chat/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2024 Marimo. All rights reserved.

--- a/marimo/_plugins/ui/_impl/dataframes/__init__.py
+++ b/marimo/_plugins/ui/_impl/dataframes/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2024 Marimo. All rights reserved.

--- a/tests/_utils/snapshots/docstring_complex.txt
+++ b/tests/_utils/snapshots/docstring_complex.txt
@@ -2,20 +2,6 @@
 Stack items vertically, in a column.
 Combine with `hstack` to build a grid of items.
 
-# Arguments
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `items` | `Sequence[object]` | A list of items. |
-| `align` | `Literal["start", "end", "center", "stretch"], optional` | Align items horizontally: start, end, center, or stretch. |
-| `justify` | `Literal["start", "center", "end", "space-between", "space-around"]` | Justify items vertically: start, center, end, space-between, or space-around. Defaults to "start". |
-| `gap` | `float, optional` | Gap between items as a float in rem. 1rem is 16px by default. Defaults to 0.5. |
-| `heights` | `Union[Literal["equal"], Sequence[float]], optional` | "equal" to give items equal height; or a list of relative heights with same length as `items`, eg, [1, 2] means the second item is twice as tall as the first; or None for a sensible default. |
-
-# Returns
-| Type | Description |
-|------|-------------|
-| `Html` | An Html object. |
-
 # Examples
 Build a column of items:
 ```python
@@ -32,3 +18,18 @@ mo.vstack(
     ]
 )
 ```
+
+
+# Arguments
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `items` | `Sequence[object]` | A list of items. |
+| `align` | `Literal["start", "end", "center", "stretch"], optional` | Align items horizontally: start, end, center, or stretch. |
+| `justify` | `Literal["start", "center", "end", "space-between", "space-around"]` | Justify items vertically: start, center, end, space-between, or space-around. Defaults to "start". |
+| `gap` | `float, optional` | Gap between items as a float in rem. 1rem is 16px by default. Defaults to 0.5. |
+| `heights` | `Union[Literal["equal"], Sequence[float]], optional` | "equal" to give items equal height; or a list of relative heights with same length as `items`, eg, [1, 2] means the second item is twice as tall as the first; or None for a sensible default. |
+
+# Returns
+| Type | Description |
+|------|-------------|
+| `Html` | An Html object. |

--- a/tests/_utils/snapshots/docstring_summary.txt
+++ b/tests/_utils/snapshots/docstring_summary.txt
@@ -1,11 +1,23 @@
 # Summary
 This is the summary.
 
+# Examples
+```python
+print('Hello, world!')
+print(foo, bar)
+```
+
 # Arguments
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `foo` | `str` | Lorem ipsum |
 | `bar` | `int` | Dolor sit amet |
+
+# Attributes
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `baz` | `str` | Lorem ipsum |
+| `boo` | `int` | Dolor sit amet |
 
 # Returns
 | Type | Description |
@@ -14,9 +26,3 @@ This is the summary.
 
 # Raises
 - **ValueError**: Something about the value
-
-# Examples
-```python
-print('Hello, world!')
-print(foo, bar)
-```

--- a/tests/_utils/test_docs.py
+++ b/tests/_utils/test_docs.py
@@ -11,6 +11,10 @@ def test_google_docstring_to_markdown_summary():
         foo (str): Lorem ipsum
         bar (int): Dolor sit amet
 
+    Attributes:
+        baz (str): Lorem ipsum
+        boo (int): Dolor sit amet
+
     Returns:
         bool: Return description
 
@@ -32,6 +36,9 @@ def test_google_docstring_to_markdown_summary():
         "# Arguments",
         "`foo`",
         "`bar`",
+        "# Attributes",
+        "`baz`",
+        "`boo`",
         "# Returns",
         "`bool`",
         "# Raises",


### PR DESCRIPTION
Also, show examples right after summary, then args, attrs, ...

I noticed that some (but not all) of the attributes sections had been converted to google-style and weren't rendering properly. This change fixes that.