### PR TITLE
fix: resolve relateive paths in uv.sources

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -210,7 +210,7 @@ def construct_uv_command(
     pyproject = (
         PyProjectReader.from_filename(name)
         if name is not None
-        else PyProjectReader({})
+        else PyProjectReader({}, config_path=None)
     )
 
     uv_cmd = ["uv", "run"]

--- a/marimo/_utils/inline_script_metadata.py
+++ b/marimo/_utils/inline_script_metadata.py
@@ -173,7 +173,7 @@ def _pyproject_toml_to_requirements_txt(
             # If path is relative and we have a config path, resolve it relative to the config path
             if not source_path.is_absolute() and config_path:
                 config_dir = Path(config_path).parent
-                source_path = (config_dir / source_path).absolute()
+                source_path = (config_dir / source_path).resolve()
             new_dependency = f"{dependency} @ {str(source_path)}"
 
         # Handle URLs

--- a/marimo/_utils/inline_script_metadata.py
+++ b/marimo/_utils/inline_script_metadata.py
@@ -173,7 +173,7 @@ def _pyproject_toml_to_requirements_txt(
             # If path is relative and we have a config path, resolve it relative to the config path
             if not source_path.is_absolute() and config_path:
                 config_dir = Path(config_path).parent
-                source_path = (config_dir / source_path).resolve()
+                source_path = (config_dir / source_path).absolute()
             new_dependency = f"{dependency} @ {str(source_path)}"
 
         # Handle URLs

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -195,7 +195,7 @@ def test_construct_uv_cmd_with_index_urls() -> None:
         }
     }
     with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject)
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
         uv_cmd = construct_uv_command(
             ["edit", "test.py", "--sandbox"],
             "test.py",
@@ -223,7 +223,7 @@ def test_construct_uv_cmd_with_index_configs() -> None:
         }
     }
     with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject)
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
         uv_cmd = construct_uv_command(
             ["edit", "test.py", "--sandbox"],
             name="test.py",
@@ -248,7 +248,7 @@ def test_construct_uv_cmd_with_sandbox_flag() -> None:
 def test_construct_uv_cmd_empty_dependencies() -> None:
     # Test empty dependencies triggers refresh
     with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader({})
+        mock.return_value = PyProjectReader({}, config_path=None)
         uv_cmd = construct_uv_command(
             ["edit", "test.py"],
             name="test.py",


### PR DESCRIPTION
Fixes #4809

This resolves relative `uv.sources` paths to include the path to the pyproject config