### PR TITLE
feat: move LSP out of experimental,  keep LSP optional

### DIFF
--- a/frontend/src/components/app-config/optional-features.tsx
+++ b/frontend/src/components/app-config/optional-features.tsx
@@ -20,7 +20,6 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/utils/cn";
 import { SettingSubtitle } from "./common";
 import { isWasm } from "@/core/wasm/utils";
-import { getFeatureFlag } from "@/core/config/feature-flag";
 
 interface Package {
   name: string;
@@ -89,12 +88,13 @@ const OPTIONAL_DEPENDENCIES: OptionalFeature[] = [
   },
 ];
 
-if (getFeatureFlag("lsp")) {
+// Only available outside wasm
+if (!isWasm()) {
   OPTIONAL_DEPENDENCIES.push({
     id: "lsp",
     packagesRequired: [{ name: "python-lsp-server" }, { name: "websockets" }],
     additionalPackageInstalls: [{ name: "python-lsp-ruff" }],
-    description: "Language Server Protocol",
+    description: "Language Server Protocol*",
   });
 }
 
@@ -178,6 +178,8 @@ export const OptionalFeatures: React.FC = () => {
           })}
         </TableBody>
       </Table>
+
+      <p className="text-muted-foreground mt-2">*Requires server restart</p>
     </div>
   );
 };

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -51,8 +51,9 @@ import { get } from "lodash-es";
 import { Tooltip } from "../ui/tooltip";
 import { getMarimoVersion } from "@/core/dom/marimo-tag";
 import { OptionalFeatures } from "./optional-features";
-import { getFeatureFlag } from "@/core/config/feature-flag";
 import { Badge } from "../ui/badge";
+import { capabilitiesAtom, hasCapability } from "@/core/config/capabilities";
+import { Banner } from "@/plugins/impl/common/error-banner";
 
 const formItemClasses = "flex flex-row items-center space-x-1 space-y-0";
 const categories = [
@@ -113,6 +114,7 @@ export const UserConfigForm: React.FC = () => {
   const [activeCategory, setActiveCategory] = useAtom(
     activeUserConfigCategoryAtom,
   );
+  const capabilities = useAtomValue(capabilitiesAtom);
 
   // Create form
   const form = useForm<UserConfig>({
@@ -423,12 +425,12 @@ export const UserConfigForm: React.FC = () => {
                 )}
               />
             </SettingGroup>
-            {getFeatureFlag("lsp") && (
-              <SettingGroup title="Language Servers">
-                <FormField
-                  control={form.control}
-                  name="language_servers.pylsp.enabled"
-                  render={({ field }) => (
+            <SettingGroup title="Language Servers">
+              <FormField
+                control={form.control}
+                name="language_servers.pylsp.enabled"
+                render={({ field }) => (
+                  <div className="flex flex-col gap-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>
                         <Badge variant="defaultOutline" className="mr-2">
@@ -456,47 +458,55 @@ export const UserConfigForm: React.FC = () => {
                         name="language_servers.pylsp.enabled"
                       />
                     </FormItem>
-                  )}
-                />
-                <FormDescription>
-                  See the{" "}
-                  <ExternalLink href="https://docs.marimo.io/guides/editor_features/language_server/">
-                    docs
-                  </ExternalLink>{" "}
-                  for more information about language server support.
-                </FormDescription>
+                    {field.value && !hasCapability("pylsp") && (
+                      <Banner kind="danger">
+                        The Python Language Server is not available in your
+                        current environment. Please install{" "}
+                        <Kbd className="inline">python-lsp-server</Kbd> in your
+                        environment.
+                      </Banner>
+                    )}
+                  </div>
+                )}
+              />
+              <FormDescription>
+                See the{" "}
+                <ExternalLink href="https://docs.marimo.io/guides/editor_features/language_server/">
+                  docs
+                </ExternalLink>{" "}
+                for more information about language server support.
+              </FormDescription>
 
-                <FormField
-                  control={form.control}
-                  name="diagnostics.enabled"
-                  render={({ field }) => (
-                    <FormItem className={formItemClasses}>
-                      <FormLabel>
-                        <Badge variant="defaultOutline" className="mr-2">
-                          Beta
-                        </Badge>
-                        Diagnostics
-                      </FormLabel>
-                      <FormControl>
-                        <Checkbox
-                          data-testid="diagnostics-checkbox"
-                          checked={field.value}
-                          disabled={field.disabled}
-                          onCheckedChange={(checked) => {
-                            field.onChange(Boolean(checked));
-                          }}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="diagnostics.enabled"
+              <FormField
+                control={form.control}
+                name="diagnostics.enabled"
+                render={({ field }) => (
+                  <FormItem className={formItemClasses}>
+                    <FormLabel>
+                      <Badge variant="defaultOutline" className="mr-2">
+                        Beta
+                      </Badge>
+                      Diagnostics
+                    </FormLabel>
+                    <FormControl>
+                      <Checkbox
+                        data-testid="diagnostics-checkbox"
+                        checked={field.value}
+                        disabled={field.disabled}
+                        onCheckedChange={(checked) => {
+                          field.onChange(Boolean(checked));
+                        }}
                       />
-                    </FormItem>
-                  )}
-                />
-              </SettingGroup>
-            )}
+                    </FormControl>
+                    <FormMessage />
+                    <IsOverridden
+                      userConfig={config}
+                      name="diagnostics.enabled"
+                    />
+                  </FormItem>
+                )}
+              />
+            </SettingGroup>
 
             <SettingGroup title="Keymap">
               <FormField
@@ -902,7 +912,7 @@ export const UserConfigForm: React.FC = () => {
                     <FormControl>
                       <Checkbox
                         data-testid="reactive-test-checkbox"
-                        checked={field.value === true}
+                        checked={field.value}
                         onCheckedChange={field.onChange}
                       />
                     </FormControl>

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -52,7 +52,7 @@ import { Tooltip } from "../ui/tooltip";
 import { getMarimoVersion } from "@/core/dom/marimo-tag";
 import { OptionalFeatures } from "./optional-features";
 import { Badge } from "../ui/badge";
-import { capabilitiesAtom, hasCapability } from "@/core/config/capabilities";
+import { capabilitiesAtom } from "@/core/config/capabilities";
 import { Banner } from "@/plugins/impl/common/error-banner";
 
 const formItemClasses = "flex flex-row items-center space-x-1 space-y-0";
@@ -458,7 +458,7 @@ export const UserConfigForm: React.FC = () => {
                         name="language_servers.pylsp.enabled"
                       />
                     </FormItem>
-                    {field.value && !hasCapability("pylsp") && (
+                    {field.value && !capabilities.pylsp && (
                       <Banner kind="danger">
                         The Python Language Server is not available in your
                         current environment. Please install{" "}

--- a/frontend/src/components/ui/kbd.tsx
+++ b/frontend/src/components/ui/kbd.tsx
@@ -13,7 +13,7 @@ export const Kbd: React.FC<Props> = (props) => {
         props.className,
         // text-[0.75rem]: don't want to set line height; want to inherit
         // whatever line height is used to make sure text is not off-center
-        "rounded-md bg-muted/40 px-2 text-[0.75rem] font-prose center border border-foreground/20 text-muted-foreground block",
+        "rounded-md bg-muted/40 px-2 text-[0.75rem] font-prose center border border-foreground/20 text-muted-foreground block whitespace-nowrap",
       )}
     >
       {props.children}

--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -123,7 +123,7 @@ export const setupCodeMirror = (opts: CodeMirrorSetupOpts): Extension[] => {
     basicBundle(opts),
     // Underline cmd+clickable placeholder
     goToDefinitionBundle(),
-    getFeatureFlag("lsp") && diagnosticsConfig?.enabled ? lintGutter() : [],
+    diagnosticsConfig?.enabled ? lintGutter() : [],
     // AI edit inline
     enableAI && getFeatureFlag("inline_ai_tooltip")
       ? aiExtension({
@@ -188,7 +188,7 @@ export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
     scrollActiveLineIntoView(),
     theme === "dark" ? darkTheme : lightTheme,
 
-    hintTooltip(),
+    hintTooltip(lspConfig),
     copilotBundle(completionConfig),
     foldGutter(),
     closeBrackets(),

--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -7,13 +7,14 @@ import type { EditorState, Text } from "@codemirror/state";
 import { debounce } from "lodash-es";
 import { documentationAtom } from "@/core/documentation/state";
 import { store } from "@/core/state/jotai";
-import { getFeatureFlag } from "@/core/config/feature-flag";
 import { chromeAtom } from "@/components/editor/chrome/state";
+import type { LSPConfig } from "@/core/config/config-schema";
+import { hasCapability } from "@/core/config/capabilities";
 
-export function hintTooltip() {
+export function hintTooltip(lspConfig: LSPConfig) {
   return [
     // Hover tooltip is already covered by LSP
-    getFeatureFlag("lsp")
+    lspConfig?.pylsp?.enabled && hasCapability("pylsp")
       ? []
       : hoverTooltip(
           async (view, pos) => {

--- a/frontend/src/core/codemirror/language/python.ts
+++ b/frontend/src/core/codemirror/language/python.ts
@@ -31,7 +31,6 @@ import { resolveToWsUrl } from "@/core/websocket/createWsUrl";
 import { WebSocketTransport } from "@open-rpc/client-js";
 import { NotebookLanguageServerClient } from "../lsp/notebook-lsp";
 import { once } from "@/utils/once";
-import { getFeatureFlag } from "@/core/config/feature-flag";
 import { autocompletion } from "@codemirror/autocomplete";
 import { completer } from "../completion/completer";
 import { getFilenameFromDOM } from "@/core/dom/htmlUtils";
@@ -41,6 +40,7 @@ import { cellActionsState } from "../cells/state";
 import { openFile } from "@/core/network/requests";
 import { Logger } from "@/utils/Logger";
 import { CellDocumentUri } from "../lsp/types";
+import { hasCapability } from "@/core/config/capabilities";
 
 const pylspTransport = once(() => {
   const transport = new WebSocketTransport(resolveToWsUrl("/lsp/pylsp"));
@@ -174,7 +174,7 @@ export class PythonLanguageAdapter implements LanguageAdapter {
         hideOnChange: true,
       };
 
-      if (getFeatureFlag("lsp") && lspConfig?.pylsp?.enabled) {
+      if (lspConfig?.pylsp?.enabled && hasCapability("pylsp")) {
         const client = lspClient(lspConfig);
         return [
           languageServerWithClient({

--- a/frontend/src/core/config/capabilities.ts
+++ b/frontend/src/core/config/capabilities.ts
@@ -1,7 +1,13 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { atom } from "jotai";
 import type { Capabilities } from "../kernel/messages";
+import { store } from "../state/jotai";
 
 export const capabilitiesAtom = atom<Capabilities>({
   terminal: false,
+  pylsp: false,
 });
+
+export function hasCapability(key: keyof Capabilities): boolean {
+  return store.get(capabilitiesAtom)[key];
+}

--- a/frontend/src/core/config/feature-flag.tsx
+++ b/frontend/src/core/config/feature-flag.tsx
@@ -7,7 +7,6 @@ import { getResolvedMarimoConfig } from "./config";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ExperimentalFeatures {
-  lsp: boolean;
   markdown: boolean;
   inline_ai_tooltip: boolean;
   wasm_layouts: boolean;
@@ -21,7 +20,6 @@ export interface ExperimentalFeatures {
 }
 
 const defaultValues: ExperimentalFeatures = {
-  lsp: import.meta.env.DEV,
   markdown: true,
   inline_ai_tooltip: import.meta.env.DEV,
   wasm_layouts: false,

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -32,6 +32,7 @@ from marimo._data.models import (
     DataTable,
     DataTableSource,
 )
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.completion_option import CompletionOption
 from marimo._messaging.context import RUN_ID_CTX, RunId_t
@@ -415,10 +416,12 @@ class CompletedRun(Op):
 @dataclass
 class KernelCapabilities:
     terminal: bool = False
+    pylsp: bool = False
 
     def __post_init__(self) -> None:
         # Only available in mac/linux
         self.terminal = not is_windows() and not is_pyodide()
+        self.pylsp = DependencyManager.pylsp.has()
 
 
 @dataclass

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -85,7 +85,7 @@ class MarimoConvertValueException(Exception):
 
 
 @mddoc
-class UIElement(Html, Generic[S, T], metaclass=abc.ABCMeta):
+class UIElement(Html, Generic[S, T]):
     """An HTML element with a value
 
     A `UIElement` is an HTML element with a value; when the value of the

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -177,6 +177,13 @@ class CopilotLspServer(BaseLspServer):
 class PyLspServer(BaseLspServer):
     id = "pylsp"
 
+    def start(self) -> Optional[Alert]:
+        # pylsp is not required, so we don't want to alert or fail if it is not installed
+        if not DependencyManager.pylsp.has():
+            return None
+
+        return super().start()
+
     def validate_requirements(self) -> Union[str, Literal[True]]:
         if DependencyManager.pylsp.has():
             return True

--- a/marimo/_server/print.py
+++ b/marimo/_server/print.py
@@ -111,6 +111,7 @@ def print_experimental_features(config: MarimoConfig) -> None:
     # These experiments have been released
     finished_experiments = {
         "rtc",
+        "lsp",
         "chat_sidebar",
         "multi_column",
         "scratchpad",

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1145,10 +1145,13 @@ components:
           type: object
         capabilities:
           properties:
+            pylsp:
+              type: boolean
             terminal:
               type: boolean
           required:
           - terminal
+          - pylsp
           type: object
         cell_ids:
           items:
@@ -2493,7 +2496,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.12.8
+  version: 0.12.9
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2791,6 +2791,7 @@ export interface components {
         width: "normal" | "compact" | "medium" | "full" | "columns";
       };
       capabilities: {
+        pylsp: boolean;
         terminal: boolean;
       };
       cell_ids: string[];


### PR DESCRIPTION
- Move LSP out of feature flag
- Keep it optional by adding it to `KernelCapabilities`. Don't show errors when enabled but not installed (since it is enabled by default)