### PR TITLE
feat: add persistent cache directory configuration and retrieval

### DIFF
--- a/docs/api/caching.md
+++ b/docs/api/caching.md
@@ -31,7 +31,9 @@ memory, letting you pick up where you left off.
 
 !!! tip "Cache location"
     By default, caches are stored in `__marimo__/cache/`, in the directory of the
-    current notebook. For projects versioned with `git`, consider adding
+    current notebook. You can set a global cache directory by adding
+    `persistent_cache_dir = "/your/cache/path"` to your marimo config file, or by setting the
+    environment variable `MARIMO_PERSISTENT_CACHE_DIR`. For projects versioned with `git`, consider adding
     `**/__marimo__/cache/` to your `.gitignore`.
 
 ::: marimo.persistent_cache

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -395,6 +395,7 @@ class MarimoConfig(TypedDict):
     experimental: NotRequired[dict[str, Any]]
     snippets: NotRequired[SnippetsConfig]
     datasources: NotRequired[DatasourcesConfig]
+    persistent_cache_dir: NotRequired[str]
 
 
 @mddoc
@@ -416,6 +417,7 @@ class PartialMarimoConfig(TypedDict, total=False):
     experimental: NotRequired[dict[str, Any]]
     snippets: SnippetsConfig
     datasources: NotRequired[DatasourcesConfig]
+    persistent_cache_dir: NotRequired[str]
 
 
 DEFAULT_CONFIG: MarimoConfig = {
@@ -469,6 +471,7 @@ DEFAULT_CONFIG: MarimoConfig = {
         "custom_paths": [],
         "include_default_snippets": True,
     },
+    "persistent_cache_dir": None,
 }
 
 

--- a/marimo/_save/stores/cache_config.py
+++ b/marimo/_save/stores/cache_config.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Marimo. All rights reserved.
+"""
+Config access for marimo persistent cache directory.
+"""
+import os
+from marimo._config.manager import get_default_config_manager
+
+def get_persistent_cache_dir() -> str | None:
+    # 1. Check environment variable
+    env = os.getenv("MARIMO_PERSISTENT_CACHE_DIR")
+    if env:
+        return env
+    # 2. Check config (user, project, script)
+    config_mgr = get_default_config_manager(current_path=None)
+    config = config_mgr.get_config()
+    # Allow both top-level and [runtime] for flexibility
+    if "persistent_cache_dir" in config:
+        return config["persistent_cache_dir"]
+    if "runtime" in config and "persistent_cache_dir" in config["runtime"]:
+        return config["runtime"]["persistent_cache_dir"]
+    return None

--- a/marimo/_save/stores/cache_config.py
+++ b/marimo/_save/stores/cache_config.py
@@ -2,8 +2,11 @@
 """
 Config access for marimo persistent cache directory.
 """
+
 import os
+
 from marimo._config.manager import get_default_config_manager
+
 
 def get_persistent_cache_dir() -> str | None:
     # 1. Check environment variable

--- a/marimo/_save/stores/file.py
+++ b/marimo/_save/stores/file.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 from marimo._runtime.runtime import notebook_dir
+from marimo._save.stores.cache_config import get_persistent_cache_dir
 from marimo._save.stores.store import Store
 
 
@@ -14,7 +15,9 @@ def _valid_path(path: Path) -> bool:
 
 class FileStore(Store):
     def __init__(self, save_path: Optional[str] = None) -> None:
-        self.save_path = Path(save_path or self._default_save_path())
+        # Use global config if no explicit save_path
+        cache_dir = save_path or get_persistent_cache_dir() or self._default_save_path()
+        self.save_path = Path(cache_dir)
         self._init_save_path()
 
     def _default_save_path(self) -> Path:

--- a/marimo/_save/stores/file.py
+++ b/marimo/_save/stores/file.py
@@ -16,7 +16,11 @@ def _valid_path(path: Path) -> bool:
 class FileStore(Store):
     def __init__(self, save_path: Optional[str] = None) -> None:
         # Use global config if no explicit save_path
-        cache_dir = save_path or get_persistent_cache_dir() or self._default_save_path()
+        cache_dir = (
+            save_path
+            or get_persistent_cache_dir()
+            or self._default_save_path()
+        )
         self.save_path = Path(cache_dir)
         self._init_save_path()
 


### PR DESCRIPTION
## 📝 Summary

Add support for global configuration of persistent cache directory. This gives users more control over where marimo stores cache data, allowing for sharing caches across multiple notebooks or keeping cache separate from project files.

## 🔍 Description of Changes

This PR adds functionality to configure a global persistent cache directory in marimo, which can be set through:

1. Environment variable: `MARIMO_PERSISTENT_CACHE_DIR`
2. Configuration file setting: `persistent_cache_dir = "/path/to/cache"`

The changes include:
- Adding a new configuration option (`persistent_cache_dir`) in marimo config schema
- Creating a new utility `cache_config.py` to centralize the logic for retrieving cache directory settings
- Updating the FileStore implementation to respect this configuration
- Documenting this feature in the caching.md documentation

This change enhances the flexibility of marimo's caching system by allowing users to:
- Share cached computations across multiple notebooks
- Store cache data in a different location from the project
- Configure project-wide cache settings for teams

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
Will add test later
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka @mscolnick
