### PR TITLE
fix: change back to csv parsing for data editor

### DIFF
--- a/frontend/src/plugins/impl/DataEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/DataEditorPlugin.tsx
@@ -14,6 +14,8 @@ import gridCss from "./data-editor/grid.css?inline";
 import agGridCss from "ag-grid-community/styles/ag-grid.css?inline";
 import agThemeCss from "ag-grid-community/styles/ag-theme-quartz.css?inline";
 import { DATA_TYPES } from "@/core/kernel/messages";
+import { toFieldTypes } from "@/components/data-table/types";
+import { getVegaFieldTypes } from "./vega/utils";
 
 type CsvURL = string;
 type TableData<T> = T[] | CsvURL;
@@ -90,10 +92,12 @@ const LoadingDataEditor = (props: Props) => {
       return props.data;
     }
 
+    const withoutExternalTypes = toFieldTypes(props.fieldTypes ?? []);
+
     // Otherwise, load the data from the URL
     return await vegaLoadData(
       props.data,
-      { type: "json" },
+      { type: "csv", parse: getVegaFieldTypes(withoutExternalTypes) },
       { handleBigIntAndNumberLike: true },
     );
   }, [props.fieldTypes, props.data]);

--- a/marimo/_smoke_tests/tables/rich_elements.py
+++ b/marimo/_smoke_tests/tables/rich_elements.py
@@ -193,5 +193,26 @@ def _(mo):
     return
 
 
+@app.cell
+def _(mo, pd, pl):
+    pd.DataFrame({"button": [mo.ui.button()]})
+
+    pl.DataFrame({"button": mo.ui.button()})
+    mo.ui.table({"button": mo.ui.button()})
+    return
+
+
+@app.cell
+def _(data, mo):
+    mo.ui.experimental_data_editor(data=data, label="Edit Data")
+    return
+
+
+@app.cell
+def _(data, mo):
+    mo.ui.data_explorer(data)
+    return
+
+
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #4226 . Revert back to csv on the frontend. I could change to json on the backend, but json doesn't work as well for data editor.

<img width="612" alt="image" src="https://github.com/user-attachments/assets/07dda135-7122-4b4d-bfa2-73eed364f94e" />

I am also checking if we can make the vegaLoader smarter (doesn't need to know format / will correct the format when needed)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka  or @mscolnick
