### PR TITLE
fix: (outlines)  Headings with the same name are highlighted multiple…

### DIFF
--- a/frontend/src/components/editor/chrome/panels/outline-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/outline-panel.tsx
@@ -15,7 +15,8 @@ import { OutlineList } from "./outline/floating-outline";
 export const OutlinePanel: React.FC = () => {
   const { items } = useAtomValue(notebookOutline);
   const headerElements = useMemo(() => findOutlineElements(items), [items]);
-  const { activeHeaderId } = useActiveOutline(headerElements);
+  const { activeHeaderId, activeOccurrences } =
+    useActiveOutline(headerElements);
 
   if (items.length === 0) {
     return (
@@ -27,5 +28,11 @@ export const OutlinePanel: React.FC = () => {
     );
   }
 
-  return <OutlineList items={items} activeHeaderId={activeHeaderId} />;
+  return (
+    <OutlineList
+      items={items}
+      activeHeaderId={activeHeaderId}
+      activeOccurrences={activeOccurrences}
+    />
+  );
 };

--- a/frontend/src/components/editor/chrome/panels/outline/floating-outline.tsx
+++ b/frontend/src/components/editor/chrome/panels/outline/floating-outline.tsx
@@ -12,7 +12,9 @@ import type { OutlineItem } from "@/core/cells/outline";
 
 export const FloatingOutline: React.FC = () => {
   const { items } = useAtomValue(notebookOutline);
-  const { activeHeaderId } = useActiveOutline(findOutlineElements(items));
+  const { activeHeaderId, activeOccurrences } = useActiveOutline(
+    findOutlineElements(items),
+  );
   const [isHovered, setIsHovered] = React.useState(false);
 
   // Hide if < 2 items
@@ -39,8 +41,13 @@ export const FloatingOutline: React.FC = () => {
         )}
         items={items}
         activeHeaderId={activeHeaderId}
+        activeOccurrences={activeOccurrences}
       />
-      <MiniMap items={items} activeHeaderId={activeHeaderId} />
+      <MiniMap
+        items={items}
+        activeHeaderId={activeHeaderId}
+        activeOccurrences={activeOccurrences}
+      />
     </div>
   );
 };
@@ -48,7 +55,8 @@ export const FloatingOutline: React.FC = () => {
 export const MiniMap: React.FC<{
   items: OutlineItem[];
   activeHeaderId: string | undefined;
-}> = ({ items, activeHeaderId }) => {
+  activeOccurrences: number | undefined;
+}> = ({ items, activeHeaderId, activeOccurrences }) => {
   // Map of selector to its occurrences
   const seen = new Map<string, number>();
   return (
@@ -68,7 +76,9 @@ export const MiniMap: React.FC<{
               item.level === 2 && "w-4",
               item.level === 3 && "w-3",
               item.level === 4 && "w-2",
-              activeHeaderId === identifier && "bg-foreground",
+              occurrences === activeOccurrences &&
+                activeHeaderId === identifier &&
+                "bg-foreground",
             )}
             onClick={() => scrollToOutlineItem(item, occurrences)}
           />
@@ -82,7 +92,8 @@ export const OutlineList: React.FC<{
   className?: string;
   items: OutlineItem[];
   activeHeaderId: string | undefined;
-}> = ({ items, activeHeaderId, className }) => {
+  activeOccurrences: number | undefined;
+}> = ({ items, activeHeaderId, activeOccurrences, className }) => {
   // Map of selector to its occurrences
   const seen = new Map<string, number>();
   return (
@@ -102,7 +113,9 @@ export const OutlineList: React.FC<{
               item.level === 2 && "ml-3",
               item.level === 3 && "ml-6",
               item.level === 4 && "ml-9",
-              activeHeaderId === identifier && "text-accent-foreground",
+              occurrences === activeOccurrences &&
+                activeHeaderId === identifier &&
+                "text-accent-foreground",
             )}
             onClick={() => scrollToOutlineItem(item, occurrences)}
           >

--- a/frontend/src/components/editor/chrome/panels/outline/useActiveOutline.tsx
+++ b/frontend/src/components/editor/chrome/panels/outline/useActiveOutline.tsx
@@ -22,8 +22,15 @@ export function useActiveOutline(
   const [activeHeaderId, setActiveHeaderId] = useState<string | undefined>(
     undefined,
   );
+  const [activeOccurrences, setActiveOccurrences] = useState<
+    number | undefined
+  >(undefined);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const topmostHeader = useRef<HTMLElement | null>(null);
+
+  const occurrences = useRef<Map<HTMLElement, number>>(
+    new Map<HTMLElement, number>(),
+  );
 
   useEffect(() => {
     if (headerElements.length === 0) {
@@ -54,6 +61,7 @@ export function useActiveOutline(
         const identifier = headingToIdentifier(topmostHeader.current);
         const id = "id" in identifier ? identifier.id : identifier.path;
         setActiveHeaderId(id);
+        setActiveOccurrences(occurrences.current.get(topmostHeader.current));
       }
     };
 
@@ -65,6 +73,16 @@ export function useActiveOutline(
 
     headerElements.forEach((element) => {
       if (element) {
+        const identifier: OutlineItem["by"] = headingToIdentifier(element[0]);
+        const idxOfEl: number = headerElements
+          .map(([el]: readonly [HTMLElement, string]) => el)
+          .filter((el: HTMLElement) =>
+            "id" in identifier
+              ? el.id === identifier.id
+              : el.textContent === element[0].textContent,
+          )
+          .indexOf(element[0]);
+        occurrences.current.set(element[0], idxOfEl);
         observerRef.current?.observe(element[0]);
       }
     });
@@ -77,7 +95,7 @@ export function useActiveOutline(
     };
   }, [headerElements]);
 
-  return { activeHeaderId };
+  return { activeHeaderId, activeOccurrences };
 }
 
 /**


### PR DESCRIPTION
Headings with the same name are highlighted multiple time in the table of contents

fixes #2087

## 📝 Summary

fixes an issue related to the currently active header if there are multiple headings of the same type with the same content. 

fixes #2087

## 🔍 Description of Changes

similar to how it was already done for navigating this PR keeps track of the occurrence of an id-header pair and highlights only the correct occurrence 

## 📋 Checklist

- [(/) ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [(/) ] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
