### PR TITLE
feat: mo.thread lifecycle

### DIFF
--- a/docs/api/control_flow.md
+++ b/docs/api/control_flow.md
@@ -1,9 +1,19 @@
 # Control flow
 
-Use `mo.stop` to halt execution of a cell, and optionally output an object.
-This function is useful for validating user input.
+## Controlling when cells run
+
+* Use [`mo.stop`][marimo.stop] to halt execution of a cell when a condition is met.
+* Combine [`mo.stop`][marimo.stop] with [`mo.ui.run_button`][marimo.ui.run_button] to gate execution on button click.
+* Use [`mo.ui.refresh`][marimo.ui.refresh] to make cells run periodically.
+
+!!! tip "Lazy execution"
+
+    In addition to these utilities, you can [configure the runtime to be lazy](../guides/expensive_notebooks.md#configure-how-marimo-runs-cells), marking cells as stale instead of automatically running them.
 
 ::: marimo.stop
 
-Use [`mo.ui.refresh`][marimo.ui.refresh] to trigger other cells to run periodically, on a configurable
-interval (or on click).
+## Threading
+
+::: marimo.Thread
+
+::: marimo.current_thread

--- a/docs/api/miscellaneous.md
+++ b/docs/api/miscellaneous.md
@@ -9,5 +9,3 @@
 ::: marimo.notebook_dir
 
 ::: marimo.notebook_location
-
-::: marimo.Thread

--- a/docs/guides/outputs.md
+++ b/docs/guides/outputs.md
@@ -196,6 +196,28 @@ To create a thread that can reliably communicate outputs to the frontend,
 use [`mo.Thread`][marimo.Thread], which has exactly the same API as
 as `threading.Thread`.
 
+### Cleaning up your thread
+
+When the cell that spawned a [`mo.Thread`][marimo.Thread] is invalidated
+(re-run, deleted, interrupted, or otherwise errored), the thread's
+`should_exit` property will evaluate to `True`, at which point it is your
+responsibility to clean up your thread. You can retrieve the current
+[`mo.Thread`][marimo.Thread] with [`mo.current_thread`][marimo.current_thread].
+
+**Example.**
+
+```python
+def target():
+    import marimo as mo
+
+    thread = mo.current_thread()
+    while not thread.should_exit:
+        ...
+```
+
+
+### Patching threads created by third-party code
+
 If you need to forward outputs from threads spawned by third-party code, try
 patching `threading.Thread`:
 
@@ -205,3 +227,6 @@ import marimo as mo
 
 threading.Thread = mo.Thread
 ```
+
+This however may leak threads, since the patched threads won't know to check the `mo.Thread`'s
+`should_exit` property.

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "MarimoIslandGenerator",
     "MarimoStopError",
     "Thread",
+    "current_thread",
     # Other namespaces
     "ai",
     "ui",
@@ -137,7 +138,7 @@ from marimo._runtime.runtime import (
     refs,
 )
 from marimo._runtime.state import state
-from marimo._runtime.threads import Thread
+from marimo._runtime.threads import Thread, current_thread
 from marimo._save.save import cache, lru_cache, persistent_cache
 from marimo._server.asgi import create_asgi_app
 from marimo._sql.sql import sql

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import functools
 import threading
 from typing import Any
 

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -1,10 +1,12 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import functools
 import threading
 from typing import Any
 
 from marimo._messaging.streams import ThreadSafeStream
+from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
 from marimo._runtime.context.kernel_context import KernelRuntimeContext
 from marimo._runtime.context.script_context import ScriptRuntimeContext
 from marimo._runtime.context.types import (
@@ -21,7 +23,7 @@ THREADS = set()
 
 
 class Thread(threading.Thread):
-    """A Thread subclass that is aware of marimo internals.
+    """A Thread subclass that can communicate with the frontend.
 
     `mo.Thread` has the same API as threading.Thread,
     but `mo.Thread`s are able to communicate with the marimo
@@ -33,17 +35,56 @@ class Thread(threading.Thread):
 
     Writing directly to sys.stdout or sys.stderr, or to file descriptors 1 and
     2, is not yet supported.
+
+    **Thread lifecycle.** When the cell that spawned this thread is invalidated
+    (re-run, deleted, interrupted, or otherwise errored), this thread's
+    `should_exit` property will evaluate to `True`, at which point it
+    is the developer's responsibility to clean up their thread.
+
+    **Example.**
+
+    ```python
+    def target():
+        import time
+        import marimo as mo
+
+        thread = mo.current_thread()
+        while not thread.should_exit:
+            time.sleep(1)
+            print("hello")
+    ```
+
+    ```python
+    import marimo as mo
+
+    mo.Thread(target=target).start()
+    ```
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
         self._marimo_ctx: RuntimeContext | None = None
+        exit_event = threading.Event()
+        self._exit_event = exit_event
 
         if not runtime_context_installed():
             return
 
+        class ThreadLifecycle(CellLifecycleItem):
+            def create(self, context: RuntimeContext) -> None:
+                del context
+                pass
+
+            def dispose(self, context: RuntimeContext, deletion: bool) -> bool:
+                del context
+                del deletion
+                exit_event.set()
+                return True
+
         ctx = get_context()
+        ctx.cell_lifecycle_registry.add(ThreadLifecycle())
+
         if isinstance(ctx, KernelRuntimeContext):
             self._marimo_ctx = KernelRuntimeContext(**ctx.__dict__)
             # standard IO is not yet threadsafe
@@ -77,6 +118,30 @@ class Thread(threading.Thread):
                     "Unsupported stream type " + str(type(ctx.stream))
                 )
 
+    @property
+    def should_exit(self) -> bool:
+        """Whether this thread should exit.
+
+        Returns `True` when the cell that spawned this thread has been invalidated;
+        for example, if the cell:
+
+        - was re-run
+        - was deleted
+        - was interrupted
+
+        then this property evaluates to True.
+
+        It is the developer's responsibility to clean up and finish their
+        thread when this flag is set. Retrieve the current `mo.Thread` with
+
+        ```python
+        import marimo as mo
+
+        mo.current_thread()
+        ```
+        """
+        return self._exit_event.is_set()
+
     def run(self) -> None:
         if self._marimo_ctx is not None:
             initialize_context(self._marimo_ctx)
@@ -90,3 +155,21 @@ class Thread(threading.Thread):
         super().run()
         THREADS.remove(thread_id)
         teardown_context()
+
+
+def current_thread() -> Thread:
+    """Return the `marimo.Thread` object for the caller's thread of control.
+
+    Returns:
+        The current `marimo.Thread` object.
+
+    Raises:
+        RuntimeError: If the current thread of control is not a `marimo.Thread`.
+    """
+    thread = threading.current_thread()
+    if not isinstance(thread, Thread):
+        raise RuntimeError(
+            "mo.current_thread() must be called from a "
+            "thread created with mo.Thread."
+        )
+    return thread

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -74,7 +74,6 @@ class Thread(threading.Thread):
         class ThreadLifecycle(CellLifecycleItem):
             def create(self, context: RuntimeContext) -> None:
                 del context
-                pass
 
             def dispose(self, context: RuntimeContext, deletion: bool) -> bool:
                 del context

--- a/tests/snapshots/api.txt
+++ b/tests/snapshots/api.txt
@@ -25,6 +25,7 @@ carousel
 center
 cli_args
 create_asgi_app
+current_thread
 defs
 doc
 download


### PR DESCRIPTION
Closes #4564 

This change adds a `should_exit` property to `mo.Thread` which evaluates to `True`
when the thread's spawning cell lifecycle has ended. This makes it
possible for developers to clean up their threads.

This change also adds a utility method, mo.current_thread(), that
returns the current thread of control if it is a marimo.Thread object,
and raises otherwise. Developers could technically use
threading.current_thread() instead, but this method provides
type safety and validation.