### PR TITLE
fix: checks whether latestEngineSelected is in list of engines

### DIFF
--- a/frontend/src/core/cells/data-source-connections.ts
+++ b/frontend/src/core/cells/data-source-connections.ts
@@ -1,9 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { createReducerAndAtoms } from "@/utils/createReducer";
 import type { TypedString } from "@/utils/typed";
-import { DEFAULT_ENGINE } from "../codemirror/language/sql";
 import type { VariableName } from "../variables/types";
 import { atom } from "jotai";
+import { DEFAULT_ENGINE } from "../codemirror/language/sql";
 
 export type ConnectionName = TypedString<"ConnectionName">;
 
@@ -20,8 +20,8 @@ export interface DataSourceState {
 
 function initialState(): DataSourceState {
   return {
-    connectionsMap: new Map().set(DEFAULT_ENGINE, {
-      name: DEFAULT_ENGINE,
+    connectionsMap: new Map().set("_marimo_duckdb", {
+      name: "_marimo_duckdb",
       source: "duckdb",
       dialect: "duckdb",
       display_name: "DuckDB In-Memory",

--- a/frontend/src/core/codemirror/language/sql.ts
+++ b/frontend/src/core/codemirror/language/sql.ts
@@ -15,7 +15,10 @@ import { datasetsAtom } from "@/core/datasets/state";
 import { type QuotePrefixKind, upgradePrefixKind } from "./utils/quotes";
 import { capabilitiesAtom } from "@/core/config/capabilities";
 import { MarkdownLanguageAdapter } from "./markdown";
-import type { ConnectionName } from "@/core/cells/data-source-connections";
+import {
+  dataConnectionsMapAtom,
+  type ConnectionName,
+} from "@/core/cells/data-source-connections";
 import { atom } from "jotai";
 import { parser } from "@lezer/python";
 import type { SyntaxNode, TreeCursor } from "@lezer/common";
@@ -42,7 +45,8 @@ export class SQLLanguageAdapter implements LanguageAdapter {
   engine: ConnectionName = store.get(latestEngineSelected);
 
   getDefaultCode(): string {
-    if (this.engine === DEFAULT_ENGINE) {
+    const currConnections = store.get(dataConnectionsMapAtom);
+    if (this.engine === DEFAULT_ENGINE || !currConnections.has(this.engine)) {
       return this.defaultCode;
     }
     return `_df = mo.sql(f"""SELECT * FROM """, engine=${this.engine})`;


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
When you delete an engine and create a new SQL cell, the cell's code still uses the deleted engine. This fixes that.

However, it's not an ideal fix, using the constant variable triggers a 
`Uncaught ReferenceError: can't access lexical declaration 'DEFAULT_ENGINE' before initialization`

makes me think I have designed the latestEngineSelected feature wrongly.

another smaller issue:
- delete an engine, refresh the page, undelete the engine, the sql cells's dropdown do not update

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
