### PR TITLE
fix: row viewer panel for many columns

### DIFF
--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -31,6 +31,7 @@ import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
 
 // Artificial limit to display long strings
 const MAX_STRING_LENGTH = 50;
+export const MAX_COLUMNS = 50;
 
 function inferDataType(value: unknown): [type: DataType, displayType: string] {
   if (typeof value === "string") {

--- a/frontend/src/components/data-table/row-viewer-panel/__tests__/filter-rows.test.ts
+++ b/frontend/src/components/data-table/row-viewer-panel/__tests__/filter-rows.test.ts
@@ -1,24 +1,22 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import { describe, expect, it } from "vitest";
-import { filterRows } from "../row-viewer";
+import { inSearchQuery } from "../row-viewer";
 
-describe("filterRows", () => {
-  const defaultRowValues = {
-    name: "John",
-    age: 30,
-  };
-
+describe("inSearchQuery", () => {
   it("should filter rows based on column name", () => {
-    const result = filterRows(defaultRowValues, "name");
-    expect(result).toHaveLength(1);
-    expect(result[0][0]).toBe("name");
+    const result = inSearchQuery("name", "John", "name");
+    expect(result).toBe(true);
   });
 
   it("should filter rows based on cell value", () => {
-    const result = filterRows(defaultRowValues, "john");
-    expect(result).toHaveLength(1);
-    expect(result[0][0]).toBe("name");
+    const result = inSearchQuery("name", "John", "John");
+    expect(result).toBe(true);
+  });
+
+  it("should return false when no matches found", () => {
+    const result = inSearchQuery("name", "John", "xyz");
+    expect(result).toBe(false);
   });
 
   it("should handle object values by converting them to strings", () => {
@@ -26,51 +24,27 @@ describe("filterRows", () => {
       data: { key: "value" },
     };
 
-    const result = filterRows(rowValues, "value");
-    expect(result).toHaveLength(1);
-    expect(result[0][0]).toBe("data");
+    const result = inSearchQuery("data", rowValues, "value");
+    expect(result).toBe(true);
   });
 
   it("should be case insensitive", () => {
-    const rowValues = {
-      Name: "John",
-      AGE: 30,
-    };
-
-    const result = filterRows(rowValues, "name");
-    expect(result).toHaveLength(1);
-    expect(result[0][0]).toBe("Name");
+    const result = inSearchQuery("name", "John", "john");
+    expect(result).toBe(true);
   });
 
   it("should handle partial matches", () => {
-    const rowValues = {
-      firstName: "John",
-      lastName: "Doe",
-    };
-
-    const result = filterRows(rowValues, "name");
-    expect(result).toHaveLength(2);
-    expect(result.map(([name]) => name)).toEqual(["firstName", "lastName"]);
-  });
-
-  it("should return empty array when no matches found", () => {
-    const result = filterRows(defaultRowValues, "xyz");
-    expect(result).toHaveLength(0);
+    const result = inSearchQuery("name", "Johnathan Clark", "john");
+    expect(result).toBe(true);
   });
 
   it("should handle empty search query", () => {
-    const result = filterRows(defaultRowValues, "");
-    expect(result).toHaveLength(2);
+    const result = inSearchQuery("name", "John", "");
+    expect(result).toBe(true);
   });
 
   it("should handle null values", () => {
-    const rowValues = {
-      name: null,
-      age: 30,
-    };
-
-    const result = filterRows(rowValues, "null");
-    expect(result).toHaveLength(1);
-    expect(result[0][0]).toBe("name");
+    const result = inSearchQuery("name", null, "null");
+    expect(result).toBe(true);
   });
 });

--- a/frontend/src/components/data-table/row-viewer-panel/row-viewer.tsx
+++ b/frontend/src/components/data-table/row-viewer-panel/row-viewer.tsx
@@ -273,24 +273,6 @@ export const RowViewerPanel: React.FC<RowViewerPanelProps> = ({
   );
 };
 
-export function filterRows(rowValues: object, searchQuery: string) {
-  return Object.entries(rowValues).filter(([columnName, columnValue]) => {
-    const colName = columnName.toLowerCase();
-
-    let columnValueString =
-      typeof columnValue === "object"
-        ? JSON.stringify(columnValue)
-        : String(columnValue);
-    columnValueString = columnValueString.toLowerCase();
-    const searchQueryLower = searchQuery.toLowerCase();
-
-    return (
-      colName.includes(searchQueryLower) ||
-      columnValueString.includes(searchQueryLower)
-    );
-  });
-}
-
 export function inSearchQuery(
   columnName: string,
   columnValue: unknown,

--- a/frontend/src/components/data-table/row-viewer-panel/row-viewer.tsx
+++ b/frontend/src/components/data-table/row-viewer-panel/row-viewer.tsx
@@ -140,8 +140,6 @@ export const RowViewerPanel: React.FC<RowViewerPanelProps> = ({
       }
     }
 
-    const filteredRows = filterRows(rowValues, searchQuery);
-
     return (
       <Table className="mb-4">
         <TableHeader>
@@ -151,12 +149,14 @@ export const RowViewerPanel: React.FC<RowViewerPanelProps> = ({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {filteredRows.map(([columnName, columnValue]) => {
-            const dataType = fieldTypes?.find(
-              ([name]) => name === columnName,
-            )?.[1][0];
-
+          {fieldTypes?.map(([columnName, [dataType, externalType]]) => {
             const Icon = dataType ? DATA_TYPE_ICON[dataType] : null;
+            const columnValue = rowValues[columnName];
+
+            if (!inSearchQuery(columnName, columnValue, searchQuery)) {
+              return null;
+            }
+
             const mockColumn = {
               id: columnName,
               columnDef: {
@@ -175,6 +175,7 @@ export const RowViewerPanel: React.FC<RowViewerPanelProps> = ({
               undefined,
               "text-left break-all",
             );
+
             const copyValue =
               typeof columnValue === "object"
                 ? JSON.stringify(columnValue)
@@ -288,6 +289,26 @@ export function filterRows(rowValues: object, searchQuery: string) {
       columnValueString.includes(searchQueryLower)
     );
   });
+}
+
+export function inSearchQuery(
+  columnName: string,
+  columnValue: unknown,
+  searchQuery: string,
+) {
+  const colName = columnName.toLowerCase();
+  const searchQueryLower = searchQuery.toLowerCase();
+
+  let columnValueString =
+    typeof columnValue === "object"
+      ? JSON.stringify(columnValue)
+      : String(columnValue);
+  columnValueString = columnValueString.toLowerCase();
+
+  return (
+    colName.includes(searchQueryLower) ||
+    columnValueString.includes(searchQueryLower)
+  );
 }
 
 const SimpleBanner: React.FC<{

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -5,6 +5,7 @@ import { DataTable } from "../../components/data-table/data-table";
 import {
   generateColumns,
   inferFieldTypes,
+  MAX_COLUMNS,
 } from "../../components/data-table/columns";
 import { Labeled } from "./common/labeled";
 import { Alert, AlertTitle } from "@/components/ui/alert";
@@ -674,10 +675,17 @@ const DataTableComponent = ({
   }, [fieldTypes, columnSummaries]);
 
   const fieldTypesOrInferred = fieldTypes ?? inferFieldTypes(data);
-  const shownColumns = fieldTypesOrInferred.length;
+  // Clamp number of columns
+  const clampedFieldTypesOrInferred = fieldTypesOrInferred.slice(
+    0,
+    MAX_COLUMNS,
+  );
+  const shownColumns = clampedFieldTypesOrInferred.length;
 
   const memoizedRowHeaders = useDeepCompareMemoize(rowHeaders);
-  const memoizedFieldTypes = useDeepCompareMemoize(fieldTypesOrInferred);
+  const memoizedUnclampedFieldTypes =
+    useDeepCompareMemoize(fieldTypesOrInferred);
+  const memoizedFieldTypes = useDeepCompareMemoize(clampedFieldTypesOrInferred);
   const memoizedTextJustifyColumns = useDeepCompareMemoize(textJustifyColumns);
   const memoizedWrappedColumns = useDeepCompareMemoize(wrappedColumns);
   const memoizedChartSpecModel = useDeepCompareMemoize(chartSpecModel);
@@ -772,7 +780,7 @@ const DataTableComponent = ({
         <ContextAwarePanelItem>
           <RowViewerPanel
             getRow={getRow}
-            fieldTypes={memoizedFieldTypes}
+            fieldTypes={memoizedUnclampedFieldTypes}
             totalRows={totalRows === "too_many" ? 100 : totalRows}
             rowIdx={focusedRowIdx}
             setRowIdx={setFocusedRowIdx}

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -132,6 +132,7 @@ type DataTableFunctions = {
     filters?: ConditionType[];
     page_number: number;
     page_size: number;
+    max_columns?: number | null;
   }) => Promise<{
     data: TableData<T>;
     total_rows: number | "too_many";
@@ -223,6 +224,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
           filters: z.array(ConditionSchema).optional(),
           page_number: z.number(),
           page_size: z.number(),
+          max_columns: z.number().nullable().optional(),
         }),
       )
       .output(
@@ -485,6 +487,8 @@ export const LoadingDataTableComponent = memo(
               filter.value as ColumnFilterValue,
             );
           }),
+          // Do not clamp number of columns since we are viewing a single row
+          max_columns: null,
         });
         const loadedData = await loadTableData(result.data);
         return {

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -675,28 +675,24 @@ const DataTableComponent = ({
   }, [fieldTypes, columnSummaries]);
 
   const fieldTypesOrInferred = fieldTypes ?? inferFieldTypes(data);
-  // Clamp number of columns
-  const clampedFieldTypesOrInferred = fieldTypesOrInferred.slice(
-    0,
-    MAX_COLUMNS,
-  );
-  const shownColumns = clampedFieldTypesOrInferred.length;
-
-  const memoizedRowHeaders = useDeepCompareMemoize(rowHeaders);
   const memoizedUnclampedFieldTypes =
     useDeepCompareMemoize(fieldTypesOrInferred);
-  const memoizedFieldTypes = useDeepCompareMemoize(clampedFieldTypesOrInferred);
+  const clampedFieldTypes = memoizedUnclampedFieldTypes.slice(0, MAX_COLUMNS);
+
+  const memoizedRowHeaders = useDeepCompareMemoize(rowHeaders);
   const memoizedTextJustifyColumns = useDeepCompareMemoize(textJustifyColumns);
   const memoizedWrappedColumns = useDeepCompareMemoize(wrappedColumns);
   const memoizedChartSpecModel = useDeepCompareMemoize(chartSpecModel);
   const showDataTypes = Boolean(fieldTypes);
+  const shownColumns = clampedFieldTypes.length;
+
   const columns = useMemo(
     () =>
       generateColumns({
         rowHeaders: memoizedRowHeaders,
         selection: selection,
         chartSpecModel: memoizedChartSpecModel,
-        fieldTypes: memoizedFieldTypes,
+        fieldTypes: clampedFieldTypes,
         textJustifyColumns: memoizedTextJustifyColumns,
         wrappedColumns: memoizedWrappedColumns,
         // Only show data types if they are explicitly set
@@ -708,7 +704,7 @@ const DataTableComponent = ({
       showDataTypes,
       memoizedChartSpecModel,
       memoizedRowHeaders,
-      memoizedFieldTypes,
+      clampedFieldTypes,
       memoizedTextJustifyColumns,
       memoizedWrappedColumns,
       calculate_top_k_rows,

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -675,16 +675,20 @@ const DataTableComponent = ({
   }, [fieldTypes, columnSummaries]);
 
   const fieldTypesOrInferred = fieldTypes ?? inferFieldTypes(data);
+
   const memoizedUnclampedFieldTypes =
     useDeepCompareMemoize(fieldTypesOrInferred);
-  const clampedFieldTypes = memoizedUnclampedFieldTypes.slice(0, MAX_COLUMNS);
+  const memoizedClampedFieldTypes = useMemo(
+    () => memoizedUnclampedFieldTypes.slice(0, MAX_COLUMNS),
+    [memoizedUnclampedFieldTypes],
+  );
 
   const memoizedRowHeaders = useDeepCompareMemoize(rowHeaders);
   const memoizedTextJustifyColumns = useDeepCompareMemoize(textJustifyColumns);
   const memoizedWrappedColumns = useDeepCompareMemoize(wrappedColumns);
   const memoizedChartSpecModel = useDeepCompareMemoize(chartSpecModel);
   const showDataTypes = Boolean(fieldTypes);
-  const shownColumns = clampedFieldTypes.length;
+  const shownColumns = memoizedClampedFieldTypes.length;
 
   const columns = useMemo(
     () =>
@@ -692,7 +696,7 @@ const DataTableComponent = ({
         rowHeaders: memoizedRowHeaders,
         selection: selection,
         chartSpecModel: memoizedChartSpecModel,
-        fieldTypes: clampedFieldTypes,
+        fieldTypes: memoizedClampedFieldTypes,
         textJustifyColumns: memoizedTextJustifyColumns,
         wrappedColumns: memoizedWrappedColumns,
         // Only show data types if they are explicitly set
@@ -704,7 +708,7 @@ const DataTableComponent = ({
       showDataTypes,
       memoizedChartSpecModel,
       memoizedRowHeaders,
-      clampedFieldTypes,
+      memoizedClampedFieldTypes,
       memoizedTextJustifyColumns,
       memoizedWrappedColumns,
       calculate_top_k_rows,

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -260,27 +260,23 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
   })
   .renderer((props) => {
     return (
-      <Provider store={store}>
-        <SlotzProvider controller={slotsController}>
-          <TooltipProvider>
-            <LazyDataTableComponent
-              isLazy={props.data.lazy}
-              preload={props.data.preload}
-            >
-              <LoadingDataTableComponent
-                {...props.data}
-                {...props.functions}
-                host={props.host}
-                enableSearch={true}
-                data={props.data.data}
-                value={props.value}
-                setValue={props.setValue}
-                experimentalChartsEnabled={true}
-              />
-            </LazyDataTableComponent>
-          </TooltipProvider>
-        </SlotzProvider>
-      </Provider>
+      <TableProviders>
+        <LazyDataTableComponent
+          isLazy={props.data.lazy}
+          preload={props.data.preload}
+        >
+          <LoadingDataTableComponent
+            {...props.data}
+            {...props.functions}
+            host={props.host}
+            enableSearch={true}
+            data={props.data.data}
+            value={props.value}
+            setValue={props.setValue}
+            experimentalChartsEnabled={true}
+          />
+        </LazyDataTableComponent>
+      </TableProviders>
     );
   });
 
@@ -828,5 +824,20 @@ const DataTableComponent = ({
         </Labeled>
       </ColumnChartContext.Provider>
     </>
+  );
+};
+
+/**
+ * Common providers for data tables
+ */
+export const TableProviders: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <Provider store={store}>
+      <SlotzProvider controller={slotsController}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </SlotzProvider>
+    </Provider>
   );
 };

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -13,11 +13,10 @@ import type { ColumnDataTypes, ColumnId } from "./types";
 import { createPlugin } from "@/plugins/core/builder";
 import { rpc } from "@/plugins/core/rpc";
 import { useAsyncData } from "@/hooks/useAsyncData";
-import { LoadingDataTableComponent } from "../DataTablePlugin";
+import { LoadingDataTableComponent, TableProviders } from "../DataTablePlugin";
 import { Functions } from "@/utils/functions";
 import { Arrays } from "@/utils/arrays";
 import { memo, useEffect, useRef, useState } from "react";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { ErrorBanner } from "../common/error-banner";
 import type { DataType } from "../vega/vega-loader";
 import type { FieldTypesWithExternalType } from "@/components/data-table/types";
@@ -129,7 +128,7 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
       ),
   })
   .renderer((props) => (
-    <TooltipProvider>
+    <TableProviders>
       <DataFrameComponent
         {...props.data}
         {...props.functions}
@@ -137,7 +136,7 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
         setValue={props.setValue}
         host={props.host}
       />
-    </TooltipProvider>
+    </TableProviders>
   ));
 
 interface DataTableProps extends Data, PluginFunctions {

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -583,11 +583,7 @@ class table(
                 text_justify_columns, wrapped_columns, column_names_set
             )
 
-            # Clamp field types to max columns
             field_types = self._manager.get_field_types()
-            field_types = _get_clamped_field_types(
-                field_types, self._max_columns
-            )
 
         super().__init__(
             component_name=table._name,
@@ -1103,14 +1099,6 @@ class table(
 
     def __hash__(self) -> int:
         return id(self)
-
-
-def _get_clamped_field_types(
-    field_types: list[Any], max_columns: Optional[int]
-) -> list[Any]:
-    if max_columns is not None and len(field_types) > max_columns:
-        return field_types[:max_columns]
-    return field_types
 
 
 def _validate_frozen_columns(

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -98,7 +98,9 @@ class ColumnSummaries:
 
 
 DEFAULT_MAX_COLUMNS = 50
-MAX_COLUMNS_NOT_PROVIDED = "max_columns_not_provided"
+
+MaxColumnsNotProvided = Literal["max_columns_not_provided"]
+MAX_COLUMNS_NOT_PROVIDED: MaxColumnsNotProvided = "max_columns_not_provided"
 
 
 @dataclass(frozen=True)
@@ -109,7 +111,7 @@ class SearchTableArgs:
     sort: Optional[SortArgs] = None
     filters: Optional[list[Condition]] = None
     limit: Optional[int] = None
-    max_columns: Optional[int | Literal["max_columns_not_provided"]] = (
+    max_columns: Optional[int | MaxColumnsNotProvided] = (
         MAX_COLUMNS_NOT_PROVIDED
     )
 

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1425,7 +1425,8 @@ def test_column_clamping_with_polars():
     json_data = json.loads(table._component_args["data"])
     headers = json_data[0].keys()
     assert len(headers) == 50  # 50 columns
-    assert len(table._component_args["field-types"]) == 50
+    # Field types are not clamped
+    assert len(table._component_args["field-types"]) == 60
 
     table = ui.table(data, max_columns=40)
 
@@ -1435,7 +1436,8 @@ def test_column_clamping_with_polars():
     json_data = json.loads(table._component_args["data"])
     headers = json_data[0].keys()
     assert len(headers) == 40  # 40 columns
-    assert len(table._component_args["field-types"]) == 40
+    # Field types aren't clamped
+    assert len(table._component_args["field-types"]) == 60
 
     table = ui.table(data, max_columns=None)
 

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1348,6 +1348,25 @@ def test_search_no_clamping_columns():
     assert len(selected_data) == 100
 
 
+def test_search_clamp_max_columns_in_search():
+    data = {f"col{i}": [1, 2, 3] for i in range(100)}
+    table = ui.table(data, max_columns=20)
+
+    response = table._search(
+        SearchTableArgs(page_size=10, page_number=0, query="1", max_columns=1)
+    )
+    result_data = json.loads(response.data)
+    # Only 1 column is shown
+    assert len(result_data[0].keys()) == 1
+
+    response = table._search(
+        SearchTableArgs(page_size=10, page_number=0, query="1", max_columns=30)
+    )
+    result_data = json.loads(response.data)
+    # Show 30 columns
+    assert len(result_data[0].keys()) == 30
+
+
 def test_column_clamping_with_exact_max_columns():
     data = {f"col{i}": [1, 2, 3] for i in range(50)}
     table = ui.table(data, max_columns=50)


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Previously the number of cols were clamped hence not all columns showed up in the panel.

The workaround is to unclamp during search, and also pass all field types and clamp the field types on the frontend.

Alternative: Create a new function to get all field types, so don't need to slice in the frontend.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
