### PR TITLE
improve: scratchpad hint on multiple definition error

### DIFF
--- a/frontend/src/components/datasources/__tests__/install-package-button.test.tsx
+++ b/frontend/src/components/datasources/__tests__/install-package-button.test.tsx
@@ -3,10 +3,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { InstallPackageButton } from "../install-package-button";
 
-const mockOpenApplication = vi.fn();
+const mockToggleApplication = vi.fn();
 vi.mock("@/components/editor/chrome/state", () => ({
   useChromeActions: () => ({
-    openApplication: mockOpenApplication,
+    toggleApplication: mockToggleApplication,
   }),
 }));
 
@@ -62,6 +62,6 @@ describe("InstallPackageButton", () => {
 
     expect(mockSetPackagesToInstall).toHaveBeenCalledWith("altair");
 
-    expect(mockOpenApplication).toHaveBeenCalledWith("packages");
+    expect(mockToggleApplication).toHaveBeenCalledWith("packages");
   });
 });

--- a/frontend/src/components/datasources/install-package-button.tsx
+++ b/frontend/src/components/datasources/install-package-button.tsx
@@ -30,7 +30,7 @@ export const InstallPackageButton: React.FC<InstallPackageButtonProps> = ({
     setPackagesToInstall(packagesString);
 
     // Open the packages panel
-    chromeActions.openApplication("packages");
+    chromeActions.toggleApplication("packages");
   };
 
   return (

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -94,7 +94,7 @@ const NOOP_HANDLER = (event?: Event) => {
 export function useNotebookActions() {
   const filename = useFilename();
   const { openModal, closeModal } = useImperativeModal();
-  const { openApplication } = useChromeActions();
+  const { toggleApplication } = useChromeActions();
   const { selectedPanel } = useChromeState();
   const [viewState] = useAtom(viewStateAtom);
   const kioskMode = useAtomValue(kioskModeAtom);
@@ -272,7 +272,7 @@ export function useNotebookActions() {
           label: startCase(type),
           rightElement: renderCheckboxElement(selectedPanel === type),
           icon: <Icon size={14} strokeWidth={1.5} />,
-          handle: () => openApplication(type),
+          handle: () => toggleApplication(type),
         };
       }),
     },

--- a/frontend/src/components/editor/chrome/state.ts
+++ b/frontend/src/components/editor/chrome/state.ts
@@ -45,6 +45,15 @@ const {
       selectedPanel,
       isSidebarOpen: true,
     }),
+    toggleApplication: (state, selectedPanel: PanelType) => ({
+      ...state,
+      selectedPanel,
+      // If it was closed, open it
+      // If it was open, keep it open unless it was the same application
+      isSidebarOpen: state.isSidebarOpen
+        ? state.selectedPanel !== selectedPanel
+        : true,
+    }),
     toggleSidebarPanel: (state) => ({
       ...state,
       isSidebarOpen: !state.isSidebarOpen,

--- a/frontend/src/components/editor/chrome/state.ts
+++ b/frontend/src/components/editor/chrome/state.ts
@@ -43,11 +43,7 @@ const {
     openApplication: (state, selectedPanel: PanelType) => ({
       ...state,
       selectedPanel,
-      // If it was closed, open it
-      // If it was open, keep it open unless it was the same application
-      isSidebarOpen: state.isSidebarOpen
-        ? state.selectedPanel !== selectedPanel
-        : true,
+      isSidebarOpen: true,
     }),
     toggleSidebarPanel: (state) => ({
       ...state,

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -32,7 +32,7 @@ import { isWasm } from "@/core/wasm/utils";
 
 export const Footer: React.FC = () => {
   const { selectedPanel, isTerminalOpen } = useChromeState();
-  const { openApplication, toggleTerminal } = useChromeActions();
+  const { toggleApplication, toggleTerminal } = useChromeActions();
   const [config, setConfig] = useResolvedMarimoConfig();
   const errorCount = useAtomValue(cellErrorCount);
 
@@ -52,7 +52,7 @@ export const Footer: React.FC = () => {
       <FooterItem
         tooltip={errorPanel.tooltip}
         selected={selectedPanel === errorPanel.type}
-        onClick={() => openApplication(errorPanel.type)}
+        onClick={() => toggleApplication(errorPanel.type)}
       >
         {renderIcon(errorPanel, errorCount > 0 ? "text-destructive" : "")}
         <span className="ml-1 font-mono mt-[0.125rem]">{errorCount}</span>

--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -12,7 +12,7 @@ import { useAtomValue } from "jotai";
 
 export const Sidebar: React.FC = () => {
   const { selectedPanel } = useChromeState();
-  const { openApplication } = useChromeActions();
+  const { toggleApplication } = useChromeActions();
 
   const renderIcon = ({ Icon }: PanelDescriptor, className?: string) => {
     return <Icon className={cn("h-5 w-5", className)} />;
@@ -29,7 +29,7 @@ export const Sidebar: React.FC = () => {
           key={p.type}
           tooltip={p.tooltip}
           selected={selectedPanel === p.type}
-          onClick={() => openApplication(p.type)}
+          onClick={() => toggleApplication(p.type)}
         >
           {renderIcon(p)}
         </SidebarItem>

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -11,12 +11,14 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { Fragment } from "react";
+import { Button } from "@/components/ui/button";
+import { Fragment, useCallback } from "react";
 import { CellLinkError } from "../links/cell-link";
 import type { CellId } from "@/core/cells/ids";
 import { AutoFixButton } from "../errors/auto-fix";
-import { SquareArrowOutUpRightIcon } from "lucide-react";
+import { NotebookPenIcon, SquareArrowOutUpRightIcon } from "lucide-react";
 import { ExternalLink } from "@/components/ui/links";
+import { useChromeActions } from "../chrome/state";
 
 const Tip = (props: {
   title?: string;
@@ -128,6 +130,12 @@ export const MarimoErrorOutput = ({
   const unknownErrors = errors.filter(
     (e): e is Extract<MarimoError, { type: "unknown" }> => e.type === "unknown",
   );
+
+  const chromeActions = useChromeActions();
+
+  const openScratchpad = useCallback(() => {
+    chromeActions.openApplication("scratchpad");
+  }, [chromeActions]);
 
   const renderMessages = () => {
     const messages: JSX.Element[] = [];
@@ -270,9 +278,24 @@ export const MarimoErrorOutput = ({
               </ul>
             </Fragment>
           ))}
+
+          <div>
+            Throwaway code?{" "}
+            <Button
+              size="xs"
+              variant="outline"
+              className="my-2 font-normal"
+              onClick={openScratchpad}
+            >
+              <NotebookPenIcon className="h-3 w-3 mr-2" />
+              Open the scratchpad
+            </Button>
+          </div>
+
           {cellId && (
             <AutoFixButton errors={multipleDefsErrors} cellId={cellId} />
           )}
+
           <Tip title="Why can't I redefine variables?">
             <p className="pb-2">
               marimo requires that each variable is defined in just one cell.
@@ -509,7 +532,7 @@ export const MarimoErrorOutput = ({
     >
       {title}
       <div>
-        <ul className="flex flex-col gap-8">{renderMessages()}</ul>
+        <ul className="flex flex-col gap-8">{renderMessages(chromeActions)}</ul>
       </div>
     </Alert>
   );

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -288,7 +288,7 @@ export const MarimoErrorOutput = ({
               onClick={openScratchpad}
             >
               <NotebookPenIcon className="h-3 w-3 mr-2" />
-              Open the scratchpad
+              Use the scratchpad
             </Button>
           </div>
 

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -209,6 +209,11 @@ export const ScratchPad: React.FC = () => {
       className="flex flex-col h-full overflow-hidden divide-y"
       id={HTMLCellId.create(cellId)}
     >
+      <p className="mx-2 my-2 text-muted-foreground text-sm">
+        Use this scratchpad cell to experiment with throwaway code. Scratchpad
+        code can redefine variables from the notebook; its variables aren't
+        saved to notebook memory.
+      </p>
       <div className="flex items-center flex-shrink-0">
         <Tooltip content={renderShortcut("cell.run")}>
           <Button


### PR DESCRIPTION
The scratchpad is very handy when working with throwaway
code. The time to use it is often when you hit a multiple
definition error, so this change adds a suggestion/button
to open the scratchpad from the multiple definition error output.

This change was informed by watching students use marimo for the first time; they loved the scratchpad panel for this use case when shown how to open it.

<img width="793" alt="image" src="https://github.com/user-attachments/assets/e39987ed-0f7e-4e9d-8304-41488c1a0b9b" />
