### PR TITLE
Allow any characters in HTML title

### DIFF
--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -165,9 +165,7 @@ export type SaveConfig = UserConfig["save"];
 export type CompletionConfig = UserConfig["completion"];
 export type KeymapConfig = UserConfig["keymap"];
 
-export const AppTitleSchema = z.string().regex(/^[\w '-]*$/, {
-  message: "Invalid application title",
-});
+export const AppTitleSchema = z.string();
 export const AppConfigSchema = z
   .object({
     width: z


### PR DESCRIPTION
## 📝 Summary

Allow any characters in the HTML title.

## 🔍 Description of Changes

#1264 added the ability to set a notebook title, in turn setting `document.title`. Currently there is a fairly strict schema in place:

https://github.com/marimo-team/marimo/blob/62cf74d7ae9e8973baa1a0479980c9caa8aaeba6/frontend/src/core/config/config-schema.ts#L168-L170

This means that a title such as "My App 2.0" will get parsed as "My App 2".

The `title` of an HTML document does not have any such restrictions. The HTML spec says to use ["string replace all"](https://dom.spec.whatwg.org/#string-replace-all) when [setting the `title` attribute](https://html.spec.whatwg.org/multipage/dom.html#document.title), which will create a `Text` node, which cannot contain HTML, so anything goes.

Screenshot:

![CleanShot-2025-03-13-10-03-45](https://github.com/user-attachments/assets/377f84dc-ea2d-43bf-8bbf-f3dffb50b540)

I did not add any test. Let me know if you need that.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
