### PR TITLE
improvement: diagnostics configuration, upgrade codemirror-languageserver

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "@lezer/python": "^1.1.16",
     "@marimo-team/codemirror-ai": "^0.1.9",
     "@marimo-team/marimo-api": "file:../openapi",
-    "@marimo-team/codemirror-languageserver": "^1.13.8",
+    "@marimo-team/codemirror-languageserver": "^1.13.11",
     "@marimo-team/react-slotz": "^0.1.8",
     "@open-rpc/client-js": "^1.8.1",
     "@paralleldrive/cuid2": "^2.2.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.1.9
         version: 0.1.9(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.13.8
-        version: 1.13.8(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
+        specifier: ^1.13.11
+        version: 1.13.11(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/marimo-api':
         specifier: file:../openapi
         version: file:../openapi
@@ -1546,8 +1546,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.13.8':
-    resolution: {integrity: sha512-EoDdfLZXl/a7MQOT/1q6LKmDPb67PkZ2HrMdQA554sX1R4mkoS6z/DpXzAZmCrhQb6J1PA7OrXqW0Qb+LszJxg==}
+  '@marimo-team/codemirror-languageserver@1.13.11':
+    resolution: {integrity: sha512-cvBmUtTkvczvp7ii8Ub4qyahNmjx1q9HT26j2xarkCWgUBms34JXmt2cCMlfZfZVYC8wSd+SWjXANQg/pNT5AQ==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -10225,7 +10225,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
 
-  '@marimo-team/codemirror-languageserver@1.13.8(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
+  '@marimo-team/codemirror-languageserver@1.13.11(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lint': 6.8.4

--- a/frontend/src/components/app-config/optional-features.tsx
+++ b/frontend/src/components/app-config/optional-features.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/utils/cn";
 import { SettingSubtitle } from "./common";
 import { isWasm } from "@/core/wasm/utils";
+import { getFeatureFlag } from "@/core/config/feature-flag";
 
 interface Package {
   name: string;
@@ -81,6 +82,15 @@ const OPTIONAL_DEPENDENCIES: OptionalFeature[] = [
     description: "Export as IPYNB",
   },
 ];
+
+if (getFeatureFlag("lsp")) {
+  OPTIONAL_DEPENDENCIES.push({
+    id: "lsp",
+    packagesRequired: [{ name: "python-lsp-server" }, { name: "websockets" }],
+    additionalPackageInstalls: [{ name: "python-lsp-ruff" }],
+    description: "Language Server Protocol",
+  });
+}
 
 export const OptionalFeatures: React.FC = () => {
   const [config] = useResolvedMarimoConfig();

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -50,6 +50,8 @@ import { get } from "lodash-es";
 import { Tooltip } from "../ui/tooltip";
 import { getMarimoVersion } from "@/core/dom/marimo-tag";
 import { OptionalFeatures } from "./optional-features";
+import { getFeatureFlag } from "@/core/config/feature-flag";
+import { Badge } from "../ui/badge";
 
 const formItemClasses = "flex flex-row items-center space-x-1 space-y-0";
 const categories = [
@@ -425,6 +427,79 @@ export const UserConfigForm: React.FC = () => {
                 )}
               />
             </SettingGroup>
+            {getFeatureFlag("lsp") && (
+              <SettingGroup title="Language Servers">
+                <FormField
+                  control={form.control}
+                  name="language_servers.pylsp.enabled"
+                  render={({ field }) => (
+                    <FormItem className={formItemClasses}>
+                      <FormLabel>
+                        <Badge variant="defaultOutline" className="mr-2">
+                          Beta
+                        </Badge>
+                        Python Language Server (
+                        <a
+                          href="https://github.com/python-lsp/python-lsp-server"
+                          target="_blank"
+                          className="text-link hover:underline"
+                          rel="noreferrer"
+                        >
+                          pylsp
+                        </a>
+                        )
+                      </FormLabel>
+                      <FormControl>
+                        <Checkbox
+                          data-testid="pylsp-checkbox"
+                          checked={field.value}
+                          disabled={field.disabled}
+                          onCheckedChange={(checked) => {
+                            field.onChange(Boolean(checked));
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                      <IsOverridden
+                        userConfig={config}
+                        name="language_servers.pylsp.enabled"
+                      />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="diagnostics.enabled"
+                  render={({ field }) => (
+                    <FormItem className={formItemClasses}>
+                      <FormLabel>
+                        <Badge variant="defaultOutline" className="mr-2">
+                          Beta
+                        </Badge>
+                        Diagnostics
+                      </FormLabel>
+                      <FormControl>
+                        <Checkbox
+                          data-testid="diagnostics-checkbox"
+                          checked={field.value}
+                          disabled={field.disabled}
+                          onCheckedChange={(checked) => {
+                            field.onChange(Boolean(checked));
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                      <IsOverridden
+                        userConfig={config}
+                        name="diagnostics.enabled"
+                      />
+                    </FormItem>
+                  )}
+                />
+              </SettingGroup>
+            )}
+
             <SettingGroup title="Keymap">
               <FormField
                 control={form.control}

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -165,6 +165,7 @@ const CellEditorInternal = ({
       lspConfig: userConfig.language_servers,
       theme,
       hotkeys: new OverridingHotkeyProvider(userConfig.keymap.overrides ?? {}),
+      diagnosticsConfig: userConfig.diagnostics,
     });
 
     extensions.push(
@@ -191,6 +192,7 @@ const CellEditorInternal = ({
     userConfig.keymap,
     userConfig.completion,
     userConfig.language_servers,
+    userConfig.diagnostics,
     aiEnabled,
     theme,
     showPlaceholder,

--- a/frontend/src/core/codemirror/__tests__/setup.test.ts
+++ b/frontend/src/core/codemirror/__tests__/setup.test.ts
@@ -59,6 +59,7 @@ function getOpts() {
         enabled: false,
       },
     },
+    diagnosticsConfig: {},
     hotkeys: new OverridingHotkeyProvider({}),
     theme: "light",
   } as const;

--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -39,6 +39,7 @@ import {
 import { EditorState, type Extension, Prec } from "@codemirror/state";
 import type {
   CompletionConfig,
+  DiagnosticsConfig,
   KeymapConfig,
   LSPConfig,
 } from "../config/config-schema";
@@ -78,6 +79,7 @@ export interface CodeMirrorSetupOpts {
   theme: Theme;
   hotkeys: HotkeyProvider;
   lspConfig: LSPConfig;
+  diagnosticsConfig: DiagnosticsConfig;
 }
 
 function getPlaceholderType(opts: CodeMirrorSetupOpts) {
@@ -97,6 +99,7 @@ export const setupCodeMirror = (opts: CodeMirrorSetupOpts): Extension[] => {
     cellActions,
     completionConfig,
     lspConfig,
+    diagnosticsConfig,
   } = opts;
   const placeholderType = getPlaceholderType(opts);
 
@@ -107,13 +110,19 @@ export const setupCodeMirror = (opts: CodeMirrorSetupOpts): Extension[] => {
     pasteBundle(),
     jupyterHelpExtension(),
     // Cell editing
-    cellConfigExtension(completionConfig, hotkeys, placeholderType, lspConfig),
+    cellConfigExtension(
+      completionConfig,
+      hotkeys,
+      placeholderType,
+      lspConfig,
+      diagnosticsConfig,
+    ),
     cellBundle(cellId, hotkeys, cellActions),
     // Comes last so that it can be overridden
     basicBundle(opts),
     // Underline cmd+clickable placeholder
     goToDefinitionBundle(),
-    getFeatureFlag("lsp") ? lintGutter() : [],
+    getFeatureFlag("lsp") && diagnosticsConfig?.enabled ? lintGutter() : [],
     // AI edit inline
     enableAI && getFeatureFlag("inline_ai_tooltip")
       ? aiExtension({

--- a/frontend/src/core/codemirror/config/extension.ts
+++ b/frontend/src/core/codemirror/config/extension.ts
@@ -1,50 +1,43 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import type { CompletionConfig, LSPConfig } from "@/core/config/config-schema";
+import type {
+  CompletionConfig,
+  DiagnosticsConfig,
+  LSPConfig,
+} from "@/core/config/config-schema";
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
-import { Facet } from "@codemirror/state";
 import type { CellId } from "@/core/cells/ids";
+import { singleFacet } from "../facet";
 
 /**
  * State for completion config
  */
-export const completionConfigState = Facet.define<
-  CompletionConfig,
-  CompletionConfig
->({
-  combine: (values) => values[0],
-});
+export const completionConfigState = singleFacet<CompletionConfig>();
 
 /**
  * State for hotkeys provider
  */
-export const hotkeysProviderState = Facet.define<
-  HotkeyProvider,
-  HotkeyProvider
->({
-  combine: (values) => values[0],
-});
+export const hotkeysProviderState = singleFacet<HotkeyProvider>();
 
+export type PlaceholderType = "marimo-import" | "ai" | "none";
 /**
  * State for placeholder type
  */
-export type PlaceholderType = "marimo-import" | "ai" | "none";
-export const placeholderState = Facet.define<PlaceholderType, PlaceholderType>({
-  combine: (values) => values[0],
-});
+export const placeholderState = singleFacet<PlaceholderType>();
 
 /**
  * State for cell id
  */
-export const cellIdState = Facet.define<CellId, CellId>({
-  combine: (values) => values[0],
-});
+export const cellIdState = singleFacet<CellId>();
 
 /**
  * State for LSP config
  */
-export const lspConfigState = Facet.define<LSPConfig, LSPConfig>({
-  combine: (values) => values[0],
-});
+export const lspConfigState = singleFacet<LSPConfig>();
+
+/**
+ * State for diagnostics config
+ */
+export const diagnosticsConfigState = singleFacet<DiagnosticsConfig>();
 
 /**
  * Extension for cell config
@@ -54,6 +47,7 @@ export function cellConfigExtension(
   hotkeys: HotkeyProvider,
   placeholderType: PlaceholderType,
   lspConfig: LSPConfig,
+  diagnosticsConfig: DiagnosticsConfig,
 ) {
   return [
     // Store state
@@ -61,5 +55,6 @@ export function cellConfigExtension(
     hotkeysProviderState.of(hotkeys),
     placeholderState.of(placeholderType),
     lspConfigState.of(lspConfig),
+    diagnosticsConfigState.of(diagnosticsConfig),
   ];
 }

--- a/frontend/src/core/codemirror/config/extension.ts
+++ b/frontend/src/core/codemirror/config/extension.ts
@@ -7,6 +7,7 @@ import type {
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import type { CellId } from "@/core/cells/ids";
 import { singleFacet } from "../facet";
+import { diagnosticsEnabled } from "@marimo-team/codemirror-languageserver";
 
 /**
  * State for completion config
@@ -56,5 +57,7 @@ export function cellConfigExtension(
     placeholderState.of(placeholderType),
     lspConfigState.of(lspConfig),
     diagnosticsConfigState.of(diagnosticsConfig),
+    // Enable diagnostics (default to false)
+    diagnosticsEnabled.of(diagnosticsConfig?.enabled ?? false),
   ];
 }

--- a/frontend/src/core/codemirror/copilot/__tests__/getCode.test.ts
+++ b/frontend/src/core/codemirror/copilot/__tests__/getCode.test.ts
@@ -52,6 +52,7 @@ function createMockEditorView(code: string) {
           new OverridingHotkeyProvider({}),
           "marimo-import",
           {},
+          {},
         ),
       ],
     }),

--- a/frontend/src/core/codemirror/copilot/client.ts
+++ b/frontend/src/core/codemirror/copilot/client.ts
@@ -94,8 +94,6 @@ export const getCopilotClient = once(
   () =>
     new CopilotLanguageServerClient({
       rootUri: FILE_URI,
-      documentUri: FILE_URI,
-      languageId: LANGUAGE_ID,
       workspaceFolders: null,
       transport: createWSTransport(),
     }),

--- a/frontend/src/core/codemirror/facet.ts
+++ b/frontend/src/core/codemirror/facet.ts
@@ -1,0 +1,19 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { Facet } from "@codemirror/state";
+
+/**
+ * A facet that combines a single value.
+ *
+ * This is useful for creating a facet that can be used to store a single value.
+ *
+ * @example
+ * ```ts
+ * const myFacet = singleFacet<string>();
+ * const myValue = myFacet.of("hello");
+ * ```
+ */
+export function singleFacet<T>() {
+  return Facet.define<T, T>({
+    combine: (values) => values[0],
+  });
+}

--- a/frontend/src/core/codemirror/language/__tests__/extension.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/extension.test.ts
@@ -36,6 +36,7 @@ function createState(content: string, selection?: { anchor: number }) {
         new OverridingHotkeyProvider({}),
         "marimo-import",
         {},
+        {},
       ),
     ],
     selection,

--- a/frontend/src/core/codemirror/language/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/utils.test.ts
@@ -41,6 +41,7 @@ function createEditor(doc: string) {
               enabled: true,
             },
           },
+          {},
         ),
       ],
     }),

--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -13,11 +13,7 @@ import {
 } from "@codemirror/language";
 import type { CompletionConfig, LSPConfig } from "@/core/config/config-schema";
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
-import {
-  cellIdState,
-  diagnosticsConfigState,
-  type PlaceholderType,
-} from "../config/extension";
+import type { PlaceholderType } from "../config/extension";
 import {
   smartPlaceholderExtension,
   clickablePlaceholderExtension,
@@ -26,7 +22,6 @@ import {
   LanguageServerClient,
   languageServerWithTransport,
   documentUri,
-  diagnosticsEnabled,
 } from "@marimo-team/codemirror-languageserver";
 import { resolveToWsUrl } from "@/core/websocket/createWsUrl";
 import { WebSocketTransport } from "@open-rpc/client-js";
@@ -172,13 +167,7 @@ export class PythonLanguageAdapter implements LanguageAdapter {
               });
             },
           }),
-          documentUri.compute([cellIdState], (state) => {
-            return CellDocumentUri.of(state.facet(cellIdState));
-          }),
-          diagnosticsEnabled.compute([diagnosticsConfigState], (state) => {
-            // default to false
-            return state.facet(diagnosticsConfigState)?.enabled ?? false;
-          }),
+          documentUri.of(CellDocumentUri.of(cellId)),
         ];
       }
 

--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -13,7 +13,11 @@ import {
 } from "@codemirror/language";
 import type { CompletionConfig, LSPConfig } from "@/core/config/config-schema";
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
-import type { PlaceholderType } from "../config/extension";
+import {
+  cellIdState,
+  diagnosticsConfigState,
+  type PlaceholderType,
+} from "../config/extension";
 import {
   smartPlaceholderExtension,
   clickablePlaceholderExtension,
@@ -21,10 +25,11 @@ import {
 import {
   LanguageServerClient,
   languageServerWithTransport,
+  documentUri,
+  diagnosticsEnabled,
 } from "@marimo-team/codemirror-languageserver";
 import { resolveToWsUrl } from "@/core/websocket/createWsUrl";
 import { WebSocketTransport } from "@open-rpc/client-js";
-import { CellDocumentUri } from "../lsp/types";
 import { NotebookLanguageServerClient } from "../lsp/notebook-lsp";
 import { once } from "@/utils/once";
 import { getFeatureFlag } from "@/core/config/feature-flag";
@@ -36,6 +41,7 @@ import type { CellId } from "@/core/cells/ids";
 import { cellActionsState } from "../cells/state";
 import { openFile } from "@/core/network/requests";
 import { Logger } from "@/utils/Logger";
+import { CellDocumentUri } from "../lsp/types";
 
 const pylspTransport = once(() => {
   const transport = new WebSocketTransport(resolveToWsUrl("/lsp/pylsp"));
@@ -46,7 +52,6 @@ const lspClient = once((lspConfig: LSPConfig) => {
   const lspClientOpts = {
     transport: pylspTransport(),
     rootUri: `file://${Paths.dirname(getFilenameFromDOM() ?? "/")}`,
-    languageId: "python",
     workspaceFolders: [],
   };
   const config = lspConfig?.pylsp;
@@ -112,7 +117,6 @@ const lspClient = once((lspConfig: LSPConfig) => {
   return new NotebookLanguageServerClient(
     new LanguageServerClient({
       ...lspClientOpts,
-      documentUri: "file:///unused.py", // Incorrect types
       autoClose: false,
     }),
     settings,
@@ -148,26 +152,34 @@ export class PythonLanguageAdapter implements LanguageAdapter {
     const getCompletionsExtension = () => {
       if (getFeatureFlag("lsp") && lspConfig?.pylsp?.enabled) {
         const client = lspClient(lspConfig);
-        return languageServerWithTransport({
-          client: client as unknown as LanguageServerClient,
-          documentUri: CellDocumentUri.of(cellId),
-          transport: pylspTransport(),
-          rootUri: "file:///",
-          languageId: "python",
-          workspaceFolders: [],
-          allowHTMLContent: true,
-          onGoToDefinition: (result) => {
-            Logger.debug("onGoToDefinition", result);
-            if (client.documentUri === result.uri) {
-              // Local definition
-              return;
-            }
+        return [
+          languageServerWithTransport({
+            client: client as unknown as LanguageServerClient,
+            transport: pylspTransport(),
+            rootUri: "file:///",
+            languageId: "python",
+            workspaceFolders: [],
+            allowHTMLContent: true,
+            onGoToDefinition: (result) => {
+              Logger.debug("onGoToDefinition", result);
+              if (client.documentUri === result.uri) {
+                // Local definition
+                return;
+              }
 
-            openFile({
-              path: result.uri.replace("file://", ""),
-            });
-          },
-        });
+              openFile({
+                path: result.uri.replace("file://", ""),
+              });
+            },
+          }),
+          documentUri.compute([cellIdState], (state) => {
+            return CellDocumentUri.of(state.facet(cellIdState));
+          }),
+          diagnosticsEnabled.compute([diagnosticsConfigState], (state) => {
+            // default to false
+            return state.facet(diagnosticsConfigState)?.enabled ?? false;
+          }),
+        ];
       }
 
       // Whether or not to require keypress to activate autocompletion (default

--- a/frontend/src/core/codemirror/lsp/lens.ts
+++ b/frontend/src/core/codemirror/lsp/lens.ts
@@ -1,5 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import type { CellId } from "@/core/cells/ids";
+import { Logger } from "@/utils/Logger";
 import { Objects } from "@/utils/objects";
 import type * as LSP from "vscode-languageserver-protocol";
 
@@ -47,7 +48,10 @@ export function createNotebookLens(
   });
 
   function getCurrentLineOffset(cellId: CellId): number {
-    return cellLineOffsets.get(cellId) || 0;
+    if (!cellLineOffsets.has(cellId)) {
+      Logger.warn("[lsp] no cell line offsets for", cellId);
+    }
+    return cellLineOffsets.get(cellId) ?? 0;
   }
 
   const mergedText = Object.values(codes).join("\n");
@@ -88,7 +92,7 @@ export function createNotebookLens(
         if (!cellLineOffsets.has(cellId)) {
           continue;
         }
-        const offset = cellLineOffsets.get(cellId) || 0;
+        const offset = cellLineOffsets.get(cellId) ?? 0;
 
         const numCellLines = code.split("\n").length;
         const newCellLines = newLines.slice(offset, offset + numCellLines);

--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -176,7 +176,7 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
 
       const cellId = CellDocumentUri.parse(documentUri);
       const newCode = editsToNewCode.get(cellId);
-      if (!newCode) {
+      if (newCode == null) {
         Logger.warn("No new code for cell", cellId);
         continue;
       }
@@ -346,7 +346,8 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
       const lens = createNotebookLens(cellIds, codes);
 
       const version = params.textDocument.version;
-      const globalDocumentVersion = this.documentVersion + 1;
+      this.documentVersion++;
+      const globalDocumentVersion = this.documentVersion;
 
       this.versionToCellNumberAndVersion.set(globalDocumentVersion, {
         cellDocumentUri,

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -165,6 +165,7 @@ export type SaveConfig = UserConfig["save"];
 export type CompletionConfig = UserConfig["completion"];
 export type KeymapConfig = UserConfig["keymap"];
 export type LSPConfig = UserConfig["language_servers"];
+export type DiagnosticsConfig = UserConfig["diagnostics"];
 
 export const AppTitleSchema = z.string();
 export const AppConfigSchema = z

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -136,7 +136,7 @@ class RuntimeConfig(TypedDict):
 
 # TODO(akshayka): remove normal, migrate to compact
 # normal == compact
-WidthType = Literal["normal", "compact", "medium", "full"]
+WidthType = Literal["normal", "compact", "medium", "full", "columns"]
 Theme = Literal["light", "dark", "system"]
 
 
@@ -264,7 +264,11 @@ class GoogleAiConfig(TypedDict, total=False):
 
 @dataclass
 class PythonLanguageServerConfig(TypedDict, total=False):
-    """Configuration options for Python Language Server."""
+    """
+    Configuration options for Python Language Server.
+
+    pylsp handles completion, hover, go-to-definition, and diagnostics.
+    """
 
     enabled: bool
     enable_mypy: bool
@@ -285,6 +289,18 @@ class LanguageServersConfig(TypedDict, total=False):
     """
 
     pylsp: PythonLanguageServerConfig
+
+
+@dataclass
+class DiagnosticsConfig(TypedDict, total=False):
+    """Configuration options for diagnostics.
+
+    **Keys.**
+
+    - `enabled`: if `True`, diagnostics will be shown in the editor
+    """
+
+    enabled: bool
 
 
 @dataclass
@@ -331,6 +347,7 @@ class MarimoConfig(TypedDict):
     package_management: PackageManagementConfig
     ai: NotRequired[AiConfig]
     language_servers: NotRequired[LanguageServersConfig]
+    diagnostics: NotRequired[DiagnosticsConfig]
     experimental: NotRequired[dict[str, Any]]
     snippets: NotRequired[SnippetsConfig]
     datasources: NotRequired[DatasourcesConfig]
@@ -351,6 +368,7 @@ class PartialMarimoConfig(TypedDict, total=False):
     package_management: PackageManagementConfig
     ai: NotRequired[AiConfig]
     language_servers: NotRequired[LanguageServersConfig]
+    diagnostics: NotRequired[DiagnosticsConfig]
     experimental: NotRequired[dict[str, Any]]
     snippets: SnippetsConfig
     datasources: NotRequired[DatasourcesConfig]

--- a/marimo/_server/api/endpoints/packages.py
+++ b/marimo/_server/api/endpoints/packages.py
@@ -139,6 +139,11 @@ async def list_packages(request: Request) -> ListPackagesResponse:
 
 
 def _get_package_manager(request: Request) -> PackageManager:
+    if not AppState(request).get_current_session():
+        return create_package_manager(
+            AppState(request).config_manager.package_manager
+        )
+
     config_manager = AppState(request).app_config_manager
     return create_package_manager(config_manager.package_manager)
 

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -112,7 +112,7 @@ class BaseLspServer(LspServer):
     def binary_name(self) -> str:
         raise NotImplementedError()
 
-    def get_command(self) -> str:
+    def get_command(self) -> list[str]:
         raise NotImplementedError()
 
     def missing_binary_alert(self) -> Alert:
@@ -132,14 +132,19 @@ class CopilotLspServer(BaseLspServer):
         )
         return lsp_bin
 
-    def get_command(self) -> str:
+    def get_command(self) -> list[str]:
         lsp_bin = self._lsp_bin()
         # Check if the LSP binary exists
         if not os.path.exists(lsp_bin):
             # Only debug since this may not exist in conda environments
             LOGGER.debug("LSP binary not found at %s", lsp_bin)
             return ""
-        return f"node {lsp_bin} --port {self.port}"
+        return [
+            "node",
+            lsp_bin,
+            "--port",
+            str(self.port),
+        ]
 
     def missing_binary_alert(self) -> Alert:
         return Alert(
@@ -155,10 +160,19 @@ class PyLspServer(BaseLspServer):
     def binary_name(self) -> str:
         return "pylsp"
 
-    def get_command(self) -> str:
+    def get_command(self) -> list[str]:
         import sys
 
-        return f"{sys.executable} -m pylsp --ws -v --port {self.port} --check-parent-process"
+        return [
+            sys.executable,
+            "-m",
+            "pylsp",
+            "--ws",
+            "-v",
+            "--port",
+            str(self.port),
+            "--check-parent-process",
+        ]
 
     def missing_binary_alert(self) -> Alert:
         return Alert(

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -74,7 +74,7 @@ class BaseLspServer(LspServer):
             )
             LOGGER.debug("... running command: %s", cmd)
             self.process = subprocess.Popen(
-                cmd.split(),
+                cmd,
                 stdout=file_out,
                 stderr=file_out,
                 stdin=None,

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -138,7 +138,7 @@ class CopilotLspServer(BaseLspServer):
         if not os.path.exists(lsp_bin):
             # Only debug since this may not exist in conda environments
             LOGGER.debug("LSP binary not found at %s", lsp_bin)
-            return ""
+            return []
         return [
             "node",
             lsp_bin,

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -156,7 +156,9 @@ class PyLspServer(BaseLspServer):
         return "pylsp"
 
     def get_command(self) -> str:
-        return f"pylsp --ws -v --port {self.port} --check-parent-process"
+        import sys
+
+        return f"{sys.executable} -m pylsp --ws -v --port {self.port} --check-parent-process"
 
     def missing_binary_alert(self) -> Alert:
         return Alert(

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1117,6 +1117,7 @@ components:
               - compact
               - medium
               - full
+              - columns
               type: string
           required:
           - width
@@ -1356,6 +1357,11 @@ components:
                 - auto
                 type: string
           type: object
+        diagnostics:
+          properties:
+            enabled:
+              type: boolean
+          type: object
         display:
           properties:
             cell_output:
@@ -1376,6 +1382,7 @@ components:
               - compact
               - medium
               - full
+              - columns
               type: string
             theme:
               enum:
@@ -2386,7 +2393,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.11.21
+  version: 0.11.23
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2671,7 +2671,7 @@ export interface components {
         html_head_file?: string | null;
         layout_file?: string | null;
         /** @enum {string} */
-        width: "normal" | "compact" | "medium" | "full";
+        width: "normal" | "compact" | "medium" | "full" | "columns";
       };
       capabilities: {
         terminal: boolean;
@@ -2789,6 +2789,9 @@ export interface components {
         auto_discover_schemas?: boolean | "auto";
         auto_discover_tables?: boolean | "auto";
       };
+      diagnostics?: {
+        enabled?: boolean;
+      };
       display: {
         /** @enum {string} */
         cell_output: "above" | "below";
@@ -2796,7 +2799,7 @@ export interface components {
         /** @enum {string} */
         dataframes: "rich" | "plain";
         /** @enum {string} */
-        default_width: "normal" | "compact" | "medium" | "full";
+        default_width: "normal" | "compact" | "medium" | "full" | "columns";
         /** @enum {string} */
         theme: "light" | "dark" | "system";
       };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # - 0.26.1 introduced lifespans, which we use
     # - starlette 0.36.0 introduced a bug
     "starlette>=0.26.1,!=0.36.0",
-    # websockets for use with starlette
+    # websockets for use with starlette, and for lsp
     "websockets >= 10.0.0",
     # pycrdt for collaborative editing
     "pycrdt >=0.11.0,<0.12.0",

--- a/tests/_server/test_lsp.py
+++ b/tests/_server/test_lsp.py
@@ -93,9 +93,8 @@ def test_base_lsp_server_missing_binary(mock_which: mock.MagicMock):
 def test_pylsp_server():
     server = PyLspServer(port=8000)
     assert server.binary_name() == "pylsp"
-    assert (
-        server.get_command()
-        == "pylsp --ws -v --port 8000 --check-parent-process"
+    assert server.get_command().endswith(
+        "pylsp --ws -v --port 8000 --check-parent-process"
     )
     alert = server.missing_binary_alert()
     assert "Python LSP" in alert.title

--- a/tests/_server/test_lsp.py
+++ b/tests/_server/test_lsp.py
@@ -91,11 +91,21 @@ def test_base_lsp_server_missing_binary(mock_which: mock.MagicMock):
 
 
 def test_pylsp_server():
+    import sys
+
     server = PyLspServer(port=8000)
+
     assert server.binary_name() == "pylsp"
-    assert server.get_command().endswith(
-        "pylsp --ws -v --port 8000 --check-parent-process"
-    )
+    assert server.get_command() == [
+        sys.executable,
+        "-m",
+        "pylsp",
+        "--ws",
+        "-v",
+        "--port",
+        "8000",
+        "--check-parent-process",
+    ]
     alert = server.missing_binary_alert()
     assert "Python LSP" in alert.title
 

--- a/tests/_server/test_lsp.py
+++ b/tests/_server/test_lsp.py
@@ -117,7 +117,7 @@ def test_copilot_server():
         assert "node" in server.get_command()
         assert str(8000) in server.get_command()
     else:
-        assert server.get_command() == ""
+        assert server.get_command() == []
     alert = server.missing_binary_alert()
     assert "GitHub Copilot" in alert.title
 


### PR DESCRIPTION
Upgrades @marimo-team/codemirror-languageserver to pick up some improvements and adds `DiagnosticsConfiguration` which for now just has enabled/disabled, but in future could include ignore keys