### PR TITLE
fix: prevent double trigger for column filtering

### DIFF
--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -466,12 +466,6 @@ const PopoverFilterByValues = <TData, TValue>({
               >
                 <Checkbox
                   checked={chosenValues.size === filteredData.length}
-                  onCheckedChange={(checked) => {
-                    if (typeof checked === "string") {
-                      return;
-                    }
-                    handleToggleAll(checked);
-                  }}
                   aria-label="Select all"
                   className="mr-3 h-3.5 w-3.5"
                 />
@@ -490,9 +484,6 @@ const PopoverFilterByValues = <TData, TValue>({
                 >
                   <Checkbox
                     checked={isSelected}
-                    onCheckedChange={() => {
-                      handleToggle(value);
-                    }}
                     aria-label="Select row"
                     className="mr-3 h-3.5 w-3.5"
                   />


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Small bug where clicking on a checkbox would trigger the toggle twice, making it unchecked. The entire command item already has the toggle function.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
