### PR TITLE
feat: added disabled prop to date range plugin

### DIFF
--- a/frontend/src/plugins/impl/DateRangePlugin.tsx
+++ b/frontend/src/plugins/impl/DateRangePlugin.tsx
@@ -14,6 +14,7 @@ interface Data {
   stop: string;
   step?: string;
   fullWidth: boolean;
+  disabled?: boolean;
 }
 
 export class DateRangePickerPlugin implements IPlugin<T, Data> {
@@ -26,6 +27,7 @@ export class DateRangePickerPlugin implements IPlugin<T, Data> {
     stop: z.string(),
     step: z.string().optional(),
     fullWidth: z.boolean().default(false),
+    disabled: z.boolean().optional(),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -72,6 +74,7 @@ const DateRangePickerComponent = (props: DateRangePickerProps): JSX.Element => {
         aria-label={props.label ?? "date range picker"}
         minValue={parseDate(props.start)}
         maxValue={parseDate(props.stop)}
+        isDisabled={props.disabled}
       />
     </Labeled>
   );

--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -355,6 +355,7 @@ class date_range(UIElement[tuple[str, str], tuple[dt.date, dt.date]]):
         label (str, optional): Markdown label for the element.
         on_change (Callable[[Tuple[datetime.date, datetime.date]], None], optional): Optional callback to run when this element's value changes.
         full_width (bool, optional): Whether the input should take up the full width of its container.
+        disabled (bool, optional): Whether the input should be disabled.
     """
 
     _name: Final[str] = "marimo-date-range"
@@ -369,6 +370,7 @@ class date_range(UIElement[tuple[str, str], tuple[dt.date, dt.date]]):
         label: Optional[str] = None,
         on_change: Optional[Callable[[tuple[dt.date, dt.date]], None]] = None,
         full_width: bool = False,
+        disabled: bool = False,
     ):
         if isinstance(start, str):
             start = self._convert_single_value(start)
@@ -410,6 +412,7 @@ class date_range(UIElement[tuple[str, str], tuple[dt.date, dt.date]]):
                 "start": self._start.isoformat(),
                 "stop": self._stop.isoformat(),
                 "full-width": full_width,
+                "disabled": disabled,
             },
             on_change=on_change,
         )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Added disabled to mo.ui.date_range

<img width="534" alt="Screenshot 2025-05-21 at 6 34 19 PM" src="https://github.com/user-attachments/assets/58a36fb6-9129-4750-b6f7-8687029eb96b" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

- Added disabled prop to DateRangePlugin.tsx with validation and mapped it to the isDisabled property of DateRangePicker
- Mapped the disabled property to the python class with definition in dates.py

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
