### PR TITLE
fix: wait longer in pyodide to render output

### DIFF
--- a/frontend/src/core/wasm/PyodideLoader.tsx
+++ b/frontend/src/core/wasm/PyodideLoader.tsx
@@ -36,7 +36,7 @@ const PyodideLoaderInner: React.FC<PropsWithChildren> = ({ children }) => {
     return <WasmSpinner />;
   }
 
-  // If we:
+  // If ALL are true:
   // - are in read mode
   // - we are not showing the code
   // - and there is no output
@@ -54,7 +54,7 @@ const PyodideLoaderInner: React.FC<PropsWithChildren> = ({ children }) => {
 };
 
 function isCodeHidden() {
-  // Code is hidden if:
+  // Code is hidden if ANY are true:
   // - the query param is set to false
   // - the marimo-code html-tag has data-show-code="false"
   return (

--- a/frontend/src/core/wasm/PyodideLoader.tsx
+++ b/frontend/src/core/wasm/PyodideLoader.tsx
@@ -10,6 +10,7 @@ import { hasAnyOutputAtom, wasmInitializationAtom } from "./state";
 import { initialMode } from "../mode";
 import { hasQueryParam } from "@/utils/urls";
 import { KnownQueryParams } from "../constants";
+import { getMarimoShowCode } from "../dom/marimo-tag";
 
 /**
  * HOC to load Pyodide before rendering children, if necessary.
@@ -40,11 +41,7 @@ const PyodideLoaderInner: React.FC<PropsWithChildren> = ({ children }) => {
   // - we are not showing the code
   // - and there is no output
   // then show the spinner
-  if (
-    !hasOutput &&
-    initialMode === "read" &&
-    hasQueryParam(KnownQueryParams.showCode, "false")
-  ) {
+  if (!hasOutput && initialMode === "read" && isCodeHidden()) {
     return <WasmSpinner />;
   }
 
@@ -55,6 +52,15 @@ const PyodideLoaderInner: React.FC<PropsWithChildren> = ({ children }) => {
 
   return children;
 };
+
+function isCodeHidden() {
+  // Code is hidden if:
+  // - the query param is set to false
+  // - the marimo-code html-tag has data-show-code="false"
+  return (
+    hasQueryParam(KnownQueryParams.showCode, "false") || !getMarimoShowCode()
+  );
+}
 
 export const WasmSpinner: React.FC<PropsWithChildren> = ({ children }) => {
   const wasmInitialization = useAtomValue(wasmInitializationAtom);


### PR DESCRIPTION
We have some logic that would wait for output when the code is hidden. You could only previously set this from the URL param. We later added to do it from the HTML config, but did not update this logic. 


Fixes #4069