### PR TITLE
fix: md format fix for columns and sql engine

### DIFF
--- a/marimo/_convert/utils.py
+++ b/marimo/_convert/utils.py
@@ -23,14 +23,25 @@ def markdown_to_marimo(source: str) -> str:
     )
 
 
-def sql_to_marimo(source: str, table: str) -> str:
+def sql_to_marimo(
+    source: str,
+    table: str,
+    hide_output: bool = False,
+    engine: str | None = None,
+) -> str:
+    terminal_options = [codegen.indent_text('"""')]
+    if hide_output:
+        terminal_options.append(codegen.indent_text("output=False"))
+    if engine:
+        terminal_options.append(codegen.indent_text(f"engine={engine}"))
+
     return "\n".join(
         [
             f"{table} = mo.sql(",
             # f-string: expected for sql
             codegen.indent_text('f"""'),
             codegen.indent_text(source),
-            codegen.indent_text('"""'),
+            ",\n".join(terminal_options),
             ")",
         ]
     )

--- a/marimo/_server/export/utils.py
+++ b/marimo/_server/export/utils.py
@@ -49,6 +49,12 @@ def _const_string(args: list[ast.stmt]) -> str:
     return f"{inner.value}"  # type: ignore[attr-defined]
 
 
+def _const_or_id(args: ast.stmt) -> str:
+    if hasattr(args, "value"):
+        return f"{args.value}"  # type: ignore[attr-defined]
+    return f"{args.id}"  # type: ignore[attr-defined]
+
+
 def get_markdown_from_cell(
     cell: Cell, code: str, native_callout: bool = False
 ) -> Optional[str]:
@@ -103,3 +109,28 @@ def get_markdown_from_cell(
           :::"""
         )
     return md
+
+
+def get_sql_options_from_cell(code: str) -> Optional[dict[str, str]]:
+    # Note frontend/src/core/codemirror/language/sql.ts
+    # also extracts options via ast. Ideally, these should be synced.
+    options = {}
+    code = code.strip()
+    try:
+        (body,) = ast.parse(code).body
+        (target,) = body.targets  # type: ignore[attr-defined]
+        options["query"] = target.id
+        if body.value.func.attr == "sql":  # type: ignore[attr-defined]
+            value = body.value  # type: ignore[attr-defined]
+        else:
+            return None
+        if value.keywords:
+            for keyword in value.keywords:  # type: ignore[attr-defined]
+                options[keyword.arg] = _const_or_id(keyword.value)  # type: ignore[attr-defined]
+        output = options.pop("output", "True").lower()
+        if output == "false":
+            options["hide_output"] = "True"
+
+        return options
+    except (AssertionError, AttributeError, ValueError):
+        return None

--- a/marimo/_tutorials/markdown_format.md
+++ b/marimo/_tutorials/markdown_format.md
@@ -1,7 +1,6 @@
 ---
 title: Markdown
 marimo-version: 0.10.19
-width: columns
 ---
 
 # Markdown file format

--- a/marimo/_tutorials/markdown_format.md
+++ b/marimo/_tutorials/markdown_format.md
@@ -1,6 +1,7 @@
 ---
 title: Markdown
-marimo-version: 0.10.9
+marimo-version: 0.10.19
+width: columns
 ---
 
 # Markdown file format
@@ -66,20 +67,39 @@ You can break up markdown into multiple cells by using an empty html tag `<!----
 <!---->
 View the source of this notebook to see how this cell was created.
 <!---->
-You can still hide and disable code cells in markdown notebooks:
+You can still hide cell code in markdown notebooks:
 
 ````md
 ```python {.marimo hide_code="true"}
-import pandas as pd
-pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+form = (
+    # ...
+    # Just something a bit more complicated
+    # you might not want to see in the editor.
+    # ...
+)
+form
 ```
 ````
 
 ```python {.marimo hide_code="true"}
-import pandas as pd
+form = (
+    mo.md('''
+    **Just how great is markdown?.**
 
-pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    {markdown_is_awesome}
+
+    {marimo_is_amazing}
+''')
+    .batch(
+        markdown_is_awesome=mo.ui.text(label="How much do you like markdown?", placeholder="It is pretty swell 🌊"),
+        marimo_is_amazing=mo.ui.slider(label="How much do you like marimo?", start=0, stop=11, value=11),
+    )
+    .form(show_clear_button=True, bordered=False)
+)
+form
 ```
+
+and disable cells too:
 
 ````md
 ```python {.marimo disabled="true"}
@@ -120,7 +140,7 @@ supposed to be computed, and what values are static. To interpolate Python
 values, just use a Python cell:
 
 ```python {.marimo}
-"🍃" * 7
+mo.md(f"""Like so: {"🍃" * 7}""")
 ```
 
 ### Limitations on conversion
@@ -151,6 +171,17 @@ It's not likely that you'll run into this issue, but rest assured that marimo
 is working behind the scenes to keep your notebooks unambiguous and clean as
 possible.
 <!---->
+### Saving multicolumn mode
+
+Multicolumn mode works, but the first cell in a column must be a python cell in
+order to specify column start and to save correctly:
+
+````md
+```python {.marimo column="1"}
+print("First cell in column 1")
+```
+````
+<!---->
 ### Naming cells
 
 Since the markdown notebook really is just markdown, you can't import from a
@@ -167,6 +198,54 @@ give your cells a name:
 # But here's my `cell_id`, so call me, `maybe` 🎶
 ```
 
+### SQL in markdown
+
+You can also run SQL queries in markdown cells through marimo, using a `sql` code block. For instance:
+
+````md
+```sql {.marimo}
+SELECT GREATEST(x, y), SQRT(z) from uniformly_random_numbers
+```
+````
+
+The resultant distribution may be surprising! 🎲[^surprise]
+
+[^surprise]: The general distributions should be the same
+
+```sql {.marimo}
+SELECT GREATEST(a, b), SQRT(c) from uniformly_random_numbers
+```
+
+In this SQL format, Python variable interpolation in SQL queries occurs automatically. Additionally, query results can be assigned to a dataframe with the `query` attribute.
+For instance, here's how to create a random uniform distribution and assign it to the dataframe `uniformly_random_numbers` used above:
+
+````md
+```sql {.marimo query="uniformly_random_numbers" hide_output="true"}
+SELECT i.range::text AS id,
+       random() AS x,
+       random() AS y,
+       random() AS z
+FROM
+    -- Note sample_count comes from the slider below!
+    range(1, {sample_count.value + 1}) i;
+```
+````
+
+You can learn more about other SQL use in the SQL tutorial (`marimo tutorial sql`)
+
+```python {.marimo hide_code="true"}
+sample_count = mo.ui.slider(1, 1000, value=1000, label="Sample Count")
+sample_count
+```
+
+```sql {.marimo query="uniformly_random_numbers" hide_output="True"}
+SELECT i.range::text AS id,
+       random() AS a,
+       random() AS b,
+       random() AS c
+FROM range(1, {sample_count.value + 1}) i;
+```
+
 ## Converting back to the Python file format
 
 The markdown format is supposed to lower the barrier for writing text heavy
@@ -176,41 +255,7 @@ format. You can always convert back to a Python notebook if you need to:
 ```bash
 $ marimo convert my_marimo.md > my_marimo.py
 ```
-
 <!---->
-
-## SQL in markdown
-
-You can also run parameterized SQL queries in markdown cells through marimo.
-
-```python {.marimo hide_code="true"}
-num = mo.ui.slider(1, 15, label="Fibonacci numbers")
-num
-```
-
-```python {.marimo}
-_df = mo.sql(
-    f"""
-    WITH RECURSIVE fibonacci AS (
-      SELECT
-        1 as n,
-        1 as fib,
-        1 as prev
-      UNION ALL
-      SELECT
-        n + 1,
-        fib + prev,
-        fib
-      FROM fibonacci
-      WHERE n < {num.value}
-    )
-    SELECT n, fib
-    FROM fibonacci
-    ORDER BY n;
-    """
-)
-```
-
 ## More on markdown
 
 Be sure to checkout the markdown.py tutorial (`marimo tutorial markdown`) for

--- a/tests/_cli/snapshots/sql-notebook.py.txt
+++ b/tests/_cli/snapshots/sql-notebook.py.txt
@@ -15,8 +15,8 @@ def _(mo):
 
 
 @app.cell
-def _(mo):
-    mem_engine = mo.create_engine("sqlite:///:memory:")
+def _(fn_that_creates_engine):
+    mem_engine = fn_that_creates_engine("sqlite:///:memory:")
     return (mem_engine,)
 
 

--- a/tests/_cli/snapshots/sql-notebook.py.txt
+++ b/tests/_cli/snapshots/sql-notebook.py.txt
@@ -15,11 +15,19 @@ def _(mo):
 
 
 @app.cell
-def _(mo, my_table):
+def _(mo):
+    mem_engine = mo.create_engine("sqlite:///:memory:")
+    return (mem_engine,)
+
+
+@app.cell
+def _(mem_engine, mo, my_table):
     export = mo.sql(
         f"""
         SELECT * FROM my_table;
-        """
+        """,
+        output=False,
+        engine=mem_engine
     )
     return (export,)
 

--- a/tests/_cli/test_markdown_conversion.py
+++ b/tests/_cli/test_markdown_conversion.py
@@ -193,7 +193,11 @@ def test_markdown_with_sql() -> None:
 
     # SQL notebook
 
-    ```sql {.marimo query="export"}
+    ```python {.marimo}
+    mem_engine = mo.create_engine("sqlite:///:memory:")
+    ```
+
+    ```sql {.marimo query="export" engine="mem_engine" hide_output="true"}
     SELECT * FROM my_table;
     ```
 
@@ -210,11 +214,18 @@ def test_markdown_with_sql() -> None:
     app = InternalApp(convert_from_md_to_app(script))
     assert app.config.app_title == "My Title"
     ids = list(app.cell_manager.cell_ids())
-    assert len(ids) == 3
-    for i in range(3):
+    assert len(ids) == 4
+    for i in range(4):
         # Unparsables are None
         assert app.cell_manager.cell_data_at(ids[i]).cell is not None
-    assert app.cell_manager.cell_data_at(ids[1]).cell.defs == {"export"}
+    assert app.cell_manager.cell_data_at(ids[2]).cell.defs == {"export"}
+    assert app.cell_manager.cell_data_at(ids[2]).cell.refs == {
+        "mem_engine",
+        "my_table",
+        "mo",
+    }
+    # hide_output=True => output=False
+    assert "False" in app.cell_manager.cell_data_at(ids[2]).cell._cell.code
 
 
 def test_markdown_empty() -> None:

--- a/tests/_cli/test_markdown_conversion.py
+++ b/tests/_cli/test_markdown_conversion.py
@@ -194,7 +194,7 @@ def test_markdown_with_sql() -> None:
     # SQL notebook
 
     ```python {.marimo}
-    mem_engine = mo.create_engine("sqlite:///:memory:")
+    mem_engine = fn_that_creates_engine("sqlite:///:memory:")
     ```
 
     ```sql {.marimo query="export" engine="mem_engine" hide_output="true"}


### PR DESCRIPTION
SQL engines can be specified with `engine=` and column is now preserved in markdown blocks.
Documented changes in the tutorial file

@mscolnick