### PR TITLE
Fix blur behavior for output-variable-name input field

### DIFF
--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -46,6 +46,14 @@ export const LanguagePanelComponent: React.FC<{
 
   if (languageAdapter instanceof SQLLanguageAdapter) {
     showDivider = true;
+    const sanitizeAndTriggerUpdate = (e: React.SyntheticEvent<HTMLInputElement>) => {
+      // Normalize the name to a valid variable name
+      const name = normalizeName(e.currentTarget.value, false);
+      languageAdapter.setDataframeName(name);
+      e.currentTarget.value = name;
+
+      triggerUpdate();
+    };
     actions = (
       <div className="flex flex-1 gap-2 relative items-center">
         <label className="flex gap-2 items-center">
@@ -57,13 +65,11 @@ export const LanguagePanelComponent: React.FC<{
               languageAdapter.setDataframeName(e.target.value);
               inputProps.onChange?.(e);
             }}
-            onBlur={(e) => {
-              // Normalize the name to a valid variable name
-              const name = normalizeName(e.target.value, false);
-              languageAdapter.setDataframeName(name);
-              e.target.value = name;
-
-              triggerUpdate();
+            onBlur={sanitizeAndTriggerUpdate}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && e.shiftKey) {
+                sanitizeAndTriggerUpdate(e);
+              }
             }}
             className="min-w-14 w-auto border border-border rounded px-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           />

--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -46,7 +46,9 @@ export const LanguagePanelComponent: React.FC<{
 
   if (languageAdapter instanceof SQLLanguageAdapter) {
     showDivider = true;
-    const sanitizeAndTriggerUpdate = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    const sanitizeAndTriggerUpdate = (
+      e: React.SyntheticEvent<HTMLInputElement>,
+    ) => {
       // Normalize the name to a valid variable name
       const name = normalizeName(e.currentTarget.value, false);
       languageAdapter.setDataframeName(name);


### PR DESCRIPTION
## 📝 Summary

As discussed in #3464, there is currently a bug in the output-variable input field on SQL cells.

The problem is that if you change the variable name and do shift-enter, the name change doesn't propagate to `notebookState` and therefore doesn't persist to disk. When the same notebook is opened again later, therefore, these variable names are lost.

I believe that the reason for this is that there's some kind of race condition between the cell evaluation that occurs when you do shift-enter, and the state-update operation that is supposed to occur in response to the same event. However, I have not been able to track down the root cause of this behavior.

## 🔍 Description of Changes

This PR makes the smallest possible change to workaround this problem. It circumvents the race condition by making the variable-update happen before the cell execution, specifically on the `keydown` event.

The ideal fix for this problem might be to identify the race condition and adjust the event-handling mechanisms accordingly, but in my estimation this is a reasonable and effective approach in the meantime.

To check that this PR fixes the problem, make a Marimo notebook while on `main` and create a SQL cell that says `select 1`. Then change the output variable name, do shift enter, and then immediately refresh the browser page. You should find that the variable name has reverted. Then switch to this branch and repeat the experiment; you should find that the variable name persists.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick

P.S. I have not added tests yet because I'm not sure whether this is the approach the maintainers want to take.