### PR TITLE
fix: bug in pytest scope determination

### DIFF
--- a/docs/guides/testing/pytest.md
+++ b/docs/guides/testing/pytest.md
@@ -57,7 +57,7 @@ def test_sanity(inc):
 
 @app.cell
 def collection_of_tests(inc, pytest):
-    @pytest.mark.parametrize("input, expected", [(3, 4), (4, 5)])
+    @pytest.mark.parametrize(("x", "y"), [(3, 4), (4, 5)])
     def test_answer(x, y):
         assert inc(x) == y, "These tests should pass."
 
@@ -71,7 +71,7 @@ prints
 
 ```pytest
 ============================= test session starts ==============================
-platform linux -- Python 3.11.10, pytest-8.3.4, pluggy-1.5.0
+platform linux -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
 rootdir: /notebooks
 configfile: pyproject.toml
 collected 4 items
@@ -108,7 +108,5 @@ E        +  where 4 = <function inc>(3)
 test_notebook.py:17: AssertionError
 =========================== short test summary info ============================
 FAILED test_notebook.py::test_fails - AssertionError: This test fails
-assert 4 == 5
- +  where 4 = <function inc>(3)
-========================= 1 failed, 3 passed in 0.65s ==========================
+========================= 1 failed, 3 passed in 0.82s ==========================
 ```

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -620,10 +620,13 @@ class Cell:
         assert self._app is not None
         # Definitions on a module level are not part of the signature, and as
         # such, should not be provided with the call.
-        extraction = TopLevelExtraction.from_app(self._app)
-        arg_names = sorted(
-            (self._cell.refs - extraction.allowed_refs) - self._cell.defs
-        )
+
+        # NB. TopLevelExtraction assumes that all cells that can be exposed will
+        # be, but signature provides context for what is actually scoped.
+        allowed_refs = TopLevelExtraction.from_app(self._app).allowed_refs
+        allowed_refs -= set(self._expected_signature or ())
+
+        arg_names = sorted((self._cell.refs - allowed_refs) - self._cell.defs)
         argc = len(arg_names)
 
         call_args = {name: arg for name, arg in zip(arg_names, args)}

--- a/tests/_ast/test_pytest_scoped.py
+++ b/tests/_ast/test_pytest_scoped.py
@@ -19,5 +19,20 @@ def _(test_cases):
     return (test_function,)
 
 
+@app.cell
+def _():
+    def inc(x):
+        return x + 1
+
+    return (inc,)
+
+
+@app.cell
+def collection_of_tests(inc, pytest):
+    @pytest.mark.parametrize(("x", "y"), [(3, 4), (4, 5)])
+    def test_answer(x, y):
+        assert inc(x) == y, "These tests should pass."
+
+
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
## 📝 Summary

fixes #4440

Preemptively enabled a capability than only works with library mode.

@akshayka OR @mscolnick