### PR TITLE
fix: don't round slider if not in scientific notation 

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/marimo-bot.yml
+++ b/.github/workflows/marimo-bot.yml
@@ -77,7 +77,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,7 +58,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -22,6 +22,7 @@ jobs:
           filters: |
             backend:
               - 'marimo/**'
+              - '!marimo/_smoke_tests/**'
               - 'tests/**'
               - 'pyproject.toml'
             docs:

--- a/.github/workflows/test_be_dagger.yaml.skip
+++ b/.github/workflows/test_be_dagger.yaml.skip
@@ -18,6 +18,7 @@ jobs:
           filters: |
             backend:
               - 'marimo/**'
+              - '!marimo/_smoke_tests/**'
               - 'tests/**'
               - 'pyproject.toml'
               - 'dagger/**'

--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/.github/workflows/test_fe.yaml
+++ b/.github/workflows/test_fe.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/frontend/src/components/data-table/__tests__/column_formatting.test.ts
+++ b/frontend/src/components/data-table/__tests__/column_formatting.test.ts
@@ -41,7 +41,7 @@ describe("applyFormat", () => {
       expect(applyFormat(number, "Auto", "number")).toBe("1,234.57");
       expect(applyFormat(number, "Percent", "number")).toBe("123,456.7%");
       expect(applyFormat(number, "Scientific", "number")).toBe(
-        prettyScientificNumber(1234.567),
+        prettyScientificNumber(1234.567, { shouldRound: true }),
       );
       expect(applyFormat(number, "Engineering", "number")).toBe(
         prettyEngineeringNumber(1234.567),

--- a/frontend/src/components/data-table/column-formatting/feature.ts
+++ b/frontend/src/components/data-table/column-formatting/feature.ts
@@ -144,7 +144,7 @@ export const applyFormat = (
         case "Percent":
           return percentFormatter.format(num);
         case "Scientific":
-          return prettyScientificNumber(num);
+          return prettyScientificNumber(num, { shouldRound: true });
         case "Engineering":
           return prettyEngineeringNumber(num);
         case "Integer":

--- a/frontend/src/components/data-table/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary.tsx
@@ -102,13 +102,13 @@ export const TableColumnSummary = <TData, TValue>({
               <span>
                 min:{" "}
                 {typeof summary.min === "number"
-                  ? prettyScientificNumber(summary.min)
+                  ? prettyScientificNumber(summary.min, { shouldRound: true })
                   : summary.min}
               </span>
               <span>
                 max:{" "}
                 {typeof summary.max === "number"
-                  ? prettyScientificNumber(summary.max)
+                  ? prettyScientificNumber(summary.max, { shouldRound: true })
                   : summary.max}
               </span>
               <span>unique: {prettyNumber(summary.unique)}</span>

--- a/frontend/src/utils/__tests__/numbers.test.ts
+++ b/frontend/src/utils/__tests__/numbers.test.ts
@@ -22,20 +22,30 @@ describe("prettyScientificNumber", () => {
     expect(prettyScientificNumber(Number.NEGATIVE_INFINITY)).toBe("-Infinity");
   });
 
-  it("should format decimals with scientific notation, ignoring integer part", () => {
+  it("should format decimals with scientific notation, ignoring integer part rounding", () => {
+    const opts = { shouldRound: true };
+    expect(prettyScientificNumber(123_456, opts)).toBe("123,456");
+    expect(prettyScientificNumber(123_456.7, opts)).toBe("123,456.7");
+    expect(prettyScientificNumber(12_345.6789, opts)).toBe("12,345.68");
+    expect(prettyScientificNumber(1.2345, opts)).toBe("1.23");
+    expect(prettyScientificNumber(1.000_001_234, opts)).toBe("1");
+    expect(prettyScientificNumber(0.12, opts)).toBe("0.12");
+    expect(prettyScientificNumber(0.1234, opts)).toBe("0.12");
+    expect(prettyScientificNumber(0.000_123_4, opts)).toBe("1.2e-4");
+    expect(prettyScientificNumber(-1.2345, opts)).toBe("-1.23"); // Test with negative numbers
+    expect(prettyScientificNumber(-1.000_001_234, opts)).toBe("-1");
+    expect(prettyScientificNumber(-0.12, opts)).toBe("-0.12");
+    expect(prettyScientificNumber(-0.1234, opts)).toBe("-0.12");
+    expect(prettyScientificNumber(-0.000_123_4, opts)).toBe("-1.2e-4");
+  });
+
+  it("should not round numbers when shouldRound is false", () => {
     expect(prettyScientificNumber(123_456)).toBe("123,456");
     expect(prettyScientificNumber(123_456.7)).toBe("123,456.7");
-    expect(prettyScientificNumber(12_345.6789)).toBe("12,345.68");
-    expect(prettyScientificNumber(1.2345)).toBe("1.23");
-    expect(prettyScientificNumber(1.000_001_234)).toBe("1");
-    expect(prettyScientificNumber(0.12)).toBe("0.12");
-    expect(prettyScientificNumber(0.1234)).toBe("0.12");
-    expect(prettyScientificNumber(0.000_123_4)).toBe("1.2e-4");
-    expect(prettyScientificNumber(-1.2345)).toBe("-1.23"); // Test with negative numbers
-    expect(prettyScientificNumber(-1.000_001_234)).toBe("-1");
-    expect(prettyScientificNumber(-0.12)).toBe("-0.12");
-    expect(prettyScientificNumber(-0.1234)).toBe("-0.12");
-    expect(prettyScientificNumber(-0.000_123_4)).toBe("-1.2e-4");
+    expect(prettyScientificNumber(12_345.6789)).toBe("12,345.6789");
+    expect(prettyScientificNumber(1.234_567_891_011_12)).toBe(
+      "1.23456789101112",
+    );
   });
 });
 

--- a/frontend/src/utils/numbers.ts
+++ b/frontend/src/utils/numbers.ts
@@ -76,10 +76,17 @@ export function prettyScientificNumber(
   }
 
   // Don't round
-  return new Intl.NumberFormat(undefined, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 100,
-  }).format(value);
+  try {
+    return new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 100,
+    }).format(value);
+  } catch {
+    return new Intl.NumberFormat("en-us", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 100,
+    }).format(value);
+  }
 }
 
 const prefixes = {

--- a/frontend/src/utils/numbers.ts
+++ b/frontend/src/utils/numbers.ts
@@ -76,10 +76,10 @@ export function prettyScientificNumber(
   }
 
   // Don't round
-  return new Intl.NumberFormat(undefined, {
+  return value.toLocaleString(undefined, {
     minimumFractionDigits: 0,
-    maximumFractionDigits: 30,
-  }).format(value);
+    maximumFractionDigits: 100,
+  });
 }
 
 const prefixes = {

--- a/frontend/src/utils/numbers.ts
+++ b/frontend/src/utils/numbers.ts
@@ -76,17 +76,10 @@ export function prettyScientificNumber(
   }
 
   // Don't round
-  try {
-    return new Intl.NumberFormat(undefined, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 100,
-    }).format(value);
-  } catch {
-    return new Intl.NumberFormat("en-us", {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 100,
-    }).format(value);
-  }
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 30,
+  }).format(value);
 }
 
 const prefixes = {

--- a/frontend/src/utils/numbers.ts
+++ b/frontend/src/utils/numbers.ts
@@ -40,7 +40,13 @@ function scientificSpecialCase(value: number): string | null {
   return null;
 }
 
-export function prettyScientificNumber(value: number): string {
+export function prettyScientificNumber(
+  value: number,
+  opts: {
+    // Default to false
+    shouldRound?: boolean;
+  } = {},
+): string {
   // Handle special cases first
   const specialCase = scientificSpecialCase(value);
   if (specialCase !== null) {
@@ -59,13 +65,21 @@ export function prettyScientificNumber(value: number): string {
       .toLowerCase();
   }
 
-  // Number has an integer part, format with 2 decimal places
-  const formatter = new Intl.NumberFormat(undefined, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  });
+  const { shouldRound } = opts;
 
-  return formatter.format(value);
+  if (shouldRound) {
+    // Number has an integer part, format with 2 decimal places
+    return new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
+  // Don't round
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 100,
+  }).format(value);
 }
 
 const prefixes = {

--- a/marimo/_smoke_tests/inputs/sliders.py
+++ b/marimo/_smoke_tests/inputs/sliders.py
@@ -1,0 +1,42 @@
+import marimo
+
+__generated_with = "0.11.26"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    # Precision should be accurate, no rounding
+    mo.ui.slider(
+        label="1/1000 precision value",
+        start=0,
+        stop=0.1,
+        step=0.001,
+        value=0.025,
+        show_value=True,
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    # Precision should be accurate, no rounding
+    mo.ui.slider(
+        label="1/1000 precision value",
+        start=0,
+        stop=0.0001,
+        step=0.000001,
+        value=0.000025,
+        show_value=True,
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #4229

Don't round the slider when not scientific 