### PR TITLE
docs: link to multiple definition explainer video

### DIFF
--- a/docs/guides/understanding_errors/cycles.md
+++ b/docs/guides/understanding_errors/cycles.md
@@ -4,7 +4,7 @@ You're probably on this page because you just saw an error like this one:
 
 <div align="center">
 <figure>
-<img src="/_static/docs_cycle_error.png" width="700px"/>
+<img src="/_static/docs_cycles_error.png" width="700px"/>
 </figure>
 </div>
 

--- a/docs/guides/understanding_errors/multiple_definitions.md
+++ b/docs/guides/understanding_errors/multiple_definitions.md
@@ -13,6 +13,12 @@ this example, `x` was already defined, and the subsequent cell raised
 an error when we tried to run it. In your case, perhaps your variable
 is a loop variable (`i`), a dataframe (`df`), or a plot (`fig`, `ax`).
 
+??? Tip "Watch our YouTube explainer"
+
+    <div align="center">
+    <iframe width="700" height="393" src="https://www.youtube.com/embed/5TzAADGRfxU?si=ZtwQoAzEUL2UABNq" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    </div>
+
 ## Why can't I redefine variables?
 
 **Understanding the error message.** The error message tells you which other


### PR DESCRIPTION
- Link to @koaning's latest YouTube video on multiple definition errors
- Fix an image link