### PR TITLE
compat: interrupt using KeyboardInterrupt

### DIFF
--- a/marimo/_runtime/control_flow.py
+++ b/marimo/_runtime/control_flow.py
@@ -3,15 +3,10 @@ from typing import Optional
 
 from marimo._output.rich_help import mddoc
 
-
-class MarimoInterrupt(BaseException):
-    """Raised when user stops execution of entire program with interrupt.
-
-    Inherits from `BaseException` to prevent accidental capture with
-    `except Exception` (similar to `KeyboardInterrupt`)
-    """
-
-    pass
+# We used to define a custom MarimoInterrupt BaseException to interrupt the
+# kernel; however, some third-party libraries like databricks-connect have
+# special case handling of KeyboardInterrupt.
+MarimoInterrupt = KeyboardInterrupt
 
 
 class MarimoStopError(BaseException):


### PR DESCRIPTION
Interrupt the kernel using a keyboard interrupt instead of a custom exception, for compatibility with libraries like databricks-connect that do custom handling of keyboard interrupts.

Fixes https://github.com/marimo-team/marimo/issues/3494