### PR TITLE
fix: Fix refresh period

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-all: fe py
 # ✓ Check if all required tools are installed
 check-prereqs:
 	@command -v pnpm >/dev/null 2>&1 || { echo "pnpm is required. See https://pnpm.io/installation"; exit 1; }
-	@pnpm -v | grep -q "9." || { echo "pnpm v9+ is required. Current version: $(shell pnpm -v)"; exit 1; }
+	@pnpm -v | grep -vq "^[0-8]\." || { echo "pnpm v9+ is required. Current version: $(shell pnpm -v)"; exit 1; }
 	@command -v uv >/dev/null 2>&1 || { echo "uv is required. See https://docs.astral.sh/uv/getting-started/installation/"; exit 1; }
 	@command -v hatch >/dev/null 2>&1 || { echo "hatch is required. See https://hatch.pypa.io/dev/install/"; exit 1; }
 	@command -v node >/dev/null 2>&1 || { echo "Node.js is required. See https://nodejs.org/en/download/"; exit 1; }

--- a/frontend/src/plugins/impl/RefreshPlugin.tsx
+++ b/frontend/src/plugins/impl/RefreshPlugin.tsx
@@ -103,8 +103,8 @@ const RefreshComponent = ({ setValue, data }: IPluginProps<Value, Data>) => {
           ? timestring(selected)
           : timestring(`${selected}s`); // default to seconds if no units
 
-    // Smallest interval is 1 second
-    asSeconds = Math.max(asSeconds, 1);
+    // Constrain to smallest interval
+    asSeconds = Math.max(asSeconds, MIN_INTERVAL);
 
     const id = setInterval(refresh, asSeconds * 1000);
     return () => clearInterval(id);


### PR DESCRIPTION
`mo.ui.refresh()` allows the user to set a period interval down to 0.1 secs but then artificially constrains it to >=1 sec at run time. There doesn't seem to be any downside to removing this constraint as done by this pr/commit.
