### PR TITLE
fix: set default type when adding pyiceberg

### DIFF
--- a/frontend/src/components/editor/database/schemas.ts
+++ b/frontend/src/components/editor/database/schemas.ts
@@ -381,6 +381,9 @@ export const IcebergConnectionSchema = z.object({
           ),
       }),
     ])
+    .default({
+      type: "REST",
+    })
     .describe(FieldOptions.of({ special: "tabs" })),
 });
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
After adding all the fields, the button used to be disabled. This fixes that (but as a side effect you can enter nothing in the below fields, which I think is still better than disabling it).
![Image](https://github.com/user-attachments/assets/85105ff0-3353-4cf5-a15c-cd75d48b1d94)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
