### PR TITLE
feat: add MarkdownRenderer to ReasoningAccordion

### DIFF
--- a/frontend/src/components/chat/reasoning-accordion.tsx
+++ b/frontend/src/components/chat/reasoning-accordion.tsx
@@ -7,7 +7,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { MarkdownRenderer } from "./markdown-renderer";
 
 interface ReasoningAccordionProps {
   reasoning: string;
@@ -37,11 +37,11 @@ export const ReasoningAccordion: React.FC<ReasoningAccordionProps> = ({
           </span>
         </AccordionTrigger>
         <AccordionContent className="pb-2 px-2">
-          <ScrollArea className="max-h-[200px] w-full">
-            <div className="bg-muted/30 border border-muted rounded-md p-3 text-xs font-mono whitespace-pre-wrap text-muted-foreground">
-              {reasoning}
+          <div className="bg-muted/30 border border-muted/50 rounded-md p-3 italic text-muted-foreground/90 relative">
+            <div className="pr-6">
+              <MarkdownRenderer content={reasoning} />
             </div>
-          </ScrollArea>
+          </div>
         </AccordionContent>
       </AccordionItem>
     </Accordion>


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Added markdown rendering inside the ReasoningAccordion because both GoogleProvider and AnthropicProvider return thinking tokens as markdown.

<img width="432" alt="Screenshot 2025-06-09 at 11 10 20 PM" src="https://github.com/user-attachments/assets/cba263b5-9784-4e74-be9f-b1c263158c45" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

- Added MarkdownRenderer to reasoning text inside ReasoningAccordion
- Removed scroll area so that when expanded you see the full thoughts
- Made text italic and muted to differentiate the style of thoughts from the style of responses

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
