### PR TITLE
improvement : Adding functionality to handle numpy array as src in mo.audio simliar to ipython audio

### DIFF
--- a/marimo/_plugins/stateless/audio.py
+++ b/marimo/_plugins/stateless/audio.py
@@ -60,18 +60,18 @@ def audio(
     """Render an audio file as HTML.
 
     Args:
-        src: a path or URL to an audio file, bytes,
+        src: a path or URL to an audio `file`, `bytes`,
             or a file-like object opened in binary mode
-            Numpy 1d array containing the desired waveform (mono)
-            Numpy 2d array containing waveforms for each channel.Shape=(NCHAN, NSAMPLES).
-        rate : integer
+            `Numpy 1d array` containing the desired waveform (mono)
+            `Numpy 2d array` containing waveforms for each channel.Shape=(NCHAN, NSAMPLES).
+        rate :
             The sampling rate of the raw data.
-            Only required when data parameter is being used as an array
-        normalize : bool
+            Only required when data parameter is being used as an array.
+        normalize :
             Whether audio should be normalized (rescaled) to the maximum possible
-            range. Default is `True`. When set to `False`, `data` must be between
+            range. Default is `True`. When set to `False`, `src` must be between
             -1 and 1 (inclusive), otherwise an error is raised.
-            Applies only when `data` is a list or array of samples; other types of
+            Applies only when `src` is a numpy array; other types of
             audio are never normalized.
 
     Returns:

--- a/marimo/_plugins/stateless/audio.py
+++ b/marimo/_plugins/stateless/audio.py
@@ -54,7 +54,7 @@ def convert_numpy_to_wav(data, rate: int, normalize: bool) -> bytes:
 
 def get_resolved_src(
     src: Union[str, io.BytesIO], rate: Optional[int], normalize: bool
-) -> str:
+) -> Optional[str]:
     """Determines the correct URL for the given audio source."""
 
     if isinstance(src, (io.BufferedReader, io.BytesIO)):

--- a/marimo/_plugins/stateless/audio.py
+++ b/marimo/_plugins/stateless/audio.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import io
 import os
 import wave
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import marimo._output.data.data as mo_data
 from marimo._dependencies.dependencies import DependencyManager
@@ -13,12 +13,18 @@ from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.media import io_to_data_url
 
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
 
-def convert_numpy_to_wav(data, rate: int, normalize: bool) -> bytes:
+
+def convert_numpy_to_wav(
+    data: NDArray[np.int16], rate: int, normalize: bool
+) -> bytes:
     import numpy as np
 
     def get_normalization_factor(
-        max_abs_value, normalize
+        max_abs_value: float, normalize: bool
     ) -> Union[float, int]:
         if not normalize and max_abs_value > 1:
             raise ValueError(
@@ -38,7 +44,7 @@ def convert_numpy_to_wav(data, rate: int, normalize: bool) -> bytes:
     max_abs_value = np.max(np.abs(data))
     normalization_factor = get_normalization_factor(max_abs_value, normalize)
     scaled = data / normalization_factor * 32767
-    scaled = scaled.astype("<h").tobytes()
+    scaled_bytes = scaled.astype("<h").tobytes()
 
     buffer = io.BytesIO()
     waveobj = wave.open(buffer, mode="wb")
@@ -46,7 +52,7 @@ def convert_numpy_to_wav(data, rate: int, normalize: bool) -> bytes:
     waveobj.setframerate(rate)
     waveobj.setsampwidth(2)
     waveobj.setcomptype("NONE", "NONE")
-    waveobj.writeframes(scaled)
+    waveobj.writeframes(scaled_bytes)
     val = buffer.getvalue()
     waveobj.close()
     return val


### PR DESCRIPTION
Added functionality to handle `numpy` array in mo.audio 

fixes #4197

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] I have run the code and verified that it works as expected.

@akshayka
