### PR TITLE
fix: ignore click 8.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dynamic = ["version"]
 # Dependencies should have lower bounds, which should be as loose as possible.
 dependencies = [
     # For maintainable cli
-    "click>=8.0,<9",
+    # - 8.2.0 introduced a bug where boolean flags broke
+    "click>=8.0,!=8.2.0,<9",
     # code completion
     "jedi>=0.18.0",
     # compile markdown to html


### PR DESCRIPTION
There is a fix foward but requires more LOC. This ignores the bad version and `8.2.1` should have the fix


Related: https://github.com/pallets/click/issues/2897