### PR TITLE
fix: cell staleness when autorun on startup is off

### DIFF
--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -362,13 +362,16 @@ class CellImpl:
     ) -> None:
         self._run_result_status.state = run_result_status
 
-    def set_stale(self, stale: bool, stream: Stream | None = None) -> None:
+    def set_stale(
+        self, stale: bool, stream: Stream | None = None, broadcast: bool = True
+    ) -> None:
         from marimo._messaging.ops import CellOp
 
         self._stale.state = stale
-        CellOp.broadcast_stale(
-            cell_id=self.cell_id, stale=stale, stream=stream
-        )
+        if broadcast:
+            CellOp.broadcast_stale(
+                cell_id=self.cell_id, stale=stale, stream=stream
+            )
 
     def set_output(self, output: Any) -> None:
         self._output.output = output

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -101,7 +101,7 @@ class AppKernelRunner:
         # Register cells through the kernel runner, so that compilation only
         # occurs once.
         for cell_id, cell in app.cell_manager.valid_cells():
-            self._kernel._register_cell(cell_id, cell._cell)
+            self._kernel._register_cell(cell_id, cell._cell, stale=False)
 
     @property
     def outputs(self) -> dict[CellId_t, Any]:

--- a/marimo/_runtime/runner/hooks_preparation.py
+++ b/marimo/_runtime/runner/hooks_preparation.py
@@ -30,8 +30,7 @@ def _update_stale_statuses(runner: cell_runner.Runner) -> None:
         else:
             graph.cells[cid].set_runtime_state(status="queued")
             if graph.cells[cid].stale:
-                if runner.execution_mode == "autorun":
-                    graph.cells[cid].set_stale(stale=False)
+                graph.cells[cid].set_stale(stale=False)
 
 
 PREPARATION_HOOKS: list[PreparationHookType] = [_update_stale_statuses]

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -717,7 +717,12 @@ class Kernel:
                         reload=False,
                     )
 
-    def _register_cell(self, cell_id: CellId_t, cell: CellImpl) -> None:
+    def _register_cell(
+        self,
+        cell_id: CellId_t,
+        cell: CellImpl,
+        stale: bool,
+    ) -> None:
         if cell_id in self.cell_metadata:
             # If we already have a config for this cell id, restore it
             # This can happen when a cell was previously deactivated (due to a
@@ -728,6 +733,8 @@ class Kernel:
             self.cell_metadata[cell_id] = CellMetadata()
 
         self.graph.register_cell(cell_id, cell)
+        if stale:
+            self.graph.cells[cell_id].set_stale(stale=True, broadcast=False)
         # leaky abstraction: the graph doesn't know about stale modules, so
         # we have to check for them here.
         module_reloader = self.module_reloader
@@ -768,7 +775,11 @@ class Kernel:
         return cell, error
 
     def _try_registering_cell(
-        self, cell_id: CellId_t, code: str, carried_imports: list[ImportData]
+        self,
+        cell_id: CellId_t,
+        code: str,
+        carried_imports: list[ImportData],
+        stale: bool,
     ) -> Optional[Error]:
         """Attempt to register a cell with given id and code.
 
@@ -780,12 +791,12 @@ class Kernel:
         cell, error = self._try_compiling_cell(cell_id, code, carried_imports)
 
         if cell is not None:
-            self._register_cell(cell_id, cell)
+            self._register_cell(cell_id, cell, stale)
 
         return error
 
     def _maybe_register_cell(
-        self, cell_id: CellId_t, code: str
+        self, cell_id: CellId_t, code: str, stale: bool
     ) -> tuple[set[CellId_t], Optional[Error]]:
         """Register a cell (given by id, code) if not already registered.
 
@@ -827,7 +838,7 @@ class Kernel:
                 previous_children = self._deactivate_cell(cell_id)
 
             error = self._try_registering_cell(
-                cell_id, code, carried_imports=carried_imports
+                cell_id, code, carried_imports=carried_imports, stale=stale
             )
             if error is not None and previous_cell is not None:
                 # The frontend keeps the cell around in the case of a
@@ -1017,6 +1028,7 @@ class Kernel:
         self,
         execution_requests: Sequence[ExecutionRequest],
         deletion_requests: Sequence[DeleteCellRequest],
+        cells_starting_stale: set[CellId_t] | None = None,
     ) -> set[CellId_t]:
         """Add and remove cells to/from the graph.
 
@@ -1042,6 +1054,9 @@ class Kernel:
         cells_with_errors_before_mutation = set(self.errors.keys())
         edges_before = deepcopy(self.graph.children)
         definitions_before = set(self.graph.definitions.keys())
+        cells_starting_stale = (
+            set() if cells_starting_stale is None else cells_starting_stale
+        )
 
         # The set of cells that were successfully registered
         registered_cell_ids: set[CellId_t] = set()
@@ -1056,7 +1071,7 @@ class Kernel:
         # Register and delete cells
         for er in execution_requests:
             old_children, error = self._maybe_register_cell(
-                er.cell_id, er.code
+                er.cell_id, er.code, stale=er.cell_id in cells_starting_stale
             )
             cells_that_were_children_of_mutated_cells |= old_children
             if error is None:
@@ -1428,12 +1443,16 @@ class Kernel:
                 er.cell_id for er in execution_requests
             }
             graph = dataflow.DirectedGraph()
+            # cells in execution_requests that should be initially marked as
+            # stale:
+            cells_starting_stale: set[CellId_t] = set()
             for cid, er in list(
                 self._uninstantiated_execution_requests.items()
             ):
                 if cid in execution_requests_cell_ids:
                     # Running a previously uninstantiated cell; just remove
                     # it from our cache of uninstantiated execution requests.
+                    cells_starting_stale.add(cid)
                     del self._uninstantiated_execution_requests[cid]
                     continue
 
@@ -1461,6 +1480,7 @@ class Kernel:
                     previously_uninstantiated_requests.append(
                         self._uninstantiated_execution_requests[ancestor_cid]
                     )
+                    cells_starting_stale.add(ancestor_cid)
                     del self._uninstantiated_execution_requests[ancestor_cid]
 
             await self._run_cells(
@@ -1468,6 +1488,7 @@ class Kernel:
                     list(execution_requests)
                     + previously_uninstantiated_requests,
                     deletion_requests=[],
+                    cells_starting_stale=cells_starting_stale,
                 )
             )
 
@@ -1561,6 +1582,7 @@ class Kernel:
             self.mutate_graph(
                 list(self._uninstantiated_execution_requests.values()),
                 deletion_requests=[],
+                cells_starting_stale=cells_to_run,
             )
             self._uninstantiated_execution_requests = {}
 

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -458,7 +458,9 @@ async def test_reload_with_modified_cell(
     assert not k.graph.cells[er_3.cell_id].stale
 
     # modify the first cell and make sure it is still marked as stale;
-    k._maybe_register_cell(er_1.cell_id, f"from {py_modname} import foo; 1")
+    k._maybe_register_cell(
+        er_1.cell_id, f"from {py_modname} import foo; 1", stale=False
+    )
     assert er_1.cell_id in k.graph.get_stale()
 
 

--- a/tests/_runtime/test_manage_script_metadata.py
+++ b/tests/_runtime/test_manage_script_metadata.py
@@ -54,7 +54,7 @@ async def test_manage_script_metadata_uv(
         )
     )
     # Add marimo, skip os
-    k._maybe_register_cell("0", "import marimo as mo\nimport os")
+    k._maybe_register_cell("0", "import marimo as mo\nimport os", stale=False)
 
     with open(filename) as f:  # noqa: ASYNC230
         contents = f.read()
@@ -63,7 +63,7 @@ async def test_manage_script_metadata_uv(
         assert '"os",' not in contents
 
     # Add markdown
-    k._maybe_register_cell("1", "import markdown")
+    k._maybe_register_cell("1", "import markdown", stale=False)
 
     with open(filename) as f:  # noqa: ASYNC230
         contents = f.read()
@@ -72,7 +72,7 @@ async def test_manage_script_metadata_uv(
         assert '"markdown==' in contents
 
     # Remove marimo, it's still in requirements
-    k._maybe_register_cell("0", "import os")
+    k._maybe_register_cell("0", "import os", stale=False)
 
     with open(filename) as f:  # noqa: ASYNC230
         contents = f.read()
@@ -104,7 +104,7 @@ async def test_manage_script_metadata_uv_deletion(
     )
 
     # Add marimo, skip os
-    k._maybe_register_cell("0", "import marimo as mo\nimport os")
+    k._maybe_register_cell("0", "import marimo as mo\nimport os", stale=False)
 
     with open(filename) as f:  # noqa: ASYNC230
         contents = f.read()
@@ -112,7 +112,7 @@ async def test_manage_script_metadata_uv_deletion(
         assert '"os",' not in contents
 
     # Add markdown
-    k._maybe_register_cell("1", "import markdown")
+    k._maybe_register_cell("1", "import markdown", stale=False)
 
     with open(filename) as f:  # noqa: ASYNC230
         contents = f.read()
@@ -162,7 +162,7 @@ async def test_manage_script_metadata_uv_off(
     )
 
     # Add
-    k._maybe_register_cell("0", "import marimo as mo\nimport os")
+    k._maybe_register_cell("0", "import marimo as mo\nimport os", stale=False)
 
     with open(filename) as f:  # noqa: ASYNC230
         assert "" == f.read()
@@ -190,7 +190,7 @@ async def test_manage_script_metadata_uv_no_filename(
     )
 
     # Add
-    k._maybe_register_cell("0", "import marimo as mo\nimport os")
+    k._maybe_register_cell("0", "import marimo as mo\nimport os", stale=False)
 
     with open(filename) as f:  # noqa: ASYNC230
         assert "" == f.read()
@@ -218,7 +218,7 @@ async def test_manage_script_metadata_pip_noop(
     )
 
     # Add
-    k._maybe_register_cell("0", "import marimo as mo\nimport os")
+    k._maybe_register_cell("0", "import marimo as mo\nimport os", stale=False)
 
     with open(filename) as f:  # noqa: ASYNC230
         assert "" == f.read()


### PR DESCRIPTION
Fixes #3438

Previously, when autorun on startup was disabled, running a cell wouldn't transition it out of stale. For long-running cells, this would give the incorrect impression to the user that their cell had not been submitted for execution.

This change updates the kernel to register uninstantiated cells as stale, so they are correctly transitioned out of stale on run.