### PR TITLE
fix(vim): restore j/k cell navigation broken by #3395

### DIFF
--- a/frontend/src/core/codemirror/keymaps/keymaps.ts
+++ b/frontend/src/core/codemirror/keymaps/keymaps.ts
@@ -49,9 +49,10 @@ export function keymapBundle(
             },
           ),
         ),
-        Prec.highest(vim({ status: false })),
-        // Needs to come after the vim extension
-        Prec.highest(vimKeymapExtension(callbacks)),
+        // Base vim mode
+        vim({ status: false }),
+        // Custom vim keymaps for cell navigation
+        Prec.high(vimKeymapExtension(callbacks)),
       ];
     default:
       logNever(config.preset);


### PR DESCRIPTION
## 📝 Summary

Fixes #3504 - Restores vim j/k cell navigation that was broken by PR #3395. The issue prevented users from navigating between cells using j/k keys when at the end/start of cells in vim normal mode.

## 🔍 Description of Changes

Before:

```ts
Prec.highest(vim({ status: false })),
Prec.highest(vimKeymapExtension(callbacks)),
```

After:

```ts
vim({ status: false }),
Prec.high(vimKeymapExtension(callbacks)),
```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
