### PR TITLE
feat: added disabled to datetime

### DIFF
--- a/frontend/src/plugins/impl/DateTimePickerPlugin.tsx
+++ b/frontend/src/plugins/impl/DateTimePickerPlugin.tsx
@@ -14,6 +14,7 @@ interface Data {
   stop: string;
   step?: string;
   fullWidth: boolean;
+  disabled?: boolean;
 }
 
 export class DateTimePickerPlugin implements IPlugin<T, Data> {
@@ -26,6 +27,7 @@ export class DateTimePickerPlugin implements IPlugin<T, Data> {
     stop: z.string(),
     step: z.string().optional(),
     fullWidth: z.boolean().default(false),
+    disabled: z.boolean().optional(),
   });
 
   render(props: IPluginProps<T, Data>): JSX.Element {
@@ -66,6 +68,7 @@ const DateTimePickerComponent = (props: DateTimePickerProps): JSX.Element => {
         aria-label={props.label ?? "date time picker"}
         minValue={parseDateTime(props.start)}
         maxValue={parseDateTime(props.stop)}
+        isDisabled={props.disabled}
       />
     </Labeled>
   );

--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -209,6 +209,7 @@ class datetime(UIElement[Optional[str], Optional[dt.datetime]]):
         label (str, optional): Markdown label for the element.
         on_change (Callable[[Optional[datetime.datetime]], None], optional): Optional callback to run when this element's value changes.
         full_width (bool, optional): Whether the input should take up the full width of its container.
+        disabled (bool, optional): Whether the input should be disabled. Defaults to False.
     """
 
     _name: Final[str] = "marimo-datetime"
@@ -223,6 +224,7 @@ class datetime(UIElement[Optional[str], Optional[dt.datetime]]):
         label: Optional[str] = None,
         on_change: Optional[Callable[[Optional[dt.datetime]], None]] = None,
         full_width: bool = False,
+        disabled: bool = False,
     ):
         if isinstance(start, str):
             start = self._convert_value(start)
@@ -264,6 +266,7 @@ class datetime(UIElement[Optional[str], Optional[dt.datetime]]):
                 "start": self._start.strftime(self.DATETIME_FORMAT),
                 "stop": self._stop.strftime(self.DATETIME_FORMAT),
                 "full-width": full_width,
+                "disabled": disabled,
             },
             on_change=on_change,
         )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Added disabled to mo.ui.datetime

<img width="504" alt="Screenshot 2025-05-22 at 6 43 35 PM" src="https://github.com/user-attachments/assets/63b03809-b7d2-4f1c-9385-399d34fa6f65" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Added disabled to DateTimePickerPlugin.tsx and mapped it to isDisabled from DatePicker
- Mapped disabled to python datetime class with validation in dates.py

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
