### PR TITLE
Add support for initial chart properties in `data_explorer` (take 2)

### DIFF
--- a/docs/api/inputs/data_explorer.md
+++ b/docs/api/inputs/data_explorer.md
@@ -24,4 +24,29 @@ def __():
 
 ///
 
+To set an initial configuration, you can pass keyword arguments to `mo.ui.data_explorer`. For example, to start with `sepal_length` on the x-axis, `sepal_width` on the y-axis, and `species` as the color encoding:
+
+/// marimo-embed
+    size: large
+    app_width: full
+
+```python
+@app.cell
+def __():
+    import marimo as mo
+    import pandas as pd
+    import pyodide
+    csv = pyodide.http.open_url("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv")
+    df = pd.read_csv(csv)
+    mo.ui.data_explorer(
+        df,
+        x="sepal_length",
+        y="sepal_width",
+        color="species",
+    )
+    return
+```
+
+///
+
 ::: marimo.ui.data_explorer

--- a/marimo/_plugins/ui/_impl/data_explorer.py
+++ b/marimo/_plugins/ui/_impl/data_explorer.py
@@ -60,17 +60,25 @@ class data_explorer(UIElement[dict[str, Any], dict[str, Any]]):
 
         manager = get_table_manager(df_no_idx)
 
+        initial_spec = {}
+        if x is not None:
+            initial_spec["x"] = x
+        if y is not None:
+            initial_spec["y"] = y
+        if row is not None:
+            initial_spec["row"] = row
+        if column is not None:
+            initial_spec["column"] = column
+        if color is not None:
+            initial_spec["color"] = color
+        if size is not None:
+            initial_spec["size"] = size
+        if shape is not None:
+            initial_spec["shape"] = shape
+
         super().__init__(
             component_name=data_explorer._name,
-            initial_value={
-                "x": x,
-                "y": y,
-                "row": row,
-                "column": column,
-                "color": color,
-                "size": size,
-                "shape": shape,
-            },
+            initial_value=initial_spec,
             on_change=on_change,
             label="",
             args={

--- a/marimo/_plugins/ui/_impl/data_explorer.py
+++ b/marimo/_plugins/ui/_impl/data_explorer.py
@@ -20,15 +20,24 @@ class data_explorer(UIElement[dict[str, Any], dict[str, Any]]):
     Examples:
         ```python
         mo.ui.data_explorer(data)
+        mo.ui.data_explorer(data, x="col_A", y="col_B", color="col_C")
         ```
 
     Attributes:
-        value (Dict[str, Any]): The resulting DataFrame chart spec.
+        value (Dict[str, Any]): The chart specification, which may include
+            initial selections if provided via keyword arguments.
 
     Args:
         df (IntoDataFrame): The DataFrame to visualize.
-        on_change (Callable[[dict[str, object]], None], optional): Optional callback
+        on_change (Callable[[dict[str, Any]], None], optional): Optional callback
             to run when this element's value changes.
+        x (Optional[str]): Initial column for the x-axis. Defaults to None.
+        y (Optional[str]): Initial column for the y-axis. Defaults to None.
+        row (Optional[str]): Initial column for the row dimension. Defaults to None.
+        column (Optional[str]): Initial column for the column dimension. Defaults to None.
+        color (Optional[str]): Initial column for the color encoding. Defaults to None.
+        size (Optional[str]): Initial column for the size encoding. Defaults to None.
+        shape (Optional[str]): Initial column for the shape encoding. Defaults to None.
     """
 
     _name: Final[str] = "marimo-data-explorer"
@@ -37,16 +46,31 @@ class data_explorer(UIElement[dict[str, Any], dict[str, Any]]):
         self,
         df: IntoDataFrame,
         on_change: Optional[Callable[[dict[str, Any]], None]] = None,
+        x: Optional[str] = None,
+        y: Optional[str] = None,
+        row: Optional[str] = None,
+        column: Optional[str] = None,
+        color: Optional[str] = None,
+        size: Optional[str] = None,
+        shape: Optional[str] = None,
     ) -> None:
         # Drop the index since empty column names break the data explorer
-        df = _drop_index(df)
-        self._data = df
+        df_no_idx = _drop_index(df)
+        self._data = df_no_idx
 
-        manager = get_table_manager(df)
+        manager = get_table_manager(df_no_idx)
 
         super().__init__(
             component_name=data_explorer._name,
-            initial_value={},
+            initial_value={
+                "x": x,
+                "y": y,
+                "row": row,
+                "column": column,
+                "color": color,
+                "size": size,
+                "shape": shape,
+            },
             on_change=on_change,
             label="",
             args={

--- a/tests/_plugins/ui/_impl/test_data_explorer.py
+++ b/tests/_plugins/ui/_impl/test_data_explorer.py
@@ -84,7 +84,5 @@ def test_data_explorer_initial_spec(
     expected_value: dict[str, str],
 ) -> None:
     """Test data_explorer with various initial spec keyword arguments."""
-    valid_keys = ("x", "y", "row", "column", "color", "size", "shape")
-    expected_value = {**dict.fromkeys(valid_keys, None), **expected_value}
     explorer = data_explorer.data_explorer(df_input, **initial_spec_kwargs)
     assert explorer.value == expected_value

--- a/tests/_plugins/ui/_impl/test_data_explorer.py
+++ b/tests/_plugins/ui/_impl/test_data_explorer.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -12,6 +13,12 @@ from marimo._utils.platform import is_windows
 from tests._data.mocks import create_dataframes
 
 HAS_DEPS = DependencyManager.pandas.has()
+
+
+if HAS_DEPS:
+    import pandas as pd
+else:
+    pd = Mock()
 
 
 @pytest.mark.parametrize(
@@ -28,8 +35,6 @@ def test_data_explorer(df: Any) -> None:
     reason="optional dependencies not installed or windows",
 )
 def test_data_explorer_index() -> None:
-    import pandas as pd
-
     # With index
     df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["a", "b", "c"])
     explorer = data_explorer.data_explorer(df)
@@ -47,3 +52,39 @@ def test_data_explorer_index() -> None:
     explorer = data_explorer.data_explorer(df)
     data = explorer._component_args["data"]
     assert from_data_uri(data)[1] == b"A,B\n1,4\n2,5\n3,6\n"
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+@pytest.mark.parametrize(
+    ("df_input", "initial_spec_kwargs", "expected_value"),
+    [
+        (
+            pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]}),
+            {"x": "A", "y": "B", "color": "C"},
+            {"x": "A", "y": "B", "color": "C"},
+        ),
+        (
+            pd.DataFrame({"X": [10, 20], "Y": [30, 40]}),
+            {"x": "X", "size": "Y"},
+            {"x": "X", "size": "Y"},
+        ),
+        (
+            pd.DataFrame(
+                {"C1": [100, 200], "C2": [300, 400], "C3": [500, 600]}
+            ),
+            {"row": "C1", "column": "C2", "shape": "C3"},
+            {"row": "C1", "column": "C2", "shape": "C3"},
+        ),
+        (pd.DataFrame({"E": [1, 2], "F": [3, 4]}), {}, {}),
+    ],
+)
+def test_data_explorer_initial_spec(
+    df_input: Any,
+    initial_spec_kwargs: dict[str, str],
+    expected_value: dict[str, str],
+) -> None:
+    """Test data_explorer with various initial spec keyword arguments."""
+    valid_keys = ("x", "y", "row", "column", "color", "size", "shape")
+    expected_value = {**dict.fromkeys(valid_keys, None), **expected_value}
+    explorer = data_explorer.data_explorer(df_input, **initial_spec_kwargs)
+    assert explorer.value == expected_value


### PR DESCRIPTION
reapply PR https://github.com/marimo-team/marimo/pull/5028 reverted in https://github.com/marimo-team/marimo/pull/5057, this time only including non-`None` values in `data_explorer`'s `initial_value` dict

@mscolnick i think this should address the error you saw in https://github.com/marimo-team/marimo/pull/5057#issuecomment-2933048190