### PR TITLE
fix: basic support for bokeh.plotting.show

### DIFF
--- a/marimo/_output/formatters/bokeh_formatters.py
+++ b/marimo/_output/formatters/bokeh_formatters.py
@@ -20,28 +20,15 @@ class BokehFormatter(FormatterFactory):
     def register(self) -> Callable[[], None]:
         import bokeh.models  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
         import bokeh.plotting  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
-        from bokeh.io import install_notebook_hook  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
-        from bokeh.io.state import curstate  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
-        from bokeh.io.notebook import run_notebook_hook  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
 
         from marimo._output import formatting
         from marimo._runtime.output import _output
 
-        # Support output_notebook() and show(); see
-        # https://github.com/marimo-team/marimo/pull/3796#issuecomment-2658190907 # noqa: E501
-        def load_notebook(*args: Any, **kwargs: Any) -> None:
-            del args
-            del kwargs
+        old_show = bokeh.plotting.show
 
-        def show_app(*args: Any, **kwargs: Any) -> None:
-            del args
-            del kwargs
-            raise RuntimeError("show_app is not supported in marimo")
-
-        def show_doc(*args: Any, **kwargs: Any) -> None:
+        @functools.wraps(old_show)
+        def show(*args: Any, **kwargs: Any) -> None:
             # Imperatively display the Bokeh object in the marimo output
-            print("SHOWING DOC")
-            print(args)
             # area.
             if args:
                 obj = args[0]
@@ -50,24 +37,10 @@ class BokehFormatter(FormatterFactory):
             if obj is not None:
                 _output.append(obj)
 
-        curstate().notebook_type = "marimo"  # type: ignore
-        install_notebook_hook("marimo", load_notebook, show_doc, show_app)  # type: ignore # noqa: E501
-
-        # output_notebook() resets curstate().notebook_type to Jupyter,
-        # so we need to patch it and run the notebook hook directly.
-        old_output_notebook = bokeh.plotting.output_notebook
-
-        @functools.wraps(old_output_notebook)
-        def output_notebook(*args: Any, **kwargs: Any) -> None:
-            del args
-            del kwargs
-            old_output_notebook()
-            curstate().notebook_type = "marimo"  # type: ignore
-
-        bokeh.plotting.output_notebook = output_notebook
+        bokeh.plotting.show = show
 
         def unpatch() -> None:
-            bokeh.plotting.output_notebook = old_output_notebook
+            bokeh.plotting.show = old_show
 
         @formatting.formatter(bokeh.models.Plot)
         def _show_plot(

--- a/marimo/_output/formatters/bokeh_formatters.py
+++ b/marimo/_output/formatters/bokeh_formatters.py
@@ -20,15 +20,28 @@ class BokehFormatter(FormatterFactory):
     def register(self) -> Callable[[], None]:
         import bokeh.models  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
         import bokeh.plotting  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        from bokeh.io import install_notebook_hook  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        from bokeh.io.state import curstate  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        from bokeh.io.notebook import run_notebook_hook  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
 
         from marimo._output import formatting
         from marimo._runtime.output import _output
 
-        old_show = bokeh.plotting.show
+        # Support output_notebook() and show(); see
+        # https://github.com/marimo-team/marimo/pull/3796#issuecomment-2658190907 # noqa: E501
+        def load_notebook(*args: Any, **kwargs: Any) -> None:
+            del args
+            del kwargs
 
-        @functools.wraps(old_show)
-        def show(*args: Any, **kwargs: Any) -> None:
+        def show_app(*args: Any, **kwargs: Any) -> None:
+            del args
+            del kwargs
+            raise RuntimeError("show_app is not supported in marimo")
+
+        def show_doc(*args: Any, **kwargs: Any) -> None:
             # Imperatively display the Bokeh object in the marimo output
+            print("SHOWING DOC")
+            print(args)
             # area.
             if args:
                 obj = args[0]
@@ -37,10 +50,24 @@ class BokehFormatter(FormatterFactory):
             if obj is not None:
                 _output.append(obj)
 
-        bokeh.plotting.show = show
+        curstate().notebook_type = "marimo"  # type: ignore
+        install_notebook_hook("marimo", load_notebook, show_doc, show_app)  # type: ignore # noqa: E501
+
+        # output_notebook() resets curstate().notebook_type to Jupyter,
+        # so we need to patch it and run the notebook hook directly.
+        old_output_notebook = bokeh.plotting.output_notebook
+
+        @functools.wraps(old_output_notebook)
+        def output_notebook(*args: Any, **kwargs: Any) -> None:
+            del args
+            del kwargs
+            old_output_notebook()
+            curstate().notebook_type = "marimo"  # type: ignore
+
+        bokeh.plotting.output_notebook = output_notebook
 
         def unpatch() -> None:
-            bokeh.plotting.show = old_show
+            bokeh.plotting.output_notebook = old_output_notebook
 
         @formatting.formatter(bokeh.models.Plot)
         def _show_plot(

--- a/marimo/_smoke_tests/bokeh_figure.py
+++ b/marimo/_smoke_tests/bokeh_figure.py
@@ -20,13 +20,8 @@ def _():
 
 @app.cell
 def _():
-    from bokeh.plotting import figure, show, output_notebook
-    from bokeh.io.state import curstate
-
-    print(curstate().notebook_type)
-    output_notebook()
-    print(curstate().notebook_type)
-    return curstate, figure, output_notebook, show
+    from bokeh.plotting import figure, show
+    return figure, show
 
 
 @app.cell

--- a/marimo/_smoke_tests/bokeh_figure.py
+++ b/marimo/_smoke_tests/bokeh_figure.py
@@ -20,8 +20,13 @@ def _():
 
 @app.cell
 def _():
-    from bokeh.plotting import figure, show
-    return figure, show
+    from bokeh.plotting import figure, show, output_notebook
+    from bokeh.io.state import curstate
+
+    print(curstate().notebook_type)
+    output_notebook()
+    print(curstate().notebook_type)
+    return curstate, figure, output_notebook, show
 
 
 @app.cell

--- a/marimo/_smoke_tests/bokeh_figure.py
+++ b/marimo/_smoke_tests/bokeh_figure.py
@@ -1,0 +1,49 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "bokeh==3.6.3",
+#     "marimo",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.11.4"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import bokeh
+    return (bokeh,)
+
+
+@app.cell
+def _():
+    from bokeh.plotting import figure, show
+    return figure, show
+
+
+@app.cell
+def _(figure):
+    p = figure()
+    # Shows GlyphRenderer
+    p.scatter([1, 2], [3, 4])
+    return (p,)
+
+
+@app.cell
+def _(p, show):
+    show(p)
+    return
+
+
+@app.cell
+def _(p):
+    # Shows plot
+    p
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/bokeh_figure.py
+++ b/marimo/_smoke_tests/bokeh_figure.py
@@ -20,8 +20,10 @@ def _():
 
 @app.cell
 def _():
-    from bokeh.plotting import figure, show
-    return figure, show
+    from bokeh.plotting import figure, show, output_notebook
+    # NOOP in marimo
+    output_notebook()
+    return figure, output_notebook, show
 
 
 @app.cell


### PR DESCRIPTION
Patches bokeh.plotting.show() to display its first argument in the output area. Other arguments are ignored. This is similar to our patch of `IPython.display.display`.

Not an elegant fix, but should work for many use cases. The proper fix would be to support `bokeh`'s `output_notebook()` — I believe this uses `IPython.display.publish_display_data`under the hood, which we don't yet support.

cc @bryevdv

<img width="711" alt="image" src="https://github.com/user-attachments/assets/696baa69-1dee-4848-a5c2-6bc8c5f903fc" />