### PR TITLE
chore(deps): set openai dependency to >=1.55.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ recommended = [
     "altair>=5.4.0",            # Plotting in datasource viewer
     "polars[pyarrow]>=1.9.0",   # SQL output back in Python
     "sqlglot>=23.4",            # SQL cells parsing
-    "openai>=1.41.1",           # AI features
+    "openai>=1.55.3",           # AI features
     "ruff",                     # Formatting
     "nbformat>=5.7.0",          # Export as IPYNB
 ]
@@ -107,7 +107,7 @@ dev = [
     # For linting
     "ruff~=0.6.1",
     # For AI
-    "openai~=1.41.1",
+    "openai>=1.55.3",
 ]
 
 docs = [
@@ -240,7 +240,7 @@ extra-dependencies = [
     "anywidget~=0.9.13",
     "ipython~=8.12.3",
     # testing gen ai
-    "openai~=1.41.1",
+    "openai>=1.55.3",
     "anthropic==0.34.1",
     "google-generativeai==0.8.2",
     # exporting as ipynb


### PR DESCRIPTION
## 📝 Summary

The minimum version requirement ensures compatibility with httpx>=0.28.0,  specifically around the 'proxies' kwarg handling that was fixed in openai 1.55.3. 

Earlier versions of openai conflict with httpx>=0.28.0.

See:
https://github.com/openai/openai-python/issues/1902
https://github.com/openai/openai-python/pull/1905

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
