### PR TITLE
fix: rename all unnamed columns to empty string for pd.multiIndex

### DIFF
--- a/marimo/_smoke_tests/tables/pandas_multi_idx.py
+++ b/marimo/_smoke_tests/tables/pandas_multi_idx.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.12.4"
+__generated_with = "0.13.12"
 app = marimo.App(width="medium")
 
 
@@ -12,7 +12,7 @@ def _():
 
 
 @app.cell
-def _(pd):
+def _(mo, pd):
     arrays = [
         ["bar", "bar"],
         ["one", "two"],
@@ -20,38 +20,69 @@ def _(pd):
     tuples = list(zip(*arrays))
     index = pd.MultiIndex.from_tuples(tuples, names=["first", "second"])
     named_indexes = pd.Series([1, 2], index=index)
-    named_indexes
-    return arrays, index, named_indexes, tuples
+
+    mo.vstack([mo.md("## Named indexes (works)"), named_indexes])
+    return
 
 
 @app.cell
-def _(pd):
+def _(mo, pd):
     unnamed_indexes = pd.concat(
         {
             "a": pd.DataFrame({"foo": [1]}, index=["hello"]),
             "b": pd.DataFrame({"baz": [2.0]}, index=["world"]),
         }
     )
-    unnamed_indexes
-    # unnamed_indexes.reset_index() # this works
-    return (unnamed_indexes,)
+
+    mo.md(f"""
+    ## Unnamed indexes does not work correctly
+
+    {mo.vstack([mo.plain(unnamed_indexes), unnamed_indexes])}
+
+    ### Using reset_index works but changes structure
+    {mo.ui.table(unnamed_indexes.reset_index())}
+    """)
+    return
 
 
 @app.cell
 def _(mo, pd):
+    _multi_idx = pd.MultiIndex.from_tuples([("weight", "kg"), ("height", "m")])
+    _df = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0]], index=["cat", "dog"], columns=_multi_idx
+    )
+    _multi_col_stack = _df.stack(future_stack=True)
+    mo.vstack([mo.plain(_multi_col_stack), _multi_col_stack])
+
+    mo.vstack(
+        [
+            mo.md("## Row multi-idx with stack (not working correctly)"),
+            mo.plain(_multi_col_stack),
+            _multi_col_stack,
+        ]
+    )
+    return
+
+
+@app.cell
+def _(pd):
     cols = pd.MultiIndex.from_arrays(
         [["basic_amt"] * 2, ["NSW", "QLD"]], names=[None, "Faculty"]
     )
     idx = pd.Index(["All", "Full"])
     column_multi_idx = pd.DataFrame([(1, 1), (0, 1)], index=idx, columns=cols)
-
-    mo.ui.table(column_multi_idx)
-    return cols, column_multi_idx, idx
+    return (column_multi_idx,)
 
 
 @app.cell
-def _(column_multi_idx):
-    print("Raw data:\n", column_multi_idx)
+def _(column_multi_idx, mo):
+    mo.vstack(
+        [
+            mo.md("## Column multi index (we flatten)"),
+            mo.plain(column_multi_idx),
+            column_multi_idx,
+        ]
+    )
     return
 
 

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -285,6 +285,42 @@ class TestPandasTableManager(unittest.TestCase):
             {"level_0": "z", "level_1": 3, "a": 3, "b": 6},
         ]
 
+    def test_to_json_multi_index_unnamed_2(self) -> None:
+        # Create a DataFrame with a MultiIndex where second level is unnamed
+        df = pd.DataFrame(
+            {
+                "A": [1, 2, 3, 4],
+                "B": [5, 6, 7, 8],
+            },
+            index=pd.MultiIndex.from_tuples(
+                [("x", 1), ("x", 2), ("y", 1), ("y", 2)],
+                names=["level1", None],  # Second level is unnamed
+            ),
+        )
+
+        json_data = self.factory_create_json_from_df(df)
+        # Second level converted to empty string
+        assert json_data == [
+            {"level1": "x", "": 1, "A": 1, "B": 5},
+            {"level1": "x", "": 2, "A": 2, "B": 6},
+            {"level1": "y", "": 1, "A": 3, "B": 7},
+            {"level1": "y", "": 2, "A": 4, "B": 8},
+        ]
+
+    def test_to_json_multi_index_unnamed_3(self) -> None:
+        cols = pd.MultiIndex.from_tuples([("weight", "kg"), ("height", "m")])
+        df = pd.DataFrame(
+            [[1.0, 2.0], [3.0, 4.0]], index=["cat", "dog"], columns=cols
+        )
+        df = df.stack(future_stack=True)
+        json_data = self.factory_create_json_from_df(df)
+        assert json_data == [
+            {"": "cat", " ": "kg", "weight": 1.0, "height": None},
+            {"": "cat", " ": "m", "weight": None, "height": 2.0},
+            {"": "dog", " ": "kg", "weight": 3.0, "height": None},
+            {"": "dog", " ": "m", "weight": None, "height": 4.0},
+        ]
+
     def test_to_json_multi_col_index(self) -> None:
         cols = pd.MultiIndex.from_arrays(
             [["basic_amt"] * 2, ["NSW", "QLD"]], names=[None, "Faculty"]


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #5085 . There are still a few edge cases we don't handle but this case can be handled by setting the col names to unique empty strings when the index is null. It is a hacky solution.

<img width="784" alt="image" src="https://github.com/user-attachments/assets/39870341-4c69-4dd1-972e-65c9ace9bf9a" />

Case we don't solve:
<img width="785" alt="CleanShot 2025-05-27 at 19 58 56@2x" src="https://github.com/user-attachments/assets/55a9987f-e9ff-43b6-8ad3-e7c21fb55d90" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
