### PR TITLE
improvement: Configurable SQL output type

### DIFF
--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -83,17 +83,17 @@ marimo supports different output types for SQL queries, which is particularly us
 
 The available options are:
 
-- `"native"`: Uses DuckDB's native lazy relation (recommended for best performance)
-- `"lazy-polars"`: Returns a lazy Polars DataFrame
-- `"pandas"`: Returns a Pandas DataFrame
-- `"polars"`: Returns an eager Polars DataFrame
-- `"auto"`: Automatically chooses based on installed packages (first tries `polars` then `pandas`)
+- `native`: Uses DuckDB's native lazy relation (recommended for best performance)
+- `lazypolars"`: Returns a lazy Polars DataFrame
+- `pandas`: Returns a Pandas DataFrame
+- `polars`: Returns an eager Polars DataFrame
+- `auto`: Automatically chooses based on installed packages (first tries `polars` then `pandas`)
 
-For best performance with large datasets, we recommend using `"native"` to avoid loading the entire result set into memory and to more easily chain SQL cells together. By default, only the first 10 rows are displayed in the UI to prevent memory issues.
+For best performance with large datasets, we recommend using `native` to avoid loading the entire result set into memory and to more easily chain SQL cells together. By default, only the first 10 rows are displayed in the UI to prevent memory issues.
 
 ??? note "Set a default"
 
-  The default output type is currently `"auto"`, but we recommend explicitly setting the output type to `"native"` for best performance with large datasets or `"polars"` if you need to work with the results in Python code. You can configure this in your application settings.
+  The default output type is currently `auto`, but we recommend explicitly setting the output type to `native` for best performance with large datasets or `polars` if you need to work with the results in Python code. You can configure this in your application settings.
 
 ## Reference a local dataframe
 

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -77,6 +77,24 @@ interpolate Python values into the query with `{}`. In particular, this means
 your SQL queries can depend on the values of UI elements or other Python values,
 and they are fit into marimo's reactive dataflow graph.
 
+## SQL Output Types
+
+marimo supports different output types for SQL queries, which is particularly useful when working with large datasets. You can configure this in your application configuration in the top right of the marimo editor.
+
+The available options are:
+
+- `"native"`: Uses DuckDB's native lazy relation (recommended for best performance)
+- `"lazy-polars"`: Returns a lazy Polars DataFrame
+- `"pandas"`: Returns a Pandas DataFrame
+- `"polars"`: Returns an eager Polars DataFrame
+- `"auto"`: Automatically chooses based on installed packages (first tries `polars` then `pandas`)
+
+For best performance with large datasets, we recommend using `"native"` to avoid loading the entire result set into memory and to more easily chain SQL cells together. By default, only the first 10 rows are displayed in the UI to prevent memory issues.
+
+??? note "Set a default"
+
+  The default output type is currently `"auto"`, but we recommend explicitly setting the output type to `"native"` for best performance with large datasets or `"polars"` if you need to work with the results in Python code. You can configure this in your application settings.
+
 ## Reference a local dataframe
 
 You can reference a local dataframe in your SQL cell by using the name of the

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -84,7 +84,7 @@ marimo supports different output types for SQL queries, which is particularly us
 The available options are:
 
 - `native`: Uses DuckDB's native lazy relation (recommended for best performance)
-- `lazypolars"`: Returns a lazy Polars DataFrame
+- `lazy-polars`: Returns a lazy Polars DataFrame
 - `pandas`: Returns a Pandas DataFrame
 - `polars`: Returns an eager Polars DataFrame
 - `auto`: Automatically chooses based on installed packages (first tries `polars` then `pandas`)

--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -26,6 +26,7 @@ import { Checkbox } from "../ui/checkbox";
 import { arrayToggle } from "@/utils/arrays";
 import { Kbd } from "../ui/kbd";
 import { ExternalLink } from "../ui/links";
+import { toast } from "../ui/use-toast";
 export const AppConfigForm: React.FC = () => {
   const [config, setConfig] = useAppConfig();
 
@@ -186,7 +187,14 @@ export const AppConfigForm: React.FC = () => {
                 <FormControl>
                   <NativeSelect
                     data-testid="sql-output-select"
-                    onChange={(e) => field.onChange(e.target.value)}
+                    onChange={(e) => {
+                      field.onChange(e.target.value);
+                      toast({
+                        title: "Kernel Restart Required",
+                        description:
+                          "This change requires a kernel restart to take effect.",
+                      });
+                    }}
                     value={field.value}
                     disabled={field.disabled}
                     className="inline-flex mr-2"

--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -234,6 +234,32 @@ export const AppConfigForm: React.FC = () => {
             </div>
           )}
         />
+        <FormField
+          control={form.control}
+          name="sql_output"
+          render={({ field }) => (
+            <FormItem
+              className={"flex flex-row items-center space-x-1 space-y-0"}
+            >
+              <FormLabel>SQL Output Type</FormLabel>
+              <FormControl>
+                <NativeSelect
+                  data-testid="sql-output-select"
+                  onChange={(e) => field.onChange(e.target.value)}
+                  value={field.value}
+                  disabled={field.disabled}
+                  className="inline-flex mr-2"
+                >
+                  <option value="auto">Auto (Default)</option>
+                  <option value="polars">Polars</option>
+                  <option value="lazy-polars">Lazy Polars</option>
+                  <option value="native">Native</option>
+                </NativeSelect>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
       </form>
     </Form>
   );

--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -25,7 +25,7 @@ import { useEffect } from "react";
 import { Checkbox } from "../ui/checkbox";
 import { arrayToggle } from "@/utils/arrays";
 import { Kbd } from "../ui/kbd";
-
+import { ExternalLink } from "../ui/links";
 export const AppConfigForm: React.FC = () => {
   const [config, setConfig] = useAppConfig();
 
@@ -176,6 +176,44 @@ export const AppConfigForm: React.FC = () => {
         />
         <FormField
           control={form.control}
+          name="sql_output"
+          render={({ field }) => (
+            <div className="flex flex-col gap-y-1">
+              <FormItem
+                className={"flex flex-row items-center space-x-1 space-y-0"}
+              >
+                <FormLabel>SQL Output Type</FormLabel>
+                <FormControl>
+                  <NativeSelect
+                    data-testid="sql-output-select"
+                    onChange={(e) => field.onChange(e.target.value)}
+                    value={field.value}
+                    disabled={field.disabled}
+                    className="inline-flex mr-2"
+                  >
+                    <option value="auto">Auto (Default)</option>
+                    <option value="native">Native</option>
+                    <option value="polars">Polars</option>
+                    <option value="lazy-polars">Lazy Polars</option>
+                    <option value="pandas">Pandas</option>
+                  </NativeSelect>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+              <FormDescription>
+                The Python type returned by a SQL cell. For best performance
+                with large datasets, we recommend using{" "}
+                <Kbd className="inline">native</Kbd>. See the{" "}
+                <ExternalLink href="http://docs.marimo.io/guides/working_with_data/sql">
+                  SQL guide
+                </ExternalLink>{" "}
+                for more information.
+              </FormDescription>
+            </div>
+          )}
+        />
+        <FormField
+          control={form.control}
           name="auto_download"
           render={({ field }) => (
             <div className="flex flex-col gap-y-1">
@@ -232,32 +270,6 @@ export const AppConfigForm: React.FC = () => {
                 file.
               </FormDescription>
             </div>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="sql_output"
-          render={({ field }) => (
-            <FormItem
-              className={"flex flex-row items-center space-x-1 space-y-0"}
-            >
-              <FormLabel>SQL Output Type</FormLabel>
-              <FormControl>
-                <NativeSelect
-                  data-testid="sql-output-select"
-                  onChange={(e) => field.onChange(e.target.value)}
-                  value={field.value}
-                  disabled={field.disabled}
-                  className="inline-flex mr-2"
-                >
-                  <option value="auto">Auto (Default)</option>
-                  <option value="polars">Polars</option>
-                  <option value="lazy-polars">Lazy Polars</option>
-                  <option value="native">Native</option>
-                </NativeSelect>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
           )}
         />
       </form>

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -15,8 +15,8 @@ test("default AppConfig", () => {
   expect(defaultConfig).toMatchInlineSnapshot(`
     {
       "auto_download": [],
-      "width": "medium",
       "sql_output": "auto",
+      "width": "medium",
     }
   `);
 });
@@ -30,6 +30,7 @@ test("another AppConfig", () => {
     {
       "app_title": null,
       "auto_download": [],
+      "sql_output": "auto",
       "width": "medium",
     }
   `);

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -16,6 +16,7 @@ test("default AppConfig", () => {
     {
       "auto_download": [],
       "width": "medium",
+      "sql_output": "auto",
     }
   `);
 });

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -29,6 +29,17 @@ const VALID_APP_WIDTHS = [
   "full",
   "columns",
 ] as const;
+
+/**
+ * SQL output formats
+ */
+const VALID_SQL_OUTPUT_FORMATS = [
+  "polars",
+  "lazy-polars",
+  "native",
+  "auto",
+] as const;
+
 export const UserConfigSchema = z
   .object({
     completion: z
@@ -168,6 +179,8 @@ export type LSPConfig = UserConfig["language_servers"];
 export type DiagnosticsConfig = UserConfig["diagnostics"];
 
 export const AppTitleSchema = z.string();
+export const SqlOutputSchema = z.enum(VALID_SQL_OUTPUT_FORMATS).default("auto");
+
 export const AppConfigSchema = z
   .object({
     width: z
@@ -183,6 +196,7 @@ export const AppConfigSchema = z
     css_file: z.string().nullish(),
     html_head_file: z.string().nullish(),
     auto_download: z.array(z.enum(["html", "markdown", "ipynb"])).default([]),
+    sql_output: SqlOutputSchema,
   })
   .default({ width: "medium", auto_download: [] });
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -34,10 +34,11 @@ const VALID_APP_WIDTHS = [
  * SQL output formats
  */
 const VALID_SQL_OUTPUT_FORMATS = [
+  "auto",
+  "native",
   "polars",
   "lazy-polars",
-  "native",
-  "auto",
+  "pandas",
 ] as const;
 
 export const UserConfigSchema = z

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -4,7 +4,6 @@ import type { CellId } from "../cells/ids";
 
 export type schemas = components["schemas"];
 export type AiCompletionRequest = schemas["AiCompletionRequest"];
-export type AppMetadata = schemas["AppMetadata"];
 export type BaseResponse = schemas["BaseResponse"];
 export type CellConfig = schemas["CellConfig"];
 /**

--- a/frontend/src/css/app/codemirror-completions.css
+++ b/frontend/src/css/app/codemirror-completions.css
@@ -28,7 +28,7 @@
     padding-top: 1px;
     padding-bottom: 1px;
     padding-right: 12px;
-    @apply text-xs;
+    @apply text-xs font-mono;
   }
 
   .cm-completionDetail {
@@ -192,7 +192,7 @@
 
   /* Completion matching text highlight */
   .cm-completionMatchedText {
-    @apply font-semibold text-primary underline underline-offset-2;
+    @apply text-accent-foreground font-medium underline underline-offset-2;
   }
 
   /* Scrollbar styling for autocomplete list */

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -43,7 +43,7 @@ from marimo._ast.errors import (
     SetupRootError,
     UnparsableError,
 )
-from marimo._config.config import WidthType
+from marimo._config.config import SqlOutputType, WidthType
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
@@ -85,6 +85,7 @@ class _AppConfig:
     """
 
     width: WidthType = "compact"
+
     app_title: Optional[str] = None
 
     # The file path of the layout file, relative to the app file.
@@ -100,6 +101,9 @@ class _AppConfig:
     auto_download: list[Literal["html", "markdown"]] = field(
         default_factory=list
     )
+
+    # The type of SQL output to display
+    sql_output: SqlOutputType = "auto"
 
     # Experimental top-level cell support
     _toplevel_fn: bool = False

--- a/marimo/_ast/app_config.py
+++ b/marimo/_ast/app_config.py
@@ -1,0 +1,66 @@
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal, Optional
+
+from marimo import _loggers
+from marimo._config.config import SqlOutputType, WidthType
+
+LOGGER = _loggers.marimo_logger()
+
+
+@dataclass
+class _AppConfig:
+    """Program-specific configuration.
+
+    Configuration for frontends or runtimes that is specific to
+    a single marimo program.
+    """
+
+    width: WidthType = "compact"
+
+    app_title: Optional[str] = None
+
+    # The file path of the layout file, relative to the app file.
+    layout_file: Optional[str] = None
+
+    # CSS file, relative to the app file
+    css_file: Optional[str] = None
+
+    # HTML head file, relative to the app file
+    html_head_file: Optional[str] = None
+
+    # Whether to automatically download the app as HTML and Markdown
+    auto_download: list[Literal["html", "markdown"]] = field(
+        default_factory=list
+    )
+
+    # The type of SQL output to display
+    sql_output: SqlOutputType = "auto"
+
+    # Experimental top-level cell support
+    _toplevel_fn: bool = False
+
+    @staticmethod
+    def from_untrusted_dict(updates: dict[str, Any]) -> "_AppConfig":
+        config = _AppConfig()
+        for key in updates:
+            if hasattr(config, key):
+                config.__setattr__(key, updates[key])
+            else:
+                LOGGER.warning(
+                    f"Unrecognized key '{key}' in app config. Ignoring."
+                )
+        return config
+
+    def asdict(self) -> dict[str, Any]:
+        # Used for experimental hooks which start with _
+        return {
+            k: v for (k, v) in asdict(self).items() if not k.startswith("_")
+        }
+
+    def update(self, updates: dict[str, Any]) -> "_AppConfig":
+        config_dict = asdict(self)
+        for key in updates:
+            if key in config_dict:
+                self.__setattr__(key, updates[key])
+
+        return self

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -12,7 +12,8 @@ import textwrap
 from typing import Any, Literal, Optional, cast
 
 from marimo import __version__
-from marimo._ast.app import App, _AppConfig
+from marimo._ast.app import App
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
 from marimo._ast.names import DEFAULT_CELL_NAME, SETUP_CELL_NAME

--- a/marimo/_cli/convert/markdown.py
+++ b/marimo/_cli/convert/markdown.py
@@ -24,7 +24,8 @@ from pymdownx.superfences import (  # type: ignore
 
 from marimo import _loggers
 from marimo._ast import codegen
-from marimo._ast.app import App, InternalApp, _AppConfig
+from marimo._ast.app import App, InternalApp
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import Cell, CellConfig
 from marimo._ast.compiler import compile_cell
 from marimo._ast.names import DEFAULT_CELL_NAME

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -124,7 +124,6 @@ def _generate_server_api_schema() -> dict[str, Any]:
     # dataclass components used in requests/responses
     REQUEST_RESPONSES = [
         # Sub components
-        requests.AppMetadata,
         home.MarimoFile,
         files.FileInfo,
         requests.ExecutionRequest,

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -142,6 +142,7 @@ class RuntimeConfig(TypedDict):
 # normal == compact
 WidthType = Literal["normal", "compact", "medium", "full", "columns"]
 Theme = Literal["light", "dark", "system"]
+SqlOutputType = Literal["polars", "lazy-polars", "pandas", "native", "auto"]
 
 
 @mddoc

--- a/marimo/_convert/utils.py
+++ b/marimo/_convert/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Optional
 
 from marimo._ast import codegen
-from marimo._ast.app import _AppConfig
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig
 from marimo._ast.names import DEFAULT_CELL_NAME
 

--- a/marimo/_islands/_island_generator.py
+++ b/marimo/_islands/_island_generator.py
@@ -8,7 +8,8 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Optional, Union, cast
 
 from marimo import __version__, _loggers
-from marimo._ast.app import App, InternalApp, _AppConfig
+from marimo._ast.app import App, InternalApp
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import Cell, CellConfig
 from marimo._ast.compiler import compile_cell
 from marimo._messaging.cell_output import CellOutput

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -23,7 +23,7 @@ from typing import (
 from uuid import uuid4
 
 from marimo import _loggers as loggers
-from marimo._ast.app import _AppConfig
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig, RuntimeStateType
 from marimo._ast.toplevel import TopLevelHints, TopLevelStatus
 from marimo._data.models import (

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -14,7 +14,6 @@ from typing import (
     cast,
 )
 
-import narwhals.stable.v1 as nw
 from narwhals.typing import IntoDataFrame, IntoLazyFrame
 
 import marimo._output.data.data as mo_data
@@ -51,7 +50,10 @@ from marimo._plugins.validators import (
     validate_page_size,
 )
 from marimo._runtime.functions import EmptyArgs, Function
-from marimo._utils.narwhals_utils import unwrap_narwhals_dataframe
+from marimo._utils.narwhals_utils import (
+    can_narwhalify_lazyframe,
+    unwrap_narwhals_dataframe,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -270,7 +272,7 @@ class table(
     _name: Final[str] = "marimo-table"
 
     @staticmethod
-    def lazy(data: IntoLazyFrame) -> table:
+    def lazy(data: IntoLazyFrame, *, preload: bool = False) -> table:
         """
         Create a table from a Polars LazyFrame.
 
@@ -278,10 +280,18 @@ class table(
         Once requested, only the first 10 rows will be loaded.
 
         Pagination and selection are not supported for lazy tables.
+
+        Args:
+            data (IntoLazyFrame): The data to display.
+            preload (bool, optional): Whether to load the first page of data
+                without user confirmation. Defaults to False.
         """
 
-        if not nw.dependencies.is_polars_lazyframe(data):
-            raise ValueError("data must be a Polars LazyFrame")
+        if not can_narwhalify_lazyframe(data):
+            raise ValueError(
+                "data must be a Polars LazyFrame or DuckDBRelation. Got: "
+                + type(data).__name__
+            )
 
         return table(
             data=data,
@@ -304,6 +314,7 @@ class table(
             _internal_summary_row_limit=None,
             _internal_total_rows="too_many",
             _internal_lazy=True,
+            _internal_preload=preload,
         )
 
     def __init__(
@@ -358,6 +369,7 @@ class table(
         _internal_summary_row_limit: Optional[int] = None,
         _internal_total_rows: Optional[Union[int, Literal["too_many"]]] = None,
         _internal_lazy: bool = False,
+        _internal_preload: bool = False,
     ) -> None:
         validate_no_integer_columns(data)
         validate_page_size(page_size)
@@ -551,6 +563,7 @@ class table(
                 "has-stable-row-id": self._has_stable_row_id,
                 "cell-styles": search_result_styles,
                 "lazy": _internal_lazy,
+                "preload": _internal_preload,
             },
             on_change=on_change,
             functions=(

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -14,7 +14,7 @@ from typing import (
     cast,
 )
 
-from narwhals.typing import IntoDataFrame, IntoLazyFrame
+from narwhals.typing import IntoDataFrame
 
 import marimo._output.data.data as mo_data
 from marimo import _loggers
@@ -57,6 +57,8 @@ from marimo._utils.narwhals_utils import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from narwhals.typing import IntoLazyFrame
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_pyodide/bootstrap.py
+++ b/marimo/_pyodide/bootstrap.py
@@ -126,6 +126,7 @@ def create_session(
             filename=filename,
             cli_args={},
             argv=[""],
+            app_config=app.config,
         ),
         user_config,
     )

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -68,7 +68,11 @@ class AppKernelRunner:
         self._kernel = Kernel(
             cell_configs={},
             app_metadata=AppMetadata(
-                {}, ctx.cli_args.to_dict(), argv=ctx.argv, filename=filename
+                {},
+                ctx.cli_args.to_dict(),
+                argv=ctx.argv,
+                filename=filename,
+                app_config=app.config,
             ),
             stream=ctx.stream,
             stdout=None,

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -171,6 +171,7 @@ def create_kernel_context(
         children=[],
         parent=parent,
         filename=kernel.app_metadata.filename,
+        app_config=kernel.app_metadata.app_config,
     )
 
 

--- a/marimo/_runtime/context/script_context.py
+++ b/marimo/_runtime/context/script_context.py
@@ -160,5 +160,6 @@ def initialize_script_context(
         children=[],
         parent=None,
         filename=filename,
+        app_config=app.config,
     )
     initialize_context(runtime_context=runtime_context)

--- a/marimo/_runtime/context/types.py
+++ b/marimo/_runtime/context/types.py
@@ -12,22 +12,25 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
-from marimo._config.config import MarimoConfig
+from marimo._ast.app_config import _AppConfig
 from marimo._messaging.context import HTTP_REQUEST_CTX
-from marimo._messaging.types import Stderr, Stdout
-from marimo._runtime import dataflow
-from marimo._runtime.cell_lifecycle_registry import CellLifecycleRegistry
-from marimo._runtime.functions import FunctionRegistry
-from marimo._runtime.requests import HTTPRequest
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from marimo._ast.app import AppKernelRunnerRegistry, InternalApp
-    from marimo._messaging.types import Stream
+    from marimo._ast.app import (
+        AppKernelRunnerRegistry,
+        InternalApp,
+    )
+    from marimo._config.config import MarimoConfig
+    from marimo._messaging.types import Stderr, Stdout, Stream
     from marimo._output.hypertext import Html
     from marimo._plugins.ui._core.registry import UIElementRegistry
+    from marimo._runtime import dataflow
+    from marimo._runtime.cell_lifecycle_registry import CellLifecycleRegistry
+    from marimo._runtime.functions import FunctionRegistry
     from marimo._runtime.params import CLIArgs, QueryParams
+    from marimo._runtime.requests import HTTPRequest
     from marimo._runtime.state import State, StateRegistry
     from marimo._runtime.virtual_file import VirtualFileRegistry
     from marimo._save.stores import Store
@@ -83,6 +86,7 @@ class RuntimeContext(abc.ABC):
     children: list[RuntimeContext]
     parent: RuntimeContext | None
     filename: str | None
+    app_config: _AppConfig
 
     @property
     @abc.abstractmethod

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -14,6 +14,7 @@ from typing import (
 )
 from uuid import uuid4
 
+from marimo._ast.app_config import _AppConfig
 from marimo._config.config import MarimoConfig
 from marimo._data.models import DataTableSource
 from marimo._types.ids import CellId_t, RequestId, UIElementId
@@ -21,6 +22,7 @@ from marimo._types.ids import CellId_t, RequestId, UIElementId
 if TYPE_CHECKING:
     from starlette.datastructures import URL
     from starlette.requests import HTTPConnection
+
 
 CompletionRequestId = str
 
@@ -234,6 +236,7 @@ class AppMetadata:
 
     query_params: SerializedQueryParams
     cli_args: SerializedCLIArgs
+    app_config: _AppConfig
     argv: Union[list[str], None] = None
 
     filename: Optional[str] = None

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -291,6 +291,7 @@ async def run_app_until_completion(
             filename=file_manager.path,
             cli_args=cli_args,
             argv=argv,
+            app_config=file_manager.app.config,
         ),
         app_file_manager=file_manager,
         config_manager=config_manager,

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -229,7 +229,7 @@ class Exporter:
     def export_as_md(self, file_manager: AppFileManager) -> tuple[str, str]:
         import yaml
 
-        from marimo._ast.app import _AppConfig
+        from marimo._ast.app_config import _AppConfig
         from marimo._ast.cell import Cell
         from marimo._ast.compiler import compile_cell
         from marimo._cli.convert.markdown import (

--- a/marimo/_server/file_manager.py
+++ b/marimo/_server/file_manager.py
@@ -9,7 +9,8 @@ from typing import Any, Optional, Union
 
 from marimo import _loggers
 from marimo._ast import codegen
-from marimo._ast.app import App, InternalApp, _AppConfig
+from marimo._ast.app import App, InternalApp
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig
 from marimo._config.config import WidthType
 from marimo._runtime.layout.layout import (

--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -838,6 +838,7 @@ class SessionManager:
                     filename=app_file_manager.path,
                     cli_args=self.cli_args,
                     argv=self.argv,
+                    app_config=app_file_manager.app.config,
                 ),
                 app_file_manager=app_file_manager,
                 config_manager=self._config_manager,

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 from typing import Any, Literal, Optional, Union, cast
 
 from marimo import __version__
-from marimo._ast.app import _AppConfig
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig
 from marimo._config.config import MarimoConfig, PartialMarimoConfig
 from marimo._messaging.cell_output import CellOutput

--- a/marimo/_sql/engines/duckdb.py
+++ b/marimo/_sql/engines/duckdb.py
@@ -51,6 +51,17 @@ class DuckDBEngine(SQLEngine):
         if relation is None:
             return None
 
+        sql_output_format = self.sql_output_format()
+        if sql_output_format == "polars":
+            return relation.pl()
+        if sql_output_format == "lazy-polars":
+            return relation.pl().lazy()
+        if sql_output_format == "native":
+            return relation
+        if sql_output_format == "pandas":
+            return relation.df()
+
+        # Auto
         if DependencyManager.polars.has():
             import polars as pl
 

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -24,9 +24,9 @@ def register_engine(cls: type[SQLEngine]) -> type[SQLEngine]:
 
 @dataclass
 class InferenceConfig(ABC):
-    auto_discover_schemas: Union[bool | Literal["auto"]]
-    auto_discover_tables: Union[bool | Literal["auto"]]
-    auto_discover_columns: Union[bool | Literal["auto"]]
+    auto_discover_schemas: Union[bool, Literal["auto"]]
+    auto_discover_tables: Union[bool, Literal["auto"]]
+    auto_discover_columns: Union[bool, Literal["auto"]]
 
 
 def _validate_sql_output_format(sql_output: SqlOutputType) -> SqlOutputType:
@@ -48,13 +48,15 @@ class SQLEngine(ABC):
         if runtime_context_installed():
             try:
                 ctx = get_context()
-                return _validate_sql_output_format(ctx.app.config.sql_output)
+                return _validate_sql_output_format(ctx.app_config.sql_output)
             except ContextNotInitializedError:
                 return "auto"
         return "auto"
 
     @abstractmethod
-    def __init__(self, connection: Any, engine_name: str) -> None:
+    def __init__(
+        self, connection: Any, engine_name: Optional[str] = None
+    ) -> None:
         pass
 
     @property

--- a/marimo/_utils/narwhals_utils.py
+++ b/marimo/_utils/narwhals_utils.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 import narwhals.dtypes as nw_dtypes
 import narwhals.stable.v1 as nw
 
+from marimo._dependencies.dependencies import DependencyManager
+
 if sys.version_info < (3, 11):
     from typing_extensions import TypeGuard
 else:
@@ -148,3 +150,20 @@ def unwrap_py_scalar(value: Any) -> Any:
         return nw.to_py_scalar(value)
     except ValueError:
         return value
+
+
+def can_narwhalify_lazyframe(df: Any) -> TypeGuard[Any]:
+    """
+    Check if the given object is a narwhals lazyframe.
+    """
+    if nw.dependencies.is_polars_lazyframe(df):
+        return True
+    if hasattr(nw.dependencies, "is_duckdb_relation"):
+        if nw.dependencies.is_duckdb_relation(df):
+            return True
+    elif DependencyManager.duckdb.has():
+        # Fallback if is_duckdb_relation is not available
+        import duckdb
+
+        return isinstance(df, duckdb.DuckDBPyRelation)
+    return False

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -86,43 +86,6 @@ components:
       - description
       - name
       type: object
-    AppMetadata:
-      properties:
-        argv:
-          items:
-            type: string
-          nullable: true
-          type: array
-        cliArgs:
-          additionalProperties:
-            oneOf:
-            - type: string
-            - type: boolean
-            - type: integer
-            - type: number
-            - items:
-                oneOf:
-                - type: string
-                - type: boolean
-                - type: integer
-                - type: number
-              type: array
-          type: object
-        filename:
-          nullable: true
-          type: string
-        queryParams:
-          additionalProperties:
-            oneOf:
-            - type: string
-            - items:
-                type: string
-              type: array
-          type: object
-      required:
-      - queryParams
-      - cliArgs
-      type: object
     Banner:
       properties:
         action:
@@ -1161,6 +1124,14 @@ components:
             layout_file:
               nullable: true
               type: string
+            sql_output:
+              enum:
+              - polars
+              - lazy-polars
+              - pandas
+              - native
+              - auto
+              type: string
             width:
               enum:
               - normal
@@ -1172,6 +1143,7 @@ components:
           required:
           - width
           - auto_download
+          - sql_output
           - _toplevel_fn
           type: object
         capabilities:
@@ -2528,7 +2500,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.12.5
+  version: 0.12.6
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2363,20 +2363,6 @@ export interface components {
       /** @enum {string|null} */
       variant?: "danger" | null;
     };
-    AppMetadata: {
-      argv?: string[] | null;
-      cliArgs: {
-        [key: string]:
-          | string
-          | boolean
-          | number
-          | (string | boolean | number)[];
-      };
-      filename?: string | null;
-      queryParams: {
-        [key: string]: string | string[];
-      };
-    };
     Banner: {
       /** @enum {string|null} */
       action?: "restart" | null;
@@ -2800,6 +2786,8 @@ export interface components {
         css_file?: string | null;
         html_head_file?: string | null;
         layout_file?: string | null;
+        /** @enum {string} */
+        sql_output: "polars" | "lazy-polars" | "pandas" | "native" | "auto";
         /** @enum {string} */
         width: "normal" | "compact" | "medium" | "full" | "columns";
       };

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -363,6 +363,7 @@ class TestApp:
             "width": "full",
             "layout_file": None,
             "auto_download": [],
+            "sql_output": "auto",
         }
 
     @staticmethod
@@ -692,6 +693,7 @@ def test_app_config() -> None:
         "width": "full",
         "layout_file": None,
         "auto_download": [],
+        "sql_output": "auto",
     }
 
 
@@ -708,6 +710,7 @@ def test_app_config_extra_args_ignored() -> None:
         "width": "full",
         "layout_file": None,
         "auto_download": [],
+        "sql_output": "auto",
     }
 
 

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -8,10 +8,10 @@ from typing import Any, TYPE_CHECKING
 
 import pytest
 
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.app import (
     App,
     AppKernelRunnerRegistry,
-    _AppConfig,
     InternalApp,
 )
 from marimo._ast.errors import (

--- a/tests/_ast/test_app_config.py
+++ b/tests/_ast/test_app_config.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from marimo._ast.app import _AppConfig
+from marimo._ast.app_config import _AppConfig
 
 
 def test_app_config_default():

--- a/tests/_ast/test_app_config.py
+++ b/tests/_ast/test_app_config.py
@@ -77,9 +77,9 @@ def test_app_config_update():
 
     # Test updating a single field
     updated_config = config.update({"app_title": "Updated App"})
-    assert updated_config.width == "compact"
+    assert updated_config.width == "full"
     assert updated_config.app_title == "Updated App"
-    assert updated_config.sql_output == "auto"
+    assert updated_config.sql_output == "lazy-polars"
 
 
 @pytest.mark.parametrize(

--- a/tests/_ast/test_app_config.py
+++ b/tests/_ast/test_app_config.py
@@ -14,6 +14,7 @@ def test_app_config_default():
     assert config.css_file is None
     assert config.html_head_file is None
     assert config.auto_download == []
+    assert config.sql_output == "auto"
 
 
 def test_app_config_from_untrusted_dict():
@@ -24,6 +25,7 @@ def test_app_config_from_untrusted_dict():
         "html_head_file": "head.html",
         "auto_download": ["html", "markdown"],
         "invalid_key": "should be ignored",
+        "sql_output": "polars",
     }
     config = _AppConfig.from_untrusted_dict(updates)
     assert config.width == "full"
@@ -31,6 +33,7 @@ def test_app_config_from_untrusted_dict():
     assert config.css_file == "custom.css"
     assert config.html_head_file == "head.html"
     assert config.auto_download == ["html", "markdown"]
+    assert config.sql_output == "polars"
     assert not hasattr(config, "invalid_key")
 
 
@@ -41,6 +44,7 @@ def test_app_config_asdict():
         css_file="style.css",
         html_head_file="head.html",
         auto_download=["html"],
+        sql_output="lazy-polars",
     )
     config_dict = config.asdict()
     assert config_dict == {
@@ -50,21 +54,32 @@ def test_app_config_asdict():
         "html_head_file": "head.html",
         "auto_download": ["html"],
         "layout_file": None,
+        "sql_output": "lazy-polars",
     }
 
 
 def test_app_config_update():
     config = _AppConfig()
-    updates = {
-        "width": "full",
-        "app_title": "Updated App",
-        "auto_download": ["markdown"],
-    }
-    updated_config = config.update(updates)
+    assert config.width == "compact"
+    assert config.app_title is None
+    assert config.sql_output == "auto"
+
+    updated_config = config.update(
+        {
+            "width": "full",
+            "app_title": "Test App",
+            "sql_output": "lazy-polars",
+        }
+    )
     assert updated_config.width == "full"
+    assert updated_config.app_title == "Test App"
+    assert updated_config.sql_output == "lazy-polars"
+
+    # Test updating a single field
+    updated_config = config.update({"app_title": "Updated App"})
+    assert updated_config.width == "compact"
     assert updated_config.app_title == "Updated App"
-    assert updated_config.auto_download == ["markdown"]
-    assert updated_config.css_file is None
+    assert updated_config.sql_output == "auto"
 
 
 @pytest.mark.parametrize(

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -14,7 +14,8 @@ import pytest
 
 from marimo import __version__
 from marimo._ast import codegen, compiler
-from marimo._ast.app import App, InternalApp, _AppConfig
+from marimo._ast.app import App, InternalApp
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig
 from marimo._ast.names import is_internal_cell_name
 

--- a/tests/_islands/test_island_generator.py
+++ b/tests/_islands/test_island_generator.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from marimo import __version__
-from marimo._ast.app import _AppConfig
+from marimo._ast.app_config import _AppConfig
 from marimo._islands._island_generator import (
     MarimoIslandGenerator,
 )

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from marimo._ast.app_config import _AppConfig
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.cell_output import CellChannel
@@ -1159,6 +1160,7 @@ class TestExecution:
                     filename=filename,
                     cli_args={},
                     argv=None,
+                    app_config=_AppConfig(),
                 ),
                 enqueue_control_request=lambda _: None,
                 module=create_main_module(None, None, None),
@@ -1223,6 +1225,7 @@ class TestExecution:
                     filename=filename,
                     cli_args={},
                     argv=None,
+                    app_config=_AppConfig(),
                 ),
                 enqueue_control_request=lambda _: None,
                 module=create_main_module(None, None, None),
@@ -1249,6 +1252,7 @@ class TestExecution:
                     filename=filename,
                     cli_args={},
                     argv=["foo", "bar"],
+                    app_config=_AppConfig(),
                 ),
                 enqueue_control_request=lambda _: None,
                 module=create_main_module(None, None, None),
@@ -1281,6 +1285,7 @@ class TestExecution:
                     filename=filename,
                     cli_args={},
                     argv=None,
+                    app_config=_AppConfig(),
                 ),
                 enqueue_control_request=lambda _: None,
                 module=create_main_module(None, None, None),
@@ -1317,6 +1322,7 @@ class TestExecution:
                     filename=str(filename),
                     cli_args={},
                     argv=None,
+                    app_config=_AppConfig(),
                 ),
                 enqueue_control_request=lambda _: None,
                 module=create_main_module(None, None, None),

--- a/tests/_server/templates/snapshots/export1.txt
+++ b/tests/_server/templates/snapshots/export1.txt
@@ -56,7 +56,7 @@
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
     <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "language_servers": {"pylsp": {"enable_flake8": false, "enable_mypy": true, "enable_pydocstyle": false, "enable_pyflakes": false, "enable_pylint": false, "enable_ruff": true, "enabled": true}}, "package_management": {"manager": "uv"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun", "output_max_bytes": 8000000, "std_stream_max_bytes": 1000000, "watcher_on_save": "lazy"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}, "snippets": {"custom_paths": [], "include_default_snippets": true}}' data-overrides='{"formatting": {"line_length": 100}}' hidden></marimo-user-config>
-    <marimo-app-config data-config='{"width": "compact"}' hidden></marimo-app-config>
+    <marimo-app-config data-config='{"sql_output": "auto", "width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>

--- a/tests/_server/templates/snapshots/export2.txt
+++ b/tests/_server/templates/snapshots/export2.txt
@@ -56,7 +56,7 @@
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
     <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "language_servers": {"pylsp": {"enable_flake8": false, "enable_mypy": true, "enable_pydocstyle": false, "enable_pyflakes": false, "enable_pylint": false, "enable_ruff": true, "enabled": true}}, "package_management": {"manager": "uv"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun", "output_max_bytes": 8000000, "std_stream_max_bytes": 1000000, "watcher_on_save": "lazy"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}, "snippets": {"custom_paths": [], "include_default_snippets": true}}' data-overrides='{"formatting": {"line_length": 100}}' hidden></marimo-user-config>
-    <marimo-app-config data-config='{"width": "compact"}' hidden></marimo-app-config>
+    <marimo-app-config data-config='{"sql_output": "auto", "width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>marimo</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>

--- a/tests/_server/templates/snapshots/export3.txt
+++ b/tests/_server/templates/snapshots/export3.txt
@@ -56,7 +56,7 @@
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
     <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "language_servers": {"pylsp": {"enable_flake8": false, "enable_mypy": true, "enable_pydocstyle": false, "enable_pyflakes": false, "enable_pylint": false, "enable_ruff": true, "enabled": true}}, "package_management": {"manager": "uv"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun", "output_max_bytes": 8000000, "std_stream_max_bytes": 1000000, "watcher_on_save": "lazy"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}, "snippets": {"custom_paths": [], "include_default_snippets": true}}' data-overrides='{"formatting": {"line_length": 100}}' hidden></marimo-user-config>
-    <marimo-app-config data-config='{"width": "compact"}' hidden></marimo-app-config>
+    <marimo-app-config data-config='{"sql_output": "auto", "width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>

--- a/tests/_server/templates/snapshots/export4.txt
+++ b/tests/_server/templates/snapshots/export4.txt
@@ -56,7 +56,7 @@
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
     <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "language_servers": {"pylsp": {"enable_flake8": false, "enable_mypy": true, "enable_pydocstyle": false, "enable_pyflakes": false, "enable_pylint": false, "enable_ruff": true, "enabled": true}}, "package_management": {"manager": "uv"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun", "output_max_bytes": 8000000, "std_stream_max_bytes": 1000000, "watcher_on_save": "lazy"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}, "snippets": {"custom_paths": [], "include_default_snippets": true}}' data-overrides='{"formatting": {"line_length": 100}}' hidden></marimo-user-config>
-    <marimo-app-config data-config='{"css_file": "custom.css", "width": "compact"}' hidden></marimo-app-config>
+    <marimo-app-config data-config='{"css_file": "custom.css", "sql_output": "auto", "width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>

--- a/tests/_server/templates/snapshots/export5.txt
+++ b/tests/_server/templates/snapshots/export5.txt
@@ -56,7 +56,7 @@
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
     <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "language_servers": {"pylsp": {"enable_flake8": false, "enable_mypy": true, "enable_pydocstyle": false, "enable_pyflakes": false, "enable_pylint": false, "enable_ruff": true, "enabled": true}}, "package_management": {"manager": "uv"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun", "output_max_bytes": 8000000, "std_stream_max_bytes": 1000000, "watcher_on_save": "lazy"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}, "snippets": {"custom_paths": [], "include_default_snippets": true}}' data-overrides='{"formatting": {"line_length": 100}}' hidden></marimo-user-config>
-    <marimo-app-config data-config='{"app_title": "My App", "html_head_file": "head.html", "width": "compact"}' hidden></marimo-app-config>
+    <marimo-app-config data-config='{"app_title": "My App", "html_head_file": "head.html", "sql_output": "auto", "width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>My App</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>

--- a/tests/_server/templates/snapshots/export6.txt
+++ b/tests/_server/templates/snapshots/export6.txt
@@ -56,7 +56,7 @@
     <marimo-mode data-mode='read' hidden></marimo-mode>
     <marimo-version data-version='0.0.0' hidden></marimo-version>
     <marimo-user-config data-config='{"completion": {"activate_on_typing": true, "copilot": false}, "display": {"cell_output": "above", "code_editor_font_size": 14, "custom_css": ["custom1.css", "custom2.css"], "dataframes": "rich", "default_width": "medium", "theme": "light"}, "formatting": {"line_length": 79}, "keymap": {"overrides": {}, "preset": "default"}, "language_servers": {"pylsp": {"enable_flake8": false, "enable_mypy": true, "enable_pydocstyle": false, "enable_pyflakes": false, "enable_pylint": false, "enable_ruff": true, "enabled": true}}, "package_management": {"manager": "uv"}, "runtime": {"auto_instantiate": true, "auto_reload": "off", "on_cell_change": "autorun", "output_max_bytes": 8000000, "std_stream_max_bytes": 1000000, "watcher_on_save": "lazy"}, "save": {"autosave": "after_delay", "autosave_delay": 1000, "format_on_save": false}, "server": {"browser": "default", "follow_symlink": false}, "snippets": {"custom_paths": [], "include_default_snippets": true}}' data-overrides='{"formatting": {"line_length": 100}}' hidden></marimo-user-config>
-    <marimo-app-config data-config='{"width": "compact"}' hidden></marimo-app-config>
+    <marimo-app-config data-config='{"sql_output": "auto", "width": "compact"}' hidden></marimo-app-config>
     <marimo-server-token data-token='token' hidden></marimo-server-token>
     <title>notebook</title>
     <script type="module" crossorigin crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.js""></script>

--- a/tests/_server/templates/test_templates.py
+++ b/tests/_server/templates/test_templates.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 from typing import Literal
 
-from marimo._ast.app import _AppConfig
+from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig
 from marimo._config.config import (
     MarimoConfig,

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from marimo._ast.app import App, InternalApp
+from marimo._ast.app_config import _AppConfig
 from marimo._config.manager import (
     get_default_config_manager,
 )
@@ -52,6 +53,7 @@ app_metadata = AppMetadata(
     filename="test.py",
     cli_args={},
     argv=None,
+    app_config=_AppConfig(),
 )
 
 
@@ -320,7 +322,9 @@ def test_session_disconnect_reconnect() -> None:
         queue_manager,
         SessionMode.RUN,
         {},
-        AppMetadata(query_params={}, cli_args={}, argv=None),
+        AppMetadata(
+            query_params={}, cli_args={}, argv=None, app_config=_AppConfig()
+        ),
         get_default_config_manager(current_path=None),
         virtual_files_supported=True,
         redirect_console_to_browser=False,

--- a/tests/_sql/test_duckdb.py
+++ b/tests/_sql/test_duckdb.py
@@ -11,6 +11,7 @@ from marimo._data.models import Database, DataTable, DataTableColumn, Schema
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._sql.engines.duckdb import DuckDBEngine
 from marimo._sql.sql import sql
+from marimo._types.ids import VariableName
 
 HAS_DUCKDB = DependencyManager.duckdb.has()
 HAS_PANDAS = DependencyManager.pandas.has()
@@ -54,7 +55,7 @@ def duckdb_connection() -> Generator[duckdb.DuckDBPyConnection, None, None]:
 @pytest.mark.skipif(not HAS_DUCKDB, reason="DuckDB not installed")
 def test_duckdb_engine_dialect() -> None:
     """Test DuckDBEngine dialect property."""
-    engine = DuckDBEngine(None)
+    engine = DuckDBEngine(None, engine_name=None)
     assert engine.dialect == "duckdb"
 
 
@@ -69,7 +70,7 @@ def test_duckdb_engine_execute(
     import polars as pl
 
     # Test with explicit connection
-    engine = DuckDBEngine(duckdb_connection)
+    engine = DuckDBEngine(duckdb_connection, engine_name=None)
     result = engine.execute("SELECT * FROM test ORDER BY id")
     assert isinstance(result, (pd.DataFrame, pl.DataFrame))
     assert len(result) == 4
@@ -79,7 +80,7 @@ expected_databases_with_conn = [
     Database(
         name="memory",
         dialect="duckdb",
-        engine="test_duckdb",
+        engine=VariableName("test_duckdb"),
         schemas=[
             Schema(
                 name="main",
@@ -91,7 +92,7 @@ expected_databases_with_conn = [
                         num_rows=None,
                         num_columns=2,
                         variable_name=None,
-                        engine="test_duckdb",
+                        engine=VariableName("test_duckdb"),
                         columns=[
                             DataTableColumn(
                                 name="id",
@@ -120,7 +121,9 @@ def test_duckdb_engine_get_databases(
 ) -> None:
     """Test DuckDBEngine get_databases method."""
 
-    engine = DuckDBEngine(duckdb_connection, engine_name="test_duckdb")
+    engine = DuckDBEngine(
+        duckdb_connection, engine_name=VariableName("test_duckdb")
+    )
     databases = engine.get_databases(
         include_schemas=True, include_tables=True, include_table_details=True
     )
@@ -131,7 +134,7 @@ def test_duckdb_engine_get_databases(
 @pytest.mark.skipif(not HAS_DUCKDB, reason="DuckDB not installed")
 def test_duckdb_engine_get_databases_no_conn() -> None:
     """Test DuckDBEngine get_databases method."""
-    engine = DuckDBEngine()
+    engine = DuckDBEngine(None, engine_name=None)
     initial_databases = engine.get_databases(
         include_schemas=False,
         include_table_details=False,
@@ -172,7 +175,9 @@ def test_get_current_database_schema() -> None:
     import duckdb
 
     engine = duckdb.connect(":memory:")
-    duckdb_engine = DuckDBEngine(engine)
+    duckdb_engine = DuckDBEngine(
+        engine, engine_name=VariableName("test_duckdb")
+    )
 
     assert duckdb_engine.get_default_database() == "memory"
     assert duckdb_engine.get_default_schema() == "main"
@@ -195,9 +200,81 @@ def test_get_current_database_schema() -> None:
 def test_duckdb_engine_execute_polars_fallback() -> None:
     import pandas as pd
 
-    engine = DuckDBEngine(None)
+    engine = DuckDBEngine(None, engine_name=VariableName("test_duckdb"))
     # This dtype is currently not supported by polars
     result = engine.execute(
         "select to_days(cast((current_date - DATE '2025-01-01') as INTEGER));"
     )
     assert isinstance(result, pd.DataFrame)
+
+
+@pytest.mark.skipif(
+    not HAS_DUCKDB or not HAS_POLARS or not HAS_PANDAS,
+    reason="DuckDB, Polars, and Pandas not installed",
+)
+def test_duckdb_engine_sql_output_formats(
+    duckdb_connection: duckdb.DuckDBPyConnection,
+) -> None:
+    """Test DuckDBEngine execute with different SQL output formats."""
+    from unittest import mock
+
+    import pandas as pd
+    import polars as pl
+
+    # Test with polars output format
+    with mock.patch.object(
+        DuckDBEngine, "sql_output_format", return_value="polars"
+    ):
+        engine = DuckDBEngine(
+            duckdb_connection, engine_name=VariableName("test_duckdb")
+        )
+        result = engine.execute("SELECT * FROM test ORDER BY id")
+        assert isinstance(result, pl.DataFrame)
+        assert len(result) == 4
+
+    # Test with lazy-polars output format
+    with mock.patch.object(
+        DuckDBEngine, "sql_output_format", return_value="lazy-polars"
+    ):
+        engine = DuckDBEngine(
+            duckdb_connection, engine_name=VariableName("test_duckdb")
+        )
+        result = engine.execute("SELECT * FROM test ORDER BY id")
+        assert isinstance(result, pl.LazyFrame)
+        assert len(result.collect()) == 4
+
+    # Test with pandas output format
+    with mock.patch.object(
+        DuckDBEngine, "sql_output_format", return_value="pandas"
+    ):
+        engine = DuckDBEngine(
+            duckdb_connection, engine_name=VariableName("test_duckdb")
+        )
+        result = engine.execute("SELECT * FROM test ORDER BY id")
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 4
+
+    # Test with native output format
+    with mock.patch.object(
+        DuckDBEngine, "sql_output_format", return_value="native"
+    ):
+        engine = DuckDBEngine(
+            duckdb_connection, engine_name=VariableName("test_duckdb")
+        )
+        result = engine.execute("SELECT * FROM test ORDER BY id")
+        assert not isinstance(
+            result, (pd.DataFrame, pl.DataFrame, pl.LazyFrame)
+        )
+        # DuckDB native result has a different interface than SQLAlchemy
+        assert hasattr(result, "fetchall") or hasattr(result, "fetch_df")
+
+    # Test with auto output format (should use polars if available)
+    with mock.patch.object(
+        DuckDBEngine, "sql_output_format", return_value="auto"
+    ):
+        engine = DuckDBEngine(
+            duckdb_connection, engine_name=VariableName("test_duckdb")
+        )
+        result = engine.execute("SELECT * FROM test ORDER BY id")
+        assert isinstance(result, (pd.DataFrame, pl.DataFrame))
+        assert len(result) == 4

--- a/tests/_utils/test_narwhals_utils.py
+++ b/tests/_utils/test_narwhals_utils.py
@@ -10,6 +10,7 @@ from marimo._utils.narwhals_utils import (
     assert_narwhals_dataframe,
     assert_narwhals_series,
     can_narwhalify,
+    can_narwhalify_lazyframe,
     dataframe_to_csv,
     empty_df,
     is_narwhals_integer_type,
@@ -123,3 +124,27 @@ def test_unwrap_py_scalar():
     # Test non-scalar values are returned as-is
     complex_obj = {"a": 1}
     assert unwrap_py_scalar(complex_obj) == complex_obj
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_can_narwhalify_lazyframe():
+    import duckdb
+    import polars as pl
+
+    # Test with a LazyFrame
+    lazy_df = pl.DataFrame({"a": [1, 2, 3]}).lazy()
+    assert can_narwhalify_lazyframe(lazy_df) is True
+
+    # Test with a regular DataFrame
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    assert can_narwhalify_lazyframe(df) is False
+
+    # Test with non-polars objects
+    assert can_narwhalify_lazyframe({"a": [1, 2, 3]}) is False
+    assert can_narwhalify_lazyframe([1, 2, 3]) is False
+    assert can_narwhalify_lazyframe(None) is False
+
+    # Test with duckdb relation
+    con = duckdb.connect(":memory:")
+    rel = con.sql("SELECT 1")
+    assert can_narwhalify_lazyframe(rel) is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import pytest
 from _pytest import runner
 
 from marimo._ast.app import App, CellManager
+from marimo._ast.app_config import _AppConfig
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._messaging.mimetypes import ConsoleMimeType
 from marimo._messaging.ops import CellOp, MessageOperation
@@ -167,6 +168,7 @@ class MockedKernel:
                 filename=None,
                 cli_args={},
                 argv=None,
+                app_config=_AppConfig(),
             ),
             debugger_override=MarimoPdb(stdout=self.stdout, stdin=self.stdin),
             enqueue_control_request=lambda _: None,


### PR DESCRIPTION
**SQL Output Types**

marimo supports different output types for SQL queries, which is particularly useful when working with large datasets. You can configure this in your application configuration in the top right of the marimo editor.

The available options are:

- `"native"`: Uses DuckDB's native lazy relation (recommended for best performance)
- `"lazy-polars"`: Returns a lazy Polars DataFrame
- `"pandas"`: Returns a Pandas DataFrame
- `"polars"`: Returns an eager Polars DataFrame
- `"auto"`: Automatically chooses based on installed packages (first tries `polars` then `pandas`)

For best performance with large datasets, we recommend using `"native"` to avoid loading the entire result set into memory and to more easily chain SQL cells together. By default, only the first 10 rows are displayed in the UI to prevent memory issues.
