### PR TITLE
fix: default to opt-in for introspection of tables

### DIFF
--- a/docs/guides/configuration/snippets.md
+++ b/docs/guides/configuration/snippets.md
@@ -4,7 +4,7 @@ marimo provides a snippets feature that allows you to quickly insert commonly us
 
 ## Configuration Options
 
-You can configure snippets through your `marimo.toml` file:
+You can configure snippets through your `.marimo.toml` file:
 
 ```toml
 [snippets]

--- a/docs/guides/configuration/snippets.md
+++ b/docs/guides/configuration/snippets.md
@@ -4,7 +4,7 @@ marimo provides a snippets feature that allows you to quickly insert commonly us
 
 ## Configuration Options
 
-You can configure snippets through your `.marimo.toml` file:
+You can configure snippets through your `marimo.toml` file:
 
 ```toml
 [snippets]

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -189,13 +189,13 @@ marimo will automatically discover the database connection and display the datab
 
 !!! note
 
-    marimo currently supports auto-discovery up to the schema level. If you want to discover tables and columns, you can enable it in `marimo.toml`:
+    marimo currently supports auto-discovery up to the schema level. If you want to discover tables and columns, you can enable it in your `.marimo.toml` file. Note that auto-discovery can be slow for large databases.
 
-    ```toml
+    ```toml title=".marimo.toml"
     [datasources]
-    include_schemas = true        # Defaults to true, set to false to disable schema discovery
-    include_tables = false        # Defaults to false, set to true to enable table discovery
-    include_table_details = false # Defaults to false, set to true to enable column discovery & table metadata
+    include_schemas = true         # Defaults to true, set to false to disable schema discovery
+    include_tables = false         # Defaults to false, set to true to enable table discovery
+    include_table_details = false  # Defaults to false, set to true to enable column discovery & table metadata
     ```
 
 ## Interactive tutorial

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -187,6 +187,17 @@ marimo will automatically discover the database connection and display the datab
   </figure>
 </div>
 
+!!! note
+
+    marimo currently supports auto-discovery up to the schema level. If you want to discover tables and columns, you can enable it in `marimo.toml`:
+
+    ```toml
+    [datasources]
+    include_schemas = true        # Defaults to true, set to false to disable schema discovery
+    include_tables = false        # Defaults to false, set to true to enable table discovery
+    include_table_details = false # Defaults to false, set to true to enable column discovery & table metadata
+    ```
+
 ## Interactive tutorial
 
 For an interactive tutorial, run

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -189,10 +189,10 @@ marimo will automatically discover the database connection and display the datab
 
 !!! note
 
-    marimo currently supports auto-discovery up to the schema level. If you want to discover tables and columns, you can enable it in your `.marimo.toml` file. Note that auto-discovery can be slow for large databases.
+    marimo by default supports auto-discovery up to the schema level. If you want to discover tables and columns, you can enable it in your `pyproject.toml` file. Note that auto-discovery can be slow for large databases.
 
-    ```toml title=".marimo.toml"
-    [datasources]
+    ```toml title="pyproject.toml"
+    [tool.marimo.datasources]
     include_schemas = true         # Defaults to true, set to false to disable schema discovery
     include_tables = false         # Defaults to false, set to true to enable table discovery
     include_table_details = false  # Defaults to false, set to true to enable column discovery & table metadata

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -187,15 +187,15 @@ marimo will automatically discover the database connection and display the datab
   </figure>
 </div>
 
-!!! note
+???+ note
 
-    marimo by default supports auto-discovery up to the schema level. If you want to discover tables and columns, you can enable it in your `pyproject.toml` file. Note that auto-discovery can be slow for large databases.
+    By default, marimo auto-discovers databases and schemas, but not tables and columns (to avoid performance issues with large databases). You can configure this behavior in your `pyproject.toml` file:
 
     ```toml title="pyproject.toml"
     [tool.marimo.datasources]
-    include_schemas = true         # Defaults to true, set to false to disable schema discovery
-    include_tables = false         # Defaults to false, set to true to enable table discovery
-    include_table_details = false  # Defaults to false, set to true to enable column discovery & table metadata
+    auto_discover_schemas = true   # Default: true
+    auto_discover_tables = false   # Default: false - enable for table auto-discovery
+    auto_discover_columns = false  # Default: false - enable for column auto-discovery
     ```
 
 ## Interactive tutorial

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -384,7 +384,7 @@ const TableList: React.FC<{
       <div className="text-sm text-muted-foreground py-1 pl-9">
         No tables found or{" "}
         <a
-          className="text-blue-500 dark:text-blue-50"
+          className="text-link"
           href="https://docs.marimo.io/guides/working_with_data/sql/#database-schema-and-table-auto-discovery"
           target="_blank"
           rel="noreferrer"

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -379,7 +379,20 @@ const TableList: React.FC<{
   searchValue?: string;
 }> = ({ tables, sqlTableContext, searchValue }) => {
   if (tables.length === 0) {
-    return <EmptyState content="No tables found" className="pl-9" />;
+    // TODO: We should preview tables instead of disabling introspection
+    return (
+      <div className="text-sm text-muted-foreground py-1 pl-9">
+        No tables found or{" "}
+        <a
+          className="text-blue-500 dark:text-blue-50"
+          href="https://docs.marimo.io/guides/working_with_data/sql/#database-schema-and-table-auto-discovery"
+          target="_blank"
+          rel="noreferrer"
+        >
+          introspection is disabled
+        </a>
+      </div>
+    );
   }
 
   const filteredTables = tables.filter((table) => {

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -263,14 +263,14 @@ class DatasourcesConfig(TypedDict):
 
     **Keys.**
 
-    - `include_schemas`: if `True`, include schemas in the datasource
-    - `include_tables`: if `True`, include tables in the datasource
-    - `include_table_details`: if `True`, include table details like columns in the datasource
+    - `auto_discover_schemas`: if `True`, include schemas in the datasource
+    - `auto_discover_tables`: if `True`, include tables in the datasource
+    - `auto_discover_columns`: if `True`, include columns & table metadata in the datasource
     """
 
-    include_schemas: NotRequired[bool]
-    include_tables: NotRequired[bool]
-    include_table_details: NotRequired[bool]
+    auto_discover_schemas: NotRequired[bool]
+    auto_discover_tables: NotRequired[bool]
+    auto_discover_columns: NotRequired[bool]
 
 
 @mddoc

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -257,6 +257,22 @@ class SnippetsConfig(TypedDict):
     include_default_snippets: NotRequired[bool]
 
 
+@dataclass
+class DatasourcesConfig(TypedDict):
+    """Configuration for datasources panel.
+
+    **Keys.**
+
+    - `include_schemas`: if `True`, include schemas in the datasource
+    - `include_tables`: if `True`, include tables in the datasource
+    - `include_table_details`: if `True`, include table details like columns in the datasource
+    """
+
+    include_schemas: NotRequired[bool]
+    include_tables: NotRequired[bool]
+    include_table_details: NotRequired[bool]
+
+
 @mddoc
 @dataclass
 class MarimoConfig(TypedDict):
@@ -273,6 +289,7 @@ class MarimoConfig(TypedDict):
     ai: NotRequired[AiConfig]
     experimental: NotRequired[dict[str, Any]]
     snippets: NotRequired[SnippetsConfig]
+    datasources: NotRequired[DatasourcesConfig]
 
 
 @mddoc
@@ -291,6 +308,7 @@ class PartialMarimoConfig(TypedDict, total=False):
     ai: NotRequired[AiConfig]
     experimental: NotRequired[dict[str, Any]]
     snippets: SnippetsConfig
+    datasources: NotRequired[DatasourcesConfig]
 
 
 DEFAULT_CONFIG: MarimoConfig = {

--- a/marimo/_sql/get_engines.py
+++ b/marimo/_sql/get_engines.py
@@ -53,20 +53,11 @@ def engine_to_data_source_connection(
 ) -> DataSourceConnection:
     databases: list[Database] = []
     if isinstance(engine, SQLAlchemyEngine):
-        config: DatasourcesConfig = {}
-        try:
-            config = get_context().marimo_config.get("datasources", {})
-        except ContextNotInitializedError:
-            config = (
-                get_default_config_manager(current_path=None)
-                .get_config()
-                .get("datasources", {})
-            )
-
+        config = get_datasources_config()
         databases = engine.get_databases(
-            include_schemas=config.get("include_schemas", True),
-            include_tables=config.get("include_tables", False),
-            include_table_details=config.get("include_table_details", False),
+            include_schemas=config.get("auto_discover_schemas", True),
+            include_tables=config.get("auto_discover_tables", False),
+            include_table_details=config.get("auto_discover_columns", False),
         )
     elif isinstance(engine, DuckDBEngine):
         databases = engine.get_databases()
@@ -88,3 +79,26 @@ def engine_to_data_source_connection(
         display_name=display_name,
         databases=databases,
     )
+
+
+def get_datasources_config() -> DatasourcesConfig:
+    try:
+        return get_context().marimo_config.get("datasources", {})
+    except ContextNotInitializedError:
+        pass
+    except Exception as e:
+        LOGGER.warning(
+            f"Failed to get datasources config from context: {e}. Falling back to default config."
+        )
+
+    try:
+        return (
+            get_default_config_manager(current_path=None)
+            .get_config()
+            .get("datasources", {})
+        )
+    except Exception as e:
+        LOGGER.warning(
+            f"Failed to get datasources config from default config: {e}. Returning empty config."
+        )
+        return {}

--- a/marimo/_sql/get_engines.py
+++ b/marimo/_sql/get_engines.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from marimo import _loggers
+from marimo._config.manager import get_default_config_manager
 from marimo._data.models import Database, DataSourceConnection
 from marimo._sql.engines import (
     INTERNAL_DUCKDB_ENGINE,
@@ -47,10 +48,16 @@ def engine_to_data_source_connection(
 ) -> DataSourceConnection:
     databases: list[Database] = []
     if isinstance(engine, SQLAlchemyEngine):
+        config = (
+            get_default_config_manager(current_path=None)
+            .get_config()
+            .get("datasources", {})
+        )
+
         databases = engine.get_databases(
-            include_schemas=True,
-            include_tables=True,
-            include_table_details=False,
+            include_schemas=config.get("include_schemas", True),
+            include_tables=config.get("include_tables", False),
+            include_table_details=config.get("include_table_details", False),
         )
     elif isinstance(engine, DuckDBEngine):
         databases = engine.get_databases()

--- a/marimo/_sql/get_engines.py
+++ b/marimo/_sql/get_engines.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 from typing import Any, cast
 
 from marimo import _loggers
+from marimo._config.config import DatasourcesConfig
 from marimo._config.manager import get_default_config_manager
 from marimo._data.models import Database, DataSourceConnection
-from marimo._runtime.context.types import get_context
+from marimo._runtime.context.types import (
+    ContextNotInitializedError,
+    get_context,
+)
 from marimo._sql.engines import (
     INTERNAL_DUCKDB_ENGINE,
     DuckDBEngine,
@@ -49,11 +53,15 @@ def engine_to_data_source_connection(
 ) -> DataSourceConnection:
     databases: list[Database] = []
     if isinstance(engine, SQLAlchemyEngine):
-        config = get_context().marimo_config.get(
-            "datasources"
-        ) or get_default_config_manager(current_path=None).get_config().get(
-            "datasources", {}
-        )
+        config: DatasourcesConfig = {}
+        try:
+            config = get_context().marimo_config.get("datasources", {})
+        except ContextNotInitializedError:
+            config = (
+                get_default_config_manager(current_path=None)
+                .get_config()
+                .get("datasources", {})
+            )
 
         databases = engine.get_databases(
             include_schemas=config.get("include_schemas", True),

--- a/marimo/_sql/get_engines.py
+++ b/marimo/_sql/get_engines.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from marimo import _loggers
 from marimo._config.manager import get_default_config_manager
 from marimo._data.models import Database, DataSourceConnection
+from marimo._runtime.context.types import get_context
 from marimo._sql.engines import (
     INTERNAL_DUCKDB_ENGINE,
     DuckDBEngine,
@@ -48,10 +49,10 @@ def engine_to_data_source_connection(
 ) -> DataSourceConnection:
     databases: list[Database] = []
     if isinstance(engine, SQLAlchemyEngine):
-        config = (
-            get_default_config_manager(current_path=None)
-            .get_config()
-            .get("datasources", {})
+        config = get_context().marimo_config.get(
+            "datasources"
+        ) or get_default_config_manager(current_path=None).get_config().get(
+            "datasources", {}
         )
 
         databases = engine.get_databases(

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1266,6 +1266,15 @@ components:
           - activate_on_typing
           - copilot
           type: object
+        datasources:
+          properties:
+            include_schemas:
+              type: boolean
+            include_table_details:
+              type: boolean
+            include_tables:
+              type: boolean
+          type: object
         display:
           properties:
             cell_output:
@@ -2207,7 +2216,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.11.11
+  version: 0.11.12
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1268,11 +1268,11 @@ components:
           type: object
         datasources:
           properties:
-            include_schemas:
+            auto_discover_columns:
               type: boolean
-            include_table_details:
+            auto_discover_schemas:
               type: boolean
-            include_tables:
+            auto_discover_tables:
               type: boolean
           type: object
         display:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2649,6 +2649,11 @@ export interface components {
         codeium_api_key?: string | null;
         copilot: boolean | ("github" | "codeium");
       };
+      datasources?: {
+        include_schemas?: boolean;
+        include_table_details?: boolean;
+        include_tables?: boolean;
+      };
       display: {
         /** @enum {string} */
         cell_output: "above" | "below";

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2650,9 +2650,9 @@ export interface components {
         copilot: boolean | ("github" | "codeium");
       };
       datasources?: {
-        include_schemas?: boolean;
-        include_table_details?: boolean;
-        include_tables?: boolean;
+        auto_discover_columns?: boolean;
+        auto_discover_schemas?: boolean;
+        auto_discover_tables?: boolean;
       };
       display: {
         /** @enum {string} */


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Not sure what you think about this, but this may be a temporary solution for the issue here: https://discord.com/channels/1059888774789730424/1338959377411084390/1344967482577915905. 

By default, we do not introspect tables, we let users opt-in by changing config.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
For future MRs:
- [ ] ~remove introspection for meta schemas, make this a config. `information_schema` does not need to be introspected I think..~ (if we load on-demand, we do not need to do this)
- [ ] possible to request in the background(?) or same as table details preview, request on-demand.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
