### PR TITLE
fix: map pdfminer module to pdfminer-six package

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -595,6 +595,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "path": "path.py",
         "patricia": "patricia-trie",
         "paver": "Paver",
+        "pdfminer": "pdfminer.six",
         "peak": "ProxyTypes",
         "picasso": "anderson.picasso",
         "picklefield": "django-picklefield",


### PR DESCRIPTION
## 📝 Summary

Another one 😉 

`pdfminer` latest release was on Nov 25, 2019 and the project was archived on Apr 15, 2024.
On the other hand, `pdfminer.six` is still maintained, so this PR sets it as the default choice for the `pdfminer` import.

## 🔍 Description of Changes

added pdfminer import to pdfminer.six package mapping.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka
