### PR TITLE
fix: always re-mount anywidgets to clear state

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -129,7 +129,15 @@ const AnyWidgetSlot = (props: Props) => {
   }
 
   return (
-    <LoadedSlot {...props} widget={module.default} value={valueWithBuffer} />
+    <LoadedSlot
+      // Use the jsUrl as a key to force a re-render when the jsUrl changes
+      // Plugins may be stateful and we cannot make assumptions that we won't be
+      // so it is safer to just re-render.
+      key={jsUrl}
+      {...props}
+      widget={module.default}
+      value={valueWithBuffer}
+    />
   );
 };
 


### PR DESCRIPTION
Fixes #4101

This forces re-mounting (not just re-renders) when an anywidget's cell is run again. This makes things flash (un-mount, re-mount), but this is safest because they are 3rd party plugins that we don't have control over. 