### PR TITLE
improvement: handle pl.Duration

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -215,18 +215,21 @@ class NarwhalsTableManager(
                 p75=col.quantile(0.75, interpolation="nearest"),
                 p95=col.quantile(0.95, interpolation="nearest"),
             )
-        if col.dtype == nw.Duration:
+        if col.dtype == nw.Duration and isinstance(col.dtype, nw.Duration):
             unit_map = {
-                "ms": col.dt.total_milliseconds,
-                "ns": col.dt.total_nanoseconds,
-                "us": col.dt.total_microseconds,
+                "ms": (col.dt.total_milliseconds, "ms"),
+                "ns": (col.dt.total_nanoseconds, "ns"),
+                "us": (col.dt.total_microseconds, "μs"),
+                "s": (col.dt.total_seconds, "s"),
             }
+            method, unit = unit_map[col.dtype.time_unit]
+            res = method()
             return ColumnSummary(
                 total=total,
                 nulls=col.null_count(),
-                min=str(unit_map["us"]().min()) + "μs",
-                max=str(unit_map["us"]().max()) + "μs",
-                mean=str(unit_map["us"]().mean()) + "μs",
+                min=str(res.min()) + unit,
+                max=str(res.max()) + unit,
+                mean=str(res.mean()) + unit,
             )
         if (
             col.dtype == nw.List

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -119,6 +119,8 @@ class NarwhalsTableManager(
             return ("integer", dtype_string)
         elif is_narwhals_temporal_type(dtype):
             return ("date", dtype_string)
+        elif dtype == nw.Duration:
+            return ("number", dtype_string)
         elif dtype.is_numeric():
             return ("number", dtype_string)
         else:
@@ -147,6 +149,7 @@ class NarwhalsTableManager(
             elif (
                 dtype.is_numeric()
                 or is_narwhals_temporal_type(dtype)
+                or dtype == nw.Duration
                 or dtype == nw.Boolean
             ):
                 expressions.append(
@@ -211,6 +214,19 @@ class NarwhalsTableManager(
                 p25=col.quantile(0.25, interpolation="nearest"),
                 p75=col.quantile(0.75, interpolation="nearest"),
                 p95=col.quantile(0.95, interpolation="nearest"),
+            )
+        if col.dtype == nw.Duration:
+            unit_map = {
+                "ms": col.dt.total_milliseconds,
+                "ns": col.dt.total_nanoseconds,
+                "us": col.dt.total_microseconds,
+            }
+            return ColumnSummary(
+                total=total,
+                nulls=col.null_count(),
+                min=str(unit_map["us"]().min()) + "μs",
+                max=str(unit_map["us"]().max()) + "μs",
+                mean=str(unit_map["us"]().mean()) + "μs",
             )
         if (
             col.dtype == nw.List

--- a/marimo/_plugins/ui/_impl/tables/polars_table.py
+++ b/marimo/_plugins/ui/_impl/tables/polars_table.py
@@ -98,6 +98,7 @@ class PolarsTableManagerFactory(TableManagerFactory):
                                 "ms": column.dt.total_milliseconds,
                                 "ns": column.dt.total_nanoseconds,
                                 "us": column.dt.total_microseconds,
+                                "s": column.dt.total_seconds,
                             }
                             if dtype.time_unit in unit_map:
                                 method = unit_map[dtype.time_unit]

--- a/marimo/_plugins/ui/_impl/tables/polars_table.py
+++ b/marimo/_plugins/ui/_impl/tables/polars_table.py
@@ -94,19 +94,14 @@ class PolarsTableManagerFactory(TableManagerFactory):
                                     )
                                 )
                         elif isinstance(dtype, pl.Duration):
-                            if dtype.time_unit == "ms":
-                                result = result.with_columns(
-                                    column.dt.total_milliseconds()
-                                )
-
-                            elif dtype.time_unit == "ns":
-                                result = result.with_columns(
-                                    column.dt.total_nanoseconds()
-                                )
-                            elif dtype.time_unit == "us":
-                                result = result.with_columns(
-                                    column.dt.total_microseconds()
-                                )
+                            unit_map = {
+                                "ms": column.dt.total_milliseconds,
+                                "ns": column.dt.total_nanoseconds,
+                                "us": column.dt.total_microseconds,
+                            }
+                            if dtype.time_unit in unit_map:
+                                method = unit_map[dtype.time_unit]
+                                result = result.with_columns(method())
                     return result.write_csv().encode("utf-8")
 
             def to_json(self) -> bytes:
@@ -198,6 +193,8 @@ class PolarsTableManagerFactory(TableManagerFactory):
                     return ("date", dtype_string)
                 elif dtype == pl.Time:
                     return ("time", dtype_string)
+                elif dtype == pl.Duration:
+                    return ("number", dtype_string)
                 elif dtype == pl.Datetime:
                     return ("datetime", dtype_string)
                 elif dtype.is_temporal():

--- a/marimo/_smoke_tests/tables/polars_duration.py
+++ b/marimo/_smoke_tests/tables/polars_duration.py
@@ -1,0 +1,57 @@
+import marimo
+
+__generated_with = "0.10.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import polars as pl
+    return mo, pl
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""## Polars""")
+    return
+
+
+@app.cell
+def _(pl):
+    df = pl.read_csv(
+        "https://raw.githubusercontent.com/vega/vega-datasets/refs/heads/main/data/co2-concentration.csv"
+    )
+    df = df.with_columns(
+        pl.col("CO2").cast(pl.Duration),
+    )
+    df
+    return (df,)
+
+
+@app.cell
+def _(df, mo):
+    mo.plain(df)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""## Pandas""")
+    return
+
+
+@app.cell
+def _(df):
+    df.to_pandas()
+    return
+
+
+@app.cell
+def _(df, mo):
+    mo.plain(df.to_pandas())
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_utils/narwhals_utils.py
+++ b/marimo/_utils/narwhals_utils.py
@@ -111,13 +111,11 @@ def is_narwhals_integer_type(
 
 def is_narwhals_temporal_type(
     dtype: Any,
-) -> TypeGuard[nw.Datetime | nw.Date | nw.Duration | nw.Duration]:
+) -> TypeGuard[nw.Datetime | nw.Date]:
     """
     Check if the given dtype is temporal type.
     """
-    return bool(
-        dtype == nw.Datetime or dtype == nw.Date or dtype == nw.Duration
-    )
+    return bool(dtype == nw.Datetime or dtype == nw.Date)
 
 
 def is_narwhals_string_type(

--- a/tests/_plugins/ui/_impl/tables/snapshots/narwhals.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/narwhals.field_types.json
@@ -13,6 +13,6 @@
   ["set", ["unknown", "Object"]],
   ["imaginary", ["unknown", "Object"]],
   ["time", ["unknown", "Unknown"]],
-  ["duration", ["date", "Duration(time_unit='us')"]],
+  ["duration", ["number", "Duration(time_unit='us')"]],
   ["mixed_list", ["unknown", "List(String)"]]
 ]

--- a/tests/_plugins/ui/_impl/tables/snapshots/polars.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/polars.field_types.json
@@ -13,6 +13,6 @@
   ["set", ["unknown", "object"]],
   ["imaginary", ["unknown", "object"]],
   ["time", ["time", "Time"]],
-  ["duration", ["datetime", "duration[\u03bcs]"]],
+  ["duration", ["number", "duration[\u03bcs]"]],
   ["mixed_list", ["unknown", "list[str]"]]
 ]

--- a/tests/_utils/test_narwhals_utils.py
+++ b/tests/_utils/test_narwhals_utils.py
@@ -90,6 +90,7 @@ def test_narwhals_type_checks():
     assert is_narwhals_temporal_type(nw.Datetime)
     assert is_narwhals_temporal_type(nw.Date)
     assert not is_narwhals_temporal_type(nw.Int64)
+    assert not is_narwhals_temporal_type(nw.Duration)
 
     assert is_narwhals_string_type(nw.String)
     assert is_narwhals_string_type(nw.Categorical)


### PR DESCRIPTION
Fixes #3267 

This handles narwhals and polars Duration types, by treating them as `floats` and not temporal. We differ in the that we don't show the units for each entry (just at the top).

For pandas, we treat them as strings (with the same formatting as their plain HTML)

<img width="953" alt="Screenshot 2024-12-21 at 2 02 30 PM" src="https://github.com/user-attachments/assets/784108bd-4358-4bea-accd-b0c26a2d7d9e" />

<img width="972" alt="Screenshot 2024-12-21 at 2 02 33 PM" src="https://github.com/user-attachments/assets/9aa18399-855d-4558-8fe0-4ae036403610" />
