### PR TITLE
fix: use Union instead of pipe operator for tables

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -111,7 +111,7 @@ class SearchTableArgs:
     sort: Optional[SortArgs] = None
     filters: Optional[list[Condition]] = None
     limit: Optional[int] = None
-    max_columns: Optional[int | MaxColumnsNotProvided] = (
+    max_columns: Optional[Union[int, MaxColumnsNotProvided]] = (
         MAX_COLUMNS_NOT_PROVIDED
     )
 
@@ -934,7 +934,7 @@ class table(
             columns = self._searched_manager.get_column_names()
             response = self._get_row_ids(EmptyArgs())
 
-            row_ids: list[int] | range
+            row_ids: Union[list[int], range]
             if response.all_rows is True or response.error is not None:
                 # TODO: Handle sorted rows, they have reverse order of row_ids
                 row_ids = range(skip, skip + take)


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #4978. Python 3.9 doesn't have support for pipe operators.
Ref: https://stackoverflow.com/questions/76712720/typeerror-unsupported-operand-types-for-type-and-nonetype

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
