### PR TITLE
chore(frontend): Add `invariant` debugger statement for development

### DIFF
--- a/frontend/src/utils/assertNever.ts
+++ b/frontend/src/utils/assertNever.ts
@@ -1,11 +1,12 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { invariant } from "./invariant";
 import { Logger } from "./Logger";
 
 /**
  * Type-safe exhaustiveness check for discriminated unions.
  */
 export function assertNever(x: never): never {
-  throw new Error(`Unexpected object: ${x}`);
+  invariant(false, `Unexpected object: ${x}`);
 }
 
 /**

--- a/frontend/src/utils/invariant.ts
+++ b/frontend/src/utils/invariant.ts
@@ -27,6 +27,11 @@ export function invariant(
   msg: string,
 ): asserts expression {
   if (!expression) {
+    if (import.meta.env.DEV) {
+      // Triggers a breakpoint in development; stripped out in production builds.
+      // biome-ignore lint/suspicious/noDebugger: code block is stripped out in production builds
+      debugger; // eslint-disable-line no-debugger
+    }
     throw new Error(msg);
   }
 }


### PR DESCRIPTION
I do this often during development and find it really useful for debugging invariant failures. Thought I'd share this either to show other folks or check it into the repo so other developers can use it too.

The conditional `debugger` statement to the `invariant()` utility only runs in development. When an invariant fails, it automatically triggers a breakpoint in the browser before throwing the error. This immediately allows you to step into where some assertion failed.

The nice property is that the entire `if (import.meta.env.DEV)` block gets stripped out in production builds (e.g., `vite build`) since the bundler resolves to `if (false) {}`.
