### PR TITLE
fix: invalid f-string in markdown mode breaks

### DIFF
--- a/marimo/_server/export/utils.py
+++ b/marimo/_server/export/utils.py
@@ -56,7 +56,7 @@ def _const_or_id(args: ast.stmt) -> str:
 
 
 def get_markdown_from_cell(
-    cell: Cell, code: str, native_callout: bool = False
+    cell: Cell, code: str
 ) -> Optional[str]:
     """Attempt to extract markdown from a cell, or return None"""
 
@@ -73,24 +73,13 @@ def get_markdown_from_cell(
     # Wish there was a more compact to ignore ignore[attr-defined] for all.
     try:
         (body,) = ast.parse(code).body
-        callout = None
         if body.value.func.attr == "md":  # type: ignore[attr-defined]
             value = body.value  # type: ignore[attr-defined]
-        elif body.value.func.attr == "callout":  # type: ignore[attr-defined]
-            if not native_callout:
-                return None
-            if body.value.args:  # type: ignore[attr-defined]
-                callout = _const_string(body.value.args)  # type: ignore[attr-defined]
-            else:
-                (keyword,) = body.value.keywords  # type: ignore[attr-defined]
-                assert keyword.arg == "kind"
-                callout = _const_string([keyword.value])  # type: ignore
-            value = body.value.func.value  # type: ignore[attr-defined]
         else:
             return None
         assert value.func.value.id == "mo"
         md_lines = _const_string(value.args).split("\n")
-    except (AssertionError, AttributeError, ValueError):
+    except (AssertionError, AttributeError, ValueError, SyntaxError):
         # No reason to explicitly catch exceptions if we can't parse out
         # markdown. Just handle it as a code block.
         return None
@@ -100,14 +89,6 @@ def get_markdown_from_cell(
     md_lines = [line.rstrip() for line in md_lines]
     md = dedent(md_lines[0]) + "\n" + dedent("\n".join(md_lines[1:]))
     md = md.strip()
-
-    if callout:
-        md = dedent(
-            f"""
-          ::: {{.callout-{callout}}}
-          {md}
-          :::"""
-        )
     return md
 
 

--- a/marimo/_server/export/utils.py
+++ b/marimo/_server/export/utils.py
@@ -55,9 +55,7 @@ def _const_or_id(args: ast.stmt) -> str:
     return f"{args.id}"  # type: ignore[attr-defined]
 
 
-def get_markdown_from_cell(
-    cell: Cell, code: str
-) -> Optional[str]:
+def get_markdown_from_cell(cell: Cell, code: str) -> Optional[str]:
     """Attempt to extract markdown from a cell, or return None"""
 
     if not (cell.refs == {"mo"} and not cell.defs):

--- a/tests/_server/export/test_utils.py
+++ b/tests/_server/export/test_utils.py
@@ -1,0 +1,30 @@
+from marimo._ast.compiler import compile_cell
+from marimo._server.export.utils import get_markdown_from_cell
+
+
+def test_extract_markdown_base():
+    # Test with a simple markdown string
+    empty_markdown_str = "mo.md('hello')"
+    markdown = get_markdown_from_cell(
+        compile_cell(empty_markdown_str, "id"), empty_markdown_str
+    )
+    assert markdown == "hello"
+
+
+def test_extract_markdown_empty():
+    # Test with a simple markdown string
+    empty_markdown_str = "mo.md()"
+    markdown = get_markdown_from_cell(
+        compile_cell(empty_markdown_str, "id"), empty_markdown_str
+    )
+    assert markdown is None
+
+
+def test_extract_markdown_broken():
+    # Test with a simple markdown string
+    empty_markdown_str = "mo.md()"
+    # This can occut because the cell isn't recompiled at this point.
+    markdown = get_markdown_from_cell(
+        compile_cell(empty_markdown_str, "id"), "mo.md(f'{broken(}')"
+    )
+    assert markdown is None


### PR DESCRIPTION
## 📝 Summary

Removed callout code (I never implemented this in the format, and now we have native admonitions)
+ add syntax error catch for parse (export runtime error). Added a unit test because catching the actual behavior is a dynamic thing

@akshayka OR @mscolnick
