### PR TITLE
feat: add sqlglot to parse sql dataflow

### DIFF
--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -348,19 +348,17 @@ def find_sql_refs(
             for table in expression.find_all(exp.Table):
                 append_refs_from_table(table)
 
-        # this traversal is only available for select statements
-        root = build_scope(expression)
-        if root is None:
-            continue
-        if is_dml:
-            LOGGER.warning(
-                "Scopes should not exist for dml's, may need rework if this occurs"
-            )
+        # build_scope only works for select statements
+        if root := build_scope(expression):
+            if is_dml:
+                LOGGER.warning(
+                    "Scopes should not exist for dml's, may need rework if this occurs"
+                )
 
-        for scope in root.traverse():  # type: ignore
-            for _alias, (_node, source) in scope.selected_sources.items():
-                if isinstance(source, exp.Table):
-                    append_refs_from_table(source)
+            for scope in root.traverse():  # type: ignore
+                for _alias, (_node, source) in scope.selected_sources.items():
+                    if isinstance(source, exp.Table):
+                        append_refs_from_table(source)
 
     # remove duplicates while preserving order
     return list(dict.fromkeys(refs))

--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -341,9 +341,7 @@ def find_sql_refs(
 
     expression_list = parse(sql_statement)
     for expression in expression_list:
-        dml_expression = False
-        if expression.find(exp.Update, exp.Insert, exp.Delete):
-            dml_expression = True
+        if is_dml := bool(expression.find(exp.Update, exp.Insert, exp.Delete)):
             for table in expression.find_all(exp.Table):
                 append_refs_from_table(table)
 
@@ -351,7 +349,7 @@ def find_sql_refs(
         root = build_scope(expression)
         if root is None:
             continue
-        if dml_expression:
+        if is_dml:
             LOGGER.warning(
                 "Scopes should not exist for dml's, may need rework if this occurs"
             )

--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -319,6 +319,7 @@ def find_sql_refs(
         return []
 
     from sqlglot import exp, parse
+    from sqlglot.errors import ParseError
     from sqlglot.optimizer.scope import build_scope
 
     refs: list[str] = []
@@ -339,7 +340,12 @@ def find_sql_refs(
             if table.name:
                 refs.append(table.name)
 
-    expression_list = parse(sql_statement)
+    try:
+        expression_list = parse(sql_statement, dialect="duckdb")
+    except ParseError as e:
+        LOGGER.error(f"Unable to parse SQL. Error: {e}")
+        return []
+
     for expression in expression_list:
         if expression is None:
             continue

--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -325,8 +325,8 @@ def find_sql_refs(
     asts = parse(sql_statement)
     for sql_ast in asts:
         root = build_scope(sql_ast)
-        if not root:  # likely not a query
-            return []
+        if root is None:  # Skip ddl's and comments
+            continue
 
         for scope in root.traverse():
             for _alias, (_node, source) in scope.selected_sources.items():

--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -301,8 +301,6 @@ def find_sql_defs(sql_statement: str) -> SQLDefs:
     )
 
 
-# TODO(akshayka): there are other kinds of refs to find; this should be
-# find_sql_refs
 def find_sql_refs(
     sql_statement: str,
 ) -> list[str]:
@@ -315,109 +313,38 @@ def find_sql_refs(
     Returns:
         A list of table and schema names referenced in the statement.
     """
-    if not DependencyManager.duckdb.has():
+
+    # Use sqlglot to parse ast (https://github.com/tobymao/sqlglot/blob/main/posts/ast_primer.md)
+    if not DependencyManager.sqlglot.has():
         return []
 
-    import duckdb
+    from sqlglot import exp, parse
+    from sqlglot.optimizer.scope import build_scope
 
-    tokens = duckdb.tokenize(sql_statement)
-    token_extractor = TokenExtractor(
-        sql_statement=sql_statement, tokens=tokens
-    )
     refs: list[str] = []
-    cte_names: set[str] = set()
-    i = 0
+    asts = parse(sql_statement)
+    for sql_ast in asts:
+        root = build_scope(sql_ast)
+        if not root:  # likely not a query
+            return []
 
-    # First pass - collect CTE names
-    while i < len(tokens):
-        if token_extractor.is_keyword(i, "with"):
-            i += 1
-            # Handle optional parenthesis after WITH
-            if token_extractor.token_str(i) == "(":
-                i += 1
-            while i < len(tokens):
-                if token_extractor.is_keyword(i, "select"):
-                    break
-                if (
-                    token_extractor.token_str(i) == ","
-                    or token_extractor.token_str(i) == "("
-                ):
-                    i += 1
-                    continue
-                cte_name = token_extractor.strip_quotes(
-                    token_extractor.token_str(i)
-                )
-                if not token_extractor.is_keyword(i, "as"):
-                    cte_names.add(cte_name)
-                i += 1
-                if token_extractor.is_keyword(i, "as"):
-                    break
-        i += 1
-
-    # Second pass - collect references excluding CTEs
-    i = 0
-    while i < len(tokens):
-        if token_extractor.is_keyword(i, "from") or token_extractor.is_keyword(
-            i, "join"
-        ):
-            i += 1
-            if i < len(tokens):
-                # Skip over opening parenthesis for subqueries
-                if token_extractor.token_str(i) == "(":
-                    continue
-
-                # Get table name parts, this could be:
-                # - catalog.schema.table
-                # - catalog.table (this is shorthand for catalog.main.table)
-                # - table
-
-                parts: List[str] = []
-                while i < len(tokens):
-                    part = token_extractor.strip_quotes(
-                        token_extractor.token_str(i)
-                    )
-                    parts.append(part)
-                    # next token is a dot, so we continue getting parts
-                    if (
-                        i + 1 < len(tokens)
-                        and token_extractor.token_str(i + 1) == "."
-                    ):
-                        i += 2
-                        continue
-                    break
-
-                if len(parts) == 3:
-                    # If its the default in-memory catalog,
-                    # only add the table name
-                    if parts[0] == "memory":
-                        refs.append(parts[2])
+        for scope in root.traverse():
+            for _alias, (_node, source) in scope.selected_sources.items():
+                if isinstance(source, exp.Table):
+                    if source.catalog == "memory":
+                        # Default in-memory catalog, only include table name
+                        refs.append(source.name)
                     else:
-                        # Just add the catalog and table, skip schema
-                        refs.extend([parts[0], parts[2]])
-                elif len(parts) == 2:
-                    # If its the default in-memory catalog, only add the table
-                    if parts[0] == "memory":
-                        refs.append(parts[1])
-                    else:
-                        # It's a catalog and table, add both
-                        refs.extend(parts)
-                elif len(parts) == 1:
-                    # It's a table, make sure it's not a CTE
-                    if parts[0] not in cte_names:
-                        refs.append(parts[0])
-                else:
-                    LOGGER.warning(
-                        "Unexpected number of parts in SQL reference: %s",
-                        parts,
-                    )
+                        # We skip schema if there is a catalog
+                        # Because it may be called "public" or "main" across all catalogs
+                        # and they aren't referenced in the code
+                        if source.catalog:
+                            refs.append(source.catalog)
+                        elif source.db:
+                            refs.append(source.db)  # schema
 
-                i -= 1  # Compensate for outer loop increment
-        i += 1
+                        if source.name:
+                            refs.append(source.name)  # table name
 
-    # Re-use find_sql_defs to find referenced schemas and catalogs during creation.
-    defs = find_sql_defs(sql_statement)
-    refs.extend(defs.reffed_schemas)
-    refs.extend(defs.reffed_catalogs)
-
-    # Remove duplicates while preserving order
+    # removes duplicates while preserving order
     return list(dict.fromkeys(refs))

--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -341,6 +341,9 @@ def find_sql_refs(
 
     expression_list = parse(sql_statement)
     for expression in expression_list:
+        if expression is None:
+            continue
+
         if is_dml := bool(expression.find(exp.Update, exp.Insert, exp.Delete)):
             for table in expression.find_all(exp.Table):
                 append_refs_from_table(table)
@@ -354,7 +357,7 @@ def find_sql_refs(
                 "Scopes should not exist for dml's, may need rework if this occurs"
             )
 
-        for scope in root.traverse():
+        for scope in root.traverse():  # type: ignore
             for _alias, (_node, source) in scope.selected_sources.items():
                 if isinstance(source, exp.Table):
                     append_refs_from_table(source)

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -147,6 +147,7 @@ class DependencyManager:
     numpy = Dependency("numpy")
     altair = Dependency("altair", min_version="5.3.0", max_version="6.0.0")
     duckdb = Dependency("duckdb")
+    sqlglot = Dependency("sqlglot")
     pillow = Dependency("PIL")
     plotly = Dependency("plotly")
     bokeh = Dependency("bokeh")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ homepage = "https://github.com/marimo-team/marimo"
 sql = [
     "duckdb >= 1.1.0",
     "polars[pyarrow] >= 1.9.0",
-    "sqlglot >= 23.4"
+    "sqlglot >= 25.20"
 ]
 
 # List of deps that are recommended for most users
@@ -87,7 +87,7 @@ recommended = [
     "duckdb>=1.1.0",            # SQL cells
     "altair>=5.4.0",            # Plotting in datasource viewer
     "polars[pyarrow]>=1.9.0",   # SQL output back in Python
-    "sqlglot>=23.4",            # SQL cells parsing
+    "sqlglot>=25.20",           # SQL cells parsing
     "openai>=1.41.1",           # AI features
     "ruff",                     # Formatting
     "nbformat>=5.7.0",          # Export as IPYNB
@@ -101,7 +101,7 @@ dev = [
     "opentelemetry-sdk~=1.26.0",
     # For SQL
     "duckdb>=1.1.0",
-    "sqlglot>=23.4",
+    "sqlglot>=25.20",
     # For linting
     "ruff~=0.6.1",
     # For AI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,9 @@ homepage = "https://github.com/marimo-team/marimo"
 
 [project.optional-dependencies]
 sql = [
-    "duckdb >= 1.1.0",
-    "polars[pyarrow] >= 1.9.0",
-    "sqlglot >= 25.20"
+    "duckdb>=1.1.0",
+    "polars[pyarrow]>=1.9.0",
+    "sqlglot>=23.4"
 ]
 
 # List of deps that are recommended for most users
@@ -87,7 +87,7 @@ recommended = [
     "duckdb>=1.1.0",            # SQL cells
     "altair>=5.4.0",            # Plotting in datasource viewer
     "polars[pyarrow]>=1.9.0",   # SQL output back in Python
-    "sqlglot>=25.20",           # SQL cells parsing
+    "sqlglot>=23.4",            # SQL cells parsing
     "openai>=1.41.1",           # AI features
     "ruff",                     # Formatting
     "nbformat>=5.7.0",          # Export as IPYNB
@@ -101,7 +101,7 @@ dev = [
     "opentelemetry-sdk~=1.26.0",
     # For SQL
     "duckdb>=1.1.0",
-    "sqlglot>=25.20",
+    "sqlglot>=23.4",
     # For linting
     "ruff~=0.6.1",
     # For AI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ homepage = "https://github.com/marimo-team/marimo"
 
 [project.optional-dependencies]
 sql = [
-    "duckdb >= 1.1.0", 
-    "polars[pyarrow] >= 1.9.0", 
+    "duckdb >= 1.1.0",
+    "polars[pyarrow] >= 1.9.0",
     "sqlglot >= 26.0.1"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,8 @@ dev = [
     "opentelemetry-api~=1.26.0",
     "opentelemetry-sdk~=1.26.0",
     # For SQL
-    "duckdb>=1.0.0",
+    "duckdb>=1.1.0",
+    "sqlglot>=26.0.1",
     # For linting
     "ruff~=0.6.1",
     # For AI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ homepage = "https://github.com/marimo-team/marimo"
 sql = [
     "duckdb >= 1.1.0",
     "polars[pyarrow] >= 1.9.0",
-    "sqlglot >= 26.0.1"
+    "sqlglot >= 23.4"
 ]
 
 # List of deps that are recommended for most users
@@ -87,7 +87,7 @@ recommended = [
     "duckdb>=1.1.0",            # SQL cells
     "altair>=5.4.0",            # Plotting in datasource viewer
     "polars[pyarrow]>=1.9.0",   # SQL output back in Python
-    "sqlglot>=26.0.1",          # SQL cells parsing
+    "sqlglot>=23.4",            # SQL cells parsing
     "openai>=1.41.1",           # AI features
     "ruff",                     # Formatting
     "nbformat>=5.7.0",          # Export as IPYNB
@@ -101,7 +101,7 @@ dev = [
     "opentelemetry-sdk~=1.26.0",
     # For SQL
     "duckdb>=1.1.0",
-    "sqlglot>=26.0.1",
+    "sqlglot>=23.4",
     # For linting
     "ruff~=0.6.1",
     # For AI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ homepage = "https://github.com/marimo-team/marimo"
 
 [project.optional-dependencies]
 sql = [
-    "duckdb>=1.1.0",
+    "duckdb>=1.0.0",
     "polars[pyarrow]>=1.9.0",
     "sqlglot>=23.4"
 ]
@@ -84,7 +84,7 @@ sql = [
 # List of deps that are recommended for most users
 # in order to unlock all features in marimo
 recommended = [
-    "duckdb>=1.1.0",            # SQL cells
+    "duckdb>=1.0.0",            # SQL cells
     "altair>=5.4.0",            # Plotting in datasource viewer
     "polars[pyarrow]>=1.9.0",   # SQL output back in Python
     "sqlglot>=23.4",            # SQL cells parsing
@@ -100,7 +100,7 @@ dev = [
     "opentelemetry-api~=1.26.0",
     "opentelemetry-sdk~=1.26.0",
     # For SQL
-    "duckdb>=1.1.0",
+    "duckdb>=1.0.0",
     "sqlglot>=23.4",
     # For linting
     "ruff~=0.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,16 +75,22 @@ marimo = "marimo._cli.cli:main"
 homepage = "https://github.com/marimo-team/marimo"
 
 [project.optional-dependencies]
-sql = ["duckdb >= 1.0.0", "polars[pyarrow] >= 1.9.0"]
+sql = [
+    "duckdb >= 1.1.0", 
+    "polars[pyarrow] >= 1.9.0", 
+    "sqlglot >= 26.0.1"
+]
+
 # List of deps that are recommended for most users
 # in order to unlock all features in marimo
 recommended = [
-    "duckdb>=1.1.0",   # SQL cells
-    "altair>=5.4.0",   # Plotting in datasource viewer
-    "polars>=1.9.0",   # SQL output back in Python
-    "openai>=1.41.1",  # AI features
-    "ruff",            # Formatting
-    "nbformat>=5.7.0", # Export as IPYNB
+    "duckdb>=1.1.0",            # SQL cells
+    "altair>=5.4.0",            # Plotting in datasource viewer
+    "polars[pyarrow]>=1.9.0",   # SQL output back in Python
+    "sqlglot>=26.0.1",          # SQL cells parsing
+    "openai>=1.41.1",           # AI features
+    "ruff",                     # Formatting
+    "nbformat>=5.7.0",          # Export as IPYNB
 ]
 
 dev = [

--- a/tests/_ast/test_sql_visitor.py
+++ b/tests/_ast/test_sql_visitor.py
@@ -726,3 +726,8 @@ class TestFindSQLRefs:
         );
         """
         assert find_sql_refs(sql) == ["table1", "table2"]
+
+    @staticmethod
+    def test_find_sql_refs_invalid_sql() -> None:
+        sql = "SELECT * FROM"
+        assert find_sql_refs(sql) == []

--- a/tests/_ast/test_sql_visitor.py
+++ b/tests/_ast/test_sql_visitor.py
@@ -627,18 +627,6 @@ class TestFindSQLRefs:
         assert find_sql_refs(sql) == ["table2", "table3", "table4", "table1"]
 
     @staticmethod
-    def test_find_sql_refs_with_recursive_cte() -> None:
-        sql = """
-        WITH RECURSIVE cte AS (
-            SELECT 1 AS n FROM table1
-            UNION ALL
-            SELECT n + 1 FROM cte WHERE n < 10
-        )
-        SELECT * FROM cte;
-        """
-        assert find_sql_refs(sql) == ["table1"]
-
-    @staticmethod
     def test_find_sql_refs_with_alias() -> None:
         sql = "SELECT * FROM employees AS e;"
         assert find_sql_refs(sql) == ["employees"]

--- a/tests/_ast/test_sql_visitor.py
+++ b/tests/_ast/test_sql_visitor.py
@@ -395,17 +395,6 @@ class TestFindSQLDefs:
         )
 
     @staticmethod
-    def test_find_sql_defs_with_create_as() -> None:
-        sql = """
-        CREATE TABLE t2 AS
-        WITH t3 AS (
-            SELECT * from t1
-        )
-        SELECT * FROM t3;
-        """
-        assert find_sql_defs(sql) == SQLDefs(tables=["t2"])
-
-    @staticmethod
     def test_find_sql_defs_with_catalog_and_schema() -> None:
         sql = """
         CREATE TABLE my_catalog.my_schema.my_table (id INT);

--- a/tests/_ast/test_sql_visitor.py
+++ b/tests/_ast/test_sql_visitor.py
@@ -627,6 +627,18 @@ class TestFindSQLRefs:
         assert find_sql_refs(sql) == ["table2", "table3", "table4", "table1"]
 
     @staticmethod
+    def test_find_sql_refs_with_recursive_cte() -> None:
+        sql = """
+        WITH RECURSIVE cte AS (
+            SELECT 1 AS n FROM table1
+            UNION ALL
+            SELECT n + 1 FROM cte WHERE n < 10
+        )
+        SELECT * FROM cte;
+        """
+        assert find_sql_refs(sql) == ["table1"]
+
+    @staticmethod
     def test_find_sql_refs_with_alias() -> None:
         sql = "SELECT * FROM employees AS e;"
         assert find_sql_refs(sql) == ["employees"]


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #3103. Adds sqlglot as an optional dependency to handle complex sql refs parsing. Also supports DML statements (insert, update and delete).

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

- set sqlglot version to lowest possible (likely >23.4, due to ibis lib)
- If we're keen on supporting dml's, then I could add more tests (I added some here alrdy)
- `def find_sql_def()` can also be modified to use sqlglot in the future, not included in this PR.
- small change: updated duckdb version to 1.1.0 to be synchronised across all installations (some were 1.0 and some were 1.1)

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
