### PR TITLE
feat: Skip undo delete toast for empty cells

### DIFF
--- a/frontend/src/components/editor/cell/useDeleteCell.tsx
+++ b/frontend/src/components/editor/cell/useDeleteCell.tsx
@@ -1,7 +1,11 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { UndoButton } from "@/components/buttons/undo-button";
 import { toast } from "@/components/ui/use-toast";
-import { hasOnlyOneCellAtom, useCellActions } from "@/core/cells/cells";
+import {
+  notebookAtom,
+  hasOnlyOneCellAtom,
+  useCellActions,
+} from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
 import { sendDeleteCell } from "@/core/network/requests";
 import { store } from "@/core/state/jotai";
@@ -17,25 +21,31 @@ export function useDeleteCellCallback() {
     }
 
     const { cellId } = opts;
+    const notebook = store.get(notebookAtom);
+    const isEmptyCell = (notebook.cellData[cellId]?.code ?? "").trim() === "";
+
     // Optimistic update
     deleteCell({ cellId });
     sendDeleteCell({ cellId: cellId }).catch(() => {
       // Fall back on failure
       undoDeleteCell();
     });
-    const { dismiss } = toast({
-      title: "Cell deleted",
-      description:
-        "You can bring it back by clicking undo or through the command palette.",
-      action: (
-        <UndoButton
-          data-testid="undo-delete-button"
-          onClick={() => {
-            undoDeleteCell();
-            dismiss();
-          }}
-        />
-      ),
-    });
+
+    if (!isEmptyCell) {
+      const { dismiss } = toast({
+        title: "Cell deleted",
+        description:
+          "You can bring it back by clicking undo or through the command palette.",
+        action: (
+          <UndoButton
+            data-testid="undo-delete-button"
+            onClick={() => {
+              undoDeleteCell();
+              dismiss();
+            }}
+          />
+        ),
+      });
+    }
   });
 }


### PR DESCRIPTION
Fixes #5055 

## 📝 Summary

Skip the "Undo delete" toast when deleting an empty cell.

In the future, we might want to make this configurable (e.g., a global setting to disable the toast entirely) but this seems like a safe and reasonable default.

I'm not totally sure how to test this, however. It seems like something that could go into `frontend/e2e-tests/cells.spec.ts`.


## 🔍 Description of Changes

Checks whether the deleted cell had any content before deciding to show the undo toast. If the cell is empty, we skip the toast.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka
