### PR TITLE
feat(hotkeys): add configurable completion selection movement

### DIFF
--- a/docs/guides/editor_features/hotkeys.md
+++ b/docs/guides/editor_features/hotkeys.md
@@ -36,6 +36,8 @@ You can find a list of available hotkeys below:
 | `cell.unfold`               |
 | `cell.unfoldAll`            |
 | `cell.viewAsMarkdown`       |
+| `completion.moveDown`        |
+| `completion.moveUp`          |
 | `global.commandPalette`     |
 | `global.focusBottom`        |
 | `global.focusTop`           |

--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -173,8 +173,7 @@ export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
         preventDefault: true,
       },
       {
-        key: "Alt-j",
-        mac: "Ctrl-j",
+        key: hotkeys.getHotkey("completion.moveDown").key,
         run: (cm) => {
           if (completionStatus(cm.state) !== null) {
             moveCompletionSelection(true)(cm);
@@ -185,8 +184,7 @@ export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
         preventDefault: true,
       },
       {
-        key: "Alt-k",
-        mac: "Ctrl-k",
+        key: hotkeys.getHotkey("completion.moveUp").key,
         run: (cm) => {
           if (completionStatus(cm.state) !== null) {
             moveCompletionSelection(false)(cm);

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -344,6 +344,16 @@ const DEFAULT_HOT_KEY = {
     group: "Navigation",
     key: "F12",
   },
+  "completion.moveDown": {
+    name: "Move completion selection down",
+    group: "Editing",
+    key: "Ctrl-j",
+  },
+  "completion.moveUp": {
+    name: "Move completion selection up",
+    group: "Editing",
+    key: "Ctrl-k",
+  },
 } satisfies Record<string, Hotkey>;
 
 export type HotkeyAction = keyof typeof DEFAULT_HOT_KEY;


### PR DESCRIPTION
## 📝 Summary

make keymaps introduced in #3382  configurable

<img width="411" alt="Bildschirmfoto 2025-01-17 um 07 57 00" src="https://github.com/user-attachments/assets/9ea65d92-e93d-4bad-8737-cba4d1c9897c" />

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
