### PR TITLE
fix: sandbox alerts to stderr

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -195,6 +195,7 @@ def maybe_prompt_run_in_sandbox(name: str | None) -> bool:
                 bold=True,
             ),
             default=True,
+            err=True,
         )
     else:
         echo(
@@ -374,7 +375,7 @@ def run_in_sandbox(
         args, name, additional_features or [], additional_deps or []
     )
 
-    echo(f"Running in a sandbox: {muted(' '.join(uv_cmd))}")
+    echo(f"Running in a sandbox: {muted(' '.join(uv_cmd))}", err=True)
 
     env = os.environ.copy()
     env["MARIMO_MANAGE_SCRIPT_METADATA"] = "true"

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -353,7 +353,7 @@ class TestExportHTML:
             capture_output=True,
         )
         assert p.returncode == 0, p.stderr.decode()
-        output = p.stdout.decode()
+        output = p.stderr.decode()
         # Check for sandbox message
         assert "Running in a sandbox" in output
         assert "uv run --isolated" in output
@@ -892,7 +892,7 @@ class TestExportIpynb:
             capture_output=True,
         )
         assert p.returncode == 0, p.stderr.decode()
-        output = p.stdout.decode()
+        output = p.stderr.decode()
         # Check for sandbox message
         assert "Running in a sandbox" in output
         assert "uv run --isolated" in output


### PR DESCRIPTION
## 📝 Summary

`marimo export md mynotebook.py > file`

creates a bunch of noise at the top of the file. Easy way to get the same functionality is just to log to stderr instead of stdout

@akshayka OR @mscolnick