### PR TITLE
docs: update `watching.md` to reflect support for data file watching

### DIFF
--- a/docs/guides/editor_features/watching.md
+++ b/docs/guides/editor_features/watching.md
@@ -216,7 +216,7 @@ Guide](module_autoreloading.md)
     marimo now supports watching data files and automatically refreshing cells that
     depend on them using `mo.watch.file()` and `mo.watch.directory()`.
 
-    Learn more in the [watch API documentation](https://docs.marimo.io/api/watch/).
+    Learn more in the [watch API documentation](../../api/watch.md).
 
 ## Hot-reloading WebAssembly notebooks
 

--- a/docs/guides/editor_features/watching.md
+++ b/docs/guides/editor_features/watching.md
@@ -212,11 +212,11 @@ Guide](module_autoreloading.md)
 
 ## Watching for data changes
 
-!!! note
-    Support for watching data files and automatically refreshing cells that
-    depend on them is not yet supported. Follow along at
-    <https://github.com/marimo-team/marimo/issues/3258> and let us know
-    if it is important to you.
+!!! info "Data file watching now supported!"
+    marimo now supports watching data files and automatically refreshing cells that
+    depend on them using `mo.watch.file()` and `mo.watch.directory()`.
+
+    Learn more in the [watch API documentation](https://docs.marimo.io/api/watch/).
 
 ## Hot-reloading WebAssembly notebooks
 


### PR DESCRIPTION
## 📝 Summary

Updated [(outdated) docs](https://docs.marimo.io/guides/editor_features/watching/#watching-for-data-changes) which linked to issue addressed recently.

## 🔍 Description of Changes

- marimo now supports watching data files and automatically refreshing dependent cells using `mo.watch.file()` and `mo.watch.directory()` (relevant [PR](https://github.com/marimo-team/marimo/pull/4884)).
- Added a link to the [watch API documentation](https://docs.marimo.io/api/watch/) for further details.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
CC: @dmadisetti 
