### PR TITLE
feat: add initial selection table

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -263,13 +263,6 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
                 )
         self._initial_value_frontend = initial_value
         self._value_frontend = initial_value
-
-        # if user defined an initial value, we use that
-        initial_value = (
-            self._initial_value
-            if hasattr(self, "_initial_value")
-            else initial_value
-        )
         self._value = self._initial_value = self._convert_value(initial_value)
 
         self._on_change = on_change

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -263,7 +263,15 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
                 )
         self._initial_value_frontend = initial_value
         self._value_frontend = initial_value
+
+        # if user defined an initial value, we use that
+        initial_value = (
+            self._initial_value
+            if hasattr(self, "_initial_value")
+            else initial_value
+        )
         self._value = self._initial_value = self._convert_value(initial_value)
+
         self._on_change = on_change
         self._component_args = args
 

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -264,7 +264,6 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
         self._initial_value_frontend = initial_value
         self._value_frontend = initial_value
         self._value = self._initial_value = self._convert_value(initial_value)
-
         self._on_change = on_change
         self._component_args = args
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -99,7 +99,11 @@ class SortArgs:
 
 
 @mddoc
-class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
+class table(
+    UIElement[
+        Union[List[str], List[int]], Union[List[JSONType], IntoDataFrame]
+    ]
+):
     """A table component with selectable rows.
 
     Get the selected rows with `table.value`. The table data can be supplied as:
@@ -464,7 +468,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
         return ""
 
     def _convert_value(
-        self, value: list[str]
+        self, value: Union[List[int] | List[str]]
     ) -> Union[List[JSONType], "IntoDataFrame"]:
         indices = [int(v) for v in value]
         self._selected_manager = self._searched_manager.select_rows(indices)

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -189,7 +189,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
             Defaults to True when above 10 rows, False otherwise.
         selection (Literal["single", "multi"], optional): 'single' or 'multi' to enable row selection,
             or None to disable. Defaults to "multi".
-        initial_selection (List[int], optional): Indexes of the rows you want selected by default.
+        initial_selection (List[int], optional): Indices of the rows you want selected by default.
         page_size (int, optional): The number of rows to show per page. Defaults to 10.
         show_column_summaries (Union[bool, Literal["stats", "chart"]], optional): Whether to show column summaries.
             Defaults to True when the table has less than 40 columns, False otherwise.

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -296,6 +296,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
         # Holds the data after user selecting from the component
         self._selected_manager: Optional[TableManager[Any]] = None
 
+        initial_value = []
         if initial_selection and self._manager.supports_selection():
             if selection == "single" and len(initial_selection) > 1:
                 raise ValueError(
@@ -309,7 +310,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
                 raise IndexError(
                     "initial_selection contains invalid row indices"
                 ) from e
-            self._initial_value = initial_selection
+            initial_value = initial_selection
             self._has_any_selection = True
 
         # We will need this when calling table manager's to_data()
@@ -400,7 +401,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
         super().__init__(
             component_name=table._name,
             label=label,
-            initial_value=[],
+            initial_value=initial_value,
             args={
                 "data": search_result.data,
                 "total-rows": total_rows,

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -189,6 +189,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
             Defaults to True when above 10 rows, False otherwise.
         selection (Literal["single", "multi"], optional): 'single' or 'multi' to enable row selection,
             or None to disable. Defaults to "multi".
+        initial_selection (List[int], optional): Indexes of the rows you want selected by default.
         page_size (int, optional): The number of rows to show per page. Defaults to 10.
         show_column_summaries (Union[bool, Literal["stats", "chart"]], optional): Whether to show column summaries.
             Defaults to True when the table has less than 40 columns, False otherwise.
@@ -221,6 +222,7 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
         ],
         pagination: Optional[bool] = None,
         selection: Optional[Literal["single", "multi"]] = "multi",
+        initial_selection: Optional[List[int]] = None,
         page_size: int = 10,
         show_column_summaries: Optional[
             Union[bool, Literal["stats", "chart"]]
@@ -293,6 +295,22 @@ class table(UIElement[List[str], Union[List[JSONType], IntoDataFrame]]):
         self._searched_manager = self._manager
         # Holds the data after user selecting from the component
         self._selected_manager: Optional[TableManager[Any]] = None
+
+        if initial_selection and self._manager.supports_selection():
+            if selection == "single" and len(initial_selection) > 1:
+                raise ValueError(
+                    "For single selection mode, initial_selection can only contain one row index"
+                )
+            try:
+                self._selected_manager = self._searched_manager.select_rows(
+                    initial_selection
+                )
+            except IndexError as e:
+                raise IndexError(
+                    "initial_selection contains invalid row indices"
+                ) from e
+            self._initial_value = initial_selection
+            self._has_any_selection = True
 
         # We will need this when calling table manager's to_data()
         self._format_mapping = format_mapping

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -223,6 +223,25 @@ def test_value_with_selection() -> None:
     assert list(table._convert_value(["0", "2"])) == ["banana", "cherry"]
 
 
+def test_value_with_initial_selection() -> None:
+    data = ["banana", "apple", "cherry", "date", "elderberry"]
+    table = ui.table(data, initial_selection=[0, 2])
+    assert table.value == ["banana", "cherry"]
+
+
+def test_invalid_initial_selection() -> None:
+    data = ["banana", "apple"]
+    with pytest.raises(IndexError):
+        ui.table(data, initial_selection=[2])
+
+    with pytest.raises(TypeError):
+        ui.table(data, initial_selection=["apple"])
+
+    # multiple rows cannot be selected for single selection mode
+    with pytest.raises(ValueError):
+        ui.table(data, selection="single", initial_selection=[0, 1])
+
+
 def test_value_with_sorting_then_selection() -> None:
     data = ["banana", "apple", "cherry", "date", "elderberry"]
     table = ui.table(data)


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #2736 . Allows user to select some rows by default upon table creation.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
```.py
table = mo.ui.table(
    {"a": [1, 2, 3], "b": [2, 3, 4], "c": ["apple", "banana", "carrots"]},
    label="table",
    initial_selection=[2],
)
```
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a1954130-4652-403f-b828-8bfa4a755aec" />

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
