### PR TITLE
docs: fix image rendering in carousel preview

### DIFF
--- a/docs/api/layouts/carousel.md
+++ b/docs/api/layouts/carousel.md
@@ -10,7 +10,7 @@ def __():
         mo.md("# Introduction"),
         "By the marimo team",
         mo.md("## What is marimo?"),
-        mo.md("![marimo moss ball](https://marimo.io/logo.png)"),
+        mo.md("![marimo moss ball](https://marimo.app/logotype-wide.svg)"),
         mo.md("## Questions?"),
     ])
     return


### PR DESCRIPTION
## 📝 Summary

Fix image rendering in Carousel docs.

<details>

<summary> Screenshot: </summary>

![image](https://github.com/user-attachments/assets/0b1ec205-83c9-42e5-aa15-2ac2ce7775c1)

</details>

## 🔍 Description of Changes

Replace URL with `https://marimo.app/logotype-wide.svg` which works.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
