### PR TITLE
fix: column resize handler not always showing up

### DIFF
--- a/frontend/src/components/editor/columns/cell-column.tsx
+++ b/frontend/src/components/editor/columns/cell-column.tsx
@@ -80,26 +80,22 @@ const ResizableComponent = ({
     onResize,
   });
 
-  const renderResizeHandler = (
-    ref: React.RefObject<HTMLDivElement>,
-    groupHover: boolean,
-  ) => {
-    const hoverClass = groupHover ? "group-hover" : "hover";
-
+  const renderResizeHandler = (ref: React.RefObject<HTMLDivElement>) => {
     return (
       <div
         ref={ref}
-        className={`w-1 cursor-col-resize transition-colors duration-200 z-10
-        relative before:content-[''] before:absolute before:inset-y-0 before:-left-[4px] before:right-[-4px] before:w-[11px] before:z-[-1]
-        ${hoverClass}/column:bg-[var(--slate-3)] dark:${hoverClass}/column:bg-[var(--slate-5)]
-        ${hoverClass}/column:hover:bg-primary/60 dark:${hoverClass}/column:hover:bg-primary/60`}
+        className={`w-[3px] cursor-col-resize transition-colors duration-200 z-[100]
+          relative before:content-[''] before:absolute before:inset-y-0 before:-left-[3px] 
+          before:right-[-3px] before:w-[9px] before:z-[-1]
+          hover/column:bg-[var(--slate-3)] dark:hover/column:bg-[var(--slate-5)]
+          hover/column:hover:bg-primary/60 dark:hover/column:hover:bg-primary/60`}
       />
     );
   };
 
   return (
     <div className="flex flex-row">
-      {renderResizeHandler(handleRefs.left, false)}
+      {renderResizeHandler(handleRefs.left)}
       <div
         ref={resizableDivRef}
         className="flex flex-col gap-5 box-content min-h-[100px] px-11 py-6 min-w-[500px] z-1"
@@ -107,7 +103,7 @@ const ResizableComponent = ({
       >
         {children}
       </div>
-      {renderResizeHandler(handleRefs.right, true)}
+      {renderResizeHandler(handleRefs.right)}
     </div>
   );
 };


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
The blue hover line would sometimes not display on hover.

- This change displays both left and right side handlers, but only when cursor is close to edge (always displaying will overlay the cell-status)
- Increases the z-index so it's always draggable
- slightly reduce invisible widths

https://github.com/user-attachments/assets/0d2b173a-0bdc-4780-985c-95296fa2b54e

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
