### PR TITLE
fix: use encoding='utf-8' for remove marimo notebooks

### DIFF
--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -285,7 +285,7 @@ class RemoteFileHandler(FileHandler):
         # If doesn't end in .py, add it
         if not path_to_app.endswith(".py"):
             path_to_app += ".py"
-        with open(path_to_app, "w") as f:
+        with open(path_to_app, "w", encoding="utf-8") as f:
             f.write(content)
         LOGGER.info("App saved to %s", path_to_app)
         return path_to_app

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -27,6 +27,7 @@ from marimo._ast.cell import CellConfig
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._server.templates.templates import get_version
 from marimo._utils.config.config import ROOT_DIR as CONFIG_ROOT_DIR
+from marimo._utils.platform import is_windows
 from marimo._utils.toml import read_toml
 
 if TYPE_CHECKING:
@@ -597,6 +598,7 @@ def test_cli_sandbox_edit_new_file() -> None:
     _check_contents(p, b"marimo-mode data-mode='edit'", contents)
 
 
+@pytest.mark.skipif(is_windows(), reason="Windows will prompt for Docker")
 def test_cli_edit_by_url() -> None:
     port = _get_port()
     p = subprocess.Popen(

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -597,6 +597,23 @@ def test_cli_sandbox_edit_new_file() -> None:
     _check_contents(p, b"marimo-mode data-mode='edit'", contents)
 
 
+def test_cli_edit_by_url() -> None:
+    port = _get_port()
+    p = subprocess.Popen(
+        [
+            "marimo",
+            "edit",
+            "https://github.com/marimo-team/marimo/blob/main/examples/ui/button.py",
+            "-p",
+            str(port),
+            "--headless",
+            "--no-token",
+        ]
+    )
+    contents = _try_fetch(port)
+    _check_contents(p, b"marimo-mode data-mode='edit'", contents)
+
+
 @pytest.mark.skipif(not HAS_UV, reason="uv is required for sandbox tests")
 def test_cli_sandbox_run(temp_marimo_file: str) -> None:
     port = _get_port()


### PR DESCRIPTION
Fixes #4003 