### PR TITLE
improve: indication when cell output is loading

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -40,7 +40,7 @@ import { CellActionsContextMenu } from "./cell/cell-context-menu";
 import type { AppMode } from "@/core/mode";
 import useEvent from "react-use-event-hook";
 import { CellEditor } from "./cell/code/cell-editor";
-import { outputIsStale } from "@/core/cells/cell";
+import { outputIsLoading, outputIsStale } from "@/core/cells/cell";
 import { isOutputEmpty } from "@/core/cells/outputs";
 import { useHotkeysOnElement, useKeydownOnElement } from "@/hooks/useHotkey";
 import { useSetAtom } from "jotai";
@@ -411,6 +411,8 @@ const CellComponent = (
     edited,
   );
 
+  const loading = outputIsLoading(status);
+
   if (id === SETUP_CELL_ID) {
     return (
       <SetupCellComponent
@@ -437,7 +439,7 @@ const CellComponent = (
     );
   }
 
-  return <ReadonlyCellComponent {...props} outputStale={outputStale} />;
+  return <ReadonlyCellComponent {...props} outputStale={outputStale} outputLoading={loading}/>;
 };
 
 const ReadonlyCellComponent = forwardRef(
@@ -447,6 +449,7 @@ const ReadonlyCellComponent = forwardRef(
       "id" | "output" | "interrupted" | "errored" | "stopped" | "name"
     > & {
       outputStale: boolean;
+      outputLoading: boolean;
     },
     ref: React.ForwardedRef<HTMLDivElement>,
   ) => {
@@ -458,6 +461,7 @@ const ReadonlyCellComponent = forwardRef(
       stopped,
       name,
       outputStale,
+      outputLoading,
     } = props;
 
     const className = clsx("marimo-cell", "hover-actions-parent z-10", {
@@ -490,6 +494,7 @@ const ReadonlyCellComponent = forwardRef(
           className="output-area"
           cellId={cellId}
           stale={outputStale}
+          loading={outputLoading}
         />
       </div>
     );
@@ -559,7 +564,7 @@ const EditableCellComponent = ({
 
   const needsRun =
     edited || interrupted || (staleInputs && !disabledOrAncestorDisabled);
-  const loading = status === "running" || status === "queued";
+  const loading = outputIsLoading(status);
 
   // console output is cleared immediately on run, so check for queued instead
   // of loading to determine staleness
@@ -674,6 +679,7 @@ const EditableCellComponent = ({
         className="output-area"
         cellId={cellId}
         stale={outputStale}
+        loading={loading}
       />
       {isMarkdownCodeHidden &&
         hasOutputAbove &&
@@ -1258,6 +1264,7 @@ const SetupCellComponent = ({
               className="output-area"
               cellId={cellId}
               stale={false}
+              loading={loading}
             />
           )}
           <ConsoleOutput

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -266,6 +266,7 @@ interface OutputAreaProps {
   output: OutputMessage | null;
   cellId: CellId;
   stale: boolean;
+  loading: boolean;
   /**
    * Whether to allow expanding the output
    * This shows the expand button and allows the user to expand the output
@@ -284,6 +285,7 @@ export const OutputArea = React.memo(
     output,
     cellId,
     stale,
+    loading,
     allowExpand,
     forceExpand,
     className,
@@ -309,7 +311,11 @@ export const OutputArea = React.memo(
           cellId={cellId}
           forceExpand={forceExpand}
           id={CellOutputId.create(cellId)}
-          className={cn(stale && "marimo-output-stale", className)}
+          className={cn(
+            stale && "marimo-output-stale",
+            loading && "marimo-output-loading",
+            className,
+          )}
         >
           <OutputRenderer cellId={cellId} message={output} />
         </Container>

--- a/frontend/src/components/editor/__tests__/data-attributes.test.tsx
+++ b/frontend/src/components/editor/__tests__/data-attributes.test.tsx
@@ -130,6 +130,7 @@ describe("Output data attributes", () => {
           output={output}
           cellId={cellId}
           stale={false}
+          loading={false}
           allowExpand={true}
           className="test-output"
         />

--- a/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
@@ -42,6 +42,7 @@ import { Maps } from "@/utils/maps";
 import { startCase } from "lodash-es";
 import { BorderAllIcon } from "@radix-ui/react-icons";
 import { NumberField } from "@/components/ui/number-field";
+import { outputIsLoading } from "@/core/cells/cell";
 
 type Props = ICellRendererProps<GridLayout>;
 
@@ -362,7 +363,7 @@ const GridCell = memo(
     side,
     className,
   }: GridCellProps) => {
-    const loading = status === "running" || status === "queued";
+    const loading = outputIsLoading(status);
 
     const isOutputEmpty = output == null || output.data === "";
     // If not reading, show code when there is no output
@@ -388,6 +389,7 @@ const GridCell = memo(
           output={output}
           cellId={cellId}
           stale={loading}
+          loading={loading}
         />
       </div>
     );

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -7,6 +7,7 @@ import type { CellId } from "@/core/cells/ids";
 import type { CellRuntimeState } from "@/core/cells/types";
 import type { AppMode } from "@/core/mode";
 import { OutputArea } from "../../Output";
+import { outputIsLoading } from "@/core/cells/cell";
 
 type Props = ICellRendererProps<SlidesLayout>;
 
@@ -59,7 +60,7 @@ interface SlideProps extends Pick<CellRuntimeState, "output" | "status"> {
 }
 
 const Slide = memo(({ output, cellId, status }: SlideProps) => {
-  const loading = status === "running" || status === "queued";
+  const loading = outputIsLoading(status);
   return (
     <OutputArea
       className="contents"
@@ -67,6 +68,7 @@ const Slide = memo(({ output, cellId, status }: SlideProps) => {
       output={output}
       cellId={cellId}
       stale={loading}
+      loading={loading}
     />
   );
 });

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { Button } from "@/components/ui/button";
-import { outputIsStale } from "@/core/cells/cell";
+import { outputIsLoading, outputIsStale } from "@/core/cells/cell";
 import { isStaticNotebook } from "@/core/static/static-state";
 import { ConsoleOutput } from "@/components/editor/output/ConsoleOutput";
 import {
@@ -279,6 +279,7 @@ const VerticalCell = memo(
       },
       false,
     );
+    const loading = outputIsLoading(status);
 
     // Kiosk and not presenting
     const kioskFull = kiosk && mode !== "present";
@@ -308,6 +309,7 @@ const VerticalCell = memo(
           className="output-area"
           cellId={cellId}
           stale={outputStale}
+          loading={loading}
         />
       );
 
@@ -366,6 +368,7 @@ const VerticalCell = memo(
           className="output-area"
           cellId={cellId}
           stale={outputStale}
+          loading={loading}
         />
       </div>
     );

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -155,6 +155,7 @@ export const ScratchPad: React.FC = () => {
             className="output-area"
             cellId={cellId}
             stale={false}
+            loading={false}
           />
         </div>
         <div className="overflow-auto flex-shrink-0 max-h-[35%]">

--- a/frontend/src/core/cells/__tests__/cell.test.ts
+++ b/frontend/src/core/cells/__tests__/cell.test.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { expect, describe, it } from "vitest";
-import { outputIsStale } from "../cell";
+import { outputIsLoading, outputIsStale } from "../cell";
 import type { OutputMessage } from "@/core/kernel/messages";
 import type { Seconds } from "@/utils/time";
 import type { RuntimeState } from "@/core/network/types";
@@ -22,6 +22,23 @@ function createOutput(): OutputMessage {
     timestamp: Date.now(),
   };
 }
+describe("outputIsStale", () => {
+  it("should return true if the cell is running", () => {
+    expect(outputIsLoading("running" as RuntimeState)).toBe(true);
+  });
+
+  it("should return true if the cell is queued", () => {
+    expect(outputIsLoading("queued" as RuntimeState)).toBe(true);
+  });
+
+  it("should return false if the cell is idle", () => {
+    expect(outputIsLoading("idle" as RuntimeState)).toBe(false);
+  });
+
+  it("should return false if the cell is disabled-transitively", () => {
+    expect(outputIsLoading("disabled-transitively" as RuntimeState)).toBe(false);
+  });
+});
 
 describe("outputIsStale", () => {
   it.each(STATUSES)(

--- a/frontend/src/core/cells/__tests__/cell.test.ts
+++ b/frontend/src/core/cells/__tests__/cell.test.ts
@@ -22,7 +22,7 @@ function createOutput(): OutputMessage {
     timestamp: Date.now(),
   };
 }
-describe("outputIsStale", () => {
+describe("outputIsLoading", () => {
   it("should return true if the cell is running", () => {
     expect(outputIsLoading("running" as RuntimeState)).toBe(true);
   });

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -6,6 +6,7 @@ import { collapseConsoleOutputs } from "./collapseConsoleOutputs";
 import { parseOutline } from "../dom/outline";
 import { type Seconds, Time } from "@/utils/time";
 import { invariant } from "@/utils/invariant";
+import { RuntimeState } from "../network/types";
 
 export function transitionCell(
   cell: CellRuntimeState,
@@ -171,6 +172,13 @@ export function prepareCellForExecution(
 }
 
 /**
+ * A cell's output is loading if it is running or queued.
+ */
+export function outputIsLoading(status: RuntimeState): boolean {
+  return status === "running" || status === "queued";
+}
+
+/**
  * A cell's output is stale if it has been edited, is loading, or has errored.
  */
 export function outputIsStale(
@@ -193,7 +201,7 @@ export function outputIsStale(
   }
 
   // The cell is loading
-  const loading = status === "running" || status === "queued";
+  const loading = outputIsLoading(status);
 
   // Output is received while the cell is running (e.g. mo.output.append())
   const outputReceivedWhileRunning =

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -387,7 +387,17 @@
 .marimo-output-stale,
 .marimo-cell.stale .output-area.marimo-output-stale,
 .marimo-cell.stale .console-output-area.marimo-output-stale {
-  opacity: 0.5;
+  opacity: 0.8;
+  filter: grayscale(50%);
+  transition: 300ms;
+  transition-delay: 200ms;
+}
+
+.marimo-output-stale.marimo-output-loading,
+.marimo-cell.stale .output-area.marimo-output-stale.marimo-output-loading,
+.marimo-cell.stale
+  .console-output-area.marimo-output-stale.marimo-output-loading {
+  opacity: 0.4;
   filter: grayscale(50%);
   transition: 300ms;
   transition-delay: 200ms;

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -387,7 +387,7 @@
 .marimo-output-stale,
 .marimo-cell.stale .output-area.marimo-output-stale,
 .marimo-cell.stale .console-output-area.marimo-output-stale {
-  opacity: 0.8;
+  opacity: 0.5;
   filter: grayscale(50%);
   transition: 300ms;
   transition-delay: 200ms;


### PR DESCRIPTION
Decrease opacity of stale loading outputs to make staleness more easily parsed visually.

When cells are queued or running (not edited), it needs to be clear that their output is loading and stale. This is important both for editing notebooks and running long-running cells that have big outputs, as well as for app view.