### PR TITLE
feat: add 'Insert breakpoint' in traceback

### DIFF
--- a/frontend/src/components/debugger/debugger-code.tsx
+++ b/frontend/src/components/debugger/debugger-code.tsx
@@ -207,7 +207,10 @@ export const DebuggerControls: React.FC<{
             variant="text"
             size="icon"
             data-testid="debugger-clear-button"
-            className={buttonClasses}
+            className={cn(
+              buttonClasses,
+              "text-[var(--red-11)] hover:text-[var(--red-11)] hover:bg-[var(--red-2)] hover:border-[var(--red-8)]",
+            )}
             onClick={onClear}
           >
             <TrashIcon fontSize={36} className={iconClasses} />

--- a/frontend/src/components/debugger/debugger-code.tsx
+++ b/frontend/src/components/debugger/debugger-code.tsx
@@ -13,6 +13,7 @@ import {
   LayersIcon,
   PlayIcon,
   SkipForwardIcon,
+  TrashIcon,
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { cn } from "@/utils/cn";
@@ -140,11 +141,15 @@ const DebuggerInput: React.FC<{
   );
 };
 
-const DebuggerControls: React.FC<{
+export const DebuggerControls: React.FC<{
   onSubmit: (code: string) => void;
-}> = ({ onSubmit }) => {
-  const buttonClasses =
-    "border m-0 w-9 h-7 bg-[var(--blue-2)] text-[var(--slate-11)] hover:text-[var(--blue-11)] rounded-none border-[var(--blue-2)] hover:bg-[var(--sky-3)] hover:border-[var(--blue-8)]";
+  onClear?: () => void;
+}> = ({ onSubmit, onClear }) => {
+  const buttonClasses = cn(
+    "m-0 w-9 h-8 bg-[var(--slate-2)] text-[var(--slate-11)] hover:text-[var(--blue-11)] rounded-none hover:bg-[var(--sky-3)] hover:border-[var(--blue-8)]",
+    "first:rounded-l-lg first:border-l border-t border-b hover:border",
+    "last:rounded-r-lg last:border-r",
+  );
   const iconClasses = "w-5 h-5";
 
   return (
@@ -154,7 +159,7 @@ const DebuggerControls: React.FC<{
           variant="text"
           size="icon"
           data-testid="debugger-next-button"
-          className={cn(buttonClasses, "rounded-bl-lg")}
+          className={buttonClasses}
           onClick={() => onSubmit("n")}
         >
           <SkipForwardIcon fontSize={36} className={iconClasses} />
@@ -196,6 +201,19 @@ const DebuggerControls: React.FC<{
           <HelpCircleIcon fontSize={36} className={iconClasses} />
         </Button>
       </Tooltip>
+      {onClear && (
+        <Tooltip content="Clear">
+          <Button
+            variant="text"
+            size="icon"
+            data-testid="debugger-clear-button"
+            className={buttonClasses}
+            onClick={onClear}
+          >
+            <TrashIcon fontSize={36} className={iconClasses} />
+          </Button>
+        </Tooltip>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -325,6 +325,7 @@ export type CellComponentActions = Pick<
   | "updateCellConfig"
   | "clearSerializedEditorState"
   | "setStdinResponse"
+  | "clearCellConsoleOutput"
   | "sendToBottom"
   | "sendToTop"
 >;
@@ -901,6 +902,9 @@ const EditableCellComponent = ({
               // Empty name if serialization triggered
               cellName={serialization ? "_" : name}
               onRefactorWithAI={handleRefactorWithAI}
+              onClear={() => {
+                actions.clearCellConsoleOutput({ cellId });
+              }}
               onSubmitDebugger={(text, index) => {
                 actions.setStdinResponse({
                   cellId,
@@ -1345,6 +1349,9 @@ const SetupCellComponent = ({
             // Don't show name
             cellName={"_"}
             onRefactorWithAI={handleRefactorWithAI}
+            onClear={() => {
+              actions.clearCellConsoleOutput({ cellId });
+            }}
             onSubmitDebugger={(text, index) => {
               actions.setStdinResponse({
                 cellId,

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -135,6 +135,7 @@ export const OutputRenderer: React.FC<{
         <MarimoTracebackOutput
           onRefactorWithAI={onRefactorWithAI}
           traceback={data}
+          cellId={cellId}
         />
       );
 

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -113,10 +113,11 @@ const CellEditorInternal = ({
   });
 
   const handleRunCell = useEvent(() => {
-    if (status !== "idle") {
-      return;
+    if (loading) {
+      return false;
     }
     runCell();
+    return true;
   });
 
   const toggleHideCode = useEvent(() => {

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -112,6 +112,13 @@ const CellEditorInternal = ({
     return true;
   });
 
+  const handleRunCell = useEvent(() => {
+    if (status !== "idle") {
+      return;
+    }
+    runCell();
+  });
+
   const toggleHideCode = useEvent(() => {
     // Use cellConfig.hide_code instead of hidden, since it may be temporarily shown
     const nextHidden = !cellConfig.hide_code;
@@ -136,7 +143,7 @@ const CellEditorInternal = ({
       cellActions: {
         ...cellActions,
         afterToggleMarkdown,
-        onRun: runCell,
+        onRun: handleRunCell,
         deleteCell: handleDelete,
         saveNotebook: saveOrNameNotebook,
         createManyBelow: (cells) => {
@@ -218,7 +225,7 @@ const CellEditorInternal = ({
     splitCell,
     toggleHideCode,
     handleDelete,
-    runCell,
+    handleRunCell,
     setAiCompletionCell,
     afterToggleMarkdown,
     setLanguageAdapter,

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -11,6 +11,8 @@ import { AnsiUp } from "ansi_up";
 import type { WithResponse } from "@/core/cells/types";
 import { invariant } from "@/utils/invariant";
 import { ErrorBoundary } from "../boundary/ErrorBoundary";
+import { DebuggerControls } from "@/components/debugger/debugger-code";
+import { ChevronRightIcon } from "lucide-react";
 
 const ansiUp = new AnsiUp();
 
@@ -22,6 +24,7 @@ interface Props {
   stale: boolean;
   debuggerActive: boolean;
   onRefactorWithAI?: (opts: { prompt: string }) => void;
+  onClear?: () => void;
   onSubmitDebugger: (text: string, index: number) => void;
 }
 
@@ -41,6 +44,7 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
     cellName,
     cellId,
     onSubmitDebugger,
+    onClear,
     onRefactorWithAI,
     className,
   } = props;
@@ -85,6 +89,10 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
   }
 
   const reversedOutputs = [...consoleOutputs].reverse();
+  const isPdb = reversedOutputs.some(
+    (output) =>
+      typeof output.data === "string" && output.data.includes("(Pdb)"),
+  );
 
   return (
     <div
@@ -116,7 +124,9 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
               <StdInput
                 key={idx}
                 output={output.data}
+                isPdb={isPdb}
                 onSubmit={(text) => onSubmitDebugger(text, originalIdx)}
+                onClear={onClear}
               />
             );
           }
@@ -151,18 +161,21 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
 
 const StdInput = (props: {
   onSubmit: (text: string) => void;
+  onClear?: () => void;
   output: string;
   response?: string;
+  isPdb: boolean;
 }) => {
   return (
-    <div className="flex gap-2 items-center">
+    <div className="flex gap-2 items-center pt-2">
       {renderText(props.output)}
       <Input
         data-testid="console-input"
         type="text"
         autoComplete="off"
         autoFocus={true}
-        className="m-0"
+        icon={<ChevronRightIcon className="w-5 h-5" />}
+        className="m-0 h-8 focus-visible:shadow-xsSolid"
         placeholder="stdin"
         onKeyDown={(e) => {
           if (e.key === "Enter" && !e.shiftKey) {
@@ -170,6 +183,7 @@ const StdInput = (props: {
           }
         }}
       />
+      <DebuggerControls onSubmit={props.onSubmit} onClear={props.onClear} />
     </div>
   );
 };
@@ -187,6 +201,10 @@ const StdInputWithResponse = (props: {
 };
 
 const renderText = (text: string) => {
+  if (!text) {
+    return null;
+  }
+
   return (
     <span dangerouslySetInnerHTML={{ __html: ansiUp.ansi_to_html(text) }} />
   );

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -100,7 +100,7 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
       data-testid="console-output-area"
       ref={ref}
       className={cn(
-        "console-output-area overflow-hidden rounded-b-lg flex flex-col-reverse w-full",
+        "console-output-area overflow-hidden rounded-b-lg flex flex-col-reverse w-full gap-1",
         stale && "marimo-output-stale",
         hasOutputs ? "p-5" : "p-3",
         className,
@@ -200,7 +200,7 @@ const StdInputWithResponse = (props: {
   );
 };
 
-const renderText = (text: string) => {
+const renderText = (text: string | null) => {
   if (!text) {
     return null;
   }

--- a/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
@@ -22,7 +22,7 @@ import {
 import { useState } from "react";
 import { useAtomValue } from "jotai";
 import { aiEnabledAtom } from "@/core/config/config";
-import type { DOMNode } from "html-react-parser";
+import { Element, Text, type DOMNode } from "html-react-parser";
 
 import { CellLinkTraceback } from "../links/cell-link";
 import {

--- a/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
@@ -98,7 +98,7 @@ export const MarimoTracebackOutput = ({
               {errorMessage}
             </div>
           </div>
-          <AccordionContent className="px-4 text-muted-foreground px-4 pt-2 text-xs overflow-auto">
+          <AccordionContent className="text-muted-foreground px-4 pt-2 text-xs overflow-auto">
             {htmlTraceback}
           </AccordionContent>
         </AccordionItem>

--- a/frontend/src/components/editor/output/__tests__/traceback.test.tsx
+++ b/frontend/src/components/editor/output/__tests__/traceback.test.tsx
@@ -8,10 +8,15 @@ import { renderHTML } from "@/plugins/core/RenderHTML";
 import { Tracebacks } from "@/__mocks__/tracebacks";
 import { render } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
+import type { CellId } from "@/core/cells/ids";
+
+const cellId = "1" as CellId;
 
 describe("traceback component", () => {
   test("extracts cell-link", () => {
-    const traceback = <MarimoTracebackOutput traceback={Tracebacks.raw} />;
+    const traceback = (
+      <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cellId} />
+    );
     const { unmount, getAllByRole } = render(traceback);
 
     // Has traceback links
@@ -27,7 +32,9 @@ describe("traceback component", () => {
   });
 
   test("renames File to Cell for relevant lines", () => {
-    const traceback = <MarimoTracebackOutput traceback={Tracebacks.raw} />;
+    const traceback = (
+      <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cellId} />
+    );
     const { unmount, container } = render(traceback);
 
     expect(container).not.toBeNull();

--- a/frontend/src/components/editor/output/__tests__/traceback.test.tsx
+++ b/frontend/src/components/editor/output/__tests__/traceback.test.tsx
@@ -9,13 +9,16 @@ import { Tracebacks } from "@/__mocks__/tracebacks";
 import { render } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import type { CellId } from "@/core/cells/ids";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const cellId = "1" as CellId;
 
 describe("traceback component", () => {
   test("extracts cell-link", () => {
     const traceback = (
-      <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cellId} />
+      <TooltipProvider>
+        <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cellId} />
+      </TooltipProvider>
     );
     const { unmount, getAllByRole } = render(traceback);
 
@@ -33,7 +36,9 @@ describe("traceback component", () => {
 
   test("renames File to Cell for relevant lines", () => {
     const traceback = (
-      <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cellId} />
+      <TooltipProvider>
+        <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cellId} />
+      </TooltipProvider>
     );
     const { unmount, container } = render(traceback);
 
@@ -53,7 +58,9 @@ describe("traceback replacement", () => {
       html: Tracebacks.assertion,
       additionalReplacements: [replaceTracebackPrefix],
     });
-    const { unmount, container } = render(traceback);
+    const { unmount, container } = render(
+      <TooltipProvider>{traceback}</TooltipProvider>,
+    );
 
     expect(container).not.toBeNull();
 
@@ -70,7 +77,9 @@ describe("traceback replacement", () => {
       html: Tracebacks.assertion,
       additionalReplacements: [replaceTracebackFilenames],
     });
-    const { unmount, getAllByRole, container } = render(traceback);
+    const { unmount, getAllByRole, container } = render(
+      <TooltipProvider>{traceback}</TooltipProvider>,
+    );
 
     expect(container).not.toBeNull();
 

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -28,7 +28,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className={cn("relative", props.rootClassName)}>
         {icon && (
-          <div className="absolute inset-y-0 left-0 flex items-center pl-[6px] pointer-events-none text-muted-foreground h-6">
+          <div className="absolute inset-y-0 left-0 flex items-center pl-[6px] pointer-events-none text-muted-foreground">
             {icon}
           </div>
         )}

--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -1948,6 +1948,57 @@ describe("cell reducer", () => {
     expect(cell.consoleOutputs).toEqual([]);
   });
 
+  it("can clear console output of a single cell", () => {
+    // Set up initial state with output
+    actions.handleCellMessage({
+      cell_id: firstCellId,
+      output: {
+        channel: "output",
+        mimetype: "text/plain",
+        data: "test output",
+        timestamp: 0,
+      },
+      console: {
+        channel: "stdout",
+        mimetype: "text/plain",
+        data: "console output",
+        timestamp: 0,
+      },
+      status: "idle",
+      stale_inputs: null,
+      timestamp: new Date(33).getTime() as Seconds,
+    });
+
+    // Add a stdin console output that should be preserved
+    actions.handleCellMessage({
+      cell_id: firstCellId,
+      console: {
+        channel: "stdin",
+        mimetype: "text/plain",
+        data: "stdin prompt",
+        timestamp: 0,
+      },
+      status: "idle",
+      stale_inputs: null,
+      timestamp: new Date(34).getTime() as Seconds,
+    });
+
+    // Verify initial state has output and console outputs
+    let cell = cells[0];
+    expect(cell.output).not.toBeNull();
+    expect(cell.consoleOutputs.length).toBe(2);
+
+    // Clear console output
+    actions.clearCellConsoleOutput({ cellId: firstCellId });
+
+    // Verify only console output is cleared, but stdin is preserved
+    cell = cells[0];
+    expect(cell.output).not.toBeNull(); // Output should remain
+    expect(cell.consoleOutputs.length).toBe(1);
+    expect(cell.consoleOutputs[0].channel).toBe("stdin");
+    expect(cell.consoleOutputs[0].data).toBe("stdin prompt");
+  });
+
   it("can clear output of all cells", () => {
     // Create multiple cells with output
     actions.createNewCell({ cellId: firstCellId, before: false });

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -221,9 +221,9 @@ export function outputIsStale(
 }
 
 /**
- * Convert a list of outputs to a traceback.
+ * Convert a list of outputs to a traceback info.
  */
-export function outputToTraceback(
+export function outputToTracebackInfo(
   outputs: OutputMessage[],
 ): TracebackInfo[] | undefined {
   const firstTraceback = outputs.find(

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -221,7 +221,10 @@ export function outputIsStale(
 }
 
 /**
- * Convert a list of outputs to a traceback info.
+ * Extract traceback information from a list of outputs.
+ * This function searches for the first output with a mimetype of
+ * "application/vnd.marimo+traceback" and parses its data to retrieve
+ * all traceback details.
  */
 export function outputToTracebackInfo(
   outputs: OutputMessage[],

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1198,6 +1198,16 @@ const {
       consoleOutputs: [],
     }));
   },
+  clearCellConsoleOutput: (state, action: { cellId: CellId }) => {
+    const { cellId } = action;
+    return updateCellRuntimeState(state, cellId, (cell) => ({
+      ...cell,
+      // Remove everything except unresponsed stdin
+      consoleOutputs: cell.consoleOutputs.filter(
+        (output) => output.channel === "stdin" && output.response == null,
+      ),
+    }));
+  },
   clearAllCellOutputs: (state) => {
     const newCellRuntime = { ...state.cellRuntime };
     for (const cellId of state.cellIds.inOrderIds) {

--- a/frontend/src/core/codemirror/editing/__tests__/debugging.test.ts
+++ b/frontend/src/core/codemirror/editing/__tests__/debugging.test.ts
@@ -1,0 +1,182 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { python } from "@codemirror/lang-python";
+import { insertDebuggerAtLine } from "../debugging";
+
+describe("insertDebuggerAtLine", () => {
+  let container: HTMLElement;
+  let view: EditorView;
+
+  beforeEach(() => {
+    // Create a container for the editor
+    container = document.createElement("div");
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    view.destroy();
+    container.remove();
+  });
+
+  it("should insert a debugger statement at the beginning of a line", () => {
+    // Create an editor with some python code
+    const initialDoc = 'def test():\n  print("hello")\n  return True';
+
+    view = new EditorView({
+      state: EditorState.create({
+        doc: initialDoc,
+        extensions: [python()],
+      }),
+      parent: container,
+    });
+
+    // Insert a debugger statement at line 2
+    const result = insertDebuggerAtLine(view, 2);
+
+    // Check the result
+    expect(result).toBe(true);
+
+    // Check the updated document content
+    const expectedDoc =
+      'def test():\n  breakpoint()\n  print("hello")\n  return True';
+    expect(view.state.doc.toString()).toBe(expectedDoc);
+  });
+
+  it("should match the indentation of the target line", () => {
+    // Create an editor with code that has different indentation levels
+    const initialDoc =
+      'def test():\n    if True:\n        print("nested")\n    return True';
+
+    view = new EditorView({
+      state: EditorState.create({
+        doc: initialDoc,
+        extensions: [python()],
+      }),
+      parent: container,
+    });
+
+    // Insert a debugger statement at the deeply indented line
+    const result = insertDebuggerAtLine(view, 3);
+
+    // Check the result
+    expect(result).toBe(true);
+
+    // Check that the debugger statement has the same indentation
+    const expectedDoc =
+      'def test():\n    if True:\n        breakpoint()\n        print("nested")\n    return True';
+    expect(view.state.doc.toString()).toBe(expectedDoc);
+  });
+
+  it("should handle the first line correctly", () => {
+    const initialDoc = "x = 1\ny = 2";
+
+    view = new EditorView({
+      state: EditorState.create({
+        doc: initialDoc,
+        extensions: [python()],
+      }),
+      parent: container,
+    });
+
+    // Insert a debugger statement at line 1
+    const result = insertDebuggerAtLine(view, 1);
+
+    // Check the result
+    expect(result).toBe(true);
+
+    // Check the updated document content
+    const expectedDoc = "breakpoint()\nx = 1\ny = 2";
+    expect(view.state.doc.toString()).toBe(expectedDoc);
+  });
+
+  it("should return false for invalid line numbers", () => {
+    const initialDoc = "x = 1\ny = 2";
+
+    view = new EditorView({
+      state: EditorState.create({
+        doc: initialDoc,
+        extensions: [python()],
+      }),
+      parent: container,
+    });
+
+    // Try to insert a debugger statement at an invalid line
+    const result = insertDebuggerAtLine(view, 999);
+
+    // Check the result
+    expect(result).toBe(false);
+
+    // Check that the document was not modified
+    expect(view.state.doc.toString()).toBe(initialDoc);
+  });
+
+  it("should handle empty lines correctly", () => {
+    const initialDoc = "x = 1\n\ny = 2";
+
+    view = new EditorView({
+      state: EditorState.create({
+        doc: initialDoc,
+        extensions: [python()],
+      }),
+      parent: container,
+    });
+
+    // Insert a debugger statement at the empty line
+    const result = insertDebuggerAtLine(view, 2);
+
+    // Check the result
+    expect(result).toBe(true);
+
+    // Check the updated document content
+    const expectedDoc = "x = 1\nbreakpoint()\n\ny = 2";
+    expect(view.state.doc.toString()).toBe(expectedDoc);
+  });
+
+  it("should handle tab indentation correctly", () => {
+    const initialDoc =
+      'def test():\n\tif True:\n\t\tprint("tabbed")\n\treturn True';
+
+    view = new EditorView({
+      state: EditorState.create({
+        doc: initialDoc,
+        extensions: [python()],
+      }),
+      parent: container,
+    });
+
+    // Insert a debugger statement at the tabbed line
+    const result = insertDebuggerAtLine(view, 3);
+
+    // Check the result
+    expect(result).toBe(true);
+
+    // Check that the debugger statement has the same tab indentation
+    const expectedDoc =
+      'def test():\n\tif True:\n\t\tbreakpoint()\n\t\tprint("tabbed")\n\treturn True';
+    expect(view.state.doc.toString()).toBe(expectedDoc);
+  });
+
+  it("should skip insertion if line already contains breakpoint()", () => {
+    const initialDoc = "x = 1\nbreakpoint()\ny = 2";
+
+    view = new EditorView({
+      state: EditorState.create({
+        doc: initialDoc,
+        extensions: [python()],
+      }),
+      parent: container,
+    });
+
+    // Try to insert a debugger statement at line 2 which already has breakpoint()
+    const result = insertDebuggerAtLine(view, 2);
+
+    // Check the result
+    expect(result).toBe(true);
+
+    // Check that the document was not modified
+    expect(view.state.doc.toString()).toBe(initialDoc);
+  });
+});

--- a/frontend/src/core/codemirror/editing/__tests__/debugging.test.ts
+++ b/frontend/src/core/codemirror/editing/__tests__/debugging.test.ts
@@ -43,6 +43,11 @@ describe("insertDebuggerAtLine", () => {
     const expectedDoc =
       'def test():\n  breakpoint()\n  print("hello")\n  return True';
     expect(view.state.doc.toString()).toBe(expectedDoc);
+
+    // Check that the cursor is at the end of the breakpoint line
+    const cursorPos = view.state.selection.main.head;
+    const breakpointLine = view.state.doc.line(2);
+    expect(cursorPos).toBe(breakpointLine.to);
   });
 
   it("should match the indentation of the target line", () => {
@@ -68,6 +73,11 @@ describe("insertDebuggerAtLine", () => {
     const expectedDoc =
       'def test():\n    if True:\n        breakpoint()\n        print("nested")\n    return True';
     expect(view.state.doc.toString()).toBe(expectedDoc);
+
+    // Check that the cursor is at the end of the breakpoint line
+    const cursorPos = view.state.selection.main.head;
+    const breakpointLine = view.state.doc.line(3);
+    expect(cursorPos).toBe(breakpointLine.to);
   });
 
   it("should handle the first line correctly", () => {

--- a/frontend/src/core/codemirror/editing/debugging.ts
+++ b/frontend/src/core/codemirror/editing/debugging.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { Logger } from "@/utils/Logger";
-import type { EditorView } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 
 export function insertDebuggerAtLine(view: EditorView, line: number): boolean {
   // Get the document
@@ -41,7 +41,17 @@ export function insertDebuggerAtLine(view: EditorView, line: number): boolean {
       to: insertPos,
       insert: breakpointStatement,
     },
+    // Scroll to the breakpoint
+    selection: {
+      anchor: insertPos + breakpointStatement.length - 1,
+      head: insertPos + breakpointStatement.length - 1,
+    },
+    scrollIntoView: true,
+    effects: [EditorView.scrollIntoView(insertPos, { y: "center" })],
   });
+
+  // Focus the editor after the transaction
+  view.focus();
 
   return true;
 }

--- a/frontend/src/core/codemirror/editing/debugging.ts
+++ b/frontend/src/core/codemirror/editing/debugging.ts
@@ -1,0 +1,47 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { Logger } from "@/utils/Logger";
+import type { EditorView } from "@codemirror/view";
+
+export function insertDebuggerAtLine(view: EditorView, line: number): boolean {
+  // Get the document
+  const { state } = view;
+  const doc = state.doc;
+
+  // Check if the line number is valid
+  if (line <= 0 || line > doc.lines) {
+    Logger.warn(
+      `Invalid line number: ${line}. Document has ${doc.lines} lines.`,
+    );
+    return false;
+  }
+
+  // Get the target line
+  const targetLine = doc.line(line);
+
+  // Skip if line already contains breakpoint()
+  if (targetLine.text.includes("breakpoint()")) {
+    return true;
+  }
+
+  // Extract the indentation from the target line
+  const lineContent = targetLine.text;
+  const indentMatch = lineContent.match(/^(\s*)/);
+  const indentation = indentMatch ? indentMatch[1] : "";
+
+  // Create the breakpoint statement with the same indentation
+  const breakpointStatement = `${indentation}breakpoint()\n`;
+
+  // Get the position where we need to insert the breakpoint statement
+  const insertPos = targetLine.from;
+
+  // Create and dispatch the transaction
+  view.dispatch({
+    changes: {
+      from: insertPos,
+      to: insertPos,
+      insert: breakpointStatement,
+    },
+  });
+
+  return true;
+}

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -45,6 +45,7 @@ const props: CellProps = {
   deleteCell: Logger.log,
   actions: {
     updateCellCode: Logger.log,
+    clearCellConsoleOutput: Logger.log,
     collapseCell: Logger.log,
     expandCell: Logger.log,
     createNewCell: Logger.log,


### PR DESCRIPTION
This adds a button to insert breakpoints at the notebook line-numbers.
As well as a single one at the bottom to insert one at the most deepest level.

This also improves the `stdin` styling, input, and PDB controls.


<img width="677" alt="Screenshot 2025-05-02 at 5 52 16 PM" src="https://github.com/user-attachments/assets/02f3b855-63e8-44d9-bc93-42f165fe8775" />
<img width="810" alt="Screenshot 2025-05-02 at 5 51 58 PM" src="https://github.com/user-attachments/assets/f9a621aa-ed69-4f25-b218-80d0426cf923" />
