### PR TITLE
docs: update repeated tabs with chat content tab

### DIFF
--- a/docs/api/inputs/tabs.md
+++ b/docs/api/inputs/tabs.md
@@ -17,6 +17,14 @@ def __():
     plt.title("Random Bar Chart")
     plt.xlabel("Categories")
     plt.ylabel("Values")
+    def simple_echo_model(messages, config):
+        return f"You said: {messages[-1].content}"
+
+    chat = mo.ui.chat(
+        simple_echo_model,
+        prompts=["Hello", "How are you?"],
+        show_configuration_controls=True
+    )
     None
     return
 
@@ -25,7 +33,7 @@ def __():
     mo.ui.tabs(
         {
             "📈 Sales": bar,
-            "📊 Subscriptions": bar,
+            "📊 Data Explorer": chat,
             "💻 Settings": mo.ui.text(placeholder="Key"),
         }
     )

--- a/docs/api/inputs/tabs.md
+++ b/docs/api/inputs/tabs.md
@@ -33,7 +33,7 @@ def __():
     mo.ui.tabs(
         {
             "📈 Sales": bar,
-            "📊 Data Explorer": chat,
+            "📊 Chatbot": chat,
             "💻 Settings": mo.ui.text(placeholder="Key"),
         }
     )


### PR DESCRIPTION
## 📝 Summary

docs preview for tabs shows repeated graph, thought it would be nice to add `chat` option. Got confused the first time while using tabs whether it was switching or not.

![image](https://github.com/user-attachments/assets/51cb606e-ebfd-48d7-89ca-f8cf41f4306b)


## 🔍 Description of Changes

Updated with [chat](https://docs.marimo.io/api/inputs/chat/?h=chat) instead of bar.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
