### PR TITLE
Adding a boolean to see the code first, then result in marimo.show_code

### DIFF
--- a/marimo/_output/show_code.py
+++ b/marimo/_output/show_code.py
@@ -16,7 +16,10 @@ def substitute_show_code_with_arg(code: str) -> str:
     modified_code = re.sub(pattern, r"\1", code, flags=re.DOTALL).strip()
     # Remove code_first=True or code_first=False from the end
     modified_code = re.sub(
-        r",\s*code_first\s*=\s*(True|False)$", "", modified_code
+        r",?\s*code_first\s*=\s*(True|False),?\s*\)?$",
+        "",
+        modified_code,
+        flags=re.DOTALL,
     ).strip()
     return modified_code
 
@@ -58,8 +61,10 @@ def show_code(output: object = None, code_first: bool = False) -> Html:
 
     **Args:**
 
-    - output: the output to display above the cell's code; omit the output
+    - `output`: the output to display above the cell's code; omit the output
       to just show the cell's code, without an output.
+    - `code_first` : If `True`, the code will be displayed above the output.
+      If `False` (default), the output appears above the code.
 
     **Returns:**
 

--- a/marimo/_output/show_code.py
+++ b/marimo/_output/show_code.py
@@ -13,7 +13,12 @@ from marimo._runtime.context.types import ContextNotInitializedError
 
 def substitute_show_code_with_arg(code: str) -> str:
     pattern = r"mo\.show_code\((.*)\)"
-    return re.sub(pattern, r"\1", code, flags=re.DOTALL).strip()
+    modified_code = re.sub(pattern, r"\1", code, flags=re.DOTALL).strip()
+    # Remove code_first=True or code_first=False from the end
+    modified_code = re.sub(
+        r",\s*code_first\s*=\s*(True|False)$", "", modified_code
+    ).strip()
+    return modified_code
 
 
 def show_code(output: object = None, code_first: bool = False) -> Html:

--- a/marimo/_output/show_code.py
+++ b/marimo/_output/show_code.py
@@ -16,7 +16,7 @@ def substitute_show_code_with_arg(code: str) -> str:
     return re.sub(pattern, r"\1", code, flags=re.DOTALL).strip()
 
 
-def show_code(output: object = None) -> Html:
+def show_code(output: object = None, code_first: bool = False) -> Html:
     """Display an output along with the code of the current cell.
 
     Use `mo.show_code` to show the code of the current cell along with
@@ -73,11 +73,19 @@ def show_code(output: object = None) -> Html:
     code = substitute_show_code_with_arg(cell.code)
 
     if output is not None:
-        return vstack(
-            [
-                as_html(output),
-                code_editor(value=code, disabled=True, min_height=1),
-            ]
-        )
+        if code_first:
+            return vstack(
+                [
+                    code_editor(value=code, disabled=True, min_height=1),
+                    as_html(output),
+                ]
+            )
+        else:
+            return vstack(
+                [
+                    as_html(output),
+                    code_editor(value=code, disabled=True, min_height=1),
+                ]
+            )
     else:
         return code_editor(value=code, disabled=True, min_height=1)

--- a/tests/_output/test_show_code.py
+++ b/tests/_output/test_show_code.py
@@ -80,3 +80,139 @@ hello, world
 hello, world
 '''"""
     )
+
+
+async def test_show_code_code_first_true(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    await k.run(
+        [
+            exec_req.get(
+                "import marimo as mo; x = mo.show_code(1, code_first=True)"
+            )
+        ]
+    )
+    result = k.globals["x"].text
+    print("Debug Output (code_first=True):", result)  # Print actual output
+    assert "<marimo-code-editor" in result, (
+        "Expected '<marimo-code-editor>' in output but not found"
+    )
+    assert "<span>1</span>" in result, (
+        "Expected '<span>1</span>' in output but not found"
+    )
+    assert result.index("<marimo-code-editor") < result.index(
+        "<span>1</span>"
+    ), "Code should appear before output"
+
+
+async def test_show_code_code_first_false(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    await k.run(
+        [
+            exec_req.get(
+                "import marimo as mo; x = mo.show_code(1, code_first=False)"
+            )
+        ]
+    )
+    result = k.globals["x"].text
+    print("Debug Output (code_first=False):", result)  # Print actual output
+    assert "<marimo-code-editor" in result, (
+        "Expected '<marimo-code-editor>' in output but not found"
+    )
+    assert "<span>1</span>" in result, (
+        "Expected '<span>1</span>' in output but not found"
+    )
+    assert result.index("<span>1</span>") < result.index(
+        "<marimo-code-editor"
+    ), "Output should appear before code"
+
+
+async def test_show_code_code_first_default(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    await k.run([exec_req.get("import marimo as mo; x = mo.show_code(1)")])
+    result = k.globals["x"].text
+    print("Debug Output (code_first=False):", result)  # Print actual output
+    assert "<marimo-code-editor" in result, (
+        "Expected '<marimo-code-editor>' in output but not found"
+    )
+    assert "<span>1</span>" in result, (
+        "Expected '<span>1</span>' in output but not found"
+    )
+    assert result.index("<span>1</span>") < result.index(
+        "<marimo-code-editor"
+    ), "Output should appear before code"
+
+
+def test_substitute_show_code_removes_code_first() -> None:
+    # Basic cases
+    code = "mo.show_code(1, code_first=True)"
+    assert substitute_show_code_with_arg(code) == "1"
+
+    code = "mo.show_code(1, code_first=False)"
+    assert substitute_show_code_with_arg(code) == "1"
+
+    code = "mo.show_code(foo(1) + 1, code_first=True)"
+    assert substitute_show_code_with_arg(code) == "foo(1) + 1"
+
+    # Case with extra spaces
+    code = "mo.show_code(   42   ,    code_first =  True   )"
+    assert substitute_show_code_with_arg(code) == "42"
+
+    code = "mo.show_code(foo(2), bar(3), code_first=True)"
+    assert substitute_show_code_with_arg(code) == "foo(2), bar(3)"
+
+    code = "mo.show_code(100)"
+    assert substitute_show_code_with_arg(code) == "100"
+
+    code = "mo.show_code(foo(bar(5)))"
+    assert substitute_show_code_with_arg(code) == "foo(bar(5))"
+
+    code = "mo.show_code(mo.show_code(1), code_first=True)"
+    assert substitute_show_code_with_arg(code) == "mo.show_code(1)"
+
+    code = "mo.show_code(mo.show_code(foo(3) + 1, code_first=False), code_first=True)"
+    assert (
+        substitute_show_code_with_arg(code)
+        == "mo.show_code(foo(3) + 1, code_first=False)"
+    )
+
+    code = "mo.show_code((x + y) * 2, code_first=True)"
+    assert substitute_show_code_with_arg(code) == "(x + y) * 2"
+
+    code = "mo.show_code({'a': 1, 'b': 2}, code_first=False)"
+    assert substitute_show_code_with_arg(code) == "{'a': 1, 'b': 2}"
+
+    code = "mo.show_code([i for i in range(10)], code_first=True)"
+    assert substitute_show_code_with_arg(code) == "[i for i in range(10)]"
+
+    code = "mo.show_code()"
+    assert substitute_show_code_with_arg(code) == ""
+
+    code = "mo.show_code(, code_first=True)"
+    assert substitute_show_code_with_arg(code) == ""
+
+    code = 'mo.show_code("hello, world", code_first=True)'
+    assert substitute_show_code_with_arg(code) == '"hello, world"'
+
+    code = "mo.show_code('single quotes test', code_first=False)"
+    assert substitute_show_code_with_arg(code) == "'single quotes test'"
+
+    code = "mo.show_code(mo.show_code(1, code_first=False), code_first=True)"
+    assert (
+        substitute_show_code_with_arg(code)
+        == "mo.show_code(1, code_first=False)"
+    )
+
+    code = "mo.show_code(mo.show_code(foo(3) + 1, code_first=False), code_first=True)"
+    assert (
+        substitute_show_code_with_arg(code)
+        == "mo.show_code(foo(3) + 1, code_first=False)"
+    )
+
+    code = "mo.show_code(mo.show_code(42, code_first=True), code_first=False)"
+    assert (
+        substitute_show_code_with_arg(code)
+        == "mo.show_code(42, code_first=True)"
+    )

--- a/tests/_output/test_show_code.py
+++ b/tests/_output/test_show_code.py
@@ -93,7 +93,6 @@ async def test_show_code_code_first_true(
         ]
     )
     result = k.globals["x"].text
-    print("Debug Output (code_first=True):", result)  # Print actual output
     assert "<marimo-code-editor" in result, (
         "Expected '<marimo-code-editor>' in output but not found"
     )
@@ -116,7 +115,6 @@ async def test_show_code_code_first_false(
         ]
     )
     result = k.globals["x"].text
-    print("Debug Output (code_first=False):", result)  # Print actual output
     assert "<marimo-code-editor" in result, (
         "Expected '<marimo-code-editor>' in output but not found"
     )
@@ -133,7 +131,6 @@ async def test_show_code_code_first_default(
 ) -> None:
     await k.run([exec_req.get("import marimo as mo; x = mo.show_code(1)")])
     result = k.globals["x"].text
-    print("Debug Output (code_first=False):", result)  # Print actual output
     assert "<marimo-code-editor" in result, (
         "Expected '<marimo-code-editor>' in output but not found"
     )
@@ -216,3 +213,15 @@ def test_substitute_show_code_removes_code_first() -> None:
         substitute_show_code_with_arg(code)
         == "mo.show_code(42, code_first=True)"
     )
+
+    code = """mo.show_code(
+        42,
+        code_first=True,
+    )"""
+    assert substitute_show_code_with_arg(code) == "42"
+
+    code = """mo.show_code(
+        42,
+        code_first=True,
+    )"""
+    assert substitute_show_code_with_arg(code) == "42"


### PR DESCRIPTION
### 📝 Summary

Added a ``code_first`` boolean to ``marimo.show_code``  to control the order of code and results (default: False, maintaining previous behavior). A new setting for this, as requested in part 2 of the issue, I think is unnecessary.

Related Issue: #3997 

### 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] I have run the code and verified that it works as expected.

@mscolnick
