### PR TITLE
chore: add hatch build hook to build marimo when installed from github

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ If you use vscode, you might find the following `settings.json` useful:
 
 ## Testing a branch from GitHub
 
-This requires `uv` to be installed.
+This requires `uv` to be installed. This may take a bit to install frontend dependencies and build the frontend.
 
 ```bash
 MARIMO_BUILD_FRONTEND=true \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,11 +186,13 @@ hatch run test:test tests/_ast/
 ```
 
 Run tests with optional dependencies
+
 ```bash
 hatch run test-optional:test tests/_ast/
 ```
 
 Run tests with a specific Python version
+
 ```bash
 hatch run +py=3.10 test:test tests/_ast/
 # or
@@ -327,6 +329,24 @@ If you use vscode, you might find the following `settings.json` useful:
     "editor.defaultFormatter": "biomejs.biome"
   }
 }
+```
+
+## Testing a branch from GitHub
+
+This requires `uv` to be installed.
+
+```bash
+MARIMO_BUILD_FRONTEND=true \
+uvx --with git+https://github.com/marimo-team/marimo.git@BRANCH_NAME \
+marimo edit
+```
+
+Additionally, you can run `marimo` from the main branch:
+
+```bash
+MARIMO_BUILD_FRONTEND=true \
+uvx --with git+https://github.com/marimo-team/marimo.git \
+marimo edit
 ```
 
 ## Your first PR

--- a/build_hook.py
+++ b/build_hook.py
@@ -4,12 +4,10 @@ import os
 import subprocess
 from typing import Any, Dict
 
-from hatchling.builders.hooks.plugin.interface import (  # type: ignore
-    BuildHookInterface,  # type: ignore
-)
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
-class FrontendBuildHook(BuildHookInterface):  # type: ignore
+class FrontendBuildHook(BuildHookInterface[Any]):
     def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
         # Only build frontend if MARIMO_BUILD_FRONTEND variable exists
         MARIMO_BUILD_FRONTEND = os.getenv("MARIMO_BUILD_FRONTEND")

--- a/build_hook.py
+++ b/build_hook.py
@@ -1,40 +1,40 @@
 from __future__ import annotations
 
 import subprocess
-import sys
+from pathlib import Path
 from typing import Any, Dict
 
 from hatchling.builders.hooks.plugin.interface import (  # type: ignore
     BuildHookInterface,  # type: ignore
 )
 
-# info logs get swallowed by hatch, so we use this to print them
-
-DEBUG = False
-
-
-def _print(message: str) -> None:
-    sys.stdout.write(message + "\n")
-
-
-def _error(message: str) -> None:
-    sys.stderr.write(message + "\n")
-
 
 class FrontendBuildHook(BuildHookInterface):  # type: ignore
     def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
-        _print(str(build_data))
+        self.app.display_info(f"Build data: {str(build_data)}")
+        self.app.display_info(f"Project root: {self.root}")
+        self.app.display_info(f"Build dir: {self.directory}")
 
-        _print("Starting frontend build process. This may take a minute...")
+        # Skip frontend build if _static already exists
+        static_dir = Path(self.directory) / "_static"
+        if static_dir.exists():
+            self.app.display_info(
+                "_static directory already exists, skipping frontend build"
+            )
+            return
+
+        self.app.display_info(
+            "Starting frontend build process. This may take a minute..."
+        )
         try:
             self._check_binary("node", "Node.js")
             self._check_binary("pnpm", "pnpm")
             self._run_frontend_build()
         except Exception as e:
-            _error(f"Frontend build failed: {e}")
+            self.app.display_error(f"Frontend build failed: {e}")
             raise
 
-        _print("Frontend build completed successfully")
+        self.app.display_info("Frontend build completed successfully")
         return super().initialize(version, build_data)
 
     def _check_binary(self, binary: str, display_name: str) -> None:
@@ -57,7 +57,7 @@ class FrontendBuildHook(BuildHookInterface):  # type: ignore
     def _run_frontend_build(self) -> None:
         try:
             # Uncomment to hide output
-            capture_output = False
+            capture_output = True
             result = subprocess.run(
                 ["make", "fe"],
                 check=True,
@@ -65,14 +65,14 @@ class FrontendBuildHook(BuildHookInterface):  # type: ignore
                 text=True,
                 cwd=self.root,
             )
-            if DEBUG:
-                _print(f"Build output: {result.stdout}")
+            if capture_output:
+                self.app.display_debug(f"Build output: {result.stdout}")
         except subprocess.CalledProcessError as e:
-            _error(f"Build script stderr: {e.stderr}")
+            self.app.display_error(f"Build script stderr: {e.stderr}")
             raise RuntimeError("Frontend build script failed") from e
 
     def clean(self, versions: list[str]) -> None:
         """Clean up build artifacts"""
-        _print("Cleaning frontend build artifacts...")
+        self.app.display_info("Cleaning frontend build artifacts...")
         # Add any frontend cleanup logic here if needed
         super().clean(versions)

--- a/build_hook.py
+++ b/build_hook.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import os
 import subprocess
-from pathlib import Path
 from typing import Any, Dict
 
 from hatchling.builders.hooks.plugin.interface import (  # type: ignore
@@ -11,17 +11,17 @@ from hatchling.builders.hooks.plugin.interface import (  # type: ignore
 
 class FrontendBuildHook(BuildHookInterface):  # type: ignore
     def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
+        # Only build frontend if MARIMO_BUILD_FRONTEND variable exists
+        MARIMO_BUILD_FRONTEND = os.getenv("MARIMO_BUILD_FRONTEND")
+        if not MARIMO_BUILD_FRONTEND:
+            self.app.display_debug(
+                "MARIMO_BUILD_FRONTEND is not set, skipping frontend build"
+            )
+            return
+
         self.app.display_info(f"Build data: {str(build_data)}")
         self.app.display_info(f"Project root: {self.root}")
         self.app.display_info(f"Build dir: {self.directory}")
-
-        # Skip frontend build if _static already exists
-        static_dir = Path(self.directory) / "_static"
-        if static_dir.exists():
-            self.app.display_info(
-                "_static directory already exists, skipping frontend build"
-            )
-            return
 
         self.app.display_info(
             "Starting frontend build process. This may take a minute..."

--- a/build_hook.py
+++ b/build_hook.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any, Dict
+
+from hatchling.builders.hooks.plugin.interface import (  # type: ignore
+    BuildHookInterface,  # type: ignore
+)
+
+# info logs get swallowed by hatch, so we use this to print them
+
+DEBUG = False
+
+
+def _print(message: str) -> None:
+    sys.stdout.write(message + "\n")
+
+
+def _error(message: str) -> None:
+    sys.stderr.write(message + "\n")
+
+
+class FrontendBuildHook(BuildHookInterface):  # type: ignore
+    def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
+        _print(str(build_data))
+
+        _print("Starting frontend build process. This may take a minute...")
+        try:
+            self._check_binary("node", "Node.js")
+            self._check_binary("pnpm", "pnpm")
+            self._run_frontend_build()
+        except Exception as e:
+            _error(f"Frontend build failed: {e}")
+            raise
+
+        _print("Frontend build completed successfully")
+        return super().initialize(version, build_data)
+
+    def _check_binary(self, binary: str, display_name: str) -> None:
+        try:
+            subprocess.run(
+                [binary, "--version"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            raise RuntimeError(
+                f"{display_name} is not installed. Please install {display_name} and try again."
+            ) from None
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"{display_name} check failed: {e.stderr}"
+            ) from None
+
+    def _run_frontend_build(self) -> None:
+        try:
+            # Uncomment to hide output
+            capture_output = False
+            result = subprocess.run(
+                ["make", "fe"],
+                check=True,
+                capture_output=capture_output,
+                text=True,
+                cwd=self.root,
+            )
+            if DEBUG:
+                _print(f"Build output: {result.stdout}")
+        except subprocess.CalledProcessError as e:
+            _error(f"Build script stderr: {e.stderr}")
+            raise RuntimeError("Frontend build script failed") from e
+
+    def clean(self, versions: list[str]) -> None:
+        """Clean up build artifacts"""
+        _print("Cleaning frontend build artifacts...")
+        # Add any frontend cleanup logic here if needed
+        super().clean(versions)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -226,7 +226,7 @@
     "stylelint": "^16.8.2",
     "stylelint-config-standard": "^36.0.1",
     "tailwindcss": "^3.4.17",
-    "turbo": "^2.0.14",
+    "turbo": "^2.3.4",
     "typescript": "^5.7.3",
     "vite": "^5.4.13",
     "vite-tsconfig-paths": "^4.3.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -575,8 +575,8 @@ importers:
         specifier: ^3.4.17
         version: 3.4.17
       turbo:
-        specifier: ^2.0.14
-        version: 2.0.14
+        specifier: ^2.3.4
+        version: 2.3.4
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -8418,38 +8418,38 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo-darwin-64@2.0.14:
-    resolution: {integrity: sha512-kwfDmjNwlNfvtrvT29+ZBg5n1Wvxl891bFHchMJyzMoR0HOE9N1NSNdSZb9wG3e7sYNIu4uDkNk+VBEqJW0HzQ==}
+  turbo-darwin-64@2.3.4:
+    resolution: {integrity: sha512-uOi/cUIGQI7uakZygH+cZQ5D4w+aMLlVCN2KTGot+cmefatps2ZmRRufuHrEM0Rl63opdKD8/JIu+54s25qkfg==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.0.14:
-    resolution: {integrity: sha512-m3LXYEshCx3wc4ZClM6gb01KYpFmtjQ9IBF3A7ofjb6ahux3xlYZJZ3uFCLAGHuvGLuJ3htfiPbwlDPTdknqqw==}
+  turbo-darwin-arm64@2.3.4:
+    resolution: {integrity: sha512-IIM1Lq5R+EGMtM1YFGl4x8Xkr0MWb4HvyU8N4LNoQ1Be5aycrOE+VVfH+cDg/Q4csn+8bxCOxhRp5KmUflrVTQ==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.0.14:
-    resolution: {integrity: sha512-7vBzCPdoTtR92SNn2JMgj1FlMmyonGmpMaQdgAB1OVYtuQ6NVGoh7/lODfaILqXjpvmFSVbpBIDrKOT6EvcprQ==}
+  turbo-linux-64@2.3.4:
+    resolution: {integrity: sha512-1aD2EfR7NfjFXNH3mYU5gybLJEFi2IGOoKwoPLchAFRQ6OEJQj201/oNo9CDL75IIrQo64/NpEgVyZtoPlfhfA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.0.14:
-    resolution: {integrity: sha512-jwH+c0bfjpBf26K/tdEFatmnYyXwGROjbr6bZmNcL8R+IkGAc/cglL+OToqJnQZTgZvH7uDGbeSyUo7IsHyjuA==}
+  turbo-linux-arm64@2.3.4:
+    resolution: {integrity: sha512-MxTpdKwxCaA5IlybPxgGLu54fT2svdqTIxRd0TQmpRJIjM0s4kbM+7YiLk0mOh6dGqlWPUsxz/A0Mkn8Xr5o7Q==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.0.14:
-    resolution: {integrity: sha512-w9/XwkHSzvLjmioo6cl3S1yRfI6swxsV1j1eJwtl66JM4/pn0H2rBa855R0n7hZnmI6H5ywLt/nLt6Ae8RTDmw==}
+  turbo-windows-64@2.3.4:
+    resolution: {integrity: sha512-yyCrWqcRGu1AOOlrYzRnizEtdkqi+qKP0MW9dbk9OsMDXaOI5jlWtTY/AtWMkLw/czVJ7yS9Ex1vi9DB6YsFvw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.0.14:
-    resolution: {integrity: sha512-XaQlyYk+Rf4xS5XWCo8XCMIpssgGGy8blzLfolN6YBp4baElIWMlkLZHDbGyiFmCbNf9I9gJI64XGRG+LVyyjA==}
+  turbo-windows-arm64@2.3.4:
+    resolution: {integrity: sha512-PggC3qH+njPfn1PDVwKrQvvQby8X09ufbqZ2Ha4uSu+5TvPorHHkAbZVHKYj2Y+tvVzxRzi4Sv6NdHXBS9Be5w==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.0.14:
-    resolution: {integrity: sha512-00JjdCMD/cpsjP0Izkjcm8Oaor5yUCfDwODtaLb+WyblyadkaDEisGhy3Dbd5az9n+5iLSPiUgf+WjPbns6MRg==}
+  turbo@2.3.4:
+    resolution: {integrity: sha512-1kiLO5C0Okh5ay1DbHsxkPsw9Sjsbjzm6cF85CpWjR0BIyBFNDbKqtUyqGADRS1dbbZoQanJZVj4MS5kk8J42Q==}
     hasBin: true
 
   tweetnacl@0.14.5:
@@ -18799,32 +18799,32 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo-darwin-64@2.0.14:
+  turbo-darwin-64@2.3.4:
     optional: true
 
-  turbo-darwin-arm64@2.0.14:
+  turbo-darwin-arm64@2.3.4:
     optional: true
 
-  turbo-linux-64@2.0.14:
+  turbo-linux-64@2.3.4:
     optional: true
 
-  turbo-linux-arm64@2.0.14:
+  turbo-linux-arm64@2.3.4:
     optional: true
 
-  turbo-windows-64@2.0.14:
+  turbo-windows-64@2.3.4:
     optional: true
 
-  turbo-windows-arm64@2.0.14:
+  turbo-windows-arm64@2.3.4:
     optional: true
 
-  turbo@2.0.14:
+  turbo@2.3.4:
     optionalDependencies:
-      turbo-darwin-64: 2.0.14
-      turbo-darwin-arm64: 2.0.14
-      turbo-linux-64: 2.0.14
-      turbo-linux-arm64: 2.0.14
-      turbo-windows-64: 2.0.14
-      turbo-windows-arm64: 2.0.14
+      turbo-darwin-64: 2.3.4
+      turbo-darwin-arm64: 2.3.4
+      turbo-linux-64: 2.3.4
+      turbo-linux-arm64: 2.3.4
+      turbo-windows-64: 2.3.4
+      turbo-windows-arm64: 2.3.4
 
   tweetnacl@0.14.5: {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,9 @@ docs = [
 [tool.hatch]
 installer = "uv"
 
+[tool.hatch.build.hooks.custom]
+path = "build_hook.py"
+
 [tool.hatch.version]
 path = "marimo/__init__.py"
 

--- a/tests/_server/api/endpoints/test_terminal.py
+++ b/tests/_server/api/endpoints/test_terminal.py
@@ -15,9 +15,10 @@ if TYPE_CHECKING:
     from starlette.testclient import TestClient
 
 is_windows = sys.platform == "win32"
+is_mac = sys.platform == "darwin"
 
 
-@pytest.mark.skipif(is_windows, reason="Skip on Windows")
+@pytest.mark.skipif(is_windows or is_mac, reason="Skip on Windows or Mac")
 def test_terminal_ws(client: TestClient) -> None:
     with client.websocket_connect("/terminal/ws") as websocket:
         # Send echo message


### PR DESCRIPTION
This allows you to do stuff like:

```
# Run marimo from a branch
MARIMO_BUILD_FRONTEND=true uvx --with git+https://github.com/marimo-team/marimo.git@<branch-name> marimo edit

# Run marimo from main
MARIMO_BUILD_FRONTEND=true uvx --with git+https://github.com/marimo-team/marimo.git marimo edit

# Example
MARIMO_BUILD_FRONTEND=true uvx --with git+https://github.com/marimo-team/marimo.git@ms/build-hook marimo edit
```