### PR TITLE
improvement: style auto-complete, pass down custom config

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "@lezer/python": "^1.1.16",
     "@marimo-team/codemirror-ai": "^0.1.9",
     "@marimo-team/marimo-api": "file:../openapi",
-    "@marimo-team/codemirror-languageserver": "^1.13.11",
+    "@marimo-team/codemirror-languageserver": "^1.14.0",
     "@marimo-team/react-slotz": "^0.1.8",
     "@open-rpc/client-js": "^1.8.1",
     "@paralleldrive/cuid2": "^2.2.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.1.9
         version: 0.1.9(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.13.11
-        version: 1.13.11(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
+        specifier: ^1.14.0
+        version: 1.14.0(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/marimo-api':
         specifier: file:../openapi
         version: file:../openapi
@@ -1546,8 +1546,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.13.11':
-    resolution: {integrity: sha512-cvBmUtTkvczvp7ii8Ub4qyahNmjx1q9HT26j2xarkCWgUBms34JXmt2cCMlfZfZVYC8wSd+SWjXANQg/pNT5AQ==}
+  '@marimo-team/codemirror-languageserver@1.14.0':
+    resolution: {integrity: sha512-5x3FaopUPaq7tDMEf3VPBkh3CsxA1KfV0554JmvOHwzv0aJ3FIbvWDAnnyi3TZZicmhoJUdyigMHOxtz0GIZKg==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -10225,7 +10225,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
 
-  '@marimo-team/codemirror-languageserver@1.13.11(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
+  '@marimo-team/codemirror-languageserver@1.14.0(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lint': 6.8.4

--- a/frontend/src/core/codemirror/copilot/client.ts
+++ b/frontend/src/core/codemirror/copilot/client.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { once } from "@/utils/once";
-import { languageServerWithTransport } from "@marimo-team/codemirror-languageserver";
+import { languageServerWithClient } from "@marimo-team/codemirror-languageserver";
 import { CopilotLanguageServerClient } from "./language-server";
 import { WebSocketTransport } from "@open-rpc/client-js";
 import { Transport } from "@open-rpc/client-js/build/transports/Transport";
@@ -100,11 +100,8 @@ export const getCopilotClient = once(
 );
 
 export function copilotServer() {
-  return languageServerWithTransport({
-    rootUri: FILE_URI,
+  return languageServerWithClient({
     documentUri: FILE_URI,
-    workspaceFolders: [],
-    transport: createWSTransport(),
     client: getCopilotClient(),
     languageId: LANGUAGE_ID,
   });

--- a/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
+++ b/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
@@ -9,7 +9,7 @@ import type { CellId } from "@/core/cells/ids";
 import { EditorView } from "@codemirror/view";
 import {
   type LanguageServerClient,
-  languageServerWithTransport,
+  languageServerWithClient,
 } from "@marimo-team/codemirror-languageserver";
 
 const Cells = {
@@ -342,9 +342,8 @@ describe("NotebookLanguageServerClient", () => {
       const mockView1 = new EditorView({
         doc: "# this is a comment",
         extensions: [
-          languageServerWithTransport({
+          languageServerWithClient({
             client: mockClient as unknown as LanguageServerClient,
-            rootUri: "file:///",
             documentUri: CellDocumentUri.of(Cells.cell1),
             ...props,
           }),
@@ -355,9 +354,8 @@ describe("NotebookLanguageServerClient", () => {
       const mockView2 = new EditorView({
         doc: "import math\nimport numpy",
         extensions: [
-          languageServerWithTransport({
+          languageServerWithClient({
             client: mockClient as unknown as LanguageServerClient,
-            rootUri: "file:///",
             documentUri: CellDocumentUri.of(Cells.cell2),
             ...props,
           }),
@@ -368,9 +366,8 @@ describe("NotebookLanguageServerClient", () => {
       const mockView3 = new EditorView({
         doc: "print(math.sqrt(4))",
         extensions: [
-          languageServerWithTransport({
+          languageServerWithClient({
             client: mockClient as unknown as LanguageServerClient,
-            rootUri: "file:///",
             documentUri: CellDocumentUri.of(Cells.cell3),
             ...props,
           }),

--- a/frontend/src/css/app/App.css
+++ b/frontend/src/css/app/App.css
@@ -4,6 +4,7 @@
 @import url("./fonts.css");
 @import url("./Header.css");
 @import url("./print.css");
+@import url("./codemirror-completions.css");
 
 /* stylelint-disable unit-allowed-list */
 

--- a/frontend/src/css/app/codemirror-completions.css
+++ b/frontend/src/css/app/codemirror-completions.css
@@ -1,0 +1,188 @@
+/* -- Autocomplete Styling -- */
+
+#root {
+  /* Base styling for autocomplete container */
+  .cm-tooltip-autocomplete {
+    /* CodeMirror's default is too wide. */
+    max-width: 200px;
+    @apply bg-popover shadow-md border border-border;
+  }
+
+  /* Autocomplete list */
+  .cm-tooltip-autocomplete > ul {
+    @apply max-h-[300px] overflow-y-auto;
+    scrollbar-width: thin;
+    min-width: unset;
+  }
+
+  /* Autocomplete list items */
+  .cm-tooltip-autocomplete > ul > li {
+    padding: 0;
+    height: 16px;
+    @apply flex items-center gap-2 cursor-pointer;
+  }
+
+  /* Hover state for list items */
+  .cm-tooltip-autocomplete > ul > li:hover {
+    background-color: var(--blue-3);
+  }
+
+  /* Selected item in autocomplete */
+  .cm-tooltip-autocomplete > ul > li[aria-selected] {
+    background-color: var(--blue-4);
+    color: var(--blue-12);
+  }
+
+  /* Completion icons container */
+  .cm-completionIcon {
+    width: 1rem;
+    height: 100%;
+    flex-shrink: 0;
+    line-height: 16px;
+    font-weight: bold;
+    opacity: 0.9;
+    padding: 0 1px;
+    @apply flex items-center justify-center font-medium;
+  }
+
+  .cm-completionIcon-variable {
+    color: var(--blue-10);
+    background-color: var(--blue-3);
+
+    &::after {
+      content: "𝑣"; /* Italic small v for variables */
+    }
+  }
+
+  .cm-completionIcon-property {
+    color: var(--lime-11);
+    background-color: var(--lime-3);
+
+    &::after {
+      content: "≡"; /* Identical to symbol for properties */
+    }
+  }
+
+  .cm-completionIcon-method {
+    color: var(--amber-11);
+    background-color: var(--amber-3);
+
+    &::after {
+      content: "⚙"; /* Gear symbol for methods */
+    }
+  }
+
+  .cm-completionIcon-function {
+    color: var(--purple-11);
+    background-color: var(--purple-3);
+
+    &::after {
+      content: "ƒ"; /* Function symbol for functions */
+    }
+  }
+
+  .cm-completionIcon-class {
+    color: var(--orange-11);
+    background-color: var(--orange-3);
+
+    &::after {
+      content: "C"; /* Capital C for classes */
+    }
+  }
+
+  .cm-completionIcon-module {
+    color: var(--grass-11);
+    background-color: var(--grass-3);
+
+    &::after {
+      content: "⧉"; /* Interlocking squares for modules */
+    }
+  }
+
+  .cm-completionIcon-statement {
+    color: var(--red-11);
+    background-color: var(--red-3);
+
+    &::after {
+      content: "§"; /* Section symbol for statements */
+    }
+  }
+
+  .cm-completionIcon-keyword {
+    color: var(--cyan-11);
+    background-color: var(--cyan-3);
+
+    &::after {
+      content: "⌘"; /* Command symbol for keywords */
+    }
+  }
+
+  .cm-completionIcon-reference {
+    color: var(--gray-10);
+    background-color: var(--gray-3);
+
+    &::after {
+      content: "→"; /* Right arrow for references */
+    }
+  }
+
+  /* Completion info tooltip */
+  .cm-completionInfo {
+    @apply max-w-md border-l border-border;
+  }
+
+  /* Completion matching text highlight */
+  .cm-completionMatchedText {
+    @apply font-semibold text-primary underline underline-offset-2;
+  }
+
+  /* Scrollbar styling for autocomplete list */
+  .cm-tooltip-autocomplete > ul::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .cm-tooltip-autocomplete > ul::-webkit-scrollbar-track {
+    @apply bg-transparent;
+  }
+
+  .cm-tooltip-autocomplete > ul::-webkit-scrollbar-thumb {
+    @apply bg-muted-foreground/30 rounded-full;
+  }
+
+  .cm-tooltip-autocomplete > ul::-webkit-scrollbar-thumb:hover {
+    @apply bg-muted-foreground/50;
+  }
+
+  /* Copilot and AI completion styling */
+  .cm-tooltip-autocomplete > ul > li.cm-ai-completion {
+    @apply border-l-2 border-green-500;
+  }
+
+  .cm-tooltip.cm-completionInfo {
+    /* Codemirror generates an inline style for these properties,
+      * so we have to override them with !important. */
+    top: 0 !important;
+
+    /* CodeMirror's default of 400px is often too small. */
+    max-width: 36rem !important;
+  }
+
+  .cm-completionInfo.cm-completionInfo-right-narrow {
+    /* CodeMirror's default makes the completionInfo overlap with the
+      * compeletion symbol */
+    left: 100%;
+  }
+
+  /* Completion Info may show up to the left or right of another menu item.
+    First is the parent (completion list)
+    Second is the child (completion info) */
+  .cm-tooltip:has(.cm-completionInfo-left),
+  .cm-tooltip.cm-completionInfo-right {
+    border-top-left-radius: 0;
+  }
+
+  .cm-tooltip:has(.cm-completionInfo-right),
+  .cm-tooltip.cm-completionInfo-left {
+    border-top-right-radius: 0;
+  }
+}

--- a/frontend/src/css/app/codemirror-completions.css
+++ b/frontend/src/css/app/codemirror-completions.css
@@ -166,7 +166,7 @@
   .cm-tooltip.cm-completionInfo {
     /* Codemirror generates an inline style for these properties,
       * so we have to override them with !important. */
-    top: 0 !important;
+    top: -1px !important;
 
     /* CodeMirror's default of 400px is often too small. */
     max-width: 36rem !important;

--- a/frontend/src/css/app/codemirror-completions.css
+++ b/frontend/src/css/app/codemirror-completions.css
@@ -18,8 +18,13 @@
   /* Autocomplete list items */
   .cm-tooltip-autocomplete > ul > li {
     padding: 0;
-    height: 16px;
+    height: 18px;
     @apply flex items-center gap-2 cursor-pointer;
+  }
+
+  .cm-completionLabel {
+    padding: 1px 0;
+    @apply text-xs;
   }
 
   /* Hover state for list items */
@@ -38,7 +43,7 @@
     width: 1rem;
     height: 100%;
     flex-shrink: 0;
-    line-height: 16px;
+    line-height: 18px;
     font-weight: bold;
     opacity: 0.9;
     padding: 0 1px;

--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -61,76 +61,6 @@
   z-index: 1000;
 }
 
-/* -- Completion Info -- */
-
-/* Compeletion Symbol */
-#root .cm-tooltip-autocomplete {
-  /* CodeMirror's default is too wide. */
-  max-width: 200px;
-}
-
-#root .cm-tooltip.cm-tooltip-autocomplete > ul {
-  min-width: unset;
-}
-
-#root .cm-tooltip-autocomplete ul li[aria-selected] {
-  background: #1177ccb0;
-  max-width: 200px;
-}
-
-.dark #root .cm-tooltip-autocomplete ul li[aria-selected] {
-  background: #1177cc80;
-  max-width: 200px;
-}
-
-#root .cm-tooltip.cm-completionInfo {
-  /* Codemirror generates an inline style for these properties,
-   * so we have to override them with !important. */
-  top: 0 !important;
-
-  /* CodeMirror's default of 400px is often too small. */
-  max-width: 36rem !important;
-}
-
-#root .cm-completionInfo.cm-completionInfo-right-narrow {
-  /* CodeMirror's default makes the completionInfo overlap with the
-   * compeletion symbol */
-  left: 100%;
-}
-
-/* Completion Info may show up to the left or right of another menu item.
- First is the parent (completion list)
- Second is the child (completion info) */
-#root .cm-tooltip:has(.cm-completionInfo-left),
-#root .cm-tooltip.cm-completionInfo-right {
-  border-top-left-radius: 0;
-}
-
-#root .cm-tooltip:has(.cm-completionInfo-right),
-#root .cm-tooltip.cm-completionInfo-left {
-  border-top-right-radius: 0;
-}
-
-.cm .cm-completionIcon-function::after {
-  content: "λ";
-}
-
-.cm .cm-completionIcon-class::after {
-  content: "τ";
-}
-
-.cm .cm-completionIcon-module::after {
-  content: "μ";
-}
-
-.cm .cm-completionIcon-statement::after {
-  content: "χ";
-}
-
-.cm .cm-completionIcon-keyword::after {
-  content: "κ";
-}
-
 /* -- Panels -- */
 
 .cm .cm-panels {
@@ -144,6 +74,8 @@
   @apply text-xs;
 }
 
+/* -- Ghost Text -- */
+
 .cm-ghostText,
 .cm-ghostText * {
   opacity: 0.6;
@@ -154,6 +86,8 @@
 .cm-ghostText:hover {
   background: var(--gray-3);
 }
+
+/* -- Codeium -- */
 
 .cm-codeium-cycle {
   font-size: 9px;

--- a/frontend/src/css/globals.css
+++ b/frontend/src/css/globals.css
@@ -24,6 +24,8 @@
 @import url("@radix-ui/colors/blue-dark.css");
 @import url("@radix-ui/colors/purple.css");
 @import url("@radix-ui/colors/purple-dark.css");
+@import url("@radix-ui/colors/green.css");
+@import url("@radix-ui/colors/green-dark.css");
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
Coloring and more icons (a few icons were missing)

Also passes down the config to the codemirror-languageserver plugin.


<img width="979" alt="Screenshot 2025-03-20 at 9 13 30 PM" src="https://github.com/user-attachments/assets/1c00ce7c-ccd6-4f4e-a8a9-84cef383eaf4" />

