### PR TITLE
feat: added disabled prop to radio

### DIFF
--- a/frontend/src/plugins/impl/RadioPlugin.tsx
+++ b/frontend/src/plugins/impl/RadioPlugin.tsx
@@ -18,6 +18,7 @@ interface Data {
   label: string | null;
   inline: boolean;
   options: string[];
+  disabled?: boolean;
 }
 
 // The value is null when `initialValue` is null
@@ -31,6 +32,7 @@ export class RadioPlugin implements IPlugin<S, Data> {
     inline: z.boolean().default(false),
     label: z.string().nullable(),
     options: z.array(z.string()),
+    disabled: z.boolean().optional(),
   });
 
   render(props: IPluginProps<S, Data>): JSX.Element {
@@ -56,6 +58,7 @@ export const Radio = (props: RadioProps): JSX.Element => {
         onValueChange={props.setValue}
         className={cn(props.inline && "grid-flow-col gap-4")}
         aria-label="Radio Group"
+        disabled={props.disabled}
       >
         {props.options.map((option, i) => (
           <div className="flex items-center space-x-2" key={i}>

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -664,6 +664,7 @@ class radio(UIElement[Optional[str], Any]):
         label (str, optional): Optional markdown label for the element. Defaults to "".
         on_change (Callable[[Any], None], optional): Optional callback to run when
             this element's value changes. Defaults to None.
+        disabled (bool, optional): Whether the radio group is disabled. Defaults to False.
     """
 
     _name: Final[str] = "marimo-radio"
@@ -676,6 +677,7 @@ class radio(UIElement[Optional[str], Any]):
         *,
         label: str = "",
         on_change: Optional[Callable[[Any], None]] = None,
+        disabled: bool = False,
     ) -> None:
         if not isinstance(options, dict):
             if len(set(options)) != len(options):
@@ -689,6 +691,7 @@ class radio(UIElement[Optional[str], Any]):
             args={
                 "options": list(options.keys()),
                 "inline": inline,
+                "disabled": disabled,
             },
             on_change=on_change,
         )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Added disabled to radio

<img width="577" alt="Screenshot 2025-05-19 at 5 14 03 PM" src="https://github.com/user-attachments/assets/031809ff-7518-4cc8-9a9b-fab54aa9aed6" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

- Added disabled to RadioPlugin.tsx and connected it to existing RadioGroup disabled property
- Mapped radio python class to disabled property with definition

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
