### PR TITLE
docs(guides)📚: Add section on specifying alternative package indexes

### DIFF
--- a/docs/guides/package_reproducibility.md
+++ b/docs/guides/package_reproducibility.md
@@ -119,6 +119,38 @@ When developing a local package, you can install it in editable mode using the `
 
 This is particularly useful when you want to test changes to your package without reinstalling it. The package will be installed in "editable" mode, meaning changes to the source code will be reflected immediately in your notebook.
 
+### Specifying alternative package indexes
+
+When you need to use packages from a custom PyPI server or alternative index, you can specify these in your script metadata using the `[[tool.uv.index]]` section. This is useful for private packages or when you want to use packages from a specific source.
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pandas==<version>",
+#     "private-package==<version>",
+# ]
+#
+# [[tool.uv.index]]
+# name = "custom-index"
+# url = "https://custom-pypi-server.example.com/simple/"
+# explicit = true
+#
+# [tool.uv.sources]
+# private-package = { index = "custom-index" }
+# ///
+```
+
+In this example:
+
+- `[[tool.uv.index]]` defines a custom package index
+- `name` is an identifier for the index
+- `url` points to your custom PyPI server
+- `explicit = true` means this index will only be used for packages explicitly associated with it
+- `[tool.uv.sources]` specifies which packages should come from which indexes
+
+This approach ensures that specific packages are always fetched from your designated custom index, while other packages continue to be fetched from the default PyPI repository.
+
 ## Configuration
 
 Running marimo in a sandbox environment uses `uv` to create an isolated virtual


### PR DESCRIPTION
- Introduce a new section in the package reproducibility guide for specifying alternative package indexes.
- Provide an example of how to use the [[tool.uv.index]] section for custom PyPI servers.
- Explain the use of the explicit flag and the [tool.uv.sources] section.

## 📝 Summary

Add documentation for using alternative package indexes in the package reproducibility guide, enhancing the flexibility of package management configurations.

## 🔍 Description of Changes

This PR enhances the package reproducibility guide by:

1. Introducing a new section dedicated to configuring alternative package indexes
2. Adding examples of how to use the `[[tool.uv.index]]` section to specify custom PyPI servers
3. Documenting the `explicit` flag functionality and explaining the `[tool.uv.sources]` section for more advanced index configurations

These changes help users who need to work with private PyPI repositories or organization-specific package indexes, making the guide more comprehensive for enterprise and specialized development environments.

As discussed in #4605 with @mscolnick.

## 📋 Checklist

- [x] I have read the [[contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md)](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [[Discord](https://marimo.io/discord?ref=pr)](https://marimo.io/discord?ref=pr), or the community [[discussions](https://github.com/marimo-team/marimo/discussions)](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka @mscolnick