### PR TITLE
fix: remove dml warning; add test

### DIFF
--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -361,17 +361,12 @@ def find_sql_refs(
         if expression is None:
             continue
 
-        if is_dml := bool(expression.find(exp.Update, exp.Insert, exp.Delete)):
+        if bool(expression.find(exp.Update, exp.Insert, exp.Delete)):
             for table in expression.find_all(exp.Table):
                 append_refs_from_table(table)
 
         # build_scope only works for select statements
         if root := build_scope(expression):
-            if is_dml:
-                LOGGER.warning(
-                    "Scopes should not exist for dml's, may need rework if this occurs"
-                )
-
             for scope in root.traverse():  # type: ignore
                 for _node, source in scope.selected_sources.values():
                     if isinstance(source, exp.Table):

--- a/tests/_ast/test_sql_visitor.py
+++ b/tests/_ast/test_sql_visitor.py
@@ -734,6 +734,25 @@ class TestFindSQLRefs:
 
     @staticmethod
     def test_dml_with_subquery() -> None:
+        # first
+        sql = """
+        insert into table1 (column1) select distinct column1 from table2 order by random();
+        """
+        assert find_sql_refs(sql) == [
+            "table1",
+            "table2",
+        ]
+
+        # second
+        sql = """
+        update table3 set column1=(select column2 from table1 t where t.column1=table3.column1);
+        """
+        assert find_sql_refs(sql) == [
+            "table3",
+            "table1",
+        ]
+
+        # combined
         sql = """
         insert into table1 (column1) select distinct column1 from table2 order by random();
         update table3 set column1=(select column2 from table1 t where t.column1=table3.column1);

--- a/tests/_ast/test_sql_visitor.py
+++ b/tests/_ast/test_sql_visitor.py
@@ -731,3 +731,15 @@ class TestFindSQLRefs:
     def test_find_sql_refs_invalid_sql() -> None:
         sql = "SELECT * FROM"
         assert find_sql_refs(sql) == []
+
+    @staticmethod
+    def test_dml_with_subquery() -> None:
+        sql = """
+        insert into table1 (column1) select distinct column1 from table2 order by random();
+        update table3 set column1=(select column2 from table1 t where t.column1=table3.column1);
+        """
+        assert find_sql_refs(sql) == [
+            "table1",
+            "table2",
+            "table3",
+        ]


### PR DESCRIPTION
This warning was logged with the query: 

```sql
insert into table1 (column1) select distinct column1 from table2 order by random();
```

The result looks correct, so I think it should be ok to remove this warning. cc @Light2Dark 