### PR TITLE
fix: run markdown cells synchronously before hiding code

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -157,6 +157,12 @@ const CellEditorInternal = ({
   const toggleHideCode = useEvent(() => {
     // Use cellConfig.hide_code instead of hidden, since it may be temporarily shown
     const nextHidden = !cellConfig.hide_code;
+    
+    // For markdown cells, ensure the cell is run before hiding
+    if (nextHidden && languageAdapter === "markdown") {
+      runCell();
+    }
+
     // Fire-and-forget save
     void saveCellConfig({ configs: { [cellId]: { hide_code: nextHidden } } });
     updateCellConfig({ cellId, config: { hide_code: nextHidden } });

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -157,7 +157,7 @@ const CellEditorInternal = ({
   const toggleHideCode = useEvent(() => {
     // Use cellConfig.hide_code instead of hidden, since it may be temporarily shown
     const nextHidden = !cellConfig.hide_code;
-    
+
     // For markdown cells, ensure the cell is run before hiding
     if (nextHidden && languageAdapter === "markdown") {
       runCell();


### PR DESCRIPTION
## 📝 Summary

reported here
https://discord.com/channels/1059888774789730424/1326825858337607704

This ensures markdown cells are properly rendered before their code is hidden from view, while maintaining a smoother user experience.

Before

https://github.com/user-attachments/assets/ddd4bae2-4b4b-4442-ad3a-c4e062596b64

Now

https://github.com/user-attachments/assets/57cbca06-e356-4ddb-8f5d-fdc5340e3e21

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
