### PR TITLE
Add mapping for quaternion -> numpy-quaternion

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -639,6 +639,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "pyutilib": "PyUtilib",
         "pyximport": "Cython",
         "qs": "qserve",
+        "quaternion": "numpy-quaternion",
         "quickapi": "django-quickapi",
         "quickunit": "nose-quickunit",
         "radical": "radical.utils",


### PR DESCRIPTION
## 📝 Summary

This adds a mapping for the `quaternion` package, which is named `numpy-quaternion` on PyPI.

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

Just added the key:value pair to the `module_name_to_pypi_name` dict.  I'm hoping a test is not needed for such a simple change, though I have tried it locally and verified that it works by automatically installing `numpy-quaternion`.


## 📋 Checklist

- [X] I have read the [contributor guidelines]([[https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md]]).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
