### PR TITLE
fix: printing in mo.Threads

### DIFF
--- a/marimo/_messaging/print_override.py
+++ b/marimo/_messaging/print_override.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import functools
 import threading
 from typing import Any

--- a/marimo/_messaging/print_override.py
+++ b/marimo/_messaging/print_override.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import functools
+import threading
+from typing import Any
+
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.ops import CellOp
+from marimo._runtime.context.types import (
+    ContextNotInitializedError,
+    get_context,
+)
+from marimo._runtime.threads import THREADS
+
+_original_print = print
+
+
+@functools.wraps(print)
+def print_override(*args: Any, **kwargs: Any) -> None:
+    """Override print to be aware of marimo threads.
+
+    When running marimo without mo.Threads, this just forwards to the built-in
+    print. When running with mo.Threads, it gets the threads cell ID and
+    forwards the print message to the appropriate cell.
+
+    This method is only necessary because the file descriptors for standard
+    out and standard in are currently redirected, and sys.stdout is not
+    always patched / is not aware of mo.Threads.
+    """
+    tid = threading.get_ident()
+    if tid not in THREADS:
+        _original_print(*args, **kwargs)
+        return
+
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        _original_print(*args, **kwargs)
+        return
+
+    execution_context = ctx.execution_context
+    if execution_context is None:
+        _original_print(*args, **kwargs)
+        return
+
+    cell_id = execution_context.cell_id
+
+    sep = kwargs.get("sep", " ")
+    end = kwargs.get("end", "\n")
+    msg = sep.join([str(arg) for arg in args]) + end
+
+    CellOp(
+        cell_id=cell_id,
+        console=CellOutput(
+            channel=CellChannel.STDOUT,
+            mimetype="text/plain",
+            data=msg,
+        ),
+    ).broadcast(ctx.stream)

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -358,7 +358,9 @@ def _launch_pyodide_kernel(
         stderr=stderr,
         stdin=stdin,
         module=patches.patch_main_module(
-            file=app_metadata.filename, input_override=input_override
+            file=app_metadata.filename,
+            input_override=input_override,
+            print_override=None,
         ),
         enqueue_control_request=_enqueue_control_request,
         debugger_override=debugger,

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -71,7 +71,9 @@ class AppKernelRunner:
             stdout=None,
             stderr=None,
             stdin=None,
-            module=create_main_module(filename, None),
+            module=create_main_module(
+                filename, input_override=None, print_override=None
+            ),
             user_config=DEFAULT_CONFIG,
             enqueue_control_request=lambda _: None,
             post_execution_hooks=[cache_output, _reset_matplotlib_context],

--- a/marimo/_runtime/app/script_runner.py
+++ b/marimo/_runtime/app/script_runner.py
@@ -133,7 +133,9 @@ class AppScriptRunner:
         post_execute_hooks: list[Callable[[], Any]],
     ) -> RunOutput:
         with patch_main_module_context(
-            create_main_module(file=self.filename, input_override=None)
+            create_main_module(
+                file=self.filename, input_override=None, print_override=None
+            )
         ) as module:
             glbls = module.__dict__
             outputs: dict[CellId_t, Any] = {}
@@ -150,7 +152,9 @@ class AppScriptRunner:
         post_execute_hooks: list[Callable[[], Any]],
     ) -> RunOutput:
         with patch_main_module_context(
-            create_main_module(file=self.filename, input_override=None)
+            create_main_module(
+                file=self.filename, input_override=None, print_override=None
+            )
         ) as module:
             glbls = module.__dict__
             outputs: dict[CellId_t, Any] = {}

--- a/marimo/_runtime/context/script_context.py
+++ b/marimo/_runtime/context/script_context.py
@@ -49,7 +49,9 @@ class ScriptRuntimeContext(RuntimeContext):
     @property
     def globals(self) -> dict[str, Any]:
         with patch_main_module_context(
-            create_main_module(file=None, input_override=None)
+            create_main_module(
+                file=None, input_override=None, print_override=None
+            )
         ) as module:
             glbls = module.__dict__
         glbls.update(sys.modules["__main__"].__dict__)

--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -117,7 +117,9 @@ del Loader; del MetaPathFinder
 
 
 def create_main_module(
-    file: str | None, input_override: Callable[[Any], str] | None
+    file: str | None,
+    input_override: Callable[[Any], str] | None,
+    print_override: Callable[[Any], None] | None,
 ) -> types.ModuleType:
     # Every kernel gets its own main module, whose __dict__ attribute
     # serves as the global namespace
@@ -129,6 +131,8 @@ def create_main_module(
 
     if input_override is not None:
         _module.__dict__.setdefault("input", input_override)
+    if print_override is not None:
+        _module.__dict__.setdefault("print", print_override)
 
     if file is not None:
         _module.__dict__.setdefault("__file__", file)
@@ -145,14 +149,16 @@ def create_main_module(
 
 
 def patch_main_module(
-    file: str | None, input_override: Callable[[Any], str] | None
+    file: str | None,
+    input_override: Callable[[Any], str] | None,
+    print_override: Callable[[Any], None] | None,
 ) -> types.ModuleType:
     """Patches __main__ module
 
     - Makes functions pickleable
     - Loads some overrides and mocks into globals
     """
-    _module = create_main_module(file, input_override)
+    _module = create_main_module(file, input_override, print_override)
 
     # TODO(akshayka): In run mode, this can introduce races between different
     # kernel threads, since they each share sys.modules. Unfortunately, Python

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -30,7 +30,6 @@ from marimo._data.preview_column import (
     get_column_preview_for_sql,
 )
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._messaging.print_override import print_override
 from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.context import http_request_context, run_id_context
 from marimo._messaging.errors import (
@@ -55,6 +54,7 @@ from marimo._messaging.ops import (
     VariableValue,
     VariableValues,
 )
+from marimo._messaging.print_override import print_override
 from marimo._messaging.streams import (
     QueuePipe,
     ThreadSafeStderr,

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -30,6 +30,7 @@ from marimo._data.preview_column import (
     get_column_preview_for_sql,
 )
 from marimo._dependencies.dependencies import DependencyManager
+from marimo._messaging.print_override import print_override
 from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.context import http_request_context, run_id_context
 from marimo._messaging.errors import (
@@ -2198,7 +2199,9 @@ def launch_kernel(
         stderr=stderr,
         stdin=stdin,
         module=patches.patch_main_module(
-            file=app_metadata.filename, input_override=input_override
+            file=app_metadata.filename,
+            input_override=input_override,
+            print_override=print_override,
         ),
         debugger_override=debugger,
         user_config=user_config,

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -17,6 +17,10 @@ from marimo._runtime.context.types import (
 )
 
 
+# Set of thread ids for running mo.Threads
+THREADS = set()
+
+
 class Thread(threading.Thread):
     """A Thread subclass that is aware of marimo internals.
 
@@ -24,9 +28,12 @@ class Thread(threading.Thread):
     but `mo.Thread`s are able to communicate with the marimo
     frontend, whereas `threading.Thread` can't.
 
-    Currently, threads can append to a cell's output using
-    `mo.output.append`, but messages written to stdout and stderr won't
-    be forwarded to the frontend.
+    Threads can append to a cell's output using `mo.output.append`, or to the
+    console output area using `print`. The corresponding outputs will be
+    forwarded to the frontend.
+
+    Writing directly to sys.stdout or sys.stderr, or to file descriptors 1 and
+    2, is not yet supported.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -84,4 +91,7 @@ class Thread(threading.Thread):
                 cell_id=self._marimo_ctx.stream.cell_id,  # type: ignore
                 setting_element_value=False,
             )
+        thread_id = threading.get_ident()
+        THREADS.add(thread_id)
         super().run()
+        THREADS.remove(thread_id)

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -16,7 +16,6 @@ from marimo._runtime.context.types import (
     runtime_context_installed,
 )
 
-
 # Set of thread ids for running mo.Threads
 THREADS = set()
 

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -1090,7 +1090,7 @@ class TestExecution:
                     query_params={}, filename=filename, cli_args={}
                 ),
                 enqueue_control_request=lambda _: None,
-                module=create_main_module(None, None),
+                module=create_main_module(None, None, None),
             )
             initialize_kernel_context(
                 kernel=k,
@@ -1151,7 +1151,7 @@ class TestExecution:
                     query_params={}, filename=filename, cli_args={}
                 ),
                 enqueue_control_request=lambda _: None,
-                module=create_main_module(None, None),
+                module=create_main_module(None, None, None),
             )
             assert str(tmp_path) in sys.path
             assert str(tmp_path) == sys.path[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from marimo._ast.cell import CellId_t
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._messaging.ops import CellOp, MessageOperation
+from marimo._messaging.print_override import print_override
 from marimo._messaging.streams import (
     ThreadSafeStderr,
     ThreadSafeStdin,
@@ -132,7 +133,9 @@ class MockedKernel:
         self.stdin = MockStdin(self.stream)
         self._main = sys.modules["__main__"]
         module = patches.patch_main_module(
-            file=None, input_override=input_override
+            file=None,
+            input_override=input_override,
+            print_override=print_override,
         )
 
         self.k = Kernel(


### PR DESCRIPTION
Makes print statements work with mo.Thread by patching the print builtin.

Writing directly to `sys.stdout` and `sys.stderr` does not work, and writing directly to fds 1 and 2 does not work (so standard out from extension libraries like NumPy won't be work). Still, this might be good enough for many use cases.

Supporting `sys.stdout` and `sys.stderr` is possible and can be done in a follow up if there is a need, but prefer to wait and see.

Supporting fds 1 and 2 is possible but requires more work.

Fixes #3532 