### PR TITLE
fix: mo.Thread communication to output area

### DIFF
--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -364,7 +364,7 @@ def _launch_pyodide_kernel(
         debugger_override=debugger,
         user_config=user_config,
     )
-    initialize_kernel_context(
+    ctx = initialize_kernel_context(
         kernel=kernel,
         stream=stream,
         stdout=stdout,
@@ -374,9 +374,7 @@ def _launch_pyodide_kernel(
     )
 
     if is_edit_mode:
-        signal.signal(
-            signal.SIGINT, handlers.construct_interrupt_handler(kernel)
-        )
+        signal.signal(signal.SIGINT, handlers.construct_interrupt_handler(ctx))
 
     ui_element_request_mgr = SetUIElementRequestManager(set_ui_element_queue)
 

--- a/marimo/_runtime/handlers.py
+++ b/marimo/_runtime/handlers.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from marimo import _loggers
 from marimo._messaging.ops import Interrupted
 from marimo._runtime.context import get_context
+from marimo._runtime.context.kernel_context import KernelRuntimeContext
 from marimo._runtime.control_flow import MarimoInterrupt
 
 LOGGER = _loggers.marimo_logger()
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 
 
 def construct_interrupt_handler(
-    kernel: "Kernel",
+    context: KernelRuntimeContext,
 ) -> Callable[[int, Any], None]:
     def interrupt_handler(signum: int, frame: Any) -> None:
         """Tries to interrupt the kernel."""
@@ -26,7 +27,7 @@ def construct_interrupt_handler(
         # TODO(akshayka): if kernel is in `run` but not executing,
         # it won't be interrupted, which isn't right ... but the
         # probability of that happening is low.
-        if kernel.execution_context is not None:
+        if context.execution_context is not None:
             Interrupted().broadcast()
             raise MarimoInterrupt
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -79,7 +79,10 @@ from marimo._runtime.context import (
     ExecutionContext,
     get_context,
 )
-from marimo._runtime.context.kernel_context import initialize_kernel_context
+from marimo._runtime.context.kernel_context import (
+    KernelRuntimeContext,
+    initialize_kernel_context,
+)
 from marimo._runtime.control_flow import MarimoInterrupt
 from marimo._runtime.input_override import input_override
 from marimo._runtime.packages.module_registry import ModuleRegistry
@@ -510,8 +513,6 @@ class Kernel:
         ).get("execution_type", "relaxed")
         self._update_runtime_from_user_config(user_config)
 
-        # Set up the execution context
-        self.execution_context: Optional[ExecutionContext] = None
         # initializers to override construction of ui elements
         self.ui_initializers: dict[str, Any] = {}
         # errored cells
@@ -640,8 +641,10 @@ class Kernel:
     def _install_execution_context(
         self, cell_id: CellId_t, setting_element_value: bool = False
     ) -> Iterator[ExecutionContext]:
-        self.execution_context = ExecutionContext(
-            cell_id, setting_element_value
+        ctx = get_context()
+        assert isinstance(ctx, KernelRuntimeContext)
+        ctx.execution_context = (
+            exec_ctx := ExecutionContext(cell_id, setting_element_value)
         )
         with (
             get_context().provide_ui_ids(str(cell_id)),
@@ -661,9 +664,9 @@ class Kernel:
                     self.module_reloader.check(
                         modules=sys.modules, reload=True
                     )
-                yield self.execution_context
+                yield exec_ctx
             finally:
-                self.execution_context = None
+                ctx.execution_context = None
                 if self.module_reloader is not None and modules is not None:
                     # Note timestamps for newly loaded modules
                     new_modules = set(sys.modules) - modules
@@ -1335,8 +1338,9 @@ class Kernel:
         Should be called when a state's setter is called.
         """
         # store the state and the currently executing cell
-        assert self.execution_context is not None
-        self.state_updates[state] = self.execution_context.cell_id
+        ctx = get_context()
+        assert ctx.execution_context is not None
+        self.state_updates[state] = ctx.execution_context.cell_id
         # TODO(akshayka): Send VariableValues message for any globals
         # bound to this state object (just like UI elements)
 
@@ -2186,7 +2190,7 @@ def launch_kernel(
         user_config=user_config,
         enqueue_control_request=_enqueue_control_request,
     )
-    initialize_kernel_context(
+    ctx = initialize_kernel_context(
         kernel=kernel,
         stream=stream,
         stdout=stdout,
@@ -2214,9 +2218,7 @@ def launch_kernel(
         # install the formatter import hooks
         register_formatters(theme=user_config["display"]["theme"])
 
-        signal.signal(
-            signal.SIGINT, handlers.construct_interrupt_handler(kernel)
-        )
+        signal.signal(signal.SIGINT, handlers.construct_interrupt_handler(ctx))
 
         if sys.platform == "win32":
             if interrupt_queue is not None:

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -79,7 +79,6 @@ class Thread(threading.Thread):
     def run(self) -> None:
         if self._marimo_ctx is not None:
             initialize_context(self._marimo_ctx)
-        print(self._marimo_ctx)
         if isinstance(self._marimo_ctx, KernelRuntimeContext):
             self._marimo_ctx.execution_context = ExecutionContext(
                 cell_id=self._marimo_ctx.stream.cell_id,  # type: ignore

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -44,14 +44,14 @@ class Thread(threading.Thread):
             self._marimo_ctx.stdout = None
             self._marimo_ctx.stderr = None
             if isinstance(ctx.stream, ThreadSafeStream):
-                self._marimo_ctx.stream = ThreadSafeStream(
+                self._marimo_ctx.stream = type(ctx.stream)(
                     pipe=ctx.stream.pipe,
                     # TODO(akshayka): stdin is not threadsafe
                     input_queue=ctx.stream.input_queue,
                     cell_id=ctx.stream.cell_id,
                 )
             elif isinstance(ctx.stream, PyodideStream):
-                self._marimo_ctx.stream = PyodideStream(
+                self._marimo_ctx.stream = type(ctx.stream)(
                     pipe=ctx.stream.pipe,
                     # TODO(akshayka): stdin is not threadsafe
                     input_queue=ctx.stream.input_queue,

--- a/tests/_runtime/test_threads.py
+++ b/tests/_runtime/test_threads.py
@@ -4,15 +4,35 @@ from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
 
 
-async def test_set_ui_element_value_lensed(
-    any_kernel: Kernel, exec_req: ExecReqProvider
-) -> None:
-    """Test setting the value of a lensed element.
+# Doesn't work with strict kernel ...
+async def test_thread_set_global(k: Kernel, exec_req: ExecReqProvider) -> None:
+    """Test that a thread starts and runs."""
 
-    Make sure reactivity flows through its parent, and that its on_change
-    handler is called exactly once.
-    """
-    k = any_kernel
+    await k.run(
+        [
+            exec_req.get("import marimo as mo"),
+            exec_req.get(
+                """
+                value = 0
+                def target():
+                    global value
+                    value = 1
+                """
+            ),
+            exec_req.get("t = mo.Thread(target=target); t.start(); t.join()"),
+        ]
+    )
+
+    # thread run should be basically instantaneous, but sleep just in case ...
+    assert not k.errors
+    time.sleep(0.01)  # noqa: ASYNC251
+    assert k.globals["value"] == 1
+
+
+async def test_thread_has_own_stream(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    """Test that a thread starts and runs."""
 
     await k.run(
         [
@@ -20,16 +40,21 @@ async def test_set_ui_element_value_lensed(
             exec_req.get("ctx_main = mo._runtime.context.get_context()"),
             exec_req.get(
                 """
-                ctx_thread = None
+                cell_id = ctx_main.stream.cell_id
+                thread_ctx = None
                 def target():
-                    global ctx_thread
-                    ctx_thread = mo._runtime.context.get_context()
-                mo.Thread(target=target).start().join()
+                    global thread_ctx
+                    thread_ctx = mo._runtime.context.get_context()
+                t = mo.Thread(target=target); t.start(); t.join()
                 """
             ),
         ]
     )
 
     # thread run should be basically instantaneous, but sleep just in case ...
+    assert not k.errors
     time.sleep(0.01)  # noqa: ASYNC251
-    assert k.globals["ctx_main"] == k.globals["ctx_thread"]
+    # thread gets its own context
+    assert k.globals["thread_ctx"] != k.globals["ctx_main"]
+    stream = k.globals["thread_ctx"].stream
+    assert stream.cell_id == k.globals["cell_id"]

--- a/tests/_runtime/test_threads.py
+++ b/tests/_runtime/test_threads.py
@@ -58,3 +58,42 @@ async def test_thread_has_own_stream(
     assert k.globals["thread_ctx"] != k.globals["ctx_main"]
     stream = k.globals["thread_ctx"].stream
     assert stream.cell_id == k.globals["cell_id"]
+
+
+async def test_thread_output_append(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    """Test that a thread starts and runs."""
+
+    await k.run(
+        [
+            exec_req.get("import marimo as mo"),
+            exec_req.get(
+                """
+                stream = mo._runtime.context.get_context().stream
+                thread_stream = None
+                def target():
+                    global thread_stream
+                    import marimo as mo
+                    mo.output.append("hello")
+                    mo.output.append("world")
+                    thread_stream = mo._runtime.context.get_context().stream
+                t = mo.Thread(target=target); t.start(); t.join()
+                """
+            ),
+        ]
+    )
+
+    # thread run should be basically instantaneous, but sleep just in case ...
+    assert not k.errors
+    time.sleep(0.01)  # noqa: ASYNC251
+    # The main thread should not have any output, but the new thread should
+    stream = k.globals["stream"]
+    for m in stream.messages:
+        if m[0] == "cell-op" and m[1]["output"] is not None:
+            assert "hello" not in m[1]["output"]["data"]
+            assert "world" not in m[1]["output"]["data"]
+    thread_stream = k.globals["thread_stream"]
+    assert len(thread_stream.messages) == 2
+    assert "hello" in thread_stream.messages[0][1]["output"]["data"]
+    assert "world" in thread_stream.messages[1][1]["output"]["data"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,10 @@ register_formatters()
 class _MockStream(ThreadSafeStream):
     """Captures the ops sent through the stream"""
 
-    cell_id: int = 0
+    cell_id: int | None = None
     input_queue: None = None
     pipe: None = None
+
     messages: list[tuple[str, dict[Any, Any]]] = dataclasses.field(
         default_factory=list
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,9 @@ register_formatters()
 class _MockStream(ThreadSafeStream):
     """Captures the ops sent through the stream"""
 
+    cell_id: int = 0
+    input_queue: None = None
+    pipe: None = None
     messages: list[tuple[str, dict[Any, Any]]] = dataclasses.field(
         default_factory=list
     )


### PR DESCRIPTION
This change lets `mo.Thread`'s actually communicate to the output area. Printing to stdout and stderr still does not work.

Related to #3532 

https://github.com/user-attachments/assets/c8dcc2ff-7e17-4da1-88ef-73510e6388d6
