### PR TITLE
feat: add --include-cloudflare for easy deployment of wasm to cloudflare workers

### DIFF
--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -179,6 +179,7 @@ Options:
 - `--output`: Directory to save the HTML and required assets
 - `--show-code/--no-show-code`: Whether to initially show or hide the code in the notebook
 - `--watch/--no-watch`: Watch the notebook for changes and automatically export
+- `--include-cloudflare`: Write configuration files necessary for deploying to Cloudflare
 
 !!! note "Note"
 
@@ -188,6 +189,26 @@ Options:
     a simpler publishing experience, publish to [GitHub
     Pages](publishing/github_pages.md), [Cloudflare Pages](publishing/cloudflare_pages.md) or use the [online
     playground](publishing/playground.md).
+
+??? note "Deploying to Cloudflare"
+
+    You can include `--include-cloudflare` for deploying to Cloudflare. For example:
+
+    ```
+    marimo export html-wasm notebook.py -o my_app/dist --include-cloudflare
+    ```
+
+    To run locally, run:
+
+    ```
+    npx wrangler dev
+    ```
+
+    To deploy to Cloudflare, run:
+
+    ```
+    npx wrangler deploy
+    ```
 
 ### Testing the export
 
@@ -208,7 +229,6 @@ to include data files in exported WASM HTML notebooks.
 After exporting your notebook to WASM HTML, you can publish it to
 [GitHub Pages](https://pages.github.com/) for free. See our [guide on
 GitHub Pages](publishing/github_pages.md) to learn more.
-
 
 ### Exporting multiple notebooks
 
@@ -357,6 +377,5 @@ In order to use marimo islands, you need to import the necessary JS/CSS headers 
   </marimo-island>
 </body>
 ```
-
 
 ::: marimo.MarimoIslandGenerator

--- a/marimo/_cli/export/cloudflare.py
+++ b/marimo/_cli/export/cloudflare.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from marimo._cli.print import bold, echo, green
+from marimo._server.print import _utf8
+
+
+def create_cloudflare_files(title: str, out_dir: Path) -> None:
+    parent_dir = out_dir.parent
+    index_js = parent_dir / "index.js"
+    wrangler_jsonc = parent_dir / "wrangler.jsonc"
+
+    # Create index.js
+    index_js.write_text(
+        """
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname.startsWith("/health")) {
+      return new Response(JSON.stringify({ made: "with marimo" }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};""".strip()
+    )
+
+    # Create wrangler.jsonc
+    wrangler_jsonc.write_text(
+        f"""
+{{
+  "name": "{title}",
+  "main": "{index_js.name}",
+  "compatibility_date": "2025-01-01",
+  "assets": {{
+    "directory": "./{out_dir.relative_to(parent_dir)}",
+    "binding": "ASSETS"
+  }}
+}}""".strip()
+    )
+
+    cwd = ""
+    if parent_dir != Path.cwd() and str(parent_dir) != ".":
+        cwd = f" --cwd {parent_dir}"
+
+    echo(
+        f"""
+{_utf8("☁️☁️☁️☁️☁️☁️")}
+Cloudflare configuration files created at {green(str(parent_dir.absolute()))}.
+
+To run locally, run:
+
+    {bold("npx wrangler dev" + cwd)}
+
+To deploy to Cloudflare Pages, run:
+
+    {bold("npx wrangler deploy" + cwd)}
+
+{_utf8("☁️☁️☁️☁️☁️☁️")}
+"""
+    )

--- a/marimo/_cli/export/cloudflare.py
+++ b/marimo/_cli/export/cloudflare.py
@@ -5,13 +5,22 @@ from marimo._server.print import _utf8
 
 
 def create_cloudflare_files(title: str, out_dir: Path) -> None:
+    echo("\n" + _utf8("☁️☁️☁️☁️☁️☁️") + "\n")
+
     parent_dir = out_dir.parent
     index_js = parent_dir / "index.js"
     wrangler_jsonc = parent_dir / "wrangler.jsonc"
+    created_files = False
 
-    # Create index.js
-    index_js.write_text(
-        """
+    if index_js.exists():
+        echo(
+            f"Cloudflare {index_js.name} already exists at {green(str(index_js.absolute()))}. Skipping..."
+        )
+    else:
+        created_files = True
+        # Create index.js
+        index_js.write_text(
+            """
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -25,11 +34,17 @@ export default {
     return env.ASSETS.fetch(request);
   },
 };""".strip()
-    )
+        )
 
-    # Create wrangler.jsonc
-    wrangler_jsonc.write_text(
-        f"""
+    if wrangler_jsonc.exists():
+        echo(
+            f"Cloudflare {wrangler_jsonc.name} already exists at {green(str(wrangler_jsonc.absolute()))}. Skipping..."
+        )
+    else:
+        created_files = True
+        # Create wrangler.jsonc
+        wrangler_jsonc.write_text(
+            f"""
 {{
   "name": "{title}",
   "main": "{index_js.name}",
@@ -39,17 +54,19 @@ export default {
     "binding": "ASSETS"
   }}
 }}""".strip()
-    )
+        )
 
     cwd = ""
     if parent_dir != Path.cwd() and str(parent_dir) != ".":
         cwd = f" --cwd {parent_dir}"
 
+    if created_files:
+        echo(
+            f"Cloudflare configuration files created at {green(str(parent_dir.absolute()))}."
+        )
+
     echo(
         f"""
-{_utf8("☁️☁️☁️☁️☁️☁️")}
-Cloudflare configuration files created at {green(str(parent_dir.absolute()))}.
-
 To run locally, run:
 
     {bold("npx wrangler dev" + cwd)}
@@ -57,7 +74,6 @@ To run locally, run:
 To deploy to Cloudflare Pages, run:
 
     {bold("npx wrangler deploy" + cwd)}
-
-{_utf8("☁️☁️☁️☁️☁️☁️")}
 """
     )
+    echo(_utf8("☁️☁️☁️☁️☁️☁️"))

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -7,10 +7,12 @@ from typing import Callable, Literal, Optional
 
 import click
 
+from marimo._cli.export.cloudflare import create_cloudflare_files
 from marimo._cli.parse_args import parse_args
 from marimo._cli.print import echo, green
 from marimo._cli.utils import prompt_to_overwrite
 from marimo._dependencies.dependencies import DependencyManager
+from marimo._server.api.utils import parse_title
 from marimo._server.export import (
     ExportResult,
     export_as_ipynb,
@@ -493,6 +495,15 @@ and cannot be opened directly from the file system (e.g. file://).
     ),
 )
 @click.option(
+    "--include-cloudflare/--no-include-cloudflare",
+    default=False,
+    show_default=True,
+    help=(
+        "Whether to include Cloudflare Worker configuration files"
+        " (index.js and wrangler.jsonc) for easy deployment."
+    ),
+)
+@click.option(
     "--sandbox/--no-sandbox",
     is_flag=True,
     default=None,
@@ -511,6 +522,7 @@ def html_wasm(
     mode: Literal["edit", "run"],
     watch: bool,
     show_code: bool,
+    include_cloudflare: bool,
     sandbox: Optional[bool],
 ) -> None:
     """Export a notebook as a WASM-powered standalone HTML file."""
@@ -566,6 +578,9 @@ def html_wasm(
         f"  python -m http.server --directory {out_dir}\n"
         "Then open the URL that is printed to your terminal."
     )
+
+    if include_cloudflare:
+        create_cloudflare_files(parse_title(name), out_dir)
 
     outfile = out_dir / filename
     return watch_and_export(MarimoPath(name), outfile, watch, export_callback)

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -130,6 +130,36 @@ class TestExportHTML:
         shutil.rmtree(public_dir)
 
     @staticmethod
+    def test_cli_export_html_wasm_cloudflare(temp_marimo_file: str) -> None:
+        out_dir = Path(temp_marimo_file).parent / "cloudflare" / "out"
+        p = subprocess.run(
+            [
+                "marimo",
+                "export",
+                "html-wasm",
+                temp_marimo_file,
+                "--output",
+                out_dir,
+                "--include-cloudflare",
+            ],
+            capture_output=True,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
+        # Verify Cloudflare files were created
+        assert (out_dir.parent / "index.js").exists()
+        assert (out_dir.parent / "wrangler.jsonc").exists()
+
+        # Verify index.js content
+        index_js = (out_dir.parent / "index.js").read_text()
+        assert "env.ASSETS.fetch(request)" in index_js
+
+        # Verify wrangler.jsonc content
+        wrangler = (out_dir.parent / "wrangler.jsonc").read_text()
+        assert "name" in wrangler
+        assert "main" in wrangler
+
+    @staticmethod
     def test_cli_export_html_wasm_output_is_file(
         temp_marimo_file: str,
     ) -> None:


### PR DESCRIPTION
Deploy to cloudflare in two commands:

    marimo export html-wasm notebook.py -o dist --include-cloudflare

To run locally, run:

    npx wrangler dev

To deploy to Cloudflare, run:

    npx wrangler deploy


![Screenshot 2025-04-23 at 5 57 54 PM](https://github.com/user-attachments/assets/29f99332-b2df-4457-b818-4d2651718fae)