### PR TITLE
fix: anywidget re-render in wasm

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -128,12 +128,16 @@ const AnyWidgetSlot = (props: Props) => {
     return <ErrorBanner error={error} />;
   }
 
+  // Find the closest parent element with an attribute of `random-id`
+  const randomId = props.host.closest("[random-id]")?.getAttribute("random-id");
+  const key = randomId ?? jsUrl;
+
   return (
     <LoadedSlot
-      // Use the jsUrl as a key to force a re-render when the jsUrl changes
+      // Use the a key to force a re-render when the randomId (or jsUrl) changes
       // Plugins may be stateful and we cannot make assumptions that we won't be
       // so it is safer to just re-render.
-      key={jsUrl}
+      key={key}
       {...props}
       widget={module.default}
       value={valueWithBuffer}


### PR DESCRIPTION
Fixes #4173 

This fixes the force-render for anywidget in wasm. Since we pass the esm as a data-uri instead of a URL, we need a better key that causes the re-render. 