### PR TITLE
fix: cell actions and notebook settings scroll

### DIFF
--- a/frontend/src/components/app-config/app-config-button.tsx
+++ b/frontend/src/components/app-config/app-config-button.tsx
@@ -55,7 +55,7 @@ export const ConfigButton: React.FC<Props> = ({ showAppConfig = true }) => {
       <Popover>
         <PopoverTrigger asChild={true}>{button}</PopoverTrigger>
         <PopoverContent
-          className="w-80 overflow-auto"
+          className="w-[650px] overflow-auto max-h-[80vh] max-w-[80vw]"
           align="end"
           side="bottom"
           // prevent focus outside to hack around a bug in which

--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -27,6 +27,7 @@ import { arrayToggle } from "@/utils/arrays";
 import { Kbd } from "../ui/kbd";
 import { ExternalLink } from "../ui/links";
 import { toast } from "../ui/use-toast";
+
 export const AppConfigForm: React.FC = () => {
   const [config, setConfig] = useAppConfig();
 
@@ -55,232 +56,244 @@ export const AppConfigForm: React.FC = () => {
     <Form {...form}>
       <form
         onChange={form.handleSubmit(onSubmit)}
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-6"
       >
         <div>
-          <SettingTitle>Application Config</SettingTitle>
+          <SettingTitle>Notebook Settings</SettingTitle>
           <SettingDescription>
-            Settings applied to this notebook
+            Configure how your notebook or application looks and behaves.
           </SettingDescription>
         </div>
-        <FormField
-          control={form.control}
-          name="width"
-          render={({ field }) => (
-            <FormItem
-              className={"flex flex-row items-center space-x-1 space-y-0"}
-            >
-              <FormLabel>Width</FormLabel>
-              <FormControl>
-                <NativeSelect
-                  data-testid="app-width-select"
-                  onChange={(e) => field.onChange(e.target.value)}
-                  value={field.value}
-                  disabled={field.disabled}
-                  className="inline-flex mr-2"
+
+        <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+          <SettingSection title="Display Settings">
+            <FormField
+              control={form.control}
+              name="width"
+              render={({ field }) => (
+                <FormItem
+                  className={"flex flex-row items-center space-x-1 space-y-0"}
                 >
-                  {getAppWidths().map((option) => (
-                    <option value={option} key={option}>
-                      {option}
-                    </option>
-                  ))}
-                </NativeSelect>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="app_title"
-          render={({ field }) => (
-            <div className="flex flex-col gap-y-1">
-              <FormItem className="flex flex-row items-center space-x-1 space-y-0">
-                <FormLabel>App title</FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    value={field.value ?? ""}
-                    onChange={(e) => {
-                      field.onChange(e.target.value);
-                      if (AppTitleSchema.safeParse(e.target.value).success) {
-                        document.title = e.target.value;
-                      }
-                    }}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-              <FormDescription>
-                The application title is put in the title tag in the HTML code
-                and typically displayed in the title bar of the browser window.
-              </FormDescription>
-            </div>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="css_file"
-          render={({ field }) => (
-            <div className="flex flex-col gap-y-1">
-              <FormItem className="flex flex-row items-center space-x-1 space-y-0">
-                <FormLabel className="flex-shrink-0">Custom CSS</FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    value={field.value ?? ""}
-                    placeholder="custom.css"
-                    onChange={(e) => {
-                      field.onChange(e.target.value);
-                      if (AppTitleSchema.safeParse(e.target.value).success) {
-                        document.title = e.target.value;
-                      }
-                    }}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-              <FormDescription>
-                A filepath to a custom css file to be injected into the
-                notebook.
-              </FormDescription>
-            </div>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="html_head_file"
-          render={({ field }) => (
-            <div className="flex flex-col gap-y-1">
-              <FormItem className="flex flex-row items-center space-x-1 space-y-0">
-                <FormLabel className="flex-shrink-0">HTML Head</FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    value={field.value ?? ""}
-                    placeholder="head.html"
-                    onChange={(e) => {
-                      field.onChange(e.target.value);
-                    }}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-              <FormDescription>
-                A filepath to an HTML file to be injected into the{" "}
-                <Kbd className="inline">{"<head/>"}</Kbd> section of the
-                notebook. Use this to add analytics, custom fonts, meta tags, or
-                external scripts.
-              </FormDescription>
-            </div>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="sql_output"
-          render={({ field }) => (
-            <div className="flex flex-col gap-y-1">
-              <FormItem
-                className={"flex flex-row items-center space-x-1 space-y-0"}
-              >
-                <FormLabel>SQL Output Type</FormLabel>
-                <FormControl>
-                  <NativeSelect
-                    data-testid="sql-output-select"
-                    onChange={(e) => {
-                      field.onChange(e.target.value);
-                      toast({
-                        title: "Kernel Restart Required",
-                        description:
-                          "This change requires a kernel restart to take effect.",
-                      });
-                    }}
-                    value={field.value}
-                    disabled={field.disabled}
-                    className="inline-flex mr-2"
+                  <FormLabel>Width</FormLabel>
+                  <FormControl>
+                    <NativeSelect
+                      data-testid="app-width-select"
+                      onChange={(e) => field.onChange(e.target.value)}
+                      value={field.value}
+                      disabled={field.disabled}
+                      className="inline-flex mr-2"
+                    >
+                      {getAppWidths().map((option) => (
+                        <option value={option} key={option}>
+                          {option}
+                        </option>
+                      ))}
+                    </NativeSelect>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="app_title"
+              render={({ field }) => (
+                <div className="flex flex-col gap-y-1">
+                  <FormItem className="flex flex-row items-center space-x-1 space-y-0">
+                    <FormLabel>App title</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) => {
+                          field.onChange(e.target.value);
+                          if (
+                            AppTitleSchema.safeParse(e.target.value).success
+                          ) {
+                            document.title = e.target.value;
+                          }
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                  <FormDescription>
+                    The application title is put in the title tag in the HTML
+                    code and typically displayed in the title bar of the browser
+                    window.
+                  </FormDescription>
+                </div>
+              )}
+            />
+          </SettingSection>
+
+          <SettingSection title="Custom Files">
+            <FormField
+              control={form.control}
+              name="css_file"
+              render={({ field }) => (
+                <div className="flex flex-col gap-y-1">
+                  <FormItem className="flex flex-row items-center space-x-1 space-y-0">
+                    <FormLabel className="flex-shrink-0">Custom CSS</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value ?? ""}
+                        placeholder="custom.css"
+                        onChange={(e) => {
+                          field.onChange(e.target.value);
+                          if (
+                            AppTitleSchema.safeParse(e.target.value).success
+                          ) {
+                            document.title = e.target.value;
+                          }
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                  <FormDescription>
+                    A filepath to a custom css file to be injected into the
+                    notebook.
+                  </FormDescription>
+                </div>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="html_head_file"
+              render={({ field }) => (
+                <div className="flex flex-col gap-y-1">
+                  <FormItem className="flex flex-row items-center space-x-1 space-y-0">
+                    <FormLabel className="flex-shrink-0">HTML Head</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value ?? ""}
+                        placeholder="head.html"
+                        onChange={(e) => {
+                          field.onChange(e.target.value);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                  <FormDescription>
+                    A filepath to an HTML file to be injected into the{" "}
+                    <Kbd className="inline">{"<head/>"}</Kbd> section of the
+                    notebook. Use this to add analytics, custom fonts, meta
+                    tags, or external scripts.
+                  </FormDescription>
+                </div>
+              )}
+            />
+          </SettingSection>
+
+          <SettingSection title="Data Settings">
+            <FormField
+              control={form.control}
+              name="sql_output"
+              render={({ field }) => (
+                <div className="flex flex-col gap-y-1">
+                  <FormItem
+                    className={"flex flex-row items-center space-x-1 space-y-0"}
                   >
-                    <option value="auto">Auto (Default)</option>
-                    <option value="native">Native</option>
-                    <option value="polars">Polars</option>
-                    <option value="lazy-polars">Lazy Polars</option>
-                    <option value="pandas">Pandas</option>
-                  </NativeSelect>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-              <FormDescription>
-                The Python type returned by a SQL cell. For best performance
-                with large datasets, we recommend using{" "}
-                <Kbd className="inline">native</Kbd>. See the{" "}
-                <ExternalLink href="https://docs.marimo.io/guides/working_with_data/sql">
-                  SQL guide
-                </ExternalLink>{" "}
-                for more information.
-              </FormDescription>
-            </div>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="auto_download"
-          render={({ field }) => (
-            <div className="flex flex-col gap-y-1">
-              <div className="text-base font-bold text-muted-foreground">
-                Auto-download
-              </div>
-              <FormItem className="flex flex-col gap-2">
-                <FormControl>
-                  <div className="flex gap-4">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="html-checkbox"
-                        checked={field.value.includes("html")}
-                        onCheckedChange={() => {
-                          field.onChange(arrayToggle(field.value, "html"));
+                    <FormLabel>SQL Output Type</FormLabel>
+                    <FormControl>
+                      <NativeSelect
+                        data-testid="sql-output-select"
+                        onChange={(e) => {
+                          field.onChange(e.target.value);
+                          toast({
+                            title: "Kernel Restart Required",
+                            description:
+                              "This change requires a kernel restart to take effect.",
+                          });
                         }}
-                      />
-                      <FormLabel htmlFor="html-checkbox">HTML</FormLabel>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="ipynb-checkbox"
-                        checked={field.value.includes("ipynb")}
-                        onCheckedChange={() => {
-                          field.onChange(arrayToggle(field.value, "ipynb"));
-                        }}
-                      />
-                      <FormLabel htmlFor="ipynb-checkbox">IPYNB</FormLabel>
-                    </div>
-                    {/* Disable markdown until we save outputs in the exported markdown */}
-                    {/* <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="markdown-checkbox"
-                        checked={field.value.includes("markdown")}
-                        onCheckedChange={() => {
-                          field.onChange(arrayToggle(field.value, "markdown"));
-                        }}
-                      />
-                      <label
-                        htmlFor="markdown-checkbox"
-                        className="cursor-pointer"
+                        value={field.value}
+                        disabled={field.disabled}
+                        className="inline-flex mr-2"
                       >
-                        Markdown
-                      </label>
-                    </div> */}
-                  </div>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-              <FormDescription>
-                When enabled, marimo will periodically save this notebook in
-                your selected formats (HTML, IPYNB) to a folder named{" "}
-                <Kbd className="inline">__marimo__</Kbd> next to your notebook
-                file.
-              </FormDescription>
-            </div>
-          )}
-        />
+                        <option value="auto">Auto (Default)</option>
+                        <option value="native">Native</option>
+                        <option value="polars">Polars</option>
+                        <option value="lazy-polars">Lazy Polars</option>
+                        <option value="pandas">Pandas</option>
+                      </NativeSelect>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                  <FormDescription>
+                    The Python type returned by a SQL cell. For best performance
+                    with large datasets, we recommend using{" "}
+                    <Kbd className="inline">native</Kbd>. See the{" "}
+                    <ExternalLink href="https://docs.marimo.io/guides/working_with_data/sql">
+                      SQL guide
+                    </ExternalLink>{" "}
+                    for more information.
+                  </FormDescription>
+                </div>
+              )}
+            />
+          </SettingSection>
+
+          <SettingSection title="Auto-save Settings">
+            <FormField
+              control={form.control}
+              name="auto_download"
+              render={({ field }) => (
+                <div className="flex flex-col gap-y-1">
+                  <FormItem className="flex flex-col gap-2">
+                    <FormControl>
+                      <div className="flex gap-4">
+                        <div className="flex items-center space-x-2">
+                          <Checkbox
+                            id="html-checkbox"
+                            checked={field.value.includes("html")}
+                            onCheckedChange={() => {
+                              field.onChange(arrayToggle(field.value, "html"));
+                            }}
+                          />
+                          <FormLabel htmlFor="html-checkbox">HTML</FormLabel>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                          <Checkbox
+                            id="ipynb-checkbox"
+                            checked={field.value.includes("ipynb")}
+                            onCheckedChange={() => {
+                              field.onChange(arrayToggle(field.value, "ipynb"));
+                            }}
+                          />
+                          <FormLabel htmlFor="ipynb-checkbox">IPYNB</FormLabel>
+                        </div>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                  <FormDescription>
+                    When enabled, marimo will periodically save this notebook in
+                    your selected formats (HTML, IPYNB) to a folder named{" "}
+                    <Kbd className="inline">__marimo__</Kbd> next to your
+                    notebook file.
+                  </FormDescription>
+                </div>
+              )}
+            />
+          </SettingSection>
+        </div>
       </form>
     </Form>
+  );
+};
+
+const SettingSection = ({
+  title,
+  children,
+}: { title: string; children: React.ReactNode }) => {
+  return (
+    <div className="flex flex-col gap-y-2">
+      <h3 className="text-base font-semibold mb-1">{title}</h3>
+      {children}
+    </div>
   );
 };

--- a/frontend/src/components/editor/cell/cell-actions.tsx
+++ b/frontend/src/components/editor/cell/cell-actions.tsx
@@ -65,7 +65,11 @@ const CellActionsDropdownInternal = (
   }));
 
   const content = (
-    <PopoverContent className="w-[300px] p-0 pt-1" {...restoreFocus}>
+    <PopoverContent
+      className="w-[300px] p-0 pt-1 overflow-auto"
+      scrollable={true}
+      {...restoreFocus}
+    >
       <Command>
         <CommandInput placeholder="Search actions..." className="h-6 m-1" />
         <CommandList>

--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -171,7 +171,7 @@ export const CellActionsContextMenu = ({ children, ...props }: Props) => {
       >
         {children}
       </ContextMenuTrigger>
-      <ContextMenuContent className="w-[300px]">
+      <ContextMenuContent className="w-[300px]" scrollable={true}>
         {allActions.map((group, i) => (
           <Fragment key={i}>
             {group.map((action) => {

--- a/frontend/src/components/ui/context-menu.tsx
+++ b/frontend/src/components/ui/context-menu.tsx
@@ -66,13 +66,26 @@ ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
 
 const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content> & {
+    scrollable?: boolean;
+  }
+>(({ className, scrollable = true, ...props }, ref) => (
   <ContextMenuPortal>
     <StyleNamespace>
       <ContextMenuPrimitive.Content
         ref={ref}
-        className={cn(menuContentCommon(), contentCommon, className)}
+        className={cn(
+          menuContentCommon(),
+          contentCommon,
+          scrollable && "overflow-auto",
+          className,
+        )}
+        style={{
+          ...props.style,
+          maxHeight: scrollable
+            ? "calc(var(--radix-context-menu-content-available-height) - 30px)"
+            : undefined,
+        }}
         {...props}
       />
     </StyleNamespace>

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -61,8 +61,10 @@ DropdownMenuSubContent.displayName =
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
+    scrollable?: boolean;
+  }
+>(({ className, scrollable = true, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPortal>
     <StyleNamespace>
       <DropdownMenuPrimitive.Content
@@ -71,8 +73,15 @@ const DropdownMenuContent = React.forwardRef<
         className={cn(
           menuContentCommon(),
           "animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          scrollable && "overflow-auto",
           className,
         )}
+        style={{
+          ...props.style,
+          maxHeight: scrollable
+            ? "calc(var(--radix-dropdown-menu-content-available-height) - 30px)"
+            : undefined,
+        }}
         {...props}
       />
     </StyleNamespace>

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -16,10 +16,18 @@ const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
     portal?: boolean;
+    scrollable?: boolean;
   }
 >(
   (
-    { className, align = "center", sideOffset = 4, portal = true, ...props },
+    {
+      className,
+      align = "center",
+      sideOffset = 4,
+      portal = true,
+      scrollable = false,
+      ...props
+    },
     ref,
   ) => {
     const content = (
@@ -31,7 +39,14 @@ const PopoverContent = React.forwardRef<
           className={cn(
             "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             className,
+            scrollable && "overflow-auto",
           )}
+          style={{
+            ...props.style,
+            maxHeight: scrollable
+              ? "calc(var(--radix-popover-content-available-height) - 30px)"
+              : undefined,
+          }}
           {...props}
         />
       </StyleNamespace>


### PR DESCRIPTION
Fixes #4632

Clamp many popovers throughout the app, and make scrollable. Also make the notebook settings 2 columns.

<img width="1254" alt="Screenshot 2025-04-22 at 10 54 13 PM" src="https://github.com/user-attachments/assets/e626f628-22bf-40d9-8bb5-ad033c6dcd3d" />

------------

<img width="870" alt="Screenshot 2025-04-22 at 10 54 05 PM" src="https://github.com/user-attachments/assets/997f0633-0f65-40eb-84ed-02c68d2cd093" />

------------

<img width="669" alt="Screenshot 2025-04-22 at 11 04 18 PM" src="https://github.com/user-attachments/assets/d7e7e205-1848-4920-9b1e-0e5961c638f0" />

