### PR TITLE
feat: embed independent copies of app objects

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -177,8 +177,15 @@ class App:
             ...
         self._app_kernel_runner: AppKernelRunner | None = None
 
-
     def clone(self) -> App:
+        """Clone an app to embed multiple copies of it.
+
+        Utility method to clone an app object; use with `embed()` to create
+        independent copies of apps.
+
+        Returns:
+            A new `app` object with the same code.
+        """
         app = App()
         app._cell_manager = CellManager(prefix=str(uuid4()))
         for cell_id, code, name, config in zip(

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -21,7 +21,7 @@ from typing import (
 from uuid import uuid4
 
 from marimo import _loggers
-from marimo._ast.cell import Cell, CellConfig, CellId_t
+from marimo._ast.cell import Cell, CellConfig, CellId_t, CellImpl
 from marimo._ast.cell_manager import CellManager
 from marimo._ast.errors import (
     CycleError,
@@ -176,6 +176,39 @@ class App:
         except Exception:
             ...
         self._app_kernel_runner: AppKernelRunner | None = None
+
+
+    def clone(self) -> App:
+        app = App()
+        app._cell_manager = CellManager(prefix=str(uuid4()))
+        for cell_id, code, name, config in zip(
+            self._cell_manager.cell_ids(),
+            self._cell_manager.codes(),
+            self._cell_manager.names(),
+            self._cell_manager.configs(),
+        ):
+            cell = None
+            # If the cell exists, the cell data should be set.
+            cell_data = self._cell_manager._cell_data.get(cell_id)
+            new_cell_id = app._cell_manager.create_cell_id()
+            if cell_data is not None:
+                cell = cell_data.cell
+                if cell is not None:
+                    new_cell = Cell(
+                        _name=cell.name,
+                        _cell=CellImpl(
+                            **{**cell._cell.__dict__, "cell_id": new_cell_id}
+                        ),
+                        _app=InternalApp(app),
+                    )
+                    app._cell_manager.register_cell(
+                        cell_id=new_cell_id,
+                        code=code,
+                        name=name,
+                        config=config,
+                        cell=new_cell,
+                    )
+        return app
 
     def cell(
         self,
@@ -351,10 +384,19 @@ class App:
         The `embed` method lets you embed the output of a notebook
         into another notebook and access the values of its variables.
 
-        Returns:
-            An object `result` with two attributes: `result.output` (visual
-            output of the notebook) and `result.defs` (a dictionary mapping
-            variable names defined by the notebook to their values).
+        Running `await app.embed()` executes the notebook and results an object
+        encapsulating the notebook visual output and its definitions.
+
+        Embedded notebook outputs are interactive: when you interact with
+        UI elements in an embedded notebook's output, any cell referring
+        to the `app` object other than the one that imported it is marked for
+        execution, and its internal state is automatically updated. This lets
+        you use notebooks as building blocks or components to create
+        higher-level notebooks.
+
+        Multiple levels of nesting are supported: it's possible to embed a
+        notebook that in turn embeds another notebook, and marimo will do the
+        right thing.
 
         Example:
             ```python
@@ -377,19 +419,27 @@ class App:
             result.defs
             ```
 
-            Running `await app.embed()` executes the notebook and results an object
-            encapsulating the notebook visual output and its definitions.
+        To embed independent copies of same app object, first clone the
+        app with `app.clone()`:
 
-            Embedded notebook outputs are interactive: when you interact with
-            UI elements in an embedded notebook's output, any cell referring
-            to the `app` object other than the one that imported it is marked for
-            execution, and its internal state is automatically updated. This lets
-            you use notebooks as building blocks or components to create
-            higher-level notebooks.
+            ```python
+            from my_notebook import app
+            ```
 
-            Multiple levels of nesting are supported: it's possible to embed a
-            notebook that in turn embeds another notebook, and marimo will do the
-            right thing.
+            ```python
+            one = app.clone()
+            r1 = await one.embed()
+            ```
+
+            ```python
+            two = app.clone()
+            r2 = await two.embed()
+
+        Returns:
+            An object `result` with two attributes: `result.output` (visual
+            output of the notebook) and `result.defs` (a dictionary mapping
+            variable names defined by the notebook to their values).
+
         """
         from marimo._plugins.stateless.flex import vstack
         from marimo._runtime.context.utils import running_in_notebook

--- a/marimo/_utils/data_uri.py
+++ b/marimo/_utils/data_uri.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 from __future__ import annotations
 
 import base64

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -8,7 +8,7 @@ import textwrap
 from typing import Any
 
 import pytest
-from marimo._ast.app import App, _AppConfig
+from marimo._ast.app import App, _AppConfig, InternalApp
 from marimo._ast.errors import (
     CycleError,
     DeleteNonlocalError,
@@ -525,6 +525,28 @@ class TestApp:
         assert dirpath is not None
         assert location is not None
         assert dirpath == location
+
+    def test_app_clone(self) -> None:
+        app = App()
+
+        @app.cell
+        def __():
+            import marimo as mo
+
+            dirpath = mo.notebook_dir()
+            location = mo.notebook_location()
+
+        # same codes and names, different cell_ids
+        clone = app.clone()
+        assert list(InternalApp(clone).cell_manager.codes()) == list(
+            InternalApp(app).cell_manager.codes()
+        )
+        assert list(InternalApp(clone).cell_manager.names()) == list(
+            InternalApp(app).cell_manager.names()
+        )
+        assert list(InternalApp(clone).cell_manager.cell_ids()) != list(
+            InternalApp(app).cell_manager.cell_ids()
+        )
 
 
 def test_app_config() -> None:


### PR DESCRIPTION
This change makes it possible to create copies of an `app` object, for use with `app.embed()` to embed multiple independent copies of the app.

A new public method, `clone()`, is added on `App`.

Usage:

```python
from notebook import app
clone = app.clone()
```

```
await clone.embed()
```

Fixes #3398 