### PR TITLE
fix: auto-export ipynb from reload/remapping

### DIFF
--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -386,10 +386,13 @@ class CellManager:
         id_mapping = dict(zip(sorted_ids, current_ids))
 
         # Update the cell data in place
-        self._cell_data = {
-            new_id: self._cell_data[old_id]
-            for new_id, old_id in id_mapping.items()
-        }
+        new_cell_data: dict[CellId_t, CellData] = {}
+        for new_id, old_id in id_mapping.items():
+            prev_cell_data = self._cell_data[old_id]
+            prev_cell_data.cell_id = new_id
+            new_cell_data[new_id] = prev_cell_data
+
+        self._cell_data = new_cell_data
 
         # Add the new ids to the set, so we don't reuse them in the future
         for _id in sorted_ids:

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -187,6 +187,9 @@ class Exporter:
 
         notebook["cells"] = []
         for cid in cell_ids:
+            if cid not in graph.cells:
+                LOGGER.warning("Cell %s not found in graph", cid)
+                continue
             cell = graph.cells[cid]
             outputs: list[NotebookNode] = []
 

--- a/marimo/_server/file_manager.py
+++ b/marimo/_server/file_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 import pathlib
 import shutil
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from marimo import _loggers
 from marimo._ast import codegen
@@ -24,14 +24,19 @@ from marimo._server.models.models import (
 from marimo._server.utils import canonicalize_filename
 from marimo._types.ids import CellId_t
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 LOGGER = _loggers.marimo_logger()
 
 
 class AppFileManager:
     def __init__(
-        self, filename: Optional[str], default_width: WidthType | None = None
+        self,
+        filename: Optional[Union[str, Path]],
+        default_width: WidthType | None = None,
     ) -> None:
-        self.filename = filename
+        self.filename = str(filename) if filename else None
         self._default_width: WidthType | None = default_width
         self.app = self._load_app(self.path)
 

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -421,7 +421,7 @@ def test_auto_export_ipynb_with_new_cell(
             time.sleep(0.1)
             continue
         cell_op = session.session_view.cell_operations["new_cell"]
-        if cell_op:
+        if cell_op.output is not None:
             break
     assert cell_op
     assert cell_op.output is not None

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import os
+import shutil
+import time
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,8 +12,13 @@ import pytest
 from marimo import __version__
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.utils import uri_encode_component
+from marimo._types.ids import SessionId
 from tests._server.conftest import get_session_manager
-from tests._server.mocks import token_header, with_read_session, with_session
+from tests._server.mocks import (
+    token_header,
+    with_read_session,
+    with_session,
+)
 from tests.mocks import snapshotter
 
 if TYPE_CHECKING:
@@ -18,7 +26,7 @@ if TYPE_CHECKING:
 
 snapshot = snapshotter(__file__)
 
-SESSION_ID = "session-123"
+SESSION_ID = SessionId("session-123")
 HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
     **token_header("fake-token"),
@@ -332,6 +340,86 @@ def test_auto_export_ipynb(
     assert os.path.exists(
         os.path.join(os.path.dirname(temp_marimo_file), "__marimo__")
     )
+
+
+@pytest.mark.skipif(
+    not DependencyManager.nbformat.has(), reason="nbformat not installed"
+)
+@with_session(SESSION_ID)
+def test_auto_export_ipynb_with_new_cell(
+    client: TestClient, *, temp_marimo_file: str
+) -> None:
+    """Test that auto-exporting to ipynb works after creating and running a new cell.
+
+    This test addresses the bug in https://github.com/marimo-team/marimo/issues/3992
+    where cell ID inconsistency causes KeyError when auto-exporting as ipynb.
+    """
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.filename = temp_marimo_file
+
+    # First, create and run a cell with constant value 1
+    create_cell_response = client.post(
+        "/api/kernel/run",
+        headers=HEADERS,
+        json={
+            "cell_ids": ["new_cell"],
+            "codes": ["3.14"],
+        },
+    )
+    assert create_cell_response.status_code == 200
+
+    time.sleep(0.5)
+
+    # Save the session
+    save_response = client.post(
+        "/api/kernel/save",
+        headers=HEADERS,
+        json={
+            "cell_ids": ["new_cell"],
+            "filename": temp_marimo_file,
+            "codes": ["3.14"],
+            "names": ["_"],
+            "configs": [
+                {
+                    "hideCode": True,
+                    "disabled": False,
+                }
+            ],
+        },
+    )
+    assert save_response.status_code == 200, save_response.text
+
+    # Clean up the marimo directory
+    marimo_dir = Path(temp_marimo_file).parent / "__marimo__"
+    shutil.rmtree(marimo_dir, ignore_errors=True)
+
+    # Now attempt to auto-export as ipynb
+    export_response = client.post(
+        "/api/export/auto_export/ipynb",
+        headers=HEADERS,
+        json={
+            "download": False,
+        },
+    )
+    assert export_response.status_code == 200
+    assert export_response.json() == {"success": True}
+
+    # Verify the exported file exists
+    assert marimo_dir.exists()
+
+    # Verify the cell output is correct
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    cell_op = session.session_view.cell_operations["new_cell"]
+    assert cell_op.output is not None
+    assert "3.14" in cell_op.output.data
+
+    # Verify the ipynb file exists
+    filename = Path(temp_marimo_file).name.replace(".py", ".ipynb")
+    ipynb_path = marimo_dir / filename
+    notebook = ipynb_path.read_text()
+    assert "<pre style='font-size: 12px'>3.14</pre>" in notebook
 
 
 @with_session(SESSION_ID)

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -411,7 +411,19 @@ def test_auto_export_ipynb_with_new_cell(
     # Verify the cell output is correct
     session = get_session_manager(client).get_session(SESSION_ID)
     assert session
-    cell_op = session.session_view.cell_operations["new_cell"]
+
+    # Wait for the cell operation to be created
+    timeout = 2
+    start = time.time()
+    cell_op = None
+    while time.time() - start < timeout:
+        if "new_cell" not in session.session_view.cell_operations:
+            time.sleep(0.1)
+            continue
+        cell_op = session.session_view.cell_operations["new_cell"]
+        if cell_op:
+            break
+    assert cell_op
     assert cell_op.output is not None
     assert "3.14" in cell_op.output.data
 

--- a/tests/_server/api/endpoints/test_resume_session.py
+++ b/tests/_server/api/endpoints/test_resume_session.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from marimo._config.manager import UserConfigManager
 from marimo._messaging.ops import CellOp, KernelCapabilities, KernelReady
 from marimo._server.sessions import Session
+from marimo._types.ids import SessionId
 from marimo._utils.parse_dataclass import parse_raw
 from tests._server.conftest import get_session_manager
 from tests._server.mocks import token_header
@@ -67,7 +68,9 @@ def assert_kernel_ready_response(
     assert data.capabilities == expected.capabilities
 
 
-def get_session(client: TestClient, session_id: str) -> Optional[Session]:
+def get_session(
+    client: TestClient, session_id: SessionId
+) -> Optional[Session]:
     return get_session_manager(client).get_session(session_id)
 
 
@@ -77,7 +80,7 @@ def test_refresh_session(client: TestClient) -> None:
         assert_kernel_ready_response(data, create_response({}))
 
     # Check the session still exists after closing the websocket
-    session = get_session(client, "123")
+    session = get_session(client, SessionId("123"))
     assert session
     session_view = session.session_view
 


### PR DESCRIPTION
Fixes #3992 

When we added `--watch` with remapping cell ids (https://github.com/marimo-team/marimo/pull/3451), this didn't make the `ID` of the `Cell` itself (just in the map).  And this failed when updating the `graph`, so there was an inconsistency causing #3992 

This now fixes that and adds a few tests