### PR TITLE
fix: remove starlette from top level import

### DIFF
--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -15,9 +15,6 @@ from typing import (
     Union,
 )
 
-from marimo._server.registry import LIFESPAN_REGISTRY
-from marimo._utils.lifespans import Lifespans
-
 if TYPE_CHECKING:
     import sys
 
@@ -389,9 +386,11 @@ def create_asgi_app(
     from marimo._server.lsp import NoopLspServer
     from marimo._server.main import create_starlette_app
     from marimo._server.model import SessionMode
+    from marimo._server.registry import LIFESPAN_REGISTRY
     from marimo._server.sessions import SessionManager
     from marimo._server.tokens import AuthToken
     from marimo._server.utils import initialize_asyncio
+    from marimo._utils.lifespans import Lifespans
     from marimo._utils.marimo_path import MarimoPath
 
     config_reader = get_default_config_manager(current_path=None)

--- a/marimo/_server/registry.py
+++ b/marimo/_server/registry.py
@@ -1,16 +1,17 @@
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from starlette.applications import Starlette  # noqa: TC004
-    from starlette.middleware import Middleware  # noqa: TC004
-    from starlette.types import Lifespan  # noqa: TC004
-
 from marimo._entrypoints.registry import EntryPointRegistry
 
-MIDDLEWARE_REGISTRY = EntryPointRegistry[Middleware](
+if TYPE_CHECKING:
+    from starlette.applications import Starlette
+    from starlette.middleware import Middleware
+    from starlette.types import Lifespan
+
+
+MIDDLEWARE_REGISTRY: EntryPointRegistry["Middleware"] = EntryPointRegistry(
     entry_point_group="marimo.server.asgi.middleware"
 )
 
-LIFESPAN_REGISTRY = EntryPointRegistry[Lifespan[Starlette]](
-    entry_point_group="marimo.server.asgi.lifespan"
+LIFESPAN_REGISTRY: EntryPointRegistry["Lifespan[Starlette]"] = (
+    EntryPointRegistry(entry_point_group="marimo.server.asgi.lifespan")
 )

--- a/marimo/_server/registry.py
+++ b/marimo/_server/registry.py
@@ -1,6 +1,9 @@
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.types import Lifespan
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.applications import Starlette  # noqa: TC004
+    from starlette.middleware import Middleware  # noqa: TC004
+    from starlette.types import Lifespan  # noqa: TC004
 
 from marimo._entrypoints.registry import EntryPointRegistry
 


### PR DESCRIPTION
Remove some eager imports that bring in starlette and break wasm