### PR TITLE
docs: changelog

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -240,6 +240,7 @@ nav:
       - Community: community.md
       - Contributing: https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md
       - Code of Conduct: https://github.com/marimo-team/marimo/blob/main/CODE_OF_CONDUCT.md
+  - Changelog: https://github.com/marimo-team/marimo/releases
   - Integrations:
       - Integrations: integrations/index.md
       - BigQuery: integrations/google_cloud_bigquery.md


### PR DESCRIPTION
Link to the GitHub releases for the changelog, using it as the source of truth. (This is what Polars does too.)

In the future we can mirror the release notes in our docs on a dedicated page. But I didn't want to invest the effort in that right now, and this is still an improvement.