### PR TITLE
improve: group error types in error output

### DIFF
--- a/frontend/src/components/editor/errors/auto-fix.tsx
+++ b/frontend/src/components/editor/errors/auto-fix.tsx
@@ -6,7 +6,7 @@ import type { CellId } from "@/core/cells/ids";
 import { getAutoFixes } from "@/core/errors/errors";
 import type { MarimoError } from "@/core/kernel/messages";
 import { store } from "@/core/state/jotai";
-import { LightbulbIcon } from "lucide-react";
+import { WrenchIcon } from "lucide-react";
 
 export const AutoFixButton = ({
   errors,
@@ -48,7 +48,7 @@ export const AutoFixButton = ({
           editorView?.focus();
         }}
       >
-        <LightbulbIcon className="h-3 w-3 mr-2" />
+        <WrenchIcon className="h-3 w-3 mr-2" />
         {firstFix.title}
       </Button>
     </Tooltip>

--- a/frontend/src/components/editor/errors/auto-fix.tsx
+++ b/frontend/src/components/editor/errors/auto-fix.tsx
@@ -11,7 +11,7 @@ import { LightbulbIcon } from "lucide-react";
 export const AutoFixButton = ({
   errors,
   cellId,
-}: { errors: MarimoError[]; cellId: CellId }) => {
+}: { errors: MarimoError[]; cellId: CellId; className?: string }) => {
   const { createNewCell } = useCellActions();
   const autoFixes = errors.flatMap((error) => getAutoFixes(error));
 
@@ -27,7 +27,8 @@ export const AutoFixButton = ({
     <Tooltip content={firstFix.description} align="start">
       <Button
         size="xs"
-        variant="secondary"
+        variant="outline"
+        className="my-2 font-normal"
         onClick={() => {
           const editorView =
             store.get(notebookAtom).cellHandles[cellId].current?.editorView;

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -167,8 +167,20 @@ export const MarimoErrorOutput = ({
             )}
           </ul>
           {cellId && <AutoFixButton errors={cycleErrors} cellId={cellId} />}
-          <Tip title="Resolving cycles" className="mb-2">
-            Merge these cells into a single cell.
+          <Tip
+            title="What are cycles and how do I resolve them?"
+            className="mb-2"
+          >
+            <p className="pb-2">
+              An example of a cycle is if one cell declares a variable 'a' and
+              reads 'b', and another cell declares 'b' and and reads 'a'. Cycles
+              like this make it impossible for marimo to know how to run your
+              cells, and generally suggest that your code has a bug.
+            </p>
+
+            <p className="py-2">
+              Try merging these cells into a single cell to eliminate the cycle.
+            </p>
           </Tip>
         </li>,
       );

--- a/frontend/src/core/errors/__tests__/errors.test.ts
+++ b/frontend/src/core/errors/__tests__/errors.test.ts
@@ -26,7 +26,7 @@ describe("getAutoFixes", () => {
 
     const fixes = getAutoFixes(error);
     expect(fixes).toHaveLength(1);
-    expect(fixes[0].title).toBe("Wrap in a function");
+    expect(fixes[0].title).toBe("Fix: Wrap in a function");
   });
 
   it("returns import fix for NameError with known import", () => {
@@ -38,7 +38,7 @@ describe("getAutoFixes", () => {
 
     const fixes = getAutoFixes(error);
     expect(fixes).toHaveLength(1);
-    expect(fixes[0].title).toBe("Add 'import numpy as np'");
+    expect(fixes[0].title).toBe("Fix: Add 'import numpy as np'");
   });
 
   it("returns no fixes for NameError with unknown import", () => {

--- a/frontend/src/core/errors/errors.ts
+++ b/frontend/src/core/errors/errors.ts
@@ -19,7 +19,7 @@ export function getAutoFixes(error: MarimoError): AutoFix[] {
   if (error.type === "multiple-defs") {
     return [
       {
-        title: "Wrap in a function",
+        title: "Fix: Wrap in a function",
         description:
           "Make this cell's variables local by wrapping the cell in a function.",
         onFix: async (ctx) => {
@@ -48,7 +48,7 @@ export function getAutoFixes(error: MarimoError): AutoFix[] {
 
     return [
       {
-        title: `Add '${cellCode}'`,
+        title: `Fix: Add '${cellCode}'`,
         description: "Add a new cell for the missing import",
         onFix: async (ctx) => {
           ctx.addCodeBelow(cellCode);


### PR DESCRIPTION
This PR improves the presentation of errors in the cell output area.

* Errors are grouped by error type, with all multiple definition errors
  appearing in a group, all cycle errors appearing in another group, and
  so on.
* Tips are shown once per error group, instead of once per error.
* More informative tip titles.
* Style improvements to make the error output more legible.

In a follow up, I will improve add docs pages with more context for multiple definition errors and import star errors, and will link to them from Tips.

Comparison images below.

**With changes.**

<details>
<summary>Single multiple definition error</summary>
<img src="https://github.com/user-attachments/assets/623357e8-f242-426c-83cd-3a4d7a5ee72a"></img>
</details>

<details>
<summary>Many multiple definition errors</summary>
<img src="https://github.com/user-attachments/assets/63bb5efc-8e8b-48f0-8505-0a9bb46a6183"></img>
</details>

<details>
<summary>Multiple types of errors</summary>
<img src="https://github.com/user-attachments/assets/406f7c16-6443-490a-99cf-9564537b5e4e"></img>
</details>

**Before changes.**

<details>
<summary>Single multiple definition error</summary>
<img src="https://github.com/user-attachments/assets/8debf560-f47b-45f2-9f9f-d6ed5cf9343c"></img>
</details>

<details>
<summary>Many multiple definition errors</summary>
<img src="https://github.com/user-attachments/assets/b9c31a5e-c5e8-415e-b4b2-c025beba5665"></img>
</details>

<details>
<summary>Multiple types of errors</summary>
<img src="https://github.com/user-attachments/assets/fd6dc901-0f49-47b7-aec8-63a36dcaa714"></img>
</details>
