### PR TITLE
fix: set select colour to blue in dark mode

### DIFF
--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -5,6 +5,10 @@
   background-color: #d7d4f0 !important;
 }
 
+.dark .cm-selectionBackground {
+  background-color: #1177cc80 !important;
+}
+
 .cm-focused.cm-focused {
   outline: none;
 }


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
previously:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/0e473461-5154-4d15-bdf4-0284ca18bbcb" />

now:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/50d8f48c-84e6-4fc2-8e26-0f6e190bbb8e" />

I'm not a huge fan of the duplicate selection color too, but couldn't find a good color :/

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
