### PR TITLE
fix: button stretch in vstack

### DIFF
--- a/frontend/src/plugins/impl/ButtonPlugin.tsx
+++ b/frontend/src/plugins/impl/ButtonPlugin.tsx
@@ -44,6 +44,7 @@ export class ButtonPlugin implements IPlugin<number, Data> {
         keyboardShortcut={keyboardShortcut}
         className={cn({
           "w-full": fullWidth,
+          "w-fit": !fullWidth,
         })}
         onClick={(evt) => {
           if (disabled) {

--- a/frontend/src/plugins/impl/RangeSliderPlugin.tsx
+++ b/frontend/src/plugins/impl/RangeSliderPlugin.tsx
@@ -93,6 +93,7 @@ const RangeSliderComponent = ({
       label={label}
       id={id}
       align={orientation === "horizontal" ? "left" : "top"}
+      className={cn(fullWidth && "my-1 w-full")}
       fullWidth={fullWidth}
     >
       <div
@@ -100,6 +101,7 @@ const RangeSliderComponent = ({
           "flex items-center gap-2",
           orientation === "vertical" &&
             "items-end inline-flex justify-center self-center mx-2",
+          fullWidth && "w-full",
         )}
       >
         <RangeSlider
@@ -153,9 +155,5 @@ const RangeSliderComponent = ({
     </Labeled>
   );
 
-  return fullWidth ? (
-    <div className="my-3">{sliderElement}</div>
-  ) : (
-    sliderElement
-  );
+  return sliderElement;
 };

--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -93,6 +93,7 @@ const SliderComponent = ({
       id={id}
       align={orientation === "horizontal" ? "left" : "top"}
       fullWidth={fullWidth}
+      className={cn(fullWidth && "my-1 w-full")}
     >
       <div
         className={cn(
@@ -137,9 +138,5 @@ const SliderComponent = ({
     </Labeled>
   );
 
-  return fullWidth ? (
-    <div className="my-3">{sliderElement}</div>
-  ) : (
-    sliderElement
-  );
+  return sliderElement;
 };

--- a/frontend/src/plugins/impl/common/labeled.tsx
+++ b/frontend/src/plugins/impl/common/labeled.tsx
@@ -36,7 +36,7 @@ export const Labeled: React.FC<PropsWithChildren<Props>> = ({
   if (!label) {
     // If its a top label, just return the children
     if (align === "top") {
-      return children;
+      return <div className={className}>{children}</div>;
     }
     // Otherwise, return the children in an inline-flex container
     return <div className={cn("inline-flex", className)}>{children}</div>;

--- a/marimo/_smoke_tests/issues/4544_flex.py
+++ b/marimo/_smoke_tests/issues/4544_flex.py
@@ -5,11 +5,16 @@ import marimo
 __generated_with = "0.12.9"
 app = marimo.App(width="medium")
 
-
 @app.cell
 def _():
     import marimo as mo
     return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""## Buttons""")
+    return
 
 
 @app.cell
@@ -58,6 +63,58 @@ def _(different_height_items, mo):
 @app.cell
 def _(different_height_items, mo):
     mo.hstack(different_height_items)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""## Sliders""")
+    return
+
+
+@app.cell(hide_code=True)
+def _(full_width):
+    full_width
+    return
+
+
+@app.cell
+def _(full_width, mo):
+    range_slider = mo.ui.range_slider(
+        start=1, stop=10, step=2, value=[2, 6], full_width=full_width.value
+    )
+    range_slider
+    return (range_slider,)
+
+
+@app.cell
+def _(mo, range_slider):
+    mo.hstack([range_slider])
+    return
+
+
+@app.cell
+def _(mo, range_slider):
+    mo.vstack([range_slider])
+    return
+
+
+@app.cell
+def _(full_width, mo):
+    slider = mo.ui.slider(start=1, stop=10, step=2, full_width=full_width.value)
+    slider
+    return (slider,)
+
+
+@app.cell
+def _(mo, slider):
+    mo.hstack([slider])
+    return
+
+
+@app.cell
+def _(mo, slider):
+    mo.vstack([slider])
     return
 
 

--- a/marimo/_smoke_tests/issues/4544_flex.py
+++ b/marimo/_smoke_tests/issues/4544_flex.py
@@ -1,0 +1,65 @@
+
+
+import marimo
+
+__generated_with = "0.12.9"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    full_width = mo.ui.checkbox(label="Full width")
+    full_width
+    return (full_width,)
+
+
+@app.cell
+def _(full_width, mo):
+    items = [
+        mo.ui.button(label="button", full_width=full_width.value),
+        mo.ui.text(label="button"),
+    ]
+    return (items,)
+
+
+@app.cell
+def _(items, mo):
+    mo.vstack(items)
+    return
+
+
+@app.cell
+def _(items, mo):
+    mo.hstack(items)
+    return
+
+
+@app.cell
+def _(items, mo):
+    different_height_items = [
+        *items,
+        mo.ui.text_area(label="button"),
+    ]
+    return (different_height_items,)
+
+
+@app.cell
+def _(different_height_items, mo):
+    mo.vstack(different_height_items)
+    return
+
+
+@app.cell
+def _(different_height_items, mo):
+    mo.hstack(different_height_items)
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #4544 

Rather than changing how vstack work, this just makes sure the button doesn't stretch without being `full_width`

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/b3edd729-671f-436f-8a79-7b22365ae536" />
