### PR TITLE
fix: automatic port selection

### DIFF
--- a/marimo/_server/utils.py
+++ b/marimo/_server/utils.py
@@ -45,9 +45,8 @@ def find_free_port(port: int, attempts: int = 100) -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         try:
             sock.settimeout(0.1)
-            in_use = sock.connect_ex(("localhost", port)) == 0
-            if not in_use:
-                return port
+            sock.bind(("", port))
+            return port
         except OSError:
             LOGGER.debug(f"Port {port} is already in use")
             pass


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Automatic port selection does not work correctly on multi-user system (specifically HPC cluster node). 

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

Use `sock.bind` instead of `sock.connect_ex` to check for port availability 

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
