### PR TITLE
fix: copilot connection

### DIFF
--- a/frontend/src/core/runtime/runtime.ts
+++ b/frontend/src/core/runtime/runtime.ts
@@ -104,6 +104,12 @@ export class RuntimeManager {
    * The URL of the copilot server.
    */
   getLSPURL(lsp: "pylsp" | "copilot"): URL {
+    if (lsp === "copilot") {
+      // For copilot, don't include any query parameters
+      const url = this.formatWsURL(`/lsp/${lsp}`);
+      url.search = "";
+      return url;
+    }
     return this.formatWsURL(`/lsp/${lsp}`);
   }
 


### PR DESCRIPTION
The copilot language server's URL is just /copilot, no query parameters (such as the file) are used.

Without this change, we were attempting to connect to

/copilot?file=...

which would fail.

In previous releases, we first tried connecting to /copilot?file=..., which failed, but then we somehow connected to /copilot, which succeeded.

It seems like a recent change removed the second connection attempt, exposing this bug.

I've tested locally ... but in the future it would be good to have a better test for this.

Fixes #5364 