### PR TITLE
improvement: support more parameter descriptions, e.g. in `polars`

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -200,7 +200,7 @@ class DependencyManager:
     vl_convert_python = Dependency("vl_convert")
     dotenv = Dependency("dotenv")
     docstring_to_markdown = Dependency(
-        "docstring_to_markdown", min_version="0.16.0"
+        "docstring_to_markdown", min_version="0.17.0"
     )
 
     # Version requirements to properly support the new superfences introduced in

--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -307,13 +307,16 @@ def patch_jedi_parameter_completion() -> None:
         for line in lines[start + 2 :]:
             if line.strip() == "" or line.startswith("#"):
                 continue
-            param_start = re.match(r"^\- `(.+)`: (.*)$", line.strip())
+            param_start = re.match(r"^\- `(.+)`:(?: (.*))?$", line.strip())
             if param_start:
                 param, first_line = param_start.groups()
-                param_descriptions[param] = first_line
+                param_descriptions[param] = first_line or ""
             else:
                 if param:
-                    param_descriptions[param] += "\n" + line.strip()
+                    if param_descriptions[param]:
+                        param_descriptions[param] += "\n" + line.strip()
+                    else:
+                        param_descriptions[param] = line.strip()
         return param_descriptions
 
     def py__doc__(self: ParamNameWrapper) -> str:

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -136,6 +136,17 @@ def collect_functions_to_check():
     return objects_to_check
 
 
+def dummy_func(arg1: str, arg2: str) -> None:
+    """
+    Parameters
+    ----------
+    arg1
+        description
+    arg2
+        description
+    """
+
+
 @pytest.mark.skipif(
     not DependencyManager.docstring_to_markdown.has(),
     reason="docstring_to_markdown is not installed",
@@ -145,7 +156,8 @@ def collect_functions_to_check():
     [[obj, False] for obj in collect_functions_to_check()]
     + [
         # Test runtime inference for a subset of values
-        [marimo.accordion, True]
+        [marimo.accordion, True],
+        [dummy_func, False],
     ],
     ids=lambda obj: f"{obj}"
     if isinstance(obj, bool)

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -141,9 +141,9 @@ def dummy_func(arg1: str, arg2: str) -> None:
     Parameters
     ----------
     arg1
-        description
-    arg2
-        description
+        polars often uses this format
+    arg2 : str, required
+        while other libraries prefer this format (which polars uses too)
     """
 
 


### PR DESCRIPTION
## 📝 Summary

Small follow up to #4673.

## 🔍 Description of Changes

Polars often uses a simplified rst format for parameters where it does not include types.

This requires `docstring-to-markdown` v0.17 with:
- https://github.com/python-lsp/docstring-to-markdown/pull/44

For example, before there was only one parameter with description for `polars.io.parquet.functions.read_parquet`, and now all 22 are displayed.

Parameters from functions with overloads such as `polars.io.database.functions.read_database` remain without good suggestions.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
