### PR TITLE
chore: bump codemirror-languageserver, fix GitHub Copilot incremental updates

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@lezer/markdown": "^1.4.2",
     "@lezer/python": "^1.1.17",
     "@marimo-team/codemirror-ai": "^0.1.11",
-    "@marimo-team/codemirror-languageserver": "^1.15.7",
+    "@marimo-team/codemirror-languageserver": "^1.15.10",
     "@marimo-team/marimo-api": "file:../openapi",
     "@marimo-team/react-slotz": "^0.1.8",
     "@open-rpc/client-js": "^1.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@lezer/markdown": "^1.4.2",
     "@lezer/python": "^1.1.17",
     "@marimo-team/codemirror-ai": "^0.1.11",
-    "@marimo-team/codemirror-languageserver": "^1.15.10",
+    "@marimo-team/codemirror-languageserver": "^1.15.13",
     "@marimo-team/marimo-api": "file:../openapi",
     "@marimo-team/react-slotz": "^0.1.8",
     "@open-rpc/client-js": "^1.8.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^0.1.11
         version: 0.1.11(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.15.10
-        version: 1.15.10(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)
+        specifier: ^1.15.13
+        version: 1.15.13(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)
       '@marimo-team/marimo-api':
         specifier: file:../openapi
         version: file:../openapi
@@ -1570,8 +1570,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.15.10':
-    resolution: {integrity: sha512-AAY3lHhwXk8c1ffBo13XEBveEYzvLsepEX2yF762wQ1rG9lFPxmHiANJeHxtOqlkvZVDtIC3HXH5CxvNXO3fWQ==}
+  '@marimo-team/codemirror-languageserver@1.15.13':
+    resolution: {integrity: sha512-Ff7ED3wI4TPyyZjEK//asxfaWHU+0Duhkg7n+dDUKOcOwnq0IsNrqYtWmKYTV2hb8KSIjZre9xfIwM3fh1FSug==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -10351,7 +10351,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.5
 
-  '@marimo-team/codemirror-languageserver@1.15.10(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)':
+  '@marimo-team/codemirror-languageserver@1.15.13(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lint': 6.8.5

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^0.1.11
         version: 0.1.11(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.15.7
-        version: 1.15.7(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)
+        specifier: ^1.15.10
+        version: 1.15.10(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)
       '@marimo-team/marimo-api':
         specifier: file:../openapi
         version: file:../openapi
@@ -1570,8 +1570,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.15.7':
-    resolution: {integrity: sha512-g9p8mWemJcvFo8H3wzjrERKeDXzT+uVXj3q28kiMqMk92mnA/+mEZIYkl1aiPT87UZ7iTY5Uk8Gom0hCVsWAdw==}
+  '@marimo-team/codemirror-languageserver@1.15.10':
+    resolution: {integrity: sha512-AAY3lHhwXk8c1ffBo13XEBveEYzvLsepEX2yF762wQ1rG9lFPxmHiANJeHxtOqlkvZVDtIC3HXH5CxvNXO3fWQ==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -10351,7 +10351,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.5
 
-  '@marimo-team/codemirror-languageserver@1.15.7(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)':
+  '@marimo-team/codemirror-languageserver@1.15.10(@codemirror/state@6.5.2)(@codemirror/view@6.36.5)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/lint': 6.8.5

--- a/frontend/src/core/codemirror/copilot/client.ts
+++ b/frontend/src/core/codemirror/copilot/client.ts
@@ -113,5 +113,6 @@ export function copilotServer() {
     codeActionsEnabled: false,
     signatureHelpEnabled: false,
     diagnosticsEnabled: false,
+    sendIncrementalChanges: false,
   });
 }

--- a/frontend/src/core/codemirror/copilot/language-server.ts
+++ b/frontend/src/core/codemirror/copilot/language-server.ts
@@ -49,6 +49,7 @@ export interface LSPRequestMap {
  */
 export class CopilotLanguageServerClient extends LanguageServerClient {
   private documentVersion = 0;
+  private hasOpenedDocument = false;
 
   private async _request<Method extends keyof LSPRequestMap>(
     method: Method,
@@ -73,6 +74,7 @@ export class CopilotLanguageServerClient extends LanguageServerClient {
     if (this.isDisabled()) {
       return params;
     }
+    this.hasOpenedDocument = true;
     return super.textDocumentDidOpen(params);
   }
 
@@ -89,9 +91,38 @@ export class CopilotLanguageServerClient extends LanguageServerClient {
     if (this.isDisabled()) {
       return params;
     }
+
+    if (!this.hasOpenedDocument) {
+      await this.textDocumentDidOpen({
+        textDocument: {
+          uri: params.textDocument.uri,
+          languageId: "python",
+          version: params.textDocument.version,
+          text: params.contentChanges[0].text,
+        },
+      });
+    }
+
+    const changes = params.contentChanges;
+    if (changes.length !== 1) {
+      Logger.warn(
+        "CopilotLanguageServerClient#textDocumentDidChange: Multiple changes detected. This is not supported.",
+        changes,
+      );
+    }
+    const change = changes[0];
+    if ("range" in change) {
+      // Copilot doesn't support rangeLength
+      Logger.warn(
+        "CopilotLanguageServerClient#textDocumentDidChange: Copilot doesn't support rangeLength",
+        change,
+      );
+    }
+
+    const text = getCodes(change.text);
     return super.textDocumentDidChange({
       ...params,
-      contentChanges: [{ text: getCodes(params.contentChanges[0].text) }],
+      contentChanges: [{ text: text }],
       textDocument: VersionedTextDocumentIdentifier.create(
         params.textDocument.uri,
         ++this.documentVersion,

--- a/frontend/src/core/codemirror/copilot/language-server.ts
+++ b/frontend/src/core/codemirror/copilot/language-server.ts
@@ -112,9 +112,8 @@ export class CopilotLanguageServerClient extends LanguageServerClient {
     }
     const change = changes[0];
     if ("range" in change) {
-      // Copilot doesn't support rangeLength
       Logger.warn(
-        "CopilotLanguageServerClient#textDocumentDidChange: Copilot doesn't support rangeLength",
+        "CopilotLanguageServerClient#textDocumentDidChange: Copilot doesn't support range changes.",
         change,
       );
     }

--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -185,6 +185,7 @@ export class PythonLanguageAdapter implements LanguageAdapter {
             completionConfig: autocompleteOptions,
             // Default to false
             diagnosticsEnabled: lspConfig.diagnostics?.enabled ?? false,
+            sendIncrementalChanges: false,
             signatureHelpEnabled: true,
             signatureActivateOnTyping: false,
             keyboardShortcuts: {

--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -7,8 +7,8 @@ import { invariant } from "@/utils/invariant";
 import { Logger } from "@/utils/Logger";
 import { LRUCache } from "@/utils/lru";
 import type { CellId } from "@/core/cells/ids";
-import { getFilenameFromDOM } from "@/core/dom/htmlUtils";
 import type { EditorView } from "@codemirror/view";
+import { getLSPDocument } from "./utils";
 
 export class NotebookLanguageServerClient implements ILanguageServerClient {
   public readonly documentUri: LSP.DocumentUri;
@@ -33,7 +33,7 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
     client: ILanguageServerClient,
     initialSettings: Record<string, unknown>,
   ) {
-    this.documentUri = `file://${getFilenameFromDOM() ?? "/__marimo_notebook__.py"}`;
+    this.documentUri = getLSPDocument();
 
     this.client = client;
     this.patchProcessNotification();

--- a/frontend/src/core/codemirror/lsp/utils.ts
+++ b/frontend/src/core/codemirror/lsp/utils.ts
@@ -1,0 +1,6 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { getFilenameFromDOM } from "@/core/dom/htmlUtils";
+
+export function getLSPDocument() {
+  return `file://${getFilenameFromDOM() ?? "/__marimo_notebook__.py"}`;
+}


### PR DESCRIPTION
Bump codemirror-language server:
 - snippets
 - configurable incremental edits

Fixes #4464 

We don't send incremental edits since it breaks copilot. This also adds some fixes for the websocket proxy and multiple LSPs running at once