### PR TITLE
docs: add %pip usage instruction to Jupyter guide

### DIFF
--- a/docs/guides/coming_from/jupyter.md
+++ b/docs/guides/coming_from/jupyter.md
@@ -175,7 +175,7 @@ subprocess.run(["ls", "-l"])
 | %autoreload   | marimo's [module autoreloader](../../editor_features/module_autoreloading/)                       |
 | %matplotlib   | marimo auto-displays plots                                                                     |
 | %pwd          | `os.getcwd()`                                                                                  |
-| %pip          | Use the package manager option on the sidebar to install packages                              |
+| %pip          | Use marimo's [built-in package management](../../editor_features/package_management/)   |                
 | %who_ls       | `dir()`, `globals()`, [`mo.refs()`][marimo.refs], [`mo.defs()`][marimo.defs]                   |
 | %system       | `subprocess.run()`                                                                             |
 | %%time        | `time.perf_counter()` or Python's timeit module                                                |

--- a/docs/guides/coming_from/jupyter.md
+++ b/docs/guides/coming_from/jupyter.md
@@ -175,6 +175,7 @@ subprocess.run(["ls", "-l"])
 | %autoreload   | marimo's [module autoreloader](../../editor_features/module_autoreloading/)                       |
 | %matplotlib   | marimo auto-displays plots                                                                     |
 | %pwd          | `os.getcwd()`                                                                                  |
+| %pip          | Use the package manager option on the sidebar to install packages                              |
 | %who_ls       | `dir()`, `globals()`, [`mo.refs()`][marimo.refs], [`mo.defs()`][marimo.defs]                   |
 | %system       | `subprocess.run()`                                                                             |
 | %%time        | `time.perf_counter()` or Python's timeit module                                                |


### PR DESCRIPTION
## 📝 Summary

Add a row for %pip installation guide in cell block `Common magic commands replacements` introduced in this PR #3408 

## 🔍 Description of Changes

Add the following to the existing table guide (for magic commands replacement):

| Magic Command| Replacement |
|--------|--------|
| %pip| Use the package manager option on the sidebar to install packages| 

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
