### PR TITLE
fix: transforms on dataframe to be reactive

### DIFF
--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -217,14 +217,14 @@ export const DataFrameComponent = memo(
             <TransformPanel
               initialValue={internalValue}
               columns={columns}
-              onChange={(v) => {
+              onChange={(newValue) => {
                 // Ignore changes that are the same
-                if (isEqual(v, internalValue)) {
+                if (isEqual(newValue, value)) {
                   return;
                 }
                 // Update the value valid changes
-                setValue(v);
-                setInternalValue(v);
+                setValue(newValue);
+                setInternalValue(newValue);
               }}
               onInvalidChange={setInternalValue}
               getColumnValues={get_column_values}


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #3090 . Previously, the `isEqual` check will always return true.
onInvalidChange -> sets `internalValue` to `newValue` from the form
onChange -> checks whether `newValue` and `internalValue` are the same. Yes, they would be.

https://github.com/user-attachments/assets/936f648d-de7d-43c7-9895-6df070287205

There's some flickering going on (not new issue) when toggling from no cols to 1 col, hard to figure out..

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
