### PR TITLE
feat: support ipython display update

### DIFF
--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Optional
 
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._output.builder import h
@@ -22,7 +22,7 @@ class IPythonFormatter(FormatterFactory):
         from marimo._runtime.output import _output
 
         # Dictionary to store display objects by ID
-        display_objects: Dict[str, Any] = {}
+        display_objects: dict[str, Any] = {}
 
         old_display = IPython.display.display
         old_update_display = getattr(IPython.display, "update_display", None)

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Dict, Optional
 
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._output.builder import h
@@ -21,39 +21,104 @@ class IPythonFormatter(FormatterFactory):
         from marimo._output import formatting
         from marimo._runtime.output import _output
 
+        # Dictionary to store display objects by ID
+        display_objects: Dict[str, Any] = {}
+
         old_display = IPython.display.display
-        # monkey patch IPython.display.display, which imperatively writes
+        old_update_display = getattr(IPython.display, "update_display", None)
+
+        # DisplayHandle class to match IPython's API
+        class DisplayHandle:
+            def __init__(self, display_id: str):
+                self.display_id = display_id
+
+            def update(self, obj: Any, **kwargs: Any) -> None:
+                update_display(obj, display_id=self.display_id, **kwargs)
+
+        # Monkey patch IPython.display.display, which imperatively writes
         # outputs to the frontend
-
         @functools.wraps(old_display)
-        def display(*objs: Any, **kwargs: Any) -> None:
-            # IPython.display.display returns a DisplayHandle, which
-            # can be used to update the displayed object. We don't support
-            # that yet ...
-
+        def display(*objs: Any, **kwargs: Any) -> Optional[DisplayHandle]:
             # If clear is True, clear the output before displaying
             if kwargs.pop("clear", False):
                 _output.clear()
+
+            # Get display_id if provided
+            display_id = kwargs.pop("display_id", None)
+            if display_id is True:  # Generate a new display_id if True
+                import uuid
+                display_id = str(uuid.uuid4())
 
             raw = kwargs.pop("raw", False)
             for value in objs:
                 # raw means it's a mimebundle, with the key (mime) and value (raw data)
                 if raw and isinstance(value, dict):
-                    _output.append(ReprMimeBundle(value))
+                    output_value = ReprMimeBundle(value)
                 else:
-                    _output.append(value)
+                    output_value = value
+                
+                # Store the object if display_id is provided
+                if display_id is not None:
+                    display_objects[display_id] = output_value
+                
+                _output.append(output_value)
+            
+            # Return a DisplayHandle if display_id is provided
+            if display_id is not None:
+                return DisplayHandle(display_id)
+            return None
 
+        # Implement update_display function
+        def update_display(obj: Any, *, display_id: str, **kwargs: Any) -> None:
+            """Update an existing display by id
+
+            Parameters
+            ----------
+            obj : Any
+                The object with which to update the display
+            display_id : str
+                The id of the display to update
+            """
+            if display_id not in display_objects:
+                return
+            
+            # Clear the output before updating
+            _output.clear()
+            
+            # Update the stored object
+            raw = kwargs.pop("raw", False)
+            if raw and isinstance(obj, dict):
+                display_objects[display_id] = ReprMimeBundle(obj)
+            else:
+                display_objects[display_id] = obj
+            
+            # Append the updated object to the output
+            _output.append(display_objects[display_id])
+
+        # Patch both display and update_display
         IPython.display.display = display
+        IPython.display.update_display = update_display
+        
         # Patching display_functions handles display_markdown, display_x, etc.
         try:
             IPython.core.display_functions.display = display  # type: ignore
+            IPython.core.display_functions.update_display = update_display  # type: ignore
         except AttributeError:
             pass
 
         def unpatch() -> None:
             IPython.display.display = old_display  # type: ignore
+            if old_update_display is not None:
+                IPython.display.update_display = old_update_display  # type: ignore
+            else:
+                delattr(IPython.display, "update_display")
+                
             try:
                 IPython.core.display_functions.display = old_display  # type: ignore
+                if old_update_display is not None:
+                    IPython.core.display_functions.update_display = old_update_display  # type: ignore
+                else:
+                    delattr(IPython.core.display_functions, "update_display")
             except AttributeError:
                 pass
 

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -83,7 +83,7 @@ class IPythonFormatter(FormatterFactory):
                 return
             
             # Clear the output before updating
-            _output.clear()
+            # _output.clear()
             
             # Update the stored object
             raw = kwargs.pop("raw", False)
@@ -93,7 +93,7 @@ class IPythonFormatter(FormatterFactory):
                 display_objects[display_id] = obj
             
             # Append the updated object to the output
-            _output.append(display_objects[display_id])
+            _output.replace(display_objects[display_id])
 
         # Patch both display and update_display
         IPython.display.display = display

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -47,6 +47,7 @@ class IPythonFormatter(FormatterFactory):
             display_id = kwargs.pop("display_id", None)
             if display_id is True:  # Generate a new display_id if True
                 import uuid
+
                 display_id = str(uuid.uuid4())
 
             raw = kwargs.pop("raw", False)
@@ -56,20 +57,22 @@ class IPythonFormatter(FormatterFactory):
                     output_value = ReprMimeBundle(value)
                 else:
                     output_value = value
-                
+
                 # Store the object if display_id is provided
                 if display_id is not None:
                     display_objects[display_id] = output_value
-                
+
                 _output.append(output_value)
-            
+
             # Return a DisplayHandle if display_id is provided
             if display_id is not None:
                 return DisplayHandle(display_id)
             return None
 
         # Implement update_display function
-        def update_display(obj: Any, *, display_id: str, **kwargs: Any) -> None:
+        def update_display(
+            obj: Any, *, display_id: str, **kwargs: Any
+        ) -> None:
             """Update an existing display by id
 
             Parameters
@@ -81,24 +84,24 @@ class IPythonFormatter(FormatterFactory):
             """
             if display_id not in display_objects:
                 return
-            
+
             # Clear the output before updating
             # _output.clear()
-            
+
             # Update the stored object
             raw = kwargs.pop("raw", False)
             if raw and isinstance(obj, dict):
                 display_objects[display_id] = ReprMimeBundle(obj)
             else:
                 display_objects[display_id] = obj
-            
+
             # Append the updated object to the output
             _output.replace(display_objects[display_id])
 
         # Patch both display and update_display
         IPython.display.display = display
         IPython.display.update_display = update_display
-        
+
         # Patching display_functions handles display_markdown, display_x, etc.
         try:
             IPython.core.display_functions.display = display  # type: ignore
@@ -112,11 +115,13 @@ class IPythonFormatter(FormatterFactory):
                 IPython.display.update_display = old_update_display  # type: ignore
             else:
                 delattr(IPython.display, "update_display")
-                
+
             try:
                 IPython.core.display_functions.display = old_display  # type: ignore
                 if old_update_display is not None:
-                    IPython.core.display_functions.update_display = old_update_display  # type: ignore
+                    IPython.core.display_functions.update_display = (
+                        old_update_display  # type: ignore
+                    )
                 else:
                     delattr(IPython.core.display_functions, "update_display")
             except AttributeError:

--- a/tests/_output/formatters/test_ipython_update.py
+++ b/tests/_output/formatters/test_ipython_update.py
@@ -20,40 +20,40 @@ def test_display_update(mock_clear: MagicMock, mock_append: MagicMock):
     """Test that display with display_id returns a handle and update works."""
     # Import IPython before patching to ensure we get the module
     import IPython.display
-    
+
     # Apply our formatter patch
     unpatch = IPythonFormatter().register()
-    
+
     try:
         # Now use the patched functions
         obj1 = IPython.display.HTML("<div>Initial Content</div>")
         handle = IPython.display.display(obj1, display_id="test-id")
-        
+
         # Verify handle was returned and append was called
         assert handle is not None
         assert handle.display_id == "test-id"
         mock_append.assert_called_once_with(obj1)
         mock_append.reset_mock()
-        
+
         # Test update_display
         obj2 = IPython.display.HTML("<div>Updated Content</div>")
         IPython.display.update_display(obj2, display_id="test-id")
-        
+
         # Verify clear and append were called
         mock_clear.assert_called_once()
         mock_append.assert_called_once_with(obj2)
-        
+
         # Test handle.update method
         mock_clear.reset_mock()
         mock_append.reset_mock()
-        
+
         obj3 = IPython.display.HTML("<div>Handle Updated Content</div>")
         handle.update(obj3)
-        
+
         # Verify clear and append were called
         mock_clear.assert_called_once()
         mock_append.assert_called_once_with(obj3)
-        
+
     finally:
         unpatch()
 
@@ -65,20 +65,20 @@ def test_display_auto_id(mock_clear: MagicMock, mock_append: MagicMock):
     """Test that display with display_id=True auto-generates an ID."""
     # Import IPython before patching
     import IPython.display
-    
+
     # Apply our formatter patch
     unpatch = IPythonFormatter().register()
-    
+
     try:
         # Test display with auto-generated display_id
         obj = IPython.display.HTML("<div>Auto ID Content</div>")
         handle = IPython.display.display(obj, display_id=True)
-        
+
         # Verify handle was returned with a UUID
         assert handle is not None
         assert isinstance(handle.display_id, str)
         assert len(handle.display_id) > 0
         mock_append.assert_called_once_with(obj)
-        
+
     finally:
         unpatch()

--- a/tests/_output/formatters/test_ipython_update.py
+++ b/tests/_output/formatters/test_ipython_update.py
@@ -13,9 +13,9 @@ HAS_DEPS = DependencyManager.ipython.has()
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="IPython not installed")
+@patch("marimo._runtime.output._output.replace")
 @patch("marimo._runtime.output._output.append")
-@patch("marimo._runtime.output._output.clear")
-def test_display_update(mock_clear: MagicMock, mock_append: MagicMock):
+def test_display_update(mock_append: MagicMock, mock_replace: MagicMock):
     """Test that display with display_id returns a handle and update works."""
     # Import IPython before patching to ensure we get the module
     import IPython.display
@@ -38,20 +38,17 @@ def test_display_update(mock_clear: MagicMock, mock_append: MagicMock):
         obj2 = IPython.display.HTML("<div>Updated Content</div>")
         IPython.display.update_display(obj2, display_id="test-id")
 
-        # Verify clear and append were called
-        mock_clear.assert_called_once()
-        mock_append.assert_called_once_with(obj2)
+        # Verify replace was called
+        mock_replace.assert_called_once_with(obj2)
 
         # Test handle.update method
-        mock_clear.reset_mock()
-        mock_append.reset_mock()
+        mock_replace.reset_mock()
 
         obj3 = IPython.display.HTML("<div>Handle Updated Content</div>")
         handle.update(obj3)
 
-        # Verify clear and append were called
-        mock_clear.assert_called_once()
-        mock_append.assert_called_once_with(obj3)
+        # Verify replace was called
+        mock_replace.assert_called_once_with(obj3)
 
     finally:
         unpatch()
@@ -59,8 +56,7 @@ def test_display_update(mock_clear: MagicMock, mock_append: MagicMock):
 
 @pytest.mark.skipif(not HAS_DEPS, reason="IPython not installed")
 @patch("marimo._runtime.output._output.append")
-@patch("marimo._runtime.output._output.clear")
-def test_display_auto_id(_: MagicMock, mock_append: MagicMock):
+def test_display_auto_id(mock_append: MagicMock):
     """Test that display with display_id=True auto-generates an ID."""
     # Import IPython before patching
     import IPython.display

--- a/tests/_output/formatters/test_ipython_update.py
+++ b/tests/_output/formatters/test_ipython_update.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._output.formatters.ipython_formatters import (
+    IPythonFormatter,
+    ReprMimeBundle,
+)
+
+HAS_DEPS = DependencyManager.ipython.has()
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="IPython not installed")
+@patch("marimo._runtime.output._output.append")
+@patch("marimo._runtime.output._output.clear")
+def test_display_update(mock_clear: MagicMock, mock_append: MagicMock):
+    """Test that display with display_id returns a handle and update works."""
+    # Import IPython before patching to ensure we get the module
+    import IPython.display
+    
+    # Apply our formatter patch
+    unpatch = IPythonFormatter().register()
+    
+    try:
+        # Now use the patched functions
+        obj1 = IPython.display.HTML("<div>Initial Content</div>")
+        handle = IPython.display.display(obj1, display_id="test-id")
+        
+        # Verify handle was returned and append was called
+        assert handle is not None
+        assert handle.display_id == "test-id"
+        mock_append.assert_called_once_with(obj1)
+        mock_append.reset_mock()
+        
+        # Test update_display
+        obj2 = IPython.display.HTML("<div>Updated Content</div>")
+        IPython.display.update_display(obj2, display_id="test-id")
+        
+        # Verify clear and append were called
+        mock_clear.assert_called_once()
+        mock_append.assert_called_once_with(obj2)
+        
+        # Test handle.update method
+        mock_clear.reset_mock()
+        mock_append.reset_mock()
+        
+        obj3 = IPython.display.HTML("<div>Handle Updated Content</div>")
+        handle.update(obj3)
+        
+        # Verify clear and append were called
+        mock_clear.assert_called_once()
+        mock_append.assert_called_once_with(obj3)
+        
+    finally:
+        unpatch()
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="IPython not installed")
+@patch("marimo._runtime.output._output.append")
+@patch("marimo._runtime.output._output.clear")
+def test_display_auto_id(mock_clear: MagicMock, mock_append: MagicMock):
+    """Test that display with display_id=True auto-generates an ID."""
+    # Import IPython before patching
+    import IPython.display
+    
+    # Apply our formatter patch
+    unpatch = IPythonFormatter().register()
+    
+    try:
+        # Test display with auto-generated display_id
+        obj = IPython.display.HTML("<div>Auto ID Content</div>")
+        handle = IPython.display.display(obj, display_id=True)
+        
+        # Verify handle was returned with a UUID
+        assert handle is not None
+        assert isinstance(handle.display_id, str)
+        assert len(handle.display_id) > 0
+        mock_append.assert_called_once_with(obj)
+        
+    finally:
+        unpatch()

--- a/tests/_output/formatters/test_ipython_update.py
+++ b/tests/_output/formatters/test_ipython_update.py
@@ -7,7 +7,6 @@ import pytest
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.formatters.ipython_formatters import (
     IPythonFormatter,
-    ReprMimeBundle,
 )
 
 HAS_DEPS = DependencyManager.ipython.has()
@@ -61,7 +60,7 @@ def test_display_update(mock_clear: MagicMock, mock_append: MagicMock):
 @pytest.mark.skipif(not HAS_DEPS, reason="IPython not installed")
 @patch("marimo._runtime.output._output.append")
 @patch("marimo._runtime.output._output.clear")
-def test_display_auto_id(mock_clear: MagicMock, mock_append: MagicMock):
+def test_display_auto_id(_: MagicMock, mock_append: MagicMock):
     """Test that display with display_id=True auto-generates an ID."""
     # Import IPython before patching
     import IPython.display


### PR DESCRIPTION
## 📝 Summary

Current iPython Display implementation doesn't support updates, it keeps appending to the cell output
This is how it looks today when using HugginFace transformers in notebook mode:

https://github.com/user-attachments/assets/b4c9bb17-9a39-4488-8996-9a6f07d9bae7




## 🔍 Description of Changes

This PR expands the support to Python display so it now returns a DisplayHandle and that DisplyHanle has an update function.
This is how the change works when using HuggingFaace Transformers:

https://github.com/user-attachments/assets/a5819222-7cae-401c-bb2c-1f24489df120



## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
