### PR TITLE
docs: add example notebook link for slides layout

### DIFF
--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -61,6 +61,9 @@ can reconstruct your layout.
 
 If you prefer a slideshow-like experience, you can use the slides layout. Enable the slides layout in the app preview, via the same dropdown as above.
 
+!!! info "See slides layout in action"
+    Check out this [example notebook](https://marimo.io/p/@gvarnavides/stem-probes) that runs in slides mode, powered by our [Community Cloud](./publishing/community_cloud/).
+
 Unlike the grid layout, the slides are much less customizable:
 
 - The order of the slides is determined by the order of the cells in the notebook.


### PR DESCRIPTION
## 📝 Summary

Add notebook running with slides layout.

## 🔍 Description of Changes

Add mkdocs-powered note linking to relevant notebook using slides layout.

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
