### PR TITLE
docs: fix broken links in html

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -200,38 +200,38 @@ GitHub to learn more.
 <table border="0">
   <tr>
     <td>
-      <a target="_blank" href="getting_started/key_concepts.md">
+      <a target="_blank" href="getting_started/key_concepts">
         <img src="_static/reactive.gif" style="max-height: 150px; width: auto; display: block" />
       </a>
     </td>
     <td>
-      <a target="_blank" href="api/inputs/index.md">
+      <a target="_blank" href="api/inputs/">
         <img src="https://raw.githubusercontent.com/marimo-team/marimo/main/docs/_static/readme-ui.gif" style="max-height: 150px; width: auto; display: block" />
       </a>
     </td>
     <td>
-      <a target="_blank" href="guides/working_with_data/plotting.md">
+      <a target="_blank" href="guides/working_with_data/plotting">
         <img src="https://raw.githubusercontent.com/marimo-team/marimo/main/docs/_static/docs-intro.gif" style="max-height: 150px; width: auto; display: block" />
       </a>
     </td>
     <td>
-      <a target="_blank" href="api/layouts/index.md">
+      <a target="_blank" href="api/layouts/">
         <img src="https://raw.githubusercontent.com/marimo-team/marimo/main/docs/_static/outputs.gif" style="max-height: 150px; width: auto; display: block" />
       </a>
     </td>
   </tr>
   <tr>
     <td>
-      <a target="_blank" href="getting_started/key_concepts.md"> Tutorial </a>
+      <a target="_blank" href="getting_started/key_concepts"> Tutorial </a>
     </td>
     <td>
-      <a target="_blank" href="api/inputs/index.md"> Inputs </a>
+      <a target="_blank" href="api/inputs/"> Inputs </a>
     </td>
     <td>
-      <a target="_blank" href="guides/working_with_data/plotting.md"> Plots </a>
+      <a target="_blank" href="guides/working_with_data/plotting"> Plots </a>
     </td>
     <td>
-      <a target="_blank" href="api/layouts/index.md"> Layout </a>
+      <a target="_blank" href="api/layouts/"> Layout </a>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## 📝 Summary

Fixes broken links on docs.marimo.io

## 🔍 Description of Changes

links inside html elements are not automatically converted to the correct url during the docs build process, leading to 404s on the main marimo docs page: https://docs.marimo.io/#learn-more (see the html table below "check out our guides ...")

## 📋 Checklist

- [x ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).

## 📜 Reviewers

@akshayka
