### PR TITLE
Support some JupyterBook cell tags in marimo convert

### DIFF
--- a/marimo/_convert/ipynb.py
+++ b/marimo/_convert/ipynb.py
@@ -724,23 +724,23 @@ def _transform_sources(
     ]
 
     # Run all the source transforms
-    for transform in source_transforms:
-        new_sources = transform(sources)
+    for source_transform in source_transforms:
+        new_sources = source_transform(sources)
         assert len(new_sources) == len(sources), (
-            f"{transform.__name__} changed cell count"
+            f"{source_transform.__name__} changed cell count"
         )
         sources = new_sources
 
     cells = bind_cell_metadata(sources, metadata, hide_flags)
 
     # may change cell count
-    cell_transforms = [
+    cell_transforms: list[CellsTransform] = [
         transform_add_marimo_import,
         transform_remove_empty_cells,
     ]
 
-    for transform in cell_transforms:
-        cells = transform(cells)
+    for cell_transform in cell_transforms:
+        cells = cell_transform(cells)
 
     return cells
 

--- a/scripts/generate_ipynb_fixtures.py
+++ b/scripts/generate_ipynb_fixtures.py
@@ -126,6 +126,18 @@ for i_1 in range(X_1.shape[0]):
                     "custom": {"key": "value"},
                 },
             ),
+            nb.new_code_cell(
+                "print('hidden cell')",
+                metadata={
+                    "tags": ["hide-cell"],
+                },
+            ),
+            nb.new_code_cell(
+                "print('hidden cell, with other tags')",
+                metadata={
+                    "tags": ["hide-cell", "remove-print"],
+                },
+            ),
         ],
     )
 

--- a/scripts/generate_ipynb_fixtures.py
+++ b/scripts/generate_ipynb_fixtures.py
@@ -22,7 +22,6 @@ Output notebooks are written to `tests/_convert/ipynb_data/`.
 """
 
 from __future__ import annotations
-from io import FileIO
 from pathlib import Path
 
 import nbformat.v4.nbbase as nb
@@ -99,6 +98,34 @@ for i_1 in range(X_1.shape[0]):
         [
             "x ( b 2 d & !",
             "x",
+        ],
+    )
+
+    create_notebook_fixture(
+        "cell_metadata",
+        [
+            nb.new_code_cell(
+                "print('Hello')", metadata={"tags": ["tag1", "tag2"]}
+            ),
+            nb.new_code_cell("print('World')", metadata={}),
+            nb.new_code_cell(
+                "print('Cell 1')",
+                metadata={"tags": ["important", "data-processing"]},
+            ),
+            nb.new_code_cell("print('Cell 2')", metadata={"tags": []}),
+            nb.new_code_cell(
+                "print('Cell 3')",
+                metadata={"tags": ["visualization"], "collapsed": True},
+            ),
+            nb.new_code_cell(
+                "print('Complex metadata')",
+                metadata={
+                    "tags": ["tag1", "tag2"],
+                    "collapsed": True,
+                    "scrolled": False,
+                    "custom": {"key": "value"},
+                },
+            ),
         ],
     )
 

--- a/scripts/generate_ipynb_fixtures.py
+++ b/scripts/generate_ipynb_fixtures.py
@@ -141,6 +141,21 @@ for i_1 in range(X_1.shape[0]):
         ],
     )
 
+    create_notebook_fixture(
+        "hides_markdown_cells",
+        [
+            nb.new_markdown_cell("A markdown cell."),
+            nb.new_markdown_cell(
+                "A markdown cell with tags: ['blah'].",
+                metadata={"tags": ["blah"]},
+            ),
+            nb.new_markdown_cell(
+                "A markdown cell with tags: ['blah', 'hide-cell'].",
+                metadata={"tags": ["blah", "hide-cell"]},
+            ),
+        ],
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/tests/_convert/ipynb_data/cell_metadata.ipynb
+++ b/tests/_convert/ipynb_data/cell_metadata.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {
+    "tags": [
+     "tag1",
+     "tag2"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print('Hello')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('World')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {
+    "tags": [
+     "important",
+     "data-processing"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print('Cell 1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print('Cell 2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "visualization"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print('Cell 3')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {
+    "collapsed": true,
+    "custom": {
+     "key": "value"
+    },
+    "scrolled": false,
+    "tags": [
+     "tag1",
+     "tag2"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print('Complex metadata')"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/_convert/ipynb_data/cell_metadata.ipynb
+++ b/tests/_convert/ipynb_data/cell_metadata.ipynb
@@ -86,6 +86,35 @@
    "source": [
     "print('Complex metadata')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print('hidden cell')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {
+    "tags": [
+     "hide-cell",
+     "remove-print"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print('hidden cell, with other tags')"
+   ]
   }
  ],
  "metadata": {},

--- a/tests/_convert/ipynb_data/hides_markdown_cells.ipynb
+++ b/tests/_convert/ipynb_data/hides_markdown_cells.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "A markdown cell."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {
+    "tags": [
+     "blah"
+    ]
+   },
+   "source": [
+    "A markdown cell with tags: ['blah']."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {
+    "tags": [
+     "blah",
+     "hide-cell"
+    ]
+   },
+   "source": [
+    "A markdown cell with tags: ['blah', 'hide-cell']."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/_convert/snapshots/convert_cell_metadata.py.txt
+++ b/tests/_convert/snapshots/convert_cell_metadata.py.txt
@@ -1,0 +1,47 @@
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    # Cell tags: tag1, tag2
+    print('Hello')
+    return
+
+
+@app.cell
+def _():
+    print('World')
+    return
+
+
+@app.cell
+def _():
+    # Cell tags: data-processing, important
+    print('Cell 1')
+    return
+
+
+@app.cell
+def _():
+    print('Cell 2')
+    return
+
+
+@app.cell
+def _():
+    # Cell tags: visualization
+    print('Cell 3')
+    return
+
+
+@app.cell
+def _():
+    # Cell tags: tag1, tag2
+    print('Complex metadata')
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_convert/snapshots/convert_cell_metadata.py.txt
+++ b/tests/_convert/snapshots/convert_cell_metadata.py.txt
@@ -43,5 +43,18 @@ def _():
     return
 
 
+@app.cell(hide_code=True)
+def _():
+    print('hidden cell')
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    # Cell tags: remove-print
+    print('hidden cell, with other tags')
+    return
+
+
 if __name__ == "__main__":
     app.run()

--- a/tests/_convert/snapshots/convert_hides_markdown_cells.py.txt
+++ b/tests/_convert/snapshots/convert_hides_markdown_cells.py.txt
@@ -1,0 +1,45 @@
+import marimo
+
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+        A markdown cell.
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell tags: blah
+    mo.md(
+        r"""
+        A markdown cell with tags: ['blah'].
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell tags: blah
+    mo.md(
+        r"""
+        A markdown cell with tags: ['blah', 'hide-cell'].
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_convert/test_ipynb.py
+++ b/tests/_convert/test_ipynb.py
@@ -6,8 +6,10 @@ from textwrap import dedent
 import pytest
 
 from marimo._convert.ipynb import (
+    CellsTransform,
+    CodeCell,
+    Transform,
     transform_add_marimo_import,
-    transform_cell_metadata,
     transform_duplicate_definitions,
     transform_exclamation_mark,
     transform_fixup_multiple_definitions,
@@ -18,6 +20,16 @@ from marimo._convert.ipynb import (
 
 def dd(sources: list[str]) -> list[str]:
     return [dedent(s) for s in sources]
+
+
+def strip_cells(transform: CellsTransform) -> Transform:
+    """Test wrapper for cell transforms - extracts only source content for testing."""
+
+    def wrapped(sources: list[str]) -> list[str]:
+        cells = [CodeCell(s) for s in sources]
+        return [cell.source for cell in transform(cells)]
+
+    return wrapped
 
 
 def assert_sources_equal(transformed: list[str], expected: list[str]) -> None:
@@ -126,7 +138,7 @@ def test_transform_add_marimo_import():
         "mo.md('# Hello')",
         "print('World')",
     ]
-    result = transform_add_marimo_import(sources)
+    result = strip_cells(transform_add_marimo_import)(sources)
     assert "import marimo as mo" in result
 
     # mo.sql
@@ -134,13 +146,13 @@ def test_transform_add_marimo_import():
         "mo.sql('SELECT * FROM table')",
         "print('World')",
     ]
-    result = transform_add_marimo_import(sources)
+    result = strip_cells(transform_add_marimo_import)(sources)
     assert "import marimo as mo" in result
 
     # if `import marimo as mo` is already present
     # it should not be added again
     existing = sources + ["import marimo as mo"]
-    assert transform_add_marimo_import(existing) == existing
+    assert strip_cells(transform_add_marimo_import)(existing) == existing
 
     existing = [
         # slight support for different import orders
@@ -148,7 +160,7 @@ def test_transform_add_marimo_import():
         "import antigravity; import marimo as mo",
         "mo.md('# Hello')",
     ]
-    assert transform_add_marimo_import(existing) == existing
+    assert strip_cells(transform_add_marimo_import)(existing) == existing
 
 
 def test_transform_add_marimo_import_already_imported():
@@ -157,7 +169,7 @@ def test_transform_add_marimo_import_already_imported():
         "mo.md('# Hello')",
         "print('World')",
     ]
-    result = transform_add_marimo_import(sources)
+    result = strip_cells(transform_add_marimo_import)(sources)
     assert result == sources
 
 
@@ -167,7 +179,7 @@ def test_transform_add_marimo_import_already_but_in_comment_or_definition():
         "mo.md('# Hello')",
         "# import marimo as mo",
     ]
-    result = transform_add_marimo_import(sources)
+    result = strip_cells(transform_add_marimo_import)(sources)
     assert result == sources + ["import marimo as mo"]
 
     # Definition
@@ -175,7 +187,7 @@ def test_transform_add_marimo_import_already_but_in_comment_or_definition():
         "mo.md('# Hello')",
         "def foo():\n    import marimo as mo",
     ]
-    result = transform_add_marimo_import(sources)
+    result = strip_cells(transform_add_marimo_import)(sources)
     assert result == sources + ["import marimo as mo"]
 
 
@@ -353,7 +365,7 @@ def test_transform_add_marimo_import_edge_cases():
         "print('mo.sql is not a real call')",
         "mo = 'not the real mo'",
     ]
-    result = transform_add_marimo_import(sources)
+    result = strip_cells(transform_add_marimo_import)(sources)
     assert "import marimo as mo" not in result
 
 

--- a/tests/_convert/test_ipynb.py
+++ b/tests/_convert/test_ipynb.py
@@ -287,22 +287,6 @@ def test_transform_duplicate_definitions():
     ]
 
 
-def test_transform_cell_metadata():
-    sources = [
-        "print('Hello')",
-        "print('World')",
-    ]
-    metadata = [
-        {"tags": ["tag1", "tag2"]},
-        {},
-    ]
-    result = transform_cell_metadata(sources, metadata)
-    assert result == [
-        "# Cell tags: tag1, tag2\nprint('Hello')",
-        "print('World')",
-    ]
-
-
 def test_transform_remove_duplicate_imports():
     sources = [
         "import numpy as np\nimport pandas as pd\nimport numpy as np",
@@ -429,25 +413,6 @@ def test_transform_duplicate_definitions_complex():
     ]
 
 
-def test_transform_cell_metadata_complex():
-    sources = [
-        "print('Cell 1')",
-        "print('Cell 2')",
-        "print('Cell 3')",
-    ]
-    metadata = [
-        {"tags": ["important", "data-processing"]},
-        {"tags": []},
-        {"tags": ["visualization"], "collapsed": True},
-    ]
-    result = transform_cell_metadata(sources, metadata)
-    assert result == [
-        "# Cell tags: important, data-processing\nprint('Cell 1')",
-        "print('Cell 2')",
-        "# Cell tags: visualization\nprint('Cell 3')",
-    ]
-
-
 def test_transform_remove_duplicate_imports_complex():
     sources = [
         "import numpy as np\nfrom pandas import DataFrame\nimport matplotlib.pyplot as plt",  # noqa: E501
@@ -527,24 +492,6 @@ def test_transform_duplicate_definitions_with_reference_to_previous():
         "x = 1",
         "x_1 = x + 1\nprint(x_1)",
         "print(x_1)",
-    ]
-
-
-def test_transform_cell_metadata_with_complex_metadata():
-    sources = [
-        "print('Complex metadata')",
-    ]
-    metadata = [
-        {
-            "tags": ["tag1", "tag2"],
-            "collapsed": True,
-            "scrolled": False,
-            "custom": {"key": "value"},
-        }
-    ]
-    result = transform_cell_metadata(sources, metadata)
-    assert result == [
-        "# Cell tags: tag1, tag2\nprint('Complex metadata')",
     ]
 
 


### PR DESCRIPTION
## 📝 Summary

`_transform_sources` is no longer a pure transform (it's wasn't really with the transforms that are source-to-source, followed by some that modify number of cells). It now forms a "pipeline" for converting Jupyter notebook cells to marimo (python-only) format.

This structure lets us handle tags like "hide-code" and cleanly separate source-only and cell-level logic.

## 🔍 Description of Changes

The pipeline is:

- A series of source-to-source transforms
- One source → CodeCell binding step (binds/resolve source with ipynb metadata to create `CellConfig`)
- A series of cell-to-cell transforms (may add/remove cells)

I had to update some tests... I chattted with @mscolnick about maybe updating some of these tests with snapshotting since this is so internal.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
