### PR TITLE
fix: cache rtc value to avoid weird initialization states

### DIFF
--- a/frontend/src/core/rtc/state.ts
+++ b/frontend/src/core/rtc/state.ts
@@ -1,6 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { atomWithStorage } from "jotai/utils";
 import { getFeatureFlag } from "../config/feature-flag";
+import { once } from "lodash-es";
 
 /**
  * The username for the current user when using real-time collaboration.
@@ -10,7 +11,10 @@ export const usernameAtom = atomWithStorage<string>("marimo:rtc:username", "");
 
 /**
  * Whether RTC is enabled.
+ *
+ * This is cached on page-load because this UI can get into
+ * weird states, so we require a page reload to take effect.
  */
-export function isRtcEnabled() {
+export const isRtcEnabled = once(() => {
   return getFeatureFlag("rtc_v2");
-}
+});


### PR DESCRIPTION
When you switch into RTC. The server reinitializes the code as empty, so instead we are caching it on page-load