### PR TITLE
fix: single line magic conversion

### DIFF
--- a/marimo/_convert/ipynb.py
+++ b/marimo/_convert/ipynb.py
@@ -82,10 +82,6 @@ def transform_add_marimo_import(sources: List[str]) -> List[str]:
     return sources
 
 
-# TODO(akshayka): Handle multiple magic lines in a row in a single cell
-# % foo
-# % bar
-# asdfadsf
 def transform_magic_commands(sources: List[str]) -> List[str]:
     """
     Transform Jupyter magic commands to their marimo equivalents

--- a/marimo/_convert/ipynb.py
+++ b/marimo/_convert/ipynb.py
@@ -173,13 +173,13 @@ def transform_magic_commands(sources: List[str]) -> List[str]:
         os.makedirs('path/to/directory', exist_ok=True)
         """
         del command
-        return f"import os\nos.mkdir({source!r}, exist_ok=True)"
+        return f"import os\nos.makedirs({source!r}, exist_ok=True)"
 
     def magic_cd(source: str, command: str) -> str:
         """
         Transform cd magic into marimo cd functions.
 
-        command := %cd path/to/directory
+        %cd path/to/directory
 
         to
 

--- a/tests/_convert/test_ipynb.py
+++ b/tests/_convert/test_ipynb.py
@@ -136,6 +136,7 @@ def test_transform_magic_commands():
         "%%sql\nSELECT * FROM table",
         "%%sql\nSELECT * \nFROM table",
         "%cd /path/to/dir",
+        "%mkdir /path/to/dir",
         "%matplotlib inline",
     ]
     result = transform_magic_commands(sources)
@@ -143,6 +144,7 @@ def test_transform_magic_commands():
         '_df = mo.sql("""\nSELECT * FROM table\n""")',
         '_df = mo.sql("""\nSELECT * \nFROM table\n""")',
         "import os\nos.chdir('/path/to/dir')",
+        "import os\nos.makedirs('/path/to/dir', exist_ok=True)",
         "# '%matplotlib inline' command supported automatically in marimo",
     ]
 

--- a/tests/_convert/test_ipynb.py
+++ b/tests/_convert/test_ipynb.py
@@ -147,6 +147,52 @@ def test_transform_magic_commands():
     ]
 
 
+def test_transform_magic_command_with_code():
+    sources = dd(
+        [
+            """
+        %matplotlib inline
+        import numpy as np
+        import matplotlib.pyplot as plt
+        plt.style.use('seaborn-whitegrid')
+        """
+        ]
+    )
+    result = transform_magic_commands(sources)
+    expected = dd(
+        [
+            """# '%matplotlib inline' command supported automatically in marimo
+import numpy as np
+import matplotlib.pyplot as plt
+plt.style.use('seaborn-whitegrid')"""
+        ]
+    )
+    assert result == expected
+
+
+def test_transform_magic_command_multiple_args_with_code():
+    sources = dd(
+        [
+            """
+        %matplotlib inline foo
+        import numpy as np
+        import matplotlib.pyplot as plt
+        plt.style.use('seaborn-whitegrid')
+        """
+        ]
+    )
+    result = transform_magic_commands(sources)
+    expected = dd(
+        [
+            """# '%matplotlib inline foo' command supported automatically in marimo
+import numpy as np
+import matplotlib.pyplot as plt
+plt.style.use('seaborn-whitegrid')"""
+        ]
+    )
+    assert result == expected
+
+
 def test_transform_exclamation_mark():
     sources = [
         "!pip install package",
@@ -269,7 +315,7 @@ def test_transform_magic_commands_complex():
         "%env MY_VAR=value",
     ]
     result = transform_magic_commands(sources)
-    assert result == [
+    expected = [
         '_df = mo.sql("""\nSELECT *\nFROM table\nWHERE condition\n""")',
         (
             "# magic command not supported in marimo; please file an issue to add support\n"  # noqa: E501
@@ -277,10 +323,13 @@ def test_transform_magic_commands_complex():
             "    pass"
         ),
         (
-            "# '%load_ext autoreload\\n%autoreload 2' command supported automatically in marimo"  # noqa: E501
+            "# magic command not supported in marimo; please file an issue to add support\n"  # noqa: E501
+            "# %load_ext autoreload\n"
+            "# '%autoreload 2' command supported automatically in marimo"
         ),
         "import os\nos.environ['MY_VAR'] = 'value'",
     ]
+    assert result == expected
 
 
 def test_transform_exclamation_mark_complex():
@@ -372,7 +421,7 @@ def test_transform_magic_commands_unsupported():
     ]
     result = transform_magic_commands(sources)
     assert result == [
-        "# magic command not supported in marimo; please file an issue to add support\n# %custom_magic # arg1 arg2",  # noqa: E501
+        "# magic command not supported in marimo; please file an issue to add support\n# %custom_magic arg1 arg2",  # noqa: E501
         "# magic command not supported in marimo; please file an issue to add support\n# %%custom_cell_magic\n# some\n# content",  # noqa: E501
     ]
 


### PR DESCRIPTION
- Support magic commands that have arguments (%matplotlib inline)
- Support cells that start with a single-line magic but have Python code after
- Support cells that have multiple single-line magics