### PR TITLE
fix: markdown wrapping for LaTeX

### DIFF
--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -46,7 +46,22 @@
       > span.paragraph:not(:has(> :only-child)):not(:empty),
     /* Target span.paragraph that only contains basic elements */
       > span.paragraph:not(
-        :has(> :not(code, a, strong, i, b, del, em, u, mark, sub, sup, marimo-tex))
+        :has(
+            > :not(
+                code,
+                a,
+                strong,
+                i,
+                b,
+                del,
+                em,
+                u,
+                mark,
+                sub,
+                sup,
+                marimo-tex
+              )
+          )
       ) {
       max-width: var(--markdown-max-width);
     }

--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -46,7 +46,7 @@
       > span.paragraph:not(:has(> :only-child)):not(:empty),
     /* Target span.paragraph that only contains basic elements */
       > span.paragraph:not(
-        :has(> :not(code, a, strong, i, b, del, em, u, mark, sub, sup))
+        :has(> :not(code, a, strong, i, b, del, em, u, mark, sub, sup, marimo-tex))
       ) {
       max-width: var(--markdown-max-width);
     }


### PR DESCRIPTION
Fixes wrapping for md paragraphs that contain tex elements, an issue raised on Discord.

<img width="797" alt="image" src="https://github.com/user-attachments/assets/908ada5b-4b84-40da-967b-80cd54e1fb26" />