### PR TITLE
Support shells on windows (with extensions)

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -800,7 +800,8 @@ def shell_completion() -> None:
         )
         return
 
-    shell_name = Path(shell).name
+    # in case we're on a windows system, use .stem to remove extension
+    shell_name = Path(shell).stem
 
     commands = {
         "bash": (

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -800,21 +800,27 @@ def test_cli_run_sandbox_prompt_yes() -> None:
 
 # shell-completion has 1 input (value of $SHELL) & 3 outputs (return code, stdout, & stderr)
 # parameterize to give coverage. We use a boolean to specify if output on that stream should be present.
-shell_completion_test_results = [
-    # valid shell values, rc of 0, data only on stdout
-    ("bash", 0, True, False),
-    ("bash.exe", 0, True, False),
-    ("/usr/bin/zsh", 0, True, False),
-    (r"c:\spam\eggs\fish.exe", 0, True, False),
-    # invalid shell values, rc of 0, data only on stderr
-    # (N.B. rc will become 2 when Issue #3476 is fixed)
-    ("bogus", 0, False, True),
-]
-
-
 @pytest.mark.parametrize(
     "shell,rc,expect_stdout,expect_stderr".split(","),
-    shell_completion_test_results,
+    [
+        # valid shell values, rc of 0, data only on stdout
+        ("bash", 0, True, False),
+        ("bash.exe", 0, True, False),
+        ("/usr/bin/zsh", 0, True, False),
+        pytest.param(
+            r"c:\spam\eggs\fish.exe",
+            0,
+            True,
+            False,
+            marks=pytest.mark.skipif(
+                not sys.platform.startswith(("win32", "cygwin")),
+                reason="win32 only",
+            ),
+        ),
+        # invalid shell values, rc of 0, data only on stderr
+        # (N.B. rc will become 2 when Issue #3476 is fixed)
+        ("bogus", 0, False, True),
+    ],
 )
 def test_shell_completion(
     shell: str, rc: int, expect_stdout: bool, expect_stderr: bool

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -806,13 +806,19 @@ shell_completion_test_results = [
     ("bash.exe", 0, True, False),
     ("/usr/bin/zsh", 0, True, False),
     (r"c:\spam\eggs\fish.exe", 0, True, False),
-
     # invalid shell values, rc of 0, data only on stderr
     # (N.B. rc will become 2 when Issue #3476 is fixed)
     ("bogus", 0, False, True),
 ]
-@pytest.mark.parametrize("shell,rc,expect_stdout,expect_stderr".split(','), shell_completion_test_results)
-def test_shell_completion(shell:str, rc:int, expect_stdout:bool, expect_stderr:bool) -> None:
+
+
+@pytest.mark.parametrize(
+    "shell,rc,expect_stdout,expect_stderr".split(","),
+    shell_completion_test_results,
+)
+def test_shell_completion(
+    shell: str, rc: int, expect_stdout: bool, expect_stderr: bool
+) -> None:
     test_env = os.environ.copy()
     test_env["SHELL"] = shell
     p = subprocess.run(

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -798,13 +798,31 @@ def test_cli_run_sandbox_prompt_yes() -> None:
     p.kill()
 
 
-def test_shell_completion() -> None:
+# shell-completion has 1 input (value of $SHELL) & 3 outputs (return code, stdout, & stderr)
+# parameterize to give coverage. We use a boolean to specify if output on that stream should be present.
+shell_completion_test_results = [
+    # valid shell values, rc of 0, data only on stdout
+    ("bash", 0, True, False),
+    ("bash.exe", 0, True, False),
+    ("/usr/bin/zsh", 0, True, False),
+    (r"c:\spam\eggs\fish.exe", 0, True, False),
+
+    # invalid shell values, rc of 0, data only on stderr
+    # (N.B. rc will become 2 when Issue #3476 is fixed)
+    ("bogus", 0, False, True),
+]
+@pytest.mark.parametrize("shell,rc,expect_stdout,expect_stderr".split(','), shell_completion_test_results)
+def test_shell_completion(shell:str, rc:int, expect_stdout:bool, expect_stderr:bool) -> None:
+    test_env = os.environ.copy()
+    test_env["SHELL"] = shell
     p = subprocess.run(
         ["marimo", "shell-completion"],
         capture_output=True,
+        env=test_env,
     )
-    assert p.returncode == 0
-    assert p.stdout is not None
+    assert p.returncode == rc
+    assert bool(len(p.stdout)) == expect_stdout
+    assert bool(len(p.stderr)) == expect_stderr
 
 
 HAS_DOCKER = DependencyManager.which("docker")


### PR DESCRIPTION


## 📝 Summary

Fixes #3445

## 🔍 Description of Changes

Even though the value of $SHELL is just "bash" at the command line, it is the full path to the executable in the program. (i.e. 'c:\foo\bar\bash.exe'). The "name" attribute returns "bash.exe" in that case, which doesn't match "bash". Fortunately, pathlib.Path also offers a "stem" attribute which strips the extension. \o/

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
