### PR TITLE
fix: export ipynb with sandbox

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -420,6 +420,7 @@ def ipynb(
             from marimo._cli.sandbox import run_in_sandbox
 
             run_in_sandbox(sys.argv[1:], name)
+            return
 
     def export_callback(file_path: MarimoPath) -> ExportResult:
         if include_outputs:

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -869,6 +869,7 @@ class TestExportIpynb:
         reason="This test requires both uv and nbformat.",
     )
     def test_cli_export_ipynb_sandbox(temp_marimo_file: str) -> None:
+        output_file = temp_marimo_file.replace(".py", "_sandbox.ipynb")
         p = subprocess.run(
             [
                 "marimo",
@@ -877,6 +878,8 @@ class TestExportIpynb:
                 temp_marimo_file,
                 "--sandbox",
                 "--include-outputs",
+                "--output",
+                output_file,
             ],
             capture_output=True,
         )


### PR DESCRIPTION
Fixes #4121

We were accidentally exporting twice (once in the sandbox and once out)