### PR TITLE
improvement: support dropping or copying base64 image files

### DIFF
--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -290,7 +290,9 @@ export async function insertImage(view: EditorView, file: File) {
 
       // A cancelled prompt returns null
       if (promptInput !== null) {
-        let filename = promptInput.trim();
+        let filename = promptInput;
+
+        // If user clicks Ok or presses Enter without typing anything
         if (filename.trim() === "") {
           filename = file.name;
         } else if (!filename.endsWith(`.${extension}`)) {

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -283,13 +283,19 @@ export async function insertImage(view: EditorView, file: File) {
   try {
     if (dataUrl.startsWith("data:")) {
       const base64 = dataUrl.split(",")[1];
-      const inputFilename = prompt(
-        "We can save your image as a file. Please enter a filename.",
+      const promptInput = prompt(
+        "Save image as a file. Enter a custom filename or leave blank to use the original filename.",
       );
+      const extension = file.type.split("/")[1];
 
-      if (inputFilename) {
-        const extension = file.type.split("/")[1];
-        const filename = `${inputFilename}.${extension}`;
+      // A cancelled prompt returns null
+      if (promptInput !== null) {
+        let filename = promptInput.trim();
+        if (filename.trim() === "") {
+          filename = file.name;
+        } else if (!filename.endsWith(`.${extension}`)) {
+          filename = `${filename}.${extension}`;
+        }
 
         const fileCreationResponse = await sendCreateFileOrFolder({
           path: "" as FilePath, // Root path

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -284,7 +284,7 @@ export async function insertImage(view: EditorView, file: File) {
     if (dataUrl.startsWith("data:")) {
       const base64 = dataUrl.split(",")[1];
       const inputFilename = prompt(
-        "Save your image as a file? Please enter a filename.",
+        "We can save your image as a file. Please enter a filename.",
       );
 
       if (inputFilename) {

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -283,26 +283,24 @@ export async function insertImage(view: EditorView, file: File) {
   try {
     if (dataUrl.startsWith("data:")) {
       const base64 = dataUrl.split(",")[1];
-      const promptInput = prompt(
-        "We can save your image as a file. Enter a custom filename or leave blank to use the original filename.",
+      let inputFilename = prompt(
+        "We can save your image as a file. Enter a filename.",
+        file.name,
       );
       const extension = file.type.split("/")[1];
 
       // A cancelled prompt returns null
-      if (promptInput !== null) {
-        let filename = promptInput;
-
-        // If user clicks Ok or presses Enter without typing anything
-        if (filename.trim() === "") {
-          filename = file.name;
-        } else if (!filename.endsWith(`.${extension}`)) {
-          filename = `${filename}.${extension}`;
+      if (inputFilename !== null) {
+        if (inputFilename.trim() === "") {
+          inputFilename = file.name;
+        } else if (!inputFilename.endsWith(`.${extension}`)) {
+          inputFilename = `${inputFilename}.${extension}`;
         }
 
         const fileCreationResponse = await sendCreateFileOrFolder({
           path: "" as FilePath, // Root path
           type: "file",
-          name: filename,
+          name: inputFilename,
           contents: base64,
         });
 

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -284,7 +284,7 @@ export async function insertImage(view: EditorView, file: File) {
     if (dataUrl.startsWith("data:")) {
       const base64 = dataUrl.split(",")[1];
       const promptInput = prompt(
-        "Save image as a file. Enter a custom filename or leave blank to use the original filename.",
+        "We can save your image as a file. Enter a custom filename or leave blank to use the original filename.",
       );
       const extension = file.type.split("/")[1];
 

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -1,4 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { toast } from "@/components/ui/use-toast";
+import { sendCreateFileOrFolder } from "@/core/network/requests";
+import type { FilePath } from "@/utils/paths";
 import {
   EditorSelection,
   type SelectionRange,
@@ -274,11 +277,55 @@ export async function insertImage(view: EditorView, file: File) {
     reader.readAsDataURL(file);
   });
 
+  let savedFilePath: string | undefined;
+
+  // If the file is base64 encoded, we can save it locally to prevent large file strings
+  try {
+    if (dataUrl.startsWith("data:")) {
+      const base64 = dataUrl.split(",")[1];
+      const inputFilename = prompt(
+        "Save your image as a file? Please enter a filename.",
+      );
+
+      if (inputFilename) {
+        const extension = file.type.split("/")[1];
+        const filename = `${inputFilename}.${extension}`;
+
+        const fileCreationResponse = await sendCreateFileOrFolder({
+          path: "" as FilePath, // Root path
+          type: "file",
+          name: filename,
+          contents: base64,
+        });
+
+        if (fileCreationResponse.success) {
+          savedFilePath = fileCreationResponse.info?.path;
+          toast({
+            title: "Image uploaded successfully",
+            description: `We've uploaded your image as ${savedFilePath}`,
+          });
+        } else {
+          toast({
+            title: "Failed to upload image. Using raw base64 string.",
+          });
+        }
+      }
+    }
+  } catch {
+    toast({
+      title: "Failed to upload image. Using raw base64 string.",
+    });
+  }
+
   const changes = view.state.changeByRange((range) => {
     const text = view.state.sliceDoc(range.from, range.to);
     return {
       changes: [
-        { from: range.from, to: range.to, insert: `![${text}](${dataUrl})` },
+        {
+          from: range.from,
+          to: range.to,
+          insert: `![${text}](${savedFilePath ?? dataUrl})`,
+        },
       ],
       range,
     };


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #4278. When copying/dropping base64 images, it will prompt you and subsequently save the image in the root directory.
<img width="583" alt="image" src="https://github.com/user-attachments/assets/8621e94f-b213-43ed-8ccd-0aff288d9720" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d64daaf2-5849-4fd1-985a-307fb252bc03" />

Because it's not a react component, I wasn't sure how to use a custom prompt/popup box.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
