### PR TITLE
fix: Add missing open bracket in docs/faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,7 +50,7 @@ relationships between cells, and automatically re-running cells as needed.
 
 In addition, marimo notebooks can serialize package requirements inline;
 marimo runs these "sandboxed" notebooks in temporary virtual environments,
-making them [reproducible down to the packages]guides/editor_features/package_management.md).
+making them [reproducible down to the packages](guides/editor_features/package_management.md).
 
 **Maintainability.**
 marimo notebooks are stored as pure Python programs (`.py` files). This lets you


### PR DESCRIPTION
## 📝 Summary

This PR adds a missing open bracket in the FAQ that broke one of the links.

## 🔍 Description of Changes

I added the open bracket

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected - I have manually verified that the link links to a site that actually exists.

## 📜 Reviewers

@akshayka OR @mscolnick
