### PR TITLE
feat: marimo new 'prompt to generate notebook'

### DIFF
--- a/marimo/_ai/text_to_notebook.py
+++ b/marimo/_ai/text_to_notebook.py
@@ -1,0 +1,108 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import datetime
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+from marimo import __version__
+from marimo._cli.print import bold, green, muted
+from marimo._config.cli_state import (
+    get_cli_state,
+    write_cli_state,
+)
+from marimo._server.utils import print_
+
+TERMS = """
+Before using marimo's Text-To-Notebook AI feature, you must accept the following terms:
+
+1. Your prompt will be sent to marimo's API at `https://ai.marimo.app/`
+2. The API uses OpenAI/Anthropic's models to convert your prompt into a notebook
+3. Your prompt is securely stored for caching and service improvement purposes
+4. No personal data beyond the prompt itself is collected
+5. You can revoke consent at any time by modifying ~/.marimo/state.toml
+"""
+
+TERMS_LAST_UPDATED = datetime.datetime(2025, 4, 1)
+
+
+def text_to_notebook(prompt: str) -> str:
+    """
+    Generate a notebook from a text prompt.
+
+    Args:
+        prompt: The text prompt to generate a notebook from.
+
+    Returns:
+        The generated notebook as a string.
+
+    Raises:
+        ValueError: If the user has not accepted the terms.
+        RuntimeError: If the API request fails.
+    """
+    # Check if the user has accepted the terms
+    state = get_cli_state()
+    if not state:
+        raise RuntimeError(
+            "Failed to get CLI configuration at ~/.marimo/state.toml"
+        )
+
+    if _should_show_terms(state.accepted_text_to_notebook_terms_at):
+        # User hasn't accepted terms
+        print_(bold(TERMS))
+        print_(bold("Do you accept these terms? (y/n)"))
+
+        response = input().strip().lower()
+        if response != "y":
+            raise ValueError("Terms not accepted.")
+
+        # Update state with acceptance
+        today = datetime.datetime.now().date().strftime("%Y-%m-%d")
+        state.accepted_text_to_notebook_terms_at = today
+
+        write_cli_state(state)
+
+    # Call the API
+    try:
+        url = f"https://ai.marimo.app/api/notebook.py?prompt={urllib.parse.quote(prompt)}"
+        print_(muted("Generating notebook this may take a few seconds..."))
+
+        # Create a request with a proper User-Agent header
+        headers = {"User-Agent": f"marimo-cli/{__version__}"}
+        req = urllib.request.Request(url, headers=headers)
+
+        with urllib.request.urlopen(req) as response:
+            result = response.read().decode()
+
+        print_(green("Notebook generated successfully."))
+
+        # Check if the response is valid
+        if "marimo.App" not in result:
+            raise RuntimeError(
+                "Invalid response from API: missing 'marimo.App' key"
+            )
+
+        return result
+
+    except Exception as e:
+        raise RuntimeError(f"Failed to generate notebook: {str(e)}") from e
+
+
+def _should_show_terms(last_accepted_at: Optional[str]) -> bool:
+    """
+    Determine if the terms should be shown to the user.
+
+    Args:
+        last_accepted_at (Optional[str]): The date the user last accepted the terms.
+
+    Returns:
+        bool: Whether the terms should be shown to the user.
+    """
+    if not last_accepted_at:
+        return True
+    last_accepted_date = datetime.datetime.strptime(
+        last_accepted_at, "%Y-%m-%d"
+    )
+    return last_accepted_date < TERMS_LAST_UPDATED

--- a/marimo/_ai/text_to_notebook.py
+++ b/marimo/_ai/text_to_notebook.py
@@ -5,7 +5,7 @@ import datetime
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Optional
+from typing import Optional, cast
 
 from marimo import __version__
 from marimo._cli.print import bold, green, muted
@@ -16,11 +16,11 @@ from marimo._config.cli_state import (
 from marimo._server.utils import print_
 
 TERMS = """
-Before using marimo's Text-To-Notebook AI feature, you must accept the following terms:
+Before using marimo's Text-To-Notebook AI feature, you should know:
 
 1. Your prompt will be sent to marimo's API at `https://ai.marimo.app/`
 2. The API uses OpenAI/Anthropic's models to convert your prompt into a notebook
-3. Your prompt is securely stored for caching and service improvement purposes
+3. Your prompt is securely stored for caching purposes (fast response times)
 4. No personal data beyond the prompt itself is collected
 5. You can revoke consent at any time by modifying ~/.marimo/state.toml
 """
@@ -74,7 +74,7 @@ def text_to_notebook(prompt: str) -> str:
         req = urllib.request.Request(url, headers=headers)
 
         with urllib.request.urlopen(req) as response:
-            result = response.read().decode()
+            result = response.read().decode("utf-8")  # type: ignore[attr-defined]
 
         print_(green("Notebook generated successfully."))
 
@@ -84,7 +84,7 @@ def text_to_notebook(prompt: str) -> str:
                 "Invalid response from API: missing 'marimo.App' key"
             )
 
-        return result
+        return cast(str, result)
 
     except Exception as e:
         raise RuntimeError(f"Failed to generate notebook: {str(e)}") from e

--- a/marimo/_cli/upgrade.py
+++ b/marimo/_cli/upgrade.py
@@ -75,10 +75,7 @@ def _update_with_latest_version(state: MarimoCLIState) -> MarimoCLIState:
     # querying pypi is +250kb and there is not a better API
     # this endpoint just returns the version
     # so we only use pypi in tests
-    is_test = (
-        os.environ.get("MARIMO_PYTEST_HOME_DIR") is not None
-        or os.environ.get("PYTEST_CURRENT_TEST") is not None
-    )
+    is_test = os.environ.get("MARIMO_PYTEST_HOME_DIR") is not None
     if is_test:
         api_url = "https://pypi.org/pypi/marimo/json"
     else:

--- a/marimo/_cli/upgrade.py
+++ b/marimo/_cli/upgrade.py
@@ -5,25 +5,22 @@ import json
 import os
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from marimo import __version__ as current_version, _loggers
 from marimo._cli.print import echo, green, orange
+from marimo._config.cli_state import (
+    MarimoCLIState,
+    get_cli_state,
+    write_cli_state,
+)
 from marimo._server.api.status import HTTPException
 from marimo._tracer import server_tracer
-from marimo._utils.config.config import ConfigReader
 
 FETCH_TIMEOUT = 3
 
 LOGGER = _loggers.marimo_logger()
-
-
-@dataclass
-class MarimoCLIState:
-    latest_version: Optional[str] = None
-    last_checked_at: Optional[str] = None
 
 
 def print_latest_version(current_version: str, latest_version: str) -> None:
@@ -46,15 +43,9 @@ def check_for_updates(on_update: Callable[[str, str], None]) -> None:
 def _check_for_updates_internal(on_update: Callable[[str, str], None]) -> None:
     from packaging import version
 
-    config_reader = ConfigReader.for_filename("state.toml")
-    if not config_reader:
-        # Couldn't find home directory, so do nothing
+    state = get_cli_state()
+    if not state:
         return
-
-    # Load the state file or create a default state if it doesn't exist
-    state: MarimoCLIState = config_reader.read_toml(
-        MarimoCLIState, fallback=MarimoCLIState()
-    )
 
     # Maybe update the state with the latest version
     state = _update_with_latest_version(state)
@@ -70,7 +61,7 @@ def _check_for_updates_internal(on_update: Callable[[str, str], None]) -> None:
         on_update(current_version, state.latest_version)
 
     # Save the state, create directories if necessary
-    config_reader.write_toml(state)
+    write_cli_state(state)
 
 
 DATE_FORMAT = "%Y-%m-%d"
@@ -84,7 +75,10 @@ def _update_with_latest_version(state: MarimoCLIState) -> MarimoCLIState:
     # querying pypi is +250kb and there is not a better API
     # this endpoint just returns the version
     # so we only use pypi in tests
-    is_test = os.environ.get("MARIMO_PYTEST_HOME_DIR") is not None
+    is_test = (
+        os.environ.get("MARIMO_PYTEST_HOME_DIR") is not None
+        or os.environ.get("PYTEST_CURRENT_TEST") is not None
+    )
     if is_test:
         api_url = "https://pypi.org/pypi/marimo/json"
     else:

--- a/marimo/_config/cli_state.py
+++ b/marimo/_config/cli_state.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from marimo._utils.config.config import ConfigReader
+
+
+@dataclass
+class MarimoCLIState:
+    latest_version: Optional[str] = None
+    last_checked_at: Optional[str] = None
+    accepted_text_to_notebook_terms_at: Optional[str] = None
+
+
+FILE_NAME = "state.toml"
+
+
+def get_cli_state() -> Optional[MarimoCLIState]:
+    config_reader = ConfigReader.for_filename(FILE_NAME)
+    if not config_reader:
+        # Couldn't find home directory, so do nothing
+        return
+
+    # Load the state file or create a default state if it doesn't exist
+    state = config_reader.read_toml(MarimoCLIState, fallback=MarimoCLIState())
+    return state
+
+
+def write_cli_state(state: MarimoCLIState) -> None:
+    config_reader = ConfigReader.for_filename(FILE_NAME)
+    if not config_reader:
+        # Couldn't find home directory, so do nothing
+        return
+    config_reader.write_toml(state)

--- a/marimo/_config/cli_state.py
+++ b/marimo/_config/cli_state.py
@@ -21,7 +21,7 @@ def get_cli_state() -> Optional[MarimoCLIState]:
     config_reader = ConfigReader.for_filename(FILE_NAME)
     if not config_reader:
         # Couldn't find home directory, so do nothing
-        return
+        return None
 
     # Load the state file or create a default state if it doesn't exist
     state = config_reader.read_toml(MarimoCLIState, fallback=MarimoCLIState())

--- a/tests/_cli/test_upgrade.py
+++ b/tests/_cli/test_upgrade.py
@@ -8,11 +8,11 @@ from typing import Any
 from unittest.mock import mock_open, patch
 
 from marimo._cli.upgrade import (
-    MarimoCLIState,
     _update_with_latest_version,
     check_for_updates,
     print_latest_version,
 )
+from marimo._config.cli_state import MarimoCLIState
 
 
 @patch("marimo._cli.upgrade.current_version", "0.1.0")


### PR DESCRIPTION
This adds marimo's text-to-notebook directly in the CLI.

Users can run `marimo new "notebook to analyze a csv about cars"` that will create a brand new notebook use the same endpoints used in https://marimo.app/ai

For now it defaults to our backed, but in future we can extend to a user's own endpoints. 