### PR TITLE
improvement: Use docstring_to_markdown and custom MarimoConverter for non marimo docs

### DIFF
--- a/frontend/src/components/editor/documentation.css
+++ b/frontend/src/components/editor/documentation.css
@@ -20,11 +20,7 @@
   }
 
   .section {
-    padding: 0.5rem 0;
-  }
-
-  dt {
-    padding-top: 0.6rem;
+    line-height: normal;
   }
 
   ul,
@@ -102,12 +98,12 @@
       font-weight: initial;
       @apply text-sm font-mono;
     }
-
-    .docutils dd {
-      white-space: pre-wrap;
-      padding-left: 1rem;
-    }
   }
+}
+
+.docutils dd {
+  white-space: pre-wrap;
+  padding-left: 1rem;
 }
 
 /* Custom overrides when in a tooltip */

--- a/marimo/_data/get_datasets.py
+++ b/marimo/_data/get_datasets.py
@@ -241,12 +241,12 @@ def _db_type_to_data_type(db_type: str) -> DataType:
     ]:
         return "datetime"
     # Nested types
-    if db_type in ["array", "list", "struct", "map", "union"]:
+    if db_type in ["array", "list", "struct", "map", "union", "varchar[]"]:
         return "unknown"
     # Special types
     if db_type == "bit":
         return "string"  # Representing bit as string
-    if db_type == "enum":
+    if db_type == "enum" or db_type.startswith("enum"):
         return "string"  # Representing enum as string
 
     LOGGER.warning("Unknown DuckDB type: %s", db_type)

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -198,6 +198,9 @@ class DependencyManager:
     vegafusion = Dependency("vegafusion")
     vl_convert_python = Dependency("vl_convert")
     dotenv = Dependency("dotenv")
+    docstring_to_markdown = Dependency(
+        "docstring_to_markdown", min_version="0.16.0"
+    )
 
     # Version requirements to properly support the new superfences introduced in
     # pymdown#2470

--- a/marimo/_plugins/stateless/style.py
+++ b/marimo/_plugins/stateless/style.py
@@ -15,18 +15,23 @@ def style(
 ) -> Html:
     """Wrap an object in a styled container.
 
-    **Example.**
+    Example:
+        ```python
+        mo.style(item, styles={"max-height": "300px", "overflow": "auto"})
+        mo.style(item, max_height="300px", overflow="auto")
+        ```
 
-    ```python
-    mo.style(item, styles={"max-height": "300px", "overflow": "auto"})
-    mo.style(item, max_height="300px", overflow="auto")
-    ```
+    Args:
+        item (object): An object to render as HTML.
+        style (Optional[dict[str, Any]]): A dictionary of CSS styles,
+            keyed by property name (e.g., "max-height"). Defaults to None.
+        **kwargs (Any): Additional CSS styles specified as keyword arguments.
+            Underscores in keyword arguments are converted to hyphens
+            (e.g., `max_height` becomes `max-height`).
 
-    **Args.**
-
-    - `item`: an object to render as HTML
-    - `styles`: a optional dict of CSS styles, keyed by property name
-    - `**kwargs`: additional CSS styles
+    Returns:
+        Html: An HTML object representing the item wrapped in a div
+                with the specified styles.
     """
     # Initialize combined_style with style dict if provided,
     # otherwise empty dict

--- a/marimo/_plugins/ui/_impl/data_editor.py
+++ b/marimo/_plugins/ui/_impl/data_editor.py
@@ -89,7 +89,7 @@ class data_editor(
         Union[RowOrientedData, ColumnOrientedData, IntoDataFrame],
     ]
 ):
-    """[EXPERIMENTAL] A data editor component for editing tabular data.
+    """A data editor component for editing tabular data.
 
     This component is experimental and intentionally limited in features,
     if you have any feature requests, please file an issue at

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -45,43 +45,42 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
     """
     A number picker over an interval.
 
-    **Example.**
+    Example:
+        ```python
+        number = mo.ui.number(start=1, stop=10, step=2)
+        ```
 
-    ```python
-    number = mo.ui.number(start=1, stop=10, step=2)
-    ```
+        Or for integer-only values:
 
-    Or for integer-only values:
+        ```python
+        number = mo.ui.number(step=1)
+        ```
 
-    ```python
-    number = mo.ui.number(step=1)
-    ```
+        Or from a dataframe series:
 
-    Or from a dataframe series:
+        ```python
+        number = mo.ui.number.from_series(df["column_name"])
+        ```
 
-    ```python
-    number = mo.ui.number.from_series(df["column_name"])
-    ```
+    Attributes:
+        value (Optional[Numeric]): The value of the number, possibly `None`.
+        start (Optional[float]): The minimum value of the interval.
+        stop (Optional[float]): The maximum value of the interval.
+        step (Optional[float]): The number increment.
 
-    **Attributes.**
+    Args:
+        start (Optional[float]): The minimum value of the interval. Defaults to None.
+        stop (Optional[float]): The maximum value of the interval. Defaults to None.
+        step (Optional[float]): The number increment. Defaults to None.
+        value (Optional[float]): The default value. Defaults to None.
+        debounce (bool): Whether to debounce (rate-limit) value updates from the frontend. Defaults to False.
+        label (str): Markdown label for the element. Defaults to an empty string.
+        on_change (Optional[Callable[[Optional[Numeric]], None]]): Optional callback to run when this element's value changes. Defaults to None.
+        full_width (bool): Whether the input should take up the full width of its container. Defaults to False.
 
-    - `value`: the value of the number, possibly `None`
-    - `start`: the minimum value of the interval
-    - `stop`: the maximum value of the interval
-    - `step`: the number increment
-
-    **Initialization Args.**
-
-    - `start`: optional, the minimum value of the interval
-    - `stop`: optional, the maximum value of the interval
-    - `step`: the number increment
-    - `value`: default value
-    - `debounce`: whether to debounce (rate-limit) value
-        updates from the frontend
-    - `label`: markdown label for the element
-    - `on_change`: optional callback to run when this element's value changes
-    - `full_width`: whether the input should take up the full width of its
-        container
+    Methods:
+        from_series(series: DataFrameSeries, **kwargs: Any) -> number:
+            Create a number picker from a dataframe series.
     """
 
     _name: Final[str] = "marimo-number"
@@ -145,60 +144,70 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
 
 @mddoc
 class slider(UIElement[Numeric, Numeric]):
-    """
-    A numeric slider over an interval.
+    """A numeric slider over an interval.
 
-    **Example.**
+    Example:
+        ```python
+        slider = mo.ui.slider(start=1, stop=10, step=2)
+        ```
 
-    ```python
-    slider = mo.ui.slider(start=1, stop=10, step=2)
-    ```
+        Or from a dataframe series:
 
-    Or from a dataframe series:
+        ```python
+        slider = mo.ui.slider.from_series(df["column_name"])
+        ```
 
-    ```python
-    slider = mo.ui.slider.from_series(df["column_name"])
-    ```
+        Or using numpy arrays:
 
-    Or using numpy arrays:
+        ```python
+        import numpy as np
 
-    ```python
-    import numpy as np
+        # linear steps
+        steps = np.array([1, 2, 3, 4, 5])
+        slider = mo.ui.slider(steps=steps)
+        # log steps
+        log_slider = mo.ui.slider(steps=np.logspace(0, 3, 4))
+        # power steps
+        power_slider = mo.ui.slider(steps=np.power([1, 2, 3], 2))
+        ```
 
-    # linear steps
-    steps = np.array([1, 2, 3, 4, 5])
-    slider = mo.ui.slider(steps=steps)
-    # log steps
-    log_slider = mo.ui.slider(steps=np.logspace(0, 3, 4))
-    # power steps
-    power_slider = mo.ui.slider(steps=np.power([1, 2, 3], 2))
-    ```
+    Attributes:
+        value (Numeric): The current numeric value of the slider.
+        start (Numeric): The minimum value of the interval.
+        stop (Numeric): The maximum value of the interval.
+        step (Optional[Numeric]): The slider increment.
+        steps (Optional[Sequence[Numeric]]): List of steps.
 
-    **Attributes.**
+    Args:
+        start (Optional[Numeric]): The minimum value of the interval.
+        stop (Optional[Numeric]): The maximum value of the interval.
+        step (Optional[Numeric]): The slider increment.
+        value (Optional[Numeric]): Default value.
+        debounce (bool): Whether to debounce the slider to only send the value
+            on mouse-up or drag-end. Defaults to False.
+        orientation (Literal["horizontal", "vertical"]): The orientation of the
+            slider, either "horizontal" or "vertical". Defaults to "horizontal".
+        show_value (bool): Whether to display the current value of the slider.
+            Defaults to False.
+        steps (Optional[Sequence[Numeric]]): List of steps to customize the
+            slider, mutually exclusive with `start`, `stop`, and `step`.
+        label (str): Markdown label for the element. Defaults to an empty string.
+        on_change (Optional[Callable[[Optional[Numeric]], None]]): Optional
+            callback to run when this element's value changes.
+        full_width (bool): Whether the input should take up the full width of
+            its container. Defaults to False.
 
-    - `value`: the current numeric value of the slider
-    - `start`: the minimum value of the interval
-    - `stop`: the maximum value of the interval
-    - `step`: the slider increment
-    - `steps`: list of steps
+    Raises:
+        ValueError: If `steps` is provided along with `start`, `stop`, or `step`.
+        ValueError: If neither `steps` nor both `start` and `stop` are provided.
+        ValueError: If `stop` is less than `start`.
+        ValueError: If `value` is out of bounds.
+        TypeError: If `steps` is not a sequence of numbers.
 
-    **Initialization Args.**
+    Methods:
+        from_series(series: DataFrameSeries, **kwargs: Any) -> slider:
+            Create a slider from a dataframe series.
 
-    - `start`: the minimum value of the interval
-    - `stop`: the maximum value of the interval
-    - `step`: the slider increment
-    - `value`: default value
-    - `debounce`: whether to debounce the slider to only send
-        the value on mouse-up or drag-end
-    - `orientation`: the orientation of the slider,
-        either "horizontal" or "vertical"
-    - `show_value`: whether to display the current value of the slider
-    - `steps`: list of steps to customize the slider, mutually exclusive
-        with `start`, `stop`, and `step`
-    - `label`: markdown label for the element
-    - `on_change`: optional callback to run when this element's value changes
-    - `full_width`: whether the input should take up the full width of its
-        container
     """
 
     _name: Final[str] = "marimo-slider"
@@ -349,57 +358,56 @@ class range_slider(UIElement[list[Numeric], Sequence[Numeric]]):
     """
     A numeric slider for specifying a range over an interval.
 
-    **Example.**
+    Example:
+        ```python
+        range_slider = mo.ui.range_slider(
+            start=1, stop=10, step=2, value=[2, 6]
+        )
+        ```
 
-    ```python
-    range_slider = mo.ui.range_slider(start=1, stop=10, step=2, value=[2, 6])
-    ```
+        Or from a dataframe series:
 
-    Or from a dataframe series:
+        ```python
+        range_slider = mo.ui.range_slider.from_series(df["column_name"])
+        ```
 
-    ```python
-    range_slider = mo.ui.range_slider.from_series(df["column_name"])
-    ```
+        Or using numpy arrays:
 
-    Or using numpy arrays:
+        ```python
+        import numpy as np
 
-    ```python
-    import numpy as np
+        steps = np.array([1, 2, 3, 4, 5])
+        # linear steps
+        range_slider = mo.ui.range_slider(steps=steps)
+        # log steps
+        log_range_slider = mo.ui.range_slider(steps=np.logspace(0, 3, 4))
+        # power steps
+        power_range_slider = mo.ui.range_slider(steps=np.power([1, 2, 3], 2))
+        ```
 
-    steps = np.array([1, 2, 3, 4, 5])
-    # linear steps
-    range_slider = mo.ui.range_slider(steps=steps)
-    # log steps
-    log_range_slider = mo.ui.range_slider(steps=np.logspace(0, 3, 4))
-    # power steps
-    power_range_slider = mo.ui.range_slider(steps=np.power([1, 2, 3], 2))
-    ```
+    Attributes:
+        value (list[Numeric]): The current range value of the slider.
+        start (Numeric): The minimum value of the interval.
+        stop (Numeric): The maximum value of the interval.
+        step (Optional[Numeric]): The slider increment.
+        steps (Optional[Sequence[Numeric]]): List of steps.
 
-    **Attributes.**
+    Args:
+        start (Optional[Numeric]): The minimum value of the interval.
+        stop (Optional[Numeric]): The maximum value of the interval.
+        step (Optional[Numeric]): The slider increment.
+        value (Optional[Sequence[Numeric]]): Default value.
+        debounce (bool): Whether to debounce the slider to only send the value on mouse-up or drag-end.
+        orientation (Literal["horizontal", "vertical"]): The orientation of the slider, either "horizontal" or "vertical".
+        show_value (bool): Whether to display the current value of the slider.
+        steps (Optional[Sequence[Numeric]]): List of steps to customize the slider, mutually exclusive with `start`, `stop`, and `step`.
+        label (str): Markdown label for the element.
+        on_change (Optional[Callable[[Sequence[Numeric]], None]]): Optional callback to run when this element's value changes.
+        full_width (bool): Whether the input should take up the full width of its container.
 
-    - `value`: the current range value of the slider
-    - `start`: the minimum value of the interval
-    - `stop`: the maximum value of the interval
-    - `step`: the slider increment
-    - `steps`: list of steps
-
-    **Initialization Args.**
-
-    - `start`: the minimum value of the interval
-    - `stop`: the maximum value of the interval
-    - `step`: the slider increment
-    - `value`: default value
-    - `debounce`: whether to debounce the slider to only send
-        the value on mouse-up or drag-end
-    - `orientation`: the orientation of the slider,
-        either "horizontal" or "vertical"
-    - `show_value`: whether to display the current value of the slider
-    - `steps`: list of steps to customize the slider, mutually exclusive
-        with `start`, `stop`, and `step`
-    - `label`: markdown label for the element
-    - `on_change`: optional callback to run when this element's value changes
-    - `full_width`: whether the input should take up the full width of its
-        container
+    Methods:
+        from_series(series: DataFrameSeries, **kwargs: Any) -> range_slider:
+            Create a range slider from a dataframe series.
     """
 
     _name: Final[str] = "marimo-range-slider"

--- a/marimo/_runtime/capture.py
+++ b/marimo/_runtime/capture.py
@@ -1,11 +1,16 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import contextlib
 import io
 import sys
-from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 from marimo._plugins.stateless.plain_text import plain_text
 from marimo._runtime.output import _output
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @contextlib.contextmanager
@@ -15,12 +20,11 @@ def capture_stdout() -> Iterator[io.StringIO]:
     Use this context manager to capture print statements and
     other output sent to standard output.
 
-    **Example.**
-
-    ```python
-    with mo.capture_stdout() as buffer:
-        print("Hello!")
-    output = buffer.getvalue()
+    Examples:
+        ```python
+        with mo.capture_stdout() as buffer:
+            print("Hello!")
+        output = buffer.getvalue()
     ```
     """
     with contextlib.redirect_stdout(io.StringIO()) as buffer:
@@ -33,13 +37,12 @@ def capture_stderr() -> Iterator[io.StringIO]:
 
     Use this context manager to capture output sent to standard error.
 
-    **Example.**
-
-    ```python
-    with mo.capture_stderr() as buffer:
-        sys.stderr.write("Hello!")
-    output = buffer.getvalue()
-    ```
+    Examples:
+        ```python
+        with mo.capture_stderr() as buffer:
+            sys.stderr.write("Hello!")
+        output = buffer.getvalue()
+        ```
     """
     with contextlib.redirect_stderr(io.StringIO()) as buffer:
         yield buffer
@@ -53,12 +56,13 @@ def _redirect(msg: str) -> None:
 def redirect_stdout() -> Iterator[None]:
     """Redirect stdout to a cell's output area.
 
-    ```python
-    with mo.redirect_stdout():
-        # These print statements will show up in the cell's output area
-        print("Hello!")
-        print("World!")
-    ```
+    Examples:
+        ```python
+        with mo.redirect_stdout():
+            # These print statements will show up in the cell's output area
+            print("Hello!")
+            print("World!")
+        ```
     """
     old_stdout_write = sys.stdout.write
     sys.stdout.write = _redirect  # type: ignore
@@ -72,12 +76,13 @@ def redirect_stdout() -> Iterator[None]:
 def redirect_stderr() -> Iterator[None]:
     """Redirect `stderr` to a cell's output area.
 
-    ```python
-    with mo.redirect_stderr():
-        # These messages will show up in the cell's output area
-        sys.stderr.write("Hello!")
-        sys.stderr.write("World!")
-    ```
+    Examples:
+        ```python
+        with mo.redirect_stderr():
+            # These messages will show up in the cell's output area
+            sys.stderr.write("Hello!")
+            sys.stderr.write("World!")
+        ```
     """
     old_stderr_write = sys.stderr.write
     sys.stderr.write = _redirect  # type: ignore

--- a/marimo/_runtime/control_flow.py
+++ b/marimo/_runtime/control_flow.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 from typing import Optional
 
 from marimo._output.rich_help import mddoc
@@ -30,15 +32,13 @@ def stop(predicate: bool, output: Optional[object] = None) -> None:
     scheduled to run will not be run, and their defs will be removed from
     program memory.
 
-    **Example:**
+    Examples:
+        ```python
+        mo.stop(form.value is None, mo.md("**Submit the form to continue.**"))
+        ```
 
-    ```python
-    mo.stop(form.value is None, mo.md("**Submit the form to continue.**"))
-    ```
-
-    **Raises:**
-
-    When `predicate` is `True`, raises a `MarimoStopError`.
+    Raises:
+        When `predicate` is `True`, raises a `MarimoStopError`.
     """
     if predicate:
         raise MarimoStopError(output)

--- a/marimo/_utils/docs.py
+++ b/marimo/_utils/docs.py
@@ -201,7 +201,7 @@ def google_docstring_to_markdown(docstring: str) -> str:
 class MarimoConverter:
     priority = 100
 
-    SECTION_HEADERS = ["Args", "Returns", "Raises"]
+    SECTION_HEADERS = ["Args", "Returns", "Raises", "Examples"]
 
     def convert(self, docstring: str) -> str:
         return google_docstring_to_markdown(docstring)

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._runtime.complete import _build_docstring_cached
 from tests.mocks import snapshotter
 
@@ -17,7 +18,8 @@ def test_build_docstring_function_no_init():
     assert "my_func" in result
     assert "This is a simple docstring for a function." in result
     assert '<div class="codehilite">' in result
-    snapshot("docstrings_function.txt", result)
+    if DependencyManager.docstring_to_markdown.has():
+        snapshot("docstrings_function.txt", result)
 
 
 def test_docstring_function_with_google_style():
@@ -53,7 +55,8 @@ def test_build_docstring_class_with_init():
     assert "MyClass" in result
     assert "Some docstring for the class." in result
     assert "Class init details." in result
-    snapshot("docstrings_class.txt", result)
+    if DependencyManager.docstring_to_markdown.has():
+        snapshot("docstrings_class.txt", result)
 
 
 def test_build_docstring_module():

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -42,19 +42,6 @@ def test_docstring_function_with_google_style():
     snapshot("docstrings_function_google.txt", result)
 
 
-def test_docstring_function_from_external_module():
-    result = _build_docstring_cached(
-        completion_type="function",
-        completion_name="my_func",
-        signature_strings=("my_func(arg1, arg2)",),
-        raw_body="This is a simple docstring for a function.",
-        init_docstring=None,
-    )
-    assert "This is a simple docstring for a function." in result
-    assert "<div class='external-docs'>" in result
-    snapshot("docstrings_function_external.txt", result)
-
-
 def test_build_docstring_class_with_init():
     result = _build_docstring_cached(
         completion_type="class",

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from marimo._runtime.complete import _build_docstring_cached
 from tests.mocks import snapshotter
 
@@ -8,7 +10,6 @@ def test_build_docstring_function_no_init():
     result = _build_docstring_cached(
         completion_type="function",
         completion_name="my_func",
-        module_name="marimo.my_module",
         signature_strings=("my_func(arg1, arg2)",),
         raw_body="This is a simple docstring for a function.",
         init_docstring=None,
@@ -23,7 +24,6 @@ def test_docstring_function_with_google_style():
     result = _build_docstring_cached(
         completion_type="function",
         completion_name="my_func",
-        module_name="marimo.my_module",
         signature_strings=("my_func(arg1, arg2)",),
         raw_body="""
         Args:
@@ -46,7 +46,6 @@ def test_docstring_function_from_external_module():
     result = _build_docstring_cached(
         completion_type="function",
         completion_name="my_func",
-        module_name="os",
         signature_strings=("my_func(arg1, arg2)",),
         raw_body="This is a simple docstring for a function.",
         init_docstring=None,
@@ -60,7 +59,6 @@ def test_build_docstring_class_with_init():
     result = _build_docstring_cached(
         completion_type="class",
         completion_name="MyClass",
-        module_name="marimo.some_class",
         signature_strings=("MyClass()",),
         raw_body="Some docstring for the class.",
         init_docstring="__init__ docstring:\n\nClass init details.",
@@ -75,7 +73,6 @@ def test_build_docstring_module():
     result = _build_docstring_cached(
         completion_type="module",
         completion_name="os",
-        module_name="os",
         signature_strings=(),
         raw_body=None,
         init_docstring=None,
@@ -89,7 +86,6 @@ def test_build_docstring_keyword():
     result = _build_docstring_cached(
         completion_type="keyword",
         completion_name="yield",
-        module_name="",
         signature_strings=(),
         raw_body=None,
         init_docstring=None,
@@ -103,7 +99,6 @@ def test_build_docstring_no_signature_no_body():
     result = _build_docstring_cached(
         completion_type="statement",
         completion_name="random_statement",
-        module_name="random.module",
         signature_strings=(),
         raw_body=None,
         init_docstring=None,


### PR DESCRIPTION
Improve docstrings when using our jedi completions (non-LSP)

* use `docstring_to_markdown` if installed, then use `MarimoConverter` as a fallback
* convert some other docstrings to google format
* tiny bit of padding improvements 

![image](https://github.com/user-attachments/assets/1407ed05-73d4-4322-919a-71ed8265ef51)
