### PR TITLE
fix: pytest decorated class methods fails

### DIFF
--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -49,7 +49,7 @@ def build_stub_fn(
 
     args = {arg.arg: arg for arg in func_body.args.args}
     if allowed is None:
-        allowed = [arg for arg in args.keys() if arg != "self"]
+        allowed = [arg for arg in args.keys()]
     name = func_body.name
 
     # Typing checks for mypy

--- a/tests/_ast/test_pytest_toplevel.py
+++ b/tests/_ast/test_pytest_toplevel.py
@@ -38,6 +38,15 @@ class TestClassWorks:
     def test_sanity(self):
         assert True
 
+    @pytest.mark.parametrize(("a", "b", "c"), [(1, 1, 2), (1, 2, 3)])
+    def test_decorated(self, a, b, c):
+        assert add(a, b) == c
+
+    @staticmethod
+    @pytest.mark.parametrize(("a", "b", "c"), [(1, 1, 2), (1, 2, 3)])
+    def test_decorated_static(a, b, c):
+        assert add(a, b) == c
+
 
 if __name__ == "__main__":
     app.run()

--- a/tests/_ast/test_pytest_toplevel.py
+++ b/tests/_ast/test_pytest_toplevel.py
@@ -44,7 +44,7 @@ class TestClassWorks:
 
     @staticmethod
     @pytest.mark.parametrize(("a", "b", "c"), [(1, 1, 2), (1, 2, 3)])
-    def test_decorated_static(a, b, c):
+    def test_decorated_static(a, b, c) -> None:
         assert add(a, b) == c
 
 


### PR DESCRIPTION
## 📝 Summary

Didn't have robust enough unit tests, and some faulty logic got in

@akshayka OR @mscolnick