### PR TITLE
allow passing an extra script to wasm export

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,15 +51,13 @@
         });
         resizeObserver.observe(obj.contentWindow.document.body);
       }
+      window.__MARIMO_MOUNT_CONFIG__ = '{{ mount_config }}';
     </script>
     <marimo-filename hidden>{{ filename }}</marimo-filename>
     <title>{{ title }}</title>
   </head>
   <body>
     <div id="root"></div>
-    <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = '{{ mount_config }}';
-    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -511,6 +511,12 @@ and cannot be opened directly from the file system (e.g. file://).
     type=bool,
     help=_sandbox_message,
 )
+@click.option(
+    "--extra-script",
+    type=click.Path(path_type=Path),
+    required=False,
+    help="Extra JavaScript file to include in the exported HTML.",
+)
 @click.argument(
     "name",
     required=True,
@@ -524,6 +530,7 @@ def html_wasm(
     show_code: bool,
     include_cloudflare: bool,
     sandbox: Optional[bool],
+    extra_script: Optional[Path] = None,
 ) -> None:
     """Export a notebook as a WASM-powered standalone HTML file."""
     import sys
@@ -540,6 +547,11 @@ def html_wasm(
         run_in_sandbox(sys.argv[1:], name=name)
         return
 
+    if extra_script is not None:  # read the script contents
+        script_data = extra_script.read_text(encoding="utf-8")
+    else:
+        script_data = None
+
     out_dir = output
     filename = "index.html"
     ignore_index_html = False
@@ -552,7 +564,9 @@ def html_wasm(
     marimo_file = MarimoPath(name)
 
     def export_callback(file_path: MarimoPath) -> ExportResult:
-        return export_as_wasm(file_path, mode, show_code=show_code)
+        return export_as_wasm(
+            file_path, mode, show_code=show_code, extra_script=script_data
+        )
 
     # Export assets first
     Exporter().export_assets(out_dir, ignore_index_html=ignore_index_html)

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -513,9 +513,16 @@ and cannot be opened directly from the file system (e.g. file://).
 )
 @click.option(
     "--extra-script",
-    type=click.Path(path_type=Path),
+    multiple=True,
+    type=str,
     required=False,
-    help="Extra JavaScript file to include in the exported HTML.",
+    help="Extra JavaScript URLs to include in the exported HTML. Can be specified multiple times.",
+)
+@click.option(
+    "--show-save/--no-show-save",
+    default=False,
+    show_default=True,
+    help="Whether to show the save button in the exported HTML file.",
 )
 @click.argument(
     "name",
@@ -530,7 +537,8 @@ def html_wasm(
     show_code: bool,
     include_cloudflare: bool,
     sandbox: Optional[bool],
-    extra_script: Optional[Path] = None,
+    extra_script: tuple[str, ...] = (),
+    show_save: bool = False,
 ) -> None:
     """Export a notebook as a WASM-powered standalone HTML file."""
     import sys
@@ -547,11 +555,6 @@ def html_wasm(
         run_in_sandbox(sys.argv[1:], name=name)
         return
 
-    if extra_script is not None:  # read the script contents
-        script_data = extra_script.read_text(encoding="utf-8")
-    else:
-        script_data = None
-
     out_dir = output
     filename = "index.html"
     ignore_index_html = False
@@ -565,7 +568,11 @@ def html_wasm(
 
     def export_callback(file_path: MarimoPath) -> ExportResult:
         return export_as_wasm(
-            file_path, mode, show_code=show_code, extra_script=script_data
+            file_path,
+            mode,
+            show_code=show_code,
+            extra_scripts=extra_script,
+            show_save=show_save,
         )
 
     # Export assets first

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -512,11 +512,10 @@ and cannot be opened directly from the file system (e.g. file://).
     help=_sandbox_message,
 )
 @click.option(
-    "--extra-script",
-    multiple=True,
+    "--html-head",
     type=str,
     required=False,
-    help="Extra JavaScript URLs to include in the exported HTML. Can be specified multiple times.",
+    help="Path to an HTML file containing content to inject into the <head> section of the exported HTML.",
 )
 @click.option(
     "--show-save/--no-show-save",
@@ -537,7 +536,7 @@ def html_wasm(
     show_code: bool,
     include_cloudflare: bool,
     sandbox: Optional[bool],
-    extra_script: tuple[str, ...] = (),
+    html_head: Optional[str] = None,
     show_save: bool = False,
 ) -> None:
     """Export a notebook as a WASM-powered standalone HTML file."""
@@ -571,7 +570,7 @@ def html_wasm(
             file_path,
             mode,
             show_code=show_code,
-            extra_scripts=extra_script,
+            html_head_file=html_head,
             show_save=show_save,
         )
 

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -105,7 +105,8 @@ def export_as_wasm(
     mode: Literal["edit", "run"],
     show_code: bool,
     asset_url: Optional[str] = None,
-    extra_script: Optional[str] = None,
+    extra_scripts: tuple[str, ...] = (),
+    show_save: bool = False,
 ) -> ExportResult:
     file_router = AppFileRouter.from_filename(path)
     file_key = file_router.get_unique_file_key()
@@ -122,7 +123,8 @@ def export_as_wasm(
         code=file_manager.to_code(),
         asset_url=asset_url,
         show_code=show_code,
-        extra_script=extra_script,
+        extra_scripts=extra_scripts,
+        show_save=show_save,
     )
     return ExportResult(
         contents=result[0],

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -105,7 +105,7 @@ def export_as_wasm(
     mode: Literal["edit", "run"],
     show_code: bool,
     asset_url: Optional[str] = None,
-    extra_scripts: tuple[str, ...] = (),
+    html_head_file: Optional[str] = None,
     show_save: bool = False,
 ) -> ExportResult:
     file_router = AppFileRouter.from_filename(path)
@@ -114,6 +114,11 @@ def export_as_wasm(
     file_manager = file_router.get_file_manager(file_key)
     # Inline the layout file, if it exists
     file_manager.app.inline_layout_file()
+
+    # Update the app config to set html_head_file if provided
+    if html_head_file is not None:
+        file_manager.app.config.html_head_file = html_head_file
+
     config = get_default_config_manager(current_path=file_manager.path)
 
     result = Exporter().export_as_wasm(
@@ -123,7 +128,6 @@ def export_as_wasm(
         code=file_manager.to_code(),
         asset_url=asset_url,
         show_code=show_code,
-        extra_scripts=extra_scripts,
         show_save=show_save,
     )
     return ExportResult(

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -105,6 +105,7 @@ def export_as_wasm(
     mode: Literal["edit", "run"],
     show_code: bool,
     asset_url: Optional[str] = None,
+    extra_script: Optional[str] = None,
 ) -> ExportResult:
     file_router = AppFileRouter.from_filename(path)
     file_key = file_router.get_unique_file_key()
@@ -121,6 +122,7 @@ def export_as_wasm(
         code=file_manager.to_code(),
         asset_url=asset_url,
         show_code=show_code,
+        extra_script=extra_script,
     )
     return ExportResult(
         contents=result[0],

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -45,7 +45,6 @@ from marimo._server.session.serialize import (
 )
 from marimo._server.session.session_view import SessionView
 from marimo._server.templates.templates import (
-    inject_script,
     static_notebook_template,
     wasm_notebook_template,
 )
@@ -392,7 +391,8 @@ class Exporter:
         mode: Literal["edit", "run"],
         show_code: bool,
         asset_url: Optional[str] = None,
-        extra_script: Optional[str] = None,
+        extra_scripts: tuple[str, ...] = (),
+        show_save: bool = False,
     ) -> tuple[str, str]:
         """Export notebook as a WASM-powered standalone HTML file."""
         index_html = get_html_contents()
@@ -415,9 +415,9 @@ class Exporter:
             code=code,
             asset_url=asset_url,
             show_code=show_code,
+            extra_scripts=extra_scripts,
+            show_save=show_save,
         )
-        if extra_script is not None:
-            html = inject_script(html, extra_script)
 
         download_filename = get_download_filename(
             file_manager.filename, "wasm.html"

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -45,6 +45,7 @@ from marimo._server.session.serialize import (
 )
 from marimo._server.session.session_view import SessionView
 from marimo._server.templates.templates import (
+    inject_script,
     static_notebook_template,
     wasm_notebook_template,
 )
@@ -391,6 +392,7 @@ class Exporter:
         mode: Literal["edit", "run"],
         show_code: bool,
         asset_url: Optional[str] = None,
+        extra_script: Optional[str] = None,
     ) -> tuple[str, str]:
         """Export notebook as a WASM-powered standalone HTML file."""
         index_html = get_html_contents()
@@ -414,6 +416,8 @@ class Exporter:
             asset_url=asset_url,
             show_code=show_code,
         )
+        if extra_script is not None:
+            html = inject_script(html, extra_script)
 
         download_filename = get_download_filename(
             file_manager.filename, "wasm.html"

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -391,7 +391,6 @@ class Exporter:
         mode: Literal["edit", "run"],
         show_code: bool,
         asset_url: Optional[str] = None,
-        extra_scripts: tuple[str, ...] = (),
         show_save: bool = False,
     ) -> tuple[str, str]:
         """Export notebook as a WASM-powered standalone HTML file."""
@@ -415,7 +414,6 @@ class Exporter:
             code=code,
             asset_url=asset_url,
             show_code=show_code,
-            extra_scripts=extra_scripts,
             show_save=show_save,
         )
 

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -293,7 +293,6 @@ def wasm_notebook_template(
     code: str,
     show_code: bool,
     asset_url: Optional[str] = None,
-    extra_scripts: tuple[str, ...] = (),
     show_save: bool = False,
 ) -> str:
     """Template for WASM notebooks."""
@@ -382,13 +381,6 @@ def wasm_notebook_template(
         "</head>",
         f'<marimo-code hidden="">{uri_encode_component(code)}</marimo-code></head>',
     )
-
-    # Inject extra scripts as <script src="..."> tags before closing body
-    if extra_scripts:
-        script_tags = "\n".join(
-            [f'<script src="{url}"></script>' for url in extra_scripts]
-        )
-        body = body.replace("</body>", f"{script_tags}\n</body>")
 
     return body
 

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -293,6 +293,8 @@ def wasm_notebook_template(
     code: str,
     show_code: bool,
     asset_url: Optional[str] = None,
+    extra_scripts: tuple[str, ...] = (),
+    show_save: bool = False,
 ) -> str:
     """Template for WASM notebooks."""
     import re
@@ -341,7 +343,6 @@ def wasm_notebook_template(
     """
     body = body.replace("</head>", f"{warning_script}</head>")
 
-    # Hide save button in WASM mode
     wasm_styles = """
     <style>
         #save-button {
@@ -352,7 +353,9 @@ def wasm_notebook_template(
         }
     </style>
     """
-    body = body.replace("</head>", f"{wasm_styles}</head>")
+    # Hide save button in WASM mode unless explicitly requested to show
+    if not show_save:
+        body = body.replace("</head>", f"{wasm_styles}</head>")
 
     # If has custom css, inline the css and add to the head
     if app_config.css_file:
@@ -379,6 +382,13 @@ def wasm_notebook_template(
         "</head>",
         f'<marimo-code hidden="">{uri_encode_component(code)}</marimo-code></head>',
     )
+
+    # Inject extra scripts as <script src="..."> tags before closing body
+    if extra_scripts:
+        script_tags = "\n".join(
+            [f'<script src="{url}"></script>' for url in extra_scripts]
+        )
+        body = body.replace("</body>", f"{script_tags}\n</body>")
 
     return body
 

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -329,7 +329,7 @@ def wasm_notebook_template(
     )
 
     body = body.replace(
-        "</head>", '<marimo-wasm hidden=""></marimo-wasm></head>'
+        "</head>", '<marimo-wasm hidden=""></marimo-wasm>\n</head>'
     )
 
     warning_script = """
@@ -386,7 +386,7 @@ def wasm_notebook_template(
 def inject_script(html: str, script: str) -> str:
     """Inject a script into the HTML before the closing body tag."""
     script_tag = f"<script>{script}</script>"
-    return html.replace("</body>", f"{script_tag}</body>")
+    return html.replace("</body>", f"{script_tag}\n</body>")
 
 
 def _del_none_or_empty(d: Any) -> Any:


### PR DESCRIPTION
## 📝 Summary

in #5161 I introduced a method for setting a custom file store, which works, but using it seems very fragile.

The reason is that marimo uses vite to render the index.html template with content hashes baked into the assets. So when writing my own html, I was faced with the problem of including the right assets which will have a different file name for every minor change.

I have not found a way to load these assets in a maintainable way, so instead I've extended the WASM export to be usable directly.

## 🔍 Description of Changes

The python wasm export command has a new parameter `--extra-script` which is passed through several layers until it eventually injects an extra script tag at the end of the body. The idea is that you can pass a script file to modify and extend Marimo.

I have tested this with a dummy script, but tomorrow morning I'll port the PouchDB file handler over and confirm it works.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
