### PR TITLE
improvement: Support Format for more `Bokeh` objects

### DIFF
--- a/marimo/_output/formatters/bokeh_formatters.py
+++ b/marimo/_output/formatters/bokeh_formatters.py
@@ -54,9 +54,10 @@ class BokehFormatter(FormatterFactory):
             bokeh.plotting.show = old_show
             bokeh.plotting.output_notebook = old_output_notebook
 
-        @formatting.formatter(bokeh.models.Plot)
+        @formatting.formatter(bokeh.models.Model)
+        @formatting.formatter(bokeh.document.Document)
         def _show_plot(
-            plot: bokeh.models.Plot,
+            plot: bokeh.models.Model | bokeh.document.Document,
         ) -> tuple[KnownMimeType, str]:
             import bokeh.embed  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
             import bokeh.resources  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501


### PR DESCRIPTION
## 📝 Summary

FIX:  marimo don't render GirdPlot as it isn't subclass of Plot
<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

Relax the input type of the formatter from `bokeh.models.Plot` to `bokeh.models.Model|bokeh.document.Document`, according to `bokeh.embed.file_html(models: Model | Document | Sequence[Model])`
<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
