### PR TITLE
ci: run "typos" command with "hatch run" in "fe-check" make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ e2e:
 .PHONY: fe-lint
 # 🧹 Lint frontend
 fe-lint:
-	cd frontend/src && typos && cd - && cd frontend && pnpm lint
+	cd frontend/src && hatch run typos && cd - && cd frontend && pnpm lint
 
 .PHONY: fe-typecheck
 # 🔍 Typecheck frontend


### PR DESCRIPTION
## 📝 Summary

The make command for `fe-lint` was assuming the hatch environment was active when invoking `typos`, this fix allows running `make check` outside of the hatch environment and matches the rest of the Makefile.

## 🔍 Description of Changes

Just added `hatch run` before the `typos` invocation.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
