### PR TITLE
chore: notify readme owners when README.md is updated

### DIFF
--- a/.github/workflows/notify-readme-owners.yml
+++ b/.github/workflows/notify-readme-owners.yml
@@ -1,0 +1,52 @@
+name: README Translation Notification
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'README.md'
+
+jobs:
+  notify-translators:
+    # Only run this job when the PR is merged, not when it's closed without merging
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Comment on PR with translation notification
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Define translation maintainers
+            const translations = [
+              { file: 'README_Chinese.md', language: 'Chinese', maintainers: ['@metaboulie'] },
+              { file: 'README_Japanese.md', language: 'Japanese', maintainers: ['@kiwamizamurai'] },
+              { file: 'README_Spanish.md', language: 'Spanish', maintainers: ['@Francisco-G-P'] }
+            ];
+            
+            // Create a notification comment tagging all translation maintainers
+            const maintainersList = translations.map(t => 
+              `- ${t.language} (${t.file}): ${t.maintainers.join(', ')}`
+            ).join('\n');
+            
+            const comment = `
+            ## README Translation Update Needed
+            
+            This PR includes changes to the main README.md. The following translation files may need to be updated:
+            
+            ${maintainersList}
+            
+            Translation maintainers, please review the changes in this PR and update your respective README translations accordingly.
+            
+            CC: ${translations.flatMap(t => t.maintainers).join(' ')}
+            `;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: github.event.number,
+              body: comment
+            });


### PR DESCRIPTION
This adds a workflow that notifies owners of our readme trasnlations when a pull request on README.md is merged.

The notification is a comment on the merged pull request.