### PR TITLE
fix: add reasoning config only if is reasoning model

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -259,6 +259,14 @@ class OpenAIProvider(
         "ChatCompletionChunk", "OpenAiStream[ChatCompletionChunk]"
     ]
 ):
+    # Medium effort provides a balance between speed and accuracy
+    # https://openai.com/index/openai-o3-mini/
+    DEFAULT_REASONING_EFFORT = "medium"
+
+    def is_reasoning_model(self, model: str) -> bool:
+        # only o-series models support reasoning
+        return model.startswith("o")
+
     def get_client(self, config: AnyProviderConfig) -> OpenAI:
         DependencyManager.openai.require(why="for AI assistance with OpenAI")
 
@@ -357,9 +365,9 @@ class OpenAIProvider(
         max_tokens: int,
     ) -> OpenAiStream[ChatCompletionChunk]:
         client = self.get_client(self.config)
-        return client.chat.completions.create(
-            model=self.model,
-            messages=cast(
+        create_params = {
+            "model": self.model,
+            "messages": cast(
                 Any,
                 convert_to_openai_messages(
                     self._maybe_convert_roles(
@@ -368,10 +376,13 @@ class OpenAIProvider(
                     + messages
                 ),
             ),
-            max_completion_tokens=max_tokens,
-            stream=True,
-            timeout=15,
-        )
+            "max_completion_tokens": max_tokens,
+            "stream": True,
+            "timeout": 15,
+        }
+        if self.is_reasoning_model(self.model):
+            create_params["reasoning_effort"] = self.DEFAULT_REASONING_EFFORT
+        return client.chat.completions.create(**create_params)
 
     def extract_content(
         self, response: ChatCompletionChunk
@@ -452,21 +463,23 @@ class AnthropicProvider(
         max_tokens: int,
     ) -> AnthropicStream[RawMessageStreamEvent]:
         client = self.get_client(self.config)
-        return client.messages.create(
-            model=self.model,
-            max_tokens=max_tokens,
-            messages=cast(
+        create_params = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "messages": cast(
                 Any,
                 convert_to_anthropic_messages(messages),
             ),
-            system=system_prompt,
-            stream=True,
-            temperature=self.get_temperature(),
-            thinking={
+            "system": system_prompt,
+            "stream": True,
+            "temperature": self.get_temperature(),
+        }
+        if self.is_extended_thinking_model(self.model):
+            create_params["thinking"] = {
                 "type": "enabled",
                 "budget_tokens": self.DEFAULT_EXTENDED_THINKING_BUDGET_TOKENS,
-            },
-        )
+            }
+        return client.messages.create(**create_params)
 
     def extract_content(
         self, response: RawMessageStreamEvent


### PR DESCRIPTION

## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Updated openai and anthropic to only include the reasoning config if using a reasoning model, because it throws errors with non-reasoning models.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Added reasoning_effort, DEFAULT_REASONING_EFFORT, and is_reasoning_model for openai
- Decoupled create_params from the .create() method of openai and anthropic
- Only added in reasoning or thinking related config if model is reasoning or thinking, otherwise dont add it at all (I tried just passing in None or other null types but it kept throwing errors for non-reasoning models)

_Note: Openai does not send back reasoning tokens for streaming but adding medium to the reasoning_effort does improve the output_

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
