### PR TITLE
join newlines with spaces in Html.__format__

### DIFF
--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -133,7 +133,9 @@ class Html(MIME):
     def __format__(self, spec: str) -> str:
         """Format `self` as HTML text"""
         del spec
-        return " ".join([line.strip() for line in self.text.split("\n")])
+        return " ".join(
+            [line.strip() for line in self.text.split("\n")]
+        ).strip()
 
     @mddoc
     def batch(self, **elements: UIElement[JSONType, object]) -> batch_plugin:

--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -133,7 +133,7 @@ class Html(MIME):
     def __format__(self, spec: str) -> str:
         """Format `self` as HTML text"""
         del spec
-        return "".join([line.strip() for line in self.text.split("\n")])
+        return " ".join([line.strip() for line in self.text.split("\n")])
 
     @mddoc
     def batch(self, **elements: UIElement[JSONType, object]) -> batch_plugin:

--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -134,8 +134,8 @@ class Html(MIME):
         """Format `self` as HTML text"""
         del spec
         return " ".join(
-            [line.strip() for line in self.text.split("\n")]
-        ).strip()
+            [line.strip() for line in self.text.strip().split("\n")]
+        )
 
     @mddoc
     def batch(self, **elements: UIElement[JSONType, object]) -> batch_plugin:

--- a/tests/_output/test_hypertext.py
+++ b/tests/_output/test_hypertext.py
@@ -23,7 +23,48 @@ def test_html_mime():
 
 def test_html_format():
     html = Html("<p>\n  Hello\n</p>")
-    assert f"{html}" == "<p>Hello</p>"
+    assert f"{html}" == "<p> Hello </p>"
+
+
+def test_html_format_multiline():
+    html = Html("""
+        <div>
+            <p>Hello</p>
+            <p>World</p>
+        </div>
+    """)
+    assert f"{html}" == "<div> <p>Hello</p> <p>World</p> </div>"
+
+
+def test_html_format_nested():
+    html = Html("""
+        <div>
+            <span>
+                Text
+            </span>
+        </div>
+    """)
+    assert f"{html}" == "<div> <span> Text </span> </div>"
+
+
+def test_html_format_attributes():
+    html = Html("""
+        <div class="test"
+             id="main">
+            Content
+        </div>
+    """)
+    assert f"{html}" == '<div class="test" id="main"> Content </div>'
+
+
+def test_html_format_empty():
+    html = Html("")
+    assert f"{html}" == ""
+
+
+def test_html_format_whitespace():
+    html = Html("  <p>  Lots   of    spaces  </p>  ")
+    assert f"{html}" == "<p>  Lots   of    spaces  </p>"
 
 
 def test_html_batch():


### PR DESCRIPTION
## 📝 Summary
Fixes a bug in `Html.__format__` when the provided html text has newlines _inside_ an html tag.

## 🔍 Description of Changes

Previously, newlines were effectively removed when formatting an Html object. This breaks in cases where html tags are split across multiple lines. For example,
```python
Html("""
  <div
    style="..."
  ></div>
""")
```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
