### PR TITLE
improve: error messages for import *, multiple definition

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 6.8.4
       '@codemirror/search':
         specifier: ^6.5.8
-        version: 6.5.9
+        version: 6.5.10
       '@codemirror/state':
         specifier: ^6.5.2
         version: 6.5.2
@@ -191,7 +191,7 @@ importers:
         version: 3.19.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@replit/codemirror-vim':
         specifier: ^6.2.1
-        version: 6.2.1(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)
+        version: 6.2.1(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.17)
@@ -221,7 +221,7 @@ importers:
         version: 4.23.8(@codemirror/autocomplete@6.18.6)(@codemirror/language-data@6.5.1)(@codemirror/language@6.10.8)(@codemirror/legacy-modes@6.4.1)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)(@lezer/common@1.2.3)(@lezer/highlight@1.2.1)(@lezer/javascript@1.4.18)(@lezer/lr@1.4.2)
       '@uiw/react-codemirror':
         specifier: ^4.23.7
-        version: 4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@uwdata/flechette':
         specifier: ^1.1.2
         version: 1.1.2
@@ -338,7 +338,7 @@ importers:
         version: 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-codemirror-merge:
         specifier: ^4.23.7
-        version: 4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dropzone:
         specifier: ^14.3.5
         version: 14.3.5(react@18.3.1)
@@ -1000,9 +1000,6 @@ packages:
 
   '@codemirror/search@6.5.10':
     resolution: {integrity: sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==}
-
-  '@codemirror/search@6.5.9':
-    resolution: {integrity: sha512-7DdQ9aaZMMxuWB1u6IIFWWuK9NocVZwvo4nG8QjJTS6oZGvteoLSiXw3EbVZVlO08Ri2ltO89JVInMpfcJxhtg==}
 
   '@codemirror/state@6.5.2':
     resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
@@ -9629,12 +9626,6 @@ snapshots:
       '@codemirror/view': 6.36.3
       crelt: 1.0.6
 
-  '@codemirror/search@6.5.9':
-    dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.3
-      crelt: 1.0.6
-
   '@codemirror/state@6.5.2':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
@@ -12120,11 +12111,11 @@ snapshots:
       '@lezer/javascript': 1.4.18
       '@lezer/lr': 1.4.2
 
-  '@replit/codemirror-vim@6.2.1(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)':
+  '@replit/codemirror-vim@6.2.1(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)':
     dependencies:
       '@codemirror/commands': 6.8.0
       '@codemirror/language': 6.10.8
-      '@codemirror/search': 6.5.9
+      '@codemirror/search': 6.5.10
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.3
 
@@ -12998,13 +12989,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@uiw/codemirror-extensions-basic-setup@4.23.7(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)':
+  '@uiw/codemirror-extensions-basic-setup@4.23.7(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.0
       '@codemirror/language': 6.10.8
       '@codemirror/lint': 6.8.4
-      '@codemirror/search': 6.5.9
+      '@codemirror/search': 6.5.10
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.3
 
@@ -13047,14 +13038,14 @@ snapshots:
       - '@lezer/javascript'
       - '@lezer/lr'
 
-  '@uiw/react-codemirror@4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@uiw/react-codemirror@4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
       '@codemirror/commands': 6.8.0
       '@codemirror/state': 6.5.2
       '@codemirror/theme-one-dark': 6.1.2
       '@codemirror/view': 6.36.3
-      '@uiw/codemirror-extensions-basic-setup': 4.23.7(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)
+      '@uiw/codemirror-extensions-basic-setup': 4.23.7(@codemirror/autocomplete@6.18.6)(@codemirror/commands@6.8.0)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/view@6.36.3)
       codemirror: 6.0.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -17364,14 +17355,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-codemirror-merge@4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-codemirror-merge@4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.6
       '@codemirror/merge': 6.6.0
       '@codemirror/state': 6.5.2
       '@codemirror/theme-one-dark': 6.1.2
       '@codemirror/view': 6.36.3
-      '@uiw/react-codemirror': 4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.9)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@uiw/react-codemirror': 4.23.7(@babel/runtime@7.25.6)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.10.8)(@codemirror/lint@6.8.4)(@codemirror/search@6.5.10)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.3)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       codemirror: 6.0.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -998,6 +998,9 @@ packages:
   '@codemirror/merge@6.6.0':
     resolution: {integrity: sha512-VXKxm8Jrv2HpEVW9CcYiV4VMVWsFz2XOk34Ve9ouqFT4iKc2r9+IGuMjyeH+g5T0HKUnRGYIv2wayMsPtao7Zw==}
 
+  '@codemirror/search@6.5.10':
+    resolution: {integrity: sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==}
+
   '@codemirror/search@6.5.9':
     resolution: {integrity: sha512-7DdQ9aaZMMxuWB1u6IIFWWuK9NocVZwvo4nG8QjJTS6oZGvteoLSiXw3EbVZVlO08Ri2ltO89JVInMpfcJxhtg==}
 
@@ -8115,8 +8118,8 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  terser-webpack-plugin@5.3.11:
-    resolution: {integrity: sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==}
+  terser-webpack-plugin@5.3.12:
+    resolution: {integrity: sha512-jDLYqo7oF8tJIttjXO6jBY5Hk8p3A8W4ttih7cCEq64fQFWmgJ4VqAQjKr7WwIDlmXKEc6QeoRb5ecjZ+2afcg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -9619,6 +9622,12 @@ snapshots:
       '@codemirror/view': 6.36.3
       '@lezer/highlight': 1.2.1
       style-mod: 4.1.2
+
+  '@codemirror/search@6.5.10':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.3
+      crelt: 1.0.6
 
   '@codemirror/search@6.5.9':
     dependencies:
@@ -13791,7 +13800,7 @@ snapshots:
       '@codemirror/commands': 6.8.0
       '@codemirror/language': 6.10.8
       '@codemirror/lint': 6.8.4
-      '@codemirror/search': 6.5.9
+      '@codemirror/search': 6.5.10
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.3
 
@@ -18432,7 +18441,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  terser-webpack-plugin@5.3.11(esbuild@0.24.2)(webpack@5.96.1(esbuild@0.24.2)):
+  terser-webpack-plugin@5.3.12(esbuild@0.24.2)(webpack@5.96.1(esbuild@0.24.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -19303,7 +19312,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(esbuild@0.24.2)(webpack@5.96.1(esbuild@0.24.2))
+      terser-webpack-plugin: 5.3.12(esbuild@0.24.2)(webpack@5.96.1(esbuild@0.24.2))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -24,8 +24,29 @@ const Tip = (props: {
   return (
     <Accordion type="single" collapsible={true} className={props.className}>
       <AccordionItem value="item-1" className="text-muted-foreground">
-        <AccordionTrigger className="py-2">Tip:</AccordionTrigger>
-        <AccordionContent>{props.children}</AccordionContent>
+        <AccordionTrigger className="pt-4 pb-2">Tip</AccordionTrigger>
+        <AccordionContent className="mr-24 text-[0.84375rem]">
+          {props.children}
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+const Explainer = (props: {
+  title?: string;
+  className?: string;
+  children: React.ReactNode;
+}): JSX.Element => {
+  return (
+    <Accordion type="single" collapsible={true} className={props.className}>
+      <AccordionItem value="item-1" className="text-muted-foreground">
+        <AccordionTrigger className="pt-4 pb-2">
+          {props.title ?? "Learn more"}
+        </AccordionTrigger>
+        <AccordionContent className="mr-24 text-[0.84375rem]">
+          {props.children}
+        </AccordionContent>
       </AccordionItem>
     </Accordion>
   );
@@ -58,7 +79,9 @@ export const MarimoErrorOutput = ({
       case "cycle":
         return (
           <Fragment key={idx}>
-            <p>{"This cell is in a cycle:"}</p>
+            <p className="text-muted-foreground">
+              {"This cell is in a cycle:"}
+            </p>
             <ul className="list-disc">
               {error.edges_with_vars.map((edge) => (
                 <li className={liStyle} key={`${edge[0]}-${edge[1]}`}>
@@ -79,7 +102,7 @@ export const MarimoErrorOutput = ({
       case "multiple-defs":
         return (
           <Fragment key={idx}>
-            <p>{`The variable '${error.name}' was defined by another cell:`}</p>
+            <p className="text-muted-foreground">{`The variable '${error.name}' was defined by another cell:`}</p>
             <ul className="list-disc">
               {error.cells.map((cid) => (
                 <li className={liStyle} key={cid}>
@@ -88,10 +111,45 @@ export const MarimoErrorOutput = ({
               ))}
             </ul>
             <Tip>
-              Try merging this cell with the above cells. Alternatively, rename
-              '{error.name}' to '_{error.name}' to make the variable private to
-              this cell.
+              <p className="pb-2">
+                marimo requires that each variable is defined in just one cell.
+                This constraint enables reactive and reproducible execution,
+                arbitrary cell reordering, seamless UI elements, execution as a
+                script, and more.
+              </p>
+
+              <p className="py-2">
+                Try merging this cell with the above cells or wrapping it in a
+                function. Alternatively, rename '{error.name}' to '_{error.name}
+                ' to make the variable private to this cell.
+              </p>
             </Tip>
+          </Fragment>
+        );
+
+      case "import-star":
+        return (
+          <Fragment key={idx}>
+            <p className="text-muted-foreground">{error.msg}</p>
+
+            <Explainer>
+              <p className="pb-2">
+                Star imports are incompatible with marimo's git-friendly file
+                format and reproducible reactive execution.
+              </p>
+
+              <p className="py-2">
+                marimo's Python file format stores code in functions, so
+                notebooks can be imported as regular Python modules without
+                executing all their code. But Python disallows `import *`
+                everywhere except at the top-level of a module.
+              </p>
+
+              <p className="py-2">
+                Star imports would also silently add names to globals, which
+                would be incompatible with reactive execution.
+              </p>
+            </Explainer>
           </Fragment>
         );
 
@@ -120,8 +178,8 @@ export const MarimoErrorOutput = ({
         titleContents = error.exception_type;
         return error.raising_cell == null ? (
           <Fragment key={idx}>
-            <p>{error.msg}</p>
-            <div className="text-sm text-muted-foreground mt-2">
+            <p className="text-muted-foreground">{error.msg}</p>
+            <div className="text-muted-foreground mt-2">
               See the console area for a traceback.
             </div>
           </Fragment>

--- a/marimo/_ast/errors.py
+++ b/marimo/_ast/errors.py
@@ -3,6 +3,10 @@ class CycleError(Exception):
     pass
 
 
+class ImportStarError(SyntaxError):
+    pass
+
+
 class MultipleDefinitionError(Exception):
     pass
 

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -10,6 +10,7 @@ from typing import Callable, Literal, Optional, Union
 from uuid import uuid4
 
 from marimo import _loggers
+from marimo._ast.errors import ImportStarError
 from marimo._ast.sql_visitor import (
     SQLDefs,
     find_sql_defs,
@@ -220,8 +221,9 @@ class ScopedVisitor(ast.NodeVisitor):
                     if hasattr(node, "lineno")
                     else "line ..."
                 )
-                raise SyntaxError(
-                    f"{line} SyntaxError: `import *` is not allowed in marimo."
+                raise ImportStarError(
+                    f"{line} SyntaxError: Importing symbols with `import *` "
+                    "is not allowed in marimo."
                 )
             return basename
         else:

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -57,6 +57,7 @@ def _generate_server_api_schema() -> dict[str, Any]:
         # Errors
         errors.CycleError,
         errors.MultipleDefinitionError,
+        errors.ImportStarError,
         errors.DeleteNonlocalError,
         errors.MarimoInterruptionError,
         errors.MarimoInternalError,

--- a/marimo/_messaging/errors.py
+++ b/marimo/_messaging/errors.py
@@ -28,6 +28,15 @@ class MultipleDefinitionError:
 
 
 @dataclass
+class ImportStarError:
+    msg: str
+    type: Literal["import-star"] = "import-star"
+
+    def describe(self) -> str:
+        return self.msg
+
+
+@dataclass
 class DeleteNonlocalError:
     name: str
     cells: tuple[CellId_t, ...]
@@ -154,6 +163,7 @@ def is_sensitive_error(error: Error) -> bool:
 Error = Union[
     CycleError,
     MultipleDefinitionError,
+    ImportStarError,
     DeleteNonlocalError,
     MarimoAncestorStoppedError,
     MarimoAncestorPreventedError,

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -22,6 +22,7 @@ from uuid import uuid4
 from marimo import _loggers
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
+from marimo._ast.errors import ImportStarError
 from marimo._ast.variables import is_local
 from marimo._ast.visitor import ImportData, Name, VariableData
 from marimo._config.config import ExecutionType, MarimoConfig, OnCellChangeType
@@ -35,6 +36,7 @@ from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.context import http_request_context, run_id_context
 from marimo._messaging.errors import (
     Error,
+    ImportStarError as MarimoImportStarError,
     MarimoInterruptionError,
     MarimoStrictExecutionError,
     MarimoSyntaxError,
@@ -766,7 +768,10 @@ class Kernel:
                 syntax_error[0] = syntax_error[0][
                     syntax_error[0].find("line") :
                 ]
-                error = MarimoSyntaxError(msg="\n".join(syntax_error))
+                if isinstance(e, ImportStarError):
+                    error = MarimoImportStarError(msg=str(e))
+                else:
+                    error = MarimoSyntaxError(msg="\n".join(syntax_error))
             else:
                 tmpio = io.StringIO()
                 traceback.print_exc(file=tmpio)

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -586,6 +586,7 @@ components:
       oneOf:
       - $ref: '#/components/schemas/CycleError'
       - $ref: '#/components/schemas/MultipleDefinitionError'
+      - $ref: '#/components/schemas/ImportStarError'
       - $ref: '#/components/schemas/DeleteNonlocalError'
       - $ref: '#/components/schemas/MarimoAncestorStoppedError'
       - $ref: '#/components/schemas/MarimoAncestorPreventedError'
@@ -948,6 +949,18 @@ components:
           type: string
       required:
       - code
+      type: object
+    ImportStarError:
+      properties:
+        msg:
+          type: string
+        type:
+          enum:
+          - import-star
+          type: string
+      required:
+      - msg
+      - type
       type: object
     InstallMissingPackagesRequest:
       properties:
@@ -2194,7 +2207,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.11.9
+  version: 0.11.11
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -4,2993 +4,2901 @@
  */
 
 export interface paths {
-  "/@file/{filename_and_length}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description The filename and byte length of the virtual file */
-          filename_and_length: string;
+    "/@file/{filename_and_length}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Get a virtual file */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/octet-stream": string;
-          };
-        };
-        /** @description Invalid byte length in virtual file request */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/ai/completion": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      /** @description The prompt to get AI completion for */
-      requestBody: {
-        content: {
-          "application/json": components["schemas"]["AiCompletionRequest"];
-        };
-      };
-      responses: {
-        /** @description Get AI completion for a prompt */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              [key: string]: unknown;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description The filename and byte length of the virtual file */
+                    filename_and_length: string;
+                };
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/datasources/preview_column": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["PreviewDatasetColumnRequest"];
-        };
-      };
-      responses: {
-        /** @description Preview a column in a dataset */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/datasources/preview_sql_table": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["PreviewSQLTableRequest"];
-        };
-      };
-      responses: {
-        /** @description Preview a SQL table */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/documentation/snippets": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Load the snippets for the documentation page */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["Snippets"];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/export/auto_export/html": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ExportAsHTMLRequest"];
-        };
-      };
-      responses: {
-        /** @description Export the notebook as HTML */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-        /** @description File must be saved before downloading */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/export/auto_export/ipynb": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ExportAsIPYNBRequest"];
-        };
-      };
-      responses: {
-        /** @description Export the notebook as IPYNB */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-        /** @description File must be saved before downloading */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/export/auto_export/markdown": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ExportAsMarkdownRequest"];
-        };
-      };
-      responses: {
-        /** @description Export the notebook as a markdown */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-        /** @description File must be saved before downloading */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/export/html": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ExportAsHTMLRequest"];
-        };
-      };
-      responses: {
-        /** @description Export the notebook as HTML */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/html": string;
-          };
-        };
-        /** @description File must be saved before downloading */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/export/markdown": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ExportAsMarkdownRequest"];
-        };
-      };
-      responses: {
-        /** @description Export the notebook as a markdown */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/plain": string;
-          };
-        };
-        /** @description File must be saved before downloading */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/export/script": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ExportAsScriptRequest"];
-        };
-      };
-      responses: {
-        /** @description Export the notebook as a script */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/plain": string;
-          };
-        };
-        /** @description File must be saved before downloading */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/files/create": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FileCreateRequest"];
-        };
-      };
-      responses: {
-        /** @description Create a new file or directory */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["FileCreateResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/files/delete": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FileDeleteRequest"];
-        };
-      };
-      responses: {
-        /** @description Delete a file or directory */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["FileDeleteResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/files/file_details": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FileDetailsRequest"];
-        };
-      };
-      responses: {
-        /** @description Get details of a specific file or directory */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["FileDetailsResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/files/list_files": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FileListRequest"];
-        };
-      };
-      responses: {
-        /** @description List files and directories in a given path */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["FileListResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/files/move": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FileMoveRequest"];
-        };
-      };
-      responses: {
-        /** @description Move a file or directory */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["FileMoveResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/files/open": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FileOpenRequest"];
-        };
-      };
-      responses: {
-        /** @description Open a file in the system editor */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["BaseResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/files/update": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FileUpdateRequest"];
-        };
-      };
-      responses: {
-        /** @description Update a file or directory */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["FileUpdateResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/home/recent_files": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Get the recent files */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["RecentFilesResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/home/running_notebooks": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Get the running files */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["RunningNotebooksResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/home/shutdown_session": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["ShutdownSessionRequest"];
-        };
-      };
-      responses: {
-        /** @description Shutdown the current session */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["RunningNotebooksResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/home/tutorial/open": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["OpenTutorialRequest"];
-        };
-      };
-      responses: {
-        /** @description Open a new tutorial */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["MarimoFile"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/home/workspace_files": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["WorkspaceFilesRequest"];
-        };
-      };
-      responses: {
-        /** @description Get the files in the workspace */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["WorkspaceFilesResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/code_autocomplete": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["CodeCompletionRequest"];
-        };
-      };
-      responses: {
-        /** @description Complete a code fragment */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/copy": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["CopyNotebookRequest"];
-        };
-      };
-      responses: {
-        /** @description Copy notebook */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/plain": string;
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/delete": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["DeleteCellRequest"];
-        };
-      };
-      responses: {
-        /** @description Delete a cell */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/format": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FormatRequest"];
-        };
-      };
-      responses: {
-        /** @description Format code */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["FormatResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/function_call": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FunctionCallRequest"];
-        };
-      };
-      responses: {
-        /** @description Invoke an RPC */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/install_missing_packages": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["InstallMissingPackagesRequest"];
-        };
-      };
-      responses: {
-        /** @description Install missing packages */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/instantiate": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["InstantiateRequest"];
-        };
-      };
-      responses: {
-        /** @description Instantiate a component */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/interrupt": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Interrupt the kernel's execution */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/read_code": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Read the code from the server */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["ReadCodeResponse"];
-          };
-        };
-        /** @description File must be saved before downloading */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/rename": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["RenameFileRequest"];
-        };
-      };
-      responses: {
-        /** @description Rename the current app */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/restart_session": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Restart the current session without affecting other sessions. */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/run": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["RunRequest"];
-        };
-      };
-      responses: {
-        /** @description Run a cell. Updates cell code in the kernel if needed; registers new cells for unseen cell IDs. Only allowed in edit mode. */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/save": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["SaveNotebookRequest"];
-        };
-      };
-      responses: {
-        /** @description Save the current app */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/plain": string;
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/save_app_config": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["SaveAppConfigurationRequest"];
-        };
-      };
-      responses: {
-        /** @description Save the app configuration */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/plain": string;
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/save_user_config": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["SaveUserConfigurationRequest"];
-        };
-      };
-      responses: {
-        /** @description Update the user config on disk and in the kernel. Only allowed in edit mode. */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/scratchpad/run": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["RunScratchpadRequest"];
-        };
-      };
-      responses: {
-        /** @description Run the scratchpad */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/set_cell_config": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["SetCellConfigRequest"];
-        };
-      };
-      responses: {
-        /** @description Set the configuration of a cell */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/set_ui_element_value": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["UpdateComponentValuesRequest"];
-        };
-      };
-      responses: {
-        /** @description Set UI element values */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/shutdown": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Shutdown the kernel */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/stdin": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["StdinRequest"];
-        };
-      };
-      responses: {
-        /** @description Send input to the stdin stream */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/sync/cell_ids": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["UpdateCellIdsRequest"];
-        };
-      };
-      responses: {
-        /** @description Sync cell ids */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/kernel/takeover": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: never;
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/packages/add": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["AddPackageRequest"];
-        };
-      };
-      responses: {
-        /** @description Install package */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PackageOperationResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/packages/list": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description List installed packages */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["ListPackagesResponse"];
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/packages/remove": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["RemovePackageRequest"];
-        };
-      };
-      responses: {
-        /** @description Uninstall package */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["PackageOperationResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/status": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Get the status of the application */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              filenames?: string[];
-              lsp_running?: boolean;
-              mode?: string;
-              node_version?: string;
-              requirements?: string[];
-              sessions?: number;
-              status?: string;
-              version?: string;
+            requestBody?: never;
+            responses: {
+                /** @description Get a virtual file */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/octet-stream": string;
+                    };
+                };
+                /** @description Invalid byte length in virtual file request */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
-          };
         };
-      };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/status/connections": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Get the number of active websocket connections */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              active?: number;
+    "/api/ai/completion": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
             };
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/usage": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Get the current memory and CPU usage of the application */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              cpu: {
-                percent: number;
-              };
-              kernel?: {
-                memory?: number;
-              };
-              memory: {
-                available: number;
-                free: number;
-                percent: number;
-                total: number;
-                used: number;
-              };
-              server?: {
-                memory: number;
-              };
+            /** @description The prompt to get AI completion for */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["AiCompletionRequest"];
+                };
             };
-          };
+            responses: {
+                /** @description Get AI completion for a prompt */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
         };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/api/version": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Get the version of the application */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/plain": string;
-          };
+    "/api/datasources/preview_column": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/login": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Submit login form */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/x-www-form-urlencoded": {
-            /** @description Access token or password */
-            password?: string;
-          };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["PreviewDatasetColumnRequest"];
+                };
+            };
+            responses: {
+                /** @description Preview a column in a dataset */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
         };
-      };
-      responses: {
-        /** @description Login page */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/html": string;
-          };
-        };
-        /** @description Redirect to the next URL */
-        302: {
-          headers: {
-            Location?: string;
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/api/datasources/preview_sql_table": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["PreviewSQLTableRequest"];
+                };
+            };
+            responses: {
+                /** @description Preview a SQL table */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/documentation/snippets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Load the snippets for the documentation page */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Snippets"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/export/auto_export/html": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ExportAsHTMLRequest"];
+                };
+            };
+            responses: {
+                /** @description Export the notebook as HTML */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+                /** @description File must be saved before downloading */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/export/auto_export/ipynb": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ExportAsIPYNBRequest"];
+                };
+            };
+            responses: {
+                /** @description Export the notebook as IPYNB */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+                /** @description File must be saved before downloading */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/export/auto_export/markdown": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ExportAsMarkdownRequest"];
+                };
+            };
+            responses: {
+                /** @description Export the notebook as a markdown */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+                /** @description File must be saved before downloading */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/export/html": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ExportAsHTMLRequest"];
+                };
+            };
+            responses: {
+                /** @description Export the notebook as HTML */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/html": string;
+                    };
+                };
+                /** @description File must be saved before downloading */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/export/markdown": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ExportAsMarkdownRequest"];
+                };
+            };
+            responses: {
+                /** @description Export the notebook as a markdown */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                    };
+                };
+                /** @description File must be saved before downloading */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/export/script": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ExportAsScriptRequest"];
+                };
+            };
+            responses: {
+                /** @description Export the notebook as a script */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                    };
+                };
+                /** @description File must be saved before downloading */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/files/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FileCreateRequest"];
+                };
+            };
+            responses: {
+                /** @description Create a new file or directory */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FileCreateResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/files/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FileDeleteRequest"];
+                };
+            };
+            responses: {
+                /** @description Delete a file or directory */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FileDeleteResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/files/file_details": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FileDetailsRequest"];
+                };
+            };
+            responses: {
+                /** @description Get details of a specific file or directory */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FileDetailsResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/files/list_files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FileListRequest"];
+                };
+            };
+            responses: {
+                /** @description List files and directories in a given path */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FileListResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/files/move": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FileMoveRequest"];
+                };
+            };
+            responses: {
+                /** @description Move a file or directory */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FileMoveResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/files/open": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FileOpenRequest"];
+                };
+            };
+            responses: {
+                /** @description Open a file in the system editor */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BaseResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/files/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FileUpdateRequest"];
+                };
+            };
+            responses: {
+                /** @description Update a file or directory */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FileUpdateResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/home/recent_files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Get the recent files */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RecentFilesResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/home/running_notebooks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Get the running files */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RunningNotebooksResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/home/shutdown_session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ShutdownSessionRequest"];
+                };
+            };
+            responses: {
+                /** @description Shutdown the current session */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RunningNotebooksResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/home/tutorial/open": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["OpenTutorialRequest"];
+                };
+            };
+            responses: {
+                /** @description Open a new tutorial */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MarimoFile"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/home/workspace_files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["WorkspaceFilesRequest"];
+                };
+            };
+            responses: {
+                /** @description Get the files in the workspace */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["WorkspaceFilesResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/code_autocomplete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["CodeCompletionRequest"];
+                };
+            };
+            responses: {
+                /** @description Complete a code fragment */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/copy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["CopyNotebookRequest"];
+                };
+            };
+            responses: {
+                /** @description Copy notebook */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["DeleteCellRequest"];
+                };
+            };
+            responses: {
+                /** @description Delete a cell */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/format": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FormatRequest"];
+                };
+            };
+            responses: {
+                /** @description Format code */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FormatResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/function_call": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["FunctionCallRequest"];
+                };
+            };
+            responses: {
+                /** @description Invoke an RPC */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/install_missing_packages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["InstallMissingPackagesRequest"];
+                };
+            };
+            responses: {
+                /** @description Install missing packages */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/instantiate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["InstantiateRequest"];
+                };
+            };
+            responses: {
+                /** @description Instantiate a component */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/interrupt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Interrupt the kernel's execution */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/read_code": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Read the code from the server */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ReadCodeResponse"];
+                    };
+                };
+                /** @description File must be saved before downloading */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/rename": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["RenameFileRequest"];
+                };
+            };
+            responses: {
+                /** @description Rename the current app */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/restart_session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Restart the current session without affecting other sessions. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["RunRequest"];
+                };
+            };
+            responses: {
+                /** @description Run a cell. Updates cell code in the kernel if needed; registers new cells for unseen cell IDs. Only allowed in edit mode. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/save": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["SaveNotebookRequest"];
+                };
+            };
+            responses: {
+                /** @description Save the current app */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/save_app_config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["SaveAppConfigurationRequest"];
+                };
+            };
+            responses: {
+                /** @description Save the app configuration */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/save_user_config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["SaveUserConfigurationRequest"];
+                };
+            };
+            responses: {
+                /** @description Update the user config on disk and in the kernel. Only allowed in edit mode. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/scratchpad/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["RunScratchpadRequest"];
+                };
+            };
+            responses: {
+                /** @description Run the scratchpad */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/set_cell_config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["SetCellConfigRequest"];
+                };
+            };
+            responses: {
+                /** @description Set the configuration of a cell */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/set_ui_element_value": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UpdateComponentValuesRequest"];
+                };
+            };
+            responses: {
+                /** @description Set UI element values */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/shutdown": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Shutdown the kernel */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/stdin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["StdinRequest"];
+                };
+            };
+            responses: {
+                /** @description Send input to the stdin stream */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/sync/cell_ids": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UpdateCellIdsRequest"];
+                };
+            };
+            responses: {
+                /** @description Sync cell ids */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SuccessResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/kernel/takeover": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/packages/add": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["AddPackageRequest"];
+                };
+            };
+            responses: {
+                /** @description Install package */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PackageOperationResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/packages/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List installed packages */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ListPackagesResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/packages/remove": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["RemovePackageRequest"];
+                };
+            };
+            responses: {
+                /** @description Uninstall package */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["PackageOperationResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Get the status of the application */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            filenames?: string[];
+                            lsp_running?: boolean;
+                            mode?: string;
+                            node_version?: string;
+                            requirements?: string[];
+                            sessions?: number;
+                            status?: string;
+                            version?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/status/connections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Get the number of active websocket connections */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            active?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Get the current memory and CPU usage of the application */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            cpu: {
+                                percent: number;
+                            };
+                            kernel?: {
+                                memory?: number;
+                            };
+                            memory: {
+                                available: number;
+                                free: number;
+                                percent: number;
+                                total: number;
+                                used: number;
+                            };
+                            server?: {
+                                memory: number;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/version": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Get the version of the application */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Submit login form */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/x-www-form-urlencoded": {
+                        /** @description Access token or password */
+                        password?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Login page */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/html": string;
+                    };
+                };
+                /** @description Redirect to the next URL */
+                302: {
+                    headers: {
+                        Location?: string;
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    AddPackageRequest: {
-      package: string;
-    };
-    AiCompletionRequest: {
-      code: string;
-      context?: {
-        schema: {
-          columns: {
+    schemas: {
+        AddPackageRequest: {
+            package: string;
+        };
+        AiCompletionRequest: {
+            code: string;
+            context?: {
+                schema: {
+                    columns: {
+                        name: string;
+                        sampleValues: unknown[];
+                        type: string;
+                    }[];
+                    name: string;
+                }[];
+            } | null;
+            includeOtherCode: string;
+            /** @enum {string} */
+            language: "python" | "markdown" | "sql";
+            prompt: string;
+        };
+        Alert: {
+            description: string;
+            /** @enum {string} */
+            name: "alert";
+            title: string;
+            /** @enum {string|null} */
+            variant?: "danger" | null;
+        };
+        AppMetadata: {
+            cliArgs: {
+                [key: string]: string | boolean | number | (string | boolean | number)[];
+            };
+            filename?: string | null;
+            queryParams: {
+                [key: string]: string | string[];
+            };
+        };
+        Banner: {
+            /** @enum {string|null} */
+            action?: "restart" | null;
+            description: string;
+            /** @enum {string} */
+            name: "banner";
+            title: string;
+            /** @enum {string|null} */
+            variant?: "danger" | null;
+        };
+        BaseResponse: {
+            success: boolean;
+        };
+        /** @enum {string} */
+        CellChannel: "stdout" | "stderr" | "stdin" | "pdb" | "output" | "marimo-error" | "media";
+        CellConfig: {
+            column?: number | null;
+            disabled: boolean;
+            hide_code: boolean;
+        };
+        CellOp: {
+            cell_id: string;
+            console?: (components["schemas"]["CellOutput"] | components["schemas"]["CellOutput"][]) | null;
+            /** @enum {string} */
+            name: "cell-op";
+            output?: components["schemas"]["CellOutput"];
+            run_id?: string | null;
+            stale_inputs?: boolean | null;
+            status?: components["schemas"]["RuntimeState"];
+            timestamp: number;
+        };
+        CellOutput: {
+            channel: components["schemas"]["CellChannel"];
+            data: string | components["schemas"]["Error"][] | {
+                [key: string]: unknown;
+            };
+            mimetype: components["schemas"]["MimeType"];
+            timestamp: number;
+        };
+        CodeCompletionRequest: {
+            cellId: string;
+            document: string;
+            id: string;
+        };
+        ColumnSummary: {
+            false?: number | null;
+            max?: components["schemas"]["NonNestedLiteral"];
+            mean?: components["schemas"]["NonNestedLiteral"];
+            median?: components["schemas"]["NonNestedLiteral"];
+            min?: components["schemas"]["NonNestedLiteral"];
+            nulls?: number | null;
+            p25?: components["schemas"]["NonNestedLiteral"];
+            p5?: components["schemas"]["NonNestedLiteral"];
+            p75?: components["schemas"]["NonNestedLiteral"];
+            p95?: components["schemas"]["NonNestedLiteral"];
+            std?: components["schemas"]["NonNestedLiteral"];
+            total?: number | null;
+            true?: number | null;
+            unique?: number | null;
+        };
+        CompletedRun: {
+            /** @enum {string} */
+            name: "completed-run";
+        };
+        CompletionResult: {
+            completion_id: string;
+            /** @enum {string} */
+            name: "completion-result";
+            options: {
+                completion_info?: string | null;
+                name: string;
+                type: string;
+            }[];
+            prefix_length: number;
+        };
+        CopyNotebookRequest: {
+            destination: string;
+            source: string;
+        };
+        CycleError: {
+            edges_with_vars: [
+                string,
+                string[],
+                string
+            ][];
+            /** @enum {string} */
+            type: "cycle";
+        };
+        DataColumnPreview: {
+            chart_code?: string | null;
+            chart_max_rows_errors: boolean;
+            chart_spec?: string | null;
+            column_name: string;
+            error?: string | null;
+            /** @enum {string} */
+            name: "data-column-preview";
+            summary?: components["schemas"]["ColumnSummary"];
+            table_name: string;
+        };
+        DataSourceConnection: {
+            databases: {
+                dialect: string;
+                engine?: string | null;
+                name: string;
+                schemas: {
+                    name: string;
+                    tables: components["schemas"]["DataTable"][];
+                }[];
+            }[];
+            dialect: string;
+            display_name: string;
             name: string;
-            sampleValues: unknown[];
-            type: string;
-          }[];
-          name: string;
-        }[];
-      } | null;
-      includeOtherCode: string;
-      /** @enum {string} */
-      language: "python" | "markdown" | "sql";
-      prompt: string;
-    };
-    Alert: {
-      description: string;
-      /** @enum {string} */
-      name: "alert";
-      title: string;
-      /** @enum {string|null} */
-      variant?: "danger" | null;
-    };
-    AppMetadata: {
-      cliArgs: {
-        [key: string]:
-          | string
-          | boolean
-          | number
-          | (string | boolean | number)[];
-      };
-      filename?: string | null;
-      queryParams: {
-        [key: string]: string | string[];
-      };
-    };
-    Banner: {
-      /** @enum {string|null} */
-      action?: "restart" | null;
-      description: string;
-      /** @enum {string} */
-      name: "banner";
-      title: string;
-      /** @enum {string|null} */
-      variant?: "danger" | null;
-    };
-    BaseResponse: {
-      success: boolean;
-    };
-    /** @enum {string} */
-    CellChannel:
-      | "stdout"
-      | "stderr"
-      | "stdin"
-      | "pdb"
-      | "output"
-      | "marimo-error"
-      | "media";
-    CellConfig: {
-      column?: number | null;
-      disabled: boolean;
-      hide_code: boolean;
-    };
-    CellOp: {
-      cell_id: string;
-      console?:
-        | (
-            | components["schemas"]["CellOutput"]
-            | components["schemas"]["CellOutput"][]
-          )
-        | null;
-      /** @enum {string} */
-      name: "cell-op";
-      output?: components["schemas"]["CellOutput"];
-      run_id?: string | null;
-      stale_inputs?: boolean | null;
-      status?: components["schemas"]["RuntimeState"];
-      timestamp: number;
-    };
-    CellOutput: {
-      channel: components["schemas"]["CellChannel"];
-      data:
-        | string
-        | components["schemas"]["Error"][]
-        | {
-            [key: string]: unknown;
-          };
-      mimetype: components["schemas"]["MimeType"];
-      timestamp: number;
-    };
-    CodeCompletionRequest: {
-      cellId: string;
-      document: string;
-      id: string;
-    };
-    ColumnSummary: {
-      false?: number | null;
-      max?: components["schemas"]["NonNestedLiteral"];
-      mean?: components["schemas"]["NonNestedLiteral"];
-      median?: components["schemas"]["NonNestedLiteral"];
-      min?: components["schemas"]["NonNestedLiteral"];
-      nulls?: number | null;
-      p25?: components["schemas"]["NonNestedLiteral"];
-      p5?: components["schemas"]["NonNestedLiteral"];
-      p75?: components["schemas"]["NonNestedLiteral"];
-      p95?: components["schemas"]["NonNestedLiteral"];
-      std?: components["schemas"]["NonNestedLiteral"];
-      total?: number | null;
-      true?: number | null;
-      unique?: number | null;
-    };
-    CompletedRun: {
-      /** @enum {string} */
-      name: "completed-run";
-    };
-    CompletionResult: {
-      completion_id: string;
-      /** @enum {string} */
-      name: "completion-result";
-      options: {
-        completion_info?: string | null;
-        name: string;
-        type: string;
-      }[];
-      prefix_length: number;
-    };
-    CopyNotebookRequest: {
-      destination: string;
-      source: string;
-    };
-    CycleError: {
-      edges_with_vars: [string, string[], string][];
-      /** @enum {string} */
-      type: "cycle";
-    };
-    DataColumnPreview: {
-      chart_code?: string | null;
-      chart_max_rows_errors: boolean;
-      chart_spec?: string | null;
-      column_name: string;
-      error?: string | null;
-      /** @enum {string} */
-      name: "data-column-preview";
-      summary?: components["schemas"]["ColumnSummary"];
-      table_name: string;
-    };
-    DataSourceConnection: {
-      databases: {
-        dialect: string;
-        engine?: string | null;
-        name: string;
-        schemas: {
-          name: string;
-          tables: components["schemas"]["DataTable"][];
-        }[];
-      }[];
-      dialect: string;
-      display_name: string;
-      name: string;
-      source: string;
-    };
-    DataSourceConnections: {
-      connections: components["schemas"]["DataSourceConnection"][];
-      /** @enum {string} */
-      name: "data-source-connections";
-    };
-    DataTable: {
-      columns: components["schemas"]["DataTableColumn"][];
-      engine?: string | null;
-      indexes?: string[] | null;
-      name: string;
-      num_columns?: number | null;
-      num_rows?: number | null;
-      primary_keys?: string[] | null;
-      source: string;
-      /** @enum {string} */
-      source_type: "local" | "duckdb" | "connection";
-      /** @enum {string} */
-      type: "table" | "view";
-      variable_name?: string | null;
-    };
-    DataTableColumn: {
-      external_type: string;
-      name: string;
-      sample_values: unknown[];
-      type: components["schemas"]["DataType"];
-    };
-    /** @enum {string} */
-    DataType:
-      | "string"
-      | "boolean"
-      | "integer"
-      | "number"
-      | "date"
-      | "datetime"
-      | "time"
-      | "unknown";
-    Database: {
-      dialect: string;
-      engine?: string | null;
-      name: string;
-      schemas: components["schemas"]["Schema"][];
-    };
-    Datasets: {
-      /** @enum {string|null} */
-      clear_channel?: "local" | "duckdb" | "connection" | null;
-      /** @enum {string} */
-      name: "datasets";
-      tables: components["schemas"]["DataTable"][];
-    };
-    DeleteCellRequest: {
-      cellId: string;
-    };
-    DeleteNonlocalError: {
-      cells: string[];
-      name: string;
-      /** @enum {string} */
-      type: "delete-nonlocal";
-    };
-    Error:
-      | components["schemas"]["CycleError"]
-      | components["schemas"]["MultipleDefinitionError"]
-      | components["schemas"]["DeleteNonlocalError"]
-      | components["schemas"]["MarimoAncestorStoppedError"]
-      | components["schemas"]["MarimoAncestorPreventedError"]
-      | components["schemas"]["MarimoExceptionRaisedError"]
-      | components["schemas"]["MarimoStrictExecutionError"]
-      | components["schemas"]["MarimoInterruptionError"]
-      | components["schemas"]["MarimoSyntaxError"]
-      | components["schemas"]["MarimoInternalError"]
-      | components["schemas"]["UnknownError"];
-    ExecuteMultipleRequest: {
-      cellIds: string[];
-      codes: string[];
-      request?: components["schemas"]["HTTPRequest"];
-      timestamp: number;
-    };
-    ExecuteScratchpadRequest: {
-      code: string;
-      request?: components["schemas"]["HTTPRequest"];
-    };
-    ExecuteStaleRequest: Record<string, never>;
-    ExecutionRequest: {
-      cellId: string;
-      code: string;
-      request?: components["schemas"]["HTTPRequest"];
-      timestamp: number;
-    };
-    ExportAsHTMLRequest: {
-      assetUrl?: string | null;
-      download: boolean;
-      files: string[];
-      includeCode: boolean;
-    };
-    ExportAsIPYNBRequest: {
-      download: boolean;
-    };
-    ExportAsMarkdownRequest: {
-      download: boolean;
-    };
-    ExportAsScriptRequest: {
-      download: boolean;
-    };
-    FileCreateRequest: {
-      contents?: string | null;
-      name: string;
-      path: string;
-      /** @enum {string} */
-      type: "file" | "directory";
-    };
-    FileCreateResponse: {
-      info?: components["schemas"]["FileInfo"];
-      message?: string | null;
-      success: boolean;
-    };
-    FileDeleteRequest: {
-      path: string;
-    };
-    FileDeleteResponse: {
-      message?: string | null;
-      success: boolean;
-    };
-    FileDetailsRequest: {
-      path: string;
-    };
-    FileDetailsResponse: {
-      contents?: string | null;
-      file: components["schemas"]["FileInfo"];
-      mimeType?: string | null;
-    };
-    FileInfo: {
-      children: components["schemas"]["FileInfo"][];
-      id: string;
-      isDirectory: boolean;
-      isMarimoFile: boolean;
-      lastModified?: number | null;
-      name: string;
-      path: string;
-    };
-    FileListRequest: {
-      path?: string | null;
-    };
-    FileListResponse: {
-      files: components["schemas"]["FileInfo"][];
-      root: string;
-    };
-    FileMoveRequest: {
-      newPath: string;
-      path: string;
-    };
-    FileMoveResponse: {
-      info?: components["schemas"]["FileInfo"];
-      message?: string | null;
-      success: boolean;
-    };
-    FileOpenRequest: {
-      path: string;
-    };
-    FileUpdateRequest: {
-      contents: string;
-      path: string;
-    };
-    FileUpdateResponse: {
-      info?: components["schemas"]["FileInfo"];
-      message?: string | null;
-      success: boolean;
-    };
-    FocusCell: {
-      cell_id: string;
-      /** @enum {string} */
-      name: "focus-cell";
-    };
-    FormatRequest: {
-      codes: {
-        [key: string]: string;
-      };
-      lineLength: number;
-    };
-    FormatResponse: {
-      codes: {
-        [key: string]: string;
-      };
-    };
-    FunctionCallRequest: {
-      args: {
-        [key: string]: unknown;
-      };
-      functionCallId: string;
-      functionName: string;
-      namespace: string;
-    };
-    FunctionCallResult: {
-      function_call_id: string;
-      /** @enum {string} */
-      name: "function-call-result";
-      return_value?: components["schemas"]["JSONType"];
-      status: components["schemas"]["HumanReadableStatus"];
-    };
-    HTTPRequest: null;
-    HumanReadableStatus: {
-      /** @enum {string} */
-      code: "ok" | "error";
-      message?: string | null;
-      title?: string | null;
-    };
-    InstallMissingPackagesRequest: {
-      manager: string;
-      versions: {
-        [key: string]: string;
-      };
-    };
-    InstallingPackageAlert: {
-      /** @enum {string} */
-      name: "installing-package-alert";
-      packages: {
-        [key: string]: "queued" | "installing" | "installed" | "failed";
-      };
-    };
-    InstantiateRequest: {
-      autoRun: boolean;
-      objectIds: string[];
-      values: unknown[];
-    };
-    Interrupted: {
-      /** @enum {string} */
-      name: "interrupted";
-    };
-    JSONType:
-      | string
-      | number
-      | Record<string, never>
-      | unknown[]
-      | boolean
-      | null;
-    KernelReady: {
-      app_config: {
-        _toplevel_fn: boolean;
-        app_title?: string | null;
-        auto_download: ("html" | "markdown")[];
-        css_file?: string | null;
-        html_head_file?: string | null;
-        layout_file?: string | null;
-        /** @enum {string} */
-        width: "normal" | "compact" | "medium" | "full";
-      };
-      capabilities: {
-        sql: boolean;
-        terminal: boolean;
-      };
-      cell_ids: string[];
-      codes: string[];
-      configs: components["schemas"]["CellConfig"][];
-      kiosk: boolean;
-      last_executed_code?: {
-        [key: string]: string;
-      } | null;
-      last_execution_time?: {
-        [key: string]: number;
-      } | null;
-      layout?: {
-        data: {
-          [key: string]: unknown;
+            source: string;
         };
-        type: string;
-      } | null;
-      /** @enum {string} */
-      name: "kernel-ready";
-      names: string[];
-      resumed: boolean;
-      ui_values?: {
-        [key: string]:
-          | (
-              | {
-                  [key: string]: components["schemas"]["JSONType"];
-                }
-              | components["schemas"]["JSONType"][]
-              | string
-              | number
-              | boolean
-              | {
-                  [key: string]: unknown;
-                }
-              | components["schemas"]["MIME"]
-            )
-          | null;
-      } | null;
-    };
-    ListPackagesResponse: {
-      packages: components["schemas"]["PackageDescription"][];
-    };
-    MIME: Record<string, never>;
-    MarimoAncestorPreventedError: {
-      blamed_cell?: string | null;
-      msg: string;
-      raising_cell: string;
-      /** @enum {string} */
-      type: "ancestor-prevented";
-    };
-    MarimoAncestorStoppedError: {
-      msg: string;
-      raising_cell: string;
-      /** @enum {string} */
-      type: "ancestor-stopped";
-    };
-    MarimoConfig: {
-      ai?: {
-        anthropic?: {
-          api_key?: string;
+        DataSourceConnections: {
+            connections: components["schemas"]["DataSourceConnection"][];
+            /** @enum {string} */
+            name: "data-source-connections";
         };
-        google?: {
-          api_key?: string;
+        DataTable: {
+            columns: components["schemas"]["DataTableColumn"][];
+            engine?: string | null;
+            indexes?: string[] | null;
+            name: string;
+            num_columns?: number | null;
+            num_rows?: number | null;
+            primary_keys?: string[] | null;
+            source: string;
+            /** @enum {string} */
+            source_type: "local" | "duckdb" | "connection";
+            /** @enum {string} */
+            type: "table" | "view";
+            variable_name?: string | null;
         };
-        open_ai?: {
-          api_key?: string;
-          base_url?: string;
-          model?: string;
-        };
-        rules?: string;
-      };
-      completion: {
-        activate_on_typing: boolean;
-        codeium_api_key?: string | null;
-        copilot: boolean | ("github" | "codeium");
-      };
-      display: {
-        /** @enum {string} */
-        cell_output: "above" | "below";
-        code_editor_font_size: number;
-        /** @enum {string} */
-        dataframes: "rich" | "plain";
-        /** @enum {string} */
-        default_width: "normal" | "compact" | "medium" | "full";
-        /** @enum {string} */
-        theme: "light" | "dark" | "system";
-      };
-      experimental?: {
-        [key: string]: unknown;
-      };
-      formatting: {
-        line_length: number;
-      };
-      keymap: {
-        overrides?: {
-          [key: string]: string;
+        DataTableColumn: {
+            external_type: string;
+            name: string;
+            sample_values: unknown[];
+            type: components["schemas"]["DataType"];
         };
         /** @enum {string} */
-        preset: "default" | "vim";
-      };
-      package_management: {
-        /** @enum {string} */
-        manager: "pip" | "rye" | "uv" | "poetry" | "pixi";
-      };
-      runtime: {
-        auto_instantiate: boolean;
-        /** @enum {string} */
-        auto_reload: "off" | "lazy" | "autorun";
-        /** @enum {string} */
-        on_cell_change: "lazy" | "autorun";
-        output_max_bytes: number;
-        std_stream_max_bytes: number;
-        /** @enum {string} */
-        watcher_on_save: "lazy" | "autorun";
-      };
-      save: {
-        /** @enum {string} */
-        autosave: "off" | "after_delay";
-        autosave_delay: number;
-        format_on_save: boolean;
-      };
-      server: {
-        browser: "default" | string;
-        follow_symlink: boolean;
-      };
-      snippets?: {
-        custom_paths?: string[];
-        include_default_snippets?: boolean;
-      };
-    };
-    MarimoExceptionRaisedError: {
-      exception_type: string;
-      msg: string;
-      raising_cell?: string | null;
-      /** @enum {string} */
-      type: "exception";
-    };
-    MarimoFile: {
-      initializationId?: string | null;
-      lastModified?: number | null;
-      name: string;
-      path: string;
-      sessionId?: string | null;
-    };
-    MarimoInternalError: {
-      error_id: string;
-      msg: string;
-      /** @enum {string} */
-      type: "internal";
-    };
-    MarimoInterruptionError: {
-      /** @enum {string} */
-      type: "interruption";
-    };
-    MarimoStrictExecutionError: {
-      blamed_cell?: string | null;
-      msg: string;
-      ref: string;
-      /** @enum {string} */
-      type: "strict-exception";
-    };
-    MarimoSyntaxError: {
-      msg: string;
-      /** @enum {string} */
-      type: "syntax";
-    };
-    MessageOperation:
-      | components["schemas"]["CellOp"]
-      | components["schemas"]["FunctionCallResult"]
-      | components["schemas"]["SendUIElementMessage"]
-      | components["schemas"]["RemoveUIElements"]
-      | components["schemas"]["Reload"]
-      | components["schemas"]["Reconnected"]
-      | components["schemas"]["Interrupted"]
-      | components["schemas"]["CompletedRun"]
-      | components["schemas"]["KernelReady"]
-      | components["schemas"]["CompletionResult"]
-      | components["schemas"]["Alert"]
-      | components["schemas"]["Banner"]
-      | components["schemas"]["MissingPackageAlert"]
-      | components["schemas"]["InstallingPackageAlert"]
-      | components["schemas"]["Variables"]
-      | components["schemas"]["VariableValues"]
-      | components["schemas"]["QueryParamsSet"]
-      | components["schemas"]["QueryParamsAppend"]
-      | components["schemas"]["QueryParamsDelete"]
-      | components["schemas"]["QueryParamsClear"]
-      | components["schemas"]["Datasets"]
-      | components["schemas"]["DataColumnPreview"]
-      | components["schemas"]["SQLTablePreview"]
-      | {
-          connections: components["schemas"]["DataSourceConnection"][];
-          /** @enum {string} */
-          name: "data-source-connections";
-        }
-      | components["schemas"]["FocusCell"]
-      | components["schemas"]["UpdateCellCodes"]
-      | components["schemas"]["UpdateCellIdsRequest"];
-    /** @enum {string} */
-    MimeType:
-      | "application/json"
-      | "application/vnd.marimo+error"
-      | "application/vnd.marimo+traceback"
-      | "application/vnd.marimo+mimebundle"
-      | "application/vnd.vega.v5+json"
-      | "application/vnd.vegalite.v5+json"
-      | "image/png"
-      | "image/svg+xml"
-      | "image/tiff"
-      | "image/avif"
-      | "image/bmp"
-      | "image/gif"
-      | "image/jpeg"
-      | "video/mp4"
-      | "video/mpeg"
-      | "text/html"
-      | "text/plain"
-      | "text/markdown"
-      | "text/latex"
-      | "text/csv";
-    MissingPackageAlert: {
-      isolated: boolean;
-      /** @enum {string} */
-      name: "missing-package-alert";
-      packages: string[];
-    };
-    MultipleDefinitionError: {
-      cells: string[];
-      name: string;
-      /** @enum {string} */
-      type: "multiple-defs";
-    };
-    NonNestedLiteral: number | string | boolean;
-    OpenTutorialRequest: {
-      tutorialId:
-        | (
-            | "intro"
-            | "dataflow"
-            | "ui"
-            | "markdown"
-            | "plots"
-            | "sql"
-            | "layout"
-            | "fileformat"
-            | "for-jupyter-users"
-          )
-        | "markdown-format";
-    };
-    PackageDescription: {
-      name: string;
-      version: string;
-    };
-    PackageOperationResponse: {
-      error?: string | null;
-      success: boolean;
-    };
-    PreviewDatasetColumnRequest: {
-      columnName: string;
-      source: string;
-      /** @enum {string} */
-      sourceType: "local" | "duckdb" | "connection";
-      tableName: string;
-    };
-    PreviewSQLTableRequest: {
-      database: string;
-      engine: string;
-      requestId: string;
-      schema: string;
-      tableName: string;
-    };
-    QueryParamsAppend: {
-      key: string;
-      /** @enum {string} */
-      name: "query-params-append";
-      value: string;
-    };
-    QueryParamsClear: {
-      /** @enum {string} */
-      name: "query-params-clear";
-    };
-    QueryParamsDelete: {
-      key: string;
-      /** @enum {string} */
-      name: "query-params-delete";
-      value?: string | null;
-    };
-    QueryParamsSet: {
-      key: string;
-      /** @enum {string} */
-      name: "query-params-set";
-      value: string | string[];
-    };
-    ReadCodeResponse: {
-      contents: string;
-    };
-    RecentFilesResponse: {
-      files: components["schemas"]["MarimoFile"][];
-    };
-    Reconnected: {
-      /** @enum {string} */
-      name: "reconnected";
-    };
-    Reload: {
-      /** @enum {string} */
-      name: "reload";
-    };
-    RemovePackageRequest: {
-      package: string;
-    };
-    RemoveUIElements: {
-      cell_id: string;
-      /** @enum {string} */
-      name: "remove-ui-elements";
-    };
-    RenameFileRequest: {
-      filename: string;
-    };
-    RenameRequest: {
-      filename: string;
-    };
-    RunRequest: {
-      cellIds: string[];
-      codes: string[];
-      request?: components["schemas"]["HTTPRequest"];
-    };
-    RunScratchpadRequest: {
-      code: string;
-      request?: components["schemas"]["HTTPRequest"];
-    };
-    RunningNotebooksResponse: {
-      files: components["schemas"]["MarimoFile"][];
-    };
-    /** @enum {string} */
-    RuntimeState: "idle" | "queued" | "running" | "disabled-transitively";
-    SQLTablePreview: {
-      error?: string | null;
-      /** @enum {string} */
-      name: "sql-table-preview";
-      request_id: string;
-      table?: components["schemas"]["DataTable"];
-    };
-    SaveAppConfigurationRequest: {
-      config: {
-        [key: string]: unknown;
-      };
-    };
-    SaveNotebookRequest: {
-      cellIds: string[];
-      codes: string[];
-      configs: components["schemas"]["CellConfig"][];
-      filename: string;
-      layout?: {
-        [key: string]: unknown;
-      } | null;
-      names: string[];
-      persist: boolean;
-    };
-    SaveUserConfigurationRequest: {
-      config: components["schemas"]["MarimoConfig"];
-    };
-    Schema: {
-      name: string;
-      tables: components["schemas"]["DataTable"][];
-    };
-    SendUIElementMessage: {
-      buffers?: string[] | null;
-      message: {
-        [key: string]: {
-          [key: string]: unknown;
+        DataType: "string" | "boolean" | "integer" | "number" | "date" | "datetime" | "time" | "unknown";
+        Database: {
+            dialect: string;
+            engine?: string | null;
+            name: string;
+            schemas: components["schemas"]["Schema"][];
         };
-      };
-      /** @enum {string} */
-      name: "send-ui-element-message";
-      ui_element: string;
-    };
-    SetCellConfigRequest: {
-      configs: {
-        [key: string]: {
-          [key: string]: unknown;
+        Datasets: {
+            /** @enum {string|null} */
+            clear_channel?: "local" | "duckdb" | "connection" | null;
+            /** @enum {string} */
+            name: "datasets";
+            tables: components["schemas"]["DataTable"][];
         };
-      };
+        DeleteCellRequest: {
+            cellId: string;
+        };
+        DeleteNonlocalError: {
+            cells: string[];
+            name: string;
+            /** @enum {string} */
+            type: "delete-nonlocal";
+        };
+        Error: components["schemas"]["CycleError"] | components["schemas"]["MultipleDefinitionError"] | components["schemas"]["ImportStarError"] | components["schemas"]["DeleteNonlocalError"] | components["schemas"]["MarimoAncestorStoppedError"] | components["schemas"]["MarimoAncestorPreventedError"] | components["schemas"]["MarimoExceptionRaisedError"] | components["schemas"]["MarimoStrictExecutionError"] | components["schemas"]["MarimoInterruptionError"] | components["schemas"]["MarimoSyntaxError"] | components["schemas"]["MarimoInternalError"] | components["schemas"]["UnknownError"];
+        ExecuteMultipleRequest: {
+            cellIds: string[];
+            codes: string[];
+            request?: components["schemas"]["HTTPRequest"];
+            timestamp: number;
+        };
+        ExecuteScratchpadRequest: {
+            code: string;
+            request?: components["schemas"]["HTTPRequest"];
+        };
+        ExecuteStaleRequest: Record<string, never>;
+        ExecutionRequest: {
+            cellId: string;
+            code: string;
+            request?: components["schemas"]["HTTPRequest"];
+            timestamp: number;
+        };
+        ExportAsHTMLRequest: {
+            assetUrl?: string | null;
+            download: boolean;
+            files: string[];
+            includeCode: boolean;
+        };
+        ExportAsIPYNBRequest: {
+            download: boolean;
+        };
+        ExportAsMarkdownRequest: {
+            download: boolean;
+        };
+        ExportAsScriptRequest: {
+            download: boolean;
+        };
+        FileCreateRequest: {
+            contents?: string | null;
+            name: string;
+            path: string;
+            /** @enum {string} */
+            type: "file" | "directory";
+        };
+        FileCreateResponse: {
+            info?: components["schemas"]["FileInfo"];
+            message?: string | null;
+            success: boolean;
+        };
+        FileDeleteRequest: {
+            path: string;
+        };
+        FileDeleteResponse: {
+            message?: string | null;
+            success: boolean;
+        };
+        FileDetailsRequest: {
+            path: string;
+        };
+        FileDetailsResponse: {
+            contents?: string | null;
+            file: components["schemas"]["FileInfo"];
+            mimeType?: string | null;
+        };
+        FileInfo: {
+            children: components["schemas"]["FileInfo"][];
+            id: string;
+            isDirectory: boolean;
+            isMarimoFile: boolean;
+            lastModified?: number | null;
+            name: string;
+            path: string;
+        };
+        FileListRequest: {
+            path?: string | null;
+        };
+        FileListResponse: {
+            files: components["schemas"]["FileInfo"][];
+            root: string;
+        };
+        FileMoveRequest: {
+            newPath: string;
+            path: string;
+        };
+        FileMoveResponse: {
+            info?: components["schemas"]["FileInfo"];
+            message?: string | null;
+            success: boolean;
+        };
+        FileOpenRequest: {
+            path: string;
+        };
+        FileUpdateRequest: {
+            contents: string;
+            path: string;
+        };
+        FileUpdateResponse: {
+            info?: components["schemas"]["FileInfo"];
+            message?: string | null;
+            success: boolean;
+        };
+        FocusCell: {
+            cell_id: string;
+            /** @enum {string} */
+            name: "focus-cell";
+        };
+        FormatRequest: {
+            codes: {
+                [key: string]: string;
+            };
+            lineLength: number;
+        };
+        FormatResponse: {
+            codes: {
+                [key: string]: string;
+            };
+        };
+        FunctionCallRequest: {
+            args: {
+                [key: string]: unknown;
+            };
+            functionCallId: string;
+            functionName: string;
+            namespace: string;
+        };
+        FunctionCallResult: {
+            function_call_id: string;
+            /** @enum {string} */
+            name: "function-call-result";
+            return_value?: ({
+                [key: string]: components["schemas"]["JSONType"];
+            } | components["schemas"]["JSONType"][] | string | number | boolean | {
+                [key: string]: unknown;
+            } | components["schemas"]["MIME"]) | null;
+            status: components["schemas"]["HumanReadableStatus"];
+        };
+        HTTPRequest: null;
+        HumanReadableStatus: {
+            /** @enum {string} */
+            code: "ok" | "error";
+            message?: string | null;
+            title?: string | null;
+        };
+        ImportStarError: {
+            msg: string;
+            /** @enum {string} */
+            type: "import-star";
+        };
+        InstallMissingPackagesRequest: {
+            manager: string;
+            versions: {
+                [key: string]: string;
+            };
+        };
+        InstallingPackageAlert: {
+            /** @enum {string} */
+            name: "installing-package-alert";
+            packages: {
+                [key: string]: "queued" | "installing" | "installed" | "failed";
+            };
+        };
+        InstantiateRequest: {
+            autoRun: boolean;
+            objectIds: string[];
+            values: unknown[];
+        };
+        Interrupted: {
+            /** @enum {string} */
+            name: "interrupted";
+        };
+        JSONType: string | number | Record<string, never> | unknown[] | boolean | null;
+        KernelReady: {
+            app_config: {
+                _toplevel_fn: boolean;
+                app_title?: string | null;
+                auto_download: ("html" | "markdown")[];
+                css_file?: string | null;
+                html_head_file?: string | null;
+                layout_file?: string | null;
+                /** @enum {string} */
+                width: "normal" | "compact" | "medium" | "full";
+            };
+            capabilities: {
+                sql: boolean;
+                terminal: boolean;
+            };
+            cell_ids: string[];
+            codes: string[];
+            configs: components["schemas"]["CellConfig"][];
+            kiosk: boolean;
+            last_executed_code?: {
+                [key: string]: string;
+            } | null;
+            last_execution_time?: {
+                [key: string]: number;
+            } | null;
+            layout?: {
+                data: {
+                    [key: string]: unknown;
+                };
+                type: string;
+            } | null;
+            /** @enum {string} */
+            name: "kernel-ready";
+            names: string[];
+            resumed: boolean;
+            ui_values?: {
+                [key: string]: ({
+                    [key: string]: ({
+                        [key: string]: components["schemas"]["JSONType"];
+                    } | components["schemas"]["JSONType"][] | string | number | boolean | {
+                        [key: string]: unknown;
+                    } | components["schemas"]["MIME"]) | null;
+                } | (({
+                    [key: string]: components["schemas"]["JSONType"];
+                } | components["schemas"]["JSONType"][] | string | number | boolean | {
+                    [key: string]: unknown;
+                } | components["schemas"]["MIME"]) | null)[] | string | number | boolean | {
+                    [key: string]: unknown;
+                } | components["schemas"]["MIME"]) | null;
+            } | null;
+        };
+        ListPackagesResponse: {
+            packages: components["schemas"]["PackageDescription"][];
+        };
+        MIME: Record<string, never>;
+        MarimoAncestorPreventedError: {
+            blamed_cell?: string | null;
+            msg: string;
+            raising_cell: string;
+            /** @enum {string} */
+            type: "ancestor-prevented";
+        };
+        MarimoAncestorStoppedError: {
+            msg: string;
+            raising_cell: string;
+            /** @enum {string} */
+            type: "ancestor-stopped";
+        };
+        MarimoConfig: {
+            ai?: {
+                anthropic?: {
+                    api_key?: string;
+                };
+                google?: {
+                    api_key?: string;
+                };
+                open_ai?: {
+                    api_key?: string;
+                    base_url?: string;
+                    model?: string;
+                };
+                rules?: string;
+            };
+            completion: {
+                activate_on_typing: boolean;
+                codeium_api_key?: string | null;
+                copilot: boolean | ("github" | "codeium");
+            };
+            display: {
+                /** @enum {string} */
+                cell_output: "above" | "below";
+                code_editor_font_size: number;
+                /** @enum {string} */
+                dataframes: "rich" | "plain";
+                /** @enum {string} */
+                default_width: "normal" | "compact" | "medium" | "full";
+                /** @enum {string} */
+                theme: "light" | "dark" | "system";
+            };
+            experimental?: {
+                [key: string]: unknown;
+            };
+            formatting: {
+                line_length: number;
+            };
+            keymap: {
+                overrides?: {
+                    [key: string]: string;
+                };
+                /** @enum {string} */
+                preset: "default" | "vim";
+            };
+            package_management: {
+                /** @enum {string} */
+                manager: "pip" | "rye" | "uv" | "poetry" | "pixi";
+            };
+            runtime: {
+                auto_instantiate: boolean;
+                /** @enum {string} */
+                auto_reload: "off" | "lazy" | "autorun";
+                /** @enum {string} */
+                on_cell_change: "lazy" | "autorun";
+                output_max_bytes: number;
+                std_stream_max_bytes: number;
+                /** @enum {string} */
+                watcher_on_save: "lazy" | "autorun";
+            };
+            save: {
+                /** @enum {string} */
+                autosave: "off" | "after_delay";
+                autosave_delay: number;
+                format_on_save: boolean;
+            };
+            server: {
+                browser: "default" | string;
+                follow_symlink: boolean;
+            };
+            snippets?: {
+                custom_paths?: string[];
+                include_default_snippets?: boolean;
+            };
+        };
+        MarimoExceptionRaisedError: {
+            exception_type: string;
+            msg: string;
+            raising_cell?: string | null;
+            /** @enum {string} */
+            type: "exception";
+        };
+        MarimoFile: {
+            initializationId?: string | null;
+            lastModified?: number | null;
+            name: string;
+            path: string;
+            sessionId?: string | null;
+        };
+        MarimoInternalError: {
+            error_id: string;
+            msg: string;
+            /** @enum {string} */
+            type: "internal";
+        };
+        MarimoInterruptionError: {
+            /** @enum {string} */
+            type: "interruption";
+        };
+        MarimoStrictExecutionError: {
+            blamed_cell?: string | null;
+            msg: string;
+            ref: string;
+            /** @enum {string} */
+            type: "strict-exception";
+        };
+        MarimoSyntaxError: {
+            msg: string;
+            /** @enum {string} */
+            type: "syntax";
+        };
+        MessageOperation: components["schemas"]["CellOp"] | components["schemas"]["FunctionCallResult"] | components["schemas"]["SendUIElementMessage"] | components["schemas"]["RemoveUIElements"] | components["schemas"]["Reload"] | components["schemas"]["Reconnected"] | components["schemas"]["Interrupted"] | components["schemas"]["CompletedRun"] | components["schemas"]["KernelReady"] | components["schemas"]["CompletionResult"] | components["schemas"]["Alert"] | components["schemas"]["Banner"] | components["schemas"]["MissingPackageAlert"] | components["schemas"]["InstallingPackageAlert"] | components["schemas"]["Variables"] | components["schemas"]["VariableValues"] | components["schemas"]["QueryParamsSet"] | components["schemas"]["QueryParamsAppend"] | components["schemas"]["QueryParamsDelete"] | components["schemas"]["QueryParamsClear"] | components["schemas"]["Datasets"] | components["schemas"]["DataColumnPreview"] | components["schemas"]["SQLTablePreview"] | {
+            connections: components["schemas"]["DataSourceConnection"][];
+            /** @enum {string} */
+            name: "data-source-connections";
+        } | components["schemas"]["FocusCell"] | components["schemas"]["UpdateCellCodes"] | components["schemas"]["UpdateCellIdsRequest"];
+        /** @enum {string} */
+        MimeType: "application/json" | "application/vnd.marimo+error" | "application/vnd.marimo+traceback" | "application/vnd.marimo+mimebundle" | "application/vnd.vega.v5+json" | "application/vnd.vegalite.v5+json" | "image/png" | "image/svg+xml" | "image/tiff" | "image/avif" | "image/bmp" | "image/gif" | "image/jpeg" | "video/mp4" | "video/mpeg" | "text/html" | "text/plain" | "text/markdown" | "text/latex" | "text/csv";
+        MissingPackageAlert: {
+            isolated: boolean;
+            /** @enum {string} */
+            name: "missing-package-alert";
+            packages: string[];
+        };
+        MultipleDefinitionError: {
+            cells: string[];
+            name: string;
+            /** @enum {string} */
+            type: "multiple-defs";
+        };
+        NonNestedLiteral: number | string | boolean;
+        OpenTutorialRequest: {
+            tutorialId: ("intro" | "dataflow" | "ui" | "markdown" | "plots" | "sql" | "layout" | "fileformat" | "for-jupyter-users") | "markdown-format";
+        };
+        PackageDescription: {
+            name: string;
+            version: string;
+        };
+        PackageOperationResponse: {
+            error?: string | null;
+            success: boolean;
+        };
+        PreviewDatasetColumnRequest: {
+            columnName: string;
+            source: string;
+            /** @enum {string} */
+            sourceType: "local" | "duckdb" | "connection";
+            tableName: string;
+        };
+        PreviewSQLTableRequest: {
+            database: string;
+            engine: string;
+            requestId: string;
+            schema: string;
+            tableName: string;
+        };
+        QueryParamsAppend: {
+            key: string;
+            /** @enum {string} */
+            name: "query-params-append";
+            value: string;
+        };
+        QueryParamsClear: {
+            /** @enum {string} */
+            name: "query-params-clear";
+        };
+        QueryParamsDelete: {
+            key: string;
+            /** @enum {string} */
+            name: "query-params-delete";
+            value?: string | null;
+        };
+        QueryParamsSet: {
+            key: string;
+            /** @enum {string} */
+            name: "query-params-set";
+            value: string | string[];
+        };
+        ReadCodeResponse: {
+            contents: string;
+        };
+        RecentFilesResponse: {
+            files: components["schemas"]["MarimoFile"][];
+        };
+        Reconnected: {
+            /** @enum {string} */
+            name: "reconnected";
+        };
+        Reload: {
+            /** @enum {string} */
+            name: "reload";
+        };
+        RemovePackageRequest: {
+            package: string;
+        };
+        RemoveUIElements: {
+            cell_id: string;
+            /** @enum {string} */
+            name: "remove-ui-elements";
+        };
+        RenameFileRequest: {
+            filename: string;
+        };
+        RenameRequest: {
+            filename: string;
+        };
+        RunRequest: {
+            cellIds: string[];
+            codes: string[];
+            request?: components["schemas"]["HTTPRequest"];
+        };
+        RunScratchpadRequest: {
+            code: string;
+            request?: components["schemas"]["HTTPRequest"];
+        };
+        RunningNotebooksResponse: {
+            files: components["schemas"]["MarimoFile"][];
+        };
+        /** @enum {string} */
+        RuntimeState: "idle" | "queued" | "running" | "disabled-transitively";
+        SQLTablePreview: {
+            error?: string | null;
+            /** @enum {string} */
+            name: "sql-table-preview";
+            request_id: string;
+            table?: components["schemas"]["DataTable"];
+        };
+        SaveAppConfigurationRequest: {
+            config: {
+                [key: string]: unknown;
+            };
+        };
+        SaveNotebookRequest: {
+            cellIds: string[];
+            codes: string[];
+            configs: components["schemas"]["CellConfig"][];
+            filename: string;
+            layout?: {
+                [key: string]: unknown;
+            } | null;
+            names: string[];
+            persist: boolean;
+        };
+        SaveUserConfigurationRequest: {
+            config: components["schemas"]["MarimoConfig"];
+        };
+        Schema: {
+            name: string;
+            tables: components["schemas"]["DataTable"][];
+        };
+        SendUIElementMessage: {
+            buffers?: string[] | null;
+            message: {
+                [key: string]: {
+                    [key: string]: unknown;
+                };
+            };
+            /** @enum {string} */
+            name: "send-ui-element-message";
+            ui_element: string;
+        };
+        SetCellConfigRequest: {
+            configs: {
+                [key: string]: {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        SetUIElementValueRequest: {
+            objectIds: string[];
+            request?: components["schemas"]["HTTPRequest"];
+            token: string;
+            values: unknown[];
+        };
+        SetUserConfigRequest: {
+            config: components["schemas"]["MarimoConfig"];
+        };
+        ShutdownSessionRequest: {
+            sessionId: string;
+        };
+        Snippet: {
+            sections: components["schemas"]["SnippetSection"][];
+            title: string;
+        };
+        SnippetSection: {
+            code?: string | null;
+            html?: string | null;
+            id: string;
+        };
+        Snippets: {
+            snippets: components["schemas"]["Snippet"][];
+        };
+        StdinRequest: {
+            text: string;
+        };
+        StopRequest: Record<string, never>;
+        SuccessResponse: {
+            success: boolean;
+        };
+        UnknownError: {
+            msg: string;
+            /** @enum {string} */
+            type: "unknown";
+        };
+        UpdateCellCodes: {
+            cell_ids: string[];
+            code_is_stale: boolean;
+            codes: string[];
+            /** @enum {string} */
+            name: "update-cell-codes";
+        };
+        UpdateCellIdsRequest: {
+            cell_ids: string[];
+            /** @enum {string} */
+            name: "update-cell-ids";
+        };
+        UpdateComponentValuesRequest: {
+            objectIds: string[];
+            values: unknown[];
+        };
+        VariableDeclaration: {
+            declared_by: string[];
+            name: string;
+            used_by: string[];
+        };
+        VariableValue: {
+            datatype?: string | null;
+            name: string;
+            value?: string | null;
+        };
+        VariableValues: {
+            /** @enum {string} */
+            name: "variable-values";
+            variables: components["schemas"]["VariableValue"][];
+        };
+        Variables: {
+            /** @enum {string} */
+            name: "variables";
+            variables: components["schemas"]["VariableDeclaration"][];
+        };
+        WorkspaceFilesRequest: {
+            includeMarkdown: boolean;
+        };
+        WorkspaceFilesResponse: {
+            files: components["schemas"]["FileInfo"][];
+            root: string;
+        };
     };
-    SetUIElementValueRequest: {
-      objectIds: string[];
-      request?: components["schemas"]["HTTPRequest"];
-      token: string;
-      values: unknown[];
-    };
-    SetUserConfigRequest: {
-      config: components["schemas"]["MarimoConfig"];
-    };
-    ShutdownSessionRequest: {
-      sessionId: string;
-    };
-    Snippet: {
-      sections: components["schemas"]["SnippetSection"][];
-      title: string;
-    };
-    SnippetSection: {
-      code?: string | null;
-      html?: string | null;
-      id: string;
-    };
-    Snippets: {
-      snippets: components["schemas"]["Snippet"][];
-    };
-    StdinRequest: {
-      text: string;
-    };
-    StopRequest: Record<string, never>;
-    SuccessResponse: {
-      success: boolean;
-    };
-    UnknownError: {
-      msg: string;
-      /** @enum {string} */
-      type: "unknown";
-    };
-    UpdateCellCodes: {
-      cell_ids: string[];
-      code_is_stale: boolean;
-      codes: string[];
-      /** @enum {string} */
-      name: "update-cell-codes";
-    };
-    UpdateCellIdsRequest: {
-      cell_ids: string[];
-      /** @enum {string} */
-      name: "update-cell-ids";
-    };
-    UpdateComponentValuesRequest: {
-      objectIds: string[];
-      values: unknown[];
-    };
-    VariableDeclaration: {
-      declared_by: string[];
-      name: string;
-      used_by: string[];
-    };
-    VariableValue: {
-      datatype?: string | null;
-      name: string;
-      value?: string | null;
-    };
-    VariableValues: {
-      /** @enum {string} */
-      name: "variable-values";
-      variables: components["schemas"]["VariableValue"][];
-    };
-    Variables: {
-      /** @enum {string} */
-      name: "variables";
-      variables: components["schemas"]["VariableDeclaration"][];
-    };
-    WorkspaceFilesRequest: {
-      includeMarkdown: boolean;
-    };
-    WorkspaceFilesResponse: {
-      files: components["schemas"]["FileInfo"][];
-      root: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -4,2901 +4,3042 @@
  */
 
 export interface paths {
-    "/@file/{filename_and_length}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description The filename and byte length of the virtual file */
-                    filename_and_length: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get a virtual file */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/octet-stream": string;
-                    };
-                };
-                /** @description Invalid byte length in virtual file request */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/@file/{filename_and_length}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/ai/completion": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          /** @description The filename and byte length of the virtual file */
+          filename_and_length: string;
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description The prompt to get AI completion for */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["AiCompletionRequest"];
-                };
-            };
-            responses: {
-                /** @description Get AI completion for a prompt */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            [key: string]: unknown;
-                        };
-                    };
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Get a virtual file */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/octet-stream": string;
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Invalid byte length in virtual file request */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/datasources/preview_column": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["PreviewDatasetColumnRequest"];
-                };
-            };
-            responses: {
-                /** @description Preview a column in a dataset */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/ai/completion": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/datasources/preview_sql_table": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      /** @description The prompt to get AI completion for */
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["AiCompletionRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
+      };
+      responses: {
+        /** @description Get AI completion for a prompt */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              [key: string]: unknown;
             };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["PreviewSQLTableRequest"];
-                };
-            };
-            responses: {
-                /** @description Preview a SQL table */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/documentation/snippets": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Load the snippets for the documentation page */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Snippets"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/datasources/preview_column": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/export/auto_export/html": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["PreviewDatasetColumnRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ExportAsHTMLRequest"];
-                };
-            };
-            responses: {
-                /** @description Export the notebook as HTML */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-                /** @description File must be saved before downloading */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+      };
+      responses: {
+        /** @description Preview a column in a dataset */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/export/auto_export/ipynb": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ExportAsIPYNBRequest"];
-                };
-            };
-            responses: {
-                /** @description Export the notebook as IPYNB */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-                /** @description File must be saved before downloading */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/datasources/preview_sql_table": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/export/auto_export/markdown": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["PreviewSQLTableRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ExportAsMarkdownRequest"];
-                };
-            };
-            responses: {
-                /** @description Export the notebook as a markdown */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-                /** @description File must be saved before downloading */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+      };
+      responses: {
+        /** @description Preview a SQL table */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/export/html": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ExportAsHTMLRequest"];
-                };
-            };
-            responses: {
-                /** @description Export the notebook as HTML */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/html": string;
-                    };
-                };
-                /** @description File must be saved before downloading */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/documentation/snippets": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/export/markdown": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Load the snippets for the documentation page */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Snippets"];
+          };
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ExportAsMarkdownRequest"];
-                };
-            };
-            responses: {
-                /** @description Export the notebook as a markdown */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/plain": string;
-                    };
-                };
-                /** @description File must be saved before downloading */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/export/script": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ExportAsScriptRequest"];
-                };
-            };
-            responses: {
-                /** @description Export the notebook as a script */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/plain": string;
-                    };
-                };
-                /** @description File must be saved before downloading */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/export/auto_export/html": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/files/create": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ExportAsHTMLRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FileCreateRequest"];
-                };
-            };
-            responses: {
-                /** @description Create a new file or directory */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["FileCreateResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Export the notebook as HTML */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/files/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FileDeleteRequest"];
-                };
-            };
-            responses: {
-                /** @description Delete a file or directory */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["FileDeleteResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/export/auto_export/ipynb": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/files/file_details": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ExportAsIPYNBRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FileDetailsRequest"];
-                };
-            };
-            responses: {
-                /** @description Get details of a specific file or directory */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["FileDetailsResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Export the notebook as IPYNB */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/files/list_files": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FileListRequest"];
-                };
-            };
-            responses: {
-                /** @description List files and directories in a given path */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["FileListResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/export/auto_export/markdown": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/files/move": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ExportAsMarkdownRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FileMoveRequest"];
-                };
-            };
-            responses: {
-                /** @description Move a file or directory */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["FileMoveResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Export the notebook as a markdown */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/files/open": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FileOpenRequest"];
-                };
-            };
-            responses: {
-                /** @description Open a file in the system editor */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["BaseResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/export/html": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/files/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ExportAsHTMLRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FileUpdateRequest"];
-                };
-            };
-            responses: {
-                /** @description Update a file or directory */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["FileUpdateResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Export the notebook as HTML */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/html": string;
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/home/recent_files": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get the recent files */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["RecentFilesResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/export/markdown": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/home/running_notebooks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ExportAsMarkdownRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get the running files */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["RunningNotebooksResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Export the notebook as a markdown */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/plain": string;
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/home/shutdown_session": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["ShutdownSessionRequest"];
-                };
-            };
-            responses: {
-                /** @description Shutdown the current session */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["RunningNotebooksResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/export/script": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/home/tutorial/open": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ExportAsScriptRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["OpenTutorialRequest"];
-                };
-            };
-            responses: {
-                /** @description Open a new tutorial */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["MarimoFile"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Export the notebook as a script */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/plain": string;
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/home/workspace_files": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["WorkspaceFilesRequest"];
-                };
-            };
-            responses: {
-                /** @description Get the files in the workspace */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["WorkspaceFilesResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/files/create": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/code_autocomplete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FileCreateRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["CodeCompletionRequest"];
-                };
-            };
-            responses: {
-                /** @description Complete a code fragment */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Create a new file or directory */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["FileCreateResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/copy": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["CopyNotebookRequest"];
-                };
-            };
-            responses: {
-                /** @description Copy notebook */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/plain": string;
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/files/delete": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FileDeleteRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["DeleteCellRequest"];
-                };
-            };
-            responses: {
-                /** @description Delete a cell */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Delete a file or directory */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["FileDeleteResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/format": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FormatRequest"];
-                };
-            };
-            responses: {
-                /** @description Format code */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["FormatResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/files/file_details": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/function_call": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FileDetailsRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["FunctionCallRequest"];
-                };
-            };
-            responses: {
-                /** @description Invoke an RPC */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Get details of a specific file or directory */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["FileDetailsResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/install_missing_packages": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["InstallMissingPackagesRequest"];
-                };
-            };
-            responses: {
-                /** @description Install missing packages */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/files/list_files": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/instantiate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FileListRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["InstantiateRequest"];
-                };
-            };
-            responses: {
-                /** @description Instantiate a component */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description List files and directories in a given path */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["FileListResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/interrupt": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Interrupt the kernel's execution */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/files/move": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/read_code": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FileMoveRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Read the code from the server */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ReadCodeResponse"];
-                    };
-                };
-                /** @description File must be saved before downloading */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+      };
+      responses: {
+        /** @description Move a file or directory */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["FileMoveResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/rename": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["RenameFileRequest"];
-                };
-            };
-            responses: {
-                /** @description Rename the current app */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/files/open": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/restart_session": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FileOpenRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Restart the current session without affecting other sessions. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Open a file in the system editor */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["BaseResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/run": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["RunRequest"];
-                };
-            };
-            responses: {
-                /** @description Run a cell. Updates cell code in the kernel if needed; registers new cells for unseen cell IDs. Only allowed in edit mode. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/files/update": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/save": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FileUpdateRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["SaveNotebookRequest"];
-                };
-            };
-            responses: {
-                /** @description Save the current app */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/plain": string;
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Update a file or directory */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["FileUpdateResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/save_app_config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["SaveAppConfigurationRequest"];
-                };
-            };
-            responses: {
-                /** @description Save the app configuration */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/plain": string;
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/home/recent_files": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/save_user_config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Get the recent files */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["RecentFilesResponse"];
+          };
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["SaveUserConfigurationRequest"];
-                };
-            };
-            responses: {
-                /** @description Update the user config on disk and in the kernel. Only allowed in edit mode. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/scratchpad/run": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["RunScratchpadRequest"];
-                };
-            };
-            responses: {
-                /** @description Run the scratchpad */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/home/running_notebooks": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/set_cell_config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Get the running files */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["RunningNotebooksResponse"];
+          };
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["SetCellConfigRequest"];
-                };
-            };
-            responses: {
-                /** @description Set the configuration of a cell */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/set_ui_element_value": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["UpdateComponentValuesRequest"];
-                };
-            };
-            responses: {
-                /** @description Set UI element values */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/home/shutdown_session": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/shutdown": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["ShutdownSessionRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Shutdown the kernel */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Shutdown the current session */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["RunningNotebooksResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/stdin": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["StdinRequest"];
-                };
-            };
-            responses: {
-                /** @description Send input to the stdin stream */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/home/tutorial/open": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/kernel/sync/cell_ids": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["OpenTutorialRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["UpdateCellIdsRequest"];
-                };
-            };
-            responses: {
-                /** @description Sync cell ids */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SuccessResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Open a new tutorial */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["MarimoFile"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/kernel/takeover": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/home/workspace_files": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/packages/add": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["WorkspaceFilesRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["AddPackageRequest"];
-                };
-            };
-            responses: {
-                /** @description Install package */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PackageOperationResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Get the files in the workspace */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["WorkspaceFilesResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/packages/list": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description List installed packages */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ListPackagesResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/code_autocomplete": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/packages/remove": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["CodeCompletionRequest"];
         };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["RemovePackageRequest"];
-                };
-            };
-            responses: {
-                /** @description Uninstall package */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PackageOperationResponse"];
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Complete a code fragment */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get the status of the application */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            filenames?: string[];
-                            lsp_running?: boolean;
-                            mode?: string;
-                            node_version?: string;
-                            requirements?: string[];
-                            sessions?: number;
-                            status?: string;
-                            version?: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/copy": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/status/connections": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["CopyNotebookRequest"];
         };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get the number of active websocket connections */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            active?: number;
-                        };
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Copy notebook */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/plain": string;
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/usage": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get the current memory and CPU usage of the application */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            cpu: {
-                                percent: number;
-                            };
-                            kernel?: {
-                                memory?: number;
-                            };
-                            memory: {
-                                available: number;
-                                free: number;
-                                percent: number;
-                                total: number;
-                                used: number;
-                            };
-                            server?: {
-                                memory: number;
-                            };
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/delete": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/version": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["DeleteCellRequest"];
         };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get the version of the application */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/plain": string;
-                    };
-                };
-            };
+      };
+      responses: {
+        /** @description Delete a cell */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/auth/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Submit login form */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/x-www-form-urlencoded": {
-                        /** @description Access token or password */
-                        password?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Login page */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/html": string;
-                    };
-                };
-                /** @description Redirect to the next URL */
-                302: {
-                    headers: {
-                        Location?: string;
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/format": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FormatRequest"];
+        };
+      };
+      responses: {
+        /** @description Format code */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["FormatResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/function_call": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FunctionCallRequest"];
+        };
+      };
+      responses: {
+        /** @description Invoke an RPC */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/install_missing_packages": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["InstallMissingPackagesRequest"];
+        };
+      };
+      responses: {
+        /** @description Install missing packages */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/instantiate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["InstantiateRequest"];
+        };
+      };
+      responses: {
+        /** @description Instantiate a component */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/interrupt": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Interrupt the kernel's execution */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/read_code": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Read the code from the server */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["ReadCodeResponse"];
+          };
+        };
+        /** @description File must be saved before downloading */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/rename": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["RenameFileRequest"];
+        };
+      };
+      responses: {
+        /** @description Rename the current app */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/restart_session": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Restart the current session without affecting other sessions. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/run": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["RunRequest"];
+        };
+      };
+      responses: {
+        /** @description Run a cell. Updates cell code in the kernel if needed; registers new cells for unseen cell IDs. Only allowed in edit mode. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/save": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["SaveNotebookRequest"];
+        };
+      };
+      responses: {
+        /** @description Save the current app */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/plain": string;
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/save_app_config": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["SaveAppConfigurationRequest"];
+        };
+      };
+      responses: {
+        /** @description Save the app configuration */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/plain": string;
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/save_user_config": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["SaveUserConfigurationRequest"];
+        };
+      };
+      responses: {
+        /** @description Update the user config on disk and in the kernel. Only allowed in edit mode. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/scratchpad/run": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["RunScratchpadRequest"];
+        };
+      };
+      responses: {
+        /** @description Run the scratchpad */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/set_cell_config": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["SetCellConfigRequest"];
+        };
+      };
+      responses: {
+        /** @description Set the configuration of a cell */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/set_ui_element_value": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["UpdateComponentValuesRequest"];
+        };
+      };
+      responses: {
+        /** @description Set UI element values */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/shutdown": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Shutdown the kernel */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/stdin": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["StdinRequest"];
+        };
+      };
+      responses: {
+        /** @description Send input to the stdin stream */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/sync/cell_ids": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["UpdateCellIdsRequest"];
+        };
+      };
+      responses: {
+        /** @description Sync cell ids */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/kernel/takeover": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: never;
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/packages/add": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["AddPackageRequest"];
+        };
+      };
+      responses: {
+        /** @description Install package */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PackageOperationResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/packages/list": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description List installed packages */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["ListPackagesResponse"];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/packages/remove": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["RemovePackageRequest"];
+        };
+      };
+      responses: {
+        /** @description Uninstall package */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["PackageOperationResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/status": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Get the status of the application */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              filenames?: string[];
+              lsp_running?: boolean;
+              mode?: string;
+              node_version?: string;
+              requirements?: string[];
+              sessions?: number;
+              status?: string;
+              version?: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/status/connections": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Get the number of active websocket connections */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              active?: number;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/usage": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Get the current memory and CPU usage of the application */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              cpu: {
+                percent: number;
+              };
+              kernel?: {
+                memory?: number;
+              };
+              memory: {
+                available: number;
+                free: number;
+                percent: number;
+                total: number;
+                used: number;
+              };
+              server?: {
+                memory: number;
+              };
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/version": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Get the version of the application */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/plain": string;
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/login": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Submit login form */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/x-www-form-urlencoded": {
+            /** @description Access token or password */
+            password?: string;
+          };
+        };
+      };
+      responses: {
+        /** @description Login page */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "text/html": string;
+          };
+        };
+        /** @description Redirect to the next URL */
+        302: {
+          headers: {
+            Location?: string;
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        AddPackageRequest: {
-            package: string;
-        };
-        AiCompletionRequest: {
-            code: string;
-            context?: {
-                schema: {
-                    columns: {
-                        name: string;
-                        sampleValues: unknown[];
-                        type: string;
-                    }[];
-                    name: string;
-                }[];
-            } | null;
-            includeOtherCode: string;
-            /** @enum {string} */
-            language: "python" | "markdown" | "sql";
-            prompt: string;
-        };
-        Alert: {
-            description: string;
-            /** @enum {string} */
-            name: "alert";
-            title: string;
-            /** @enum {string|null} */
-            variant?: "danger" | null;
-        };
-        AppMetadata: {
-            cliArgs: {
-                [key: string]: string | boolean | number | (string | boolean | number)[];
-            };
-            filename?: string | null;
-            queryParams: {
-                [key: string]: string | string[];
-            };
-        };
-        Banner: {
-            /** @enum {string|null} */
-            action?: "restart" | null;
-            description: string;
-            /** @enum {string} */
-            name: "banner";
-            title: string;
-            /** @enum {string|null} */
-            variant?: "danger" | null;
-        };
-        BaseResponse: {
-            success: boolean;
-        };
-        /** @enum {string} */
-        CellChannel: "stdout" | "stderr" | "stdin" | "pdb" | "output" | "marimo-error" | "media";
-        CellConfig: {
-            column?: number | null;
-            disabled: boolean;
-            hide_code: boolean;
-        };
-        CellOp: {
-            cell_id: string;
-            console?: (components["schemas"]["CellOutput"] | components["schemas"]["CellOutput"][]) | null;
-            /** @enum {string} */
-            name: "cell-op";
-            output?: components["schemas"]["CellOutput"];
-            run_id?: string | null;
-            stale_inputs?: boolean | null;
-            status?: components["schemas"]["RuntimeState"];
-            timestamp: number;
-        };
-        CellOutput: {
-            channel: components["schemas"]["CellChannel"];
-            data: string | components["schemas"]["Error"][] | {
-                [key: string]: unknown;
-            };
-            mimetype: components["schemas"]["MimeType"];
-            timestamp: number;
-        };
-        CodeCompletionRequest: {
-            cellId: string;
-            document: string;
-            id: string;
-        };
-        ColumnSummary: {
-            false?: number | null;
-            max?: components["schemas"]["NonNestedLiteral"];
-            mean?: components["schemas"]["NonNestedLiteral"];
-            median?: components["schemas"]["NonNestedLiteral"];
-            min?: components["schemas"]["NonNestedLiteral"];
-            nulls?: number | null;
-            p25?: components["schemas"]["NonNestedLiteral"];
-            p5?: components["schemas"]["NonNestedLiteral"];
-            p75?: components["schemas"]["NonNestedLiteral"];
-            p95?: components["schemas"]["NonNestedLiteral"];
-            std?: components["schemas"]["NonNestedLiteral"];
-            total?: number | null;
-            true?: number | null;
-            unique?: number | null;
-        };
-        CompletedRun: {
-            /** @enum {string} */
-            name: "completed-run";
-        };
-        CompletionResult: {
-            completion_id: string;
-            /** @enum {string} */
-            name: "completion-result";
-            options: {
-                completion_info?: string | null;
-                name: string;
-                type: string;
-            }[];
-            prefix_length: number;
-        };
-        CopyNotebookRequest: {
-            destination: string;
-            source: string;
-        };
-        CycleError: {
-            edges_with_vars: [
-                string,
-                string[],
-                string
-            ][];
-            /** @enum {string} */
-            type: "cycle";
-        };
-        DataColumnPreview: {
-            chart_code?: string | null;
-            chart_max_rows_errors: boolean;
-            chart_spec?: string | null;
-            column_name: string;
-            error?: string | null;
-            /** @enum {string} */
-            name: "data-column-preview";
-            summary?: components["schemas"]["ColumnSummary"];
-            table_name: string;
-        };
-        DataSourceConnection: {
-            databases: {
-                dialect: string;
-                engine?: string | null;
-                name: string;
-                schemas: {
-                    name: string;
-                    tables: components["schemas"]["DataTable"][];
-                }[];
-            }[];
-            dialect: string;
-            display_name: string;
-            name: string;
-            source: string;
-        };
-        DataSourceConnections: {
-            connections: components["schemas"]["DataSourceConnection"][];
-            /** @enum {string} */
-            name: "data-source-connections";
-        };
-        DataTable: {
-            columns: components["schemas"]["DataTableColumn"][];
-            engine?: string | null;
-            indexes?: string[] | null;
-            name: string;
-            num_columns?: number | null;
-            num_rows?: number | null;
-            primary_keys?: string[] | null;
-            source: string;
-            /** @enum {string} */
-            source_type: "local" | "duckdb" | "connection";
-            /** @enum {string} */
-            type: "table" | "view";
-            variable_name?: string | null;
-        };
-        DataTableColumn: {
-            external_type: string;
-            name: string;
-            sample_values: unknown[];
-            type: components["schemas"]["DataType"];
-        };
-        /** @enum {string} */
-        DataType: "string" | "boolean" | "integer" | "number" | "date" | "datetime" | "time" | "unknown";
-        Database: {
-            dialect: string;
-            engine?: string | null;
-            name: string;
-            schemas: components["schemas"]["Schema"][];
-        };
-        Datasets: {
-            /** @enum {string|null} */
-            clear_channel?: "local" | "duckdb" | "connection" | null;
-            /** @enum {string} */
-            name: "datasets";
-            tables: components["schemas"]["DataTable"][];
-        };
-        DeleteCellRequest: {
-            cellId: string;
-        };
-        DeleteNonlocalError: {
-            cells: string[];
-            name: string;
-            /** @enum {string} */
-            type: "delete-nonlocal";
-        };
-        Error: components["schemas"]["CycleError"] | components["schemas"]["MultipleDefinitionError"] | components["schemas"]["ImportStarError"] | components["schemas"]["DeleteNonlocalError"] | components["schemas"]["MarimoAncestorStoppedError"] | components["schemas"]["MarimoAncestorPreventedError"] | components["schemas"]["MarimoExceptionRaisedError"] | components["schemas"]["MarimoStrictExecutionError"] | components["schemas"]["MarimoInterruptionError"] | components["schemas"]["MarimoSyntaxError"] | components["schemas"]["MarimoInternalError"] | components["schemas"]["UnknownError"];
-        ExecuteMultipleRequest: {
-            cellIds: string[];
-            codes: string[];
-            request?: components["schemas"]["HTTPRequest"];
-            timestamp: number;
-        };
-        ExecuteScratchpadRequest: {
-            code: string;
-            request?: components["schemas"]["HTTPRequest"];
-        };
-        ExecuteStaleRequest: Record<string, never>;
-        ExecutionRequest: {
-            cellId: string;
-            code: string;
-            request?: components["schemas"]["HTTPRequest"];
-            timestamp: number;
-        };
-        ExportAsHTMLRequest: {
-            assetUrl?: string | null;
-            download: boolean;
-            files: string[];
-            includeCode: boolean;
-        };
-        ExportAsIPYNBRequest: {
-            download: boolean;
-        };
-        ExportAsMarkdownRequest: {
-            download: boolean;
-        };
-        ExportAsScriptRequest: {
-            download: boolean;
-        };
-        FileCreateRequest: {
-            contents?: string | null;
-            name: string;
-            path: string;
-            /** @enum {string} */
-            type: "file" | "directory";
-        };
-        FileCreateResponse: {
-            info?: components["schemas"]["FileInfo"];
-            message?: string | null;
-            success: boolean;
-        };
-        FileDeleteRequest: {
-            path: string;
-        };
-        FileDeleteResponse: {
-            message?: string | null;
-            success: boolean;
-        };
-        FileDetailsRequest: {
-            path: string;
-        };
-        FileDetailsResponse: {
-            contents?: string | null;
-            file: components["schemas"]["FileInfo"];
-            mimeType?: string | null;
-        };
-        FileInfo: {
-            children: components["schemas"]["FileInfo"][];
-            id: string;
-            isDirectory: boolean;
-            isMarimoFile: boolean;
-            lastModified?: number | null;
-            name: string;
-            path: string;
-        };
-        FileListRequest: {
-            path?: string | null;
-        };
-        FileListResponse: {
-            files: components["schemas"]["FileInfo"][];
-            root: string;
-        };
-        FileMoveRequest: {
-            newPath: string;
-            path: string;
-        };
-        FileMoveResponse: {
-            info?: components["schemas"]["FileInfo"];
-            message?: string | null;
-            success: boolean;
-        };
-        FileOpenRequest: {
-            path: string;
-        };
-        FileUpdateRequest: {
-            contents: string;
-            path: string;
-        };
-        FileUpdateResponse: {
-            info?: components["schemas"]["FileInfo"];
-            message?: string | null;
-            success: boolean;
-        };
-        FocusCell: {
-            cell_id: string;
-            /** @enum {string} */
-            name: "focus-cell";
-        };
-        FormatRequest: {
-            codes: {
-                [key: string]: string;
-            };
-            lineLength: number;
-        };
-        FormatResponse: {
-            codes: {
-                [key: string]: string;
-            };
-        };
-        FunctionCallRequest: {
-            args: {
-                [key: string]: unknown;
-            };
-            functionCallId: string;
-            functionName: string;
-            namespace: string;
-        };
-        FunctionCallResult: {
-            function_call_id: string;
-            /** @enum {string} */
-            name: "function-call-result";
-            return_value?: ({
-                [key: string]: components["schemas"]["JSONType"];
-            } | components["schemas"]["JSONType"][] | string | number | boolean | {
-                [key: string]: unknown;
-            } | components["schemas"]["MIME"]) | null;
-            status: components["schemas"]["HumanReadableStatus"];
-        };
-        HTTPRequest: null;
-        HumanReadableStatus: {
-            /** @enum {string} */
-            code: "ok" | "error";
-            message?: string | null;
-            title?: string | null;
-        };
-        ImportStarError: {
-            msg: string;
-            /** @enum {string} */
-            type: "import-star";
-        };
-        InstallMissingPackagesRequest: {
-            manager: string;
-            versions: {
-                [key: string]: string;
-            };
-        };
-        InstallingPackageAlert: {
-            /** @enum {string} */
-            name: "installing-package-alert";
-            packages: {
-                [key: string]: "queued" | "installing" | "installed" | "failed";
-            };
-        };
-        InstantiateRequest: {
-            autoRun: boolean;
-            objectIds: string[];
-            values: unknown[];
-        };
-        Interrupted: {
-            /** @enum {string} */
-            name: "interrupted";
-        };
-        JSONType: string | number | Record<string, never> | unknown[] | boolean | null;
-        KernelReady: {
-            app_config: {
-                _toplevel_fn: boolean;
-                app_title?: string | null;
-                auto_download: ("html" | "markdown")[];
-                css_file?: string | null;
-                html_head_file?: string | null;
-                layout_file?: string | null;
-                /** @enum {string} */
-                width: "normal" | "compact" | "medium" | "full";
-            };
-            capabilities: {
-                sql: boolean;
-                terminal: boolean;
-            };
-            cell_ids: string[];
-            codes: string[];
-            configs: components["schemas"]["CellConfig"][];
-            kiosk: boolean;
-            last_executed_code?: {
-                [key: string]: string;
-            } | null;
-            last_execution_time?: {
-                [key: string]: number;
-            } | null;
-            layout?: {
-                data: {
-                    [key: string]: unknown;
-                };
-                type: string;
-            } | null;
-            /** @enum {string} */
-            name: "kernel-ready";
-            names: string[];
-            resumed: boolean;
-            ui_values?: {
-                [key: string]: ({
-                    [key: string]: ({
-                        [key: string]: components["schemas"]["JSONType"];
-                    } | components["schemas"]["JSONType"][] | string | number | boolean | {
-                        [key: string]: unknown;
-                    } | components["schemas"]["MIME"]) | null;
-                } | (({
-                    [key: string]: components["schemas"]["JSONType"];
-                } | components["schemas"]["JSONType"][] | string | number | boolean | {
-                    [key: string]: unknown;
-                } | components["schemas"]["MIME"]) | null)[] | string | number | boolean | {
-                    [key: string]: unknown;
-                } | components["schemas"]["MIME"]) | null;
-            } | null;
-        };
-        ListPackagesResponse: {
-            packages: components["schemas"]["PackageDescription"][];
-        };
-        MIME: Record<string, never>;
-        MarimoAncestorPreventedError: {
-            blamed_cell?: string | null;
-            msg: string;
-            raising_cell: string;
-            /** @enum {string} */
-            type: "ancestor-prevented";
-        };
-        MarimoAncestorStoppedError: {
-            msg: string;
-            raising_cell: string;
-            /** @enum {string} */
-            type: "ancestor-stopped";
-        };
-        MarimoConfig: {
-            ai?: {
-                anthropic?: {
-                    api_key?: string;
-                };
-                google?: {
-                    api_key?: string;
-                };
-                open_ai?: {
-                    api_key?: string;
-                    base_url?: string;
-                    model?: string;
-                };
-                rules?: string;
-            };
-            completion: {
-                activate_on_typing: boolean;
-                codeium_api_key?: string | null;
-                copilot: boolean | ("github" | "codeium");
-            };
-            display: {
-                /** @enum {string} */
-                cell_output: "above" | "below";
-                code_editor_font_size: number;
-                /** @enum {string} */
-                dataframes: "rich" | "plain";
-                /** @enum {string} */
-                default_width: "normal" | "compact" | "medium" | "full";
-                /** @enum {string} */
-                theme: "light" | "dark" | "system";
-            };
-            experimental?: {
-                [key: string]: unknown;
-            };
-            formatting: {
-                line_length: number;
-            };
-            keymap: {
-                overrides?: {
-                    [key: string]: string;
-                };
-                /** @enum {string} */
-                preset: "default" | "vim";
-            };
-            package_management: {
-                /** @enum {string} */
-                manager: "pip" | "rye" | "uv" | "poetry" | "pixi";
-            };
-            runtime: {
-                auto_instantiate: boolean;
-                /** @enum {string} */
-                auto_reload: "off" | "lazy" | "autorun";
-                /** @enum {string} */
-                on_cell_change: "lazy" | "autorun";
-                output_max_bytes: number;
-                std_stream_max_bytes: number;
-                /** @enum {string} */
-                watcher_on_save: "lazy" | "autorun";
-            };
-            save: {
-                /** @enum {string} */
-                autosave: "off" | "after_delay";
-                autosave_delay: number;
-                format_on_save: boolean;
-            };
-            server: {
-                browser: "default" | string;
-                follow_symlink: boolean;
-            };
-            snippets?: {
-                custom_paths?: string[];
-                include_default_snippets?: boolean;
-            };
-        };
-        MarimoExceptionRaisedError: {
-            exception_type: string;
-            msg: string;
-            raising_cell?: string | null;
-            /** @enum {string} */
-            type: "exception";
-        };
-        MarimoFile: {
-            initializationId?: string | null;
-            lastModified?: number | null;
-            name: string;
-            path: string;
-            sessionId?: string | null;
-        };
-        MarimoInternalError: {
-            error_id: string;
-            msg: string;
-            /** @enum {string} */
-            type: "internal";
-        };
-        MarimoInterruptionError: {
-            /** @enum {string} */
-            type: "interruption";
-        };
-        MarimoStrictExecutionError: {
-            blamed_cell?: string | null;
-            msg: string;
-            ref: string;
-            /** @enum {string} */
-            type: "strict-exception";
-        };
-        MarimoSyntaxError: {
-            msg: string;
-            /** @enum {string} */
-            type: "syntax";
-        };
-        MessageOperation: components["schemas"]["CellOp"] | components["schemas"]["FunctionCallResult"] | components["schemas"]["SendUIElementMessage"] | components["schemas"]["RemoveUIElements"] | components["schemas"]["Reload"] | components["schemas"]["Reconnected"] | components["schemas"]["Interrupted"] | components["schemas"]["CompletedRun"] | components["schemas"]["KernelReady"] | components["schemas"]["CompletionResult"] | components["schemas"]["Alert"] | components["schemas"]["Banner"] | components["schemas"]["MissingPackageAlert"] | components["schemas"]["InstallingPackageAlert"] | components["schemas"]["Variables"] | components["schemas"]["VariableValues"] | components["schemas"]["QueryParamsSet"] | components["schemas"]["QueryParamsAppend"] | components["schemas"]["QueryParamsDelete"] | components["schemas"]["QueryParamsClear"] | components["schemas"]["Datasets"] | components["schemas"]["DataColumnPreview"] | components["schemas"]["SQLTablePreview"] | {
-            connections: components["schemas"]["DataSourceConnection"][];
-            /** @enum {string} */
-            name: "data-source-connections";
-        } | components["schemas"]["FocusCell"] | components["schemas"]["UpdateCellCodes"] | components["schemas"]["UpdateCellIdsRequest"];
-        /** @enum {string} */
-        MimeType: "application/json" | "application/vnd.marimo+error" | "application/vnd.marimo+traceback" | "application/vnd.marimo+mimebundle" | "application/vnd.vega.v5+json" | "application/vnd.vegalite.v5+json" | "image/png" | "image/svg+xml" | "image/tiff" | "image/avif" | "image/bmp" | "image/gif" | "image/jpeg" | "video/mp4" | "video/mpeg" | "text/html" | "text/plain" | "text/markdown" | "text/latex" | "text/csv";
-        MissingPackageAlert: {
-            isolated: boolean;
-            /** @enum {string} */
-            name: "missing-package-alert";
-            packages: string[];
-        };
-        MultipleDefinitionError: {
-            cells: string[];
-            name: string;
-            /** @enum {string} */
-            type: "multiple-defs";
-        };
-        NonNestedLiteral: number | string | boolean;
-        OpenTutorialRequest: {
-            tutorialId: ("intro" | "dataflow" | "ui" | "markdown" | "plots" | "sql" | "layout" | "fileformat" | "for-jupyter-users") | "markdown-format";
-        };
-        PackageDescription: {
-            name: string;
-            version: string;
-        };
-        PackageOperationResponse: {
-            error?: string | null;
-            success: boolean;
-        };
-        PreviewDatasetColumnRequest: {
-            columnName: string;
-            source: string;
-            /** @enum {string} */
-            sourceType: "local" | "duckdb" | "connection";
-            tableName: string;
-        };
-        PreviewSQLTableRequest: {
-            database: string;
-            engine: string;
-            requestId: string;
-            schema: string;
-            tableName: string;
-        };
-        QueryParamsAppend: {
-            key: string;
-            /** @enum {string} */
-            name: "query-params-append";
-            value: string;
-        };
-        QueryParamsClear: {
-            /** @enum {string} */
-            name: "query-params-clear";
-        };
-        QueryParamsDelete: {
-            key: string;
-            /** @enum {string} */
-            name: "query-params-delete";
-            value?: string | null;
-        };
-        QueryParamsSet: {
-            key: string;
-            /** @enum {string} */
-            name: "query-params-set";
-            value: string | string[];
-        };
-        ReadCodeResponse: {
-            contents: string;
-        };
-        RecentFilesResponse: {
-            files: components["schemas"]["MarimoFile"][];
-        };
-        Reconnected: {
-            /** @enum {string} */
-            name: "reconnected";
-        };
-        Reload: {
-            /** @enum {string} */
-            name: "reload";
-        };
-        RemovePackageRequest: {
-            package: string;
-        };
-        RemoveUIElements: {
-            cell_id: string;
-            /** @enum {string} */
-            name: "remove-ui-elements";
-        };
-        RenameFileRequest: {
-            filename: string;
-        };
-        RenameRequest: {
-            filename: string;
-        };
-        RunRequest: {
-            cellIds: string[];
-            codes: string[];
-            request?: components["schemas"]["HTTPRequest"];
-        };
-        RunScratchpadRequest: {
-            code: string;
-            request?: components["schemas"]["HTTPRequest"];
-        };
-        RunningNotebooksResponse: {
-            files: components["schemas"]["MarimoFile"][];
-        };
-        /** @enum {string} */
-        RuntimeState: "idle" | "queued" | "running" | "disabled-transitively";
-        SQLTablePreview: {
-            error?: string | null;
-            /** @enum {string} */
-            name: "sql-table-preview";
-            request_id: string;
-            table?: components["schemas"]["DataTable"];
-        };
-        SaveAppConfigurationRequest: {
-            config: {
-                [key: string]: unknown;
-            };
-        };
-        SaveNotebookRequest: {
-            cellIds: string[];
-            codes: string[];
-            configs: components["schemas"]["CellConfig"][];
-            filename: string;
-            layout?: {
-                [key: string]: unknown;
-            } | null;
-            names: string[];
-            persist: boolean;
-        };
-        SaveUserConfigurationRequest: {
-            config: components["schemas"]["MarimoConfig"];
-        };
-        Schema: {
-            name: string;
-            tables: components["schemas"]["DataTable"][];
-        };
-        SendUIElementMessage: {
-            buffers?: string[] | null;
-            message: {
-                [key: string]: {
-                    [key: string]: unknown;
-                };
-            };
-            /** @enum {string} */
-            name: "send-ui-element-message";
-            ui_element: string;
-        };
-        SetCellConfigRequest: {
-            configs: {
-                [key: string]: {
-                    [key: string]: unknown;
-                };
-            };
-        };
-        SetUIElementValueRequest: {
-            objectIds: string[];
-            request?: components["schemas"]["HTTPRequest"];
-            token: string;
-            values: unknown[];
-        };
-        SetUserConfigRequest: {
-            config: components["schemas"]["MarimoConfig"];
-        };
-        ShutdownSessionRequest: {
-            sessionId: string;
-        };
-        Snippet: {
-            sections: components["schemas"]["SnippetSection"][];
-            title: string;
-        };
-        SnippetSection: {
-            code?: string | null;
-            html?: string | null;
-            id: string;
-        };
-        Snippets: {
-            snippets: components["schemas"]["Snippet"][];
-        };
-        StdinRequest: {
-            text: string;
-        };
-        StopRequest: Record<string, never>;
-        SuccessResponse: {
-            success: boolean;
-        };
-        UnknownError: {
-            msg: string;
-            /** @enum {string} */
-            type: "unknown";
-        };
-        UpdateCellCodes: {
-            cell_ids: string[];
-            code_is_stale: boolean;
-            codes: string[];
-            /** @enum {string} */
-            name: "update-cell-codes";
-        };
-        UpdateCellIdsRequest: {
-            cell_ids: string[];
-            /** @enum {string} */
-            name: "update-cell-ids";
-        };
-        UpdateComponentValuesRequest: {
-            objectIds: string[];
-            values: unknown[];
-        };
-        VariableDeclaration: {
-            declared_by: string[];
-            name: string;
-            used_by: string[];
-        };
-        VariableValue: {
-            datatype?: string | null;
-            name: string;
-            value?: string | null;
-        };
-        VariableValues: {
-            /** @enum {string} */
-            name: "variable-values";
-            variables: components["schemas"]["VariableValue"][];
-        };
-        Variables: {
-            /** @enum {string} */
-            name: "variables";
-            variables: components["schemas"]["VariableDeclaration"][];
-        };
-        WorkspaceFilesRequest: {
-            includeMarkdown: boolean;
-        };
-        WorkspaceFilesResponse: {
-            files: components["schemas"]["FileInfo"][];
-            root: string;
-        };
+  schemas: {
+    AddPackageRequest: {
+      package: string;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    AiCompletionRequest: {
+      code: string;
+      context?: {
+        schema: {
+          columns: {
+            name: string;
+            sampleValues: unknown[];
+            type: string;
+          }[];
+          name: string;
+        }[];
+      } | null;
+      includeOtherCode: string;
+      /** @enum {string} */
+      language: "python" | "markdown" | "sql";
+      prompt: string;
+    };
+    Alert: {
+      description: string;
+      /** @enum {string} */
+      name: "alert";
+      title: string;
+      /** @enum {string|null} */
+      variant?: "danger" | null;
+    };
+    AppMetadata: {
+      cliArgs: {
+        [key: string]:
+          | string
+          | boolean
+          | number
+          | (string | boolean | number)[];
+      };
+      filename?: string | null;
+      queryParams: {
+        [key: string]: string | string[];
+      };
+    };
+    Banner: {
+      /** @enum {string|null} */
+      action?: "restart" | null;
+      description: string;
+      /** @enum {string} */
+      name: "banner";
+      title: string;
+      /** @enum {string|null} */
+      variant?: "danger" | null;
+    };
+    BaseResponse: {
+      success: boolean;
+    };
+    /** @enum {string} */
+    CellChannel:
+      | "stdout"
+      | "stderr"
+      | "stdin"
+      | "pdb"
+      | "output"
+      | "marimo-error"
+      | "media";
+    CellConfig: {
+      column?: number | null;
+      disabled: boolean;
+      hide_code: boolean;
+    };
+    CellOp: {
+      cell_id: string;
+      console?:
+        | (
+            | components["schemas"]["CellOutput"]
+            | components["schemas"]["CellOutput"][]
+          )
+        | null;
+      /** @enum {string} */
+      name: "cell-op";
+      output?: components["schemas"]["CellOutput"];
+      run_id?: string | null;
+      stale_inputs?: boolean | null;
+      status?: components["schemas"]["RuntimeState"];
+      timestamp: number;
+    };
+    CellOutput: {
+      channel: components["schemas"]["CellChannel"];
+      data:
+        | string
+        | components["schemas"]["Error"][]
+        | {
+            [key: string]: unknown;
+          };
+      mimetype: components["schemas"]["MimeType"];
+      timestamp: number;
+    };
+    CodeCompletionRequest: {
+      cellId: string;
+      document: string;
+      id: string;
+    };
+    ColumnSummary: {
+      false?: number | null;
+      max?: components["schemas"]["NonNestedLiteral"];
+      mean?: components["schemas"]["NonNestedLiteral"];
+      median?: components["schemas"]["NonNestedLiteral"];
+      min?: components["schemas"]["NonNestedLiteral"];
+      nulls?: number | null;
+      p25?: components["schemas"]["NonNestedLiteral"];
+      p5?: components["schemas"]["NonNestedLiteral"];
+      p75?: components["schemas"]["NonNestedLiteral"];
+      p95?: components["schemas"]["NonNestedLiteral"];
+      std?: components["schemas"]["NonNestedLiteral"];
+      total?: number | null;
+      true?: number | null;
+      unique?: number | null;
+    };
+    CompletedRun: {
+      /** @enum {string} */
+      name: "completed-run";
+    };
+    CompletionResult: {
+      completion_id: string;
+      /** @enum {string} */
+      name: "completion-result";
+      options: {
+        completion_info?: string | null;
+        name: string;
+        type: string;
+      }[];
+      prefix_length: number;
+    };
+    CopyNotebookRequest: {
+      destination: string;
+      source: string;
+    };
+    CycleError: {
+      edges_with_vars: [string, string[], string][];
+      /** @enum {string} */
+      type: "cycle";
+    };
+    DataColumnPreview: {
+      chart_code?: string | null;
+      chart_max_rows_errors: boolean;
+      chart_spec?: string | null;
+      column_name: string;
+      error?: string | null;
+      /** @enum {string} */
+      name: "data-column-preview";
+      summary?: components["schemas"]["ColumnSummary"];
+      table_name: string;
+    };
+    DataSourceConnection: {
+      databases: {
+        dialect: string;
+        engine?: string | null;
+        name: string;
+        schemas: {
+          name: string;
+          tables: components["schemas"]["DataTable"][];
+        }[];
+      }[];
+      dialect: string;
+      display_name: string;
+      name: string;
+      source: string;
+    };
+    DataSourceConnections: {
+      connections: components["schemas"]["DataSourceConnection"][];
+      /** @enum {string} */
+      name: "data-source-connections";
+    };
+    DataTable: {
+      columns: components["schemas"]["DataTableColumn"][];
+      engine?: string | null;
+      indexes?: string[] | null;
+      name: string;
+      num_columns?: number | null;
+      num_rows?: number | null;
+      primary_keys?: string[] | null;
+      source: string;
+      /** @enum {string} */
+      source_type: "local" | "duckdb" | "connection";
+      /** @enum {string} */
+      type: "table" | "view";
+      variable_name?: string | null;
+    };
+    DataTableColumn: {
+      external_type: string;
+      name: string;
+      sample_values: unknown[];
+      type: components["schemas"]["DataType"];
+    };
+    /** @enum {string} */
+    DataType:
+      | "string"
+      | "boolean"
+      | "integer"
+      | "number"
+      | "date"
+      | "datetime"
+      | "time"
+      | "unknown";
+    Database: {
+      dialect: string;
+      engine?: string | null;
+      name: string;
+      schemas: components["schemas"]["Schema"][];
+    };
+    Datasets: {
+      /** @enum {string|null} */
+      clear_channel?: "local" | "duckdb" | "connection" | null;
+      /** @enum {string} */
+      name: "datasets";
+      tables: components["schemas"]["DataTable"][];
+    };
+    DeleteCellRequest: {
+      cellId: string;
+    };
+    DeleteNonlocalError: {
+      cells: string[];
+      name: string;
+      /** @enum {string} */
+      type: "delete-nonlocal";
+    };
+    Error:
+      | components["schemas"]["CycleError"]
+      | components["schemas"]["MultipleDefinitionError"]
+      | components["schemas"]["ImportStarError"]
+      | components["schemas"]["DeleteNonlocalError"]
+      | components["schemas"]["MarimoAncestorStoppedError"]
+      | components["schemas"]["MarimoAncestorPreventedError"]
+      | components["schemas"]["MarimoExceptionRaisedError"]
+      | components["schemas"]["MarimoStrictExecutionError"]
+      | components["schemas"]["MarimoInterruptionError"]
+      | components["schemas"]["MarimoSyntaxError"]
+      | components["schemas"]["MarimoInternalError"]
+      | components["schemas"]["UnknownError"];
+    ExecuteMultipleRequest: {
+      cellIds: string[];
+      codes: string[];
+      request?: components["schemas"]["HTTPRequest"];
+      timestamp: number;
+    };
+    ExecuteScratchpadRequest: {
+      code: string;
+      request?: components["schemas"]["HTTPRequest"];
+    };
+    ExecuteStaleRequest: Record<string, never>;
+    ExecutionRequest: {
+      cellId: string;
+      code: string;
+      request?: components["schemas"]["HTTPRequest"];
+      timestamp: number;
+    };
+    ExportAsHTMLRequest: {
+      assetUrl?: string | null;
+      download: boolean;
+      files: string[];
+      includeCode: boolean;
+    };
+    ExportAsIPYNBRequest: {
+      download: boolean;
+    };
+    ExportAsMarkdownRequest: {
+      download: boolean;
+    };
+    ExportAsScriptRequest: {
+      download: boolean;
+    };
+    FileCreateRequest: {
+      contents?: string | null;
+      name: string;
+      path: string;
+      /** @enum {string} */
+      type: "file" | "directory";
+    };
+    FileCreateResponse: {
+      info?: components["schemas"]["FileInfo"];
+      message?: string | null;
+      success: boolean;
+    };
+    FileDeleteRequest: {
+      path: string;
+    };
+    FileDeleteResponse: {
+      message?: string | null;
+      success: boolean;
+    };
+    FileDetailsRequest: {
+      path: string;
+    };
+    FileDetailsResponse: {
+      contents?: string | null;
+      file: components["schemas"]["FileInfo"];
+      mimeType?: string | null;
+    };
+    FileInfo: {
+      children: components["schemas"]["FileInfo"][];
+      id: string;
+      isDirectory: boolean;
+      isMarimoFile: boolean;
+      lastModified?: number | null;
+      name: string;
+      path: string;
+    };
+    FileListRequest: {
+      path?: string | null;
+    };
+    FileListResponse: {
+      files: components["schemas"]["FileInfo"][];
+      root: string;
+    };
+    FileMoveRequest: {
+      newPath: string;
+      path: string;
+    };
+    FileMoveResponse: {
+      info?: components["schemas"]["FileInfo"];
+      message?: string | null;
+      success: boolean;
+    };
+    FileOpenRequest: {
+      path: string;
+    };
+    FileUpdateRequest: {
+      contents: string;
+      path: string;
+    };
+    FileUpdateResponse: {
+      info?: components["schemas"]["FileInfo"];
+      message?: string | null;
+      success: boolean;
+    };
+    FocusCell: {
+      cell_id: string;
+      /** @enum {string} */
+      name: "focus-cell";
+    };
+    FormatRequest: {
+      codes: {
+        [key: string]: string;
+      };
+      lineLength: number;
+    };
+    FormatResponse: {
+      codes: {
+        [key: string]: string;
+      };
+    };
+    FunctionCallRequest: {
+      args: {
+        [key: string]: unknown;
+      };
+      functionCallId: string;
+      functionName: string;
+      namespace: string;
+    };
+    FunctionCallResult: {
+      function_call_id: string;
+      /** @enum {string} */
+      name: "function-call-result";
+      return_value?:
+        | (
+            | {
+                [key: string]: components["schemas"]["JSONType"];
+              }
+            | components["schemas"]["JSONType"][]
+            | string
+            | number
+            | boolean
+            | {
+                [key: string]: unknown;
+              }
+            | components["schemas"]["MIME"]
+          )
+        | null;
+      status: components["schemas"]["HumanReadableStatus"];
+    };
+    HTTPRequest: null;
+    HumanReadableStatus: {
+      /** @enum {string} */
+      code: "ok" | "error";
+      message?: string | null;
+      title?: string | null;
+    };
+    ImportStarError: {
+      msg: string;
+      /** @enum {string} */
+      type: "import-star";
+    };
+    InstallMissingPackagesRequest: {
+      manager: string;
+      versions: {
+        [key: string]: string;
+      };
+    };
+    InstallingPackageAlert: {
+      /** @enum {string} */
+      name: "installing-package-alert";
+      packages: {
+        [key: string]: "queued" | "installing" | "installed" | "failed";
+      };
+    };
+    InstantiateRequest: {
+      autoRun: boolean;
+      objectIds: string[];
+      values: unknown[];
+    };
+    Interrupted: {
+      /** @enum {string} */
+      name: "interrupted";
+    };
+    JSONType:
+      | string
+      | number
+      | Record<string, never>
+      | unknown[]
+      | boolean
+      | null;
+    KernelReady: {
+      app_config: {
+        _toplevel_fn: boolean;
+        app_title?: string | null;
+        auto_download: ("html" | "markdown")[];
+        css_file?: string | null;
+        html_head_file?: string | null;
+        layout_file?: string | null;
+        /** @enum {string} */
+        width: "normal" | "compact" | "medium" | "full";
+      };
+      capabilities: {
+        sql: boolean;
+        terminal: boolean;
+      };
+      cell_ids: string[];
+      codes: string[];
+      configs: components["schemas"]["CellConfig"][];
+      kiosk: boolean;
+      last_executed_code?: {
+        [key: string]: string;
+      } | null;
+      last_execution_time?: {
+        [key: string]: number;
+      } | null;
+      layout?: {
+        data: {
+          [key: string]: unknown;
+        };
+        type: string;
+      } | null;
+      /** @enum {string} */
+      name: "kernel-ready";
+      names: string[];
+      resumed: boolean;
+      ui_values?: {
+        [key: string]:
+          | (
+              | {
+                  [key: string]:
+                    | (
+                        | {
+                            [key: string]: components["schemas"]["JSONType"];
+                          }
+                        | components["schemas"]["JSONType"][]
+                        | string
+                        | number
+                        | boolean
+                        | {
+                            [key: string]: unknown;
+                          }
+                        | components["schemas"]["MIME"]
+                      )
+                    | null;
+                }
+              | (
+                  | (
+                      | {
+                          [key: string]: components["schemas"]["JSONType"];
+                        }
+                      | components["schemas"]["JSONType"][]
+                      | string
+                      | number
+                      | boolean
+                      | {
+                          [key: string]: unknown;
+                        }
+                      | components["schemas"]["MIME"]
+                    )
+                  | null
+                )[]
+              | string
+              | number
+              | boolean
+              | {
+                  [key: string]: unknown;
+                }
+              | components["schemas"]["MIME"]
+            )
+          | null;
+      } | null;
+    };
+    ListPackagesResponse: {
+      packages: components["schemas"]["PackageDescription"][];
+    };
+    MIME: Record<string, never>;
+    MarimoAncestorPreventedError: {
+      blamed_cell?: string | null;
+      msg: string;
+      raising_cell: string;
+      /** @enum {string} */
+      type: "ancestor-prevented";
+    };
+    MarimoAncestorStoppedError: {
+      msg: string;
+      raising_cell: string;
+      /** @enum {string} */
+      type: "ancestor-stopped";
+    };
+    MarimoConfig: {
+      ai?: {
+        anthropic?: {
+          api_key?: string;
+        };
+        google?: {
+          api_key?: string;
+        };
+        open_ai?: {
+          api_key?: string;
+          base_url?: string;
+          model?: string;
+        };
+        rules?: string;
+      };
+      completion: {
+        activate_on_typing: boolean;
+        codeium_api_key?: string | null;
+        copilot: boolean | ("github" | "codeium");
+      };
+      display: {
+        /** @enum {string} */
+        cell_output: "above" | "below";
+        code_editor_font_size: number;
+        /** @enum {string} */
+        dataframes: "rich" | "plain";
+        /** @enum {string} */
+        default_width: "normal" | "compact" | "medium" | "full";
+        /** @enum {string} */
+        theme: "light" | "dark" | "system";
+      };
+      experimental?: {
+        [key: string]: unknown;
+      };
+      formatting: {
+        line_length: number;
+      };
+      keymap: {
+        overrides?: {
+          [key: string]: string;
+        };
+        /** @enum {string} */
+        preset: "default" | "vim";
+      };
+      package_management: {
+        /** @enum {string} */
+        manager: "pip" | "rye" | "uv" | "poetry" | "pixi";
+      };
+      runtime: {
+        auto_instantiate: boolean;
+        /** @enum {string} */
+        auto_reload: "off" | "lazy" | "autorun";
+        /** @enum {string} */
+        on_cell_change: "lazy" | "autorun";
+        output_max_bytes: number;
+        std_stream_max_bytes: number;
+        /** @enum {string} */
+        watcher_on_save: "lazy" | "autorun";
+      };
+      save: {
+        /** @enum {string} */
+        autosave: "off" | "after_delay";
+        autosave_delay: number;
+        format_on_save: boolean;
+      };
+      server: {
+        browser: "default" | string;
+        follow_symlink: boolean;
+      };
+      snippets?: {
+        custom_paths?: string[];
+        include_default_snippets?: boolean;
+      };
+    };
+    MarimoExceptionRaisedError: {
+      exception_type: string;
+      msg: string;
+      raising_cell?: string | null;
+      /** @enum {string} */
+      type: "exception";
+    };
+    MarimoFile: {
+      initializationId?: string | null;
+      lastModified?: number | null;
+      name: string;
+      path: string;
+      sessionId?: string | null;
+    };
+    MarimoInternalError: {
+      error_id: string;
+      msg: string;
+      /** @enum {string} */
+      type: "internal";
+    };
+    MarimoInterruptionError: {
+      /** @enum {string} */
+      type: "interruption";
+    };
+    MarimoStrictExecutionError: {
+      blamed_cell?: string | null;
+      msg: string;
+      ref: string;
+      /** @enum {string} */
+      type: "strict-exception";
+    };
+    MarimoSyntaxError: {
+      msg: string;
+      /** @enum {string} */
+      type: "syntax";
+    };
+    MessageOperation:
+      | components["schemas"]["CellOp"]
+      | components["schemas"]["FunctionCallResult"]
+      | components["schemas"]["SendUIElementMessage"]
+      | components["schemas"]["RemoveUIElements"]
+      | components["schemas"]["Reload"]
+      | components["schemas"]["Reconnected"]
+      | components["schemas"]["Interrupted"]
+      | components["schemas"]["CompletedRun"]
+      | components["schemas"]["KernelReady"]
+      | components["schemas"]["CompletionResult"]
+      | components["schemas"]["Alert"]
+      | components["schemas"]["Banner"]
+      | components["schemas"]["MissingPackageAlert"]
+      | components["schemas"]["InstallingPackageAlert"]
+      | components["schemas"]["Variables"]
+      | components["schemas"]["VariableValues"]
+      | components["schemas"]["QueryParamsSet"]
+      | components["schemas"]["QueryParamsAppend"]
+      | components["schemas"]["QueryParamsDelete"]
+      | components["schemas"]["QueryParamsClear"]
+      | components["schemas"]["Datasets"]
+      | components["schemas"]["DataColumnPreview"]
+      | components["schemas"]["SQLTablePreview"]
+      | {
+          connections: components["schemas"]["DataSourceConnection"][];
+          /** @enum {string} */
+          name: "data-source-connections";
+        }
+      | components["schemas"]["FocusCell"]
+      | components["schemas"]["UpdateCellCodes"]
+      | components["schemas"]["UpdateCellIdsRequest"];
+    /** @enum {string} */
+    MimeType:
+      | "application/json"
+      | "application/vnd.marimo+error"
+      | "application/vnd.marimo+traceback"
+      | "application/vnd.marimo+mimebundle"
+      | "application/vnd.vega.v5+json"
+      | "application/vnd.vegalite.v5+json"
+      | "image/png"
+      | "image/svg+xml"
+      | "image/tiff"
+      | "image/avif"
+      | "image/bmp"
+      | "image/gif"
+      | "image/jpeg"
+      | "video/mp4"
+      | "video/mpeg"
+      | "text/html"
+      | "text/plain"
+      | "text/markdown"
+      | "text/latex"
+      | "text/csv";
+    MissingPackageAlert: {
+      isolated: boolean;
+      /** @enum {string} */
+      name: "missing-package-alert";
+      packages: string[];
+    };
+    MultipleDefinitionError: {
+      cells: string[];
+      name: string;
+      /** @enum {string} */
+      type: "multiple-defs";
+    };
+    NonNestedLiteral: number | string | boolean;
+    OpenTutorialRequest: {
+      tutorialId:
+        | (
+            | "intro"
+            | "dataflow"
+            | "ui"
+            | "markdown"
+            | "plots"
+            | "sql"
+            | "layout"
+            | "fileformat"
+            | "for-jupyter-users"
+          )
+        | "markdown-format";
+    };
+    PackageDescription: {
+      name: string;
+      version: string;
+    };
+    PackageOperationResponse: {
+      error?: string | null;
+      success: boolean;
+    };
+    PreviewDatasetColumnRequest: {
+      columnName: string;
+      source: string;
+      /** @enum {string} */
+      sourceType: "local" | "duckdb" | "connection";
+      tableName: string;
+    };
+    PreviewSQLTableRequest: {
+      database: string;
+      engine: string;
+      requestId: string;
+      schema: string;
+      tableName: string;
+    };
+    QueryParamsAppend: {
+      key: string;
+      /** @enum {string} */
+      name: "query-params-append";
+      value: string;
+    };
+    QueryParamsClear: {
+      /** @enum {string} */
+      name: "query-params-clear";
+    };
+    QueryParamsDelete: {
+      key: string;
+      /** @enum {string} */
+      name: "query-params-delete";
+      value?: string | null;
+    };
+    QueryParamsSet: {
+      key: string;
+      /** @enum {string} */
+      name: "query-params-set";
+      value: string | string[];
+    };
+    ReadCodeResponse: {
+      contents: string;
+    };
+    RecentFilesResponse: {
+      files: components["schemas"]["MarimoFile"][];
+    };
+    Reconnected: {
+      /** @enum {string} */
+      name: "reconnected";
+    };
+    Reload: {
+      /** @enum {string} */
+      name: "reload";
+    };
+    RemovePackageRequest: {
+      package: string;
+    };
+    RemoveUIElements: {
+      cell_id: string;
+      /** @enum {string} */
+      name: "remove-ui-elements";
+    };
+    RenameFileRequest: {
+      filename: string;
+    };
+    RenameRequest: {
+      filename: string;
+    };
+    RunRequest: {
+      cellIds: string[];
+      codes: string[];
+      request?: components["schemas"]["HTTPRequest"];
+    };
+    RunScratchpadRequest: {
+      code: string;
+      request?: components["schemas"]["HTTPRequest"];
+    };
+    RunningNotebooksResponse: {
+      files: components["schemas"]["MarimoFile"][];
+    };
+    /** @enum {string} */
+    RuntimeState: "idle" | "queued" | "running" | "disabled-transitively";
+    SQLTablePreview: {
+      error?: string | null;
+      /** @enum {string} */
+      name: "sql-table-preview";
+      request_id: string;
+      table?: components["schemas"]["DataTable"];
+    };
+    SaveAppConfigurationRequest: {
+      config: {
+        [key: string]: unknown;
+      };
+    };
+    SaveNotebookRequest: {
+      cellIds: string[];
+      codes: string[];
+      configs: components["schemas"]["CellConfig"][];
+      filename: string;
+      layout?: {
+        [key: string]: unknown;
+      } | null;
+      names: string[];
+      persist: boolean;
+    };
+    SaveUserConfigurationRequest: {
+      config: components["schemas"]["MarimoConfig"];
+    };
+    Schema: {
+      name: string;
+      tables: components["schemas"]["DataTable"][];
+    };
+    SendUIElementMessage: {
+      buffers?: string[] | null;
+      message: {
+        [key: string]: {
+          [key: string]: unknown;
+        };
+      };
+      /** @enum {string} */
+      name: "send-ui-element-message";
+      ui_element: string;
+    };
+    SetCellConfigRequest: {
+      configs: {
+        [key: string]: {
+          [key: string]: unknown;
+        };
+      };
+    };
+    SetUIElementValueRequest: {
+      objectIds: string[];
+      request?: components["schemas"]["HTTPRequest"];
+      token: string;
+      values: unknown[];
+    };
+    SetUserConfigRequest: {
+      config: components["schemas"]["MarimoConfig"];
+    };
+    ShutdownSessionRequest: {
+      sessionId: string;
+    };
+    Snippet: {
+      sections: components["schemas"]["SnippetSection"][];
+      title: string;
+    };
+    SnippetSection: {
+      code?: string | null;
+      html?: string | null;
+      id: string;
+    };
+    Snippets: {
+      snippets: components["schemas"]["Snippet"][];
+    };
+    StdinRequest: {
+      text: string;
+    };
+    StopRequest: Record<string, never>;
+    SuccessResponse: {
+      success: boolean;
+    };
+    UnknownError: {
+      msg: string;
+      /** @enum {string} */
+      type: "unknown";
+    };
+    UpdateCellCodes: {
+      cell_ids: string[];
+      code_is_stale: boolean;
+      codes: string[];
+      /** @enum {string} */
+      name: "update-cell-codes";
+    };
+    UpdateCellIdsRequest: {
+      cell_ids: string[];
+      /** @enum {string} */
+      name: "update-cell-ids";
+    };
+    UpdateComponentValuesRequest: {
+      objectIds: string[];
+      values: unknown[];
+    };
+    VariableDeclaration: {
+      declared_by: string[];
+      name: string;
+      used_by: string[];
+    };
+    VariableValue: {
+      datatype?: string | null;
+      name: string;
+      value?: string | null;
+    };
+    VariableValues: {
+      /** @enum {string} */
+      name: "variable-values";
+      variables: components["schemas"]["VariableValue"][];
+    };
+    Variables: {
+      /** @enum {string} */
+      name: "variables";
+      variables: components["schemas"]["VariableDeclaration"][];
+    };
+    WorkspaceFilesRequest: {
+      includeMarkdown: boolean;
+    };
+    WorkspaceFilesResponse: {
+      files: components["schemas"]["FileInfo"][];
+      root: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 import pytest
 
 from marimo._ast import visitor
+from marimo._ast.errors import ImportStarError
 from marimo._ast.visitor import (
     ImportData,
     VariableData,
@@ -798,7 +799,7 @@ def test_from_import_star() -> None:
     expr = "from a.b.c import *"
     v = visitor.ScopedVisitor()
     mod = ast.parse(expr)
-    with pytest.raises(SyntaxError) as e:
+    with pytest.raises(ImportStarError) as e:
         v.visit(mod)
     assert "`import *` is not allowed in marimo." in str(e)
     assert v.defs == set()


### PR DESCRIPTION
Provide more helpful error messages for import star and multiple definition errors, explaining the reasoning behind these errors.

This PR also changes error description text to be muted instead of red, matching the accordion text, based on feedback that too much red can be stressful. Headlines (which describe the exception type) are still red and bold.

![image](https://github.com/user-attachments/assets/ffa54805-596a-4f31-8981-bf62d1568af7)