### PR TITLE
Fix StateRegistry retain_active_states

### DIFF
--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -80,7 +80,10 @@ class DirectedGraph:
 
         This is a singleton for well-formed graphs.
         """
-        return self.definitions[name]
+        if name in self.definitions:
+            return self.definitions[name]
+        else:
+            return set()
 
     def get_referring_cells(
         self, name: Name, language: Literal["python", "sql"]

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -551,9 +551,11 @@ class Runner:
     ) -> tuple[str, Optional[CellId_t]]:
         ref = e.ref
         blamed_cell = None
-        try:
-            (blamed_cell, *_) = self.graph.get_defining_cells(ref)
-        except KeyError:
+
+        definitions = self.graph.get_defining_cells(ref)
+        if definitions:
+            (blamed_cell, *_) = definitions
+        else:
             # The reference is not found anywhere else in the graph
             # but it might be private
             ref, var_cell_id = unmangle_local(ref)

--- a/marimo/_runtime/state.py
+++ b/marimo/_runtime/state.py
@@ -116,7 +116,7 @@ class StateRegistry:
                         del self._inv_states[id_key]
                 del self._states[state_key]
             else:
-                active_state_ids.add(id(self._states[state_key]))
+                active_state_ids.add(self._states[state_key].id)
 
         # Remove all non-active states by id
         for state_id in list(self._inv_states.keys()):

--- a/tests/_runtime/test_state.py
+++ b/tests/_runtime/test_state.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from marimo._runtime.runtime import Kernel
+from marimo._runtime.state import StateRegistry, State
 from tests.conftest import ExecReqProvider
 
 
@@ -218,3 +219,17 @@ async def test_set_state_not_strict_copied(
 
     assert id(k.globals["a"]) == id(k.globals["state"])
     assert id(k.globals["b"]) == id(k.globals["set_state"])
+
+
+def test_retain_active_states() -> None:
+    state_registry = StateRegistry()
+    state = State(None)
+    state_registry.register(state, "state")
+
+    assert state_registry.lookup("state")
+    assert state_registry.bound_names(state) == {"state"}
+
+    state_registry.retain_active_states({"state"})
+
+    assert state_registry.lookup("state")
+    assert state_registry.bound_names(state) == {"state"}

--- a/tests/_runtime/test_state.py
+++ b/tests/_runtime/test_state.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from marimo._runtime.runtime import Kernel
-from marimo._runtime.state import StateRegistry, State
+from marimo._runtime.state import State, StateRegistry
 from tests.conftest import ExecReqProvider
 
 


### PR DESCRIPTION
## 📝 Summary

The `retain_active_states` method of the `StateRegistry` class was incorrectly removing elements from the `_inv_states` instance variable when they had been marked as active due to a confusion between `State` and `StateItem` references.

## 🔍 Description of Changes

This PR is primarily to address the above error by getting the `id` reference of the underlying `State` item when marking states are active instead of using the `id` of the `StateItem` reference itself.

When a state is registered, the reference in the `_states` instance variable is a `StateItem`, not the `State` itself.

```python
        # register
        state_item = StateItem(id(state), weakref.ref(state))
        self._states[name] = state_item
```

The prior logic in `retain_active_states` marked a state as active by storing the `id` of the element in `_states`, and checking that against the keys in `_inv_state`. The keys in `_inv_state` are the IDs of the `State`s, not the `StateItem`s, so they are _never_ retained properly.


```python
        # register
        id_to_ref = self._inv_states.get(id(state), set())
        id_to_ref.add(name)
        self._inv_states[id(state)] = id_to_ref
```


```python
        # retain_active_states
        ...
                active_state_ids.add(id(self._states[state_key]))
        ...
        for state_id in list(self._inv_states.keys()):
            if state_id not in active_state_ids:
                del self._inv_states[state_id]
```

This was addressed by storing the `id` of the `State` instead of the `StateItem` in `active_state_ids`

The other changes present in the PR are a consequence of that fix. With this change states are no longer incorrectly removed from the registry (at least partially). This leads to the `update_stateful_values` calls when a `PathState` is updated to actually be passed the bound names of the `PathState` (which include ones of the form `file:<uuid>`), which causes the `get_defining_cells` calls of `Graph` to throw an exception since there is no defining cell for these `file:<uuid>` form names.

This is the snippet in question that throws an exception now that the names are retained.

```python
                referring_cells |= self.graph.get_referring_cells(
                    name, language="python"
                ) - self.graph.get_defining_cells(name)
```

To address this, I have changed `get_defining_cells` to not throw a `KeyError` when given a name that isn't defined and instead return an empty `Set`.

This itself required a small change to the one place in the codebase that was handling the `KeyError`. It has been refactored to handling an empty return object.

This is only half of the fix necessary for the above `PathState`s because they are _still_ not being retained fully. The post execution hook that actually calls `retain_active_states` is only passing it all the definitions of the `Graph`, which does not have these `file:<uuid>` names in them, so they're still being removed. I am not familiar enough with the system to suggest a fix for that though, so I'm stopping at fixing the broken retaining logic (at least for now)

https://github.com/marimo-team/marimo/blob/80a17194c84711eeca2bd9264ad6c09d07b44675/marimo/_runtime/runner/hooks_post_execution.py#L244-L246

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
