### PR TITLE
improvement: python poet cleanup

### DIFF
--- a/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
+++ b/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
@@ -375,4 +375,33 @@ describe("generateAltairChart", () => {
       )"
     `);
   });
+
+  it("should handle complex x/y axis", () => {
+    const spec = createSpec({
+      mark: Mocks.marks.bar,
+      encoding: {
+        x: Mocks.xAxisFull,
+        y: Mocks.yAxisFull,
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar(
+          opacity=0.8,
+          color='red'
+      )
+      .encode(
+          x=alt.X(field='category', axis={
+              'title': 'X Axis'
+          }),
+          y=alt.Y(field='value', axis={
+              'title': 'Y Axis'
+          })
+      )"
+    `);
+  });
 });

--- a/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
+++ b/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
@@ -6,15 +6,97 @@ import {
 } from "../chart-spec/altair-generator";
 import type { VegaLiteSpec } from "@/plugins/impl/vega/types";
 
+function createSpec(spec: {
+  mark: string | Record<string, unknown>;
+  encoding: Record<
+    string,
+    | { field: string }
+    | Array<{ field: string; tooltip?: Record<string, string> }>
+  >;
+  resolve?: Record<string, unknown>;
+  title?: string;
+  width?: number;
+  height?: number;
+}): VegaLiteSpec {
+  return {
+    ...spec,
+    data: { name: "_unused_" },
+  } as VegaLiteSpec;
+}
+
+const Mocks = {
+  // Simple
+  xAxis: {
+    field: "category",
+  },
+  yAxis: {
+    field: "value",
+  },
+
+  // Full
+  xAxisFull: {
+    field: "category",
+    axis: {
+      title: "X Axis",
+    },
+  },
+  yAxisFull: {
+    field: "value",
+    axis: {
+      title: "Y Axis",
+    },
+  },
+
+  // Color
+  colorAxis: {
+    field: "color",
+  },
+  thetaAxis: {
+    field: "theta",
+    axis: {
+      title: "Theta Axis",
+    },
+  },
+  rowAxis: {
+    field: "row",
+    axis: {
+      title: "Row Axis",
+    },
+  },
+  columnAxis: {
+    field: "column",
+    axis: {
+      title: "Column Axis",
+    },
+  },
+  tooltip: {
+    field: "tooltip",
+    tooltip: {
+      title: "Tooltip",
+    },
+  },
+  marks: {
+    bar: {
+      type: "bar",
+      opacity: 0.8,
+      color: "red",
+    },
+    arc: {
+      type: "arc",
+      innerRadius: 100,
+    },
+  },
+};
+
 describe("generateAltairChart", () => {
   it("should generate a basic bar chart", () => {
-    const spec: VegaLiteSpec = {
+    const spec = createSpec({
       mark: "bar",
       encoding: {
-        x: { field: "category" },
-        y: { field: "value" },
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
       },
-    } as VegaLiteSpec;
+    });
     const datasource = "df";
 
     const result = generateAltairChart(spec, datasource).toCode();
@@ -23,23 +105,19 @@ describe("generateAltairChart", () => {
       "alt.Chart(df)
       .mark_bar()
       .encode(
-          x=alt.X(
-              field='category'
-          ),
-          y=alt.Y(
-              field='value'
-          )
+          x=alt.X(field='category'),
+          y=alt.Y(field='value')
       )"
     `);
   });
 
   it("should generate a donut chart", () => {
-    const spec: VegaLiteSpec = {
-      mark: { type: "arc", innerRadius: 100 },
+    const spec = createSpec({
+      mark: Mocks.marks.arc,
       encoding: {
-        theta: { field: "value" },
+        theta: Mocks.thetaAxis,
       },
-    } as VegaLiteSpec;
+    });
     const datasource = "df";
 
     const result = generateAltairChart(spec, datasource).toCode();
@@ -47,20 +125,20 @@ describe("generateAltairChart", () => {
     expect(result).toMatchInlineSnapshot(`
       "alt.Chart(df)
       .mark_arc(innerRadius=100)
-      .encode(theta=alt.Theta(
-          field='value'
-      ))"
+      .encode(theta=alt.Theta(field='theta', axis={
+          'title': 'Theta Axis'
+      }))"
     `);
   });
 
   it("should use the provided datasource variable name", () => {
-    const spec = {
+    const spec = createSpec({
       mark: "bar",
       encoding: {
-        x: { field: "x" },
-        y: { field: "y" },
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
       },
-    } as VegaLiteSpec;
+    });
     const datasource = "my_custom_dataframe";
 
     const result = generateAltairChart(spec, datasource).toCode();
@@ -69,24 +147,20 @@ describe("generateAltairChart", () => {
       "alt.Chart(my_custom_dataframe)
       .mark_bar()
       .encode(
-          x=alt.X(
-              field='x'
-          ),
-          y=alt.Y(
-              field='y'
-          )
+          x=alt.X(field='category'),
+          y=alt.Y(field='value')
       )"
     `);
   });
 
   it("should generate a snippet", () => {
-    const spec = {
+    const spec = createSpec({
       mark: "bar",
       encoding: {
-        x: { field: "x" },
-        y: { field: "y" },
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
       },
-    } as VegaLiteSpec;
+    });
     const datasource = "df";
 
     const result = generateAltairChartSnippet(spec, datasource, "_chart");
@@ -96,15 +170,209 @@ describe("generateAltairChart", () => {
           alt.Chart(df)
           .mark_bar()
           .encode(
-              x=alt.X(
-                  field='x'
-              ),
-              y=alt.Y(
-                  field='y'
-              )
+              x=alt.X(field='category'),
+              y=alt.Y(field='value')
           )
       )
       _chart"
+    `);
+  });
+
+  it("should generate a chart with color encoding", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
+        color: Mocks.colorAxis,
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value'),
+          color=alt.Color(field='color')
+      )"
+    `);
+  });
+
+  it("should generate a chart with tooltip", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
+        tooltip: Mocks.tooltip,
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value'),
+          tooltip=alt.Tooltip(field='tooltip', tooltip={
+              'title': 'Tooltip'
+          })
+      )"
+    `);
+  });
+
+  it("should handle array tooltips", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
+        tooltip: [Mocks.tooltip, Mocks.tooltip],
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value'),
+          tooltip=[
+              alt.Tooltip(field='tooltip', tooltip={
+                  'title': 'Tooltip'
+              }),
+              alt.Tooltip(field='tooltip', tooltip={
+                  'title': 'Tooltip'
+              })
+          ]
+      )"
+    `);
+  });
+
+  it("should generate a chart with row and column facets", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
+        row: Mocks.rowAxis,
+        column: Mocks.columnAxis,
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value'),
+          row=alt.Row(field='row', axis={
+              'title': 'Row Axis'
+          }),
+          column=alt.Column(field='column', axis={
+              'title': 'Column Axis'
+          })
+      )"
+    `);
+  });
+
+  it("should generate a chart with resolve_scale", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
+      },
+      resolve: {
+        axis: {
+          x: "independent",
+          y: "shared",
+        },
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value')
+      )
+      .resolve_scale(
+          x='independent',
+          y='shared'
+      )"
+    `);
+  });
+
+  it("should generate a chart with properties", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
+      },
+      title: "Chart Title",
+      width: 600,
+      height: 400,
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value')
+      )
+      .properties(
+          title='Chart Title',
+          height=400,
+          width=600
+      )"
+    `);
+  });
+
+  it("should handle custom mark properties", () => {
+    const spec = createSpec({
+      mark: Mocks.marks.bar,
+      encoding: {
+        x: Mocks.xAxis,
+        y: Mocks.yAxis,
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar(
+          opacity=0.8,
+          color='red'
+      )
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value')
+      )"
     `);
   });
 });

--- a/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
+++ b/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
@@ -10,7 +10,7 @@ function createSpec(spec: {
   mark: string | Record<string, unknown>;
   encoding: Record<
     string,
-    | { field: string }
+    | { field: string; type?: string }
     | Array<{ field: string; tooltip?: Record<string, string> }>
   >;
   resolve?: Record<string, unknown>;
@@ -89,6 +89,23 @@ const Mocks = {
 };
 
 describe("generateAltairChart", () => {
+  it("should remove undefined values", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: { ...Mocks.xAxis, type: undefined },
+      },
+    });
+
+    const result = generateAltairChart(spec, "df").toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(x=alt.X(field='category'))"
+    `);
+  });
+
   it("should generate a basic bar chart", () => {
     const spec = createSpec({
       mark: "bar",

--- a/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
@@ -8,7 +8,6 @@ import {
 } from "@/utils/python-poet/poet";
 
 import type { VegaLiteSpec } from "@/plugins/impl/vega/types";
-import { Objects } from "@/utils/objects";
 
 /**
  * Generates Python code for an Altair chart.
@@ -145,5 +144,13 @@ ${variableName}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeKwargs<T extends Record<string, any>>(obj: T) {
-  return Objects.mapValues(obj, (v) => new Literal(v));
+  const result: Record<string, PythonCode> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== undefined) {
+      result[key] = new Literal(value);
+    }
+  }
+
+  return result;
 }

--- a/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
@@ -2,13 +2,13 @@
 import {
   FunctionCall,
   Literal,
-  objectsToPythonCode,
   type PythonCode,
   Variable,
   VariableDeclaration,
 } from "@/utils/python-poet/poet";
 
 import type { VegaLiteSpec } from "@/plugins/impl/vega/types";
+import { Objects } from "@/utils/objects";
 
 /**
  * Generates Python code for an Altair chart.
@@ -25,19 +25,17 @@ export function generateAltairChart(
       typeof spec.mark === "string" ? spec.mark : spec.mark?.type;
 
     if (markType) {
-      const markProps =
-        typeof spec.mark === "object" && "type" in spec.mark
-          ? Object.fromEntries(
-              Object.entries(spec.mark)
-                .filter(([key]) => key !== "type")
-                .map(([key, value]) => [key, new Literal(value)]),
-            )
-          : {};
+      let markProps: Record<string, PythonCode> = {};
 
-      code = code.chain(
-        `mark_${markType}`,
-        Object.keys(markProps).length > 0 ? markProps : [],
-      );
+      if (typeof spec.mark === "object" && "type" in spec.mark) {
+        markProps = Object.fromEntries(
+          Object.entries(spec.mark)
+            .filter(([key]) => key !== "type")
+            .map(([key, value]) => [key, new Literal(value)]),
+        );
+      }
+
+      code = code.chain(`mark_${markType}`, markProps);
     }
   }
 
@@ -47,48 +45,49 @@ export function generateAltairChart(
     const encodings = spec.encoding;
 
     if (encodings?.x) {
-      encodeArgs.x = new FunctionCall("alt.X", [
-        new Literal(encodings.x, { objectAsFieldNames: true }),
-      ]);
+      const kwargs = makeKwargs(encodings.x);
+      encodeArgs.x = new FunctionCall("alt.X", kwargs);
     }
 
     if (encodings?.y) {
-      encodeArgs.y = new FunctionCall("alt.Y", [
-        new Literal(encodings.y, { objectAsFieldNames: true }),
-      ]);
+      const kwargs = makeKwargs(encodings.y);
+      encodeArgs.y = new FunctionCall("alt.Y", kwargs);
     }
 
     if (encodings?.color) {
-      encodeArgs.color = new FunctionCall("alt.Color", [
-        new Literal(encodings.color, { objectAsFieldNames: true }),
-      ]);
+      const kwargs = makeKwargs(encodings.color);
+      encodeArgs.color = new FunctionCall("alt.Color", kwargs);
     }
 
     if (encodings?.theta) {
-      encodeArgs.theta = new FunctionCall("alt.Theta", [
-        new Literal(encodings.theta, { objectAsFieldNames: true }),
-      ]);
+      const kwargs = makeKwargs(encodings.theta);
+      encodeArgs.theta = new FunctionCall("alt.Theta", kwargs);
     }
 
     const hasRow = encodings && "row" in encodings;
     if (hasRow && encodings.row) {
-      encodeArgs.row = new FunctionCall("alt.Row", [
-        new Literal(encodings.row, { objectAsFieldNames: true }),
-      ]);
+      const kwargs = makeKwargs(encodings.row);
+      encodeArgs.row = new FunctionCall("alt.Row", kwargs);
     }
 
     const hasColumn = encodings && "column" in encodings;
     if (hasColumn && encodings.column) {
-      encodeArgs.column = new FunctionCall("alt.Column", [
-        new Literal(encodings.column, { objectAsFieldNames: true }),
-      ]);
+      const kwargs = makeKwargs(encodings.column);
+      encodeArgs.column = new FunctionCall("alt.Column", kwargs);
     }
 
     if (encodings?.tooltip) {
       const tooltip = encodings.tooltip;
-      const tooltipArray = Array.isArray(tooltip) ? tooltip : [tooltip];
-      const tooltipCode = objectsToPythonCode(tooltipArray, "alt.Tooltip");
-      encodeArgs.tooltip = tooltipCode;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const makeTooltip = (t: Record<string, any>) => {
+        const kwargs = makeKwargs(t);
+        return new FunctionCall("alt.Tooltip", kwargs);
+      };
+
+      const tooltipArray = Array.isArray(tooltip)
+        ? new Literal(tooltip.map(makeTooltip))
+        : makeTooltip(tooltip);
+      encodeArgs.tooltip = tooltipArray;
     }
 
     code = code.chain("encode", encodeArgs);
@@ -110,14 +109,11 @@ export function generateAltairChart(
   }
 
   const propertiesArgs: Record<string, PythonCode> = {};
-  if (spec.title) {
-    propertiesArgs.title = new Literal(spec.title);
-  }
-  if ("height" in spec) {
-    propertiesArgs.height = new Literal(spec.height);
-  }
-  if ("width" in spec) {
-    propertiesArgs.width = new Literal(spec.width);
+  const propertiesKeys = ["title", "height", "width"];
+  for (const key of propertiesKeys) {
+    if (key in spec) {
+      propertiesArgs[key] = new Literal(spec[key as keyof VegaLiteSpec]);
+    }
   }
 
   if (Object.keys(propertiesArgs).length > 0) {
@@ -145,4 +141,9 @@ export function generateAltairChartSnippet(
 ${new VariableDeclaration(variableName, code).toCode()}
 ${variableName}
   `.trim();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeKwargs<T extends Record<string, any>>(obj: T) {
+  return Objects.mapValues(obj, (v) => new Literal(v));
 }

--- a/frontend/src/utils/python-poet/__tests__/poet.test.ts
+++ b/frontend/src/utils/python-poet/__tests__/poet.test.ts
@@ -152,29 +152,6 @@ describe("Python Poet", () => {
     ]
 }`);
     });
-
-    it("should return direct field names when objectAsFieldNames is true", () => {
-      const literal = new Literal({ a: 1, b: 2 }, { objectAsFieldNames: true });
-      expect(literal.toCode()).toBe(`
-    a=1,
-    b=2
-`);
-    });
-
-    it("should maintain nested object structure when objectAsFieldNames is true", () => {
-      const literal = new Literal(
-        { a: 1, b: { c: 1, d: null, e: "5" } },
-        { objectAsFieldNames: true },
-      );
-      expect(literal.toCode()).toBe(`
-    a=1,
-    b={
-        'c': 1,
-        'd': None,
-        'e': '5'
-    }
-`);
-    });
   });
 
   describe("Altair Charts", () => {


### PR DESCRIPTION
Some cleanup just branching off the main branch

- removes `objectAsFieldNames` since this does actually work for nested object. but we have this logic, just needed to re-use as `args` in the `FunctionCall`
-  removes `objectsToPythonCode`. i added `Literal` to handling `toCode` so we could compose this a bit better.