### PR TITLE
improvement: add error message when the imported module matches a filename

### DIFF
--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -5,11 +5,11 @@ import asyncio
 import contextlib
 import functools
 import io
-import os
 import signal
 import threading
 import traceback
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from marimo._ast.cell import CellImpl
@@ -438,17 +438,12 @@ class Runner:
                 if isinstance(unwrapped_exception, ModuleNotFoundError):
                     try:
                         module_name = getattr(unwrapped_exception, "name", "")
+                        # Grab the base module name if it's a submodule
                         module_name = module_name.split(".")[0]
 
-                        python_files = [
-                            file.split(".")[0]
-                            for file in os.listdir()
-                            if file.endswith(".py")
-                        ]
-                        if (
-                            module_name in python_files
-                            and DependencyManager.has(module_name)
-                        ):
+                        if Path(
+                            f"{module_name}.py"
+                        ).exists() and DependencyManager.has(module_name):
                             error_message = f"There is a file named '{module_name}.py' which conflicts with the imported package. Please rename the file."
                             output = MarimoExceptionRaisedError(
                                 error_message,

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -5,6 +5,7 @@ import asyncio
 import contextlib
 import functools
 import io
+import os
 import signal
 import threading
 import traceback
@@ -14,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from marimo._ast.cell import CellImpl
 from marimo._ast.variables import unmangle_local
 from marimo._config.config import ExecutionType, OnCellChangeType
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._dependencies.errors import ManyModulesNotFoundError
 from marimo._loggers import marimo_logger
 from marimo._messaging.errors import (
@@ -430,6 +432,33 @@ class Runner:
                 (ModuleNotFoundError, ManyModulesNotFoundError),
             ):
                 self.missing_packages = True
+
+                # If the user has a library and a file with the same name
+                # we should inform that this is a conflict.
+                if isinstance(unwrapped_exception, ModuleNotFoundError):
+                    try:
+                        module_name = getattr(unwrapped_exception, "name", "")
+                        module_name = module_name.split(".")[0]
+
+                        python_files = [
+                            file.split(".")[0]
+                            for file in os.listdir()
+                            if file.endswith(".py")
+                        ]
+                        if (
+                            module_name in python_files
+                            and DependencyManager.has(module_name)
+                        ):
+                            error_message = f"Error: You have a file named '{module_name}.py' which conflicts with the imported package. Please rename the file."
+                            output = MarimoExceptionRaisedError(
+                                error_message,
+                                unwrapped_exception.__class__.__name__,
+                                None,
+                            )
+                            LOGGER.error(error_message)
+                            exception = output
+                    except Exception as e:
+                        pass
 
             elif isinstance(unwrapped_exception, MarimoStopError):
                 output = unwrapped_exception.output

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -449,7 +449,7 @@ class Runner:
                             module_name in python_files
                             and DependencyManager.has(module_name)
                         ):
-                            error_message = f"Error: You have a file named '{module_name}.py' which conflicts with the imported package. Please rename the file."
+                            error_message = f"There is a file named '{module_name}.py' which conflicts with the imported package. Please rename the file."
                             output = MarimoExceptionRaisedError(
                                 error_message,
                                 unwrapped_exception.__class__.__name__,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
We could show a better error when an imported module matches a filename.
This might be crude, but maybe it can inspire a better fix :>
<img width="700" alt="image" src="https://github.com/user-attachments/assets/dc56bb19-7d8e-49fa-b0d9-649362f9967c" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
