### PR TITLE
improve: smaller column summary charts

### DIFF
--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -45,13 +45,6 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
       "axis": null,
       "bin": true,
       "field": "a",
-      "scale": {
-        "align": 0,
-        "paddingInner": 0,
-        "paddingOuter": {
-          "expr": "length(data('source_0')) == 2 ? 1 : length(data('source_0')) == 3 ? 0.5 : length(data('source_0')) == 4 ? 0 : 0",
-        },
-      },
       "type": "nominal",
     },
     "y": {
@@ -67,9 +60,6 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
   "mark": {
     "align": "right",
     "color": "#027864",
-    "size": {
-      "expr": "min(28, 120 / length(data('source_0')) - 1)",
-    },
     "type": "bar",
   },
 }
@@ -127,13 +117,6 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
       "axis": null,
       "bin": true,
       "field": "a",
-      "scale": {
-        "align": 0,
-        "paddingInner": 0,
-        "paddingOuter": {
-          "expr": "length(data('data_0')) == 2 ? 1 : length(data('data_0')) == 3 ? 0.5 : length(data('data_0')) == 4 ? 0 : 0",
-        },
-      },
       "type": "nominal",
     },
     "y": {
@@ -149,9 +132,6 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
   "mark": {
     "align": "right",
     "color": "#027864",
-    "size": {
-      "expr": "min(28, 120 / length(data('data_0')) - 1)",
-    },
     "type": "bar",
   },
 }
@@ -209,13 +189,6 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
       "axis": null,
       "bin": true,
       "field": "a",
-      "scale": {
-        "align": 0,
-        "paddingInner": 0,
-        "paddingOuter": {
-          "expr": "length(data('data_0')) == 2 ? 1 : length(data('data_0')) == 3 ? 0.5 : length(data('data_0')) == 4 ? 0 : 0",
-        },
-      },
       "type": "nominal",
     },
     "y": {
@@ -231,9 +204,6 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
   "mark": {
     "align": "right",
     "color": "#027864",
-    "size": {
-      "expr": "min(28, 120 / length(data('data_0')) - 1)",
-    },
     "type": "bar",
   },
 }
@@ -299,9 +269,6 @@ exports[`ColumnChartSpecModel > snapshot > url data 1`] = `
   "mark": {
     "color": "#027864",
     "type": "bar",
-    "width": {
-      "expr": "min(28, 120 / length(data('data_0')) - 1)",
-    },
   },
 }
 `;

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -7,10 +7,8 @@ import { parseCsvData } from "@/plugins/impl/vega/loader";
 import { logNever } from "@/utils/assertNever";
 import type { TopLevelSpec } from "vega-lite";
 
-const MAX_BAR_HEIGHT = 24; // px
-const MAX_BAR_WIDTH = 28; // px
-const CONTAINER_WIDTH = 120; // px
-const PAD = 1; // px
+// We rely on vega's built-in binning to determine bar widths.
+const MAX_BAR_HEIGHT = 20; // px
 
 export class ColumnChartSpecModel<T> {
   private columnSummaries = new Map<string | number, ColumnHeaderSummary>();
@@ -103,7 +101,6 @@ export class ColumnChartSpecModel<T> {
     column = column.replaceAll(":", "\\:");
 
     const scale = this.getScale();
-    const variableWidth = `min(${MAX_BAR_WIDTH}, ${CONTAINER_WIDTH} / length(data('${this.sourceName}')) - ${PAD})`;
 
     switch (type) {
       case "date":
@@ -114,7 +111,6 @@ export class ColumnChartSpecModel<T> {
           mark: {
             type: "bar",
             color: mint.mint11,
-            width: { expr: variableWidth },
           },
           encoding: {
             x: {
@@ -163,16 +159,15 @@ export class ColumnChartSpecModel<T> {
           mark: {
             type: "bar",
             color: mint.mint11,
-            size: { expr: variableWidth },
             align: "right",
           },
           encoding: {
             x: {
               field: column,
+              // nominal to support a null bin
               type: "nominal",
               axis: null,
               bin: true,
-              scale: scale,
             },
             y: {
               aggregate: "count",

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -7,10 +7,8 @@ import { parseCsvData } from "@/plugins/impl/vega/loader";
 import { logNever } from "@/utils/assertNever";
 import type { TopLevelSpec } from "vega-lite";
 
-const MAX_BAR_HEIGHT = 24; // px
-const MAX_BAR_WIDTH = 28; // px
-const CONTAINER_WIDTH = 70; // px
-const PAD = 1; // px
+// We rely on vega's built-in binning to determine bar widths.
+const MAX_BAR_HEIGHT = 20; // px
 
 export class ColumnChartSpecModel<T> {
   private columnSummaries = new Map<string | number, ColumnHeaderSummary>();
@@ -103,7 +101,6 @@ export class ColumnChartSpecModel<T> {
     column = column.replaceAll(":", "\\:");
 
     const scale = this.getScale();
-    const variableWidth = `min(${MAX_BAR_WIDTH}, ${CONTAINER_WIDTH} / length(data('${this.sourceName}')) - ${PAD})`;
 
     switch (type) {
       case "date":
@@ -114,7 +111,6 @@ export class ColumnChartSpecModel<T> {
           mark: {
             type: "bar",
             color: mint.mint11,
-            width: { expr: variableWidth},
           },
           encoding: {
             x: {
@@ -164,7 +160,6 @@ export class ColumnChartSpecModel<T> {
             type: "bar",
             color: mint.mint11,
             align: "right",
-            size: {expr: variableWidth },
           },
           encoding: {
             x: {
@@ -173,7 +168,6 @@ export class ColumnChartSpecModel<T> {
               type: "nominal",
               axis: null,
               bin: true,
-              scale: scale,
             },
             y: {
               aggregate: "count",

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -7,8 +7,10 @@ import { parseCsvData } from "@/plugins/impl/vega/loader";
 import { logNever } from "@/utils/assertNever";
 import type { TopLevelSpec } from "vega-lite";
 
-// We rely on vega's built-in binning to determine bar widths.
-const MAX_BAR_HEIGHT = 20; // px
+const MAX_BAR_HEIGHT = 24; // px
+const MAX_BAR_WIDTH = 28; // px
+const CONTAINER_WIDTH = 70; // px
+const PAD = 1; // px
 
 export class ColumnChartSpecModel<T> {
   private columnSummaries = new Map<string | number, ColumnHeaderSummary>();
@@ -101,6 +103,7 @@ export class ColumnChartSpecModel<T> {
     column = column.replaceAll(":", "\\:");
 
     const scale = this.getScale();
+    const variableWidth = `min(${MAX_BAR_WIDTH}, ${CONTAINER_WIDTH} / length(data('${this.sourceName}')) - ${PAD})`;
 
     switch (type) {
       case "date":
@@ -111,6 +114,7 @@ export class ColumnChartSpecModel<T> {
           mark: {
             type: "bar",
             color: mint.mint11,
+            width: { expr: variableWidth},
           },
           encoding: {
             x: {
@@ -160,6 +164,7 @@ export class ColumnChartSpecModel<T> {
             type: "bar",
             color: mint.mint11,
             align: "right",
+            size: {expr: variableWidth },
           },
           encoding: {
             x: {
@@ -168,6 +173,7 @@ export class ColumnChartSpecModel<T> {
               type: "nominal",
               axis: null,
               bin: true,
+              scale: scale,
             },
             y: {
               aggregate: "count",

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -278,7 +278,7 @@ export const DataTableColumnHeaderWithSummary = <TData, TValue>({
   return (
     <div
       className={cn(
-        "flex flex-col h-full py-1 justify-between items-start gap-1",
+        "flex flex-col h-full py-0.5 justify-between items-start",
         className,
       )}
     >

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -125,7 +125,9 @@ export const TableColumnSummary = <TData, TValue>({
           return (
             <div className="flex justify-between w-full px-2 whitespace-pre">
               <span>{prettyScientificNumber(summary.min)}</span>
-              <span>{prettyScientificNumber(summary.max)}</span>
+              {summary.min === summary.max ? null : (
+                <span>{prettyScientificNumber(summary.max)}</span>
+              )}
             </div>
           );
         }

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -39,15 +39,15 @@ export const TableColumnSummary = <TData, TValue>({
         milliseconds={200}
         visibility={true}
         rootMargin="200px"
-        fallback={<ChartSkeleton seed={columnId} width={130} height={60} />}
+        fallback={<ChartSkeleton seed={columnId} width={80} height={40} />}
       >
         <LazyVegaLite
           spec={spec}
-          width={120}
-          height={50}
+          width={70}
+          height={30}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           loader={batchedLoader as any}
-          style={{ minWidth: "unset", maxHeight: "60px" }}
+          style={{ minWidth: "unset", maxHeight: "40px" }}
           actions={false}
           theme={theme === "dark" ? "dark" : "vox"}
         />

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -89,9 +89,9 @@ export const TableColumnSummary = <TData, TValue>({
         return (
           <div className="flex justify-between w-full px-2 whitespace-pre">
             <span>{renderDate(summary.min, type)}</span>
-            {summary.min === summary.max
-              ? null
-              : -(<span>{renderDate(summary.max, type)}</span>)}
+            {summary.min === summary.max ? null : (
+              <span>-{renderDate(summary.max, type)}</span>
+            )}
           </div>
         );
       case "integer":

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -88,8 +88,10 @@ export const TableColumnSummary = <TData, TValue>({
 
         return (
           <div className="flex justify-between w-full px-2 whitespace-pre">
-            <span>{renderDate(summary.min, type)}</span>-
-            <span>{renderDate(summary.max, type)}</span>
+            <span>{renderDate(summary.min, type)}</span>
+            {summary.min === summary.max
+              ? null
+              : -(<span>{renderDate(summary.max, type)}</span>)}
           </div>
         );
       case "integer":
@@ -123,7 +125,9 @@ export const TableColumnSummary = <TData, TValue>({
           return (
             <div className="flex justify-between w-full px-2 whitespace-pre">
               <span>{prettyScientificNumber(summary.min)}</span>
-              <span>{prettyScientificNumber(summary.max)}</span>
+              {summary.min === summary.max ? null : (
+                <span>{prettyScientificNumber(summary.max)}</span>
+              )}
             </div>
           );
         }

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -90,7 +90,7 @@ export const TableColumnSummary = <TData, TValue>({
           <div className="flex justify-between w-full px-2 whitespace-pre">
             <span>{renderDate(summary.min, type)}</span>
             {summary.min === summary.max ? null : (
-              <span>{-renderDate(summary.max, type)}</span>
+              <span>-{renderDate(summary.max, type)}</span>
             )}
           </div>
         );

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -90,7 +90,7 @@ export const TableColumnSummary = <TData, TValue>({
           <div className="flex justify-between w-full px-2 whitespace-pre">
             <span>{renderDate(summary.min, type)}</span>
             {summary.min === summary.max ? null : (
-              <span>-{renderDate(summary.max, type)}</span>
+              <span>{-renderDate(summary.max, type)}</span>
             )}
           </div>
         );
@@ -125,9 +125,7 @@ export const TableColumnSummary = <TData, TValue>({
           return (
             <div className="flex justify-between w-full px-2 whitespace-pre">
               <span>{prettyScientificNumber(summary.min)}</span>
-              {summary.min === summary.max ? null : (
-                <span>{prettyScientificNumber(summary.max)}</span>
-              )}
+              <span>{prettyScientificNumber(summary.max)}</span>
             </div>
           );
         }

--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -74,6 +74,7 @@ export function renderTableBody<TData>(
             cell.column.getColumnWrapping &&
               cell.column.getColumnWrapping() === "wrap" &&
               "whitespace-pre-wrap min-w-[200px]",
+            "px-1.5 py-0.5",
             className,
           )}
           style={style}

--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -74,7 +74,7 @@ export function renderTableBody<TData>(
             cell.column.getColumnWrapping &&
               cell.column.getColumnWrapping() === "wrap" &&
               "whitespace-pre-wrap min-w-[200px]",
-            "px-1.5 py-0.5",
+            "px-1.5 py-[0.18rem]",
             className,
           )}
           style={style}


### PR DESCRIPTION
This change makes column summary charts smaller, both width and height, to prioritize fitting more table columns on the screen.

This change also replaces the manual bar width calculation and lets the bin sizes be determined by vega/the chart renderer.

Before: 

![image](https://github.com/user-attachments/assets/d5befd7a-4944-4220-9384-b87a02570c2d)

After: 

![image](https://github.com/user-attachments/assets/5ff4267d-9424-4658-9f6c-fde1c28a347f)