### PR TITLE
fix: align font size for line numbers with the code editor

### DIFF
--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -334,6 +334,10 @@
   font-size: var(--marimo-code-editor-font-size, 0.9rem);
 }
 
+.cm-lineNumbers {
+  font-size: var(--marimo-code-editor-font-size, 0.9rem);
+}
+
 /* .marimo-cell is needed to take precedence over codemirror's generated class ... */
 .marimo-cell .cm-editor {
   border: 1px solid transparent;


### PR DESCRIPTION
## 📝 Summary

The font size for the line numbers remained unchanged when the "Code editor font size" was changed in the user settings. The following video demonstrates the difference when the font size is increased to 16px before and after applying the patch.

https://github.com/user-attachments/assets/63bd8ec5-c380-46a3-9527-843b1eefed89

## 🔍 Description of Changes
I added a CSS class that uses the font size for the code editor on the line numbers.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
