### PR TITLE
Add openai-whisper to module name list

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # on PyPI
 def module_name_to_pypi_name() -> dict[str, str]:
     return {
-        "whisper": "openai-whisper", 
+        "whisper": "openai-whisper",
         "cv2": "opencv-python",
         "shopify": "ShopifyAPI",
         "bigquery": "google-cloud-bigquery",

--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 # on PyPI
 def module_name_to_pypi_name() -> dict[str, str]:
     return {
+        "whisper": "openai-whisper", 
         "cv2": "opencv-python",
         "shopify": "ShopifyAPI",
         "bigquery": "google-cloud-bigquery",


### PR DESCRIPTION
Fix the issue where `whisper` is not picked up as `openai-whisper`. 

![image](https://github.com/user-attachments/assets/30012746-c7e1-43b3-aee4-2f99c66caf08)