### PR TITLE
mep/8: Formatting for library serialization

### DIFF
--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -212,6 +212,13 @@ class CellManager:
             name: Optional name for the cell
             cell_config: Configuration for the cell
         """
+        # If this is the first cell, and it's name is setup, assume that it's
+        # the setup cell.
+        if len(self._cell_data) == 0 and name == SETUP_CELL_NAME:
+            cell_id = CellId_t(SETUP_CELL_NAME)
+        else:
+            cell_id = self.create_cell_id()
+
         # - code.split("\n")[1:-1] disregards first and last lines, which are
         #   empty
         # - line[4:] removes leading indent in multiline string
@@ -222,7 +229,7 @@ class CellManager:
         )
 
         self.register_cell(
-            cell_id=self.create_cell_id(),
+            cell_id=cell_id,
             code=code,
             config=cell_config,
             name=name or DEFAULT_CELL_NAME,

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -212,7 +212,7 @@ class CellManager:
             name: Optional name for the cell
             cell_config: Configuration for the cell
         """
-        # If this is the first cell, and it's name is setup, assume that it's
+        # If this is the first cell, and its name is setup, assume that it's
         # the setup cell.
         if len(self._cell_data) == 0 and name == SETUP_CELL_NAME:
             cell_id = CellId_t(SETUP_CELL_NAME)

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -136,6 +136,7 @@ def build_setup_section(setup_cell: Optional[CellImpl]) -> str:
         [
             "with app.setup:",
             indent_text(block),
+            "\n",
         ]
     )
 
@@ -334,7 +335,8 @@ def generate_filecontents(
         toplevel_defs = set(setup_cell.defs)
     extraction = TopLevelExtraction(codes, names, cell_configs, toplevel_defs)
     cell_blocks = [
-        serialize_cell(extraction, status, toplevel_fn) for status in extraction
+        serialize_cell(extraction, status, toplevel_fn)
+        for status in extraction
     ]
 
     if not toplevel_fn:
@@ -352,7 +354,6 @@ def generate_filecontents(
             generate_app_constructor(config),
             "",
             build_setup_section(setup_cell),
-            "\n",
             "\n\n\n".join(cell_blocks),
             "\n",
             'if __name__ == "__main__":',

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -177,9 +177,6 @@ def to_functiondef(
     # other static analysis tools can capture unused variables across cells.
     defs: tuple[str, ...] = tuple()
     if cell.defs:
-        # There are possible name error cases where a cell defines, and also
-        # requires a variable. We remove defs from the signature such that
-        # this causes a lint error in pyright.
         if used_refs is None:
             defs = tuple(name for name in sorted(cell.defs))
         else:
@@ -255,9 +252,9 @@ def serialize_cell(
         return to_functiondef(
             cell,
             status.name,
-            # There are possible name error cases where a cell defines, and also
+            # There are possible NameError cases where a cell defines and also
             # requires a variable. We remove defs from the signature such that
-            # this causes a lint error in pyright.
+            # this causes a lint error in programs like pyright.
             extraction.allowed_refs | cell.defs,
             extraction.used_refs,
             fn="cell",

--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -67,6 +67,9 @@ def ends_with_semicolon(code: str) -> bool:
             token_types.NEWLINE,
             token_types.NL,
             token_types.COMMENT,
+            token_types.INDENT,
+            token_types.DEDENT,
+            token_types.ENCODING,
         ):
             continue
         return token.string == ";"

--- a/marimo/_ast/toplevel.py
+++ b/marimo/_ast/toplevel.py
@@ -5,6 +5,11 @@ import builtins
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Optional, Union, get_args
 
+from tokenize import tokenize
+import token as token_types
+from io import BytesIO
+from tokenize import TokenInfo
+
 from marimo._ast.app import InternalApp
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
@@ -25,6 +30,7 @@ TopLevelInvalidHints = Literal[
     "Signature and decorators depend on {} defined out of correct cell order",
     "Function contains references to variables {} which are not top level.",
     "Function contains references to variables {} which failed to be toplevel.",
+    "Cell cannot contain non-indented trailing comments.",
 ]
 (
     HINT_UNPARSABLE,
@@ -33,10 +39,28 @@ TopLevelInvalidHints = Literal[
     HINT_ORDER_DEPENDENT,
     HINT_HAS_REFS,
     HINT_HAS_CLOSE_REFS,
+    HINT_HAS_COMMENT,
 ) = get_args(TopLevelInvalidHints)
 
 TopLevelHints = Union[Literal["Valid"], TopLevelInvalidHints]
 HINT_VALID, *_ = get_args(TopLevelHints)
+
+
+def has_trailing_comment(code: str) -> bool:
+    # Requires tokenization because multiline strings can start a line with #.
+    tokens = tokenize(BytesIO(code.strip().encode("utf-8")).readline)
+    for token in reversed(list(tokens)):
+        if token.type in (
+            token_types.ENDMARKER,
+            token_types.NEWLINE,
+            token_types.NL,
+            token_types.INDENT,
+            token_types.DEDENT,
+            token_types.ENCODING,
+        ):
+            continue
+        return token.type == token_types.COMMENT and token.start[1] == 0
+    return False
 
 
 class TopLevelType(Enum):
@@ -107,6 +131,12 @@ class TopLevelStatus:
         (self.name,) = self._cell.defs
         if self.name in ("app", "__generated_with", "__name__"):
             self.demote(HINT_BAD_NAME)
+            return
+
+        # Trailing comments are not allowed, since no easy way to recapture
+        # them.
+        if has_trailing_comment(self.code):
+            self.demote(HINT_HAS_COMMENT)
             return
 
         allowed_refs = set(allowed_refs) | {self.name}

--- a/marimo/_ast/toplevel.py
+++ b/marimo/_ast/toplevel.py
@@ -2,13 +2,11 @@
 from __future__ import annotations
 
 import builtins
-from enum import Enum
-from typing import TYPE_CHECKING, Literal, Optional, Union, get_args
-
-from tokenize import tokenize
 import token as token_types
+from enum import Enum
 from io import BytesIO
-from tokenize import TokenInfo
+from tokenize import tokenize
+from typing import TYPE_CHECKING, Literal, Optional, Union, get_args
 
 from marimo._ast.app import InternalApp
 from marimo._ast.cell import CellConfig, CellImpl

--- a/marimo/_ast/toplevel.py
+++ b/marimo/_ast/toplevel.py
@@ -332,9 +332,9 @@ class TopLevelExtraction:
         names = ["_" for cell in cells]
         cell_configs = [cell.config for cell in cells]
 
-        from marimo._ast.codegen import get_setup_cell
+        from marimo._ast.codegen import pop_setup_cell
 
-        setup = get_setup_cell(codes, names, cell_configs, True)
+        setup = pop_setup_cell(codes, names, cell_configs, True)
         if setup:
             return cls(codes, names, cell_configs, setup.defs)
         return cls(codes, names, cell_configs, set())
@@ -345,9 +345,9 @@ class TopLevelExtraction:
         names = list(app.cell_manager.names())
         cell_configs = list(app.cell_manager.configs())
 
-        from marimo._ast.codegen import get_setup_cell
+        from marimo._ast.codegen import pop_setup_cell
 
-        setup = get_setup_cell(codes, names, cell_configs, True)
+        setup = pop_setup_cell(codes, names, cell_configs, True)
         if setup:
             return cls(codes, names, cell_configs, setup.defs)
         return cls(codes, names, cell_configs, set())

--- a/tests/_ast/codegen_data/test_generate_filecontents_toplevel.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_toplevel.py
@@ -74,5 +74,13 @@ def fun_that_uses_another():
     return fun_that_uses_mo()
 
 
+@app.cell
+def cell_with_ref_and_def():
+    if mo is None:
+        var = maybe
+    maybe = 1
+    return (maybe,)
+
+
 if __name__ == "__main__":
     app.run()

--- a/tests/_ast/codegen_data/test_generate_filecontents_toplevel.py
+++ b/tests/_ast/codegen_data/test_generate_filecontents_toplevel.py
@@ -46,7 +46,6 @@ def shadow_case(shadow):
 def _(shadow):
     def reference_case():
         return shadow
-
     return
 
 
@@ -55,7 +54,6 @@ def _(globe):
     def global_case():
         global globe
         return globe
-
     return
 
 
@@ -80,6 +78,15 @@ def cell_with_ref_and_def():
         var = maybe
     maybe = 1
     return (maybe,)
+
+
+@app.cell
+def _():
+    # Trailing comments should break function serialization.
+    def addition_with_trailing_comments(a, b):
+        return a + b
+    # This is a comment
+    return
 
 
 if __name__ == "__main__":

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -66,10 +66,6 @@ def wrap_generate_filecontents(
     )
 
 
-def strip_blank_lines(text: str) -> str:
-    return "\n".join([line for line in text.splitlines() if line.strip()])
-
-
 def get_idempotent_marimo_source(name: str) -> str:
     from marimo._utils.formatter import Formatter
 
@@ -89,15 +85,11 @@ def get_idempotent_marimo_source(name: str) -> str:
     with open(path) as f:
         python_source = sanitized_version(f.read())
 
-    # TODO(dmadisetti): not totally idempotent for now. Revise; seems to strip
-    # on imports (possibly during compile?).
     formatted = Formatter(codegen.MAX_LINE_LENGTH).format(
         {"source": python_source, "generated": generated_contents}
     )
 
-    assert strip_blank_lines(formatted["source"]) == strip_blank_lines(
-        formatted["generated"]
-    )
+    assert formatted["source"] == formatted["generated"]
     return formatted["generated"]
 
 

--- a/tests/_ast/test_toplevel.py
+++ b/tests/_ast/test_toplevel.py
@@ -143,6 +143,38 @@ class TestTopLevelExtraction:
         assert [TopLevelType.TOPLEVEL] == [s.type for s in extraction]
 
     @staticmethod
+    def test_function_trailing_comment(app) -> None:
+        @app.cell
+        def cell():
+            def add(a: int, b: int) -> float:
+                return a + b
+
+            # Comment
+
+        extraction = TopLevelExtraction.from_app(InternalApp(app))
+        assert [TopLevelType.CELL] == [s.type for s in extraction]
+        assert extraction.statuses[0].hint == toplevel.HINT_HAS_COMMENT
+
+    @staticmethod
+    def test_function_trailing_comment_ok(app) -> None:
+        @app.cell
+        def cell():
+            def add(a: int, b: int) -> float:
+                return a + b
+                # Comment
+
+        @app.cell
+        def tricky_cell():
+            def md() -> float:
+                return """
+            #"""
+
+        extraction = TopLevelExtraction.from_app(InternalApp(app))
+        assert [TopLevelType.TOPLEVEL, TopLevelType.TOPLEVEL] == [
+            s.type for s in extraction
+        ]
+
+    @staticmethod
     def test_function_uses_top_fn_unresolved(app) -> None:
         @app.cell
         def cell(c):


### PR DESCRIPTION
## 📝 Summary

Followup for mep/8. These are minor formatting tweaks needed for broader release.

 - Fixes some white space variation between ruff and serialization
 - prevents trailing comments from being stripped in top level functions
 - allows for unparseable setup cells

@akshayka OR @mscolnick