### PR TITLE
fix: max width on md admonition, details

### DIFF
--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -36,7 +36,9 @@
     > ul,
     > ol,
     > blockquote,
+    > details,
     div.codehilite,
+    div.admonition,
     /* Target <span> that is not empty and does not consist entirely of child elements;
      * this makes sure text with embedded HTML (such as a slider) has a max width,
      * but standalone elements (like tables, plots) don't get a max width. */


### PR DESCRIPTION
These elements were previously missed.

Fixes #4658 