### PR TITLE
fix: remove autoscroll

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -380,11 +380,6 @@ export interface CellProps
    * False only when there is only one cell in the notebook.
    */
   canDelete: boolean;
-  /**
-   * If true, the cell is allowed to be focus on.
-   * This is false when the app is initially loading.
-   */
-  allowFocus: boolean;
   userConfig: UserConfig;
   /**
    * If true, the cell is allowed to be moved left and right.
@@ -539,7 +534,6 @@ ReadonlyCellComponent.displayName = "ReadonlyCellComponent";
 const EditableCellComponent = ({
   theme,
   showPlaceholder,
-  allowFocus,
   id: cellId,
   code,
   output,
@@ -816,7 +810,6 @@ const EditableCellComponent = ({
               <CellEditor
                 theme={theme}
                 showPlaceholder={showPlaceholder}
-                allowFocus={allowFocus}
                 id={cellId}
                 code={code}
                 config={cellConfig}
@@ -1118,7 +1111,6 @@ const CellToolbar = ({
 const SetupCellComponent = ({
   theme,
   showPlaceholder,
-  allowFocus,
   id: cellId,
   code,
   output,
@@ -1287,7 +1279,6 @@ const SetupCellComponent = ({
             <CellEditor
               theme={theme}
               showPlaceholder={showPlaceholder}
-              allowFocus={allowFocus}
               id={cellId}
               code={code}
               config={cellConfig}

--- a/frontend/src/components/editor/__tests__/data-attributes.test.tsx
+++ b/frontend/src/components/editor/__tests__/data-attributes.test.tsx
@@ -107,7 +107,6 @@ describe("Cell data attributes", () => {
             canMoveX={false}
             theme="light"
             showPlaceholder={false}
-            allowFocus={true}
           />
         </TooltipProvider>,
       );

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -226,7 +226,6 @@ const CellColumn: React.FC<{
             key={SETUP_CELL_ID}
             theme={theme}
             showPlaceholder={false}
-            allowFocus={!invisible}
             {...notebook.cellData[SETUP_CELL_ID]}
             {...notebook.cellRuntime[SETUP_CELL_ID]}
             {...actions}
@@ -261,7 +260,6 @@ const CellColumn: React.FC<{
               key={cellData.id.toString()}
               theme={theme}
               showPlaceholder={hasOnlyOneCell}
-              allowFocus={!invisible}
               {...cellData}
               {...cellRuntime}
               runElapsedTimeMs={

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -130,7 +130,6 @@ export const ScratchPad: React.FC = () => {
         <div className="overflow-auto flex-shrink-0 max-h-[40%]">
           <CellEditor
             theme={theme}
-            allowFocus={false}
             showPlaceholder={false}
             id={cellId}
             code={code}

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -38,7 +38,6 @@ const props: CellProps = {
   name: "cell_1",
   connectionState: WebSocketState.OPEN,
   canDelete: true,
-  allowFocus: false,
   debuggerActive: false,
   isCollapsed: false,
   collapseCount: 0,


### PR DESCRIPTION
This autoscroll logic might be old and unused since we still get auto-scroll via the `scrollKey` logic in the cell action/reducer. 

This autoscroll was triggered incorrectly when connection is delayed or RTC, but no longer seems needed. 