### PR TITLE
fix: rendering with panel when not a native panel object

### DIFF
--- a/marimo/_plugins/ui/_impl/from_panel.py
+++ b/marimo/_plugins/ui/_impl/from_panel.py
@@ -218,7 +218,7 @@ class panel(UIElement[T, T]):
         # This gets set to True in super().__init__()
         self._initialized = False
 
-        ref, docs_json, render_json = render_component(obj)
+        ref, docs_json, render_json = render_component(self.obj)
         self._ref = ref
         self._manager = PanelCommManager(plot_id=ref)  # type: ignore[no-untyped-call]
 

--- a/marimo/_smoke_tests/third_party/holoviews_scatter.py
+++ b/marimo/_smoke_tests/third_party/holoviews_scatter.py
@@ -1,0 +1,60 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "bokeh==3.6.2",
+#     "hvplot==0.11.2",
+#     "marimo",
+#     "panel==1.5.5",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.10.9"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import hvplot.pandas
+    import panel
+
+    from bokeh.sampledata.iris import flowers as df
+
+    df.sample(n=5)
+
+    df.hvplot.scatter(
+        x="sepal_length",
+        y="sepal_width",
+        by="species",
+        legend="top",
+        height=400,
+        width=400,
+    )
+    return df, hvplot, panel
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.ui.panel({1: 2})
+    return
+
+
+@app.cell
+def _(mo):
+    import panel as pn
+
+    slider = pn.widgets.IntSlider(start=0, end=10, value=5)
+    rx_stars = mo.ui.panel(slider.rx() * "*")
+    rx_stars
+    return pn, rx_stars, slider
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,7 @@ extra-dependencies = [
     "altair>=5.4.0",
     "polars~=1.9.0",
     "pandas>=1.5.3",
+    "hvplot~=0.11.2",
     "geopandas~=0.14.4; python_version > '3.9'",
     # FOr testing sql
     "ibis-framework[duckdb]~=9.5.0; python_version > '3.9'",

--- a/tests/_plugins/ui/_impl/test_panel.py
+++ b/tests/_plugins/ui/_impl/test_panel.py
@@ -1,0 +1,77 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._plugins.ui._impl.from_panel import panel
+from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider
+
+HAS_DEPS = DependencyManager.panel.has()
+
+if HAS_DEPS:
+    import panel as pn
+else:
+    pn = Mock()
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+class TestPanel:
+    @staticmethod
+    async def test_instances(k: Kernel, exec_req: ExecReqProvider) -> None:
+        await k.run(
+            [
+                exec_req.get(
+                    """
+import panel as pn
+import marimo as mo
+
+slider = pn.widgets.IntSlider(start=0, end=10, value=5)
+slider = mo.ui.panel(slider)
+"""
+                )
+            ]
+        )
+
+    @staticmethod
+    def test_proxy_attributes() -> None:
+        slider = pn.widgets.IntSlider(start=0, end=10, value=5)
+        wrapped = panel(slider)
+
+        # Test attribute access
+        assert (
+            wrapped.value == {}
+        )  # slider gets wrapped in a row, so it's value is empty
+        assert wrapped.start == 0
+        assert wrapped.end == 10
+
+        # Test attribute modification
+        wrapped.value = 7
+        assert (
+            wrapped.value == {}
+        )  # slider gets wrapped in a row, so it's value is empty
+        assert slider.value == 7
+
+    @staticmethod
+    def test_layout_components() -> None:
+        row = panel(pn.Row("Test"))
+        col = panel(pn.Column("Test"))
+        tabs = panel(pn.Tabs(("Tab1", "Content")))
+
+        assert isinstance(row, panel)
+        assert isinstance(col, panel)
+        assert isinstance(tabs, panel)
+
+    @staticmethod
+    def test_any_object() -> None:
+        assert panel({}) is not None
+        assert panel([]) is not None
+        assert panel(()) is not None
+        assert panel(1) is not None
+        assert panel("test") is not None
+        assert panel(True) is not None
+        assert panel(False) is not None
+        assert panel(None) is not None


### PR DESCRIPTION
Issue from discord: https://discord.com/channels/1059888774789730424/1319756390759141429/1319756390759141429

The issue was:
```diff
- ref, docs_json, render_json = render_component(obj)
+ ref, docs_json, render_json = render_component(self.obj)
```

This PR also adds a fallback and unit tests.