### PR TITLE
fix: create public folder and then file

### DIFF
--- a/frontend/src/core/codemirror/markdown/__tests__/commands.test.ts
+++ b/frontend/src/core/codemirror/markdown/__tests__/commands.test.ts
@@ -220,7 +220,20 @@ describe("insertImage", () => {
     vi.mocked(sendCreateFileOrFolder).mockResolvedValueOnce({
       success: true,
       info: {
-        path: "hello.png",
+        path: "public",
+        name: "public",
+        isMarimoFile: true,
+        isDirectory: true,
+        lastModified: null,
+        children: [],
+        id: "",
+      },
+    });
+
+    vi.mocked(sendCreateFileOrFolder).mockResolvedValueOnce({
+      success: true,
+      info: {
+        path: "public/hello.png",
         name: "hello.png",
         isMarimoFile: true,
         isDirectory: false,
@@ -232,9 +245,9 @@ describe("insertImage", () => {
 
     await insertImage(view, mockPngFile());
 
-    expect(sendCreateFileOrFolder).toHaveBeenCalledTimes(1);
+    expect(sendCreateFileOrFolder).toHaveBeenCalledTimes(2);
     expect(view.state.doc.toString()).toMatchInlineSnapshot(
-      `"Hello, ![](hello.png)world!"`,
+      `"Hello, ![](public/hello.png)world!"`,
     );
   });
 
@@ -247,7 +260,20 @@ describe("insertImage", () => {
     vi.mocked(sendCreateFileOrFolder).mockResolvedValueOnce({
       success: true,
       info: {
-        path: "hello.jpg",
+        path: "public",
+        name: "public",
+        isMarimoFile: true,
+        isDirectory: true,
+        lastModified: null,
+        children: [],
+        id: "",
+      },
+    });
+
+    vi.mocked(sendCreateFileOrFolder).mockResolvedValueOnce({
+      success: true,
+      info: {
+        path: "public/hello.jpg",
         name: "hello.jpg",
         children: [],
         id: "",
@@ -263,9 +289,9 @@ describe("insertImage", () => {
 
     await insertImage(view, mockJpgFile());
 
-    expect(sendCreateFileOrFolder).toHaveBeenCalledTimes(1);
+    expect(sendCreateFileOrFolder).toHaveBeenCalledTimes(2);
     expect(view.state.doc.toString()).toMatchInlineSnapshot(
-      `"Hello, ![](hello.jpg)world!"`,
+      `"Hello, ![](public/hello.jpg)world!"`,
     );
   });
 

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -297,22 +297,37 @@ export async function insertImage(view: EditorView, file: File) {
           inputFilename = `${inputFilename}.${extension}`;
         }
 
-        const fileCreationResponse = await sendCreateFileOrFolder({
-          path: "" as FilePath, // Root path
-          type: "file",
-          name: inputFilename,
-          contents: base64,
+        // Create public folder if it doesn't exist
+        // Images must be in this folder as a static file
+        const createPublicFolderRes = await sendCreateFileOrFolder({
+          path: "public" as FilePath,
+          type: "directory",
+          name: "public",
         });
 
-        if (fileCreationResponse.success) {
-          savedFilePath = fileCreationResponse.info?.path;
-          toast({
-            title: "Image uploaded successfully",
-            description: `We've uploaded your image as ${savedFilePath}`,
+        if (createPublicFolderRes.success) {
+          const createFileRes = await sendCreateFileOrFolder({
+            path: "public" as FilePath,
+            type: "file",
+            name: inputFilename,
+            contents: base64,
           });
+
+          if (createFileRes.success) {
+            savedFilePath = createFileRes.info?.path;
+            toast({
+              title: "Image uploaded successfully",
+              description: `We've uploaded your image as ${savedFilePath}`,
+            });
+          } else {
+            toast({
+              title:
+                "Created public folder but failed to upload image. Using raw base64 string.",
+            });
+          }
         } else {
           toast({
-            title: "Failed to upload image. Using raw base64 string.",
+            title: "Failed to create public folder",
           });
         }
       }

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -321,13 +321,12 @@ export async function insertImage(view: EditorView, file: File) {
             });
           } else {
             toast({
-              title:
-                "Created public folder but failed to upload image. Using raw base64 string.",
+              title: "Failed to upload image. Using raw base64 string.",
             });
           }
         } else {
           toast({
-            title: "Failed to create public folder",
+            title: "Failed to create public folder to store the image.",
           });
         }
       }

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -307,7 +307,7 @@ export async function insertImage(view: EditorView, file: File) {
 
         if (createPublicFolderRes.success) {
           const createFileRes = await sendCreateFileOrFolder({
-            path: "public" as FilePath,
+            path: "" as FilePath, // Create at root
             type: "file",
             name: inputFilename,
             contents: base64,

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -300,14 +300,14 @@ export async function insertImage(view: EditorView, file: File) {
         // Create public folder if it doesn't exist
         // Images must be in this folder as a static file
         const createPublicFolderRes = await sendCreateFileOrFolder({
-          path: "public" as FilePath,
+          path: "" as FilePath, // Create at root dir
           type: "directory",
           name: "public",
         });
 
         if (createPublicFolderRes.success) {
           const createFileRes = await sendCreateFileOrFolder({
-            path: "" as FilePath, // Create at root
+            path: "public" as FilePath,
             type: "file",
             name: inputFilename,
             contents: base64,

--- a/frontend/src/core/saving/filename.ts
+++ b/frontend/src/core/saving/filename.ts
@@ -12,7 +12,7 @@ import { useImperativeModal } from "@/components/modal/ImperativeModal";
 import { connectionAtom } from "../network/connection";
 import { getAppConfig } from "../config/config";
 
-const filenameAtom = atom<string | null>(getFilenameFromDOM());
+export const filenameAtom = atom<string | null>(getFilenameFromDOM());
 
 export function useFilename() {
   return useAtomValue(filenameAtom);

--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -144,6 +144,7 @@ class OSFileSystem(FileSystem):
         if file_type == "directory":
             full_path.mkdir(parents=True, exist_ok=True)
         else:
+            full_path.parent.mkdir(parents=True, exist_ok=True)
             full_path.write_bytes(contents or b"")
         # encoding latin-1 to get an invertible representation of the
         # bytes as a string ...

--- a/tests/_server/files/test_os_file_system.py
+++ b/tests/_server/files/test_os_file_system.py
@@ -43,6 +43,17 @@ def test_create_file_with_duplicate_name(
     assert os.path.exists(expected_path)
 
 
+def test_create_file_and_parent_directories(
+    test_dir: str, fs: OSFileSystem
+) -> None:
+    test_file_name = "test_file.txt"
+    fs.create_file_or_directory(
+        f"{test_dir}/parent", "file", test_file_name, None
+    )
+    expected_path = os.path.join(test_dir, "parent", test_file_name)
+    assert os.path.exists(expected_path)
+
+
 def test_create_directory(test_dir: str, fs: OSFileSystem) -> None:
     test_dir_name = "test_dir"
     fs.create_file_or_directory(test_dir, "directory", test_dir_name, None)


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Creates a public folder and then saves the base64 file inside it. If notebook is in a nested directory, it will save it in a public folder next to it.
```
![](public/screenshot.png)
![](nested/public/screenshot.png)
```

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
