### PR TITLE
Make async data states impossible to misrepresent in `useAsyncData`

### DIFF
--- a/frontend/src/components/app-config/optional-features.tsx
+++ b/frontend/src/components/app-config/optional-features.tsx
@@ -101,12 +101,12 @@ if (!isWasm()) {
 export const OptionalFeatures: React.FC = () => {
   const [config] = useResolvedMarimoConfig();
   const packageManager = config.package_management.manager;
-  const { data, loading, error, reload } = useAsyncData(
+  const { data, error, refetch, isPending } = useAsyncData(
     () => getPackageList(),
     [packageManager],
   );
 
-  if (loading && !data) {
+  if (isPending) {
     return <Spinner size="medium" centered={true} />;
   }
 
@@ -168,7 +168,7 @@ export const OptionalFeatures: React.FC = () => {
                           ...dep.additionalPackageInstalls,
                         ]}
                         packageManager={packageManager}
-                        onSuccess={reload}
+                        onSuccess={refetch}
                       />
                     </div>
                   )}

--- a/frontend/src/components/data-table/charts/charts.tsx
+++ b/frontend/src/components/data-table/charts/charts.tsx
@@ -244,7 +244,7 @@ export const ChartPanel: React.FC<{
   const [selectedChartType, setSelectedChartType] =
     useState<ChartType>(chartType);
 
-  const { data, loading, error } = useAsyncData(async () => {
+  const { data, isPending, error } = useAsyncData(async () => {
     if (!getDataUrl) {
       return [];
     }
@@ -285,7 +285,7 @@ export const ChartPanel: React.FC<{
 
   // Prevent unnecessary re-renders of the chart
   const memoizedChart = useMemo(() => {
-    if (loading) {
+    if (isPending) {
       return <ChartLoadingState />;
     }
     if (error) {
@@ -294,7 +294,7 @@ export const ChartPanel: React.FC<{
     return (
       <LazyChart baseSpec={specWithoutData} data={data} height={CHART_HEIGHT} />
     );
-  }, [loading, error, specWithoutData, data]);
+  }, [isPending, error, specWithoutData, data]);
 
   const developmentMode = import.meta.env.DEV;
 

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -170,7 +170,7 @@ const ColumnPreview = ({
 }) => {
   const { theme } = useTheme();
 
-  const { data, error, loading } = useAsyncData(async () => {
+  const { data, error, isPending } = useAsyncData(async () => {
     const response = await previewColumn({ column: columnName });
     return response;
   }, []);
@@ -179,7 +179,7 @@ const ColumnPreview = ({
     return <ErrorState error={error} />;
   }
 
-  if (loading) {
+  if (isPending) {
     return <LoadingState message="Loading..." />;
   }
 

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -377,7 +377,7 @@ const PopoverFilterByValues = <TData, TValue>({
   const [chosenValues, setChosenValues] = useState<Set<unknown>>(new Set());
   const [query, setQuery] = useState<string>("");
 
-  const { data, loading, error } = useAsyncData(async () => {
+  const { data, isPending, error } = useAsyncData(async () => {
     if (!calculateTopKRows) {
       return null;
     }
@@ -406,7 +406,7 @@ const PopoverFilterByValues = <TData, TValue>({
 
   let dataTable: React.ReactNode;
 
-  if (loading) {
+  if (isPending) {
     dataTable = <Spinner size="medium" className="mx-auto mt-12 mb-10" />;
   }
 

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -434,7 +434,7 @@ const TableList: React.FC<{
   // useAsyncData's loading state may return false before data has propagated
   const [tablesLoading, setTablesLoading] = React.useState(false);
 
-  const { loading, error } = useAsyncData(async () => {
+  const { isPending, error } = useAsyncData(async () => {
     if (tables.length === 0 && sqlTableContext && !tablesRequested) {
       setTablesRequested(true);
       setTablesLoading(true);
@@ -459,7 +459,7 @@ const TableList: React.FC<{
     }
   }, [tables.length, sqlTableContext, tablesRequested]);
 
-  if (loading || tablesLoading) {
+  if (isPending || tablesLoading) {
     return <LoadingState message="Loading tables..." className="pl-12" />;
   }
 
@@ -504,7 +504,7 @@ const DatasetTableItem: React.FC<{
     React.useState(false);
   const tableDetailsExist = table.columns.length > 0;
 
-  const { loading, error } = useAsyncData(async () => {
+  const { isPending, error } = useAsyncData(async () => {
     if (
       isExpanded &&
       !tableDetailsExist &&
@@ -591,7 +591,7 @@ const DatasetTableItem: React.FC<{
   };
 
   const renderColumns = () => {
-    if (loading) {
+    if (isPending) {
       return <LoadingState message="Loading columns..." className="pl-12" />;
     }
 

--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -139,13 +139,13 @@ const PackageActionButton: React.FC<{
 export const PackagesPanel: React.FC = () => {
   const [config] = useResolvedMarimoConfig();
   const packageManager = config.package_management.manager;
-  const { data, loading, error, reload } = useAsyncData(
+  const { data, error, refetch, isPending } = useAsyncData(
     () => getPackageList(),
     [packageManager],
   );
 
   // Only show on the first load
-  if (loading && !data) {
+  if (isPending) {
     return <Spinner size="medium" centered={true} />;
   }
 
@@ -157,8 +157,8 @@ export const PackagesPanel: React.FC = () => {
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      <InstallPackageForm packageManager={packageManager} onSuccess={reload} />
-      <PackagesList packages={packages} onSuccess={reload} />
+      <InstallPackageForm packageManager={packageManager} onSuccess={refetch} />
+      <PackagesList packages={packages} onSuccess={refetch} />
     </div>
   );
 };

--- a/frontend/src/components/editor/chrome/panels/secrets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/secrets-panel.tsx
@@ -24,28 +24,28 @@ import { sortProviders, WriteSecretModal } from "./write-secret-modal";
 export const SecretsPanel: React.FC = () => {
   const { openModal, closeModal } = useImperativeModal();
   const {
-    data: secretKeyProviders = [],
-    loading,
+    data: secretKeyProviders,
+    isPending,
     error,
-    reload,
+    refetch,
   } = useAsyncData(async () => {
     const result = await SECRETS_REGISTRY.request({});
     return sortProviders(result.secrets);
   }, []);
 
-  // Provider names without 'env' provider
-  const providerNames = secretKeyProviders
-    .filter((provider) => provider.provider !== "env")
-    .map((provider) => provider.name);
-
   // Only show on the first load
-  if (loading && secretKeyProviders.length === 0) {
+  if (isPending) {
     return <Spinner size="medium" centered={true} />;
   }
 
   if (error) {
     return <ErrorBanner error={error} />;
   }
+
+  // Provider names without 'env' provider
+  const providerNames = secretKeyProviders
+    .filter((provider) => provider.provider !== "env")
+    .map((provider) => provider.name);
 
   if (secretKeyProviders.length === 0) {
     return (
@@ -68,7 +68,7 @@ export const SecretsPanel: React.FC = () => {
               <WriteSecretModal
                 providerNames={providerNames}
                 onSuccess={() => {
-                  reload();
+                  refetch();
                   closeModal();
                 }}
                 onClose={closeModal}

--- a/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
@@ -36,7 +36,7 @@ export const SnippetsPanel: React.FC = () => {
   const {
     data: snippets,
     error,
-    loading,
+    isPending,
   } = useAsyncData(() => {
     return readSnippets();
   }, []);
@@ -45,7 +45,7 @@ export const SnippetsPanel: React.FC = () => {
     return <ErrorBanner error={error} />;
   }
 
-  if (loading || !snippets) {
+  if (isPending || !snippets) {
     return <Spinner size="medium" centered={true} />;
   }
 

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/backend-status.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/backend-status.tsx
@@ -17,7 +17,7 @@ export const BackendConnection: React.FC = () => {
   const connection = useAtomValue(connectionAtom).state;
   const runtime = useRuntimeManager();
 
-  const { loading, error, data, reload } = useAsyncData(async () => {
+  const { isFetching, error, data, refetch } = useAsyncData(async () => {
     if (connection !== WebSocketState.OPEN) {
       return;
     }
@@ -38,7 +38,7 @@ export const BackendConnection: React.FC = () => {
     }
   }, [runtime, connection]);
 
-  useInterval(reload, {
+  useInterval(refetch, {
     delayMs:
       connection === WebSocketState.OPEN ? CHECK_HEALTH_INTERVAL_MS : null,
     whenVisible: true,
@@ -58,7 +58,7 @@ export const BackendConnection: React.FC = () => {
   };
 
   const getStatusIcon = () => {
-    if (loading || connection === WebSocketState.CONNECTING) {
+    if (isFetching || connection === WebSocketState.CONNECTING) {
       return <Spinner size="small" />;
     }
 
@@ -92,7 +92,7 @@ export const BackendConnection: React.FC = () => {
         </div>
       }
       selected={false}
-      onClick={reload}
+      onClick={refetch}
     >
       {getStatusIcon()}
     </FooterItem>

--- a/frontend/src/components/editor/database/form-renderers.tsx
+++ b/frontend/src/components/editor/database/form-renderers.tsx
@@ -60,7 +60,12 @@ interface SecretsProviderProps {
 }
 
 export const SecretsProvider = ({ children }: SecretsProviderProps) => {
-  const { data, loading, error, reload } = useAsyncData(async () => {
+  const {
+    data,
+    isPending,
+    error,
+    refetch: reload,
+  } = useAsyncData(async () => {
     const result = await SECRETS_REGISTRY.request({});
     // Provider names without 'env' provider
     const providerNames = sortProviders(result.secrets)
@@ -78,7 +83,7 @@ export const SecretsProvider = ({ children }: SecretsProviderProps) => {
       value={{
         secretKeys: data?.secretKeys || [],
         providerNames: data?.providerNames || [],
-        loading,
+        loading: isPending,
         error,
         refreshSecrets: reload,
       }}

--- a/frontend/src/components/editor/file-tree/file-explorer.tsx
+++ b/frontend/src/components/editor/file-tree/file-explorer.tsx
@@ -76,7 +76,7 @@ export const FileExplorer: React.FC<{
   // when this component is unmounted
   const [openState, setOpenState] = useAtom(openStateAtom);
 
-  const { loading, error } = useAsyncData(() => tree.initialize(setData), []);
+  const { isPending, error } = useAsyncData(() => tree.initialize(setData), []);
 
   const handleRefresh = useEvent(() => {
     tree.refreshAll(Object.keys(openState).filter((id) => openState[id]));
@@ -105,7 +105,7 @@ export const FileExplorer: React.FC<{
     setOpenState({});
   });
 
-  if (loading) {
+  if (isPending) {
     return <Spinner size="medium" centered={true} />;
   }
 

--- a/frontend/src/components/editor/file-tree/file-viewer.tsx
+++ b/frontend/src/components/editor/file-tree/file-viewer.tsx
@@ -40,7 +40,7 @@ export const FileViewer: React.FC<Props> = ({ file, onOpenNotebook }) => {
   // undefined value means not modified yet
   const [internalValue, setInternalValue] = useState<string>("");
 
-  const { data, loading, error, setData } = useAsyncData(async () => {
+  const { data, isPending, error, setData } = useAsyncData(async () => {
     const details = await sendFileDetails({ path: file.path });
     const contents = details.contents || "";
     setInternalValue(unsavedContentsForFile.get(file.path) || contents);
@@ -85,7 +85,7 @@ export const FileViewer: React.FC<Props> = ({ file, onOpenNotebook }) => {
     return <ErrorBanner error={error} />;
   }
 
-  if (loading || !data) {
+  if (isPending || !data) {
     return null;
   }
 

--- a/frontend/src/components/editor/file-tree/file-viewer.tsx
+++ b/frontend/src/components/editor/file-tree/file-viewer.tsx
@@ -56,9 +56,7 @@ export const FileViewer: React.FC<Props> = ({ file, onOpenNotebook }) => {
       (response) => {
         if (response.success) {
           // Update the last saved value
-          setData((prev) =>
-            prev ? { ...prev, contents: internalValue } : undefined,
-          );
+          setData((prev) => ({ ...prev, contents: internalValue }));
           setInternalValue(internalValue);
         }
       },

--- a/frontend/src/components/editor/header/filename-input.tsx
+++ b/frontend/src/components/editor/header/filename-input.tsx
@@ -73,7 +73,7 @@ export const FilenameInput = ({
     Paths.basename(suggestion.path).startsWith(basename),
   );
 
-  const { loading } = useAsyncData(async () => {
+  const { isPending } = useAsyncData(async () => {
     if (!focused) {
       setSuggestions([]);
       return;
@@ -97,7 +97,7 @@ export const FilenameInput = ({
   const shouldShowList = suggestedNamed || filteredSuggestions.length > 0;
   const suggestionsList = shouldShowList && (
     <CommandList className="font-mono">
-      {!loading && <CommandEmpty>No files</CommandEmpty>}
+      {!isPending && <CommandEmpty>No files</CommandEmpty>}
 
       {suggestedNamed && (
         <CommandItem

--- a/frontend/src/components/editor/package-alert.tsx
+++ b/frontend/src/components/editor/package-alert.tsx
@@ -424,7 +424,7 @@ const ExtrasSelector: React.FC<ExtrasSelectorProps> = ({
   onExtrasChange,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { loading, error, data: pkgMeta } = usePackageMetadata(packageName);
+  const { isPending, error, data: pkgMeta } = usePackageMetadata(packageName);
 
   const handleExtraToggle = (extra: string, checked: boolean) => {
     if (checked) {
@@ -434,7 +434,7 @@ const ExtrasSelector: React.FC<ExtrasSelectorProps> = ({
     }
   };
 
-  const canSelectExtras = !loading && !error;
+  const canSelectExtras = !isPending && !error;
   const availableExtras = (pkgMeta?.extras ?? []).filter(
     // Filter out common development-only extras like "dev" and "test".
     (extra) => !/^(dev|test|testing)$/i.test(extra),
@@ -559,7 +559,7 @@ const PackageVersionSelect: React.FC<PackageVersionSelectProps> = ({
   onChange,
   packageName,
 }) => {
-  const { error, loading, data: pkgMeta } = usePackageMetadata(packageName);
+  const { error, isPending, data: pkgMeta } = usePackageMetadata(packageName);
 
   if (error) {
     return (
@@ -580,10 +580,10 @@ const PackageVersionSelect: React.FC<PackageVersionSelectProps> = ({
     <NativeSelect
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      disabled={loading}
+      disabled={isPending}
       className="inline-flex ml-2 w-24 text-ellipsis"
     >
-      {loading ? (
+      {isPending ? (
         <option value="latest">latest</option>
       ) : (
         ["latest", ...pkgMeta.versions.slice(0, 100)].map((version) => (

--- a/frontend/src/core/wasm/PyodideLoader.tsx
+++ b/frontend/src/core/wasm/PyodideLoader.tsx
@@ -26,14 +26,14 @@ export const PyodideLoader: React.FC<PropsWithChildren> = ({ children }) => {
 
 const PyodideLoaderInner: React.FC<PropsWithChildren> = ({ children }) => {
   // isPyodide() is constant, so this is safe
-  const { loading, error } = useAsyncData(async () => {
+  const { isPending, error } = useAsyncData(async () => {
     await PyodideBridge.INSTANCE.initialized.promise;
     return true;
   }, []);
 
   const hasOutput = useAtomValue(hasAnyOutputAtom);
 
-  if (loading) {
+  if (isPending) {
     return <WasmSpinner />;
   }
 

--- a/frontend/src/hooks/__tests__/usePackageMetadata.test.tsx
+++ b/frontend/src/hooks/__tests__/usePackageMetadata.test.tsx
@@ -52,7 +52,7 @@ describe("usePackageMetadata", () => {
       }),
     );
     const { result } = renderHook(() => usePackageMetadata("numpy"));
-    expect(result.current.loading).toBe(true);
+    expect(result.current.isPending).toBe(true);
     expect(result.current.data).toBeUndefined();
     expect(result.current.error).toBeUndefined();
   });
@@ -71,7 +71,7 @@ describe("usePackageMetadata", () => {
 
     const { result } = renderHook(() => usePackageMetadata("pandas"));
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.data).toEqual({
       versions: ["2.0.0", "1.5.3", "1.4.0"],
       extras: ["test", "performance", "plotting"],
@@ -92,7 +92,7 @@ describe("usePackageMetadata", () => {
     );
 
     const { result } = renderHook(() => usePackageMetadata("requests"));
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.data).toEqual({
       versions: ["2.28.0", "2.27.1"],
       extras: [],
@@ -108,7 +108,7 @@ describe("usePackageMetadata", () => {
     );
 
     const { result } = renderHook(() => usePackageMetadata("nonexistent"));
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.data).toBeUndefined();
     expect(result.current.error).toBeInstanceOf(Error);
   });
@@ -128,7 +128,7 @@ describe("usePackageMetadata", () => {
     const { result } = renderHook(() =>
       usePackageMetadata("package-name[extra1,extra2]"),
     );
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.data).toEqual({
       versions: ["1.0.0"],
       extras: ["extra1", "extra2"],
@@ -148,7 +148,7 @@ describe("usePackageMetadata", () => {
     );
 
     const { result } = renderHook(() => usePackageMetadata("scipy"));
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.data).toMatchInlineSnapshot(`
       {
         "extras": [],
@@ -173,7 +173,7 @@ describe("usePackageMetadata", () => {
     const { result } = renderHook(() =>
       usePackageMetadata("package-not-found"),
     );
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.data).toBeUndefined();
     expect(result.current.error).toBeInstanceOf(Error);
   });
@@ -197,7 +197,7 @@ describe("usePackageMetadata", () => {
       usePackageMetadata("cached-package"),
     );
 
-    await waitFor(() => expect(result1.current.loading).toBe(false));
+    await waitFor(() => expect(result1.current.isPending).toBe(false));
     expect(result1.current.data).toEqual({
       versions: ["1.0.0"],
       extras: ["test"],
@@ -208,7 +208,7 @@ describe("usePackageMetadata", () => {
     const { result: result2 } = renderHook(() =>
       usePackageMetadata("cached-package"),
     );
-    await waitFor(() => expect(result2.current.loading).toBe(false));
+    await waitFor(() => expect(result2.current.isPending).toBe(false));
     expect(result2.current.data).toEqual({
       versions: ["1.0.0"],
       extras: ["test"],

--- a/frontend/src/hooks/usePackageMetadata.ts
+++ b/frontend/src/hooks/usePackageMetadata.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { useAsyncData } from "./useAsyncData";
+import { useAsyncData, type AsyncDataResponse } from "./useAsyncData";
 import { cleanPythonModuleName, reverseSemverSort } from "@/utils/versions";
 import { TimedCache } from "@/utils/timed-cache";
 import * as z from "zod";
@@ -23,35 +23,11 @@ const PyPiPackageResponse = z.object({
   releases: z.record(z.string(), z.unknown()),
 });
 
-interface LoadingResponse {
-  loading: true;
-  data: undefined;
-  error: undefined;
-}
-
-interface ErrorResponse {
-  loading: false;
-  data: undefined;
-  error: Error;
-}
-
-interface SuccessResponse<T> {
-  loading: false;
-  data: T;
-  error: undefined;
-}
-
-type AsyncDataResponse<T> =
-  | LoadingResponse
-  | ErrorResponse
-  | SuccessResponse<T>;
-
 export function usePackageMetadata(
   packageName: string,
 ): AsyncDataResponse<PackageMetadata> {
   const cleanedName = cleanPythonModuleName(packageName);
-
-  const { data, loading, error } = useAsyncData(async () => {
+  return useAsyncData(async () => {
     const cached = PACKAGE_CACHE.get(cleanedName);
     if (cached) {
       return cached;
@@ -73,6 +49,4 @@ export function usePackageMetadata(
     PACKAGE_CACHE.set(cleanedName, pkgMeta);
     return pkgMeta;
   }, [cleanedName]);
-
-  return { data, loading, error } as AsyncDataResponse<PackageMetadata>;
 }

--- a/frontend/src/hooks/usePackageMetadata.ts
+++ b/frontend/src/hooks/usePackageMetadata.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { useAsyncData, type AsyncDataResponse } from "./useAsyncData";
+import { useAsyncData, type AsyncDataResult } from "./useAsyncData";
 import { cleanPythonModuleName, reverseSemverSort } from "@/utils/versions";
 import { TimedCache } from "@/utils/timed-cache";
 import * as z from "zod";
@@ -25,7 +25,7 @@ const PyPiPackageResponse = z.object({
 
 export function usePackageMetadata(
   packageName: string,
-): AsyncDataResponse<PackageMetadata> {
+): AsyncDataResult<PackageMetadata> {
   const cleanedName = cleanPythonModuleName(packageName);
   return useAsyncData(async () => {
     const cached = PACKAGE_CACHE.get(cleanedName);

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -412,7 +412,7 @@ export const LoadingDataTableComponent = memo(
     }, [props.pageSize]);
 
     // Data loading
-    const { data, loading, error } = useAsyncData<{
+    const { data, error, isPending, isFetching } = useAsyncData<{
       rows: T[];
       totalRows: number | TooManyRows;
       cellStyles: CellStyleState | undefined | null;
@@ -556,7 +556,7 @@ export const LoadingDataTableComponent = memo(
       }
     }, [columnSummariesError]);
 
-    if (loading && !data) {
+    if (isPending) {
       return (
         <DelayMount milliseconds={200}>
           <LoadingTable
@@ -601,7 +601,7 @@ export const LoadingDataTableComponent = memo(
         setSearchQuery={setSearchQuery}
         filters={filters}
         setFilters={setFilters}
-        reloading={loading}
+        reloading={isFetching && !isPending}
         totalRows={data?.totalRows ?? props.totalRows}
         paginationState={paginationState}
         setPaginationState={setPaginationState}

--- a/frontend/src/plugins/impl/FileBrowserPlugin.tsx
+++ b/frontend/src/plugins/impl/FileBrowserPlugin.tsx
@@ -138,7 +138,7 @@ export const FileBrowser = ({
   const [selectAllLabel, setSelectAllLabel] = useState("Select all");
   const [isUpdatingPath, setIsUpdatingPath] = useState(false);
 
-  const { data, loading, error } = useAsyncData(
+  const { data, error, isPending } = useAsyncData(
     () =>
       list_directory({
         path: path,
@@ -155,7 +155,7 @@ export const FileBrowser = ({
     });
   }
 
-  if (loading && !data) {
+  if (isPending) {
     return null;
   }
 

--- a/frontend/src/plugins/impl/data-explorer/ConnectedDataExplorerComponent.tsx
+++ b/frontend/src/plugins/impl/data-explorer/ConnectedDataExplorerComponent.tsx
@@ -84,7 +84,7 @@ export const DataExplorerComponent = ({
   data: dataUrl,
 }: DataTableProps): JSX.Element => {
   const actions = useChartSpecActions();
-  const { data, loading, error } = useAsyncData(async () => {
+  const { data, isPending, error } = useAsyncData(async () => {
     if (!dataUrl) {
       return {};
     }
@@ -114,7 +114,7 @@ export const DataExplorerComponent = ({
     return <div />;
   }
   const { chartData, schema } = data;
-  if (loading || !schema) {
+  if (isPending || !schema) {
     return <div />;
   }
 

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -160,7 +160,7 @@ export const DataFrameComponent = memo(
     search,
     host,
   }: DataTableProps): JSX.Element => {
-    const { data, error, loading } = useAsyncData(
+    const { data, error, isPending } = useAsyncData(
       () => get_dataframe({}),
       [value?.transforms],
     );
@@ -210,7 +210,7 @@ export const DataFrameComponent = memo(
               )}
               <div className="flex-grow" />
             </TabsList>
-            {loading && <Spinner size="small" />}
+            {isPending && <Spinner size="small" />}
           </div>
           <TabsContent
             value="transform"

--- a/frontend/src/plugins/impl/data-frames/forms/renderers.tsx
+++ b/frontend/src/plugins/impl/data-frames/forms/renderers.tsx
@@ -221,14 +221,14 @@ export const columnValuesRenderer = <T extends FieldValues>(): FormRenderer<
     );
     const column = React.use(ColumnNameContext);
     const fetchValues = React.use(ColumnFetchValuesContext);
-    const { data, loading } = useAsyncData(
+    const { data, isPending } = useAsyncData(
       () => fetchValues({ column }),
       [column],
     );
 
     const options = data?.values || [];
 
-    if (options.length === 0 && !loading) {
+    if (options.length === 0 && !isPending) {
       return (
         <FormField
           control={form.control}
@@ -298,14 +298,14 @@ export const multiColumnValuesRenderer = <
   Component: ({ schema, form, path }) => {
     const column = React.use(ColumnNameContext);
     const fetchValues = React.use(ColumnFetchValuesContext);
-    const { data, loading } = useAsyncData(
+    const { data, isPending } = useAsyncData(
       () => fetchValues({ column }),
       [column],
     );
 
     const options = data?.values || [];
 
-    if (options.length === 0 && !loading) {
+    if (options.length === 0 && !isPending) {
       return (
         <FormField
           control={form.control}

--- a/frontend/src/plugins/layout/LazyPlugin.tsx
+++ b/frontend/src/plugins/layout/LazyPlugin.tsx
@@ -71,7 +71,7 @@ const LazyComponent = ({
   // We could improve performance if the BE was able to know if the same
   // mo.lazy has already been loaded, and when re-rendering it would
   // include the 'lazy' content by default (unlazily)
-  const { data, loading, error } = useAsyncData(
+  const { data, error, isPending } = useAsyncData(
     (ctx) => {
       if (!value) {
         ctx.previous();
@@ -88,7 +88,7 @@ const LazyComponent = ({
 
   return (
     <div ref={ref} className="min-h-4">
-      {loading && !data && showLoadingIndicator ? (
+      {isPending && showLoadingIndicator ? (
         <Loader2Icon className="w-12 h-12 animate-spin text-primary my-4 mx-4" />
       ) : (
         data && renderHTML({ html: data.html })


### PR DESCRIPTION
Migrates the async data state management to align with [React Query](https://tanstack.com/query/latest/docs/framework/react/overview) conventions, replacing the previous implementation that allowed ambiguous states.

## Changes

Updated to use React Query-like state patterns with explicit status types:
- **Pending**: `{ status: "pending", isPending: true, isFetching: true, data: undefined, error: undefined }`
- **Loading**: `{ status: "loading", isPending: false, isFetching: true, data: T, error: undefined }`
- **Error**: `{ status: "error", isPending: false, isFetching: false, data: undefined, error: Error }`
- **Success**: `{ status: "success", isPending: false, isFetching: false, data: T, error: undefined }`

## Side Effects

- Updated all components using `useAsyncData` to use new property names
- **file-viewer.tsx**: Implementation updated to work with new discriminated union types

This change shrinks the state space and _should_ make invalid states unrepresentable.