### PR TITLE
experimental: add LSP docs and pyproject.toml requirements

### DIFF
--- a/docs/guides/editor_features/index.md
+++ b/docs/guides/editor_features/index.md
@@ -1,4 +1,3 @@
-
 # Editor features
 
 The **marimo editor** is the browser-based IDE in which you write marimo
@@ -11,6 +10,7 @@ with code and data.
 | [Overview](overview.md) | An overview of editor features and configuration |
 | [Package Management](package_management.md) | Using package managers in marimo |
 | [AI Completion](ai_completion.md) | Code with the help of a language model |
+| [Language Server](language_server.md) | Code intelligence via LSP |
 | [Hotkeys](hotkeys.md) | Our hotkeys |
 
 Highlights include:
@@ -21,6 +21,7 @@ Highlights include:
 - code completion
 - GitHub Copilot
 - language-model assisted coding
+- language server protocol (LSP) for diagnostics and code intelligence
 - vim keybindings
 - live documentation preiews as you type
 

--- a/docs/guides/editor_features/language_server.md
+++ b/docs/guides/editor_features/language_server.md
@@ -1,0 +1,79 @@
+# Language Server Protocol (LSP)
+
+!!! warning "Experimental Feature"
+
+    LSP support in marimo is currently an experimental feature. It may have bugs or performance issues. To enable it add the following to your `pyproject.toml` file:
+
+    ```toml title="pyproject.toml"
+    [tool.marimo.experimental]
+    lsp = true
+    ```
+
+The marimo editor supports the Language Server Protocol (LSP) to provide enhanced code intelligence features like:
+
+- Code completion
+- Hover information
+- Go to definition
+- Error checking and diagnostics
+
+## Installation
+
+LSP support requires additional dependencies. You can install them with:
+
+```bash
+pip install "marimo[lsp]"
+# or
+uv add marimo[lsp]
+# or
+conda install -c conda-forge python-lsp-server python-lsp-ruff
+```
+
+This will install the necessary packages including:
+
+- [`python-lsp-server`](https://github.com/python-lsp/python-lsp-server): The core Python language server
+- `python-lsp-ruff`: Ruff integration for fast linting
+
+You may optionally install other `pylsp` plugins.
+
+!!! note "Other Python Language Servers"
+
+    Support for other Python language servers is planned for future releases.
+
+## Configuration
+
+LSP support can be configured in your `pyproject.toml` file.
+
+```toml title="pyproject.toml"
+[tool.marimo.experimental]
+lsp = true
+```
+
+```toml title="pyproject.toml"
+
+# Language server configuration
+[tool.marimo.language_servers.pylsp]
+enabled = true               # Enable/disable the Python language server
+enable_mypy = true           # Type checking with mypy (enabled by default, if installed)
+enable_ruff = true           # Linting with ruff (enabled by default, if installed)
+enable_flake8 = false        # Linting with flake8
+enable_pydocstyle = false    # Check docstring style
+enable_pylint = false        # Linting with pylint
+enable_pyflakes = false      # Syntax checking with pyflakes
+
+# Diagnostics configuration
+[tool.marimo.diagnostics]
+enabled = true               # Show diagnostics in the editor
+```
+
+## WebAssembly
+
+Language Servers are not available when running marimo in WebAssembly.
+
+## Troubleshooting
+
+If you encounter issues with the language server:
+
+1. Make sure you've installed the required dependencies with `pip install "marimo[lsp]"`
+2. Check if the language server is enabled in your configuration
+3. Try restarting the marimo server
+4. Check the terminal for any error messages

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "@lezer/python": "^1.1.16",
     "@marimo-team/codemirror-ai": "^0.1.9",
     "@marimo-team/marimo-api": "file:../openapi",
-    "@marimo-team/codemirror-languageserver": "^1.14.1",
+    "@marimo-team/codemirror-languageserver": "^1.15.0",
     "@marimo-team/react-slotz": "^0.1.8",
     "@open-rpc/client-js": "^1.8.1",
     "@paralleldrive/cuid2": "^2.2.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.1.9
         version: 0.1.9(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.14.1
-        version: 1.14.1(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
+        specifier: ^1.15.0
+        version: 1.15.0(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/marimo-api':
         specifier: file:../openapi
         version: file:../openapi
@@ -1546,8 +1546,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.14.1':
-    resolution: {integrity: sha512-Dvt06J0FdPmulsy7HPg3AORc6edBtfxqST5L3Y5TOPrgXrIpE+3kOrs9+mWKTRG5jGJ7wgxGh9+TRFgsOoTxlQ==}
+  '@marimo-team/codemirror-languageserver@1.15.0':
+    resolution: {integrity: sha512-wxGmoE07fev5fmaaXbBzzhy0Jh8+G//BzUwKcvO2/c5IljWpupH5sR3eICObVugG7s2UBNSSbEjaH1l+pBHL+A==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -10225,7 +10225,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
 
-  '@marimo-team/codemirror-languageserver@1.14.1(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
+  '@marimo-team/codemirror-languageserver@1.15.0(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lint': 6.8.4

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { closeCompletion, completionStatus } from "@codemirror/autocomplete";
+import { completionStatus } from "@codemirror/autocomplete";
 import type { EditorView } from "@codemirror/view";
 import {
   memo,
@@ -75,7 +75,7 @@ function useCellCompletion(
       !cellRef.current.contains(e.relatedTarget) &&
       editorView.current !== null
     ) {
-      closeCompletion(editorView.current);
+      // closeCompletion(editorView.current);
     }
   });
 

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -255,7 +255,10 @@ const CellEditorInternal = ({
           editorViewRef.current,
           userConfig.completion,
           new OverridingHotkeyProvider(userConfig.keymap.overrides ?? {}),
-          userConfig.language_servers,
+          {
+            ...userConfig.language_servers,
+            diagnostics: userConfig.diagnostics,
+          },
         ),
       ],
     });

--- a/frontend/src/core/codemirror/__tests__/setup.test.ts
+++ b/frontend/src/core/codemirror/__tests__/setup.test.ts
@@ -58,6 +58,9 @@ function getOpts() {
       pylsp: {
         enabled: false,
       },
+      diagnostics: {
+        enabled: false,
+      },
     },
     diagnosticsConfig: {},
     hotkeys: new OverridingHotkeyProvider({}),

--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -156,7 +156,14 @@ const startCompletionAtEndOfLine = (cm: EditorView): boolean => {
 
 // Based on codemirror's basicSetup extension
 export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
-  const { theme, hotkeys, completionConfig, cellId, lspConfig } = opts;
+  const {
+    theme,
+    hotkeys,
+    completionConfig,
+    cellId,
+    lspConfig,
+    diagnosticsConfig,
+  } = opts;
   const placeholderType = getPlaceholderType(opts);
 
   return [
@@ -198,7 +205,7 @@ export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
       completionConfig,
       hotkeys,
       cellId,
-      lspConfig,
+      lspConfig: { ...lspConfig, diagnostics: diagnosticsConfig },
     }),
 
     ///// Editing

--- a/frontend/src/core/codemirror/config/extension.ts
+++ b/frontend/src/core/codemirror/config/extension.ts
@@ -7,7 +7,6 @@ import type {
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import type { CellId } from "@/core/cells/ids";
 import { singleFacet } from "../facet";
-import { diagnosticsEnabled } from "@marimo-team/codemirror-languageserver";
 
 /**
  * State for completion config
@@ -33,12 +32,9 @@ export const cellIdState = singleFacet<CellId>();
 /**
  * State for LSP config
  */
-export const lspConfigState = singleFacet<LSPConfig>();
-
-/**
- * State for diagnostics config
- */
-export const diagnosticsConfigState = singleFacet<DiagnosticsConfig>();
+export const lspConfigState = singleFacet<
+  LSPConfig & { diagnostics: DiagnosticsConfig }
+>();
 
 /**
  * Extension for cell config
@@ -55,9 +51,6 @@ export function cellConfigExtension(
     completionConfigState.of(completionConfig),
     hotkeysProviderState.of(hotkeys),
     placeholderState.of(placeholderType),
-    lspConfigState.of(lspConfig),
-    diagnosticsConfigState.of(diagnosticsConfig),
-    // Enable diagnostics (default to false)
-    diagnosticsEnabled.of(diagnosticsConfig?.enabled ?? false),
+    lspConfigState.of({ ...lspConfig, diagnostics: diagnosticsConfig }),
   ];
 }

--- a/frontend/src/core/codemirror/language/extension.ts
+++ b/frontend/src/core/codemirror/language/extension.ts
@@ -13,7 +13,11 @@ import {
   showPanel,
 } from "@codemirror/view";
 import { clamp } from "@/utils/math";
-import type { CompletionConfig, LSPConfig } from "@/core/config/config-schema";
+import type {
+  CompletionConfig,
+  DiagnosticsConfig,
+  LSPConfig,
+} from "@/core/config/config-schema";
 import {
   cellIdState,
   completionConfigState,
@@ -184,7 +188,7 @@ export function adaptiveLanguageConfiguration(opts: {
   placeholderType: PlaceholderType;
   completionConfig: CompletionConfig;
   hotkeys: HotkeyProvider;
-  lspConfig: LSPConfig;
+  lspConfig: LSPConfig & { diagnostics?: DiagnosticsConfig };
   cellId: CellId;
 }) {
   const { placeholderType, completionConfig, hotkeys, cellId, lspConfig } =
@@ -264,7 +268,7 @@ export function reconfigureLanguageEffect(
   view: EditorView,
   completionConfig: CompletionConfig,
   hotkeysProvider: HotkeyProvider,
-  lspConfig: LSPConfig,
+  lspConfig: LSPConfig & { diagnostics?: DiagnosticsConfig },
 ) {
   const language = view.state.field(languageAdapterState);
   const placeholderType = view.state.facet(placeholderState);

--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -11,7 +11,11 @@ import {
   foldInside,
   LanguageSupport,
 } from "@codemirror/language";
-import type { CompletionConfig, LSPConfig } from "@/core/config/config-schema";
+import type {
+  CompletionConfig,
+  DiagnosticsConfig,
+  LSPConfig,
+} from "@/core/config/config-schema";
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import type { PlaceholderType } from "../config/extension";
 import {
@@ -142,7 +146,7 @@ export class PythonLanguageAdapter implements LanguageAdapter {
     completionConfig: CompletionConfig,
     _hotkeys: HotkeyProvider,
     placeholderType: PlaceholderType,
-    lspConfig: LSPConfig,
+    lspConfig: LSPConfig & { diagnostics: DiagnosticsConfig },
   ): Extension[] {
     const getCompletionsExtension = () => {
       const autocompleteOptions = {
@@ -170,6 +174,8 @@ export class PythonLanguageAdapter implements LanguageAdapter {
             allowHTMLContent: true,
             hoverConfig: hoverOptions,
             completionConfig: autocompleteOptions,
+            // Default to false
+            diagnosticsEnabled: lspConfig.diagnostics?.enabled ?? false,
             // Match completions before the cursor is at the end of a word,
             // after a dot, after a slash, after a comma.
             completionMatchBefore: /(\w+|\w+\.|\/|,)$/,

--- a/frontend/src/core/codemirror/language/types.ts
+++ b/frontend/src/core/codemirror/language/types.ts
@@ -1,5 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import type { CompletionConfig, LSPConfig } from "@/core/config/config-schema";
+import type {
+  CompletionConfig,
+  DiagnosticsConfig,
+  LSPConfig,
+} from "@/core/config/config-schema";
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import type { Extension } from "@codemirror/state";
 import type { PlaceholderType } from "../config/extension";
@@ -21,7 +25,7 @@ export interface LanguageAdapter {
     completionConfig: CompletionConfig,
     hotkeys: HotkeyProvider,
     placeholderType: PlaceholderType,
-    lspConfig: LSPConfig,
+    lspConfig: LSPConfig & { diagnostics?: DiagnosticsConfig },
   ): Extension[];
 }
 

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -347,7 +347,10 @@ class ProxyMiddleware:
                 ws_url = ws_url.replace("https", "wss", 1)
 
             LOGGER.debug(f"Creating websocket proxy for {ws_url}")
-            await self._proxy_websocket(scope, receive, send, ws_url)
+            try:
+                await self._proxy_websocket(scope, receive, send, ws_url)
+            except Exception as e:
+                LOGGER.error(f"Error proxying websocket: {e}")
             LOGGER.debug(f"Done with websocket proxy for {ws_url}")
             return
 

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -105,15 +105,9 @@ def start(
 
     config_reader = get_default_config_manager(current_path=start_path)
 
-    user_config = config_reader.get_config()
-
     lsp_composite_server = CompositeLspServer(
-        lsp_config=(
-            user_config["language_servers"]
-            if "language_servers" in user_config
-            else {}
-        ),
-        completion_config=user_config["completion"],
+        lsp_config=config_reader.language_servers,
+        completion_config=config_reader.completion,
         min_port=DEFAULT_PORT + 400,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,11 @@ dev = [
     "openai>=1.55.3",
 ]
 
+lsp = [
+    "python-lsp-server>=1.10.0",
+    "python-lsp-ruff>=2.0.0",
+]
+
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.5.49",


### PR DESCRIPTION
Add docs and `marimo[lsp]` to pyproject toml. 

Also add warnings when LSP was requested but cannot be installed.