### PR TITLE
fix: default to syntax highlighting in markdown when Editor is not ready

### DIFF
--- a/frontend/src/core/codemirror/language/languages/markdown.ts
+++ b/frontend/src/core/codemirror/language/languages/markdown.ts
@@ -209,6 +209,10 @@ export class MarkdownLanguageAdapter
 
     // Only activate completions for f-strings
     const isFStringActive = () => {
+      if (!view) {
+        return true;
+      }
+
       const metadata = view?.state.field(languageMetadataField);
       if (metadata === undefined) {
         return false;


### PR DESCRIPTION
Does not fix #4926, but defaults to syntax highlighted. this may return false positives on initialization, but could be better while we find a better solution. 