### PR TITLE
feat: added collapseAllCells() to cells.ts and tests

### DIFF
--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -1548,7 +1548,7 @@ describe("cell reducer", () => {
       },
     };
 
-    // Check if bother the parent and child are collapsed
+    // Check if both the parent and child are collapsed
     actions.collapseAllCells();
     expect(state.cellIds.atOrThrow(FIRST_COLUMN).isCollapsed(headerId)).toBe(
       true,

--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -1447,7 +1447,7 @@ describe("cell reducer", () => {
     expect(state.cellIds.atOrThrow(FIRST_COLUMN).isCollapsed(id)).toBe(false);
   });
 
-  it("can expand all cells in multiple columns", () => {
+  it("can collapse and expand all cells in multiple columns", () => {
     actions.createNewCell({ cellId: firstCellId, before: false });
     actions.createNewCell({
       cellId: "1" as CellId,
@@ -1497,12 +1497,10 @@ describe("cell reducer", () => {
       },
     };
 
-    actions.collapseCell({ cellId: firstColumnHeaderId });
+    actions.collapseAllCells();
     expect(
       state.cellIds.atOrThrow(FIRST_COLUMN).isCollapsed(firstColumnHeaderId),
     ).toBe(true);
-
-    actions.collapseCell({ cellId: secondColumnHeaderId });
     expect(
       state.cellIds.atOrThrow(SECOND_COLUMN).isCollapsed(secondColumnHeaderId),
     ).toBe(true);
@@ -1516,7 +1514,7 @@ describe("cell reducer", () => {
     ).toBe(false);
   });
 
-  it("can expand nested cells in one call", () => {
+  it("can collapse and expand nested cells in one call", () => {
     actions.createNewCell({ cellId: firstCellId, before: false });
     actions.createNewCell({
       cellId: "1" as CellId,
@@ -1550,15 +1548,18 @@ describe("cell reducer", () => {
       },
     };
 
-    actions.collapseCell({ cellId: subheaderId });
+    // Check if bother the parent and child are collapsed
+    actions.collapseAllCells();
+    expect(state.cellIds.atOrThrow(FIRST_COLUMN).isCollapsed(headerId)).toBe(
+      true,
+    );
+    actions.expandCell({ cellId: headerId });
     expect(state.cellIds.atOrThrow(FIRST_COLUMN).isCollapsed(subheaderId)).toBe(
       true,
     );
     actions.collapseCell({ cellId: headerId });
-    expect(state.cellIds.atOrThrow(FIRST_COLUMN).isCollapsed(headerId)).toBe(
-      true,
-    );
 
+    // Check if both the parent and child are expanded
     actions.expandAllCells();
     expect(state.cellIds.atOrThrow(FIRST_COLUMN).isCollapsed(headerId)).toBe(
       false,

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1125,10 +1125,7 @@ const {
           i--;
         }
 
-        // Reverse the reversedCollapseRanges to get them in original order
         const collapseRanges = reversedCollapseRanges.reverse();
-
-        // Collapse all ranges
         return column.collapseAll(collapseRanges);
       }),
     };

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1104,7 +1104,7 @@ const {
 
             // Check if the parent's end point is inside any already-collapsed child range
             const parentEndInChild = rangeIndexes.find(
-              (r) => r.start <= endIndex && r.end === endIndex,
+              (child) => child.start <= endIndex && child.end === endIndex,
             );
 
             if (parentEndInChild) {

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1108,17 +1108,16 @@ const {
             );
 
             if (parentEndInChild) {
-              // Adjust the new endIndex it to the child's start
+              // Adjust the new endIndex to the child's start
               endIndex = parentEndInChild.start;
             }
-
-            // Add the range to the list of ranges
-            const cellId = column.atOrThrow(startIndex);
-            const until = column.atOrThrow(endIndex);
 
             // Store this range for future child checks
             rangeIndexes.push({ start: startIndex, end: endIndex });
 
+            // Add the range to the list of ranges
+            const cellId = column.atOrThrow(startIndex);
+            const until = column.atOrThrow(endIndex);
             reversedCollapseRanges.push({ id: cellId, until });
           } else {
             reversedCollapseRanges.push(null);

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1076,6 +1076,32 @@ const {
       scrollKey: cellId,
     };
   },
+  collapseAllCells: (state) => {
+    return {
+      ...state,
+      cellIds: state.cellIds.transformAll((column) => {
+        // Get all the top-level outlines
+        const outlines = column.topLevelIds.map((id) => {
+          const cell = state.cellRuntime[id];
+          return cell.outline;
+        });
+
+        // Find the start/end of the collapsed ranges
+        const collapseRanges = column.nodes.map((_, i) => {
+          const range = findCollapseRange(i, outlines);
+          if (range) {
+            const cellId = column.atOrThrow(i);
+            const until = column.atOrThrow(range[1]);
+            return { id: cellId, until };
+          }
+          return null;
+        });
+
+        // Collapse all ranges
+        return column.collapseAll(collapseRanges);
+      }),
+    };
+  },
   expandAllCells: (state) => {
     return {
       ...state,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Created an collapseAllCells function that runs both transformAll() and collapseAll() together. Partially resolves #4163 by adding a way to collapse all top-level nested cells in all columns with one command

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Created collapseAllCells
- Modified the expandAllCells tests in #4791 to include collapseAllCells as well for both multicolumn and nested testing

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
