### PR TITLE
add an alias to ffmpeg-python module

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -431,6 +431,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "fabric": "Fabric",
         "faker": "Faker",
         "fedora": "python-fedora",
+        "ffmpeg": "ffmpeg-python",
         "fias": "ailove-django-fias",
         "fiftyone_degrees": "51degrees-mobile-detector",
         "five": "five.pt",


### PR DESCRIPTION
## 📝 Summary

This pull request adds a module alias to map "ffmpeg" to "ffmpeg-python", enabling marimo to properly detect and install the correct Python package when ffmpeg imports are used in notebooks.

## 🔍 Description of Changes

**Added an alias mapping** from "ffmpeg" to "ffmpeg-python" in the package alias configuration. This change allows marimo to:

1. **Correctly identify** the required package when users import the ffmpeg module
2. **Install the proper PyPI package** (ffmpeg-python) instead of attempting to install an incorrect package
3. **Improve user experience** by reducing installation errors and confusion

This is necessary because the module name (ffmpeg) differs from the package name (ffmpeg-python) that needs to be installed via pip.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick

