### PR TITLE
improve: stale indicator precedence over error

### DIFF
--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -118,6 +118,28 @@
     }
   }
 
+  /* Error styles for Cell, less precedence than needs run */
+  &.has-error,
+  &.error-outline {
+    outline: 1px solid var(--red-4);
+    @apply shadow-mdSolid shadow-[var(--red-8)];
+  }
+
+  &.has-error:hover {
+    @apply shadow-lgSolid shadow-[var(--red-8)];
+  }
+
+  &.has-error:focus-within,
+  &.has-error:focus-within:hover {
+    @apply shadow-xlSolid shadow-[var(--red-8)];
+  }
+
+  &.error-outline,
+  &.error-outline:focus-within {
+    box-shadow: 8px 8px 0 0 color-mix(in srgb, var(--error), transparent 80%);
+    background-color: var(--red-2);
+  }
+
   /* Needs Run */
   &.needs-run {
     @apply divide-stale shadow-mdSolid shadow-stale;
@@ -141,27 +163,6 @@
     }
   }
 
-  /* Error styles for Cell */
-  &.has-error,
-  &.error-outline {
-    outline: 1px solid var(--red-4);
-    @apply shadow-mdSolid shadow-[var(--red-8)];
-  }
-
-  &.has-error:hover {
-    @apply shadow-lgSolid shadow-[var(--red-8)];
-  }
-
-  &.has-error:focus-within,
-  &.has-error:focus-within:hover {
-    @apply shadow-xlSolid shadow-[var(--red-8)];
-  }
-
-  &.error-outline,
-  &.error-outline:focus-within {
-    box-shadow: 8px 8px 0 0 color-mix(in srgb, var(--error), transparent 80%);
-    background-color: var(--red-2);
-  }
 
   /* Focus state */
   &.focus-outline {

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -142,6 +142,8 @@
 
   /* Needs Run */
   &.needs-run {
+    /* TODO(akshayka): Can give this an outline to make more visible. */
+    outline: none;
     @apply divide-stale shadow-mdSolid shadow-stale;
 
     &:hover {


### PR DESCRIPTION
This change updates styling so that when a cell that has errors becomes stale (due to editing notebook code, for example), it is styled as a stale cell instead of an errored cell. This makes it easier to see which cells need to be rerun, and makes fixing errors feel less intimidating.

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/a05f35c6-19e5-4952-8026-e5c8df7362e3" />
