### PR TITLE
improvement: Add "left" and "right" to `position` argument in `show_code`

### DIFF
--- a/marimo/_output/show_code.py
+++ b/marimo/_output/show_code.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from marimo._output.formatting import as_html
 from marimo._output.hypertext import Html
-from marimo._plugins.stateless.flex import vstack, hstack
+from marimo._plugins.stateless.flex import hstack, vstack
 from marimo._plugins.ui._impl.input import code_editor
 from marimo._runtime.context import get_context
 from marimo._runtime.context.types import ContextNotInitializedError
@@ -33,7 +33,9 @@ def substitute_show_code_with_arg(code: str) -> str:
 
 
 def show_code(
-    output: object = None, *, position: Literal["above", "below", "left", "right"] = "below"
+    output: object = None,
+    *,
+    position: Literal["above", "below", "left", "right"] = "below",
 ) -> Html:
     """Display an output along with the code of the current cell.
 
@@ -75,7 +77,7 @@ def show_code(
       to just show the cell's code.
     - `position`: Where to display the code relative to the output.
       Use "above" to show code above the output, "below" (default) to show
-      code below the output, "left" to show code left of the ouptut, or
+      code below the output, "left" to show code left of the output, or
       "right" to show code right of the output.
 
     **Returns:**

--- a/marimo/_output/show_code.py
+++ b/marimo/_output/show_code.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from marimo._output.formatting import as_html
 from marimo._output.hypertext import Html
-from marimo._plugins.stateless.flex import vstack
+from marimo._plugins.stateless.flex import vstack, hstack
 from marimo._plugins.ui._impl.input import code_editor
 from marimo._runtime.context import get_context
 from marimo._runtime.context.types import ContextNotInitializedError
@@ -33,7 +33,7 @@ def substitute_show_code_with_arg(code: str) -> str:
 
 
 def show_code(
-    output: object = None, *, position: Literal["above", "below"] = "below"
+    output: object = None, *, position: Literal["above", "below", "left", "right"] = "below"
 ) -> Html:
     """Display an output along with the code of the current cell.
 
@@ -74,15 +74,16 @@ def show_code(
     - `output`: the output to display with the cell's code; omit the output
       to just show the cell's code.
     - `position`: Where to display the code relative to the output.
-      Use "above" to show code above the output, or "below" (default) to show
-      code below the output.
+      Use "above" to show code above the output, "below" (default) to show
+      code below the output, "left" to show code left of the ouptut, or
+      "right" to show code right of the output.
 
     **Returns:**
 
     HTML of the `output` arg displayed with its code.
     """
-    assert position in ["above", "below"], (
-        "position must be 'above' or 'below'"
+    assert position in ["above", "below", "left", "right"], (
+        "position must be 'above', 'below', 'left' or 'right'."
     )
 
     try:
@@ -105,12 +106,27 @@ def show_code(
                     as_html(output),
                 ]
             )
-        else:
+        elif position == "below":
             return vstack(
                 [
                     as_html(output),
                     code_editor(value=code, disabled=True, min_height=1),
                 ]
             )
+        elif position == "left":
+            return hstack(
+                [
+                    code_editor(value=code, disabled=True, min_height=1),
+                    as_html(output),
+                ]
+            )
+        else:
+            return hstack(
+                [
+                    as_html(output),
+                    code_editor(value=code, disabled=True, min_height=1),
+                ]
+            )
+
     else:
         return code_editor(value=code, disabled=True, min_height=1)

--- a/tests/_output/test_show_code.py
+++ b/tests/_output/test_show_code.py
@@ -130,6 +130,50 @@ async def test_show_code_position_below(
     ), "Output should appear before code"
 
 
+async def test_show_code_position_left(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    await k.run(
+        [
+            exec_req.get(
+                'import marimo as mo; x = mo.show_code(1, position="left")'
+            )
+        ]
+    )
+    result = k.globals["x"].text
+    assert "<marimo-code-editor" in result, (
+        "Expected '<marimo-code-editor>' in output but not found"
+    )
+    assert "<span>1</span>" in result, (
+        "Expected '<span>1</span>' in output but not found"
+    )
+    assert result.index("<marimo-code-editor") < result.index(
+        "<span>1</span>"
+    ), "Code should appear before output"
+
+
+async def test_show_code_position_right(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    await k.run(
+        [
+            exec_req.get(
+                'import marimo as mo; x = mo.show_code(1, position="right")'
+            )
+        ]
+    )
+    result = k.globals["x"].text
+    assert "<marimo-code-editor" in result, (
+        "Expected '<marimo-code-editor>' in output but not found"
+    )
+    assert "<span>1</span>" in result, (
+        "Expected '<span>1</span>' in output but not found"
+    )
+    assert result.index("<span>1</span>") < result.index(
+        "<marimo-code-editor"
+    ), "Output should appear before code"
+
+
 async def test_show_code_position_default(
     k: Kernel, exec_req: ExecReqProvider
 ) -> None:


### PR DESCRIPTION
## 📝 Summary

`mo.show_code()` has a position option that currently has two possible values, "above" and "below". For the `Slides` view it would be nice to have code and output side-by-side. This tries to add that.

## 🔍 Description of Changes

Basically just copied the cases for above/below and replaced the `vstack` with `hstack`. Not sure if this has implications I'm unaware of.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
