### PR TITLE
improve: instant slide swipes

### DIFF
--- a/frontend/src/components/slides/slides-component.tsx
+++ b/frontend/src/components/slides/slides-component.tsx
@@ -79,6 +79,9 @@ const SlidesComponent = ({
         clickable: true,
       }}
       virtual={true}
+      // Instant swipes, which make sequences of slides
+      // that overlay content more legible
+      speed={1}
     >
       {React.Children.map(children, (child, index) => {
         if (child == null) {


### PR DESCRIPTION
Remove the slider swipe transition, to accommodate sequences of slides that overlay content one after the other.

cc @koaning 