### PR TITLE
improve: run mode performance for streams

### DIFF
--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -56,13 +56,7 @@ class Thread(threading.Thread):
                     # TODO(akshayka): stdin is not threadsafe
                     input_queue=ctx.stream.input_queue,
                     cell_id=ctx.stream.cell_id,
-                )
-            elif isinstance(ctx.stream, PyodideStream):
-                self._marimo_ctx.stream = type(ctx.stream)(
-                    pipe=ctx.stream.pipe,
-                    # TODO(akshayka): stdin is not threadsafe
-                    input_queue=ctx.stream.input_queue,
-                    cell_id=ctx.stream.cell_id,
+                    redirect_console=False,
                 )
             else:
                 raise RuntimeError(
@@ -77,6 +71,7 @@ class Thread(threading.Thread):
                     pipe=ctx.stream.pipe,
                     input_queue=ctx.stream.input_queue,
                     cell_id=ctx.stream.cell_id,
+                    redirect_console=False,
                 )
             else:
                 raise RuntimeError(

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -5,7 +5,6 @@ import threading
 from typing import Any
 
 from marimo._messaging.streams import ThreadSafeStream
-from marimo._pyodide.streams import PyodideStream
 from marimo._runtime.context.kernel_context import KernelRuntimeContext
 from marimo._runtime.context.script_context import ScriptRuntimeContext
 from marimo._runtime.context.types import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ class _MockStream(ThreadSafeStream):
     cell_id: int | None = None
     input_queue: None = None
     pipe: None = None
+    redirect_console: bool = False
 
     messages: list[tuple[str, dict[Any, Any]]] = dataclasses.field(
         default_factory=list


### PR DESCRIPTION
When console output is not redirected, there is no reason for the stream to start a console writer thread. This affects both the main thread for a session as well as `mo.Thread`s.