### PR TITLE
improve: include .nojekyll file in assets export

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Literal, Optional
 
 import click
@@ -24,9 +25,6 @@ from marimo._server.utils import asyncio_run
 from marimo._utils.file_watcher import FileWatcher
 from marimo._utils.marimo_path import MarimoPath
 from marimo._utils.paths import maybe_make_dirs
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 _watch_message = (
     "Watch notebook for changes and regenerate the output on modification. "
@@ -451,6 +449,11 @@ def html_wasm(
 
     # Export assets first
     Exporter().export_assets(out_dir, ignore_index_html=ignore_index_html)
+
+    # Create .nojekyll file to prevent GitHub Pages from interfering with asset
+    # resolution
+    (Path(out_dir) / ".nojekyll").touch()
+
     echo(
         f"Assets copied to {green(out_dir)}. These assets are required for the "
         "notebook to run in the browser."

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Literal, Optional
+from typing import Callable, Literal, Optional
 
 import click
 

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -85,6 +85,7 @@ class TestExportHTML:
             not in html
         )
         assert "<marimo-wasm" in html
+        assert Path(out_dir / ".nojekyll").exists()
 
     @staticmethod
     def test_cli_export_html_wasm_output_is_file(


### PR DESCRIPTION
Include a .nojekyll file in the assets exported by marimo export html-wasm to prevent GitHub Pages from interfering with asset resolution.

This issue arose when attempting to manually deploy a directory to GitHub Pages (instead of using an action).