### PR TITLE
fix: still log info to file logging for better debugging

### DIFF
--- a/marimo/_loggers.py
+++ b/marimo/_loggers.py
@@ -74,7 +74,9 @@ def set_level(level: str | int = logging.WARNING) -> None:
     for logger in _LOGGERS.values():
         # We have to set update the logger's level in order
         # for its handlers level's to be respected.
-        logger.setLevel(_LOG_LEVEL)
+        # but it needs to be set to the minimum LOG_LEVEL and INFO
+        # so the file handler can still pick it up
+        logger.setLevel(min(_LOG_LEVEL, logging.INFO))
         for handler in logger.handlers:
             if isinstance(handler, logging.FileHandler):
                 # Don't increase the log level of a file handler

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -35,7 +35,7 @@ def test_set_level():
     # Test with string levels
     for level in ["WARNING", "WARN", "DEBUG", "INFO", "ERROR", "CRITICAL"]:
         set_level(level)
-        assert logger.level == logging._nameToLevel[level]
+        assert logger.level == min(logging._nameToLevel[level], logging.INFO)
         assert logger.handlers[0].level == logging._nameToLevel[level]
 
     # Test invalid levels


### PR DESCRIPTION
We still want to log `INFO` to the file. These will get filtered out by StreamHandler 