### PR TITLE
fix: per-block reference resolution

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -124,6 +124,8 @@ class RefData:
 
     # Whether the ref was deleted
     deleted: bool
+    # Block in which this ref was referenced
+    block: Block
     # Ancestors of the block in which this ref was used
     parent_blocks: list[Block]
 
@@ -157,7 +159,10 @@ class ScopedVisitor(ast.NodeVisitor):
         self.ref_stack: list[set[Name]] = [set()]
         self.obscured_scope_stack: list[ObscuredScope] = []
         # Mapping from referenced names to their metadata
-        self._refs: dict[Name, RefData] = {}
+        # Each referenced name may be defined multiple blocks;
+        # ie, self._refs maps each name to RefData for each block it was
+        # defined in
+        self._refs: dict[Name, list[RefData]] = {}
         # Function (node, name, block stack) -> None
         self._on_def = on_def if on_def is not None else lambda *_: None
         # Function (node) -> None
@@ -189,7 +194,11 @@ class ScopedVisitor(ast.NodeVisitor):
     @property
     def deleted_refs(self) -> set[Name]:
         """Referenced names that were deleted with `del`."""
-        return set(name for name in self._refs if self._refs[name].deleted)
+        return set(
+            name
+            for name in self._refs
+            if any(ref.deleted for ref in self._refs[name])
+        )
 
     def _if_local_then_mangle(
         self, name: str, ignore_scope: bool = False
@@ -242,25 +251,45 @@ class ScopedVisitor(ast.NodeVisitor):
         self, node: NamedNode | None, name: Name, deleted: bool
     ) -> None:
         """Register a referenced name."""
-        self._refs[name] = RefData(
-            deleted=deleted,
-            parent_blocks=self.block_stack[:-1],
-        )
+        if name not in self._refs:
+            self._refs[name] = []
+
+        # Register the ref if it doesn't already exist
+        current_block = self.block_stack[-1]
+        parents = self.block_stack[:-1]
+        if all(ref.block != current_block for ref in self._refs[name]):
+            # The reference does not yet exist in the current block, so
+            # we add it.
+            self._refs[name].append(
+                RefData(
+                    deleted=deleted,
+                    parent_blocks=parents,
+                    block=current_block,
+                )
+            )
+
         self.ref_stack[-1].add(name)
         if node is not None:
             self._on_ref(node)
 
-    def _remove_ref(self, name: Name) -> None:
-        """Remove a referenced name."""
-        del self._refs[name]
+    def _remove_ref(self, name: Name, block: Block) -> None:
+        """Remove references of name with block among its parents."""
+        refs = []
+        for ref in self._refs[name]:
+            if block not in ref.parent_blocks:
+                refs.append(ref)
+        self._refs[name] = refs
+        if not self._refs[name]:
+            del self._refs[name]
 
     def _define_in_block(
         self, name: Name, variable_data: VariableData, block_idx: int
     ) -> None:
         """Define a name in a given block."""
 
-        self.block_stack[block_idx].defs.add(name)
-        self.block_stack[block_idx].variable_data[name].append(variable_data)
+        block = self.block_stack[block_idx]
+        block.defs.add(name)
+        block.variable_data[name].append(variable_data)
         # If `name` is added to the top-level block, it is also evicted from
         # any captured refs (if present) --- this handles cases where a name is
         # encountered and captured before it is declared, such as in
@@ -270,12 +299,11 @@ class ScopedVisitor(ast.NodeVisitor):
         #   print(x)
         # x = 0
         # ```
-        if (
-            name in self._refs
-            and self.block_stack[block_idx] in self._refs[name].parent_blocks
+        if name in self._refs and any(
+            block in ref.parent_blocks for ref in self._refs[name]
         ):
             # `name` was used as a capture, not a reference
-            self._remove_ref(name)
+            self._remove_ref(name, block)
 
     def _define(
         self, node: NamedNode | None, name: Name, variable_data: VariableData

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -257,7 +257,17 @@ class ScopedVisitor(ast.NodeVisitor):
         # Register the ref if it doesn't already exist
         current_block = self.block_stack[-1]
         parents = self.block_stack[:-1]
-        if all(ref.block != current_block for ref in self._refs[name]):
+        found_ref: RefData | None = None
+
+        for ref in self._refs[name]:
+            if ref.block == current_block:
+                found_ref = ref
+
+        if found_ref is not None and deleted:
+            # The ref may have already existed, but perhaps it
+            # wasn't deleted
+            found_ref.deleted = True
+        elif found_ref is None:
             # The reference does not yet exist in the current block, so
             # we add it.
             self._refs[name].append(

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -214,11 +214,7 @@ class ScopedVisitor(ast.NodeVisitor):
         return set(
             name
             for name in self._refs
-            if any(
-                ref.deleted
-                for ref in self._refs[name]
-                if len(ref.parent_blocks) == 1
-            )
+            if any(ref.deleted for ref in self._refs[name])
         )
 
     def _if_local_then_mangle(

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -829,7 +829,9 @@ class ScopedVisitor(ast.NodeVisitor):
         ]
         for name in node.names:
             self.block_stack[-1].global_names.add(name)
-            if not self._is_defined(name):
+            # We only add a reference if the name is not
+            # already defined at the global scope
+            if not self.block_stack[0].is_defined(name):
                 self._add_ref(node, name, deleted=False)
         return node
 

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -829,7 +829,8 @@ class ScopedVisitor(ast.NodeVisitor):
         ]
         for name in node.names:
             self.block_stack[-1].global_names.add(name)
-            self._add_ref(node, name, deleted=False)
+            if not self._is_defined(name):
+                self._add_ref(node, name, deleted=False)
         return node
 
     def visit_Import(self, node: ast.Import) -> ast.Import:

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -482,6 +482,36 @@ def test_global_def() -> None:
     }
 
 
+def test_global_not_ref() -> None:
+    code = cleandoc(
+        """
+        x = 0
+        def foo(a):
+          global x
+        """
+    )
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == set(["foo", "x"])
+    assert v.refs == set()
+
+
+def test_global_not_ref_define_later() -> None:
+    code = cleandoc(
+        """
+        def foo(a):
+          global x
+        x = 0
+        """
+    )
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == set(["foo", "x"])
+    assert v.refs == set()
+
+
 def test_global_ref() -> None:
     code = cleandoc(
         """

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -972,6 +972,44 @@ def test_outer_ref_not_resolved_by_inner_resolution() -> None:
     assert v.refs == {"x"}
 
 
+def test_not_deleted_ref() -> None:
+    code = cleandoc(
+        """
+    x = 0
+    def fn():
+        if False:
+            z = x
+            del x
+    x
+    """
+    )
+
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == {"x", "fn"}
+    assert not v.refs
+    assert not v.deleted_refs
+
+
+def test_deleted_ref() -> None:
+    code = cleandoc(
+        """
+    def fn():
+        if False:
+            z = x
+            del x
+    """
+    )
+
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == {"fn"}
+    assert v.refs == {"x"}
+    assert v.deleted_refs == {"x"}
+
+
 HAS_DEPS = DependencyManager.duckdb.has()
 
 

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -512,6 +512,24 @@ def test_global_not_ref_define_later() -> None:
     assert v.refs == set()
 
 
+def test_global_after_scoped_def() -> None:
+    code = cleandoc(
+        """
+        def f():
+            x = 0
+
+            def g():
+                global x
+                x = 1
+        """
+    )
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == set(["f", "x"])
+    assert not v.refs
+
+
 def test_global_ref() -> None:
     code = cleandoc(
         """

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -1036,6 +1036,17 @@ def test_outer_ref_not_resolved_by_inner_resolution() -> None:
     assert v.refs == {"x"}
 
 
+def test_deleted_ref_basic() -> None:
+    code = "del x"
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert not v.defs
+    assert v.refs == {"x"}
+    breakpoint()
+    assert v.deleted_refs == {"x"}
+
+
 def test_not_deleted_ref() -> None:
     code = cleandoc(
         """

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -954,6 +954,24 @@ def test_private_ref_requirement_caught() -> None:
     }
 
 
+def test_outer_ref_not_resolved_by_inner_resolution() -> None:
+    code = cleandoc(
+        """
+        def f():
+            x
+            def g():
+                def h():
+                    x
+                x = 0
+        """
+    )
+    v = visitor.ScopedVisitor()
+    mod = ast.parse(code)
+    v.visit(mod)
+    assert v.defs == {"f"}
+    assert v.refs == {"x"}
+
+
 HAS_DEPS = DependencyManager.duckdb.has()
 
 


### PR DESCRIPTION
For each instance of a referenced name, we need to track the blocks it appears in;
previously, references on new blocks (scopes) were evicting
references on other scopes. These newer references could be
resolved but the other ones weren't, leading to us drop references.

Fixes #4742 