### PR TITLE
fix: `typos` failing on pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     rev: v1.31.1
     hooks:
       - id: typos
+        pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.6


### PR DESCRIPTION
## 📝 Summary

Fixes pre-commit failures following recommendation to set `pass_filenames: false` from https://github.com/crate-ci/typos/issues/926

## 🔍 Description of Changes

- [x] add the `pass_filenames: false` workaround
- [ ] fix typos in codebase which were smuggled through while the `typos` check was malfunctioning; :confused: while it passes on CI, it fails locally for me on:
   ```
    typos....................................................................Failed
    - hook id: typos
    - exit code: 2
    
    error: `fo` should be `of`, `for`, `do`, `go`, `to`
      --> ./codemirror-languageserver-marimo/src/utils.test.ts:117:35
        |
    117 |         expect(createMockContext("fo").matchBefore(pattern)).toEqual({
        |                                   ^^
        |
    error: `fo` should be `of`, `for`, `do`, `go`, `to`
      --> ./codemirror-languageserver-marimo/src/utils.test.ts:120:20
        |
    120 |             text: "fo",
        |                    ^^
        |
    ```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
