### PR TITLE
fix: map docx module to python-docx package

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -402,6 +402,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "dns": "dnspython",
         "docgen": "ansible-docgenerator",
         "docker": "docker-py",
+        "docx": "python-docx",
         "dogpile": "dogpile.core",
         "dogshell": "dogapi",
         "dot_parser": "pydot3k",


### PR DESCRIPTION
## 📝 Summary

When using `import docx` in a marimo notebook, the package discovery detects and installs the[ `docx` package from pypi](https://pypi.org/project/docx/).

That package, though, is unmaintained since 2014, and the repository archived since 2018.

The successor of that package, that still imports as `docx`, is [`python-docx`](https://pypi.org/project/python-docx/) from the same authors.

## 🔍 Description of Changes

added the mapping docx -> python-docx to `module_name_to_pypi_name`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka