### PR TITLE
fix: skew potection token in run-mode when auth is enabled

### DIFF
--- a/marimo/_server/tokens.py
+++ b/marimo/_server/tokens.py
@@ -30,7 +30,7 @@ class AuthToken:
 
     @staticmethod
     def from_code(code: str) -> AuthToken:
-        return AuthToken(str(hash(code)))
+        return AuthToken(str(hash("auth:" + code)))
 
     @staticmethod
     def is_empty(token: AuthToken) -> bool:
@@ -51,7 +51,7 @@ class SkewProtectionToken:
 
     @staticmethod
     def from_code(code: str) -> SkewProtectionToken:
-        return SkewProtectionToken(str(hash(code)))
+        return SkewProtectionToken(str(hash("skew:" + code)))
 
     @staticmethod
     def random() -> SkewProtectionToken:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,7 +280,7 @@ extra-dependencies = [
     "ipython~=8.12.3",
     # testing gen ai
     "openai>=1.55.3",
-    "anthropic==0.34.1",
+    "anthropic==0.52.2",
     "google-generativeai==0.8.5",
     "boto3>=1.38.25",
     "litellm>=1.70.0",


### PR DESCRIPTION
Bug fix where we were using the random skew potection token instead of one based on the code, in run mode.