### PR TITLE
fix: preserve user defined user in mo.app_meta().request

### DIFF
--- a/docs/guides/deploying/programmatically.md
+++ b/docs/guides/deploying/programmatically.md
@@ -99,6 +99,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             "username": "example_user",
             # Add any other user data
         }
+
+        # Optional add metadata to the request
+        request.scope["meta"] = {
+            "some_key": "some_value",
+        }
+
         response = await call_next(request)
         return response
 
@@ -114,3 +120,4 @@ The `request` object provides access to:
 - `request.path_params`: Path parameters
 - `request.user`: User data added by authentication middleware
 - `request.url`: URL information including path, query parameters
+- `request.meta`: Metadata added by your custom middleware

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -51,6 +51,7 @@ class HTTPRequest(Mapping[str, Any]):
     query_params: dict[str, list[str]]  # Raw query params
     path_params: dict[str, Any]
     cookies: dict[str, str]
+    meta: dict[str, Any]
     user: Any
 
     # We don't include session or auth because they may contain
@@ -114,6 +115,7 @@ class HTTPRequest(Mapping[str, Any]):
             path_params=request.path_params,
             cookies=request.cookies,
             user=request["user"] if "user" in request else {},
+            meta=request["meta"] if "meta" in request else {},
             # Left out for now. This may contain information that the app author
             # does not want to expose.
             # session=request.session if "session" in request else {},

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -54,8 +54,6 @@ class AuthBackend(AuthenticationBackend):
     async def authenticate(
         self, conn: HTTPConnection
     ) -> Optional[tuple["AuthCredentials", "BaseUser"]]:
-        mode = AppStateBase(conn.app.state).session_manager.mode
-
         # We may not need to authenticate. This can be disabled
         # because the user is running in a trusted environment
         # or authentication is handled by a layer above us
@@ -66,6 +64,8 @@ class AuthBackend(AuthenticationBackend):
             valid = validate_auth(conn)
             if not valid:
                 return None
+
+        mode = AppStateBase(conn.app.state).session_manager.mode
 
         # User's get Read access in Run mode
         if mode == SessionMode.RUN:

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING, List, Optional
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
-from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
 from marimo import _loggers
 from marimo._server.api.auth import (
     RANDOM_SECRET,
+    CustomAuthenticationMiddleware,
     CustomSessionMiddleware,
     on_auth_error,
 )
@@ -65,7 +65,7 @@ def create_starlette_app(
         [
             Middleware(OpenTelemetryMiddleware),
             Middleware(
-                AuthenticationMiddleware,
+                CustomAuthenticationMiddleware,
                 backend=AuthBackend(should_authenticate=enable_auth),
                 on_error=on_auth_error,
             ),

--- a/marimo/_smoke_tests/requests.py
+++ b/marimo/_smoke_tests/requests.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.10.17"
+__generated_with = "0.11.3"
 app = marimo.App(width="medium")
 
 
@@ -21,7 +21,7 @@ def _(mo):
 def _(mo, refresh):
     refresh
     user = mo.app_meta().request.user
-    [user, user.is_authenticated, user.display_name]
+    [user]
     return (user,)
 
 

--- a/tests/_messaging/test_context_vars.py
+++ b/tests/_messaging/test_context_vars.py
@@ -54,6 +54,7 @@ class TestHTTPRequestContext:
             user={"is_authenticated": True},
             headers={},
             query_params={},
+            meta={},
         )
 
     def test_http_request_context(self, mock_request: HTTPRequest):
@@ -69,6 +70,7 @@ class TestHTTPRequestContext:
             user={"is_authenticated": True},
             headers={},
             query_params={},
+            meta={},
         )
 
         with http_request_context(mock_request):

--- a/tests/_runtime/test_requests.py
+++ b/tests/_runtime/test_requests.py
@@ -56,6 +56,7 @@ def test_http_request_like_basic_mapping():
         path_params={},
         cookies={},
         user={"is_authenticated": True},
+        meta={},
     )
 
     assert request["url"] == {"path": "/test"}
@@ -67,6 +68,7 @@ def test_http_request_like_basic_mapping():
         "path_params",
         "cookies",
         "user",
+        "meta",
     }
 
 
@@ -137,6 +139,7 @@ def test_display():
         path_params={},
         cookies={},
         user={"is_authenticated": True},
+        meta={},
     )
 
     display_dict = request._display_()

--- a/tests/_server/api/endpoints/test_execution.py
+++ b/tests/_server/api/endpoints/test_execution.py
@@ -199,8 +199,8 @@ class TestExecutionRoutes_EditMode:
             "marimo" not in header
             for header in app_meta_response["headers"].keys()
         )
-        # Check user is True
-        assert app_meta_response["user"] is True
+        # Check user is False
+        assert app_meta_response["user"] is False
 
 
 class TestExecutionRoutes_RunMode:

--- a/tests/_server/api/endpoints/test_execution.py
+++ b/tests/_server/api/endpoints/test_execution.py
@@ -189,6 +189,7 @@ class TestExecutionRoutes_EditMode:
             "cookies",
             "headers",
             "user",
+            "meta",
             "path_params",
             "query_params",
             "url",

--- a/tests/_server/api/test_auth.py
+++ b/tests/_server/api/test_auth.py
@@ -5,15 +5,18 @@ from typing import Any
 
 import pytest
 from starlette.applications import Starlette
+from starlette.authentication import SimpleUser
 from starlette.datastructures import Headers, QueryParams
 from starlette.requests import HTTPConnection
 
 from marimo._config.manager import UserConfigManager
 from marimo._server.api.auth import (
     AppState,
+    CustomAuthenticationMiddleware,
     CustomSessionMiddleware,
     validate_auth,
 )
+from marimo._server.api.middleware import AuthBackend
 from marimo._server.main import create_starlette_app
 from tests._server.mocks import get_mock_session_manager
 
@@ -140,3 +143,52 @@ async def test_validate_auth_with_no_auth(app: Starlette):
     # Run all middleware
     await app.build_middleware_stack()(conn.scope, mock_receive, mock_send)
     assert validate_auth(conn) is False
+
+
+async def test_custom_auth_middleware_preserves_user():
+    app = Starlette()
+    app.state.session_manager = get_mock_session_manager()
+
+    async def test_app(scope: Any, receive: Any, send: Any) -> None:
+        del receive, send
+        # Verify the user was swapped during middleware execution
+        assert scope["user"].username == "test_user"
+        assert (
+            scope[CustomAuthenticationMiddleware.KEY].username == "test_user"
+        )
+
+    middleware = CustomAuthenticationMiddleware(
+        test_app, backend=AuthBackend(should_authenticate=False)
+    )
+    scope = {
+        "type": "http",
+        "user": SimpleUser("test_user"),
+        "app": app,
+        "path": "/",
+    }
+
+    await middleware(scope, mock_receive, mock_send)
+    # Verify original user was restored and temp key was cleaned up
+    assert scope["user"].username == "test_user"
+    assert CustomAuthenticationMiddleware.KEY not in scope
+
+
+async def test_custom_auth_middleware_without_user():
+    app = Starlette()
+    app.state.session_manager = get_mock_session_manager()
+
+    async def test_app(scope: Any, receive: Any, send: Any) -> None:
+        del receive, send
+        assert scope["user"] is None
+
+    middleware = CustomAuthenticationMiddleware(
+        test_app, backend=AuthBackend(should_authenticate=False)
+    )
+    scope = {
+        "type": "http",
+        "app": app,
+        "path": "/",
+    }
+
+    await middleware(scope, mock_receive, mock_send)
+    assert CustomAuthenticationMiddleware.KEY not in scope


### PR DESCRIPTION
This overrides the `AuthenticationMiddleware` to preserve the upstream `user` object. Also adds a 'meta' field to let authors include more meta