### PR TITLE
fix quotes in save.py:persistent_cache docstring

### DIFF
--- a/marimo/_save/save.py
+++ b/marimo/_save/save.py
@@ -347,7 +347,7 @@ class persistent_cache(object):
     - `name`: the name of the cache, used to set saving path- to manually
       invalidate the cache, change the name.
     - `save_path`: the folder in which to save the cache, defaults to
-      "__marimo__/cache" in the directory of the notebook file
+      `__marimo__/cache` in the directory of the notebook file
     - `pin_modules`: if True, the cache will be invalidated if module versions
       differ between runs, defaults to False.
     """


### PR DESCRIPTION
Wrap default filepath in backticks to avoid double underscore rendering as bold

## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
