### PR TITLE
chore(frontend/lsp): Replace "as `any`" type assertion with a type guard

### DIFF
--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -8,7 +8,11 @@ import { Logger } from "@/utils/Logger";
 import { LRUCache } from "@/utils/lru";
 import { getTopologicalCodes } from "../copilot/getCodes";
 import { createNotebookLens } from "./lens";
-import { CellDocumentUri, type ILanguageServerClient } from "./types";
+import {
+  CellDocumentUri,
+  type ILanguageServerClient,
+  isNotifyingClient,
+} from "./types";
 import { getLSPDocument } from "./utils";
 
 export class NotebookLanguageServerClient implements ILanguageServerClient {
@@ -42,12 +46,10 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
     // Handle configuration after initialization
     this.initializePromise.then(() => {
       invariant(
-        "notify" in this.client,
+        isNotifyingClient(this.client),
         "notify is not a method on the client",
       );
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this.client as any).notify("workspace/didChangeConfiguration", {
+      this.client.notify("workspace/didChangeConfiguration", {
         settings: initialSettings,
       });
     });

--- a/frontend/src/core/codemirror/lsp/types.ts
+++ b/frontend/src/core/codemirror/lsp/types.ts
@@ -25,3 +25,18 @@ export const CellDocumentUri = {
     return uri.slice(this.PREFIX.length) as CellId;
   },
 };
+
+/**
+ * Notify is a @protected method on `LanguageServerClient`,
+ * hiding public use with TypeScript.
+ */
+export function isNotifyingClient(
+  client: ILanguageServerClient,
+): client is ILanguageServerClient & {
+  notify: (
+    kind: string,
+    options: { settings: Record<string, unknown> },
+  ) => void;
+} {
+  return "notify" in client;
+}


### PR DESCRIPTION
Adds a custom type guard for the protected `notify` method on
`LanguageServerClient`s. Removes the need for a type assertion and
ignoring eslint rule.
