### PR TITLE
Add option for copy button in code-editor

### DIFF
--- a/examples/ui/code_editor.py
+++ b/examples/ui/code_editor.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.10.6"
+__generated_with = "0.12.4"
 app = marimo.App(width="medium")
 
 
@@ -29,6 +29,17 @@ def _(mo):
 def _(editor):
     editor.value
     return
+
+
+@app.cell
+def _(mo):
+    copy_editor = mo.ui.code_editor(
+        value="let a = 'b';",
+        language="javascript",
+        show_copy_button = True
+    )
+    copy_editor
+    return (copy_editor,)
 
 
 if __name__ == "__main__":

--- a/frontend/src/plugins/impl/CodeEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/CodeEditorPlugin.tsx
@@ -16,6 +16,7 @@ interface Data {
   disabled?: boolean;
   minHeight?: number;
   maxHeight?: number;
+  showCopyButton?: boolean;
 }
 
 export class CodeEditorPlugin implements IPlugin<T, Data> {
@@ -30,6 +31,7 @@ export class CodeEditorPlugin implements IPlugin<T, Data> {
     disabled: z.boolean().optional(),
     minHeight: z.number().optional(),
     maxHeight: z.number().optional(),
+    showCopyButton: z.boolean().optional(),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -66,6 +68,7 @@ const CodeEditorComponent = (props: CodeEditorComponentProps) => {
         value={props.value}
         language={props.language}
         onChange={props.setValue}
+        showCopyButton={props.showCopyButton}
       />
     </Labeled>
   );

--- a/frontend/src/plugins/impl/code/any-language-editor.tsx
+++ b/frontend/src/plugins/impl/code/any-language-editor.tsx
@@ -9,9 +9,13 @@ import {
   type LanguageName,
 } from "@uiw/codemirror-extensions-langs";
 import React, { useMemo } from "react";
+import { CopyIcon } from "lucide-react";
 import { Logger } from "@/utils/Logger";
 import { ErrorBanner } from "../common/error-banner";
 import type { ResolvedTheme } from "@/theme/useTheme";
+import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/utils/copy";
+import { toast } from "@/components/ui/use-toast";
 
 /**
  * A code editor that supports any language.
@@ -23,8 +27,9 @@ const AnyLanguageCodeMirror: React.FC<
   ReactCodeMirrorProps & {
     language: string | undefined;
     theme: ResolvedTheme;
+    showCopyButton: boolean | undefined;
   }
-> = ({ language, extensions = [], ...props }) => {
+> = ({ language, showCopyButton, extensions = [], ...props }) => {
   const isNotSupported = language && !(language in langs);
   if (isNotSupported) {
     Logger.warn(`Language ${language} not found in CodeMirror.`);
@@ -40,7 +45,7 @@ const AnyLanguageCodeMirror: React.FC<
   }, [language, extensions]);
 
   return (
-    <>
+    <div className="flex flex-col">
       {isNotSupported && (
         <ErrorBanner
           className="mb-1 rounded-sm"
@@ -49,8 +54,23 @@ const AnyLanguageCodeMirror: React.FC<
           ).join(", ")}`}
         />
       )}
+      {showCopyButton && (
+        <Button
+          key="copy-button"
+          data-testid="any-language-editor-copy-button"
+          variant="secondary"
+          className="self-end mb-2"
+          onClick={async () => {
+            await copyToClipboard(props.value || "");
+            toast({ title: "Copied to clipboard" });
+          }}
+        >
+          <CopyIcon className="w-4 h-4 mr-1" />
+          Copy code
+        </Button>
+      )}
       <ReactCodeMirror {...props} extensions={finalExtensions} />
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/plugins/impl/code/any-language-editor.tsx
+++ b/frontend/src/plugins/impl/code/any-language-editor.tsx
@@ -27,7 +27,7 @@ const AnyLanguageCodeMirror: React.FC<
   ReactCodeMirrorProps & {
     language: string | undefined;
     theme: ResolvedTheme;
-    showCopyButton: boolean | undefined;
+    showCopyButton?: boolean;
   }
 > = ({ language, showCopyButton, extensions = [], ...props }) => {
   const isNotSupported = language && !(language in langs);

--- a/frontend/src/plugins/impl/code/any-language-editor.tsx
+++ b/frontend/src/plugins/impl/code/any-language-editor.tsx
@@ -45,7 +45,7 @@ const AnyLanguageCodeMirror: React.FC<
   }, [language, extensions]);
 
   return (
-    <div className="flex flex-col">
+    <div className="relative w-full  hover-actions-parent">
       {isNotSupported && (
         <ErrorBanner
           className="mb-1 rounded-sm"
@@ -54,12 +54,13 @@ const AnyLanguageCodeMirror: React.FC<
           ).join(", ")}`}
         />
       )}
-      {showCopyButton && (
+      {showCopyButton && !isNotSupported && (
         <Button
           key="copy-button"
           data-testid="any-language-editor-copy-button"
           variant="secondary"
-          className="self-end mb-2"
+          size="xs"
+          className="absolute top-0 right-0 z-10 hover-action"
           onClick={async () => {
             await copyToClipboard(props.value || "");
             toast({ title: "Copied to clipboard" });

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -834,6 +834,7 @@ class code_editor(UIElement[str, str]):
         label (str, optional): Markdown label for the element. Defaults to "".
         on_change (Callable[[str], None], optional): Optional callback to run when
             this element's value changes. Defaults to None.
+        show_copy_button (bool, optional): Whether to show a button to copy the code
     """
 
     _name: Final[str] = "marimo-code-editor"
@@ -847,6 +848,7 @@ class code_editor(UIElement[str, str]):
         disabled: bool = False,
         min_height: Optional[int] = None,
         max_height: Optional[int] = None,
+        show_copy_button: Optional[bool] = None,
         *,
         label: str = "",
         on_change: Optional[Callable[[str], None]] = None,
@@ -871,6 +873,7 @@ class code_editor(UIElement[str, str]):
                 "disabled": disabled,
                 "min-height": min_height,
                 "max-height": max_height,
+                "show-copy-button": show_copy_button,
             },
             on_change=on_change,
         )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Fixes #4085

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

Adds an boolean flag to `mo.ui.code_editor`, which in turn adds an additional button to copy the code.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
