### PR TITLE
fix: expand cells that are collapsed

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -265,36 +265,44 @@ function useCellHiddenLogic(
   const isMarkdownCodeHidden = isMarkdown && !isCellCodeShown;
 
   // Callback to show the code editor temporarily
-  const temporarilyShowCode = useCallback(() => {
-    if (!isCellCodeShown) {
-      setTemporarilyVisible(true);
+  const temporarilyShowCode = useEvent((opts?: { focus?: boolean }) => {
+    if (isCellCodeShown) {
+      return;
+    }
+
+    // Default to true
+    const focus = opts?.focus ?? true;
+    setTemporarilyVisible(true);
+
+    if (focus) {
       editorView.current?.focus();
-      // Reach one parent up
-      const parent = editorViewParentRef.current?.parentElement;
-      if (!parent) {
-        Logger.error("Cell: No parent element found for editor view");
-        return;
-      }
-
-      const handleFocusOut = () => {
-        requestAnimationFrame(() => {
-          if (!parent.contains(document.activeElement)) {
-            // Hide the code editor
-            setTemporarilyVisible(false);
-            editorView.current?.dom.blur();
-            parent.removeEventListener("focusout", handleFocusOut);
-          }
-        });
-      };
-      parent.addEventListener("focusout", handleFocusOut);
     }
-  }, [isCellCodeShown, editorView, editorViewParentRef, setTemporarilyVisible]);
 
-  const showHiddenMarkdownCode = useCallback(() => {
+    // Reach one parent up
+    const parent = editorViewParentRef.current?.parentElement;
+    if (!parent) {
+      Logger.error("Cell: No parent element found for editor view");
+      return;
+    }
+
+    const handleFocusOut = () => {
+      requestAnimationFrame(() => {
+        if (!parent.contains(document.activeElement)) {
+          // Hide the code editor
+          setTemporarilyVisible(false);
+          editorView.current?.dom.blur();
+          parent.removeEventListener("focusout", handleFocusOut);
+        }
+      });
+    };
+    parent.addEventListener("focusout", handleFocusOut);
+  });
+
+  const showHiddenMarkdownCode = useEvent(() => {
     if (isMarkdownCodeHidden) {
-      temporarilyShowCode();
+      temporarilyShowCode({ focus: true });
     }
-  }, [isMarkdownCodeHidden, temporarilyShowCode]);
+  });
 
   return {
     isCellCodeShown,

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -66,7 +66,7 @@ export interface CellEditorProps
   // Props below are not used by scratchpad.
   // DOM node where the editorView will be mounted
   editorViewParentRef?: React.MutableRefObject<HTMLDivElement | null>;
-  temporarilyShowCode: () => void;
+  temporarilyShowCode: (opts?: { focus?: boolean }) => void;
 }
 
 const CellEditorInternal = ({
@@ -186,6 +186,19 @@ const CellEditorInternal = ({
           },
         };
       }),
+      // Listen to selection changes, and show the code if it is hidden
+      EditorView.updateListener.of((update) => {
+        if (update.selectionSet) {
+          const selection = update.state.selection;
+          const selectedText = selection.ranges
+            .map((range) => update.state.doc.sliceString(range.from, range.to))
+            .join("\n");
+
+          if (selectedText) {
+            temporarilyShowCode({ focus: false });
+          }
+        }
+      }),
     );
 
     return extensions;
@@ -206,6 +219,7 @@ const CellEditorInternal = ({
     setAiCompletionCell,
     afterToggleMarkdown,
     setLanguageAdapter,
+    temporarilyShowCode,
   ]);
 
   const handleInitializeEditor = useEvent(() => {

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -190,11 +190,11 @@ const CellEditorInternal = ({
       EditorView.updateListener.of((update) => {
         if (update.selectionSet) {
           const selection = update.state.selection;
-          const selectedText = selection.ranges
-            .map((range) => update.state.doc.sliceString(range.from, range.to))
-            .join("\n");
+          const hasSelection = selection.ranges.some(
+            (range) => range.from !== range.to,
+          );
 
-          if (selectedText) {
+          if (hasSelection) {
             temporarilyShowCode({ focus: false });
           }
         }


### PR DESCRIPTION
Fixes #4362

This expands cells by listening to selection changes. We expand, but don't focus. 