### PR TITLE
fix: return 'False' to let normal error handling occur

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -132,6 +132,11 @@ class _SetupContext:
         instance: Optional[BaseException],
         _traceback: Optional[TracebackType],
     ) -> Literal[False]:
+        if exception is not None:
+            # Always should fail, since static loading still allows bad apps to
+            # load.
+            return False
+
         # Manually hold on to defs for injection into script mode.
         if self._frame is not None:
             for var in self._cell.defs:
@@ -148,10 +153,6 @@ class _SetupContext:
             self._frame.f_locals["app"] = self._previous.get("app", app)
             self._previous = {}
 
-        if exception is not None:
-            # Always should fail, since static loading still allows bad apps to
-            # load.
-            raise exception
         return False
 
 


### PR DESCRIPTION
## 📝 Summary

Raising in __exit__ causes double errors, the correct handling is just to let it through

@akshayka OR @mscolnick
