### PR TITLE
fix: skip test when sqlalchemy when not installed

### DIFF
--- a/tests/_sql/test_sqlalchemy.py
+++ b/tests/_sql/test_sqlalchemy.py
@@ -359,6 +359,7 @@ def test_sqlalchemy_engine_get_tables_in_schema(
     assert tables[0] == expected_table
 
 
+@pytest.mark.skipif(not HAS_SQLALCHEMY, reason="SQLAlchemy not installed")
 def test_sqlalchemy_skip_meta_schemas(
     sqlite_engine_meta: sa.Engine,
 ) -> None:


### PR DESCRIPTION
Fixes CI, test was running that depended on sqlalchemy