### PR TITLE
feat: added collapseAll function to CollapsibleTree to handle collapsing of all nested expanded nodes in one call

### DIFF
--- a/frontend/src/utils/__tests__/id-tree.test.ts
+++ b/frontend/src/utils/__tests__/id-tree.test.ts
@@ -115,6 +115,47 @@ describe("CollapsibleTree", () => {
     ).toThrowErrorMatchingInlineSnapshot(
       "[Error: Node one is before node two]",
     );
+    expect(() => {
+      tree = tree.collapse("two", undefined);
+      tree = tree.collapse("two", undefined);
+    }).toThrowErrorMatchingInlineSnapshot(
+      "[Error: Node two is already collapsed]",
+    );
+  });
+
+  it("collapses all nodes from leaves to root in one call", () => {
+    const collapsedTree = tree.collapseAll([
+      { id: "one", until: undefined },
+      { id: "two", until: undefined },
+      { id: "three", until: undefined },
+      { id: "four", until: undefined },
+    ]);
+    expect(collapsedTree.toString()).toMatchInlineSnapshot(`
+      "one (collapsed)
+        two (collapsed)
+          three (collapsed)
+            four (collapsed)
+      "
+    `);
+  });
+
+  it("collapses some nodes from leaves to root in one call", () => {
+    const collapsedTree = tree.collapseAll([
+      { id: "one", until: undefined },
+      null,
+      { id: "three", until: "four" },
+      null,
+    ]);
+    expect(collapsedTree.toString()).toMatchInlineSnapshot(`
+      "one (collapsed)
+        two
+        three (collapsed)
+          four
+      "
+    `);
+  });
+
+  it("failures to collapse all", () => {
     expect(() => tree.collapseAll([])).toThrowErrorMatchingInlineSnapshot(
       "[Error: No collapse ranges provided]",
     );
@@ -126,12 +167,20 @@ describe("CollapsibleTree", () => {
     ).toThrowErrorMatchingInlineSnapshot(
       "[Error: Collapse ranges length 2 does not match tree length 4]",
     );
-
-    expect(() => {
-      tree = tree.collapse("two", undefined);
-      tree = tree.collapse("two", undefined);
-    }).toThrowErrorMatchingInlineSnapshot(
-      "[Error: Node two is already collapsed]",
+    expect(() =>
+      tree.collapseAll([null, { id: "one", until: undefined }, null, null]),
+    ).toThrowErrorMatchingInlineSnapshot(
+      "[Error: Node two does not match collapse range id one]",
+    );
+    expect(() =>
+      tree.collapseAll([{ id: "one", until: "five" }, null, null, null]),
+    ).toThrowErrorMatchingInlineSnapshot(
+      "[Error: Node five not found in tree]",
+    );
+    expect(() =>
+      tree.collapseAll([null, { id: "two", until: "one" }, null, null]),
+    ).toThrowErrorMatchingInlineSnapshot(
+      "[Error: Node one is before node two]",
     );
   });
 

--- a/frontend/src/utils/__tests__/id-tree.test.ts
+++ b/frontend/src/utils/__tests__/id-tree.test.ts
@@ -115,6 +115,17 @@ describe("CollapsibleTree", () => {
     ).toThrowErrorMatchingInlineSnapshot(
       "[Error: Node one is before node two]",
     );
+    expect(() => tree.collapseAll([])).toThrowErrorMatchingInlineSnapshot(
+      "[Error: No collapse ranges provided]",
+    );
+    expect(() =>
+      tree.collapseAll([
+        { id: "one", until: undefined },
+        { id: "two", until: undefined },
+      ]),
+    ).toThrowErrorMatchingInlineSnapshot(
+      "[Error: Collapse ranges length 2 does not match tree length 4]",
+    );
 
     expect(() => {
       tree = tree.collapse("two", undefined);

--- a/frontend/src/utils/id-tree.tsx
+++ b/frontend/src/utils/id-tree.tsx
@@ -299,7 +299,7 @@ export class CollapsibleTree<T> {
 
     if (collapseRanges.length !== nodes.length) {
       throw new Error(
-        `Collapse ranges length ${collapseRanges.length} does not match tree length ${this.nodes.length}`,
+        `Collapse ranges length ${collapseRanges.length} does not match tree length ${nodes.length}`,
       );
     }
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Created a collapseAll function to handle collapsing all expanded nodes including nested children. Partially resolves #4163 by adding a way to collapse all nested expanded nodes

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Created a collapseAll function in id-tree.tsx
- Created tests to ensure it collapses all top-level nodes from leaves to root and some top-level nested nodes
- Create tests for all error cases

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
