### PR TITLE
chore: add defaults to table args

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -214,14 +214,14 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
         )
         .nullish(),
       totalColumns: z.number(),
-      maxColumns: z.union([z.number(), z.literal("all")]),
+      maxColumns: z.union([z.number(), z.literal("all")]).default("all"),
       hasStableRowId: z.boolean().default(false),
       cellStyles: z.record(z.record(z.object({}).passthrough())).optional(),
       // Whether to load the data lazily.
-      lazy: z.boolean(),
+      lazy: z.boolean().default(false),
       // If lazy, this will preload the first page of data
       // without user confirmation.
-      preload: z.boolean(),
+      preload: z.boolean().default(false),
     }),
   )
   .withFunctions<DataTableFunctions>({


### PR DESCRIPTION
Not sure why this shows up in the playground, but providing defaults as a fallback should fix it