### PR TITLE
feat: toggle between markdown formats and set r-string as default

### DIFF
--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -180,6 +180,14 @@ describe("MarkdownLanguageAdapter", () => {
       expect(offset).toBe(9);
     });
 
+    it("defaults to r-string when there is no last quote prefix", () => {
+      const adapter = new MarkdownLanguageAdapter();
+      const code = "Hello world";
+      const [wrappedCode, offset] = adapter.transformOut(code);
+      expect(wrappedCode).toBe(`mo.md(r"""Hello world""")`);
+      expect(offset).toBe(10);
+    });
+
     it("single line", () => {
       const code = "Hello world";
       adapter.lastQuotePrefix = "";

--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -1,6 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { expect, describe, it } from "vitest";
 import { MarkdownLanguageAdapter } from "../markdown";
+import { getQuotePrefix } from "../panel";
 
 const adapter = new MarkdownLanguageAdapter();
 
@@ -341,5 +342,36 @@ describe("MarkdownLanguageAdapter", () => {
         expect(adapter.isSupported(pythonCode)).toBe(true);
       }
     });
+  });
+});
+
+describe("getQuotePrefix", () => {
+  it("should return the correct quote prefix when checked", () => {
+    expect(getQuotePrefix("", true, "r")).toBe("r");
+    expect(getQuotePrefix("", true, "f")).toBe("f");
+    expect(getQuotePrefix("r", true, "f")).toBe("rf");
+    expect(getQuotePrefix("f", true, "r")).toBe("rf");
+  });
+
+  it("should return the correct quote prefix when unchecked", () => {
+    expect(getQuotePrefix("r", false, "r")).toBe("");
+    expect(getQuotePrefix("f", false, "f")).toBe("");
+    expect(getQuotePrefix("rf", false, "r")).toBe("f");
+    expect(getQuotePrefix("rf", false, "f")).toBe("r");
+  });
+
+  it("should return the correct quote prefix even when not possible to toggle", () => {
+    expect(getQuotePrefix("", false, "r")).toBe("");
+    expect(getQuotePrefix("", false, "f")).toBe("");
+    expect(getQuotePrefix("r", false, "f")).toBe("r");
+    expect(getQuotePrefix("f", false, "r")).toBe("f");
+
+    expect(getQuotePrefix("rf", true, "r")).toBe("rf");
+    expect(getQuotePrefix("rf", true, "f")).toBe("rf");
+    expect(getQuotePrefix("f", true, "f")).toBe("f");
+    expect(getQuotePrefix("r", true, "r")).toBe("r");
+
+    expect(getQuotePrefix("", false, "")).toBe("");
+    expect(getQuotePrefix("", true, "")).toBe("");
   });
 });

--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -278,15 +278,23 @@ describe("MarkdownLanguageAdapter", () => {
   describe("isSupported", () => {
     it("should return true for supported markdown string formats", () => {
       const pythonCode = 'mo.md("""# Markdown Title\n\nSome content here.""")';
-      expect(adapter.isSupported(pythonCode)).toBe(true);
-      expect(adapter.isSupported("mo.md()")).toBe(true);
-      expect(adapter.isSupported("mo.md('')")).toBe(true);
-      expect(adapter.isSupported('mo.md("")')).toBe(true);
-    });
-
-    it("should return false for unsupported markdown string formats", () => {
-      expect(adapter.isSupported("mo.md(f'hello world')")).toBe(false);
-      expect(adapter.isSupported('mo.md(f"hello world")')).toBe(false);
+      const VALID_FORMATS = [
+        pythonCode,
+        "mo.md()",
+        "mo.md('')",
+        'mo.md("")',
+        "mo.md(f'hello world')",
+        'mo.md(f"hello world")',
+        "mo.md(r'hello world')",
+        'mo.md(r"hello world")',
+        "mo.md(rf'hello world')",
+        'mo.md(rf"hello world")',
+        "mo.md(fr'hello world')",
+        'mo.md(fr"hello world")',
+      ];
+      for (const format of VALID_FORMATS) {
+        expect(adapter.isSupported(format)).toBe(true);
+      }
     });
 
     it("should return false for unsupported string formats", () => {

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -64,7 +64,7 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
     return `mo.md(r"""\n${markdown}\n""")`;
   }
 
-  lastQuotePrefix: QuotePrefixKind = "";
+  lastQuotePrefix: QuotePrefixKind | "unset" = "unset";
 
   transformIn(pythonCode: string): [string, number] {
     pythonCode = pythonCode.trim();
@@ -97,8 +97,9 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
   }
 
   transformOut(code: string): [string, number] {
-    // Get the quote type from the last transformIn
-    const prefix = this.lastQuotePrefix;
+    // Get the quote type from the last transformIn or defaults to "r"
+    const prefix =
+      this.lastQuotePrefix === "unset" ? "r" : this.lastQuotePrefix;
 
     // Empty string
     if (code === "") {
@@ -183,10 +184,12 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
               const pattern = /{(.*?)}/g;
               let match: RegExpExecArray | null;
 
-              while ((match = pattern.exec(text)) !== null) {
+              match = pattern.exec(text);
+              while (match !== null) {
                 const start = match.index + 1;
                 const end = pattern.lastIndex - 1;
                 overlays.push({ from: start, to: end });
+                match = pattern.exec(text);
               }
 
               if (overlays.length === 0) {

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -182,9 +182,7 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
 
               // Find all { } groupings
               const pattern = /{(.*?)}/g;
-              let match: RegExpExecArray | null;
-
-              match = pattern.exec(text);
+              let match: RegExpExecArray | null = pattern.exec(text);
               while (match !== null) {
                 const start = match.index + 1;
                 const end = pattern.lastIndex - 1;

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -19,7 +19,11 @@ import { enhancedMarkdownExtension } from "../markdown/extension";
 import type { CompletionConfig } from "@/core/config/config-schema";
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { indentOneTab } from "./utils/indentOneTab";
-import { type QuotePrefixKind, splitQuotePrefix } from "./utils/quotes";
+import {
+  QUOTE_PREFIX_KINDS,
+  type QuotePrefixKind,
+  splitQuotePrefix,
+} from "./utils/quotes";
 import { markdownAutoRunExtension } from "../cells/extensions";
 import type { PlaceholderType } from "../config/extension";
 import type { CellId } from "@/core/cells/ids";
@@ -38,9 +42,9 @@ const quoteKinds = [
 //
 // A note on f-strings:
 //
-// f-strings are not yet supported due to bad interactions with
+// f-strings are not well supported due to bad interactions with
 // string escaping, LaTeX, and loss of Python syntax highlighting
-const pairs = ["", "r"].flatMap((prefix) =>
+const pairs = QUOTE_PREFIX_KINDS.flatMap((prefix) =>
   quoteKinds.map(([start, end]) => [prefix + start, end]),
 );
 
@@ -64,7 +68,7 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
     return `mo.md(r"""\n${markdown}\n""")`;
   }
 
-  lastQuotePrefix: QuotePrefixKind | "unset" = "unset";
+  lastQuotePrefix: QuotePrefixKind = "r";
 
   transformIn(pythonCode: string): [string, number] {
     pythonCode = pythonCode.trim();
@@ -97,9 +101,8 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
   }
 
   transformOut(code: string): [string, number] {
-    // Get the quote type from the last transformIn or defaults to "r"
-    const prefix =
-      this.lastQuotePrefix === "unset" ? "r" : this.lastQuotePrefix;
+    // Get the quote type from the last transformIn
+    const prefix = this.lastQuotePrefix;
 
     // Empty string
     if (code === "") {
@@ -218,6 +221,10 @@ export class MarkdownLanguageAdapter implements LanguageAdapter {
       markdownAutoRunExtension(),
       python().support,
     ];
+  }
+
+  setQuotePrefix(prefix: QuotePrefixKind) {
+    this.lastQuotePrefix = prefix;
   }
 }
 

--- a/frontend/src/core/codemirror/language/markdown.ts
+++ b/frontend/src/core/codemirror/language/markdown.ts
@@ -39,11 +39,6 @@ const quoteKinds = [
 ];
 
 // explode into all combinations
-//
-// A note on f-strings:
-//
-// f-strings are not well supported due to bad interactions with
-// string escaping, LaTeX, and loss of Python syntax highlighting
 const pairs = QUOTE_PREFIX_KINDS.flatMap((prefix) =>
   quoteKinds.map(([start, end]) => [prefix + start, end]),
 );

--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -28,6 +28,8 @@ import type { DataSourceConnection } from "@/core/kernel/messages";
 import { formatSQL } from "../format";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
+import { MarkdownLanguageAdapter } from "./markdown";
+import type { QuotePrefixKind } from "./utils/quotes";
 
 const Divider = () => <div className="h-4 border-r border-border" />;
 
@@ -117,6 +119,19 @@ export const LanguagePanelComponent: React.FC<{
     );
   }
 
+  if (languageAdapter instanceof MarkdownLanguageAdapter) {
+    showDivider = true;
+
+    actions = (
+      <div className="flex flex-row w-full justify-end">
+        <MarkdownPrefixButton
+          languageAdapter={languageAdapter}
+          triggerUpdate={triggerUpdate}
+        />
+      </div>
+    );
+  }
+
   return (
     <TooltipProvider>
       <div className="flex justify-between items-center gap-4 pl-2 pt-2">
@@ -125,6 +140,54 @@ export const LanguagePanelComponent: React.FC<{
         {languageAdapter.type}
       </div>
     </TooltipProvider>
+  );
+};
+
+const MarkdownPrefixButton: React.FC<{
+  languageAdapter: MarkdownLanguageAdapter;
+  triggerUpdate: () => void;
+}> = ({ languageAdapter, triggerUpdate }) => {
+  // Cycle through the different quote prefixes when clicked
+  const prefixMap: Record<
+    QuotePrefixKind,
+    { next: QuotePrefixKind; tooltip: string }
+  > = {
+    r: {
+      next: "f",
+      tooltip: "Toggle f-string",
+    },
+    f: {
+      next: "rf",
+      tooltip: "Toggle raw + f-string",
+    },
+    fr: {
+      next: "r",
+      tooltip: "Toggle raw string",
+    },
+    rf: {
+      next: "r",
+      tooltip: "Toggle raw string",
+    },
+    "": {
+      next: "r",
+      tooltip: "Toggle raw string",
+    },
+  };
+
+  const handleClick = () => {
+    const nextPrefix = prefixMap[languageAdapter.lastQuotePrefix].next;
+    languageAdapter.setQuotePrefix(nextPrefix);
+    triggerUpdate();
+  };
+
+  const tooltipContent = prefixMap[languageAdapter.lastQuotePrefix].tooltip;
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <Button variant="text" size="icon" onClick={handleClick}>
+        <i>{languageAdapter.lastQuotePrefix}</i>
+      </Button>
+    </Tooltip>
   );
 };
 

--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -122,12 +122,20 @@ export const LanguagePanelComponent: React.FC<{
   if (languageAdapter instanceof MarkdownLanguageAdapter) {
     showDivider = true;
 
+    const handleClick = () => {
+      const nextPrefix = prefixMap[languageAdapter.lastQuotePrefix].next;
+      languageAdapter.setQuotePrefix(nextPrefix);
+      triggerUpdate();
+    };
+    const tooltipContent = prefixMap[languageAdapter.lastQuotePrefix].tooltip;
+
     actions = (
       <div className="flex flex-row w-full justify-end">
-        <MarkdownPrefixButton
-          languageAdapter={languageAdapter}
-          triggerUpdate={triggerUpdate}
-        />
+        <Tooltip content={tooltipContent}>
+          <Button variant="text" size="icon" onClick={handleClick}>
+            <i>{languageAdapter.lastQuotePrefix}</i>
+          </Button>
+        </Tooltip>
       </div>
     );
   }
@@ -140,54 +148,6 @@ export const LanguagePanelComponent: React.FC<{
         {languageAdapter.type}
       </div>
     </TooltipProvider>
-  );
-};
-
-const MarkdownPrefixButton: React.FC<{
-  languageAdapter: MarkdownLanguageAdapter;
-  triggerUpdate: () => void;
-}> = ({ languageAdapter, triggerUpdate }) => {
-  // Cycle through the different quote prefixes when clicked
-  const prefixMap: Record<
-    QuotePrefixKind,
-    { next: QuotePrefixKind; tooltip: string }
-  > = {
-    r: {
-      next: "f",
-      tooltip: "Toggle f-string",
-    },
-    f: {
-      next: "rf",
-      tooltip: "Toggle raw + f-string",
-    },
-    fr: {
-      next: "r",
-      tooltip: "Toggle raw string",
-    },
-    rf: {
-      next: "r",
-      tooltip: "Toggle raw string",
-    },
-    "": {
-      next: "r",
-      tooltip: "Toggle raw string",
-    },
-  };
-
-  const handleClick = () => {
-    const nextPrefix = prefixMap[languageAdapter.lastQuotePrefix].next;
-    languageAdapter.setQuotePrefix(nextPrefix);
-    triggerUpdate();
-  };
-
-  const tooltipContent = prefixMap[languageAdapter.lastQuotePrefix].tooltip;
-
-  return (
-    <Tooltip content={tooltipContent}>
-      <Button variant="text" size="icon" onClick={handleClick}>
-        <i>{languageAdapter.lastQuotePrefix}</i>
-      </Button>
-    </Tooltip>
   );
 };
 
@@ -290,3 +250,31 @@ const SQLEngineSelect: React.FC<SelectProps> = ({
 const HELP_KEY = "__help__";
 const HELP_URL =
   "http://docs.marimo.io/guides/working_with_data/sql/#connecting-to-a-custom-database";
+
+// Cycle through the different quote prefixes for markdown when clicked
+// rf and fr are almost identical, we can remove one for clarity
+const prefixMap: Record<
+  QuotePrefixKind,
+  { next: QuotePrefixKind; tooltip: string }
+> = {
+  r: {
+    next: "f",
+    tooltip: "Toggle f-string",
+  },
+  f: {
+    next: "rf",
+    tooltip: "Toggle raw + f-string",
+  },
+  fr: {
+    next: "r",
+    tooltip: "Toggle raw string",
+  },
+  rf: {
+    next: "r",
+    tooltip: "Toggle raw string",
+  },
+  "": {
+    next: "r",
+    tooltip: "Toggle raw string",
+  },
+};

--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -141,11 +141,9 @@ export const LanguagePanelComponent: React.FC<{
     };
 
     actions = (
-      <div className="flex flex-row w-full justify-end gap-1 items-center">
-        <div className="flex items-center gap-2">
-          <span>
-            <i>r</i>
-          </span>
+      <div className="flex flex-row w-full justify-end gap-1.5 items-center">
+        <div className="flex items-center gap-1.5">
+          <span>r</span>
           <Checkbox
             aria-label="Toggle raw string"
             className="w-3 h-3"
@@ -155,10 +153,8 @@ export const LanguagePanelComponent: React.FC<{
             }}
           />
         </div>
-        <div className="flex items-center gap-2">
-          <span>
-            <i>f</i>
-          </span>
+        <div className="flex items-center gap-1.5">
+          <span>f</span>
           <Checkbox
             aria-label="Toggle f-string"
             className="w-3 h-3"

--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -133,7 +133,11 @@ export const LanguagePanelComponent: React.FC<{
       <div className="flex flex-row w-full justify-end">
         <Tooltip content={tooltipContent}>
           <Button variant="text" size="icon" onClick={handleClick}>
-            <i>{languageAdapter.lastQuotePrefix}</i>
+            {languageAdapter.lastQuotePrefix === "" ? (
+              <i>f</i>
+            ) : (
+              <i>{languageAdapter.lastQuotePrefix}</i>
+            )}
           </Button>
         </Tooltip>
       </div>
@@ -274,7 +278,7 @@ const prefixMap: Record<
     tooltip: "Toggle raw string",
   },
   "": {
-    next: "r",
-    tooltip: "Toggle raw string",
+    next: "f",
+    tooltip: "Toggle f string",
   },
 };


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #4573 . Defaults to using r-string.

Fixes #3895, #3884 . Introduce a toggle in markdown cells that can flip between raw string, f-string and raw + f-string.
<img width="276" alt="image" src="https://github.com/user-attachments/assets/eca66aa8-e78a-4e46-a4df-3fe70a50edb1" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- possible to use Select, but I felt this was cleaner. If we want to add a plain option, maybe change to a select.
- small lint fix for expressions in while loop (https://biomejs.dev/linter/rules/no-assign-in-expressions/)

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
