### PR TITLE
fix: getting stuck waiting for socket to connect

### DIFF
--- a/marimo/_server/utils.py
+++ b/marimo/_server/utils.py
@@ -44,6 +44,7 @@ def find_free_port(port: int, attempts: int = 100) -> int:
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         try:
+            sock.settimeout(0.1)
             in_use = sock.connect_ex(("localhost", port)) == 0
             if not in_use:
                 return port


### PR DESCRIPTION
## 📝 Summary

Fixes one of the potential causes for #4067 

## 🔍 Description of Changes

Marimo was getting completely stuck for me, waiting for a timeout that [will never happen](https://docs.python.org/3/library/socket.html#notes-on-socket-timeouts).

(At least for WSL - I have no idea if it worked in other OS, but if it did, I'm confused as for why that was not a problem)

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick suggested looking into that function in the linked issue 
