### PR TITLE
Fix matplotlib plots not rendering in HTML export

### DIFF
--- a/marimo/_schemas/session.py
+++ b/marimo/_schemas/session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Literal, Optional, Union
 
+from marimo._messaging.mimetypes import KnownMimeType
 from marimo._schemas.common import BaseDict
 
 # This file contains the schema for the notebook session.
@@ -27,6 +28,13 @@ class StreamOutput(BaseDict):
     text: str
 
 
+class StreamMediaOutput(BaseDict):
+    type: Literal["stream"]
+    name: Literal["media"]
+    data: str
+    mimetype: KnownMimeType
+
+
 class ErrorOutput(BaseDict):
     type: Literal["error"]
     ename: str
@@ -46,6 +54,11 @@ OutputType = Union[
     # Dict[str, Any],  # For future output types, forwards-compatible
 ]
 
+ConsoleType = Union[
+    StreamOutput,
+    StreamMediaOutput,
+]
+
 
 class Cell(BaseDict):
     """Code cell specific structure"""
@@ -53,7 +66,7 @@ class Cell(BaseDict):
     id: str
     code_hash: Optional[str]
     outputs: list[OutputType]
-    console: list[StreamOutput]
+    console: list[ConsoleType]
 
     # We don't need to store code or cell config
     # since that exists in the notebook.py itself

--- a/marimo/_server/session/serialize.py
+++ b/marimo/_server/session/serialize.py
@@ -201,7 +201,7 @@ def serialize_notebook(
     """Convert a SessionView to a Notebook schema."""
     cells: list[NotebookCell] = []
 
-    for cell_id in view.cell_operations.keys():
+    for cell_id in cell_manager.cell_ids():
         # Get the code from last_executed_code, fallback to empty string
         code = view.last_executed_code.get(cell_id, "")
         cell_data = cell_manager.get_cell_data(cell_id)

--- a/marimo/_server/session/serialize.py
+++ b/marimo/_server/session/serialize.py
@@ -27,11 +27,13 @@ from marimo._schemas.notebook import (
 from marimo._schemas.session import (
     VERSION,
     Cell,
+    ConsoleType,
     DataOutput,
     ErrorOutput,
     NotebookSessionMetadata,
     NotebookSessionV1,
     OutputType,
+    StreamMediaOutput,
     StreamOutput,
 )
 from marimo._server.session.session_view import SessionView
@@ -67,7 +69,7 @@ def serialize_session_view(view: SessionView) -> NotebookSessionV1:
 
     for cell_id, cell_op in view.cell_operations.items():
         outputs: list[OutputType] = []
-        console: list[StreamOutput] = []
+        console: list[ConsoleType] = []
 
         # Convert output
         if cell_op.output:
@@ -90,7 +92,17 @@ def serialize_session_view(view: SessionView) -> NotebookSessionV1:
         # Convert console outputs
         for console_out in as_list(cell_op.console):
             assert isinstance(console_out, CellOutput)
-            if console_out:
+            if console_out.channel == CellChannel.MEDIA:
+                console.append(
+                    StreamMediaOutput(
+                        type="stream",
+                        name="media",
+                        mimetype=console_out.mimetype,
+                        data=str(console_out.data),
+                    )
+                )
+            else:
+                # catch all for everything else
                 console.append(
                     StreamOutput(
                         type="stream",
@@ -172,15 +184,24 @@ def deserialize_session(session: NotebookSessionV1) -> SessionView:
         # Convert console
         console_outputs: list[CellOutput] = []
         for console in cell["console"]:
-            console_outputs.append(
-                CellOutput(
-                    channel=CellChannel.STDERR
-                    if console["name"] == "stderr"
-                    else CellChannel.STDOUT,
-                    data=console["text"],
-                    mimetype="text/plain",
+            if console["name"] == "media":
+                console_outputs.append(
+                    CellOutput(
+                        channel=CellChannel.MEDIA,
+                        data=console["data"],
+                        mimetype=console["mimetype"],
+                    )
                 )
-            )
+            else:
+                console_outputs.append(
+                    CellOutput(
+                        channel=CellChannel.STDERR
+                        if console["name"] == "stderr"
+                        else CellChannel.STDOUT,
+                        data=console["text"],
+                        mimetype="text/plain",
+                    )
+                )
 
         cell_id = CellId_t(cell["id"])
 
@@ -201,6 +222,8 @@ def serialize_notebook(
     """Convert a SessionView to a Notebook schema."""
     cells: list[NotebookCell] = []
 
+    # Use document order from cell_manager instead of execution order from session_view
+    # to ensure cells appear in the correct sequence in HTML export
     for cell_id in cell_manager.cell_ids():
         # Get the code from last_executed_code, fallback to empty string
         code = view.last_executed_code.get(cell_id, "")


### PR DESCRIPTION
The issues experienced in #5370 seem to be related to two separate things:

1. Cell outputs appear to be in topological order instead of document order
2. Rich media console outputs aren't rendered in the HTML export

The latter seems to be related to our recent schema/serialization work where matplotlib plots get stuck in console outputs instead of being promoted to main outputs for frontend rendering.

I think I'm close to a fix but I haven't been able to run a local build to verify, so marking this as draft.

Fixes #5370
