### PR TITLE
feat: apply pytest rewrites for better testing

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -176,7 +176,8 @@ def compile_cell(
             )
 
             rewrite_asserts(module, code.encode("utf-8"), module_path=filename)
-        except ImportError:
+        # general catch-all, in case of internal pytest API changes
+        except Exception:
             LOGGER.warning(
                 "pytest is not installed, skipping assertion rewriting"
             )

--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -71,7 +71,7 @@ def wrap_fn_for_pytest(
     local = {"stub": cell.__call__, "Any": Any}
     eval(compile(fn, inspect.getfile(func), "exec"), local)
 
-    # The remaining expected attributes is needed to ensure attribute count
+    # The remaining expected attributes are needed to ensure attribute count
     # matches.
     cell._pytest_reserved = reserved
 

--- a/marimo/_messaging/context.py
+++ b/marimo/_messaging/context.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 import uuid
 from contextvars import ContextVar
 from dataclasses import dataclass

--- a/tests/_ast/test_pytest.py
+++ b/tests/_ast/test_pytest.py
@@ -81,3 +81,18 @@ def test_cell_extra_refs_fail(mo):  # noqa: ARG001
 @app.cell
 def test_cell_args_resolved_by_name(mo):  # noqa: ARG001
     assert x  # noqa: F821
+
+
+@app.cell
+def test_cell_assert_rewritten():
+    import pytest
+
+    a = 1
+    b = 2
+
+    with pytest.raises(AssertionError) as exc_info:
+        assert a + b == a * b
+
+    # Check expansion works. Without rewrite, this just produces
+    # "AssertionError", without showing the expanded expression.
+    assert "assert (1 + 2) == (1 * 2)" in str(exc_info.value)


### PR DESCRIPTION
merry merry 🎄 

---

Slight improvement on pytest errors, by manually running pytest's assertion rewrite magic. So that takes us from this:

![image](https://github.com/user-attachments/assets/e2ddf88b-a6c1-4f89-a98b-20f70b0e8c6d)

to this

![image](https://github.com/user-attachments/assets/317a9d4b-faa1-4d9b-9f54-fa5e8c747e39)

Also a little fun- this rewrite can be applied in general and shown in editor.

![image](https://github.com/user-attachments/assets/18934182-732a-4dad-8e91-12b9abd32f7c)

Not sure the overhead this might have- so not sure about setting it generally, but could set `test_rewrite=True` if the cell name starts with `test_`. Wanted to run this by you all first


@akshayka OR @mscolnick
