### PR TITLE
Specify the encoding for reading files to keep from encoding error for some Asian Windows platform.

### DIFF
--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -58,7 +58,7 @@ class LocalFileReader(FileReader):
         # Is directory
         if os.path.isdir(name):
             return "", os.path.basename(name)
-        with open(name, "r") as f:
+        with open(name, "r", encoding="utf-8") as f:
             content = f.read()
         return content, os.path.basename(name)
 

--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -162,7 +162,7 @@ class ScriptConfigManager(PartialMarimoConfigReader):
 
             from marimo._utils.scripts import read_pyproject_from_script
 
-            script_content = filepath.read_text()
+            script_content = filepath.read_text(encoding="utf-8")
             script_config = read_pyproject_from_script(script_content)
             if script_config is None:
                 return {}


### PR DESCRIPTION
## 📝 Summary

If the file encoding is not specified when reading a file, it may cause issues on Windows platforms in certain Asian regions. If the file contains non-ANSI characters, such as Chinese, it can result in a decode error.

---
I have read the CLA Document and I hereby sign the CLA
---


## 🔍 Description of Changes

On Windows platforms in Asia, the default file encoding is specific to the region. For example, in Taiwan, the default encoding is CP950. However, Python files are now stored using UTF-8 encoding. If the file content contains only ANSI characters, there will be no issues. However, if a file containing Chinese characters is read using the default encoding, a decode error will occur because Chinese characters encoded in UTF-8 cannot be decoded using CP950. Therefore, this modification primarily adds an explicit specification to read files using UTF-8 encoding to prevent such errors.

## 📋 Checklist

- [Y] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [Y] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [Y] I have added tests for the changes made.
- [Y] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
