### PR TITLE
improvement: LSP completion inside parens (), and Mod+Shift+Space for signature

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "@lezer/lr": "^1.4.2",
     "@lezer/python": "^1.1.16",
     "@marimo-team/codemirror-ai": "^0.1.11",
-    "@marimo-team/codemirror-languageserver": "^1.15.0",
+    "@marimo-team/codemirror-languageserver": "^1.15.3",
     "@marimo-team/marimo-api": "file:../openapi",
     "@marimo-team/react-slotz": "^0.1.8",
     "@open-rpc/client-js": "^1.8.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^0.1.11
         version: 0.1.11(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.15.0
-        version: 1.15.0(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
+        specifier: ^1.15.3
+        version: 1.15.3(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
       '@marimo-team/marimo-api':
         specifier: file:../openapi
         version: file:../openapi
@@ -1572,8 +1572,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.15.0':
-    resolution: {integrity: sha512-wxGmoE07fev5fmaaXbBzzhy0Jh8+G//BzUwKcvO2/c5IljWpupH5sR3eICObVugG7s2UBNSSbEjaH1l+pBHL+A==}
+  '@marimo-team/codemirror-languageserver@1.15.3':
+    resolution: {integrity: sha512-GWkPUHpT0wSUfLp8El54icbqN4UkUur+oC6NUME9Vd1hW4wt8vObHzdX1KrX69caC149s+xH9SB9LaPMXivaRg==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -10359,7 +10359,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
 
-  '@marimo-team/codemirror-languageserver@1.15.0(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
+  '@marimo-team/codemirror-languageserver@1.15.3(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lint': 6.8.4

--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -144,7 +144,7 @@ export class PythonLanguageAdapter implements LanguageAdapter {
   getExtension(
     cellId: CellId,
     completionConfig: CompletionConfig,
-    _hotkeys: HotkeyProvider,
+    hotkeys: HotkeyProvider,
     placeholderType: PlaceholderType,
     lspConfig: LSPConfig & { diagnostics: DiagnosticsConfig },
   ): Extension[] {
@@ -176,9 +176,16 @@ export class PythonLanguageAdapter implements LanguageAdapter {
             completionConfig: autocompleteOptions,
             // Default to false
             diagnosticsEnabled: lspConfig.diagnostics?.enabled ?? false,
+            signatureHelpEnabled: true,
+            signatureActivateOnTyping: false,
+            keyboardShortcuts: {
+              signatureHelp: hotkeys.getHotkey("cell.signatureHelp").key,
+              goToDefinition: hotkeys.getHotkey("cell.goToDefinition").key,
+              rename: hotkeys.getHotkey("cell.renameSymbol").key,
+            },
             // Match completions before the cursor is at the end of a word,
             // after a dot, after a slash, after a comma.
-            completionMatchBefore: /(\w+|\w+\.|\/|,)$/,
+            completionMatchBefore: /(\w+|\w+\.|\(|\/|,)$/,
             onGoToDefinition: (result) => {
               Logger.debug("onGoToDefinition", result);
               if (client.documentUri === result.uri) {

--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -89,14 +89,6 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
   async textDocumentSignatureHelp(
     params: LSP.SignatureHelpParams,
   ): Promise<LSP.SignatureHelp | null> {
-    // TODO: not implemented yet
-    // It currently doesn't provide too much value over the autocomplete
-    // and blocks the completion list when it is open.
-    const disabledSignatureHelp = true;
-    if (disabledSignatureHelp) {
-      return null;
-    }
-
     const cellDocumentUri = params.textDocument.uri;
     if (!CellDocumentUri.is(cellDocumentUri)) {
       Logger.warn("Invalid cell document URI", cellDocumentUri);

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -142,6 +142,11 @@ const DEFAULT_HOT_KEY = {
     group: "Editing",
     key: "Ctrl-Space",
   },
+  "cell.signatureHelp": {
+    name: "Signature help",
+    group: "Editing",
+    key: "Mod-Shift-Space",
+  },
   "cell.undo": {
     name: "Undo",
     group: "Editing",
@@ -221,6 +226,11 @@ const DEFAULT_HOT_KEY = {
     group: "Editing",
     key: "Mod-/",
     editable: false,
+  },
+  "cell.renameSymbol": {
+    name: "Rename symbol",
+    group: "Editing",
+    key: "F2",
   },
 
   // Markdown

--- a/frontend/src/css/app/codemirror-completions.css
+++ b/frontend/src/css/app/codemirror-completions.css
@@ -213,6 +213,8 @@
 }
 
 .cm-signature-help {
+  max-width: 700px !important;
+  margin-right: 16px !important;
   @apply bg-popover shadow-md border border-border rounded-md text-sm;
 
   .cm-signature {
@@ -225,5 +227,27 @@
 
   .cm-signature-docs {
     @apply text-xs;
+  }
+
+  ul {
+    @apply list-disc;
+  }
+
+  ol {
+    @apply list-decimal;
+  }
+
+  li {
+    margin-bottom: 2px;
+
+    @apply pl-2;
+  }
+
+  code:not(:empty) {
+    @apply bg-[var(--gray-3)] rounded-sm px-1;
+  }
+
+  h4 {
+    @apply text-sm font-semibold mt-2 mb-1;
   }
 }

--- a/tests/_plugins/ui/_impl/dataframes/test_handlers.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_handlers.py
@@ -915,28 +915,18 @@ class TestTransformHandler:
 
     @staticmethod
     @pytest.mark.parametrize(
-        ("df", "expected"),
+        "df",
         [
-            (
-                pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}),
-                pd.DataFrame({"A": [1, 3], "B": [4, 6]}),
-            ),
-            (
-                pl.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}),
-                pl.DataFrame({"A": [1, 3], "B": [4, 6]}),
-            ),
-            (
-                ibis.memtable({"A": [1, 2, 3], "B": [4, 5, 6]}),
-                ibis.memtable({"A": [1, 3], "B": [4, 6]}),
-            ),
+            pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}),
+            pl.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}),
         ],
     )
-    def test_sample_rows(df: DataFrameType, expected: DataFrameType) -> None:
+    def test_sample_rows(df: DataFrameType) -> None:
         transform = SampleRowsTransform(
             type=TransformType.SAMPLE_ROWS, n=2, seed=42, replace=False
         )
         result = apply(df, transform)
-        assert df_size(result) == df_size(expected)
+        assert df_size(result) == 2
         assert "A" in result.columns
         assert "B" in result.columns
 

--- a/tests/_plugins/ui/_impl/dataframes/test_handlers.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_handlers.py
@@ -80,9 +80,9 @@ def assert_frame_not_equal(df1: DataFrameType, df2: DataFrameType) -> None:
 
 def df_size(df: DataFrameType) -> int:
     if isinstance(df, pd.DataFrame):
-        return df.size
+        return len(df)
     if isinstance(df, pl.DataFrame):
-        return df.shape[0]
+        return len(df)
     if isinstance(df, ibis.Table):
         return df.count().execute()
     raise ValueError("Unsupported dataframe type")
@@ -926,7 +926,7 @@ class TestTransformHandler:
             type=TransformType.SAMPLE_ROWS, n=2, seed=42, replace=False
         )
         result = apply(df, transform)
-        assert df_size(result) == 2
+        assert len(result) == 2
         assert "A" in result.columns
         assert "B" in result.columns
 


### PR DESCRIPTION
Fixes #2080

* Add signature completion via configurable hotkey (`Mod+Shift+Space`) . 
* Signature parameter get sorted to the top
* Pass down configurable hotkeys to plugin


<img width="510" alt="image" src="https://github.com/user-attachments/assets/0c82c91f-773b-4569-bf22-f1eb4b84cbc5" />
