### PR TITLE
docs: document markdown format and add quarto/ mkdocs plugins

### DIFF
--- a/docs/guides/coming_from/jupytext.md
+++ b/docs/guides/coming_from/jupytext.md
@@ -7,11 +7,14 @@ are stored as `.py` files by default. However, Jupytext works with IPython
 notebooks, whereas marimo works with marimo notebooks, which are not based
 on IPython/Jupyter. Here's a comparison to help you transition smoothly.
 
+!!! tip "marimo also has a markdown fileformat"
+    Learn more about it with `marimo tutorials markdown-format`.
+
 ## Notebook Format
 
 | Jupytext | marimo |
 |----------|--------|
-| Jupytext uses comments or special markers to define cell types in notebooks. | Notebooks are pure Python (`.py`) files by default, using standard Python syntax, such as decorators and functions, to define cells. |
+| Jupytext uses comments or special markers to define cell types in notebooks. | Notebooks are pure Python (`.py`) files by default, using standard Python syntax, such as decorators and functions, to define cells. In markdown form (`.md`), marimo has no special syntax, meaning your notebook will render well in locations like Github. |
 
 ## Converting Jupyter notebooks
 

--- a/docs/guides/coming_from/jupytext.md
+++ b/docs/guides/coming_from/jupytext.md
@@ -8,7 +8,7 @@ notebooks, whereas marimo works with marimo notebooks, which are not based
 on IPython/Jupyter. Here's a comparison to help you transition smoothly.
 
 !!! tip "marimo also has a markdown fileformat"
-    Learn more about it with `marimo tutorials markdown-format`.
+    Learn more by running `marimo tutorial markdown-format` at the command-line.
 
 ## Notebook Format
 

--- a/docs/guides/editor_features/watching.md
+++ b/docs/guides/editor_features/watching.md
@@ -11,9 +11,9 @@ have the changes automatically reflected in your browser.
     For better performance, install [watchdog](https://pypi.org/project/watchdog/).
     Without watchdog, marimo resorts to polling.
 
-## marimo's File Format
+## marimo's File format
 
-### Python File Format
+### Python file format
 
 !!! tip "File format tutorial"
 
@@ -83,10 +83,9 @@ def cell_2(x: int, y: str):
     z = f"{x} & {y}"
 ```
 
-### Markdown File Format
+### Markdown file format
 
 !!! tip "Markdown File format tutorial"
-
     Run `marimo tutorial markdown-format` at the command line for a full guide.
 
 marimo notebooks can also be stored as Markdown files. This is a good option

--- a/docs/guides/editor_features/watching.md
+++ b/docs/guides/editor_features/watching.md
@@ -11,15 +11,17 @@ have the changes automatically reflected in your browser.
     For better performance, install [watchdog](https://pypi.org/project/watchdog/).
     Without watchdog, marimo resorts to polling.
 
-## marimo's file format
+## marimo's File Format
+
+### Python File Format
 
 !!! tip "File format tutorial"
 
     Run `marimo tutorial fileformat` at the command line for a full guide.
 
-marimo stores notebooks as Python cells. Cells are stored as functions,
-decorated with`@app.cell`; you can optionally give cells names in the editor
-UI or by editing the notebook file.
+marimo stores notebooks as Python files with cell definitions. Cells are stored
+as functions, decorated with`@app.cell`; you can optionally give cells names in
+the editor UI or by editing the notebook file.
 
 ```python
 @app.cell
@@ -53,6 +55,74 @@ def my_function(x): ...
 @app.class_definition
 class MyClass: ...
 ```
+
+!!! question "Want to use your own LSP for typing?"
+    Explicitly typing your definitions will let marimo carry the annotations
+    into function signatures. For instance
+
+```python
+# cell 1
+x: int
+y: str
+
+# cell 2
+z = f"{x} & {y}"
+```
+
+will be serialized as
+
+```python
+@app.cell
+def cell_1():
+    x: int
+    y: str
+    return x, y
+
+@app.cell
+def cell_2(x: int, y: str):
+    z = f"{x} & {y}"
+```
+
+### Markdown File Format
+
+!!! tip "Markdown File format tutorial"
+
+    Run `marimo tutorial markdown-format` at the command line for a full guide.
+
+marimo notebooks can also be stored as Markdown files. This is a good option
+for prose heavy text, and can be easy to navigate and edit in external editors.
+
+marimo conforms to standard markdown document format, and will render most
+places like Github.
+Metadata in this file format is saved in the frontmatter, which marimo may use
+for information like [sandboxing](../package_reproducibility.md), and the
+marimo version. All other fields are kept, but ignored.
+
+For execution, marimo extracts code fences that contain `marimo` in braces. For
+instance `python {marimo}`, `{marimo}` or `{.marimo .python}`. The marimo
+editor uses `python {.marimo}` which is Pandoc compatible, and correctly
+processed by text highlighters.
+
+````markdown
+---
+title: My Notebook
+marimo-version: 0.0.0
+description: A notebook with a description
+---
+
+# Just a notebook
+
+```python {.marimo}
+print("Hello World!")
+```
+````
+
+marimo's markdown format can be used with a [`mkdocs
+plugin`](https://github.com/marimo-team/mkdocs-marimo), and
+[`Quarto`](https://github.com/marimo-team/quarto-marimo).
+
+Note, there is some feature loss in this format. Reactive tests will not work,
+and the notebooks cannot be imported or used as a library.
 
 ## `marimo edit --watch`
 

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -104,6 +104,9 @@ marimo export md notebook.py -o notebook.md
 
 This can be useful to plug into other tools that read markdown, such as [Quarto](https://quarto.org/) or [MyST](https://myst-parser.readthedocs.io/).
 
+!!! tip "marimo can directly open markdown files as notebooks"
+    Learn more with `marimo tutorial markdown-format` at the command line.
+
 You can also convert the markdown back to a marimo notebook:
 
 ```bash
@@ -121,7 +124,10 @@ marimo export ipynb notebook.py -o notebook.ipynb
 
 ## Exporting to PDF, slides, or rst
 
-If you export to a Jupyter notebook, you can leverage various Jupyter ecosystem tools. For PDFs, you will
+The marimo [Quarto](https://www.github.com/marimo-team/quarto-marimo) plugin
+enables exporting to PDF and other formats with Pandoc. See this [publishing](./publishing/quarto.md) for more details.
+
+Howeverm If you export to a Jupyter notebook, you can leverage various other Jupyter ecosystem tools. For PDFs, you will
 need to have [Pandoc](https://nbconvert.readthedocs.io/en/latest/install.html#installing-pandoc) and [Tex](https://nbconvert.readthedocs.io/en/latest/install.html#installing-tex) installed. The examples below use `uvx`, which you can obtain by [installing `uv`](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```bash

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -127,7 +127,7 @@ marimo export ipynb notebook.py -o notebook.ipynb
 The marimo [Quarto](https://www.github.com/marimo-team/quarto-marimo) plugin
 enables exporting to PDF and other formats with Pandoc. See this [publishing](./publishing/quarto.md) for more details.
 
-Howeverm If you export to a Jupyter notebook, you can leverage various other Jupyter ecosystem tools. For PDFs, you will
+However If you export to a Jupyter notebook, you can leverage various other Jupyter ecosystem tools. For PDFs, you will
 need to have [Pandoc](https://nbconvert.readthedocs.io/en/latest/install.html#installing-pandoc) and [Tex](https://nbconvert.readthedocs.io/en/latest/install.html#installing-tex) installed. The examples below use `uvx`, which you can obtain by [installing `uv`](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```bash

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -127,7 +127,7 @@ marimo export ipynb notebook.py -o notebook.ipynb
 The marimo [Quarto](https://www.github.com/marimo-team/quarto-marimo) plugin
 enables exporting to PDF and other formats with Pandoc. See this [publishing](./publishing/quarto.md) for more details.
 
-However If you export to a Jupyter notebook, you can leverage various other Jupyter ecosystem tools. For PDFs, you will
+However, if you export to a Jupyter notebook, you can leverage various other Jupyter ecosystem tools. For PDFs, you will
 need to have [Pandoc](https://nbconvert.readthedocs.io/en/latest/install.html#installing-pandoc) and [Tex](https://nbconvert.readthedocs.io/en/latest/install.html#installing-tex) installed. The examples below use `uvx`, which you can obtain by [installing `uv`](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```bash

--- a/docs/guides/package_reproducibility.md
+++ b/docs/guides/package_reproducibility.md
@@ -151,6 +151,26 @@ In this example:
 
 This approach ensures that specific packages are always fetched from your designated custom index, while other packages continue to be fetched from the default PyPI repository.
 
+## Markdown File Support
+
+Sandboxing support is also provided in marimo's markdown file format under the
+`pyproject` entry of your frontmatter.
+
+```markdown
+---
+title: My Notebook
+marimo-version: 0.0.0
+pyproject: |
+  requires-python: ">=3.11"
+  dependencies:
+    - pandas==<version>
+    - altair==<version>
+---
+```
+
+Note, that sandboxing will still work in the `header` entry of markdown
+frontmatter.
+
 ## Configuration
 
 Running marimo in a sandbox environment uses `uv` to create an isolated virtual

--- a/docs/guides/package_reproducibility.md
+++ b/docs/guides/package_reproducibility.md
@@ -153,7 +153,7 @@ This approach ensures that specific packages are always fetched from your design
 
 ## Markdown file support
 
-Sandboxing support is also provided in marimo's markdown file format under the
+Sandboxing support is also provided in [marimo's markdown file format](./editor_features/watching.md#markdown-file-format) under the
 `pyproject` entry of your frontmatter.
 
 ```markdown

--- a/docs/guides/package_reproducibility.md
+++ b/docs/guides/package_reproducibility.md
@@ -151,7 +151,7 @@ In this example:
 
 This approach ensures that specific packages are always fetched from your designated custom index, while other packages continue to be fetched from the default PyPI repository.
 
-## Markdown File Support
+## Markdown file support
 
 Sandboxing support is also provided in marimo's markdown file format under the
 `pyproject` entry of your frontmatter.

--- a/docs/guides/publishing/index.md
+++ b/docs/guides/publishing/index.md
@@ -22,3 +22,5 @@ This guide provides an overview of the various ways to publish marimo notebooks.
 | [Self-host WebAssembly notebooks](self_host_wasm.md)  | Self-hosting interactive WebAssembly (HTML export) notebooks |
 | [View notebooks on GitHub](view_outputs_on_github.md) | Viewing notebook outputs on GitHub                           |
 | [Deploy on a backend](deploy.md)                      | Deploying notebooks on backends                              |
+| [With MkDocs](mkdocs.md)                              | Publish reactive websites with MkDocs from markdown          |
+| [With Quarto](quarto.md)                              | Publish reactive websites with Quarto from markdown          |

--- a/docs/guides/publishing/mkdocs.md
+++ b/docs/guides/publishing/mkdocs.md
@@ -2,7 +2,7 @@
 
 [MkDocs](https://www.mkdocs.org/) is a widely used static site generator that uses plain markdown files as page inputs.
 
-You can use MkDocs to publish your marimo notebooks as a interactive website with marimo's [MkDocs extension](https://github.com/marimo-team/quarto-marimo).
+You can use MkDocs to publish your marimo notebooks as a interactive website with marimo's [MkDocs extension](https://github.com/marimo-team/mkdocs-marimo).
 
 !!! tip "Try the markdown file format tutorial"
     Learn more with `marimo tutorial markdown-format` at the command line.

--- a/docs/guides/publishing/mkdocs.md
+++ b/docs/guides/publishing/mkdocs.md
@@ -1,0 +1,10 @@
+# Publishing with MkDocs
+
+[MkDocs](https://www.mkdocs.org/) is a widely used static site generator that uses plain markdown files as page inputs.
+
+You can use MkDocs to publish your marimo notebooks as a interactive website with marimo's [MkDocs extension](https://github.com/marimo-team/quarto-marimo).
+
+!!! tip "Try the markdown file format tutorial"
+    Learn more with `marimo tutorials markdown-format`.
+
+Alternatively, see our [Quarto guide](quarto.md) for other methods of publishing marimo's markdown format.

--- a/docs/guides/publishing/mkdocs.md
+++ b/docs/guides/publishing/mkdocs.md
@@ -5,6 +5,6 @@
 You can use MkDocs to publish your marimo notebooks as a interactive website with marimo's [MkDocs extension](https://github.com/marimo-team/quarto-marimo).
 
 !!! tip "Try the markdown file format tutorial"
-    Learn more with `marimo tutorials markdown-format`.
+    Learn more with `marimo tutorial markdown-format` at the command line.
 
 Alternatively, see our [Quarto guide](quarto.md) for other methods of publishing marimo's markdown format.

--- a/docs/guides/publishing/quarto.md
+++ b/docs/guides/publishing/quarto.md
@@ -1,0 +1,17 @@
+# Publishing with Quarto
+
+[Quarto](https://quarto.org/) is a commonly
+used open-source scientific and technical
+publishing system that can be used to create
+documents, presentations, websites, and more.
+Quarto supports a variety of output formats,
+including HTML, PDF, and Word.
+
+marimo's [Quarto extension](https://github.com/marimo-team/quarto-marimo) allows you to utilize Quarto on marimo's markdown format to produce interactive, reactive, webpages.
+
+!!! tip "Try the markdown file format tutorial"
+    Learn more with `marimo tutorials markdown-format`.
+
+To encourage quarto support, `.qmd` and `.md` files are interchangeable to marimo as an editor.
+
+Alternatively, see our [MkDocs guide](mkdocs.md) for other methods of publishing marimo's markdown format.

--- a/docs/guides/publishing/quarto.md
+++ b/docs/guides/publishing/quarto.md
@@ -10,7 +10,7 @@ including HTML, PDF, and Word.
 marimo's [Quarto extension](https://github.com/marimo-team/quarto-marimo) allows you to utilize Quarto on marimo's markdown format to produce interactive, reactive, webpages.
 
 !!! tip "Try the markdown file format tutorial"
-    Learn more with `marimo tutorials markdown-format`.
+    Learn more with `marimo tutorial markdown-format` at the command line.
 
 To encourage quarto support, `.qmd` and `.md` files are interchangeable to marimo as an editor.
 

--- a/docs/guides/reusing_functions.md
+++ b/docs/guides/reusing_functions.md
@@ -116,6 +116,7 @@ print(stats)
 
 - Functions cannot depend on variables defined in regular cells
 - Like other cells, cyclic dependencies between functions are not allowed
+- Functions cannot be exported from notebooks in [marimo's markdown format](editor_features/watching.md#markdown-file-support).
 
 ## Learn more
 


### PR DESCRIPTION
## 📝 Summary

Update the docs to mention the markdown format in various places, in addition to mentioning the mkdocs and quarto plugins

@akshayka OR @mscolnick
