### PR TITLE
fix: Simplify and resolve pandas snippet error

### DIFF
--- a/marimo/_snippets/data/pandas-9.py
+++ b/marimo/_snippets/data/pandas-9.py
@@ -1,12 +1,13 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 import marimo
 
-__generated_with = "0.3.8"
+__generated_with = "0.10.12"
 app = marimo.App()
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md(
         r"""
         # Pandas: Describe Timestamp values in a column
@@ -16,29 +17,18 @@ def __(mo):
 
 
 @app.cell
-def __():
+def _():
     import pandas as pd
 
-    df = pd.DataFrame(
-        {
-            "time": [
-                "2022-09-14 00:52:00-07:00",
-                "2022-09-14 00:52:30-07:00",
-                "2022-09-14 01:52:30-07:00",
-            ],
-            "letter": ["A", "B", "C"],
-        }
-    )
-    df["time"] = pd.to_datetime(df.time)
+    df = pd.DataFrame({'timestamp': pd.date_range('2023-01-01', periods=5, freq='D')})
 
-    df["time"].describe(datetime_is_numeric=True)
+    df['timestamp'].describe()
     return df, pd
 
 
 @app.cell
-def __():
+def _():
     import marimo as mo
-
     return (mo,)
 
 


### PR DESCRIPTION
## 📝 Summary

Fix error in existing pandas snippet-9.py; (`Pandas: Describe Timestamp values in a column`):
`TypeError: describe() got an unexpected keyword argument 'datetime_is_numeric`
<details>
<summary> Screenshot of error </summary>

![image](https://github.com/user-attachments/assets/bf609888-109d-4ce8-9e0a-cb6c09d07e99)

</details>

## 🔍 Description of Changes

Simplified code snippet.


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
