### PR TITLE
fix: uv, start tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ pip install marimo && marimo tutorial intro
 /// tab | install with uv
 
 ```bash
-uv add marimo && marimo tutorial intro
+uv add marimo && uv run marimo tutorial intro
 ```
 
 ///


### PR DESCRIPTION
## 📝 Summary

Currently running the provided command will install the dependencies but fail to start the tutorial. 

This change adds `uv run` to the command to ensure we invoke `uv` when starting the tutorial.

```bash
$ uv add marimo && marimo tutorial intro
$ Using CPython 3.13.2 interpreter at: /opt/homebrew/opt/python@3.13/bin/python3.13
Creating virtual environment at: .venv
Resolved 24 packages in 964ms
Prepared 22 packages in 5.27s
Installed 22 packages in 87ms
 + anyio==4.9.0
 + click==8.1.8
 + docutils==0.21.2
 + h11==0.16.0
 + idna==3.10
 + itsdangerous==2.2.0
 + jedi==0.19.2
 + marimo==0.13.6
 + markdown==3.8
 + narwhals==1.38.2
 + packaging==25.0
 + parso==0.8.4
 + psutil==7.0.0
 + pycrdt==0.11.1
 + pygments==2.19.1
 + pymdown-extensions==10.15
 + pyyaml==6.0.2
 + sniffio==1.3.1
 + starlette==0.46.2
 + tomlkit==0.13.2
 + uvicorn==0.34.2
 + websockets==15.0.1
zsh: command not found: marimo
```

## 🔍 Description of Changes

Add `uv run` to the start tutorial command.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
