### PR TITLE
fix: don't compile code with annotations future flag

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -147,6 +147,8 @@ def compile_cell(
         code,
         "<unknown>",
         mode="exec",
+        # don't inherit compiler flags, in particular future annotations
+        dont_inherit=True,
         flags=ast.PyCF_ONLY_AST | ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
     )
     if not module.body:
@@ -221,8 +223,12 @@ def compile_cell(
             )
 
     flags = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
-    body = compile(module, filename, mode="exec", flags=flags)
-    last_expr = compile(expr, filename, mode="eval", flags=flags)
+    body = compile(
+        module, filename, mode="exec", dont_inherit=True, flags=flags
+    )
+    last_expr = compile(
+        expr, filename, mode="eval", dont_inherit=True, flags=flags
+    )
 
     nonlocals = {name for name in v.defs if not is_local(name)}
     temporaries = v.defs - nonlocals

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -71,6 +71,14 @@ class TestParseCell:
         assert not cell.imported_namespaces
 
 
+class TestCompilerFlags:
+    @staticmethod
+    def test_top_level_await_ok() -> None:
+        code = "await foo()"
+        cell = compile_cell(code)
+        assert cell.refs == {"foo"}
+
+
 class TestImportWorkspace:
     @staticmethod
     def test_import() -> None:

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -2810,6 +2810,25 @@ def test_notebook_dir_in_non_notebook_mode() -> None:
     assert notebook_location() == pathlib.Path().absolute()
 
 
+async def test_future_annotations_not_inherited(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    await k.run(
+        [
+            exec_req.get(
+                """
+        class A: pass
+        def foo() -> A:
+            ...
+        anno = foo.__annotations__
+        """
+            )
+        ]
+    )
+    assert not k.errors
+    assert k.globals["A"] == k.globals["anno"]["return"]
+
+
 def _parse_error_output(cell_op: CellOp) -> list[Error]:
     error_output = cell_op.output
     assert error_output is not None


### PR DESCRIPTION
This changes our compiler to not inherit the main program's compiler flags; in particular this means that user code is not compiled with deferred/stringified annotations (`__future__.annotations`).

This is technically a breaking change, but it better matches user code.

Note that it is not currently possible to save a notebook file with `from __future__ import annotations`, since Python requires future imports to be at the top of the file. If people want deferred annotations we can make it configurable.

Fixes #3915, #3312