### PR TITLE
fix: from_panel using private APIs

### DIFF
--- a/marimo/_plugins/ui/_impl/from_panel.py
+++ b/marimo/_plugins/ui/_impl/from_panel.py
@@ -94,6 +94,7 @@ def render_extension(load_timeout: int = 500, loaded: bool = False) -> str:
     Returns:
         JavaScript code for Panel extension
     """
+    # See panel.io.notebook.py
     from panel.config import panel_extension
 
     new_exts: list[str] = [
@@ -106,26 +107,22 @@ def render_extension(load_timeout: int = 500, loaded: bool = False) -> str:
 
     from bokeh.io.notebook import curstate  # type: ignore
     from bokeh.resources import CDN, INLINE
-    from bokeh.settings import settings
     from panel.config import config
     from panel.io.notebook import (  # type: ignore
         Resources,
         _autoload_js,
-        _Unset,
         bundle_resources,
         require_components,
         state,
     )
+    from panel.io.resources import set_resource_mode  # type: ignore
 
     curstate().output_notebook()
 
     resources = INLINE if config.inline else CDN
-    prev_resources = settings.resources(default="server")
-    user_resources = settings.resources._user_value is not _Unset
     nb_endpoint = not state._is_pyodide
-    resources = Resources.from_bokeh(resources, notebook=nb_endpoint)  # type: ignore[no-untyped-call]
-
-    try:
+    with set_resource_mode(resources.mode):
+        resources = Resources.from_bokeh(resources, notebook=nb_endpoint)  # type: ignore[no-untyped-call]
         bundle = bundle_resources(  # type: ignore[no-untyped-call]
             None,
             resources,
@@ -145,11 +142,6 @@ def render_extension(load_timeout: int = 500, loaded: bool = False) -> str:
             reloading=loaded,
             load_timeout=load_timeout,
         )
-    finally:
-        if user_resources:
-            settings.resources = prev_resources
-        else:
-            settings.resources.unset_value()
     loaded_extensions.extend(new_exts)
     return bokeh_js  # type: ignore[no-any-return]
 


### PR DESCRIPTION
`from_panel` was using a private panel API that was recently removed; this caused our tests to fail and presumably broke our Panel integration.

This PR updates the plugin to use a public alternative, copying a recent change made in Panel.

Context: https://github.com/holoviz/panel/pull/7716/

(cc @philippjfr)