### PR TITLE
improv: privatize mime bundle

### DIFF
--- a/frontend/src/components/data-table/__tests__/columns.test.tsx
+++ b/frontend/src/components/data-table/__tests__/columns.test.tsx
@@ -287,6 +287,12 @@ describe("getMimeValues", () => {
     expect(getMimeValues(value)).toEqual([mimeValue]);
   });
 
+  it("should return array with MimeValue when input has _serialized_mime_bundle", () => {
+    const mimeValue = { mimetype: "text/plain", data: "test data" };
+    const value = { _serialized_mime_bundle: mimeValue };
+    expect(getMimeValues(value)).toEqual([mimeValue]);
+  });
+
   it("should return array of MimeValues when input is an array of MimeValues", () => {
     const values = [
       { mimetype: "text/plain", data: "test data 1" },
@@ -313,6 +319,12 @@ describe("getMimeValues", () => {
   it("should return undefined for invalid serialized_mime_bundle", () => {
     expect(
       getMimeValues({ serialized_mime_bundle: "not a mime value" }),
+    ).toBeUndefined();
+  });
+
+  it("should return undefined for invalid _serialized_mime_bundle", () => {
+    expect(
+      getMimeValues({ _serialized_mime_bundle: "not a mime value" }),
     ).toBeUndefined();
   });
 

--- a/frontend/src/components/data-table/mime-cell.tsx
+++ b/frontend/src/components/data-table/mime-cell.tsx
@@ -44,10 +44,12 @@ export function getMimeValues(value: unknown): MimeValue[] | undefined {
   const hasSerializedMimeBundle =
     typeof value === "object" &&
     value !== null &&
-    "serialized_mime_bundle" in value;
+    ("_serialized_mime_bundle" in value || "serialized_mime_bundle" in value);
 
   if (hasSerializedMimeBundle) {
-    const serializedMimeBundle = value.serialized_mime_bundle;
+    const obj = value as Record<string, unknown>;
+    const serializedMimeBundle =
+      obj._serialized_mime_bundle || obj.serialized_mime_bundle;
     if (isMimeValue(serializedMimeBundle)) {
       return [serializedMimeBundle];
     }

--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -92,8 +92,8 @@ class Html(MIME):
             "data": data,
         }
         # Whenever _serialized_mime_bundle is set, ensure a public copy exists.
-        # This avoids declaring a public attribute in the class definition
-        # Pandas does not serialize private variables, so we need a public copy.
+        # This avoids declaring a public attribute (does not show up in docs)
+        # Pandas does not serialize private variables, so we need this.
         self.__setattr__(
             "serialized_mime_bundle", self._serialized_mime_bundle
         )

--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -86,10 +86,17 @@ class Html(MIME):
         """
         self._text = text
         mimetype, data = self._mime_()
+
         self._serialized_mime_bundle = {
             "mimetype": mimetype,
             "data": data,
         }
+        # Whenever _serialized_mime_bundle is set, ensure a public copy exists.
+        # This avoids declaring a public attribute in the class definition
+        # Pandas does not serialize private variables, so we need a public copy.
+        self.__setattr__(
+            "serialized_mime_bundle", self._serialized_mime_bundle
+        )
 
         # A list of the virtual file names referenced by this HTML element.
         self._virtual_filenames: list[str] = []
@@ -280,14 +287,6 @@ class Html(MIME):
 
     def _repr_html_(self) -> str:
         return self.text
-
-    def __setattr__(self, name, value) -> None:
-        super().__setattr__(name, value)
-        # HACK: Whenever _serialized_mime_bundle is set, ensure a public copy exists.
-        # This avoids declaring a public attribute in the class definition (to not show up in docs)
-        # Pandas does not serialize private variables, so we need a public copy.
-        if name == "_serialized_mime_bundle":
-            super().__setattr__("serialized_mime_bundle", value)
 
 
 def _js(text: str) -> Html:

--- a/marimo/_smoke_tests/tables/rich_elements.py
+++ b/marimo/_smoke_tests/tables/rich_elements.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.11.24"
+__generated_with = "0.11.26"
 app = marimo.App(width="medium")
 
 

--- a/tests/_output/test_hypertext.py
+++ b/tests/_output/test_hypertext.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.hypertext import (
     Html,
     _js,
@@ -7,6 +10,7 @@ from marimo._output.hypertext import (
 )
 from marimo._plugins.ui._impl.batch import batch as batch_plugin
 from marimo._plugins.ui._impl.input import button
+from marimo._plugins.ui._impl.table import table
 
 
 def test_html_initialization():
@@ -210,3 +214,38 @@ def test_html_patch_for_non_interactive_output():
         "text/html",
         "<web-component>Hello</web-component>",
     )
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has() or not DependencyManager.pandas.has(),
+    reason="Pandas and Polars not installed",
+)
+def test_html_rich_elems():
+    tbl = table({"button": button()})
+    html = Html(tbl)
+
+    assert isinstance(html._serialized_mime_bundle, dict)
+    assert html._serialized_mime_bundle == {
+        "mimetype": "text/html",
+        "data": tbl,
+    }
+
+    import pandas as pd
+
+    df = pd.DataFrame({"button": [button()]})
+    html = Html(df)
+    # ensure public copy exists
+    assert hasattr(html, "serialized_mime_bundle") is True
+    assert html.serialized_mime_bundle == {
+        "mimetype": "text/html",
+        "data": df,
+    }
+
+    import polars as pl
+
+    df = pl.DataFrame({"button": button()})
+    html = Html(df)
+    assert html._serialized_mime_bundle == {
+        "mimetype": "text/html",
+        "data": df,
+    }

--- a/tests/_output/test_hypertext.py
+++ b/tests/_output/test_hypertext.py
@@ -20,7 +20,7 @@ def test_html_mime():
     assert mime_type == "text/html"
     assert content == "<p>Test</p>"
 
-    assert html.serialized_mime_bundle == {
+    assert html._serialized_mime_bundle == {
         "mimetype": "text/html",
         "data": "<p>Test</p>",
     }


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
`serialized_mime_bundle` shows up in API docs since it's treated as a public attribute. This PR makes it private and hacks around to create a public copy.

example: https://docs.marimo.io/api/inputs/button/

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
