### PR TITLE
fix: vim <CR> carriage return

### DIFF
--- a/frontend/src/core/codemirror/__tests__/__snapshots__/setup.test.ts.snap
+++ b/frontend/src/core/codemirror/__tests__/__snapshots__/setup.test.ts.snap
@@ -166,17 +166,6 @@ exports[`snapshot all duplicate keymaps > vim keymaps 2`] = `
       "shift": "deleteCharBackward",
     },
   ],
-  "Enter": [
-    {
-      "key": "Enter",
-      "run": "acceptCompletion",
-    },
-    {
-      "key": "Enter",
-      "run": "<no name>",
-      "shift": "<no name>",
-    },
-  ],
   "Escape": [
     {
       "key": "Escape",

--- a/frontend/src/core/codemirror/__tests__/setup.test.ts
+++ b/frontend/src/core/codemirror/__tests__/setup.test.ts
@@ -115,7 +115,7 @@ describe("snapshot all duplicate keymaps", () => {
     );
     // Total duplicates:
     // if this changes, please make sure to validate they are not conflicting
-    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot("19");
+    expect(Object.values(duplicates).flat().length).toMatchInlineSnapshot("17");
     expect(duplicates).toMatchSnapshot();
   });
 });

--- a/frontend/src/core/codemirror/keymaps/keymaps.ts
+++ b/frontend/src/core/codemirror/keymaps/keymaps.ts
@@ -6,6 +6,7 @@ import { type Extension, Prec } from "@codemirror/state";
 import { type EditorView, keymap } from "@codemirror/view";
 import { vim } from "@replit/codemirror-vim";
 import { vimKeymapExtension } from "./vim";
+import { once } from "@/utils/once";
 
 export const KEYMAP_PRESETS = ["default", "vim"] as const;
 
@@ -48,16 +49,21 @@ export function keymapBundle(
             },
           ),
         ),
+        keymap.of(defaultVimKeymap()),
         vim({ status: false }),
         // Needs to come after the vim extension
         vimKeymapExtension(callbacks),
-        keymap.of(defaultKeymap),
       ];
     default:
       logNever(config.preset);
       return [];
   }
 }
+
+const defaultVimKeymap = once(() => {
+  // Remove Enter (<CR>) from the keymap
+  return defaultKeymap.filter((k) => k.key !== "Enter");
+});
 
 /**
  * Listen for a double keypress of a character and call a callback.


### PR DESCRIPTION
Fixes #3318 

Remove the "Enter" from the `defaultKeymap`