### PR TITLE
docs: touch up marimo snippets

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -16,7 +16,8 @@ These guides cover marimo's core concepts.
 | [Expensive notebooks](expensive_notebooks.md)         | Tips for working with expensive notebooks                  |
 | [Working with data](working_with_data/index.md)       | Using SQL cells, no-code dataframe, and reactive plots     |
 | [Package reproducibility](package_reproducibility.md) | Making notebooks reproducible down to the packages         |
-| [Editor Features](editor_features/index.md)           | View variables, dataframe schemas, docstrings, and more    |
+| [Editor features](editor_features/index.md)           | View variables, dataframe schemas, docstrings, and more    |
+| [Using your own editor](editor_features/watching.md)  | Edit notebooks in your own editor and stream changes back to the browser |
 | [Apps](apps.md)                                       | Running notebooks as apps                                  |
 | [Scripts](scripts.md)                                 | Running notebooks as scripts                               |
 | [Tests](testing/index.md)                             | Running unit tests in notebooks                            |

--- a/docs/guides/publishing/embedding.md
+++ b/docs/guides/publishing/embedding.md
@@ -8,6 +8,7 @@ are two ways:
   and `<iframe>` the published notebook.
 * `<iframe>` a [playground](playground.md) notebook, and [customize the embedding](playground.md#embedding-in-other-web-pages) with query params.
   (This is what we do throughout docs.marimo.io.)
+* Use the [marimo snippets](from_code_snippets.md) plugin to replace code snippets in HTML or markdown with interactive notebooks.
 
 We plan to provide more turn-key solutions for static site generation with
 marimo notebooks in the future.

--- a/docs/guides/publishing/from_code_snippets.md
+++ b/docs/guides/publishing/from_code_snippets.md
@@ -1,8 +1,11 @@
 # Publish using `marimo-snippets` 
 
-You can host marimo entire notebooks directly by exporting them to WASM but thanks to the `marimo-snippets` library you can also choose to embed a marimo notebook on your site via markdown blocks. 
+`marimo-snippets` is a single-file JavaScript utility that lets you embed interactive
+marimo notebooks in static web pages, powered by WebAssembly. Simply wrap code
+elements in a custom tag, and marimo snippets does the rest; marimo-snippets
+is even compatible with MkDocs-generated markdown.
 
-Here's a quick demo on how you might set that up. 
+Here's a demo:
 
 ````md
 <div>
@@ -24,11 +27,8 @@ slider.value * "🍃"
 <script src="https://cdn.jsdelivr.net/npm/@marimo-team/marimo-snippets@1"></script>
 ````
 
-!!! note
-
-    You might wonder why we wrap the `<marimo-button>` element with an extra `<div>`. This is related to how different markdown preprocessors might handle the custom HTML elements. To guarantee that this approach works across most markdown tools, we need to wrap the custom elements in a block element.
-
-This will embed an iframe on your behalf with an interactive slider. 
+This embeds an iframe on your page with an interactive slider, like the one below.
+Fun fact: this page is itself using `marimo-snippets`!
 
 <div>
 <marimo-iframe>
@@ -71,4 +71,4 @@ You can also configure data attributes per-element.
 </marimo-iframe>
 ```
 
-Check the [Github repository](https://github.com/marimo-team/marimo-snippets) to learn more about [the configuration options](https://github.com/marimo-team/marimo-snippets?tab=readme-ov-file#configuration).
+Check the [Github repository](https://github.com/marimo-team/marimo-snippets) for a full example and more [documentation on configuration](https://github.com/marimo-team/marimo-snippets?tab=readme-ov-file#configuration).

--- a/docs/guides/publishing/index.md
+++ b/docs/guides/publishing/index.md
@@ -13,11 +13,11 @@ This guide provides an overview of the various ways to publish marimo notebooks.
 | Guide                                                 | Description                                                  |
 | ----------------------------------------------------- | ------------------------------------------------------------ |
 | [Embedding](embedding.md)                             | An overview of embedding notebooks in other sites            |
-| [Markdown Snippets](marimo-snippets.md)               | Use the `marimo-snippets` plugin to host marimo              |
-| [From GitHub](from_github.md)                         | How to share links to executable notebooks hosted on GitHUb  |
-| [GitHub Pages](github_pages.md)                       | Publishing interactive notebooks on GitHub Pages             |
-| [Cloudflare Pages](cloudflare_pages.md)               | Publishing interactive notebooks on Cloudflare Pages         |
-| [Online playground](playground.md)                    | Sharing notebook links using our online playground           |
+| [From GitHub](from_github.md)                         | Share links to executable notebooks hosted on GitHub         |
+| [From code snippets](from_code_snippets.md)           | Convert code snippets in Markdown or HTML to interactive notebooks |
+| [GitHub Pages](github_pages.md)                       | Publish interactive notebooks on GitHub Pages                |
+| [Cloudflare Pages](cloudflare_pages.md)               | Publish interactive notebooks on Cloudflare Pages            |
+| [Online playground](playground.md)                    | Share links to notebooks using our online playground         |
 | [Community Cloud](community_cloud/index.md)           | Save notebooks to our free Community Cloud                   |
 | [Self-host WebAssembly notebooks](self_host_wasm.md)  | Self-hosting interactive WebAssembly (HTML export) notebooks |
 | [View notebooks on GitHub](view_outputs_on_github.md) | Viewing notebook outputs on GitHub                           |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,7 +110,7 @@ nav:
       - Publish to the web:
           - Publish to the web: guides/publishing/index.md
           - Embedding: guides/publishing/embedding.md
-          - Marimo Snippets: guides/publishing/marimo-snippets.md
+          - From code snippets: guides/publishing/from_code_snippets.md
           - From GitHub: guides/publishing/from_github.md
           - GitHub Pages: guides/publishing/github_pages.md
           - Cloudflare Pages: guides/publishing/cloudflare_pages.md


### PR DESCRIPTION
- Make the description of marimo snippets on the overview page more descriptive
- Change the overview title to describe the activity the user wants to do, instead of the name of the plugin
- Edit prose