### PR TITLE
handle multiindex with numeric levels

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -175,7 +175,10 @@ class PandasTableManagerFactory(TableManagerFactory):
                     if INDEX_COLUMN_NAME in data_copy.columns:
                         data_copy.columns = pd.Index(
                             [INDEX_COLUMN_NAME]
-                            + [",".join([str(lev) for lev in c]) for c in _cols[1:]]
+                            + [
+                                ",".join([str(lev) for lev in c])
+                                for c in _cols[1:]
+                            ]
                         )
                     else:
                         data_copy.columns = pd.Index(

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -171,14 +171,15 @@ class PandasTableManagerFactory(TableManagerFactory):
                     LOGGER.info(
                         "Multi-column indexes are not supported, converting to single index"
                     )
+                    _cols = data_copy.columns
                     if INDEX_COLUMN_NAME in data_copy.columns:
                         data_copy.columns = pd.Index(
                             [INDEX_COLUMN_NAME]
-                            + [",".join(col) for col in data_copy.columns[1:]]
+                            + [",".join([str(lev) for lev in c]) for c in _cols[1:]]
                         )
                     else:
                         data_copy.columns = pd.Index(
-                            [",".join(col) for col in data_copy.columns]
+                            [",".join([str(lev) for lev in c]) for c in _cols]
                         )
                     return data_copy
 

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -265,12 +265,9 @@ class TestPandasTableManager(unittest.TestCase):
             }
         )
         data_pivoted = data.pivot(
-            index="category",
-            columns=["num_col", "str_col"],
-            values="val"
+            index="category", columns=["num_col", "str_col"], values="val"
         )
         assert PandasTableManagerFactory.create()(data_pivoted) is not None
-
 
     @pytest.mark.xfail(reason="Implementation not yet supported")
     def test_to_json_multi_index_unnamed(self) -> None:

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -254,6 +254,24 @@ class TestPandasTableManager(unittest.TestCase):
             {"X": "z", "Y": 3, "a": 3, "b": 6},
         ]
 
+    def test_to_json_multi_index_numeric(self) -> None:
+        # MultiIndex with numeric levels
+        data = pd.DataFrame(
+            {
+                "category": list("abab"),
+                "num_col": [0, 0, 1, 1],
+                "str_col": list("aabb"),
+                "val": [1, 2, 3, 4],
+            }
+        )
+        data_pivoted = data.pivot(
+            index="category",
+            columns=["num_col", "str_col"],
+            values="val"
+        )
+        assert PandasTableManagerFactory.create()(data_pivoted) is not None
+
+
     @pytest.mark.xfail(reason="Implementation not yet supported")
     def test_to_json_multi_index_unnamed(self) -> None:
         data = pd.DataFrame(


### PR DESCRIPTION
## 📝 Summary

Allows multiindex pandas dataframes with non-string levels to be displayed (otherwise `TypeError: sequence item 0: expected str instance, int found`)

## 🔍 Description of Changes

Dataframes with multiindex columns can originate from a pivot on multiple columns; one of the levels may be a number.  Existing code fails in those cases. 

Subbing `",".join(col)` with `",".join([str(level) for level in col])` takes care of it.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

