### PR TITLE
improve: link to error documentation

### DIFF
--- a/frontend/src/components/editor/links/cell-link.tsx
+++ b/frontend/src/components/editor/links/cell-link.tsx
@@ -30,7 +30,7 @@ export const CellLink = (props: Props): JSX.Element => {
   return (
     <div
       className={cn(
-        "inline-block cursor-pointer text-[var(--blue-10)] hover:underline",
+        "inline-block cursor-pointer text-link hover:underline",
         className,
       )}
       role="link"

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -16,6 +16,7 @@ import { CellLinkError } from "../links/cell-link";
 import type { CellId } from "@/core/cells/ids";
 import { AutoFixButton } from "../errors/auto-fix";
 import { SquareArrowOutUpRightIcon } from "lucide-react";
+import { ExternalLink } from "@/components/ui/links";
 
 const Tip = (props: {
   title?: string;
@@ -184,17 +185,12 @@ export const MarimoErrorOutput = ({
             </p>
 
             <p className="py-2">
-              <a
-                className={cn(
-                  "cursor-pointer text-[var(--blue-10)] hover:underline",
-                )}
+              <ExternalLink
                 href="https://links.marimo.app/errors-cycles"
-                target="_blank"
-                rel="noreferrer"
               >
                 Learn more at our docs{" "}
                 <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
-              </a>
+              </ExternalLink>
               .
             </p>
           </Tip>
@@ -239,17 +235,12 @@ export const MarimoErrorOutput = ({
             </p>
 
             <p className="py-2">
-              <a
-                className={cn(
-                  "cursor-pointer text-[var(--blue-10)] hover:underline",
-                )}
+              <ExternalLink
                 href="https://links.marimo.app/errors-multiple-definitions"
-                target="_blank"
-                rel="noreferrer"
               >
                 Learn more at our docs{" "}
                 <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
-              </a>
+              </ExternalLink>
               .
             </p>
           </Tip>
@@ -287,17 +278,12 @@ export const MarimoErrorOutput = ({
             </p>
 
             <p className="py-2">
-              <a
-                className={cn(
-                  "cursor-pointer text-[var(--blue-10)] hover:underline",
-                )}
+              <ExternalLink
                 href="https://links.marimo.app/errors-import-star"
-                target="_blank"
-                rel="noreferrer"
               >
                 Learn more at our docs{" "}
                 <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
-              </a>
+              </ExternalLink>
               .
             </p>
           </Tip>

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -15,6 +15,7 @@ import { Fragment } from "react";
 import { CellLinkError } from "../links/cell-link";
 import type { CellId } from "@/core/cells/ids";
 import { AutoFixButton } from "../errors/auto-fix";
+import { SquareArrowOutUpRightIcon } from "lucide-react";
 
 const Tip = (props: {
   title?: string;
@@ -181,6 +182,21 @@ export const MarimoErrorOutput = ({
             <p className="py-2">
               Try merging these cells into a single cell to eliminate the cycle.
             </p>
+
+            <p className="py-2">
+              <a
+                className={cn(
+                  "cursor-pointer text-[var(--blue-10)] hover:underline",
+                )}
+                href="https://links.marimo.app/errors-cycles"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more at our docs{" "}
+                <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
+              </a>
+              .
+            </p>
           </Tip>
         </li>,
       );
@@ -192,6 +208,7 @@ export const MarimoErrorOutput = ({
           <p className="text-muted-foreground font-medium">
             This cell redefines variables from other cells.
           </p>
+
           {multipleDefsErrors.map((error, idx) => (
             <Fragment key={`multiple-defs-${idx}`}>
               <p className="text-muted-foreground mt-2">{`'${error.name}' was also defined by:`}</p>
@@ -219,6 +236,21 @@ export const MarimoErrorOutput = ({
               Try merging this cell with the mentioned cells or wrapping it in a
               function. Alternatively, rename variables to make them private to
               this cell by prefixing them with an underscore.
+            </p>
+
+            <p className="py-2">
+              <a
+                className={cn(
+                  "cursor-pointer text-[var(--blue-10)] hover:underline",
+                )}
+                href="https://links.marimo.app/errors-multiple-definitions"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more at our docs{" "}
+                <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
+              </a>
+              .
             </p>
           </Tip>
         </li>,
@@ -252,6 +284,21 @@ export const MarimoErrorOutput = ({
             <p className="py-2">
               Star imports would also silently add names to globals, which would
               be incompatible with reactive execution.
+            </p>
+
+            <p className="py-2">
+              <a
+                className={cn(
+                  "cursor-pointer text-[var(--blue-10)] hover:underline",
+                )}
+                href="https://links.marimo.app/errors-import-star"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more at our docs{" "}
+                <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
+              </a>
+              .
             </p>
           </Tip>
         </li>,

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -185,9 +185,7 @@ export const MarimoErrorOutput = ({
             </p>
 
             <p className="py-2">
-              <ExternalLink
-                href="https://links.marimo.app/errors-cycles"
-              >
+              <ExternalLink href="https://links.marimo.app/errors-cycles">
                 Learn more at our docs{" "}
                 <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
               </ExternalLink>
@@ -235,9 +233,7 @@ export const MarimoErrorOutput = ({
             </p>
 
             <p className="py-2">
-              <ExternalLink
-                href="https://links.marimo.app/errors-multiple-definitions"
-              >
+              <ExternalLink href="https://links.marimo.app/errors-multiple-definitions">
                 Learn more at our docs{" "}
                 <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
               </ExternalLink>
@@ -278,9 +274,7 @@ export const MarimoErrorOutput = ({
             </p>
 
             <p className="py-2">
-              <ExternalLink
-                href="https://links.marimo.app/errors-import-star"
-              >
+              <ExternalLink href="https://links.marimo.app/errors-import-star">
                 Learn more at our docs{" "}
                 <SquareArrowOutUpRightIcon size="0.75rem" className="inline" />
               </ExternalLink>


### PR DESCRIPTION
Add links to understanding errors docs from common marimo errors.

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/f71d9661-b760-4791-9c02-cd5fe9aaae6d" />
