### PR TITLE
fix: setup cell is a 'root' to all cells

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -25,6 +25,7 @@ from marimo import _loggers
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
 from marimo._ast.errors import ImportStarError
+from marimo._ast.names import SETUP_CELL_NAME
 from marimo._ast.variables import is_local
 from marimo._ast.visitor import ImportData, Name, VariableData
 from marimo._config.config import ExecutionType, MarimoConfig, OnCellChangeType
@@ -1272,6 +1273,12 @@ class Kernel:
             - cells_registered_without_error
         ) & cells_in_graph
 
+        # If there is a setup cell and it is currently stale
+        if setup_cell := self.graph.cells.get(CellId_t(SETUP_CELL_NAME)):
+            # - then add it to the set of cells to run.
+            # This makes the setup cell like a "root" cell to everything.
+            if setup_cell.stale:
+                cells_registered_without_error.add(setup_cell.cell_id)
         if self.reactive_execution_mode == "lazy":
             self.graph.set_stale(stale_cells, prune_imports=True)
             return cells_registered_without_error

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -880,6 +880,54 @@ class TestExecution:
         assert set(k.errors.keys()) == {"0", "1"}
         assert not k.graph.cells["1"].stale
 
+    async def test_setup_runs(self, any_kernel: Kernel) -> None:
+        k = any_kernel
+        from marimo._ast.names import SETUP_CELL_NAME
+
+        await k.run(
+            [
+                ExecutionRequest(cell_id=SETUP_CELL_NAME, code="x=0"),
+                # NB. no explicit tie from setup to er.
+                er := ExecutionRequest(cell_id="1", code="y=1"),
+            ]
+        )
+        assert not k.graph.get_stale()
+        assert k.globals["x"] == 0
+        assert k.globals["y"] == 1
+        assert not k.errors
+
+        await k.run([ExecutionRequest(cell_id=SETUP_CELL_NAME, code="x=")])
+        assert SETUP_CELL_NAME not in k.graph.cells
+        assert "1" in k.graph.cells
+        assert "x" not in k.globals
+        if k.lazy():
+            # Opinionated - but because setup is not a true root, it should not
+            # invalidate other cells unless there is explicitly a tie.
+            assert k.graph.get_stale() == set()
+            await k.run([er])
+        assert not k.graph.get_stale()
+        assert "y" in k.globals
+
+        # fix syntax error
+        await k.run([ExecutionRequest(cell_id=SETUP_CELL_NAME, code="x=0")])
+        assert k.globals["x"] == 0
+        assert SETUP_CELL_NAME in k.graph.cells
+        assert "1" in k.graph.cells
+        assert not k.errors
+        if k.lazy():
+            # Wasn't stale previously
+            assert k.graph.get_stale() == set()
+            await k.run([er])
+        assert not k.graph.get_stale()
+        assert k.globals["y"] == 1
+
+        # set setup to stale
+        k.graph.cells[SETUP_CELL_NAME].set_stale(True)
+        print(k.graph.cells[SETUP_CELL_NAME].stale)
+        await k.run([er])
+        # Should have run!
+        assert not k.graph.get_stale()
+
     async def test_syntax_error(self, any_kernel: Kernel) -> None:
         k = any_kernel
         await k.run(

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -923,7 +923,6 @@ class TestExecution:
 
         # set setup to stale
         k.graph.cells[SETUP_CELL_NAME].set_stale(True)
-        print(k.graph.cells[SETUP_CELL_NAME].stale)
         await k.run([er])
         # Should have run!
         assert not k.graph.get_stale()


### PR DESCRIPTION
## 📝 Summary

Always run the setup cell if it is present and stale (making it like a root cell)

@akshayka