### PR TITLE
docs: add llm.txt file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,12 @@ jobs:
       - name: 📚 Build docs
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
+      - name: 📚 llm.txt
+        # This is technically off by 1 commit, but generating the llm.txt file is easiest from a
+        # deployed site.
+        # We also ignore txt and xml files
+        run: npx sitefetch https://docs.marimo.io -o site/llm.txt --match "!**/*.{txt,xml}"
+
       - name: 🚀 Deploy to Vercel
         if: github.ref == 'refs/heads/main'
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -106,7 +106,7 @@ marimo is both a notebook and a library.
 - Use the _marimo library_ (`import marimo as mo`) in
   marimo notebooks. Write markdown with `mo.md(...)`,
   create stateful interactive elements with `mo.ui` (`mo.ui.slider(...)`), and
-  more. See the docs for an [API reference](https://docs.marimo.io/api/).
+  more. See the docs for an [API reference](./api/index.md).
 
 <a name="faq-notebook-app"></a>
 

--- a/docs/getting_started/key_concepts.md
+++ b/docs/getting_started/key_concepts.md
@@ -116,7 +116,7 @@ The marimo library also comes with elements for laying out outputs, including
 [`mo.hstack`][marimo.hstack], [`mo.vstack`][marimo.vstack],
 [`mo.accordion`][marimo.accordion], [`mo.ui.tabs`][marimo.ui.tabs], [`mo.sidebar`][marimo.sidebar],
 [`mo.nav_menu`][marimo.nav_menu], [`mo.ui.table`][marimo.ui.table],
-and [many more](https://docs.marimo.io/api/layouts/index.html).
+and [many more](../api/layouts/index.md).
 
 For more on outputs, try these tutorials:
 

--- a/docs/guides/deploying/index.md
+++ b/docs/guides/deploying/index.md
@@ -34,12 +34,12 @@ These guides help you deploy marimo notebooks as read-only apps.
 
 |                                 |                                                          |
 | :------------------------------ | :------------------------------------------------------- |
-| [programmatically](programmatically.md) | Programmatically run and customize read-only marimo apps |
-| [deploying_docker](deploying_docker.md) | Deploy with Docker                                       |
-| [authentication](authentication.md) | Authentication and security                              |
-| [deploying_public_gallery](deploying_public_gallery.md) | Deploy to our public gallery                             |
-| [deploying_hugging_face](deploying_hugging_face.md) | Deploy to Hugging Face                                   |
-| [deploying_ploomber](deploying_ploomber.md) | Deploy to Ploomber Cloud                                 |
+| [programmatically](./programmatically.md) | Programmatically run and customize read-only marimo apps |
+| [deploying_docker](./deploying_docker.md) | Deploy with Docker                                       |
+| [authentication](./authentication.md) | Authentication and security                              |
+| [deploying_public_gallery](./deploying_public_gallery.md) | Deploy to our public gallery                             |
+| [deploying_hugging_face](./deploying_hugging_face.md) | Deploy to Hugging Face                                   |
+| [deploying_ploomber](./deploying_ploomber.md) | Deploy to Ploomber Cloud                                 |
 
 ### Health and status endpoints
 

--- a/docs/guides/editor_features/ai_completion.md
+++ b/docs/guides/editor_features/ai_completion.md
@@ -76,7 +76,7 @@ marimo has built-in support for generating and refactoring code with AI, with a 
 
 ### Custom AI Rules
 
-You can customize how the AI assistant behaves by adding rules in the marimo settings. These rules help ensure consistent code generation across all AI providers. You can find more information about marimo's supported plotting libraries and data handling in the [plotting guide](https://docs.marimo.io/guides/working_with_data/plotting.html#plotting) and [working with data guide](https://docs.marimo.io/guides/working_with_data/index.html).
+You can customize how the AI assistant behaves by adding rules in the marimo settings. These rules help ensure consistent code generation across all AI providers. You can find more information about marimo's supported plotting libraries and data handling in the [plotting guide](../working_with_data/plotting.md#plotting) and [working with data guide](../working_with_data/index.md).
 
 <div align="center">
   <figure>

--- a/docs/guides/interactivity.md
+++ b/docs/guides/interactivity.md
@@ -12,7 +12,7 @@ global variable automatically runs all cells that reference it.**
 </div>
 
 !!! example "Examples"
-    See the [API reference](http://127.0.0.1:8000/api/inputs/) or our [GitHub
+    See the [API reference](../api/inputs/index.md) or our [GitHub
     repo](https://github.com/marimo-team/marimo/tree/main/examples/ui) for
     bite-sized examples on using input elements.
 

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -24,7 +24,7 @@ traditional client-server model. WASM notebooks:
     with code and models, doing lightweight data exploration, authoring blog
     posts, tutorials, and educational materials, and even building tools. For
     notebooks that do heavy computation, [use marimo
-    locally](http://127.0.0.1:8000/getting_started/) or on a backend.
+    locally](../getting_started/index.md) or on a backend.
 
 **Try it!** Try editing the below notebook (your browser, not a backend server, is executing it!)
 
@@ -95,7 +95,6 @@ For a full list of supported packages, see [Pyodide's
 documentation on supported packages.](https://pyodide.org/en/stable/usage/packages-in-pyodide.html)
 
 If you want a package to be supported, consider [filing an issue](https://github.com/pyodide/pyodide/issues/new?assignees=&labels=new+package+request&projects=&template=package_request.md&title=).
-
 
 ## Including data
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ use them are automatically re-run with their latest values.
 <img src="https://raw.githubusercontent.com/marimo-team/marimo/main/docs/_static/readme-ui.gif" width="700px" />
 
 **Interactive dataframes.** [Page through, search, filter, and
-sort](https://docs.marimo.io/guides/working_with_data/dataframes.html)
+sort](./guides/working_with_data/dataframes.md)
 millions of rows blazingly fast, no code required.
 
 <img src="_static/docs-df.gif">


### PR DESCRIPTION
```
        # This is technically off by 1 commit, but generating the llm.txt file is easiest from a
        # deployed site.
        # We also ignore txt and xml files
        run: npx sitefetch https://docs.marimo.io -o site/llm.txt --match "!**/*.{txt,xml}"
```