### PR TITLE
improve: example installation instructions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,22 +32,23 @@ use marimo's features as well as inspire you to make awesome notebooks.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook-url>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `marimo edit --sandbox <notebook-url>`.
 
 For example:
 
 ```bash
-marimo edit --sandbox https://github.com/marimo-team/marimo/blob/main/examples/ui/reactive_plots.py
+uvx marimo edit --sandbox https://github.com/marimo-team/marimo/blob/main/examples/misc/seam_carving.py
 ```
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook.py>`; however, you'll also need to
+install the requirements yourself.
 
 ## More examples 🌟
 

--- a/examples/ai/README.md
+++ b/examples/ai/README.md
@@ -16,13 +16,14 @@ These examples showcase a few simple applications of AI.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.

--- a/examples/cloud/README.md
+++ b/examples/cloud/README.md
@@ -11,13 +11,14 @@ These examples show how to use various cloud provider APIs.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.

--- a/examples/control_flow/README.md
+++ b/examples/control_flow/README.md
@@ -14,13 +14,14 @@ examples folder_.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.

--- a/examples/layouts/README.md
+++ b/examples/layouts/README.md
@@ -14,13 +14,14 @@ adding sidebars.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.

--- a/examples/markdown/README.md
+++ b/examples/markdown/README.md
@@ -11,13 +11,14 @@ These basic examples show how to use write markdown in marimo.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.

--- a/examples/misc/README.md
+++ b/examples/misc/README.md
@@ -11,9 +11,8 @@ A hodgepodge of examples!
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook.py>`.
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,

--- a/examples/sql/README.md
+++ b/examples/sql/README.md
@@ -28,14 +28,14 @@ comprehensive guide on duckdb.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook-url>`.
-
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.

--- a/examples/third_party/README.md
+++ b/examples/third_party/README.md
@@ -11,13 +11,14 @@ These examples showcase how to use various third-party packages in marimo.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.

--- a/examples/ui/README.md
+++ b/examples/ui/README.md
@@ -14,13 +14,14 @@ examples folder_.
 The requirements of each notebook are serialized in them as a top-level
 comment. Here are the steps to open an example notebook:
 
-1. [Install marimo](https://docs.marimo.io/getting_started/index.html#installation)
-2. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
-3. Open an example with `marimo edit --sandbox <notebook.py>`.
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
 
 > [!TIP]
 > The [`--sandbox` flag](https://docs.marimo.io/guides/editor_features/package_management.html) opens the notebook in an isolated virtual environment,
 > automatically installing the notebook's dependencies 📦
 
-You can also open notebooks without `uv`, with just `marimo edit <notebook.py>`;
-however, you'll need to install the requirements yourself.
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.


### PR DESCRIPTION
Simplify instructions for running examples (two steps instead of 3).