### PR TITLE
Upgrade minimum version of pytest

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -216,7 +216,7 @@ class DependencyManager:
     panel = Dependency("panel")
     sqlalchemy = Dependency("sqlalchemy")
     pylsp = Dependency("pylsp")
-    pytest = Dependency("pytest")
+    pytest = Dependency("pytest", min_version="8.0.0")
     vegafusion = Dependency("vegafusion")
     vl_convert_python = Dependency("vl_convert")
     dotenv = Dependency("dotenv")


### PR DESCRIPTION
I noticed some failures because the installed pytest was too old, keeping up with the latest major version might be safe. 