### PR TITLE
docs: markdown extensions

### DIFF
--- a/docs/guides/outputs.md
+++ b/docs/guides/outputs.md
@@ -62,6 +62,60 @@ mo.md(
 )
 ```
 
+### Markdown editor
+
+marimo automatically renders cells that only use `mo.md("")`, without an
+`f`-string, in a markdown editor that supports common hotkeys.
+
+Because the Markdown editor doesn't support f-strings, you'll need to use
+`mo.md` directly to interpolate Python values into your Markdown. You can
+switch between the Markdown and Python editors by clicking the button in the
+top right.
+
+<div align="center">
+<figure>
+<video autoplay muted loop width="100%" height="100%" align="center" src="/_static/docs-markdown-toggle.webm">
+</video>
+<figcaption>marimo is pure Python, even when you're using markdown.</figcaption>
+</figure>
+</div>
+
+### Markdown extensions
+#### Details
+
+Create expandable details with additional context:
+
+```markdown
+/// details | Heads up
+
+Here's some additional context.
+///
+```
+
+/// marimo-embed-file
+    filepath: examples/markdown/details.py
+///
+
+
+#### Admonitions
+
+Highlight text using admonitions:
+
+```markdown
+/// attention | This is important.
+
+Pay attention to this text!
+///
+```
+
+/// marimo-embed-file
+    filepath: examples/markdown/admonitions.py
+///
+
+#### Emoji
+
+Use `:emoji:` syntax to add emojis; for example, `:rocket:` creates 🚀.
+
 ### Static files
 
 marimo supports serving static files from a `public/` folder located next to your notebook. This is useful for including images or other static assets in your notebook.
@@ -86,23 +140,6 @@ For security reasons:
 - Symlinks are not followed
 - Path traversal attempts (e.g., `../`) are blocked
 
-### Markdown editor
-
-marimo automatically renders cells that only use `mo.md("")`, without an
-`f`-string, in a markdown editor that supports common hotkeys.
-
-Because the Markdown editor doesn't support f-strings, you'll need to use
-`mo.md` directly to interpolate Python values into your Markdown. You can
-switch between the Markdown and Python editors by clicking the button in the
-top right.
-
-<div align="center">
-<figure>
-<video autoplay muted loop width="100%" height="100%" align="center" src="/_static/docs-markdown-toggle.webm">
-</video>
-<figcaption>marimo is pure Python, even when you're using markdown.</figcaption>
-</figure>
-</div>
 
 ## Layout
 

--- a/examples/markdown/admonitions.py
+++ b/examples/markdown/admonitions.py
@@ -1,0 +1,46 @@
+import marimo
+
+__generated_with = "0.10.19"
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""Use **admonitions** in markdown to bring attention to text. Here are some examples.""")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        /// admonition | Heads up.
+
+        Here's some information.
+        ///
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        /// attention | Attention!
+
+        This is important.
+        ///
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/markdown/details.py
+++ b/examples/markdown/details.py
@@ -1,0 +1,96 @@
+import marimo
+
+__generated_with = "0.10.19"
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""Create expandable markdown blocks with `details`:""")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        /// details | Hello, details!
+
+        Some additional content.
+
+        ///
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""Style details using the "type" argument:""")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        /// details | Info details
+            type: info
+
+        Some additional content.
+        ///
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        /// details | Warning details  
+            type: warn
+
+        This highlights something to watch out for
+        ///
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        /// details | Danger details
+            type: danger
+
+        This indicates a critical warning or dangerous situation
+        ///
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        /// details | Success details
+            type: success
+
+        This indicates a successful outcome or positive note
+        ///
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/markdown/dynamic_markdown.py
+++ b/examples/markdown/dynamic_markdown.py
@@ -1,0 +1,78 @@
+import marimo
+
+__generated_with = "0.10.19"
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""Use `mo.md` with an `f-string` to create markdown that depends on the value of Python objects.""")
+    return
+
+
+@app.cell
+def _():
+    name = "Alice"
+    return (name,)
+
+
+@app.cell
+def _(mo, name):
+    mo.md(
+        f"""
+        Hello, {name}!
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""Embed marimo UI elements in markdown directly:""")
+    return
+
+
+@app.cell
+def _(mo):
+    text_input = mo.ui.text(placeholder="My name is ...", debounce=False)
+    return (text_input,)
+
+
+@app.cell
+def _(mo, text_input):
+    mo.md(
+        f"""
+        What's your name? {text_input}
+
+        Hello, {text_input.value}!
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""Wrap plots and data structures in `mo.as_html()` to hook into marimo's rich media viewer:""")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        f"""
+        Here's a list of numbers:
+        
+        {mo.as_html([1, 2, 3])}
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/markdown/emoji.py
+++ b/examples/markdown/emoji.py
@@ -1,0 +1,26 @@
+import marimo
+
+__generated_with = "0.10.19"
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""Use colon syntax as a shortcut for **emojis** in your markdown.""")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r""":rocket: :smile:""")
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_output/md.py
+++ b/marimo/_output/md.py
@@ -77,6 +77,7 @@ def get_extensions() -> list[Union[str, markdown.Extension]]:
                     "pymdownx.blocks.caption",
                     "pymdownx.blocks.tab",
                     "pymdownx.blocks.details",
+                    "pymdownx.blocks.admonition",
                 ]
                 if _has_module(module)
             ]
@@ -94,8 +95,6 @@ def get_extensions() -> list[Union[str, markdown.Extension]]:
         "toc",
         # Footnotes
         "footnotes",
-        # Admonitions
-        "admonition",
         # Sane lists, to include <ol start="n">
         "sane_lists",
         # Links


### PR DESCRIPTION
Show how to use details, admonitions, and emojis in our docs; also adds a few md usage examples.

Swaps out the deprecated admonitions extension with `pymdown.blocks.admonition` for consistency with details. Technically a breaking change but admonitions were not previously documented.