### PR TITLE
feat: added disabled prop to range-slider

### DIFF
--- a/frontend/src/components/ui/range-slider.tsx
+++ b/frontend/src/components/ui/range-slider.tsx
@@ -28,6 +28,7 @@ const RangeSlider = React.forwardRef<
         "relative flex touch-none select-none hover:cursor-pointer",
         "data-[orientation=horizontal]:w-full data-[orientation=horizontal]:items-center",
         "data-[orientation=vertical]:h-full data-[orientation=vertical]:justify-center",
+        "data-[disabled]:cursor-not-allowed",
         className,
       )}
       {...props}
@@ -46,6 +47,7 @@ const RangeSlider = React.forwardRef<
             "absolute bg-blue-500 dark:bg-primary",
             "data-[orientation=horizontal]:h-full",
             "data-[orientation=vertical]:w-full",
+            "data-[disabled]:opacity-50",
           )}
         />
       </SliderPrimitive.Track>
@@ -54,7 +56,7 @@ const RangeSlider = React.forwardRef<
           <TooltipTrigger asChild={true}>
             <SliderPrimitive.Thumb
               data-testid="thumb"
-              className="block h-4 w-4 rounded-full shadow-xsSolid border border-blue-500 dark:border-primary dark:bg-accent bg-white hover:bg-blue-300 focus:bg-blue-300 transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+              className="block h-4 w-4 rounded-full shadow-xsSolid border border-blue-500 dark:border-primary dark:bg-accent bg-white hover:bg-blue-300 focus:bg-blue-300 transition-colors focus-visible:outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
               onFocus={openActions.setTrue}
               onBlur={openActions.setFalse}
               onMouseEnter={openActions.setTrue}
@@ -75,7 +77,7 @@ const RangeSlider = React.forwardRef<
           <TooltipTrigger asChild={true}>
             <SliderPrimitive.Thumb
               data-testid="thumb"
-              className="block h-4 w-4 rounded-full shadow-xsSolid border border-blue-500 dark:border-primary dark:bg-accent bg-white hover:bg-blue-300 focus:bg-blue-300 transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+              className="block h-4 w-4 rounded-full shadow-xsSolid border border-blue-500 dark:border-primary dark:bg-accent bg-white hover:bg-blue-300 focus:bg-blue-300 transition-colors focus-visible:outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
               onFocus={openActions.setTrue}
               onBlur={openActions.setFalse}
               onMouseEnter={openActions.setTrue}

--- a/frontend/src/plugins/impl/RangeSliderPlugin.tsx
+++ b/frontend/src/plugins/impl/RangeSliderPlugin.tsx
@@ -21,6 +21,7 @@ interface Data {
   orientation: "horizontal" | "vertical";
   showValue: boolean;
   fullWidth: boolean;
+  disabled?: boolean;
 }
 
 export class RangeSliderPlugin implements IPlugin<T, Data> {
@@ -37,6 +38,7 @@ export class RangeSliderPlugin implements IPlugin<T, Data> {
     orientation: z.enum(["horizontal", "vertical"]).default("horizontal"),
     showValue: z.boolean().default(false),
     fullWidth: z.boolean().default(false),
+    disabled: z.boolean().optional(),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -76,6 +78,7 @@ const RangeSliderComponent = ({
   orientation,
   showValue,
   fullWidth,
+  disabled,
   valueMap,
 }: RangeSliderProps): JSX.Element => {
   const id = useId();
@@ -116,6 +119,7 @@ const RangeSliderComponent = ({
           max={stop}
           step={step}
           orientation={orientation}
+          disabled={disabled}
           // Triggered on all value changes
           onValueChange={(nextValue: number[]) => {
             setInternalValue(nextValue);

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -416,6 +416,7 @@ class range_slider(UIElement[list[Numeric], Sequence[Numeric]]):
         label (str): Markdown label for the element.
         on_change (Optional[Callable[[Sequence[Numeric]], None]]): Optional callback to run when this element's value changes.
         full_width (bool): Whether the input should take up the full width of its container.
+        disabled (bool, optional): Whether the slider is disabled. Defaults to False.
 
     Methods:
         from_series(series: DataFrameSeries, **kwargs: Any) -> range_slider:
@@ -439,6 +440,7 @@ class range_slider(UIElement[list[Numeric], Sequence[Numeric]]):
         label: str = "",
         on_change: Optional[Callable[[Sequence[Numeric]], None]] = None,
         full_width: bool = False,
+        disabled: bool = False,
     ) -> None:
         self.start: Numeric
         self.stop: Numeric
@@ -504,6 +506,7 @@ class range_slider(UIElement[list[Numeric], Sequence[Numeric]]):
                     "orientation": orientation,
                     "show-value": show_value,
                     "full-width": full_width,
+                    "disabled": disabled,
                 },
                 on_change=on_change,
             )
@@ -544,6 +547,7 @@ class range_slider(UIElement[list[Numeric], Sequence[Numeric]]):
                     "orientation": orientation,
                     "show-value": show_value,
                     "full-width": full_width,
+                    "disabled": disabled,
                 },
                 on_change=on_change,
             )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Added disabled to range slider, updated the css so that the disabled style shows properly.

<img width="719" alt="Screenshot 2025-05-16 at 1 14 42 AM" src="https://github.com/user-attachments/assets/ee8c0f1e-1228-4a96-9462-614522c084d3" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Changed disabled:[css-class] to data-[disabled]:[css-class] because disabled CSS styles were not rendering in range-slider.tsx.
- Added disabled as an optional boolean prop with validation to RangeSliderPlugin.tsx
- Mapped disabled to range-slider python args with definition in input.py

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
