### PR TITLE
fix: Skip PEP 723 check on directories

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -34,6 +34,9 @@ def maybe_prompt_run_in_sandbox(name: str | None) -> bool:
     if name is None:
         return False
 
+    if Path(name).is_dir():
+        return False
+
     pyproject = PyProjectReader.from_filename(name)
     if not pyproject.dependencies:
         return False


### PR DESCRIPTION
Fixes #4999

I think there could be an opportunity to try to read from `pyproject.toml` ourselves... but honestly I'd rather defer to recommending users use `uv` to bootstrap the environment in that case.

Their project discovery is very robust, and it would ensure alignment. For example:


```py
uv init my_project && cd my_project
uv add polars duckdb
uv run --with=marimo marimo . # will have polars and duckdb installed

mkdir notebooks
cd notebooks
uv run --with=marimo marimo . # will also have polars and duckdb installed
```
