### PR TITLE
fix: show at most two decimal points in column summary axes

### DIFF
--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -57,8 +57,9 @@ exports[`ColumnChartSpecModel > snapshot > array 1`] = `
         ],
         "x": {
           "axis": {
-            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : datum.value",
-            "labelFontSize": 8,
+            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : format(datum.value, '.2~f')",
+            "labelFontSize": 8.5,
+            "labelOpacity": 0.5,
             "title": null,
           },
           "bin": true,
@@ -144,8 +145,9 @@ exports[`ColumnChartSpecModel > snapshot > csv data 1`] = `
         ],
         "x": {
           "axis": {
-            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : datum.value",
-            "labelFontSize": 8,
+            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : format(datum.value, '.2~f')",
+            "labelFontSize": 8.5,
+            "labelOpacity": 0.5,
             "title": null,
           },
           "bin": true,
@@ -231,8 +233,9 @@ exports[`ColumnChartSpecModel > snapshot > csv string 1`] = `
         ],
         "x": {
           "axis": {
-            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : datum.value",
-            "labelFontSize": 8,
+            "labelExpr": "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : format(datum.value, '.2~f')",
+            "labelFontSize": 8.5,
+            "labelOpacity": 0.5,
             "title": null,
           },
           "bin": true,

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -232,9 +232,10 @@ export class ColumnChartSpecModel<T> {
                   bin: true,
                   axis: {
                     title: null,
-                    labelFontSize: 8,
+                    labelFontSize: 8.5,
+                    labelOpacity: 0.5,
                     labelExpr:
-                      "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : datum.value",
+                      "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : format(datum.value, '.2~f')",
                   },
                 },
                 y: {

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -278,7 +278,7 @@ export const DataTableColumnHeaderWithSummary = <TData, TValue>({
   return (
     <div
       className={cn(
-        "flex flex-col h-full py-0.5 justify-between items-start",
+        "flex flex-col h-full pt-0.5 pb-3 justify-between items-start",
         className,
       )}
     >


### PR DESCRIPTION
Fixes a formatting bug in which the x-axis ticks for numerical column summaries showed an unbounded number of decimals.