### PR TITLE
Ensure terminal uses monospace font

### DIFF
--- a/frontend/src/components/terminal/terminal.tsx
+++ b/frontend/src/components/terminal/terminal.tsx
@@ -16,7 +16,8 @@ const TerminalComponent: React.FC<{
   const [{ terminal, fitAddon }] = useState(() => {
     // Create a new terminal instance
     const term = new Terminal({
-      fontFamily: 'Menlo, DejaVu Sans Mono, Consolas, Lucida Console, monospace',
+      fontFamily:
+        "Menlo, DejaVu Sans Mono, Consolas, Lucida Console, monospace",
       fontSize: 14,
     });
     const fitAddon = new FitAddon();

--- a/frontend/src/components/terminal/terminal.tsx
+++ b/frontend/src/components/terminal/terminal.tsx
@@ -18,11 +18,6 @@ const TerminalComponent: React.FC<{
     const term = new Terminal({
       fontFamily: 'Menlo, DejaVu Sans Mono, Consolas, Lucida Console, monospace',
       fontSize: 14,
-      theme: {
-        background: 'var(--slate-1)',
-        foreground: 'var(--slate-12)',
-        cursor: 'var(--slate-12)'
-      }
     });
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);

--- a/frontend/src/components/terminal/terminal.tsx
+++ b/frontend/src/components/terminal/terminal.tsx
@@ -15,7 +15,15 @@ const TerminalComponent: React.FC<{
   // eslint-disable-next-line react/hook-use-state
   const [{ terminal, fitAddon }] = useState(() => {
     // Create a new terminal instance
-    const term = new Terminal({});
+    const term = new Terminal({
+      fontFamily: 'Menlo, DejaVu Sans Mono, Consolas, Lucida Console, monospace',
+      fontSize: 14,
+      theme: {
+        background: 'var(--slate-1)',
+        foreground: 'var(--slate-12)',
+        cursor: 'var(--slate-12)'
+      }
+    });
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     return { terminal: term, fitAddon };

--- a/frontend/src/components/terminal/xterm.css
+++ b/frontend/src/components/terminal/xterm.css
@@ -1,7 +1,3 @@
 .xterm {
   padding: .5rem;
 }
-
-.xterm-rows {
-  font-family: var(--marimo-monospace-font) !important;
-}


### PR DESCRIPTION
I will gladly admit this is a minimum-effort PR that seems to do the trick. 

This is before (not monospace): 

![CleanShot 2025-04-29 at 15 27 53](https://github.com/user-attachments/assets/0a9991e7-0e74-4301-b8f8-742e909d7e53)

This is after:

![CleanShot 2025-04-29 at 15 28 01](https://github.com/user-attachments/assets/4f9ea97e-6418-4c81-83f6-abc78c128ccb)

It seems the CSS variable was somehow ignored, so the naive fix seems to be just to configure it directly from the component? Will gladly hear it if we prefer to go with the CSS route though.