### PR TITLE
docs: update docker base image info

### DIFF
--- a/docs/guides/deploying/prebuilt_containers.md
+++ b/docs/guides/deploying/prebuilt_containers.md
@@ -12,7 +12,7 @@ We provide the following variants:
 
 or any particular version of marimo; for example, `marimo:0.8.3`, `marimo:0.8.3-data`, `marimo:0.8.3-sql`.
 
-Each container is built on `3.12-slim`, but if you'd like to see different configurations, please file an issue or submit a PR!
+Each container is built on `3.13-slim`, but if you'd like to see different configurations, please file an issue or submit a PR!
 
 ## Running locally
 


### PR DESCRIPTION
## 📝 Summary

Updates docs to reflect that prebuilt containers run on top of `3.13-slim` instead of `3.12-slim`.
