### PR TITLE
docs: overview page on sharing notebooks from github

### DIFF
--- a/docs/guides/publishing/embedding.md
+++ b/docs/guides/publishing/embedding.md
@@ -6,7 +6,7 @@ are two ways:
 
 * Host on [GitHub Pages](github_pages.md) or [self-host WASM HTML](self_host_wasm.md),
   and `<iframe>` the published notebook.
-* `<iframe>` a playground notebook, and [customize the embedding](playground.md#embedding-in-other-web-pages) with query params.
+* `<iframe>` a [playground](playground.md) notebook, and [customize the embedding](playground.md#embedding-in-other-web-pages) with query params.
   (This is what we do throughout docs.marimo.io.)
 
 We plan to provide more turn-key solutions for static site generation with

--- a/docs/guides/publishing/from_github.md
+++ b/docs/guides/publishing/from_github.md
@@ -1,0 +1,12 @@
+# From GitHub
+
+marimo makes it very easy to share links to executable notebooks from notebooks
+hosted on GitHub. Unlike Google Colab, marimo also automatically synchronizes
+data stored in your GitHub repo to the notebook's filesystem, making it
+easy to bundle data with your notebooks.
+
+
+- Publish notebooks to [GitHub Pages](github_pages.md)
+- Edit notebooks on the [marimo playground](playground.md), with public link-based sharing
+  (no login required!)
+- Synchronize to our [Community Cloud](community_cloud/index.md) for email-based sharing

--- a/docs/guides/publishing/index.md
+++ b/docs/guides/publishing/index.md
@@ -13,8 +13,9 @@ This guide provides an overview of the various ways to publish marimo notebooks.
 | Guide                                                 | Description                                                  |
 | ----------------------------------------------------- | ------------------------------------------------------------ |
 | [Embedding](embedding.md)                             | An overview of embedding notebooks in other sites            |
+| [From GitHub](from_github.md)                         | How to share links to executable notebooks hosted on GitHUb  |
 | [GitHub Pages](github_pages.md)                       | Publishing interactive notebooks on GitHub Pages             |
-| [Online playground](playground.md)                    | Sharing notebook links using our online playground           |
+| [Online playground](playground.md)                    | Sharing interactive notebook using our online playground     |
 | [Community Cloud](community_cloud/index.md)           | Save notebooks to our free Community Cloud                   |
 | [Self-host WebAssembly notebooks](self_host_wasm.md)  | Self-hosting interactive WebAssembly (HTML export) notebooks |
 | [View notebooks on GitHub](view_outputs_on_github.md) | Viewing notebook outputs on GitHub                           |

--- a/docs/guides/publishing/index.md
+++ b/docs/guides/publishing/index.md
@@ -15,7 +15,7 @@ This guide provides an overview of the various ways to publish marimo notebooks.
 | [Embedding](embedding.md)                             | An overview of embedding notebooks in other sites            |
 | [From GitHub](from_github.md)                         | How to share links to executable notebooks hosted on GitHUb  |
 | [GitHub Pages](github_pages.md)                       | Publishing interactive notebooks on GitHub Pages             |
-| [Online playground](playground.md)                    | Sharing interactive notebook using our online playground     |
+| [Online playground](playground.md)                    | Sharing notebook links using our online playground           |
 | [Community Cloud](community_cloud/index.md)           | Save notebooks to our free Community Cloud                   |
 | [Self-host WebAssembly notebooks](self_host_wasm.md)  | Self-hosting interactive WebAssembly (HTML export) notebooks |
 | [View notebooks on GitHub](view_outputs_on_github.md) | Viewing notebook outputs on GitHub                           |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
       - Publish to the web:
           - Publish to the web: guides/publishing/index.md
           - Embedding: guides/publishing/embedding.md
+          - From GitHub: guides/publishing/from_github.md
           - GitHub Pages: guides/publishing/github_pages.md
           - Online playground: guides/publishing/playground.md
           - Community Cloud: guides/publishing/community_cloud/index.md


### PR DESCRIPTION
This adds a short overview page and navigation entry (publishing > from github) on how to publish/share notebooks from GitHub, for discoverability.

- GitHub pages
- Online playground
- Community Cloud

Analagous to the publishing > embedding page.