### PR TITLE
fix: disable charts for > max_rows without vegafusion

### DIFF
--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -24,7 +24,6 @@ import { useAsyncData } from "@/hooks/useAsyncData";
 import {
   AddDataframeChart,
   renderChart,
-  renderChartMaxRowsWarning,
   renderPreviewError,
   renderStats,
 } from "@/components/datasources/column-preview";
@@ -179,7 +178,6 @@ const ColumnPreview = ({
   const {
     chart_spec,
     chart_code,
-    chart_max_rows_errors,
     error: previewError,
     missing_packages,
     stats,
@@ -196,14 +194,10 @@ const ColumnPreview = ({
     <AddDataframeChart chartCode={chart_code} />
   );
 
-  const chartMaxRowsWarning =
-    chart_max_rows_errors && renderChartMaxRowsWarning();
-
   return (
     <ColumnPreviewContainer className="px-2 py-1">
       {errorState}
       {addDataframeChart}
-      {chartMaxRowsWarning}
       {chart}
       {previewStats}
     </ColumnPreviewContainer>

--- a/frontend/src/components/datasources/column-preview.tsx
+++ b/frontend/src/components/datasources/column-preview.tsx
@@ -118,10 +118,7 @@ export const DatasetColumnPreview: React.FC<{
     </Tooltip>
   );
 
-  const chartMaxRowsWarning =
-    preview.chart_max_rows_errors && renderChartMaxRowsWarning();
-
-  if (!error && !stats && !chart && !chartMaxRowsWarning) {
+  if (!error && !stats && !chart) {
     return <span className="text-xs text-muted-foreground">No data</span>;
   }
 
@@ -130,7 +127,6 @@ export const DatasetColumnPreview: React.FC<{
       {error}
       {addDataframeChart}
       {addSQLChart}
-      {chartMaxRowsWarning}
       {chart}
       {stats}
     </ColumnPreviewContainer>
@@ -142,9 +138,11 @@ export function renderPreviewError(
   missing_packages?: string[] | null,
 ) {
   return (
-    <div className="text-xs text-muted-foreground p-2 border border-muted rounded flex items-center">
+    <div className="text-xs text-muted-foreground p-2 border border-muted rounded flex items-center justify-between">
       <span>{error}</span>
-      {missing_packages && <InstallPackageButton packages={missing_packages} />}
+      {missing_packages && (
+        <InstallPackageButton packages={missing_packages} className="h-8" />
+      )}
     </div>
   );
 }
@@ -176,14 +174,6 @@ export function renderStats(
         );
       })}
     </div>
-  );
-}
-
-export function renderChartMaxRowsWarning() {
-  return (
-    <span className="text-xs text-muted-foreground">
-      Too many rows to render the chart.
-    </span>
   );
 }
 

--- a/frontend/src/components/datasources/install-package-button.tsx
+++ b/frontend/src/components/datasources/install-package-button.tsx
@@ -4,9 +4,11 @@ import { Button } from "@/components/ui/button";
 import { useChromeActions } from "@/components/editor/chrome/state";
 import { packagesToInstallAtom } from "@/components/editor/chrome/panels/packages-state";
 import { useSetAtom } from "jotai";
+import { cn } from "@/utils/cn";
 
 interface InstallPackageButtonProps {
   packages: string[] | undefined;
+  className?: string;
 }
 
 /**
@@ -15,6 +17,7 @@ interface InstallPackageButtonProps {
  */
 export const InstallPackageButton: React.FC<InstallPackageButtonProps> = ({
   packages,
+  className,
 }) => {
   const chromeActions = useChromeActions();
   const setPackagesToInstall = useSetAtom(packagesToInstallAtom);
@@ -30,11 +33,16 @@ export const InstallPackageButton: React.FC<InstallPackageButtonProps> = ({
     setPackagesToInstall(packagesString);
 
     // Open the packages panel
-    chromeActions.toggleApplication("packages");
+    chromeActions.openApplication("packages");
   };
 
   return (
-    <Button variant="outline" size="xs" onClick={handleClick} className="ml-2">
+    <Button
+      variant="outline"
+      size="xs"
+      onClick={handleClick}
+      className={cn("ml-2", className)}
+    >
       Install {packages.join(", ")}
     </Button>
   );

--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -187,13 +187,20 @@ const InstallPackageForm: React.FC<{
   const handleAddPackage = async () => {
     try {
       setLoading(true);
-      const response = await addPackage({ package: input });
-      if (response.success) {
-        onSuccess();
-        showAddPackageToast(input);
-      } else {
-        showAddPackageToast(input, response.error);
+      const packages = input.split(",").map((p) => p.trim());
+      for (const [idx, packageName] of packages.entries()) {
+        const response = await addPackage({ package: packageName });
+        if (response.success) {
+          showAddPackageToast(packageName);
+        } else {
+          showAddPackageToast(packageName, response.error);
+        }
+        // Wait 1s if there are more packages to install
+        if (idx < packages.length - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
       }
+      onSuccess();
     } finally {
       setInput("");
       setLoading(false);

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -126,12 +126,13 @@ export const SearchInput = React.forwardRef<
     },
     ref,
   ) => {
-    const id = React.useId();
+    const uniqueId = React.useId();
+    const inputId = props.id || uniqueId;
     return (
       <div className={cn("flex items-center border-b px-3", rootClassName)}>
         {icon}
         <input
-          id={id}
+          id={inputId}
           ref={ref}
           className={cn(
             "placeholder:text-foreground-muted flex h-7 m-1 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50",
@@ -144,7 +145,7 @@ export const SearchInput = React.forwardRef<
             onPointerDown={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              const input = document.getElementById(id);
+              const input = document.getElementById(inputId);
               if (input && input instanceof HTMLInputElement) {
                 input.focus();
                 input.value = "";
@@ -157,7 +158,7 @@ export const SearchInput = React.forwardRef<
               }
             }}
           >
-            <XIcon className="h-4 w-4 opacity-50 hover:opacity-90" />
+            <XIcon className="h-4 w-4 opacity-50 hover:opacity-90 cursor-pointer" />
           </span>
         )}
       </div>

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -94,7 +94,6 @@ export type CalculateTopKRows = <T>(req: {
 
 export type PreviewColumn = (opts: { column: string }) => Promise<{
   chart_spec: string | null;
-  chart_max_rows_errors: boolean;
   chart_code: string | null;
   error: string | null;
   missing_packages: string[] | null;
@@ -283,7 +282,6 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
     preview_column: rpc.input(z.object({ column: z.string() })).output(
       z.object({
         chart_spec: z.string().nullable(),
-        chart_max_rows_errors: z.boolean(),
         chart_code: z.string().nullable(),
         error: z.string().nullable(),
         missing_packages: z.array(z.string()).nullable(),

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -621,7 +621,6 @@ class SQLTableListPreview(Op):
 @dataclass
 class ColumnPreview:
     chart_spec: Optional[str] = None
-    chart_max_rows_errors: bool = False
     chart_code: Optional[str] = None
     error: Optional[str] = None
     missing_packages: Optional[list[str]] = None

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -409,8 +409,6 @@ components:
         chart_code:
           nullable: true
           type: string
-        chart_max_rows_errors:
-          type: boolean
         chart_spec:
           nullable: true
           type: string
@@ -434,7 +432,6 @@ components:
         table_name:
           type: string
       required:
-      - chart_max_rows_errors
       - table_name
       - column_name
       - name

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2620,7 +2620,6 @@ export interface components {
     };
     DataColumnPreview: {
       chart_code?: string | null;
-      chart_max_rows_errors: boolean;
       chart_spec?: string | null;
       column_name: string;
       error?: string | null;

--- a/tests/_data/test_preview_column.py
+++ b/tests/_data/test_preview_column.py
@@ -467,8 +467,10 @@ def test_get_column_preview_for_duckdb_over_limit() -> None:
 
     assert result is not None
     assert result.stats is not None
-    assert result.error is None
-    assert result.chart_max_rows_errors is True
+    assert (
+        result.error == "Too many rows, vegafusion required to render charts"
+    )
+    assert result.missing_packages == ["vegafusion", "vl_convert_python"]
     assert result.chart_spec is None
 
     # Not implemented yet


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
- Suggest installation of vegafusion when num of rows > 20k for charts
- Fix some styling and package installation issues
- Remove chart_max_rows_error in API since we can use the error field + missing packages

![image](https://github.com/user-attachments/assets/a7e7b624-4595-4203-a16c-f9441b045ff5)


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
