### PR TITLE
fix: improve bookmarklet functionality for GitHub notebook URLs

### DIFF
--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -59,7 +59,7 @@ navigate to `https://marimo.app/path/to/notebook.py`. For example:
     For a convenient way to create notebooks from GitHub, drag and drop the
     following button to your bookmarks bar:
 
-    <a href="javascript:(function(e){if(!location.hostname.includes('github.com')||(!location.href.endsWith('.py')&&!location.href.endsWith('.ipynb'))){alert('Please use this bookmarklet on a GitHub marimo notebook URL (.py or .ipynb file)');e.preventDefault();return;}const newUrl=location.href.replace('github.com', 'marimo.app/github.com');window.open(newUrl,'_blank');})(event);" 
+    <a href="javascript:(function(e){if(!location.hostname.includes('github.com')||(!location.href.endsWith('.py')&&!location.href.endsWith('.ipynb'))){alert('Please use this bookmarklet on a GitHub notebook URL (.py or .ipynb file)');e.preventDefault();return;}const newUrl=location.href.replace('github.com', 'marimo.app/github.com');window.open(newUrl,'_blank');})(event);" 
           style="padding: 5px 10px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px; font-weight: bold;">
     Open in marimo
     </a>

--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -59,13 +59,13 @@ navigate to `https://marimo.app/path/to/notebook.py`. For example:
     For a convenient way to create notebooks from GitHub, drag and drop the
     following button to your bookmarks bar:
 
-    <a href="javascript:(function(e){if(!location.hostname.includes('github.com')||(!location.href.endsWith('.py')&&!location.href.endsWith('.ipynb'))){alert('Please use this bookmarklet on a GitHub notebook URL (.py or .ipynb file)');e.preventDefault();return;}const newUrl=location.href.replace('github.com', 'marimo.app/github.com');window.open(newUrl,'_blank');})(event);" 
+    <a href="javascript:(function(){if(!location.href.endsWith('.py')&&!location.href.endsWith('.ipynb')){alert('Please use this bookmarklet on a URL ending with .py or .ipynb');return;}let url=window.location.href.replace(/^https:\/\//,'');window.open('https://marimo.app/' + url, '_blank');})();" 
           style="padding: 5px 10px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px; font-weight: bold;">
     Open in marimo
     </a>
 
-    Clicking the bookmark when you are viewing a notebook in GitHub will
-    open it in marimo.app.
+    Clicking the bookmark when you are viewing a notebook will
+    open it in [marimo.app](https://marimo.app/).
 
 !!! note "From Jupyter notebooks"
 

--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -59,7 +59,7 @@ navigate to `https://marimo.app/path/to/notebook.py`. For example:
     For a convenient way to create notebooks from GitHub, drag and drop the
     following button to your bookmarks bar:
 
-    <a href="javascript:(function(){let url=window.location.href.replace(/^https:\/\//,'');window.open('https://marimo.app/' + url, '_blank');})();" 
+    <a href="javascript:(function(e){if(!location.hostname.includes('github.com')||!location.href.endsWith('.py')){alert('Please use this bookmarklet on a GitHub marimo notebook URL (.py file)');e.preventDefault();return;}const newUrl=location.href.replace('github.com', 'marimo.app/github.com');window.open(newUrl,'_blank');})(event);" 
           style="padding: 5px 10px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px; font-weight: bold;">
     Open in marimo
     </a>

--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -59,7 +59,7 @@ navigate to `https://marimo.app/path/to/notebook.py`. For example:
     For a convenient way to create notebooks from GitHub, drag and drop the
     following button to your bookmarks bar:
 
-    <a href="javascript:(function(e){if(!location.hostname.includes('github.com')||!location.href.endsWith('.py')){alert('Please use this bookmarklet on a GitHub marimo notebook URL (.py file)');e.preventDefault();return;}const newUrl=location.href.replace('github.com', 'marimo.app/github.com');window.open(newUrl,'_blank');})(event);" 
+    <a href="javascript:(function(e){if(!location.hostname.includes('github.com')||(!location.href.endsWith('.py')&&!location.href.endsWith('.ipynb'))){alert('Please use this bookmarklet on a GitHub marimo notebook URL (.py or .ipynb file)');e.preventDefault();return;}const newUrl=location.href.replace('github.com', 'marimo.app/github.com');window.open(newUrl,'_blank');})(event);" 
           style="padding: 5px 10px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px; font-weight: bold;">
     Open in marimo
     </a>


### PR DESCRIPTION
## 📝 Summary

Fix incorrect bookmark hyperlink redirecting to 404 page.
![image](https://github.com/user-attachments/assets/5865e7af-eae8-41b8-8512-7e5b35c2aa5e)

## 🔍 Description of Changes
Create a popup dialog box instructing to open the bookmark/use it to open a marimo notebook on GitHub

## 📋 Checklist

- [x]  I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
