### PR TITLE
tests: logging

### DIFF
--- a/marimo/_smoke_tests/logs.py
+++ b/marimo/_smoke_tests/logs.py
@@ -1,0 +1,109 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
+# Copyright 2024 Marimo. All rights reserved.
+
+import marimo
+
+__generated_with = "0.10.15"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    level_dropdown = mo.ui.dropdown(
+        label="Log level",
+        options=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        value="INFO",
+    )
+    level_dropdown
+    return (level_dropdown,)
+
+
+@app.cell
+def _(level_dropdown):
+    # Configure logging
+    import logging
+
+    logging.basicConfig(level=level_dropdown.value)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(level_dropdown.value)
+
+    # Test different log levels
+    logger.debug("This is a DEBUG message")
+    logger.info("This is an INFO message")
+    logger.warning("This is a WARNING message")
+    logger.error("This is an ERROR message")
+    logger.critical("This is a CRITICAL message")
+    return logger, logging
+
+
+@app.cell
+def _(logger, mo):
+    # Test logging in a cell with output
+    logger.info("Starting computation...")
+    result = 42
+    logger.debug(f"Result computed: {result}")
+    mo.md(f"The result is {result}")
+    return (result,)
+
+
+@app.cell
+def _(logger):
+    # Test logging with exception
+    try:
+        x = 1 / 0
+    except ZeroDivisionError as e:
+        logger.error("Division by zero!", exc_info=True)
+    return (x,)
+
+
+@app.cell
+def _(level_dropdown, logging):
+    # Test logging with custom formatting
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    _logger = logging.getLogger("custom_logger")
+    _logger.addHandler(handler)
+    _logger.setLevel(level_dropdown.value)
+    _logger.info("Custom formatted log message")
+
+    # Test logging with extra context
+    extra_logger = logging.getLogger("context_logger")
+    extra = {"user": "john", "ip": "192.168.1.1"}
+    extra_logger.info("User action", extra=extra)
+
+    # Test logging with different string formatting
+    template_logger = logging.getLogger("template_logger")
+    name = "Alice"
+    age = 30
+    template_logger.info("User %s is %d years old", name, age)
+    template_logger.info(f"User {name} is {age} years old")
+    template_logger.info(
+        "User %(name)s is %(age)d years old", {"name": name, "age": age}
+    )
+    return (
+        age,
+        extra,
+        extra_logger,
+        formatter,
+        handler,
+        name,
+        template_logger,
+    )
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from marimo._loggers import (
+    _LOGGERS,
+    get_logger,
+    set_level,
+)
+
+
+def test_set_level():
+    # Test with integer levels
+    set_level(logging.DEBUG)
+    logger = get_logger("test1")
+    assert logger.level == logging.DEBUG
+
+    set_level(logging.INFO)
+    assert logger.level == logging.INFO
+
+    # Test with string levels
+    for level in ["WARNING", "WARN", "DEBUG", "INFO", "ERROR", "CRITICAL"]:
+        set_level(level)
+        assert logger.level == logging._nameToLevel[level]
+
+    # Test invalid levels
+    with pytest.raises(ValueError):
+        set_level("INVALID")
+
+    with pytest.raises(ValueError):
+        set_level(999)
+
+
+def test_get_logger():
+    # Test basic logger creation
+    logger1 = get_logger("test2")
+    assert logger1.name == "test2"
+    assert not logger1.propagate
+    assert len(logger1.handlers) == 1
+
+    # Test logger caching
+    logger2 = get_logger("test2")
+    assert logger1 is logger2  # Same logger instance
+
+    # Test custom level
+    logger3 = get_logger("test3", level=logging.DEBUG)
+    assert logger3.level == logging.DEBUG
+
+    # Test handlers
+    handler = logger3.handlers[0]
+    assert isinstance(handler, logging.StreamHandler)
+
+
+@pytest.fixture(autouse=True)
+def clear_loggers():
+    # Clear the logger cache before each test
+    _LOGGERS.clear()
+    return


### PR DESCRIPTION
This is currently required to get your own logging. Can we default this internally 

```python
import logging
level = logging.INFO
logging.basicConfig(level=level)
logger = logging.getLogger(__name__)
logger.setLevel(level)
```

ideally its just

```python
import logging
logger = logging.getLogger(__name__) # defaults to INFO
```