### PR TITLE
fix: apply borderless view in dark mode

### DIFF
--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -202,14 +202,7 @@
 
   /* Borderless styles for Cell */
   &.borderless {
-    border-color: transparent;
-    box-shadow: none;
-
-    /* Apply the original styles */
-    &:hover {
-      border: 1px solid var(--gray-4);
-      @apply shadow-smSolid shadow-shade;
-    }
+    @apply borderless-common;
   }
 
   /* -------------------------- Shoulders/Buttons ---------------------------- */
@@ -233,8 +226,23 @@
   @apply bg-background;
 }
 
+.borderless-common {
+  border-color: transparent;
+  box-shadow: none;
+
+  /* Apply the original styles */
+  &:hover {
+    border: 1px solid var(--gray-4);
+    @apply shadow-smSolid shadow-shade;
+  }
+}
+
 .dark .Cell {
   @apply border-border;
+
+  &.borderless {
+    @apply borderless-common;
+  }
 }
 
 #App.disconnected {


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Borderless mode isn't applied in dark mode, this is to fix that
<img width="793" alt="image" src="https://github.com/user-attachments/assets/2e0cedeb-9782-455d-9923-249999f3ece2" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
