### PR TITLE
docs: fix paths for "Exporting multiple notebooks" scripts

### DIFF
--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -187,19 +187,19 @@ files=("batch_and_form.py" "data_explorer.py")
 
 for file in "${files[@]}"; do
   without_extension="${file%.*}"
-  marimo export html-wasm "$file" -o public/"$without_extension".html --mode run
+  marimo export html-wasm "$file" -o site/"$without_extension".html --mode run
 done
 ```
 
 Optionally, you can create an `index.html` file in the public directory:
 
 ```bash
-echo "<html><body><ul>" > public/index.html
+echo "<html><body><ul>" > site/index.html
 for file in "${files[@]}"; do
   without_extension="${file%.*}"
-  echo "<li><a href=\"$without_extension.html\">$without_extension</a></li>" >> public/index.html
+  echo "<li><a href=\"$without_extension.html\">$without_extension</a></li>" >> site/index.html
 done
-echo "</ul></body></html>" >> public/index.html
+echo "</ul></body></html>" >> site/index.html
 ```
 
 ## 🏝️ Embed marimo outputs in HTML using Islands


### PR DESCRIPTION
## 📝 Summary

The script proposed to export multiple notebooks as html-wasm is using the `public` directory as destination,
but that folder is the one that gets copied over to the destination directory to include public assets, resulting in a recursive copy of the same files inside `public/public`.

Using a different output directory like `site`  (I used it because is the default for mkdocs) solves the issue.

## 🔍 Description of Changes

changed the output directory of the example script to "site" instead of "public".

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick