### PR TITLE
chore: deflake tmpdir cleanup in tests

### DIFF
--- a/docs/guides/editor_features/watching.md
+++ b/docs/guides/editor_features/watching.md
@@ -48,9 +48,9 @@ Guide](module_autoreloading.md)
 ## Hot-reloading WebAssembly notebooks
 
 Follow these steps to develop a notebook using your own editor while
-previewing it as a WebAssembly notebook in the browser. This lets you take
-advantage of local development tools while seeing the notebook as it appears
-when deployed as a [WebAssembly notebook](../wasm.md).
+previewing it as a [WebAssembly notebook](../wasm.md) in the browser. This lets
+you take advantage of local development tools while seeing the notebook as it
+appears when deployed as a WebAssembly notebook.
 
 ```bash
 # in one terminal, start a watched edit (or run) session

--- a/docs/guides/editor_features/watching.md
+++ b/docs/guides/editor_features/watching.md
@@ -45,11 +45,15 @@ Guide](module_autoreloading.md)
 !!! note
     Support for watching data files and automatically refreshing cells that depend on them is coming soon. Follow along at <https://github.com/marimo-team/marimo/issues/3258>
 
-## Developing in WASM mode
+## Hot-reloading WebAssembly notebooks
 
-Follow these steps to develop a notebook using your own editor, while previewing it as a WebAssembly notebook in the browser. This lets you take advantage of local development tools while seeing the notebook as it appears when deployed as a [WebAssembly notebook](../wasm.md).
+Follow these steps to develop a notebook using your own editor while
+previewing it as a WebAssembly notebook in the browser. This lets you take
+advantage of local development tools while seeing the notebook as it appears
+when deployed as a [WebAssembly notebook](../wasm.md).
+
 ```bash
-# in one terminal, start a watched edit session
+# in one terminal, start a watched edit (or run) session
 marimo edit notebook.py --watch
 
 # in another terminal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,7 +235,7 @@ def _cleanup_tmp_dir(tmp_dir: TemporaryDirectory) -> None:
         # fails. Python 3.10+ has an ignore_cleanup_error argument,
         # but we still support 3.9.
         tmp_dir.cleanup()
-    except:
+    except Exception:
         pass
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,6 +229,16 @@ def executing_kernel() -> Generator[Kernel, None, None]:
     mocked.teardown()
 
 
+def _cleanup_tmp_dir(tmp_dir: TemporaryDirectory) -> None:
+    try:
+        # Tests shouldn't care whether temporary directory cleanup
+        # fails. Python 3.10+ has an ignore_cleanup_error argument,
+        # but we still support 3.9.
+        tmp_dir.cleanup()
+    except:
+        pass
+
+
 @pytest.fixture
 def temp_marimo_file() -> Generator[str, None, None]:
     tmp_dir = TemporaryDirectory()
@@ -258,7 +268,7 @@ def temp_marimo_file() -> Generator[str, None, None]:
             f.write(content)
         yield tmp_file
     finally:
-        tmp_dir.cleanup()
+        _cleanup_tmp_dir(tmp_dir)
 
 
 @pytest.fixture
@@ -301,7 +311,7 @@ def temp_sandboxed_marimo_file() -> Generator[str, None, None]:
             f.write(content)
         yield tmp_file
     finally:
-        tmp_dir.cleanup()
+        _cleanup_tmp_dir(tmp_dir)
 
 
 @pytest.fixture
@@ -330,7 +340,7 @@ def temp_async_marimo_file() -> Generator[str, None, None]:
             f.flush()
         yield tmp_file
     finally:
-        tmp_dir.cleanup()
+        _cleanup_tmp_dir(tmp_dir)
 
 
 @pytest.fixture
@@ -372,7 +382,7 @@ def temp_unparsable_marimo_file() -> Generator[str, None, None]:
             f.flush()
         yield tmp_file
     finally:
-        tmp_dir.cleanup()
+        _cleanup_tmp_dir(tmp_dir)
 
 
 @pytest.fixture
@@ -416,7 +426,7 @@ def temp_marimo_file_with_md() -> Generator[str, None, None]:
             f.write(content)
         yield tmp_file
     finally:
-        tmp_dir.cleanup()
+        _cleanup_tmp_dir(tmp_dir)
 
 
 @pytest.fixture
@@ -449,7 +459,7 @@ def temp_md_marimo_file() -> Generator[str, None, None]:
             f.write(content)
         yield tmp_file
     finally:
-        tmp_dir.cleanup()
+        _cleanup_tmp_dir(tmp_dir)
 
 
 @pytest.fixture
@@ -486,7 +496,7 @@ def temp_marimo_file_with_errors() -> Generator[str, None, None]:
             f.write(content)
         yield tmp_file
     finally:
-        tmp_dir.cleanup()
+        _cleanup_tmp_dir(tmp_dir)
 
 
 @pytest.fixture
@@ -518,7 +528,7 @@ def temp_marimo_file_with_multiple_definitions() -> Generator[str, None, None]:
             f.write(content)
         yield tmp_file
     finally:
-        tmp_dir.cleanup()
+        _cleanup_tmp_dir(tmp_dir)
 
 
 # Factory to create ExecutionRequests and abstract away cell ID


### PR DESCRIPTION
Tests shouldn't care whether temporary directory cleanup fails.