### PR TITLE
chore: fix pixi build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,7 @@ dynamic = ["version"]
 # Dependencies should have lower bounds, which should be as loose as possible.
 dependencies = [
     # For maintainable cli
-    # - 8.2.0 introduced a bug where boolean flags broke
-    "click>=8.0,!=8.2.0,<9",
+    "click>=8.0,<9",
     # code completion
     "jedi>=0.18.0",
     # compile markdown to html


### PR DESCRIPTION
This removes the `8.2.0` restrictions on `click`, since this breaks pixi's resolver. 

Click did not yank `8.2.0` but they did release a new version. While it's still possible to install a bad version of click (very unlikely), I think its worth the tradeoff of pixi not resolving. 