### PR TITLE
improvement: add split cell to cell dropdown, command palette, and fix undo split cell

### DIFF
--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -25,6 +25,7 @@ import {
   XCircleIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  ScissorsIcon,
 } from "lucide-react";
 import type { ActionButton } from "./types";
 import { MultiIcon } from "@/components/icons/multi-icon";
@@ -54,6 +55,7 @@ import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import type { CellConfig, RuntimeState } from "@/core/network/types";
 import { kioskModeAtom } from "@/core/mode";
 import { switchLanguage } from "@/core/codemirror/language/extension";
+import { useSplitCellCallback } from "../cell/useSplitCell";
 
 export interface CellActionButtonProps
   extends Pick<CellData, "name" | "config"> {
@@ -79,6 +81,7 @@ export function useCellActionButtons({ cell }: Props) {
     addColumnBreakpoint,
     clearCellOutput,
   } = useCellActions();
+  const splitCell = useSplitCellCallback();
   const runCell = useRunCell(cell?.cellId);
   const hasOnlyOneCell = useAtomValue(hasOnlyOneCellAtom);
   const canDelete = !hasOnlyOneCell;
@@ -184,6 +187,12 @@ export function useCellActionButtons({ cell }: Props) {
           );
         },
         hotkey: "cell.aiCompletion",
+      },
+      {
+        icon: <ScissorsIcon size={13} strokeWidth={1.5} />,
+        label: "Split cell",
+        hotkey: "cell.splitCell",
+        handle: () => splitCell({ cellId }),
       },
       {
         icon: <ImageIcon size={13} strokeWidth={1.5} />,

--- a/frontend/src/components/editor/cell/useSplitCell.tsx
+++ b/frontend/src/components/editor/cell/useSplitCell.tsx
@@ -3,6 +3,7 @@ import { UndoButton } from "@/components/buttons/undo-button";
 import { toast } from "@/components/ui/use-toast";
 import { getCellEditorView, useCellActions } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
+import { getEditorCodeAsPython } from "@/core/codemirror/language/utils";
 import useEvent from "react-use-event-hook";
 
 export function useSplitCellCallback() {
@@ -11,7 +12,10 @@ export function useSplitCellCallback() {
   return useEvent((opts: { cellId: CellId }) => {
     // Save snapshot of code for undo
     const cellEditorView = getCellEditorView(opts.cellId);
-    const code = cellEditorView?.state.doc.toString() ?? "";
+    if (!cellEditorView) {
+      return;
+    }
+    const code = getEditorCodeAsPython(cellEditorView);
 
     // Optimistic update
     splitCell(opts);


### PR DESCRIPTION
- add split cell to cell dropdown
- command palette
- and fix undo split cell, when using markdown or SQL