### PR TITLE
chore(convert): Move `_transform_sources` tests to snapshot-based tests

### DIFF
--- a/scripts/generate_ipynb_fixtures.py
+++ b/scripts/generate_ipynb_fixtures.py
@@ -74,6 +74,34 @@ for i_1 in range(X_1.shape[0]):
         ],
     )
 
+    create_notebook_fixture(
+        "duplicate_definitions_and_aug_assign",
+        [
+            "x = 1",
+            "x",
+            "x += 1",
+            "x",
+        ],
+    )
+
+    create_notebook_fixture(
+        "duplicate_definitions_read_before_write",
+        [
+            "x = 1",
+            "x",
+            "x; x = 2; x",
+            "x",
+        ],
+    )
+
+    create_notebook_fixture(
+        "duplicate_definitions_syntax_error",
+        [
+            "x ( b 2 d & !",
+            "x",
+        ],
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/tests/_convert/ipynb_data/duplicate_definitions_and_aug_assign.ipynb
+++ b/tests/_convert/ipynb_data/duplicate_definitions_and_aug_assign.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/_convert/ipynb_data/duplicate_definitions_read_before_write.ipynb
+++ b/tests/_convert/ipynb_data/duplicate_definitions_read_before_write.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x; x = 2; x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/_convert/ipynb_data/duplicate_definitions_syntax_error.ipynb
+++ b/tests/_convert/ipynb_data/duplicate_definitions_syntax_error.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x ( b 2 d & !"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/_convert/snapshots/convert_duplicate_definitions_and_aug_assign.py.txt
+++ b/tests/_convert/snapshots/convert_duplicate_definitions_and_aug_assign.py.txt
@@ -1,0 +1,31 @@
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    x = 1
+    return (x,)
+
+
+@app.cell
+def _(x):
+    x
+    return
+
+
+@app.cell
+def _(x):
+    x_1 = x + 1
+    return (x_1,)
+
+
+@app.cell
+def _(x_1):
+    x_1
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_convert/snapshots/convert_duplicate_definitions_read_before_write.py.txt
+++ b/tests/_convert/snapshots/convert_duplicate_definitions_read_before_write.py.txt
@@ -1,0 +1,33 @@
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    x = 1
+    return (x,)
+
+
+@app.cell
+def _(x):
+    x
+    return
+
+
+@app.cell
+def _(x):
+    x
+    x_1 = 2
+    x_1
+    return (x_1,)
+
+
+@app.cell
+def _(x_1):
+    x_1
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_convert/snapshots/convert_duplicate_definitions_syntax_error.py.txt
+++ b/tests/_convert/snapshots/convert_duplicate_definitions_syntax_error.py.txt
@@ -1,0 +1,21 @@
+import marimo
+
+app = marimo.App()
+
+
+app._unparsable_cell(
+    r"""
+    x ( b 2 d & !
+    """,
+    name="_"
+)
+
+
+@app.cell
+def _(x):
+    x
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_convert/test_ipynb.py
+++ b/tests/_convert/test_ipynb.py
@@ -6,7 +6,6 @@ from textwrap import dedent
 import pytest
 
 from marimo._convert.ipynb import (
-    _transform_sources,
     transform_add_marimo_import,
     transform_cell_metadata,
     transform_duplicate_definitions,
@@ -929,64 +928,5 @@ def test_transform_duplicate_definitions_numbered():
             "df_2",
             "df_3 = 3",
             "df_3",
-        ],
-    )
-
-
-def test_transform_duplicate_definitions_and_aug_assign() -> None:
-    sources = dd(
-        [
-            "x = 1",
-            "x",
-            "x += 1",
-            "x",
-        ]
-    )
-    result = _transform_sources(sources, [{} for _ in sources])
-    assert_sources_equal(
-        result,
-        [
-            "x = 1",
-            "x",
-            "x_1 = x + 1",
-            "x_1",
-        ],
-    )
-
-
-def test_transform_duplicate_definitions_read_before_write() -> None:
-    sources = dd(
-        [
-            "x = 1",
-            "x",
-            "x; x = 2; x",
-            "x",
-        ]
-    )
-    result = _transform_sources(sources, [{} for _ in sources])
-    assert_sources_equal(
-        result,
-        [
-            "x = 1",
-            "x",
-            "x; x_1 = 2; x_1",
-            "x_1",
-        ],
-    )
-
-
-def test_transform_duplicate_definitions_syntax_error() -> None:
-    sources = dd(
-        [
-            "x ( b 2 d & !",
-            "x",
-        ]
-    )
-    result = _transform_sources(sources, [{} for _ in sources])
-    assert_sources_equal(
-        result,
-        [
-            "x ( b 2 d & !",
-            "x",
         ],
     )


### PR DESCRIPTION

## 📝 Summary

Follow up to #5179

These tests were exercising the full transformation pipeline, not individual transforms. This change converts them to snapshot tests (ipynb -> py) to better reflect the final output of `marimo convert` and guard against future changes to `_transform_sources` internals (e.g., as

## 🔍 Description of Changes

Move existing `_transform_sources` unit tests to snapshots.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@mscolnick
