### PR TITLE
fix: copilot directory structure

### DIFF
--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -86,6 +86,11 @@ jobs:
             fi
           done
 
+          if unzip -l "$wheel_file" | grep -q "marimo/_lsp/copilot/dist" ]; then
+              echo "Error: marimo/_lsp/copilot should not have a dist/ directory"
+              exit 1
+          fi
+
       - name: Run LSP binary
         run: ./scripts/test-lsp.sh
       - name: Upload wheel

--- a/scripts/test-lsp.sh
+++ b/scripts/test-lsp.sh
@@ -6,11 +6,14 @@ list_directories() {
 }
 
 
+list_directories
+
 if [ -d "marimo/_lsp/copilot/dist" ]; then
     echo "Error: marimo/_lsp/copilot should not have a dist/ directory"
     list_directories
     exit 1
 fi
+echo "Copilot directory structure looks correct."
 
 
 node marimo/_lsp/index.cjs --help > /dev/null

--- a/scripts/test-lsp.sh
+++ b/scripts/test-lsp.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
+list_directories() {
+    # List out contents of the directories
+    tree marimo/_lsp
+    tree lsp/dist
+}
+
+
+if [ -d "marimo/_lsp/copilot/dist" ]; then
+    echo "Error: marimo/_lsp/copilot should not have a dist/ directory"
+    list_directories
+    exit 1
+fi
+
+
 node marimo/_lsp/index.cjs --help > /dev/null
 if [ $? -ne 0 ]; then
     echo "LSP binary failed to start"
-    # List out contents of the directory
-    tree marimo/_lsp
-    tree lsp/dist
+    list_directories
     exit 1
 fi
 echo "LSP binary started successfully"


### PR DESCRIPTION
We expect the copilot assets to be at

marimo/_lsp/copilot/

When running in CI (building releases) we are sometimes incorrectly putting them at

marimo/_lsp/dist/...

Getting this test to pass should fix #5063. Marking as a draft as the fix is not yet implemented, I just need to see what we're building in CI. 

Edit: never mind, misunderstood what was going on. Back to square one, closing.