### PR TITLE
Minor correction in fileformat.py

### DIFF
--- a/marimo/_tutorials/fileformat.py
+++ b/marimo/_tutorials/fileformat.py
@@ -94,7 +94,7 @@ def _(mo):
 
         @app.cell
         def _(mo):
-            text = mo.ui.text(value="Hello, World!")
+            text = mo.ui.text(value=say_hello())
             text
             return (text,)
 


### PR DESCRIPTION
marimo generates `value=say_hello()`, not `value="Hello, World!"` for "cell three" in the example.

## 📝 Summary

Hi, trying out mariomo for the first time today- what a gorgeous experience, props to the whole team behind this.

I was following the tutorial and noticed a minor mistake in the [fileformat tutorial](https://github.com/marimo-team/marimo/blob/main/marimo/_tutorials/fileformat.py) - line 97 in the markdown cell about the file generated by marimo suggests it would contain
```python
            text = mo.ui.text(value="Hello, World!")
```

## 🔍 Description of Changes

However, this line should be 
```python
            text = mo.ui.text(value=say_hello())
```

I've updated the `fileformat.py` tutorial accordingly.

This does not effect the functionality of the tutorial, only the accuracy.

Cheers, Matt

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
- [x] I have read the CLA Document and I hereby sign the CLA.


## 📜 Reviewers

@akshayka OR @mscolnick
