### PR TITLE
Fix weakvaluedict issue

### DIFF
--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import functools
-import weakref
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
@@ -23,9 +22,7 @@ class IPythonFormatter(FormatterFactory):
         from marimo._runtime.output import _output
 
         # Dictionary to store display objects by ID
-        display_objects: weakref.WeakValueDictionary[str, Any] = (
-            weakref.WeakValueDictionary()
-        )
+        display_objects: dict[str, Any] = {}
 
         def clear_display_objects() -> None:
             """Clear all stored display objects."""


### PR DESCRIPTION
## 📝 Summary

@mscolnick, unfortunately, the WeakValueDictionary broke the iPython update implementation
Now it only outputs the initial empty bar, as it can be seen in the video below

https://github.com/user-attachments/assets/2d591719-119f-44fd-9a25-e788540b3faf

## 🔍 Description of Changes

Reverting WeakValueDictionary change while keeping the cleanup functions.

Analysis and issues
- noticed the dictionary adds one record per cell display
- known issue, the iPython is not unpatching, therefore the dictionary is never cleared

 Here is a short video where I analyse the current behaviour

https://www.loom.com/share/16a282de56724584ac0c49bc81a68539

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
