### PR TITLE
fix: date range not defaulting to `start` and `stop`

### DIFF
--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -385,7 +385,10 @@ class date_range(UIElement[Tuple[str, str], Tuple[dt.date, dt.date]]):
             )
 
         if value is None:
-            value = (dt.date.today(), dt.date.today())
+            if start is None or stop is None:
+                value = (dt.date.today(), dt.date.today())
+            else:
+                value = (start, stop)
         elif (
             value[0] < self._start
             or value[1] > self._stop

--- a/tests/_plugins/ui/_impl/test_dates.py
+++ b/tests/_plugins/ui/_impl/test_dates.py
@@ -76,6 +76,15 @@ def test_date_range() -> None:
 
     # Test with start and stop
     dr = ui.date_range(
+        start="2024-01-01",
+        stop="2024-12-31",
+    )
+    assert dr.start == datetime.date(2024, 1, 1)
+    assert dr.stop == datetime.date(2024, 12, 31)
+    assert dr.value == (dr.start, dr.stop)
+
+    # Test with start, stop and value
+    dr = ui.date_range(
         value=("2024-03-01", "2024-03-15"),
         start="2024-01-01",
         stop="2024-12-31",


### PR DESCRIPTION
## 📝 Summary

`date_range` should default to `start` and `stop` according to the docs but it doesn't. This fixes this.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.


## Pixi

Even though you did a nice job with encapsulating work with `hatch` and `make` I was still surprised how many steps are needed to get a working setup.
With pixi you could install all prerequisites, and replace both hatch and make. Let me know if you'd be interested in a PR for that.  

@akshayka OR @mscolnick
