### PR TITLE
fix: show 'Clear Output' cell action when console has output

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -42,7 +42,7 @@ import useEvent from "react-use-event-hook";
 import { CellEditor } from "./cell/code/cell-editor";
 import { getEditorCodeAsPython } from "@/core/codemirror/language/utils";
 import { outputIsStale } from "@/core/cells/cell";
-import { isConsoleOutputEmpty, isOutputEmpty } from "@/core/cells/outputs";
+import { isOutputEmpty } from "@/core/cells/outputs";
 import { useHotkeysOnElement, useKeydownOnElement } from "@/hooks/useHotkey";
 import { useSetAtom } from "jotai";
 import { aiCompletionCellAtom } from "@/core/ai/state";
@@ -373,7 +373,7 @@ const CellComponent = (
   };
 
   const hasOutput = !isOutputEmpty(output);
-  const hasConsoleOutput = !isConsoleOutputEmpty(consoleOutputs);
+  const hasConsoleOutput = consoleOutputs.length > 0;
   const cellOutput = userConfig.display.cell_output;
 
   const hasOutputAbove = hasOutput && cellOutput === "above";

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -42,7 +42,7 @@ import useEvent from "react-use-event-hook";
 import { CellEditor } from "./cell/code/cell-editor";
 import { getEditorCodeAsPython } from "@/core/codemirror/language/utils";
 import { outputIsStale } from "@/core/cells/cell";
-import { isOutputEmpty } from "@/core/cells/outputs";
+import { isConsoleOutputEmpty, isOutputEmpty } from "@/core/cells/outputs";
 import { useHotkeysOnElement, useKeydownOnElement } from "@/hooks/useHotkey";
 import { useSetAtom } from "jotai";
 import { aiCompletionCellAtom } from "@/core/ai/state";
@@ -373,6 +373,7 @@ const CellComponent = (
   };
 
   const hasOutput = !isOutputEmpty(output);
+  const hasConsoleOutput = !isConsoleOutputEmpty(consoleOutputs);
   const cellOutput = userConfig.display.cell_output;
 
   const hasOutputAbove = hasOutput && cellOutput === "above";
@@ -588,6 +589,7 @@ const CellComponent = (
       status={status}
       getEditorView={getEditorView}
       hasOutput={hasOutput}
+      hasConsoleOutput={hasConsoleOutput}
       name={name}
     >
       <SortableCell
@@ -617,6 +619,7 @@ const CellComponent = (
                 cellConfig={cellConfig}
                 needsRun={needsRun}
                 hasOutput={hasOutput}
+                hasConsoleOutput={hasConsoleOutput}
                 cellActionDropdownRef={cellActionDropdownRef}
                 cellId={cellId}
                 name={name}
@@ -733,6 +736,7 @@ interface CellToolbarProps {
   cellConfig: CellConfig;
   needsRun: boolean;
   hasOutput: boolean;
+  hasConsoleOutput: boolean;
   cellActionDropdownRef: React.RefObject<CellActionsDropdownHandle>;
   cellId: CellId;
   name: string;
@@ -747,6 +751,7 @@ const CellToolbar = ({
   cellConfig,
   needsRun,
   hasOutput,
+  hasConsoleOutput,
   onRun,
   cellActionDropdownRef,
   cellId,
@@ -777,6 +782,7 @@ const CellToolbar = ({
         name={name}
         config={cellConfig}
         hasOutput={hasOutput}
+        hasConsoleOutput={hasConsoleOutput}
       >
         <ToolbarItem
           variant={"green"}

--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -62,6 +62,7 @@ export interface CellActionButtonProps
   cellId: CellId;
   status: RuntimeState;
   hasOutput: boolean;
+  hasConsoleOutput: boolean;
   getEditorView: () => EditorView | null;
 }
 
@@ -97,7 +98,15 @@ export function useCellActionButtons({ cell }: Props) {
     return [];
   }
 
-  const { cellId, config, getEditorView, name, hasOutput, status } = cell;
+  const {
+    cellId,
+    config,
+    getEditorView,
+    name,
+    hasOutput,
+    hasConsoleOutput,
+    status,
+  } = cell;
 
   const toggleDisabled = async () => {
     const newConfig = { disabled: !config.disabled };
@@ -242,7 +251,7 @@ export function useCellActionButtons({ cell }: Props) {
       {
         icon: <XCircleIcon size={13} strokeWidth={1.5} />,
         label: "Clear output",
-        hidden: !hasOutput,
+        hidden: !(hasOutput || hasConsoleOutput),
         handle: () => {
           clearCellOutput({ cellId });
         },

--- a/frontend/src/core/cells/focus.ts
+++ b/frontend/src/core/cells/focus.ts
@@ -30,6 +30,7 @@ export const lastFocusedCellAtom = atom<{
   status: RuntimeState;
   getEditorView: () => EditorView | null;
   hasOutput: boolean;
+  hasConsoleOutput: boolean;
 } | null>((get) => {
   const cellId = get(lastFocusedCellIdAtom);
   if (!cellId) {
@@ -66,5 +67,6 @@ function cellFocusDetails(cellId: CellId, notebookState: NotebookState) {
     status: runtime ? runtime.status : "idle",
     getEditorView: getEditorView,
     hasOutput: runtime?.output != null,
+    hasConsoleOutput: runtime?.consoleOutputs != null,
   };
 }

--- a/frontend/src/core/cells/outputs.ts
+++ b/frontend/src/core/cells/outputs.ts
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { CellId } from "./ids";
 import type { OutputMessage } from "../kernel/messages";
+import type { WithResponse } from "./types";
 
 // This does not need to be overcomplicated. We can just store the expanded
 // state in a global map instead of Jotai since state is not shared between cells.
@@ -27,6 +28,20 @@ export function isOutputEmpty(
   }
 
   if (output.data == null || output.data === "") {
+    return true;
+  }
+
+  return false;
+}
+
+export function isConsoleOutputEmpty(
+  output: Array<WithResponse<OutputMessage>> | undefined | null,
+): boolean {
+  if (output == null) {
+    return true;
+  }
+
+  if (output.length === 0) {
     return true;
   }
 

--- a/frontend/src/core/cells/outputs.ts
+++ b/frontend/src/core/cells/outputs.ts
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import type { CellId } from "./ids";
 import type { OutputMessage } from "../kernel/messages";
-import type { WithResponse } from "./types";
 
 // This does not need to be overcomplicated. We can just store the expanded
 // state in a global map instead of Jotai since state is not shared between cells.
@@ -28,20 +27,6 @@ export function isOutputEmpty(
   }
 
   if (output.data == null || output.data === "") {
-    return true;
-  }
-
-  return false;
-}
-
-export function isConsoleOutputEmpty(
-  output: Array<WithResponse<OutputMessage>> | undefined | null,
-): boolean {
-  if (output == null) {
-    return true;
-  }
-
-  if (output.length === 0) {
     return true;
   }
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
When there is console output, the 'Clear Output' option is not shown. This is to fix that.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/3af06b17-4443-4c20-aeea-bd0426388f11" />

Another solution is to not hide this option at all. Or to merge the hasOutput & hasConsoleOutput prop into one.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
