### PR TITLE
fix: exit vim insert mode when closing inline completion hints with escape

### DIFF
--- a/frontend/src/core/codemirror/completion/keymap.ts
+++ b/frontend/src/core/codemirror/completion/keymap.ts
@@ -6,6 +6,7 @@ import {
 } from "@codemirror/autocomplete";
 import { keymap } from "@codemirror/view";
 import type { EditorView } from "@codemirror/view";
+import { isInVimMode } from "../utils";
 
 export function completionKeymap(): Extension {
   const withoutEscape = defaultCompletionKeymap.filter(
@@ -13,9 +14,12 @@ export function completionKeymap(): Extension {
   );
 
   const closeCompletionAndPropagate = (view: EditorView) => {
-    closeCompletion(view);
-    // Return false to propagate the Escape key
-    return false;
+    const status = closeCompletion(view);
+    // When in vim mode, we need to propagate Escape to exit insert mode.
+    if (isInVimMode(view)) {
+      return false;
+    }
+    return status;
   };
 
   return Prec.highest(

--- a/frontend/src/core/codemirror/utils.ts
+++ b/frontend/src/core/codemirror/utils.ts
@@ -37,6 +37,10 @@ export function moveToEndOfEditor(ev: EditorView | undefined) {
   });
 }
 
+export function isInVimMode(ev: EditorView): boolean {
+  return getCM(ev)?.state.vim != null;
+}
+
 export function isInVimNormalMode(ev: EditorView): boolean {
   const vimState = getCM(ev)?.state.vim;
   if (!vimState) {


### PR DESCRIPTION
This change ensures that hitting escape when an inline (AI) completion is active makes vim leave insert mode.

Additionally, this change fixes a bug in which hitting escape to close overlay completions would make the cell editor lose focus when _not_ in vim mode.

This should fix #4716, but I had difficulty testing the behavior on inline completion — copilot connected at first, but didn't connect thereafter. Similarly I can't get the custom completion to work either.

For copilot:
* I see `Copilot#signInInitiate: Sign-in flow started successfully`
* But `client.signInInitiate` returns `undefined`

For custom completion with api.openai.com, I see:
* `Suggestion fetch error: Error: Internal Server Error`