### PR TITLE
fix: don't show data-types for dict/list tables (again)

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -485,6 +485,7 @@ const DataTableComponent = ({
   const memoizedFieldTypes = useDeepCompareMemoize(fieldTypesOrInferred);
   const memoizedTextJustifyColumns = useDeepCompareMemoize(textJustifyColumns);
   const memoizedWrappedColumns = useDeepCompareMemoize(wrappedColumns);
+  const showDataTypes = Boolean(fieldTypes);
   const columns = useMemo(
     () =>
       generateColumns({
@@ -494,10 +495,11 @@ const DataTableComponent = ({
         textJustifyColumns: memoizedTextJustifyColumns,
         wrappedColumns: memoizedWrappedColumns,
         // Only show data types if they are explicitly set
-        showDataTypes: Boolean(memoizedFieldTypes),
+        showDataTypes: showDataTypes,
       }),
     [
       selection,
+      showDataTypes,
       memoizedRowHeaders,
       memoizedFieldTypes,
       memoizedTextJustifyColumns,


### PR DESCRIPTION
Fixes #3893