### PR TITLE
fix: dark mode charts and json viewer crashing

### DIFF
--- a/frontend/src/components/datasources/column-preview.tsx
+++ b/frontend/src/components/datasources/column-preview.tsx
@@ -192,6 +192,7 @@ export function renderChart(chartSpec: string, theme: Theme) {
   const updateSpec = (spec: TopLevelFacetedUnitSpec) => {
     return {
       ...spec,
+      background: "transparent",
       config: { ...spec.config, background: "transparent" },
     };
   };

--- a/frontend/src/components/editor/output/JsonOutput.tsx
+++ b/frontend/src/components/editor/output/JsonOutput.tsx
@@ -128,8 +128,9 @@ export const JsonOutput: React.FC<Props> = memo(
             collapseStringsAfterLength={COLLAPSED_TEXT_LENGTH}
             // leave the default valueTypes as it was - 'python', only 'json' is changed
             valueTypes={valueTypesMap[valueTypes]}
-            // disable array grouping (it's misleading) by using a large value
-            groupArraysAfterLength={1_000_000}
+            // When the number of elements exceed 50, we group them in sizes of 50
+            // This improves perf but may look like there are nested arrays
+            groupArraysAfterLength={50}
             // Built-in clipboard shifts content on hover
             // so we provide our own copy button
             enableClipboard={false}

--- a/marimo/_smoke_tests/tables/complex_types.py
+++ b/marimo/_smoke_tests/tables/complex_types.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.13.14"
+__generated_with = "0.13.15"
 app = marimo.App(width="medium")
 
 
@@ -143,6 +143,30 @@ def _(mo):
     )
     mo.ui.dataframe(pandas_with_timestamp)
     return (pd,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+    ## Stress testing
+
+    We can use a large dataset to stress test our rendering, charting. Notebook credit to Vincent: [WoW Dataset](https://github.com/koaning/wow-avatar-datasets)
+
+    ~36 million rows, 7 columns
+    """
+    )
+    return
+
+
+@app.cell
+def _(pl):
+    wow_data = pl.scan_parquet(
+        "https://github.com/koaning/wow-avatar-datasets/raw/refs/heads/main/wow-full.parquet"
+    )
+    wow_data
+    # wow_data.collect()
+    return
 
 
 if __name__ == "__main__":

--- a/marimo/_smoke_tests/tables/rich_elements.py
+++ b/marimo/_smoke_tests/tables/rich_elements.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.11.30"
+__generated_with = "0.13.15"
 app = marimo.App(width="medium")
 
 
@@ -108,6 +108,14 @@ def _(alt, mo, pd):
             "lorem_ipsum_dollar_sit" * 20,
             "lorem_ipsum_dollar_sit" * 20,
         ],
+        "large_array": [
+            [1] * 60,
+            [2] * 60,
+        ],
+        "large_json": [
+            [{"key": i, "value": i} for i in range(60)],
+            [{"key": i, "value": i} for i in range(60)],
+        ],
         "images": [img, html_img],
         "batch": user_info,
         "dropdowns": [
@@ -124,24 +132,7 @@ def _(alt, mo, pd):
     }
 
     mo.vstack([mo.md("## Dictionary"), data])
-    return (
-        chart,
-        chat,
-        data,
-        dictionary,
-        html_img,
-        img,
-        mermaid,
-        office_characters,
-        password,
-        simple_echo_model,
-        source,
-        table,
-        tabs,
-        text,
-        user_info,
-        warn_btn,
-    )
+    return data, password
 
 
 @app.cell
@@ -176,7 +167,7 @@ def _(data, mo, pl):
 
 @app.cell
 def _(mo, password):
-    mo.md(f"### Password value: {password.value}")
+    mo.md(f"""### Password value: {password.value}""")
     return
 
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Browser crashed because there were too many elements rendered at once in the json viewer (one array containing many nested arrays recursively).

This fix groups them by 50 (and only when exceeding 50),  which isn't ideal because it looks like there are nested arrays.
<img width="508" alt="Screenshot 2025-06-18 at 6 47 11 AM" src="https://github.com/user-attachments/assets/567328f9-9865-4fe4-a5b7-e6398e21cf64" />

Normal
<img width="508" alt="Screenshot 2025-06-18 at 6 48 53 AM" src="https://github.com/user-attachments/assets/4f148e7d-0abc-40bc-a155-fccb36b13d04" />

Maybe an alternative is to extend jsonviewer with some custom rendering.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
