### PR TITLE
improve: background color for markdown code blocks

### DIFF
--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -357,4 +357,5 @@ button .prose.prose {
 
 .markdown .codehilite {
   background-color: var(--slate-2);
+  border-radius: 4px;
 }

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -354,3 +354,7 @@ button .prose.prose {
 .markdown details > :not(summary) {
   @apply p-4 pt-0;
 }
+
+.markdown .codehilite {
+  background-color: var(--slate-2);
+}


### PR DESCRIPTION
This change adds a background color for code blocks in markdown to improve readability.

Example: 

<img width="597" alt="image" src="https://github.com/user-attachments/assets/665bf0a2-aa47-4c08-9cab-436557144f00" />
