### PR TITLE
improvement: default altair charts to full width, add typechecking

### DIFF
--- a/marimo/_data/charts.py
+++ b/marimo/_data/charts.py
@@ -20,7 +20,7 @@ class ChartBuilder:
         raise NotImplementedError
 
     def altair_json(self, data: Any, column: str) -> str:
-        import altair as alt  # type: ignore[import-not-found]
+        import altair as alt
 
         if alt.data_transformers.active.startswith("vegafusion"):
             return cast(str, self.altair(data, column).to_json(format="vega"))
@@ -40,7 +40,7 @@ class ChartParams:
 
 class NumberChartBuilder(ChartBuilder):
     def altair(self, data: Any, column: str) -> Any:
-        import altair as alt  # type: ignore[import-not-found]
+        import altair as alt
 
         return (
             alt.Chart(data)
@@ -73,7 +73,7 @@ class StringChartBuilder(ChartBuilder):
         super().__init__()
 
     def altair(self, data: Any, column: str) -> Any:
-        import altair as alt  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        import altair as alt
 
         if self.should_limit_to_10_items:
             return (
@@ -177,7 +177,7 @@ class DateChartBuilder(ChartBuilder):
             return "%Y-%m-%d %H:%M"  # Date and time (hours, minutes)
 
     def altair(self, data: Any, column: str) -> Any:
-        import altair as alt  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        import altair as alt
 
         return (
             alt.Chart(data)
@@ -218,7 +218,7 @@ class DateChartBuilder(ChartBuilder):
 
 class BooleanChartBuilder(ChartBuilder):
     def altair(self, data: Any, column: str) -> Any:
-        import altair as alt  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        import altair as alt
 
         return (
             alt.Chart(data)
@@ -247,7 +247,7 @@ class BooleanChartBuilder(ChartBuilder):
 
 class IntegerChartBuilder(ChartBuilder):
     def altair(self, data: Any, column: str) -> Any:
-        import altair as alt  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        import altair as alt
 
         return (
             alt.Chart(data)
@@ -276,7 +276,7 @@ class IntegerChartBuilder(ChartBuilder):
 
 class UnknownChartBuilder(ChartBuilder):
     def altair(self, data: Any, column: str) -> Any:
-        import altair as alt  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        import altair as alt
 
         return (
             alt.Chart(data)

--- a/marimo/_data/preview_column.py
+++ b/marimo/_data/preview_column.py
@@ -143,7 +143,7 @@ def get_column_preview_for_duckdb(
     should_limit_to_10_items = True
 
     if DependencyManager.altair.has():
-        from altair import MaxRowsError  # type: ignore[import-not-found]
+        from altair import MaxRowsError
 
         try:
             total_rows: int = wrapped_sql(
@@ -191,7 +191,7 @@ def _get_altair_chart(
     if not DependencyManager.altair.has() or not table.supports_altair():
         return None, None, False
 
-    from altair import MaxRowsError  # type: ignore[import-not-found]
+    from altair import MaxRowsError
 
     (column_type, _external_type) = table.get_field_type(request.column_name)
 
@@ -239,7 +239,7 @@ def _get_chart_spec(
     column_name: str,
     should_limit_to_10_items: bool,
 ) -> str:
-    import altair as alt  # type: ignore[import-not-found]
+    import altair as alt
 
     chart_builder = get_chart_builder(column_type, should_limit_to_10_items)
 

--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -8,6 +8,7 @@ from marimo._config.config import Theme
 from marimo._messaging.mimetypes import KnownMimeType, MimeBundleOrTuple
 from marimo._output.formatters.formatter_factory import FormatterFactory
 from marimo._plugins.core.media import io_to_data_url
+from marimo._plugins.ui._impl.altair_chart import maybe_make_full_width
 
 if TYPE_CHECKING:
     import altair  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
@@ -81,6 +82,8 @@ class AltairFormatter(FormatterFactory):
                 alt.data_transformers.options["max_rows"] = 20_000
 
             chart = _apply_embed_options(chart)
+
+            chart = maybe_make_full_width(chart)
 
             # Return the chart as a vega-lite chart with embed options
             return (

--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -11,7 +11,7 @@ from marimo._plugins.core.media import io_to_data_url
 from marimo._plugins.ui._impl.altair_chart import maybe_make_full_width
 
 if TYPE_CHECKING:
-    import altair  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+    import altair
 
 
 class AltairFormatter(FormatterFactory):
@@ -20,7 +20,7 @@ class AltairFormatter(FormatterFactory):
         return "altair"
 
     def register(self) -> None:
-        import altair  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+        import altair
 
         from marimo._output import formatting
         from marimo._plugins.ui._impl.charts.altair_transformer import (

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -34,7 +34,7 @@ from marimo._utils.narwhals_utils import (
 LOGGER = _loggers.marimo_logger()
 
 if TYPE_CHECKING:
-    import altair  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+    import altair
 
 # Selection is a dictionary of the form:
 # {
@@ -369,7 +369,7 @@ class altair_chart(UIElement[ChartSelection, ChartDataType]):
             )
             chart_selection = False
             legend_selection = False
-        if _has_geoshape(vega_spec) and (has_chart_selection):
+        if _has_geoshape(chart) and (has_chart_selection):
             sys.stderr.write(
                 "Geoshapes + chart selection is not yet supported in "
                 "marimo.ui.chart.\n"
@@ -431,7 +431,7 @@ class altair_chart(UIElement[ChartSelection, ChartDataType]):
 
         import altair
 
-        if chart.data is altair.Undefined:
+        if chart.data is altair.Undefined:  # type: ignore[comparison-overlap]
             return None
 
         return cast(ChartDataType, chart.data)

--- a/marimo/_plugins/ui/_impl/charts/altair_transformer.py
+++ b/marimo/_plugins/ui/_impl/charts/altair_transformer.py
@@ -96,14 +96,14 @@ def _to_marimo_inline_csv(data: Data, **kwargs: Any) -> _TransformResult:
 # Copied from https://github.com/altair-viz/altair/blob/0ca83784e2455f2b84d0f6d789af2abbe8814348/altair/utils/data.py#L263C1-L288C10
 def _data_to_json_string(data: _DataType) -> str:
     """Return a JSON string representation of the input data"""
-    import altair as alt  # type: ignore[import-not-found,import-untyped,unused-ignore] # noqa: E501
+    import altair as alt
     import pandas as pd
 
     if isinstance(data, pd.DataFrame):
         if "sanitize_pandas_dataframe" in dir(alt.utils):
-            sanitized = alt.utils.sanitize_pandas_dataframe(data)
+            sanitized = alt.utils.sanitize_pandas_dataframe(data)  # type: ignore[attr-defined]
         elif "sanitize_dataframe" in dir(alt.utils):
-            sanitized = alt.utils.sanitize_dataframe(data)
+            sanitized = alt.utils.sanitize_dataframe(data)  # type: ignore[attr-defined]
         else:
             raise NotImplementedError(
                 "No sanitize_pandas_dataframe or "
@@ -152,8 +152,8 @@ def register_transformers() -> None:
 
     # Default to CSV. Due to the columnar nature of CSV, it is more efficient
     # than JSON for large datasets (~80% smaller file size).
-    alt.data_transformers.register("marimo", _to_marimo_csv)
-    alt.data_transformers.register("marimo_inline_csv", _to_marimo_inline_csv)
-    alt.data_transformers.register("marimo_json", _to_marimo_json)
-    alt.data_transformers.register("marimo_csv", _to_marimo_csv)
-    alt.data_transformers.register("marimo_arrow", _to_marimo_arrow)
+    alt.data_transformers.register("marimo", _to_marimo_csv)  # type: ignore[arg-type]
+    alt.data_transformers.register("marimo_inline_csv", _to_marimo_inline_csv)  # type: ignore[arg-type]
+    alt.data_transformers.register("marimo_json", _to_marimo_json)  # type: ignore[arg-type]
+    alt.data_transformers.register("marimo_csv", _to_marimo_csv)  # type: ignore[arg-type]
+    alt.data_transformers.register("marimo_arrow", _to_marimo_arrow)  # type: ignore[arg-type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ installer = "uv"
 dependencies = [
     "mypy~=1.15.0",
     # Types for mypy
+    "altair>=5.4.0",
     "leafmap~=0.39.2",
     "panel~=1.5.3",
     "polars~=1.9.0",

--- a/tests/_output/formatters/test_altair_formatters.py
+++ b/tests/_output/formatters/test_altair_formatters.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._output.formatters.altair_formatters import AltairFormatter
+from marimo._output.formatters.formatters import register_formatters
+from marimo._output.formatting import get_formatter
+from marimo._plugins.ui._impl.altair_chart import maybe_make_full_width
+
+HAS_DEPS = DependencyManager.altair.has() and DependencyManager.polars.has()
+
+
+def get_data():
+    import polars as pl
+
+    return pl.DataFrame(
+        {
+            "Horsepower": [100, 150, 200],
+            "Miles_per_Gallon": [20, 25, 30],
+            "Origin": ["USA", "Europe", "Asia"],
+        }
+    )
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="altair not installed")
+def test_altair_formatter_registration():
+    register_formatters()
+
+    import altair as alt
+
+    cars = get_data()
+    chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+    )
+
+    formatter = get_formatter(chart)
+    assert formatter is not None
+    mime, content = formatter(chart)
+    assert mime == "application/vnd.vegalite.v5+json"
+    assert isinstance(content, str)
+    # Verify it's valid JSON
+    json_content = json.loads(content)
+    assert "data" in json_content
+    assert "mark" in json_content
+    assert "encoding" in json_content
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="altair not installed")
+@patch("marimo._output.formatters.altair_formatters.maybe_make_full_width")
+def test_altair_formatter_full_width(mock_make_full_width: MagicMock):
+    AltairFormatter().register()
+
+    mock_make_full_width.side_effect = maybe_make_full_width
+
+    import altair as alt
+
+    cars = get_data()
+    chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+        )
+    )
+
+    mock_make_full_width.return_value = chart
+
+    formatter = get_formatter(chart)
+    assert formatter is not None
+    res = formatter(chart)
+    assert res is not None
+    mime, content = res
+    assert mime == "application/vnd.vegalite.v5+json"
+    assert isinstance(content, str)
+    assert "container" in content
+
+    # Verify maybe_make_full_width was called
+    mock_make_full_width.assert_called_once()
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="altair not installed")
+def test_altair_formatter_mimebundle():
+    AltairFormatter().register()
+
+    import altair as alt
+
+    # Create a mock chart with a _repr_mimebundle_ method that returns multiple mime types
+    mock_chart = MagicMock(spec=alt.Chart)
+    mock_chart._repr_mimebundle_.return_value = {
+        "image/svg+xml": "<svg></svg>",
+        "application/vnd.vegalite.v5+json": json.dumps({"test": "data"}),
+    }
+
+    formatter = get_formatter(mock_chart)
+    assert formatter is not None
+    mime, content = formatter(mock_chart)
+
+    # Should return a mimebundle with both types
+    assert mime == "application/vnd.marimo+mimebundle"
+    mimebundle = json.loads(content)
+    assert "image/svg+xml" in mimebundle
+    assert "application/vnd.vegalite.v5+json" in mimebundle
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="altair not installed")
+def test_altair_formatter_svg():
+    AltairFormatter().register()
+
+    import altair as alt
+
+    # Create a mock chart with a _repr_mimebundle_ method that returns SVG
+    mock_chart = MagicMock(spec=alt.Chart)
+    mock_chart._repr_mimebundle_.return_value = {
+        "image/svg+xml": "<svg></svg>"
+    }
+
+    formatter = get_formatter(mock_chart)
+    assert formatter is not None
+    mime, content = formatter(mock_chart)
+
+    assert mime == "image/svg+xml"
+    assert content == "<svg></svg>"


### PR DESCRIPTION
This defaults the altair charts to be full-width when a width is not given. While it is opinionated, i think it looks much better. 

This can be ignore by providing an actual width. 

This also adds typechecking for altair in our codebase