### PR TITLE
fix: improved parsing of Error object

### DIFF
--- a/marimo/_messaging/cell_output.py
+++ b/marimo/_messaging/cell_output.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Sequence  # noqa: TC003
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Union
@@ -33,7 +32,7 @@ class CellOutput:
     # descriptive name about the kind of output: e.g., stdout, stderr, ...
     channel: CellChannel
     mimetype: KnownMimeType
-    data: Union[str, Sequence[Error], dict[str, Any]]
+    data: Union[str, list[Error], dict[str, Any]]
     timestamp: float = field(default_factory=lambda: time.time())
 
     def __repr__(self) -> str:

--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import sys
 from enum import Enum
 from typing import (
     Any,
@@ -14,6 +15,12 @@ from typing import (
     get_origin,
     get_type_hints,
 )
+
+# Import NotRequired from typing_extensions for Python < 3.11
+if sys.version_info < (3, 11):
+    from typing_extensions import NotRequired
+else:
+    from typing import NotRequired
 
 T = TypeVar("T")
 
@@ -61,6 +68,13 @@ class DataclassParser:
             # against the supertype
             supertype = cls.__supertype__  # type: ignore
             return cls(self._build_value(value, supertype))  # type: ignore
+
+        # Handle NotRequired type
+        if origin_cls is NotRequired:
+            (arg_type,) = get_args(cls)
+            if value is None:
+                return None  # type: ignore[return-value]
+            return self._build_value(value, arg_type)  # type: ignore[no-any-return]
 
         if origin_cls is Optional:
             (arg_type,) = get_args(cls)

--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
+import datetime
 import json
 import sys
 from enum import Enum
@@ -49,6 +50,12 @@ class DataclassParser:
             return bool(value)  # type: ignore[return-value]
         if cls is bytes and isinstance(value, bytes):
             return bytes(value)  # type: ignore[return-value]
+
+        # Handle date and datetime types
+        if cls is datetime.date and isinstance(value, str):
+            return datetime.datetime.fromisoformat(value).date()  # type: ignore[return-value]
+        if cls is datetime.datetime and isinstance(value, str):
+            return datetime.datetime.fromisoformat(value)  # type: ignore[return-value]
 
         if cls is Any:  # type: ignore[comparison-overlap]
             return value  # type: ignore[no-any-return]

--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -33,22 +33,22 @@ class DataclassParser:
     def _build_value(self, value: Any, cls: type[T]) -> T:
         # Handle basic types
         if cls is float and isinstance(value, (int, float)):
-            return float(value)  # type: ignore[no-any-return]
+            return float(value)  # type: ignore[return-value]
         if cls is int and isinstance(value, int):
-            return int(value)  # type: ignore[no-any-return]
+            return int(value)  # type: ignore[return-value]
         if cls is str and isinstance(value, str):
-            return str(value)  # type: ignore[no-any-return]
+            return str(value)  # type: ignore[return-value]
         if cls is bool and isinstance(value, bool):
-            return bool(value)  # type: ignore[no-any-return]
+            return bool(value)  # type: ignore[return-value]
         if cls is bytes and isinstance(value, bytes):
-            return bytes(value)  # type: ignore[no-any-return]
+            return bytes(value)  # type: ignore[return-value]
 
-        if cls is Any:
+        if cls is Any:  # type: ignore[comparison-overlap]
             return value  # type: ignore[no-any-return]
 
         # Already a dataclass
         if dataclasses.is_dataclass(value):
-            return value  # type: ignore[no-any-return]
+            return value  # type: ignore[return-value]
 
         # Handle container types
         # origin_cls is not None if cls is a container (such as list,

--- a/tests/_messaging/test_cell_output.py
+++ b/tests/_messaging/test_cell_output.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.errors import MarimoSyntaxError
+from marimo._messaging.ops import serialize
+from marimo._plugins.core.json_encoder import WebComponentEncoder
+from marimo._utils.parse_dataclass import parse_raw
+
+
+def as_json(obj: Any):
+    return WebComponentEncoder.json_dumps(obj)
+
+
+timestamp = 0
+
+stderr_output = CellOutput(
+    channel=CellChannel.STDERR,
+    mimetype="text/plain",
+    data="Error!",
+    timestamp=0,
+)
+
+stdout_output = CellOutput(
+    channel=CellChannel.STDOUT,
+    mimetype="text/plain",
+    data="Hello!",
+    timestamp=0,
+)
+
+error_output = CellOutput(
+    channel=CellChannel.MARIMO_ERROR,
+    mimetype="application/vnd.marimo+error",
+    data=[MarimoSyntaxError(msg="Syntax Error!")],
+    timestamp=0,
+)
+
+data_output = CellOutput(
+    channel=CellChannel.OUTPUT,
+    mimetype="application/vnd.marimo+mimebundle",
+    data={
+        "text/plain": "hi",
+        "text/markdown": "# hi",
+    },
+    timestamp=0,
+)
+
+
+def test_serialize_cell_output():
+    output = serialize(stderr_output)
+    assert output == {
+        "channel": "stderr",
+        "mimetype": "text/plain",
+        "data": "Error!",
+        "timestamp": 0,
+    }
+
+    output = serialize(stdout_output)
+    assert output == {
+        "channel": "stdout",
+        "mimetype": "text/plain",
+        "data": "Hello!",
+        "timestamp": 0,
+    }
+
+    output = serialize(error_output)
+    assert output == {
+        "channel": "marimo-error",
+        "mimetype": "application/vnd.marimo+error",
+        "data": [
+            {
+                "msg": "Syntax Error!",
+                "type": "syntax",
+            }
+        ],
+        "timestamp": 0,
+    }
+
+    output = serialize(data_output)
+    assert output == {
+        "channel": "output",
+        "mimetype": "application/vnd.marimo+mimebundle",
+        "data": {
+            "text/plain": "hi",
+            "text/markdown": "# hi",
+        },
+        "timestamp": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "subject", [stderr_output, stdout_output, error_output, data_output]
+)
+def test_identity(subject: CellOutput):
+    serialized = serialize(subject)
+    assert subject == parse_raw(serialized, CellOutput)

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -9,6 +9,7 @@ from marimo._ast.app import App, InternalApp
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.ops import CellOp
+from marimo._plugins.core.json_encoder import WebComponentEncoder
 from marimo._server.export import (
     export_as_wasm,
     run_app_then_export_as_ipynb,
@@ -397,7 +398,7 @@ def _print_messages(messages: list[CellOp]) -> str:
                 "status": message.status,
             }
         )
-    return json.dumps(result, indent=2)
+    return json.dumps(result, indent=2, cls=WebComponentEncoder)
 
 
 def _as_list(data: Any) -> list[Any]:


### PR DESCRIPTION
This improves the parsing from #3977, so that we get back `Error` objects instead of a dictionary. 

This makes the parser a bit more strict which does some validation as well. It used to only validate fields, but now validates some values.