### PR TITLE
Feature ipython progress css style

### DIFF
--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -7,3 +7,4 @@
 @import url("./md-tooltip.css");
 @import url("./admonition.css");
 @import url("./table.css");
+@import url("./progress.css");

--- a/frontend/src/css/progress.css
+++ b/frontend/src/css/progress.css
@@ -1,0 +1,95 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+/* 
+ * Global styling for progress bars to ensure consistent appearance
+ * across both marimo native components and IPython outputs
+ */
+
+/* Container styling */
+.progress-container {
+    display: flex;
+    flex-direction: column;
+    max-width: 384px; /* max-w-sm */
+    padding: 1.5rem; /* p-6 */
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* Title styling */
+.progress-title {
+    font-size: 1.125rem; /* text-lg */
+    font-weight: 700; /* font-bold */
+    color: rgba(55, 65, 81, 0.6); /* text-foreground/60 */
+    font-family: var(--heading-font, "Lora", serif);
+}
+
+/* Subtitle styling */
+.progress-subtitle {
+    font-size: 0.875rem; /* text-sm */
+    color: rgba(107, 114, 128, 0.8); /* text-muted-foreground */
+    font-family: var(--text-font, "PT Sans", sans-serif);
+}
+
+/* Progress wrapper */
+.progress-wrapper {
+    margin-top: 0.5rem; /* mt-2 */
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem; /* gap-1 */
+}
+
+/* Progress bar row */
+.progress-row {
+    display: flex;
+    gap: 0.75rem; /* gap-3 */
+    font-size: 0.875rem; /* text-sm */
+    color: rgba(107, 114, 128, 0.8); /* text-muted-foreground */
+    align-items: baseline;
+    font-family: var(--text-font, "PT Sans", sans-serif);
+}
+
+/* Meta information row */
+.progress-meta {
+    display: flex;
+    gap: 0.5rem; /* gap-2 */
+    color: rgba(107, 114, 128, 0.8); /* text-muted-foreground */
+    font-size: 0.875rem; /* text-sm */
+    font-family: var(--text-font, "PT Sans", sans-serif);
+}
+
+/* Base progress element styling */
+progress {
+    -webkit-appearance: none;
+    appearance: none;
+    position: relative;
+    height: 8px !important;
+    max-height: 8px !important;
+    width: 100% !important;
+    overflow: hidden;
+    border-radius: 9999px;
+    background-color: rgba(59, 130, 246, 0.2);
+    border: none;
+    flex: 1;
+}
+
+/* Progress bar fill styling */
+progress::-webkit-progress-bar {
+    background-color: rgba(59, 130, 246, 0.2);
+    border-radius: 9999px;
+}
+
+progress::-webkit-progress-value {
+    background-color: rgb(59, 130, 246);
+    transition: width 0.2s ease;
+}
+
+progress::-moz-progress-bar {
+    background-color: rgb(59, 130, 246);
+    transition: width 0.2s ease;
+}
+
+/* Wrap existing progress elements */
+progress:not(.wrapped) {
+    display: inline-block;
+}

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -145,6 +145,46 @@ class IPythonFormatter(FormatterFactory):
             else:
                 data = str(html._repr_html_())  # type: ignore
 
+                # Add global styling for progress elements if needed
+                if "<progress" in data:
+                    import re
+                    
+                    # Add a style block with global CSS for progress elements
+                    # This matches the marimo styling from ProgressPlugin.tsx
+                    style_block = '''
+                    <style>
+                        /* Base progress element styling */
+                        progress {
+                            -webkit-appearance: none;
+                            appearance: none;
+                            position: relative;
+                            height: 8px;
+                            width: 100%;
+                            overflow: hidden;
+                            border-radius: 9999px;
+                            background-color: rgba(59, 130, 246, 0.2);
+                            border: none;
+                        }
+                        
+                        /* Progress bar fill styling */
+                        progress::-webkit-progress-bar {
+                            background-color: rgba(59, 130, 246, 0.2);
+                            border-radius: 9999px;
+                        }
+                        
+                        progress::-webkit-progress-value {
+                            background-color: rgb(59, 130, 246);
+                            transition: width 0.2s ease;
+                        }
+                        
+                        progress::-moz-progress-bar {
+                            background-color: rgb(59, 130, 246);
+                            transition: width 0.2s ease;
+                        }
+                    </style>
+                    '''
+                    data = style_block + data
+
             return ("text/html", data)
 
         return unpatch

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -144,46 +144,17 @@ class IPythonFormatter(FormatterFactory):
                 )
             else:
                 data = str(html._repr_html_())  # type: ignore
-
-                # Hardcoded progress bar styling
-                # Add global styling for progress elements if needed
+                
+                # Remove inline styles from progress elements to allow global CSS to apply
                 if "<progress" in data:
-                    # Add a style block with global CSS for progress elements
-                    # This matches the marimo styling from ProgressPlugin.tsx
-                    style_block = """
-                    <style>
-                        /* Base progress element styling */
-                        progress {
-                            -webkit-appearance: none;
-                            appearance: none;
-                            position: relative;
-                            height: 8px;
-                            max-height: 8px;
-                            width: 100%;
-                            overflow: hidden;
-                            border-radius: 9999px;
-                            background-color: rgba(59, 130, 246, 0.2);
-                            border: none;
-                        }
-
-                        /* Progress bar fill styling */
-                        progress::-webkit-progress-bar {
-                            background-color: rgba(59, 130, 246, 0.2);
-                            border-radius: 9999px;
-                        }
-
-                        progress::-webkit-progress-value {
-                            background-color: rgb(59, 130, 246);
-                            transition: width 0.2s ease;
-                        }
-
-                        progress::-moz-progress-bar {
-                            background-color: rgb(59, 130, 246);
-                            transition: width 0.2s ease;
-                        }
-                    </style>
-                    """
-                    data = style_block + data
+                    import re
+                    
+                    # Replace progress elements with inline styles to use our global styling
+                    data = re.sub(
+                        r'<progress([^>]*) style="([^>]*)"([^>]*)>',
+                        r'<progress\1\3>',
+                        data
+                    )
 
             return ("text/html", data)
 

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -148,7 +148,6 @@ class IPythonFormatter(FormatterFactory):
                 # Hardcoded progress bar styling
                 # Add global styling for progress elements if needed
                 if "<progress" in data:
-                    import re
                     
                     # Add a style block with global CSS for progress elements
                     # This matches the marimo styling from ProgressPlugin.tsx

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -145,6 +145,7 @@ class IPythonFormatter(FormatterFactory):
             else:
                 data = str(html._repr_html_())  # type: ignore
 
+                # Hardcoded progress bar styling
                 # Add global styling for progress elements if needed
                 if "<progress" in data:
                     import re

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -148,10 +148,9 @@ class IPythonFormatter(FormatterFactory):
                 # Hardcoded progress bar styling
                 # Add global styling for progress elements if needed
                 if "<progress" in data:
-                    
                     # Add a style block with global CSS for progress elements
                     # This matches the marimo styling from ProgressPlugin.tsx
-                    style_block = '''
+                    style_block = """
                     <style>
                         /* Base progress element styling */
                         progress {
@@ -183,7 +182,7 @@ class IPythonFormatter(FormatterFactory):
                             transition: width 0.2s ease;
                         }
                     </style>
-                    '''
+                    """
                     data = style_block + data
 
             return ("text/html", data)

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -165,18 +165,18 @@ class IPythonFormatter(FormatterFactory):
                             background-color: rgba(59, 130, 246, 0.2);
                             border: none;
                         }
-                        
+
                         /* Progress bar fill styling */
                         progress::-webkit-progress-bar {
                             background-color: rgba(59, 130, 246, 0.2);
                             border-radius: 9999px;
                         }
-                        
+
                         progress::-webkit-progress-value {
                             background-color: rgb(59, 130, 246);
                             transition: width 0.2s ease;
                         }
-                        
+
                         progress::-moz-progress-bar {
                             background-color: rgb(59, 130, 246);
                             transition: width 0.2s ease;

--- a/marimo/_output/formatters/ipython_formatters.py
+++ b/marimo/_output/formatters/ipython_formatters.py
@@ -160,6 +160,7 @@ class IPythonFormatter(FormatterFactory):
                             appearance: none;
                             position: relative;
                             height: 8px;
+                            max-height: 8px;
                             width: 100%;
                             overflow: hidden;
                             border-radius: 9999px;


### PR DESCRIPTION
## 📝 Summary

The current implementation of iPython HTML has a green/grey progress bar that doesn't match Marimo's style.

<img width="841" alt="image" src="https://github.com/user-attachments/assets/a6601830-dc8c-4709-816f-f1541e24c56f" />


## 🔍 Description of Changes

I made a simple change to match Marimo's style, but it is not very elegant since it hardcodes the python formatted the CSS styling instead of using Tailwind.

This is the result, visually it matches Marimo's progress bar style:

https://github.com/user-attachments/assets/21d64622-c4fc-40dc-b064-78588e0369d1


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
