### PR TITLE
improvement: configurable max-size for mo.ui.file() upload

### DIFF
--- a/frontend/src/stories/file-upload.stories.tsx
+++ b/frontend/src/stories/file-upload.stories.tsx
@@ -15,6 +15,7 @@ export const AcceptAny = {
       label={null}
       value={[]}
       setValue={() => null}
+      max_size={100_000_000}
     />
   ),
 
@@ -30,6 +31,7 @@ export const AcceptLongText = {
       label={"Drop here, ".repeat(100)}
       value={[]}
       setValue={() => null}
+      max_size={100_000_000}
     />
   ),
 
@@ -45,6 +47,7 @@ export const AcceptTxtOnly = {
       label={null}
       value={[]}
       setValue={() => null}
+      max_size={100_000_000}
     />
   ),
 
@@ -60,6 +63,7 @@ export const AcceptTxtOnlyButton = {
       label={null}
       value={[]}
       setValue={() => null}
+      max_size={100_000_000}
     />
   ),
 
@@ -75,6 +79,7 @@ export const SingleFileArea = {
       label={null}
       value={[]}
       setValue={() => null}
+      max_size={100_000_000}
     />
   ),
 
@@ -90,6 +95,7 @@ export const SingleFileButton = {
       label={null}
       value={[]}
       setValue={() => null}
+      max_size={100_000_000}
     />
   ),
 

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -1324,6 +1324,8 @@ class file(UIElement[list[tuple[str, str]], Sequence[FileUploadResults]]):
         on_change (Callable[[Sequence[FileUploadResults]], None], optional):
             Optional callback to run when this element's value changes.
             Defaults to None.
+        max_size (int, optional): The maximum size of the file to upload
+            (in bytes). Defaults to 100MB.
     """
 
     _name: Final[str] = "marimo-file"
@@ -1334,6 +1336,7 @@ class file(UIElement[list[tuple[str, str]], Sequence[FileUploadResults]]):
         multiple: bool = False,
         kind: Literal["button", "area"] = "button",
         *,
+        max_size: int = 100_000_000,  # 100MB default
         label: str = "",
         on_change: Optional[
             Callable[[Sequence[FileUploadResults]], None]
@@ -1351,6 +1354,9 @@ class file(UIElement[list[tuple[str, str]], Sequence[FileUploadResults]]):
                     f"Invalid types: {', '.join(invalid_types)}"
                 )
 
+        if max_size <= 0:
+            raise ValueError("max_size must be greater than 0")
+
         super().__init__(
             component_name=file._name,
             initial_value=[],
@@ -1359,6 +1365,7 @@ class file(UIElement[list[tuple[str, str]], Sequence[FileUploadResults]]):
                 "filetypes": filetypes if filetypes is not None else [],
                 "multiple": multiple,
                 "kind": kind,
+                "max_size": max_size,
             },
             on_change=on_change,
         )

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -608,6 +608,23 @@ def test_file_validation() -> None:
     assert "or contain a forward slash" in str(e.value)
     assert "doc, pdf" in str(e.value)
 
+    # Test max_size validation
+    with pytest.raises(ValueError) as e:
+        ui.file(max_size=0)
+    assert "max_size must be greater than 0" in str(e.value)
+
+    with pytest.raises(ValueError) as e:
+        ui.file(max_size=-1)
+    assert "max_size must be greater than 0" in str(e.value)
+
+    # Test default max_size
+    f = ui.file()
+    assert f._component_args["max_size"] == 100_000_000  # 100MB
+
+    # Test custom max_size
+    f = ui.file(max_size=50_000_000)  # 50MB
+    assert f._component_args["max_size"] == 50_000_000
+
 
 @pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")
 def test_numpy_steps() -> None:


### PR DESCRIPTION
Fixes #4723

`mo.ui.file()` takes in a `max_size` argument for the file size