### PR TITLE
Configure jedi completion for snippet support

### DIFF
--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -80,6 +80,12 @@ const lspClient = once((lspConfig: LSPConfig) => {
         jedi: {
           auto_import_modules: ["marimo", "numpy"],
         },
+        jedi_completion: {
+          // Ensure that parameters are included for completion snippets.
+          include_params: true,
+          // Include snippets and signatures it at most 50 suggestions.
+          resolve_at_most: 50,
+        },
         flake8: {
           enabled: config?.enable_flake8,
           extendIgnore: ignoredFlakeRules,


### PR DESCRIPTION
## 📝 Summary

Depends on https://github.com/marimo-team/codemirror-languageserver/pull/5

This allows basic use of completion snippets, for example on the video below the the cursor is correctly placed within the parentheses:

#### Before

[before.webm](https://github.com/user-attachments/assets/e58fe13b-51a6-4d8d-9eb4-eed68f09aeb4)

####  After

[cursor-goes-within-parens.webm](https://github.com/user-attachments/assets/55ab213d-06d6-4452-933d-90eec395fac6)

## 🔍 Description of Changes

This sets values needed for python-lsp-server to provide snippets:
- `include_params` must be true for snippets in completion
- `resolve_at_most` the default is 25, I propose to increase it to make snippets more reliably present

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
