### PR TITLE
fix: markdown clamping again

### DIFF
--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -26,6 +26,14 @@
   max-width: 100%;
 }
 
+.output {
+  /* Unset max-width on .markdown. Instead, we will apply
+  to individual elements so it does not affect UI elements in markdown. */
+  .markdown {
+    max-width: unset;
+  }
+}
+
 .stdout,
 .stderr,
 .marimo-error {


### PR DESCRIPTION
Fixes #5039 

We still want to unset max-width for all markdown again.