### PR TITLE
improvement: format using popover for long strings

### DIFF
--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -222,8 +222,6 @@ export function generateColumns<T>({
         const format = column.getColumnFormatting?.();
 
         if (typeof value === "string" && value.length > MAX_STRING_LENGTH) {
-          const rendered = renderValue();
-
           if (format) {
             const formattedValue = column.applyColumnFormatting(value);
             return (
@@ -245,6 +243,7 @@ export function generateColumns<T>({
           }
 
           // Handle unformatted string values
+          const rendered = renderValue();
           let valueToDisplay: React.ReactNode;
 
           if (rendered === null) {

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -249,7 +249,7 @@ export function generateColumns<T>({
 
           return (
             <div onClick={selectCell} className={cellStyles}>
-              {stringValue}
+              <UrlDetector text={stringValue} />
             </div>
           );
         }

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -228,21 +228,29 @@ export function generateColumns<T>({
 
         const format = column.getColumnFormatting?.();
 
-        if (typeof value === "string" && value.length > MAX_STRING_LENGTH) {
+        if (typeof value === "string") {
           const stringValue = format
             ? String(column.applyColumnFormatting(value))
             : String(renderValue());
 
+          if (stringValue.length > MAX_STRING_LENGTH) {
+            return (
+              <PopoutColumn
+                cellStyles={cellStyles}
+                selectCell={selectCell}
+                rawStringValue={stringValue}
+                contentClassName="max-h-64 overflow-auto whitespace-pre-wrap break-words text-sm"
+                buttonText="X"
+              >
+                <UrlDetector text={stringValue} />
+              </PopoutColumn>
+            );
+          }
+
           return (
-            <PopoutColumn
-              cellStyles={cellStyles}
-              selectCell={selectCell}
-              rawStringValue={stringValue}
-              contentClassName="max-h-64 overflow-auto whitespace-pre-wrap break-words text-sm"
-              buttonText="X"
-            >
-              <UrlDetector text={stringValue} />
-            </PopoutColumn>
+            <div onClick={selectCell} className={cellStyles}>
+              {stringValue}
+            </div>
           );
         }
 
@@ -347,13 +355,6 @@ export function generateColumns<T>({
   }
 
   return columns;
-}
-
-function isLongString(value: unknown): boolean {
-  if (typeof value === "string") {
-    return value.length > MAX_STRING_LENGTH;
-  }
-  return false;
 }
 
 const PopoutColumn = ({

--- a/marimo/_smoke_tests/tables/rich_elements.py
+++ b/marimo/_smoke_tests/tables/rich_elements.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.11.26"
+__generated_with = "0.11.30"
 app = marimo.App(width="medium")
 
 
@@ -103,6 +103,10 @@ def _(alt, mo, pd):
         "raw_lists": [
             ["fruits", "trees", "animals"],
             ["humans", "aliens", "life"],
+        ],
+        "long_text": [
+            "lorem_ipsum_dollar_sit" * 20,
+            "lorem_ipsum_dollar_sit" * 20,
         ],
         "images": [img, html_img],
         "batch": user_info,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Some refactors and display long strings in a popup. Setting an artificial limit of 50 to decide when to use popup (else might be quite complex with useEffects and useRef).

![image](https://github.com/user-attachments/assets/d29f6352-2d0d-4d61-8653-4253d714a589)

The code feels messy, I will try to refactor.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
