### PR TITLE
improvement: open external document on go-to-definction when LSP is enabled

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "@lezer/python": "^1.1.16",
     "@marimo-team/codemirror-ai": "^0.1.9",
     "@marimo-team/marimo-api": "file:../openapi",
-    "@marimo-team/codemirror-languageserver": "^1.13.5",
+    "@marimo-team/codemirror-languageserver": "^1.13.6",
     "@marimo-team/react-slotz": "^0.1.8",
     "@open-rpc/client-js": "^1.8.1",
     "@paralleldrive/cuid2": "^2.2.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.1.9
         version: 0.1.9(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.13.5
-        version: 1.13.5(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
+        specifier: ^1.13.6
+        version: 1.13.6(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/marimo-api':
         specifier: file:../openapi
         version: file:../openapi
@@ -1546,8 +1546,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.13.5':
-    resolution: {integrity: sha512-rinzDRfL0dyjcdfOLHq0hh0nbzhtB8XZ3kkLx/MRekJyNnsSfGklSrGno9hXSNhegtUpcT3sIss4u4dvEwpxdg==}
+  '@marimo-team/codemirror-languageserver@1.13.6':
+    resolution: {integrity: sha512-53iaZY/1mk+WspRvzesECdZSP/YJBCCySnHJC+MNsUa4CyxizpiRogyyZ26/Xab2wMDWsAimtxhEE+wOPnd0+w==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -10205,7 +10205,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
 
-  '@marimo-team/codemirror-languageserver@1.13.5(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
+  '@marimo-team/codemirror-languageserver@1.13.6(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lint': 6.8.4

--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -32,6 +32,10 @@ import { autocompletion } from "@codemirror/autocomplete";
 import { completer } from "../completion/completer";
 import { getFilenameFromDOM } from "@/core/dom/htmlUtils";
 import { Paths } from "@/utils/paths";
+import type { CellId } from "@/core/cells/ids";
+import { cellActionsState } from "../cells/state";
+import { openFile } from "@/core/network/requests";
+import { Logger } from "@/utils/Logger";
 
 const pylspTransport = once(() => {
   const transport = new WebSocketTransport(resolveToWsUrl("/lsp/pylsp"));
@@ -112,11 +116,9 @@ const lspClient = once((lspConfig: LSPConfig) => {
       autoClose: false,
     }),
     settings,
-  ) as unknown as LanguageServerClient;
+  );
 });
 
-import type { CellId } from "@/core/cells/ids";
-import { cellActionsState } from "../cells/state";
 /**
  * Language adapter for Python.
  */
@@ -143,30 +145,48 @@ export class PythonLanguageAdapter implements LanguageAdapter {
     placeholderType: PlaceholderType,
     lspConfig: LSPConfig,
   ): Extension[] {
+    const getCompletionsExtension = () => {
+      if (getFeatureFlag("lsp") && lspConfig?.pylsp?.enabled) {
+        const client = lspClient(lspConfig);
+        return languageServerWithTransport({
+          client: client as unknown as LanguageServerClient,
+          documentUri: CellDocumentUri.of(cellId),
+          transport: pylspTransport(),
+          rootUri: "file:///",
+          languageId: "python",
+          workspaceFolders: [],
+          allowHTMLContent: true,
+          onGoToDefinition: (result) => {
+            Logger.debug("onGoToDefinition", result);
+            if (client.documentUri === result.uri) {
+              // Local definition
+              return;
+            }
+
+            openFile({
+              path: result.uri.replace("file://", ""),
+            });
+          },
+        });
+      }
+
+      // Whether or not to require keypress to activate autocompletion (default
+      // keymap is Ctrl+Space)
+      return autocompletion({
+        activateOnTyping: completionConfig.activate_on_typing,
+        // The Cell component handles the blur event. `closeOnBlur` is too
+        // aggressive and doesn't let the user click into the completion info
+        // element (which contains the docstring/type --- users might want to
+        // copy paste from the docstring). The main issue is that the completion
+        // tooltip is not part of the editable DOM tree:
+        // https://discuss.codemirror.net/t/adding-click-event-listener-to-autocomplete-tooltip-info-panel-is-not-working/4741
+        closeOnBlur: false,
+        override: [completer],
+      });
+    };
+
     return [
-      getFeatureFlag("lsp") && lspConfig?.pylsp?.enabled
-        ? languageServerWithTransport({
-            client: lspClient(lspConfig),
-            documentUri: CellDocumentUri.of(cellId),
-            transport: pylspTransport(),
-            rootUri: "file:///",
-            languageId: "python",
-            workspaceFolders: [],
-            allowHTMLContent: true,
-          })
-        : // Whether or not to require keypress to activate autocompletion (default
-          // keymap is Ctrl+Space)
-          autocompletion({
-            activateOnTyping: completionConfig.activate_on_typing,
-            // The Cell component handles the blur event. `closeOnBlur` is too
-            // aggressive and doesn't let the user click into the completion info
-            // element (which contains the docstring/type --- users might want to
-            // copy paste from the docstring). The main issue is that the completion
-            // tooltip is not part of the editable DOM tree:
-            // https://discuss.codemirror.net/t/adding-click-event-listener-to-autocomplete-tooltip-info-panel-is-not-working/4741
-            closeOnBlur: false,
-            override: [completer],
-          }),
+      getCompletionsExtension(),
       customPythonLanguageSupport(),
       placeholderType === "marimo-import"
         ? Prec.highest(smartPlaceholderExtension("import marimo as mo"))

--- a/frontend/src/utils/lru.ts
+++ b/frontend/src/utils/lru.ts
@@ -37,4 +37,12 @@ export class LRUCache<K, V> {
   public keys() {
     return this.cache.keys();
   }
+
+  public values() {
+    return this.cache.values();
+  }
+
+  public entries() {
+    return this.cache.entries();
+  }
 }


### PR DESCRIPTION
Add go-to-definition for external files, upgrade our `@marimo-team/codemirror-languageserver`