### PR TITLE
logging: downgrade warning to debug for session cache serialization

### DIFF
--- a/marimo/_server/session/serialize.py
+++ b/marimo/_server/session/serialize.py
@@ -82,7 +82,8 @@ def serialize_session_view(
         if view.cell_ids is not None:
             cell_ids = view.cell_ids.cell_ids
         else:
-            LOGGER.warning(
+            # TODO: Reconcile HTML, and json exports. Something seems a bit off.
+            LOGGER.debug(
                 "When serializing session view, the notebook-order of cells was "
                 "not known. This may cause issues when attempting to "
                 "reconstruct the notebook state from the serialized session "

--- a/marimo/_server/session/serialize.py
+++ b/marimo/_server/session/serialize.py
@@ -82,7 +82,7 @@ def serialize_session_view(
         if view.cell_ids is not None:
             cell_ids = view.cell_ids.cell_ids
         else:
-            # TODO: Reconcile HTML, and json exports. Something seems a bit off.
+            # TODO: This is a problem for exporting to HTML, but not for caching the session view for replays. Something seems off.
             LOGGER.debug(
                 "When serializing session view, the notebook-order of cells was "
                 "not known. This may cause issues when attempting to "


### PR DESCRIPTION
Demote log warning when serializing the session view to a log info.
* The session cache writer does not seem to know the notebook-order of cells. This doesn't seem to be a problem in practice (can run a notebook and hydrate from a cached session view object just fine). But it's odd that not having the notebook order does pose a problem when hydrating an exported HTML object.

@akshayka