### PR TITLE
improvement: detect if in uv project and use 'uv add'

### DIFF
--- a/marimo/_smoke_tests/packages/is_in_uv.py
+++ b/marimo/_smoke_tests/packages/is_in_uv.py
@@ -1,0 +1,32 @@
+import marimo
+
+__generated_with = "0.13.11"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import os
+    from pathlib import Path
+
+    # Check we have a virtual environment
+    venv_path = os.environ.get("VIRTUAL_ENV", None)
+    # Check that the `UV` environment variable is set
+    # This tells us that marimo was run by uv
+    uv_env_exists = os.environ.get("UV", None)
+    # Check that the uv.lock and pyproject.toml files exist
+    uv_lock_path = Path(venv_path).parent / "uv.lock"
+    pyproject_path = Path(venv_path).parent / "pyproject.toml"
+
+    # If all these are True or defined, then we are running in a uv project
+    {
+        "venv_path": venv_path,
+        "uv_env_exists": uv_env_exists,
+        "uv_lock_path": uv_lock_path.exists(),
+        "pyproject_path": pyproject_path.exists(),
+    }
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -9,6 +9,7 @@ from marimo._ast import compiler
 from marimo._runtime.packages.pypi_package_manager import (
     PackageDescription,
     PipPackageManager,
+    UvPackageManager,
 )
 
 parse_cell = partial(compiler.compile_cell, cell_id="0")
@@ -109,3 +110,176 @@ def test_list_packages_failure(mock_run: MagicMock):
     packages = manager.list_packages()
 
     assert len(packages) == 0
+
+
+# UV Package Manager Tests
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_uv_is_in_uv_project_no_venv():
+    """Test is_in_uv_project returns False when no VIRTUAL_ENV is set"""
+    mgr = UvPackageManager()
+    assert mgr.is_in_uv_project is False
+
+
+@patch.dict("os.environ", {"VIRTUAL_ENV": "/path/to/venv"}, clear=True)
+def test_uv_is_in_uv_project_no_uv_env():
+    """Test is_in_uv_project returns False when UV env var is not set"""
+    mgr = UvPackageManager()
+    assert mgr.is_in_uv_project is False
+
+
+@patch.dict(
+    "os.environ",
+    {"VIRTUAL_ENV": "/path/to/venv", "UV": "/other/path"},
+    clear=True,
+)
+def test_uv_is_in_uv_project_uv_env_mismatch():
+    """Test is_in_uv_project returns False when UV env var doesn't match VIRTUAL_ENV"""
+    mgr = UvPackageManager()
+    assert mgr.is_in_uv_project is False
+
+
+@patch.dict(
+    "os.environ",
+    {"VIRTUAL_ENV": "/path/to/venv", "UV": "/path/to/venv"},
+    clear=True,
+)
+@patch("pathlib.Path.exists")
+def test_uv_is_in_uv_project_missing_files(mock_exists: MagicMock):
+    """Test is_in_uv_project returns False when uv.lock or pyproject.toml don't exist"""
+    mock_exists.return_value = False
+    mgr = UvPackageManager()
+    assert mgr.is_in_uv_project is False
+
+
+@patch.dict(
+    "os.environ",
+    {"VIRTUAL_ENV": "/path/to/venv", "UV": "/path/to/venv"},
+    clear=True,
+)
+@patch("pathlib.Path.exists")
+def test_uv_is_in_uv_project_true(mock_exists: MagicMock):
+    """Test is_in_uv_project returns True when all conditions are met"""
+    mock_exists.return_value = True
+    mgr = UvPackageManager()
+    assert mgr.is_in_uv_project is True
+
+
+@patch.dict(
+    "os.environ",
+    {"VIRTUAL_ENV": "/path/to/venv", "UV": "/path/to/venv"},
+    clear=True,
+)
+@patch("pathlib.Path.exists")
+def test_uv_is_in_uv_project_cached(mock_exists: MagicMock):
+    """Test is_in_uv_project is cached and only evaluates once"""
+    mock_exists.return_value = True
+    mgr = UvPackageManager()
+
+    # Access the property multiple times
+    result1 = mgr.is_in_uv_project
+    result2 = mgr.is_in_uv_project
+    result3 = mgr.is_in_uv_project
+
+    # Should all return the same value
+    assert result1 is True
+    assert result2 is True
+    assert result3 is True
+
+    # Path.exists should only be called twice (once for uv.lock, once for pyproject.toml)
+    # since the property is cached after the first access
+    assert mock_exists.call_count == 2
+
+
+@patch("subprocess.run")
+@patch.object(UvPackageManager, "is_in_uv_project", False)
+async def test_uv_install_not_in_project(mock_run: MagicMock):
+    """Test UV install uses pip subcommand when not in UV project"""
+    mock_run.return_value = MagicMock(returncode=0)
+    mgr = UvPackageManager()
+
+    result = await mgr._install("package1 package2")
+
+    mock_run.assert_called_once_with(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--compile",
+            "package1",
+            "package2",
+            "-p",
+            PY_EXE,
+        ],
+    )
+    assert result is True
+
+
+@patch("subprocess.run")
+@patch.object(UvPackageManager, "is_in_uv_project", True)
+async def test_uv_install_in_project(mock_run: MagicMock):
+    """Test UV install uses add subcommand when in UV project"""
+    mock_run.return_value = MagicMock(returncode=0)
+    mgr = UvPackageManager()
+
+    result = await mgr._install("package1 package2")
+
+    mock_run.assert_called_once_with(
+        ["uv", "add", "--compile", "package1", "package2", "-p", PY_EXE],
+    )
+    assert result is True
+
+
+@patch("subprocess.run")
+@patch.object(UvPackageManager, "is_in_uv_project", False)
+async def test_uv_uninstall_not_in_project(mock_run: MagicMock):
+    """Test UV uninstall uses pip subcommand when not in UV project"""
+    mock_run.return_value = MagicMock(returncode=0)
+    mgr = UvPackageManager()
+
+    result = await mgr.uninstall("package1 package2")
+
+    mock_run.assert_called_once_with(
+        ["uv", "pip", "uninstall", "package1", "package2", "-p", PY_EXE],
+    )
+    assert result is True
+
+
+@patch("subprocess.run")
+@patch.object(UvPackageManager, "is_in_uv_project", True)
+async def test_uv_uninstall_in_project(mock_run: MagicMock):
+    """Test UV uninstall uses remove subcommand when in UV project"""
+    mock_run.return_value = MagicMock(returncode=0)
+    mgr = UvPackageManager()
+
+    result = await mgr.uninstall("package1 package2")
+
+    mock_run.assert_called_once_with(
+        ["uv", "remove", "package1", "package2", "-p", PY_EXE],
+    )
+    assert result is True
+
+
+@patch("subprocess.run")
+def test_uv_list_packages(mock_run: MagicMock):
+    """Test UV list packages uses pip list subcommand"""
+    mock_output = json.dumps(
+        [
+            {"name": "package1", "version": "1.0.0"},
+            {"name": "package2", "version": "2.1.0"},
+        ]
+    )
+    mock_run.return_value = MagicMock(returncode=0, stdout=mock_output)
+    mgr = UvPackageManager()
+
+    packages = mgr.list_packages()
+
+    mock_run.assert_called_once_with(
+        ["uv", "pip", "list", "--format=json", "-p", PY_EXE],
+        capture_output=True,
+        text=True,
+    )
+    assert len(packages) == 2
+    assert packages[0] == PackageDescription(name="package1", version="1.0.0")
+    assert packages[1] == PackageDescription(name="package2", version="2.1.0")


### PR DESCRIPTION
This detects (to the best of my knowledge) if we are in a uv project and run by the `uv run` command, without it being a temporary venv. If so, we do `uv add` which will add it to the `pyproject.toml` and update the `uv.lock` file

Fixes https://github.com/marimo-team/marimo/issues/3904

@akshayka working on docs to followup the distinction, and different usages