### PR TITLE
feat(editor): Add ability to disable keyboard shortcuts

### DIFF
--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -13,7 +13,6 @@ import {
   type HotkeyAction,
   type HotkeyGroup,
   getDefaultHotkey,
-  NOT_SET,
 } from "@/core/hotkeys/hotkeys";
 import { atom, useAtom, useAtomValue } from "jotai";
 import { useState } from "react";
@@ -54,11 +53,10 @@ export const KeyboardShortcuts: React.FC = () => {
         ...config.keymap,
         overrides: {
           ...config.keymap.overrides,
-          [action]: NOT_SET,
+          [action]: "NOT_SET",
         },
       },
     };
-    // TODO(eugene): how to add symbol to overrides (api.yaml)
     await saveConfigOptimistic(newConfig);
   };
 

--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -13,6 +13,7 @@ import {
   type HotkeyAction,
   type HotkeyGroup,
   getDefaultHotkey,
+  NOT_SET,
 } from "@/core/hotkeys/hotkeys";
 import { atom, useAtom, useAtomValue } from "jotai";
 import { useState } from "react";
@@ -44,6 +45,21 @@ export const KeyboardShortcuts: React.FC = () => {
       setConfig(prevConfig);
       throw error;
     });
+  };
+
+  const handleDisableHotkey = async (action: HotkeyAction) => {
+    const newConfig = {
+      ...config,
+      keymap: {
+        ...config.keymap,
+        overrides: {
+          ...config.keymap.overrides,
+          [action]: NOT_SET,
+        },
+      },
+    };
+    // TODO(eugene): how to add symbol to overrides (api.yaml)
+    await saveConfigOptimistic(newConfig);
   };
 
   const handleNewShortcut = async (shortcut: string[]) => {
@@ -216,17 +232,25 @@ export const KeyboardShortcuts: React.FC = () => {
         key={action}
         className="grid grid-cols-[auto,2fr,3fr] gap-2 items-center"
       >
-        {hotkeys.isEditable(action) ? (
-          <EditIcon
-            className="cursor-pointer opacity-60 hover:opacity-100 text-muted-foreground w-3 h-3"
-            onClick={() => {
-              setNewShortcut([]);
-              setEditingShortcut(action);
-            }}
-          />
-        ) : (
-          <div className="w-3 h-3" />
-        )}
+        <div className="flex gap-1">
+          {hotkeys.isEditable(action) ? (
+            <>
+              <EditIcon
+                className="cursor-pointer opacity-60 hover:opacity-100 text-muted-foreground w-3 h-3"
+                onClick={() => {
+                  setNewShortcut([]);
+                  setEditingShortcut(action);
+                }}
+              />
+              <XIcon
+                className="cursor-pointer opacity-60 hover:opacity-100 text-muted-foreground w-3 h-3"
+                onClick={() => handleDisableHotkey(action)}
+              />
+            </>
+          ) : (
+            <div className="w-3 h-3" />
+          )}
+        </div>
         <KeyboardHotkeys className="justify-end" shortcut={hotkey.key} />
         <span>{hotkey.name.toLowerCase()}</span>
       </div>

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -67,6 +67,7 @@ class KeymapConfig(TypedDict):
     """
 
     preset: Literal["default", "vim"]
+    # TODO(eugene): how to add symbol to overrides (api.yaml)
     overrides: NotRequired[Dict[str, str]]
 
 


### PR DESCRIPTION
## 📝 Summary

This PR adds the ability to disable keyboard shortcuts in the editor through the UI.

<img width="887" alt="Bildschirmfoto 2025-01-21 um 21 22 15" src="https://github.com/user-attachments/assets/1cb4c331-dc43-4bde-a11b-47504dff3533" />

## 🔍 Description of Changes

- Added a disable button (X icon) next to editable keyboard shortcuts
- Implemented `handleDisableHotkey` function to update configuration when disabling a shortcut
- Added visual feedback with hover states for the control icons
- Maintained consistent UI by showing placeholder space for non-editable shortcuts

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
