### PR TITLE
ci(chore): properly delineate `dependency-groups` per PEP 735

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ check-prereqs:
 # 🐍 Install Python dependencies in editable mode
 py:
 	@command -v uv >/dev/null 2>&1 || { echo "uv is required. See https://docs.astral.sh/uv/getting-started/installation/"; exit 1; }
-	uv pip install -e ".[dev]"
+	uv sync
 
 ######################
 # Development Tasks #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,12 @@ recommended = [
     "nbformat>=5.7.0",          # Export as IPYNB
 ]
 
+lsp = [
+    "python-lsp-server>=1.10.0",
+    "python-lsp-ruff>=2.0.0",
+]
+
+[dependency-groups]
 dev = [
     "click>=8.0,<9",
     "black~=23.12.1",
@@ -115,12 +121,6 @@ dev = [
     # For AI
     "openai>=1.55.3",
 ]
-
-lsp = [
-    "python-lsp-server>=1.10.0",
-    "python-lsp-ruff>=2.0.0",
-]
-
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.5.49",


### PR DESCRIPTION
## 📝 Summary

Astral has a [pretty good description](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups) of the difference between "optional dependencies" and "dependency groups" (and the deprecated `dev-dependencies`).

## 🔍 Description of Changes

Just moved `dev` deps and `doc` deps.  left `lsp` since it could have some runtime dependees.

I would imagine the invocation of the docs build will need to be adjusted in its own repo, will look into that for follow-up.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick OR @dmadisetti 
