### PR TITLE
fix: code editor refresh with new state

### DIFF
--- a/frontend/src/plugins/impl/CodeEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/CodeEditorPlugin.tsx
@@ -6,7 +6,7 @@ import { Labeled } from "./common/labeled";
 import { type Theme, useTheme } from "@/theme/useTheme";
 import { LazyAnyLanguageCodeMirror } from "./code/LazyAnyLanguageCodeMirror";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { useCallback, useState, useMemo } from "react";
+import { useCallback, useState, useMemo, useEffect } from "react";
 import { useDebounceControlledState } from "@/hooks/useDebounce";
 import { EditorView } from "@codemirror/view";
 import useEvent from "react-use-event-hook";
@@ -70,6 +70,12 @@ const CodeEditorComponent = (props: CodeEditorComponentProps) => {
     onChange: props.setValue,
     disabled: !Number.isFinite(props.debounce),
   });
+
+  // This is to sync the value from Python whenever the cell is updated
+  // as useState doesn't reinitialize on re-renders
+  useEffect(() => {
+    setLocalValue(props.value);
+  }, [props.value]);
 
   const handleChange = useCallback(
     (newValue: string) => {


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Previously, code editor would not refresh when you pass a new value, which I'm not sure is intentional. If this is a breaking change, maybe we can introduce a new argument.

Try:
```python
mo.ui.code_editor(value="HELLO")
```
Then, change to:
```python
mo.ui.code_editor(value="HIYA")
```
The output will still be the old value of HELLO. 

Relevant issue: [discord issue](https://discord.com/channels/1059888774789730424/1364664347917422664/1364964437361954898)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
