### PR TITLE
fix: when a widget is unhashable don't cache it

### DIFF
--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -28,9 +28,14 @@ cache: dict[Any, UIElement[Any, Any]] = weakref.WeakKeyDictionary()  # type: ign
 
 def from_anywidget(widget: AnyWidget) -> UIElement[Any, Any]:
     """Create a UIElement from an AnyWidget."""
-    if widget not in cache:
-        cache[widget] = anywidget(widget)  # type: ignore[no-untyped-call, unused-ignore, assignment]  # noqa: E501
-    return cache[widget]
+    try:
+        if widget not in cache:
+            cache[widget] = anywidget(widget)  # type: ignore[no-untyped-call, unused-ignore, assignment]  # noqa: E501
+        return cache[widget]
+    except TypeError as e:
+        # Unhashable widgets can't be used as keys in a WeakKeyDictionary
+        LOGGER.warning(e)
+        return anywidget(widget)
 
 
 T = dict[str, Any]

--- a/tests/_plugins/ui/_impl/test_anywidget.py
+++ b/tests/_plugins/ui/_impl/test_anywidget.py
@@ -6,7 +6,7 @@ from hashlib import md5
 import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._plugins.ui._impl.from_anywidget import anywidget
+from marimo._plugins.ui._impl.from_anywidget import anywidget, from_anywidget
 from marimo._runtime.requests import SetUIElementValueRequest
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
@@ -389,3 +389,19 @@ x = as_marimo_element.count
         nested_state = {"y": {"key": "value"}}
         wrapped._update(nested_state)
         assert wrapped.value == {"x": 42, "y": {"key": "value"}}
+
+    @staticmethod
+    def test_unhashable_widget() -> None:
+        """Test that unhashable widgets can still be wrapped."""
+
+        # Create a widget with an unhashable trait (list)
+        class UnhashableWidget(_anywidget.AnyWidget):
+            _esm = ""
+
+            def __hash__(self) -> int:
+                raise TypeError("Unhashable widget")
+
+        # This should work without errors despite the widget being unhashable
+        widget = UnhashableWidget()
+        wrapped = from_anywidget(widget)
+        assert wrapped is not None


### PR DESCRIPTION
We cache widgets, but i just came across one that is unhashable (not clear why it is), but in case it is, better to just skip the caching (which is used when rendering the widget twice in two different places)

Related to https://github.com/marimo-team/marimo/issues/4091, but doesn't fix it