### PR TITLE
fix: raise valueError for pageSize > 200

### DIFF
--- a/marimo/_plugins/ui/_impl/data_editor.py
+++ b/marimo/_plugins/ui/_impl/data_editor.py
@@ -25,6 +25,7 @@ from marimo import _loggers
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._plugins.ui._impl.tables.utils import get_table_manager
+from marimo._plugins.validators import validate_page_size
 
 LOGGER = _loggers.marimo_logger()
 
@@ -142,6 +143,7 @@ class data_editor(
             ]
         ] = None,
     ) -> None:
+        validate_page_size(page_size)
         table_manager = get_table_manager(data)
 
         size = table_manager.get_num_rows()

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -96,7 +96,8 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
 
     Args:
         df (DataFrameType): The DataFrame or series to transform.
-        page_size (int): The number of rows to show in the table. Defaults to 5.
+        page_size (Optional[int], optional): The number of rows to show in the table.
+            Defaults to 5.
         limit (Optional[int], optional): The number of items to load into memory, in case
             the data is remote and lazily fetched. This is likely true for SQL-backed
             dataframes via Ibis.
@@ -110,11 +111,10 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
         self,
         df: DataFrameType,
         on_change: Optional[Callable[[DataFrameType], None]] = None,
-        page_size: int = 5,
+        page_size: Optional[int] = 5,
         limit: Optional[int] = None,
     ) -> None:
         validate_no_integer_columns(df)
-        validate_page_size(page_size)
         # This will raise an error if the dataframe type is not supported.
         handler = get_handler_for_dataframe(df)
 
@@ -144,6 +144,7 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
         self._error: Optional[str] = None
         self._last_transforms = Transformations([])
         self._page_size = page_size or 5  # Default to 5 rows (.head())
+        validate_page_size(self._page_size)
 
         super().__init__(
             component_name=dataframe._name,

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -36,7 +36,10 @@ from marimo._plugins.ui._impl.tables.table_manager import (
 from marimo._plugins.ui._impl.tables.utils import (
     get_table_manager,
 )
-from marimo._plugins.validators import validate_no_integer_columns
+from marimo._plugins.validators import (
+    validate_no_integer_columns,
+    validate_page_size,
+)
 from marimo._runtime.functions import EmptyArgs, Function
 from marimo._utils.memoize import memoize_last_value
 from marimo._utils.parse_dataclass import parse_raw
@@ -112,6 +115,7 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
         limit: Optional[int] = None,
     ) -> None:
         validate_no_integer_columns(df)
+        validate_page_size(page_size)
         # This will raise an error if the dataframe type is not supported.
         handler = get_handler_for_dataframe(df)
 

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -96,8 +96,7 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
 
     Args:
         df (DataFrameType): The DataFrame or series to transform.
-        page_size (Optional[int], optional): The number of rows to show in the table.
-            Defaults to 5.
+        page_size (int): The number of rows to show in the table. Defaults to 5.
         limit (Optional[int], optional): The number of items to load into memory, in case
             the data is remote and lazily fetched. This is likely true for SQL-backed
             dataframes via Ibis.
@@ -111,7 +110,7 @@ class dataframe(UIElement[Dict[str, Any], DataFrameType]):
         self,
         df: DataFrameType,
         on_change: Optional[Callable[[DataFrameType], None]] = None,
-        page_size: Optional[int] = 5,
+        page_size: int = 5,
         limit: Optional[int] = None,
     ) -> None:
         validate_no_integer_columns(df)

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -38,7 +38,10 @@ from marimo._plugins.ui._impl.tables.table_manager import (
 )
 from marimo._plugins.ui._impl.tables.utils import get_table_manager
 from marimo._plugins.ui._impl.utils.dataframe import ListOrTuple, TableData
-from marimo._plugins.validators import validate_no_integer_columns
+from marimo._plugins.validators import (
+    validate_no_integer_columns,
+    validate_page_size,
+)
 from marimo._runtime.functions import EmptyArgs, Function
 from marimo._utils.narwhals_utils import unwrap_narwhals_dataframe
 
@@ -254,6 +257,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
         _internal_total_rows: Optional[Union[int, Literal["too_many"]]] = None,
     ) -> None:
         validate_no_integer_columns(data)
+        validate_page_size(page_size)
 
         # The original data passed in
         self._data = data

--- a/marimo/_plugins/validators.py
+++ b/marimo/_plugins/validators.py
@@ -77,3 +77,9 @@ def validate_no_integer_columns(df: Any) -> None:
             "Please use strings for column names.",
             stacklevel=3,
         )
+
+
+def validate_page_size(page_size: int) -> None:
+    # We will need to support frontend row virtualization beyond this limit
+    if page_size > 200:
+        raise ValueError("Table limited to 200 rows. If you'd like this increased, please file an issue")

--- a/marimo/_plugins/validators.py
+++ b/marimo/_plugins/validators.py
@@ -82,4 +82,4 @@ def validate_no_integer_columns(df: Any) -> None:
 def validate_page_size(page_size: int) -> None:
     # We will need to support frontend row virtualization beyond this limit
     if page_size > 200:
-        raise ValueError("Table limited to 200 rows. If you'd like this increased, please file an issue")
+        raise ValueError("Page size limited to 200 rows. If you'd like this increased, please file an issue")

--- a/marimo/_plugins/validators.py
+++ b/marimo/_plugins/validators.py
@@ -82,4 +82,6 @@ def validate_no_integer_columns(df: Any) -> None:
 def validate_page_size(page_size: int) -> None:
     # We will need to support frontend row virtualization beyond this limit
     if page_size > 200:
-        raise ValueError("Page size limited to 200 rows. If you'd like this increased, please file an issue")
+        raise ValueError(
+            "Page size limited to 200 rows. If you'd like this increased, please file an issue"
+        )

--- a/marimo/_plugins/validators.py
+++ b/marimo/_plugins/validators.py
@@ -79,8 +79,8 @@ def validate_no_integer_columns(df: Any) -> None:
         )
 
 
+# issue: https://github.com/marimo-team/marimo/issues/3407
 def validate_page_size(page_size: int) -> None:
-    # We will need to support frontend row virtualization beyond this limit
     if page_size > 200:
         raise ValueError(
             "Page size limited to 200 rows. If you'd like this increased, please file an issue"

--- a/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
@@ -218,6 +218,13 @@ class TestDataframes:
         assert search_result.data == result.url
 
     @staticmethod
+    def test_dataframe_too_large_page_size() -> None:
+        df = pd.DataFrame({"A": range(300)})
+        with pytest.raises(ValueError) as e:
+            _ = ui.dataframe(df, page_size=201)
+        assert "limited to 200 rows" in str(e.value)
+
+    @staticmethod
     def test_dataframe_with_non_string_column_names() -> None:
         df = pd.DataFrame(
             {0: [1, 2, 3], 1.5: ["a", "b", "c"], "2": [True, False, True]}

--- a/tests/_plugins/ui/_impl/test_data_editor.py
+++ b/tests/_plugins/ui/_impl/test_data_editor.py
@@ -397,6 +397,15 @@ def test_data_editor_with_custom_pagination():
 @pytest.mark.skipif(
     not DependencyManager.polars.has(), reason="Polars not installed"
 )
+def test_data_editor_with_too_large_pagesize():
+    data = [{"A": i} for i in range(300)]
+    with pytest.raises(ValueError):
+        _ = data_editor(data=data, page_size=201)
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
 def test_data_editor_on_change_callback():
     data = [{"A": 1, "B": "a"}, {"A": 2, "B": "b"}, {"A": 3, "B": "c"}]
     callback_called = False

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -396,6 +396,13 @@ def test_table_with_too_many_rows_gets_clamped() -> None:
     assert len(table._component_args["data"]) == 10
 
 
+def test_table_too_large_pagesize_throws_error() -> None:
+    data = {"a": list(range(20_002))}
+    with pytest.raises(ValueError) as e:
+        _ = ui.table(data, page_size=201)
+    assert "limited to 200 rows" in str(e.value)
+
+
 def test_can_get_second_page() -> None:
     data = {"a": list(range(40))}
     table = ui.table(data)


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #3407 . This will raise an error for `data_editor`, `dataframe` and `table` when the `page_size` configured is > 200.
<img width="450" alt="image" src="https://github.com/user-attachments/assets/8ec47f57-492b-45df-bff5-b5c2d481ebf1" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
