### PR TITLE
fix: fallback to pandas sql

### DIFF
--- a/marimo/_sql/engines/duckdb.py
+++ b/marimo/_sql/engines/duckdb.py
@@ -52,11 +52,23 @@ class DuckDBEngine(SQLEngine):
             return None
 
         if DependencyManager.polars.has():
-            return relation.pl()
-        elif DependencyManager.pandas.has():
-            return relation.df()
-        else:
-            raise_df_import_error("polars[pyarrow]")
+            import polars as pl
+
+            try:
+                return relation.pl()
+            except pl.exceptions.PolarsError:
+                LOGGER.info(
+                    "Failed to convert to polars, falling back to pandas"
+                )
+
+        if DependencyManager.pandas.has():
+            try:
+                return relation.df()
+            except Exception as e:
+                LOGGER.warning("Failed to convert dataframe", exc_info=e)
+                return None
+
+        raise_df_import_error("polars[pyarrow]")
 
     @staticmethod
     def is_compatible(var: Any) -> bool:

--- a/marimo/_sql/engines/duckdb.py
+++ b/marimo/_sql/engines/duckdb.py
@@ -56,7 +56,7 @@ class DuckDBEngine(SQLEngine):
 
             try:
                 return relation.pl()
-            except pl.exceptions.PolarsError:
+            except (pl.exceptions.PanicException, pl.exceptions.ComputeError):
                 LOGGER.info(
                     "Failed to convert to polars, falling back to pandas"
                 )

--- a/tests/_sql/test_duckdb.py
+++ b/tests/_sql/test_duckdb.py
@@ -14,6 +14,7 @@ from marimo._sql.sql import sql
 
 HAS_DUCKDB = DependencyManager.duckdb.has()
 HAS_PANDAS = DependencyManager.pandas.has()
+HAS_POLARS = DependencyManager.polars.has()
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -185,3 +186,18 @@ def test_get_current_database_schema() -> None:
 
     sql("DROP TABLE test_schema.test_table;", engine=engine)
     sql("DROP SCHEMA test_schema;", engine=engine)
+
+
+@pytest.mark.skipif(
+    not HAS_DUCKDB and not HAS_POLARS and not HAS_PANDAS,
+    reason="duckdb, polars and pandas not installed",
+)
+def test_duckdb_engine_execute_polars_fallback() -> None:
+    import pandas as pd
+
+    engine = DuckDBEngine(None)
+    # This query currently fails with polars
+    result = engine.execute(
+        "select to_days(cast((current_date - DATE '2025-01-01') as INTEGER));"
+    )
+    assert isinstance(result, pd.DataFrame)

--- a/tests/_sql/test_duckdb.py
+++ b/tests/_sql/test_duckdb.py
@@ -189,7 +189,7 @@ def test_get_current_database_schema() -> None:
 
 
 @pytest.mark.skipif(
-    not HAS_DUCKDB and not HAS_POLARS and not HAS_PANDAS,
+    not HAS_DUCKDB or not HAS_POLARS or not HAS_PANDAS,
     reason="duckdb, polars and pandas not installed",
 )
 def test_duckdb_engine_execute_polars_fallback() -> None:

--- a/tests/_sql/test_duckdb.py
+++ b/tests/_sql/test_duckdb.py
@@ -196,7 +196,7 @@ def test_duckdb_engine_execute_polars_fallback() -> None:
     import pandas as pd
 
     engine = DuckDBEngine(None)
-    # This query currently fails with polars
+    # This dtype is currently not supported by polars
     result = engine.execute(
         "select to_days(cast((current_date - DATE '2025-01-01') as INTEGER));"
     )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
The query fails to convert to polars: `select to_days(cast((current_date - DATE '2025-01-01') as INTEGER));`
so we should fallback to pandas conversion instead.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
