### PR TITLE
improve: cached session invalidation

### DIFF
--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -37,6 +37,7 @@ from marimo._server.model import (
     SessionMode,
 )
 from marimo._server.router import APIRouter
+from marimo._server.session.serialize import SessionCacheKey
 from marimo._server.sessions import Session, SessionManager
 from marimo._types.ids import CellId_t, ConsumerId, SessionId
 
@@ -651,7 +652,16 @@ class WebsocketHandler(SessionConsumer):
             self.status = ConnectionState.OPEN
             # if auto-instantiate if false, replay the previous session
             if not self.auto_instantiate:
-                new_session.sync_session_view_from_cache()
+                from marimo import __version__
+
+                app = new_session.app_file_manager.app
+                codes = tuple(
+                    cell_data.code
+                    for cell_data in app.cell_manager.cell_data()
+                )
+                new_session.sync_session_view_from_cache(
+                    SessionCacheKey(codes=codes, marimo_version=__version__)
+                )
                 self._replay_previous_session(new_session)
             return new_session
 

--- a/marimo/_server/api/endpoints/ws.py
+++ b/marimo/_server/api/endpoints/ws.py
@@ -37,7 +37,6 @@ from marimo._server.model import (
     SessionMode,
 )
 from marimo._server.router import APIRouter
-from marimo._server.session.serialize import SessionCacheKey
 from marimo._server.sessions import Session, SessionManager
 from marimo._types.ids import CellId_t, ConsumerId, SessionId
 
@@ -652,16 +651,7 @@ class WebsocketHandler(SessionConsumer):
             self.status = ConnectionState.OPEN
             # if auto-instantiate if false, replay the previous session
             if not self.auto_instantiate:
-                from marimo import __version__
-
-                app = new_session.app_file_manager.app
-                codes = tuple(
-                    cell_data.code
-                    for cell_data in app.cell_manager.cell_data()
-                )
-                new_session.sync_session_view_from_cache(
-                    SessionCacheKey(codes=codes, marimo_version=__version__)
-                )
+                new_session.sync_session_view_from_cache()
                 self._replay_previous_session(new_session)
             return new_session
 

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -700,18 +700,26 @@ class Session:
             from_consumer_id=None,
         )
 
-    def sync_session_view_from_cache(self, key: SessionCacheKey) -> None:
+    def sync_session_view_from_cache(self) -> None:
         """Sync the session view from a file.
 
         Overwrites the existing session view.
         Mutates the existing session.
         """
+        from marimo import __version__
+
         LOGGER.debug("Syncing session view from cache")
         self.session_cache_manager = SessionCacheManager(
             session_view=self.session_view,
             path=self.app_file_manager.path,
             interval=self.SESSION_CACHE_INTERVAL_SECONDS,
         )
+
+        app = self.app_file_manager.app
+        codes = tuple(
+            cell_data.code for cell_data in app.cell_manager.cell_data()
+        )
+        key = SessionCacheKey(codes=codes, marimo_version=__version__)
         self.session_view = self.session_cache_manager.read_session_view(key)
         self.session_cache_manager.start()
 

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -65,6 +65,7 @@ from marimo._server.model import ConnectionState, SessionConsumer, SessionMode
 from marimo._server.models.models import InstantiateRequest
 from marimo._server.recents import RecentFilesManager
 from marimo._server.session.serialize import (
+    SessionCacheKey,
     SessionCacheManager,
 )
 from marimo._server.session.session_view import SessionView
@@ -699,7 +700,7 @@ class Session:
             from_consumer_id=None,
         )
 
-    def sync_session_view_from_cache(self) -> None:
+    def sync_session_view_from_cache(self, key: SessionCacheKey) -> None:
         """Sync the session view from a file.
 
         Overwrites the existing session view.
@@ -711,7 +712,7 @@ class Session:
             path=self.app_file_manager.path,
             interval=self.SESSION_CACHE_INTERVAL_SECONDS,
         )
-        self.session_view = self.session_cache_manager.read_session_view()
+        self.session_view = self.session_cache_manager.read_session_view(key)
         self.session_cache_manager.start()
 
     def __repr__(self) -> str:

--- a/tests/_server/session/test_serialize_session.py
+++ b/tests/_server/session/test_serialize_session.py
@@ -10,6 +10,7 @@ from marimo import __version__
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.errors import MarimoExceptionRaisedError, UnknownError
 from marimo._messaging.ops import CellOp
+from marimo._runtime.requests import ExecuteMultipleRequest
 from marimo._schemas.session import NotebookSessionV1
 from marimo._server.session.serialize import (
     SessionCacheKey,
@@ -463,3 +464,122 @@ class TestSessionCacheManager:
             cell = loaded_view.cell_operations["cell1"]
             assert cell.output is not None
             assert cell.output.data == "test data"
+
+    async def test_read_session_view_cache_miss_code(self):
+        """Test reading session view from cache file"""
+        view = SessionView()
+        view.cell_operations["cell1"] = CellOp(
+            cell_id="cell1",
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="test data",
+            ),
+            console=[],
+            timestamp=0,
+        )
+        view.add_control_request(
+            ExecuteMultipleRequest(cell_ids=["cell1"], codes=["a"])
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "notebook.py"
+            cache_file = get_session_cache_file(path)
+            cache_file.parent.mkdir(parents=True)
+
+            # Write cache file
+            data = serialize_session_view(view)
+            cache_file.write_text(json.dumps(data))
+
+            # Read back
+            manager = SessionCacheManager(SessionView(), path, 0.1)
+            loaded_view = manager.read_session_view(
+                # foo != a, cache miss
+                SessionCacheKey(codes=("foo",), marimo_version=__version__)
+            )
+            assert not loaded_view.cell_operations
+
+    async def test_read_session_view_cache_miss_version(self):
+        """Test reading session view from cache file"""
+        view = SessionView()
+        view.add_control_request(
+            ExecuteMultipleRequest(cell_ids=["1", "2"], codes=["a", "b"])
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "notebook.py"
+            cache_file = get_session_cache_file(path)
+            cache_file.parent.mkdir(parents=True)
+
+            # Write cache file
+            data = serialize_session_view(view)
+            cache_file.write_text(json.dumps(data))
+
+            # Read back
+            manager = SessionCacheManager(SessionView(), path, 0.1)
+            loaded_view = manager.read_session_view(
+                SessionCacheKey(
+                    codes=(
+                        "a",
+                        "b",
+                    ),
+                    marimo_version="-1",
+                )
+            )
+            assert not loaded_view.cell_operations
+
+    async def test_read_session_view_cache_hit(self):
+        """Test reading session view from cache file"""
+        view = SessionView()
+        view.cell_operations["cell1"] = CellOp(
+            cell_id="cell1",
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="test data",
+            ),
+            console=[],
+            timestamp=0,
+        )
+        view.cell_operations["cell2"] = CellOp(
+            cell_id="cell2",
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="test data",
+            ),
+            console=[],
+            timestamp=0,
+        )
+
+        view.add_control_request(
+            ExecuteMultipleRequest(
+                cell_ids=["cell1", "cell2"], codes=["a", "b"]
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "notebook.py"
+            cache_file = get_session_cache_file(path)
+            cache_file.parent.mkdir(parents=True)
+
+            # Write cache file
+            data = serialize_session_view(view)
+            cache_file.write_text(json.dumps(data))
+
+            # Read back
+            manager = SessionCacheManager(SessionView(), path, 0.1)
+            loaded_view = manager.read_session_view(
+                SessionCacheKey(
+                    codes=(
+                        "a",
+                        "b",
+                    ),
+                    marimo_version=__version__,
+                )
+            )
+            # cache hit: codes and version match
+            assert len(loaded_view.cell_operations) == 2

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -17,7 +17,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from marimo import __version__
 from marimo._ast.app import App, InternalApp
 from marimo._config.manager import (
     get_default_config_manager,
@@ -33,7 +32,6 @@ from marimo._runtime.requests import (
 from marimo._server.file_manager import AppFileManager
 from marimo._server.file_router import AppFileRouter
 from marimo._server.model import ConnectionState, SessionMode
-from marimo._server.session.serialize import SessionCacheKey
 from marimo._server.session.session_view import SessionView
 from marimo._server.sessions import (
     KernelManager,
@@ -973,7 +971,6 @@ def __():
         cell_data.code
         for cell_data in app_file_manager.app.cell_manager.cell_data()
     )
-    key = SessionCacheKey(codes=codes, marimo_version=__version__)
     session = Session(
         session_id,
         session_consumer,
@@ -985,7 +982,7 @@ def __():
     )
 
     # Test syncing when no cache exists
-    session.sync_session_view_from_cache(key=key)
+    session.sync_session_view_from_cache()
     # Should create a new empty session view since no cache exists
     assert session.session_view is not None
     assert session.session_cache_manager is not None
@@ -1015,7 +1012,7 @@ def __():
         get_default_config_manager(current_path=None),
         ttl_seconds=None,
     )
-    session2.sync_session_view_from_cache(key=key)
+    session2.sync_session_view_from_cache()
 
     # Verify the session views match
     assert session2.session_view is not None
@@ -1036,52 +1033,16 @@ def __():
         get_default_config_manager(current_path=None),
         ttl_seconds=None,
     )
-    session3.sync_session_view_from_cache(key=key)
+    session3.sync_session_view_from_cache()
     # Should create a new empty session view since no path exists
     assert session3.session_view is not None
     assert session3.session_cache_manager is not None
     assert session3.session_cache_manager.path is None
 
-    # Create a new session with mismatching codes
-    session4 = Session(
-        "test4",
-        session_consumer,
-        queue_manager,
-        kernel_manager,
-        app_file_manager,
-        get_default_config_manager(current_path=None),
-        ttl_seconds=None,
-    )
-    session4.sync_session_view_from_cache(
-        SessionCacheKey(codes=("hello", "world"), marimo_version="__version__")
-    )
-
-    # Verify the session view was not restored
-    assert not session4.session_view.operations
-
-    # Create a new session with mismatching version
-    session5 = Session(
-        "test5",
-        session_consumer,
-        queue_manager,
-        kernel_manager,
-        app_file_manager,
-        get_default_config_manager(current_path=None),
-        ttl_seconds=None,
-    )
-    session5.sync_session_view_from_cache(
-        SessionCacheKey(codes=codes, marimo_version="-1")
-    )
-
-    # Verify the session view was not restored
-    assert not session5.session_view.operations
-
     # Cleanup
     session.close()
     session2.close()
     session3.close()
-    session4.close()
-    session5.close()
     if kernel_manager.kernel_task:
         kernel_manager.kernel_task.join()
 


### PR DESCRIPTION
This change adds cache invalidation to the session view restoration logic when autorun on startup is disabled. 

The cache is keyed on the notebook code and the marimo version. Invalidating on marimo version change may be more aggressive than needed, it is a proxy for plugin API changes; we can relax this in the future if needed.