### PR TITLE
fix: handle backticks with langs

### DIFF
--- a/frontend/src/components/editor/ai/add-cell-with-ai.tsx
+++ b/frontend/src/components/editor/ai/add-cell-with-ai.tsx
@@ -81,6 +81,10 @@ export const AddCellWithAI: React.FC<{
         description: prettyError(error),
       });
     },
+    onFinish: (_prompt, completion) => {
+      // Remove trailing new lines
+      setCompletion(completion.trimEnd());
+    },
   });
 
   const inputComponent = (

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -95,6 +95,10 @@ export const AiCompletionEditor: React.FC<Props> = ({
         description: prettyError(error),
       });
     },
+    onFinish: (_prompt, completion) => {
+      // Remove trailing new lines
+      setCompletion(completion.trimEnd());
+    },
   });
 
   const inputRef = React.useRef<ReactCodeMirrorRef>(null);

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -474,6 +474,8 @@ def without_wrapping_backticks(
     # First, merge backticks across chunks
     chunks = merge_backticks(chunks)
 
+    langs = ["python", "sql"]
+
     first_chunk = True
     buffer: Optional[str] = None
     has_starting_backticks = False
@@ -482,12 +484,25 @@ def without_wrapping_backticks(
         # Handle the first chunk
         if first_chunk:
             first_chunk = False
-            if chunk.startswith("```"):
-                has_starting_backticks = True
-                chunk = chunk[3:]  # Remove the starting backticks
-                # Also remove starting newline if present
-                if chunk.startswith("\n"):
-                    chunk = chunk[1:]
+            # Check for language-specific fences first
+            for lang in langs:
+                if chunk.startswith(f"```{lang}"):
+                    has_starting_backticks = True
+                    chunk = chunk[
+                        3 + len(lang) :
+                    ]  # Remove the starting backticks with lang
+                    # Also remove starting newline if present
+                    if chunk.startswith("\n"):
+                        chunk = chunk[1:]
+                    break
+            # If no language-specific fence was found, check for plain backticks
+            else:
+                if chunk.startswith("```"):
+                    has_starting_backticks = True
+                    chunk = chunk[3:]  # Remove the starting backticks
+                    # Also remove starting newline if present
+                    if chunk.startswith("\n"):
+                        chunk = chunk[1:]
 
         # If we have a buffered chunk, yield it now
         if buffer is not None:

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -840,6 +840,22 @@ class TestGetContent(unittest.TestCase):
         ([], ""),
         (["```idk```"], "idk"),
         (["Hello world"], "Hello world"),
+        (
+            ["```python\n", "def hello():\n    ", "print('world')\n```"],
+            "def hello():\n    print('world')",
+        ),
+        (
+            ["```python", "\ndef hello():\n    ", "print('world')\n```"],
+            "def hello():\n    print('world')",
+        ),
+        (
+            ["```sql", "SELECT * FROM table", " WHERE id = 1", "```"],
+            "SELECT * FROM table WHERE id = 1",
+        ),
+        (
+            ["```sql\n", "SELECT * FROM table\n", "WHERE id = 1\n```"],
+            "SELECT * FROM table\nWHERE id = 1",
+        ),
     ],
 )
 def test_without_wrapping_backticks(chunks: list[str], expected: str) -> None:


### PR DESCRIPTION
Handle when the LLM outputs the lang in the codefences