### PR TITLE
chore: enable preview rules from ruff

### DIFF
--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -52,7 +52,7 @@ def wrap_fn_for_pytest(
         ast.arg(arg, lineno=args[arg].lineno, col_offset=args[arg].col_offset)
         for arg in fixtures
     ]
-    (call_stub,) = call.keywords
+    (_call_stub,) = call.keywords
     call.keywords = [
         ast.keyword(
             arg=arg,

--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import abc
 import json
-import logging
 import os
 import pathlib
 import urllib.parse
@@ -12,9 +11,12 @@ from tempfile import TemporaryDirectory
 from typing import Optional, Tuple
 from urllib.error import HTTPError
 
+from marimo import _loggers
 from marimo._cli.print import green
 from marimo._utils.marimo_path import MarimoPath
 from marimo._utils.url import is_url
+
+LOGGER = _loggers.marimo_logger()
 
 
 def is_github_src(url: str, ext: str) -> bool:
@@ -99,7 +101,7 @@ class StaticNotebookReader(FileReader):
     @staticmethod
     def _is_static_marimo_notebook_url(url: str) -> tuple[bool, str]:
         def download(url: str) -> tuple[bool, str]:
-            logging.info("Downloading %s", url)
+            LOGGER.info("Downloading %s", url)
             request = urllib.request.Request(
                 url,
                 # User agent to avoid 403 Forbidden some bot protection
@@ -278,11 +280,11 @@ class RemoteFileHandler(FileHandler):
     def _create_tmp_file_from_content(
         content: str, name: str, temp_dir: TemporaryDirectory[str]
     ) -> str:
-        logging.info("Creating temporary file")
+        LOGGER.info("Creating temporary file")
         path_to_app = os.path.join(temp_dir.name, name)
         with open(path_to_app, "w") as f:
             f.write(content)
-        logging.info("App saved to %s", path_to_app)
+        LOGGER.info("App saved to %s", path_to_app)
         return path_to_app
 
 

--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -325,14 +325,14 @@ def plain(value: Any) -> Plain:
     return Plain(value)
 
 
+@dataclass
 class Plain:
     """
     Wrapper around a value to indicate that it should be displayed
     without any opinionated formatting.
     """
 
-    def __init__(self, child: Any):
-        self.child = child
+    child: Any
 
 
 @mddoc

--- a/marimo/_plugins/ui/_impl/tables/format.py
+++ b/marimo/_plugins/ui/_impl/tables/format.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List, Union
 
+from marimo import _loggers
 from marimo._plugins.core.web_component import JSONType
+
+LOGGER = _loggers.marimo_logger()
 
 FormatMapping = Dict[str, Union[str, Callable[..., JSONType]]]
 
@@ -38,9 +41,7 @@ def format_value(
         if callable(formatter):
             return formatter(value)
     except Exception as e:
-        import logging
-
-        logging.warning(
+        LOGGER.warning(
             f"Error formatting for value {value} in column {col}: {str(e)}"
         )
         return value

--- a/marimo/_save/ast.py
+++ b/marimo/_save/ast.py
@@ -80,7 +80,7 @@ class ExtractWithBlock(ast.NodeTransformer):
         super().__init__(*arg, **kwargs)
         self.target_line = line
 
-    def generic_visit(self, node: ast.AST) -> tuple[ast.Module, ast.Module]:  #  type: ignore[override]
+    def generic_visit(self, node: ast.AST) -> tuple[ast.Module, ast.Module]:  # type: ignore[override]
         pre_block = []
 
         # There are a few strange edges cases like:

--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -968,7 +968,7 @@ def content_cache_attempt_from_base(
         refs, scope, ctx
     )
 
-    refs, content, tmp_stateful_refs = hasher.collect_for_content_hash(
+    refs, _content, tmp_stateful_refs = hasher.collect_for_content_hash(
         refs, scope, ctx, scoped_refs, apply_hash=True
     )
     # If the execution block covers this variable, then that's OK

--- a/marimo/_server/api/endpoints/terminal.py
+++ b/marimo/_server/api/endpoints/terminal.py
@@ -91,7 +91,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     child_pid, fd = pty.fork()
     if child_pid == 0:
         default_shell = os.environ.get("SHELL", "/bin/bash")
-        subprocess.run([default_shell], shell=True)  ## noqa: ASYNC221
+        subprocess.run([default_shell], shell=True)  # noqa: ASYNC221
         return
 
     reader_task = asyncio.create_task(_read_from_pty(fd, websocket))
@@ -118,5 +118,5 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         if writer_task and not writer_task.done():
             writer_task.cancel()
         os.kill(child_pid, signal.SIGKILL)
-        os.waitpid(child_pid, 0)  ## noqa: ASYNC222
+        os.waitpid(child_pid, 0)  # noqa: ASYNC222
     LOGGER.debug("Terminal websocket closed")

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from http.client import HTTPResponse, HTTPSConnection
 from typing import (
     TYPE_CHECKING,
@@ -162,14 +163,12 @@ class OpenTelemetryMiddleware(BaseHTTPMiddleware):
             return response
 
 
+@dataclass
 class _URLRequest:
-    def __init__(
-        self, url: str, method: str, headers: dict[str, str], data: Any
-    ):
-        self.full_url = url
-        self.method = method
-        self.headers = headers
-        self.data = data
+    full_url: str
+    method: str
+    headers: dict[str, str]
+    data: Any
 
 
 class _AsyncHTTPResponse:

--- a/marimo/_server/export/utils.py
+++ b/marimo/_server/export/utils.py
@@ -13,7 +13,7 @@ from marimo._server.file_manager import AppFileManager
 
 def format_filename_title(filename: str) -> str:
     basename = os.path.basename(filename)
-    name, ext = os.path.splitext(basename)
+    name, _ext = os.path.splitext(basename)
     title = re.sub("[-_]", " ", name)
     return title.title()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,9 +304,11 @@ exclude = [
 ]
 
 [tool.ruff.lint]
+preview = true
 ignore = [
     "G004",   # Logging statement uses f-string
     "TC001", # Move application import into a type-checking block
+    "TC006", # Add quotes to type expression in typing.cast()
     "D301",   # Use r""" if any backslashes in a docstring
     "PERF203", # try-except within a loop incurs performance overhead; not always possible
     "PERF401", # Use {message_str} to create a transformed list; at the cost of readability
@@ -331,6 +333,7 @@ extend-select = [
     "ARG",
     # flake8-bugbear
     "B",
+    # Performance
     "PERF",
     "ANN002", # missing-type-args
     "ANN003", # missing-type-kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,7 +389,7 @@ unfixable = ["F401"]
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"**/{tests}/*" = ["ANN201", "ANN202", "T201", "D"]
+"**/{tests}/*" = ["ANN201", "ANN202", "T201", "D", "F841"]
 "dagger/*" = ["TID252"]
 
 [tool.ruff.lint.isort]

--- a/tests/_output/formatters/test_sympy.py
+++ b/tests/_output/formatters/test_sympy.py
@@ -56,7 +56,7 @@ def test_sympy_formatters_power() -> None:
 
     from sympy import symbols
 
-    x, y, z = symbols("x y z")
+    x, _y, _z = symbols("x y z")
     x_squared = x**2
 
     # x^2
@@ -109,7 +109,7 @@ def test_sympy_formatters_Integral() -> None:
 
     from sympy import Integral, sqrt, symbols
 
-    x, y, z = symbols("x y z")
+    x, _y, _z = symbols("x y z")
     out_exp = Integral(sqrt(1 / x), x)
 
     # symbolic integral

--- a/tests/_output/formatters/test_sympy.py
+++ b/tests/_output/formatters/test_sympy.py
@@ -56,7 +56,7 @@ def test_sympy_formatters_power() -> None:
 
     from sympy import symbols
 
-    x, _y, _z = symbols("x y z")
+    x, y, z = symbols("x y z")
     x_squared = x**2
 
     # x^2
@@ -109,7 +109,7 @@ def test_sympy_formatters_Integral() -> None:
 
     from sympy import Integral, sqrt, symbols
 
-    x, _y, _z = symbols("x y z")
+    x, y, z = symbols("x y z")
     out_exp = Integral(sqrt(1 / x), x)
 
     # symbolic integral

--- a/tests/_output/test_md.py
+++ b/tests/_output/test_md.py
@@ -69,7 +69,7 @@ def test_md_iconify() -> None:
 
     # Test multiple icons
     multiple_icons_input = "Icons: ::mdi:home:: ::fa:car:: ::lucide:settings::"
-    expected_output = '<span class="paragraph">Icons: <iconify-icon icon="mdi:home" inline=""></iconify-icon> <iconify-icon icon="fa:car" inline=""></iconify-icon> <iconify-icon icon="lucide:settings" inline=""></iconify-icon></span>'  ## noqa: E501
+    expected_output = '<span class="paragraph">Icons: <iconify-icon icon="mdi:home" inline=""></iconify-icon> <iconify-icon icon="fa:car" inline=""></iconify-icon> <iconify-icon icon="lucide:settings" inline=""></iconify-icon></span>'  # noqa: E501
     assert (
         _md(multiple_icons_input, apply_markdown_class=False).text
         == expected_output

--- a/tests/_output/test_try_format.py
+++ b/tests/_output/test_try_format.py
@@ -160,9 +160,7 @@ def test_plain_object():
     result = try_format(obj)
     # Should fall back to string representation since we opted out of opinionated formatter
     assert is_html(result)
-    assert result.data.startswith(
-        "<pre style='font-size: 12px'>&lt;marimo._output.formatting.Plain object"
-    )
+    assert result.data.startswith("<pre style='font-size: 12px'>Plain(")
 
 
 def test_opinionated_formatter():

--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -75,7 +75,7 @@ class TestScriptCache:
             with persistent_cache(name="one",
                                   _loader=MockLoader(
                                     data={"X": 7, "Y": 8})
-                                  ) as cache: # noqa: E501
+                                  ) as cache:  # noqa: E501
                 Y = 9
                 X = 10
             # fmt: on
@@ -114,8 +114,8 @@ class TestScriptCache:
             # fmt: off
             b = [2]
             if True:
-              with persistent_cache("if", _loader=_loader):
-                  b = [
+              with persistent_cache("if", _loader=_loader):  # noqa: E111
+                  b = [  # noqa: E111
                       7
                   ]
             # fmt: on
@@ -222,7 +222,7 @@ class TestScriptCache:
 
             _loader = MockLoader()
             # fmt: off
-            with persistent_cache("else", _loader=_loader): call(False) # noqa: E701
+            with persistent_cache("else", _loader=_loader): call(False)  # noqa: E701
             # fmt: on
 
         with pytest.raises(BlockException):
@@ -1259,7 +1259,7 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state, set_state = mo.state(None)
+            _state, _set_state = mo.state(None)
 
             @mo.cache
             def g(state):
@@ -1283,7 +1283,7 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state, set_state = mo.state(None)
+            state, _set_state = mo.state(None)
 
             @mo.cache
             def g():
@@ -1309,11 +1309,11 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state0, set_state0 = mo.state(1)
-            state1, set_state1 = mo.state(1)
-            state2, set_state2 = mo.state(10)
+            state0, _set_state0 = mo.state(1)
+            state1, _set_state1 = mo.state(1)
+            state2, _set_state2 = mo.state(10)
 
-            state, set_state = mo.state(100)
+            _state, _set_state = mo.state(100)
 
             @mo.cache
             def h(state):
@@ -1344,11 +1344,11 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state0, set_state0 = mo.state(1)
-            state1, set_state1 = mo.state(1)
-            state2, set_state2 = mo.state(10)
+            state0, _set_state0 = mo.state(1)
+            state1, _set_state1 = mo.state(1)
+            state2, _set_state2 = mo.state(10)
 
-            state, set_state = mo.state(100)
+            state, _set_state = mo.state(100)
 
             # Example of a case where things start to get very tricky. There
             # comes a point where you might also have to capture frame levels
@@ -1380,11 +1380,11 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state1, set_state1 = mo.state(1)
-            state2, set_state2 = mo.state(2)
+            state1, _set_state1 = mo.state(1)
+            state2, _set_state2 = mo.state(2)
 
             # Here as a var for shadowing
-            state, set_state = mo.state(3)
+            _state, _set_state = mo.state(3)
 
             @mo.cache
             def g(state):
@@ -1437,16 +1437,19 @@ class TestPersistentCache:
     ) -> None:
         await k.run(
             [
-                exec_req.get("""
+                exec_req.get(
+                    """
                 import marimo as mo
                 import os
                 from pathlib import Path
                 pc = mo.persistent_cache
-                """),
+                """
+                ),
                 exec_req.get(
                     f'tmp_path_fixture = Path("{tmp_path.as_posix()}")'
                 ),
-                exec_req.get("""
+                exec_req.get(
+                    """
                 assert not os.path.exists(tmp_path_fixture / "basic")
                 with pc("basic", save_path=tmp_path_fixture) as cache:
                     _b = 1
@@ -1454,15 +1457,18 @@ class TestPersistentCache:
                 assert not cache._cache.hit
                 assert cache._cache.meta["version"] == mo._save.MARIMO_CACHE_VERSION
                 assert os.path.exists(tmp_path_fixture / "basic" / f"P_{cache._cache.hash}.pickle")
-                """),
-                exec_req.get("""
+                """
+                ),
+                exec_req.get(
+                    """
                 with pc("basic", save_path=tmp_path_fixture) as cache_2:
                     _b = 1
                 assert _b == 1
                 assert cache_2._cache.hit
                 assert cache._cache.hash == cache_2._cache.hash
                 assert os.path.exists(tmp_path_fixture / "basic" / f"P_{cache._cache.hash}.pickle")
-                """),
+                """
+                ),
             ]
         )
         assert not k.stdout.messages, k.stdout
@@ -1473,31 +1479,37 @@ class TestPersistentCache:
     ) -> None:
         await k.run(
             [
-                exec_req.get("""
+                exec_req.get(
+                    """
                 import marimo as mo
                 import os
                 from pathlib import Path
                 pc = mo.persistent_cache
-                """),
+                """
+                ),
                 exec_req.get(
                     f'tmp_path_fixture = Path("{tmp_path.as_posix()}")'
                 ),
-                exec_req.get("""
+                exec_req.get(
+                    """
                 assert not os.path.exists(tmp_path_fixture / "json")
                 with pc("json", save_path=tmp_path_fixture, method="json") as json_cache:
                     _b = 1
                 assert _b == 1
                 assert not json_cache._cache.hit
                 assert os.path.exists(tmp_path_fixture / "json" / f"P_{json_cache._cache.hash}.json")
-                """),
-                exec_req.get("""
+                """
+                ),
+                exec_req.get(
+                    """
                 with pc("json", save_path=tmp_path_fixture, method="json") as json_cache_2:
                     _b = 1
                 assert _b == 1
                 assert json_cache_2._cache.hit
                 assert json_cache._cache.hash == json_cache_2._cache.hash
                 assert os.path.exists(tmp_path_fixture / "json" / f"P_{json_cache._cache.hash}.json")
-                """),
+                """
+                ),
             ]
         )
         assert not k.stdout.messages, k.stdout

--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -1259,7 +1259,7 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            _state, _set_state = mo.state(None)
+            state, set_state = mo.state(None)
 
             @mo.cache
             def g(state):
@@ -1283,7 +1283,7 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state, _set_state = mo.state(None)
+            state, set_state = mo.state(None)
 
             @mo.cache
             def g():
@@ -1309,11 +1309,11 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state0, _set_state0 = mo.state(1)
-            state1, _set_state1 = mo.state(1)
-            state2, _set_state2 = mo.state(10)
+            state0, set_state0 = mo.state(1)
+            state1, set_state1 = mo.state(1)
+            state2, set_state2 = mo.state(10)
 
-            _state, _set_state = mo.state(100)
+            state, set_state = mo.state(100)
 
             @mo.cache
             def h(state):
@@ -1344,11 +1344,11 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state0, _set_state0 = mo.state(1)
-            state1, _set_state1 = mo.state(1)
-            state2, _set_state2 = mo.state(10)
+            state0, set_state0 = mo.state(1)
+            state1, set_state1 = mo.state(1)
+            state2, set_state2 = mo.state(10)
 
-            state, _set_state = mo.state(100)
+            state, set_state = mo.state(100)
 
             # Example of a case where things start to get very tricky. There
             # comes a point where you might also have to capture frame levels
@@ -1380,11 +1380,11 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state1, _set_state1 = mo.state(1)
-            state2, _set_state2 = mo.state(2)
+            state1, set_state1 = mo.state(1)
+            state2, set_state2 = mo.state(2)
 
             # Here as a var for shadowing
-            _state, _set_state = mo.state(3)
+            state, set_state = mo.state(3)
 
             @mo.cache
             def g(state):
@@ -1437,19 +1437,16 @@ class TestPersistentCache:
     ) -> None:
         await k.run(
             [
-                exec_req.get(
-                    """
+                exec_req.get("""
                 import marimo as mo
                 import os
                 from pathlib import Path
                 pc = mo.persistent_cache
-                """
-                ),
+                """),
                 exec_req.get(
                     f'tmp_path_fixture = Path("{tmp_path.as_posix()}")'
                 ),
-                exec_req.get(
-                    """
+                exec_req.get("""
                 assert not os.path.exists(tmp_path_fixture / "basic")
                 with pc("basic", save_path=tmp_path_fixture) as cache:
                     _b = 1
@@ -1457,18 +1454,15 @@ class TestPersistentCache:
                 assert not cache._cache.hit
                 assert cache._cache.meta["version"] == mo._save.MARIMO_CACHE_VERSION
                 assert os.path.exists(tmp_path_fixture / "basic" / f"P_{cache._cache.hash}.pickle")
-                """
-                ),
-                exec_req.get(
-                    """
+                """),
+                exec_req.get("""
                 with pc("basic", save_path=tmp_path_fixture) as cache_2:
                     _b = 1
                 assert _b == 1
                 assert cache_2._cache.hit
                 assert cache._cache.hash == cache_2._cache.hash
                 assert os.path.exists(tmp_path_fixture / "basic" / f"P_{cache._cache.hash}.pickle")
-                """
-                ),
+                """),
             ]
         )
         assert not k.stdout.messages, k.stdout
@@ -1479,37 +1473,31 @@ class TestPersistentCache:
     ) -> None:
         await k.run(
             [
-                exec_req.get(
-                    """
+                exec_req.get("""
                 import marimo as mo
                 import os
                 from pathlib import Path
                 pc = mo.persistent_cache
-                """
-                ),
+                """),
                 exec_req.get(
                     f'tmp_path_fixture = Path("{tmp_path.as_posix()}")'
                 ),
-                exec_req.get(
-                    """
+                exec_req.get("""
                 assert not os.path.exists(tmp_path_fixture / "json")
                 with pc("json", save_path=tmp_path_fixture, method="json") as json_cache:
                     _b = 1
                 assert _b == 1
                 assert not json_cache._cache.hit
                 assert os.path.exists(tmp_path_fixture / "json" / f"P_{json_cache._cache.hash}.json")
-                """
-                ),
-                exec_req.get(
-                    """
+                """),
+                exec_req.get("""
                 with pc("json", save_path=tmp_path_fixture, method="json") as json_cache_2:
                     _b = 1
                 assert _b == 1
                 assert json_cache_2._cache.hit
                 assert json_cache._cache.hash == json_cache_2._cache.hash
                 assert os.path.exists(tmp_path_fixture / "json" / f"P_{json_cache._cache.hash}.json")
-                """
-                ),
+                """),
             ]
         )
         assert not k.stdout.messages, k.stdout

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -477,9 +477,9 @@ def no_google_ai_config(config: UserConfigManager):
 
 class TestStreamResponse(unittest.TestCase):
     def simulate_stream(self, contents: List[str]) -> Any:
+        @dataclass
         class MockContent:
-            def __init__(self, content: str) -> None:
-                self.content = content
+            content: str
 
         class MockDelta:
             def __init__(self, content: str) -> None:


### PR DESCRIPTION
Enable `preview = true` to get some more helpful rules from ruff. 