### PR TITLE
fix: column summary bars spacing, expand tooltips

### DIFF
--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -22,6 +22,27 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
   "layer": [
     {
       "encoding": {
+        "x": {
+          "axis": null,
+          "bin": {
+            "maxbins": 10,
+          },
+          "field": "a",
+          "type": "quantitative",
+        },
+        "y": {
+          "aggregate": "count",
+          "axis": null,
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#027864",
+        "type": "bar",
+      },
+    },
+    {
+      "encoding": {
         "tooltip": [
           {
             "bin": true,
@@ -46,55 +67,15 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
           "type": "quantitative",
         },
         "y": {
-          "aggregate": "count",
+          "aggregate": "max",
           "axis": null,
           "type": "quantitative",
         },
       },
       "mark": {
-        "color": "#027864",
+        "opacity": 0,
         "type": "bar",
       },
-      "transform": [
-        {
-          "filter": "datum['a'] !== null",
-        },
-      ],
-    },
-    {
-      "encoding": {
-        "tooltip": [
-          {
-            "title": "a",
-            "value": "Missing",
-          },
-          {
-            "aggregate": "count",
-            "format": ",d",
-            "title": "Null",
-            "type": "quantitative",
-          },
-        ],
-        "x": {
-          "value": 0,
-        },
-        "y": {
-          "aggregate": "count",
-          "type": "quantitative",
-        },
-      },
-      "mark": {
-        "color": "#cc4e00",
-        "type": "bar",
-        "x": {
-          "offset": -15,
-        },
-      },
-      "transform": [
-        {
-          "filter": "datum['a'] === null",
-        },
-      ],
     },
   ],
 }
@@ -129,6 +110,27 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
   "layer": [
     {
       "encoding": {
+        "x": {
+          "axis": null,
+          "bin": {
+            "maxbins": 10,
+          },
+          "field": "a",
+          "type": "quantitative",
+        },
+        "y": {
+          "aggregate": "count",
+          "axis": null,
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#027864",
+        "type": "bar",
+      },
+    },
+    {
+      "encoding": {
         "tooltip": [
           {
             "bin": true,
@@ -153,55 +155,15 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
           "type": "quantitative",
         },
         "y": {
-          "aggregate": "count",
+          "aggregate": "max",
           "axis": null,
           "type": "quantitative",
         },
       },
       "mark": {
-        "color": "#027864",
+        "opacity": 0,
         "type": "bar",
       },
-      "transform": [
-        {
-          "filter": "datum['a'] !== null",
-        },
-      ],
-    },
-    {
-      "encoding": {
-        "tooltip": [
-          {
-            "title": "a",
-            "value": "Missing",
-          },
-          {
-            "aggregate": "count",
-            "format": ",d",
-            "title": "Null",
-            "type": "quantitative",
-          },
-        ],
-        "x": {
-          "value": 0,
-        },
-        "y": {
-          "aggregate": "count",
-          "type": "quantitative",
-        },
-      },
-      "mark": {
-        "color": "#cc4e00",
-        "type": "bar",
-        "x": {
-          "offset": -15,
-        },
-      },
-      "transform": [
-        {
-          "filter": "datum['a'] === null",
-        },
-      ],
     },
   ],
 }
@@ -236,6 +198,27 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
   "layer": [
     {
       "encoding": {
+        "x": {
+          "axis": null,
+          "bin": {
+            "maxbins": 10,
+          },
+          "field": "a",
+          "type": "quantitative",
+        },
+        "y": {
+          "aggregate": "count",
+          "axis": null,
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#027864",
+        "type": "bar",
+      },
+    },
+    {
+      "encoding": {
         "tooltip": [
           {
             "bin": true,
@@ -260,55 +243,15 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
           "type": "quantitative",
         },
         "y": {
-          "aggregate": "count",
+          "aggregate": "max",
           "axis": null,
           "type": "quantitative",
         },
       },
       "mark": {
-        "color": "#027864",
+        "opacity": 0,
         "type": "bar",
       },
-      "transform": [
-        {
-          "filter": "datum['a'] !== null",
-        },
-      ],
-    },
-    {
-      "encoding": {
-        "tooltip": [
-          {
-            "title": "a",
-            "value": "Missing",
-          },
-          {
-            "aggregate": "count",
-            "format": ",d",
-            "title": "Null",
-            "type": "quantitative",
-          },
-        ],
-        "x": {
-          "value": 0,
-        },
-        "y": {
-          "aggregate": "count",
-          "type": "quantitative",
-        },
-      },
-      "mark": {
-        "color": "#cc4e00",
-        "type": "bar",
-        "x": {
-          "offset": -15,
-        },
-      },
-      "transform": [
-        {
-          "filter": "datum['a'] === null",
-        },
-      ],
     },
   ],
 }
@@ -328,52 +271,89 @@ exports[`ColumnChartSpecModel > snapshot > url data 1`] = `
   "data": {
     "values": [],
   },
-  "encoding": {
-    "color": {
-      "condition": {
-        "test": "datum["bin_maxbins_10_date_range"] === "null"",
-        "value": "#cc4e00",
-      },
-      "value": "#027864",
-    },
-    "tooltip": [
-      {
-        "bin": true,
-        "field": "date",
-        "format": "%Y-%m-%d",
-        "title": "date",
-        "type": "temporal",
-      },
-      {
-        "aggregate": "count",
-        "format": ",d",
-        "title": "Count",
-        "type": "quantitative",
-      },
-    ],
-    "x": {
-      "axis": null,
-      "bin": true,
-      "field": "date",
-      "scale": {
-        "align": 0,
-        "paddingInner": 0,
-        "paddingOuter": {
-          "expr": "length(data('data_0')) == 2 ? 1 : length(data('data_0')) == 3 ? 0.5 : length(data('data_0')) == 4 ? 0 : 0",
+  "height": 100,
+  "layer": [
+    {
+      "encoding": {
+        "color": {
+          "condition": {
+            "test": "datum["bin_maxbins_10_date_range"] === "null"",
+            "value": "#cc4e00",
+          },
+          "value": "#027864",
+        },
+        "x": {
+          "axis": null,
+          "bin": true,
+          "field": "date",
+          "scale": {
+            "align": 0,
+            "paddingInner": 0,
+            "paddingOuter": {
+              "expr": "length(data('data_0')) == 2 ? 1 : length(data('data_0')) == 3 ? 0.5 : length(data('data_0')) == 4 ? 0 : 0",
+            },
+          },
+          "type": "temporal",
+        },
+        "y": {
+          "aggregate": "count",
+          "axis": null,
+          "type": "quantitative",
         },
       },
-      "type": "temporal",
+      "mark": {
+        "color": "#027864",
+        "type": "bar",
+      },
     },
-    "y": {
-      "aggregate": "count",
-      "axis": null,
-      "type": "quantitative",
+    {
+      "encoding": {
+        "color": {
+          "condition": {
+            "test": "datum["bin_maxbins_10_date_range"] === "null"",
+            "value": "#cc4e00",
+          },
+          "value": "#027864",
+        },
+        "tooltip": [
+          {
+            "bin": true,
+            "field": "date",
+            "format": "%Y-%m-%d",
+            "title": "date",
+            "type": "temporal",
+          },
+          {
+            "aggregate": "count",
+            "format": ",d",
+            "title": "Count",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "axis": null,
+          "bin": true,
+          "field": "date",
+          "scale": {
+            "align": 0,
+            "paddingInner": 0,
+            "paddingOuter": {
+              "expr": "length(data('data_0')) == 2 ? 1 : length(data('data_0')) == 3 ? 0.5 : length(data('data_0')) == 4 ? 0 : 0",
+            },
+          },
+          "type": "temporal",
+        },
+        "y": {
+          "aggregate": "max",
+          "axis": null,
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "opacity": 0,
+        "type": "bar",
+      },
     },
-  },
-  "height": 100,
-  "mark": {
-    "color": "#027864",
-    "type": "bar",
-  },
+  ],
 }
 `;

--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -18,50 +18,85 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
       "c",
     ],
   },
-  "encoding": {
-    "color": {
-      "condition": {
-        "test": "datum["bin_maxbins_10_a_range"] === "null"",
-        "value": "#cc4e00",
-      },
-      "value": "#027864",
-    },
-    "tooltip": [
-      {
-        "bin": true,
-        "field": "a",
-        "format": ".2f",
-        "title": "a",
-        "type": "nominal",
-      },
-      {
-        "aggregate": "count",
-        "format": ",d",
-        "title": "Count",
-        "type": "quantitative",
-      },
-    ],
-    "x": {
-      "axis": null,
-      "bin": true,
-      "field": "a",
-      "type": "nominal",
-    },
-    "y": {
-      "aggregate": "count",
-      "axis": null,
-      "scale": {
-        "type": "linear",
-      },
-      "type": "quantitative",
-    },
-  },
   "height": 100,
-  "mark": {
-    "align": "right",
-    "color": "#027864",
-    "type": "bar",
-  },
+  "layer": [
+    {
+      "encoding": {
+        "tooltip": [
+          {
+            "bin": true,
+            "field": "a",
+            "format": ".2f",
+            "title": "a",
+            "type": "quantitative",
+          },
+          {
+            "aggregate": "count",
+            "format": ",d",
+            "title": "Count",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "axis": null,
+          "bin": {
+            "maxbins": 10,
+          },
+          "field": "a",
+          "type": "quantitative",
+        },
+        "y": {
+          "aggregate": "count",
+          "axis": null,
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#027864",
+        "type": "bar",
+      },
+      "transform": [
+        {
+          "filter": "datum['a'] !== null",
+        },
+      ],
+    },
+    {
+      "encoding": {
+        "tooltip": [
+          {
+            "title": "a",
+            "value": "Missing",
+          },
+          {
+            "aggregate": "count",
+            "format": ",d",
+            "title": "Null",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "value": 0,
+        },
+        "y": {
+          "aggregate": "count",
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#cc4e00",
+        "type": "bar",
+        "x": {
+          "offset": -15,
+        },
+      },
+      "transform": [
+        {
+          "filter": "datum['a'] === null",
+        },
+      ],
+    },
+  ],
 }
 `;
 
@@ -90,50 +125,85 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
       },
     ],
   },
-  "encoding": {
-    "color": {
-      "condition": {
-        "test": "datum["bin_maxbins_10_a_range"] === "null"",
-        "value": "#cc4e00",
-      },
-      "value": "#027864",
-    },
-    "tooltip": [
-      {
-        "bin": true,
-        "field": "a",
-        "format": ".2f",
-        "title": "a",
-        "type": "nominal",
-      },
-      {
-        "aggregate": "count",
-        "format": ",d",
-        "title": "Count",
-        "type": "quantitative",
-      },
-    ],
-    "x": {
-      "axis": null,
-      "bin": true,
-      "field": "a",
-      "type": "nominal",
-    },
-    "y": {
-      "aggregate": "count",
-      "axis": null,
-      "scale": {
-        "type": "linear",
-      },
-      "type": "quantitative",
-    },
-  },
   "height": 100,
-  "mark": {
-    "align": "right",
-    "color": "#027864",
-    "type": "bar",
-  },
+  "layer": [
+    {
+      "encoding": {
+        "tooltip": [
+          {
+            "bin": true,
+            "field": "a",
+            "format": ".2f",
+            "title": "a",
+            "type": "quantitative",
+          },
+          {
+            "aggregate": "count",
+            "format": ",d",
+            "title": "Count",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "axis": null,
+          "bin": {
+            "maxbins": 10,
+          },
+          "field": "a",
+          "type": "quantitative",
+        },
+        "y": {
+          "aggregate": "count",
+          "axis": null,
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#027864",
+        "type": "bar",
+      },
+      "transform": [
+        {
+          "filter": "datum['a'] !== null",
+        },
+      ],
+    },
+    {
+      "encoding": {
+        "tooltip": [
+          {
+            "title": "a",
+            "value": "Missing",
+          },
+          {
+            "aggregate": "count",
+            "format": ",d",
+            "title": "Null",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "value": 0,
+        },
+        "y": {
+          "aggregate": "count",
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#cc4e00",
+        "type": "bar",
+        "x": {
+          "offset": -15,
+        },
+      },
+      "transform": [
+        {
+          "filter": "datum['a'] === null",
+        },
+      ],
+    },
+  ],
 }
 `;
 
@@ -162,50 +232,85 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
       },
     ],
   },
-  "encoding": {
-    "color": {
-      "condition": {
-        "test": "datum["bin_maxbins_10_a_range"] === "null"",
-        "value": "#cc4e00",
-      },
-      "value": "#027864",
-    },
-    "tooltip": [
-      {
-        "bin": true,
-        "field": "a",
-        "format": ".2f",
-        "title": "a",
-        "type": "nominal",
-      },
-      {
-        "aggregate": "count",
-        "format": ",d",
-        "title": "Count",
-        "type": "quantitative",
-      },
-    ],
-    "x": {
-      "axis": null,
-      "bin": true,
-      "field": "a",
-      "type": "nominal",
-    },
-    "y": {
-      "aggregate": "count",
-      "axis": null,
-      "scale": {
-        "type": "linear",
-      },
-      "type": "quantitative",
-    },
-  },
   "height": 100,
-  "mark": {
-    "align": "right",
-    "color": "#027864",
-    "type": "bar",
-  },
+  "layer": [
+    {
+      "encoding": {
+        "tooltip": [
+          {
+            "bin": true,
+            "field": "a",
+            "format": ".2f",
+            "title": "a",
+            "type": "quantitative",
+          },
+          {
+            "aggregate": "count",
+            "format": ",d",
+            "title": "Count",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "axis": null,
+          "bin": {
+            "maxbins": 10,
+          },
+          "field": "a",
+          "type": "quantitative",
+        },
+        "y": {
+          "aggregate": "count",
+          "axis": null,
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#027864",
+        "type": "bar",
+      },
+      "transform": [
+        {
+          "filter": "datum['a'] !== null",
+        },
+      ],
+    },
+    {
+      "encoding": {
+        "tooltip": [
+          {
+            "title": "a",
+            "value": "Missing",
+          },
+          {
+            "aggregate": "count",
+            "format": ",d",
+            "title": "Null",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "value": 0,
+        },
+        "y": {
+          "aggregate": "count",
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#cc4e00",
+        "type": "bar",
+        "x": {
+          "offset": -15,
+        },
+      },
+      "transform": [
+        {
+          "filter": "datum['a'] === null",
+        },
+      ],
+    },
+  ],
 }
 `;
 

--- a/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
+++ b/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
@@ -87,8 +87,8 @@ describe("ColumnChartSpecModel", () => {
     );
     const summary = model.getHeaderSummary("column.with[special:chars]");
     expect(summary.spec).toBeDefined();
-    // @ts-expect-error numerical charts have 'layer' property
     expect(
+      // @ts-expect-error numerical charts have 'layer' property
       (summary.spec?.layer[0].encoding?.x as { field: string })?.field,
     ).toBe("column\\.with\\[special\\:chars\\]");
   });

--- a/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
+++ b/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
@@ -88,9 +88,9 @@ describe("ColumnChartSpecModel", () => {
     const summary = model.getHeaderSummary("column.with[special:chars]");
     expect(summary.spec).toBeDefined();
     // @ts-expect-error numerical charts have 'layer' property
-    expect((summary.spec?.layer[0].encoding?.x as { field: string })?.field).toBe(
-      "column\\.with\\[special\\:chars\\]",
-    );
+    expect(
+      (summary.spec?.layer[0].encoding?.x as { field: string })?.field,
+    ).toBe("column\\.with\\[special\\:chars\\]");
   });
 
   describe("snapshot", () => {

--- a/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
+++ b/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
@@ -87,8 +87,8 @@ describe("ColumnChartSpecModel", () => {
     );
     const summary = model.getHeaderSummary("column.with[special:chars]");
     expect(summary.spec).toBeDefined();
+    expect(summary.spec.layer).toBeDefined();
     expect(
-      // @ts-expect-error numerical charts have 'layer' property
       (summary.spec?.layer[0].encoding?.x as { field: string })?.field,
     ).toBe("column\\.with\\[special\\:chars\\]");
   });

--- a/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
+++ b/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
@@ -87,7 +87,8 @@ describe("ColumnChartSpecModel", () => {
     );
     const summary = model.getHeaderSummary("column.with[special:chars]");
     expect(summary.spec).toBeDefined();
-    expect((summary.spec?.encoding?.x as { field: string })?.field).toBe(
+    // @ts-expect-error numerical charts have 'layer' property
+    expect((summary.spec?.layer[0].encoding?.x as { field: string })?.field).toBe(
       "column\\.with\\[special\\:chars\\]",
     );
   });

--- a/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
+++ b/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
@@ -87,8 +87,8 @@ describe("ColumnChartSpecModel", () => {
     );
     const summary = model.getHeaderSummary("column.with[special:chars]");
     expect(summary.spec).toBeDefined();
-    expect(summary.spec.layer).toBeDefined();
     expect(
+      // @ts-expect-error layer should be available
       (summary.spec?.layer[0].encoding?.x as { field: string })?.field,
     ).toBe("column\\.with\\[special\\:chars\\]");
   });

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -65,6 +65,10 @@ export class ColumnChartSpecModel<T> {
     this.columnSummaries = new Map(summaries.map((s) => [s.column, s]));
   }
 
+  public getColumnSummary(column: string) {
+    return this.columnSummaries.get(column);
+  }
+
   public getHeaderSummary(column: string) {
     return {
       summary: this.columnSummaries.get(column),
@@ -73,11 +77,11 @@ export class ColumnChartSpecModel<T> {
     };
   }
 
-  private getVegaSpec<T>(column: string): TopLevelFacetedUnitSpec | null {
+  private getVegaSpec<T>(column: string): TopLevelSpec | null {
     if (!this.data) {
       return null;
     }
-    const base: Omit<TopLevelFacetedUnitSpec, "mark"> = {
+    const base = {
       data: this.dataSpec as TopLevelFacetedUnitSpec["data"],
       background: "transparent",
       config: {
@@ -108,48 +112,79 @@ export class ColumnChartSpecModel<T> {
       case "time":
         return {
           ...base,
-          mark: {
-            type: "bar",
-            color: mint.mint11,
-          },
-          encoding: {
-            x: {
-              field: column,
-              type: "temporal",
-              axis: null,
-              bin: true,
-              scale: scale,
+          layer: [
+            {
+              mark: {
+                type: "bar",
+                color: mint.mint11,
+              },
+              encoding: {
+                x: {
+                  field: column,
+                  type: "temporal",
+                  axis: null,
+                  bin: true,
+                  scale: scale,
+                },
+                y: { aggregate: "count", type: "quantitative", axis: null },
+                // Color nulls
+                color: {
+                  condition: {
+                    test: `datum["bin_maxbins_10_${column}_range"] === "null"`,
+                    value: orange.orange11,
+                  },
+                  value: mint.mint11,
+                },
+              },
             },
-            y: { aggregate: "count", type: "quantitative", axis: null },
-            tooltip: [
-              {
-                field: column,
-                type: "temporal",
-                format:
-                  type === "date"
-                    ? "%Y-%m-%d"
-                    : type === "time"
-                      ? "%H:%M:%S"
-                      : "%Y-%m-%dT%H:%M:%S",
-                bin: true,
-                title: column,
+
+            // 0 opacity full-height bars with tooltips, since it is too hard to trigger
+            // the tooltip for very small bars.
+            {
+              mark: {
+                type: "bar",
+                opacity: 0,
               },
-              {
-                aggregate: "count",
-                type: "quantitative",
-                title: "Count",
-                format: ",d",
+              encoding: {
+                x: {
+                  field: column,
+                  type: "temporal",
+                  axis: null,
+                  bin: true,
+                  scale: scale,
+                },
+                y: { aggregate: "max", type: "quantitative", axis: null },
+                tooltip: [
+                  {
+                    field: column,
+                    type: "temporal",
+                    format:
+                      type === "date"
+                        ? "%Y-%m-%d"
+                        : type === "time"
+                          ? "%H:%M:%S"
+                          : "%Y-%m-%dT%H:%M:%S",
+                    bin: true,
+                    title: column,
+                  },
+                  {
+                    aggregate: "count",
+                    type: "quantitative",
+                    title: "Count",
+                    format: ",d",
+                  },
+                ],
+                // Color nulls
+                color: {
+                  condition: {
+                    test: `datum["bin_maxbins_10_${column}_range"] === "null"`,
+                    value: orange.orange11,
+                  },
+                  value: mint.mint11,
+                },
               },
-            ],
-            // Color nulls
-            color: {
-              condition: {
-                test: `datum["bin_maxbins_10_${column}_range"] === "null"`,
-                value: orange.orange11,
-              },
-              value: mint.mint11,
             },
-          },
+          ],
         };
       case "integer":
       case "number": {
@@ -158,15 +193,8 @@ export class ColumnChartSpecModel<T> {
 
         return {
           ...base, // Assuming base contains shared configurations
-          // @ts-expect-error 'layer' property is needed for layered visualization but not in TopLevelFacetedUnitSpec
           layer: [
-            // Layer 1: Regular data histogram
             {
-              transform: [
-                {
-                  filter: `datum['${column}'] !== null`,
-                },
-              ],
               mark: {
                 type: "bar",
                 color: mint.mint11,
@@ -183,6 +211,25 @@ export class ColumnChartSpecModel<T> {
                   type: "quantitative",
                   axis: null,
                 },
+              },
+            },
+            {
+              mark: {
+                type: "bar",
+                opacity: 0,
+              },
+              encoding: {
+                x: {
+                  field: column,
+                  type: "quantitative",
+                  bin: { maxbins: 10 },
+                  axis: null,
+                },
+                y: {
+                  aggregate: "max",
+                  type: "quantitative",
+                  axis: null,
+                },
                 tooltip: [
                   {
                     field: column,
@@ -195,40 +242,6 @@ export class ColumnChartSpecModel<T> {
                     aggregate: "count",
                     type: "quantitative",
                     title: "Count",
-                    format: ",d",
-                  },
-                ],
-              },
-            },
-            // Layer 2: Null values as separate bar
-            {
-              transform: [
-                {
-                  filter: `datum['${column}'] === null`,
-                },
-              ],
-              mark: {
-                type: "bar",
-                color: orange.orange11,
-                x: { offset: -15 }, // Offset to visually separate from main histogram
-              },
-              encoding: {
-                x: {
-                  value: 0, // Place at beginning of axis
-                },
-                y: {
-                  aggregate: "count",
-                  type: "quantitative",
-                },
-                tooltip: [
-                  {
-                    value: "Missing",
-                    title: column,
-                  },
-                  {
-                    aggregate: "count",
-                    type: "quantitative",
-                    title: "Null",
                     format: ",d",
                   },
                 ],

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -114,7 +114,7 @@ export class ColumnChartSpecModel<T> {
           ...base,
           // Two layers: one with the visible bars, and one with invisible bars
           // that provide a larger tooltip area.
-          // @ts-expect-error layer 
+          // @ts-expect-error 'layer' property not in TopLevelFacetedUnitSpec
           layer: [
             {
               mark: {
@@ -198,7 +198,7 @@ export class ColumnChartSpecModel<T> {
           ...base, // Assuming base contains shared configurations
           // Two layers: one with the visible bars, and one with invisible bars
           // that provide a larger tooltip area.
-          // @ts-expect-error layer
+          // @ts-expect-error 'layer' property not in TopLevelFacetedUnitSpec
           layer: [
             {
               mark: {

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -77,7 +77,7 @@ export class ColumnChartSpecModel<T> {
     };
   }
 
-  private getVegaSpec<T>(column: string): TopLevelSpec | null {
+  private getVegaSpec<T>(column: string): TopLevelFacetedUnitSpec | null {
     if (!this.data) {
       return null;
     }
@@ -112,6 +112,9 @@ export class ColumnChartSpecModel<T> {
       case "time":
         return {
           ...base,
+          // Two layers: one with the visible bars, and one with invisible bars
+          // that provide a larger tooltip area.
+          // @ts-expect-error layer 
           layer: [
             {
               mark: {
@@ -193,6 +196,9 @@ export class ColumnChartSpecModel<T> {
 
         return {
           ...base, // Assuming base contains shared configurations
+          // Two layers: one with the visible bars, and one with invisible bars
+          // that provide a larger tooltip area.
+          // @ts-expect-error layer
           layer: [
             {
               mark: {

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -158,6 +158,7 @@ export class ColumnChartSpecModel<T> {
 
         return {
           ...base, // Assuming base contains shared configurations
+          // @ts-expect-error 'layer' property is needed for layered visualization but not in TopLevelFacetedUnitSpec
           layer: [
             // Layer 1: Regular data histogram
             {

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -81,7 +81,6 @@ export const TableColumnSummary = <TData, TValue>({
               <span>min: {renderDate(summary.min, type)}</span>
               <span>max: {renderDate(summary.max, type)}</span>
               <span>unique: {prettyNumber(summary.unique)}</span>
-              <span>nulls: {prettyNumber(summary.nulls)}</span>
             </div>
           );
         }
@@ -113,7 +112,6 @@ export const TableColumnSummary = <TData, TValue>({
                   : summary.max}
               </span>
               <span>unique: {prettyNumber(summary.unique)}</span>
-              <span>nulls: {prettyNumber(summary.nulls)}</span>
             </div>
           );
         }
@@ -123,7 +121,7 @@ export const TableColumnSummary = <TData, TValue>({
           typeof summary.max === "number"
         ) {
           return (
-            <div className="flex justify-between w-full px-2 whitespace-pre">
+            <div className="flex justify-between w-full whitespace-pre">
               <span>{prettyScientificNumber(summary.min)}</span>
               {summary.min === summary.max ? null : (
                 <span>{prettyScientificNumber(summary.max)}</span>
@@ -149,22 +147,13 @@ export const TableColumnSummary = <TData, TValue>({
           );
         }
 
-        if (summary.nulls == null || summary.nulls === 0) {
-          return null;
-        }
-
-        return (
-          <div className="flex flex-col whitespace-pre">
-            <span>nulls: {prettyNumber(summary.nulls)}</span>
-          </div>
-        );
+        return null;
       case "time":
         return null;
       case "string":
         return (
           <div className="flex flex-col whitespace-pre">
             <span>unique: {prettyNumber(summary.unique)}</span>
-            <span>nulls: {prettyNumber(summary.nulls)}</span>
           </div>
         );
       case "unknown":

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -9,7 +9,7 @@ import {
 import { Checkbox } from "../ui/checkbox";
 import { isMimeValue, MimeCell } from "./mime-cell";
 import type { DataType } from "@/core/kernel/messages";
-import { ColumnChartContext, TableColumnSummary } from "./column-summary";
+import { TableColumnSummary } from "./column-summary";
 import type { FilterType } from "./filters";
 import {
   type DataTableSelection,
@@ -29,7 +29,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { EmotionCacheProvider } from "../editor/output/EmotionCacheProvider";
 import { PopoverClose } from "@radix-ui/react-popover";
 import { Button } from "../ui/button";
-import { useContext } from "react";
+import type { ColumnChartSpecModel } from "./chart-spec-model";
 
 function inferDataType(value: unknown): [type: DataType, displayType: string] {
   if (typeof value === "string") {
@@ -95,6 +95,7 @@ export function generateColumns<T>({
   rowHeaders,
   selection,
   fieldTypes,
+  chartSpecModel,
   textJustifyColumns,
   wrappedColumns,
   showDataTypes,
@@ -102,6 +103,7 @@ export function generateColumns<T>({
   rowHeaders: string[];
   selection: DataTableSelection;
   fieldTypes: FieldTypesWithExternalType;
+  chartSpecModel?: ColumnChartSpecModel<unknown>;
   textJustifyColumns?: Record<string, "left" | "center" | "right">;
   wrappedColumns?: string[];
   showDataTypes?: boolean;
@@ -151,8 +153,7 @@ export function generateColumns<T>({
       },
 
       header: ({ column }) => {
-        const chartSpecModel = useContext(ColumnChartContext);
-        const summary = chartSpecModel.getColumnSummary(key);
+        const summary = chartSpecModel?.getColumnSummary(key);
         const dtype = column.columnDef.meta?.dtype;
         const dtypeHeader =
           showDataTypes && dtype ? (

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -9,7 +9,7 @@ import {
 import { Checkbox } from "../ui/checkbox";
 import { isMimeValue, MimeCell } from "./mime-cell";
 import type { DataType } from "@/core/kernel/messages";
-import { TableColumnSummary } from "./column-summary";
+import { ColumnChartContext, TableColumnSummary } from "./column-summary";
 import type { FilterType } from "./filters";
 import {
   type DataTableSelection,
@@ -29,6 +29,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { EmotionCacheProvider } from "../editor/output/EmotionCacheProvider";
 import { PopoverClose } from "@radix-ui/react-popover";
 import { Button } from "../ui/button";
+import { useContext } from "react";
 
 function inferDataType(value: unknown): [type: DataType, displayType: string] {
   if (typeof value === "string") {
@@ -150,13 +151,27 @@ export function generateColumns<T>({
       },
 
       header: ({ column }) => {
+        const chartSpecModel = useContext(ColumnChartContext);
+        const summary = chartSpecModel.getColumnSummary(key);
         const dtype = column.columnDef.meta?.dtype;
+        const dtypeHeader =
+          showDataTypes && dtype ? (
+            <div className="flex flex-row gap-1">
+              <span className="text-xs text-muted-foreground">{dtype}</span>
+              {summary &&
+                typeof summary.nulls === "number" &&
+                summary.nulls > 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    (nulls: {summary.nulls})
+                  </span>
+                )}
+            </div>
+          ) : null;
+
         const headerWithType = (
           <div className="flex flex-col">
             <span className="font-bold">{key}</span>
-            {showDataTypes && dtype && (
-              <span className="text-xs text-muted-foreground">{dtype}</span>
-            )}
+            {dtypeHeader}
           </div>
         );
 

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -511,6 +511,7 @@ const DataTableComponent = ({
       generateColumns({
         rowHeaders: memoizedRowHeaders,
         selection: selection,
+        chartSpecModel: chartSpecModel,
         fieldTypes: memoizedFieldTypes,
         textJustifyColumns: memoizedTextJustifyColumns,
         wrappedColumns: memoizedWrappedColumns,


### PR DESCRIPTION
* Updates bar charts (histograms) to be quantitative instead of nominal. This fixes an issue in which bars were incorrectly spaced.
* Expands the tooltip areas for bars so that it is possible to view tooltips for even very short bars, using zero opacity full-height bars.

This change does modify how nulls are rendered. I was unable to find a way to robustly layer null counts with a quantitative histogram. Instead, this PR proposes including a count of nulls by the dtype in the header.

Nulls:

<img width="768" alt="image" src="https://github.com/user-attachments/assets/f047f8a9-9120-4bc1-97df-773af5d432c6" />


Before (incorrect spacing, should not be uniform):

![image](https://github.com/user-attachments/assets/a874b71f-d943-4802-96ba-b662a6ad54e5)


After:

![image](https://github.com/user-attachments/assets/95330f36-50eb-46ab-9ade-1a1ed390856e)

