### PR TITLE
feat: marimo new prompt.txt

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -77,7 +77,7 @@ def _key_value_bullets(items: list[tuple[str, str]]) -> str:
     lines: list[str] = []
 
     def _sep(desc: str) -> str:
-        return ":" if desc else ""
+        return " " if desc else ""
 
     for key, desc in items:
         # "\b" tells click not to reformat our text
@@ -455,7 +455,34 @@ def edit(
     )
 
 
-@main.command(help="Create a new notebook.")
+new_help_msg = "\n".join(
+    [
+        "\b",
+        "Create an empty notebook, or generate from a prompt with AI",
+        "",
+        _key_value_bullets(
+            [
+                (
+                    "marimo new",
+                    "Create an empty notebook",
+                ),
+                (
+                    'marimo new "Plot an interactive 3D surface with matplotlib."',
+                    "Generate a notebook from a prompt.",
+                ),
+                (
+                    "marimo new prompt.txt",
+                    "Generate a notebook from a file containing a prompt.",
+                ),
+            ]
+        ),
+        "",
+        "Visit https://marimo.app/ai for more prompt examples.",
+    ]
+)
+
+
+@main.command(help=new_help_msg)
 @click.option(
     "-p",
     "--port",

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -545,6 +545,10 @@ def new(
 
         from marimo._ai.text_to_notebook import text_to_notebook
 
+        maybe_path = Path(prompt)
+        if maybe_path.is_file():
+            prompt = maybe_path.read_text()
+
         try:
             notebook_content = text_to_notebook(prompt)
             temp_file = tempfile.NamedTemporaryFile(suffix=".py")

--- a/marimo/_tutorials/dataflow.py
+++ b/marimo/_tutorials/dataflow.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [

--- a/marimo/_tutorials/markdown.py
+++ b/marimo/_tutorials/markdown.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [

--- a/marimo/_tutorials/plots.py
+++ b/marimo/_tutorials/plots.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [


### PR DESCRIPTION
This PR adds the ability for `marimo new` to read its prompt from a file. It also supports unix-style piping (but not on Windows).

 Example usage:
 
 ```
Usage: marimo new [OPTIONS] [PROMPT]

  Create an empty notebook, or generate from a prompt with AI

    * marimo new                                                     Create an empty notebook
  
    * marimo new "Plot an interactive 3D surface with matplotlib."   Generate a notebook from a prompt.
  
    * marimo new prompt.txt                                          Generate a notebook from a file containing a prompt.
    
  Visit https://marimo.app/ai for more prompt examples.
```
