### PR TITLE
fix: anywidget emit on any change (without a key)

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/hooks/useEventListener";
 import { MarimoIncomingMessageEvent } from "@/core/dom/events";
 import { updateBufferPaths } from "@/utils/data-views";
+import { debounce } from "lodash-es";
 
 interface Data {
   jsUrl: string;
@@ -325,9 +326,10 @@ export class Model<T extends Record<string, any>> implements AnyModel<T> {
     this.listeners[event].forEach((cb) => cb(value));
   }
 
-  private emitAnyChange() {
+  // Debounce 0 to send off one request in a single frame
+  private emitAnyChange = debounce(() => {
     this.listeners[this.ANY_CHANGE_EVENT]?.forEach((cb) => cb());
-  }
+  }, 0);
 }
 
 const WidgetMessageSchema = z.union([

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -65,6 +65,8 @@ const AnyWidgetSlot = (props: Props) => {
     // Re-render on jsHash change instead of url change (since URLs may change)
   }, [jsHash]);
 
+  console.warn("[debug] module value", props.value);
+
   const valueWithBuffer = useMemo(() => {
     return updateBufferPaths(props.value, bufferPaths);
   }, [props.value, bufferPaths]);
@@ -204,6 +206,8 @@ const LoadedSlot = ({
 };
 
 export class Model<T extends Record<string, any>> implements AnyModel<T> {
+  private ANY_CHANGE_EVENT = "change";
+
   constructor(
     private data: T,
     private onChange: (value: Partial<T>) => void,
@@ -261,6 +265,7 @@ export class Model<T extends Record<string, any>> implements AnyModel<T> {
     this.data = { ...this.data, [key]: value };
     this.dirtyFields.add(key);
     this.emit(`change:${key as K & string}`, value);
+    this.emitAnyChange();
   }
 
   save_changes(): void {
@@ -320,6 +325,10 @@ export class Model<T extends Record<string, any>> implements AnyModel<T> {
       return;
     }
     this.listeners[event].forEach((cb) => cb(value));
+  }
+
+  private emitAnyChange() {
+    this.listeners[this.ANY_CHANGE_EVENT]?.forEach((cb) => cb());
   }
 }
 

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -65,8 +65,6 @@ const AnyWidgetSlot = (props: Props) => {
     // Re-render on jsHash change instead of url change (since URLs may change)
   }, [jsHash]);
 
-  console.warn("[debug] module value", props.value);
-
   const valueWithBuffer = useMemo(() => {
     return updateBufferPaths(props.value, bufferPaths);
   }, [props.value, bufferPaths]);

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.ts
@@ -155,13 +155,14 @@ describe("Model", () => {
       modelWithObject.on("change:foo", callback);
 
       modelWithObject.updateAndEmitDiffs({ foo: { nested: "changed" } });
-      expect(callback).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    it("should emit change event for any changes", () => {
+    it("should emit change event for any changes", async () => {
       const callback = vi.fn();
       model.on("change", callback);
       model.updateAndEmitDiffs({ foo: "changed", bar: 456 });
+      await new Promise((resolve) => setTimeout(resolve, 0)); // flush
       expect(callback).toHaveBeenCalledTimes(1);
     });
   });
@@ -213,7 +214,7 @@ describe("Model", () => {
       });
       model.receiveCustomMessage({ invalid: "message" });
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.ts
@@ -157,6 +157,13 @@ describe("Model", () => {
       modelWithObject.updateAndEmitDiffs({ foo: { nested: "changed" } });
       expect(callback).toHaveBeenCalled();
     });
+
+    it("should emit change event for any changes", () => {
+      const callback = vi.fn();
+      model.on("change", callback);
+      model.updateAndEmitDiffs({ foo: "changed", bar: 456 });
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("receiveCustomMessage", () => {


### PR DESCRIPTION
Fixes #3888

Support this usage: https://github.com/habemus-papadum/anydiff/blob/main/src/anydiff/index.js#L60

cc @manzt, is this correct. I didn't see any where in the docs or typings that `on("change")` without a key should be a thing. but apparently this works in Jupyter (maybe for the wrong reason)

cc @habemus-papadum