### PR TITLE
improvement: make ruff optional, fallback to global ruff, prompt to install

### DIFF
--- a/marimo/_server/errors.py
+++ b/marimo/_server/errors.py
@@ -50,6 +50,7 @@ async def handle_error(request: Request, response: Any) -> Any:
             status_code=response.status_code,
         )
     if isinstance(response, ModuleNotFoundError) and response.name:
+        LOGGER.warning(response.msg)  # print to terminal
         try:
             app_state = AppState(request)
             session_id = app_state.get_current_session_id()

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -70,10 +70,8 @@ class BaseLspServer(LspServer):
                 stdout=subprocess.PIPE
                 if GLOBAL_SETTINGS.DEVELOPMENT_MODE
                 else subprocess.DEVNULL,
-                # pipe error output
-                # temporarily comment to make lsp-server work on windows
-                # TODO!  Find a nice way to keep stderr in future
-                # stderr=subprocess.PIPE,
+                # subprocess.PIPE in Windows breaks the lsp-server
+                stderr=subprocess.DEVNULL,
                 stdin=None,
                 text=True,
             )

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -105,6 +105,7 @@ def create_starlette_app(
             Exception: handle_error,
             HTTPException: handle_error,
             MarimoHTTPException: handle_error,
+            ModuleNotFoundError: handle_error,
         },
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@ dependencies = [
     "itsdangerous>=2.0.0",
     # for dataframe support
     "narwhals>=1.12.0",
-    # for cell formatting; if user version is not compatible, no-op
-    # so no lower bound needed
-    "ruff",
     # for packaging.version; not sure what the lower bound is.
     "packaging",
 ]


### PR DESCRIPTION
Fixes #4726

1. make ruff an optional dep
2. fallback to globally installed ruff e.g. `uv tool install ruff`
3. prompt to install by throwing `ModuleNotFound`