### PR TITLE
Create ipynb fixtures for `marimo convert` and snapshot outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,6 +330,7 @@ exclude = [
     "tests/_cli/ipynb_data",
     "tests/_runtime/runtime_data",
     "tests/_ast/test_app.py",
+    "tests/_convert/ipynb_data/*.ipynb",
     "frontend",
     "docs",
     "build",

--- a/scripts/generate_ipynb_fixtures.py
+++ b/scripts/generate_ipynb_fixtures.py
@@ -8,6 +8,19 @@
 # [tool.uv]
 # exclude-newer = "2025-06-03T16:30:20.082913-04:00"
 # ///
+"""
+Generate `.ipynb` test fixtures for marimo's notebook conversion pipeline.
+
+Each fixture corresponds to a named Jupyter notebook containing one or more code cells.
+To add a new fixture, call `create_notebook_fixture(name, sources)`:
+
+- `name`: the output filename (without `.ipynb`)
+- `sources`: a list of code cell contents (as strings or `nbformat` cell dicts)
+
+Run this script with `uv run scripts/generate_ipynb_fixtures.py` to regenerate all fixtures.
+Output notebooks are written to `tests/_convert/ipynb_data/`.
+"""
+
 from __future__ import annotations
 from io import FileIO
 from pathlib import Path
@@ -29,8 +42,13 @@ def create_notebook_fixture(name: str, sources: list[str | dict]) -> None:
             cell = source
         cells.append(cell)
 
+    notebook = nb.new_notebook(cells=cells)
+
+    for i, cell in enumerate(notebook.cells):
+        cell.id = str(i)  # ensure we always have 1,2,3,4
+
     (FIXTURES_DIR / f"{name}.ipynb").write_text(
-        jupytext.writes(nb.new_notebook(cells=cells), fmt="ipynb")
+        jupytext.writes(notebook, fmt="ipynb")
     )
 
 
@@ -53,165 +71,6 @@ for i_1 in range(X_1.shape[0]):
     for j in nearest_partition[i_1, :K + 1]:
         plt.plot(*zip(X_1[j], X_1[i_1]), color='black')\
 """,
-        ],
-    )
-    create_notebook_fixture(
-        "multiple_definitions_scope",
-        [
-            """K = 2\n
-def foo():
-    K
-    K = 1\
-""",
-            "K = 1",
-        ],
-    )
-    create_notebook_fixture(
-        "multiple_definitions_when_not_encapsulated",
-        [
-            "x = 1",
-            "print(x) # print",
-            "x = 2",
-            "print(x) # print",
-        ],
-    )
-    create_notebook_fixture(
-        "adds_marimo_import_for_momd",
-        [
-            "mo.md('# Hello')",
-            "print('World')",
-        ],
-    )
-    create_notebook_fixture(
-        "adds_marimo_import_for_mosql",
-        [
-            "mo.sql('SELECT * FROM table')",
-            "print('World')",
-        ],
-    )
-    create_notebook_fixture(
-        "keeps_existing_marimo_import",
-        [
-            "mo.sql('SELECT * FROM table')",
-            "print('World')",
-            "import marimo as mo",
-        ],
-    )
-    create_notebook_fixture(
-        "keeps_import_order_for_marimo_import",
-        [
-            "import antigravity; import marimo as mo",
-            "mo.md('# Hello')",
-        ],
-    )
-    create_notebook_fixture(
-        "keeps_existing_top_level_marimo_import",
-        [
-            "import marimo as mo",
-            "mo.md('# Hello')",
-            "print('World')",
-        ],
-    )
-    create_notebook_fixture(
-        "adds_marimo_import_if_commented_out",
-        [
-            "mo.md('# Hello')",
-            "# import marimo as mo",
-        ],
-    )
-    create_notebook_fixture(
-        "adds_marimo_import_if_within_definition",
-        [
-            "mo.md('# Hello')",
-            "def foo():\n    import marimo as mo",
-        ],
-    )
-    create_notebook_fixture(
-        "magic_commands",
-        [
-            "%%sql\nSELECT * FROM table",
-            "%%sql\nSELECT * \nFROM table",
-            "%cd /path/to/dir",
-            "%mkdir /path/to/dir",
-            "%matplotlib inline",
-            "\n".join(
-                [
-                    "%matplotlib inline",
-                    "import numpy as np",
-                    "import matplotlib.pyplot as plt"
-                    "plt.style.use('seaborn-whitegrid')",
-                ]
-            ),
-            "\n".join(
-                [
-                    "%matplotlib inline foo",
-                    "import numpy as np",
-                    "import matplotlib.pyplot as pl",
-                    "plt.style.use('seaborn-whitegrid')",
-                ]
-            ),
-        ],
-    )
-    create_notebook_fixture(
-        "shell_commands",
-        [
-            "!pip install package",
-            "!ls -l",
-        ],
-    )
-    create_notebook_fixture(
-        "duplicate_definitions",
-        [
-            "a = 1",
-            "print(a)",
-            "a = 2",
-            "print(a)",
-            "print(a)",
-            "a = 3",
-        ],
-    )
-    create_notebook_fixture(
-        "cell_metadata",
-        [
-            nb.new_code_cell(
-                "print('Hello')", metadata={"tags": ["tag1", "tag2"]}
-            ),
-            "print('World')",
-            nb.new_code_cell(
-                "print('Hello')", metadata={"tags": ["hide-cell"]}
-            ),
-        ],
-    )
-    create_notebook_fixture(
-        "removes_duplicate_imports",
-        [
-            # multi-line
-            "import numpy as np\nimport pandas as pd\nimport numpy as np",
-            "from sklearn.model_selection import train_test_split\nfrom sklearn.model_selection import cross_val_score",
-            "import matplotlib.pyplot as plt\nimport numpy as np",
-            # single line
-            "import polars as pl",
-            "import polars as pl",
-        ],
-    )
-    create_notebook_fixture(
-        "fake_marimo_imports",
-        [
-            "# mo.md('# Hello')",
-            "print('mo.sql is not a real call')",
-            "mo = 'not the real mo'",
-        ],
-    )
-    create_notebook_fixture(
-        "complex_multiple_definitions",
-        [
-            "x = 1\ny = 2\nprint(x, y)",
-            "x = 3\nz = 4\nprint(x, z)",
-            "y = 5\nprint(y)",
-            "def func():\n    x = 1\n    return x\nfunc()",
-            "def func():\n    y = 1\n    return y\nfunc()",
-            "xx = 2\nprint(xx)",
-            "def another_func():\n    xx = 3\n    return xx",
         ],
     )
 

--- a/scripts/generate_ipynb_fixtures.py
+++ b/scripts/generate_ipynb_fixtures.py
@@ -1,0 +1,220 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "jupytext",
+#     "nbformat",
+# ]
+#
+# [tool.uv]
+# exclude-newer = "2025-06-03T16:30:20.082913-04:00"
+# ///
+from __future__ import annotations
+from io import FileIO
+from pathlib import Path
+
+import nbformat.v4.nbbase as nb
+import jupytext
+
+
+SELF_DIR = Path(__file__).parent
+FIXTURES_DIR = SELF_DIR / "../tests/_convert/ipynb_data"
+
+
+def create_notebook_fixture(name: str, sources: list[str | dict]) -> None:
+    cells = []
+    for source in sources:
+        if isinstance(source, str):
+            cell = nb.new_code_cell(source)
+        else:
+            cell = source
+        cells.append(cell)
+
+    (FIXTURES_DIR / f"{name}.ipynb").write_text(
+        jupytext.writes(nb.new_notebook(cells=cells), fmt="ipynb")
+    )
+
+
+def main() -> None:
+    FIXTURES_DIR.mkdir(exist_ok=True)
+    create_notebook_fixture(
+        "multiple_definitions",
+        [
+            "x = 1\nprint(x) # print",
+            "x = 2\nprint(x) # print",
+        ],
+    )
+    create_notebook_fixture(
+        "multiple_definitions_multiline",
+        [
+            "K = 2\nnearest_partition = np.argpartition(dist_sq_1, K + 1, axis=1)",
+            """plt.scatter(X_1[:, 0], X_1[:, 1], s=100)
+K = 2
+for i_1 in range(X_1.shape[0]):
+    for j in nearest_partition[i_1, :K + 1]:
+        plt.plot(*zip(X_1[j], X_1[i_1]), color='black')\
+""",
+        ],
+    )
+    create_notebook_fixture(
+        "multiple_definitions_scope",
+        [
+            """K = 2\n
+def foo():
+    K
+    K = 1\
+""",
+            "K = 1",
+        ],
+    )
+    create_notebook_fixture(
+        "multiple_definitions_when_not_encapsulated",
+        [
+            "x = 1",
+            "print(x) # print",
+            "x = 2",
+            "print(x) # print",
+        ],
+    )
+    create_notebook_fixture(
+        "adds_marimo_import_for_momd",
+        [
+            "mo.md('# Hello')",
+            "print('World')",
+        ],
+    )
+    create_notebook_fixture(
+        "adds_marimo_import_for_mosql",
+        [
+            "mo.sql('SELECT * FROM table')",
+            "print('World')",
+        ],
+    )
+    create_notebook_fixture(
+        "keeps_existing_marimo_import",
+        [
+            "mo.sql('SELECT * FROM table')",
+            "print('World')",
+            "import marimo as mo",
+        ],
+    )
+    create_notebook_fixture(
+        "keeps_import_order_for_marimo_import",
+        [
+            "import antigravity; import marimo as mo",
+            "mo.md('# Hello')",
+        ],
+    )
+    create_notebook_fixture(
+        "keeps_existing_top_level_marimo_import",
+        [
+            "import marimo as mo",
+            "mo.md('# Hello')",
+            "print('World')",
+        ],
+    )
+    create_notebook_fixture(
+        "adds_marimo_import_if_commented_out",
+        [
+            "mo.md('# Hello')",
+            "# import marimo as mo",
+        ],
+    )
+    create_notebook_fixture(
+        "adds_marimo_import_if_within_definition",
+        [
+            "mo.md('# Hello')",
+            "def foo():\n    import marimo as mo",
+        ],
+    )
+    create_notebook_fixture(
+        "magic_commands",
+        [
+            "%%sql\nSELECT * FROM table",
+            "%%sql\nSELECT * \nFROM table",
+            "%cd /path/to/dir",
+            "%mkdir /path/to/dir",
+            "%matplotlib inline",
+            "\n".join(
+                [
+                    "%matplotlib inline",
+                    "import numpy as np",
+                    "import matplotlib.pyplot as plt"
+                    "plt.style.use('seaborn-whitegrid')",
+                ]
+            ),
+            "\n".join(
+                [
+                    "%matplotlib inline foo",
+                    "import numpy as np",
+                    "import matplotlib.pyplot as pl",
+                    "plt.style.use('seaborn-whitegrid')",
+                ]
+            ),
+        ],
+    )
+    create_notebook_fixture(
+        "shell_commands",
+        [
+            "!pip install package",
+            "!ls -l",
+        ],
+    )
+    create_notebook_fixture(
+        "duplicate_definitions",
+        [
+            "a = 1",
+            "print(a)",
+            "a = 2",
+            "print(a)",
+            "print(a)",
+            "a = 3",
+        ],
+    )
+    create_notebook_fixture(
+        "cell_metadata",
+        [
+            nb.new_code_cell(
+                "print('Hello')", metadata={"tags": ["tag1", "tag2"]}
+            ),
+            "print('World')",
+            nb.new_code_cell(
+                "print('Hello')", metadata={"tags": ["hide-cell"]}
+            ),
+        ],
+    )
+    create_notebook_fixture(
+        "removes_duplicate_imports",
+        [
+            # multi-line
+            "import numpy as np\nimport pandas as pd\nimport numpy as np",
+            "from sklearn.model_selection import train_test_split\nfrom sklearn.model_selection import cross_val_score",
+            "import matplotlib.pyplot as plt\nimport numpy as np",
+            # single line
+            "import polars as pl",
+            "import polars as pl",
+        ],
+    )
+    create_notebook_fixture(
+        "fake_marimo_imports",
+        [
+            "# mo.md('# Hello')",
+            "print('mo.sql is not a real call')",
+            "mo = 'not the real mo'",
+        ],
+    )
+    create_notebook_fixture(
+        "complex_multiple_definitions",
+        [
+            "x = 1\ny = 2\nprint(x, y)",
+            "x = 3\nz = 4\nprint(x, z)",
+            "y = 5\nprint(y)",
+            "def func():\n    x = 1\n    return x\nfunc()",
+            "def func():\n    y = 1\n    return y\nfunc()",
+            "xx = 2\nprint(xx)",
+            "def another_func():\n    xx = 3\n    return xx",
+        ],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_convert/ipynb_data/multiple_definitions.ipynb
+++ b/tests/_convert/ipynb_data/multiple_definitions.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 1\n",
+    "print(x) # print"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 2\n",
+    "print(x) # print"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/_convert/ipynb_data/multiple_definitions_multiline.ipynb
+++ b/tests/_convert/ipynb_data/multiple_definitions_multiline.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K = 2\n",
+    "nearest_partition = np.argpartition(dist_sq_1, K + 1, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(X_1[:, 0], X_1[:, 1], s=100)\n",
+    "K = 2\n",
+    "for i_1 in range(X_1.shape[0]):\n",
+    "    for j in nearest_partition[i_1, :K + 1]:\n",
+    "        plt.plot(*zip(X_1[j], X_1[i_1]), color='black')"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/_convert/snapshots/convert_multiple_definitions.py.txt
+++ b/tests/_convert/snapshots/convert_multiple_definitions.py.txt
@@ -1,0 +1,21 @@
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    _x = 1
+    print(_x)
+    return
+
+
+@app.cell
+def _():
+    _x = 2
+    print(_x)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_convert/snapshots/convert_multiple_definitions_multiline.py.txt
+++ b/tests/_convert/snapshots/convert_multiple_definitions_multiline.py.txt
@@ -1,0 +1,24 @@
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _(dist_sq_1, np):
+    _K = 2
+    nearest_partition = np.argpartition(dist_sq_1, _K + 1, axis=1)
+    return (nearest_partition,)
+
+
+@app.cell
+def _(X_1, nearest_partition, plt):
+    plt.scatter(X_1[:, 0], X_1[:, 1], s=100)
+    _K = 2
+    for i_1 in range(X_1.shape[0]):
+        for j in nearest_partition[i_1, :_K + 1]:
+            plt.plot(*zip(X_1[j], X_1[i_1]), color='black')
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_convert/test_convert_ipynb.py
+++ b/tests/_convert/test_convert_ipynb.py
@@ -1,0 +1,27 @@
+import pathlib
+import re
+
+import pytest
+
+from marimo._convert.converters import MarimoConvert
+from marimo._convert.ipynb import convert_from_ipynb_to_notebook_ir
+from tests.mocks import snapshotter
+
+SELF_DIR = pathlib.Path(__file__).parent
+snapshot_test = snapshotter(__file__)
+
+
+@pytest.mark.parametrize(
+    "ipynb_path", (SELF_DIR / "ipynb_data").glob("*.ipynb")
+)
+def test_marimo_convert_snapshots(ipynb_path: pathlib.Path) -> None:
+    """Test marimo convert against all notebook fixtures using snapshots."""
+    contents = ipynb_path.read_text()
+    ir = convert_from_ipynb_to_notebook_ir(contents)
+    converted = MarimoConvert.from_ir(ir).to_py()
+
+    converted = re.sub(r"__generated_with = .*\n", "", converted)
+    converted = re.sub(r"# requires-python = .*\n", "", converted)
+
+    snapshot_name = f"convert_{ipynb_path.name.replace('.ipynb', '.py.txt')}"
+    snapshot_test(snapshot_name, converted)


### PR DESCRIPTION
## 📝 Summary

This PR adds a script to generate `.ipynb` fixtures for testing `marimo convert`, along with a suite of notebooks and snapshot tests to validate conversion correctness.

For some of the more complex transformations related to combination of cell metadata + source code (e.g., hiding cells), I'd prefer to test using snapshotting instead of unit testing the individual transformations.

## 🔍 Description of Changes

- `uv run scripts/generate_ipynb_fixtures.py` creates a set of `.ipynb` files (in `tests/_convert/ipynb_data/`).
- `tests/_convert/test_convert_ipynb.py` iterates through these fixtures and snapshots the Python rendering of the converted marimo notebook IR.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
