### PR TITLE
Extend `view-as` URI parameter to handle app view in edit mode

### DIFF
--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -40,7 +40,7 @@ export const KnownQueryParams = {
   accessToken: "access_token",
   /**
    * Layout view-as. If the editor is in run-mode, this overrides the current
-   * layout view.
+   * layout view. In edit-mode, can be used to start in present mode.
    */
   viewAs: "view-as",
   /**
@@ -49,10 +49,4 @@ export const KnownQueryParams = {
    * If false, the chrome will be hidden.
    */
   showChrome: "show-chrome",
-  /**
-   * Start in app view mode.
-   * If true, the notebook will start in app view (present mode).
-   * If false, the notebook will start in edit mode.
-   */
-  appView: "app-view",
 };

--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -49,4 +49,10 @@ export const KnownQueryParams = {
    * If false, the chrome will be hidden.
    */
   showChrome: "show-chrome",
+  /**
+   * Start in app view mode.
+   * If true, the notebook will start in app view (present mode).
+   * If false, the notebook will start in edit mode.
+   */
+  appView: "app-view",
 };

--- a/frontend/src/mount.tsx
+++ b/frontend/src/mount.tsx
@@ -275,14 +275,14 @@ function initStore(options: unknown) {
   store.set(marimoVersionAtom, parsedOptions.data.version);
   store.set(showCodeInRunModeAtom, parsedOptions.data.view.showAppCode);
 
-  // Check for app-view parameter to start in present mode
-  const shouldStartInAppView = (() => {
+  // Check for view-as parameter to start in present mode
+  const shouldStartInPresentMode = (() => {
     const url = new URL(window.location.href);
-    return url.searchParams.get(KnownQueryParams.appView) === "true";
+    return url.searchParams.get(KnownQueryParams.viewAs) === "present";
   })();
 
   const initialViewMode =
-    mode === "edit" && shouldStartInAppView ? "present" : mode;
+    mode === "edit" && shouldStartInPresentMode ? "present" : mode;
   store.set(viewStateAtom, { mode: initialViewMode, cellAnchor: null });
   store.set(serverTokenAtom, parsedOptions.data.serverToken);
 

--- a/frontend/src/mount.tsx
+++ b/frontend/src/mount.tsx
@@ -274,14 +274,15 @@ function initStore(options: unknown) {
   // Meta
   store.set(marimoVersionAtom, parsedOptions.data.version);
   store.set(showCodeInRunModeAtom, parsedOptions.data.view.showAppCode);
-  
+
   // Check for app-view parameter to start in present mode
   const shouldStartInAppView = (() => {
     const url = new URL(window.location.href);
     return url.searchParams.get(KnownQueryParams.appView) === "true";
   })();
-  
-  const initialViewMode = mode === "edit" && shouldStartInAppView ? "present" : mode;
+
+  const initialViewMode =
+    mode === "edit" && shouldStartInAppView ? "present" : mode;
   store.set(viewStateAtom, { mode: initialViewMode, cellAnchor: null });
   store.set(serverTokenAtom, parsedOptions.data.serverToken);
 

--- a/frontend/src/mount.tsx
+++ b/frontend/src/mount.tsx
@@ -9,6 +9,7 @@ import {
   configOverridesAtom,
   userConfigAtom,
 } from "@/core/config/config";
+import { KnownQueryParams } from "@/core/constants";
 import { getFilenameFromDOM } from "@/core/dom/htmlUtils";
 import { getMarimoCode } from "@/core/meta/globals";
 import {
@@ -273,7 +274,15 @@ function initStore(options: unknown) {
   // Meta
   store.set(marimoVersionAtom, parsedOptions.data.version);
   store.set(showCodeInRunModeAtom, parsedOptions.data.view.showAppCode);
-  store.set(viewStateAtom, { mode, cellAnchor: null });
+  
+  // Check for app-view parameter to start in present mode
+  const shouldStartInAppView = (() => {
+    const url = new URL(window.location.href);
+    return url.searchParams.get(KnownQueryParams.appView) === "true";
+  })();
+  
+  const initialViewMode = mode === "edit" && shouldStartInAppView ? "present" : mode;
+  store.set(viewStateAtom, { mode: initialViewMode, cellAnchor: null });
   store.set(serverTokenAtom, parsedOptions.data.serverToken);
 
   // Config


### PR DESCRIPTION
## 📝 Summary

Extends the `view-as` URI parameter to acommodate `view-as=present`. This causes the notebook to be shown in the `present` or "app" view by default when served in edit mode.

This is useful because it gives a clean UI by default while still allowing the user to drop into the `edit` mode if they so desire. 

## 🔍 Description of Changes

When the user runs `marimo edit notebook.py` and navigates to `http://localhost:2718?view-as=present`, the notebook will start in app view mode (aka present mode) instead of edit mode. 

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable)
  - This is a small change
- [x] I have added tests for the changes made
  - This change is well covered by the existing URI parameter tests
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @mscolnick
