### PR TITLE
chore: maybe fix vercel docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,7 +293,7 @@ extra-dependencies = [
 python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.docs]
-features = ["dev", "docs"]
+features = ["docs"]
 dependencies = [
     "marimo_docs @ file://docs",
 ]


### PR DESCRIPTION
DuckDB `1.3.0` break vercel CI. This removes duckdb from the doc's deps, which fixes build in vercel