### PR TITLE
feat: enhance `ImportError` handling for better package suggestions

### DIFF
--- a/marimo/_runtime/packages/import_error_extractors.py
+++ b/marimo/_runtime/packages/import_error_extractors.py
@@ -1,0 +1,105 @@
+# Copyright 2025 Marimo. All rights reserved.
+from __future__ import annotations
+
+import re
+
+
+def extract_missing_module_from_cause_chain(
+    error: ImportError,
+) -> str | None:
+    """Traverse an `ImportError` cause chain maybe find a missing module name.
+
+    This handles cases where a `ModuleNotFoundError` was raised and then wrapped,
+    e.g., via `raise ImportError("helpful message") from err`
+    """
+    current: None | BaseException = error
+    while current is not None:
+        if (
+            isinstance(current, ModuleNotFoundError)
+            and hasattr(current, "name")
+            and current.name
+        ):
+            return current.name
+        current = current.__cause__
+    return None
+
+
+def extract_packages_from_pip_install_suggestion(
+    message: str,
+) -> list[str] | None:
+    """Extract package names from pip install commands in error messages."""
+
+    # First try to find quoted/backticked pip install commands (complete commands)
+    quoted_patterns = [
+        r"`pip install\s+([^`]+)`",  # backticks
+        r'"pip install\s+([^"]+)"',  # double quotes
+        r"'pip install\s+([^']+)'",  # single quotes
+    ]
+
+    for pattern in quoted_patterns:
+        match = re.search(pattern, message, re.IGNORECASE)
+        if match:
+            args_part = match.group(1)
+            args = args_part.split()
+            packages = []
+            seen = set()
+
+            for arg in args:
+                # Skip flags and duplicates
+                if not arg.startswith("-") and arg not in seen:
+                    packages.append(arg)
+                    seen.add(arg)
+
+            if packages:
+                return packages
+
+    # If no quoted command found, look for unquoted and take only first positional arg
+    unquoted_pattern = (
+        r"pip install\s+([a-zA-Z0-9_-]+(?:\[[a-zA-Z0-9_,-]+\])?)"
+    )
+    match = re.search(unquoted_pattern, message, re.IGNORECASE)
+
+    if match:
+        return [match.group(1)]
+
+    return None
+
+
+def extract_packages_special_cases(message: str) -> list[str] | None:
+    """Extract package names based on special case substrings in error messages."""
+
+    special_cases = {
+        # pd.DataFrame.to_parquet()
+        "Unable to find a usable engine; tried using: 'pyarrow', 'fastparquet'.": [
+            "pyarrow"
+        ],
+    }
+
+    packages = []
+    for substring, package_names in special_cases.items():
+        if substring in message:
+            packages.extend(package_names)
+
+    return packages if packages else None
+
+
+def try_extract_packages_from_import_error_message(
+    import_error_message: str,
+) -> list[str] | None:
+    """Try to extract package names from an `ImportError` message using various strategies.
+
+    Args:
+        import_error_message: The error message
+
+    Returns:
+        List of package names if found, None otherwise
+    """
+
+    for extract in [
+        extract_packages_from_pip_install_suggestion,
+        extract_packages_special_cases,
+    ]:
+        result = extract(import_error_message)
+        if result is not None:
+            return result
+    return None

--- a/tests/_runtime/packages/test_import_error_extractors.py
+++ b/tests/_runtime/packages/test_import_error_extractors.py
@@ -65,11 +65,29 @@ def test_extract_missing_module_from_cause_chain_no_module():
             ["requests", "pandas[all]"],
         ),
         ("Execute 'pip install -U numpy matplotlib'", ["numpy", "matplotlib"]),
+        # Additional quoted edge cases
+        ("Try: `pip install pandas`.", ["pandas"]),  # trailing punctuation
+        ('Try running `"pip install seaborn"`', ["seaborn"]),  # nested quotes
+        (
+            "Use: 'pip install   scipy   matplotlib'",
+            ["scipy", "matplotlib"],
+        ),  # extra spaces
+        (
+            "Here's the command: `pip install jupyterlab` for notebooks",
+            ["jupyterlab"],
+        ),
         # Unquoted with surrounding text (conservative parsing)
         ("Try: pip install polars if you want to do something", ["polars"]),
         ("You can pip install requests pandas but maybe not", ["requests"]),
         # No match
         ("Some other error message", None),
+        # Harder, https://github.com/flekschas/jupyter-scatter/blob/ecfd8c4e19a1ad202372c09939682e5fbe9e70ba/jscatter/dependencies.py#L33-L37
+        (
+            """Please install it with: pip install "jupyter-scatter[blah]" or pip install "jupyter-scatter[all]".""",
+            ["jupyter-scatter[blah]"],
+        ),
+        ('Try: `pip install foo bar "baz[all]"`.', ["foo", "bar", "baz[all]"]),
+        ("Try: `pip install foo bar 'baz[all]'`.", ["foo", "bar", "baz[all]"]),
     ],
 )
 def test_extract_packages_from_pip_install_suggestion(message, expected):

--- a/tests/_runtime/packages/test_import_error_extractors.py
+++ b/tests/_runtime/packages/test_import_error_extractors.py
@@ -1,0 +1,85 @@
+# Copyright 2025 Marimo. All rights reserved.
+
+import pytest
+
+from marimo._runtime.packages.import_error_extractors import (
+    extract_missing_module_from_cause_chain,
+    extract_packages_from_pip_install_suggestion,
+    extract_packages_special_cases,
+)
+
+
+def test_extract_missing_module_from_cause_chain_direct():
+    """Test direct ModuleNotFoundError (no cause chain)."""
+    module_error = ModuleNotFoundError("No module named 'numpy'")
+    module_error.name = "numpy"
+
+    result = extract_missing_module_from_cause_chain(module_error)
+    assert result == "numpy"
+
+
+def test_extract_missing_module_from_cause_chain_with_cause():
+    """Test ImportError with ModuleNotFoundError cause."""
+    module_error = ModuleNotFoundError("No module named 'numpy'")
+    module_error.name = "numpy"
+
+    import_error = ImportError("Custom message")
+    import_error.__cause__ = module_error
+
+    result = extract_missing_module_from_cause_chain(import_error)
+    assert result == "numpy"
+
+
+def test_extract_missing_module_from_cause_chain_nested():
+    """Test nested cause chain."""
+    root_error = ModuleNotFoundError("No module named 'pandas'")
+    root_error.name = "pandas"
+
+    middle_error = ImportError("Middle error")
+    middle_error.__cause__ = root_error
+
+    top_error = ImportError("Top error")
+    top_error.__cause__ = middle_error
+
+    result = extract_missing_module_from_cause_chain(top_error)
+    assert result == "pandas"
+
+
+def test_extract_missing_module_from_cause_chain_no_module():
+    """Test error with no module in chain."""
+    import_error = ImportError("No useful cause")
+    result = extract_missing_module_from_cause_chain(import_error)
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        # Simple cases
+        ("Try: pip install requests", ["requests"]),
+        ("Run: pip install pandas[all]", ["pandas[all]"]),
+        # Quoted commands (multiple packages)
+        ("Try `pip install -U polars anywidget`", ["polars", "anywidget"]),
+        (
+            'Run "pip install --upgrade requests pandas[all]"',
+            ["requests", "pandas[all]"],
+        ),
+        ("Execute 'pip install -U numpy matplotlib'", ["numpy", "matplotlib"]),
+        # Unquoted with surrounding text (conservative parsing)
+        ("Try: pip install polars if you want to do something", ["polars"]),
+        ("You can pip install requests pandas but maybe not", ["requests"]),
+        # No match
+        ("Some other error message", None),
+    ],
+)
+def test_extract_packages_from_pip_install_suggestion(message, expected):
+    """Test pip install suggestion extraction with various formats."""
+    result = extract_packages_from_pip_install_suggestion(message)
+    assert result == expected
+
+
+def test_extract_packages_special_cases_pandas_parquet():
+    """Test pandas parquet special case."""
+    message = "Unable to find a usable engine; tried using: 'pyarrow', 'fastparquet'."
+    result = extract_packages_special_cases(message)
+    assert result == ["pyarrow"]


### PR DESCRIPTION
Trying to handle all possible import patterns is a bit pathological—there’s no strong convention across packages. For instance, `fsspec` is [all over the place](https://github.com/fsspec/filesystem_spec/blob/26f1ea75351e39a80b29b27bea792351f3e8da9f/fsspec/registry.py#L62-L230). There’s a loose pattern, but it’s not consistent enough to catch reliably.

That said, I think we now have a solid approach for the common case where an error is explicitly re-raised from a failed import:

```py
except ImportError as err:
    raise ImportError("You can install this another way") from err
```

Moreover, I set up a few "passes" for package extractors (i.e., functions of the form `(error_message: str) -> list[str] | None`) that can eagerly "handle" an error. This makes it easy to add special cases, or even incorporate fuzzier logic down the line (e.g., if the user has AI API keys enabled).

The only other somewhat high-confidence "extractor" I can think of is a regex that catches a quoted word within the import error.