### PR TITLE
fix: support running in FIPS-enabled environments

### DIFF
--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -133,7 +133,9 @@ class anywidget(UIElement[T, T]):
             _put_buffers(change, buffer_paths, buffers)
             widget.set_state(change)
 
-        js_hash: str = hashlib.md5(js.encode("utf-8"), usedforsecurity=False).hexdigest()
+        js_hash: str = hashlib.md5(
+            js.encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
 
         super().__init__(
             component_name="marimo-anywidget",

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -133,7 +133,7 @@ class anywidget(UIElement[T, T]):
             _put_buffers(change, buffer_paths, buffers)
             widget.set_state(change)
 
-        js_hash: str = hashlib.md5(js.encode("utf-8")).hexdigest()
+        js_hash: str = hashlib.md5(js.encode("utf-8"), usedforsecurity=False).hexdigest()
 
         super().__init__(
             component_name="marimo-anywidget",


### PR DESCRIPTION
## 📝 Summary

### Problem

Currently, marimo will fail on FIPS-enabled environments where `md5` hashing is disabled for security purposes. This means that `js_hash` cannot be calculated in `marimo/_plugins/ui/_impl/from_anywidget.py`.

### Solution

Since md5 is being used for file integrity checks, this particular use of md5 can be considered FIPS compliant. Since python 3.9, the *usedforsecurity* flag has been introduced in hashlib functions, which allows for bypassing the FIPS enforcement check. As such, using `usedforsecurity=False` when invoking `hashlib.md5` solves the issue.

## 🔍 Description of Changes

Use `usedforsecurity=False` when invoking `hashlib.md5` in `marimo._plugins.ui._impl.from_anywidget.anywidget.__init__`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

I did not add tests because I'm not sure how to go about mocking a FIPS enabled environment, and the change is a noop for non-FIPS environments.

Working to setup an EC2 instance with FIPS enabled to verify the changes work off of my fork, but have not done so yet.

## 📜 Reviewers

@mscolnick (guessing you as the reviewer, as you've been engaging w previous python questions I've had)
