### PR TITLE
fix: next page & styling of cells

### DIFF
--- a/frontend/src/components/data-table/cell-styling/types.ts
+++ b/frontend/src/components/data-table/cell-styling/types.ts
@@ -8,7 +8,7 @@ export type CellStyleState = Record<
 >;
 
 export interface CellStylingTableState {
-  cellStyling: CellStyleState | undefined;
+  cellStyling: CellStyleState | undefined | null;
 }
 
 export interface CellStylingCell {

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -57,7 +57,7 @@ interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   selection?: DataTableSelection;
   rowSelection?: RowSelectionState;
   cellSelection?: CellSelectionState;
-  cellStyling?: CellStyleState;
+  cellStyling?: CellStyleState | null;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   onCellSelectionChange?: OnChangeFn<CellSelectionState>;
   getRowIds?: GetRowIds;

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -104,7 +104,7 @@ type DataTableFunctions = {
   }) => Promise<{
     data: TableData<T>;
     total_rows: number;
-    cell_styles: CellStyleState | null;
+    cell_styles?: CellStyleState | null;
   }>;
   get_row_ids?: GetRowIds;
 };

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -104,7 +104,7 @@ type DataTableFunctions = {
   }) => Promise<{
     data: TableData<T>;
     total_rows: number;
-    cell_styles?: CellStyleState;
+    cell_styles: CellStyleState | null;
   }>;
   get_row_ids?: GetRowIds;
 };
@@ -193,7 +193,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
           total_rows: z.number(),
           cell_styles: z
             .record(z.record(z.object({}).passthrough()))
-            .optional(),
+            .nullable(),
         }),
       ),
     get_row_ids: rpc.input(z.object({}).passthrough()).output(
@@ -228,7 +228,7 @@ interface DataTableProps<T> extends Data<T>, DataTableFunctions {
   enableSearch: boolean;
   // Filters
   enableFilters?: boolean;
-  cellStyles?: CellStyleState;
+  cellStyles?: CellStyleState | null;
 }
 
 interface DataTableSearchProps {
@@ -287,7 +287,7 @@ export const LoadingDataTableComponent = memo(
     const { data, loading, error } = useAsyncData<{
       rows: T[];
       totalRows: number | "too_many";
-      cellStyles: CellStyleState | undefined;
+      cellStyles: CellStyleState | undefined | null;
     }>(async () => {
       // If there is no data, return an empty array
       if (props.totalRows === 0) {

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -739,11 +739,19 @@ class table(
                     return self._style_cell(row, col, selected_cells[0].value)
 
             columns = self._searched_manager.get_column_names()
+            response = self._get_row_ids({})
+
+            if response.all_rows is True or response.error is not None:
+                # TODO: Handle sorted rows, they have reverse order of row_ids
+                row_ids = range(skip, skip + take)
+            else:
+                row_ids = response.row_ids[skip : skip + take]
+
             return {
                 str(row): {
                     col: do_style_cell(str(row), col) for col in columns
                 }
-                for row in range(skip, skip + take)
+                for row in row_ids
             }
 
     def _search(self, args: SearchTableArgs) -> SearchTableResponse:
@@ -813,7 +821,16 @@ class table(
         )
 
     def _get_row_ids(self, args: EmptyArgs) -> GetRowIdsResponse:
-        """Get row IDs of a table. If searched, return searched rows else all rows."""
+        """Get row IDs of a table. If searched, return searched rows else all_rows flag is True.
+
+        Args:
+            args (EmptyArgs): Empty arguments
+
+        Returns:
+            GetRowIdsResponse: Response containing:
+                - row_ids: List of row IDs
+                - all_rows: Whether all rows are selected
+        """
         del args
 
         total_rows = self._manager.get_num_rows()
@@ -837,8 +854,8 @@ class table(
                 error="Select all with search is not supported for large datasets. Please filter to less than 1,000,000 rows",
             )
 
-        # For dictionary data, return sequential indices
-        if isinstance(self.data, dict):
+        # For dictionary or list data, return sequential indices
+        if isinstance(self.data, dict) or isinstance(self.data, list):
             return GetRowIdsResponse(
                 row_ids=list(range(num_rows_searched)),
                 all_rows=False,

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -739,8 +739,9 @@ class table(
                     return self._style_cell(row, col, selected_cells[0].value)
 
             columns = self._searched_manager.get_column_names()
-            response = self._get_row_ids({})
+            response = self._get_row_ids(EmptyArgs())
 
+            row_ids: list[int] | range
             if response.all_rows is True or response.error is not None:
                 # TODO: Handle sorted rows, they have reverse order of row_ids
                 row_ids = range(skip, skip + take)

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -595,7 +595,7 @@ def test_initial_cell_selection_happy_path() -> None:
     ]
 
 
-def test_get_row_ids() -> None:
+def test_get_row_ids_dict() -> None:
     data = {
         "id": [1, 2, 3] * 3,
         "fruits": ["banana", "apple", "cherry"] * 3,
@@ -619,6 +619,26 @@ def test_get_row_ids() -> None:
     response = table._get_row_ids(EmptyArgs())
     # For dicts, we do not need to find row_id, we just return the index
     assert response.row_ids == [0, 1, 2]
+    assert response.all_rows is False
+    assert response.error is None
+
+
+def test_get_row_ids_for_lists() -> None:
+    table = ui.table(["apples", "bananas", "bananas", "cherries"])
+    initial_response = table._get_row_ids(EmptyArgs())
+    assert initial_response.all_rows is True
+    assert initial_response.row_ids == []
+    assert initial_response.error is None
+
+    table._search(
+        SearchTableArgs(
+            query="banana",
+            page_size=10,
+            page_number=0,
+        )
+    )
+    response = table._get_row_ids(EmptyArgs())
+    assert response.row_ids == [0, 1]
     assert response.all_rows is False
     assert response.error is None
 
@@ -1368,3 +1388,51 @@ def test_cell_style_of_next_page():
     assert "a" in cell_styles["2"]
     assert "backgroundColor" in cell_styles["2"]["a"]
     assert "green" in cell_styles["2"]["a"]["backgroundColor"]
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
+def test_cell_search_df_styles():
+    def always_green(_row, _col, _value):
+        return {"backgroundColor": "green"}
+
+    import polars as pl
+
+    data = ["apples", "apples", "bananas", "bananas", "carrots", "carrots"]
+
+    table = ui.table(pl.DataFrame(data), style_cell=always_green)
+    page = table._search(
+        SearchTableArgs(page_size=2, page_number=0, query="carrot")
+    )
+    assert page.cell_styles == {
+        "4": {"column_0": {"backgroundColor": "green"}},
+        "5": {"column_0": {"backgroundColor": "green"}},
+    }
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars not installed"
+)
+@pytest.mark.xfail(reason="Sorted rows are not supported for styling yet")
+def test_cell_search_df_styles_sorted():
+    def always_green(_row, _col, _value):
+        return {"backgroundColor": "green"}
+
+    import polars as pl
+
+    data = ["apples", "apples", "bananas", "bananas", "carrots", "carrots"]
+    table = ui.table(pl.DataFrame(data), style_cell=always_green)
+    page = table._search(
+        SearchTableArgs(
+            page_size=2,
+            page_number=0,
+            query="",
+            sort=SortArgs(by="column_0", descending=True),
+        )
+    )
+    # Sorted rows have reverse order of row_ids
+    assert page.cell_styles == {
+        "4": {"column_0": {"backgroundColor": "green"}},
+        "5": {"column_0": {"backgroundColor": "green"}},
+    }


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
<img width="462" alt="image" src="https://github.com/user-attachments/assets/226c975b-6b53-45fa-893e-80a4d4bae9b7" />

There is a bug where you are unable to move to next pages in a table / sort / search without an error.
This also fixes styling for dataframes as the row_id is not sequential. Sorted dfs are not handled though.

@nojaf, just fyi if i missed something. I tested with a decently large dataset but may not be correct.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
