### PR TITLE
feat: mo.notebook_location()

### DIFF
--- a/docs/api/miscellaneous.md
+++ b/docs/api/miscellaneous.md
@@ -5,6 +5,9 @@
 ::: marimo.defs
 
 ::: marimo.refs
+
 ::: marimo.notebook_dir
+
+::: marimo.notebook_location
 
 ::: marimo.Thread

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "mpl",
     "nav_menu",
     "notebook_dir",
+    "notebook_location",
     "output",
     "pdf",
     "persistent_cache",
@@ -130,6 +131,7 @@ from marimo._runtime.runtime import (
     cli_args,
     defs,
     notebook_dir,
+    notebook_location,
     query_params,
     refs,
 )

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -317,6 +317,35 @@ def notebook_dir() -> pathlib.Path | None:
     return None
 
 
+@mddoc
+def notebook_location() -> pathlib.Path | None:
+    """Get the location of the currently executing notebook.
+
+    In WASM, this is the URL the webpage, for example, `https://my-site.com`.
+    For nested paths, this is the URL including the origin and pathname.
+    `https://<my-org>.github.io/<my-repo>/folder`.
+
+    In non-WASM, this is the directory of the notebook, which is the same as
+    `mo.notebook_dir()`.
+
+    Returns:
+        pathlib.Path | None: A pathlib.Path object representing the URL or directory of the current
+            notebook, or None if the notebook's directory cannot be determined.
+    """
+    if is_pyodide():
+        from js import location  # type: ignore
+
+        path_location = pathlib.Path(str(location))
+        # The location looks like https://marimo-team.github.io/marimo-gh-pages-template/notebooks/assets/worker-BxJ8HeOy.js
+        # We want to crawl out of the assets/ folder
+        if "assets" in path_location.parts:
+            return path_location.parent.parent
+        return path_location
+
+    else:
+        return notebook_dir()
+
+
 @dataclasses.dataclass
 class CellMetadata:
     """CellMetadata class for storing cell metadata.

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -321,12 +321,25 @@ def notebook_dir() -> pathlib.Path | None:
 def notebook_location() -> pathlib.Path | None:
     """Get the location of the currently executing notebook.
 
-    In WASM, this is the URL the webpage, for example, `https://my-site.com`.
+    In WASM, this is the URL of webpage, for example, `https://my-site.com`.
     For nested paths, this is the URL including the origin and pathname.
     `https://<my-org>.github.io/<my-repo>/folder`.
 
     In non-WASM, this is the directory of the notebook, which is the same as
     `mo.notebook_dir()`.
+
+    Examples:
+        In order to access data both locally and when a notebook runs via
+        WebAssembly (e.g. hosted on GitHub Pages), you can use this
+        approach to fetch data from the notebook's location.
+
+        ```python
+        import polars as pl
+
+        data_path = mo.notebook_location() / "public" / "data.csv"
+        df = pl.read_csv(data_path)
+        df.head()
+        ```
 
     Returns:
         pathlib.Path | None: A pathlib.Path object representing the URL or directory of the current

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -508,6 +508,23 @@ class TestApp:
         assert glbls["file"] == __file__
         assert glbls["dirpath"] == pathlib.Path(glbls["file"]).parent
 
+    def test_notebook_location() -> None:
+        app = App()
+
+        @app.cell
+        def __() -> tuple[str]:
+            import marimo as mo
+
+            dirpath = mo.notebook_dir()
+            location = mo.notebook_location()
+
+        _, glbls = app.run()
+        dirpath = glbls["dirpath"]
+        location = glbls["location"]
+        assert dirpath is not None
+        assert location is not None
+        assert dirpath == location
+
 
 def test_app_config() -> None:
     config = _AppConfig.from_untrusted_dict({"width": "full"})

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -508,11 +508,11 @@ class TestApp:
         assert glbls["file"] == __file__
         assert glbls["dirpath"] == pathlib.Path(glbls["file"]).parent
 
-    def test_notebook_location() -> None:
+    def test_notebook_location(self) -> None:
         app = App()
 
         @app.cell
-        def __() -> tuple[str]:
+        def __():
             import marimo as mo
 
             dirpath = mo.notebook_dir()


### PR DESCRIPTION
This adds `mo.notebook_location()`

```py
@mddoc
def notebook_location() -> pathlib.Path | None:
    """Get the location of the currently executing notebook.

    In WASM, this is the URL of webpage, for example, `https://my-site.com`.
    For nested paths, this is the URL including the origin and pathname.
    `https://<my-org>.github.io/<my-repo>/folder`.

    In non-WASM, this is the directory of the notebook, which is the same as
    `mo.notebook_dir()`.

    Examples:
        In order to access data both locally and when a notebook runs via
        WebAssembly (e.g. hosted on GitHub Pages), you can use this
        approach to fetch data from the notebook's location.

        ```python
        import polars as pl

        data_path = mo.notebook_location() / "public" / "data.csv"
        df = pl.read_csv(data_path)
        df.head()
        ```

    Returns:
        pathlib.Path | None: A pathlib.Path object representing the URL or directory of the current
            notebook, or None if the notebook's directory cannot be determined.
   """
```

This is useful for keeping your notebook code consistent while being able to load data locally and via a URL (when deployed via webassembly)