### PR TITLE
fix: handle edit message bug

### DIFF
--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -399,7 +399,7 @@ const ChatPanelBody = () => {
   };
 
   const handleMessageEdit = (index: number, newValue: string) => {
-    // Truncate both local messages and storage
+    // Truncate both useChat and storage
     setMessages((messages) => messages.slice(0, index));
     if (chatState.activeChatId) {
       setChatState((prev) => ({

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -170,16 +170,6 @@ const ChatMessage: React.FC<ChatMessageProps> = memo(
                 return;
               }
               onEdit(index, newValue);
-              if (chatState.activeChatId) {
-                setChatState((prev: ChatState) =>
-                  addMessageToChat(
-                    prev,
-                    chatState.activeChatId,
-                    "user",
-                    newValue,
-                  ),
-                );
-              }
             }}
             onClose={() => {
               // noop
@@ -409,11 +399,33 @@ const ChatPanelBody = () => {
   };
 
   const handleMessageEdit = (index: number, newValue: string) => {
+    // Truncate both local messages and storage
     setMessages((messages) => messages.slice(0, index));
+    if (chatState.activeChatId) {
+      setChatState((prev) => ({
+        ...prev,
+        chats: prev.chats.map((chat) =>
+          chat.id === chatState.activeChatId
+            ? {
+                ...chat,
+                messages: chat.messages.slice(0, index),
+                updatedAt: Date.now(),
+              }
+            : chat,
+        ),
+      }));
+    }
+
+    // Add user message to useChat and storage
     append({
       role: "user",
       content: newValue,
     });
+    if (chatState.activeChatId) {
+      setChatState((prev) =>
+        addMessageToChat(prev, chatState.activeChatId, "user", newValue),
+      );
+    }
   };
 
   const handleChatInputSubmit = (


### PR DESCRIPTION

## 📝 Summary

Fixed message editing to truncate both useChat and storage state, preventing sync issues between local and persisted chat history.

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

- Moved addMessageToChat into handleMessageEdit
- Updated handleMessageEdit to also truncate chat messages in storage

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick
