### PR TITLE
fix: improve graceful shutdown when running under uv

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -382,10 +382,14 @@ def run_in_sandbox(
     def handler(sig: int, frame: Any) -> None:
         del sig
         del frame
-        if sys.platform == "win32":
-            os.kill(process.pid, signal.CTRL_C_EVENT)
-        else:
-            os.kill(process.pid, signal.SIGINT)
+        try:
+            if sys.platform == "win32":
+                os.kill(process.pid, signal.CTRL_C_EVENT)
+            else:
+                os.kill(process.pid, signal.SIGINT)
+        except Exception:
+            # Process may have already been terminated.
+            pass
 
     signal.signal(signal.SIGINT, handler)
 

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -387,7 +387,7 @@ def run_in_sandbox(
                 os.kill(process.pid, signal.CTRL_C_EVENT)
             else:
                 os.kill(process.pid, signal.SIGINT)
-        except Exception:
+        except ProcessLookupError:
             # Process may have already been terminated.
             pass
 

--- a/marimo/_server/api/interrupt.py
+++ b/marimo/_server/api/interrupt.py
@@ -15,11 +15,9 @@ from marimo._server.utils import (
 class InterruptHandler:
     def __init__(self, quiet: bool, shutdown: Callable[[], None]) -> None:
         self.quiet = quiet
-        self._shutdown = shutdown
+        self.shutdown = shutdown
         self.loop = asyncio.get_event_loop()
         self.original_handler = signal.getsignal(signal.SIGINT)
-        self._confirming_exit = False
-        self._has_shutdown = False
 
     def _add_interrupt_handler(self) -> None:
         try:
@@ -33,38 +31,48 @@ class InterruptHandler:
                 lambda signum, frame: self._interrupt_handler(),  # noqa: ARG005,E501
             )
 
-    def shutdown(self) -> None:
-        self._shutdown()
-        self._has_shutdown = True
-
-    def _confirm_exit(self) -> None:
+    def restore_interrupt_handler(self) -> None:
+        # Restore the original signal handler so re-entering Ctrl+C raises a
+        # keyboard interrupt instead of calling this function again (input is
+        # not re-entrant, so it's not safe to call this function again)
         try:
-            print_()
-            response = input(f"\r{TAB}Are you sure you want to quit? (y/n): ")
-            if response.lower().strip() == "y":
-                print_()
-                self.shutdown()
-            else:
-                self._confirming_exit = False
-        except (EOFError, asyncio.CancelledError):
-            print_()
-            self.shutdown()
+            self.loop.remove_signal_handler(signal.SIGINT)
+        except NotImplementedError:
+            # Windows
+            signal.signal(signal.SIGINT, self.original_handler)
 
     def _interrupt_handler(self) -> None:
-        if self._confirming_exit:
-            self.shutdown()
-            return
+        # Restore the original signal handler so re-entering Ctrl+C raises a
+        # keyboard interrupt instead of calling this function again (input is
+        # not re-entrant, so it's not safe to call this function again)
+        try:
+            self.loop.remove_signal_handler(signal.SIGINT)
+        except NotImplementedError:
+            # Windows
+            signal.signal(signal.SIGINT, self.original_handler)
 
-        self._confirming_exit = True
         if self.quiet:
             self.shutdown()
-            return
 
-        if GLOBAL_SETTINGS.YES:
+        try:
+            if GLOBAL_SETTINGS.YES:
+                self.shutdown()
+                return
+
+            response = input(
+                f"\r{TAB}\033[1;32mAre you sure you want to quit?\033[0m "
+                "\033[1m(y/n)\033[0m: "
+            )
+            if response.lower().strip() == "y":
+                self.shutdown()
+                return
+        except (KeyboardInterrupt, EOFError, asyncio.CancelledError):
+            print_()
             self.shutdown()
             return
 
-        self.loop.call_soon(self._confirm_exit)
+        # Program is still alive: restore the interrupt handler
+        self._add_interrupt_handler()
 
     def register(self) -> None:
         self._add_interrupt_handler()

--- a/marimo/_server/api/interrupt.py
+++ b/marimo/_server/api/interrupt.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import signal
+import time
 from typing import Callable
 
 from marimo._config.settings import GLOBAL_SETTINGS
@@ -18,6 +19,7 @@ class InterruptHandler:
         self.shutdown = shutdown
         self.loop = asyncio.get_event_loop()
         self.original_handler = signal.getsignal(signal.SIGINT)
+        self._time_of_last_confirmation: float | None = None
 
     def _add_interrupt_handler(self) -> None:
         try:
@@ -31,17 +33,15 @@ class InterruptHandler:
                 lambda signum, frame: self._interrupt_handler(),  # noqa: ARG005,E501
             )
 
-    def restore_interrupt_handler(self) -> None:
-        # Restore the original signal handler so re-entering Ctrl+C raises a
-        # keyboard interrupt instead of calling this function again (input is
-        # not re-entrant, so it's not safe to call this function again)
-        try:
-            self.loop.remove_signal_handler(signal.SIGINT)
-        except NotImplementedError:
-            # Windows
-            signal.signal(signal.SIGINT, self.original_handler)
-
     def _interrupt_handler(self) -> None:
+        if (
+            self._time_of_last_confirmation is not None
+            and (time.time() - self._time_of_last_confirmation) < 0.1
+        ):
+            # uv can send two SIGINTs for every one sent by the user's Ctrl+C;
+            # this hack prevents us from spamming the user with confirm messages.
+            return
+
         # Restore the original signal handler so re-entering Ctrl+C raises a
         # keyboard interrupt instead of calling this function again (input is
         # not re-entrant, so it's not safe to call this function again)
@@ -55,18 +55,28 @@ class InterruptHandler:
             self.shutdown()
 
         try:
-            if GLOBAL_SETTINGS.YES:
-                self.shutdown()
-                return
+            try:
+                if GLOBAL_SETTINGS.YES:
+                    self.shutdown()
+                    return
 
-            response = input(
-                f"\r{TAB}\033[1;32mAre you sure you want to quit?\033[0m "
-                "\033[1m(y/n)\033[0m: "
-            )
-            if response.lower().strip() == "y":
+                response = input(
+                    f"\r{TAB}Are you sure you want to quit? (y/n): "
+                )
+                self._time_of_last_confirmation = time.time()
+                if response.lower().strip() == "y":
+                    self.shutdown()
+                    return
+            except (KeyboardInterrupt, EOFError, asyncio.CancelledError):
+                print_()
                 self.shutdown()
                 return
-        except (KeyboardInterrupt, EOFError, asyncio.CancelledError):
+        except KeyboardInterrupt:
+            # This is a hack to workaround the fact that uv can send two SIGINT for
+            # every one entered by the user. Without this extra except block,
+            # when running under uv, two Ctrl-C's from the user (which uv turns
+            # into three) causes marimo to hang or abort unceremoniously instead
+            # of cleanly exiting.
             print_()
             self.shutdown()
             return

--- a/marimo/_server/api/interrupt.py
+++ b/marimo/_server/api/interrupt.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 import asyncio
 import signal
+import sys
 from typing import Callable
 
 from marimo._config.settings import GLOBAL_SETTINGS
+from marimo._server.print import print_shutdown
 from marimo._server.utils import (
     TAB,
     print_,
@@ -37,10 +39,13 @@ class InterruptHandler:
         self._shutdown()
         self._has_shutdown = True
 
-    def _confirm_exit(self) -> None:
+    async def _confirm_exit(self) -> None:
         try:
+            self._confirming_exit = True
             print_()
-            response = input(f"\r{TAB}Are you sure you want to quit? (y/n): ")
+            response = await asyncio.to_thread(
+                input, f"\r{TAB}Are you sure you want to quit? (y/n): "
+            )
             if response.lower().strip() == "y":
                 print_()
                 self.shutdown()
@@ -52,10 +57,13 @@ class InterruptHandler:
 
     def _interrupt_handler(self) -> None:
         if self._confirming_exit:
+            print_()
             self.shutdown()
-            return
+            print_shutdown()
+            import os
 
-        self._confirming_exit = True
+            os._exit(0)
+
         if self.quiet:
             self.shutdown()
             return
@@ -64,7 +72,8 @@ class InterruptHandler:
             self.shutdown()
             return
 
-        self.loop.call_soon(self._confirm_exit)
+        # self.loop.call_soon(self._confirm_exit)
+        asyncio.create_task(self._confirm_exit())
 
     def register(self) -> None:
         self._add_interrupt_handler()

--- a/marimo/_server/uvicorn_utils.py
+++ b/marimo/_server/uvicorn_utils.py
@@ -12,6 +12,8 @@ from marimo import _loggers
 
 LOGGER = _loggers.marimo_logger()
 
+_shutting_down = False
+
 
 def initialize_signals() -> None:
     from packaging import version
@@ -38,6 +40,12 @@ def initialize_signals() -> None:
 def close_uvicorn(server: uvicorn.Server) -> None:
     from packaging import version
 
+    global _shutting_down
+    if _shutting_down:
+        print("returning early")
+        return
+
+    _shutting_down = True
     LOGGER.debug("Shutting down uvicorn")
 
     # Tried using sys.exit(0) to quit instead, but that ends up not being

--- a/marimo/_server/uvicorn_utils.py
+++ b/marimo/_server/uvicorn_utils.py
@@ -12,8 +12,6 @@ from marimo import _loggers
 
 LOGGER = _loggers.marimo_logger()
 
-_shutting_down = False
-
 
 def initialize_signals() -> None:
     from packaging import version
@@ -40,12 +38,6 @@ def initialize_signals() -> None:
 def close_uvicorn(server: uvicorn.Server) -> None:
     from packaging import version
 
-    global _shutting_down
-    if _shutting_down:
-        print("returning early")
-        return
-
-    _shutting_down = True
     LOGGER.debug("Shutting down uvicorn")
 
     # Tried using sys.exit(0) to quit instead, but that ends up not being


### PR DESCRIPTION
Improves if not completely fixes #4224 

uv sends one more SIGINT than the user does after two Ctrl-Cs, which
was causing the server to die without cleanup. This introduces some
hacks to work around that behavior. It's not perfect but appears
much improved.

Tested by manually trying various combinations of:

```
[uv run] marimo tutorial intro --headless
```

followed by multiple ctrl-c's, and various combinations of `y` and `n` to the shutdown prompt.

Also fixes an issue with graceful shutdown with `--sandbox`.

A better solution would be to make shutdown robust to an arbitrary number of interrupts, but that ended up being a headache, so if this is still a problem after this change is merged we can just disable the double ctrl-c-to-exit behavior and tell people to use `Ctrl-D` or the manual confirm, neither of which leak resources.