### PR TITLE
fix: add tutorial dependencies 

### DIFF
--- a/marimo/_tutorials/dataflow.py
+++ b/marimo/_tutorials/dataflow.py
@@ -9,12 +9,12 @@
 
 import marimo
 
-__generated_with = "0.9.30"
+__generated_with = "0.12.2"
 app = marimo.App()
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         # How marimo notebooks run
@@ -31,7 +31,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         r"""
         **Tip: disabling automatic execution.**
@@ -51,7 +51,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ## References and definitions
@@ -74,7 +74,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### Example
@@ -87,7 +87,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.accordion(
         {
             "Tip: inspecting refs and defs": f"""
@@ -104,7 +104,7 @@ def __(mo):
 
 
 @app.cell
-def __(amplitude, mo, period, plot_wave):
+def _(amplitude, mo, period, plot_wave):
     mo.md(
         f"""
         {mo.as_html(plot_wave(amplitude, period))}
@@ -117,7 +117,7 @@ def __(amplitude, mo, period, plot_wave):
 
 
 @app.cell
-def __(mo):
+def _(mo):
     period = 2 * 3.14159
 
     mo.md(
@@ -130,7 +130,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def _(mo):
     amplitude = 1
 
     mo.md(
@@ -143,16 +143,8 @@ def __(mo):
 
 
 @app.cell
-def __(matplotlib_installed, mo, np, numpy_installed, plt):
+def _(mo, np, plt):
     def plot_wave(amplitude, period):
-        if not numpy_installed:
-            return mo.md(
-                "> Oops! It looks like you don't have `numpy` installed."
-            )
-        if not matplotlib_installed:
-            return mo.md(
-                "> Oops! It looks like you don't have `matplotlib` installed."
-            )
         x = np.linspace(0, 2 * np.pi, 256)
         plt.plot(x, amplitude * np.sin(2 * np.pi / period * x))
         plt.xlim(0, 2 * np.pi)
@@ -175,7 +167,7 @@ def __(matplotlib_installed, mo, np, numpy_installed, plt):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         🌊 **Try it!** In the above cells, try changing the value `period` or 
@@ -187,7 +179,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         Here is the dataflow graph for the cells that make the sine wave plot, plus
@@ -217,7 +209,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ## Dataflow programming
@@ -231,7 +223,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### Execution order is not cell order
@@ -246,7 +238,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### Global variable names must be unique
@@ -263,21 +255,21 @@ def __(mo):
 
 
 @app.cell
-def __():
+def _():
     planet = "Mars"
     planet
     return (planet,)
 
 
 @app.cell
-def __():
+def _():
     planet = "Earth"
     planet
     return (planet,)
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         **🌊 Try it!** In the previous cell, change the name `planet` to `home`, 
@@ -288,7 +280,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         Because defs must be unique, global variables cannot be modified with
@@ -303,19 +295,19 @@ def __(mo):
 
 
 @app.cell
-def __():
+def _():
     count = 0
     return (count,)
 
 
 @app.cell
-def __():
+def _():
     count += 1
     return (count,)
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### Underscore-prefixed variables are local to cells
@@ -332,28 +324,28 @@ def __(mo):
 
 
 @app.cell
-def __():
+def _():
     _private_variable, _ = 1, 2
     _private_variable, _
     return
 
 
 @app.cell
-def __():
+def _():
     _private_variable, _ = 3, 4
     _private_variable, _
     return
 
 
 @app.cell
-def __():
+def _():
     # `_private_variable` and `_` are not defined in this cell
     _private_variable, _
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### Deleting a cell deletes its variables
@@ -368,7 +360,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def _(mo):
     to_be_deleted = "variable still exists"
 
     mo.md(
@@ -382,13 +374,13 @@ def __(mo):
 
 
 @app.cell
-def __(to_be_deleted):
+def _(to_be_deleted):
     to_be_deleted
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### Cycles are not allowed
@@ -400,19 +392,19 @@ def __(mo):
 
 
 @app.cell
-def __(two):
+def _(two):
     one = two - 1
     return (one,)
 
 
 @app.cell
-def __(one):
+def _(one):
     two = one + 1
     return (two,)
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### marimo doesn't track attributes
@@ -428,19 +420,19 @@ def __(mo):
 
 
 @app.cell
-def __(state):
+def _(state):
     state.number = 1
     return
 
 
 @app.cell
-def __(state):
+def _(state):
     state.number
     return
 
 
 @app.cell
-def __():
+def _():
     class namespace:
         pass
 
@@ -450,7 +442,7 @@ def __():
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.accordion(
         {
             "Why not track attributes?": """
@@ -464,7 +456,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### marimo doesn't track mutations
@@ -478,7 +470,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.accordion(
         {
             "Tip (advanced): mutable state": (
@@ -494,7 +486,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ## Best practices
@@ -514,13 +506,13 @@ def __(mo):
 
 
 @app.cell
-def __(mo, tips):
+def _(mo, tips):
     mo.accordion(tips)
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ## What's next?
@@ -535,29 +527,15 @@ def __(mo):
     return
 
 
-@app.cell(hide_code=True)
-def __():
-    matplotlib_installed = False
-    numpy_installed = False
-
-    try:
-        import matplotlib.pyplot as plt
-
-        matplotlib_installed = True
-    except ModuleNotFoundError:
-        pass
-
-    try:
-        import numpy as np
-
-        numpy_installed = True
-    except ModuleNotFoundError:
-        pass
-    return matplotlib_installed, np, numpy_installed, plt
+@app.cell
+def _():
+    import matplotlib.pyplot as plt
+    import numpy as np
+    return np, plt
 
 
 @app.cell(hide_code=True)
-def __():
+def _():
     tips = {
         "Use global variables sparingly": (
             """
@@ -659,7 +637,7 @@ def __():
 
 
 @app.cell
-def __():
+def _():
     import marimo as mo
     return (mo,)
 

--- a/marimo/_tutorials/dataflow.py
+++ b/marimo/_tutorials/dataflow.py
@@ -1,4 +1,11 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "matplotlib==3.10.1",
+#     "numpy==2.2.4",
+# ]
+# ///
 
 import marimo
 

--- a/marimo/_tutorials/markdown.py
+++ b/marimo/_tutorials/markdown.py
@@ -1,4 +1,11 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "matplotlib==3.10.1",
+#     "numpy==2.2.4",
+# ]
+# ///
 
 import marimo
 

--- a/marimo/_tutorials/markdown.py
+++ b/marimo/_tutorials/markdown.py
@@ -4,17 +4,18 @@
 #     "marimo",
 #     "matplotlib==3.10.1",
 #     "numpy==2.2.4",
+#     "polars==1.26.0",
 # ]
 # ///
 
 import marimo
 
-__generated_with = "0.9.30"
+__generated_with = "0.12.2"
 app = marimo.App()
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         # Hello, Markdown!
@@ -41,7 +42,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def _(mo):
     mo.md(
         """
         **Tip: toggling between the Markdown and Python editor**
@@ -63,7 +64,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         r"""
         ## LaTeX
@@ -98,7 +99,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.accordion(
         {
             "Tip: `r''` strings": mo.md(
@@ -111,7 +112,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.accordion(
         {
             "Note: KaTeX": mo.md(
@@ -128,7 +129,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ## Interpolating Python values
@@ -144,20 +145,8 @@ def __(mo):
 
 
 @app.cell
-def __(
-    matplotlib_installed,
-    missing_matplotlib_msg,
-    missing_numpy_msg,
-    mo,
-    np,
-    numpy_installed,
-    plt,
-):
+def _(mo, np, plt):
     def _sine_plot():
-        if not numpy_installed:
-            return missing_numpy_msg
-        if not matplotlib_installed:
-            return missing_matplotlib_msg
         _x = np.linspace(start=0, stop=2 * np.pi)
         plt.plot(_x, np.sin(_x))
         return plt.gca()
@@ -181,7 +170,7 @@ def __(
 
 
 @app.cell
-def __(mo):
+def _(mo):
     leaves = mo.ui.slider(1, 32, label="🍃: ")
 
     mo.md(
@@ -204,13 +193,13 @@ def __(mo):
 
 
 @app.cell
-def __(leaves, mo):
+def _(leaves, mo):
     mo.md(f"Your leaves: {'🍃' * leaves.value}")
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.accordion(
         {
             "Tip: UI elements can format themselves": """
@@ -223,19 +212,13 @@ def __(mo):
 
 
 @app.cell
-def __(missing_numpy_msg, mo, np, numpy_installed):
+def _(mo, np):
+    import polars as pl
+
     def make_dataframe():
-        try:
-            import pandas as pd
-        except ModuleNotFoundError:
-            return mo.md("Oops! Looks like you don't have `pandas` installed.")
-
-        if not numpy_installed:
-            return missing_numpy_msg
-
         x = np.linspace(0, 2 * np.pi, 10)
         y = np.sin(x)
-        return pd.DataFrame({"x": x, "sin(x)": y})
+        return pl.DataFrame({"x": x, "sin(x)": y})
 
     mo.md(
         f"""
@@ -250,16 +233,16 @@ def __(missing_numpy_msg, mo, np, numpy_installed):
         - `plotly` figures, and
         - `altair` figures.
 
-        For example, here's a pandas dataframe:
+        For example, here's a Polars dataframe:
 
         {mo.as_html(make_dataframe())}
         """
     )
-    return (make_dataframe,)
+    return make_dataframe, pl
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.accordion(
         {
             "Tip: outputs are automatically converted to HTML": """
@@ -273,7 +256,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ## Putting it all together
@@ -287,7 +270,7 @@ def __(mo):
 
 
 @app.cell
-def __(math, mo):
+def _(math, mo):
     amplitude = mo.ui.slider(1, 2, step=0.1, label="amplitude: ")
     period = mo.ui.slider(
         math.pi / 4,
@@ -300,31 +283,18 @@ def __(math, mo):
 
 
 @app.cell
-def __(
-    matplotlib_installed,
-    missing_matplotlib_msg,
-    missing_numpy_msg,
-    mo,
-    np,
-    numpy_installed,
-    plt,
-):
+def _(mo, np, plt):
     @mo.cache
     def plotsin(amplitude, period):
-        if not numpy_installed:
-            return missing_numpy_msg
-        elif not matplotlib_installed:
-            return missing_matplotlib_msg
         x = np.linspace(0, 2 * np.pi, 256)
         plt.plot(x, amplitude * np.sin(2 * np.pi / period * x))
         plt.ylim(-2.2, 2.2)
         return plt.gca()
-
     return (plotsin,)
 
 
 @app.cell
-def __(amplitude, mo, period):
+def _(amplitude, mo, period):
     mo.md(
         f"""
         **A sin curve.**
@@ -337,7 +307,7 @@ def __(amplitude, mo, period):
 
 
 @app.cell
-def __(amplitude, mo, period, plotsin):
+def _(amplitude, mo, period, plotsin):
     mo.md(
         rf"""
         You're viewing the graph of
@@ -354,45 +324,17 @@ def __(amplitude, mo, period, plotsin):
 
 
 @app.cell(hide_code=True)
-def __(mo):
-    matplotlib_installed = False
-    numpy_installed = False
-    missing_numpy_msg = mo.md(
-        "Oops! Looks like you don't have `numpy` installed."
-    )
-    missing_matplotlib_msg = mo.md(
-        "Oops! Looks like you don't have `matplotlib` installed."
-    )
-
-    try:
-        import matplotlib.pyplot as plt
-
-        matplotlib_installed = True
-    except ModuleNotFoundError:
-        pass
-
-    try:
-        import numpy as np
-
-        numpy_installed = True
-    except ModuleNotFoundError:
-        pass
-    return (
-        matplotlib_installed,
-        missing_matplotlib_msg,
-        missing_numpy_msg,
-        np,
-        numpy_installed,
-        plt,
-    )
+def _():
+    import matplotlib.pyplot as plt
+    import numpy as np
+    return np, plt
 
 
 @app.cell(hide_code=True)
-def __():
+def _():
     import math
 
     import marimo as mo
-
     return math, mo
 
 

--- a/marimo/_tutorials/plots.py
+++ b/marimo/_tutorials/plots.py
@@ -1,25 +1,32 @@
-# Copyright 2024 Marimo. All rights reserved.
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "matplotlib==3.10.1",
+#     "numpy==2.2.4",
+# ]
+# ///
 
 import marimo
 
-__generated_with = "0.8.22"
+__generated_with = "0.12.2"
 app = marimo.App()
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""# Plotting""")
     return
 
 
 @app.cell(hide_code=True)
-def __(check_dependencies):
+def _(check_dependencies):
     check_dependencies()
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         marimo supports several popular plotting libraries, including matplotlib,
@@ -33,13 +40,13 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""## Matplotlib""")
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         To show a plot, include it in the last expression of a cell (just
@@ -56,13 +63,13 @@ def __(mo):
 
 
 @app.cell
-def __(plt):
+def _(plt):
     plt.plot([1, 2])
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ```python3
@@ -78,7 +85,7 @@ def __(mo):
 
 
 @app.cell
-def __(plt):
+def _(plt):
     plt.plot([1, 2])
     # ... do some work ...
     # make plt.gca() the last line of the cell
@@ -87,13 +94,13 @@ def __(plt):
 
 
 @app.cell(hide_code=True)
-def __(mo, plt_show_explainer):
+def _(mo, plt_show_explainer):
     mo.accordion(plt_show_explainer)
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         **A new figure every cell.** Every cell starts with an empty figure for 
@@ -104,13 +111,13 @@ def __(mo):
 
 
 @app.cell
-def __(np):
+def _(np):
     x = np.linspace(start=-4, stop=4, num=100, dtype=float)
     return (x,)
 
 
 @app.cell
-def __(plt, x):
+def _(plt, x):
     plt.plot(x, x)
     plt.plot(x, x**2)
     plt.gca()
@@ -118,13 +125,13 @@ def __(plt, x):
 
 
 @app.cell
-def __(plt, x):
+def _(plt, x):
     plt.plot(x, x**3)
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         To build a figure over multiple cells, use the object-oriented API and
@@ -135,7 +142,7 @@ def __(mo):
 
 
 @app.cell
-def __(plt, x):
+def _(plt, x):
     _, axis = plt.subplots()
     axis.plot(x, x)
     axis.plot(x, x**2)
@@ -144,14 +151,14 @@ def __(plt, x):
 
 
 @app.cell
-def __(axis, x):
+def _(axis, x):
     axis.plot(x, x**3)
     axis
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         ### Draw plots interactively
@@ -163,7 +170,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo):
+def _(mo):
     exponent = mo.ui.slider(1, 5, value=1, step=1, label='exponent')
 
     mo.md(
@@ -177,7 +184,7 @@ def __(mo):
 
 
 @app.cell
-def __(mo, plt, x):
+def _(mo, plt, x):
     @mo.cache
     def plot_power(exponent):
         plt.plot(x, x**exponent)
@@ -186,7 +193,7 @@ def __(mo, plt, x):
 
 
 @app.cell
-def __(exponent, mo, plot_power):
+def _(exponent, mo, plot_power):
     _tex = (
         f"$$f(x) = x^{exponent.value}$$" if exponent.value > 1 else "$$f(x) = x$$"
     )
@@ -203,13 +210,13 @@ def __(exponent, mo, plot_power):
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""## Other libraries""")
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md(
         """
         marimo also supports these other plotting libraries:
@@ -229,7 +236,7 @@ def __(mo):
 
 
 @app.cell(hide_code=True)
-def __(missing_packages, mo):
+def _(missing_packages, mo):
     module_not_found_explainer = mo.md(
         """
         ## Oops!
@@ -237,16 +244,16 @@ def __(missing_packages, mo):
         It looks like you're missing a package that this tutorial 
         requires.
 
-        Close marimo, install **`numpy`** and **`matplotlib`**, then 
-        open this tutorial once more.
+        Use the package manager panel on the left to install **numpy** and **matplotlib**,
+        then restart the tutorial.
 
-        If you use `pip`, run
+        Or, if you use `uv`, open the tutorial with
 
         ```
-        pip install numpy matplotlib
+        uvx marimo tutorial plots
         ```
 
-        at your command line.
+        at the command line.
         """
     ).callout(kind='warn')
 
@@ -257,7 +264,7 @@ def __(missing_packages, mo):
 
 
 @app.cell(hide_code=True)
-def __():
+def _():
     plt_show_explainer = {
         "Using `plt.show()`": """
         You can use `plt.show()` or `figure.show()` to display
@@ -269,7 +276,7 @@ def __():
 
 
 @app.cell
-def __():
+def _():
     try:
         import matplotlib
         import matplotlib.pyplot as plt
@@ -284,7 +291,7 @@ def __():
 
 
 @app.cell
-def __():
+def _():
     import marimo as mo
     return (mo,)
 

--- a/tests/_cli/snapshots/dataflow.md.txt
+++ b/tests/_cli/snapshots/dataflow.md.txt
@@ -94,14 +94,6 @@ mo.md(
 
 ```python {.marimo}
 def plot_wave(amplitude, period):
-    if not numpy_installed:
-        return mo.md(
-            "> Oops! It looks like you don't have `numpy` installed."
-        )
-    if not matplotlib_installed:
-        return mo.md(
-            "> Oops! It looks like you don't have `matplotlib` installed."
-        )
     x = np.linspace(0, 2 * np.pi, 256)
     plt.plot(x, amplitude * np.sin(2 * np.pi / period * x))
     plt.xlim(0, 2 * np.pi)
@@ -337,23 +329,9 @@ Check out the tutorial on interactivity for a tour of UI elements:
 marimo tutorial ui
 ```
 
-```python {.marimo hide_code="true"}
-matplotlib_installed = False
-numpy_installed = False
-
-try:
-    import matplotlib.pyplot as plt
-
-    matplotlib_installed = True
-except ModuleNotFoundError:
-    pass
-
-try:
-    import numpy as np
-
-    numpy_installed = True
-except ModuleNotFoundError:
-    pass
+```python {.marimo}
+import matplotlib.pyplot as plt
+import numpy as np
 ```
 
 ````python {.marimo hide_code="true"}


### PR DESCRIPTION
This sandboxes tutorials and allows users to use the package manager toast to install missing packages, which didn't exist at the time of tutorial authoring.

Fixes #4356 