### PR TITLE
Assume ibis interactive mode with spark? 

### DIFF
--- a/frontend/src/components/editor/database/as-code.ts
+++ b/frontend/src/components/editor/database/as-code.ts
@@ -592,6 +592,7 @@ class PySparkGenerator extends CodeGenerator<"pyspark"> {
       const host = this.secrets.printInFString("host", this.connection.host);
       const port = this.secrets.printInFString("port", this.connection.port);
       return dedent(`
+        ibis.options.interactive = True
         session = SparkSession.builder.remote(f"${username}://${host}:${port}").getOrCreate()
         con = ibis.pyspark.connect(session)
       `);


### PR DESCRIPTION
I guess `ibis` does not set this flag in general because they can't assume to be running from a Python notebook but we can, so maybe it makes sense to add this? Otherwise you need to add extra verbs to the chain to see the final output. 