### PR TITLE
Styling cells

### DIFF
--- a/examples/ui/table_advanced.py
+++ b/examples/ui/table_advanced.py
@@ -7,7 +7,7 @@
 
 import marimo
 
-__generated_with = "0.10.6"
+__generated_with = "0.11.26"
 app = marimo.App()
 
 
@@ -96,6 +96,51 @@ def _(mo, office_characters):
 
     table
     return (table,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""**Select individual cells**""")
+    return
+
+
+@app.cell
+def _(mo):
+    data = {str(col): [col * 10 + row for row in range(10)] for col in range(10)}
+    mo.ui.table(data, selection="multi-cell", initial_selection=[("3", "5"),("9","8")])
+    return (data,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""**Style individual cells**""")
+    return
+
+
+@app.cell
+def _(mo):
+    def apply_styling(row_id, column_name, value):
+        row = int(row_id)
+        column = int(column_name)
+        r = row / 8 * 12
+        g = column / 2 * 32
+        b = (row + column) / 10 * 16
+        return {
+            "backgroundColor": f"rgb({r % 256}, {g % 256}, {b % 256})",
+            "color": "white"
+            if (r * 0.299 + g * 0.587 + b * 0.114) < 186
+            else "black",
+        }
+
+
+    colors = {
+        str(col): [row * 20 + col  for row in range(320)] for col in range(10)
+    }
+    color_table = mo.ui.table(
+        data=colors, pagination=True, page_size=16, style_cell=apply_styling
+    )
+    color_table
+    return apply_styling, color_table, colors
 
 
 @app.cell
@@ -223,6 +268,11 @@ def _(mo):
         },
     ]
     return (office_characters,)
+
+
+@app.cell
+def _():
+    return
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/data-table/cell-styling/feature.ts
+++ b/frontend/src/components/data-table/cell-styling/feature.ts
@@ -11,13 +11,21 @@ import type {
   InitialTableState,
 } from "@tanstack/react-table";
 
-import type { CellStylingTableState } from "./types";
+import type { CellStyleState, CellStylingTableState } from "./types";
+import { INDEX_COLUMN_NAME } from "../types";
+
+function getRowId<TData>(row: Row<TData>): string {
+  if (row && typeof row === "object" && INDEX_COLUMN_NAME in row) {
+    return String(row[INDEX_COLUMN_NAME]);
+  }
+  return row.id;
+}
 
 export const CellStylingFeature: TableFeature = {
   getInitialState: (state?: InitialTableState): CellStylingTableState => {
     return {
       ...state,
-      cellStyling: [] as React.CSSProperties[][],
+      cellStyling: {} as CellStyleState,
     };
   },
 
@@ -27,18 +35,10 @@ export const CellStylingFeature: TableFeature = {
     row: Row<TData>,
     table: Table<TData>,
   ) => {
-    const state = table.getState().cellStyling;
-
     cell.getUserStyling = () => {
-      if (row.index < state.length) {
-        const rowStyling = state[row.index];
-        const columnIdx = column.getIndex();
-        if (columnIdx < rowStyling.length) {
-          return rowStyling[columnIdx];
-        }
-      }
-
-      return {};
+      const state = table.getState().cellStyling;
+      const rowId = getRowId(row);
+      return state[rowId]?.[column.id] || {};
     };
   },
 };

--- a/frontend/src/components/data-table/cell-styling/feature.ts
+++ b/frontend/src/components/data-table/cell-styling/feature.ts
@@ -1,0 +1,44 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+"use no memo";
+
+import type {
+  Table,
+  Cell,
+  Column,
+  Row,
+  RowData,
+  TableFeature,
+  InitialTableState,
+} from "@tanstack/react-table";
+
+import type { CellStylingTableState } from "./types";
+
+export const CellStylingFeature: TableFeature = {
+  getInitialState: (state?: InitialTableState): CellStylingTableState => {
+    return {
+      ...state,
+      cellStyling: [] as React.CSSProperties[][],
+    };
+  },
+
+  createCell: <TData extends RowData>(
+    cell: Cell<TData, unknown>,
+    column: Column<TData>,
+    row: Row<TData>,
+    table: Table<TData>,
+  ) => {
+    const state = table.getState().cellStyling;
+
+    cell.getUserStyling = () => {
+      if (row.index < state.length) {
+        const rowStyling = state[row.index];
+        const columnIdx = column.getIndex();
+        if (columnIdx < rowStyling.length) {
+          return rowStyling[columnIdx];
+        }
+      }
+
+      return {};
+    };
+  },
+};

--- a/frontend/src/components/data-table/cell-styling/feature.ts
+++ b/frontend/src/components/data-table/cell-styling/feature.ts
@@ -38,7 +38,7 @@ export const CellStylingFeature: TableFeature = {
     cell.getUserStyling = () => {
       const state = table.getState().cellStyling;
       const rowId = getRowId(row);
-      return state[rowId]?.[column.id] || {};
+      return state?.[rowId]?.[column.id] || {};
     };
   },
 };

--- a/frontend/src/components/data-table/cell-styling/types.ts
+++ b/frontend/src/components/data-table/cell-styling/types.ts
@@ -8,7 +8,7 @@ export type CellStyleState = Record<
 >;
 
 export interface CellStylingTableState {
-  cellStyling: CellStyleState;
+  cellStyling: CellStyleState | undefined;
 }
 
 export interface CellStylingCell {

--- a/frontend/src/components/data-table/cell-styling/types.ts
+++ b/frontend/src/components/data-table/cell-styling/types.ts
@@ -1,0 +1,23 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import type { RowData } from "@tanstack/react-table";
+
+export type CellStylingState = React.CSSProperties[][];
+
+export type CellStylingTableState = {
+  cellStyling: CellStylingState;
+};
+
+export interface CellStylingCell {
+  /**
+   * Returns additional styling for the cell.
+   */
+  getUserStyling?: () => React.CSSProperties;
+}
+
+// Use declaration merging to add our new feature APIs
+declare module "@tanstack/react-table" {
+  interface TableState extends CellStylingTableState {}
+
+  interface Cell<TData extends RowData, TValue> extends CellStylingCell {}
+}

--- a/frontend/src/components/data-table/cell-styling/types.ts
+++ b/frontend/src/components/data-table/cell-styling/types.ts
@@ -2,11 +2,14 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import type { RowData } from "@tanstack/react-table";
 
-export type CellStylingState = React.CSSProperties[][];
+export type CellStyleState = Record<
+  string,
+  Record<string, React.CSSProperties>
+>;
 
-export type CellStylingTableState = {
-  cellStyling: CellStylingState;
-};
+export interface CellStylingTableState {
+  cellStyling: CellStyleState;
+}
 
 export interface CellStylingCell {
   /**

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -35,7 +35,7 @@ import { CellSelectionFeature } from "./cell-selection/feature";
 import type { CellSelectionState } from "./cell-selection/types";
 import type { GetRowIds } from "@/plugins/impl/DataTablePlugin";
 import { CellStylingFeature } from "./cell-styling/feature";
-import type { CellStylingState } from "./cell-styling/types";
+import type { CellStyleState } from "./cell-styling/types";
 
 interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   wrapperClassName?: string;
@@ -57,7 +57,7 @@ interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   selection?: DataTableSelection;
   rowSelection?: RowSelectionState;
   cellSelection?: CellSelectionState;
-  cellStyling?: CellStylingState;
+  cellStyling?: CellStyleState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   onCellSelectionChange?: OnChangeFn<CellSelectionState>;
   getRowIds?: GetRowIds;

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -34,6 +34,8 @@ import { INDEX_COLUMN_NAME } from "./types";
 import { CellSelectionFeature } from "./cell-selection/feature";
 import type { CellSelectionState } from "./cell-selection/types";
 import type { GetRowIds } from "@/plugins/impl/DataTablePlugin";
+import { CellStylingFeature } from "./cell-styling/feature";
+import type { CellStylingState } from "./cell-styling/types";
 
 interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   wrapperClassName?: string;
@@ -55,6 +57,7 @@ interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   selection?: DataTableSelection;
   rowSelection?: RowSelectionState;
   cellSelection?: CellSelectionState;
+  cellStyling?: CellStylingState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   onCellSelectionChange?: OnChangeFn<CellSelectionState>;
   getRowIds?: GetRowIds;
@@ -84,6 +87,7 @@ const DataTableInternal = <TData,>({
   setSorting,
   rowSelection,
   cellSelection,
+  cellStyling,
   paginationState,
   setPaginationState,
   downloadAs,
@@ -115,6 +119,7 @@ const DataTableInternal = <TData,>({
       ColumnWrappingFeature,
       ColumnFormattingFeature,
       CellSelectionFeature,
+      CellStylingFeature,
     ],
     data,
     columns,
@@ -172,6 +177,7 @@ const DataTableInternal = <TData,>({
             { pagination: { pageIndex: 0, pageSize: data.length } }),
       rowSelection,
       cellSelection,
+      cellStyling,
       columnPinning: columnPinning,
     },
     onColumnPinningChange: setColumnPinning,

--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -65,7 +65,12 @@ export function renderTableBody<TData>(
 ): JSX.Element {
   const renderCells = (row: Row<TData>, cells: Array<Cell<TData, unknown>>) => {
     return cells.map((cell) => {
-      const { className, style } = getPinningStyles(cell.column);
+      const { className, style: pinningstyle } = getPinningStyles(cell.column);
+      const style = Object.assign(
+        {},
+        cell.getUserStyling?.() || {},
+        pinningstyle,
+      );
       return (
         <TableCell
           key={cell.id}

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -149,7 +149,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
         .nullish(),
       totalColumns: z.number(),
       hasStableRowId: z.boolean().default(false),
-      cellStyles: z.record(z.record(z.object({}).passthrough())),
+      cellStyles: z.record(z.record(z.object({}).passthrough())).optional(),
     }),
   )
   .withFunctions<DataTableFunctions>({
@@ -191,7 +191,9 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
         z.object({
           data: z.union([z.string(), z.array(z.object({}).passthrough())]),
           total_rows: z.number(),
-          cell_styles: z.record(z.record(z.object({}).passthrough())),
+          cell_styles: z
+            .record(z.record(z.object({}).passthrough()))
+            .optional(),
         }),
       ),
     get_row_ids: rpc.input(z.object({}).passthrough()).output(

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -147,6 +147,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
         .nullish(),
       totalColumns: z.number(),
       hasStableRowId: z.boolean().default(false),
+      cellStyles: z.array(z.array(z.object({}).passthrough())),
     }),
   )
   .withFunctions<DataTableFunctions>({
@@ -222,6 +223,7 @@ interface DataTableProps<T> extends Data<T>, DataTableFunctions {
   enableSearch: boolean;
   // Filters
   enableFilters?: boolean;
+  cellStyles?: any[][];
 }
 
 interface DataTableSearchProps {
@@ -475,6 +477,7 @@ const DataTableComponent = ({
   wrappedColumns,
   totalColumns,
   get_row_ids,
+  cellStyles,
 }: DataTableProps<unknown> &
   DataTableSearchProps & {
     data: unknown[];
@@ -608,6 +611,7 @@ const DataTableComponent = ({
             setPaginationState={setPaginationState}
             rowSelection={rowSelection}
             cellSelection={cellSelection}
+            cellStyling={cellStyles}
             downloadAs={showDownload ? downloadAs : undefined}
             enableSearch={enableSearch}
             searchQuery={searchQuery}

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -285,7 +285,7 @@ export const LoadingDataTableComponent = memo(
     const { data, loading, error } = useAsyncData<{
       rows: T[];
       totalRows: number | "too_many";
-      cellStyles: CellStyleState;
+      cellStyles: CellStyleState | undefined;
     }>(async () => {
       // If there is no data, return an empty array
       if (props.totalRows === 0) {
@@ -295,8 +295,7 @@ export const LoadingDataTableComponent = memo(
       // Table data is a url string or an array of objects
       let tableData = props.data;
       let totalRows = props.totalRows;
-      let cellStyles: CellStyleState =
-        props.cellStyles || ({} as CellStyleState);
+      let cellStyles = props.cellStyles;
 
       // If it is just the first page and no search query,
       // we can show the initial page.
@@ -370,7 +369,6 @@ export const LoadingDataTableComponent = memo(
       searchQuery,
       useDeepCompareMemoize(props.fieldTypes),
       props.data,
-      props.cellStyles, // maybe, not quite sure...
       paginationState.pageSize,
       paginationState.pageIndex,
     ]);

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -101,7 +101,7 @@ CellStyles = dict[RowId, dict[ColumnName, dict[str, Any]]]
 class SearchTableResponse:
     data: Union[JSONType, str]
     total_rows: int
-    cell_styles: CellStyles = dict()
+    cell_styles: Optional[CellStyles] = None
 
 
 @dataclass(frozen=True)
@@ -695,10 +695,10 @@ class table(
 
         return result
 
-    def _style_cells(self, skip: int, take: int) -> CellStyles:
+    def _style_cells(self, skip: int, take: int) -> Optional[CellStyles]:
         """Calculate the styling of the cells in the table."""
         if self._style_cell is None:
-            return dict()
+            return None
         else:
 
             def do_style_cell(row: str, col: str) -> dict[str, Any]:

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -759,7 +759,15 @@ class table(
             return SearchTableResponse(
                 data=clamp_rows_and_columns(self._manager),
                 total_rows=self._manager.get_num_rows(force=True) or 0,
-                cell_styles=self._style_cells(offset, args.page_size),
+                # The __init__ will just call this with an arbitrary offset,
+                # we need to check this is not larger than our actual number of rows.
+                cell_styles=self._style_cells(
+                    offset,
+                    min(
+                        self._searched_manager.get_num_rows(force=True),
+                        args.page_size,
+                    ),
+                ),
             )
 
         # Apply filters, query, and functools.sort using the cached method

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -781,17 +781,15 @@ class table(
         # The frontend will just show the original data
         if not args.query and not args.sort and not args.filters:
             self._searched_manager = self._manager
+            total_rows = self._manager.get_num_rows(force=True) or 0
             return SearchTableResponse(
                 data=clamp_rows_and_columns(self._manager),
-                total_rows=self._manager.get_num_rows(force=True) or 0,
+                total_rows=total_rows,
                 # The __init__ will just call this with an arbitrary offset,
                 # we need to check this is not larger than our actual number of rows.
                 cell_styles=self._style_cells(
                     offset,
-                    min(
-                        self._searched_manager.get_num_rows(force=True) or 0,
-                        args.page_size,
-                    ),
+                    min(total_rows, args.page_size),
                 ),
             )
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -36,6 +36,7 @@ from marimo._plugins.ui._impl.tables.selection import (
 )
 from marimo._plugins.ui._impl.tables.table_manager import (
     ColumnName,
+    RowId,
     TableCell,
     TableCoordinate,
     TableManager,
@@ -93,7 +94,7 @@ class SearchTableArgs:
     limit: Optional[int] = None
 
 
-CellStyles = dict[str, dict[str, dict[str, Any]]]
+CellStyles = dict[RowId, dict[ColumnName, dict[str, Any]]]
 
 
 @dataclass(frozen=True)

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -231,7 +231,7 @@ class table(
         label (str, optional): Markdown label for the element. Defaults to "".
         on_change (Callable[[Union[List[JSONType], Dict[str, List[JSONType]], IntoDataFrame, List[TableCell]]], None], optional):
             Optional callback to run when this element's value changes.
-        style_cell (Callable[[int, int, dict], dict], optional): A function that takes the row and column index and returns a dictionary of CSS styles.
+        style_cell (Callable[[str, str, Any], Dict[str, Any]], optional): A function that takes the row id, column name and value and returns a dictionary of CSS styles.
         max_columns (int, optional): Maximum number of columns to display. Defaults to 50.
             Set to None to show all columns.
     """

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -194,6 +194,31 @@ class table(
         )
         ```
 
+        Create a table with conditional cell formatting:
+
+        ```python
+        import random
+
+
+        # rowId and columnName are strings.
+        def style_cell(_rowId, _columnName, value):
+            # Apply inline styling to the visible individual cells.
+            return {
+                "backgroundColor": "lightcoral"
+                if value < 4
+                else "cornflowerblue",
+                "color": "white",
+                "fontStyle": "italic",
+            }
+
+
+        table = mo.ui.table(
+            data=[random.randint(0, 10) for x in range(200)],
+            style_cell=style_cell,
+        )
+        table
+        ```
+
         In each case, access the table data with `table.value`.
 
     Attributes:

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -10,7 +10,6 @@ from typing import (
     Final,
     Literal,
     Optional,
-    TypeAlias,
     Union,
 )
 
@@ -94,8 +93,8 @@ class SearchTableArgs:
     limit: Optional[int] = None
 
 
-CellStyle: TypeAlias = dict[str, Any]
-CellStyles: TypeAlias = dict[str, CellStyle]
+CellStyle = dict[str, Any]
+CellStyles = dict[str, CellStyle]
 
 
 @dataclass(frozen=True)

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -764,7 +764,7 @@ class table(
                 cell_styles=self._style_cells(
                     offset,
                     min(
-                        self._searched_manager.get_num_rows(force=True),
+                        self._searched_manager.get_num_rows(force=True) or 0,
                         args.page_size,
                     ),
                 ),

--- a/marimo/_plugins/ui/_impl/tables/default_table.py
+++ b/marimo/_plugins/ui/_impl/tables/default_table.py
@@ -182,6 +182,10 @@ class DefaultTableManager(TableManager[JsonTableData]):
                             value=row[column_name],
                         )
                     )
+                elif not isinstance(row, list) and column_name == "value":
+                    selected_cells.append(
+                        TableCell(row=row_id, column=column_name, value=row)
+                    )
 
         return selected_cells
 

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -13,6 +13,7 @@ from marimo._plugins.ui._impl.tables.format import FormatMapping
 T = TypeVar("T")
 
 ColumnName = str
+RowId = str
 FieldType = DataType
 FieldTypes = list[tuple[ColumnName, tuple[FieldType, ExternalDataType]]]
 

--- a/tests/_plugins/ui/_impl/tables/test_default_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_default_table.py
@@ -760,3 +760,18 @@ class TestDictionaryDefaultTable(unittest.TestCase):
             self.manager.to_json()
             == b'[{"key":"a","value":1},{"key":"b","value":2}]'
         )
+
+
+class TestListDefaultTable(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manager = DefaultTableManager([4, 5, 6])
+
+    def test_select_cells(self) -> None:
+        selected_cells = self.manager.select_cells(
+            [
+                TableCoordinate(row_id=2, column_name="value"),
+            ]
+        )
+        assert selected_cells == [
+            TableCell(row=2, column="value", value=6),
+        ]

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1321,3 +1321,38 @@ def test_dataframe_with_int_column_names():
     # Check that the table handles integer column names correctly
     assert table._manager.get_column_names() == [0, 1, 2]
     assert table._component_args["total-columns"] == 3
+
+
+def test_cell_initial_style():
+    def always_green(_row, _col, _value):
+        return {"backgroundColor": "green"}
+
+    table = ui.table([1, 2, 3], style_cell=always_green)
+    assert "cell-styles" in table._args.args
+    cell_styles = table._args.args["cell-styles"]
+    assert len(cell_styles) == 3
+    assert "1" in cell_styles
+    assert "value" in cell_styles["1"]
+    assert "backgroundColor" in cell_styles["1"]["value"]
+    assert "green" == cell_styles["1"]["value"]["backgroundColor"]
+
+
+def test_cell_style_of_next_page():
+    def always_green(_row, _col, _value):
+        return {"backgroundColor": "green"}
+
+    data = [
+        {"a": 1, "b": 2},
+        {"a": 3, "b": 4},
+        {"a": 5, "b": 6},
+        {"a": 7, "b": 8},
+    ]
+
+    table = ui.table(data, page_size=2, style_cell=always_green)
+    last_page = table._search(SearchTableArgs(page_size=2, page_number=1))
+    cell_styles = last_page.cell_styles
+    assert len(cell_styles) == 2
+    assert "2" in cell_styles
+    assert "a" in cell_styles["2"]
+    assert "backgroundColor" in cell_styles["2"]["a"]
+    assert "green" in cell_styles["2"]["a"]["backgroundColor"]


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Hello, as asked on Discord, we are hoping to add some styling options to the cells of a data-table.

![image](https://github.com/user-attachments/assets/c172d02b-32bd-450e-8154-0d5276aff939)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

On the Python side, I'm adding a new function that returns a dictionary-style object to describe the cell's style. This nested array of styles is then sent to the client and utilized by another TanStack plugin.

In our Discord conversation, we discussed foreground and background colors. I opted for a style dictionary, which provides more options. I'm not set on this idea, so please share your thoughts on what you think is best.

This is still a work in progress, so I would appreciate your guidance in the right direction.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
