### PR TITLE
fix: more specific bokeh formatter

### DIFF
--- a/marimo/_output/formatters/bokeh_formatters.py
+++ b/marimo/_output/formatters/bokeh_formatters.py
@@ -21,9 +21,9 @@ class BokehFormatter(FormatterFactory):
 
         from marimo._output import formatting
 
-        @formatting.formatter(bokeh.models.Model)
+        @formatting.formatter(bokeh.models.Plot)
         def _show_plot(
-            plot: bokeh.models.Model,
+            plot: bokeh.models.Plot,
         ) -> tuple[KnownMimeType, str]:
             import bokeh.embed  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
             import bokeh.resources  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501

--- a/marimo/_smoke_tests/third_party/holoviews_scatter.py
+++ b/marimo/_smoke_tests/third_party/holoviews_scatter.py
@@ -10,7 +10,7 @@
 
 import marimo
 
-__generated_with = "0.10.9"
+__generated_with = "0.11.2"
 app = marimo.App(width="medium")
 
 


### PR DESCRIPTION
This makes the bokeh formatter more specific, only picking up `Plot` instances. Fixes an issue in which Renderer objects returned by functions like `p.scatter(...)` were incorrectly output as blank outputs.

<img width="623" alt="image" src="https://github.com/user-attachments/assets/b2e1053d-d68d-4ecf-9539-379339ccc6c0" />

Matches Jupyter:

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/9eb326b0-1b62-439e-9063-ea4039f22d9c" />

Context: https://github.com/bokeh/bokeh/issues/13817#issuecomment-2654910127