### PR TITLE
fix: patch polars write_json in wasm with write_csv

### DIFF
--- a/marimo/_output/formatters/formatter_factory.py
+++ b/marimo/_output/formatters/formatter_factory.py
@@ -9,6 +9,8 @@ from marimo._config.config import Theme
 
 LOGGER = _loggers.marimo_logger()
 
+Unregister = Callable[[], None]
+
 
 # Abstract base class for formatters that are installed at runtime.
 class FormatterFactory(abc.ABC):
@@ -25,7 +27,7 @@ class FormatterFactory(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def register(self) -> Callable[[], None] | None:
+    def register(self) -> Unregister | None:
         """Registers formatters.
 
         Formatters can be registered using the formatters.formatter decorator.

--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -443,10 +443,10 @@ def patch_polars_write_json() -> Unpatch:
 
     def patched_write_json(
         self: polars.DataFrame,
-        file: io.IOBase | str | pathlib.Path,
+        file: io.IOBase | str | pathlib.Path | None = None,
         *args: Any,
         **kwargs: Any,
-    ) -> None:
+    ) -> str | None:
         try:
             # First try the original method
             return original_write_json(self, file, *args, **kwargs)
@@ -472,7 +472,9 @@ def patch_polars_write_json() -> Unpatch:
                     values: list[str] = line.split(",")
                     json_data.append(dict(zip(headers, values)))
 
-            if isinstance(file, io.IOBase):
+            if file is None:
+                return json.dumps(json_data)
+            elif isinstance(file, io.IOBase):
                 json.dump(json_data, file)
             elif isinstance(file, pathlib.Path):
                 file.write_text(json.dumps(json_data))

--- a/tests/_runtime/test_patches.py
+++ b/tests/_runtime/test_patches.py
@@ -1,10 +1,22 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import io
+from types import ModuleType
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._runtime.capture import capture_stderr
+from marimo._runtime.patches import patch_polars_write_json
 from marimo._runtime.runtime import Kernel
 from marimo._utils.platform import is_pyodide
 from tests.conftest import ExecReqProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestMicropip:
@@ -175,3 +187,56 @@ async def test_webbrowser_easter_egg(
 
     assert "<iframe" not in outputs[-1]
     assert "<img" in outputs[-1]
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(),
+    reason="Polars is not installed",
+)
+def test_polars_write_json_patch(tmp_path: Path):
+    import sys
+
+    import polars as pl
+
+    file_path = tmp_path / "test.json"
+
+    # Fake put pyodide in sys.modules
+    sys.modules["pyodide"] = ModuleType("pyodide")
+
+    # Make write_json throw an error
+    with patch(
+        "polars.DataFrame.write_json",
+        side_effect=ValueError("Test error"),
+    ):
+        # Test it fails
+        df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        with pytest.raises(ValueError, match="Test error"):
+            df.write_json(file_path)
+
+        # Patch to fallback to write_csv
+        unpatch_polars_write_json = patch_polars_write_json()
+
+        expected_json = '[{"a": "1", "b": "x"}, {"a": "2", "b": "y"}]'
+
+        # Test it succeeds with file path
+        df.write_json(file_path)
+        assert file_path.read_text() == expected_json
+
+        # Test it succeeds with string path
+        df.write_json(str(file_path))
+        assert file_path.read_text() == expected_json
+
+        # Test it succeeds with buffer
+        buffer = io.StringIO()
+        df.write_json(buffer)
+        assert buffer.getvalue() == expected_json
+
+        # Patch the patch
+        unpatch_polars_write_json()
+
+        # Test it fails again
+        with pytest.raises(ValueError, match="Test error"):
+            df.write_json(file_path)
+
+    # Remove pyodide from sys.modules
+    del sys.modules["pyodide"]

--- a/tests/_runtime/test_patches.py
+++ b/tests/_runtime/test_patches.py
@@ -231,6 +231,9 @@ def test_polars_write_json_patch(tmp_path: Path):
         df.write_json(buffer)
         assert buffer.getvalue() == expected_json
 
+        # Test it succeeds with None
+        assert df.write_json() == expected_json
+
         # Patch the patch
         unpatch_polars_write_json()
 


### PR DESCRIPTION
Patch polars to fallback to `write_csv` when `write_json` fails in wasm.