### PR TITLE
feat: added input field to ui slider

### DIFF
--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -7,6 +7,7 @@ import { Slider } from "../../components/ui/slider";
 import { Labeled } from "./common/labeled";
 import { cn } from "@/utils/cn";
 import { prettyScientificNumber } from "@/utils/numbers";
+import { NumberField } from "@/components/ui/number-field";
 
 type T = number;
 
@@ -138,9 +139,20 @@ const SliderComponent = ({
           </div>
         )}
         {showInput && (
-          <div className="text-xs text-muted-foreground min-w-[16px]">
-            {/* TODO: ADD THE NUMBER INPUT HERE */}
-          </div>
+          <NumberField
+            value={valueMap(internalValue)}
+            onChange={(nextValue) => {
+              setInternalValue(nextValue);
+              if (!debounce) {
+                setValue(nextValue);
+              }
+            }}
+            minValue={start}
+            maxValue={stop}
+            step={step}
+            className="w-24"
+            aria-label={`${label || "Slider"} value input`}
+          />
         )}
       </div>
     </Labeled>

--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -20,6 +20,7 @@ interface Data {
   orientation: "horizontal" | "vertical";
   showValue: boolean;
   fullWidth: boolean;
+  showInput: boolean;
 }
 
 export class SliderPlugin implements IPlugin<T, Data> {
@@ -36,6 +37,7 @@ export class SliderPlugin implements IPlugin<T, Data> {
     orientation: z.enum(["horizontal", "vertical"]).default("horizontal"),
     showValue: z.boolean().default(false),
     fullWidth: z.boolean().default(false),
+    showInput: z.boolean().default(false),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -77,6 +79,7 @@ const SliderComponent = ({
   showValue,
   fullWidth,
   valueMap,
+  showInput,
 }: SliderProps): JSX.Element => {
   const id = useId();
 
@@ -132,6 +135,11 @@ const SliderComponent = ({
         {showValue && (
           <div className="text-xs text-muted-foreground min-w-[16px]">
             {prettyScientificNumber(valueMap(internalValue))}
+          </div>
+        )}
+        {showInput && (
+          <div className="text-xs text-muted-foreground min-w-[16px]">
+            {/* TODO: ADD THE NUMBER INPUT HERE */}
           </div>
         )}
       </div>

--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -21,7 +21,7 @@ interface Data {
   orientation: "horizontal" | "vertical";
   showValue: boolean;
   fullWidth: boolean;
-  showInput: boolean;
+  includeInput: boolean;
 }
 
 export class SliderPlugin implements IPlugin<T, Data> {
@@ -38,7 +38,7 @@ export class SliderPlugin implements IPlugin<T, Data> {
     orientation: z.enum(["horizontal", "vertical"]).default("horizontal"),
     showValue: z.boolean().default(false),
     fullWidth: z.boolean().default(false),
-    showInput: z.boolean().default(false),
+    includeInput: z.boolean().default(false),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -80,7 +80,7 @@ const SliderComponent = ({
   showValue,
   fullWidth,
   valueMap,
-  showInput,
+  includeInput,
 }: SliderProps): JSX.Element => {
   const id = useId();
 
@@ -138,7 +138,7 @@ const SliderComponent = ({
             {prettyScientificNumber(valueMap(internalValue))}
           </div>
         )}
-        {showInput && (
+        {includeInput && (
           <NumberField
             value={valueMap(internalValue)}
             onChange={(nextValue) => {

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -189,8 +189,8 @@ class slider(UIElement[Numeric, Numeric]):
             slider, either "horizontal" or "vertical". Defaults to "horizontal".
         show_value (bool): Whether to display the current value of the slider.
             Defaults to False.
-        show_input (bool): Whether to display an input with the current
-            value of the slider in an editable input. Defaults to False.
+        show_input (bool): Whether to display an editable input with the current
+            value of the slider. Defaults to False.
         steps (Optional[Sequence[Numeric]]): List of steps to customize the
             slider, mutually exclusive with `start`, `stop`, and `step`.
         label (str): Markdown label for the element. Defaults to an empty string.

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -189,7 +189,7 @@ class slider(UIElement[Numeric, Numeric]):
             slider, either "horizontal" or "vertical". Defaults to "horizontal".
         show_value (bool): Whether to display the current value of the slider.
             Defaults to False.
-        show_input (bool): Whether to display an editable input with the current
+        include_input (bool): Whether to display an editable input with the current
             value of the slider. Defaults to False.
         steps (Optional[Sequence[Numeric]]): List of steps to customize the
             slider, mutually exclusive with `start`, `stop`, and `step`.
@@ -224,7 +224,7 @@ class slider(UIElement[Numeric, Numeric]):
         debounce: bool = False,
         orientation: Literal["horizontal", "vertical"] = "horizontal",
         show_value: bool = False,
-        show_input: bool = False,
+        include_input: bool = False,
         steps: Optional[Sequence[Numeric]] = None,
         *,
         label: str = "",
@@ -295,7 +295,7 @@ class slider(UIElement[Numeric, Numeric]):
                     "debounce": debounce,
                     "orientation": orientation,
                     "show-value": show_value,
-                    "show-input": show_input,
+                    "include-input": include_input,
                     "full-width": full_width,
                 },
                 on_change=on_change,
@@ -337,7 +337,7 @@ class slider(UIElement[Numeric, Numeric]):
                     "debounce": debounce,
                     "orientation": orientation,
                     "show-value": show_value,
-                    "show-input": show_input,
+                    "include-input": include_input,
                     "full-width": full_width,
                 },
                 on_change=on_change,

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -189,6 +189,8 @@ class slider(UIElement[Numeric, Numeric]):
             slider, either "horizontal" or "vertical". Defaults to "horizontal".
         show_value (bool): Whether to display the current value of the slider.
             Defaults to False.
+        show_input (bool): Whether to display an input with the current
+            value of the slider in an editable input. Defaults to False.
         steps (Optional[Sequence[Numeric]]): List of steps to customize the
             slider, mutually exclusive with `start`, `stop`, and `step`.
         label (str): Markdown label for the element. Defaults to an empty string.
@@ -222,6 +224,7 @@ class slider(UIElement[Numeric, Numeric]):
         debounce: bool = False,
         orientation: Literal["horizontal", "vertical"] = "horizontal",
         show_value: bool = False,
+        show_input: bool = False,
         steps: Optional[Sequence[Numeric]] = None,
         *,
         label: str = "",
@@ -292,6 +295,7 @@ class slider(UIElement[Numeric, Numeric]):
                     "debounce": debounce,
                     "orientation": orientation,
                     "show-value": show_value,
+                    "show-input": show_input,
                     "full-width": full_width,
                 },
                 on_change=on_change,
@@ -333,6 +337,7 @@ class slider(UIElement[Numeric, Numeric]):
                     "debounce": debounce,
                     "orientation": orientation,
                     "show-value": show_value,
+                    "show-input": show_input,
                     "full-width": full_width,
                 },
                 on_change=on_change,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Integrated number-field into the slider and added a include_input argument to manage visibility of input. Resolves #4747 by adding the requested feature.

<img width="683" alt="Screenshot 2025-05-11 at 12 32 38 PM" src="https://github.com/user-attachments/assets/6a521406-3c56-4049-8627-dfc5f03ade6b" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Added includeInput to SliderPlugin.tsx with validation
- Added include_input to input.py along with a description
- Integrated NumberField into SliderPlugin
- Added a two way data binding between the slider and the integrated number-field

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
