### PR TITLE
docs: correct on_change desc in `mo.ui.form.form`

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -406,8 +406,7 @@ class UIElement(Html, Generic[S, T]):
             clear_button_tooltip: The tooltip of the clear button.
             validate: A function that takes the form's value and returns an error message if invalid,
                 or `None` if valid.
-            on_change: A callback that takes the form's value and returns an error message if invalid,
-                or `None` if valid.
+            on_change: Optional callback to run when this element's value changes. Defaults to None.
         """
         from marimo._plugins.ui._impl.input import form as form_plugin
 


### PR DESCRIPTION
This makes it so that the description for `on_change` in the method-level API matches the class-level API.

## 📝 Summary
As mentioned in #4827 :
> The [**class-level** API reference for `marimo.ui.form` ](https://docs.marimo.io/api/inputs/form/#marimo.ui.form)correctly distinguishes the two parameters:
> 
> * **validate** (`Callable[[Optional[JSONType]], Optional[str]]`): A function that takes the form's value and returns an error message if the value is invalid, or None if the value is valid. Defaults to None.
> * **on_change** (`Callable[[Optional[T]], None]`): Optional callback to run when this element's value changes. Defaults to None.
> 
> However, the [**method-level** docs](https://docs.marimo.io/api/inputs/form/#marimo.ui.form.form) wrongly describe **both** parameters as returning an error message, implying they’re interchangeable.

## 🔍 Description of Changes
This Fixes #4827 by making sure the:
>**method-level** documentation matches the **class-level** docs for `on_change`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
