### PR TITLE
improve: don't unselect rows when clicking in other rows

### DIFF
--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -98,11 +98,6 @@ export function renderTableBody<TData>(
           <TableRow
             key={row.id}
             data-state={row.getIsSelected() && "selected"}
-            onClick={() => {
-              if (table.getIsSomeRowsSelected()) {
-                row.toggleSelected();
-              }
-            }}
             // These classes ensure that empty rows (nulls) still render
             className="border-t h-6"
           >


### PR DESCRIPTION
This change modifies the table to persist selections when clicking on table rows.

Previously, clicking anywhere in a table unselected (in the case of single selection) an existing selection, or added additional selections (in the case of multi).

Even though other tables might do this, this can sometimes be troublesome since selections and unselections trigger code execution that may be expensive. It also makes it not possible to copy text when a row is already selected. One could try detecting for drag, but that doesn't account for double click, and I think this issue would still come up.

In favor of being explicit over implicit, and prioritizing edit mode usage, it makes sense to have selection toggles be limited to the column checkboxes.

Fixes https://github.com/marimo-team/marimo/issues/1719