### PR TITLE
fix: add suspense to prevent screen flicker

### DIFF
--- a/frontend/src/components/datasources/column-preview.tsx
+++ b/frontend/src/components/datasources/column-preview.tsx
@@ -10,7 +10,7 @@ import type {
 } from "@/core/kernel/messages";
 import { type Theme, useTheme } from "@/theme/useTheme";
 import { Events } from "@/utils/events";
-import React from "react";
+import React, { Suspense } from "react";
 import { previewDatasetColumn } from "@/core/network/requests";
 import { Button } from "../ui/button";
 import { convertStatsName, sqlCode } from "./utils";
@@ -26,6 +26,7 @@ import { useLastFocusedCellId } from "@/core/cells/focus";
 import { autoInstantiateAtom } from "@/core/config/config";
 import { prettyNumber } from "@/utils/numbers";
 import { useAtomValue } from "jotai";
+import { Spinner } from "../icons/spinner";
 
 const LazyVegaLite = React.lazy(() =>
   import("react-vega").then((m) => ({ default: m.VegaLite })),
@@ -181,6 +182,12 @@ export function renderStats(
   );
 }
 
+const LoadingChart = (
+  <div className="flex justify-center">
+    <Spinner className="size-4" />
+  </div>
+);
+
 export function renderChart(chartSpec: string, theme: Theme) {
   const updateSpec = (spec: TopLevelFacetedUnitSpec) => {
     return {
@@ -190,13 +197,15 @@ export function renderChart(chartSpec: string, theme: Theme) {
   };
 
   return (
-    <LazyVegaLite
-      spec={updateSpec(JSON.parse(chartSpec) as TopLevelFacetedUnitSpec)}
-      width={"container" as unknown as number}
-      height={100}
-      actions={false}
-      theme={theme === "dark" ? "dark" : "vox"}
-    />
+    <Suspense fallback={LoadingChart}>
+      <LazyVegaLite
+        spec={updateSpec(JSON.parse(chartSpec) as TopLevelFacetedUnitSpec)}
+        width={"container" as unknown as number}
+        height={100}
+        actions={false}
+        theme={theme === "dark" ? "dark" : "vox"}
+      />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
On first time user loads any chart (maybe loading altair), a flicker occurs. Subsequent charting is fine. 
This adds a suspense to avoid the flicker.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
