### PR TITLE
docs: add relevant video for `mo.output.replace`

### DIFF
--- a/docs/api/outputs.md
+++ b/docs/api/outputs.md
@@ -11,6 +11,10 @@
     programmatically, using `mo.output.replace()` and `mo.output.append()`.
 
 ::: marimo.output.replace
+
+!!! tip "**Watch `mo.output.replace` in action**"
+    See a demo of how `mo.output.replace` works in this [short YouTube video](https://youtube.com/shorts/tCMeQb-PqNU?si=7PeFzQJzNvXsLoXN).
+
 ::: marimo.output.append
 
 ::: marimo.output.clear


### PR DESCRIPTION
## 📝 Summary

Added a relevant YouTube video showcase for `mo.output.replace` function by @koaning!

## 🔍 Description of Changes

Tip admonition that links to a YouTube short demonstrating `mo.output.replace` (shown in the prompt and the animation later on). Thought it might be a nice thing to link to (even though the video is based on Zero shotting w/ marimo.app/ai).

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ]  I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
