### PR TITLE
chore: remove pyodide-http, bump to 0.27.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -119,7 +119,7 @@
     "partysocket": "1.1.3",
     "path-to-regexp": "^8.2.0",
     "plotly.js": "^2.35.3",
-    "pyodide": "0.27.4",
+    "pyodide": "0.27.5",
     "react-arborist": "^3.4.3",
     "react-aria-components": "^1.7.1",
     "react-codemirror-merge": "^4.23.10",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -334,8 +334,8 @@ importers:
         specifier: ^2.35.3
         version: 2.35.3(mapbox-gl@1.13.3)(webpack@5.96.1(esbuild@0.25.2))
       pyodide:
-        specifier: 0.27.4
-        version: 0.27.4
+        specifier: 0.27.5
+        version: 0.27.5
       react-arborist:
         specifier: ^3.4.3
         version: 3.4.3(@types/node@20.17.30)(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7384,8 +7384,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pyodide@0.27.4:
-    resolution: {integrity: sha512-2y3ySHCBmyzYDUlB939SaU3n7RxYQxwnGHgdakW/CPrNFX2L9fC+4nfJWQJH8a0ruQa8bBZSKCImMt/cq15RiQ==}
+  pyodide@0.27.5:
+    resolution: {integrity: sha512-nXErpLzEdtQolt+sNQ/5mKuN9XTUwhxR2MRhRhZ6oDRGpYLXrOp5+kkTPGEwK+wn1ZA8+poNmoxKTj2sq/p9og==}
     engines: {node: '>=18.0.0'}
 
   qs@6.11.2:
@@ -17472,7 +17472,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pyodide@0.27.4:
+  pyodide@0.27.5:
     dependencies:
       ws: 8.18.0
     transitivePeerDependencies:

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -175,9 +175,7 @@ export class DefaultWasmController implements WasmController {
       }
     }
 
-    // Add:
-    // 1. additional dependencies of marimo that are lazily loaded.
-    // 2. pyodide-http, a patch to make basic http requests work in pyodide
+    // Add additional dependencies of marimo that are lazily loaded.
     //
     // These packages are included with Pyodide, which is why we don't add them
     // to `foundPackages`:
@@ -185,7 +183,6 @@ export class DefaultWasmController implements WasmController {
     code = `import docutils\n${code}`;
     code = `import pygments\n${code}`;
     code = `import jedi\n${code}`;
-    code = `import pyodide_http\n${code}`;
 
     const imports = [...foundPackages];
 

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -332,9 +332,6 @@ def _launch_pyodide_kernel(
 
     LOGGER.debug("Launching kernel")
 
-    # Patches for pyodide compatibility
-    patches.patch_pyodide_networking()
-
     # Some libraries mess with Python's default recursion limit, which becomes
     # a problem when running with Pyodide.
     patches.patch_recursion_limit(limit=1000)

--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -45,12 +45,6 @@ def patch_sys_module(module: types.ModuleType) -> None:
     sys.modules[module.__name__] = module
 
 
-def patch_pyodide_networking() -> None:
-    import pyodide_http  # type: ignore
-
-    pyodide_http.patch_urllib()
-
-
 def patch_recursion_limit(limit: int) -> None:
     """Set the recursion limit."""
 


### PR DESCRIPTION
This is a good playground example to test pyodide-http still works https://marimo.app/l/7dt7hf

but breaks:

```
import pandas as pd
pd.read_csv("https://raw.githubusercontent.com/dmarcelinobr/Datasets/master/Fortune1000.csv")
```