### PR TITLE
fix: only apply css when selected & expanded for db & schema

### DIFF
--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -251,6 +251,7 @@ const DatabaseItem: React.FC<{
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [isSelected, setIsSelected] = React.useState(false);
 
+  // Do not change the styling when searching
   React.useEffect(() => {
     setIsExpanded(hasSearch);
   }, [hasSearch]);
@@ -269,10 +270,12 @@ const DatabaseItem: React.FC<{
         <DatabaseIcon
           className={cn(
             "h-4 w-4",
-            isSelected ? "text-foreground" : "text-muted-foreground",
+            isSelected && isExpanded
+              ? "text-foreground"
+              : "text-muted-foreground",
           )}
         />
-        <span className={cn(isSelected && "font-semibold")}>
+        <span className={cn(isSelected && isExpanded && "font-semibold")}>
           {database.name === "" ? <i>Not connected</i> : database.name}
         </span>
       </CommandItem>
@@ -335,6 +338,7 @@ const SchemaItem: React.FC<{
   const [isSelected, setIsSelected] = React.useState(false);
   const uniqueValue = `${databaseName}:${schema.name}`;
 
+  // Do not change the styling when searching
   React.useEffect(() => {
     setIsExpanded(hasSearch);
   }, [hasSearch]);
@@ -353,10 +357,12 @@ const SchemaItem: React.FC<{
         <PaintRollerIcon
           className={cn(
             "h-4 w-4 text-muted-foreground",
-            isSelected && "text-foreground",
+            isSelected && isExpanded && "text-foreground",
           )}
         />
-        <span className={cn(isSelected && "font-semibold")}>{schema.name}</span>
+        <span className={cn(isSelected && isExpanded && "font-semibold")}>
+          {schema.name}
+        </span>
       </CommandItem>
       {isExpanded && children}
     </>

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -251,7 +251,6 @@ const DatabaseItem: React.FC<{
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [isSelected, setIsSelected] = React.useState(false);
 
-  // Do not change the styling when searching
   React.useEffect(() => {
     setIsExpanded(hasSearch);
   }, [hasSearch]);
@@ -338,7 +337,6 @@ const SchemaItem: React.FC<{
   const [isSelected, setIsSelected] = React.useState(false);
   const uniqueValue = `${databaseName}:${schema.name}`;
 
-  // Do not change the styling when searching
   React.useEffect(() => {
     setIsExpanded(hasSearch);
   }, [hasSearch]);


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
A minor UI fix so that when searching and you collapse the db/schema, the css doesn't apply wrongly. It should only apply when it's expanded + selected.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
