### PR TITLE
fix: clamp wide elements in slides

### DIFF
--- a/frontend/src/components/slides/slides-component.tsx
+++ b/frontend/src/components/slides/slides-component.tsx
@@ -102,7 +102,7 @@ const SlidesComponent = ({
               )}
             >
               {/* this centers the contents */}
-              <div className="m-auto">{child}</div>
+              <div className="m-auto max-w-full">{child}</div>
             </div>
           </SwiperSlide>
         );

--- a/marimo/_smoke_tests/slides.py
+++ b/marimo/_smoke_tests/slides.py
@@ -10,24 +10,24 @@
 
 import marimo
 
-__generated_with = "0.8.11"
+__generated_with = "0.11.31"
 app = marimo.App(layout_file="layouts/slides.slides.json")
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md("""# A Presentation on `Iris` Data""")
     return
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md("""## By the marimo team (`@marimo_io`)""")
     return
 
 
 @app.cell
-def __():
+def _():
     import marimo as mo
     import pandas as pd
     import altair as alt
@@ -35,22 +35,23 @@ def __():
 
 
 @app.cell
-def __(pd):
+def _(pd):
     df = pd.read_csv(
         "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv"
     )
-    return df,
+    df = pd.concat([df, df.add_suffix("_2")], axis=1)
+    return (df,)
 
 
 @app.cell
-def __(df, mo):
-    table = mo.ui.table(df, label="Iris Data in a table")
+def _(df, mo):
+    table = mo.ui.table(df, label="Wide Iris Data in a table")
     table
-    return table,
+    return (table,)
 
 
 @app.cell
-def __(alt, df, mo):
+def _(alt, df, mo):
     chart = mo.ui.altair_chart(
         alt.Chart(df)
         .mark_point()
@@ -58,23 +59,23 @@ def __(alt, df, mo):
         label="Iris Data in chart",
     )
     chart
-    return chart,
+    return (chart,)
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md("""# Thank you!""")
     return
 
 
 @app.cell
-def __():
+def _():
     # Some markdown testing
     return
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md(
         r"""
         # H1 (`H1`)
@@ -89,7 +90,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md(
         r"""
         - Item 1
@@ -102,7 +103,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md(
         r"""
         !!! note "Callouts"
@@ -113,7 +114,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.callout("""
     This is another callout
     """)
@@ -121,24 +122,24 @@ def __(mo):
 
 
 @app.cell
-def __():
+def _():
     return
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md(r"""## Items that don't quite work in slides""")
     return
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.accordion({"Accodrions too small": mo.md("Content")})
     return
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.ui.tabs({"Tabs to small": mo.md("Content")})
     return
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #4311 . Only wide elements are affected and scrollable horizontally.
<img width="631" alt="Screenshot 2025-03-31 at 12 05 07 PM" src="https://github.com/user-attachments/assets/09e5dfad-ed37-4aca-8d5e-888b41c132f4" />
<img width="400" alt="Screenshot 2025-03-31 at 12 05 07 PM" src="https://github.com/user-attachments/assets/a0c8d3e6-1f95-4a82-84a6-99a032eeb87a" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
