### PR TITLE
style: runtime connecting indicator

### DIFF
--- a/frontend/src/components/editor/alerts/connecting-alert.tsx
+++ b/frontend/src/components/editor/alerts/connecting-alert.tsx
@@ -1,9 +1,10 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import { useAtomValue } from "jotai";
-import { Spinner } from "@/components/icons/spinner";
+import { LoadingEllipsis } from "@/components/icons/loading-ellipsis";
 import { isConnectingAtom } from "@/core/network/connection";
-import { FloatingAlert } from "./floating-alert";
+import { DelayMount } from "@/components/utils/delay-mount";
+import { Tooltip } from "../../ui/tooltip";
 
 const DELAY_MS = 1000; // 1 second
 
@@ -11,11 +12,16 @@ export const ConnectingAlert: React.FC = () => {
   const isConnecting = useAtomValue(isConnectingAtom);
 
   return (
-    <FloatingAlert title="Connecting" show={isConnecting} delayMs={DELAY_MS}>
-      <div className="flex items-center gap-2">
-        <Spinner className="h-4 w-4" />
-        <p>Connecting to a marimo runtime ...</p>
-      </div>
-    </FloatingAlert>
+    isConnecting && (
+      <DelayMount milliseconds={DELAY_MS}>
+        <div className="absolute top-4 m-0 flex items-center min-h-[28px] left-1/2 transform -translate-x-1/2 z-[200] ">
+          <Tooltip content="Connecting to a marimo runtime">
+            <div className="flex items-center">
+              <LoadingEllipsis size={5} className="text-yellow-500" />
+            </div>
+          </Tooltip>
+        </div>
+      </DelayMount>
+    )
   );
 };

--- a/frontend/src/components/editor/alerts/connecting-alert.tsx
+++ b/frontend/src/components/editor/alerts/connecting-alert.tsx
@@ -2,8 +2,8 @@
 
 import { useAtomValue } from "jotai";
 import { LoadingEllipsis } from "@/components/icons/loading-ellipsis";
-import { isConnectingAtom } from "@/core/network/connection";
 import { DelayMount } from "@/components/utils/delay-mount";
+import { isConnectingAtom } from "@/core/network/connection";
 import { Tooltip } from "../../ui/tooltip";
 
 const DELAY_MS = 1000; // 1 second

--- a/frontend/src/components/icons/loading-ellipsis.tsx
+++ b/frontend/src/components/icons/loading-ellipsis.tsx
@@ -1,7 +1,8 @@
 /* Copyright 2025 Marimo. All rights reserved. */
-import React from "react";
-import { Circle } from "lucide-react";
+
 import clsx from "clsx";
+import { Circle } from "lucide-react";
+import React from "react";
 
 interface LoadingEllipsisProps {
   /** Extra Tailwind classes */

--- a/frontend/src/components/icons/loading-ellipsis.tsx
+++ b/frontend/src/components/icons/loading-ellipsis.tsx
@@ -1,0 +1,45 @@
+/* Copyright 2025 Marimo. All rights reserved. */
+import React from "react";
+import { Circle } from "lucide-react";
+import clsx from "clsx";
+
+interface LoadingEllipsisProps {
+  /** Extra Tailwind classes */
+  className?: string;
+  /** Diameter of each dot in pixels */
+  size?: number;
+  /** Tailwind gap utility between dots (e.g. "gap-1" or "gap-2") */
+  gap?: string;
+  /** Pulse cycle length in milliseconds */
+  durationMs?: number;
+}
+
+const LoadingEllipsis: React.FC<LoadingEllipsisProps> = ({
+  className,
+  size = 8,
+  gap = "gap-1",
+  durationMs = 1200,
+}) => {
+  const baseStyle: React.CSSProperties = {
+    animationDuration: `${durationMs}ms`,
+  };
+
+  return (
+    <div className={clsx("flex", gap, className)} aria-label="Loading">
+      {[0, 1, 2].map((i) => (
+        <Circle
+          key={i}
+          width={size}
+          height={size}
+          className="fill-current text-current animate-ellipsis-dot"
+          style={{
+            ...baseStyle,
+            animationDelay: `${(durationMs / 3) * i}ms`,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export { LoadingEllipsis };

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -152,12 +152,17 @@ module.exports = {
           "99%": { opacity: 0 },
           "100%": { opacity: 1 },
         },
+        "ellipsis-dot": {
+          "0%, 100%": { opacity: "0.3" },
+          "50%": { opacity: "1" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "delayed-show-200": "delayed-show 200ms ease-out",
         "delayed-show-400": "delayed-show 400ms ease-out",
+        'ellipsis-dot': 'ellipsis-dot 400ms ease-in-out infinite'
       },
       gridTemplateColumns: {
         "auto-fit": "repeat(auto-fit, minmax(0, 1fr))",


### PR DESCRIPTION
A more subtle, but still quite visible, connecting alert. The previous connecting alert clipped over the first cell / output, and distracted from looking at the notebook.

(cc @dmadisetti) 

https://github.com/user-attachments/assets/47cf0a36-5637-4cff-958e-04dadfb136ad

