### PR TITLE
fix: clear variables when message is empty

### DIFF
--- a/frontend/src/core/variables/__tests__/state.test.ts
+++ b/frontend/src/core/variables/__tests__/state.test.ts
@@ -56,7 +56,6 @@ describe("cell reducer", () => {
     expect(state).toEqual({});
   });
 
-
   it("should add variables", () => {
     const x = {
       name: Names.x,

--- a/frontend/src/core/variables/__tests__/state.test.ts
+++ b/frontend/src/core/variables/__tests__/state.test.ts
@@ -40,6 +40,23 @@ describe("cell reducer", () => {
     expect(state).toEqual(variables);
   });
 
+  it("should clear variables", () => {
+    const x = {
+      name: Names.x,
+      declaredBy: [CellIds.a],
+      usedBy: [CellIds.b],
+    };
+    const variables: Variables = {
+      [Names.x]: x,
+    };
+    actions.setVariables([x]);
+    expect(state).toEqual(variables);
+
+    actions.setVariables([]);
+    expect(state).toEqual({});
+  });
+
+
   it("should add variables", () => {
     const x = {
       name: Names.x,

--- a/frontend/src/core/variables/state.ts
+++ b/frontend/src/core/variables/state.ts
@@ -15,9 +15,6 @@ const {
   useActions,
 } = createReducerAndAtoms(initialState, {
   setVariables: (state, variables: Variable[]) => {
-    if (variables.length === 0) {
-      return state;
-    }
     // start with empty state, but keep the old state's metadata
     const oldVariables = { ...state };
     const newVariables: Variables = {};


### PR DESCRIPTION
The variables table wasn't clearing when the variables message was empty. This only affected notebooks that had just one variable that was then deleted.