### PR TITLE
improve: show column summary histogram axes

### DIFF
--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -23,10 +23,7 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
     {
       "encoding": {
         "x": {
-          "axis": null,
-          "bin": {
-            "maxbins": 10,
-          },
+          "bin": true,
           "field": "a",
           "type": "quantitative",
         },
@@ -59,10 +56,11 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
           },
         ],
         "x": {
-          "axis": null,
-          "bin": {
-            "maxbins": 10,
+          "axis": {
+            "labelFontSize": 8,
+            "title": null,
           },
+          "bin": true,
           "field": "a",
           "type": "quantitative",
         },
@@ -111,10 +109,7 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
     {
       "encoding": {
         "x": {
-          "axis": null,
-          "bin": {
-            "maxbins": 10,
-          },
+          "bin": true,
           "field": "a",
           "type": "quantitative",
         },
@@ -147,10 +142,11 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
           },
         ],
         "x": {
-          "axis": null,
-          "bin": {
-            "maxbins": 10,
+          "axis": {
+            "labelFontSize": 8,
+            "title": null,
           },
+          "bin": true,
           "field": "a",
           "type": "quantitative",
         },
@@ -199,10 +195,7 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
     {
       "encoding": {
         "x": {
-          "axis": null,
-          "bin": {
-            "maxbins": 10,
-          },
+          "bin": true,
           "field": "a",
           "type": "quantitative",
         },
@@ -235,10 +228,11 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
           },
         ],
         "x": {
-          "axis": null,
-          "bin": {
-            "maxbins": 10,
+          "axis": {
+            "labelFontSize": 8,
+            "title": null,
           },
+          "bin": true,
           "field": "a",
           "type": "quantitative",
         },

--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -57,6 +57,7 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
         ],
         "x": {
           "axis": {
+            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : datum.value",
             "labelFontSize": 8,
             "title": null,
           },
@@ -143,6 +144,7 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
         ],
         "x": {
           "axis": {
+            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : datum.value",
             "labelFontSize": 8,
             "title": null,
           },
@@ -229,6 +231,7 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
         ],
         "x": {
           "axis": {
+            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : datum.value",
             "labelFontSize": 8,
             "title": null,
           },

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -230,7 +230,12 @@ export class ColumnChartSpecModel<T> {
                   field: column,
                   type: "quantitative",
                   bin: true,
-                  axis: { title: null, labelFontSize: 8 },
+                  axis: {
+                    title: null,
+                    labelFontSize: 8,
+                    labelExpr:
+                      "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : datum.value",
+                  },
                 },
                 y: {
                   aggregate: "max",

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -209,8 +209,7 @@ export class ColumnChartSpecModel<T> {
                 x: {
                   field: column,
                   type: "quantitative",
-                  bin: { maxbins: 10 },
-                  axis: null,
+                  bin: true,
                 },
                 y: {
                   aggregate: "count",
@@ -219,6 +218,8 @@ export class ColumnChartSpecModel<T> {
                 },
               },
             },
+
+            // Tooltip layer
             {
               mark: {
                 type: "bar",
@@ -228,8 +229,8 @@ export class ColumnChartSpecModel<T> {
                 x: {
                   field: column,
                   type: "quantitative",
-                  bin: { maxbins: 10 },
-                  axis: null,
+                  bin: true,
+                  axis: { title: null, labelFontSize: 8 },
                 },
                 y: {
                   aggregate: "max",

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -116,26 +116,8 @@ export const TableColumnSummary = <TData, TValue>({
           );
         }
 
-        if (
-          typeof summary.min === "number" &&
-          typeof summary.max === "number"
-        ) {
-          return (
-            <div className="flex justify-between w-full whitespace-pre">
-              <span>{prettyScientificNumber(summary.min)}</span>
-              {summary.min === summary.max ? null : (
-                <span>{prettyScientificNumber(summary.max)}</span>
-              )}
-            </div>
-          );
-        }
-
-        return (
-          <div className="flex justify-between w-full px-2 whitespace-pre">
-            <span>{summary.min}</span>
-            <span>{summary.max}</span>
-          </div>
-        );
+        // Numerical bar charts use built-in vega axis and ticks
+        return null;
       case "boolean":
         // Without a chart
         if (!spec) {


### PR DESCRIPTION
For numerical histograms in column summaries, this PR renders the x-axis with Vega. This makes plots more legible, especially when histograms are sparse.

Some examples:

<img width="549" alt="image" src="https://github.com/user-attachments/assets/8e691c75-6baa-4f43-9178-f4603006b33a" />

<img width="295" alt="image" src="https://github.com/user-attachments/assets/a8dee425-098b-450f-8495-4eb6800f930e" />

Large numbers:

<img width="111" alt="image" src="https://github.com/user-attachments/assets/f85daedb-6f6a-425a-b0e5-d8031517f507" />
