### PR TITLE
feat: refresh db connections

### DIFF
--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -28,7 +28,7 @@ import { atom, useAtomValue, useSetAtom } from "jotai";
 import { Tooltip } from "@/components/ui/tooltip";
 import { PanelEmptyState } from "../editor/chrome/panels/empty-state";
 import {
-  fetchDataSourceConnection,
+  previewDataSourceConnection,
   previewDatasetColumn,
 } from "@/core/network/requests";
 import { prettyNumber } from "@/utils/numbers";
@@ -245,7 +245,7 @@ const Engine: React.FC<{
 
   const handleRefreshConnection = async () => {
     setIsSpinning(true);
-    await fetchDataSourceConnection({
+    await previewDataSourceConnection({
       engine: connection.name,
     });
     // Artificially spin the icon if the request is really fast

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -8,6 +8,7 @@ import {
   XIcon,
   Table2Icon,
   EyeIcon,
+  RefreshCwIcon,
 } from "lucide-react";
 import { Command, CommandInput, CommandItem } from "@/components/ui/command";
 import { CommandList } from "cmdk";
@@ -248,6 +249,15 @@ const Engine: React.FC<{
         <span className="text-xs text-muted-foreground">
           (<EngineVariable variableName={engineName as VariableName} />)
         </span>
+        <Tooltip content="Refresh connection">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="ml-auto hover:bg-slate-100"
+          >
+            <RefreshCwIcon className="h-4 w-4 text-muted-foreground" />
+          </Button>
+        </Tooltip>
       </DatasourceLabel>
       {hasChildren ? (
         children

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -241,10 +241,15 @@ const Engine: React.FC<{
     connection.databases.length === 0 || !connection.databases[0]?.engine;
   const engineName = internalEngine ? "In-Memory" : connection.name;
 
+  // Artificially spin the icon on click
+  const [isSpinning, setIsSpinning] = React.useState(false);
+
   const handleRefreshConnection = () => {
+    setIsSpinning(true);
     fetchDataSourceConnection({
       engine: connection.name,
     });
+    setTimeout(() => setIsSpinning(false), 500);
   };
 
   return (
@@ -263,10 +268,15 @@ const Engine: React.FC<{
             <Button
               variant="ghost"
               size="icon"
-              className="ml-auto"
+              className="ml-auto hover:bg-transparent hover:shadow-none"
               onClick={handleRefreshConnection}
             >
-              <RefreshCwIcon className="h-4 w-4 text-muted-foreground" />
+              <RefreshCwIcon
+                className={cn(
+                  "h-4 w-4 text-muted-foreground hover:text-foreground",
+                  isSpinning && "animate-[spin_0.5s]",
+                )}
+              />
             </Button>
           </Tooltip>
         )}

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -241,14 +241,14 @@ const Engine: React.FC<{
     connection.databases.length === 0 || !connection.databases[0]?.engine;
   const engineName = internalEngine ? "In-Memory" : connection.name;
 
-  // Artificially spin the icon on click
   const [isSpinning, setIsSpinning] = React.useState(false);
 
-  const handleRefreshConnection = () => {
+  const handleRefreshConnection = async () => {
     setIsSpinning(true);
-    fetchDataSourceConnection({
+    await fetchDataSourceConnection({
       engine: connection.name,
     });
+    // Artificially spin the icon if the request is really fast
     setTimeout(() => setIsSpinning(false), 500);
   };
 

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -146,6 +146,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   previewDatasetColumn = throwNotImplemented;
   previewSQLTable = throwNotImplemented;
   previewSQLTableList = throwNotImplemented;
+  fetchDataSourceConnection = throwNotImplemented;
   openFile = throwNotImplemented;
   sendListFiles = throwNotImplemented;
   sendPdb = throwNotImplemented;

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -146,7 +146,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   previewDatasetColumn = throwNotImplemented;
   previewSQLTable = throwNotImplemented;
   previewSQLTableList = throwNotImplemented;
-  fetchDataSourceConnection = throwNotImplemented;
+  previewDataSourceConnection = throwNotImplemented;
   openFile = throwNotImplemented;
   sendListFiles = throwNotImplemented;
   sendPdb = throwNotImplemented;

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -173,9 +173,9 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         })
         .then(handleResponseReturnNull);
     },
-    fetchDataSourceConnection: (request) => {
+    previewDataSourceConnection: (request) => {
       return marimoClient
-        .POST("/api/datasources/fetch_datasource_connection", {
+        .POST("/api/datasources/preview_datasource_connection", {
           body: request,
         })
         .then(handleResponseReturnNull);

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -173,6 +173,13 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         })
         .then(handleResponseReturnNull);
     },
+    fetchDataSourceConnection: (request) => {
+      return marimoClient
+        .POST("/api/datasources/fetch_datasource_connection", {
+          body: request,
+        })
+        .then(handleResponseReturnNull);
+    },
     openFile: async (request) => {
       await marimoClient
         .POST("/api/files/open", {

--- a/frontend/src/core/network/requests-static.ts
+++ b/frontend/src/core/network/requests-static.ts
@@ -52,6 +52,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     previewDatasetColumn: throwNotInEditMode,
     previewSQLTable: throwNotInEditMode,
     previewSQLTableList: throwNotInEditMode,
+    previewDataSourceConnection: throwNotInEditMode,
     openFile: throwNotInEditMode,
     getUsageStats: throwNotInEditMode,
     sendListFiles: throwNotInEditMode,

--- a/frontend/src/core/network/requests-toasting.ts
+++ b/frontend/src/core/network/requests-toasting.ts
@@ -33,6 +33,7 @@ export function createErrorToastingRequests(
     previewDatasetColumn: "Failed to fetch data sources",
     previewSQLTable: "Failed to fetch SQL table",
     previewSQLTableList: "Failed to fetch SQL table list",
+    previewDataSourceConnection: "Failed to preview data source connection",
     openFile: "Failed to open file",
     getUsageStats: "", // No toast
     sendListFiles: "Failed to list files",

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -51,6 +51,7 @@ export const {
   previewDatasetColumn,
   previewSQLTable,
   previewSQLTableList,
+  fetchDataSourceConnection,
   openFile,
   getUsageStats,
   sendPdb,

--- a/frontend/src/core/network/requests.ts
+++ b/frontend/src/core/network/requests.ts
@@ -51,7 +51,7 @@ export const {
   previewDatasetColumn,
   previewSQLTable,
   previewSQLTableList,
-  fetchDataSourceConnection,
+  previewDataSourceConnection,
   openFile,
   getUsageStats,
   sendPdb,

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -55,6 +55,8 @@ export type PreviewDatasetColumnRequest =
   schemas["PreviewDatasetColumnRequest"];
 export type PreviewSQLTableRequest = schemas["PreviewSQLTableRequest"];
 export type PreviewSQLTableListRequest = schemas["PreviewSQLTableListRequest"];
+export type FetchDataSourceConnectionRequest =
+  schemas["FetchDataSourceConnectionRequest"];
 export type PdbRequest = schemas["PdbRequest"];
 export type ReadCodeResponse = schemas["ReadCodeResponse"];
 export type RecentFilesResponse = schemas["RecentFilesResponse"];
@@ -126,6 +128,9 @@ export interface EditRequests {
   previewDatasetColumn: (request: PreviewDatasetColumnRequest) => Promise<null>;
   previewSQLTable: (request: PreviewSQLTableRequest) => Promise<null>;
   previewSQLTableList: (request: PreviewSQLTableListRequest) => Promise<null>;
+  fetchDataSourceConnection: (
+    request: FetchDataSourceConnectionRequest,
+  ) => Promise<null>;
   openFile: (request: { path: string }) => Promise<null>;
   getUsageStats: () => Promise<UsageResponse>;
   // Debugger

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -55,8 +55,8 @@ export type PreviewDatasetColumnRequest =
   schemas["PreviewDatasetColumnRequest"];
 export type PreviewSQLTableRequest = schemas["PreviewSQLTableRequest"];
 export type PreviewSQLTableListRequest = schemas["PreviewSQLTableListRequest"];
-export type FetchDataSourceConnectionRequest =
-  schemas["FetchDataSourceConnectionRequest"];
+export type PreviewDataSourceConnectionRequest =
+  schemas["PreviewDataSourceConnectionRequest"];
 export type PdbRequest = schemas["PdbRequest"];
 export type ReadCodeResponse = schemas["ReadCodeResponse"];
 export type RecentFilesResponse = schemas["RecentFilesResponse"];
@@ -128,8 +128,8 @@ export interface EditRequests {
   previewDatasetColumn: (request: PreviewDatasetColumnRequest) => Promise<null>;
   previewSQLTable: (request: PreviewSQLTableRequest) => Promise<null>;
   previewSQLTableList: (request: PreviewSQLTableListRequest) => Promise<null>;
-  fetchDataSourceConnection: (
-    request: FetchDataSourceConnectionRequest,
+  previewDataSourceConnection: (
+    request: PreviewDataSourceConnectionRequest,
   ) => Promise<null>;
   openFile: (request: { path: string }) => Promise<null>;
   getUsageStats: () => Promise<UsageResponse>;

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -478,12 +478,11 @@ export class PyodideBridge implements RunRequests, EditRequests {
     return null;
   };
 
-  fetchDataSourceConnection: EditRequests["fetchDataSourceConnection"] = async (
-    request,
-  ) => {
-    await this.putControlRequest(request);
-    return null;
-  };
+  previewDataSourceConnection: EditRequests["previewDataSourceConnection"] =
+    async (request) => {
+      await this.putControlRequest(request);
+      return null;
+    };
 
   syncCellIds = () => Promise.resolve(null);
   getUsageStats = throwNotImplemented;

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -478,6 +478,13 @@ export class PyodideBridge implements RunRequests, EditRequests {
     return null;
   };
 
+  fetchDataSourceConnection: EditRequests["fetchDataSourceConnection"] = async (
+    request,
+  ) => {
+    await this.putControlRequest(request);
+    return null;
+  };
+
   syncCellIds = () => Promise.resolve(null);
   getUsageStats = throwNotImplemented;
   openTutorial = throwNotImplemented;

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -196,6 +196,7 @@ def _generate_server_api_schema() -> dict[str, Any]:
         requests.PdbRequest,
         requests.PreviewDatasetColumnRequest,
         requests.PreviewSQLTableListRequest,
+        requests.FetchDataSourceConnectionRequest,
         requests.PreviewSQLTableRequest,
         requests.RenameRequest,
         requests.SetCellConfigRequest,

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -196,7 +196,7 @@ def _generate_server_api_schema() -> dict[str, Any]:
         requests.PdbRequest,
         requests.PreviewDatasetColumnRequest,
         requests.PreviewSQLTableListRequest,
-        requests.FetchDataSourceConnectionRequest,
+        requests.PreviewDataSourceConnectionRequest,
         requests.PreviewSQLTableRequest,
         requests.RenameRequest,
         requests.SetCellConfigRequest,

--- a/marimo/_entrypoints/ids.py
+++ b/marimo/_entrypoints/ids.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 from typing import Literal
 
 # Internal entrypoints. Not user-facing as the API is not stable.

--- a/marimo/_entrypoints/registry.py
+++ b/marimo/_entrypoints/registry.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Generic, Optional, TypeVar, cast
 

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -342,7 +342,7 @@ class PreviewSQLTableListRequest:
 
 
 @dataclass
-class FetchDataSourceConnectionRequest:
+class PreviewDataSourceConnectionRequest:
     """Fetch a datasource connection"""
 
     engine: str
@@ -370,7 +370,7 @@ ControlRequest = Union[
     PdbRequest,
     PreviewDatasetColumnRequest,
     PreviewSQLTableListRequest,
-    FetchDataSourceConnectionRequest,
+    PreviewDataSourceConnectionRequest,
     PreviewSQLTableRequest,
     RefreshSecretsRequest,
     RenameRequest,

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -342,6 +342,13 @@ class PreviewSQLTableListRequest:
 
 
 @dataclass
+class FetchDataSourceConnectionRequest:
+    """Fetch a datasource connection"""
+
+    engine: str
+
+
+@dataclass
 class ListSecretKeysRequest:
     request_id: RequestId
 
@@ -363,6 +370,7 @@ ControlRequest = Union[
     PdbRequest,
     PreviewDatasetColumnRequest,
     PreviewSQLTableListRequest,
+    FetchDataSourceConnectionRequest,
     PreviewSQLTableRequest,
     RefreshSecretsRequest,
     RenameRequest,

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -122,12 +122,12 @@ from marimo._runtime.requests import (
     ExecuteScratchpadRequest,
     ExecuteStaleRequest,
     ExecutionRequest,
-    FetchDataSourceConnectionRequest,
     FunctionCallRequest,
     InstallMissingPackagesRequest,
     ListSecretKeysRequest,
     PdbRequest,
     PreviewDatasetColumnRequest,
+    PreviewDataSourceConnectionRequest,
     PreviewSQLTableListRequest,
     PreviewSQLTableRequest,
     RefreshSecretsRequest,
@@ -2089,8 +2089,8 @@ class Kernel:
             self.datasets_callbacks.preview_sql_table_list,
         )
         handler.register(
-            FetchDataSourceConnectionRequest,
-            self.datasets_callbacks.fetch_datasource_connection,
+            PreviewDataSourceConnectionRequest,
+            self.datasets_callbacks.preview_datasource_connection,
         )
         # Secrets
         handler.register(
@@ -2298,9 +2298,9 @@ class DatasetCallbacks:
                 error="Failed to get table list: " + str(e),
             )
 
-    @kernel_tracer.start_as_current_span("fetch_datasource_connection")
-    async def fetch_datasource_connection(
-        self, request: FetchDataSourceConnectionRequest
+    @kernel_tracer.start_as_current_span("preview_datasource_connection")
+    async def preview_datasource_connection(
+        self, request: PreviewDataSourceConnectionRequest
     ) -> None:
         """Broadcasts a datasource connection for a given engine"""
         variable_name = cast(VariableName, request.engine)

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -56,6 +56,7 @@ from marimo._messaging.ops import (
     CellOp,
     CompletedRun,
     DataColumnPreview,
+    DataSourceConnections,
     FunctionCallResult,
     HumanReadableStatus,
     InstallingPackageAlert,
@@ -121,6 +122,7 @@ from marimo._runtime.requests import (
     ExecuteScratchpadRequest,
     ExecuteStaleRequest,
     ExecutionRequest,
+    FetchDataSourceConnectionRequest,
     FunctionCallRequest,
     InstallMissingPackagesRequest,
     ListSecretKeysRequest,
@@ -163,7 +165,10 @@ from marimo._secrets.secrets import get_secret_keys
 from marimo._server.model import SessionMode
 from marimo._server.types import QueueType
 from marimo._sql.engines.types import SQLEngine
-from marimo._sql.get_engines import get_engines_from_variables
+from marimo._sql.get_engines import (
+    engine_to_data_source_connection,
+    get_engines_from_variables,
+)
 from marimo._tracer import kernel_tracer
 from marimo._types.ids import CellId_t, UIElementId, VariableName
 from marimo._types.lifespan import Lifespan
@@ -2083,6 +2088,10 @@ class Kernel:
             PreviewSQLTableListRequest,
             self.datasets_callbacks.preview_sql_table_list,
         )
+        handler.register(
+            FetchDataSourceConnectionRequest,
+            self.datasets_callbacks.fetch_datasource_connection,
+        )
         # Secrets
         handler.register(
             ListSecretKeysRequest, self.secrets_callbacks.list_secrets
@@ -2184,20 +2193,22 @@ class DatasetCallbacks:
         return
 
     def _get_sql_engine(
-        self, engine_name: str
+        self, variable_name: str
     ) -> tuple[Optional[SQLEngine], Optional[str]]:
-        """Find the SQL engine associated with the given name. Returns the engine and the error message if any."""
-        engine_name = cast(VariableName, engine_name)
+        """Find the SQL engine associated with the given variable name. Returns the engine and the error message if any."""
+        variable_name = cast(VariableName, variable_name)
 
         try:
             # Should we find the existing engine instead?
-            engine_val = self._kernel.globals.get(engine_name)
-            engines = get_engines_from_variables([(engine_name, engine_val)])
+            engine_val = self._kernel.globals.get(variable_name)
+            engines = get_engines_from_variables([(variable_name, engine_val)])
             if engines is None or len(engines) == 0:
                 return None, "Engine not found"
             return engines[0][1], None
         except Exception as e:
-            LOGGER.warning("Failed to get engine %s", engine_name, exc_info=e)
+            LOGGER.warning(
+                "Failed to get engine %s", variable_name, exc_info=e
+            )
             return None, str(e)
 
     @kernel_tracer.start_as_current_span("preview_sql_table")
@@ -2211,12 +2222,12 @@ class DatasetCallbacks:
                 - schema: Name of the schema
                 - table_name: Name of the table
         """
-        engine_name = cast(VariableName, request.engine)
+        variable_name = cast(VariableName, request.engine)
         database_name = request.database
         schema_name = request.schema
         table_name = request.table_name
 
-        engine, error = self._get_sql_engine(engine_name)
+        engine, error = self._get_sql_engine(variable_name)
         if error is not None or engine is None:
             SQLTablePreview(
                 request_id=request.request_id, table=None, error=error
@@ -2257,11 +2268,11 @@ class DatasetCallbacks:
                 - database: Name of the database
                 - schema: Name of the schema
         """
-        engine_name = cast(VariableName, request.engine)
+        variable_name = cast(VariableName, request.engine)
         database_name = request.database
         schema_name = request.schema
 
-        engine, error = self._get_sql_engine(engine_name)
+        engine, error = self._get_sql_engine(variable_name)
         if error is not None or engine is None:
             SQLTableListPreview(
                 request_id=request.request_id, tables=[], error=error
@@ -2286,6 +2297,28 @@ class DatasetCallbacks:
                 tables=[],
                 error="Failed to get table list: " + str(e),
             )
+
+    @kernel_tracer.start_as_current_span("fetch_datasource_connection")
+    async def fetch_datasource_connection(
+        self, request: FetchDataSourceConnectionRequest
+    ) -> None:
+        """Broadcasts a datasource connection for a given engine"""
+        variable_name = cast(VariableName, request.engine)
+        engine, error = self._get_sql_engine(variable_name)
+        if error is not None or engine is None:
+            LOGGER.error("Failed to get engine %s", variable_name)
+            return
+
+        data_source_connection = engine_to_data_source_connection(
+            variable_name, engine
+        )
+
+        LOGGER.debug(
+            "Broadcasting datasource connection for %s engine", variable_name
+        )
+        DataSourceConnections(
+            connections=[data_source_connection],
+        ).broadcast()
 
 
 class SecretsCallbacks:

--- a/marimo/_server/api/endpoints/datasources.py
+++ b/marimo/_server/api/endpoints/datasources.py
@@ -7,8 +7,8 @@ from starlette.authentication import requires
 
 from marimo import _loggers
 from marimo._runtime.requests import (
-    FetchDataSourceConnectionRequest,
     PreviewDatasetColumnRequest,
+    PreviewDataSourceConnectionRequest,
     PreviewSQLTableListRequest,
     PreviewSQLTableRequest,
 )
@@ -107,15 +107,15 @@ async def preview_sql_table_list(request: Request) -> BaseResponse:
     return SuccessResponse()
 
 
-@router.post("/fetch_datasource_connection")
+@router.post("/preview_datasource_connection")
 @requires("edit")
-async def fetch_datasource_connection(request: Request) -> BaseResponse:
+async def preview_datasource_connection(request: Request) -> BaseResponse:
     """
     requestBody:
         content:
             application/json:
                 schema:
-                    $ref: "#/components/schemas/FetchDataSourceConnectionRequest"
+                    $ref: "#/components/schemas/PreviewDataSourceConnectionRequest"
     responses:
         200:
             description: Broadcasts a datasource connection
@@ -125,7 +125,7 @@ async def fetch_datasource_connection(request: Request) -> BaseResponse:
                         $ref: "#/components/schemas/SuccessResponse"
     """
     app_state = AppState(request)
-    body = await parse_request(request, FetchDataSourceConnectionRequest)
+    body = await parse_request(request, PreviewDataSourceConnectionRequest)
     app_state.require_current_session().put_control_request(
         body,
         from_consumer_id=ConsumerId(app_state.require_current_session_id()),

--- a/marimo/_server/api/endpoints/datasources.py
+++ b/marimo/_server/api/endpoints/datasources.py
@@ -7,6 +7,7 @@ from starlette.authentication import requires
 
 from marimo import _loggers
 from marimo._runtime.requests import (
+    FetchDataSourceConnectionRequest,
     PreviewDatasetColumnRequest,
     PreviewSQLTableListRequest,
     PreviewSQLTableRequest,
@@ -99,6 +100,32 @@ async def preview_sql_table_list(request: Request) -> BaseResponse:
     """
     app_state = AppState(request)
     body = await parse_request(request, PreviewSQLTableListRequest)
+    app_state.require_current_session().put_control_request(
+        body,
+        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
+    )
+    return SuccessResponse()
+
+
+@router.post("/fetch_datasource_connection")
+@requires("edit")
+async def fetch_datasource_connection(request: Request) -> BaseResponse:
+    """
+    requestBody:
+        content:
+            application/json:
+                schema:
+                    $ref: "#/components/schemas/FetchDataSourceConnectionRequest"
+    responses:
+        200:
+            description: Broadcasts a datasource connection
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/SuccessResponse"
+    """
+    app_state = AppState(request)
+    body = await parse_request(request, FetchDataSourceConnectionRequest)
     app_state.require_current_session().put_control_request(
         body,
         from_consumer_id=ConsumerId(app_state.require_current_session_id()),

--- a/marimo/_server/registry.py
+++ b/marimo/_server/registry.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 from typing import TYPE_CHECKING
 
 from marimo._entrypoints.registry import EntryPointRegistry

--- a/marimo/_types/lifespan.py
+++ b/marimo/_types/lifespan.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 from collections.abc import (
     Callable,
     Mapping,

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -759,13 +759,6 @@ components:
       required:
       - download
       type: object
-    FetchDataSourceConnectionRequest:
-      properties:
-        engine:
-          type: string
-      required:
-      - engine
-      type: object
     FileCreateRequest:
       properties:
         contents:
@@ -1855,6 +1848,13 @@ components:
       required:
       - cellId
       type: object
+    PreviewDataSourceConnectionRequest:
+      properties:
+        engine:
+          type: string
+      required:
+      - engine
+      type: object
     PreviewDatasetColumnRequest:
       properties:
         columnName:
@@ -2519,7 +2519,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.13.4
+  version: 0.13.6
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:
@@ -2582,20 +2582,6 @@ paths:
               schema:
                 type: string
           description: Get AI inline completion for code
-  /api/datasources/fetch_datasource_connection:
-    post:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FetchDataSourceConnectionRequest'
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessResponse'
-          description: Broadcasts a datasource connection
   /api/datasources/preview_column:
     post:
       requestBody:
@@ -2610,6 +2596,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/SuccessResponse'
           description: Preview a column in a dataset
+  /api/datasources/preview_datasource_connection:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreviewDataSourceConnectionRequest'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+          description: Broadcasts a datasource connection
   /api/datasources/preview_sql_table:
     post:
       requestBody:

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -759,6 +759,13 @@ components:
       required:
       - download
       type: object
+    FetchDataSourceConnectionRequest:
+      properties:
+        engine:
+          type: string
+      required:
+      - engine
+      type: object
     FileCreateRequest:
       properties:
         contents:
@@ -2575,6 +2582,20 @@ paths:
               schema:
                 type: string
           description: Get AI inline completion for code
+  /api/datasources/fetch_datasource_connection:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FetchDataSourceConnectionRequest'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+          description: Broadcasts a datasource connection
   /api/datasources/preview_column:
     post:
       requestBody:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -161,6 +161,45 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/datasources/fetch_datasource_connection": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["FetchDataSourceConnectionRequest"];
+        };
+      };
+      responses: {
+        /** @description Broadcasts a datasource connection */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/datasources/preview_column": {
     parameters: {
       query?: never;
@@ -2676,6 +2715,9 @@ export interface components {
     };
     ExportAsScriptRequest: {
       download: boolean;
+    };
+    FetchDataSourceConnectionRequest: {
+      engine: string;
     };
     FileCreateRequest: {
       contents?: string | null;

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -161,45 +161,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  "/api/datasources/fetch_datasource_connection": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": components["schemas"]["FetchDataSourceConnectionRequest"];
-        };
-      };
-      responses: {
-        /** @description Broadcasts a datasource connection */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": components["schemas"]["SuccessResponse"];
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   "/api/datasources/preview_column": {
     parameters: {
       query?: never;
@@ -223,6 +184,45 @@ export interface paths {
       };
       responses: {
         /** @description Preview a column in a dataset */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["SuccessResponse"];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/datasources/preview_datasource_connection": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["PreviewDataSourceConnectionRequest"];
+        };
+      };
+      responses: {
+        /** @description Broadcasts a datasource connection */
         200: {
           headers: {
             [name: string]: unknown;
@@ -2716,9 +2716,6 @@ export interface components {
     ExportAsScriptRequest: {
       download: boolean;
     };
-    FetchDataSourceConnectionRequest: {
-      engine: string;
-    };
     FileCreateRequest: {
       contents?: string | null;
       name: string;
@@ -3208,6 +3205,9 @@ export interface components {
     PdbRequest: {
       cellId: string;
       request?: components["schemas"]["HTTPRequest"];
+    };
+    PreviewDataSourceConnectionRequest: {
+      engine: string;
     };
     PreviewDatasetColumnRequest: {
       columnName: string;

--- a/tests/_server/api/endpoints/test_datasources.py
+++ b/tests/_server/api/endpoints/test_datasources.py
@@ -68,9 +68,9 @@ def test_preview_sql_table_list(client: TestClient) -> None:
 
 
 @with_session(SESSION_ID)
-def test_fetch_connection(client: TestClient) -> None:
+def test_preview_datasource_connection(client: TestClient) -> None:
     response = client.post(
-        "/api/datasources/fetch_datasource_connection",
+        "/api/datasources/preview_datasource_connection",
         headers=HEADERS,
         json={
             "engine": "test_engine",
@@ -121,7 +121,7 @@ def test_fails_in_read_mode(client: TestClient) -> None:
     assert response.status_code == 401
 
     response = client.post(
-        "/api/datasources/fetch_datasource_connection",
+        "/api/datasources/preview_datasource_connection",
         headers=HEADERS,
         json={
             "engine": "test_engine",

--- a/tests/_server/api/endpoints/test_datasources.py
+++ b/tests/_server/api/endpoints/test_datasources.py
@@ -67,6 +67,20 @@ def test_preview_sql_table_list(client: TestClient) -> None:
     assert content["success"] is True
 
 
+@with_session(SESSION_ID)
+def test_fetch_connection(client: TestClient) -> None:
+    response = client.post(
+        "/api/datasources/fetch_datasource_connection",
+        headers=HEADERS,
+        json={
+            "engine": "test_engine",
+        },
+    )
+    assert response.status_code == 200, response.text
+    content = response.json()
+    assert content["success"] is True
+
+
 @with_read_session(SESSION_ID)
 def test_fails_in_read_mode(client: TestClient) -> None:
     response = client.post(
@@ -102,6 +116,15 @@ def test_fails_in_read_mode(client: TestClient) -> None:
             "engine": "test_engine",
             "database": "test_db",
             "schema": "test_schema",
+        },
+    )
+    assert response.status_code == 401
+
+    response = client.post(
+        "/api/datasources/fetch_datasource_connection",
+        headers=HEADERS,
+        json={
+            "engine": "test_engine",
         },
     )
     assert response.status_code == 401


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Provides a button to refresh datasource connections, except internal duckdb engine.
![image](https://github.com/user-attachments/assets/f57bc5e9-05ee-41ab-b19f-fe905408413c)

- Artificially spin the button on click

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick