### PR TITLE
fix: add vega-datasets package to framework examples

### DIFF
--- a/examples/frameworks/fastapi-github/main.py
+++ b/examples/frameworks/fastapi-github/main.py
@@ -7,6 +7,7 @@
 #     "requests",
 #     "pydantic",
 #     "jinja2",
+#     "vega-datasets==0.9.0",
 # ]
 # ///
 import tempfile

--- a/examples/frameworks/fastapi/main.py
+++ b/examples/frameworks/fastapi/main.py
@@ -10,6 +10,7 @@
 #     "python-multipart",
 #     "passlib",
 #     "pydantic",
+#     "vega-datasets==0.9.0",
 # ]
 # ///
 from typing import Callable, Coroutine

--- a/examples/frameworks/fasthtml/main.py
+++ b/examples/frameworks/fasthtml/main.py
@@ -3,6 +3,7 @@
 # dependencies = [
 #     "python-fasthtml",
 #     "marimo",
+#     "vega-datasets==0.9.0",
 # ]
 # ///
 from fasthtml.common import *

--- a/examples/frameworks/flask/main.py
+++ b/examples/frameworks/flask/main.py
@@ -7,6 +7,7 @@
 #     "python-dotenv",
 #     "flask-session",
 #     "werkzeug",
+#     "vega-datasets==0.9.0",
 # ]
 # ///
 from flask import Flask, render_template, request, redirect, url_for, session


### PR DESCRIPTION


## 📝 Summary

When running the frameworks examples, the app fails to execute the dataframe.py because of vega-datasets missing dependency. This PR adds the vega-datasets package to each main.py script of the frameworks examples.

## 🔍 Description of Changes

Add the vega-datasets package to each main.py script of the frameworks examples

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
