### PR TITLE
fix: try to preseve the columns/collapse state when new ids come in

### DIFF
--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -781,7 +781,7 @@ const {
 
     return {
       ...state,
-      cellIds: MultiColumn.from([action.cellIds]),
+      cellIds: MultiColumn.fromWithPreviousShape(action.cellIds, state.cellIds),
       cellData: nextCellData,
       cellRuntime: nextCellRuntime,
       cellHandles: nextCellHandles,

--- a/frontend/src/utils/__tests__/id-tree.test.ts
+++ b/frontend/src/utils/__tests__/id-tree.test.ts
@@ -1049,3 +1049,757 @@ describe("MultiColumn", () => {
     expect(withBreakpoint.topLevelIds).toEqual([["A1"], [], ["B1"], ["C1"]]);
   });
 });
+
+describe("MultiColumn.fromWithPreviousShape", () => {
+  it("creates a new MultiColumn with a single column when no previous shape is provided", () => {
+    const ids = ["A1", "A2", "A3"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      MultiColumn.from([]),
+    );
+
+    expect(multiColumn.colLength).toBe(1);
+    expect(multiColumn.topLevelIds).toEqual([ids]);
+    expect(multiColumn.inOrderIds).toEqual(ids);
+  });
+
+  it("preserves column structure when ids exist in previous columns", () => {
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2"],
+      ["B1", "B2"],
+      ["C1", "C2"],
+    ]);
+
+    // Subset of ids from different columns
+    const ids = ["A1", "B2", "C1"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    expect(multiColumn.colLength).toBe(3);
+    expect(multiColumn.topLevelIds).toEqual([["A1"], ["B2"], ["C1"]]);
+  });
+
+  it("preserves column structure with different ordering", () => {
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2", "A3"],
+      ["B1", "B2", "B3"],
+    ]);
+
+    // Same ids but different order
+    const ids = ["A3", "B1", "A1", "B3"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([
+      ["A3", "A1"],
+      ["B1", "B3"],
+    ]);
+  });
+
+  it("handles ids not present in previous shape", () => {
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2"],
+      ["B1", "B2"],
+    ]);
+
+    // Include new ids not in previous shape
+    const ids = ["A1", "B1", "C1", "D1"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // New ids should be added to the last column
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([["A1"], ["B1", "C1", "D1"]]);
+    expect(multiColumn.inOrderIds).toEqual(["A1", "B1", "C1", "D1"]);
+  });
+
+  it("preserves collapsed state from previous shape", () => {
+    // Create a previous shape with collapsed nodes
+    let previousMultiColumn = MultiColumn.from([
+      ["A1", "A2", "A3"],
+      ["B1", "B2", "B3"],
+    ]);
+
+    // Collapse A1 to include A2
+    const columnIds = previousMultiColumn.getColumnIds();
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A1", "A2"),
+    );
+
+    // Create new shape with same ids
+    const ids = ["A1", "A2", "A3", "B1", "B2", "B3"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Check that A1 is still collapsed
+    const column = multiColumn.atOrThrow(0);
+    expect(column.isCollapsed("A1")).toBe(true);
+
+    // Check that the structure is preserved
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([
+      ["A1", "A3"],
+      ["B1", "B2", "B3"],
+    ]);
+  });
+
+  it("handles empty columns in previous shape", () => {
+    // Create a previous shape with an empty column
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2"],
+      [],
+      ["C1", "C2"],
+    ]);
+
+    const ids = ["A1", "C2"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Should preserve the column structure
+    expect(multiColumn.colLength).toBe(3);
+    expect(multiColumn.topLevelIds).toEqual([["A1"], [], ["C2"]]);
+  });
+
+  it("handles subset of ids with nested collapsed structure", () => {
+    // Create a previous shape with nested collapsed structure
+    let previousMultiColumn = MultiColumn.from([
+      ["A1", "A2", "A3", "A4", "A5"],
+      ["B1", "B2", "B3"],
+    ]);
+
+    // Collapse A1 to include A2, A3
+    const columnIds = previousMultiColumn.getColumnIds();
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A1", "A3"),
+    );
+
+    // Create new shape with subset of ids
+    const ids = ["A1", "A2", "A3", "A4", "B1"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Check that collapsed state is preserved
+    const column = multiColumn.atOrThrow(0);
+    expect(column.isCollapsed("A1")).toBe(true);
+
+    // Check that the structure is preserved
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([["A1", "A4"], ["B1"]]);
+    expect(multiColumn.inOrderIds).toEqual(["A1", "A2", "A3", "A4", "B1"]);
+  });
+
+  it("handles reordering of columns", () => {
+    // Create a previous shape with specific column order
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2"],
+      ["B1", "B2"],
+      ["C1", "C2"],
+    ]);
+
+    // Create new shape with ids in different order
+    const ids = ["C1", "A1", "B1"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Column order should be preserved
+    expect(multiColumn.colLength).toBe(3);
+    expect(multiColumn.topLevelIds).toEqual([["A1"], ["B1"], ["C1"]]);
+  });
+
+  it("handles completely different set of ids", () => {
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2"],
+      ["B1", "B2"],
+    ]);
+
+    // Completely different set of ids
+    const ids = ["X1", "X2", "X3"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // New ids should be added to the last column
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([["X1", "X2", "X3"], []]);
+    expect(multiColumn.inOrderIds).toEqual(["X1", "X2", "X3"]);
+  });
+
+  it("preserves tree structure within columns", () => {
+    // Create a previous shape with complex tree structure
+    let previousMultiColumn = MultiColumn.from([
+      ["A1", "A2", "A3", "A4"],
+      ["B1", "B2", "B3"],
+    ]);
+
+    // Create complex tree structure by collapsing nodes
+    const columnIds = previousMultiColumn.getColumnIds();
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A1", "A2"),
+    );
+    previousMultiColumn = previousMultiColumn.transform(columnIds[1], (tree) =>
+      tree.collapse("B1", "B2"),
+    );
+
+    // Create new shape with same ids
+    const ids = ["A1", "A2", "A3", "A4", "B1", "B2", "B3"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Check that collapsed state is preserved in both columns
+    expect(multiColumn.atOrThrow(0).isCollapsed("A1")).toBe(true);
+    expect(multiColumn.atOrThrow(1).isCollapsed("B1")).toBe(true);
+
+    // Check that the structure is preserved
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([
+      ["A1", "A3", "A4"],
+      ["B1", "B3"],
+    ]);
+  });
+
+  it("handles empty array of ids", () => {
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2"],
+      ["B1", "B2"],
+    ]);
+
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      [],
+      previousMultiColumn,
+    );
+
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([[], []]);
+    expect(multiColumn.inOrderIds).toEqual([]);
+  });
+
+  it("handles single id", () => {
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2"],
+      ["B1", "B2"],
+    ]);
+
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ["A1"],
+      previousMultiColumn,
+    );
+
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([["A1"], []]);
+    expect(multiColumn.inOrderIds).toEqual(["A1"]);
+  });
+
+  it("preserves complex nested structure across multiple columns", () => {
+    // Create a complex structure with multiple columns and nested collapsed nodes
+    let previousMultiColumn = MultiColumn.from([
+      ["A1", "A2", "A3", "A4", "A5"],
+      ["B1", "B2", "B3", "B4"],
+      ["C1", "C2", "C3"],
+    ]);
+
+    // Create complex nested structure
+    const columnIds = previousMultiColumn.getColumnIds();
+
+    // Collapse in first column
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A1", "A2"),
+    );
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A3", "A4"),
+    );
+
+    // Collapse in second column
+    previousMultiColumn = previousMultiColumn.transform(columnIds[1], (tree) =>
+      tree.collapse("B1", "B2"),
+    );
+
+    // Collapse in third column
+    previousMultiColumn = previousMultiColumn.transform(columnIds[2], (tree) =>
+      tree.collapse("C1", "C2"),
+    );
+
+    // Create new shape with all ids
+    const ids = [
+      "A1",
+      "A2",
+      "A3",
+      "A4",
+      "A5",
+      "B1",
+      "B2",
+      "B3",
+      "B4",
+      "C1",
+      "C2",
+      "C3",
+    ];
+
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Check that all collapsed states are preserved
+    expect(multiColumn.atOrThrow(0).isCollapsed("A1")).toBe(true);
+    expect(multiColumn.atOrThrow(0).isCollapsed("A3")).toBe(true);
+    expect(multiColumn.atOrThrow(1).isCollapsed("B1")).toBe(true);
+    expect(multiColumn.atOrThrow(2).isCollapsed("C1")).toBe(true);
+
+    // Check that the structure is preserved
+    expect(multiColumn.colLength).toBe(3);
+    expect(multiColumn.topLevelIds).toEqual([
+      ["A1", "A3", "A5"],
+      ["B1", "B3", "B4"],
+      ["C1", "C3"],
+    ]);
+  });
+
+  it("handles case where ids are distributed differently than in previous shape", () => {
+    const previousMultiColumn = MultiColumn.from([
+      ["A1", "A2"],
+      ["B1", "B2"],
+      ["C1", "C2"],
+    ]);
+
+    // Create new shape with ids from different columns grouped together
+    const ids = ["A1", "B1", "C1", "A2", "B2", "C2"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Should preserve the original column structure
+    expect(multiColumn.colLength).toBe(3);
+    expect(multiColumn.topLevelIds).toEqual([
+      ["A1", "A2"],
+      ["B1", "B2"],
+      ["C1", "C2"],
+    ]);
+  });
+
+  it("handles case where previous shape has collapsed nodes but new ids don't include children", () => {
+    // Create a previous shape with collapsed nodes
+    let previousMultiColumn = MultiColumn.from([
+      ["A1", "A2", "A3"],
+      ["B1", "B2", "B3"],
+    ]);
+
+    // Collapse nodes in both columns
+    const columnIds = previousMultiColumn.getColumnIds();
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A1", "A2"),
+    );
+    previousMultiColumn = previousMultiColumn.transform(columnIds[1], (tree) =>
+      tree.collapse("B1", "B2"),
+    );
+
+    // Create new shape without the collapsed children
+    const ids = ["A1", "A3", "B1", "B3"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Nodes should not be collapsed since children are missing
+    expect(multiColumn.atOrThrow(0).isCollapsed("A1")).toBe(false);
+    expect(multiColumn.atOrThrow(1).isCollapsed("B1")).toBe(false);
+
+    // Check that the structure is preserved
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([
+      ["A1", "A3"],
+      ["B1", "B3"],
+    ]);
+  });
+
+  it("handles deeply nested collapsed structure", () => {
+    // Create a tree with deeply nested collapsed structure
+    let previousTree = CollapsibleTree.from([
+      "one",
+      "two",
+      "three",
+      "four",
+      "five",
+      "six",
+      "seven",
+      "eight",
+    ]);
+
+    // Create nested collapses
+    previousTree = previousTree.collapse("one", "two");
+
+    // Get the collapsed node and collapse its children
+    const oneNode = previousTree._nodeMap.get("one");
+    expect(oneNode).toBeDefined();
+
+    // Create a new tree with the same structure
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "two", "three", "four", "five", "six", "seven", "eight"],
+      previousTree,
+    );
+
+    // Check that collapsed state is preserved
+    expect(tree.isCollapsed("one")).toBe(true);
+    expect(tree.topLevelIds).toEqual([
+      "one",
+      "three",
+      "four",
+      "five",
+      "six",
+      "seven",
+      "eight",
+    ]);
+  });
+
+  it("handles case where collapsed node is at the end", () => {
+    // Create a tree with collapsed node at the end
+    let previousTree = CollapsibleTree.from([
+      "one",
+      "two",
+      "three",
+      "four",
+      "five",
+    ]);
+    previousTree = previousTree.collapse("four", "five");
+
+    // Create new tree with same ids
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "two", "three", "four", "five"],
+      previousTree,
+    );
+
+    // Check that collapsed state is preserved
+    expect(tree.isCollapsed("four")).toBe(true);
+    expect(tree.topLevelIds).toEqual(["one", "two", "three", "four"]);
+  });
+
+  it("handles case with multiple collapsed nodes in the same column", () => {
+    // Create a previous shape with multiple collapsed nodes in the same column
+    let previousMultiColumn = MultiColumn.from([
+      ["A1", "A2", "A3", "A4", "A5", "A6"],
+      ["B1", "B2"],
+    ]);
+
+    // Collapse multiple nodes in the first column
+    const columnIds = previousMultiColumn.getColumnIds();
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A1", "A2"),
+    );
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A3", "A4"),
+    );
+    previousMultiColumn = previousMultiColumn.transform(columnIds[0], (tree) =>
+      tree.collapse("A5", "A6"),
+    );
+
+    // Create new shape with same ids
+    const ids = ["A1", "A2", "A3", "A4", "A5", "A6", "B1", "B2"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Check that all collapsed states are preserved
+    expect(multiColumn.atOrThrow(0).isCollapsed("A1")).toBe(true);
+    expect(multiColumn.atOrThrow(0).isCollapsed("A3")).toBe(true);
+    expect(multiColumn.atOrThrow(0).isCollapsed("A5")).toBe(true);
+
+    // Check that the structure is preserved
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds).toEqual([
+      ["A1", "A3", "A5"],
+      ["B1", "B2"],
+    ]);
+  });
+
+  it("handles case where all columns are empty in previous shape", () => {
+    // Create a previous shape with all empty columns
+    const previousMultiColumn = MultiColumn.from([[], [], []]);
+
+    // Create new shape with new ids
+    const ids = ["A1", "B1", "C1"];
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // New ids should be added to the last column
+    expect(multiColumn.colLength).toBe(3);
+    expect(multiColumn.topLevelIds).toEqual([["A1", "B1", "C1"], [], []]);
+    expect(multiColumn.inOrderIds).toEqual(["A1", "B1", "C1"]);
+  });
+
+  it("handles case with very large number of ids", () => {
+    // Create a previous shape with a reasonable number of ids
+    const previousIds1 = Array.from({ length: 50 }, (_, i) => `A${i}`);
+    const previousIds2 = Array.from({ length: 50 }, (_, i) => `B${i}`);
+    const previousMultiColumn = MultiColumn.from([previousIds1, previousIds2]);
+
+    // Create a large set of ids
+    const ids = [
+      ...Array.from({ length: 50 }, (_, i) => `A${i}`),
+      ...Array.from({ length: 50 }, (_, i) => `B${i}`),
+      ...Array.from({ length: 50 }, (_, i) => `C${i}`),
+    ];
+
+    const multiColumn = MultiColumn.fromWithPreviousShape(
+      ids,
+      previousMultiColumn,
+    );
+
+    // Should preserve the column structure for existing ids and add new ids to last column
+    expect(multiColumn.colLength).toBe(2);
+    expect(multiColumn.topLevelIds[0].length).toBe(50);
+    expect(multiColumn.topLevelIds[1].length).toBe(100); // 50 B ids + 50 C ids
+    expect(multiColumn.inOrderIds.length).toBe(150); // All ids should be included
+  });
+});
+
+describe("CollapsibleTree.fromWithPreviousShape", () => {
+  it("creates a new tree when no previous tree is provided", () => {
+    const ids = ["one", "two", "three"];
+    const tree = CollapsibleTree.fromWithPreviousShape(ids);
+
+    expect(tree.topLevelIds).toEqual(ids);
+    expect(tree.inOrderIds).toEqual(ids);
+    expect(tree.nodes.length).toBe(3);
+    expect(tree.nodes.every((node) => !node.isCollapsed)).toBe(true);
+  });
+
+  it("preserves the tree ID when previous tree is provided", () => {
+    const previousTree = CollapsibleTree.from(["one", "two", "three"]);
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "two"],
+      previousTree,
+    );
+
+    expect(tree.id).toBe(previousTree.id);
+  });
+
+  it("preserves collapsed state from previous tree", () => {
+    // Create a tree with collapsed nodes
+    let previousTree = CollapsibleTree.from(["one", "two", "three", "four"]);
+    previousTree = previousTree.collapse("one", "two");
+
+    // Create new tree with same ids
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "two", "three", "four"],
+      previousTree,
+    );
+
+    // Check that one is still collapsed
+    expect(tree.isCollapsed("one")).toBe(true);
+    expect(tree.topLevelIds).toEqual(["one", "three", "four"]);
+  });
+
+  it("handles subset of ids from previous tree", () => {
+    // Create a tree with collapsed nodes
+    let previousTree = CollapsibleTree.from([
+      "one",
+      "two",
+      "three",
+      "four",
+      "five",
+    ]);
+    previousTree = previousTree.collapse("one", "two");
+    previousTree = previousTree.collapse("three", "four");
+
+    // Create new tree with subset of ids
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "two", "three"],
+      previousTree,
+    );
+
+    // Check that collapsed state is preserved for existing nodes
+    expect(tree.isCollapsed("one")).toBe(true);
+    expect(tree.topLevelIds).toEqual(["one", "three"]);
+  });
+
+  it("handles different ordering of ids", () => {
+    // Create a tree with collapsed nodes
+    let previousTree = CollapsibleTree.from(["one", "two", "three", "four"]);
+    previousTree = previousTree.collapse("one", "two");
+
+    // Create new tree with different order
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["three", "one", "two", "four"],
+      previousTree,
+    );
+
+    // Check that collapsed state is preserved
+    expect(tree.isCollapsed("one")).toBe(true);
+    expect(tree.topLevelIds).toEqual(["three", "one", "four"]);
+  });
+
+  it("handles new ids not in previous tree", () => {
+    // Create a tree with collapsed nodes
+    let previousTree = CollapsibleTree.from(["one", "two", "three"]);
+    previousTree = previousTree.collapse("one", "two");
+
+    // Create new tree with new ids
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "two", "three", "four", "five"],
+      previousTree,
+    );
+
+    // Check that collapsed state is preserved for existing nodes
+    expect(tree.isCollapsed("one")).toBe(true);
+    expect(tree.topLevelIds).toEqual(["one", "three", "four", "five"]);
+  });
+
+  it("handles completely different set of ids", () => {
+    // Create a tree with collapsed nodes
+    let previousTree = CollapsibleTree.from(["one", "two", "three"]);
+    previousTree = previousTree.collapse("one", "two");
+
+    // Create new tree with completely different ids
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["four", "five", "six"],
+      previousTree,
+    );
+
+    // Should have no collapsed nodes
+    expect(tree.nodes.every((node) => !node.isCollapsed)).toBe(true);
+    expect(tree.topLevelIds).toEqual(["four", "five", "six"]);
+  });
+
+  it("preserves nested collapsed structure", () => {
+    // Create a tree with nested collapsed structure
+    let previousTree = CollapsibleTree.from([
+      "one",
+      "two",
+      "three",
+      "four",
+      "five",
+      "six",
+    ]);
+    previousTree = previousTree.collapse("one", "two");
+
+    // Collapse the node that contains the collapsed children
+    const oneNode = previousTree.nodes.find((n) => n.value === "one");
+    expect(oneNode).toBeDefined();
+    expect(oneNode?.children.length).toBeGreaterThan(0);
+
+    // Create a new tree with the same structure
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "two", "three", "four", "five", "six"],
+      previousTree,
+    );
+
+    // Check that collapsed state is preserved
+    expect(tree.isCollapsed("one")).toBe(true);
+    expect(tree.topLevelIds).toEqual(["one", "three", "four", "five", "six"]);
+  });
+
+  it("collapses using the last available child when some children are missing", () => {
+    // Create a tree with collapsed nodes
+    let previousTree = CollapsibleTree.from(["one", "two", "three", "four"]);
+    previousTree = previousTree.collapse("one", "three");
+
+    // Create new tree without "two" but with "three"
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "three", "four"],
+      previousTree,
+    );
+
+    // Should still collapse "one" with "three" as the child
+    expect(tree.isCollapsed("one")).toBe(true);
+    expect(tree.topLevelIds).toEqual(["one", "four"]);
+  });
+
+  it("preserves collapse state when children order changes", () => {
+    // Create a tree with collapsed nodes
+    let previousTree = CollapsibleTree.from(["one", "two", "three", "four"]);
+    previousTree = previousTree.collapse("one", "two");
+
+    // Create new tree with children in different order
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "three", "two", "four"],
+      previousTree,
+    );
+
+    // Should still be collapsed
+    expect(tree.isCollapsed("one")).toBe(true);
+    // But the topLevelIds will be different because the children order changed
+    expect(tree.topLevelIds).toEqual(["one", "four"]);
+  });
+
+  it("handles empty arrays correctly", () => {
+    const previousTree = CollapsibleTree.from(["one", "two", "three"]);
+    const tree = CollapsibleTree.fromWithPreviousShape([], previousTree);
+
+    expect(tree.nodes.length).toBe(0);
+    expect(tree.topLevelIds).toEqual([]);
+    expect(tree.inOrderIds).toEqual([]);
+  });
+
+  it("handles single item arrays correctly", () => {
+    let previousTree = CollapsibleTree.from(["one", "two", "three"]);
+    previousTree = previousTree.collapse("one", "two");
+
+    const tree = CollapsibleTree.fromWithPreviousShape(["one"], previousTree);
+
+    expect(tree.nodes.length).toBe(1);
+    expect(tree.topLevelIds).toEqual(["one"]);
+    expect(tree.inOrderIds).toEqual(["one"]);
+    // Should not be collapsed since there are no children
+    expect(tree.isCollapsed("one")).toBe(false);
+  });
+
+  it("handles multiple collapsed nodes in sequence", () => {
+    let previousTree = CollapsibleTree.from([
+      "one",
+      "two",
+      "three",
+      "four",
+      "five",
+      "six",
+    ]);
+    previousTree = previousTree.collapse("one", "two");
+    previousTree = previousTree.collapse("three", "four");
+    previousTree = previousTree.collapse("five", "six");
+
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "two", "three", "four", "five", "six"],
+      previousTree,
+    );
+
+    expect(tree.isCollapsed("one")).toBe(true);
+    expect(tree.isCollapsed("three")).toBe(true);
+    expect(tree.isCollapsed("five")).toBe(true);
+    expect(tree.topLevelIds).toEqual(["one", "three", "five"]);
+  });
+
+  it("handles case where collapsed node's children are not in new ids", () => {
+    let previousTree = CollapsibleTree.from(["one", "two", "three", "four"]);
+    previousTree = previousTree.collapse("one", "two");
+
+    // Create new tree without the collapsed child
+    const tree = CollapsibleTree.fromWithPreviousShape(
+      ["one", "three", "four"],
+      previousTree,
+    );
+
+    // Should not be collapsed since the child is missing
+    expect(tree.isCollapsed("one")).toBe(false);
+    expect(tree.topLevelIds).toEqual(["one", "three", "four"]);
+  });
+});


### PR DESCRIPTION
When using RTC, this will try to keep the column and collapse state intact