### PR TITLE
docs: Update appropriate keyboard shortcut

### DIFF
--- a/docs/guides/editor_features/hotkeys.md
+++ b/docs/guides/editor_features/hotkeys.md
@@ -1,6 +1,6 @@
 # Hotkeys
 
-If you'd like to override the default hotkeys, you can do so in the hotkeys menu (`Mod-Shift-h`), or modifying your `marimo.toml`.
+If you'd like to override the default hotkeys, you can do so in the hotkeys menu (`Ctrl/Cmd-Shift-h`), or modifying your `marimo.toml`.
 
 You can find a list of available hotkeys below:
 


### PR DESCRIPTION
## 📝 Summary

Update shortcut key listed in doc webpage from `Mod-Shift-h` to `Ctrl/Cmd-Shift-h` to resolve any ambiguity.

## 🔍 Description of Changes

Aligns with format of other docs webpages like [here](https://docs.marimo.io/guides/editor_features/overview/?h=ctr#keyboard-shortcuts) and [here](https://docs.marimo.io/guides/editor_features/ai_completion/?h=ctrl%2Fcmd#custom-ai-rules).

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
