### PR TITLE
fix: don't override user if it is None

### DIFF
--- a/marimo/_server/api/auth.py
+++ b/marimo/_server/api/auth.py
@@ -233,7 +233,8 @@ class CustomAuthenticationMiddleware(AuthenticationMiddleware):
             # Get the developer-defined that we saved earlier
             developer_defined_user = scope.get(self.KEY)
             # Store it back in the scope
-            scope["user"] = developer_defined_user
+            if developer_defined_user is not None:
+                scope["user"] = developer_defined_user
             await app(scope, receive, send)
 
         super().__init__(wrapped_app, *args, **kwargs)

--- a/tests/_server/api/endpoints/test_execution.py
+++ b/tests/_server/api/endpoints/test_execution.py
@@ -200,7 +200,7 @@ class TestExecutionRoutes_EditMode:
             for header in app_meta_response["headers"].keys()
         )
         # Check user is False
-        assert app_meta_response["user"] is False
+        assert app_meta_response["user"] is True
 
 
 class TestExecutionRoutes_RunMode:

--- a/tests/_server/api/test_auth.py
+++ b/tests/_server/api/test_auth.py
@@ -179,7 +179,8 @@ async def test_custom_auth_middleware_without_user():
 
     async def test_app(scope: Any, receive: Any, send: Any) -> None:
         del receive, send
-        assert scope["user"] is None
+        # Fallbacks to SimpleUser("user")
+        assert scope["user"].username == "user"
 
     middleware = CustomAuthenticationMiddleware(
         test_app, backend=AuthBackend(should_authenticate=False)


### PR DESCRIPTION
We don't want to override the user, if it is `None`