### PR TITLE
Integrate Biome with VCS to simplify ignore patterns

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,32 +8,14 @@
     "lineEnding": "lf",
     "lineWidth": 80,
     "attributePosition": "auto",
-    "ignore": [
-      "dist",
-      "lib",
-      "pnpm-lock.yaml",
-      "storybook-static",
-      "package.json"
-    ]
+    "ignore": ["pnpm-lock.yaml", "storybook-static", "package.json"]
   },
   "organizeImports": {
-    "ignore": [
-      "dist",
-      "lib",
-      "pnpm-lock.yaml",
-      "storybook-static",
-      "package.json"
-    ],
+    "ignore": ["pnpm-lock.yaml", "storybook-static", "package.json"],
     "enabled": false
   },
   "linter": {
-    "ignore": [
-      "dist",
-      "lib",
-      "pnpm-lock.yaml",
-      "storybook-static",
-      "package.json"
-    ],
+    "ignore": ["pnpm-lock.yaml", "storybook-static", "package.json"],
     "enabled": true,
     "rules": {
       "recommended": true,
@@ -129,5 +111,10 @@
       "quoteStyle": "double",
       "attributePosition": "auto"
     }
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
   }
 }


### PR DESCRIPTION
## 📝 Summary

Setup Biome's VCS integration.

## 🔍 Description of Changes

Configures Biome to respect `.gitignore` file using its builtin [VCS
integration](https://biomejs.dev/guides/integrate-in-vcs/).

I'm only opening this PR because this was an option in Biome that I found
surprisingly hard to discover myself in another project. Feel free to
ignore/close if it has already been considered in preference for the explicit
`ignore` list (no explanation needed 😄).

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
