### PR TITLE
fix: Allow @prop.setter in class definitions

### DIFF
--- a/marimo/_ast/toplevel.py
+++ b/marimo/_ast/toplevel.py
@@ -244,8 +244,6 @@ class TopLevelExtraction:
         defs: set[Name] = set()
         refs: set[Name] = set()
         self.allowed_refs: set[Name] = set(toplevel_defs)
-        if not self.allowed_refs:
-            self.allowed_refs.update(BUILTINS)
         self._variables: Optional[dict[Name, VariableData]] = None
         # Run through and get defs + refs, and a naive attempt at resolving cell
         # status.

--- a/marimo/_ast/toplevel.py
+++ b/marimo/_ast/toplevel.py
@@ -244,6 +244,8 @@ class TopLevelExtraction:
         defs: set[Name] = set()
         refs: set[Name] = set()
         self.allowed_refs: set[Name] = set(toplevel_defs)
+        if not self.allowed_refs:
+            self.allowed_refs.update(BUILTINS)
         self._variables: Optional[dict[Name, VariableData]] = None
         # Run through and get defs + refs, and a naive attempt at resolving cell
         # status.

--- a/tests/_ast/test_toplevel.py
+++ b/tests/_ast/test_toplevel.py
@@ -480,7 +480,7 @@ class TestTopLevelClasses:
             @property
             def prop(self) -> int:
                 return 1
-            
+
             @prop.setter
             def prop(self, value: int) -> None:
                 pass

--- a/tests/_ast/test_toplevel.py
+++ b/tests/_ast/test_toplevel.py
@@ -348,6 +348,25 @@ class TestTopLevelExtraction:
             s.type for s in extraction
         ], [s.hint for s in extraction]
 
+    @staticmethod
+    def test_name_is_not_propagated(app) -> None:
+        @app.cell
+        def cell():
+            value = 1
+
+        @app.function
+        def to_be_demoted():
+            return value + 1  # type: ignore # noqa: F821
+
+        extraction = TopLevelExtraction.from_app(InternalApp(app))
+        assert [
+            TopLevelType.CELL,
+            TopLevelType.CELL,
+        ] == [s.type for s in extraction], [s.hint for s in extraction]
+        assert ["cell", "_"] == [s.name for s in extraction], [
+            s.hint for s in extraction
+        ]
+
 
 class TestTopLevelClasses:
     @staticmethod
@@ -455,6 +474,28 @@ class TestTopLevelClasses:
         ] == [s.type for s in extraction], [s.hint for s in extraction]
 
     @staticmethod
+    def test_class_properties(app) -> None:
+        @app.class_definition
+        class Example:
+            @property
+            def prop(self) -> int:
+                return 1
+            
+            @prop.setter
+            def prop(self, value: int) -> None:
+                pass
+
+        @app.function
+        def f():
+            return Example()
+
+        extraction = TopLevelExtraction.from_app(InternalApp(app))
+        assert [
+            TopLevelType.TOPLEVEL,
+            TopLevelType.TOPLEVEL,
+        ] == [s.type for s in extraction], [s.hint for s in extraction]
+
+    @staticmethod
     def test_class_invocation(app) -> None:
         @app.class_definition
         class Example: ...
@@ -468,25 +509,6 @@ class TestTopLevelClasses:
             TopLevelType.TOPLEVEL,
             TopLevelType.TOPLEVEL,
         ] == [s.type for s in extraction], [s.hint for s in extraction]
-
-    @staticmethod
-    def test_name_is_not_propagated(app) -> None:
-        @app.cell
-        def cell():
-            value = 1
-
-        @app.function
-        def to_be_demoted():
-            return value + 1  # type: ignore # noqa: F821
-
-        extraction = TopLevelExtraction.from_app(InternalApp(app))
-        assert [
-            TopLevelType.CELL,
-            TopLevelType.CELL,
-        ] == [s.type for s in extraction], [s.hint for s in extraction]
-        assert ["cell", "_"] == [s.name for s in extraction], [
-            s.hint for s in extraction
-        ]
 
 
 class TestTopLevelHook:


### PR DESCRIPTION
## 📝 Summary

fixes #4993

`@prop` capture fix is a visitor change, since variables defined in class scope are not bound to be "unbounded" if they're set in the class body. Filtering is done in the loop since this is order dependent.

I think there might be some pretty hairy `global` edge cases I haven't taken the time to think through- but we can reserve it for a "correctness" sprint

@akshayka
