### PR TITLE
fix: embedding from code

### DIFF
--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -243,6 +243,13 @@ the notebook file's code), using the `code` query parameter:
 https://marimo.app?embed=true&show-chrome=false&code=<encoded-uri-component>
 ```
 
+where `<encoded-uri-component>` is the notebook code URI encoded. For example,
+in JavaScript:
+
+```javascript
+encodeURIComponent(notebookCode)
+```
+
 #### Using lz compression for large notebooks
 
 When using the `code` query parameter, your notebooks must no greater than `14 KB`.
@@ -252,7 +259,7 @@ For example, in JavaScript, you can use the [`lz-string`](https://www.npmjs.com/
 ```javascript
 import { compressToEncodedURIComponent } from "lz-string";
 
-const url = `https://marimo.app/#code=${compressToEncodedURIComponent(code)}`
+const url = `https://marimo.app/#code/${compressToEncodedURIComponent(code)}`
 ```
 
 #### MDX

--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -243,6 +243,18 @@ the notebook file's code), using the `code` query parameter:
 https://marimo.app?embed=true&show-chrome=false&code=<encoded-uri-component>
 ```
 
+#### Using lz compression for large notebooks
+
+When using the `code` query parameter, your notebooks must no greater than `14 KB`.
+For large notebooks, `marimo.app` supports lz-compressed notebook code with a URL hash.
+For example, in JavaScript, you can use the [`lz-string`](https://www.npmjs.com/package/lz-string) package:
+
+```javascript
+import { compressToEncodedURIComponent } from "lz-string";
+
+const url = `https://marimo.app/#code=${compressToEncodedURIComponent(code)}`
+```
+
 #### MDX
 
 For example, if you are using MDX, you can use the following snippet:

--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -252,7 +252,7 @@ encodeURIComponent(notebookCode)
 
 #### Using lz compression for large notebooks
 
-When using the `code` query parameter, your notebooks must no greater than `14 KB`.
+When using the `code` query parameter, your notebooks must be no greater than `14 KB`.
 For large notebooks, `marimo.app` supports lz-compressed notebook code with a URL hash.
 For example, in JavaScript, you can use the [`lz-string`](https://www.npmjs.com/package/lz-string) package:
 

--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -237,10 +237,10 @@ You can optionally render embedded notebooks in read-only mode by appending
 ### Embedding from code
 
 You can also embed marimo notebook from its string representation (i.e.,
-the notebook file's code), with the URL
+the notebook file's code), using the `code` query parameter:
 
 ```
-https://marimo.app?embed=true&show-chrome=false#code/<encoded-uri-component>
+https://marimo.app?embed=true&show-chrome=false&code=<encoded-uri-component>
 ```
 
 #### MDX
@@ -250,12 +250,12 @@ For example, if you are using MDX, you can use the following snippet:
 ```jsx
 const MdxNotebook = (props: { code: string }) => {
   return (
-    <iframe src={`https://marimo.app?embed=true&show-chrome=false#code/${encodeURIComponent(props.code)}`} />
+    <iframe src={`https://marimo.app?embed=true&show-chrome=false&code=${encodeURIComponent(props.code)}`} />
   );
 };
 
 <MdxNotebook code={`
-import marimo as mo
+import marimo
 
 app = marimo.App()
 


### PR DESCRIPTION
Fix docs for embedding playground notebooks from code.