### PR TITLE
fix: auto-install pyarrow when polars+mo.sql present in wasm

### DIFF
--- a/frontend/src/core/islands/worker/worker.tsx
+++ b/frontend/src/core/islands/worker/worker.tsx
@@ -90,6 +90,13 @@ const requestHandler = createRPCRequestHandler({
       code = `import pandas\n${code}`;
       code = `import duckdb\n${code}`;
       code = `import sqlglot\n${code}`;
+
+      // Polars + SQL requires pyarrow, and installing
+      // after notebook load does not work. As a heuristic,
+      // if it appears that the notebook uses polars, add pyarrow.
+      if (code.includes("polars")) {
+        code = `import pyarrow\n${code}`;
+      }
     }
 
     await self.pyodide.loadPackagesFromImports(code, {
@@ -124,9 +131,9 @@ const requestHandler = createRPCRequestHandler({
     const response =
       payloadString == null
         ? // @ts-expect-error ehh TypeScript
-          await bridge[functionName]()
+        await bridge[functionName]()
         : // @ts-expect-error ehh TypeScript
-          await bridge[functionName](payloadString);
+        await bridge[functionName](payloadString);
 
     // Post the response back to the main thread
     return typeof response === "string" ? JSON.parse(response) : response;

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -166,6 +166,13 @@ export class DefaultWasmController implements WasmController {
       code = `import pandas\n${code}`;
       code = `import duckdb\n${code}`;
       code = `import sqlglot\n${code}`;
+
+      // Polars + SQL requires pyarrow, and installing
+      // after notebook load does not work. As a heuristic,
+      // if it appears that the notebook uses polars, add pyarrow.
+      if (code.includes("polars")) {
+        code = `import pyarrow\n${code}`;
+      }
     }
 
     // Add:

--- a/frontend/src/core/wasm/worker/worker.ts
+++ b/frontend/src/core/wasm/worker/worker.ts
@@ -141,6 +141,13 @@ const requestHandler = createRPCRequestHandler({
       code = `import pandas\n${code}`;
       code = `import duckdb\n${code}`;
       code = `import sqlglot\n${code}`;
+
+      // Polars + SQL requires pyarrow, and installing
+      // after notebook load does not work. As a heuristic,
+      // if it appears that the notebook uses polars, add pyarrow.
+      if (code.includes("polars")) {
+        code = `import pyarrow\n${code}`;
+      }
     }
 
     await self.pyodide.loadPackagesFromImports(code, {
@@ -300,9 +307,9 @@ const requestHandler = createRPCRequestHandler({
     const response =
       payloadString == null
         ? // @ts-expect-error ehh TypeScript
-          await bridge[functionName]()
+        await bridge[functionName]()
         : // @ts-expect-error ehh TypeScript
-          await bridge[functionName](payloadString);
+        await bridge[functionName](payloadString);
 
     // Sync the filesystem if we're saving, creating, deleting, or renaming a file
     if (namesThatRequireSync.has(functionName)) {


### PR DESCRIPTION
This change automatically adds pyarrow when mo.sql() is used in a Wasm notebook alongside Polars.

Without pyarrow, DuckDB queries against Polars dataframes fail, but installing pyarrow within the current notebook session after the failure doesn't fix the failure.

Instead of parsing the code we just check for the presence of the string "polars" in the code, as a heuristic.