### PR TITLE
improvement: bring back SQL schema completion and AI '@' reference for datasources

### DIFF
--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -358,7 +358,7 @@ const AddCellButtons: React.FC<{
             onClick={isAiButtonOpenActions.toggle}
           >
             <SparklesIcon className="mr-2 size-4 flex-shrink-0" />
-            Generate with AI!!!
+            Generate with AI
           </Button>
         </Tooltip>
       </>

--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -1,6 +1,14 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { expect, describe, it, beforeAll, afterAll, afterEach } from "vitest";
-import { SQLLanguageAdapter } from "../sql";
+import {
+  expect,
+  describe,
+  it,
+  beforeAll,
+  afterAll,
+  afterEach,
+  beforeEach,
+} from "vitest";
+import { SQLCompletionStore, SQLLanguageAdapter } from "../sql";
 import { store } from "@/core/state/jotai";
 import { capabilitiesAtom } from "@/core/config/capabilities";
 import {
@@ -8,6 +16,8 @@ import {
   DEFAULT_ENGINE,
   type ConnectionName,
 } from "@/core/datasets/data-source-connections";
+import type { DataSourceConnection } from "@/core/kernel/messages";
+import { PostgreSQL } from "@codemirror/lang-sql";
 
 const adapter = new SQLLanguageAdapter();
 
@@ -568,5 +578,287 @@ _df = mo.sql(
         `_df = mo.sql(f"""SELECT * FROM """)`,
       );
     });
+  });
+});
+
+describe("tablesCompletionSource", () => {
+  const mockStore = store;
+  const completionStore = new SQLCompletionStore();
+
+  beforeEach(() => {
+    // Reset the adapter engine
+    adapter.engine = DEFAULT_ENGINE;
+  });
+
+  it("should return null if connection not found", () => {
+    mockStore.set(dataSourceConnectionsAtom, {
+      connectionsMap: new Map(),
+      latestEngineSelected: DEFAULT_ENGINE,
+    });
+
+    const completionSource = completionStore.getCompletionSource(
+      "test_engine" as ConnectionName,
+    );
+    expect(completionSource).toBe(null);
+  });
+
+  it("should create schema with database.schema.table structure and short table names", () => {
+    const mockConnection: DataSourceConnection = {
+      name: "test_engine",
+      dialect: "duckdb",
+      display_name: "duckdb",
+      source: "duckdb",
+      databases: [
+        {
+          dialect: "duckdb",
+          name: "test_db",
+          schemas: [
+            {
+              name: "public",
+              tables: [
+                {
+                  name: "users",
+                  source: "duckdb",
+                  source_type: "local",
+                  type: "table",
+                  columns: [
+                    {
+                      name: "id",
+                      external_type: "string",
+                      type: "string",
+                      sample_values: [],
+                    },
+                    {
+                      name: "name",
+                      external_type: "string",
+                      type: "string",
+                      sample_values: [],
+                    },
+                    {
+                      name: "email",
+                      external_type: "string",
+                      type: "string",
+                      sample_values: [],
+                    },
+                  ],
+                },
+                {
+                  name: "orders",
+                  source: "duckdb",
+                  source_type: "local",
+                  type: "table",
+                  columns: [
+                    {
+                      name: "order_id",
+                      external_type: "string",
+                      type: "string",
+                      sample_values: [],
+                    },
+                    {
+                      name: "user_id",
+                      external_type: "string",
+                      type: "string",
+                      sample_values: [],
+                    },
+                    {
+                      name: "total",
+                      external_type: "number",
+                      type: "number",
+                      sample_values: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    mockStore.set(dataSourceConnectionsAtom, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connectionsMap: new Map([
+        ["test_engine" as ConnectionName, mockConnection],
+      ]) as any,
+      latestEngineSelected: "test_engine" as ConnectionName,
+    });
+
+    adapter.engine = "test_engine" as ConnectionName;
+    const completionSource = completionStore.getCompletionSource(
+      "test_engine" as ConnectionName,
+    );
+    expect(completionSource?.defaultTable).toBeUndefined();
+    expect(completionSource?.dialect).toBe(undefined);
+    expect(completionSource?.schema).toMatchInlineSnapshot(`
+      {
+        "orders": [
+          "order_id",
+          "user_id",
+          "total",
+        ],
+        "test_db": {
+          "public": {
+            "orders": [
+              "order_id",
+              "user_id",
+              "total",
+            ],
+            "users": [
+              "id",
+              "name",
+              "email",
+            ],
+          },
+        },
+        "users": [
+          "id",
+          "name",
+          "email",
+        ],
+      }
+    `);
+  });
+
+  it("should handle multiple databases and schemas", () => {
+    const mockConnection: DataSourceConnection = {
+      name: "multi_db_engine",
+      dialect: "postgres",
+      display_name: "postgres",
+      source: "postgres",
+      databases: [
+        {
+          name: "db1",
+          dialect: "postgres",
+          schemas: [
+            {
+              name: "schema1",
+              tables: [
+                {
+                  name: "table1",
+                  source: "postgres",
+                  source_type: "local",
+                  type: "table",
+                  columns: [
+                    {
+                      name: "col1",
+                      external_type: "string",
+                      type: "string",
+                      sample_values: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "db2",
+          dialect: "postgres",
+          schemas: [
+            {
+              name: "schema2",
+              tables: [
+                {
+                  name: "table2",
+                  source: "postgres",
+                  source_type: "local",
+                  type: "table",
+                  columns: [
+                    {
+                      name: "col2",
+                      external_type: "string",
+                      type: "string",
+                      sample_values: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    mockStore.set(dataSourceConnectionsAtom, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connectionsMap: new Map([
+        [mockConnection.name as ConnectionName, mockConnection],
+      ]) as any,
+      latestEngineSelected: mockConnection.name as ConnectionName,
+    });
+
+    adapter.engine = "multi_db_engine" as ConnectionName;
+    const completionSource = completionStore.getCompletionSource(
+      "multi_db_engine" as ConnectionName,
+    );
+    expect(completionSource?.schema).toMatchInlineSnapshot(`
+      {
+        "db1": {
+          "schema1": {
+            "table1": [
+              "col1",
+            ],
+          },
+        },
+        "db2": {
+          "schema2": {
+            "table2": [
+              "col2",
+            ],
+          },
+        },
+        "table1": [
+          "col1",
+        ],
+        "table2": [
+          "col2",
+        ],
+      }
+    `);
+    expect(completionSource?.defaultTable).toBeUndefined();
+  });
+
+  it("should create a default table if there is only one table", () => {
+    const mockConnection: DataSourceConnection = {
+      name: "test_engine",
+      dialect: "postgres",
+      display_name: "postgres",
+      source: "postgres",
+      databases: [
+        {
+          name: "test_db",
+          dialect: "postgres",
+          schemas: [
+            {
+              name: "public",
+              tables: [
+                {
+                  name: "users",
+                  source: "postgres",
+                  source_type: "local",
+                  type: "table",
+                  columns: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    mockStore.set(dataSourceConnectionsAtom, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      connectionsMap: new Map([
+        [mockConnection.name as ConnectionName, mockConnection],
+      ]) as any,
+      latestEngineSelected: mockConnection.name as ConnectionName,
+    });
+
+    adapter.engine = "test_engine" as ConnectionName;
+    const completionSource = completionStore.getCompletionSource(
+      "test_engine" as ConnectionName,
+    );
+    expect(completionSource?.defaultTable).toBe("users");
+    expect(completionSource?.dialect).toBe(PostgreSQL);
   });
 });

--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -676,9 +676,9 @@ describe("tablesCompletionSource", () => {
     };
 
     mockStore.set(dataSourceConnectionsAtom, {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       connectionsMap: new Map([
         ["test_engine" as ConnectionName, mockConnection],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any,
       latestEngineSelected: "test_engine" as ConnectionName,
     });
@@ -780,9 +780,9 @@ describe("tablesCompletionSource", () => {
     };
 
     mockStore.set(dataSourceConnectionsAtom, {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       connectionsMap: new Map([
         [mockConnection.name as ConnectionName, mockConnection],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any,
       latestEngineSelected: mockConnection.name as ConnectionName,
     });
@@ -847,9 +847,9 @@ describe("tablesCompletionSource", () => {
     };
 
     mockStore.set(dataSourceConnectionsAtom, {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       connectionsMap: new Map([
         [mockConnection.name as ConnectionName, mockConnection],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ]) as any,
       latestEngineSelected: mockConnection.name as ConnectionName,
     });

--- a/frontend/src/utils/__tests__/lru.test.ts
+++ b/frontend/src/utils/__tests__/lru.test.ts
@@ -1,0 +1,74 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, test, expect } from "vitest";
+import { LRUCache } from "../lru";
+
+describe("LRUCache", () => {
+  test("basic get/set operations", () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("b")).toBe(2);
+    expect(cache.get("c")).toBe(3);
+  });
+
+  test("evicts least recently used item when over capacity", () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    cache.set("d", 4);
+
+    // "a" should be evicted as it was the least recently used
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe(2);
+    expect(cache.get("c")).toBe(3);
+    expect(cache.get("d")).toBe(4);
+  });
+
+  test("accessing an item makes it most recently used", () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    // Access "a", making it most recently used
+    cache.get("a");
+    cache.set("d", 4);
+
+    // "b" should be evicted as it becomes the least recently used
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("c")).toBe(3);
+    expect(cache.get("d")).toBe(4);
+  });
+
+  test("updating existing key maintains order", () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    // Update "a"
+    cache.set("a", 10);
+    cache.set("d", 4);
+
+    // "b" should be evicted as "a" was moved to most recent
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("a")).toBe(10);
+    expect(cache.get("c")).toBe(3);
+    expect(cache.get("d")).toBe(4);
+  });
+
+  test("keys() returns iterator in order", () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    const keys = [...cache.keys()];
+    expect(keys).toEqual(["a", "b", "c"]);
+  });
+});

--- a/frontend/src/utils/lru.ts
+++ b/frontend/src/utils/lru.ts
@@ -1,0 +1,40 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+export class LRUCache<K, V> {
+  private maxSize: number;
+  private cache = new Map<K, V>();
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  public get(key: K) {
+    const item = this.cache.get(key);
+    if (item !== undefined) {
+      // re-insert for LRU effect
+      this.cache.delete(key);
+      this.cache.set(key, item);
+    }
+    return item;
+  }
+
+  public set(key: K, value: V) {
+    // if key already in cache, remove it so we move it to the "fresh" position
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    }
+    this.cache.set(key, value);
+
+    // evict oldest
+    if (this.cache.size > this.maxSize) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.cache.delete(oldestKey);
+      }
+    }
+  }
+
+  public keys() {
+    return this.cache.keys();
+  }
+}


### PR DESCRIPTION
This brings the new datasources schemas to SQL completion in the SQL cells as well as `@` referencing them in the AI inputs

Couple todos, for later:
- [ ] We bring all table names to the top of the schema (so we don't need reference them by their fully qualified name), but we should only do this for the default db/schema
- [ ] AI completion does not handle duplicate table names (i.e. same table name from different DBs) correctly and will only pick the first one