### PR TITLE
Allow progress bar rate calculation when rate display is disabled

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -126,19 +126,22 @@ class _Progress(Html):
             ),
         )
 
+    def _calculate_rate(self) -> Optional[float]:
+        diff = time.time() - self.start_time
+        if diff == 0:
+            return None
+        rate = self.current / diff
+        return round(rate, 2)
+    
     def _get_rate(self) -> Optional[float]:
         if self.show_rate:
-            diff = time.time() - self.start_time
-            if diff == 0:
-                return None
-            rate = self.current / diff
-            return round(rate, 2)
+            return self._calculate_rate()
         else:
             return None
-
+    
     def _get_eta(self) -> Optional[float]:
         if self.show_eta and self.total is not None:
-            rate = self._get_rate()
+            rate = self._calculate_rate()
             if rate is not None and rate > 0:
                 return round((self.total - self.current) / rate, 2)
             else:

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -132,13 +132,13 @@ class _Progress(Html):
             return None
         rate = self.current / diff
         return round(rate, 2)
-    
+
     def _get_rate(self) -> Optional[float]:
         if self.show_rate:
             return self._calculate_rate()
         else:
             return None
-    
+
     def _get_eta(self) -> Optional[float]:
         if self.show_eta and self.total is not None:
             rate = self._calculate_rate()

--- a/tests/_convert/test_ipynb.py
+++ b/tests/_convert/test_ipynb.py
@@ -148,6 +148,7 @@ def test_transform_add_marimo_import():
     ]
     assert transform_add_marimo_import(existing) == existing
 
+
 def test_transform_magic_commands():
     sources = [
         "%%sql\nSELECT * FROM table",


### PR DESCRIPTION
## 📝 Summary
Fixes #5023 

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

Modify `marimo/_plugins/stateless/status/_progress.py:_Progress` to allow rate calculation when rate display is disabled.

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
