### PR TITLE
improvement: hide all markdown action (dropdown and command palette)

### DIFF
--- a/frontend/src/components/editor/actions/useHideAllMarkdownCode.ts
+++ b/frontend/src/components/editor/actions/useHideAllMarkdownCode.ts
@@ -1,0 +1,52 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { useCellActions } from "@/core/cells/cells";
+import { getNotebook } from "@/core/cells/cells";
+import { saveCellConfig } from "@/core/network/requests";
+import { useCallback } from "react";
+import { MarkdownLanguageAdapter } from "@/core/codemirror/language/markdown";
+import type { CellId } from "@/core/cells/ids";
+import type { CellConfig } from "@/core/network/types";
+import { Objects } from "@/utils/objects";
+
+/**
+ * Hook to hide all markdown code cells
+ */
+export const useHideAllMarkdownCode = () => {
+  const { updateCellConfig } = useCellActions();
+
+  return useCallback(async () => {
+    const markdownAdapter = new MarkdownLanguageAdapter();
+    const notebook = getNotebook();
+    const cellIds = notebook.cellIds.inOrderIds;
+
+    const newConfigs: Record<CellId, Partial<CellConfig>> = {};
+
+    // Find all markdown cells that aren't already hidden
+    for (const cellId of cellIds) {
+      if (notebook.cellData[cellId] === undefined) {
+        continue;
+      }
+      const { code, config } = notebook.cellData[cellId];
+      if (config.hide_code) {
+        continue;
+      }
+      if (markdownAdapter.isSupported(code)) {
+        newConfigs[cellId] = { hide_code: true };
+      }
+    }
+
+    const entries = Objects.entries(newConfigs);
+
+    if (entries.length === 0) {
+      return;
+    }
+
+    // Save to backend
+    await saveCellConfig({ configs: newConfigs });
+
+    // Update on frontend
+    for (const [cellId, config] of entries) {
+      updateCellConfig({ cellId, config });
+    }
+  }, [updateCellConfig]);
+};

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -31,6 +31,7 @@ import {
   FilePlus2Icon,
   FastForwardIcon,
   DatabaseIcon,
+  EyeOffIcon,
 } from "lucide-react";
 import { commandPaletteAtom } from "../controls/command-palette";
 import {
@@ -73,6 +74,7 @@ import { newNotebookURL } from "@/utils/urls";
 import { useRunAllCells } from "../cell/useRunCells";
 import { settingDialogAtom } from "@/components/app-config/state";
 import { AddDatabaseDialogContent } from "../database/add-database-form";
+import { useHideAllMarkdownCode } from "./useHideAllMarkdownCode";
 
 const NOOP_HANDLER = (event?: Event) => {
   event?.preventDefault();
@@ -86,6 +88,7 @@ export function useNotebookActions() {
   const { selectedPanel } = useChromeState();
   const [viewState] = useAtom(viewStateAtom);
   const kioskMode = useAtomValue(kioskModeAtom);
+  const hideAllMarkdownCode = useHideAllMarkdownCode();
 
   const { updateCellConfig, undoDeleteCell, clearAllCellOutputs } =
     useCellActions();
@@ -354,6 +357,11 @@ export function useNotebookActions() {
           updateCellConfig({ cellId, config: { disabled: true } });
         }
       },
+    },
+    {
+      icon: <EyeOffIcon size={14} strokeWidth={1.5} />,
+      label: "Hide all markdown code",
+      handle: hideAllMarkdownCode,
     },
     {
       icon: <XCircleIcon size={14} strokeWidth={1.5} />,


### PR DESCRIPTION
QOL action to quickly hide all markdown. Even though we may auto-make markdown hidden at first, this can also help fix older notebooks.