### PR TITLE
fix: json encode memory view, and anywidget partial updates

### DIFF
--- a/marimo/_plugins/core/json_encoder.py
+++ b/marimo/_plugins/core/json_encoder.py
@@ -29,6 +29,9 @@ class WebComponentEncoder(JSONEncoder):
             return o
 
         # Handle bytes objects
+        if isinstance(o, memoryview):
+            o = o.tobytes()
+
         if isinstance(o, bytes):
             try:
                 return o.decode("utf-8")

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -129,7 +129,14 @@ class anywidget(UIElement[T, T]):
         def on_change(change: T) -> None:
             _put_buffers = ipywidgets.widgets.widget._put_buffers  # type: ignore
             _put_buffers(change, buffer_paths, buffers)
-            widget.set_state(change)
+            current_state: dict[str, Any] = widget.get_state()
+            changed_state: dict[str, Any] = {}
+            for k, v in change.items():
+                if k not in current_state:
+                    changed_state[k] = v
+                elif current_state[k] != v:
+                    changed_state[k] = v
+            widget.set_state(changed_state)
 
         js_hash: str = hashlib.md5(
             js.encode("utf-8"), usedforsecurity=False

--- a/tests/_plugins/core/test_json_encoder.py
+++ b/tests/_plugins/core/test_json_encoder.py
@@ -207,6 +207,13 @@ def test_bytes_encoding() -> None:
     assert encoded == '"hello"'
 
 
+def test_memoryview_encoding() -> None:
+    bytes_obj = b"hello"
+    memview = memoryview(bytes_obj)
+    encoded = json.dumps(memview, cls=WebComponentEncoder)
+    assert encoded == '"hello"'
+
+
 def test_set_encoding() -> None:
     set_obj = set(["a", "b"])
     encoded = json.dumps(set_obj, cls=WebComponentEncoder)

--- a/tests/_plugins/ui/_impl/test_anywidget.py
+++ b/tests/_plugins/ui/_impl/test_anywidget.py
@@ -405,3 +405,30 @@ x = as_marimo_element.count
         widget = UnhashableWidget()
         wrapped = from_anywidget(widget)
         assert wrapped is not None
+
+    @staticmethod
+    async def test_partial_state_updates() -> None:
+        class MultiTraitWidget(_anywidget.AnyWidget):
+            _esm = ""
+            a = traitlets.Int(1).tag(sync=True)
+            b = traitlets.Int(2).tag(sync=True)
+            c = traitlets.Int(3).tag(sync=True)
+
+        wrapped = anywidget(MultiTraitWidget())
+        assert wrapped.value == {"a": 1, "b": 2, "c": 3}
+
+        # Test partial update
+        wrapped._update({"a": 10})
+        assert wrapped.value == {"a": 10, "b": 2, "c": 3}
+
+        # Test multiple partial updates
+        wrapped._update({"b": 20})
+        assert wrapped.value == {"a": 10, "b": 20, "c": 3}
+
+        # Test updating all traits
+        wrapped._update({"a": 100, "b": 200, "c": 300})
+        assert wrapped.value == {"a": 100, "b": 200, "c": 300}
+
+        # Test updating with new traits
+        wrapped._update({"d": 4})
+        assert wrapped.value == {"a": 100, "b": 200, "c": 300, "d": 4}


### PR DESCRIPTION
- this adds `memoryview` to our cusotm json encoder
- and only passed the subset of state changes to `widget.set_state` 