### PR TITLE
improvement: lazily load tracing panel

### DIFF
--- a/frontend/src/components/editor/chrome/panels/tracing-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/tracing-panel.tsx
@@ -1,7 +1,27 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { Tracing } from "@/components/tracing/tracing";
+import { Spinner } from "@/components/icons/spinner";
 import React from "react";
 
+const LazyTracing = React.lazy(() =>
+  import("@/components/tracing/tracing").then((module) => {
+    return {
+      default: module.Tracing,
+    };
+  }),
+);
+
 export const TracingPanel: React.FC = () => {
-  return <Tracing />;
+  return (
+    <React.Suspense fallback={<Loading />}>
+      <LazyTracing />
+    </React.Suspense>
+  );
+};
+
+const Loading = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <Spinner />
+    </div>
+  );
 };


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
I don't think tracing panel needs to load on startup, we should load it when it is rendered. I could also have lazily loaded vega stuff, but we shouldn't need to import tracing at all unless it's being used I think.

side note, compile is needed for tracing due to spec not being correct

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
