### PR TITLE
feat: Render mermaid-based (optimized) query plan for `pl.LazyFrame`

### DIFF
--- a/marimo/_output/formatters/df_formatters.py
+++ b/marimo/_output/formatters/df_formatters.py
@@ -118,7 +118,6 @@ class PolarsFormatter(FormatterFactory):
         ) -> tuple[KnownMimeType, str]:
             return tabs.tabs(
                 {
-                    "Table": table.lazy(df),
                     # NB(Trevor): Use `optimized=True` to match other methods' defaults (`show_graph`, `collect`).
                     # The _repr_html_ uses `optimized=False`, but "cost" is probably minimal and this is more
                     # accurate/opinionated default.
@@ -126,6 +125,7 @@ class PolarsFormatter(FormatterFactory):
                     "Query plan": mermaid(
                         polars_dot_to_mermaid(df._ldf.to_dot(optimized=True))
                     ),
+                    "Table": table.lazy(df),
                 }
             )._mime_()
 


### PR DESCRIPTION
Replaces markdown/text-based *repr_html* with mermaid-based diagram. The main difference is that we display the optimized query plan, rather than prompting the user to call `show_graph(optimized=True)` or `explain(optimized=True)`, where `optimized` is already the default (like `collect()`). I think it's a more accurate/opinionated default.

![image](https://uploads.linear.app/63f65126-890b-4810-98cb-b7f8eaee40ee/e6f5e9ac-83fa-4126-9e96-3f31e11ed298/8fecdc4b-acd4-453d-acf6-f1d901c63bd8?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzYzZjY1MTI2LTg5MGItNDgxMC05OGNiLWI3ZjhlYWVlNDBlZS9lNmY1ZTlhYy04M2ZhLTQxMjYtOWU5Ni0zZjMxZTExZWQyOTgvOGZlY2RjNGItYWNkNC00NTNkLWFjZjYtZjFkOTAxYzYzYmQ4IiwiaWF0IjoxNzg1NTE1Njk4LCJleHAiOjE4MTcwODYyNTh9.h73QNbzTwF-4hNGYBXxcgVBqv-SgbWk5P9ttNWNYnSA)

Closes marimo-team/marimo#3355