### PR TITLE
fix: show start to end for datetimes in col summary

### DIFF
--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -322,7 +322,7 @@ exports[`ColumnChartSpecModel > snapshot > url data 1`] = `
             },
             "field": "bin_maxbins_10_date",
             "format": "%Y-%m-%d",
-            "title": "Start",
+            "title": "date (start)",
             "type": "temporal",
           },
           {
@@ -331,7 +331,7 @@ exports[`ColumnChartSpecModel > snapshot > url data 1`] = `
             },
             "field": "bin_maxbins_10_date_end",
             "format": "%Y-%m-%d",
-            "title": "End",
+            "title": "date (end)",
             "type": "temporal",
           },
           {

--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -317,10 +317,21 @@ exports[`ColumnChartSpecModel > snapshot > url data 1`] = `
         },
         "tooltip": [
           {
-            "bin": true,
-            "field": "date",
+            "bin": {
+              "binned": true,
+            },
+            "field": "bin_maxbins_10_date",
             "format": "%Y-%m-%d",
-            "title": "date",
+            "title": "Start",
+            "type": "temporal",
+          },
+          {
+            "bin": {
+              "binned": true,
+            },
+            "field": "bin_maxbins_10_date_end",
+            "format": "%Y-%m-%d",
+            "title": "End",
             "type": "temporal",
           },
           {

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -171,14 +171,14 @@ export class ColumnChartSpecModel<T> {
                     type: "temporal",
                     format: format,
                     bin: { binned: true },
-                    title: "Start",
+                    title: `${column} (start)`,
                   },
                   {
                     field: `bin_maxbins_10_${column}_end`,
                     type: "temporal",
                     format: format,
                     bin: { binned: true },
-                    title: "End",
+                    title: `${column} (end)`,
                   },
                   {
                     aggregate: "count",

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -166,17 +166,18 @@ export class ColumnChartSpecModel<T> {
                 y: { aggregate: "max", type: "quantitative", axis: null },
                 tooltip: [
                   {
-                    // Column name is used as the bin start value
-                    field: column,
+                    // Can also use column, but this is more explicit
+                    field: `bin_maxbins_10_${column}`,
                     type: "temporal",
                     format: format,
-                    bin: true,
+                    bin: { binned: true },
                     title: "Start",
                   },
                   {
                     field: `bin_maxbins_10_${column}_end`,
                     type: "temporal",
                     format: format,
+                    bin: { binned: true },
                     title: "End",
                   },
                   {

--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -109,7 +109,14 @@ export class ColumnChartSpecModel<T> {
     switch (type) {
       case "date":
       case "datetime":
-      case "time":
+      case "time": {
+        const format =
+          type === "date"
+            ? "%Y-%m-%d"
+            : type === "time"
+              ? "%H:%M:%S"
+              : "%Y-%m-%dT%H:%M:%S";
+
         return {
           ...base,
           // Two layers: one with the visible bars, and one with invisible bars
@@ -159,16 +166,18 @@ export class ColumnChartSpecModel<T> {
                 y: { aggregate: "max", type: "quantitative", axis: null },
                 tooltip: [
                   {
+                    // Column name is used as the bin start value
                     field: column,
                     type: "temporal",
-                    format:
-                      type === "date"
-                        ? "%Y-%m-%d"
-                        : type === "time"
-                          ? "%H:%M:%S"
-                          : "%Y-%m-%dT%H:%M:%S",
+                    format: format,
                     bin: true,
-                    title: column,
+                    title: "Start",
+                  },
+                  {
+                    field: `bin_maxbins_10_${column}_end`,
+                    type: "temporal",
+                    format: format,
+                    title: "End",
                   },
                   {
                     aggregate: "count",
@@ -189,6 +198,7 @@ export class ColumnChartSpecModel<T> {
             },
           ],
         };
+      }
       case "integer":
       case "number": {
         // Create a histogram spec that properly handles null values

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -563,7 +563,7 @@ class altair_chart(UIElement[ChartSelection, ChartDataType]):
         from altair import Undefined
 
         value = super().value
-        if value is Undefined:  # type: ignore[comparison-overlap]
+        if value is Undefined:  # type: ignore
             sys.stderr.write(
                 "The underlying chart data is not available in layered"
                 " or stacked charts. "

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -563,7 +563,7 @@ class altair_chart(UIElement[ChartSelection, ChartDataType]):
         from altair import Undefined
 
         value = super().value
-        if value is Undefined:  # type: ignore
+        if value is Undefined:  # type: ignore[comparison-overlap]
             sys.stderr.write(
                 "The underlying chart data is not available in layered"
                 " or stacked charts. "


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Previously:
![image](https://github.com/user-attachments/assets/51f0deb8-ba73-481d-a9b5-529200865906)

Now:
![image](https://github.com/user-attachments/assets/83259288-4299-4a0b-998a-099fb8635b47)

Adds another row in the tooltip, ideally we can put in the same row, but this might require [signals](https://stackoverflow.com/questions/54044721/modify-vega-tooltip-in-spec-to-display-specific-fields) and calculating the field elsewhere..I think.

I'm open to changing the tooltip name, maybe we can do
`colName (start)`
`colName (end)`

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
