### PR TITLE
Pass cellSelection to table state

### DIFF
--- a/frontend/src/components/data-table/cell-selection/types.ts
+++ b/frontend/src/components/data-table/cell-selection/types.ts
@@ -8,7 +8,7 @@ export interface CellSelectionItem {
 }
 export type CellSelectionState = CellSelectionItem[];
 export interface CellSelectionTableState {
-  cellSelection?: CellSelectionState;
+  cellSelection: CellSelectionState;
 }
 
 export interface CellSelectionOptions {

--- a/frontend/src/components/data-table/cell-selection/types.ts
+++ b/frontend/src/components/data-table/cell-selection/types.ts
@@ -8,7 +8,7 @@ export interface CellSelectionItem {
 }
 export type CellSelectionState = CellSelectionItem[];
 export interface CellSelectionTableState {
-  cellSelection: CellSelectionState;
+  cellSelection?: CellSelectionState;
 }
 
 export interface CellSelectionOptions {

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -54,6 +54,7 @@ interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   // Selection
   selection?: DataTableSelection;
   rowSelection?: RowSelectionState;
+  cellSelection?: CellSelectionState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   onCellSelectionChange?: OnChangeFn<CellSelectionState>;
   getRowIds?: GetRowIds;
@@ -82,6 +83,7 @@ const DataTableInternal = <TData,>({
   sorting,
   setSorting,
   rowSelection,
+  cellSelection,
   paginationState,
   setPaginationState,
   downloadAs,
@@ -169,6 +171,7 @@ const DataTableInternal = <TData,>({
           : // No pagination, show all rows
             { pagination: { pageIndex: 0, pageSize: data.length } }),
       rowSelection,
+      cellSelection,
       columnPinning: columnPinning,
     },
     onColumnPinningChange: setColumnPinning,

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -604,6 +604,7 @@ const DataTableComponent = ({
             paginationState={paginationState}
             setPaginationState={setPaginationState}
             rowSelection={rowSelection}
+            cellSelection={cellSelection}
             downloadAs={showDownload ? downloadAs : undefined}
             enableSearch={enableSearch}
             searchQuery={searchQuery}


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

As a follow up to https://github.com/marimo-team/marimo/pull/3725, I noticed that the cell are not unselect (visually) when change the `selection` in Python code.

This is solved by passing in the cell state, similar to how the rowSelection is passed down.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
