### PR TITLE
fix: persist chat messages

### DIFF
--- a/frontend/src/plugins/impl/chat/ChatPlugin.tsx
+++ b/frontend/src/plugins/impl/chat/ChatPlugin.tsx
@@ -8,8 +8,8 @@ import type { ChatMessage, SendMessageRequest } from "./types";
 import { Arrays } from "@/utils/arrays";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-type PluginFunctions = {
-  get_chat_history: () => Promise<{ messages: ChatMessage[] }>;
+export type PluginFunctions = {
+  get_chat_history: (req: {}) => Promise<{ messages: ChatMessage[] }>;
   send_prompt: (req: SendMessageRequest) => Promise<string>;
 };
 
@@ -81,7 +81,8 @@ export const ChatPlugin = createPlugin<{ messages: ChatMessage[] }>(
         maxHeight={props.data.maxHeight}
         allowAttachments={props.data.allowAttachments}
         config={props.data.config}
-        sendPrompt={props.functions.send_prompt}
+        get_chat_history={props.functions.get_chat_history}
+        send_prompt={props.functions.send_prompt}
         value={props.value?.messages || Arrays.EMPTY}
         setValue={(messages) => props.setValue({ messages })}
       />

--- a/frontend/src/plugins/impl/chat/ChatPlugin.tsx
+++ b/frontend/src/plugins/impl/chat/ChatPlugin.tsx
@@ -10,6 +10,8 @@ import { Arrays } from "@/utils/arrays";
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type PluginFunctions = {
   get_chat_history: (req: {}) => Promise<{ messages: ChatMessage[] }>;
+  delete_chat_history: (req: {}) => Promise<null>;
+  delete_chat_message: (req: { index: number }) => Promise<null>;
   send_prompt: (req: SendMessageRequest) => Promise<string>;
 };
 
@@ -43,6 +45,10 @@ export const ChatPlugin = createPlugin<{ messages: ChatMessage[] }>(
         ),
       }),
     ),
+    delete_chat_history: rpc.input(z.object({})).output(z.null()),
+    delete_chat_message: rpc
+      .input(z.object({ index: z.number() }))
+      .output(z.null()),
     send_prompt: rpc
       .input(
         z.object({
@@ -82,6 +88,8 @@ export const ChatPlugin = createPlugin<{ messages: ChatMessage[] }>(
         allowAttachments={props.data.allowAttachments}
         config={props.data.config}
         get_chat_history={props.functions.get_chat_history}
+        delete_chat_history={props.functions.delete_chat_history}
+        delete_chat_message={props.functions.delete_chat_message}
         send_prompt={props.functions.send_prompt}
         value={props.value?.messages || Arrays.EMPTY}
         setValue={(messages) => props.setValue({ messages })}

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -75,7 +75,6 @@ export const Chatbot: React.FC<Props> = (props) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
 
-  // TODO: This component is rendering every keystroke
   const { data: initialMessages } = useAsyncData(async () => {
     const chatMessages = await props.get_chat_history({});
     const messages: Message[] = chatMessages.messages.map((message, idx) => ({

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -75,6 +75,7 @@ export const Chatbot: React.FC<Props> = (props) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
 
+  // TODO: This component is rendering every keystroke
   const { data: initialMessages } = useAsyncData(async () => {
     const chatMessages = await props.get_chat_history({});
     const messages: Message[] = chatMessages.messages.map((message, idx) => ({
@@ -149,7 +150,11 @@ export const Chatbot: React.FC<Props> = (props) => {
   });
 
   const handleDelete = (id: string) => {
-    setMessages(messages.filter((message) => message.id !== id));
+    const index = messages.findIndex((message) => message.id === id);
+    if (index !== -1) {
+      props.delete_chat_message({ index });
+      setMessages((prev) => prev.filter((message) => message.id !== id));
+    }
   };
 
   const renderAttachment = (attachment: ChatAttachment) => {
@@ -250,6 +255,7 @@ export const Chatbot: React.FC<Props> = (props) => {
           onClick={() => {
             setMessages([]);
             props.setValue([]);
+            props.delete_chat_history({});
           }}
         >
           <Trash2Icon className="h-3 w-3" />

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -6,7 +6,6 @@ import React, { useEffect, useRef } from "react";
 import type {
   ChatMessage,
   ChatConfig,
-  SendMessageRequest,
   ChatAttachment,
   ChatRole,
 } from "./types";
@@ -54,14 +53,15 @@ import {
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { useTheme } from "@/theme/useTheme";
 import { moveToEndOfEditor } from "@/core/codemirror/utils";
+import type { PluginFunctions } from "./ChatPlugin";
+import { useAsyncData } from "@/hooks/useAsyncData";
 
-interface Props {
+interface Props extends PluginFunctions {
   prompts: string[];
   config: ChatConfig;
   showConfigurationControls: boolean;
   maxHeight: number | undefined;
   allowAttachments: boolean | string[];
-  sendPrompt(req: SendMessageRequest): Promise<string>;
   value: ChatMessage[];
   setValue: (messages: ChatMessage[]) => void;
 }
@@ -74,6 +74,17 @@ export const Chatbot: React.FC<Props> = (props) => {
   const codeMirrorInputRef = useRef<ReactCodeMirrorRef>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
+
+  const { data: initialMessages } = useAsyncData(async () => {
+    const chatMessages = await props.get_chat_history({});
+    const messages: Message[] = chatMessages.messages.map((message, idx) => ({
+      id: idx.toString(),
+      role: message.role,
+      content: message.content,
+      experimental_attachments: message.attachments,
+    }));
+    return messages;
+  }, []);
 
   const {
     messages,
@@ -93,7 +104,7 @@ export const Chatbot: React.FC<Props> = (props) => {
         messages: Message[];
       };
       try {
-        const response = await props.sendPrompt({
+        const response = await props.send_prompt({
           messages: body.messages.map((m) => ({
             role: m.role as ChatRole,
             content: m.content,
@@ -118,6 +129,7 @@ export const Chatbot: React.FC<Props> = (props) => {
         return new Response(strippedError, { status: 400 });
       }
     },
+    initialMessages: initialMessages,
     onFinish: (message, { usage, finishReason }) => {
       setFiles(undefined);
 

--- a/marimo/_plugins/ui/_impl/chat/chat.py
+++ b/marimo/_plugins/ui/_impl/chat/chat.py
@@ -33,6 +33,11 @@ class GetChatHistoryResponse:
     messages: List[ChatMessage]
 
 
+@dataclass
+class DeleteChatMessageRequest:
+    index: int
+
+
 @mddoc
 class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
     """A chatbot UI element for interactive conversations.
@@ -158,6 +163,16 @@ class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
                     function=self._get_chat_history,
                 ),
                 Function(
+                    name="delete_chat_history",
+                    arg_cls=EmptyArgs,
+                    function=self._delete_chat_history,
+                ),
+                Function(
+                    name="delete_chat_message",
+                    arg_cls=DeleteChatMessageRequest,
+                    function=self._delete_chat_message,
+                ),
+                Function(
                     name="send_prompt",
                     arg_cls=SendMessageRequest,
                     function=self._send_prompt,
@@ -167,6 +182,17 @@ class chat(UIElement[Dict[str, Any], List[ChatMessage]]):
 
     def _get_chat_history(self, _args: EmptyArgs) -> GetChatHistoryResponse:
         return GetChatHistoryResponse(messages=self._chat_history)
+
+    def _delete_chat_history(self, _args: EmptyArgs) -> None:
+        self._value = self._chat_history = []
+
+    def _delete_chat_message(self, args: DeleteChatMessageRequest) -> None:
+        index = args.index
+        if index < 0 or index >= len(self._chat_history):
+            raise ValueError("Invalid message index")
+
+        del self._chat_history[index]
+        self._value = self._chat_history
 
     async def _send_prompt(self, args: SendMessageRequest) -> str:
         messages = args.messages

--- a/tests/_plugins/ui/_impl/chat/test_chat.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat.py
@@ -136,6 +136,9 @@ def test_chat_get_history():
         return "Mock response"
 
     chat = ui.chat(mock_model)
+    history = chat._get_chat_history(EmptyArgs())
+    assert history.messages == []
+
     chat._chat_history = [
         ChatMessage(role="user", content="Hello"),
         ChatMessage(role="assistant", content="Hi there!"),


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #3763.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Pass in initial messages to the frontend and call `get_chat_history` to get initial messages. Keep the state in the backend and add `delete_chat_history` and `delete_chat_message` from the frontend.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
