### PR TITLE
fix: scroll to bottom on createNewCell

### DIFF
--- a/frontend/src/components/editor/database/add-database-form.tsx
+++ b/frontend/src/components/editor/database/add-database-form.tsx
@@ -278,7 +278,6 @@ const DatabaseForm: React.FC<{
       before: false,
       cellId: lastFocusedCellId ?? "__end__",
       skipIfCodeExists: true,
-      autoFocus: true,
     });
   };
 

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1002,21 +1002,16 @@ const {
     const column = state.cellIds.findWithId(scrollKey);
     const index = column.indexOfOrThrow(scrollKey);
 
-    // Special-case scrolling to the end of the page: bug in Chrome where
-    // browser fails to scrollIntoView an element at the end of a long page
-    if (index === column.length - 1) {
-      const cellId = column.last();
-      state.cellHandles[cellId].current?.editorViewOrNull?.focus();
-    } else {
-      const nextCellId = column.atOrThrow(index);
-      focusAndScrollCellIntoView({
-        cellId: nextCellId,
-        cell: state.cellHandles[nextCellId],
-        config: state.cellData[nextCellId].config,
-        codeFocus: undefined,
-        variableName: undefined,
-      });
-    }
+    const cellId =
+      index === column.length - 1 ? column.last() : column.atOrThrow(index);
+
+    focusAndScrollCellIntoView({
+      cellId: cellId,
+      cell: state.cellHandles[cellId],
+      config: state.cellData[cellId].config,
+      codeFocus: undefined,
+      variableName: undefined,
+    });
 
     return {
       ...state,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Scrolling to the bottom is broken on new cell creation hence it can make users confused when adding a cell from the datasource panel or elsewhere.

I removed the special handling because I don't seem to face the issue. If I am wrong, I think it's possible to add `scrollToBottom`. but this was removed here https://github.com/marimo-team/marimo/pull/1782. I'm not sure why.
```typescript
    if (index === column.length - 1) {
      const cellId = column.last();
      state.cellHandles[cellId].current?.editorViewOrNull?.focus();
      >> scrollToBottom();
    } else {
      ....
```

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
