### PR TITLE
dev: Use islands as local asset server

### DIFF
--- a/frontend/islands/vite.config.mts
+++ b/frontend/islands/vite.config.mts
@@ -40,7 +40,6 @@ export default defineConfig({
     "process.env": {
       NODE_ENV: JSON.stringify(process.env.NODE_ENV),
     },
-    "import.meta.env.VITE_MARIMO_ISLANDS": JSON.stringify(true),
     // Precedence: VITE_MARIMO_VERSION > package.json version > "latest"
     "import.meta.env.VITE_MARIMO_VERSION": process.env.VITE_MARIMO_VERSION
       ? JSON.stringify(process.env.VITE_MARIMO_VERSION)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -172,6 +172,7 @@
     "lint:stylelint": "stylelint src/**/*.css --fix",
     "format": "biome format --write .",
     "preview": "vite preview",
+    "dev:quarto": "VITE_MARIMO_ISLANDS=true vite",
     "dev:islands": "cross-env VITE_MARIMO_ISLANDS=true vite --config islands/vite.config.mts",
     "build:islands": "cross-env VITE_MARIMO_ISLANDS=true vite --config islands/vite.config.mts build",
     "preview:islands": "cross-env VITE_MARIMO_VERSION='0.4.6' VITE_MARIMO_ISLANDS=true vite --config islands/vite.config.mts build",

--- a/frontend/src/core/dom/htmlUtils.ts
+++ b/frontend/src/core/dom/htmlUtils.ts
@@ -5,6 +5,7 @@ import { Objects } from "@/utils/objects";
 import { UIElementId } from "../cells/ids";
 import { PyodideRouter } from "../wasm/router";
 import { isWasm } from "../wasm/utils";
+import { isIslands } from "../islands/utils";
 import type { UIElementRegistry } from "./uiregistry";
 
 /**
@@ -50,6 +51,10 @@ export function serializeInitialValue(value: unknown) {
 }
 
 export function getFilenameFromDOM() {
+  // If running in Islands, just return the window title.
+  if (isIslands()) {
+    return document.title || null;
+  }
   // If we are running in WASM, we can get the filename from the URL
   if (isWasm()) {
     const filename = PyodideRouter.getFilename();

--- a/frontend/src/core/dom/htmlUtils.ts
+++ b/frontend/src/core/dom/htmlUtils.ts
@@ -3,9 +3,9 @@ import { assertExists } from "@/utils/assertExists";
 import { jsonParseWithSpecialChar } from "@/utils/json/json-parser";
 import { Objects } from "@/utils/objects";
 import { UIElementId } from "../cells/ids";
+import { isIslands } from "../islands/utils";
 import { PyodideRouter } from "../wasm/router";
 import { isWasm } from "../wasm/utils";
-import { isIslands } from "../islands/utils";
 import type { UIElementRegistry } from "./uiregistry";
 
 /**

--- a/frontend/src/core/islands/utils.ts
+++ b/frontend/src/core/islands/utils.ts
@@ -1,5 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 export function isIslands() {
-  return import.meta.env.VITE_MARIMO_ISLANDS === true;
+  return import.meta.env.VITE_MARIMO_ISLANDS === "true";
 }

--- a/frontend/src/core/websocket/StaticWebsocket.ts
+++ b/frontend/src/core/websocket/StaticWebsocket.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+
 import type { IReconnectingWebSocket } from "./types";
-import type { isIslands } from "@core/islands/utils";
 
 export class StaticWebsocket implements IReconnectingWebSocket {
   CONNECTING = WebSocket.CONNECTING;

--- a/frontend/src/core/websocket/StaticWebsocket.ts
+++ b/frontend/src/core/websocket/StaticWebsocket.ts
@@ -1,5 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import type { IReconnectingWebSocket } from "./types";
+import type { isIslands } from "@core/islands/utils";
 
 export class StaticWebsocket implements IReconnectingWebSocket {
   CONNECTING = WebSocket.CONNECTING;
@@ -24,7 +25,7 @@ export class StaticWebsocket implements IReconnectingWebSocket {
   ): void {
     // Normally this would be a no-op in a mock, but we simulate a synthetic "open" event
     // to mimic the WebSocket transitioning from CONNECTING to OPEN state.
-    if (type === "open") {
+    if (type === "open" && !isIslands()) {
       queueMicrotask(() => {
         callback(new Event("open"));
       });

--- a/frontend/src/core/websocket/StaticWebsocket.ts
+++ b/frontend/src/core/websocket/StaticWebsocket.ts
@@ -1,7 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import type { IReconnectingWebSocket } from "./types";
 import { isIslands } from "@/core/islands/utils";
+import type { IReconnectingWebSocket } from "./types";
 
 export class StaticWebsocket implements IReconnectingWebSocket {
   CONNECTING = WebSocket.CONNECTING;

--- a/frontend/src/core/websocket/StaticWebsocket.ts
+++ b/frontend/src/core/websocket/StaticWebsocket.ts
@@ -1,6 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import type { IReconnectingWebSocket } from "./types";
+import { isIslands } from "@/core/islands/utils";
 
 export class StaticWebsocket implements IReconnectingWebSocket {
   CONNECTING = WebSocket.CONNECTING;

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -13,6 +13,7 @@ const TARGET = `http://${HOST}:${SERVER_PORT}`;
 const isDev = process.env.NODE_ENV === "development";
 const isStorybook = process.env.npm_lifecycle_script?.includes("storybook");
 const isPyodide = process.env.PYODIDE === "true";
+const isIslands = process.env.VITE_MARIMO_ISLANDS === "true";
 
 const htmlDevPlugin = (): Plugin => {
   return {
@@ -252,6 +253,8 @@ export default defineConfig({
       : {},
   },
   define: {
+    // Used when serving local assets in dev mode for islands.
+    "import.meta.env.VITE_MARIMO_ISLANDS": JSON.stringify(isIslands),
     "import.meta.env.VITE_MARIMO_VERSION": process.env.VITE_MARIMO_VERSION
       ? JSON.stringify(process.env.VITE_MARIMO_VERSION)
       : JSON.stringify("latest"),

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -13,7 +13,6 @@ const TARGET = `http://${HOST}:${SERVER_PORT}`;
 const isDev = process.env.NODE_ENV === "development";
 const isStorybook = process.env.npm_lifecycle_script?.includes("storybook");
 const isPyodide = process.env.PYODIDE === "true";
-const isIslands = process.env.VITE_MARIMO_ISLANDS === "true";
 
 const htmlDevPlugin = (): Plugin => {
   return {
@@ -253,8 +252,6 @@ export default defineConfig({
       : {},
   },
   define: {
-    // Used when serving local assets in dev mode for islands.
-    "import.meta.env.VITE_MARIMO_ISLANDS": JSON.stringify(isIslands),
     "import.meta.env.VITE_MARIMO_VERSION": process.env.VITE_MARIMO_VERSION
       ? JSON.stringify(process.env.VITE_MARIMO_VERSION)
       : JSON.stringify("latest"),


### PR DESCRIPTION
## 📝 Summary

quarto `0.14.7` is broken.

I'm having trouble confirming this is the issue by replicating it locally, since I can't replicate the breakage. My dev served assets seem to work in general. But `being islands` != `being wasm` as is, and I think some of the logic around sockets gets lost (0.14.6 works, so this may be the offending PR: #5403)

@akshayka