### PR TITLE
fix: Overload @app.cell for mypy typing

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -284,6 +284,14 @@ class App:
                     )
         return app
 
+    # Overloads are required to preserve the wrapped function's signature.
+    # mypy is not smart enough to carry transitive typing in this case.
+    @overload
+    def cell(self, func: Fn[P, R]) -> Cell: ...
+
+    @overload
+    def cell(self, **kwargs: Any) -> Callable[[Fn[P, R]], Cell]: ...
+
     def cell(
         self,
         func: Fn[P, R] | None = None,
@@ -328,8 +336,6 @@ class App:
             ),
         )
 
-    # Overloads are required to preserve the wrapped function's signature.
-    # mypy is not smart enough to carry transitive typing in this case.
     @overload
     def function(self, func: Fn[P, R]) -> Fn[P, R]: ...
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -35,7 +35,7 @@ from marimo._tutorials import (
     Tutorial,
     create_temp_tutorial_file,
     tutorial_order,
-)
+)  # type: ignore
 from marimo._utils.marimo_path import MarimoPath, create_temp_notebook_file
 from marimo._utils.platform import is_windows
 

--- a/marimo/_server/api/endpoints/home.py
+++ b/marimo/_server/api/endpoints/home.py
@@ -23,7 +23,7 @@ from marimo._server.models.home import (
     WorkspaceFilesResponse,
 )
 from marimo._server.router import APIRouter
-from marimo._tutorials import create_temp_tutorial_file
+from marimo._tutorials import create_temp_tutorial_file  # type: ignore
 from marimo._utils.paths import pretty_path
 
 if TYPE_CHECKING:

--- a/marimo/_server/models/home.py
+++ b/marimo/_server/models/home.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from marimo._server.models.files import FileInfo
-from marimo._tutorials import Tutorial
+from marimo._tutorials import Tutorial  # type: ignore
 from marimo._types.ids import SessionId
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,11 @@ dependencies = [
 ]
 
 [tool.hatch.envs.typecheck.scripts]
-check = "mypy marimo/"
+# tutorials shouldn't be type-checked (should be excluded), but they get
+# included due to import following; so ensure tutorial imports are type
+# ignored.
+check = "mypy marimo --exclude=marimo/_tutorials/"
+tutorials = "mypy marimo/_tutorials"
 
 [tool.hatch.envs.test]
 extra-dependencies = [
@@ -460,17 +464,10 @@ exclude = [
     'tests/_cli/cli_data',
     'tests/_cli/ipynb_data',
     'tests/_runtime/runtime_data',
-    'marimo/_tutorials/',
     'marimo/_snippets/data/',
     'marimo/_smoke_tests/',
 ]
 warn_unused_ignores = false
-
-# tutorials shouldn't be type-checked (should be excluded), but they
-# get included anyway, maybe due to import following; this is coarse but works
-[[tool.mypy.overrides]]
-module = "marimo._tutorials.*"
-ignore_errors = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
## 📝 Summary

fixes #4511

additionally, `hatch run typecheck:tutorials` can be manually triggered to run on tutorials - I didn't add this to CI because there's a lot that lights up- but maybe something to keep in mind (or even isolate a single tutorial for)

@akshayka OR @mscolnick
