### PR TITLE
fix: fix refresh interval constraint

### DIFF
--- a/frontend/src/plugins/impl/RefreshPlugin.tsx
+++ b/frontend/src/plugins/impl/RefreshPlugin.tsx
@@ -103,8 +103,8 @@ const RefreshComponent = ({ setValue, data }: IPluginProps<Value, Data>) => {
           ? timestring(selected)
           : timestring(`${selected}s`); // default to seconds if no units
 
-    // Smallest interval is 1 second
-    asSeconds = Math.max(asSeconds, 1);
+    // Constrain to smallest interval
+    asSeconds = Math.max(asSeconds, MIN_INTERVAL);
 
     const id = setInterval(refresh, asSeconds * 1000);
     return () => clearInterval(id);


### PR DESCRIPTION
`mo.ui.refresh()` allows the user to set a period interval down to 0.1 secs but then artificially constrains it to >=1 sec at run time. There doesn't seem to be any downside to removing this constraint as done by this pr/commit.
