### PR TITLE
fix: respect user log level

### DIFF
--- a/marimo/_loggers.py
+++ b/marimo/_loggers.py
@@ -9,13 +9,22 @@ from typing import Optional
 from marimo._utils.log_formatter import LogFormatter
 
 # This file manages and creates loggers used throughout marimo.
+#
 # It contains a global log level, which can be updated and all handlers
 # will be updated to use the new level.
+#
 # Our loggers contain two handlers:
 # - A StreamHandler to stdout
 # - A FileHandler to a rotating log file
+#
 # The stream handler is set to the global log level, but the file handler
 # is set to either INFO or DEBUG, depending on the global log level.
+#
+# NB: As is best practice for Python libraries, we do not configure the
+# root logger, and in particular we don't call basicConfig() (which would
+# preclude client of our library from configuring the root logger to their
+# own end).
+# See https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
 
 # Global log level for loggers
 _LOG_LEVEL: int = logging.WARNING
@@ -25,15 +34,6 @@ _LOG_FORMATTER = LogFormatter()
 
 # Cache of initialized loggers
 _LOGGERS: dict[str, logging.Logger] = {}
-
-# Set basic config to INFO
-# This is so notebooks pick this up automatically
-# when they write:
-# ```
-# import logging
-# logging.info("Hello, world!")
-# ```
-logging.basicConfig(level=logging.INFO)
 
 
 def log_level_string_to_int(level: str) -> int:
@@ -72,6 +72,9 @@ def set_level(level: str | int = logging.WARNING) -> None:
         _LOG_LEVEL = level
 
     for logger in _LOGGERS.values():
+        # We have to set update the logger's level in order
+        # for its handlers level's to be respected.
+        logger.setLevel(_LOG_LEVEL)
         for handler in logger.handlers:
             if isinstance(handler, logging.FileHandler):
                 # Don't increase the log level of a file handler

--- a/marimo/_loggers.py
+++ b/marimo/_loggers.py
@@ -104,8 +104,10 @@ def get_logger(name: str, level: Optional[int] = None) -> logging.Logger:
     stream_handler.setFormatter(_LOG_FORMATTER)
     if level is None:
         stream_handler.setLevel(_LOG_LEVEL)
+        logger.setLevel(_LOG_LEVEL)
     else:
         stream_handler.setLevel(level)
+        logger.setLevel(level)
 
     logger.addHandler(stream_handler)
 

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -25,17 +25,17 @@ def test_set_level():
     # Test with integer levels
     set_level(logging.DEBUG)
     logger = get_logger("test1")
-    assert logger.level == logging.NOTSET
+    assert logger.level == logging.DEBUG
     assert logger.handlers[0].level == logging.DEBUG
 
     set_level(logging.INFO)
-    assert logger.level == logging.NOTSET
+    assert logger.level == logging.INFO
     assert logger.handlers[0].level == logging.INFO
 
     # Test with string levels
     for level in ["WARNING", "WARN", "DEBUG", "INFO", "ERROR", "CRITICAL"]:
         set_level(level)
-        assert logger.level == logging.NOTSET
+        assert logger.level == logging._nameToLevel[level]
         assert logger.handlers[0].level == logging._nameToLevel[level]
 
     # Test invalid levels
@@ -62,7 +62,7 @@ def test_get_logger():
 
     # Test custom level
     logger3 = get_logger("test3", level=logging.DEBUG)
-    assert logger3.level == logging.NOTSET
+    assert logger3.level == logging.DEBUG
 
     # Test handlers
     handler = logger3.handlers[0]


### PR DESCRIPTION
This fixes an issue in which the user specified log level had no effect (debug logs were not shown in console nor file);
in addition to setting the handlers' levels, we need to set the logger's level as well.

This also removes the call to logging.basicConfig(): doing anything
with the root logger is considered poor practice for libraries as
it interferes with clients' ability to configure logging for their
application. This is somewhat complicated by the fact that marimo
is both an application and a library but I think still stands.