### PR TITLE
fix: correct pnpm version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-all: fe py
 # ✓ Check if all required tools are installed
 check-prereqs:
 	@command -v pnpm >/dev/null 2>&1 || { echo "pnpm is required. See https://pnpm.io/installation"; exit 1; }
-	@pnpm -v | grep -q "9." || { echo "pnpm v9+ is required. Current version: $(shell pnpm -v)"; exit 1; }
+	@pnpm -v | grep -vq "^[0-8]\." || { echo "pnpm v9+ is required. Current version: $(shell pnpm -v)"; exit 1; }
 	@command -v uv >/dev/null 2>&1 || { echo "uv is required. See https://docs.astral.sh/uv/getting-started/installation/"; exit 1; }
 	@command -v hatch >/dev/null 2>&1 || { echo "hatch is required. See https://hatch.pypa.io/dev/install/"; exit 1; }
 	@command -v node >/dev/null 2>&1 || { echo "Node.js is required. See https://nodejs.org/en/download/"; exit 1; }


### PR DESCRIPTION
This commit fixes two errors:

1. pnpm on Arch is version 10.8.0 but was failing the check because it was merely looking for "9.*" but it should look for any version 9 and above.

2. The check was looking for "9." anywhere in the version string but it should only look at major version component.