### PR TITLE
docs: add glightbox

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -232,6 +232,7 @@ plugins:
         color: '#000000'
         font_family: Roboto
   - tags
+  - glightbox
   - redirects:
       redirect_maps: {}
   - mkdocstrings:


### PR DESCRIPTION
Adds https://github.com/blueswen/mkdocs-glightbox to images for click effect