### PR TITLE
fix: media console outputs from serialized notebook

### DIFF
--- a/frontend/src/core/cells/session.ts
+++ b/frontend/src/core/cells/session.ts
@@ -214,12 +214,24 @@ function createCellRuntimeFromSession(
   return {
     ...runtimeState,
     outline: runtimeState.output ? parseOutline(runtimeState.output) : null,
-    consoleOutputs: consoleOutputs.map((consoleOutput) => ({
-      channel: consoleOutput.name === "stderr" ? "stderr" : "stdout",
-      data: consoleOutput.text,
-      mimetype: "text/plain",
-      timestamp: DEFAULT_TIMESTAMP,
-    })),
+    consoleOutputs: consoleOutputs.map((consoleOutput) => {
+      // Handle StreamMediaOutput (type: "streamMedia")
+      if (consoleOutput.type === "streamMedia") {
+        return {
+          channel: "media",
+          data: consoleOutput.data,
+          mimetype: consoleOutput.mimetype,
+          timestamp: DEFAULT_TIMESTAMP,
+        };
+      }
+      // Handle StreamOutput (type: "stream")
+      return {
+        channel: consoleOutput.name === "stderr" ? "stderr" : "stdout",
+        data: consoleOutput.text,
+        mimetype: "text/plain",
+        timestamp: DEFAULT_TIMESTAMP,
+      };
+    }),
   };
 }
 


### PR DESCRIPTION
When restoring the cell runtime from a serialized notebook, check for the presence of media outputs in the console output area.