### PR TITLE
Use pyodide_http.patch_all() instead of patch_urllib()

### DIFF
--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -48,7 +48,7 @@ def patch_sys_module(module: types.ModuleType) -> None:
 def patch_pyodide_networking() -> None:
     import pyodide_http  # type: ignore
 
-    pyodide_http.patch_urllib()
+    pyodide_http.patch_all()
 
 
 def patch_recursion_limit(limit: int) -> None:


### PR DESCRIPTION
HTTP requests done from a Marimo WASM notebook are not carrying any cookies that the browser may have stored. This breaks requests to URLs that use cookie-based authentication (e.g. where the user authenticates in another browser tab/window, like URLs protected by [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/)).

The underlying issue is the lack of the proper credential flags for `XMLHttpRequest` in `pyodide-http` and `urllib3`, and I've opened pull-requests for both of those projects:

- https://github.com/urllib3/urllib3/pull/3591
- https://github.com/koenvo/pyodide-http/pull/44

However, Marimo is only patching network calls for the standard library's`urllib`, and it should be patching all calls that `pyodide-http` knows about. If so, then only the `pyodide-http` change is necessary to have HTTP requests from Marimo start carrying (implicit) cookies.

See "cookies in wasm" thread on Discord: https://discord.com/channels/1059888774789730424/1358809549187977518