### PR TITLE
fix: prompt pandas installation instead of polars when duckdb parsing fails

### DIFF
--- a/marimo/_sql/engines/duckdb.py
+++ b/marimo/_sql/engines/duckdb.py
@@ -67,9 +67,13 @@ class DuckDBEngine(SQLEngine):
 
             try:
                 return relation.pl()
-            except (pl.exceptions.PanicException, pl.exceptions.ComputeError):
-                LOGGER.info(
-                    "Failed to convert to polars, falling back to pandas"
+            except (
+                pl.exceptions.PanicException,
+                pl.exceptions.ComputeError,
+            ) as e:
+                LOGGER.warning("Failed to convert to polars. Reason: %s.", e)
+                DependencyManager.pandas.require(
+                    "to convert this data correctly."
                 )
 
         if DependencyManager.pandas.has():

--- a/marimo/_sql/engines/duckdb.py
+++ b/marimo/_sql/engines/duckdb.py
@@ -72,9 +72,7 @@ class DuckDBEngine(SQLEngine):
                 pl.exceptions.ComputeError,
             ) as e:
                 LOGGER.warning("Failed to convert to polars. Reason: %s.", e)
-                DependencyManager.pandas.require(
-                    "to convert this data correctly."
-                )
+                DependencyManager.pandas.require("to convert this data")
 
         if DependencyManager.pandas.has():
             try:


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
When duckdb result failed to convert to polars df, the previous error was confusing as it prompted installation of polars[pyarrow] which wouldn't resolve the issue.

- Show warning instead of info, so users are informed
- Prompt installation of pandas instead
<img width="883" alt="image" src="https://github.com/user-attachments/assets/ddd24dec-1306-4292-9717-503a49fcf695" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
