### PR TITLE
fix: memory available machine stats

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/machine-stats.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/machine-stats.tsx
@@ -84,7 +84,7 @@ const MemoryUsageBar: React.FC<{
   kernel: UsageResponse["kernel"];
   server: UsageResponse["server"];
 }> = ({ memory, kernel, server }) => {
-  const { percent, total, used } = memory;
+  const { percent, total, available } = memory;
   const roundedPercent = Math.round(percent);
   return (
     <Tooltip
@@ -92,8 +92,8 @@ const MemoryUsageBar: React.FC<{
       content={
         <div className="flex flex-col gap-1">
           <span>
-            <b>computer memory:</b> {asGB(used)} / {asGB(total)} GB (
-            {roundedPercent}%)
+            <b>computer memory:</b> {asGB(total - available)} / {asGB(total)} GB
+            ({roundedPercent}%)
           </span>
           {server?.memory && (
             <span>


### PR DESCRIPTION
psutil docs say percent is (total - available) / total * 100, and seems like `used` not necessarily equal to total - available

https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory

Fixes #4051 