### PR TITLE
docs: Add link to vim keybindings section in overview.md

### DIFF
--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -22,7 +22,7 @@ A non-exhaustive list of settings:
 - Outputs above or below code cells
 - [Disable/enable autorun](../reactivity.md#configuring-how-marimo-runs-cells)
 - Package installation
-- Vim keybindings
+- [Vim keybindings](#vim-keybindings)
 - Dark mode
 - Auto-save
 - Auto-complete


### PR DESCRIPTION
## 📝 Summary
Adds a link to the the vim-keybindings section, in edtior overview docs.
@akshayka OR @mscolnick
