### PR TITLE
fix: cell language metadata initialization when converting python to markdown/sql

### DIFF
--- a/frontend/src/core/codemirror/language/__tests__/extension.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/extension.test.ts
@@ -11,6 +11,7 @@ import { OverridingHotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { EditorView } from "@codemirror/view";
 import type { CellId } from "@/core/cells/ids";
 import { cellConfigExtension } from "../../config/extension";
+import { languageMetadataField } from "../metadata";
 
 function createState(content: string, selection?: { anchor: number }) {
   const state = EditorState.create({
@@ -168,5 +169,74 @@ describe("switchLanguage", () => {
           """
       )"
     `);
+  });
+
+  it("sets default metadata when switching from Python to SQL with keepCodeAsIs false", () => {
+    const state = createState("SELECT * FROM df");
+    const mockEditor = new EditorView({ state });
+
+    expect(mockEditor.state.field(languageMetadataField)).toEqual({});
+
+    // Switch to SQL
+    switchLanguage(mockEditor, "sql", { keepCodeAsIs: false });
+
+    // Check that the language was switched
+    expect(mockEditor.state.field(languageAdapterState).type).toBe("sql");
+
+    // Check that the default metadata was set
+    const metadata = mockEditor.state.field(languageMetadataField);
+    expect(metadata).toMatchInlineSnapshot(`
+      {
+        "commentLines": [],
+        "dataframeName": "_df",
+        "engine": "__marimo_duckdb",
+        "quotePrefix": "f",
+        "showOutput": true,
+      }
+    `);
+
+    // Check that the document was transformed correctly
+    expect(mockEditor.state.doc.toString()).toEqual("SELECT * FROM df");
+  });
+
+  it("handle when switching from Python to Markdown with keepCodeAsIs true", () => {
+    const state = createState("# hello");
+    const mockEditor = new EditorView({ state });
+    expect(mockEditor.state.field(languageMetadataField)).toEqual({});
+
+    switchLanguage(mockEditor, "markdown", { keepCodeAsIs: true });
+    expect(mockEditor.state.doc.toString()).toEqual("# hello");
+    expect(mockEditor.state.field(languageMetadataField)).toEqual({
+      quotePrefix: "r",
+    });
+  });
+
+  it("handles when switching from Python to Markdown to SQL with keepCodeAsIs true", () => {
+    const state = createState("SELECT * FROM df");
+    const mockEditor = new EditorView({ state });
+    expect(mockEditor.state.field(languageMetadataField)).toEqual({});
+
+    switchLanguage(mockEditor, "markdown", { keepCodeAsIs: true });
+    expect(mockEditor.state.doc.toString()).toEqual("SELECT * FROM df");
+    expect(mockEditor.state.field(languageMetadataField)).toEqual({
+      quotePrefix: "r",
+    });
+
+    switchLanguage(mockEditor, "sql", { keepCodeAsIs: true });
+    expect(mockEditor.state.doc.toString()).toEqual("SELECT * FROM df");
+    expect(mockEditor.state.field(languageMetadataField)).toEqual({
+      commentLines: [],
+      dataframeName: "_df",
+      engine: "__marimo_duckdb",
+      quotePrefix: "f",
+      showOutput: true,
+    });
+
+    // Switch back to markdown
+    switchLanguage(mockEditor, "markdown", { keepCodeAsIs: true });
+    expect(mockEditor.state.doc.toString()).toEqual("SELECT * FROM df");
+    expect(mockEditor.state.field(languageMetadataField)).toEqual({
+      quotePrefix: "r",
+    });
   });
 });

--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -11,7 +11,11 @@ const adapter = new MarkdownLanguageAdapter();
 describe("MarkdownLanguageAdapter", () => {
   describe("defaultMetadata", () => {
     it("should be set", () => {
-      expect(adapter.defaultMetadata).toMatchInlineSnapshot();
+      expect(adapter.defaultMetadata).toMatchInlineSnapshot(`
+        {
+          "quotePrefix": "r",
+        }
+      `);
     });
   });
 

--- a/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/markdown.test.ts
@@ -9,6 +9,12 @@ import { getQuotePrefix } from "../panel/markdown";
 const adapter = new MarkdownLanguageAdapter();
 
 describe("MarkdownLanguageAdapter", () => {
+  describe("defaultMetadata", () => {
+    it("should be set", () => {
+      expect(adapter.defaultMetadata).toMatchInlineSnapshot();
+    });
+  });
+
   describe("transformIn", () => {
     it("empty", () => {
       const [innerCode, offset, metadata] = adapter.transformIn("");

--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -22,7 +22,15 @@ const adapter = new SQLLanguageAdapter();
 describe("SQLLanguageAdapter", () => {
   describe("defaultMetadata", () => {
     it("should be set", () => {
-      expect(adapter.defaultMetadata).toMatchInlineSnapshot();
+      expect(adapter.defaultMetadata).toMatchInlineSnapshot(`
+        {
+          "commentLines": [],
+          "dataframeName": "_df",
+          "engine": "__marimo_duckdb",
+          "quotePrefix": "f",
+          "showOutput": true,
+        }
+      `);
     });
   });
 

--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -20,6 +20,12 @@ import type { DatasetsState } from "@/core/datasets/types";
 const adapter = new SQLLanguageAdapter();
 
 describe("SQLLanguageAdapter", () => {
+  describe("defaultMetadata", () => {
+    it("should be set", () => {
+      expect(adapter.defaultMetadata).toMatchInlineSnapshot();
+    });
+  });
+
   describe("transformIn", () => {
     it("empty", () => {
       const [innerCode, offset, metadata] = adapter.transformIn("");

--- a/frontend/src/core/codemirror/language/extension.ts
+++ b/frontend/src/core/codemirror/language/extension.ts
@@ -136,7 +136,7 @@ function updateLanguageAdapterAndCode(
     finalCode = code;
     if (currentLanguage.type !== nextLanguage.type) {
       // Set the metadata to the default metadata
-      metadata = nextLanguage.defaultMetadata;
+      metadata = { ...nextLanguage.defaultMetadata };
     }
   } else {
     const [codeOut, cursorDiff1] = currentLanguage.transformOut(code, metadata);

--- a/frontend/src/core/codemirror/language/extension.ts
+++ b/frontend/src/core/codemirror/language/extension.ts
@@ -134,6 +134,10 @@ function updateLanguageAdapterAndCode(
   let finalCode: string;
   if (opts.keepCodeAsIs) {
     finalCode = code;
+    if (currentLanguage.type !== nextLanguage.type) {
+      // Set the metadata to the default metadata
+      metadata = nextLanguage.defaultMetadata;
+    }
   } else {
     const [codeOut, cursorDiff1] = currentLanguage.transformOut(code, metadata);
     const [newCode, cursorDiff2, metadataOut] =

--- a/frontend/src/core/codemirror/language/languages/markdown.ts
+++ b/frontend/src/core/codemirror/language/languages/markdown.ts
@@ -61,6 +61,9 @@ export class MarkdownLanguageAdapter
 {
   readonly type = "markdown";
   readonly defaultCode = 'mo.md(r"""\n""")';
+  readonly defaultMetadata: MarkdownLanguageAdapterMetadata = {
+    quotePrefix: "r",
+  };
 
   static fromMarkdown(markdown: string) {
     return `mo.md(r"""\n${markdown}\n""")`;
@@ -71,9 +74,7 @@ export class MarkdownLanguageAdapter
   ): [string, number, MarkdownLanguageAdapterMetadata] {
     pythonCode = pythonCode.trim();
 
-    const metadata: MarkdownLanguageAdapterMetadata = {
-      quotePrefix: "r",
-    };
+    const metadata = { ...this.defaultMetadata };
 
     // empty string
     if (pythonCode === "") {

--- a/frontend/src/core/codemirror/language/languages/python.ts
+++ b/frontend/src/core/codemirror/language/languages/python.ts
@@ -139,6 +139,7 @@ const lspClient = once((lspConfig: LSPConfig) => {
 export class PythonLanguageAdapter implements LanguageAdapter<{}> {
   readonly type = "python";
   readonly defaultCode = "";
+  readonly defaultMetadata = {};
 
   transformIn(code: string): [string, number, {}] {
     return [code, 0, {}];

--- a/frontend/src/core/codemirror/language/languages/sql.ts
+++ b/frontend/src/core/codemirror/language/languages/sql.ts
@@ -60,6 +60,15 @@ export class SQLLanguageAdapter
   implements LanguageAdapter<SQLLanguageAdapterMetadata>
 {
   readonly type = "sql";
+  get defaultMetadata(): SQLLanguageAdapterMetadata {
+    return {
+      dataframeName: "_df",
+      quotePrefix: "f",
+      commentLines: [],
+      showOutput: true,
+      engine: getLatestEngine() || this.defaultEngine,
+    };
+  }
 
   get defaultCode(): string {
     const latestEngine = getLatestEngine();
@@ -84,11 +93,8 @@ export class SQLLanguageAdapter
 
     // Default metadata
     const metadata: SQLLanguageAdapterMetadata = {
-      dataframeName: "_df",
+      ...this.defaultMetadata,
       commentLines: this.extractCommentLines(pythonCode),
-      quotePrefix: "f",
-      showOutput: true,
-      engine: getLatestEngine() || this.defaultEngine,
     };
 
     if (!this.isSupported(pythonCode)) {

--- a/frontend/src/core/codemirror/language/types.ts
+++ b/frontend/src/core/codemirror/language/types.ts
@@ -20,6 +20,7 @@ import type { CellId } from "@/core/cells/ids";
 export interface LanguageAdapter<M = Record<string, any>> {
   readonly type: LanguageAdapterType;
   readonly defaultCode: string;
+  readonly defaultMetadata: Readonly<M>;
 
   transformIn(code: string): [string, number, M];
   transformOut(code: string, metadata: M): [string, number];


### PR DESCRIPTION
In a refactor, we moved metadata to the codemirror state. this regressed some logic when converting python to markdown/sql such that we never initialized this metadata state