### PR TITLE
feat: make `uv` and `uvx` available in Docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.12
 FROM python:3.13-slim AS base
 
+# Make `uv` and `uvx` available in the PATH for all target images
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 # Create a non-root user
 RUN useradd -m appuser
 


### PR DESCRIPTION
## 📝 Summary

Adds [uv](https://docs.astral.sh/) to the pre-built Docker images.

## 🔍 Description of Changes

By including the `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/` as a base layer in the multi-stage build we ensure that `uv` and `uvx` will be in `PATH` for all build targets.

This change is purely additive, therefore it should not affect the existing image behavior.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick

Closes #4403
