### PR TITLE
chore: make LanguageAdapters stateless, store metadata in EditorState

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,10 +23,7 @@ jobs:
           filters: |
             playwright:
               - '**'
-              - '!docs/**'
-              - '!examples/**'
-              - '!README.md'
-              - '!tests/**'
+              - '!{docs/**,examples/**,README.md,tests/**}'
 
   test:
     needs: changes

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -22,10 +22,9 @@ jobs:
           filters: |
             backend:
               - 'marimo/**'
-              - '!marimo/_smoke_tests/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '!frontend/**'
+              - '!{marimo/_smoke_tests,frontend}/**'
             docs:
               - 'docs/**'
 

--- a/.github/workflows/test_be_dagger.yaml.skip
+++ b/.github/workflows/test_be_dagger.yaml.skip
@@ -18,11 +18,10 @@ jobs:
           filters: |
             backend:
               - 'marimo/**'
-              - '!marimo/_smoke_tests/**'
               - 'tests/**'
               - 'pyproject.toml'
               - 'dagger/**'
-              - '!frontend/**'
+              - '!{marimo/_smoke_tests,frontend}/**'
 
   test_python:
     needs: changes

--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -22,9 +22,7 @@ jobs:
           filters: |
             cli:
               - '**'
-              - '!docs/**'
-              - '!examples/**'
-              - '!README.md'
+              - '!{docs/**,examples/**,README.md,tests/**}'
 
   build_wheel:
     needs: changes

--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -88,7 +88,7 @@ const CreateCellButtonContextMenu = (props: {
           key="sql"
           onSelect={(evt) => {
             evt.stopPropagation();
-            onClick({ code: new SQLLanguageAdapter().getDefaultCode() });
+            onClick({ code: new SQLLanguageAdapter().defaultCode });
           }}
         >
           <div className="mr-3 text-muted-foreground">

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -347,7 +347,7 @@ const AddCellButtons: React.FC<{
             createNewCell({
               cellId: { type: "__end__", columnId },
               before: false,
-              code: new SQLLanguageAdapter().getDefaultCode(),
+              code: new SQLLanguageAdapter().defaultCode,
             });
           }}
         >

--- a/frontend/src/core/codemirror/completion/utils.ts
+++ b/frontend/src/core/codemirror/completion/utils.ts
@@ -1,15 +1,16 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import type { CompletionSource } from "@codemirror/autocomplete";
+import type { EditorState } from "@codemirror/state";
 
 /**
  * Condition CompletionSource
  */
 export function conditionalCompletion(opts: {
   completion: CompletionSource;
-  predicate: () => boolean;
+  predicate: (state: EditorState) => boolean;
 }): CompletionSource {
   return (ctx) => {
-    if (!opts.predicate()) {
+    if (!opts.predicate(ctx.state)) {
       return null;
     }
     return opts.completion(ctx);

--- a/frontend/src/core/codemirror/config/extension.ts
+++ b/frontend/src/core/codemirror/config/extension.ts
@@ -7,6 +7,7 @@ import type {
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import type { CellId } from "@/core/cells/ids";
 import { singleFacet } from "../facet";
+import type { PlaceholderType } from "./types";
 
 /**
  * State for completion config
@@ -18,7 +19,6 @@ export const completionConfigState = singleFacet<CompletionConfig>();
  */
 export const hotkeysProviderState = singleFacet<HotkeyProvider>();
 
-export type PlaceholderType = "marimo-import" | "ai" | "none";
 /**
  * State for placeholder type
  */

--- a/frontend/src/core/codemirror/config/types.ts
+++ b/frontend/src/core/codemirror/config/types.ts
@@ -1,0 +1,10 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+/**
+ * The type of placeholder to use for the editor.
+ *
+ * - "marimo-import" -> Shows `import marimo as mo`
+ * - "ai" -> Shows `Start coding or Generate with AI`
+ * - "none" -> No placeholder
+ */
+export type PlaceholderType = "marimo-import" | "ai" | "none";

--- a/frontend/src/core/codemirror/language/LanguageAdapters.ts
+++ b/frontend/src/core/codemirror/language/LanguageAdapters.ts
@@ -4,15 +4,19 @@ import { PythonLanguageAdapter } from "./python";
 import { MarkdownLanguageAdapter } from "./markdown";
 import { SQLLanguageAdapter } from "./sql";
 
-export const LanguageAdapters: Record<
-  LanguageAdapterType,
-  () => LanguageAdapter
-> = {
-  python: () => new PythonLanguageAdapter(),
-  markdown: () => new MarkdownLanguageAdapter(),
-  sql: () => new SQLLanguageAdapter(),
+export const LanguageAdapters: Record<LanguageAdapterType, LanguageAdapter> = {
+  // Getters to prevent circular dependencies
+  get python() {
+    return new PythonLanguageAdapter();
+  },
+  get markdown() {
+    return new MarkdownLanguageAdapter();
+  },
+  get sql() {
+    return new SQLLanguageAdapter();
+  },
 };
 
-export function getLanguageAdapters() {
-  return Object.values(LanguageAdapters).map((la) => la());
+export function getLanguageAdapters(): LanguageAdapter[] {
+  return Object.values(LanguageAdapters);
 }

--- a/frontend/src/core/codemirror/language/__tests__/ast.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/ast.test.ts
@@ -1,0 +1,123 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, it, expect } from "vitest";
+import { parseArgsKwargs } from "../utils/ast";
+import { parser } from "@lezer/python";
+import type { TreeCursor } from "@lezer/common";
+
+function moveToArgList(cursor: TreeCursor) {
+  cursor.next();
+  cursor.next();
+  cursor.next();
+  cursor.next();
+  expect(cursor.name).toBe("ArgList");
+}
+
+function createCursor(code: string) {
+  const tree = parser.parse(code);
+  const cursor = tree.cursor();
+  moveToArgList(cursor);
+  return cursor;
+}
+
+function printResults(
+  results: ReturnType<typeof parseArgsKwargs>,
+  code: string,
+) {
+  return {
+    args: results.args.map(
+      (arg) =>
+        `"${arg.name}" (${arg.from}, ${arg.to}, ${code.slice(arg.from, arg.to)})`,
+    ),
+    kwargs: results.kwargs.map((kwarg) => ({
+      key: kwarg.key,
+      value: kwarg.value,
+    })),
+  };
+}
+
+describe("parseArgsKwargs", () => {
+  it("should parse empty arglist", () => {
+    const code = "fn()";
+    const cursor = createCursor(code);
+    expect(
+      printResults(parseArgsKwargs(cursor, code), code),
+    ).toMatchInlineSnapshot(`
+      {
+        "args": [],
+        "kwargs": [],
+      }
+    `);
+  });
+
+  it("should parse positional arguments", () => {
+    const code = "fn(a, b)";
+    const cursor = createCursor(code);
+    expect(
+      printResults(parseArgsKwargs(cursor, code), code),
+    ).toMatchInlineSnapshot(`
+      {
+        "args": [
+          ""VariableName" (3, 4, a)",
+          ""VariableName" (6, 7, b)",
+        ],
+        "kwargs": [],
+      }
+    `);
+  });
+
+  it("should parse keyword arguments", () => {
+    const code = "fn(a=b, c=d)";
+    const cursor = createCursor(code);
+    expect(
+      printResults(parseArgsKwargs(cursor, code), code),
+    ).toMatchInlineSnapshot(`
+      {
+        "args": [],
+        "kwargs": [
+          {
+            "key": "a",
+            "value": "b",
+          },
+          {
+            "key": "c",
+            "value": "d",
+          },
+        ],
+      }
+    `);
+  });
+
+  it("should parse mixed arguments", () => {
+    const code = "fn(a, b=c)";
+    const cursor = createCursor(code);
+    expect(
+      printResults(parseArgsKwargs(cursor, code), code),
+    ).toMatchInlineSnapshot(`
+      {
+        "args": [
+          ""VariableName" (3, 4, a)",
+        ],
+        "kwargs": [
+          {
+            "key": "b",
+            "value": "c",
+          },
+        ],
+      }
+    `);
+  });
+
+  it("should handle non-ArgList input", () => {
+    const code = "x";
+    const tree = parser.parse(code);
+    const cursor = tree.cursor();
+    expect(
+      printResults(parseArgsKwargs(cursor, code), code),
+    ).toMatchInlineSnapshot(`
+      {
+        "args": [],
+        "kwargs": [],
+      }
+    `);
+  });
+});

--- a/frontend/src/core/codemirror/language/__tests__/indentOneTab.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/indentOneTab.test.ts
@@ -1,0 +1,31 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, it, expect } from "vitest";
+import { indentOneTab } from "../utils/indentOneTab";
+
+describe("indentOneTab", () => {
+  it("should indent non-empty lines by one tab", () => {
+    const input = "line1\nline2\nline3";
+    const expected = "    line1\n    line2\n    line3";
+    expect(indentOneTab(input)).toBe(expected);
+  });
+
+  it("should not indent empty lines", () => {
+    const input = "line1\n\nline2\n\nline3";
+    const expected = "    line1\n\n    line2\n\n    line3";
+    expect(indentOneTab(input)).toBe(expected);
+  });
+
+  it("should handle lines with only whitespace", () => {
+    const input = "line1\n  \nline2\n\t\nline3";
+    const expected = "    line1\n  \n    line2\n\t\n    line3";
+    expect(indentOneTab(input)).toBe(expected);
+  });
+
+  it("should handle empty string", () => {
+    expect(indentOneTab("")).toBe("");
+  });
+
+  it("should handle single line", () => {
+    expect(indentOneTab("single line")).toBe("    single line");
+  });
+});

--- a/frontend/src/core/codemirror/language/commands.ts
+++ b/frontend/src/core/codemirror/language/commands.ts
@@ -19,12 +19,13 @@ export function getCurrentLanguageAdapter(
 }
 
 /**
- *
+ * Check if we can toggle to a given language
  */
-export function canToggleToLanguage(
+function canToggleToLanguage(
   editorView: EditorView | null,
   language: LanguageAdapterType,
 ): boolean {
+  // If there is no editor view or we are already in the language, return false
   if (!editorView || getCurrentLanguageAdapter(editorView) === language) {
     return false;
   }
@@ -34,11 +35,14 @@ export function canToggleToLanguage(
     return true;
   }
 
-  return LanguageAdapters[language]().isSupported(
+  return LanguageAdapters[language].isSupported(
     getEditorCodeAsPython(editorView),
   );
 }
 
+/**
+ * Toggle to a given language
+ */
 export function toggleToLanguage(
   editorView: EditorView,
   language: LanguageAdapterType,

--- a/frontend/src/core/codemirror/language/metadata.ts
+++ b/frontend/src/core/codemirror/language/metadata.ts
@@ -1,0 +1,71 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { StateField, StateEffect, type EditorState } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+
+/**
+ * Metadata for language adapters
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type LanguageMetadata = Record<string, any>;
+
+/**
+ * Effect to set language metadata
+ */
+export const setLanguageMetadata = StateEffect.define<LanguageMetadata>();
+
+/**
+ * Effect to update language metadata (partial update)
+ */
+export const updateLanguageMetadata =
+  StateEffect.define<Partial<LanguageMetadata>>();
+
+/**
+ * State field for language metadata
+ */
+export const languageMetadataField = StateField.define<LanguageMetadata>({
+  create: () => ({}),
+  update: (value, tr) => {
+    for (const effect of tr.effects) {
+      if (effect.is(setLanguageMetadata)) {
+        return effect.value;
+      }
+      if (effect.is(updateLanguageMetadata)) {
+        return { ...value, ...effect.value };
+      }
+    }
+    return value;
+  },
+});
+
+/**
+ * Get language metadata from editor state
+ */
+export function getLanguageMetadata(state: EditorState): LanguageMetadata {
+  return state.field(languageMetadataField);
+}
+
+/**
+ * Set language metadata in editor view
+ */
+export function setLanguageMetadataCommand(
+  view: EditorView,
+  metadata: LanguageMetadata,
+): boolean {
+  view.dispatch({
+    effects: setLanguageMetadata.of(metadata),
+  });
+  return true;
+}
+
+/**
+ * Update language metadata in editor view (partial update)
+ */
+export function updateLanguageMetadataCommand(
+  view: EditorView,
+  metadata: Partial<LanguageMetadata>,
+): boolean {
+  view.dispatch({
+    effects: updateLanguageMetadata.of(metadata),
+  });
+  return true;
+}

--- a/frontend/src/core/codemirror/language/panel.tsx
+++ b/frontend/src/core/codemirror/language/panel.tsx
@@ -1,56 +1,41 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import type { EditorView } from "@codemirror/view";
-import { languageAdapterState } from "./extension";
 import { SQLLanguageAdapter } from "./sql";
 import { normalizeName } from "@/core/cells/names";
 import { useAutoGrowInputProps } from "@/hooks/useAutoGrowInputProps";
-import {
-  type ConnectionName,
-  dataConnectionsMapAtom,
-  INTERNAL_SQL_ENGINES,
-} from "@/core/datasets/data-source-connections";
-import { useAtomValue } from "jotai";
-import {
-  AlertCircle,
-  CircleHelpIcon,
-  InfoIcon,
-  PaintRollerIcon,
-} from "lucide-react";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { DatabaseLogo } from "@/components/databases/icon";
-import { transformDisplayName } from "@/components/databases/display";
-import { useNonce } from "@/hooks/useNonce";
-import type { DataSourceConnection } from "@/core/kernel/messages";
+import { InfoIcon, PaintRollerIcon } from "lucide-react";
+
 import { formatSQL } from "../format";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
 import { MarkdownLanguageAdapter } from "./markdown";
 import type { QuotePrefixKind } from "./utils/quotes";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  type LanguageMetadata,
+  languageMetadataField,
+  updateLanguageMetadata,
+} from "./metadata";
+import type { LanguageMetadataOf } from "./types";
+import { languageAdapterState } from "./extension";
+import { getQuotePrefix, MarkdownQuotePrefixTooltip } from "./panel/markdown";
+import { SQLEngineSelect } from "./panel/sql";
 
 const Divider = () => <div className="h-4 border-r border-border" />;
 
 export const LanguagePanelComponent: React.FC<{
   view: EditorView;
 }> = ({ view }) => {
-  const languageAdapter = view.state.field(languageAdapterState);
   const { spanProps, inputProps } = useAutoGrowInputProps({ minWidth: 50 });
+  const languageAdapter = view.state.field(languageAdapterState);
 
   let actions: React.ReactNode = <div />;
   let showDivider = false;
 
   // Send noop update code event, which will trigger an update to the new output variable name
-  const triggerUpdate = () => {
+  const triggerUpdate = <T extends LanguageMetadata>(update: Partial<T>) => {
     view.dispatch({
+      effects: updateLanguageMetadata.of(update),
       changes: {
         from: 0,
         to: view.state.doc.length,
@@ -60,26 +45,31 @@ export const LanguagePanelComponent: React.FC<{
   };
 
   if (languageAdapter instanceof SQLLanguageAdapter) {
+    type Metadata = LanguageMetadataOf<SQLLanguageAdapter>;
+    const metadata = view.state.field(languageMetadataField) as Metadata;
+
     showDivider = true;
+
     const sanitizeAndTriggerUpdate = (
       e: React.SyntheticEvent<HTMLInputElement>,
     ) => {
       // Normalize the name to a valid variable name
       const name = normalizeName(e.currentTarget.value, false);
-      languageAdapter.setDataframeName(name);
       e.currentTarget.value = name;
 
-      triggerUpdate();
+      triggerUpdate<Metadata>({
+        dataframeName: name,
+      });
     };
+
     actions = (
       <div className="flex flex-1 gap-2 relative items-center">
         <label className="flex gap-2 items-center">
           <span className="select-none">Output variable: </span>
           <input
             {...inputProps}
-            defaultValue={languageAdapter.dataframeName}
+            defaultValue={metadata.dataframeName}
             onChange={(e) => {
-              languageAdapter.setDataframeName(e.target.value);
               inputProps.onChange?.(e);
             }}
             onBlur={sanitizeAndTriggerUpdate}
@@ -93,8 +83,10 @@ export const LanguagePanelComponent: React.FC<{
           <span {...spanProps} />
         </label>
         <SQLEngineSelect
-          languageAdapter={languageAdapter}
-          onChange={triggerUpdate}
+          selectedEngine={metadata.engine}
+          onChange={(engine) => {
+            triggerUpdate<Metadata>({ engine });
+          }}
         />
         <div className="flex items-center gap-2 ml-auto">
           <Tooltip content="Format SQL">
@@ -113,10 +105,11 @@ export const LanguagePanelComponent: React.FC<{
             <input
               type="checkbox"
               onChange={(e) => {
-                languageAdapter.setShowOutput(!e.target.checked);
-                triggerUpdate();
+                triggerUpdate<Metadata>({
+                  showOutput: !e.target.checked,
+                });
               }}
-              checked={!languageAdapter.showOutput}
+              checked={!metadata.showOutput}
             />
             <span className="select-none">Hide output</span>
           </label>
@@ -127,7 +120,11 @@ export const LanguagePanelComponent: React.FC<{
 
   if (languageAdapter instanceof MarkdownLanguageAdapter) {
     showDivider = true;
-    const lastQuotePrefix = languageAdapter.lastQuotePrefix;
+
+    type Metadata = LanguageMetadataOf<MarkdownLanguageAdapter>;
+    const metadata = view.state.field(languageMetadataField) as Metadata;
+    const { quotePrefix } = metadata;
+
     const togglePrefix = (
       prefix: QuotePrefixKind,
       checked: boolean | string,
@@ -135,9 +132,10 @@ export const LanguagePanelComponent: React.FC<{
       if (typeof checked !== "boolean") {
         return;
       }
-      const newPrefix = getQuotePrefix(lastQuotePrefix, checked, prefix);
-      languageAdapter.setQuotePrefix(newPrefix);
-      triggerUpdate();
+      const newPrefix = getQuotePrefix(quotePrefix, checked, prefix);
+      triggerUpdate<Metadata>({
+        quotePrefix: newPrefix,
+      });
     };
 
     actions = (
@@ -147,7 +145,7 @@ export const LanguagePanelComponent: React.FC<{
           <Checkbox
             aria-label="Toggle raw string"
             className="w-3 h-3"
-            checked={lastQuotePrefix.includes("r")}
+            checked={quotePrefix.includes("r")}
             onCheckedChange={(checked) => {
               togglePrefix("r", checked);
             }}
@@ -158,7 +156,7 @@ export const LanguagePanelComponent: React.FC<{
           <Checkbox
             aria-label="Toggle f-string"
             className="w-3 h-3"
-            checked={lastQuotePrefix.includes("f")}
+            checked={quotePrefix.includes("f")}
             onCheckedChange={(checked) => {
               togglePrefix("f", checked);
             }}
@@ -181,172 +179,3 @@ export const LanguagePanelComponent: React.FC<{
     </TooltipProvider>
   );
 };
-
-// Based on the current quote prefix and the checkbox state, return the new quote prefix
-export function getQuotePrefix(
-  currentQuotePrefix: QuotePrefixKind,
-  checked: boolean,
-  prefix: QuotePrefixKind,
-) {
-  let newQuotePrefix = currentQuotePrefix;
-  if (checked) {
-    // Add a prefix
-    if (currentQuotePrefix === "") {
-      newQuotePrefix = prefix;
-    } else if (currentQuotePrefix !== "rf" && prefix !== currentQuotePrefix) {
-      newQuotePrefix = "rf";
-    }
-  } else {
-    // Removing a prefix
-    if (currentQuotePrefix === prefix) {
-      // Removing the only prefix
-      newQuotePrefix = "";
-    } else if (currentQuotePrefix === "rf") {
-      newQuotePrefix = prefix === "r" ? "f" : "r";
-    }
-  }
-
-  return newQuotePrefix;
-}
-
-const MarkdownQuotePrefixTooltip: React.FC = () => {
-  return (
-    <div className="flex flex-col gap-3.5">
-      <section className="flex flex-col gap-0.5">
-        <header className="flex items-center gap-1">
-          <code className="text-xs px-1 py-0.5 bg-[var(--slate-2)] rounded">
-            r
-          </code>
-          <span className="font-semibold">Raw String</span>
-        </header>
-        <p className="text-sm text-muted-foreground">
-          Write LaTeX without escaping special characters
-        </p>
-        <pre className="text-xs bg-[var(--slate-2)] p-2 rounded">
-          \alpha \beta
-        </pre>
-      </section>
-
-      <section className="flex flex-col gap-0.5">
-        <header className="flex items-center gap-1">
-          <code className="text-xs px-1 py-0.5 bg-[var(--slate-2)] rounded">
-            f
-          </code>
-          <span className="font-semibold">Format String</span>
-        </header>
-        <p className="text-sm text-muted-foreground">
-          Interpolate Python values
-        </p>
-        <pre className="text-xs bg-[var(--slate-2)] p-2 rounded">
-          Hello {"{name}"}! 😁
-        </pre>
-      </section>
-    </div>
-  );
-};
-
-interface SelectProps {
-  languageAdapter: SQLLanguageAdapter;
-  onChange: (engine: ConnectionName) => void;
-}
-
-const SQLEngineSelect: React.FC<SelectProps> = ({
-  languageAdapter,
-  onChange,
-}) => {
-  const connectionsMap = useAtomValue(dataConnectionsMapAtom);
-
-  const internalEngineConnections: DataSourceConnection[] = [];
-  const userDefinedConnections: DataSourceConnection[] = [];
-  for (const [connName, connection] of connectionsMap.entries()) {
-    INTERNAL_SQL_ENGINES.has(connName)
-      ? internalEngineConnections.push(connection)
-      : userDefinedConnections.push(connection);
-  }
-
-  // Use nonce to force re-render as languageAdapter.engine may not trigger change
-  // If it's disconnected, we display the engine variable.
-  const selectedEngine = languageAdapter.engine;
-  const rerender = useNonce();
-
-  const engineIsDisconnected =
-    selectedEngine && !connectionsMap.has(selectedEngine);
-
-  const handleSelectEngine = (value: string) => {
-    if (value === HELP_KEY) {
-      window.open(HELP_URL, "_blank");
-      return;
-    }
-
-    const nextEngine = connectionsMap.get(value as ConnectionName);
-    if (nextEngine) {
-      languageAdapter.selectEngine(nextEngine.name);
-      rerender();
-      onChange(nextEngine.name);
-    }
-  };
-
-  const renderConnections = (connections: DataSourceConnection[]) => {
-    // HACK: Ignore iceberg connections
-    // Ideally source_type should be on the DataSourceConnection object
-    connections = connections.filter(
-      (connection) => connection.source !== "iceberg",
-    );
-
-    return connections.map((connection) => (
-      <SelectItem key={connection.name} value={connection.name}>
-        <div className="flex items-center gap-1">
-          <DatabaseLogo className="h-3 w-3" name={connection.dialect} />
-          <span className="truncate">
-            {transformDisplayName(connection.display_name)}
-          </span>
-        </div>
-      </SelectItem>
-    ));
-  };
-
-  return (
-    <div className="flex flex-row gap-1 items-center">
-      <Select value={selectedEngine} onValueChange={handleSelectEngine}>
-        <SelectTrigger className="text-xs border-border !shadow-none !ring-0 h-4.5 px-1.5">
-          <SelectValue placeholder="Select an engine" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            <SelectLabel>Database connections</SelectLabel>
-            {engineIsDisconnected && (
-              <SelectItem key={selectedEngine} value={selectedEngine}>
-                <div className="flex items-center gap-1 opacity-50">
-                  <AlertCircle className="h-3 w-3" />
-                  <span className="truncate">
-                    {transformDisplayName(selectedEngine)}
-                  </span>
-                </div>
-              </SelectItem>
-            )}
-            {/* Prioritize showing user-defined connections */}
-            {renderConnections(userDefinedConnections)}
-            {userDefinedConnections.length > 0 && <SelectSeparator />}
-            {renderConnections(internalEngineConnections)}
-            <SelectSeparator />
-            <SelectItem className="text-muted-foreground" value={HELP_KEY}>
-              <a
-                className="flex items-center gap-1"
-                href={HELP_URL}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <CircleHelpIcon className="h-3 w-3" />
-                <span>How to add a database connection</span>
-              </a>
-            </SelectItem>
-          </SelectGroup>
-        </SelectContent>
-      </Select>
-    </div>
-  );
-};
-
-const HELP_KEY = "__help__";
-const HELP_URL =
-  "http://docs.marimo.io/guides/working_with_data/sql/#connecting-to-a-custom-database";

--- a/frontend/src/core/codemirror/language/panel/markdown.tsx
+++ b/frontend/src/core/codemirror/language/panel/markdown.tsx
@@ -1,0 +1,65 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import type { QuotePrefixKind } from "../utils/quotes";
+
+// Based on the current quote prefix and the checkbox state, return the new quote prefix
+export function getQuotePrefix(
+  currentQuotePrefix: QuotePrefixKind,
+  checked: boolean,
+  prefix: QuotePrefixKind,
+) {
+  let newQuotePrefix = currentQuotePrefix;
+  if (checked) {
+    // Add a prefix
+    if (currentQuotePrefix === "") {
+      newQuotePrefix = prefix;
+    } else if (currentQuotePrefix !== "rf" && prefix !== currentQuotePrefix) {
+      newQuotePrefix = "rf";
+    }
+  } else {
+    // Removing a prefix
+    if (currentQuotePrefix === prefix) {
+      // Removing the only prefix
+      newQuotePrefix = "";
+    } else if (currentQuotePrefix === "rf") {
+      newQuotePrefix = prefix === "r" ? "f" : "r";
+    }
+  }
+
+  return newQuotePrefix;
+}
+
+export const MarkdownQuotePrefixTooltip: React.FC = () => {
+  return (
+    <div className="flex flex-col gap-3.5">
+      <section className="flex flex-col gap-0.5">
+        <header className="flex items-center gap-1">
+          <code className="text-xs px-1 py-0.5 bg-[var(--slate-2)] rounded">
+            r
+          </code>
+          <span className="font-semibold">Raw String</span>
+        </header>
+        <p className="text-sm text-muted-foreground">
+          Write LaTeX without escaping special characters
+        </p>
+        <pre className="text-xs bg-[var(--slate-2)] p-2 rounded">
+          \alpha \beta
+        </pre>
+      </section>
+
+      <section className="flex flex-col gap-0.5">
+        <header className="flex items-center gap-1">
+          <code className="text-xs px-1 py-0.5 bg-[var(--slate-2)] rounded">
+            f
+          </code>
+          <span className="font-semibold">Format String</span>
+        </header>
+        <p className="text-sm text-muted-foreground">
+          Interpolate Python values
+        </p>
+        <pre className="text-xs bg-[var(--slate-2)] p-2 rounded">
+          Hello {"{name}"}! 😁
+        </pre>
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/core/codemirror/language/panel/sql.tsx
+++ b/frontend/src/core/codemirror/language/panel/sql.tsx
@@ -1,0 +1,129 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import {
+  type ConnectionName,
+  dataConnectionsMapAtom,
+  INTERNAL_SQL_ENGINES,
+  setLatestEngineSelected,
+} from "@/core/datasets/data-source-connections";
+import { useAtomValue } from "jotai";
+import { AlertCircle, CircleHelpIcon } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DatabaseLogo } from "@/components/databases/icon";
+import { transformDisplayName } from "@/components/databases/display";
+import { useNonce } from "@/hooks/useNonce";
+import type { DataSourceConnection } from "@/core/kernel/messages";
+
+interface SelectProps {
+  selectedEngine: ConnectionName;
+  onChange: (engine: ConnectionName) => void;
+}
+
+export const SQLEngineSelect: React.FC<SelectProps> = ({
+  selectedEngine,
+  onChange,
+}) => {
+  const connectionsMap = useAtomValue(dataConnectionsMapAtom);
+
+  const internalEngineConnections: DataSourceConnection[] = [];
+  const userDefinedConnections: DataSourceConnection[] = [];
+  for (const [connName, connection] of connectionsMap.entries()) {
+    INTERNAL_SQL_ENGINES.has(connName)
+      ? internalEngineConnections.push(connection)
+      : userDefinedConnections.push(connection);
+  }
+
+  // Use nonce to force re-render as languageAdapter.engine may not trigger change
+  // If it's disconnected, we display the engine variable.
+  const rerender = useNonce();
+
+  const engineIsDisconnected =
+    selectedEngine && !connectionsMap.has(selectedEngine);
+
+  const handleSelectEngine = (value: string) => {
+    if (value === HELP_KEY) {
+      window.open(HELP_URL, "_blank");
+      return;
+    }
+
+    const nextEngine = connectionsMap.get(value as ConnectionName);
+    if (nextEngine) {
+      rerender();
+      onChange(nextEngine.name);
+      // Update the latest engine selected
+      setLatestEngineSelected(nextEngine.name);
+    }
+  };
+
+  const renderConnections = (connections: DataSourceConnection[]) => {
+    // HACK: Ignore iceberg connections
+    // Ideally source_type should be on the DataSourceConnection object
+    connections = connections.filter(
+      (connection) => connection.source !== "iceberg",
+    );
+
+    return connections.map((connection) => (
+      <SelectItem key={connection.name} value={connection.name}>
+        <div className="flex items-center gap-1">
+          <DatabaseLogo className="h-3 w-3" name={connection.dialect} />
+          <span className="truncate">
+            {transformDisplayName(connection.display_name)}
+          </span>
+        </div>
+      </SelectItem>
+    ));
+  };
+
+  return (
+    <div className="flex flex-row gap-1 items-center">
+      <Select value={selectedEngine} onValueChange={handleSelectEngine}>
+        <SelectTrigger className="text-xs border-border !shadow-none !ring-0 h-4.5 px-1.5">
+          <SelectValue placeholder="Select an engine" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>Database connections</SelectLabel>
+            {engineIsDisconnected && (
+              <SelectItem key={selectedEngine} value={selectedEngine}>
+                <div className="flex items-center gap-1 opacity-50">
+                  <AlertCircle className="h-3 w-3" />
+                  <span className="truncate">
+                    {transformDisplayName(selectedEngine)}
+                  </span>
+                </div>
+              </SelectItem>
+            )}
+            {/* Prioritize showing user-defined connections */}
+            {renderConnections(userDefinedConnections)}
+            {userDefinedConnections.length > 0 && <SelectSeparator />}
+            {renderConnections(internalEngineConnections)}
+            <SelectSeparator />
+            <SelectItem className="text-muted-foreground" value={HELP_KEY}>
+              <a
+                className="flex items-center gap-1"
+                href={HELP_URL}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <CircleHelpIcon className="h-3 w-3" />
+                <span>How to add a database connection</span>
+              </a>
+            </SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
+
+const HELP_KEY = "__help__";
+const HELP_URL =
+  "http://docs.marimo.io/guides/working_with_data/sql/#connecting-to-a-custom-database";

--- a/frontend/src/core/codemirror/language/sql.ts
+++ b/frontend/src/core/codemirror/language/sql.ts
@@ -191,7 +191,7 @@ export class SQLLanguageAdapter
         defaultKeymap: false,
         activateOnTyping: true,
         override: [
-          tablesCompletionSource(this),
+          tablesCompletionSource(),
           // Complete for variables in SQL {} blocks
           variableCompletionSource,
           (ctx) => {
@@ -340,7 +340,7 @@ export class SQLCompletionStore {
 
 const SCHEMA_CACHE = new SQLCompletionStore();
 
-function tablesCompletionSource(adapter: SQLLanguageAdapter): CompletionSource {
+function tablesCompletionSource(): CompletionSource {
   return (ctx) => {
     const metadata = ctx.state.field(
       languageMetadataField,

--- a/frontend/src/core/codemirror/language/sql.ts
+++ b/frontend/src/core/codemirror/language/sql.ts
@@ -3,15 +3,13 @@ import type { Extension } from "@codemirror/state";
 import type { LanguageAdapter } from "./types";
 // @ts-expect-error: no declaration file
 import dedent from "string-dedent";
-import type { CompletionConfig } from "@/core/config/config-schema";
-import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { indentOneTab } from "./utils/indentOneTab";
 import {
   autocompletion,
   type CompletionSource,
 } from "@codemirror/autocomplete";
 import { store } from "@/core/state/jotai";
-import { type QuotePrefixKind, upgradePrefixKind } from "./utils/quotes";
+import type { QuotePrefixKind } from "./utils/quotes";
 import { MarkdownLanguageAdapter } from "./markdown";
 import {
   dataConnectionsMapAtom,
@@ -24,7 +22,6 @@ import { parser } from "@lezer/python";
 import type { SyntaxNode, TreeCursor } from "@lezer/common";
 import { parseArgsKwargs } from "./utils/ast";
 import { Logger } from "@/utils/Logger";
-import type { CellId } from "@/core/cells/ids";
 import {
   sql,
   StandardSQL,
@@ -42,95 +39,107 @@ import type { DataSourceConnection } from "@/core/kernel/messages";
 import { isSchemaless } from "@/components/datasources/utils";
 import { datasetTablesAtom } from "@/core/datasets/state";
 import { variableCompletionSource } from "./embedded-python";
+import { languageMetadataField } from "./metadata";
+
+export interface SQLLanguageAdapterMetadata {
+  dataframeName: string;
+  quotePrefix: QuotePrefixKind;
+  commentLines: string[];
+  showOutput: boolean;
+  engine: ConnectionName;
+}
+
+function getLatestEngine(): ConnectionName {
+  return store.get(dataSourceConnectionsAtom).latestEngineSelected;
+}
 
 /**
  * Language adapter for SQL.
  */
-export class SQLLanguageAdapter implements LanguageAdapter {
+export class SQLLanguageAdapter
+  implements LanguageAdapter<SQLLanguageAdapterMetadata>
+{
   readonly type = "sql";
-  readonly defaultCode = `_df = mo.sql(f"""SELECT * FROM """)`;
-  readonly defaultEngine = DUCKDB_ENGINE;
+
+  get defaultCode(): string {
+    const latestEngine = getLatestEngine();
+    if (latestEngine === this.defaultEngine) {
+      return `_df = mo.sql(f"""SELECT * FROM """)`;
+    }
+    return `_df = mo.sql(f"""SELECT * FROM """, engine=${latestEngine})`;
+  }
+
   static fromQuery = (query: string) => `_df = mo.sql(f"""${query.trim()}""")`;
 
-  dataframeName = "_df";
-  lastQuotePrefix: QuotePrefixKind = "f";
-  lastPythonCode = "";
-  showOutput = true;
-  engine = store.get(dataSourceConnectionsAtom).latestEngineSelected;
-
-  getDefaultCode(): string {
-    if (this.engine === this.defaultEngine) {
-      return this.defaultCode;
-    }
-    return `_df = mo.sql(f"""SELECT * FROM """, engine=${this.engine})`;
-  }
+  private readonly defaultEngine = DUCKDB_ENGINE;
 
   transformIn(
     pythonCode: string,
-  ): [sqlQuery: string, queryStartOffset: number] {
+  ): [
+    sqlQuery: string,
+    queryStartOffset: number,
+    metadata: SQLLanguageAdapterMetadata,
+  ] {
+    pythonCode = pythonCode.trim();
+
+    // Default metadata
+    const metadata: SQLLanguageAdapterMetadata = {
+      dataframeName: "_df",
+      commentLines: this.extractCommentLines(pythonCode),
+      quotePrefix: "f",
+      showOutput: true,
+      engine: getLatestEngine() || this.defaultEngine,
+    };
+
     if (!this.isSupported(pythonCode)) {
       // Attempt to remove any markdown wrappers
       const [transformedCode, offset] =
         new MarkdownLanguageAdapter().transformIn(pythonCode);
       // Just return the original code
-      return [transformedCode, offset];
+      return [transformedCode, offset, metadata];
     }
-
-    this.lastPythonCode = pythonCode;
-    pythonCode = pythonCode.trim();
 
     // Handle empty strings
     if (pythonCode === "") {
-      this.lastQuotePrefix = "f";
-      this.showOutput = true;
-      return ["", 0];
+      return ["", 0, metadata];
     }
 
     const sqlStatement = parseSQLStatement(pythonCode);
     if (sqlStatement) {
-      this.dataframeName = sqlStatement.dfName;
-      this.showOutput = sqlStatement.output ?? true;
-      this.engine =
+      metadata.dataframeName = sqlStatement.dfName;
+      metadata.showOutput = sqlStatement.output ?? true;
+      metadata.engine =
         (sqlStatement.engine as ConnectionName) ?? this.defaultEngine;
 
-      if (this.engine !== this.defaultEngine) {
+      if (metadata.engine !== this.defaultEngine) {
         // User selected a new engine, set it as latest.
         // This makes new SQL statements use the new engine by default.
-        setLatestEngineSelected(this.engine);
+        setLatestEngineSelected(metadata.engine);
       }
 
       return [
         dedent(`\n${sqlStatement.sqlString}\n`).trim(),
         sqlStatement.startPosition,
+        metadata,
       ];
     }
 
-    return [pythonCode, 0];
+    return [pythonCode, 0, metadata];
   }
 
-  transformOut(code: string): [string, number] {
-    // Get the quote type from the last transformIn
-    const prefix = upgradePrefixKind(this.lastQuotePrefix, code);
+  transformOut(
+    code: string,
+    metadata: SQLLanguageAdapterMetadata,
+  ): [string, number] {
+    const { quotePrefix, commentLines, showOutput, engine, dataframeName } =
+      metadata;
 
-    // Multiline code
-    // Retrieve any comments that the Python code may have started with
-    const lines = this.lastPythonCode.split("\n");
-    const commentLines = [];
-
-    for (const line of lines) {
-      if (line.startsWith("#")) {
-        commentLines.push(line);
-      } else {
-        break;
-      }
-    }
-
-    const start = `${this.dataframeName} = mo.sql(\n    ${prefix}"""\n`;
+    const start = `${dataframeName} = mo.sql(\n    ${quotePrefix}"""\n`;
     const escapedCode = code.replaceAll('"""', String.raw`\"""`);
 
-    const showOutputParam = this.showOutput ? "" : ",\n    output=False";
+    const showOutputParam = showOutput ? "" : ",\n    output=False";
     const engineParam =
-      this.engine === this.defaultEngine ? "" : `,\n    engine=${this.engine}`;
+      engine === this.defaultEngine ? "" : `,\n    engine=${engine}`;
     const end = `\n    """${showOutputParam}${engineParam}\n)`;
 
     return [
@@ -144,37 +153,33 @@ export class SQLLanguageAdapter implements LanguageAdapter {
       return true;
     }
 
-    // Does not have 2 `mo.sql` calls
-    if (pythonCode.split("mo.sql").length > 2) {
+    // Has at least one `mo.sql` call
+    if (!pythonCode.includes("mo.sql")) {
       return false;
     }
 
-    // Has at least one `mo.sql` call
-    if (!pythonCode.includes("mo.sql")) {
+    // Does not have 2 `mo.sql` calls
+    if (pythonCode.split("mo.sql").length > 2) {
       return false;
     }
 
     return parseSQLStatement(pythonCode) !== null;
   }
 
-  selectEngine(connectionName: ConnectionName): void {
-    this.engine = connectionName;
-    setLatestEngineSelected(this.engine);
+  private extractCommentLines(pythonCode: string): string[] {
+    const lines = pythonCode.split("\n");
+    const commentLines = [];
+    for (const line of lines) {
+      if (line.startsWith("#")) {
+        commentLines.push(line);
+      } else {
+        break;
+      }
+    }
+    return commentLines;
   }
 
-  setShowOutput(showOutput: boolean): void {
-    this.showOutput = showOutput;
-  }
-
-  setDataframeName(dataframeName: string): void {
-    this.dataframeName = dataframeName;
-  }
-
-  getExtension(
-    _cellId: CellId,
-    _completionConfig: CompletionConfig,
-    _hotkeys: HotkeyProvider,
-  ): Extension[] {
+  getExtension(): Extension[] {
     const keywordCompletion = keywordCompletionSource(StandardSQL);
     return [
       sql({
@@ -337,7 +342,10 @@ const SCHEMA_CACHE = new SQLCompletionStore();
 
 function tablesCompletionSource(adapter: SQLLanguageAdapter): CompletionSource {
   return (ctx) => {
-    const connectionName = adapter.engine;
+    const metadata = ctx.state.field(
+      languageMetadataField,
+    ) as SQLLanguageAdapterMetadata;
+    const connectionName = metadata.engine;
     const config = SCHEMA_CACHE.getCompletionSource(connectionName);
 
     if (!config) {
@@ -432,7 +440,7 @@ function getStringContent(node: SyntaxNode, code: string): string | null {
  * @param code - The Python code string to parse.
  * @returns The parsed SQL statement or null if parsing fails.
  */
-export function parseSQLStatement(code: string): SQLParseInfo | null {
+function parseSQLStatement(code: string): SQLParseInfo | null {
   try {
     const tree = parser.parse(code);
     const cursor = tree.cursor();

--- a/frontend/src/core/codemirror/language/types.ts
+++ b/frontend/src/core/codemirror/language/types.ts
@@ -1,4 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
   CompletionConfig,
   DiagnosticsConfig,
@@ -6,19 +7,22 @@ import type {
 } from "@/core/config/config-schema";
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
 import type { Extension } from "@codemirror/state";
-import type { PlaceholderType } from "../config/extension";
+import type { PlaceholderType } from "../config/types";
 import type { CellId } from "@/core/cells/ids";
 
 /**
  * A language adapter is a class that can transform code from one language to
  * another. For example, a Markdown language adapter can make it feel like
  * you're writing Markdown, but it will actually be transformed into Python.
+ *
+ * These are stateless classes that can be reused across multiple editor views.
  */
-export interface LanguageAdapter {
+export interface LanguageAdapter<M = Record<string, any>> {
   readonly type: LanguageAdapterType;
   readonly defaultCode: string;
-  transformIn(code: string): [string, number];
-  transformOut(code: string): [string, number];
+
+  transformIn(code: string): [string, number, M];
+  transformOut(code: string, metadata: M): [string, number];
   isSupported(code: string): boolean;
   getExtension(
     cellId: CellId,
@@ -28,5 +32,8 @@ export interface LanguageAdapter {
     lspConfig: LSPConfig & { diagnostics?: DiagnosticsConfig },
   ): Extension[];
 }
+
+export type LanguageMetadataOf<T extends LanguageAdapter> =
+  T extends LanguageAdapter<infer M> ? M : never;
 
 export type LanguageAdapterType = "python" | "markdown" | "sql";

--- a/frontend/src/core/codemirror/language/utils.ts
+++ b/frontend/src/core/codemirror/language/utils.ts
@@ -2,6 +2,7 @@
 import type { EditorView } from "@codemirror/view";
 import { languageAdapterState } from "./extension";
 import type { EditorState } from "@codemirror/state";
+import { languageMetadataField } from "./metadata";
 
 /**
  * Get the editor code as Python
@@ -13,11 +14,15 @@ export function getEditorCodeAsPython(
   toPos?: number,
 ): string {
   const languageAdapter = editor.state.field(languageAdapterState);
+  const metadata = editor.state.field(languageMetadataField);
   const editorText = editor.state.doc.toString();
   if (fromPos !== undefined) {
-    return languageAdapter.transformOut(editorText.slice(fromPos, toPos))[0];
+    return languageAdapter.transformOut(
+      editorText.slice(fromPos, toPos),
+      metadata,
+    )[0];
   }
-  return languageAdapter.transformOut(editorText)[0];
+  return languageAdapter.transformOut(editorText, metadata)[0];
 }
 
 /**

--- a/frontend/src/core/codemirror/language/utils/ast.ts
+++ b/frontend/src/core/codemirror/language/utils/ast.ts
@@ -15,14 +15,14 @@ export function parseArgsKwargs(
   const name = argCursor.name;
 
   if (name !== "ArgList") {
-    Logger.warn("Not an ArgList");
+    Logger.warn(`Not an ArgList, name: ${name}`);
     return { args: [], kwargs: [] };
   }
 
   return { args: parseArgs(argCursor), kwargs: parseKwargs(argCursor, code) };
 }
 
-export function parseArgs(argCursor: TreeCursor): SyntaxNode[] {
+function parseArgs(argCursor: TreeCursor): SyntaxNode[] {
   // Move to first argument
   argCursor.firstChild();
 
@@ -50,7 +50,7 @@ export function parseArgs(argCursor: TreeCursor): SyntaxNode[] {
   return args;
 }
 
-export function parseKwargs(
+function parseKwargs(
   argCursor: TreeCursor,
   code: string,
 ): Array<{ key: string; value: string }> {

--- a/frontend/src/core/codemirror/language/utils/quotes.ts
+++ b/frontend/src/core/codemirror/language/utils/quotes.ts
@@ -1,7 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { logNever } from "@/utils/assertNever";
-
 export const QUOTE_PREFIX_KINDS = ["", "f", "r", "fr", "rf"] as const;
 export type QuotePrefixKind = (typeof QUOTE_PREFIX_KINDS)[number];
 
@@ -17,31 +15,4 @@ export function splitQuotePrefix(quote: string): [QuotePrefixKind, string] {
     }
   }
   return ["", quote];
-}
-
-export function upgradePrefixKind(
-  kind: QuotePrefixKind,
-  code: string,
-): QuotePrefixKind {
-  const containsSubstitution = code.includes("{") && code.includes("}");
-
-  // If there is no substitution, keep the same prefix
-  if (!containsSubstitution) {
-    return kind;
-  }
-
-  // If there is a substitution, upgrade to an f-string
-  switch (kind) {
-    case "":
-      return "f";
-    case "r":
-      return "rf";
-    case "f":
-    case "rf":
-    case "fr":
-      return kind;
-    default:
-      logNever(kind);
-      return "f";
-  }
 }

--- a/frontend/src/core/codemirror/react-dom/createPanel.tsx
+++ b/frontend/src/core/codemirror/react-dom/createPanel.tsx
@@ -4,6 +4,9 @@ import type { EditorView, Panel } from "@codemirror/view";
 import { Provider } from "jotai";
 import { type Root, createRoot } from "react-dom/client";
 
+/**
+ * Bridge between Codemirror panels and React
+ */
 export function createPanel(
   view: EditorView,
   Component: React.ComponentType<{ view: EditorView }>,

--- a/frontend/src/core/codemirror/rtc/extension.ts
+++ b/frontend/src/core/codemirror/rtc/extension.ts
@@ -218,7 +218,7 @@ function languageObserverExtension(cellId: CellId) {
       Logger.debug(
         `[rtc] Received language change: ${currentLang} -> ${newLang}`,
       );
-      const adapter = LanguageAdapters[newLang]();
+      const adapter = LanguageAdapters[newLang];
       switchLanguage(view, adapter.type, { keepCodeAsIs: true });
     }
   };


### PR DESCRIPTION
This makes the `LanguageAdapter` stateless and instead adds `LanguageAdapterMetadata` which is a map of state that is easier to access/update. 

This change makes real-time syncing much easier. 

This also adds some new test converge and cleans up some code (moving to to new files)