### PR TITLE
feat(sandbox): Prefer `uv export` for dumping requirements.txt

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -188,12 +188,13 @@ def construct_uv_flags(
         "--no-project",
         # trade installation time for faster start time
         "--compile-bytecode",
-        # layer additional deps on top of the requirements
-        "--with",
-        ",".join(additional_deps),
         "--with-requirements",
         temp_file.name,
     ]
+
+    # Layer additional deps on top of the requirements
+    if len(additional_deps) > 0:
+        uv_flags.extend(["--with", ",".join(additional_deps)])
 
     # Add refresh
     if uv_needs_refresh:

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -147,6 +147,15 @@ def _uv_export_script_requirements_txt(
     return result.stdout.split("\n")
 
 
+def _resolve_requirements_txt_lines(pyproject: PyProjectReader) -> list[str]:
+    if pyproject.name and pyproject.name.endswith(".py"):
+        try:
+            return _uv_export_script_requirements_txt(pyproject.name)
+        except subprocess.CalledProcessError:
+            pass  # Fall back if uv fails
+    return pyproject.requirements_txt_lines
+
+
 def get_marimo_dir() -> Path:
     return Path(__file__).parent.parent.parent
 
@@ -160,12 +169,7 @@ def construct_uv_flags(
     # NB. Used in quarto plugin
 
     # If name if a filepath, parse the dependencies from the file
-    try:
-        # Try exporting env with uv
-        dependencies = _uv_export_script_requirements_txt(pyproject.name)
-    except subprocess.CalledProcessError:
-        # Otherwise fallback to marimo-parsed requirements
-        dependencies = pyproject.requirements_txt_lines
+    dependencies = _resolve_requirements_txt_lines(pyproject)
 
     # If there are no dependencies, which can happen for marimo new or
     # on marimo edit a_new_file.py, uv may use a cached venv, even though

--- a/marimo/_utils/inline_script_metadata.py
+++ b/marimo/_utils/inline_script_metadata.py
@@ -13,20 +13,31 @@ LOGGER = _loggers.marimo_logger()
 
 
 class PyProjectReader:
-    def __init__(self, project: dict[str, Any], *, config_path: str | None):
+    def __init__(
+        self,
+        project: dict[str, Any],
+        *,
+        config_path: str | None,
+        name: str | None = None,
+    ):
         self.project = project
         self.config_path = config_path
+        self.name = name
 
     @staticmethod
     def from_filename(name: str) -> PyProjectReader:
         return PyProjectReader(
-            _get_pyproject_from_filename(name) or {}, config_path=name
+            name=name,
+            project=_get_pyproject_from_filename(name) or {},
+            config_path=name,
         )
 
     @staticmethod
     def from_script(script: str) -> PyProjectReader:
         return PyProjectReader(
-            read_pyproject_from_script(script) or {}, config_path=None
+            project=read_pyproject_from_script(script) or {},
+            config_path=None,
+            name=None,
         )
 
     @property

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -294,15 +294,12 @@ def test_construct_uv_cmd_with_additional_deps() -> None:
         additional_deps=additional_deps,
     )
 
-    # Get the requirements file path from the command
-    req_file_index = uv_cmd.index("--with-requirements") + 1
-    req_file_path = uv_cmd[req_file_index]
+    # Get the additional (layered) dependencies
+    with_dependencies_index = uv_cmd.index("--with") + 1
+    with_dependencies = uv_cmd[with_dependencies_index]
 
-    # Read the requirements file to verify additional deps were added
-    with open(req_file_path) as f:
-        requirements = f.read()
-        assert "numpy>=1.20.0" in requirements
-        assert "pandas" in requirements
+    assert "pandas" in with_dependencies
+    assert "numpy>=1.20.0" in with_dependencies
 
 
 def test_markdown_sandbox(tmp_path: Path) -> None:


### PR DESCRIPTION
## 📝 Summary

Sandbox environments currently have trouble reusing cached virtual environments from `uv`, resulting in long startup times for packages like `pandas`.

From my testing, this appears to be caused by the way requirements are parsed and exported via `PyProjectReader`. The new `uv export --script` functionality allows us to defer requirements generation to uv, which seems to lead to better cache hits and improved reuse of environments.

https://github.com/user-attachments/assets/d3de1b57-b9b8-4b1a-845c-f7672457a4e9


## 🔍 Description of Changes

Rather than removing `PyProjectReader`, which is still useful in non-uv contexts (pyodide), this PR adds a shortcut: when `uv` is available, we use `uv export --script` to generate requirements.txt directly. If that fails for any reason, we fall back to the existing logic that extracts dependencies manually.

This change better aligns with how uv expects requirements to be structured and should reduce cold-start latency in sandboxed environments.

Note: This PR does not yet handle relative paths for local dependencies. I think we should address that separately by introducing a method to canonicalize relative paths during export.

~Putting this in draft for now. Some tests are failing and I’ll investigate when I get a chance.~

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
