### PR TITLE
perf: resource cleanup, don't start module reloader in run mode

### DIFF
--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -24,6 +24,10 @@ class Stream(abc.ABC):
     def write(self, op: str, data: Dict[Any, Any]) -> None:
         pass
 
+    def stop(self) -> None:
+        """Tear down resources, if any."""
+        return
+
 
 class NoopStream(Stream):
     def write(self, op: str, data: Dict[Any, Any]) -> None:
@@ -40,6 +44,10 @@ class Stdout(io.TextIOBase):
     def write(self, __s: str) -> int:
         return self._write_with_mimetype(__s, mimetype="text/plain")
 
+    def stop(self) -> None:
+        """Tear down resources, if any."""
+        pass
+
 
 class Stderr(io.TextIOBase):
     name = "stderr"
@@ -51,8 +59,14 @@ class Stderr(io.TextIOBase):
     def write(self, __s: str) -> int:
         return self._write_with_mimetype(__s, mimetype="text/plain")
 
+    def stop(self) -> None:
+        """Tear down resources, if any."""
+        pass
+
 
 class Stdin(io.TextIOBase):
     name = "stdin"
 
-    pass
+    def stop(self) -> None:
+        """Tear down resources, if any."""
+        pass

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 class KernelRuntimeContext(RuntimeContext):
     """Encapsulates runtime state for a session."""
 
+    # The kernel is _not_ owned by the context; don't teardown.
     _kernel: Kernel
     _session_mode: SessionMode
     # app that owns this context; None for top-level contexts

--- a/marimo/_runtime/context/types.py
+++ b/marimo/_runtime/context/types.py
@@ -71,6 +71,7 @@ class RuntimeContext(abc.ABC):
     cell_lifecycle_registry: CellLifecycleRegistry
     virtual_file_registry: VirtualFileRegistry
     virtual_files_supported: bool
+    # stream, stdout, stderr are _not_ owned by the context
     stream: Stream
     stdout: Stdout | None
     stderr: Stderr | None

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -536,6 +536,25 @@ class Kernel:
             patches.patch_micropip(self.globals)
         exec("import marimo as __marimo__", self.globals)
 
+    def teardown(self) -> None:
+        """Teardown resources owned by the kernel."""
+        if self.stdout is not None:
+            self.stdout.stop()
+        if self.stderr is not None:
+            self.stderr.stop()
+        if self.stdin is not None:
+            self.stdin.stop()
+        self.stream.stop()
+
+        if self.module_watcher is not None:
+            self.module_watcher.stop()
+
+        # TODO(akshayka): There's a memory leak in run mode, with memory
+        # usage increasing with each session creation. Somehow the kernel
+        # globals appear to leak, even though the thread exits. As a hack we
+        # manually clear kernel memory.
+        self._module.__dict__.clear()
+
     def lazy(self) -> bool:
         return self.reactive_execution_mode == "lazy"
 
@@ -571,10 +590,17 @@ class Kernel:
                 # NOOP.
                 self._update_script_metadata(["marimo"])
 
+        ctx = get_context()
         if (
-            autoreload_mode == "lazy" or autoreload_mode == "autorun"
+            (autoreload_mode == "lazy" or autoreload_mode == "autorun")
             # Pyodide doesn't support hot module reloading
-        ) and not is_pyodide():
+            and not is_pyodide()
+            and (
+                # We disable module reloading in run mode for performance
+                isinstance(ctx, KernelRuntimeContext)
+                and not ctx.session_mode == SessionMode.RUN
+            )
+        ):
             if self.module_reloader is None:
                 self.module_reloader = ModuleReloader()
 
@@ -2141,9 +2167,9 @@ def launch_kernel(
     should_redirect_stdio = is_edit_mode or redirect_console_to_browser
 
     # Create communication channels
+    pipe: Optional[TypedConnection[KernelMessage]] = None
     if socket_addr is not None:
         n_tries = 0
-        pipe: Optional[TypedConnection[KernelMessage]] = None
         while n_tries < 100:
             try:
                 pipe = TypedConnection[KernelMessage].of(
@@ -2173,6 +2199,7 @@ def launch_kernel(
         raise RuntimeError(
             "One of queue_pipe and socket_addr must be non None"
         )
+
     # Console output is hidden in run mode, so no need to redirect
     # (redirection of console outputs is not thread-safe anyway)
     stdout = ThreadSafeStdout(stream) if should_redirect_stdio else None
@@ -2279,20 +2306,12 @@ def launch_kernel(
     # reason; prefer using threads (for performance and clarity).
     asyncio.run(control_loop(kernel))
 
-    if stdout is not None:
-        stdout._watcher.stop()
-    if stderr is not None:
-        stderr._watcher.stop()
-    get_context().virtual_file_registry.shutdown()
-    stream.stop()
-
     if profiler is not None and profile_path is not None:
         profiler.disable()
         profiler.dump_stats(profile_path)
 
-    # TODO(akshayka): There's a memory leak in run mode, with memory
-    # usage increasing with each session creation. Somehow the kernel
-    # appears to leak, even though the thread exits. As a hack we manually
-    # clear various data structures.
+    get_context().virtual_file_registry.shutdown()
     teardown_context()
-    kernel._module.__dict__.clear()
+    kernel.teardown()
+    if isinstance(pipe, connection.Connection):
+        pipe.close()

--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -1,3 +1,4 @@
+# Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, cast


### PR DESCRIPTION
Don't start module autoreloader in run mode, since it's not needed; this should stem a memory leak in run mode. Still need to see if the reloader is leaking memory in edit mode. Hopefully improves #3623.

Cleanup some threads in on kernel shutdown, which should improve edit mode performance when using a long-lived `marimo edit` server:

* Shut down the module watcher on kernel shutdown
* Stop the standard io forwarding threads