### PR TITLE
chore: warn users about RTC code duplication

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -1134,9 +1134,10 @@ export const UserConfigForm: React.FC = () => {
                     <FormDescription>
                       Enable experimental real-time collaboration to allow
                       editing cell inputs by multiple users. This experimental
-                      feature has known issues, including duplication of
-                      code. Requires refreshing the page to take effect.
-                    </FormDescription> </div>
+                      feature has known issues, including duplication of code.
+                      Requires refreshing the page to take effect.
+                    </FormDescription>{" "}
+                  </div>
                 )}
               />
             )}


### PR DESCRIPTION
RTC is still a work in progress, and is known to duplicate user code (#3869). This change gives users a heads up so they can debug the issue on their own if it arises. 