### PR TITLE
fix: github lsp build script, language server path

### DIFF
--- a/lsp/index.ts
+++ b/lsp/index.ts
@@ -47,7 +47,6 @@ const Logger = {
 const COPILOT_LSP_PATH = path.join(
   __dirname,
   "copilot",
-  "dist",
   "language-server.js",
 );
 if (!fsSync.existsSync(COPILOT_LSP_PATH)) {

--- a/scripts/buildlsp.sh
+++ b/scripts/buildlsp.sh
@@ -1,17 +1,24 @@
 #!/bin/sh
+#
+# Builds the copilot lsp, then copies the generated dist/ folder to
+# marimo/_lsp/copilot
+
+# This script should fail if any intermediate step fails
+set -e
 
 cd lsp
 if pnpm build; then
   echo "Removing old lsp files..."
   rm -rf ../marimo/_lsp/
   echo "Copying new lsp files..."
-  mkdir ../marimo/_lsp
+  mkdir -p ../marimo/_lsp
   cp dist/index.cjs ../marimo/_lsp/
   # There seems to be a discrepancy between CI and mac for pnpm builds
   if [ -d dist/copilot ]; then
+    echo "branch 1"
     cp -R dist/copilot ../marimo/_lsp/copilot
   else
-    mkdir ../marimo/_lsp
+    echo "branch 2"
     cp -R dist ../marimo/_lsp/copilot
   fi
   echo "Compilation succeeded.\n"


### PR DESCRIPTION
The build script was calling mkdir on a directory that already existed, and failing silently.

This change fixes that and also updates the script to terminate on error so we don't get any more silent failures.

Additionally, this updates the path to the language server to not include dist -- when generating with pnpm 10.11 on macOS, at least, no such directory is present.