### PR TITLE
fix: only add packages that we haven't already tried installing

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1327,7 +1327,17 @@ class Kernel:
         # from the errors
         for e in module_not_found_errors:
             if isinstance(e, ManyModulesNotFoundError):
-                missing_packages.update(e.package_names)
+                # filter out packages that we already attempted to install
+                # to prevent an infinite loop
+                missing_packages.update(
+                    {
+                        package
+                        for package in e.package_names
+                        if not self.package_manager.attempted_to_install(
+                            package
+                        )
+                    }
+                )
             elif e.name is not None:
                 missing_modules.add(e.name)
 


### PR DESCRIPTION
Check that we haven't tried installing a package already, before adding it to the list of missing packages.