### PR TITLE
fix: add checks for code outside sql statement

### DIFF
--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -358,6 +358,31 @@ _df = mo.sql(
       expect(adapter.isSupported(pythonCode)).toBe(false);
     });
 
+    it("should return false when there are multiple sql strings", () => {
+      const pythonCode = `
+      _df = mo.sql("""SELECT * FROM table1""")
+      _df2 = mo.sql("""SELECT * FROM table2""")
+      `;
+      expect(adapter.isSupported(pythonCode)).toBe(false);
+    });
+
+    it("should return false when there are non sql strings with sql string", () => {
+      const pythonCode = `print("Hello, World!") \n_df = mo.sql("SELECT * FROM table")`;
+      expect(adapter.isSupported(pythonCode)).toBe(false);
+
+      const pythonCode2 = `_df = mo.sql("""SELECT * FROM table""") \n print("Hello, World!")`;
+      expect(adapter.isSupported(pythonCode2)).toBe(false);
+    });
+
+    it("should return true for sql strings with whitespace before or after", () => {
+      expect(
+        adapter.isSupported(' df = mo.sql("""SELECT * FROM table""")'),
+      ).toBe(true);
+      expect(
+        adapter.isSupported('df = mo.sql("""SELECT * FROM table""") '),
+      ).toBe(true);
+    });
+
     it("should support SQL strings with output flag", () => {
       expect(
         adapter.isSupported(

--- a/frontend/src/core/codemirror/language/sql.ts
+++ b/frontend/src/core/codemirror/language/sql.ts
@@ -227,6 +227,13 @@ export function parseSQLStatement(code: string): SQLConfig | null {
       return null;
     }
 
+    // Code outside of the assignment statement is not allowed
+    const outsideCode =
+      code.slice(0, assignStmt.from) + code.slice(assignStmt.to);
+    if (outsideCode.trim().length > 0) {
+      return null;
+    }
+
     let dfName: string | null = null;
     let sqlString: string | null = null;
     let engine: string | undefined;


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
fixes [discord: mo.stop not appearing disappearing upon restart](https://discord.com/channels/1059888774789730424/1254862968068243476/threads/1338534110586605639)

Will not allow non-sql code to transform to sql statements

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
