### PR TITLE
Remove (#faq-show-code) from show code FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -294,7 +294,7 @@ marimo tutorial layout
 
 <a name="faq-show-code"></a>
 
-### How do I show cell code in the app view?(#faq-show-code)
+### How do I show cell code in the app view?
 
 Use [`mo.show_code`][marimo.show_code].
 


### PR DESCRIPTION
(#faq-show-code) was attached to the title  of the show code FAQ 

Original title:

## How do I show cell code in the app view?(#faq-show-code)

Original link: https://docs.marimo.io/faq/#how-do-i-show-cell-code-in-the-app-viewfaq-show-code

![image](https://github.com/user-attachments/assets/8189fac6-3e01-47e2-9773-f2472eddc464)

## 📜 Reviewers

@mscolnick
