### PR TITLE
cache iteration: various fixes- will invalidate exisiting cache

### DIFF
--- a/marimo/_ast/models.py
+++ b/marimo/_ast/models.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/marimo/_runtime/primitives.py
+++ b/marimo/_runtime/primitives.py
@@ -79,6 +79,23 @@ def is_data_primitive(value: Any) -> bool:
             or (hasattr(value.dtype, "hasobject") and value.dtype.hasobject)
         )
     elif hasattr(value, "dtypes"):
+        # Use narwhals to normalize the dataframe if it's present, otherwise
+        # default to naive check.
+        if DependencyManager.narwhals.has():
+            import narwhals as nw
+
+            try:
+                return nw.narwhalify(
+                    lambda df: all(
+                        df[col].dtype.is_numeric for col in df.columns
+                    )
+                )(df)
+            except Exception as err:
+                raise ValueError(
+                    "Unexpected datatype, narwhals was unable to normalize "
+                    "dataframe. Please report this to "
+                    "github.com/marimo-team/marimo"
+                ) from err
         for dtype in value.dtypes:
             # Capture pandas cases
             if getattr(dtype, "hasobject", None):

--- a/marimo/_runtime/primitives.py
+++ b/marimo/_runtime/primitives.py
@@ -81,28 +81,22 @@ def is_data_primitive(value: Any) -> bool:
     elif hasattr(value, "dtypes"):
         # Use narwhals to normalize the dataframe if it's present, otherwise
         # default to naive check.
-        if DependencyManager.narwhals.has():
-            import narwhals as nw
+        import narwhals as nw
 
-            try:
-                return nw.narwhalify(
+        try:
+            return bool(
+                nw.narwhalify(
                     lambda df: all(
-                        df[col].dtype.is_numeric for col in df.columns
+                        df[col].dtype.is_numeric() for col in df.columns
                     )
-                )(df)
-            except Exception as err:
-                raise ValueError(
-                    "Unexpected datatype, narwhals was unable to normalize "
-                    "dataframe. Please report this to "
-                    "github.com/marimo-team/marimo"
-                ) from err
-        for dtype in value.dtypes:
-            # Capture pandas cases
-            if getattr(dtype, "hasobject", None):
-                return False
-            # Capture polars cases
-            if hasattr(dtype, "is_numeric") and not dtype.is_numeric:
-                return False
+                )(value)
+            )
+        except Exception as err:
+            raise err from ValueError(
+                "Unexpected datatype, narwhals was unable to normalize "
+                "dataframe. Please report this to "
+                "github.com/marimo-team/marimo"
+            )
     # Otherwise may be a closely related array object
     return True
 

--- a/marimo/_runtime/primitives.py
+++ b/marimo/_runtime/primitives.py
@@ -79,8 +79,8 @@ def is_data_primitive(value: Any) -> bool:
             or (hasattr(value.dtype, "hasobject") and value.dtype.hasobject)
         )
     elif hasattr(value, "dtypes"):
-        # Use narwhals to normalize the dataframe if it's present, otherwise
-        # default to naive check.
+        # Bit of discrepancy between objects like polars and pandas, so use
+        # narwhals to normalize the dataframe.
         import narwhals as nw
 
         try:

--- a/marimo/_save/ast.py
+++ b/marimo/_save/ast.py
@@ -201,7 +201,7 @@ class RemoveReturns(ast.NodeTransformer):
 
 def strip_function(fn: Callable[..., Any]) -> ast.Module:
     code, _ = inspect.getsourcelines(fn)
-    args = list(fn.__code__.co_varnames)
+    args = set(fn.__code__.co_varnames)
     function_ast = ast.parse(textwrap.dedent("".join(code)))
     body = function_ast.body.pop()
     assert isinstance(body, (ast.FunctionDef, ast.AsyncFunctionDef)), (

--- a/marimo/_save/ast.py
+++ b/marimo/_save/ast.py
@@ -128,7 +128,7 @@ class ExtractWithBlock(ast.NodeTransformer):
                 )
                 for body in bodies:
                     try:
-                        # Recursion by referring the the containing block also
+                        # Recursion by referring to the containing block also
                         # captures the case where the target line number was not
                         # exactly hit.
                         # for instance:

--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -57,10 +57,6 @@ class SerialRefs(NamedTuple):
     stateful_refs: set[Name]
 
 
-class ShadowedRef:
-    """Stub for scoped variables that may shadow global references"""
-
-
 def hash_module(
     code: Optional[CodeType], hash_type: str = DEFAULT_HASH
 ) -> bytes:
@@ -752,22 +748,6 @@ class BlockHasher:
         transitive_state_refs = self.graph.get_transitive_references(
             refs, inclusive=False
         )
-
-        for ref in transitive_state_refs:
-            if ref in scope and isinstance(scope[ref], ShadowedRef):
-                # TODO(akshayka, dmadisetti): Lift this restriction once
-                # function args are rewritten.
-                #
-                # This makes more sense as a NameError, but the marimo's
-                # explainer text for NameError's doesn't make sense in this
-                # context. ("Definition expected in ...")
-                raise RuntimeError(
-                    f"The cached function declares an argument '{ref}'"
-                    "but a captured function or class uses the "
-                    f"global variable '{ref}'. Please rename "
-                    "the argument, or restructure the use "
-                    f"of the global variable."
-                )
 
         # Filter for relevant stateful cases.
         refs |= set(

--- a/marimo/_save/save.py
+++ b/marimo/_save/save.py
@@ -26,7 +26,6 @@ from marimo._save.cache import Cache, CacheException
 from marimo._save.hash import (
     DEFAULT_HASH,
     BlockHasher,
-    ShadowedRef,
     cache_attempt_from_hash,
     content_cache_attempt_from_base,
 )
@@ -115,21 +114,13 @@ class _cache_base(object):
         # checking a single frame- should be good enough.
         f_locals = inspect.stack()[2 + self._frame_offset][0].f_locals
         self.scope = {**ctx.globals, **f_locals}
-        # In case scope shadows variables
-        #
-        # TODO(akshayka, dmadisetti): rewrite function args with an AST pass
-        # to make them unique, deterministically based on function body; this
-        # will allow for lifting the error when a ShadowedRef is also used
-        # as a regular ref.
-        for arg in self._args:
-            self.scope[arg] = ShadowedRef()
 
         # Scoped refs are references particular to this block, that may not be
         # defined out of the context of the block, or the cell.
         # For instance, the args of the invoked function are restricted to the
         # block.
         cell_id = ctx.cell_id or ctx.execution_context.cell_id or ""
-        self.scoped_refs = set(self._args)
+        self.scoped_refs = set([f"*{k}" for k in self._args])
         # # As are the "locals" not in globals
         self.scoped_refs |= set(f_locals.keys()) - set(ctx.globals.keys())
         # Defined in the cell, and currently available in scope
@@ -184,8 +175,10 @@ class _cache_base(object):
             self._set_context(args[0])
             return self
 
+        # Rewrite scoped args to prevent shadowed variables
+        arg_dict = {f"*{k}": v for (k, v) in zip(self._args, args)}
+        kwargs = {"*{k}": v for (k, v) in kwargs.items()}
         # Capture the call case
-        arg_dict = {k: v for (k, v) in zip(self._args, args)}
         scope = {**self.scope, **get_context().globals, **arg_dict, **kwargs}
         assert self._loader is not None, UNEXPECTED_FAILURE_BOILERPLATE
         attempt = content_cache_attempt_from_base(
@@ -193,7 +186,7 @@ class _cache_base(object):
             scope,
             self._loader(),
             scoped_refs=self.scoped_refs,
-            required_refs=set(self._args),
+            required_refs=set([f"*{k}" for k in self._args]),
             as_fn=True,
         )
 

--- a/marimo/_save/save.py
+++ b/marimo/_save/save.py
@@ -177,7 +177,7 @@ class _cache_base(object):
 
         # Rewrite scoped args to prevent shadowed variables
         arg_dict = {f"*{k}": v for (k, v) in zip(self._args, args)}
-        kwargs = {"*{k}": v for (k, v) in kwargs.items()}
+        kwargs = {f"*{k}": v for (k, v) in kwargs.items()}
         # Capture the call case
         scope = {**self.scope, **get_context().globals, **arg_dict, **kwargs}
         assert self._loader is not None, UNEXPECTED_FAILURE_BOILERPLATE

--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -102,6 +102,7 @@ class TestScriptCache:
                     8
                 ]
             # fmt: on
+            assert b == [8]
             assert cache._cache.defs == {"b": [8]}
 
         app.run()
@@ -120,7 +121,7 @@ class TestScriptCache:
             # fmt: off
             b = [2]
             if True:
-              with persistent_cache("if", _loader=_loader) as cache:
+              with persistent_cache("if", _loader=_loader):
                   b = [
                       7
                   ]
@@ -142,7 +143,7 @@ class TestScriptCache:
             _loader = MockLoader()
             b = 2
             if True:
-                with persistent_cache("if", _loader=_loader) as cache:
+                with persistent_cache("if", _loader=_loader):
                     b = 8
             assert b == 8
 
@@ -162,7 +163,7 @@ class TestScriptCache:
             if False:
                 b = 2
             else:
-                with persistent_cache("else", _loader=_loader) as cache:
+                with persistent_cache("else", _loader=_loader):
                     b = 8
             assert b == 8
 
@@ -180,7 +181,7 @@ class TestScriptCache:
             if False:
                 b = 2
             elif True:
-                with persistent_cache("else", _loader=_loader) as cache:
+                with persistent_cache("else", _loader=_loader):
                     b = 8
             assert b == 8
 
@@ -205,7 +206,7 @@ class TestScriptCache:
 
             _loader = MockLoader()
             with called(True):
-                with persistent_cache("else", _loader=_loader) as cache:
+                with persistent_cache("else", _loader=_loader):
                     b = 8
             assert b == 8
 
@@ -229,7 +230,7 @@ class TestScriptCache:
             from tests._save.mocks import MockLoader
 
             _loader = MockLoader()
-            with persistent_cache("else", _loader=_loader) as cache:
+            with persistent_cache("else", _loader=_loader):
                 with called(True):
                     b = 8
             assert b == 8
@@ -252,7 +253,7 @@ class TestScriptCache:
 
             _loader = MockLoader()
             # fmt: off
-            with persistent_cache("else", _loader=_loader) as cache: call(False)
+            with persistent_cache("else", _loader=_loader): call(False) # noqa: E701
             # fmt: on
 
         with pytest.raises(BlockException):
@@ -272,7 +273,7 @@ class TestScriptCache:
             _loader = MockLoader()
 
             def call():
-                with persistent_cache("else", _loader=_loader) as cache:
+                with persistent_cache("else", _loader=_loader):
                     return 1
 
             call()
@@ -1223,7 +1224,7 @@ class TestCacheDecorator:
                     def f(state):
                         return x + state()
 
-                    return state() + g(state2)
+                    return state() + f(state2)
 
                 return g()
 

--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -1216,17 +1216,21 @@ class TestCacheDecorator:
             @mo.cache
             def h(state):
                 x = state()
+
                 def g():
                     global state
+
                     def f(state):
                         return x + state()
-                    return state() + g(state2)
+
+                    return state() + f(state2)
+
                 return g()
 
-            assert g(state0) == 111
-            assert g.hits == 0
-            assert g(state1) == 111
-            assert g.hits == 1
+            assert h(state0) == 111
+            assert h.hits == 0
+            assert h(state1) == 111
+            assert h.hits == 1
 
         app.run()
 
@@ -1264,9 +1268,9 @@ class TestCacheDecorator:
             def g(state):
                 return state() + f()
 
-            assert g(state0) == 1111
+            assert g(state0) == 111
             assert g.hits == 0
-            assert g(state1) == 1111
+            assert g(state1) == 111
             assert g.hits == 1
 
         app.run()

--- a/tests/_save/test_hash.py
+++ b/tests/_save/test_hash.py
@@ -637,7 +637,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.mocks import MockLoader
 
-            expected_hash = "rTAh8yNbBbq9qkF1nGNUw4DXhZSxRqGe4ptbDh2AwBI"
+            expected_hash = "iV5v_cNAxBPqe8tNJnI5volNORTH_gyhKuIvHcG_cds"
             return MockLoader, persistent_cache, expected_hash, torch
 
         @app.cell
@@ -794,7 +794,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.mocks import MockLoader
 
-            expected_hash = "n4KGJ3wrRHd6pDCyekTWZXShmtT_ZkDY4Wo3C6BXzh4"
+            expected_hash = "RbeMLx994_-kB9rF2ebi6mFMbCW_S6-Q41MsrgJgwUA"
             return MockLoader, persistent_cache, expected_hash, np, pd
 
         @app.cell

--- a/tests/_save/test_hash.py
+++ b/tests/_save/test_hash.py
@@ -142,7 +142,7 @@ class TestHash:
             # Cannot be reused/ shared, because it will change the hash.
             assert (
                 _cache._cache.hash
-                == "V_BAVE7PI97W7iec44GYXD69pebyztj7R3jgGFAnnEM"
+                == "b7qDaJXGI0uohd9Q5llsyggPCtEW9dTM7Dt2ZtuuqCs"
             ), _cache._cache.hash
             assert _cache._cache.cache_type == "ContextExecutionPath"
             return
@@ -163,7 +163,7 @@ class TestHash:
             assert _X == 7
             assert (
                 _cache._cache.hash
-                == "V_BAVE7PI97W7iec44GYXD69pebyztj7R3jgGFAnnEM"
+                == "b7qDaJXGI0uohd9Q5llsyggPCtEW9dTM7Dt2ZtuuqCs"
             ), _cache._cache.hash
             assert _cache._cache.cache_type == "ContextExecutionPath"
             # and a post block difference
@@ -180,6 +180,7 @@ class TestHash:
         app = App()
         app._anonymous_file = True
 
+        # NB. load is last for cell order difference.
         @app.cell
         def one(persistent_cache, MockLoader, shared) -> tuple[int]:
             _a = [1, object()]
@@ -191,7 +192,7 @@ class TestHash:
             # Cannot be reused/ shared, because it will change the hash.
             assert (
                 _cache._cache.hash
-                == "V_BAVE7PI97W7iec44GYXD69pebyztj7R3jgGFAnnEM"
+                == "b7qDaJXGI0uohd9Q5llsyggPCtEW9dTM7Dt2ZtuuqCs"
             ), _cache._cache.hash
             assert _cache._cache.cache_type == "ContextExecutionPath"
             return
@@ -212,7 +213,7 @@ class TestHash:
             assert _X == 7
             assert (
                 _cache._cache.hash
-                == "V_BAVE7PI97W7iec44GYXD69pebyztj7R3jgGFAnnEM"
+                == "b7qDaJXGI0uohd9Q5llsyggPCtEW9dTM7Dt2ZtuuqCs"
             ), _cache._cache.hash
             assert _cache._cache.cache_type == "ContextExecutionPath"
             # and a post block difference
@@ -882,6 +883,11 @@ class TestDataHash:
 
         app.run()
 
+    @staticmethod
+    @pytest.mark.skipif(
+        not DependencyManager.has("polars"),
+        reason="optional dependencies not installed",
+    )
     @pytest.mark.skipif(
         "sys.version_info < (3, 12) or sys.version_info >= (3, 13)"
     )
@@ -896,7 +902,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.mocks import MockLoader
 
-            expected_hash = "rC6YiNsuaZKQ1JqMgSRa0itEDwi7ZTl6InABjuM0RDY"
+            expected_hash = "QzGgcNS-eEP58qkkFphgAOJNKEpoTNcXhJ-L2exXzr4"
             return MockLoader, persistent_cache, expected_hash, pl
 
         @app.cell


### PR DESCRIPTION
This has fixes for:

 - [x] Shadowed arguments
 - [x] Formatting causing issues with context block: #2633
 - [x] improved df "object detection": #2661
 
Following PR changes:

-  Detect when execution hash relies on a another hash object (cache breaking) (#3270)
-  Allow for pickle hash as fallback for "unhashable" variables (#3270)
-  Expand `@persistent_cache` api (this shouldn't cache bust, so I might just follow up) (#2653)

