### PR TITLE
fix: remove none vals from being written to toml

### DIFF
--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -43,8 +43,13 @@ class ConfigReader:
         import tomlkit
 
         _maybe_create_directory(self.filepath)
+
+        dict_data = asdict(data)
+        # None values is not valid toml, so we remove them
+        dict_data = {k: v for k, v in dict_data.items() if v is not None}
+
         with open(self.filepath, "w") as file:
-            tomlkit.dump(asdict(data), file)
+            tomlkit.dump(dict_data, file)
 
     @staticmethod
     def _get_home_directory() -> str:

--- a/tests/_utils/config/test_config_reader.py
+++ b/tests/_utils/config/test_config_reader.py
@@ -46,11 +46,12 @@ def test_read_toml_valid() -> None:
 def test_write_toml_valid() -> None:
     with NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
         config = ConfigReader(f.name)
-        config.write_toml(TestConfig(value="test"))
+        written = TestConfig(value="test", nullable_value="value")
+        config.write_toml(written)
 
         fallback = TestConfig(value="fallback")
         result = config.read_toml(TestConfig, fallback=fallback)
-        assert result == TestConfig(value="test")
+        assert result == written
 
     os.unlink(f.name)
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Small fix for warning in logs, we shouldn't write None values to toml. Just remove them.
```shell
[W 250403 19:38:22 upgrade:38] Failed to check for updates
    Traceback (most recent call last):
      File "/Users/shahmir/Development/marimo/marimo/_cli/upgrade.py", line 36, in check_for_updates
        _check_for_updates_internal(on_update)
      File "/Users/shahmir/Development/marimo/marimo/_cli/upgrade.py", line 64, in _check_for_updates_internal
        write_cli_state(state)
      File "/Users/shahmir/Development/marimo/marimo/_config/cli_state.py", line 37, in write_cli_state
        config_reader.write_toml(state)
      File "/Users/shahmir/Development/marimo/marimo/_utils/config/config.py", line 47, in write_toml
        tomlkit.dump(asdict(data), file)
      File "/Users/shahmir/Library/Application Support/hatch/env/virtual/marimo/3YIAdkuj/marimo/lib/python3.12/site-packages/tomlkit/api.py", line 84, in dump
        fp.write(dumps(data, sort_keys=sort_keys))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/shahmir/Library/Application Support/hatch/env/virtual/marimo/3YIAdkuj/marimo/lib/python3.12/site-packages/tomlkit/api.py", line 54, in dumps
        data = item(dict(data), _sort_keys=sort_keys)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/shahmir/Library/Application Support/hatch/env/virtual/marimo/3YIAdkuj/marimo/lib/python3.12/site-packages/tomlkit/items.py", line 138, in item
        val[k] = item(v, _parent=val, _sort_keys=_sort_keys)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/shahmir/Library/Application Support/hatch/env/virtual/marimo/3YIAdkuj/marimo/lib/python3.12/site-packages/tomlkit/items.py", line 212, in item
        raise ConvertError(f"Unable to convert an object of {type(value)} to a TOML item")
    tomlkit.exceptions.ConvertError: Unable to convert an object of <class 'NoneType'> to a TOML item
```

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
