### PR TITLE
fix: change default show href when printing

### DIFF
--- a/frontend/src/css/app/print.css
+++ b/frontend/src/css/app/print.css
@@ -47,10 +47,6 @@ body.printing #App {
     max-width: none;
   }
 
-  a[href]:after {
-    content: " (" attr(href) ")";
-  }
-
   * {
     box-shadow: none !important;
     text-shadow: none !important;


### PR DESCRIPTION
Closes #4369

Removes this as digital PDF is way more common than printing. This can be brought back by the various custom CSS features we support. 