### PR TITLE
Polars extension

### DIFF
--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -116,6 +116,9 @@ from marimo._plugins.stateless.style import style
 from marimo._plugins.stateless.tabs import tabs
 from marimo._plugins.stateless.tree import tree
 from marimo._plugins.stateless.video import video
+from marimo._polars import (
+    lazyframe,  # noqa: F401  # Import is required for lazyframe registration
+)
 from marimo._runtime import output
 from marimo._runtime.capture import (
     capture_stderr,

--- a/marimo/_polars/lazyframe.py
+++ b/marimo/_polars/lazyframe.py
@@ -1,0 +1,63 @@
+import re
+from typing import TYPE_CHECKING, Any
+
+from marimo import mermaid
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._output.hypertext import Html
+
+if TYPE_CHECKING:
+    import polars as pl
+
+if DependencyManager.polars.has():
+    import polars as pl
+
+    @pl.api.register_lazyframe_namespace("mo")
+    class Marimo:
+        def __init__(self, ldf: pl.LazyFrame):
+            self._ldf: pl.LazyFrame = ldf
+
+        def show_graph(self, **kwargs: Any) -> Html | str:
+            # We are specifying raw_output already, so we need to remove if it is passed
+            raw_output = kwargs.pop("raw_output", False)
+
+            dot = self._ldf.show_graph(raw_output=True, **kwargs)
+
+            if raw_output:
+                return dot
+
+            return self._dot_to_mermaid_html(dot)
+
+        # _dot_to_mermaid_html is a separate method from show_graph so that in the future
+        # polars can be updated to output mermaid directly when calling native show_graph
+        # inside a marimo environment.
+        # In order to do that we need a function that will not recursively call show_graph
+        @classmethod
+        def _dot_to_mermaid_html(self, dot: str) -> Html:
+            return mermaid(self._polars_dot_to_mermaid(dot))
+
+        @staticmethod
+        def _parse_node_label(label: str) -> str:
+            # replace escaped newlines
+            label = label.replace(r"\n", "\n")
+            # replace escaped quotes
+            label = label.replace('\\"', "#quot;")
+            return label
+
+        @classmethod
+        def _polars_dot_to_mermaid(cls, dot: str) -> str:
+            edge_regex = r"(?P<node1>\w+) -- (?P<node2>\w+)"
+            node_regex = r"(?P<node>\w+)(\s+)?\[label=\"(?P<label>.*)\"]"
+
+            nodes = [n for n in re.finditer(node_regex, dot)]
+            edges = [e for e in re.finditer(edge_regex, dot)]
+
+            return "\n".join(
+                [
+                    "graph TD",
+                    *[
+                        f'\t{n["node"]}["{cls._parse_node_label(n["label"])}"]'
+                        for n in nodes
+                    ],
+                    *[f'\t{e["node1"]} --- {e["node2"]}' for e in edges],
+                ]
+            )

--- a/tests/_polars/test_polars.py
+++ b/tests/_polars/test_polars.py
@@ -1,0 +1,69 @@
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._output.hypertext import Html
+
+HAS_DEPS = DependencyManager.polars.has()
+
+
+@pytest.fixture
+def simple_lf():
+    import polars as pl
+
+    return (
+        pl.LazyFrame(
+            {
+                "a": [1, 2, 3],
+                "b": [4, 5, 6],
+            }
+        )
+        .filter(pl.col("a") > 1)
+        .group_by("a")
+        .agg(pl.col("b").sum())
+    )
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="polars is required")
+def test_show_graph(simple_lf):
+    lf = simple_lf
+
+    assert type(lf.mo.show_graph()) is Html
+    assert type(lf.mo.show_graph(raw_output=True)) is str
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="polars is required")
+def test_dot_to_html(simple_lf):
+    lf = simple_lf
+
+    dot = lf.show_graph(raw_output=True)
+
+    assert type(lf.mo._dot_to_mermaid_html(dot)) is Html
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="polars is required")
+def test_parse_node_label(simple_lf):
+    lf = simple_lf
+
+    assert lf.mo._parse_node_label(r"\"") == "#quot;"
+    assert lf.mo._parse_node_label(r"\n") == "\n"
+    assert lf.mo._parse_node_label(r"\"\n\"") == "#quot;\n#quot;"
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="polars is required")
+def test_dot_to_mermaid(simple_lf):
+    lf = simple_lf
+    dot = lf.show_graph(raw_output=True)
+
+    mermaid_str = lf.mo._polars_dot_to_mermaid(dot)
+
+    assert type(mermaid_str) is str
+    assert mermaid_str == (
+        """graph TD
+	p2["TABLE
+π 2/2;
+σ [(col(#quot;a#quot;)) > (1)]"]
+	p1["AGG [col(#quot;b#quot;).sum()]
+BY
+[col(#quot;a#quot;)]"]
+	p1 --- p2"""
+    )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Fixes issue #3355 by adding LazyFrame extension that allows output of mermaid graphs for polars lazyframe query plans. 

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

In this pull request I have added a polars extension that adds a `mo` namespace to LazyFrames, this namespace includes one "public" method `show_graph` that accepts the same arguments as polars LazyFrame `show_graph` and returns an `Html` object containing the mermaid chart. 

Issue #3355 shows side by side outputs.

Before merging it would be necessary to add documentation for this new polars namespace, but I wanted to request your feedback before I took that step.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka 
