### PR TITLE
Add DeepSeek chatbot example

### DIFF
--- a/examples/ai/chat/deepseek_example.py
+++ b/examples/ai/chat/deepseek_example.py
@@ -1,0 +1,103 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "openai==1.60.2",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.10.17"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+        # Using DeepSeek
+
+        This example shows how to use [`mo.ui.chat`](https://docs.marimo.io/api/inputs/chat/?h=mo.ui.chat) to make a chatbot backed by [Deepseek](https://deepseek.com/).
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+        <a href="https://api-docs.deepseek.com/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="https://chat.deepseek.com/deepseek-chat.jpeg"
+            alt="Powered by deepseek"
+            width="450"
+          />
+        </a>
+        """
+    ).center()
+    return
+
+
+@app.cell
+def _(mo):
+    import os
+
+    os_key = os.environ.get("DEEPSEEK_API_KEY")
+    input_key = mo.ui.text(label="Deepseek API key", kind="password")
+    input_key if not os_key else None
+    return input_key, os, os_key
+
+
+@app.cell
+def _(input_key, mo, os_key):
+    key = os_key or input_key.value
+
+    mo.stop(
+        not key,
+        mo.md("Please provide your Deepseek AI API key in the input field."),
+    )
+    return (key,)
+
+
+@app.cell
+def _(key, mo):
+    chatbot = mo.ui.chat(
+       mo.ai.llm.openai(
+           model="deepseek-reasoner",
+           system_message="You are a helpful assistant.",
+           api_key=key,
+           base_url="https://api.deepseek.com",
+       ),
+        prompts=[
+            "Hello",
+            "How are you?",
+            "I'm doing great, how about you?",
+        ],
+    )
+    chatbot
+    return (chatbot,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""Access the chatbot's historical messages with [`chatbot.value`](https://docs.marimo.io/api/inputs/chat.html#accessing-chat-history).""")
+    return
+
+
+@app.cell
+def _(chatbot):
+    # chatbot.value is the list of chat messages
+    chatbot.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/ai/chat/groq_example.py
+++ b/examples/ai/chat/groq_example.py
@@ -3,7 +3,6 @@
 # dependencies = [
 #     "marimo",
 #     "groq==0.11.0",
-#     "anthropic==0.37.1",
 # ]
 # ///
 


### PR DESCRIPTION
## 📝 Summary

Add an example for chatting with deepseek-reasoner using `mo.ui.chat`

## 🔍 Description of Changes

Used `mo.ui.chat`; more specifically `mo.ai.llm.openai` and override the `base_url` since it's OpenAI API compatible. Specified the model along with custom prompts to use.

TODO:
- [ ] Verify working with an API locally (currently, the [services are down](https://chat.deepseek.com/503/) due to high usage). Cannot obtain an API key.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
