### PR TITLE
Add mhchem

### DIFF
--- a/frontend/src/plugins/layout/TexPlugin.tsx
+++ b/frontend/src/plugins/layout/TexPlugin.tsx
@@ -30,8 +30,13 @@ const importKatex = once(async () => {
   return (await import("katex")).default;
 });
 
+const importMhChem = once(async () => {
+  // @ts-ignore : type is not exported by katex
+  await import("katex/contrib/mhchem");
+});
+
 async function renderLatex(mount: HTMLElement, tex: string): Promise<void> {
-  const katex = await importKatex();
+  const [katex] = await Promise.all([importKatex(), importMhChem()]);
   if (tex.startsWith("||(||(") && tex.endsWith("||)||)")) {
     // when $$...$$ is used without newlines before/after the $$.
     katex.render(tex.slice(6, -6), mount, {

--- a/marimo/_tutorials/markdown.py
+++ b/marimo/_tutorials/markdown.py
@@ -105,6 +105,23 @@ def __(mo):
 
 @app.cell(hide_code=True)
 def __(mo):
+    mo.accordion(
+        {
+            "Note: KaTeX": mo.md(
+                """
+                marimo actually uses KaTeX, a math typesetting library for the
+                web which supports a subset of LaTeX. For a list of
+                (un)supported commands, visit
+                https://katex.org/docs/support_table
+                """
+            )
+        }
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def __(mo):
     mo.md(
         """
         ## Interpolating Python values
@@ -137,7 +154,6 @@ def __(
         _x = np.linspace(start=0, stop=2 * np.pi)
         plt.plot(_x, np.sin(_x))
         return plt.gca()
-
 
     mo.md(
         f"""
@@ -213,7 +229,6 @@ def __(missing_numpy_msg, mo, np, numpy_installed):
         x = np.linspace(0, 2 * np.pi, 10)
         y = np.sin(x)
         return pd.DataFrame({"x": x, "sin(x)": y})
-
 
     mo.md(
         f"""
@@ -297,6 +312,7 @@ def __(
         plt.plot(x, amplitude * np.sin(2 * np.pi / period * x))
         plt.ylim(-2.2, 2.2)
         return plt.gca()
+
     return (plotsin,)
 
 
@@ -334,7 +350,9 @@ def __(amplitude, mo, period, plotsin):
 def __(mo):
     matplotlib_installed = False
     numpy_installed = False
-    missing_numpy_msg = mo.md("Oops! Looks like you don't have `numpy` installed.")
+    missing_numpy_msg = mo.md(
+        "Oops! Looks like you don't have `numpy` installed."
+    )
     missing_matplotlib_msg = mo.md(
         "Oops! Looks like you don't have `matplotlib` installed."
     )
@@ -367,6 +385,7 @@ def __():
     import math
 
     import marimo as mo
+
     return math, mo
 
 


### PR DESCRIPTION
## 📝 Summary

I would like to be able to write chemical equations conveniently in marimo. 

This pull request is an attempt at including katex' mhchem extension, which allows for convenient chemical writing through \ce command, but also clean physical unit typesetting with the \pu command (somewhat similar to siunitx in latex). 

Related to https://discordapp.com/channels/1059888774789730424/1318274202507284531

Note : this is the first time I'm trying to contribute to an open-source project, and I honestly don't really know what I am doing, but since the change is very small, I thought I could try. I just tried to make https://katex.org/docs/node#using-mhchem-extension work.

## 🔍 Description of Changes

- import katex' mhchem extension
- also add a note on katex in markdown tutorial

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] I have added tests for the changes made. => no tests for this module at this point
- [x] I have run the code and verified that it works as expected.

I have not tested for performance. Not sure how to test for that. In case it bloats the app, maybe it should be set as an option, or marimo could detect if \ce or \pu is written somewhere. 

Note: for comparison, Jupyter uses Mathjax which also allows for mhchem functionality through an extension. The extension isn't loaded by default (although it's very easy to load, either in a cell via "$$\require{mhchem}$$" or through the user's ipython config). 
However, another example, obsidian.md (the note-taking app I use) also uses Mathjax, and does load mhchem by default.
Not sure why KaTeX chose to put mhchem commands \ce and \pu as an extension. mhchem feels like just a convenient (and thin) wrapper around things like \mathrm.

## 📜 Reviewers
@mscolnick
