### PR TITLE
fix: resolve chat message duplication on first message send

### DIFF
--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -535,13 +535,7 @@ const ChatPanelBody = () => {
         initialMessage.length > 50
           ? `${initialMessage.slice(0, 50)}...`
           : initialMessage,
-      messages: [
-        {
-          role: "user",
-          content: initialMessage,
-          timestamp: Date.now(),
-        },
-      ],
+      messages: [], // Don't pre-populate - let useChat handle it and sync back
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };


### PR DESCRIPTION
Chat messages were appearing duplicated in the AI chat panel when users sent their first message in a new conversation. I believe this regression was introduced in a2d62b3b.

The duplication occurs because `createNewThread` was pre-populating the persistent chat storage with the initial message and then calling `append()` to add the same message to `useChat`. Since `useChat` loads its `initialMessages` from persistent storage, the message appeared twice.

Fixed by removing the pre-population of messages in `createNewThread`. Now the flow is: create empty chat → `append()` adds message to `useChat` → `handleChatInputSubmit` syncs to persistent storage.
