### PR TITLE
improvement: hide_code for markdown when converting from ipynb

### DIFF
--- a/marimo/_convert/utils.py
+++ b/marimo/_convert/utils.py
@@ -24,18 +24,27 @@ def markdown_to_marimo(source: str) -> str:
 
 
 def generate_from_sources(
+    *,
     sources: list[str],
     config: Optional[_AppConfig] = None,
     header_comments: Optional[str] = None,
+    cell_configs: Optional[list[CellConfig]] = None,
 ) -> str:
     """
     Given a list of Python source code,
     generate the marimo file contents.
     """
+    if cell_configs is None:
+        cell_configs = [CellConfig() for _ in range(len(sources))]
+    else:
+        assert len(cell_configs) == len(
+            sources
+        ), "cell_configs must be the same length as sources"
+
     return codegen.generate_filecontents(
         sources,
         [DEFAULT_CELL_NAME for _ in sources],
-        [CellConfig() for _ in range(len(sources))],
+        cell_configs,
         config=config,
         header_comments=header_comments,
     )

--- a/tests/_cli/snapshots/converted_markdown.py.txt
+++ b/tests/_cli/snapshots/converted_markdown.py.txt
@@ -3,7 +3,7 @@ import marimo
 app = marimo.App()
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     mo.md(
         r"""
@@ -18,7 +18,7 @@ def _(mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     mo.md(
         r"""

--- a/tests/_convert/test_convert_utils.py
+++ b/tests/_convert/test_convert_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from textwrap import dedent
 
+from marimo._ast.cell import CellConfig
 from marimo._convert import utils
 
 
@@ -25,7 +26,7 @@ def test_markdown_to_marimo():
 def test_generate_from_sources():
     # Test with basic sources
     sources = ["print('Hello')", "x = 5"]
-    result = utils.generate_from_sources(sources)
+    result = utils.generate_from_sources(sources=sources)
     result = re.sub(r"__generated_with = .*", "", result)
 
     assert result == dedent(
@@ -51,4 +52,37 @@ def _():
 if __name__ == "__main__":
     app.run()
       """.lstrip()
+    )
+
+
+def test_generate_from_sources_with_cell_configs():
+    sources = ["print('Hello')", "x = 5"]
+    cell_configs = [CellConfig(hide_code=True), CellConfig(hide_code=False)]
+    result = utils.generate_from_sources(
+        sources=sources, cell_configs=cell_configs
+    )
+    result = re.sub(r"__generated_with = .*", "", result)
+    assert result == dedent(
+        """
+import marimo
+
+
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _():
+    print('Hello')
+    return
+
+
+@app.cell
+def _():
+    x = 5
+    return (x,)
+
+
+if __name__ == "__main__":
+    app.run()
+        """.lstrip()
     )


### PR DESCRIPTION
I think this looks better, for example https://marimo.app/gh/jakevdp/PythonDataScienceHandbook/master?entrypoint=notebooks%2F03.09-Pivot-Tables.ipynb