### PR TITLE
Fixed typo in dataflow.py (ampltitude -> amplitude)

### DIFF
--- a/marimo/_tutorials/dataflow.py
+++ b/marimo/_tutorials/dataflow.py
@@ -172,7 +172,7 @@ def _(mo):
     mo.md(
         """
         🌊 **Try it!** In the above cells, try changing the value `period` or 
-        `ampltitude`, then click the run button ( ▷ ) to register your changes. 
+        `amplitude`, then click the run button ( ▷ ) to register your changes. 
         See what happens to the sine wave.
         """
     )


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA.