### PR TITLE
fix: pytest failed in wasm due to not setting env variables in pyodid…

### DIFF
--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -638,7 +638,10 @@ class Cell:
                 f"{self.name}() got an unexpected argument(s) '{unexpected}'"
             )
 
-        is_pytest = "PYTEST_CURRENT_TEST" in os.environ
+        is_pytest = (
+            "PYTEST_CURRENT_TEST" in os.environ
+            or "MARIMO_PYTEST_WASM" in os.environ
+        )
         # Capture pytest case, where arguments don't match the references.
         if self._pytest_reserved - set(arg_names):
             raise TypeError(

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -108,7 +108,7 @@ class CellManager:
             is_top_level_pytest = (
                 "PYTEST_VERSION" in os.environ
                 and "PYTEST_CURRENT_TEST" not in os.environ
-            )
+            ) or "MARIMO_PYTEST_WASM" in os.environ
             factory: Callable[..., Cell] = (
                 toplevel_cell_factory if top_level else cell_factory
             )

--- a/marimo/_runtime/pytest.py
+++ b/marimo/_runtime/pytest.py
@@ -268,6 +268,9 @@ def run_pytest(
     # the normal behavior (in which pytest alters the system path).
     plugin = ReplaceStubPlugin(defs, lcls)
     try:
+        # pytest in wasm doesn't seem to set environment variables correctly.
+        # This work around is to prevent collision with non-wasm testing.
+        os.environ["MARIMO_PYTEST_WASM"] = "1"
         with capture_stdout() as stdout:
             pytest.main(
                 [
@@ -280,6 +283,7 @@ def run_pytest(
                 plugins=[plugin],
             )
     finally:
+        del os.environ["MARIMO_PYTEST_WASM"]
         # Note, in pytester, there are also exceptions for zope and readline.
         # However, those deps should already be in module_snapshot, since
         # dependencies are required before the given cell runs.


### PR DESCRIPTION
## 📝 Summary

Fixes issue where tests are not collected on the WASM side:

![image](https://github.com/user-attachments/assets/45be27d7-8594-4d76-9de5-4d5236d1683b)


https://marimo.app/#code/JYWwDg9gTgLgBCAhlUEBQaD6mDmBTAOzykRjwBNMB3YGACzgF44AiABgDoBGAJg4A4WaRGDBMEyVBwCCogBQBKDGgACIsBwDGeADY605PADM4mRQC40ca3FCRYElCAhxEAZwTobt8NHhgATzI3GGVvAGI4ABFjYCI4ejw4ADFgACMIAkRNTWA4IwBXAk0YYEy4OSK7HTwQQjJyJW9DEyN0uQIFS29vMHc3KxsoPBgCqAJ89IAaTxnA4NCMNVEtXX0W0zk2tK7B6w2FzG3MNPc8TE0ziz2e-uJ4bbk2BSZmNhvvO4dHrhfGZi4GGaxgSeBCR3SmDcSD0mEgblowAAbnhrj0bF8Hu0AKx-ZjYsI2A5gmAQtKYHTIfBwiAI0ootHo1xuNz3SZpORcZ6vODYgneYajcag8HHU6si5nGaHY6UqDU+GIlHSklkqEwnQ0unIvDKZYabR6AwgszbOZBEm7YEmGWQog4Ug6xnomj0ODzEkcEjAVluOQANUQOgKeAAolAoNArUzvI8ALS-G6CsYTOS28n2x3KpQYYAmbBZOrYHksbBIOLYFjdDErKBFRRoIA

Inject an orthogonal variable into the runtime to prevent potential unexpected behavior on the server side:

![image](https://github.com/user-attachments/assets/e10464c9-112d-408b-8880-104362680439)


@mscolnick
