### PR TITLE
improvement: allow turning on the LSP without restarting the server

### DIFF
--- a/frontend/src/components/app-config/optional-features.tsx
+++ b/frontend/src/components/app-config/optional-features.tsx
@@ -65,7 +65,7 @@ const OPTIONAL_DEPENDENCIES: OptionalFeature[] = [
   },
   {
     id: "formatting",
-    packagesRequired: [isWasm() ? { name: "ruff" } : { name: "black" }],
+    packagesRequired: [isWasm() ? { name: "black" } : { name: "ruff" }],
     additionalPackageInstalls: [],
     description: "Formatting",
   },

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Generator
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -12,7 +13,6 @@ from typing import (
     cast,
 )
 
-from attr import dataclass
 from starlette.exceptions import HTTPException
 
 from marimo import _loggers

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -211,9 +211,15 @@ class CompositeLspServer(LspServer):
         # With 2 servers, this is OK, but if we want to support more, we should
         # lazily construct servers, routes, and ports.
         # We still lazily start servers as they are enabled.
+        # We also need to ensure that the ports are unique
         self.servers: dict[str, LspServer] = {
-            server_name: server_constructor(find_free_port(self.min_port))
-            for server_name, server_constructor in self.LANGUAGE_SERVERS.items()
+            # We offset the ports by 2 to ensure they are unique
+            server_name: server_constructor(
+                find_free_port(self.min_port + i * 5)
+            )
+            for i, (server_name, server_constructor) in enumerate(
+                self.LANGUAGE_SERVERS.items()
+            )
         }
 
     def _is_enabled(self, server_name: str) -> bool:

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 import os
 import subprocess
 from abc import ABC, abstractmethod
-from typing import Literal, Optional, Union, cast
+from typing import Any, Literal, Optional, Union, cast
 
 from marimo import _loggers
-from marimo._config.config import CompletionConfig, LanguageServersConfig
+from marimo._config.config import MarimoConfig
+from marimo._config.manager import MarimoConfigReader
 from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.ops import Alert
@@ -192,42 +193,71 @@ class NoopLspServer(LspServer):
 
 
 class CompositeLspServer(LspServer):
-    language_servers = {
+    LANGUAGE_SERVERS = {
         "pylsp": PyLspServer,
         "copilot": CopilotLspServer,
     }
 
     def __init__(
         self,
-        lsp_config: LanguageServersConfig,
-        completion_config: CompletionConfig,
+        config_reader: MarimoConfigReader,
         min_port: int,
     ) -> None:
-        is_enabled: dict[str, bool] = {
-            "copilot": (
-                completion_config["copilot"] is True
-                or completion_config["copilot"] == "github"
-            ),
-            **{
-                server_name: cast(dict[str, bool], config)["enabled"]
-                for server_name, config in lsp_config.items()
-            },
-        }
-        self.servers: list[LspServer] = [
-            constructor(find_free_port(min_port + 100 * i))
-            for i, (server_name, constructor) in enumerate(
-                self.language_servers.items()
-            )
-            if is_enabled.get(server_name, False)
-        ]
+        self.config_reader = config_reader
+        self.min_port = min_port
 
-    def start(self) -> None:
-        for server in self.servers:
-            server.start()
+        # NOTE: we construct all servers up front regardless of whether they are enabled
+        # in order to properly mount them as Starlette routes with their own ports
+        # With 2 servers, this is OK, but if we want to support more, we should
+        # lazily construct servers, routes, and ports.
+        # We still lazily start servers as they are enabled.
+        self.servers: dict[str, LspServer] = {
+            server_name: server_constructor(find_free_port(self.min_port))
+            for server_name, server_constructor in self.LANGUAGE_SERVERS.items()
+        }
+
+    def _is_enabled(self, server_name: str) -> bool:
+        # .get_config() is not cached
+        config = self.config_reader.get_config()
+        if server_name == "copilot":
+            copilot = config["completion"]["copilot"]
+            return copilot is True or copilot == "github"
+        return cast(
+            bool,
+            cast(Any, config.get("language_servers", {}))
+            .get(server_name, {})
+            .get("enabled", False),
+        )
+
+    def start(self) -> Optional[Alert]:
+        alerts: list[Alert] = []
+        for server_name, server in self.servers.items():
+            if not self._is_enabled(server_name):
+                # We don't shut down the server if it is already running
+                # in case the user wants to re-enable it
+                continue
+            # We call start again even for existing servers in case it failed
+            # to start the first time (e.g. got new dependencies)
+            alert = server.start()
+            if alert is not None:
+                alerts.append(alert)
+
+        return alerts[0] if alerts else None
 
     def stop(self) -> None:
-        for server in self.servers:
+        for server in self.servers.values():
             server.stop()
 
     def is_running(self) -> bool:
-        return any(server.is_running() for server in self.servers)
+        return any(server.is_running() for server in self.servers.values())
+
+
+def any_lsp_server_running(config: MarimoConfig) -> bool:
+    # Check if any language servers or copilot are enabled
+    copilot_enabled = config["completion"]["copilot"]
+    language_servers = config.get("language_servers", {})
+    language_servers_enabled = any(
+        cast(dict[str, Any], server).get("enabled", False)
+        for server in language_servers.values()
+    )
+    return (copilot_enabled is not False) or language_servers_enabled

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -106,8 +106,7 @@ def start(
     config_reader = get_default_config_manager(current_path=start_path)
 
     lsp_composite_server = CompositeLspServer(
-        lsp_config=config_reader.language_servers,
-        completion_config=config_reader.completion,
+        config_reader=config_reader,
         min_port=DEFAULT_PORT + 400,
     )
 
@@ -169,7 +168,7 @@ def start(
         ),
         allow_origins=allow_origins,
         enable_auth=not AuthToken.is_empty(session_manager.auth_token),
-        lsp_servers=lsp_composite_server.servers,
+        lsp_servers=list(lsp_composite_server.servers.values()),
     )
 
     app.state.port = external_port


### PR DESCRIPTION
Create the starlette route and ports for each LSP even if they are not configured in the settings, so we can easily turn them on without having to restart the server.

This is simpler and works for 2 LSPs, but can be made lazy if we need to support more than 2.