### PR TITLE
fix: ai edit cell when there is existing text

### DIFF
--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -323,7 +323,7 @@ class CellOp(Op):
         stream: Stream | None = None,
     ) -> None:
         status: Optional[TopLevelHints] = serialization.hint
-        CellOp(cell_id=cell_id, serialization=status).broadcast(stream)
+        CellOp(cell_id=cell_id, serialization=str(status)).broadcast(stream)
 
 
 @dataclass

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -103,6 +103,11 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
             assert "<insert_here>" in cell_code
             system_prompt += "The point you'll need to insert at is marked with <insert_here></insert_here>.\n"
         else:
+            # If no selected text and <rewrite_this> is not present, we need to
+            # wrap the whole code in <rewrite_this> tags
+            if "<rewrite_this>" not in cell_code and not selected_text:
+                cell_code = f"<rewrite_this>\n{cell_code}\n</rewrite_this>"
+
             assert "<rewrite_this>" in cell_code
             system_prompt += "The section you'll need to rewrite is marked with <rewrite_this></rewrite_this> tags.\n"
 


### PR DESCRIPTION
This fixes a case when editing a cell with existing text inside, but we haven't selected anything.