### PR TITLE
Improve reporting of unparsable code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ marimo/_lsp/
 
 .vscode
 .vercel
+.idea
 
 .marimo.toml
 .mypy_cache/

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -230,13 +230,17 @@ class App:
 
     def _maybe_initialize(self) -> None:
         if self._unparsable:
-            errors = []
+            errors: list[str] = []
             for code in self._unparsable_code:
                 try:
                     ast.parse(dedent(code))
                 except SyntaxError as e:
                     error_line = e.text
-                    error_marker = " " * (e.offset - 1) + "^"
+                    error_marker: str = (
+                        " " * (e.offset - 1) + "^"
+                        if e.offset is not None
+                        else ""
+                    )
                     err = f"{error_line}{error_marker}\n{e.msg}"
                     errors.append(err)
             syntax_errors = "\n-----\n".join(errors)

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -237,17 +237,13 @@ class App:
                 except SyntaxError as e:
                     error_line = e.text
                     error_marker = " " * (e.offset - 1) + "^"
-                    err = (
-                        f"{error_line}"
-                        f"{error_marker}\n"
-                        f"{e.msg}"
-                    )
+                    err = f"{error_line}{error_marker}\n{e.msg}"
                     errors.append(err)
             syntax_errors = "\n-----\n".join(errors)
 
             raise UnparsableError(
-                f"The notebook '{self._filename}' has cells with syntax errors, " +
-                f"so it cannot be initialized:\n {syntax_errors}"
+                f"The notebook '{self._filename}' has cells with syntax errors, "
+                + f"so it cannot be initialized:\n {syntax_errors}"
             ) from None
 
         if self._initialized:

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -159,8 +159,9 @@ class TestApp:
         app._unparsable_cell("_ _")
         app._unparsable_cell("_ _", name="foo")
 
-        with pytest.raises(UnparsableError):
+        with pytest.raises(UnparsableError) as e:
             app.run()
+        e.match("_ _")
 
     @staticmethod
     def test_init_not_rewritten_as_local() -> None:


### PR DESCRIPTION
## 📝 Summary

Show the unparseable code in the error message when directly running a
notebook via the python command.

Fixes #2265

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [X] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
