### PR TITLE
fix(router): Correct router name from "terminal" to "packages"

### DIFF
--- a/marimo/_server/api/router.py
+++ b/marimo/_server/api/router.py
@@ -63,7 +63,7 @@ def build_routes(base_url: str = "") -> List[BaseRoute]:
         terminal_router, prefix="/terminal", name="terminal"
     )
     app_router.include_router(
-        packages_router, prefix="/api/packages", name="terminal"
+        packages_router, prefix="/api/packages", name="packages"
     )
     app_router.include_router(health_router, name="health")
     app_router.include_router(ws_router, name="ws")


### PR DESCRIPTION
## 📝 Summary

This PR fixes a naming issue in the router configuration where the packages endpoint was incorrectly named "terminal". The change ensures proper naming consistency with the actual endpoint functionality.

## 🔍 Description of Changes

- Updated the router name from name="terminal" to name="packages" for the packages endpoint in marimo/_server/api/router.py

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
