### PR TITLE
fix: get node version edge case

### DIFF
--- a/marimo/_utils/health.py
+++ b/marimo/_utils/health.py
@@ -22,7 +22,8 @@ def get_node_version() -> Optional[str]:
         stdout, stderr = process.communicate()
         if stderr:
             return None
-        return stdout.strip().split()[-1]
+        if stdout and (stripped := stdout.strip()):
+            return stripped.split()[-1]
     except FileNotFoundError:
         return None
 

--- a/marimo/_utils/health.py
+++ b/marimo/_utils/health.py
@@ -24,6 +24,8 @@ def get_node_version() -> Optional[str]:
             return None
         if stdout and (stripped := stdout.strip()):
             return stripped.split()[-1]
+        else:
+            return None
     except FileNotFoundError:
         return None
 


### PR DESCRIPTION
Fix marimo env when node version is not obtainable. Came up in #4581