### PR TITLE
Default to `uv` package manager when launched from `uv`

### DIFF
--- a/marimo/_config/packages.py
+++ b/marimo/_config/packages.py
@@ -14,6 +14,11 @@ PackageManagerKind = Literal["pip", "rye", "uv", "poetry", "pixi"]
 def infer_package_manager() -> PackageManagerKind:
     """Infer the package manager from the current project."""
 
+    # `uv run` sets `UV` to the uv executable path
+    # https://github.com/astral-sh/uv/issues/8775
+    if os.environ.get("UV") is not None:
+        return "uv"
+
     try:
         # Get the project root by looking for common project files
         current_dir = Path.cwd()

--- a/tests/_config/test_config_packages.py
+++ b/tests/_config/test_config_packages.py
@@ -78,6 +78,8 @@ TEST_CASES: list[
     ({"pixi.toml": ""}, {}, {}, "pixi"),
     # Test fallback to pip
     ({}, {}, {}, "pip"),
+    # Test fallback to uv when running inside `uv run` / `uvx`
+    ({}, {"UV": "/usr/bin/uv"}, {}, "uv"),
 ]
 
 if sys.platform != "win32":


### PR DESCRIPTION
## 📝 Summary

Fixes #5185. Changes the default package manager to `uv` when marimo is launched from `uv` executable (e.g., `uv run marimo` in a project, or `uvx marimo`). Expect behavior with this PR (without setting a package manager):


```py
# prefers uv when launched from uv
uv init foo && cd foo
uv add marimo
uv run marimo edit test.py

# prefers pip when inside the environment
source .venv/bin/activate
marimo edit test.py
```

```py
# prefers uv when run with `uvx`
uvx marimo
```

We could probably try to be smarter in the case above where it defaults to `pip` (since `uv` environments don't have `pip` installed), but I think this is the safest and has the nice property of the `uvx marimo` for the first time use case preferring uv.

## 🔍 Description of Changes

`uv run` and `uv tool run` (aka `uvx`) sets `UV` to the `uv` executable path (https://github.com/astral-sh/uv/pull/11326), which we inspect to infer the preferred default package. 

I think it's probably most safe to infer the "preferred" package manager is `uv` when running from inside uv, so this bypasses the `pyproject.toml` inspection.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka
