### PR TITLE
fix: pass setup cell to toplevel resolution posthook

### DIFF
--- a/marimo/_ast/toplevel.py
+++ b/marimo/_ast/toplevel.py
@@ -41,7 +41,8 @@ TopLevelInvalidHints = Literal[
 ) = get_args(TopLevelInvalidHints)
 
 TopLevelHints = Union[Literal["Valid"], TopLevelInvalidHints]
-HINT_VALID, *_ = get_args(TopLevelHints)
+# Fancy typing caused an issue, so just set the value explicitly.
+HINT_VALID: Literal["Valid"] = "Valid"
 
 
 def has_trailing_comment(code: str) -> bool:
@@ -154,6 +155,7 @@ class TopLevelStatus:
         dependent_refs = self._cell.refs - (allowed_refs | toplevel)
         if not dependent_refs:
             self.type = TopLevelType.TOPLEVEL
+            self.hint = HINT_VALID
             return
 
         defined_refs = dependent_refs - potential_refs
@@ -337,14 +339,13 @@ class TopLevelExtraction:
         assert not self.unresolved
 
     @classmethod
-    def from_cells(cls, cells: list[CellImpl]) -> TopLevelExtraction:
+    def from_cells(
+        cls, cells: list[CellImpl], setup: Optional[CellImpl] = None
+    ) -> TopLevelExtraction:
         codes = [cell.code for cell in cells]
-        names = ["_" for cell in cells]
+        names = ["_" for _ in cells]
         cell_configs = [cell.config for cell in cells]
 
-        from marimo._ast.codegen import pop_setup_cell
-
-        setup = pop_setup_cell(codes, names, cell_configs, True)
         if setup:
             return cls(codes, names, cell_configs, setup.defs)
         return cls(codes, names, cell_configs, set())

--- a/marimo/_schemas/serialization.py
+++ b/marimo/_schemas/serialization.py
@@ -64,7 +64,8 @@ class CellDef(Node):
                 if self.end_col_offset == 0 and self._ast.end_col_offset
                 else self.end_col_offset
             )
-            self.name = getattr(self._ast, "name", DEFAULT_CELL_NAME)
+            if self.name == DEFAULT_CELL_NAME:
+                self.name = getattr(self._ast, "name", DEFAULT_CELL_NAME)
 
 
 class SetupCell(CellDef): ...


### PR DESCRIPTION
## 📝 Summary

Fixes some of this issues I was seeing when writing the tutorial. Main issue seemed to be unable to discover the setup cell

Note we need actual cell order to properly do resolution, but that i information is not available runner level. Could wire that down, but this is OK for now.

Really needs some e2e tests to properly capture, but the logic in toplevel itself is throughly tested in `tests/_ast/test_toplevel.py`

@akshayka OR @mscolnick
