### PR TITLE
fix: sandbox command construction

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -288,21 +288,16 @@ def construct_uv_command(args: list[str], name: str | None) -> list[str]:
         python_version = None
 
     # Construct base UV command
-    uv_cmd = (
-        [
-            "uv",
-            "run",
-            "--isolated",
-            # sandboxed notebook shouldn't pick up existing pyproject.toml,
-            # which may conflict with the sandbox requirements
-            "--no-project",
-            "--with-requirements",
-            temp_file_path,
-        ]
-        + ["--refresh"]
-        if uv_needs_refresh
-        else []
-    )
+    uv_cmd = [
+        "uv",
+        "run",
+        "--isolated",
+        # sandboxed notebook shouldn't pick up existing pyproject.toml,
+        # which may conflict with the sandbox requirements
+        "--no-project",
+        "--with-requirements",
+        temp_file_path,
+    ] + (["--refresh"] if uv_needs_refresh else [])
 
     # Add Python version if specified
     if python_version:

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -320,6 +320,8 @@ def test_construct_uv_cmd_marimo_edit_empty_file() -> None:
     # a file that doesn't yet exist
     uv_cmd = construct_uv_command(["edit", "foo_123.py"], "foo_123.py")
     assert "--refresh" in uv_cmd
+    assert uv_cmd[0] == "uv"
+    assert uv_cmd[1] == "run"
 
 
 def test_construct_uv_cmd_marimo_edit_file_no_sandbox(
@@ -328,6 +330,8 @@ def test_construct_uv_cmd_marimo_edit_file_no_sandbox(
     # a file that has no inline metadata yet
     uv_cmd = construct_uv_command(["edit", temp_marimo_file], temp_marimo_file)
     assert "--refresh" in uv_cmd
+    assert uv_cmd[0] == "uv"
+    assert uv_cmd[1] == "run"
 
 
 def test_construct_uv_cmd_marimo_edit_sandboxed_file(
@@ -339,3 +343,5 @@ def test_construct_uv_cmd_marimo_edit_sandboxed_file(
         ["edit", temp_sandboxed_marimo_file], temp_sandboxed_marimo_file
     )
     assert "--refresh" not in uv_cmd
+    assert uv_cmd[0] == "uv"
+    assert uv_cmd[1] == "run"


### PR DESCRIPTION
Missing parentheses broke command construction. Strengthened tests.