### PR TITLE
chore: move ids to central file

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -26,13 +26,15 @@ from typing import (
 )
 from uuid import uuid4
 
+from marimo._types.ids import CellId_t
+
 if sys.version_info < (3, 10):
     from typing_extensions import ParamSpec, TypeAlias
 else:
     from typing import ParamSpec, TypeAlias
 
 from marimo import _loggers
-from marimo._ast.cell import Cell, CellConfig, CellId_t, CellImpl
+from marimo._ast.cell import Cell, CellConfig, CellImpl
 from marimo._ast.cell_manager import CellManager
 from marimo._ast.errors import (
     CycleError,

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional
 from marimo._ast.sql_visitor import SQLVisitor
 from marimo._ast.visitor import ImportData, Language, Name, VariableData
 from marimo._runtime.exceptions import MarimoRuntimeException
+from marimo._types.ids import CellId_t
 from marimo._utils.deep_merge import deep_merge
-
-CellId_t = str
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -19,11 +19,12 @@ if sys.version_info < (3, 10):
 else:
     from typing import ParamSpec, TypeAlias
 
-from marimo._ast.cell import Cell, CellConfig, CellId_t
+from marimo._ast.cell import Cell, CellConfig
 from marimo._ast.compiler import cell_factory, toplevel_cell_factory
 from marimo._ast.models import CellData
 from marimo._ast.names import DEFAULT_CELL_NAME
 from marimo._ast.pytest import wrap_fn_for_pytest
+from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
     from marimo._ast.app import InternalApp
@@ -75,8 +76,8 @@ class CellManager:
             _id = self.prefix + "".join(
                 self.random_seed.choices(string.ascii_letters, k=4)
             )
-        self.seen_ids.add(_id)
-        return _id
+        self.seen_ids.add(CellId_t(_id))
+        return CellId_t(_id)
 
     # TODO: maybe remove this, it is leaky
     def cell_decorator(

--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -15,13 +15,13 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 from marimo import _loggers
 from marimo._ast.cell import (
     Cell,
-    CellId_t,
     CellImpl,
     ImportWorkspace,
     SourcePosition,
 )
 from marimo._ast.variables import is_local
 from marimo._ast.visitor import ImportData, Name, ScopedVisitor
+from marimo._types.ids import CellId_t
 from marimo._utils.tmpdir import get_tmpdir
 
 LOGGER = _loggers.marimo_logger()
@@ -38,7 +38,7 @@ def cell_id_from_filename(filename: str) -> Optional[CellId_t]:
     """Parse cell id from filename."""
     matches = re.findall(r"__marimo__cell_(.*?)_", filename)
     if matches:
-        return str(matches[0])
+        return CellId_t(matches[0])
     return None
 
 

--- a/marimo/_ast/models.py
+++ b/marimo/_ast/models.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from marimo._ast.cell import Cell, CellConfig, CellId_t
+from marimo._ast.cell import Cell, CellConfig
+from marimo._types.ids import CellId_t
 
 
 @dataclass

--- a/marimo/_ast/variables.py
+++ b/marimo/_ast/variables.py
@@ -2,15 +2,14 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Optional
-
-if TYPE_CHECKING:
-    from marimo._ast.cell import CellId_t
-
-
 from collections import namedtuple
+from typing import Optional
+
+from marimo._types.ids import CellId_t
 
 UnmagledLocal = namedtuple("UnmagledLocal", "name cell")
+
+_EMPTY_CELL_ID = CellId_t("")
 
 
 def if_local_then_mangle(ref: str, cell_id: CellId_t) -> str:
@@ -21,7 +20,9 @@ def if_local_then_mangle(ref: str, cell_id: CellId_t) -> str:
     return ref
 
 
-def unmangle_local(name: str, cell_id: CellId_t = "") -> UnmagledLocal:
+def unmangle_local(
+    name: str, cell_id: CellId_t = _EMPTY_CELL_ID
+) -> UnmagledLocal:
     if not is_mangled_local(name, cell_id):
         return UnmagledLocal(name, "")
     private_prefix = r"^_cell_\w+?_"
@@ -30,7 +31,7 @@ def unmangle_local(name: str, cell_id: CellId_t = "") -> UnmagledLocal:
     return UnmagledLocal(re.sub(private_prefix, "_", name), name.split("_")[2])
 
 
-def is_mangled_local(name: str, cell_id: CellId_t = "") -> bool:
+def is_mangled_local(name: str, cell_id: CellId_t = _EMPTY_CELL_ID) -> bool:
     return name.startswith(f"_cell_{cell_id}")
 
 
@@ -39,7 +40,7 @@ def is_local(name: str) -> bool:
 
 
 def get_cell_from_local(
-    name: str, cell_id: CellId_t = ""
+    name: str, cell_id: CellId_t = _EMPTY_CELL_ID
 ) -> Optional[CellId_t]:
     local = unmangle_local(if_local_then_mangle(name, cell_id)).cell
     return local if local else None

--- a/marimo/_data/models.py
+++ b/marimo/_data/models.py
@@ -6,6 +6,8 @@ from datetime import date, datetime, time, timedelta  # noqa: TCH003
 from decimal import Decimal
 from typing import Any, List, Literal, Optional, Union
 
+from marimo._types.ids import VariableName
+
 DataType = Literal[
     "string",
     "boolean",
@@ -38,8 +40,6 @@ class DataTableColumn:
 
 
 DataTableSource = Literal["local", "duckdb", "connection"]
-
-VariableName = str
 
 
 @dataclass

--- a/marimo/_messaging/console_output_worker.py
+++ b/marimo/_messaging/console_output_worker.py
@@ -5,9 +5,9 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-from marimo._ast.cell import CellId_t
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.mimetypes import KnownMimeType
+from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
     from collections import deque

--- a/marimo/_messaging/errors.py
+++ b/marimo/_messaging/errors.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal, Optional, Union
 
-from marimo._ast.cell import CellId_t
 from marimo._runtime.dataflow import EdgeWithVar
+from marimo._types.ids import CellId_t
 
 
 @dataclass

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -27,7 +27,7 @@ from uuid import uuid4
 
 from marimo import _loggers as loggers
 from marimo._ast.app import _AppConfig
-from marimo._ast.cell import CellConfig, CellId_t, RuntimeStateType
+from marimo._ast.cell import CellConfig, RuntimeStateType
 from marimo._data.models import (
     ColumnSummary,
     DataSourceConnection,
@@ -54,6 +54,7 @@ from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._runtime.context import get_context
 from marimo._runtime.context.utils import get_mode
 from marimo._runtime.layout.layout import LayoutConfig
+from marimo._types.ids import CellId_t
 from marimo._utils.platform import is_pyodide, is_windows
 
 LOGGER = loggers.marimo_logger()

--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -17,7 +17,6 @@ from typing import (
 )
 
 from marimo import _loggers
-from marimo._ast.cell import CellId_t
 from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.console_output_worker import ConsoleMsg, buffered_writer
 from marimo._messaging.mimetypes import KnownMimeType
@@ -29,6 +28,7 @@ from marimo._messaging.types import (
     Stream,
 )
 from marimo._server.types import QueueType
+from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
     import queue

--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -1,10 +1,12 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import abc
 import io
 from typing import Any, Dict, Optional, Tuple
 
-from marimo._ast.cell import CellId_t
 from marimo._messaging.mimetypes import KnownMimeType
+from marimo._types.ids import CellId_t
 
 # The message from the kernel is a tuple of message type
 # and a json representation of the message

--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -13,9 +13,9 @@ else:
     from typing import TypeAlias
 
 from marimo._ast.app import _Namespace
-from marimo._ast.cell import CellId_t
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._runtime.context import get_context
+from marimo._types.ids import CellId_t
 
 UIElementId = str
 

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -9,7 +9,7 @@ import signal
 from typing import Any, Callable, Optional
 
 from marimo import _loggers
-from marimo._ast.cell import CellConfig, CellId_t
+from marimo._ast.cell import CellConfig
 from marimo._config.config import MarimoConfig
 from marimo._messaging.types import KernelMessage
 from marimo._pyodide.streams import (
@@ -62,6 +62,7 @@ from marimo._server.models.models import (
 )
 from marimo._server.session.session_view import SessionView
 from marimo._snippets.snippets import read_snippets
+from marimo._types.ids import CellId_t
 from marimo._utils.case import deep_to_camel_case
 from marimo._utils.formatter import DefaultFormatter
 from marimo._utils.parse_dataclass import parse_raw

--- a/marimo/_pyodide/streams.py
+++ b/marimo/_pyodide/streams.py
@@ -6,7 +6,6 @@ import sys
 from typing import Any, Callable, Iterable, Optional
 
 from marimo import _loggers
-from marimo._ast.cell import CellId_t
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._messaging.ops import CellOp
@@ -18,6 +17,7 @@ from marimo._messaging.types import (
     Stdout,
     Stream,
 )
+from marimo._types.ids import CellId_t
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_runtime/app/common.py
+++ b/marimo/_runtime/app/common.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple
 
-from marimo._ast.cell import CellId_t
+from marimo._types.ids import CellId_t
 
 OutputsType = Dict[CellId_t, Any]
 DefsType = Dict[str, Any]

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import weakref
 from typing import TYPE_CHECKING, Any
 
-from marimo._ast.cell import CellId_t, CellImpl
+from marimo._ast.cell import CellImpl
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._runtime.app.common import RunOutput
 from marimo._runtime.context.types import get_context
@@ -17,6 +17,7 @@ from marimo._runtime.requests import (
 )
 from marimo._runtime.runner import cell_runner
 from marimo._server.model import SessionMode
+from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
     from marimo._ast.app import InternalApp
@@ -38,7 +39,7 @@ class AppKernelRunner:
         from marimo._runtime.runtime import Kernel
 
         self.app = app
-        self._outputs: dict[str, Any] = {}
+        self._outputs: dict[CellId_t, Any] = {}
 
         ctx = get_context()
         if not isinstance(ctx, KernelRuntimeContext):

--- a/marimo/_runtime/app/script_runner.py
+++ b/marimo/_runtime/app/script_runner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Callable, Iterator
 
-from marimo._ast.cell import CellId_t, CellImpl
+from marimo._ast.cell import CellImpl
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.types import NoopStream
 from marimo._runtime.app.common import RunOutput
@@ -25,6 +25,7 @@ from marimo._runtime.patches import (
     create_main_module,
     patch_main_module_context,
 )
+from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
     from marimo._ast.app import InternalApp

--- a/marimo/_runtime/cell_lifecycle_registry.py
+++ b/marimo/_runtime/cell_lifecycle_registry.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import dataclasses
 
-from marimo._ast.cell import CellId_t
 from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
+from marimo._types.ids import CellId_t
 
 
 @dataclasses.dataclass

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -22,10 +22,10 @@ from marimo._server.model import SessionMode
 
 if TYPE_CHECKING:
     from marimo._ast.app import InternalApp
-    from marimo._ast.cell import CellId_t
     from marimo._messaging.types import Stream
     from marimo._runtime.runtime import Kernel
     from marimo._runtime.state import State
+    from marimo._types.ids import CellId_t
 
 
 @dataclass

--- a/marimo/_runtime/context/script_context.py
+++ b/marimo/_runtime/context/script_context.py
@@ -29,8 +29,8 @@ from marimo._runtime.state import State, StateRegistry
 
 if TYPE_CHECKING:
     from marimo._ast.app import InternalApp
-    from marimo._ast.cell import CellId_t
     from marimo._messaging.types import Stream
+    from marimo._types.ids import CellId_t
 
 
 @dataclass

--- a/marimo/_runtime/context/types.py
+++ b/marimo/_runtime/context/types.py
@@ -22,13 +22,13 @@ from marimo._runtime.requests import HTTPRequest
 
 if TYPE_CHECKING:
     from marimo._ast.app import AppKernelRunnerRegistry, InternalApp
-    from marimo._ast.cell import CellId_t
     from marimo._messaging.types import Stream
     from marimo._output.hypertext import Html
     from marimo._plugins.ui._core.registry import UIElementRegistry
     from marimo._runtime.params import CLIArgs, QueryParams
     from marimo._runtime.state import State, StateRegistry
     from marimo._runtime.virtual_file import VirtualFileRegistry
+    from marimo._types.ids import CellId_t
 
 
 class GlobalContext:

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -7,13 +7,13 @@ from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional, Tuple
 
 from marimo import _loggers
 from marimo._ast.cell import (
-    CellId_t,
     CellImpl,
 )
 from marimo._ast.compiler import code_key
 from marimo._ast.variables import is_mangled_local
 from marimo._ast.visitor import ImportData, Name, VariableData
 from marimo._runtime.executor import execute_cell, execute_cell_async
+from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
     from collections.abc import Collection

--- a/marimo/_runtime/functions.py
+++ b/marimo/_runtime/functions.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Callable, Coroutine, Generic, Type, TypeVar
 
-from marimo._ast.cell import CellId_t
 from marimo._loggers import marimo_logger
+from marimo._types.ids import CellId_t
 from marimo._utils.parse_dataclass import parse_raw
 
 LOGGER = marimo_logger()

--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from marimo._ast.cell import CellId_t
 from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.ops import CellOp
 from marimo._messaging.tracebacks import write_traceback
@@ -10,6 +9,7 @@ from marimo._output.rich_help import mddoc
 from marimo._plugins.stateless.flex import vstack
 from marimo._runtime.context import get_context
 from marimo._runtime.context.types import ContextNotInitializedError
+from marimo._types.ids import CellId_t
 
 
 def write_internal(cell_id: CellId_t, value: object) -> None:

--- a/marimo/_runtime/packages/module_registry.py
+++ b/marimo/_runtime/packages/module_registry.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import importlib.util
 import sys
 
-from marimo._ast.cell import CellId_t
 from marimo._runtime.dataflow import DirectedGraph
+from marimo._types.ids import CellId_t
 
 
 def _is_module_installed(module_name: str) -> bool:

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -6,11 +6,11 @@ import os
 import sys
 from typing import Iterator
 
-from marimo._ast.cell import CellId_t
 from marimo._messaging.streams import (
     redirect,
 )
 from marimo._messaging.types import Stderr, Stdin, Stdout, Stream
+from marimo._types.ids import CellId_t
 
 
 def forward_os_stream(stream_object: Stdout | Stderr, fd: int) -> None:

--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -19,7 +19,7 @@ from marimo._runtime.reload.autoreload import (
 if TYPE_CHECKING:
     import types
 
-    from marimo._ast.cell import CellId_t
+    from marimo._types.ids import CellId_t
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -18,9 +18,9 @@ from typing import (
 )
 from uuid import uuid4
 
-from marimo._ast.cell import CellId_t
 from marimo._config.config import MarimoConfig
 from marimo._data.models import DataTableSource
+from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
     from starlette.datastructures import URL

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -11,7 +11,7 @@ import traceback
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Union
 
-from marimo._ast.cell import CellId_t, CellImpl
+from marimo._ast.cell import CellImpl
 from marimo._ast.variables import unmangle_local
 from marimo._config.config import ExecutionType, OnCellChangeType
 from marimo._loggers import marimo_logger
@@ -34,6 +34,7 @@ from marimo._runtime.executor import (
     execute_cell_async,
 )
 from marimo._runtime.marimo_pdb import MarimoPdb
+from marimo._types.ids import CellId_t
 
 LOGGER = marimo_logger()
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, cast
 from uuid import uuid4
 
 from marimo import _loggers
-from marimo._ast.cell import CellConfig, CellId_t, CellImpl
+from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
 from marimo._ast.variables import is_local
 from marimo._ast.visitor import ImportData, Name, VariableData
@@ -136,6 +136,7 @@ from marimo._runtime.win32_interrupt_handler import Win32InterruptHandler
 from marimo._server.model import SessionMode
 from marimo._server.types import QueueType
 from marimo._tracer import kernel_tracer
+from marimo._types.ids import CellId_t
 from marimo._utils.assert_never import assert_never
 from marimo._utils.platform import is_pyodide
 from marimo._utils.signals import restore_signals

--- a/marimo/_runtime/scratch.py
+++ b/marimo/_runtime/scratch.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from marimo._ast.cell import CellId_t
+from marimo._types.ids import CellId_t
 
-SCRATCH_CELL_ID: CellId_t = "__scratch__"
+SCRATCH_CELL_ID = CellId_t("__scratch__")

--- a/marimo/_runtime/validate_graph.py
+++ b/marimo/_runtime/validate_graph.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import itertools
 from collections import defaultdict
 
-from marimo._ast.cell import CellId_t
 from marimo._messaging.errors import (
     CycleError,
     DeleteNonlocalError,
@@ -12,6 +11,7 @@ from marimo._messaging.errors import (
     MultipleDefinitionError,
 )
 from marimo._runtime.dataflow import DirectedGraph
+from marimo._types.ids import CellId_t
 
 
 def check_for_multiple_definitions(

--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -29,11 +29,12 @@ from marimo._runtime.primitives import (
 from marimo._runtime.state import SetFunctor, State
 from marimo._save.ast import DeprivateVisitor, strip_function
 from marimo._save.cache import Cache, CacheType
+from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
     from types import CodeType
 
-    from marimo._ast.cell import CellId_t, CellImpl
+    from marimo._ast.cell import CellImpl
     from marimo._runtime.context.types import RuntimeContext
     from marimo._runtime.dataflow import DirectedGraph
     from marimo._save.loaders import Loader

--- a/marimo/_server/api/deps.py
+++ b/marimo/_server/api/deps.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from marimo import _loggers as loggers
 from marimo._config.manager import MarimoConfigManager
-from marimo._server.ids import SessionId
 from marimo._server.model import SessionMode
 from marimo._server.sessions import Session, SessionManager
 from marimo._server.tokens import SkewProtectionToken
+from marimo._types.ids import SessionId
 
 if TYPE_CHECKING:
     from starlette.applications import Starlette

--- a/marimo/_server/api/endpoints/config.py
+++ b/marimo/_server/api/endpoints/config.py
@@ -9,13 +9,13 @@ from marimo import _loggers
 from marimo._runtime.requests import SetUserConfigRequest
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
-from marimo._server.ids import ConsumerId
 from marimo._server.models.models import (
     BaseResponse,
     SaveUserConfigurationRequest,
     SuccessResponse,
 )
 from marimo._server.router import APIRouter
+from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from starlette.requests import Request

--- a/marimo/_server/api/endpoints/datasources.py
+++ b/marimo/_server/api/endpoints/datasources.py
@@ -9,9 +9,9 @@ from marimo import _loggers
 from marimo._runtime.requests import PreviewDatasetColumnRequest
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
-from marimo._server.ids import ConsumerId
 from marimo._server.models.models import BaseResponse, SuccessResponse
 from marimo._server.router import APIRouter
+from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from starlette.requests import Request

--- a/marimo/_server/api/endpoints/editing.py
+++ b/marimo/_server/api/endpoints/editing.py
@@ -14,7 +14,6 @@ from marimo._runtime.requests import (
 )
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
-from marimo._server.ids import ConsumerId
 from marimo._server.models.models import (
     BaseResponse,
     FormatRequest,
@@ -23,6 +22,7 @@ from marimo._server.models.models import (
     SuccessResponse,
 )
 from marimo._server.router import APIRouter
+from marimo._types.ids import ConsumerId
 from marimo._utils.formatter import DefaultFormatter
 
 if TYPE_CHECKING:

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -19,7 +19,6 @@ from marimo._server.api.deps import AppState
 from marimo._server.api.endpoints.ws import FILE_QUERY_PARAM_KEY
 from marimo._server.api.utils import parse_request
 from marimo._server.file_router import MarimoFileKey
-from marimo._server.ids import ConsumerId
 from marimo._server.models.models import (
     BaseResponse,
     InstantiateRequest,
@@ -30,6 +29,7 @@ from marimo._server.models.models import (
 )
 from marimo._server.router import APIRouter
 from marimo._server.uvicorn_utils import close_uvicorn
+from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from starlette.requests import Request

--- a/marimo/_server/api/endpoints/files.py
+++ b/marimo/_server/api/endpoints/files.py
@@ -11,7 +11,6 @@ from marimo import _loggers
 from marimo._server.api.deps import AppState
 from marimo._server.api.status import HTTPStatus
 from marimo._server.api.utils import parse_request
-from marimo._server.ids import ConsumerId
 from marimo._server.models.models import (
     BaseResponse,
     CopyNotebookRequest,
@@ -22,6 +21,7 @@ from marimo._server.models.models import (
     SuccessResponse,
 )
 from marimo._server.router import APIRouter
+from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from starlette.requests import Request

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from marimo import _loggers
-from marimo._ast.cell import CellConfig, CellId_t
+from marimo._ast.cell import CellConfig
 from marimo._cli.upgrade import check_for_updates
 from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._messaging.ops import (
@@ -31,7 +31,6 @@ from marimo._plugins.core.web_component import JSONType
 from marimo._runtime.params import QueryParams
 from marimo._server.api.deps import AppState
 from marimo._server.file_router import MarimoFileKey
-from marimo._server.ids import ConsumerId
 from marimo._server.model import (
     ConnectionState,
     SessionConsumer,
@@ -39,6 +38,7 @@ from marimo._server.model import (
 )
 from marimo._server.router import APIRouter
 from marimo._server.sessions import Session, SessionManager
+from marimo._types.ids import CellId_t, ConsumerId
 
 if TYPE_CHECKING:
     from pycrdt import Doc, Text, TransactionEvent

--- a/marimo/_server/errors.py
+++ b/marimo/_server/errors.py
@@ -14,9 +14,9 @@ from marimo._server.api.status import (
     HTTPException as MarimoHTTPException,
     is_client_error,
 )
-from marimo._server.ids import ConsumerId
 from marimo._server.model import SessionMode
 from marimo._server.sessions import send_message_to_consumer
+from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from starlette.requests import Request

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -23,6 +23,7 @@ from marimo._server.model import ConnectionState, SessionConsumer, SessionMode
 from marimo._server.models.export import ExportAsHTMLRequest
 from marimo._server.models.models import InstantiateRequest
 from marimo._server.session.session_view import SessionView
+from marimo._types.ids import ConsumerId
 from marimo._utils.marimo_path import MarimoPath
 from marimo._utils.parse_dataclass import parse_raw
 
@@ -211,7 +212,7 @@ async def run_app_until_completion(
     class DefaultSessionConsumer(SessionConsumer):
         def __init__(self) -> None:
             self.did_error = False
-            super().__init__(consumer_id="default")
+            super().__init__(consumer_id=ConsumerId("default"))
 
         def on_start(
             self,

--- a/marimo/_server/file_manager.py
+++ b/marimo/_server/file_manager.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 from marimo import _loggers
 from marimo._ast import codegen
 from marimo._ast.app import App, InternalApp, _AppConfig
-from marimo._ast.cell import CellConfig, CellId_t
+from marimo._ast.cell import CellConfig
 from marimo._config.config import WidthType
 from marimo._runtime.layout.layout import (
     LayoutConfig,
@@ -22,6 +22,7 @@ from marimo._server.models.models import (
     SaveNotebookRequest,
 )
 from marimo._server.utils import canonicalize_filename
+from marimo._types.ids import CellId_t
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_server/ids.py
+++ b/marimo/_server/ids.py
@@ -1,5 +1,0 @@
-# Copyright 2024 Marimo. All rights reserved.
-from __future__ import annotations
-
-SessionId = str
-ConsumerId = str

--- a/marimo/_server/model.py
+++ b/marimo/_server/model.py
@@ -5,7 +5,7 @@ import abc
 from enum import Enum
 from typing import TYPE_CHECKING, Callable
 
-from marimo._server.ids import ConsumerId
+from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from marimo._messaging.ops import MessageOperation

--- a/marimo/_server/models/home.py
+++ b/marimo/_server/models/home.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Optional
 
-from marimo._server.ids import SessionId
 from marimo._server.models.files import FileInfo
 from marimo._tutorials import Tutorial
+from marimo._types.ids import SessionId
 
 
 @dataclass

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from marimo._ast.cell import CellConfig, CellId_t
+from marimo._ast.cell import CellConfig
 from marimo._config.config import MarimoConfig
 from marimo._runtime.requests import (
     ExecuteMultipleRequest,
@@ -13,8 +13,7 @@ from marimo._runtime.requests import (
     HTTPRequest,
     RenameRequest,
 )
-
-UIElementId = str
+from marimo._types.ids import CellId_t, UIElementId
 
 
 @dataclass

--- a/marimo/_server/session/session_view.py
+++ b/marimo/_server/session/session_view.py
@@ -5,7 +5,6 @@ import time
 from dataclasses import dataclass
 from typing import Any, Literal, Optional
 
-from marimo._ast.cell import CellId_t
 from marimo._data.models import DataSourceConnection, DataTable
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.ops import (
@@ -27,6 +26,7 @@ from marimo._runtime.requests import (
     ExecutionRequest,
     SetUIElementValueRequest,
 )
+from marimo._types.ids import CellId_t
 from marimo._utils.lists import as_list
 from marimo._utils.parse_dataclass import parse_raw
 

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, Optional, Union
 from uuid import uuid4
 
 from marimo import _loggers
-from marimo._ast.cell import CellConfig, CellId_t
+from marimo._ast.cell import CellConfig
 from marimo._cli.print import red
 from marimo._config.manager import MarimoConfigReader
 from marimo._config.settings import GLOBAL_SETTINGS
@@ -59,7 +59,6 @@ from marimo._runtime.requests import (
 from marimo._server.exceptions import InvalidSessionException
 from marimo._server.file_manager import AppFileManager
 from marimo._server.file_router import AppFileRouter, MarimoFileKey
-from marimo._server.ids import ConsumerId, SessionId
 from marimo._server.model import ConnectionState, SessionConsumer, SessionMode
 from marimo._server.models.models import InstantiateRequest
 from marimo._server.recents import RecentFilesManager
@@ -71,6 +70,7 @@ from marimo._server.tokens import AuthToken, SkewProtectionToken
 from marimo._server.types import QueueType
 from marimo._server.utils import print_, print_tabbed
 from marimo._tracer import server_tracer
+from marimo._types.ids import CellId_t, ConsumerId, SessionId
 from marimo._utils.disposable import Disposable
 from marimo._utils.distributor import (
     ConnectionDistributor,

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -9,7 +9,7 @@ from typing import Any, List, Literal, Optional, cast
 
 from marimo import __version__
 from marimo._ast.app import _AppConfig
-from marimo._ast.cell import CellConfig, CellId_t
+from marimo._ast.cell import CellConfig
 from marimo._config.config import MarimoConfig, PartialMarimoConfig
 from marimo._messaging.cell_output import CellOutput
 from marimo._output.utils import uri_encode_component
@@ -17,6 +17,7 @@ from marimo._server.api.utils import parse_title
 from marimo._server.file_manager import read_css_file, read_html_head_file
 from marimo._server.model import SessionMode
 from marimo._server.tokens import SkewProtectionToken
+from marimo._types.ids import CellId_t
 from marimo._utils.versions import is_editable
 
 

--- a/marimo/_types/ids.py
+++ b/marimo/_types/ids.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import NewType
+
+# TODO: enable NewType for better type checking
+# CellId_t = NewType("CellId_t", str)
+CellId_t = str
+
+# UIElementId = NewType("UIElementId", str)
+UIElementId = str
+
+# SessionId = NewType("SessionId", str)
+SessionId = str
+
+ConsumerId = NewType("ConsumerId", str)
+
+# VariableName = NewType("VariableName", str)
+VariableName = str

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -7,10 +7,10 @@ from typing import Dict
 
 from marimo import _loggers
 from marimo._dependencies.dependencies import DependencyManager
+from marimo._types.ids import CellId_t
 
 LOGGER = _loggers.marimo_logger()
 
-CellId_t = str
 
 CellCodes = Dict[CellId_t, str]
 

--- a/tests/_server/session/test_session_view.py
+++ b/tests/_server/session/test_session_view.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
-from marimo._ast.cell import CellId_t, RuntimeStateType
+from marimo._ast.cell import RuntimeStateType
 from marimo._data.models import DataTable, DataTableColumn
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.ops import (
@@ -27,6 +27,7 @@ from marimo._runtime.requests import (
     SetUIElementValueRequest,
 )
 from marimo._server.session.session_view import SessionView
+from marimo._types.ids import CellId_t
 from marimo._utils.parse_dataclass import parse_raw
 
 cell_id: CellId_t = "cell_1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ import pytest
 from _pytest import runner
 
 from marimo._ast.app import App, CellManager
-from marimo._ast.cell import CellId_t
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._messaging.ops import CellOp, MessageOperation
@@ -34,6 +33,7 @@ from marimo._runtime.marimo_pdb import MarimoPdb
 from marimo._runtime.requests import AppMetadata, ExecutionRequest
 from marimo._runtime.runtime import Kernel
 from marimo._server.model import SessionMode
+from marimo._types.ids import CellId_t
 from marimo._utils.parse_dataclass import parse_raw
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Move all IDs to `marimo._types.ids`. will eventually make them more strongly typed ids too