### PR TITLE
Better placeholder for dataframe @ context

### DIFF
--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -398,7 +398,7 @@ const ChatPanelBody = () => {
             <PromptInput
               key="new-thread-input"
               value={newThreadInput}
-              placeholder="Ask anything, @ to include context"
+              placeholder="Ask anything, @ to include context about tables or dataframes"
               theme={theme}
               onClose={handleOnCloseThread}
               onChange={setNewThreadInput}


### PR DESCRIPTION
Per discussion on Slack, updated the placeholder to make it clear that the context is only for tables and dataframes for now. 