### PR TITLE
improve: allow header comments in SQL cells.

### DIFF
--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -294,7 +294,7 @@ _df = mo.sql(
 
     it("should preserve Python comments", () => {
       const pythonCode = '# hello\n_df = mo.sql("""SELECT * FROM {df}""")';
-      const [innerCode]  = adapter.transformIn(pythonCode);
+      const [innerCode] = adapter.transformIn(pythonCode);
       expect(innerCode).toBe("SELECT * FROM {df}");
       adapter.lastQuotePrefix = "f";
       adapter.dataframeName = "my_df";
@@ -309,7 +309,6 @@ _df = mo.sql(
       `);
       expect(offset).toBe(26);
     });
-
 
     it("should add engine connection when provided", () => {
       const code = "SELECT * FROM table";
@@ -353,8 +352,14 @@ _df = mo.sql(
       ).toBe(true);
       expect(adapter.isSupported("my_df = mo.sql('')")).toBe(true);
       expect(adapter.isSupported('df = mo.sql("")')).toBe(true);
-      expect(adapter.isSupported('# this is a sql cell\ndf = mo.sql("")')).toBe(true);
-      expect(adapter.isSupported('# this is a sql cell\n# with multiple comments\ndf = mo.sql("")')).toBe(true);
+      expect(adapter.isSupported('# this is a sql cell\ndf = mo.sql("")')).toBe(
+        true,
+      );
+      expect(
+        adapter.isSupported(
+          '# this is a sql cell\n# with multiple comments\ndf = mo.sql("")',
+        ),
+      ).toBe(true);
       expect(adapter.isSupported(new SQLLanguageAdapter().defaultCode)).toBe(
         true,
       );


### PR DESCRIPTION
Update the SQL language adapter to accept cells that start with hash comments. These comments are preserved on transform back to Python.

While people don't typically write the Python for SQL cells directly, AIs do; this helps accommodate verbose AIs.