### PR TITLE
feat: add ai.provider_type option and handle azure with custom domains

### DIFF
--- a/docs/guides/editor_features/ai_completion.md
+++ b/docs/guides/editor_features/ai_completion.md
@@ -235,6 +235,21 @@ api_key = "gho_..."
 base_url = "https://api.githubcopilot.com/"
 ```
 
+#### Azure OpenAI
+
+1. Install openai: `pip install openai`
+
+2. Add the following to your `marimo.toml` (or configure in the UI settings in the editor):
+
+```toml title="marimo.toml"
+[ai.azure]
+api_key = "..."
+# Specify the model
+model = "gpt-4-turbo"
+# Change the base_url as provided by your IT
+base_url = "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-06-01"
+```
+
 #### Local models with Ollama { #using-ollama }
 
 Ollama allows you to run open-source LLMs on your local machine. To integrate Ollama with marimo:

--- a/frontend/src/components/app-config/constants.ts
+++ b/frontend/src/components/app-config/constants.ts
@@ -6,7 +6,7 @@ export const KNOWN_AI_MODELS = [
   "claude-3-5-haiku-latest",
   "claude-3-opus-latest",
   "claude-sonnet-4-20250514",
-  "claude-opus-4-20250514	",
+  "claude-opus-4-20250514",
 
   // DeepSeek
   "deepseek-v3",
@@ -53,12 +53,13 @@ export const AWS_REGIONS = [
   "ap-southeast-1",
 ] as const;
 
+/*
+ * Matches the providers in AiConfig
+ */
 export const KNOWN_AI_PROVIDERS = [
   "open_ai",
   "anthropic",
   "google",
-  "groq",
   "bedrock",
-  "deepseek",
   "azure",
 ] as const;

--- a/frontend/src/components/app-config/constants.ts
+++ b/frontend/src/components/app-config/constants.ts
@@ -52,3 +52,13 @@ export const AWS_REGIONS = [
   "ap-northeast-1",
   "ap-southeast-1",
 ] as const;
+
+export const KNOWN_AI_PROVIDERS = [
+  "open_ai",
+  "anthropic",
+  "google",
+  "groq",
+  "bedrock",
+  "deepseek",
+  "azure",
+] as const;

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -45,7 +45,7 @@ import {
 } from "lucide-react";
 import { ExternalLink } from "../ui/links";
 import { cn } from "@/utils/cn";
-import { KNOWN_AI_MODELS, AWS_REGIONS, KNOWN_AI_PROVIDERS } from "./constants";
+import { AWS_REGIONS, KNOWN_AI_MODELS, KNOWN_AI_PROVIDERS } from "./constants";
 import { Textarea } from "../ui/textarea";
 import { get } from "lodash-es";
 import { Tooltip } from "../ui/tooltip";
@@ -54,6 +54,12 @@ import { Badge } from "../ui/badge";
 import { capabilitiesAtom } from "@/core/config/capabilities";
 import { Banner } from "@/plugins/impl/common/error-banner";
 import { OptionalFeatures } from "./optional-features";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 const formItemClasses = "flex flex-row items-center space-x-1 space-y-0";
 const categories = [
@@ -350,7 +356,6 @@ export const UserConfigForm: React.FC = () => {
                           data-testid="line-length-input"
                           className="m-0 w-24"
                           {...field}
-                          value={field.value}
                           minValue={1}
                           maxValue={1000}
                           onChange={(value) => {
@@ -640,7 +645,6 @@ export const UserConfigForm: React.FC = () => {
                           data-testid="code-editor-font-size-input"
                           className="m-0 w-24"
                           {...field}
-                          value={field.value}
                           minValue={8}
                           maxValue={32}
                           onChange={(value) => {
@@ -744,7 +748,6 @@ export const UserConfigForm: React.FC = () => {
                           data-testid="default-table-page-size-input"
                           className="m-0 w-24"
                           {...field}
-                          value={field.value}
                           minValue={1}
                           step={1}
                           onChange={(value) => {
@@ -1070,240 +1073,24 @@ export const UserConfigForm: React.FC = () => {
 
               {renderCopilotProvider()}
             </SettingGroup>
-            <SettingGroup title="AI Keys">
-              <FormField
-                control={form.control}
-                name="ai.open_ai.api_key"
-                render={({ field }) => (
-                  <div className="flex flex-col space-y-1">
-                    <FormItem className={formItemClasses}>
-                      <FormLabel>OpenAI API Key</FormLabel>
-                      <FormControl>
-                        <Input
-                          data-testid="ai-openai-api-key-input"
-                          className="m-0 inline-flex"
-                          placeholder="sk-proj..."
-                          {...field}
-                          onChange={(e) => {
-                            const value = e.target.value;
-                            // Don't allow *
-                            if (!value.includes("*")) {
-                              field.onChange(value);
-                            }
-                          }}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="ai.open_ai.api_key"
-                      />
-                    </FormItem>
-                    <FormDescription>
-                      Your OpenAI API key from{" "}
-                      <ExternalLink href="https://platform.openai.com/account/api-keys">
-                        platform.openai.com
-                      </ExternalLink>
-                      .
-                    </FormDescription>
-                  </div>
-                )}
-              />
 
-              <FormField
-                control={form.control}
-                name="ai.anthropic.api_key"
-                render={({ field }) => (
-                  <div className="flex flex-col space-y-1">
-                    <FormItem className={formItemClasses}>
-                      <FormLabel>Anthropic API Key</FormLabel>
-                      <FormControl>
-                        <Input
-                          data-testid="ai-anthropic-api-key-input"
-                          className="m-0 inline-flex"
-                          placeholder="sk-ant..."
-                          {...field}
-                          onChange={(e) => {
-                            const value = e.target.value;
-                            // Don't allow *
-                            if (!value.includes("*")) {
-                              field.onChange(value);
-                            }
-                          }}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="ai.anthropic.api_key"
-                      />
-                    </FormItem>
-                    <FormDescription>
-                      Your Anthropic API key from{" "}
-                      <ExternalLink href="https://console.anthropic.com/settings/keys">
-                        console.anthropic.com
-                      </ExternalLink>
-                      .
-                    </FormDescription>
-                  </div>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="ai.google.api_key"
-                render={({ field }) => (
-                  <div className="flex flex-col space-y-1">
-                    <FormItem className={formItemClasses}>
-                      <FormLabel>Google AI API Key</FormLabel>
-                      <FormControl>
-                        <Input
-                          data-testid="ai-google-api-key-input"
-                          className="m-0 inline-flex"
-                          placeholder="AI..."
-                          {...field}
-                          onChange={(e) => {
-                            const value = e.target.value;
-                            // Don't allow *
-                            if (!value.includes("*")) {
-                              field.onChange(value);
-                            }
-                          }}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="ai.google.api_key"
-                      />
-                    </FormItem>
-                    <FormDescription>
-                      Your Google AI API key from{" "}
-                      <ExternalLink href="https://aistudio.google.com/app/apikey">
-                        aistudio.google.com
-                      </ExternalLink>
-                      .
-                    </FormDescription>
-                  </div>
-                )}
-              />
-
-              <p className="text-sm font-semibold mt-3">
-                AWS Bedrock Configuration
+            <SettingGroup title="AI Providers">
+              <p className="text-sm text-muted-secondary">
+                Configure your AI providers for marimo's AI assistant. Each
+                provider can be configured independently.
               </p>
-              <p className="text-sm text-muted-secondary mb-2">
-                To use AWS Bedrock, you need to configure AWS credentials and
-                region. See the{" "}
-                <ExternalLink href="https://docs.marimo.io/guides/editor_features/ai_completion.html#aws-bedrock">
-                  documentation
-                </ExternalLink>{" "}
-                for more details.
-              </p>
-              <FormField
-                control={form.control}
-                disabled={isWasmRuntime}
-                name="ai.bedrock.region_name"
-                render={({ field }) => (
-                  <div className="flex flex-col space-y-1">
-                    <FormItem className={formItemClasses}>
-                      <FormLabel>AWS Region</FormLabel>
-                      <FormControl>
-                        <NativeSelect
-                          data-testid="bedrock-region-select"
-                          onChange={(e) => field.onChange(e.target.value)}
-                          value={
-                            typeof field.value === "string"
-                              ? field.value
-                              : "us-east-1"
-                          }
-                          disabled={field.disabled}
-                          className="inline-flex mr-2"
-                        >
-                          {AWS_REGIONS.map((option) => (
-                            <option value={option} key={option}>
-                              {option}
-                            </option>
-                          ))}
-                        </NativeSelect>
-                      </FormControl>
-                      <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="ai.bedrock.region_name"
-                      />
-                    </FormItem>
-                    <FormDescription>
-                      The AWS region where Bedrock service is available.
-                    </FormDescription>
-                  </div>
-                )}
-              />
 
-              <FormField
-                control={form.control}
-                disabled={isWasmRuntime}
-                name="ai.bedrock.profile_name"
-                render={({ field }) => (
-                  <div className="flex flex-col space-y-1">
-                    <FormItem className={formItemClasses}>
-                      <FormLabel>AWS Profile Name (Optional)</FormLabel>
-                      <FormControl>
-                        <Input
-                          data-testid="bedrock-profile-input"
-                          className="m-0 inline-flex"
-                          placeholder="default"
-                          {...field}
-                          value={field.value || ""}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="ai.bedrock.profile_name"
-                      />
-                    </FormItem>
-                    <FormDescription>
-                      The AWS profile name from your ~/.aws/credentials file.
-                      Leave blank to use your default AWS credentials.
-                    </FormDescription>
-                  </div>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="ai.azure.api_key"
-                render={({ field }) => (
-                  <div className="flex flex-col space-y-1">
-                    <FormItem className={formItemClasses}>
-                      <FormLabel>Azure OpenAI API Key</FormLabel>
-                      <FormControl>
-                        <Input
-                          data-testid="ai-azure-api-key-input"
-                          className="m-0 inline-flex"
-                          placeholder="sk-proj..."
-                          {...field}
-                          onChange={(e) => {
-                            const value = e.target.value;
-                            // Don't allow *
-                            if (!value.includes("*")) {
-                              field.onChange(value);
-                            }
-                          }}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="ai.azure.api_key"
-                      />
-                    </FormItem>
-                    <FormDescription>
-                      Your Azure OpenAI API key.
-                    </FormDescription>
-                  </div>
-                )}
-              />
+              <Accordion
+                type="multiple"
+                className="w-full"
+                defaultValue={["openai"]}
+              >
+                <OpenAIAccordionSection form={form} config={config} />
+                <AnthropicAccordionSection form={form} config={config} />
+                <GoogleAccordionSection form={form} config={config} />
+                <BedrockAccordionSection form={form} config={config} />
+                <AzureAccordionSection form={form} config={config} />
+              </Accordion>
             </SettingGroup>
 
             <SettingGroup title="AI Assist">
@@ -1325,13 +1112,19 @@ export const UserConfigForm: React.FC = () => {
                     <FormItem className={formItemClasses}>
                       <FormLabel>AI Provider</FormLabel>
                       <FormControl>
-                        <Input
-                          list="ai-provider-type-datalist"
+                        <NativeSelect
                           data-testid="ai-provider-type-input"
-                          className="m-0 inline-flex"
-                          placeholder="gpt-4-turbo"
-                          {...field}
-                        />
+                          onChange={(e) => field.onChange(e.target.value)}
+                          value={field.value || ""}
+                          disabled={field.disabled}
+                          className="inline-flex mr-2"
+                        >
+                          {KNOWN_AI_PROVIDERS.map((provider) => (
+                            <option value={provider} key={provider}>
+                              {provider}
+                            </option>
+                          ))}
+                        </NativeSelect>
                       </FormControl>
                       <FormMessage />
                       <IsOverridden
@@ -1339,41 +1132,8 @@ export const UserConfigForm: React.FC = () => {
                         name="ai.provider_type"
                       />
                     </FormItem>
-                    <datalist id="ai-provider-type-datalist">
-                      {KNOWN_AI_PROVIDERS.map((provider) => (
-                        <option value={provider} key={provider}>
-                          {provider}
-                        </option>
-                      ))}
-                    </datalist>
-                    <FormDescription>AI provider to use.</FormDescription>
-                  </div>
-                )}
-              />
-              <FormField
-                control={form.control}
-                disabled={isWasmRuntime}
-                name="ai.open_ai.base_url"
-                render={({ field }) => (
-                  <div className="flex flex-col space-y-1">
-                    <FormItem className={formItemClasses}>
-                      <FormLabel>Base URL</FormLabel>
-                      <FormControl>
-                        <Input
-                          data-testid="ai-base-url-input"
-                          className="m-0 inline-flex"
-                          placeholder="https://api.openai.com/v1"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="ai.open_ai.base_url"
-                      />
-                    </FormItem>
                     <FormDescription>
-                      This URL can be any OpenAI-compatible API endpoint.
+                      The AI provider to use from above
                     </FormDescription>
                   </div>
                 )}
@@ -1409,13 +1169,7 @@ export const UserConfigForm: React.FC = () => {
                       ))}
                     </datalist>
                     <FormDescription>
-                      If the model starts with "claude-", we will use your
-                      Anthropic API key. If the model starts with "gemini-", we
-                      will use your Google AI API key. If the model starts with
-                      a "bedrock/" prefix followed by a model id (e.g.,
-                      "bedrock/anthropic.claude-3-sonnet-20240229"), we will use
-                      your AWS Bedrock configuration. Otherwise, we will use
-                      your OpenAI API key.
+                      Your model must be available in the provider's API.
                     </FormDescription>
                   </div>
                 )}
@@ -1434,7 +1188,6 @@ export const UserConfigForm: React.FC = () => {
                           className="m-0 inline-flex w-full h-32 p-2 text-sm"
                           placeholder="e.g. Always use type hints; prefer polars over pandas"
                           {...field}
-                          value={field.value}
                         />
                       </FormControl>
                       <FormMessage />
@@ -1656,3 +1409,341 @@ const IsOverridden = ({
     </Tooltip>
   );
 };
+
+// AI Provider Accordion Sections
+interface AccordionSectionProps {
+  form: ReturnType<typeof useForm<UserConfig>>;
+  config: UserConfig;
+  isWasmRuntime?: boolean;
+}
+
+const OpenAIAccordionSection: React.FC<AccordionSectionProps> = ({
+  form,
+  config,
+  isWasmRuntime,
+}) => (
+  <AccordionItem value="openai">
+    <AccordionTrigger>OpenAI or OpenAI-compatible</AccordionTrigger>
+    <AccordionContent>
+      <div className="space-y-4">
+        <FormField
+          control={form.control}
+          name="ai.open_ai.api_key"
+          render={({ field }) => (
+            <div className="flex flex-col space-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel>API Key</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="ai-openai-api-key-input"
+                    className="m-0 inline-flex"
+                    rootClassName="flex-1"
+                    placeholder="sk-proj..."
+                    {...field}
+                    value={field.value || ""}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      if (!value.includes("*")) {
+                        field.onChange(value);
+                      }
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+                <IsOverridden userConfig={config} name="ai.open_ai.api_key" />
+              </FormItem>
+              <FormDescription>
+                Your OpenAI API key from{" "}
+                <ExternalLink href="https://platform.openai.com/account/api-keys">
+                  platform.openai.com
+                </ExternalLink>
+                .
+              </FormDescription>
+            </div>
+          )}
+        />
+        <FormField
+          control={form.control}
+          disabled={isWasmRuntime}
+          name="ai.open_ai.base_url"
+          render={({ field }) => (
+            <div className="flex flex-col space-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel>Base URL</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="ai-base-url-input"
+                    className="m-0 inline-flex"
+                    rootClassName="flex-1"
+                    placeholder="https://api.openai.com/v1"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+                <IsOverridden userConfig={config} name="ai.open_ai.base_url" />
+              </FormItem>
+              <FormDescription>
+                This URL can be any OpenAI-compatible API endpoint.
+              </FormDescription>
+            </div>
+          )}
+        />
+      </div>
+    </AccordionContent>
+  </AccordionItem>
+);
+
+const AnthropicAccordionSection: React.FC<AccordionSectionProps> = ({
+  form,
+  config,
+}) => (
+  <AccordionItem value="anthropic">
+    <AccordionTrigger>Anthropic</AccordionTrigger>
+    <AccordionContent>
+      <div className="space-y-4">
+        <FormField
+          control={form.control}
+          name="ai.anthropic.api_key"
+          render={({ field }) => (
+            <div className="flex flex-col space-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel>API Key</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="ai-anthropic-api-key-input"
+                    className="m-0 inline-flex"
+                    rootClassName="flex-1"
+                    placeholder="sk-ant..."
+                    {...field}
+                    value={field.value || ""}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      if (!value.includes("*")) {
+                        field.onChange(value);
+                      }
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+                <IsOverridden userConfig={config} name="ai.anthropic.api_key" />
+              </FormItem>
+              <FormDescription>
+                Your Anthropic API key from{" "}
+                <ExternalLink href="https://console.anthropic.com/settings/keys">
+                  console.anthropic.com
+                </ExternalLink>
+                .
+              </FormDescription>
+            </div>
+          )}
+        />
+      </div>
+    </AccordionContent>
+  </AccordionItem>
+);
+
+const GoogleAccordionSection: React.FC<AccordionSectionProps> = ({
+  form,
+  config,
+}) => (
+  <AccordionItem value="google">
+    <AccordionTrigger>Google AI</AccordionTrigger>
+    <AccordionContent>
+      <div className="space-y-4">
+        <FormField
+          control={form.control}
+          name="ai.google.api_key"
+          render={({ field }) => (
+            <div className="flex flex-col space-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel>API Key</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="ai-google-api-key-input"
+                    className="m-0 inline-flex"
+                    placeholder="AI..."
+                    rootClassName="flex-1"
+                    {...field}
+                    value={field.value || ""}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      if (!value.includes("*")) {
+                        field.onChange(value);
+                      }
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+                <IsOverridden userConfig={config} name="ai.google.api_key" />
+              </FormItem>
+              <FormDescription>
+                Your Google AI API key from{" "}
+                <ExternalLink href="https://aistudio.google.com/app/apikey">
+                  aistudio.google.com
+                </ExternalLink>
+                .
+              </FormDescription>
+            </div>
+          )}
+        />
+      </div>
+    </AccordionContent>
+  </AccordionItem>
+);
+
+const BedrockAccordionSection: React.FC<AccordionSectionProps> = ({
+  form,
+  config,
+}) => (
+  <AccordionItem value="bedrock">
+    <AccordionTrigger>AWS Bedrock</AccordionTrigger>
+    <AccordionContent>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-secondary">
+          To use AWS Bedrock, you need to configure AWS credentials and region.
+          See the{" "}
+          <ExternalLink href="https://docs.marimo.io/guides/editor_features/ai_completion.html#aws-bedrock">
+            documentation
+          </ExternalLink>{" "}
+          for more details.
+        </p>
+
+        <FormField
+          control={form.control}
+          name="ai.bedrock.region_name"
+          render={({ field }) => (
+            <div className="flex flex-col space-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel>AWS Region</FormLabel>
+                <FormControl>
+                  <NativeSelect
+                    data-testid="bedrock-region-select"
+                    onChange={(e) => field.onChange(e.target.value)}
+                    value={
+                      typeof field.value === "string"
+                        ? field.value
+                        : "us-east-1"
+                    }
+                    disabled={field.disabled}
+                    className="inline-flex mr-2"
+                  >
+                    {AWS_REGIONS.map((option) => (
+                      <option value={option} key={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </NativeSelect>
+                </FormControl>
+                <FormMessage />
+                <IsOverridden
+                  userConfig={config}
+                  name="ai.bedrock.region_name"
+                />
+              </FormItem>
+              <FormDescription>
+                The AWS region where Bedrock service is available.
+              </FormDescription>
+            </div>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="ai.bedrock.profile_name"
+          render={({ field }) => (
+            <div className="flex flex-col space-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel>AWS Profile Name (Optional)</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="bedrock-profile-input"
+                    className="m-0 inline-flex"
+                    rootClassName="flex-1"
+                    placeholder="default"
+                    {...field}
+                    value={field.value || ""}
+                  />
+                </FormControl>
+                <FormMessage />
+                <IsOverridden
+                  userConfig={config}
+                  name="ai.bedrock.profile_name"
+                />
+              </FormItem>
+              <FormDescription>
+                The AWS profile name from your ~/.aws/credentials file. Leave
+                blank to use your default AWS credentials.
+              </FormDescription>
+            </div>
+          )}
+        />
+      </div>
+    </AccordionContent>
+  </AccordionItem>
+);
+
+const AzureAccordionSection: React.FC<AccordionSectionProps> = ({
+  form,
+  config,
+}) => (
+  <AccordionItem value="azure">
+    <AccordionTrigger>Azure OpenAI</AccordionTrigger>
+    <AccordionContent>
+      <div className="space-y-4">
+        <FormField
+          control={form.control}
+          name="ai.azure.api_key"
+          render={({ field }) => (
+            <div className="flex flex-col space-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel>API Key</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="ai-azure-api-key-input"
+                    className="m-0 inline-flex"
+                    rootClassName="flex-1"
+                    placeholder="sk-proj..."
+                    {...field}
+                    value={field.value || ""}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      if (!value.includes("*")) {
+                        field.onChange(value);
+                      }
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+                <IsOverridden userConfig={config} name="ai.azure.api_key" />
+              </FormItem>
+              <FormDescription>Your Azure OpenAI API key.</FormDescription>
+            </div>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="ai.azure.base_url"
+          render={({ field }) => (
+            <div className="flex flex-col space-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel>Base URL</FormLabel>
+                <FormControl>
+                  <Input
+                    data-testid="ai-azure-base-url-input"
+                    className="m-0 inline-flex"
+                    rootClassName="flex-1"
+                    placeholder="https://your-resource.openai.azure.com"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+                <IsOverridden userConfig={config} name="ai.azure.base_url" />
+              </FormItem>
+              <FormDescription>Your Azure OpenAI endpoint URL</FormDescription>
+            </div>
+          )}
+        />
+      </div>
+    </AccordionContent>
+  </AccordionItem>
+);

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -45,7 +45,7 @@ import {
 } from "lucide-react";
 import { ExternalLink } from "../ui/links";
 import { cn } from "@/utils/cn";
-import { KNOWN_AI_MODELS, AWS_REGIONS } from "./constants";
+import { KNOWN_AI_MODELS, AWS_REGIONS, KNOWN_AI_PROVIDERS } from "./constants";
 import { Textarea } from "../ui/textarea";
 import { get } from "lodash-es";
 import { Tooltip } from "../ui/tooltip";
@@ -1269,6 +1269,41 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
+
+              <FormField
+                control={form.control}
+                name="ai.azure.api_key"
+                render={({ field }) => (
+                  <div className="flex flex-col space-y-1">
+                    <FormItem className={formItemClasses}>
+                      <FormLabel>Azure OpenAI API Key</FormLabel>
+                      <FormControl>
+                        <Input
+                          data-testid="ai-azure-api-key-input"
+                          className="m-0 inline-flex"
+                          placeholder="sk-proj..."
+                          {...field}
+                          onChange={(e) => {
+                            const value = e.target.value;
+                            // Don't allow *
+                            if (!value.includes("*")) {
+                              field.onChange(value);
+                            }
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                      <IsOverridden
+                        userConfig={config}
+                        name="ai.azure.api_key"
+                      />
+                    </FormItem>
+                    <FormDescription>
+                      Your Azure OpenAI API key.
+                    </FormDescription>
+                  </div>
+                )}
+              />
             </SettingGroup>
 
             <SettingGroup title="AI Assist">
@@ -1280,6 +1315,41 @@ export const UserConfigForm: React.FC = () => {
                 </ExternalLink>{" "}
                 for more info.
               </p>
+
+              <FormField
+                control={form.control}
+                disabled={isWasmRuntime}
+                name="ai.provider_type"
+                render={({ field }) => (
+                  <div className="flex flex-col space-y-1">
+                    <FormItem className={formItemClasses}>
+                      <FormLabel>AI Provider</FormLabel>
+                      <FormControl>
+                        <Input
+                          list="ai-provider-type-datalist"
+                          data-testid="ai-provider-type-input"
+                          className="m-0 inline-flex"
+                          placeholder="gpt-4-turbo"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                      <IsOverridden
+                        userConfig={config}
+                        name="ai.provider_type"
+                      />
+                    </FormItem>
+                    <datalist id="ai-provider-type-datalist">
+                      {KNOWN_AI_PROVIDERS.map((provider) => (
+                        <option value={provider} key={provider}>
+                          {provider}
+                        </option>
+                      ))}
+                    </datalist>
+                    <FormDescription>AI provider to use.</FormDescription>
+                  </div>
+                )}
+              />
               <FormField
                 control={form.control}
                 disabled={isWasmRuntime}

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -128,6 +128,7 @@ export const UserConfigSchema = z
     ai: z
       .object({
         rules: z.string().default(""),
+        provider_type: z.string().optional(),
         open_ai: z
           .object({
             api_key: z.string().optional(),
@@ -151,6 +152,12 @@ export const UserConfigSchema = z
             profile_name: z.string().optional(),
             aws_access_key_id: z.string().optional(),
             aws_secret_access_key: z.string().optional(),
+          })
+          .optional(),
+        azure: z
+          .object({
+            api_key: z.string().optional(),
+            base_url: z.string().optional(),
           })
           .optional(),
       })

--- a/marimo/_ai/llm/__init__.py
+++ b/marimo/_ai/llm/__init__.py
@@ -1,4 +1,11 @@
 # Copyright 2025 Marimo. All rights reserved.
-from marimo._ai.llm._impl import anthropic, bedrock, google, groq, openai
+from marimo._ai.llm._impl import (
+    anthropic,
+    azure,
+    bedrock,
+    google,
+    groq,
+    openai,
+)
 
 __all__ = ["openai", "anthropic", "google", "groq", "bedrock", "azure"]

--- a/marimo/_ai/llm/__init__.py
+++ b/marimo/_ai/llm/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2025 Marimo. All rights reserved.
 from marimo._ai.llm._impl import anthropic, bedrock, google, groq, openai
 
-__all__ = ["openai", "anthropic", "google", "groq", "bedrock"]
+__all__ = ["openai", "anthropic", "google", "groq", "bedrock", "azure"]

--- a/marimo/_ai/llm/_impl.py
+++ b/marimo/_ai/llm/_impl.py
@@ -482,7 +482,12 @@ def _require_api_key(env_var: str, config_key: str, name: str) -> str:
     with contextlib.suppress(Exception):
         from marimo._runtime.context.types import get_context
 
-        api_key = get_context().marimo_config["ai"][config_key]["api_key"]
+        api_key = (
+            get_context()
+            .marimo_config.get("ai", {})
+            .get(config_key, {})
+            .get("api_key")
+        )
         if api_key:
             return api_key
 

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 import click
 
 from marimo._cli.print import orange
+from marimo._config.config import OpenAiConfig
 
 if TYPE_CHECKING:
     import psutil
@@ -56,6 +57,7 @@ def _generate_server_api_schema() -> dict[str, Any]:
         data.NonNestedLiteral,
         data.DataType,
         CellConfig,
+        OpenAiConfig,
         MarimoConfig,
         # Errors
         errors.SetupRootError,

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -227,18 +227,22 @@ class AiConfig(TypedDict, total=False):
 
     - `rules`: custom rules to include in all AI completion prompts
     - `max_tokens`: the maximum number of tokens to use in AI completions
+    - `provider_type`: the type of the provider to use from the configured ones
     - `open_ai`: the OpenAI config
     - `anthropic`: the Anthropic config
     - `google`: the Google AI config
     - `bedrock`: the Bedrock config
+    - `azure`: the Azure OpenAI config
     """
 
     rules: NotRequired[str]
     max_tokens: NotRequired[int]
+    provider_type: NotRequired[str]
     open_ai: OpenAiConfig
     anthropic: AnthropicConfig
     google: GoogleAiConfig
     bedrock: BedrockConfig
+    azure: OpenAiConfig
 
 
 @dataclass

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -153,10 +153,10 @@ async def ai_chat(
     max_tokens = get_max_tokens(config)
 
     model = body.model or get_model(ai_config)
-    provider = get_completion_provider(
-        AnyProviderConfig.for_model(model, ai_config),
-        model=model,
-    )
+    provider_config = AnyProviderConfig.from_provider_type(ai_config)
+    if provider_config is None:
+        provider_config = AnyProviderConfig.for_model(model, ai_config)
+    provider = get_completion_provider(provider_config, model=model)
     response = provider.stream_completion(
         messages=messages,
         system_prompt=system_prompt,

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1329,6 +1329,8 @@ components:
                 api_key:
                   type: string
               type: object
+            azure:
+              $ref: '#/components/schemas/OpenAiConfig'
             bedrock:
               properties:
                 aws_access_key_id:
@@ -1348,20 +1350,9 @@ components:
             max_tokens:
               type: integer
             open_ai:
-              properties:
-                api_key:
-                  type: string
-                base_url:
-                  type: string
-                ca_bundle_path:
-                  type: string
-                client_pem:
-                  type: string
-                model:
-                  type: string
-                ssl_verify:
-                  type: boolean
-              type: object
+              $ref: '#/components/schemas/OpenAiConfig'
+            provider_type:
+              type: string
             rules:
               type: string
           type: object
@@ -1817,6 +1808,21 @@ components:
       - type: boolean
       - format: byte
         type: string
+    OpenAiConfig:
+      properties:
+        api_key:
+          type: string
+        base_url:
+          type: string
+        ca_bundle_path:
+          type: string
+        client_pem:
+          type: string
+        model:
+          type: string
+        ssl_verify:
+          type: boolean
+      type: object
     OpenTutorialRequest:
       properties:
         tutorialId:
@@ -2572,7 +2578,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.13.11
+  version: 0.13.12
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -3016,6 +3016,7 @@ export interface components {
         anthropic?: {
           api_key?: string;
         };
+        azure?: components["schemas"]["OpenAiConfig"];
         bedrock?: {
           aws_access_key_id?: string;
           aws_secret_access_key?: string;
@@ -3026,14 +3027,8 @@ export interface components {
           api_key?: string;
         };
         max_tokens?: number;
-        open_ai?: {
-          api_key?: string;
-          base_url?: string;
-          ca_bundle_path?: string;
-          client_pem?: string;
-          model?: string;
-          ssl_verify?: boolean;
-        };
+        open_ai?: components["schemas"]["OpenAiConfig"];
+        provider_type?: string;
         rules?: string;
       };
       completion: {
@@ -3231,6 +3226,14 @@ export interface components {
       type: "multiple-defs";
     };
     NonNestedLiteral: number | string | boolean;
+    OpenAiConfig: {
+      api_key?: string;
+      base_url?: string;
+      ca_bundle_path?: string;
+      client_pem?: string;
+      model?: string;
+      ssl_verify?: boolean;
+    };
     OpenTutorialRequest: {
       tutorialId:
         | (


### PR DESCRIPTION
Sorry for the delay!

## 📝 Summary

Adds a `ai.provider_type` option to the settings in order to explicitly state the provider to use.

Plus, it handles Azure OpenAI models with custom domains.

**BEWARE**: as I mentioned in https://github.com/marimo-team/marimo/issues/4318#issuecomment-2821597569 the frontend part is just drafted, I don't really know what I did 😅 

closes #4460 #4318

## 🔍 Description of Changes

- added the `provider_type` and `azure`  arguments to the `AiConfig` class
- extracted the Azure part of the `openai` class to an `azure` `ChatModel` subclass, that does the parsing of the model from the url
- added a `_require_api_key` function to DRY the code
- added a `for_azure` classmethod to `AnyProviderConfig`, plus a `_for_openai_like` classmethod to share the common code with `for_openai`
- added the `from_provider_type` method to `AnyProviderConfig` to get the provider from the `provider_type` setting.
- turned `AnyProviderConfig` `staticmethod`s to `classmethod`s and introduced the `_get_ai_config` function to DRY the code

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
