### PR TITLE
Added rendering script  for static HTML exports to docs

### DIFF
--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -46,6 +46,38 @@ its visual outputs before saving as HTML.
     If any cells error during the export process, the status code will be non-zero. However, the export result may still be generated, with the error included in the output.
     Errors can be ignored by appending `|| true` to the command, e.g. `marimo export html notebook.py || true`.
 
+### Pre-render HTML exports
+
+Static marimo exports execute Javascript to render the notebook source code as HTML at browser runtime. If you would like to directly serve the HTML representation of your notebook, you can run the following post-processing script and serve the resulting file instead.
+
+```python
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "playwright",
+# ]
+# ///
+
+import os
+import subprocess
+from playwright.sync_api import sync_playwright
+
+input_file = "input.html"
+output_file = "output.html"
+
+subprocess.run(["playwright", "install", "chromium-headless-shell"], check=True)
+
+with sync_playwright() as p:
+    with p.chromium.launch(headless=True) as browser:
+        page = browser.new_page()
+        page.goto(
+            f"file:///{os.path.abspath(input_file)}",
+            wait_until="networkidle",
+        )
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(page.content())
+```
+
 ## Export to a Python script
 
 Export to a flat Python script in topological order, so the cells adhere to


### PR DESCRIPTION
## 📝 Summary

Added a script to the docs that uses [playwright](https://github.com/microsoft/playwright-python) to pre-render static HTML exports.

Fixes #4324

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
