### PR TITLE
flaky: add warning for flaky test opposed to failure

### DIFF
--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -777,9 +777,11 @@ class TestCacheDecorator:
         # Cache hit value may be flaky depending on when state is evicted from
         # the registry. The actual cache hit is less important than caching
         # occurring in the first place.
-        # 2 * 9 + 2
+        # NB. 20 = 2 * 9 + 2
         if k.globals["fib"].hits in (9, 18):
-            warnings.warn("Known flaky edge case for cache.", stacklevel=1)
+            warnings.warn(
+                "Known flaky edge case for cache with state dep.", stacklevel=1
+            )
         else:
             assert k.globals["fib"].hits == 20
 
@@ -879,7 +881,14 @@ class TestCacheDecorator:
         )
         assert not k.stderr.messages, k.stderr
         assert not k.stdout.messages, k.stdout
-        assert k.globals["fib"].hits == 10 + 3
+        # Throw a warning for flake edge case where cache is evicted earlier
+        # than expected.
+        if k.globals["fib"].hits in (10,):
+            warnings.warn(
+                "Known flaky edge case for cache rerun.", stacklevel=1
+            )
+        else:
+            assert k.globals["fib"].hits == 10 + 3
 
     async def test_full_scope_utilized(
         self, k: Kernel, exec_req: ExecReqProvider


### PR DESCRIPTION
Noticed this test is failing 1/26 of the time. Allow flaky edge case, but threw in some logging

I wonder if it's possible to analysis github action logs in bulk? Would be nice to collect some stats about cache eviction stability