### PR TITLE
fix: non-deterministic random object-ids for session caching

### DIFF
--- a/frontend/src/core/dom/uiregistry.ts
+++ b/frontend/src/core/dom/uiregistry.ts
@@ -1,4 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { Logger } from "@/utils/Logger";
 import type { CellId, UIElementId } from "../cells/ids";
 import {
   type ValueType,
@@ -134,7 +135,9 @@ export class UIElementRegistry {
     buffers: string[] | undefined | null,
   ): void {
     const entry = this.entries.get(objectId);
-    if (entry !== undefined) {
+    if (entry === undefined) {
+      Logger.warn("UIElementRegistry missing entry", objectId);
+    } else {
       const base64ToDataView = (base64: string) => {
         const bytes = window.atob(base64);
         const buffer = new ArrayBuffer(bytes.length);
@@ -176,7 +179,9 @@ export class UIElementRegistry {
     value: ValueType,
   ): void {
     const entry = this.entries.get(objectId);
-    if (entry !== undefined) {
+    if (entry === undefined) {
+      Logger.warn("UIElementRegistry missing entry", objectId);
+    } else {
       entry.value = value;
       entry.elements.forEach((element) => {
         if (element !== initiator) {

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -114,7 +114,14 @@ class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
     _value_frontend: S
     _value: T
 
-    _random_seed = random.Random(42)
+    # We want this to be fully random in production,
+    # otherwise cached session state could use incorrect object-ids.
+    # And changing object-ids are a way to force a re-render.
+    #
+    # This does mean that snapshotting exports in CI will produce
+    # different object-ids. If this is a problem, we can allow a
+    # fixed seed via an environment variable.
+    _random_seed = random.Random()
 
     def __init__(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,17 @@ if TYPE_CHECKING:
 register_formatters()
 
 
+@pytest.fixture(autouse=True)
+def patch_random_seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch UIElement._random_seed to use a fixed seed for testing"""
+    import random
+
+    from marimo._plugins.ui._core.ui_element import UIElement
+
+    # Patch the random seed to be deterministic for testing
+    monkeypatch.setattr(UIElement, "_random_seed", random.Random(42))
+
+
 @dataclasses.dataclass
 class _MockStream(ThreadSafeStream):
     """Captures the ops sent through the stream"""


### PR DESCRIPTION
This somewhat reverts https://github.com/marimo-team/marimo/pull/3061

While this may be useful for CI, it can break session caching introduced in #3807 
We can enable this `"deterministic" random ids` via env variable if it is desired again. 