### PR TITLE
fix: remove clamped markdown

### DIFF
--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -26,48 +26,6 @@
   max-width: 100%;
 }
 
-.output {
-  /* Unset max-width on .markdown. Instead, we will apply
-  to individual elements so it does not affect UI elements in markdown. */
-  .markdown {
-    max-width: unset;
-
-    > pre,
-    > ul,
-    > ol,
-    > blockquote,
-    > details,
-    div.codehilite,
-    div.codehilite-wrapper,
-    div.admonition,
-    /* Target <span> that is not empty and does not consist entirely of child elements;
-     * this makes sure text with embedded HTML (such as a slider) has a max width,
-     * but standalone elements (like tables, plots) don't get a max width. */
-      > span.paragraph:not(:has(> :only-child)):not(:empty),
-    /* Target span.paragraph that only contains basic elements */
-      > span.paragraph:not(
-        :has(
-            > :not(
-                code,
-                a,
-                strong,
-                i,
-                b,
-                del,
-                em,
-                u,
-                mark,
-                sub,
-                sup,
-                marimo-tex
-              )
-          )
-      ) {
-      max-width: var(--markdown-max-width);
-    }
-  }
-}
-
 .stdout,
 .stderr,
 .marimo-error {


### PR DESCRIPTION
We used to clamp markdown to a max width, regardless of the screen-width. While this may look better in some cases, it caused more bugs than helped. So instead we are removing this.

Fixes #4955