### PR TITLE
fix: don't render hstack/vstack in extra divs if there is no flex config

### DIFF
--- a/marimo/_plugins/stateless/flex.py
+++ b/marimo/_plugins/stateless/flex.py
@@ -59,10 +59,15 @@ def _flex(
             return ""
         return create_style({"flex": f"{child_flex}"})
 
-    grid_items = [
-        h.div(as_html(item).text, style=create_style_for_item(i))
-        for i, item in enumerate(items)
-    ]
+    # If there are no child flexes, don't wrap them in an additional <div>
+    if child_flexes is None:
+        grid_items = [as_html(item).text for item in items]
+    else:
+        grid_items = [
+            h.div(as_html(item).text, style=create_style_for_item(i))
+            for i, item in enumerate(items)
+        ]
+
     return Html(h.div(grid_items, style=style))
 
 

--- a/tests/_plugins/stateless/test_flex.py
+++ b/tests/_plugins/stateless/test_flex.py
@@ -8,7 +8,7 @@ def test_vstack() -> None:
     result = vstack(["item1", "item2"], align="center", gap=1)
     assert (
         result.text
-        == "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: center;flex-wrap: nowrap;gap: 1rem'><div><span>item1</span></div><div><span>item2</span></div></div>"  # noqa: E501
+        == "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: center;flex-wrap: nowrap;gap: 1rem'><span>item1</span><span>item2</span></div>"  # noqa: E501
     )
 
     result = vstack(["item1", "item2"], justify="center", heights=[1, 2])
@@ -22,11 +22,17 @@ def test_hstack() -> None:
     result = hstack(["item1", "item2"], justify="center", gap=1, wrap=True)
     assert (
         result.text
-        == "<div style='display: flex;flex: 1;flex-direction: row;justify-content: center;align-items: normal;flex-wrap: wrap;gap: 1rem'><div><span>item1</span></div><div><span>item2</span></div></div>"  # noqa: E501
+        == "<div style='display: flex;flex: 1;flex-direction: row;justify-content: center;align-items: normal;flex-wrap: wrap;gap: 1rem'><span>item1</span><span>item2</span></div>"  # noqa: E501
     )
 
     result = hstack(["item1", "item2"], align="center", widths=[1, 2])
     assert (
         result.text
         == "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: center;flex-wrap: nowrap;gap: 0.5rem'><div style='flex: 1'><span>item1</span></div><div style='flex: 2'><span>item2</span></div></div>"  # noqa: E501
+    )
+
+    result = hstack(["item1", "item2"], align="center", widths="equal")
+    assert (
+        result.text
+        == "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: center;flex-wrap: nowrap;gap: 0.5rem'><div style='flex: 1'><span>item1</span></div><div style='flex: 1'><span>item2</span></div></div>"  # noqa: E501
     )

--- a/tests/_server/export/snapshots/notebook_with_outputs.ipynb.txt
+++ b/tests/_server/export/snapshots/notebook_with_outputs.ipynb.txt
@@ -163,7 +163,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><div><span class=\"markdown prose dark:prose-invert\"><span class=\"paragraph\">hello</span></span></div><div><span class=\"markdown prose dark:prose-invert\"><span class=\"paragraph\">world</span></span></div></div>"
+       "<div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span class=\"markdown prose dark:prose-invert\"><span class=\"paragraph\">hello</span></span><span class=\"markdown prose dark:prose-invert\"><span class=\"paragraph\">world</span></span></div>"
       ]
      },
      "metadata": {},


### PR DESCRIPTION
This could be a breaking change for some formats. The only cases I can think of:
 - people were expecting a wrapping div and created custom css to target this

Currently if no `widths/heights` setting is passed to hstack/stack, then we wrap them in `<div>`s. This can make it hard to style the child element's width/height because the wrapping `div`.

This doesn't change when the output `widths/heights` are passed in. 