### PR TITLE
fix: skip stopped cells when running as a script

### DIFF
--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -517,6 +517,47 @@ class TestApp:
         assert "x" not in defs
         assert "y" not in defs
 
+    @staticmethod
+    def test_run_mo_stop_descendant_multiple() -> None:
+        app = App()
+
+        @app.cell
+        def _() -> Any:
+            import marimo as mo
+            return (mo,)
+
+        @app.cell
+        def _(mo) -> tuple[int]:
+            mo.stop(True)
+            x = 0
+            return (x,)
+
+        @app.cell
+        def _(mo) -> tuple[int]:
+            mo.stop(True)
+            y = 0
+            return (y,)
+
+
+        @app.cell
+        def _(x) -> tuple[int]:
+            x
+            a = 0
+            return
+
+        @app.cell
+        def _(y) -> tuple[int]:
+            y
+            b = 0
+            return
+
+
+        _, defs = app.run()
+        assert "x" not in defs
+        assert "y" not in defs
+        assert "a" not in defs
+        assert "b" not in defs
+
 
     @staticmethod
     def test_run_mo_stop_async() -> None:

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -493,6 +493,32 @@ class TestApp:
         assert defs["y"] == 1
 
     @staticmethod
+    def test_run_mo_stop_descendant() -> None:
+        app = App()
+
+        @app.cell
+        def _() -> Any:
+            import marimo as mo
+            return (mo,)
+
+        @app.cell
+        def _(mo) -> tuple[int]:
+            mo.stop(True)
+            x = 0
+            return (x,)
+
+        @app.cell
+        def _(x) -> tuple[int]:
+            y = 1
+            x
+            return
+
+        _, defs = app.run()
+        assert "x" not in defs
+        assert "y" not in defs
+
+
+    @staticmethod
     def test_run_mo_stop_async() -> None:
         app = App()
 
@@ -515,6 +541,31 @@ class TestApp:
         _, defs = app.run()
         assert "x" not in defs
         assert defs["y"] == 1
+
+    @staticmethod
+    def test_run_mo_stop_descendant_async() -> None:
+        app = App()
+
+        @app.cell
+        def _() -> Any:
+            import marimo as mo
+            return (mo,)
+
+        @app.cell
+        def _(mo) -> tuple[int]:
+            mo.stop(True)
+            x = 0
+            return (x,)
+
+        @app.cell
+        async def _(x) -> tuple[int]:
+            y = 1
+            x
+            return
+
+        _, defs = app.run()
+        assert "x" not in defs
+        assert "y" not in defs
 
 
     @pytest.mark.skipif(


### PR DESCRIPTION
The logic for skipping stopped cells when running as a script was previously broken; wasn't actually skipping cancelled cells.

Fixes #4962