### PR TITLE
fix: copy custom stylesheet

### DIFF
--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -165,6 +165,12 @@ If the server is already running, make sure it is using port ${SERVER_PORT} with
         devDoc.head.append(element);
       });
 
+      // Copy styles
+      const styles = serverDoc.querySelectorAll("style");
+      styles.forEach((style) => {
+        devDoc.head.append(style);
+      });
+
       return `<!DOCTYPE html>\n${devDoc.documentElement.outerHTML}`;
     },
   };

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -77,7 +77,7 @@ def notebook_page_template(
     if app_config.css_file:
         css_contents = read_css_file(app_config.css_file, filename=filename)
         if css_contents:
-            css_contents = f"<style>{css_contents}</style>"
+            css_contents = _custom_css_block(css_contents)
             # Append to head
             html = html.replace("</head>", f"{css_contents}</head>")
 
@@ -195,13 +195,7 @@ def static_notebook_template(
     if app_config.css_file:
         css_contents = read_css_file(app_config.css_file, filename=filepath)
         if css_contents:
-            static_block += dedent(
-                f"""
-            <style>
-                {css_contents}
-            </style>
-            """
-            )
+            static_block += _custom_css_block(css_contents)
 
     code_block = dedent(
         f"""
@@ -297,7 +291,7 @@ def wasm_notebook_template(
     if app_config.css_file:
         css_contents = read_css_file(app_config.css_file, filename=filename)
         if css_contents:
-            css_contents = f"<style>{css_contents}</style>"
+            css_contents = _custom_css_block(css_contents)
             # Append to head
             body = body.replace("</head>", f"{css_contents}</head>")
 
@@ -352,3 +346,9 @@ def get_version() -> str:
     return (
         f"{__version__} (editable)" if is_editable("marimo") else __version__
     )
+
+
+def _custom_css_block(css_contents: str) -> str:
+    # marimo-custom is used by the frontend to identify this stylesheet
+    # comes from marimo
+    return f"<style title='marimo-custom'>{css_contents}</style>"

--- a/marimo/_smoke_tests/theming/custom.css
+++ b/marimo/_smoke_tests/theming/custom.css
@@ -15,3 +15,8 @@
 h1 {
   color: light-dark(red, blue) !important;
 }
+
+input[inputmode="numeric"] {
+  border: 1px solid red;
+  text-align: right;
+}

--- a/marimo/_smoke_tests/theming/custom_css.py
+++ b/marimo/_smoke_tests/theming/custom_css.py
@@ -5,37 +5,40 @@
 #     "marimo",
 # ]
 # ///
+
 import marimo
 
-__generated_with = "0.8.3"
+__generated_with = "0.11.5"
 app = marimo.App(width="medium", css_file="custom.css")
 
 
 @app.cell
-def __():
+def _():
     import marimo as mo
     from vega_datasets import data
     return data, mo
 
 
 @app.cell
-def __(data):
+def _(data):
     data.cars()
     return
 
 
 @app.cell
-def __(mo):
-    mo.callout(mo.md("""
+def _(mo):
+    mo.callout(
+        mo.md("""
     ## Callout
 
     This font should be styled
-    """))
+    """)
+    )
     return
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md(
         r"""
         # heading
@@ -43,6 +46,13 @@ def __(mo):
         Here is a paragraph
         """
     )
+    return
+
+
+@app.cell
+def _(mo):
+    # This text should be aligned-right
+    mo.ui.number(value=50)
     return
 
 

--- a/tests/_server/templates/snapshots/export4.txt
+++ b/tests/_server/templates/snapshots/export4.txt
@@ -69,11 +69,7 @@
     window.__MARIMO_STATIC__.assetUrl = "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist";
     window.__MARIMO_STATIC__.files = {};
 </script>
-
-<style>
-    /* custom css */
-</style>
-</head>
+<style title='marimo-custom'>/* custom css */</style></head>
   <body>
     <div id="root"></div>
   <marimo-code hidden=""></marimo-code>


### PR DESCRIPTION
Fix #3816 

This adds a magic title that if starts with `marimo`, then we copy it to our shadow dom. While a bit fragile, it's not too magical. 