### PR TITLE
fix: disable controls when not connected

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -43,7 +43,7 @@ module.exports = {
     "header/header": [
       "error",
       "block",
-      " Copyright 2024 Marimo. All rights reserved. ",
+      " Copyright 2025 Marimo. All rights reserved. ",
     ],
 
     // These rules don't require type information and have autofixes

--- a/frontend/src/components/app-config/app-config-button.tsx
+++ b/frontend/src/components/app-config/app-config-button.tsx
@@ -14,13 +14,27 @@ import { Dialog, DialogContent, DialogTrigger } from "../ui/dialog";
 import { Tooltip } from "../ui/tooltip";
 import { settingDialogAtom } from "./state";
 import { UserConfigForm } from "./user-config-form";
+import type { WebSocketState } from "@/core/websocket/types";
+import {
+  getConnectionTooltip,
+  isAppInteractionDisabled,
+} from "@/core/websocket/connection-utils";
 
 interface Props {
   showAppConfig?: boolean;
+  connectionState: WebSocketState;
 }
 
-export const ConfigButton: React.FC<Props> = ({ showAppConfig = true }) => {
+export const ConfigButton: React.FC<Props> = ({
+  showAppConfig = true,
+  connectionState,
+}) => {
   const [settingDialog, setSettingDialog] = useAtom(settingDialogAtom);
+  const isDisabled = isAppInteractionDisabled(connectionState);
+  const tooltipContent = isDisabled
+    ? getConnectionTooltip(connectionState)
+    : "Settings";
+
   const button = (
     <EditorButton
       aria-label="Config"
@@ -28,9 +42,9 @@ export const ConfigButton: React.FC<Props> = ({ showAppConfig = true }) => {
       shape="circle"
       size="small"
       className="h-[27px] w-[27px]"
-      color="hint-green"
+      color={isDisabled ? "disabled" : "hint-green"}
     >
-      <Tooltip content="Settings">
+      <Tooltip content={tooltipContent}>
         <SettingsIcon strokeWidth={1.8} />
       </Tooltip>
     </EditorButton>

--- a/frontend/src/components/editor/controls/Controls.tsx
+++ b/frontend/src/components/editor/controls/Controls.tsx
@@ -31,13 +31,14 @@ import { useShouldShowInterrupt } from "../cell/useShouldShowInterrupt";
 import { HideInKioskMode } from "../kiosk-mode";
 import { LayoutSelect } from "../renderers/layout-select";
 import { CommandPaletteButton } from "./command-palette-button";
+import { WebSocketState } from "@/core/websocket/types";
 
 interface ControlsProps {
   presenting: boolean;
   onTogglePresenting: () => void;
   onInterrupt: () => void;
   onRun: () => void;
-  closed: boolean;
+  connectionState: WebSocketState;
   running: boolean;
   appConfig: AppConfig;
 }
@@ -47,7 +48,7 @@ export const Controls = ({
   onTogglePresenting,
   onInterrupt,
   onRun,
-  closed,
+  connectionState,
   running,
   appConfig,
 }: ControlsProps): JSX.Element => {
@@ -55,6 +56,7 @@ export const Controls = ({
   const undoAvailable = useAtomValue(canUndoDeletesAtom);
   const needsRun = useAtomValue(needsRunAtom);
   const { undoDeleteCell } = useCellActions();
+  const closed = connectionState === WebSocketState.CLOSED;
 
   let undoControl: JSX.Element | null = null;
   if (!closed && undoAvailable) {
@@ -80,9 +82,12 @@ export const Controls = ({
       {!closed && (
         <div className={topRightControls}>
           {presenting && <LayoutSelect />}
-          <NotebookMenuDropdown />
-          <ConfigButton />
-          <ShutdownButton description="This will terminate the Python kernel. You'll lose all data that's in memory." />
+          <NotebookMenuDropdown connectionState={connectionState} />
+          <ConfigButton connectionState={connectionState} />
+          <ShutdownButton
+            description="This will terminate the Python kernel. You'll lose all data that's in memory."
+            connectionState={connectionState}
+          />
         </div>
       )}
 

--- a/frontend/src/components/editor/controls/notebook-menu-dropdown.tsx
+++ b/frontend/src/components/editor/controls/notebook-menu-dropdown.tsx
@@ -19,9 +19,22 @@ import { getMarimoVersion } from "@/core/meta/globals";
 import { MinimalShortcut } from "../../shortcuts/renderShortcut";
 import type { ActionButton } from "../actions/types";
 import { useNotebookActions } from "../actions/useNotebookActions";
+import {
+  getConnectionTooltip,
+  isAppInteractionDisabled,
+} from "@/core/websocket/connection-utils";
+import type { WebSocketState } from "@/core/websocket/types";
 
-export const NotebookMenuDropdown: React.FC = () => {
+interface Props {
+  connectionState: WebSocketState;
+}
+
+export const NotebookMenuDropdown: React.FC<Props> = ({ connectionState }) => {
   const actions = useNotebookActions();
+  const isDisabled = isAppInteractionDisabled(connectionState);
+  const tooltipContent = isDisabled
+    ? getConnectionTooltip(connectionState)
+    : "Actions";
 
   const button = (
     <Button
@@ -30,9 +43,11 @@ export const NotebookMenuDropdown: React.FC = () => {
       size="small"
       className="h-[27px] w-[27px]"
       data-testid="notebook-menu-dropdown"
-      color="hint-green"
+      color={isDisabled ? "disabled" : "hint-green"}
     >
-      <MenuIcon strokeWidth={1.8} />
+      <Tooltip content={tooltipContent}>
+        <MenuIcon strokeWidth={1.8} />
+      </Tooltip>
     </Button>
   );
 

--- a/frontend/src/components/editor/controls/shutdown-button.tsx
+++ b/frontend/src/components/editor/controls/shutdown-button.tsx
@@ -7,8 +7,16 @@ import { useImperativeModal } from "../../modal/ImperativeModal";
 import { AlertDialogDestructiveAction } from "../../ui/alert-dialog";
 import { Tooltip } from "../../ui/tooltip";
 import { Button } from "../inputs/Inputs";
+import {
+  getConnectionTooltip,
+  isAppInteractionDisabled,
+} from "@/core/websocket/connection-utils";
+import { WebSocketState } from "@/core/websocket/types";
 
-export const ShutdownButton: React.FC<{ description: string }> = (props) => {
+export const ShutdownButton: React.FC<{
+  description: string;
+  connectionState: WebSocketState;
+}> = (props) => {
   const { openConfirm, closeModal } = useImperativeModal();
   const handleShutdown = () => {
     sendShutdown();
@@ -22,15 +30,19 @@ export const ShutdownButton: React.FC<{ description: string }> = (props) => {
     return null;
   }
 
+  const isDisabled = isAppInteractionDisabled(connectionState);
+  const tooltipContent = isDisabled ? getConnectionTooltip(connectionState) : "Shutdown";
+
   return (
-    <Tooltip content="Shutdown">
+    <Tooltip content={tooltipContent}>
       <Button
         aria-label="Shutdown"
         data-testid="shutdown-button"
         shape="circle"
         size="small"
-        color="red"
+        color={isDisabled ? "disabled" : "red"}
         className="h-[27px] w-[27px]"
+        disabled={isDisabled}
         onClick={(e) => {
           e.stopPropagation();
           openConfirm({

--- a/frontend/src/components/editor/inputs/Inputs.styles.ts
+++ b/frontend/src/components/editor/inputs/Inputs.styles.ts
@@ -18,7 +18,7 @@ export const button = cva(
         yellow: "mo-button yellow",
         // for actions that will change state but are not destructive
         "hint-green": "mo-button hint-green",
-        disabled: "mo-button disabled",
+        disabled: "mo-button disabled active:shadow-xsSolid",
       },
       shape: {
         rectangle: "rounded",

--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -34,7 +34,6 @@ import { viewStateAtom } from "./mode";
 import { useFilename } from "./saving/filename";
 import { lastSavedNotebookAtom } from "./saving/state";
 import { useJotaiEffect } from "./state/jotai";
-import { WebSocketState } from "./websocket/types";
 import { useMarimoWebSocket } from "./websocket/useMarimoWebSocket";
 
 interface AppProps {
@@ -177,7 +176,7 @@ export const EditApp: React.FC<AppProps> = ({
             onTogglePresenting={togglePresenting}
             onInterrupt={sendInterrupt}
             onRun={runStaleCells}
-            closed={connection.state === WebSocketState.CLOSED}
+            connectionState={connection.state}
             running={isRunning}
             appConfig={appConfig}
           />


### PR DESCRIPTION
Disable the following controls when the frontend is not connected to a backend:

* shutdown
* user configuration
* notebook actions

Some of the actions in notebook actions may be safe when not connected, but coarsely disabling the entire menu is the simplest solution for now.