### PR TITLE
docs: pytest in marimo

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -17,7 +17,7 @@ These guides cover marimo's core concepts.
 | [Working with data](working_with_data/index.md)      | Using SQL cells, no-code dataframe tools, and reactive plots |
 | [Apps](apps.md)                                      | Running notebooks as apps                                    |
 | [Scripts](scripts.md)                                | Running notebooks as scripts                                 |
-| [Test](test.md)                                      | Running unit tests in notebooks                              |
+| [Tests](tests.md)                                    | Running unit tests in notebooks                              |
 | [Export to HTML and other formats](exporting.md)     | Exporting notebooks to HTML and flat scripts                 |
 | [Run notebooks with WebAssembly](wasm.md)            | Create notebooks in our online playground                    |
 | [Deploying](deploying/index.md)                      | Deploying marimo notebooks and apps                          |

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -17,7 +17,7 @@ These guides cover marimo's core concepts.
 | [Working with data](working_with_data/index.md)      | Using SQL cells, no-code dataframe tools, and reactive plots |
 | [Apps](apps.md)                                      | Running notebooks as apps                                    |
 | [Scripts](scripts.md)                                | Running notebooks as scripts                                 |
-| [Tests](tests.md)                                    | Running unit tests in notebooks                              |
+| [Tests](testing/index.md)                            | Running unit tests in notebooks                              |
 | [Export to HTML and other formats](exporting.md)     | Exporting notebooks to HTML and flat scripts                 |
 | [Run notebooks with WebAssembly](wasm.md)            | Create notebooks in our online playground                    |
 | [Deploying](deploying/index.md)                      | Deploying marimo notebooks and apps                          |

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,7 +9,7 @@ These guides cover marimo's core concepts.
 
 | Guide                                                | Description                                                  |
 | :--------------------------------------------------- | :----------------------------------------------------------- |
-| [Reactive execution](reactivity.md)                  | Understanding how marimo runs cells                                        |
+| [Reactive execution](reactivity.md)                  | Understanding how marimo runs cells                          |
 | [Interactive elements](interactivity.md)             | Using interactive UI elements                                |
 | [Visualizing outputs](outputs.md)                    | Creating markdown, plots, and other visual outputs           |
 | [Migrating from Jupyter](coming_from/jupyter.md)     | Tips for transitioning from Jupyter                          |
@@ -17,6 +17,7 @@ These guides cover marimo's core concepts.
 | [Working with data](working_with_data/index.md)      | Using SQL cells, no-code dataframe tools, and reactive plots |
 | [Apps](apps.md)                                      | Running notebooks as apps                                    |
 | [Scripts](scripts.md)                                | Running notebooks as scripts                                 |
+| [Test](test.md)                                      | Running unit tests in notebooks                              |
 | [Export to HTML and other formats](exporting.md)     | Exporting notebooks to HTML and flat scripts                 |
 | [Run notebooks with WebAssembly](wasm.md)            | Create notebooks in our online playground                    |
 | [Deploying](deploying/index.md)                      | Deploying marimo notebooks and apps                          |

--- a/docs/guides/testing/doctest.md
+++ b/docs/guides/testing/doctest.md
@@ -1,0 +1,12 @@
+# Testing with doctest
+
+You can test code snippets in docstrings using
+[doctest](https://docs.python.org/3/library/doctest.html), a Python module for
+testing code snippets in documentation. This works because marimo notebooks are
+just Python programs.
+
+See this notebook for an example:
+
+/// marimo-embed-file
+    filepath: examples/testing/running_doctests.py
+///

--- a/docs/guides/testing/index.md
+++ b/docs/guides/testing/index.md
@@ -1,0 +1,9 @@
+# Testing notebooks
+
+Because marimo notebooks are stored as Python, test them like any other Python
+program.
+
+| Guide                 | Description                                                             |
+| --------------------- | ----------------------------------------------------------------------- |
+| [pytest](pytest.md)   | Include unit tests in notebooks, or implement entire tests as notebooks |
+| [doctest](doctest.md) | Test code snippets in docstrings using doctest                          |

--- a/docs/guides/testing/pytest.md
+++ b/docs/guides/testing/pytest.md
@@ -16,7 +16,7 @@ runs and tests all notebook cells whose names start with `test_`.
 
 !!! tip "Naming cells"
 
-    Name a cell by giving its function a name in the file format, or using
+    Name a cell by giving its function a name in the notebook file, or using
     the cell action menu in the notebook editor.
 
 !!! note "Use marimo notebooks just like normal pytest tests"
@@ -28,7 +28,7 @@ runs and tests all notebook cells whose names start with `test_`.
 
 ## Example
 
-Running `pytest` on the the following notebook
+Running `pytest` on
 
 ```python
 # content of test_notebook.py
@@ -55,7 +55,7 @@ def test_sanity(inc):
     assert inc(3) == 4, "This test passes"
 ```
 
-produces the following output:
+prints
 
 ```pytest
 ============================= test session starts ==============================
@@ -64,7 +64,7 @@ rootdir: /notebooks
 configfile: pyproject.toml
 collected 2 items
 
-examples.py F.                                                           [100%]
+test_notebook.py F.                                                       [100%]
 
 =================================== FAILURES ===================================
 __________________________________ test_fails __________________________________
@@ -83,12 +83,12 @@ __________________________________ test_fails __________________________________
 
 
     @app.cell
-    def test_fails(inc):
+    def test_answser(inc):
 >       assert inc(3) == 5, "This test fails"
 E       AssertionError: This test fails
 
-examples.py:16: AssertionError
+test_notebook.py:16: AssertionError
 =========================== short test summary info ============================
-FAILED examples.py::test_fails - AssertionError: This test fails
+FAILED test_notebook.py::test_fails - AssertionError: This test fails
 ========================= 1 failed, 1 passed in 0.20s ===========================
 ```

--- a/docs/guides/tests.md
+++ b/docs/guides/tests.md
@@ -73,7 +73,7 @@ FAILED examples.py::test_fails - AssertionError: This test fails
 ========================= 1 failed, 1 passedin 0.20s ===========================
 ```
 
-!!! note "marimo notebooks just like normal pytest tests"
+!!! note "You can use marimo notebooks just like normal pytest tests"
 
     You can include these notebooks in your standard test suite and
     `pytest` just like any other python script.

--- a/docs/guides/tests.md
+++ b/docs/guides/tests.md
@@ -1,16 +1,34 @@
 # Running unit tests with pytest
 
-Since marimo notebooks are just Python scripts, you can test them with
+Since marimo notebooks are Python programs, you can test them using
+[`pytest`](https://docs.pytest.org/en/stable/), a popular testing framework
+for Python.
+
+
+
+For example,
 
 ```bash
 pytest test_notebook.py
 ```
 
-[`pytest`](https://docs.pytest.org/en/stable/), a popular testing framework
-for Python, will run all the tests in `test_notebook.py` and show you the
-results. pytest detects tests by looking for functions that start with `test_`,
-so renaming your cell `test_*`, will automatically make it testable. For
-example, the following notebook:
+runs and tests all notebook cells whose names start with `test_`.
+
+!!! tip "Naming cells"
+
+    Name a cell by giving its function a name in the file format, or using
+    the cell action menu in the notebook editor.
+
+!!! note "Use marimo notebooks just like normal pytest tests"
+
+    Include test notebooks (notebooks whose names start with `test_`) in your
+    standard test suite, and `pytest` will discover them automatically.
+    In addition, you can write self-contained notebooks that contain their own
+    unit tests, and run `pytest` on them directly (`pytest my_notebook.py`).
+
+## Example
+
+Running `pytest` on the the following notebook
 
 ```python
 # content of test_notebook.py
@@ -37,7 +55,7 @@ def test_sanity(inc):
     assert inc(3) == 4, "This test passes"
 ```
 
-will produce the following output:
+produces the following output:
 
 ```pytest
 ============================= test session starts ==============================
@@ -72,68 +90,5 @@ E       AssertionError: This test fails
 examples.py:16: AssertionError
 =========================== short test summary info ============================
 FAILED examples.py::test_fails - AssertionError: This test fails
-========================= 1 failed, 1 passedin 0.20s ===========================
-```
-
-!!! note "You can use marimo notebooks just like normal pytest tests"
-
-    You can include these notebooks in your standard test suite and
-    `pytest` just like any other python script.
-
-
-## pytest fixtures
-
-A powerful feature of `pytest` is the ability to define
-[fixtures](https://docs.pytest.org/en/stable/explanation/fixtures.html#about-fixtures).
-Fixtures and are reliable ways to set up, tear down or mock resources for your
-tests. marimo uses function arguments to denote variable dependencies, but
-variables ending in `_fixture` will be treated as fixtures in `pytest`.
-For example:
-
-```python
-# content of conftest.py
-import pytest
-
-@pytest.fixture
-def working_requests_fixture():
-    def pass_request():
-        return "apple"
-    return request_fixture
-
-
-@pytest.fixture
-def failing_requests_fixture():
-    def fail_request():
-        raise Exception("Request failed")
-    return request_fixture
-
-
-@pytest.fixture(params=["working_request_fixture", "failing_request_fixture"])
-def requests_fixture(request: Any) -> Kernel:
-    return request.getfixturevalue(request.param)
-```
-
-```python
-# content of test_notebook.py
-import marimo
-
-__generated_with = "0.10.6"
-app = marimo.App()
-
-
-@app.cell
-def _():
-    import requests
-    requests_fixture = requests.get
-    return requests, requests_fixture
-
-# ... normal usage
-
-@app.cell
-def test_sanity(my_obj, requests_fixture):
-    my_obj.get = requests_fixture
-    assert (
-        my_obj.execute(),
-        f"Test issue with {requests_fixture.__name__}"
-    )
+========================= 1 failed, 1 passed in 0.20s ===========================
 ```

--- a/docs/guides/tests.md
+++ b/docs/guides/tests.md
@@ -1,0 +1,137 @@
+# Running unit tests with pytest
+
+Since marimo notebooks are just Python scripts, you can test them with
+
+```bash
+pytest test_notebook.py
+```
+
+[`pytest`](https://docs.pytest.org/en/stable/), a popular testing framework
+for Python, will run all the tests in `test_notebook.py` and show you the
+results. For example the following notebook:
+
+```python
+# content of test_notebook.py
+import marimo
+
+__generated_with = "0.10.6"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    def inc(x):
+        return x + 1
+    return inc
+
+
+@app.cell
+def test_answer(inc):
+    assert inc(3) == 5, "This test fails"
+
+
+@app.cell
+def test_sanity(inc):
+    assert inc(3) == 4, "This test passes"
+```
+
+will produce the following output:
+
+```pytest
+============================= test session starts ==============================
+platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
+rootdir: /notebooks
+configfile: pyproject.toml
+collected 2 items
+
+examples.py F.                                                           [100%]
+
+=================================== FAILURES ===================================
+__________________________________ test_fails __________________________________
+
+    import marimo
+    
+    __generated_with = "0.10.6"
+    app = marimo.App(width="medium")
+    
+    
+    @app.cell
+    def _():
+        def inc(x):
+            return x + 1
+        return (inc,)
+    
+    
+    @app.cell
+    def test_fails(inc):
+>       assert inc(3) == 5, "This test fails"
+E       AssertionError: This test fails
+
+examples.py:16: AssertionError
+=========================== short test summary info ============================
+FAILED examples.py::test_fails - AssertionError: This test fails
+========================= 1 failed, 1 passedin 0.20s ===========================
+```
+
+!!! note "marimo notebooks just like normal pytest tests"
+
+    You can include these notebooks in your standard test suite and
+    `pytest` just like any other python script.
+
+
+## pytest fixtures
+
+A powerful feature of `pytest` is the ability to define
+[fixtures](https://docs.pytest.org/en/stable/explanation/fixtures.html#about-fixtures).
+Fixtures and are reliable ways to set up, tear down or mock resources for your
+tests. marimo uses function arguments to denote variable dependencies, but
+variables ending in `_fixture` will be treated as fixtures in `pytest`.
+For example:
+
+```python
+# content of conftest.py
+import pytest
+
+@pytest.fixture
+def working_requests_fixture():
+    def pass_request():
+        return "apple"
+    return request_fixture
+
+
+@pytest.fixture
+def failing_requests_fixture():
+    def fail_request():
+        raise Exception("Request failed")
+    return request_fixture
+
+
+@pytest.fixture(params=["working_request_fixture", "failing_request_fixture"])
+def requests_fixture(request: Any) -> Kernel:
+    return request.getfixturevalue(request.param)
+```
+
+```python
+# content of test_notebook.py
+import marimo
+
+__generated_with = "0.10.6"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import requests
+    requests_fixture = requests.get
+    return requests, requests_fixture
+
+# ... normal usage
+
+@app.cell
+def test_sanity(my_obj, requests_fixture):
+    my_obj.get = requests_fixture
+    assert (
+        my_obj.execute(),
+        f"Test issue with {requests_fixture.__name__}"
+    )
+```

--- a/docs/guides/tests.md
+++ b/docs/guides/tests.md
@@ -8,7 +8,9 @@ pytest test_notebook.py
 
 [`pytest`](https://docs.pytest.org/en/stable/), a popular testing framework
 for Python, will run all the tests in `test_notebook.py` and show you the
-results. For example the following notebook:
+results. pytest detects tests by looking for functions that start with `test_`,
+so renaming your cell `test_*`, will automatically make it testable. For
+example, the following notebook:
 
 ```python
 # content of test_notebook.py
@@ -50,18 +52,18 @@ examples.py F.                                                           [100%]
 __________________________________ test_fails __________________________________
 
     import marimo
-    
+
     __generated_with = "0.10.6"
     app = marimo.App(width="medium")
-    
-    
+
+
     @app.cell
     def _():
         def inc(x):
             return x + 1
         return (inc,)
-    
-    
+
+
     @app.cell
     def test_fails(inc):
 >       assert inc(3) == 5, "This test fails"

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ reproducibility, maintainability, composability, and shareability.
 - 🖐️ **interactive:** [bind sliders, tables, plots, and more](guides/interactivity.md) to Python — no callbacks required
 - 🔬 **reproducible:** [no hidden state](guides/reactivity.md#no-hidden-state), deterministic execution, [built-in package management](guides/editor_features/package_management.md)
 - 🏃 **executable:** [execute as a Python script](guides/scripts.md), parameterized by CLI args
+- 🧪 **testable:** [run your favorite test suite](guides/test.md), verify your notebook's correctness
 - 🛜 **shareable**: [deploy as an interactive web app](guides/apps.md) or [slides](guides/apps.md#slides-layout), [run in the browser via WASM](guides/wasm.md)
 - 🛢️ **designed for data**: query dataframes and databases [with SQL](guides/working_with_data/sql.md), filter and search [dataframes](guides/working_with_data/dataframes.md)
 - 🐍 **git-friendly:** notebooks are stored as `.py` files

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ reproducibility, maintainability, composability, and shareability.
 - 🖐️ **interactive:** [bind sliders, tables, plots, and more](guides/interactivity.md) to Python — no callbacks required
 - 🔬 **reproducible:** [no hidden state](guides/reactivity.md#no-hidden-state), deterministic execution, [built-in package management](guides/editor_features/package_management.md)
 - 🏃 **executable:** [execute as a Python script](guides/scripts.md), parameterized by CLI args
-- 🧪 **testable:** [run your favorite test suite](guides/tests.md), verify your notebook's correctness
+- 🧪 **testable:** [run your favorite test suite](guides/testing/index.md), verify your notebook's correctness
 - 🛜 **shareable**: [deploy as an interactive web app](guides/apps.md) or [slides](guides/apps.md#slides-layout), [run in the browser via WASM](guides/wasm.md)
 - 🛢️ **designed for data**: query dataframes and databases [with SQL](guides/working_with_data/sql.md), filter and search [dataframes](guides/working_with_data/dataframes.md)
 - 🐍 **git-friendly:** notebooks are stored as `.py` files

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ reproducibility, maintainability, composability, and shareability.
 - 🖐️ **interactive:** [bind sliders, tables, plots, and more](guides/interactivity.md) to Python — no callbacks required
 - 🔬 **reproducible:** [no hidden state](guides/reactivity.md#no-hidden-state), deterministic execution, [built-in package management](guides/editor_features/package_management.md)
 - 🏃 **executable:** [execute as a Python script](guides/scripts.md), parameterized by CLI args
-- 🧪 **testable:** [run your favorite test suite](guides/test.md), verify your notebook's correctness
+- 🧪 **testable:** [run your favorite test suite](guides/tests.md), verify your notebook's correctness
 - 🛜 **shareable**: [deploy as an interactive web app](guides/apps.md) or [slides](guides/apps.md#slides-layout), [run in the browser via WASM](guides/wasm.md)
 - 🛢️ **designed for data**: query dataframes and databases [with SQL](guides/working_with_data/sql.md), filter and search [dataframes](guides/working_with_data/dataframes.md)
 - 🐍 **git-friendly:** notebooks are stored as `.py` files

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,10 +6,11 @@ use marimo's features as well as inspire you to make awesome notebooks.
 
 - 🖱️ [`ui/`](ui/): how to use UI elements or widgets
 - 🛢️ [`sql/`](sql/): how to use SQL in marimo
-- 🛢️ [`control_flow/`](control_flow/): how to control cell execution and output display
-- 🛢️ [`markdown/`](markdown/): how to write markdown, including dynamic markdown
+- ⛲ [`control_flow/`](control_flow/): how to control cell execution and output display
+- 📝 [`markdown/`](markdown/): how to write markdown, including dynamic markdown
 - 📽️ [`layouts/`](layouts/): how to present notebooks as slides, add sidebars, and more
 - 🤖 [`ai/`](ai/): AI-related examples
+- 🧪 [`testing/`](testing/): how to test marimo notebooks, and use marimo notebooks as tests
 - 📦 [`third_party/`](third_party/): using popular third-party packages in marimo
 - ☁️  [`cloud/`](cloud/): using various cloud providers
 - 🧩 [`frameworks/`](frameworks/): integrating with different frameworks (web/ASGI)

--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -1,0 +1,11 @@
+# Testing 🧪
+
+These basic examples show how to use test marimo notebooks.
+
+## Testing with pytest
+
+Run `pytest test_with_pytest.py`.
+
+## Testing with doctests
+
+See `running_doctests.py`

--- a/examples/testing/running_doctests.py
+++ b/examples/testing/running_doctests.py
@@ -1,0 +1,48 @@
+import marimo
+
+__generated_with = "0.10.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _():
+    def euclid_mcd(a: int, b: int) -> int:
+        """Return the MCD between positive a, b.
+        >>> euclid_mcd(42, 24)
+        6
+        >>> euclid_mcd(24, 42)
+        6
+        >>> euclid_mcd(42, 42)
+        42
+        """
+        assert a > 0
+        assert b > 0
+        if a < b:
+            a, b = b, a
+        if (a != b):
+            r = a - b
+            return euclid_mcd(b, r)
+        return a
+    return (euclid_mcd,)
+
+
+@app.cell
+def _(euclid_mcd, mo):
+    # Include a reference to each function to test
+    euclid_mcd
+
+    import doctest
+
+    failures, success = doctest.testmod(verbose=True)
+    mo.md(f"Success: {success}, Failures: {failures}")
+    return doctest, failures, success
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/testing/test_with_pytest.py
+++ b/examples/testing/test_with_pytest.py
@@ -1,0 +1,24 @@
+import marimo
+
+__generated_with = "0.10.6"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    def inc(x):
+        return x + 1
+    return inc
+
+
+@app.cell
+def test_answer(inc):
+    assert inc(3) == 5, "This test fails"
+
+
+@app.cell
+def test_sanity(inc):
+    assert inc(3) == 4, "This test passes"
+
+if __name__ == "__main__":
+	app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,7 @@ nav:
       - Testing notebooks:
           - Overview: guides/testing/index.md
           - pytest: guides/testing/pytest.md
-          - doctest: guides/testing/doctests.md
+          - doctest: guides/testing/doctest.md
       - Export to HTML and other formats: guides/exporting.md
       - Run notebooks with WebAssembly: guides/wasm.md
       - Deploy notebooks:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ nav:
           - Plotting: guides/working_with_data/plotting.md
       - Run notebooks as apps: guides/apps.md
       - Run notebooks as scripts: guides/scripts.md
-      - Run notebook tests: guides/test.md
+      - Run notebook tests: guides/tests.md
       - Export to HTML and other formats: guides/exporting.md
       - Run notebooks with WebAssembly: guides/wasm.md
       - Deploy notebooks:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,10 @@ nav:
           - Plotting: guides/working_with_data/plotting.md
       - Run notebooks as apps: guides/apps.md
       - Run notebooks as scripts: guides/scripts.md
-      - Run notebook tests: guides/tests.md
+      - Testing notebooks:
+          - Overview: guides/testing/index.md
+          - pytest: guides/testing/pytest.md
+          - doctest: guides/testing/doctests.md
       - Export to HTML and other formats: guides/exporting.md
       - Run notebooks with WebAssembly: guides/wasm.md
       - Deploy notebooks:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
           - Plotting: guides/working_with_data/plotting.md
       - Run notebooks as apps: guides/apps.md
       - Run notebooks as scripts: guides/scripts.md
+      - Run notebook tests: guides/test.md
       - Export to HTML and other formats: guides/exporting.md
       - Run notebooks with WebAssembly: guides/wasm.md
       - Deploy notebooks:


### PR DESCRIPTION
pytest specific docs with #3251
Please feel free to tweak and rewrite (you can add to this branch, I'm not touching it unless there's feedback). Just wanted to provide a starting point.

Also in `CONTRIBUTING.md`, I didn't see any updates to the docs workflow? I know you all have moved off sphinx, but haven't paid too much attention

---

Writing up the fixtures section, I realized it feels a little awkward in practice.
Maybe this would be a better user API?

```python
# content of test_notebook.py
import marimo

__generated_with = "0.10.6"
app = marimo.App()


@app.cell
def _():
    from requests import get as requests_get
    requests_fixture = mo.test.fixture(requests_get) # basically wrapper to add type
    return requests, requests_fixture

# ... normal usage

@app.cell
def test_sanity(my_fn, requests_fixture):
    # Replace requests_get in graph if test
    # Confirms that it is a mo.test.Fixture type if not testing
    # Confirms that it is not a mo.test.Fixture type if testing
    mo.test.uses(requests_get=requests_fixture)
    assert (
        my_fn(),
        f"Test issue with {requests_fixture.__name__}"
    )
```

also the new copy/paste feature works nicely!

@akshayka OR @mscolnick
