### PR TITLE
fix: show hidden cells when markdown has no output

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -419,7 +419,7 @@ const CellComponent = (
     stopped: stopped,
     disabled: cellConfig.disabled,
     stale: status === "disabled-transitively",
-    borderless: isMarkdownCodeHidden && editing,
+    borderless: isMarkdownCodeHidden && hasOutput && editing,
   });
 
   const HTMLId = HTMLCellId.create(cellId);
@@ -567,6 +567,9 @@ const CellComponent = (
 
   const cellOutput = userConfig.display.cell_output;
 
+  const hasOutputAbove = hasOutput && cellOutput === "above";
+  const hasOutputBelow = hasOutput && cellOutput === "below";
+
   return (
     <CellActionsContextMenu
       cellId={cellId}
@@ -607,8 +610,8 @@ const CellComponent = (
             <div
               className={cn(
                 "absolute flex flex-col gap-[2px] justify-center h-full left-[-34px] z-20",
-                isMarkdownCodeHidden && cellOutput === "above" && "-top-7",
-                isMarkdownCodeHidden && cellOutput === "below" && "-bottom-8",
+                isMarkdownCodeHidden && hasOutputAbove && "-top-7",
+                isMarkdownCodeHidden && hasOutputBelow && "-bottom-8",
                 isMarkdownCodeHidden && isCellButtonsInline && "-left-[3.8rem]",
               )}
             >
@@ -649,6 +652,7 @@ const CellComponent = (
               editorViewRef={editorView}
               editorViewParentRef={editorViewParentRef}
               hidden={!isCellCodeShown}
+              hasOutput={hasOutput}
               temporarilyShowCode={temporarilyShowCode}
               languageAdapter={languageAdapter}
               setLanguageAdapter={setLanguageAdapter}

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -62,6 +62,7 @@ export interface CellEditorProps
    * This is different from cellConfig.hide_code, since it may be temporarily shown.
    */
   hidden?: boolean;
+  hasOutput?: boolean;
   languageAdapter: LanguageAdapterType | undefined;
   setLanguageAdapter: React.Dispatch<
     React.SetStateAction<LanguageAdapterType | undefined>
@@ -95,6 +96,7 @@ const CellEditorInternal = ({
   editorViewRef,
   editorViewParentRef,
   hidden,
+  hasOutput,
   temporarilyShowCode,
   languageAdapter,
   setLanguageAdapter,
@@ -359,6 +361,17 @@ const CellEditorInternal = ({
     };
   }, [editorViewRef]);
 
+  // Completely hide the editor & icons if it's markdown and hidden. If there is output, we show.
+  const showHideButton =
+    (hidden && !isMarkdown) || (hidden && isMarkdown && !hasOutput);
+
+  let editorClassName = "";
+  if (isMarkdown && hidden && hasOutput) {
+    editorClassName = "h-0 overflow-hidden";
+  } else if (hidden) {
+    editorClassName = "opacity-20 h-8 overflow-hidden";
+  }
+
   return (
     <AiCompletionEditor
       enabled={aiCompletionCell?.cellId === cellId}
@@ -394,8 +407,7 @@ const CellEditorInternal = ({
         className="relative w-full"
         onFocus={() => setLastFocusedCellId(cellId)}
       >
-        {/* Completely hide the editor and icons when markdown is hidden. If just hidden, display. */}
-        {!isMarkdown && hidden && (
+        {showHideButton && (
           <HideCodeButton
             tooltip="Edit code"
             className="absolute inset-0 z-10"
@@ -403,11 +415,7 @@ const CellEditorInternal = ({
           />
         )}
         <CellCodeMirrorEditor
-          className={cn(
-            isMarkdown && hidden
-              ? "h-0 overflow-hidden"
-              : hidden && "opacity-20 h-8 overflow-hidden",
-          )}
+          className={editorClassName}
           editorView={editorViewRef.current}
           ref={editorViewParentRef}
         />


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #3317 . Should display hidden cells similar to pre-borderless-markdown era. Code may be a bit rough.
<img width="750" alt="Screenshot 2025-01-01 at 2 05 14 AM" src="https://github.com/user-attachments/assets/ac9bb7f5-3dfb-4617-bee2-b1bfa685f052" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
