### PR TITLE
fix: remove copy and pinning from variable table

### DIFF
--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -25,7 +25,7 @@ import { logNever } from "@/utils/assertNever";
 import {
   renderColumnPinning,
   renderColumnWrapping,
-  renderCopyColumnId,
+  renderCopyColumn,
   renderDataType,
   renderFormatOptions,
   renderSortIcon,
@@ -78,7 +78,7 @@ export const DataTableColumnHeader = <TData, TValue>({
       <DropdownMenuContent align="start">
         {renderDataType(column)}
         {renderSorts(column)}
-        {renderCopyColumnId(column)}
+        {renderCopyColumn(column)}
         {renderColumnPinning(column)}
         {renderColumnWrapping(column)}
         {renderFormatOptions(column)}

--- a/frontend/src/components/data-table/copy-column/feature.ts
+++ b/frontend/src/components/data-table/copy-column/feature.ts
@@ -1,0 +1,27 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import type {
+  TableFeature,
+  RowData,
+  Table,
+  Column,
+} from "@tanstack/react-table";
+import type { CopyColumnOptions } from "./types";
+
+export const CopyColumnFeature: TableFeature = {
+  getDefaultOptions: <TData extends RowData>(
+    table: Table<TData>,
+  ): CopyColumnOptions => {
+    return {
+      enableCopyColumn: true,
+    };
+  },
+
+  createColumn: <TData extends RowData>(
+    column: Column<TData>,
+    table: Table<TData>,
+  ) => {
+    column.getCanCopy = () => {
+      return table.options.enableCopyColumn ?? false;
+    };
+  },
+};

--- a/frontend/src/components/data-table/copy-column/types.ts
+++ b/frontend/src/components/data-table/copy-column/types.ts
@@ -1,0 +1,19 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import type { RowData } from "@tanstack/react-table";
+
+export interface CopyColumnOptions {
+  enableCopyColumn?: boolean;
+}
+
+export interface CopyColumnInstance {
+  getCanCopy?: () => boolean;
+}
+
+// Use declaration merging to add our new feature APIs
+declare module "@tanstack/react-table" {
+  interface TableOptionsResolved<TData extends RowData>
+    extends CopyColumnOptions {}
+
+  interface Column<TData extends RowData> extends CopyColumnInstance {}
+}

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -36,6 +36,7 @@ import type { CellSelectionState } from "./cell-selection/types";
 import type { GetRowIds } from "@/plugins/impl/DataTablePlugin";
 import { CellStylingFeature } from "./cell-styling/feature";
 import type { CellStyleState } from "./cell-styling/types";
+import { CopyColumnFeature } from "./copy-column/feature";
 
 interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   wrapperClassName?: string;
@@ -124,6 +125,7 @@ const DataTableInternal = <TData,>({
       ColumnFormattingFeature,
       CellSelectionFeature,
       CellStylingFeature,
+      CopyColumnFeature,
     ],
     data,
     columns,
@@ -168,6 +170,9 @@ const DataTableInternal = <TData,>({
     enableCellSelection:
       selection === "single-cell" || selection === "multi-cell",
     enableMultiCellSelection: selection === "multi-cell",
+    // pinning
+    onColumnPinningChange: setColumnPinning,
+    // state
     state: {
       ...(sorting ? { sorting } : {}),
       columnFilters: filters,
@@ -184,7 +189,6 @@ const DataTableInternal = <TData,>({
       cellStyling,
       columnPinning: columnPinning,
     },
-    onColumnPinningChange: setColumnPinning,
   });
 
   return (

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -133,9 +133,11 @@ export function renderColumnPinning<TData, TValue>(
   );
 }
 
-export function renderCopyColumnId<TData, TValue>(
-  column: Column<TData, TValue>,
-) {
+export function renderCopyColumn<TData, TValue>(column: Column<TData, TValue>) {
+  if (!column.getCanCopy?.()) {
+    return null;
+  }
+
   if (column.id.startsWith(NAMELESS_COLUMN_PREFIX)) {
     return null;
   }

--- a/frontend/src/components/ui/menu-items.tsx
+++ b/frontend/src/components/ui/menu-items.tsx
@@ -79,9 +79,12 @@ export const menuItemVariants = cva(
   },
 );
 
-export const menuSeparatorVariants = cva("-mx-1 my-1 h-px bg-border", {
-  variants: {},
-});
+export const menuSeparatorVariants = cva(
+  "-mx-1 my-1 h-px bg-border last:hidden",
+  {
+    variants: {},
+  },
+);
 
 export const MenuShortcut = ({
   className,

--- a/frontend/src/components/variables/variables-table.tsx
+++ b/frontend/src/components/variables/variables-table.tsx
@@ -263,6 +263,7 @@ export const VariableTable: React.FC<Props> = memo(
       getFilteredRowModel: getFilteredRowModel(),
       enableFilters: true,
       enableGlobalFilter: true,
+      enableColumnPinning: false,
       getColumnCanGlobalFilter(column) {
         // Opt-out only
         return column.columnDef.enableGlobalFilter ?? true;


### PR DESCRIPTION
Removes the `Copy column` and `Freeze left/right` menu items from the variable sidebar