### PR TITLE
fix(table): allow string literals for showColumnSummaries

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -112,7 +112,9 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
       selection: z.enum(["single", "multi"]).nullable().default(null),
       showDownload: z.boolean().default(false),
       showFilters: z.boolean().default(false),
-      showColumnSummaries: z.union([z.boolean(), z.enum(["stats", "chart"])]).default(true),
+      showColumnSummaries: z
+        .union([z.boolean(), z.enum(["stats", "chart"])])
+        .default(true),
       rowHeaders: z.array(z.string()),
       freezeColumnsLeft: z.array(z.string()).optional(),
       freezeColumnsRight: z.array(z.string()).optional(),

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -69,7 +69,7 @@ interface Data<T> {
   selection: "single" | "multi" | null;
   showDownload: boolean;
   showFilters: boolean;
-  showColumnSummaries: boolean;
+  showColumnSummaries: boolean | "stats" | "chart";
   rowHeaders: string[];
   fieldTypes?: FieldTypesWithExternalType | null;
   freezeColumnsLeft?: string[];
@@ -112,7 +112,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
       selection: z.enum(["single", "multi"]).nullable().default(null),
       showDownload: z.boolean().default(false),
       showFilters: z.boolean().default(false),
-      showColumnSummaries: z.boolean().default(true),
+      showColumnSummaries: z.union([z.boolean(), z.enum(["stats", "chart"])]).default(true),
       rowHeaders: z.array(z.string()),
       freezeColumnsLeft: z.array(z.string()).optional(),
       freezeColumnsRight: z.array(z.string()).optional(),


### PR DESCRIPTION
## 📝 Summary

Fixes #3306

The table component's showColumnSummaries prop now correctly accepts both boolean
and string literal values ("stats" or "chart"). This fixes the type validation
error when passing string literals to control column summary behavior.

Before
<img width="744" alt="Screenshot 2024-12-29 at 17 51 34" src="https://github.com/user-attachments/assets/178ffaeb-39f9-4dfd-8cdf-85da5fe90fe7" />
Now
<img width="757" alt="Screenshot 2024-12-29 at 17 48 27" src="https://github.com/user-attachments/assets/d21e766d-52b1-4d53-959c-6252c8d9d02f" />
<img width="751" alt="Screenshot 2024-12-29 at 17 51 45" src="https://github.com/user-attachments/assets/d4ff18c5-4dc4-47a1-b95c-0220a03518c2" />



## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
