### PR TITLE
docs: fix broken text_area preview

### DIFF
--- a/docs/api/inputs/text_area.md
+++ b/docs/api/inputs/text_area.md
@@ -1,20 +1,7 @@
 # Text Area
 
-/// marimo-embed
-
-```python
-@app.cell
-def __():
-    text_area = mo.ui.text_area(placeholder="Search...", label="Description")
-    return
-
-@app.cell
-def __():
-    mo.hstack([text_area, mo.md(f"Has value: {text_area.value}")])
-    return///
-
-```
-
+/// marimo-embed-file
+    filepath: examples/ui/text_area.py
 ///
 
 ::: marimo.ui.text_area

--- a/examples/ui/text_area.py
+++ b/examples/ui/text_area.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.10.6"
+__generated_with = "0.10.9"
 app = marimo.App()
 
 


### PR DESCRIPTION
## 📝 Summary

Fixed the broken text_area preview in docs currently by following mkdocs-preview embedding shown previously.

<details>

![image](https://github.com/user-attachments/assets/92a9b66c-b48a-40eb-a533-04287d761278)

</details>


## 🔍 Description of Changes

Link to `text_area` in `examples/ui/text_area.py`

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
