### PR TITLE
docs: run notebooks as scripts example

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -34,6 +34,8 @@ cells](../guides/reactivity.md).
 
 -  🐞 [**Using the debugger**](running_cells/debugging.md)
 
+-  🐍 [**Run notebooks as scripts**](../guides/scripts.md)
+
 </div>
 
 ## Visual Outputs

--- a/marimo/_runtime/control_flow.py
+++ b/marimo/_runtime/control_flow.py
@@ -38,7 +38,7 @@ def stop(predicate: bool, output: Optional[object] = None) -> None:
         ```
 
     Raises:
-        When `predicate` is `True`, raises a `MarimoStopError`.
+        MarimoStopError: When `predicate` is `True`, raises a `MarimoStopError`.
     """
     if predicate:
         raise MarimoStopError(output)


### PR DESCRIPTION
Not exactly about running cells, but close enough — link to the scripts guide, which has two example notebooks.