### PR TITLE
fix: tuples in dataclasses were not picked up for json encoding

### DIFF
--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -146,7 +146,12 @@ class WebComponentEncoder(JSONEncoder):
             }
 
         # Handle objects with __slots__
-        if hasattr(o, "__slots__"):
+        if getattr(o, "__slots__", None):
+            # Reported error that sometimes poorly formed objects do get passed
+            # in.
+            assert isinstance(o.__slots__, (tuple, list)), (
+                f"Unexpected __slots__ type for {o.__class__.__name__}",
+            )
             return {
                 slot: self._convert_to_json(getattr(o, slot))
                 for slot in o.__slots__  # type: ignore

--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -64,8 +64,8 @@ class WebComponentEncoder(JSONEncoder):
         if isinstance(o, (dict, list)):
             return o
 
-        # Handle range
-        if isinstance(o, range):
+        # Handle range and tuple
+        if isinstance(o, range) or isinstance(o, tuple):
             return list(o)
 
         # Handle MIME objects

--- a/tests/_plugins/core/test_json_encoder.py
+++ b/tests/_plugins/core/test_json_encoder.py
@@ -414,3 +414,17 @@ def test_range_encoding() -> None:
     r = range(10)
     encoded = json.dumps(r, cls=WebComponentEncoder)
     assert encoded == "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"
+
+
+def test_error_encoding() -> None:
+    from marimo._messaging.errors import MultipleDefinitionError
+    from marimo._types.ids import CellId_t
+
+    error_obj = MultipleDefinitionError(
+        "This is a custom error", (CellId_t("test"), CellId_t("test2"))
+    )
+    encoded = json.dumps(error_obj, cls=WebComponentEncoder)
+    assert (
+        encoded
+        == '{"name": "This is a custom error", "cells": ["test", "test2"], "type": "multiple-defs"}'
+    )

--- a/tests/_plugins/core/test_json_encoder.py
+++ b/tests/_plugins/core/test_json_encoder.py
@@ -428,3 +428,13 @@ def test_error_encoding() -> None:
         encoded
         == '{"name": "This is a custom error", "cells": ["test", "test2"], "type": "multiple-defs"}'
     )
+
+
+def test_invalid_class() -> None:
+    class InvalidClass: ...
+
+    invalid_obj = InvalidClass()
+    invalid_obj.__slots__ = None
+
+    encoded = json.dumps(invalid_obj, cls=WebComponentEncoder)
+    assert encoded == '{"__slots__": null}'


### PR DESCRIPTION
## 📝 Summary

Nested tuple wasn't getting captured and causing error serialization to break

@akshayka OR @mscolnick
