### PR TITLE
docs: fix some deprecated links, old components

### DIFF
--- a/docs/api/status.md
+++ b/docs/api/status.md
@@ -15,7 +15,7 @@ to `tqdm`.
 ```python
 @app.cell
 def __():
-    rerun = mo.ui.button("Rerun")
+    rerun = mo.ui.button(label="Rerun")
     rerun
     return
 
@@ -46,7 +46,7 @@ async def __():
 ```python
 @app.cell
 def __():
-    rerun = mo.ui.button("Rerun")
+    rerun = mo.ui.button(label="Rerun")
     rerun
     return
 

--- a/docs/guides/expensive_notebooks.md
+++ b/docs/guides/expensive_notebooks.md
@@ -159,7 +159,7 @@ def expensive_component():
     data = db.query("SELECT * FROM data")
     return mo.ui.table(data)
 
-accordion = mo.ui.accordion({
+accordion = mo.accordion({
     "Charts": mo.lazy(expensive_component)
 })
 ```

--- a/docs/guides/state.md
+++ b/docs/guides/state.md
@@ -62,7 +62,7 @@ But sometimes, you might want interactions to mutate state:
 !!! warning "Use reactive execution for uni-directional flow"
     If you just want the value of a single element to update another element,
     then **you shouldn't use `mo.state`**. Instead, use marimo's built-in
-    reactive execution --- see the [interactivity guide](`../guides/interactivity.md`).
+    reactive execution --- see the [interactivity guide](../guides/interactivity.md).
 
 For cases like these, marimo provides the function [`mo.state()`](../api/state.md),
 which creates a state object and returns a getter and setter function. When you

--- a/marimo/_plugins/stateless/lazy.py
+++ b/marimo/_plugins/stateless/lazy.py
@@ -40,7 +40,7 @@ class lazy(UIElement[bool, bool]):
 
         Create a lazy-loaded accordion:
         ```python
-        accordion = mo.ui.accordion({"Charts": mo.lazy(expensive_component)})
+        accordion = mo.accordion({"Charts": mo.lazy(expensive_component)})
         ```
 
         Usage with async functions:


### PR DESCRIPTION
## 📝 Summary
- replace `mo.ui.accordion` to just `mo.accordion`, fix links
- button needs a  label, if not, the string is considered `on_change` handler

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
