### PR TITLE
Use upstream signature formatting code for pylsp

### DIFF
--- a/frontend/src/core/codemirror/language/languages/python.ts
+++ b/frontend/src/core/codemirror/language/languages/python.ts
@@ -125,8 +125,8 @@ const lspClient = once((lspConfig: LSPConfig) => {
         },
         signature: {
           formatter: config?.enable_ruff ? "ruff" : "black",
-          line_length: 88
-        }
+          line_length: 88,
+        },
       },
     },
   };

--- a/frontend/src/core/codemirror/language/languages/python.ts
+++ b/frontend/src/core/codemirror/language/languages/python.ts
@@ -123,6 +123,10 @@ const lspClient = once((lspConfig: LSPConfig) => {
             ...ignoredRuffRules,
           ],
         },
+        signature: {
+          formatter: config?.enable_ruff ? "ruff" : "black",
+          line_length: 88
+        }
       },
     },
   };

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -14,8 +14,6 @@ from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.ops import Alert
 from marimo._server.utils import find_free_port
 from marimo._tracer import server_tracer
-from marimo._types.ids import CellId_t
-from marimo._utils.formatter import DefaultFormatter, FormatError
 from marimo._utils.paths import marimo_package_path
 
 LOGGER = _loggers.marimo_logger()
@@ -302,26 +300,3 @@ def any_lsp_server_running(config: MarimoConfig) -> bool:
     )
     return (copilot_enabled is not False) or language_servers_enabled
 
-
-if DependencyManager.pylsp.has():
-    from pylsp import hookimpl
-
-    formatter = DefaultFormatter(line_length=88)
-
-    def format_signature(signature: str) -> str:
-        try:
-            signature_as_func = f"def {signature.strip()}:\n    pass"
-            dummy_cell_id = cast(CellId_t, "")
-            reformatted = formatter.format({dummy_cell_id: signature_as_func})[
-                dummy_cell_id
-            ]
-            signature = reformatted.removeprefix("def ").removesuffix(
-                ":\n    pass"
-            )
-        except (ModuleNotFoundError, FormatError):
-            pass
-        return "```python\n" + signature + "\n```\n"
-
-    @hookimpl
-    def pylsp_signatures_to_markdown(signatures: list[str]) -> str:
-        return format_signature("\n".join(signatures))

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -299,4 +299,3 @@ def any_lsp_server_running(config: MarimoConfig) -> bool:
         for server in language_servers.values()
     )
     return (copilot_enabled is not False) or language_servers_enabled
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,6 @@ homepage = "https://github.com/marimo-team/marimo"
 [project.entry-points."docstring_to_markdown"]
 marimo_converter = "marimo._utils.docs:MarimoConverter"
 
-[project.entry-points."pylsp"]
-marimo_plugin = "marimo._server.lsp"
-
 [project.optional-dependencies]
 sql = [
     "duckdb>=1.0.0",
@@ -117,7 +114,7 @@ dev = [
 ]
 
 lsp = [
-    "python-lsp-server>=1.10.0",
+    "python-lsp-server>=1.13.0",
     "python-lsp-ruff>=2.0.0",
 ]
 
@@ -195,7 +192,6 @@ dependencies = [
     "sqlglot>=23.4",
     "sqlalchemy>=2.0.40",
     "loro>=1.5.0",
-    "python-lsp-server>=1.12.1",
     "pandas-stubs>=1.5.3.230321",
     "pyiceberg>=0.9.0",
     "litellm>=1.70.0",
@@ -484,11 +480,6 @@ exclude = [
     'marimo/_smoke_tests/',
 ]
 warn_unused_ignores = false
-
-[[tool.mypy.overrides]]
-module = "pylsp"
-# until https://github.com/python-lsp/python-lsp-server/pull/641 is released
-follow_untyped_imports = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
## 📝 Summary

This is a follow-up to #4864 since the signature-formatting capability was incorporated directly into `python-lsp-server`

## 🔍 Description of Changes

Removed custom plugin and typechecking dependency on `python-lsp-server`, added configuration to prefer `ruff` if enabled over `black` (default in `python-lsp-server`).

This should remain in draft pending a new release of `python-lsp-server`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

mscolnick
