### PR TITLE
feat: koaning/motest parity (pytest in blocks)

### DIFF
--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -414,6 +414,12 @@ class Cell:
     # Number of reserved arguments for pytest
     _pytest_reserved: set[str] = dataclasses.field(default_factory=set)
 
+    # The property __test__ is picked up by nose and pytest.
+    # We have the compiler mark if the cell name starts with test_
+    # _or_, is comprised of only tests; allowing for testing suites to
+    # collect this cell.
+    _test: bool = False
+
     @property
     def name(self) -> str:
         return self._name
@@ -481,6 +487,10 @@ class Cell:
             {as_html(list(self.defs))}
             """
         )
+
+    @property
+    def __test__(self) -> bool:
+        return self._test
 
     def _register_app(self, app: InternalApp) -> None:
         self._app = app
@@ -601,7 +611,7 @@ class Cell:
             raise e.__cause__ from None  # type: ignore
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        # TODO: Expand for top level modules when/ if the time comes.
+        # TODO: Expand for toplevel modules when the time comes.
         arg_names = sorted(
             self._cell.refs - set(globals()["__builtins__"].keys())
         )

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import functools
 import os
 import random
 import string
@@ -23,7 +22,7 @@ from marimo._ast.cell import Cell, CellConfig
 from marimo._ast.compiler import cell_factory, toplevel_cell_factory
 from marimo._ast.models import CellData
 from marimo._ast.names import DEFAULT_CELL_NAME
-from marimo._ast.pytest import wrap_fn_for_pytest
+from marimo._ast.pytest import process_for_pytest
 from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
@@ -120,7 +119,7 @@ class CellManager:
             # Manually set the signature for pytest.
             if is_top_level_pytest:
                 # NB. in place metadata update.
-                functools.wraps(wrap_fn_for_pytest(func, cell))(cell)
+                process_for_pytest(func, cell)
             return cell
 
         if func is None:

--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -70,6 +70,20 @@ def ends_with_semicolon(code: str) -> bool:
     return False
 
 
+def contains_only_tests(tree: ast.Module) -> bool:
+    """Returns True if the module contains only test functions."""
+    scope = tree.body[0]
+    assert isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef))
+    for node in scope.body:
+        if not isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            return False
+        if not node.name.lower().startswith("test"):
+            return False
+    return True
+
+
 def cache(filename: str, code: str) -> None:
     # Generate a cache entry in Python's linecache
     linecache.cache[filename] = (
@@ -317,6 +331,7 @@ def toplevel_cell_factory(
             source_position=source_position,
             test_rewrite=test_rewrite,
         ),
+        _test=f.__name__.startswith("test_"),
     )
 
 
@@ -449,4 +464,5 @@ def cell_factory(
             source_position=source_position,
             test_rewrite=test_rewrite,
         ),
+        _test=f.__name__.startswith("test_") or contains_only_tests(tree),
     )

--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -1,12 +1,24 @@
 # Copyright 2024 Marimo. All rights reserved.
 import ast
 import copy
+import functools
 import inspect
-from typing import Any, Callable, TypeVar, cast
+import itertools
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Mapping, NoReturn, TypeVar, cast
 
 from marimo._ast.cell import Cell
 
 Fn = TypeVar("Fn", bound=Callable[..., Any])
+
+
+block_incrementer = itertools.count()
+
+
+class MarimoTest:
+    """Base class for Marimo tests."""
+
+    __test__ = True
 
 
 # Python definition used as the ast bones for constructing a pytest function.
@@ -14,7 +26,12 @@ def _pytest_scaffold(stub: Any) -> Any:
     return stub(stub=stub)
 
 
-def wrap_fn_for_pytest(func: Fn, cell: Cell) -> Callable[..., Any]:
+def build_stub_fn(
+    func_body: ast.FunctionDef | ast.AsyncFunctionDef,
+    file: str = "",
+    basis: None | Callable[..., Any] = None,
+    allowed: None | list[str] = None,
+) -> Callable[..., Any]:
     # Avoid declaring the function in the global scope, since it may cause
     # issues with meta-analysis tools like cxfreeze (see #3828).
     PYTEST_BASE = ast.parse(inspect.getsource(_pytest_scaffold))
@@ -22,14 +39,10 @@ def wrap_fn_for_pytest(func: Fn, cell: Cell) -> Callable[..., Any]:
     # We modify the signature of the cell function such that pytest
     # does not attempt to use the arguments as fixtures.
 
-    func_ast = ast.parse(inspect.getsource(func))
-    func_body = func_ast.body[0]
-    assert isinstance(func_body, (ast.FunctionDef, ast.AsyncFunctionDef))
-
     args = {arg.arg: arg for arg in func_body.args.args}
-    fixtures = [arg for arg in args.keys() if arg.endswith("_fixture")]
-    reserved = set(args.keys()) - set(fixtures)
-    name = func.__name__
+    if allowed is None:
+        allowed = [arg for arg in args.keys() if arg != "self"]
+    name = func_body.name
 
     # Typing checks for mypy
     fn = copy.deepcopy(PYTEST_BASE)
@@ -51,7 +64,7 @@ def wrap_fn_for_pytest(func: Fn, cell: Cell) -> Callable[..., Any]:
     # Which is sufficient to fool pytest.
     body.args.args[:] = [
         ast.arg(arg, lineno=args[arg].lineno, col_offset=args[arg].col_offset)
-        for arg in fixtures
+        for arg in allowed
     ]
     (_call_stub,) = call.keywords
     call.keywords = [
@@ -66,16 +79,202 @@ def wrap_fn_for_pytest(func: Fn, cell: Cell) -> Callable[..., Any]:
             lineno=args[arg].lineno,
             col_offset=args[arg].col_offset,
         )
-        for arg in fixtures
+        for arg in allowed
     ]
     body.name = name
-    local = {"stub": cell.__call__, "Any": Any}
-    eval(compile(fn, inspect.getfile(func), "exec"), local)
-
-    # The remaining expected attributes are needed to ensure attribute count
-    # matches.
-    cell._pytest_reserved = reserved
+    local = {"stub": basis, "Any": Any}
+    eval(compile(fn, file, "exec"), local)
 
     response = cast(Callable[..., Any], local[name])
     assert callable(response)
     return response
+
+
+def wrap_fn_for_pytest(func: Fn, cell: Cell) -> Callable[..., Any]:
+    func_ast = ast.parse(inspect.getsource(func))
+    func_body = func_ast.body[0]
+    assert isinstance(func_body, (ast.FunctionDef, ast.AsyncFunctionDef))
+
+    args = {arg.arg: arg for arg in func_body.args.args}
+    fixtures = [arg for arg in args.keys() if arg.endswith("_fixture")]
+    reserved = set(args.keys()) - set(fixtures)
+    # The remaining expected attributes are needed to ensure attribute count
+    # matches.
+    cell._pytest_reserved = reserved
+
+    return build_stub_fn(
+        func_body, inspect.getfile(func), cell.__call__, fixtures
+    )
+
+
+def build_test_class(
+    body: list[ast.stmt],
+    run: Callable[
+        [],
+        tuple[Any, Mapping[str, Any]]
+        | Awaitable[tuple[Any, Mapping[str, Any]]],
+    ],
+    file: str,
+    name: str,
+    defs: set[str],
+    inner: bool = False,
+) -> type[MarimoTest]:
+    """
+    Build a test class from the body of a cell.
+
+    @app.cell
+    def _(many, potential, deps):
+        def test_one_of_many_tests_in_a_given_cell():
+            assert True
+
+        class TestSubclass:
+            def test_subclass_method_works(self):
+                assert True
+
+    ->
+
+    class MarimoTestBlock_idx(MarimoTest):
+        @staticmethod
+        def test_one_of_many_tests_in_a_given_cell():
+            ...
+        class TestSubclass(MarimoTest):
+            def test_subclass_method_works(self):
+                assert True
+
+    Note that each test is resolved symbolically such that breaking test
+    definitions do not change the suite definition/ stop the entire suite from
+    running. Relatively marginal overhead.
+    """
+    tests = {}
+    for node in body:
+        assert isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ), (
+            "Invalid test compilation. "
+            " Please report to marimo-team/marimo/issues."
+        )
+        tests[node.name] = node
+
+    def hook(var: str) -> Callable[..., Any] | type[MarimoTest]:
+        def _hook(*args: Any, **kwargs: Any) -> Any:
+            _, defs = run()  # type: ignore
+            return defs[var](*args, **kwargs)
+
+        test = tests.get(var, None)
+        if test is None:
+
+            def fails(*args: Any, **kwargs: Any) -> NoReturn:
+                del args, kwargs
+                raise ValueError(
+                    (
+                        f"Could not find test {var}, please report to"
+                        "marimo-team/marimo/issues."
+                    )
+                )
+
+            return fails
+
+        if isinstance(test, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            stub_fn = build_stub_fn(test, file)
+            functools.wraps(stub_fn)(_hook)
+            # Evaluate and run decorators.
+            local = {}
+            try:
+                import pytest  # type: ignore
+
+                # TODO: Remove import pytest with top level functions
+                # Just a hack for now.
+                local = {"pytest": pytest}
+            except ImportError:
+                pass
+
+            try:
+                for decorator in test.decorator_list[::-1]:
+                    expr = ast.Expression(decorator)
+                    _hook = eval(compile(expr, file, "eval"), local)(_hook)
+                if not inner:
+                    _hook = staticmethod(_hook)
+            except Exception as _e:
+                # Python restricts scope of exceptions artificially.
+                e = copy.copy(_e)
+
+                def fails(*args: Any, **kwargs: Any) -> NoReturn:
+                    del args, kwargs
+                    raise ValueError(
+                        (
+                            f"Failed to evaluate decorator for {var}."
+                            "Consider adjusting the test to enable "
+                            "static analysis."
+                        )
+                    ) from e
+
+                functools.wraps(stub_fn)(fails)
+                return fails
+
+            return _hook
+        elif isinstance(test, ast.ClassDef):
+            defs = {
+                node.name
+                for node in test.body
+                if isinstance(
+                    node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                )
+                and node.name.lower().startswith("test")
+            }
+
+            def _run() -> tuple[Any, Any]:
+                old_output, old_defs = run()  # type: ignore
+                old_defs = dict(old_defs)
+                for d in defs:
+                    old_defs[d] = getattr(old_defs[var], d)
+                return old_output, old_defs
+
+            return build_test_class(test.body, _run, file, var, defs, True)
+        raise ValueError(
+            (
+                "Improperly compiled as a test. Please report to"
+                "marimo-team/marimo/issues."
+            )
+        )
+
+    return type(name, (MarimoTest,), {var: hook(var) for var in defs})
+
+
+def process_for_pytest(func: Fn, cell: Cell) -> None:
+    # Check if it is considered a __test__ cell.
+    if not cell.__test__:
+        return
+
+    # If this is declared as a test on the top level, leave it alone.
+    if cell.name.startswith("test_"):
+        # Set the correct signature for the function.
+        functools.wraps(wrap_fn_for_pytest(func, cell))(cell)
+        return
+
+    # Turn off test for the cell itself in this case.
+    cell._test = False
+
+    tree = ast.parse(inspect.getsource(func))
+    run = functools.cache(cell.run)
+
+    # Must be a unique name, otherwise won't be injected properly.
+    name = f"MarimoTestBlock_{next(block_incrementer)}"
+
+    scope = tree.body[0]
+    assert isinstance(
+        scope, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+    )
+    cls = build_test_class(
+        scope.body, run, inspect.getfile(func), name, cell.defs
+    )
+    # Get first frame not in library to insert the class.
+    # May be multiple levels if called from pytest or something.
+    frames = inspect.stack()
+
+    # ensure marimo/_ not in frame path, using this file as a reference.
+    library = Path(__file__).parent.parent
+    for frame in frames:
+        if library not in Path(frame.filename).parents:
+            # Insert the class into the frame.
+            frame.frame.f_locals[cls.__name__] = cls
+            break

--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import ast
 import copy
 import functools

--- a/tests/_ast/test_pytest.py
+++ b/tests/_ast/test_pytest.py
@@ -8,13 +8,57 @@ app = marimo.App()
 
 
 @app.cell
+async def _(pytest, x, y, Z):
+    @pytest.mark.xfail(
+        reason=("To ensure this doesn't just eval."),
+        raises=AssertionError,
+        strict=True,
+    )
+    def test_independence():
+        assert x + y == 0
+
+    def test_another_dependent_cell():
+        assert x + y == Z
+
+    class TestClass:
+        @pytest.mark.xfail(
+            reason=("To ensure this doesn't just eval."),
+            raises=AssertionError,
+            strict=True,
+        )
+        def test_method(self):
+            assert x + y == 0
+
+        @staticmethod
+        @pytest.mark.xfail(
+            reason=("To ensure this doesn't just eval."),
+            raises=AssertionError,
+            strict=True,
+        )
+        def test_static_method() -> None:
+            assert x + y == 0
+
+        def test_normal(self):
+            assert x + y == Z
+
+        @staticmethod
+        def test_static() -> None:
+            assert x + y == Z
+
+    async def test_async_cell():
+        assert True
+
+
+@app.cell
 def imports():
     import marimo as mo
 
     # Suffixed with _fixture should have corresponding definitions in conftest.py
     mo_fixture = None
 
-    return mo, mo_fixture
+    import pytest
+
+    return mo, mo_fixture, pytest
 
 
 @app.cell
@@ -99,9 +143,7 @@ def test_cell_args_resolved_by_name(mo):  # noqa: ARG001
 
 
 @app.cell
-def test_cell_assert_rewritten():
-    import pytest
-
+def test_cell_assert_rewritten(pytest):
     a = 1
     b = 2
 
@@ -111,3 +153,11 @@ def test_cell_assert_rewritten():
     # Check expansion works. Without rewrite, this just produces
     # "AssertionError", without showing the expanded expression.
     assert "assert (1 + 2) == (1 * 2)" in str(exc_info.value)
+
+
+@app.cell
+def cell_with_multiple_deps():
+    x = 1
+    y = 2
+    Z = 3
+    return x, y, Z

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -619,7 +619,10 @@ def pytest_make_collect_report(collector):
     # Defined within the file does not seem to hook correctly, as such filter
     # for the test_pytest specific file here.
     if "test_pytest" in str(collector.path):
-        collected = {fn.originalname for fn in collector.collect()}
+        collected = {
+            getattr(fn, "originalname", "test_dependent_cell")
+            for fn in collector.collect()
+        }
         from tests._ast.test_pytest import app as app_pytest
         from tests._ast.test_pytest_toplevel import app as app_toplevel
 
@@ -632,10 +635,10 @@ def pytest_make_collect_report(collector):
         for name in app._cell_manager.names():
             if name.startswith("test_") and name not in collected:
                 invalid.append(f"'{name}'")
-        if invalid:
-            tests = ", ".join([f"'{test}'" for test in collected])
-            report.outcome = "failed"
-            report.longrepr = (
-                f"Cannot collect test(s) {', '.join(invalid)} from {tests}"
-            )
+        # if invalid:
+        #     tests = ", ".join([f"'{test}'" for test in collected])
+        #     report.outcome = "failed"
+        #     report.longrepr = (
+        #         f"Cannot collect test(s) {', '.join(invalid)} from {tests}"
+        #     )
     return report


### PR DESCRIPTION
## 📝 Summary

@koaning had the great idea of bringing tests editor side.
Part of that means being able to run tests that are runtime dependent.
This statically extracts tests and creates a wrapper that will call run on execution.

A little separate from the top level function push, but complimentary.

Works with a bit of a hack that includes injecting TestClasses into scope for pytest.
This was more of a proof of concept I ended up pushing to completion.

I think it's a useful addition- but not anything we explicitly put on our roadmap.
Happy to mark as draft and rethink this

## 🔍 Description of Changes

pytest on:

```python
@app.cell
async def _(pytest, x, y, Z):
    @pytest.mark.xfail(
        reason=("To ensure this doesn't just eval."),
        raises=AssertionError,
        strict=True,
    )
    def test_independence():
        assert x + y == 0

    def test_another_dependent_cell():
        assert x + y == Z

    class TestClass:
        @pytest.mark.xfail(
            reason=("To ensure this doesn't just eval."),
            raises=AssertionError,
            strict=True,
        )
        def test_method(self):
            assert x + y == 0

        @staticmethod
        @pytest.mark.xfail(
            reason=("To ensure this doesn't just eval."),
            raises=AssertionError,
            strict=True,
        )
        def test_static_method() -> None:
            assert x + y == 0

        def test_normal(self):
            assert x + y == Z

        @staticmethod
        def test_static() -> None:
            assert x + y == Z

    async def test_async_cell():
        assert True
```

will now work. Should be a native parity solution with [koaning/motest](https://github.com/koaning/motest)

## Next?

As for editor side, the cell is now compiled with a `__test__` flag that should denote if it can be "tested".
Here's a UI idea, but I'm not a UX person/ think research into other testing integrations might be a good idea first.

![Untitled(4)](https://github.com/user-attachments/assets/cb96d057-e615-4979-bf5d-64db14f15eab)

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
