### PR TITLE
fix: kernel globals memory leak in run mode

### DIFF
--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -539,9 +539,9 @@ class VariableValue:
             if table_manager is not None:
                 return str(table_manager)
             else:
+                # TODO(akshayka): str(value) can be extremely expensive
+                # for some objects; find a better solution.
                 return str(value)[:50]
-
-            return str(value)[:50]
         except BaseException:
             # Catch-all: some libraries like Polars have bugs and raise
             # BaseExceptions, which shouldn't crash the kernel

--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -120,7 +120,6 @@ class ThreadSafeStream(Stream):
             self.console_msg_cv.notify()
 
 
-
 def _forward_os_stream(standard_stream: Stdout | Stderr, fd: int) -> None:
     """Watch a file descriptor and forward it to a stream object."""
 

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -14,6 +14,7 @@ from marimo._runtime.context.types import (
     get_context,
     initialize_context,
     runtime_context_installed,
+    teardown_context,
 )
 
 # Set of thread ids for running mo.Threads
@@ -94,3 +95,4 @@ class Thread(threading.Thread):
         THREADS.add(thread_id)
         super().run()
         THREADS.remove(thread_id)
+        teardown_context()


### PR DESCRIPTION
This change fixes a memory leak in run mode in which a kernel's globals memory appeared to not be freed on session (thread) exit. However, another (smaller) leak appears to still exist.

This change also makes sure to stop the stream's buffered writer thread when kernel exits.

Also, add a TODO for performance of VariableValue construction -- calling str() on some values, such as a bytearray of size 1GB, can make memory usage spike to 25GB.

Hopefully improves #3623