### PR TITLE
fix: (static parse) warn on bad cellconfig opposed to failing

### DIFF
--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -38,8 +38,15 @@ class CellConfig:
     hide_code: bool = False
 
     @classmethod
-    def from_dict(cls, kwargs: dict[str, Any]) -> CellConfig:
-        return cls(**{k: v for k, v in kwargs.items() if k in CellConfigKeys})
+    def from_dict(
+        cls, kwargs: dict[str, Any], warn: bool = True
+    ) -> CellConfig:
+        config = cls(
+            **{k: v for k, v in kwargs.items() if k in CellConfigKeys}
+        )
+        if warn and (invalid := set(kwargs.keys()) - CellConfigKeys):
+            LOGGER.warning(f"Invalid config keys: {invalid}")
+        return config
 
     def asdict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -217,8 +217,8 @@ class CellManager:
         else:
             cell_id = self.create_cell_id()
         cell = ir_cell_factory(cell_def, cell_id=cell_id)
-        cell_config = CellConfig(
-            **cell_def.options,
+        cell_config = CellConfig.from_dict(
+            cell_def.options,
         )
         cell._cell.configure(cell_config)
         self._register_cell(cell, app=app)

--- a/tests/_ast/codegen_data/test_get_bad_kwargs.py
+++ b/tests/_ast/codegen_data/test_get_bad_kwargs.py
@@ -1,0 +1,9 @@
+import marimo
+
+app = marimo.App(
+    kwarg_that_doesnt_exist="title",
+)
+
+@app.cell(fake_kwarg=True)
+def fake_kwarg():
+    return


### PR DESCRIPTION
## 📝 Summary

fixes #4521 

Allow invalid cell config parameters to be passed and only spawn warnings over failure.

@akshayka OR @mscolnick
