### PR TITLE
chore: add setup_cell to released experiments

### DIFF
--- a/marimo/_server/print.py
+++ b/marimo/_server/print.py
@@ -121,6 +121,7 @@ def print_experimental_features(config: MarimoConfig) -> None:
         "secrets",
         "reactive_tests",
         "toplevel_defs",
+        "setup_cell",
     }
     keys = keys - finished_experiments
 


### PR DESCRIPTION
`setup_cell=True` was in my marimo.toml
