### PR TITLE
Discover `uv` executable with `UV` environment variable

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -20,6 +20,7 @@ from marimo._utils.inline_script_metadata import (
     PyProjectReader,
     is_marimo_dependency,
 )
+from marimo._utils.uv import find_uv_bin
 from marimo._utils.versions import is_editable
 
 LOGGER = _loggers.marimo_logger()
@@ -132,7 +133,7 @@ def _uv_export_script_requirements_txt(
 
     result = subprocess.run(
         [
-            "uv",
+            find_uv_bin(),
             "export",
             "--no-hashes",
             "--no-annotate",
@@ -246,7 +247,7 @@ def construct_uv_command(
         else PyProjectReader({}, config_path=None)
     )
 
-    uv_cmd = ["uv", "run"]
+    uv_cmd = [find_uv_bin(), "run"]
     with tempfile.NamedTemporaryFile(
         mode="w", delete=False, suffix=".txt", encoding="utf-8"
     ) as temp_file:
@@ -271,8 +272,10 @@ def run_in_sandbox(
     additional_features: Optional[list[DepFeatures]] = None,
     additional_deps: Optional[list[str]] = None,
 ) -> int:
-    if not DependencyManager.which("uv"):
+    # If we fall back to the plain "uv" path, ensure it's actually on the system
+    if find_uv_bin() == "uv" and not DependencyManager.which("uv"):
         raise click.UsageError("uv must be installed to use --sandbox")
+
     uv_cmd = construct_uv_command(
         args, name, additional_features or [], additional_deps or []
     )

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -20,6 +20,7 @@ from marimo._runtime.packages.package_manager import (
 )
 from marimo._runtime.packages.utils import split_packages
 from marimo._utils.platform import is_pyodide
+from marimo._utils.uv import find_uv_bin
 
 PY_EXE = sys.executable
 
@@ -135,14 +136,18 @@ class UvPackageManager(PypiPackageManager):
     name = "uv"
     docs_url = "https://docs.astral.sh/uv/"
 
+    @cached_property
+    def _uv_bin(self) -> str:
+        return find_uv_bin()
+
     async def _install(self, package: str, *, upgrade: bool) -> bool:
         install_cmd: list[str]
         if self.is_in_uv_project:
             LOGGER.info(f"Installing in {package} with 'uv add'")
-            install_cmd = ["uv", "add"]
+            install_cmd = [self._uv_bin, "add"]
         else:
             LOGGER.info(f"Installing in {package} with 'uv pip install'")
-            install_cmd = ["uv", "pip", "install"]
+            install_cmd = [self._uv_bin, "pip", "install"]
 
         if upgrade:
             install_cmd.append("--upgrade")
@@ -291,14 +296,14 @@ class UvPackageManager(PypiPackageManager):
         upgrade: bool,
     ) -> None:
         if packages_to_add:
-            cmd = ["uv", "--quiet", "add", "--script", filepath]
+            cmd = [self._uv_bin, "--quiet", "add", "--script", filepath]
             if upgrade:
                 cmd.append("--upgrade")
             cmd.extend(packages_to_add)
             self.run(cmd)
         if packages_to_remove:
             self.run(
-                ["uv", "--quiet", "remove", "--script", filepath]
+                [self._uv_bin, "--quiet", "remove", "--script", filepath]
                 + packages_to_remove
             )
 
@@ -352,10 +357,10 @@ class UvPackageManager(PypiPackageManager):
         uninstall_cmd: list[str]
         if self.is_in_uv_project:
             LOGGER.info(f"Uninstalling {package} with 'uv remove'")
-            uninstall_cmd = ["uv", "remove"]
+            uninstall_cmd = [self._uv_bin, "remove"]
         else:
             LOGGER.info(f"Uninstalling {package} with 'uv pip uninstall'")
-            uninstall_cmd = ["uv", "pip", "uninstall"]
+            uninstall_cmd = [self._uv_bin, "pip", "uninstall"]
 
         return self.run(
             uninstall_cmd + [*split_packages(package), "-p", PY_EXE]
@@ -363,7 +368,7 @@ class UvPackageManager(PypiPackageManager):
 
     def list_packages(self) -> list[PackageDescription]:
         LOGGER.info("Listing packages with 'uv pip list'")
-        cmd = ["uv", "pip", "list", "--format=json", "-p", PY_EXE]
+        cmd = [self._uv_bin, "pip", "list", "--format=json", "-p", PY_EXE]
         return self._list_packages_from_cmd(cmd)
 
 

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -140,6 +140,9 @@ class UvPackageManager(PypiPackageManager):
     def _uv_bin(self) -> str:
         return find_uv_bin()
 
+    def is_manager_installed(self) -> bool:
+        return self._uv_bin != "uv" or super().is_manager_installed()
+
     async def _install(self, package: str, *, upgrade: bool) -> bool:
         install_cmd: list[str]
         if self.is_in_uv_project:

--- a/marimo/_utils/uv.py
+++ b/marimo/_utils/uv.py
@@ -1,0 +1,6 @@
+import os
+
+
+# Could be replaced with `find_uv_bin` from uv Python package in the future
+def find_uv_bin() -> str:
+    return os.environ.get("UV", "uv")

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -382,7 +382,7 @@ class TestExportHTML:
         output = p.stderr.decode()
         # Check for sandbox message
         assert "Running in a sandbox" in output
-        assert "uv run --isolated" in output
+        assert "run --isolated" in output
         html = normalize_index_html(output)
         # Remove folder path
         dirname = path.dirname(temp_marimo_file)
@@ -921,7 +921,7 @@ class TestExportIpynb:
         output = p.stderr.decode()
         # Check for sandbox message
         assert "Running in a sandbox" in output
-        assert "uv run --isolated" in output
+        assert "run --isolated" in output
 
     @staticmethod
     @pytest.mark.skipif(


### PR DESCRIPTION
## 📝 Summary

Use the `UV` environment variable set by uv to resolve the binary path, rather than assuming "uv" is available on the system path.

## 🔍 Description of Changes

This PR replaces hardcoded "uv" subprocess calls with a utility function `find_uv_bin()`, which checks the `UV` environment variable. When a process is launched via `uv`, it sets `UV` to the executable path of the binary. The naming is taken from [`uv` python package](https://github.com/astral-sh/uv/blob/0109af1aa510bd4f0759b0d53d842c3716e5cc3f/python/uv/_find_uv.py#L8), which we could replace in the future.

For sandboxing, in cases where `find_uv_bin()` returns the unresolved string "uv" (i.e. `UV` isn't set), we still explicitly check that it's available in the system path before proceeding.
