### PR TITLE
[Windows] Fix `Copy Path` and `Copy Relative Path` returning identical results.

### DIFF
--- a/frontend/src/components/editor/file-tree/__tests__/requesting-tree.test.ts
+++ b/frontend/src/components/editor/file-tree/__tests__/requesting-tree.test.ts
@@ -1,6 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { toast } from "@/components/ui/use-toast";
+import type { FilePath } from "@/utils/paths";
 import { RequestingTree } from "../requesting-tree";
 
 const sendListFiles = vi.fn();
@@ -259,6 +260,64 @@ describe("RequestingTree", () => {
       expect(sendListFiles).toHaveBeenCalled();
       // Ensure onChange is still called to update UI even if data might not have changed
       expect(mockOnChange).toHaveBeenCalled();
+    });
+  });
+
+  describe("relativeFromRoot", () => {
+    test("should return relative path for Unix paths", async () => {
+      // Unix-style paths
+      const tree = new RequestingTree({
+        listFiles: sendListFiles,
+        createFileOrFolder: sendCreateFileOrFolder,
+        deleteFileOrFolder: sendDeleteFileOrFolder,
+        renameFileOrFolder: sendRenameFileOrFolder,
+      });
+
+      sendListFiles.mockResolvedValue({
+        files: [],
+        root: "/home/user/project",
+      });
+
+      await tree.initialize(vi.fn());
+
+      const relativePath = tree.relativeFromRoot(
+        "/home/user/project/src/file.py" as FilePath,
+      );
+      expect(relativePath).toBe("src/file.py");
+    });
+
+    test("should return relative path for Windows paths", async () => {
+      // Windows-style paths
+      const tree = new RequestingTree({
+        listFiles: sendListFiles,
+        createFileOrFolder: sendCreateFileOrFolder,
+        deleteFileOrFolder: sendDeleteFileOrFolder,
+        renameFileOrFolder: sendRenameFileOrFolder,
+      });
+
+      sendListFiles.mockResolvedValue({
+        files: [],
+        root: "C:\\Users\\test\\project",
+      });
+
+      await tree.initialize(vi.fn());
+
+      const relativePath = tree.relativeFromRoot(
+        "C:\\Users\\test\\project\\src\\file.py" as FilePath,
+      );
+      expect(relativePath).toBe("src\\file.py");
+    });
+
+    test("should return original path when not under root", async () => {
+      const relativePath = requestingTree.relativeFromRoot(
+        "/other/path/file.py" as FilePath,
+      );
+      expect(relativePath).toBe("/other/path/file.py");
+    });
+
+    test("should handle root path exactly", async () => {
+      const relativePath = requestingTree.relativeFromRoot("/root" as FilePath);
+      expect(relativePath).toBe("/root");
     });
   });
 });

--- a/frontend/src/components/editor/file-tree/requesting-tree.tsx
+++ b/frontend/src/components/editor/file-tree/requesting-tree.tsx
@@ -203,11 +203,16 @@ export class RequestingTree {
   };
 
   public relativeFromRoot = (path: FilePath): FilePath => {
-    const root = withTrailingSlash(this.rootPath);
+    const root = this.withTrailingDelimiter(this.rootPath);
     if (path.startsWith(root)) {
       return path.slice(root.length) as FilePath;
     }
     return path;
+  };
+
+  private withTrailingDelimiter = (path: string): string => {
+    const delimiter = this.path.deliminator;
+    return path.endsWith(delimiter) ? path : `${path}${delimiter}`;
   };
 
   private handleResponse = (
@@ -223,8 +228,4 @@ export class RequestingTree {
 
     return response;
   };
-}
-
-function withTrailingSlash(path: string): string {
-  return path.endsWith("/") ? path : `${path}/`;
 }


### PR DESCRIPTION
## 📝 Summary

Fix #5395 

## 🔍 Description of Changes

Both copy path options in the file explorer's (View File sidebar panel) context menu were returning the same absolute path on Windows systems. The relative path should show only the portion relative to the workspace root, not the full/absolute path.

Fixed by replacing the slash logic with a new `withTrailingDelimiter` method that uses the existing `PathBuilder.deliminator` to append the correct path separator accordingly.

Added tests covering both Unix and Windows path scenarios.

**Before**: Both options returned `D:\full\path\to\file.py`  
**After**: Copy Path returns `D:\full\path\to\file.py`, Copy Relative Path returns `subfolder\file.py`

## Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

@akshayka OR @Light2Dark 
