### PR TITLE
fix: empty notebooks should have empty venvs in sandboxes

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -288,16 +288,23 @@ def run_in_sandbox(
         python_version = None
 
     # Construct base UV command
-    uv_cmd = [
-        "uv",
-        "run",
-        "--isolated",
-        # sandboxed notebook shouldn't pick up existing pyproject.toml,
-        # which may conflict with the sandbox requirements
-        "--no-project",
-        "--with-requirements",
-        temp_file_path,
-    ]
+    uv_cmd = (
+        [
+            "uv",
+            "run",
+            "--isolated",
+            # sandboxed notebook shouldn't pick up existing pyproject.toml,
+            # which may conflict with the sandbox requirements
+            "--no-project",
+            "--with-requirements",
+        ]
+        # If there are no dependences, uv may use a cached venv, even though
+        # we are passing --isolated; `--refresh` ensures that the venv is
+        # actually ephemeral
+        + ["--refresh"]
+        if not dependencies
+        else [] + [temp_file_path]
+    )
 
     # Add Python version if specified
     if python_version:

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -264,6 +264,12 @@ def run_in_sandbox(
         get_dependencies_from_filename(name) if name is not None else []
     )
 
+    # If there are no dependences, which can happen for marimo new or
+    # on marimo edit a_new_file.py, uv may use a cached venv, even though
+    # we are passing --isolated; `--refresh` ensures that the venv is
+    # actually ephemeral.
+    uv_needs_refresh = not dependencies
+
     # Normalize marimo dependencies
     dependencies = _normalize_sandbox_dependencies(dependencies, __version__)
 
@@ -298,12 +304,10 @@ def run_in_sandbox(
             "--no-project",
             "--with-requirements",
         ]
-        # If there are no dependences, uv may use a cached venv, even though
-        # we are passing --isolated; `--refresh` ensures that the venv is
-        # actually ephemeral
+        + [temp_file_path]
         + ["--refresh"]
-        if not dependencies
-        else [] + [temp_file_path]
+        if uv_needs_refresh
+        else []
     )
 
     # Add Python version if specified

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -258,7 +258,7 @@ def construct_uv_command(args: list[str], name: str | None) -> list[str]:
         get_dependencies_from_filename(name) if name is not None else []
     )
 
-    # If there are no dependences, which can happen for marimo new or
+    # If there are no dependencies, which can happen for marimo new or
     # on marimo edit a_new_file.py, uv may use a cached venv, even though
     # we are passing --isolated; `--refresh` ensures that the venv is
     # actually ephemeral.

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -9,6 +9,7 @@ from marimo._cli.sandbox import (
     _normalize_sandbox_dependencies,
     _pyproject_toml_to_requirements_txt,
     _read_pyproject,
+    construct_uv_command,
     get_dependencies_from_filename,
 )
 
@@ -308,3 +309,33 @@ def test_is_marimo_dependency():
     assert not _is_marimo_dependency("pandas")
     assert not _is_marimo_dependency("marimo-ai")
     assert not _is_marimo_dependency("marimo-ai==0.1.0")
+
+
+def test_construct_uv_cmd_marimo_new() -> None:
+    uv_cmd = construct_uv_command(["new"], None)
+    assert "--refresh" in uv_cmd
+
+
+def test_construct_uv_cmd_marimo_edit_empty_file() -> None:
+    # a file that doesn't yet exist
+    uv_cmd = construct_uv_command(["edit", "foo_123.py"], "foo_123.py")
+    assert "--refresh" in uv_cmd
+
+
+def test_construct_uv_cmd_marimo_edit_file_no_sandbox(
+    temp_marimo_file: str,
+) -> None:
+    # a file that has no inline metadata yet
+    uv_cmd = construct_uv_command(["edit", temp_marimo_file], temp_marimo_file)
+    assert "--refresh" in uv_cmd
+
+
+def test_construct_uv_cmd_marimo_edit_sandboxed_file(
+    temp_sandboxed_marimo_file: str,
+) -> None:
+    # a file that has inline metadata; shouldn't refresh the cache, uv
+    # --isolated will do the right thing.
+    uv_cmd = construct_uv_command(
+        ["edit", temp_sandboxed_marimo_file], temp_sandboxed_marimo_file
+    )
+    assert "--refresh" not in uv_cmd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,6 +262,49 @@ def temp_marimo_file() -> Generator[str, None, None]:
 
 
 @pytest.fixture
+def temp_sandboxed_marimo_file() -> Generator[str, None, None]:
+    tmp_dir = TemporaryDirectory()
+    tmp_file = os.path.join(tmp_dir.name, "notebook.py")
+    content = inspect.cleandoc(
+        """
+        # Copyright 2024 Marimo. All rights reserved.
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #     "polars",
+        #     "marimo>=0.8.0",
+        #     "quak",
+        #     "vega-datasets",
+        # ]
+        # ///
+
+        import marimo
+        app = marimo.App()
+
+        @app.cell
+        def __():
+            import marimo as mo
+            return mo,
+
+        @app.cell
+        def __(mo):
+            slider = mo.ui.slider(0, 10)
+            return slider,
+
+        if __name__ == "__main__":
+            app.run()
+        """
+    )
+
+    try:
+        with open(tmp_file, "w") as f:
+            f.write(content)
+        yield tmp_file
+    finally:
+        tmp_dir.cleanup()
+
+
+@pytest.fixture
 def temp_async_marimo_file() -> Generator[str, None, None]:
     tmp_dir = TemporaryDirectory()
     tmp_file = os.path.join(tmp_dir.name, "notebook.py")


### PR DESCRIPTION
If there are no dependencies (specifically, if uv is not running a script with inline metadata), uv may use a cached venv, even though we are passing --isolated; `--refresh` ensures that the venv is actually ephemeral