### PR TITLE
docs: simplify setup references errors page

### DIFF
--- a/docs/guides/understanding_errors/setup.md
+++ b/docs/guides/understanding_errors/setup.md
@@ -1,4 +1,4 @@
-# Setup References
+# Setup references
 
 You're probably on this page because you just saw an error like this one:
 
@@ -9,31 +9,17 @@ You're probably on this page because you just saw an error like this one:
 </div>
 
 marimo raises this error when the setup cell references variables defined in
-other cells. When using the setup cell, you can only use builtin functions.
-In the case above, `image` is defined else where in the notebook, and hence
-cannot be referenced.
+other cells. In the example above, `image` is defined elsewhere in the notebook,
+and hence cannot be referenced.
 
 ## Why can't I refer to variables?
 
-In it's goal to be reproducible, the behavior of marimo notebooks in script and
-notebook mode needs to be consistent. Since script mode will always execute the
-setup cell first, the notebook mode needs to do the same; and at notebook
-start, no variables are defined.
+The setup cell special: it runs before all other cells run, in order to provide
+symbols that [top-level functions and classes](../reusing_functions.md) can use.
+That's why it can't reference variables defined by other cells.
 
 ## How do I fix this error?
 
-Define all needed variables in the setup cell. For example, if you need to
-
-```python
-image = "image.png"
-image
-```
-
-Alternatively, use another script or notebook, to contain more complex logic
-that you can then just import.
-
-
-```python
-from myimages import image
-image
-```
+Define all needed variables in the setup cell. Or, if this code does not
+need to run before all other cells (if you are not using top-level functions
+or classes), simply move your code to a regular cell.


### PR DESCRIPTION
Simplify the explanation of the setup references error. Fix a typo as well.