### PR TITLE
feat: added disabled prop to number field

### DIFF
--- a/frontend/src/plugins/impl/NumberPlugin.tsx
+++ b/frontend/src/plugins/impl/NumberPlugin.tsx
@@ -17,6 +17,7 @@ interface Data {
   label: string | null;
   debounce: boolean;
   fullWidth: boolean;
+  disabled?: boolean;
 }
 
 export class NumberPlugin implements IPlugin<T | null, Data> {
@@ -30,6 +31,7 @@ export class NumberPlugin implements IPlugin<T | null, Data> {
     step: z.number().optional(),
     debounce: z.boolean().default(false),
     fullWidth: z.boolean().default(false),
+    disabled: z.boolean().optional(),
   });
 
   render(props: IPluginProps<T | null, Data>): JSX.Element {
@@ -76,6 +78,7 @@ const NumberComponent = (props: NumberComponentProps): JSX.Element => {
         onChange={onChange}
         id={id}
         aria-label={props.label || "Number input"}
+        isDisabled={props.disabled}
       />
     </Labeled>
   );

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -77,6 +77,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
         label (str): Markdown label for the element. Defaults to an empty string.
         on_change (Optional[Callable[[Optional[Numeric]], None]]): Optional callback to run when this element's value changes. Defaults to None.
         full_width (bool): Whether the input should take up the full width of its container. Defaults to False.
+        disabled (bool, optional): Whether the input is disabled. Defaults to False.
 
     Methods:
         from_series(series: DataFrameSeries, **kwargs: Any) -> number:
@@ -96,6 +97,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
         label: str = "",
         on_change: Optional[Callable[[Optional[Numeric]], None]] = None,
         full_width: bool = False,
+        disabled: bool = False,
     ) -> None:
         validate_range(min_value=start, max_value=stop)
         validate_between_range(value, min_value=start, max_value=stop)
@@ -124,6 +126,7 @@ class number(UIElement[Optional[Numeric], Optional[Numeric]]):
                 "step": step if step is not None else None,
                 "debounce": debounce,
                 "full-width": full_width,
+                "disabled": disabled,
             },
             on_change=on_change,
         )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Added disabled to number field.

<img width="551" alt="Screenshot 2025-05-13 at 11 04 33 PM" src="https://github.com/user-attachments/assets/9f051d12-c62a-4cef-a9ea-3212d9ef2f12" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Added disabled as an optional boolean prop with validation to NumberPlugin.tsx
- Mapped disabled to isDisabled in number-field.tsx
- Mapped disabled to number python args with definition in input.py

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick 
