### PR TITLE
fix: anywidget should re-render whenever re-created

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -183,7 +183,7 @@ const LoadedSlot = ({
   data,
   host,
 }: Props & { widget: AnyWidget }) => {
-  const ref = useRef<HTMLDivElement>(null);
+  const htmlRef = useRef<HTMLDivElement>(null);
   const model = useRef<Model<T>>(
     new Model(
       // Merge the initial value with the current value
@@ -205,11 +205,16 @@ const LoadedSlot = ({
   );
 
   useEffect(() => {
-    if (!ref.current) {
+    if (!htmlRef.current) {
       return;
     }
-    runAnyWidgetModule(widget, model.current, ref.current);
-  }, [widget]);
+    runAnyWidgetModule(widget, model.current, htmlRef.current);
+    // We re-run the widget when the jsUrl changes, which means the cell
+    // that created the Widget has been re-run.
+    // We need to re-run the widget because it may contain initialization code
+    // that could be reset by the new widget.
+    // See example: https://github.com/marimo-team/marimo/issues/3962#issuecomment-2703184123
+  }, [widget, data.jsUrl]);
 
   // When the value changes, update the model
   const valueMemo = useDeepCompareMemoize(value);
@@ -217,5 +222,12 @@ const LoadedSlot = ({
     model.current.updateAndEmitDiffs(valueMemo);
   }, [valueMemo]);
 
-  return <div ref={ref} />;
+  return <div ref={htmlRef} />;
+};
+
+export const visibleForTesting = {
+  LoadedSlot,
+  runAnyWidgetModule,
+  isAnyWidgetModule,
+  getDirtyFields,
 };

--- a/marimo/_smoke_tests/issues/3962-anywidget-partial-state-2.py
+++ b/marimo/_smoke_tests/issues/3962-anywidget-partial-state-2.py
@@ -1,0 +1,61 @@
+import marimo
+
+__generated_with = "0.11.16"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import anywidget
+    import traitlets
+    return anywidget, mo, traitlets
+
+
+@app.cell
+def _(anywidget, traitlets):
+    class MyWidget(anywidget.AnyWidget):
+        _esm = """
+        function render({ model, el }) {
+            let in_value = model.get("in_value");
+            console.log("[debug:init] in_value", in_value);
+            model.set("out_value", in_value * 2);
+            console.log("[debug:init] out_value", in_value * 2);
+            model.save_changes();
+
+            model.on("change:in_value", () => {
+                let in_value = model.get("in_value");
+                console.log("[debug:change] in_value", in_value);
+                model.set("out_value", in_value * 2);
+                console.log("[debug:change] out_value", in_value * 2);
+                model.save_changes();
+            })
+        }
+        export default { render };
+        """
+        in_value = traitlets.Int(0).tag(sync=True)
+        out_value = traitlets.Int(123).tag(sync=True)
+    return (MyWidget,)
+
+
+@app.cell
+def _(MyWidget):
+    widget_instance = MyWidget(in_value=8)
+    return (widget_instance,)
+
+
+@app.cell
+def _(mo, widget_instance):
+    m = mo.ui.anywidget(widget_instance)
+    m
+    return (m,)
+
+
+@app.cell
+def _(m):
+    m.widget.out_value
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/issues/3962-anywidget-partial-state.py
+++ b/marimo/_smoke_tests/issues/3962-anywidget-partial-state.py
@@ -1,0 +1,58 @@
+import marimo
+
+__generated_with = "0.11.16"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import anywidget
+    import traitlets
+    import marimo as mo
+    from svg import SVG, Circle
+    return Circle, SVG, anywidget, mo, traitlets
+
+
+@app.cell
+def _(anywidget, traitlets):
+    class HoverWidget(anywidget.AnyWidget):
+        _esm = """
+        function render({ model, el }) {
+            el.innerHTML = model.get("svg");
+            el.querySelectorAll("circle").forEach((circle) => {
+                circle.addEventListener("mouseover", () => {
+                    model.set("selected_id", circle.getAttribute("id"));
+                    model.save_changes();
+                });
+            });
+        }
+        export default { render };
+        """
+        svg = traitlets.Unicode().tag(sync=True)
+        selected_id = traitlets.Any().tag(sync=True)
+    return (HoverWidget,)
+
+
+@app.cell
+def _(Circle, SVG):
+    my_svg = SVG(
+        width=200,
+        height=100,
+        elements=[
+            Circle(id="circle 1", cx=50, cy=50, r=20, fill="red"),
+            Circle(id="circle 2", cx=100, cy=50, r=20, fill="blue"),
+            Circle(id="circle 3", cx=150, cy=50, r=20, fill="green"),
+        ],
+    )
+    return (my_svg,)
+
+
+@app.cell
+def _(HoverWidget, mo, my_svg):
+    w = mo.ui.anywidget(HoverWidget(svg=my_svg.as_str(), selected_id=""))
+    [w]
+    return (w,)
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #3962

Previously, if the JS of an anywidget didn't change, we skipped a re-render. 

This could cause issues if there is initialization code in the render function, because it would not get called when the widget is created again. 

Instead we not just re-render the anywidget whenever it gets created. 