### PR TITLE
fix: loading progress bar in tables

### DIFF
--- a/frontend/src/components/data-table/TableActions.tsx
+++ b/frontend/src/components/data-table/TableActions.tsx
@@ -35,6 +35,7 @@ interface TableActionsProps<TData> {
   chartsFeatureEnabled?: boolean;
   togglePanel?: (panelType: PanelType) => void;
   isPanelOpen?: (panelType: PanelType) => boolean;
+  tableLoading?: boolean;
 }
 
 export const TableActions = <TData,>({
@@ -53,6 +54,7 @@ export const TableActions = <TData,>({
   chartsFeatureEnabled,
   togglePanel,
   isPanelOpen,
+  tableLoading,
 }: TableActionsProps<TData>) => {
   const handleSelectAllRows = (value: boolean) => {
     if (!onRowSelectionChange) {
@@ -163,6 +165,7 @@ export const TableActions = <TData,>({
           selection={selection}
           onSelectAllRowsChange={handleSelectAllRows}
           table={table}
+          tableLoading={tableLoading}
         />
       )}
       <div className="ml-auto">

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -126,11 +126,31 @@ const DataTableInternal = <TData,>({
   onViewedRowChange,
 }: DataTableProps<TData>) => {
   const [isSearchEnabled, setIsSearchEnabled] = React.useState<boolean>(false);
+  const [showLoadingBar, setShowLoadingBar] = React.useState<boolean>(false);
 
   const { columnPinning, setColumnPinning } = useColumnPinning(
     freezeColumnsLeft,
     freezeColumnsRight,
   );
+
+  // Show loading bar only after a reasonable delay
+  React.useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+
+    if (reloading) {
+      timeoutId = setTimeout(() => {
+        setShowLoadingBar(true);
+      }, 300);
+    } else {
+      setShowLoadingBar(false);
+    }
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [reloading]);
 
   // Returns the row index, accounting for pagination
   function getPaginatedRowIndex(row: TData, idx: number): number {
@@ -231,7 +251,10 @@ const DataTableInternal = <TData,>({
             reloading={reloading}
           />
         )}
-        <Table>
+        <Table className="relative">
+          {showLoadingBar && (
+            <div className="absolute top-0 left-0 h-[3px] w-1/2 bg-primary animate-slide" />
+          )}
           {renderTableHeader(table)}
           <CellSelectionProvider>
             <DataTableBody

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -283,6 +283,7 @@ const DataTableInternal = <TData,>({
         chartsFeatureEnabled={chartsFeatureEnabled}
         togglePanel={togglePanel}
         isPanelOpen={isPanelOpen}
+        tableLoading={reloading}
       />
     </div>
   );

--- a/frontend/src/components/data-table/pagination.tsx
+++ b/frontend/src/components/data-table/pagination.tsx
@@ -10,6 +10,7 @@ import {
   ChevronsRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Events } from "@/utils/events";
 import { PluralWord } from "@/utils/pluralize";
 import {
   Select,
@@ -27,6 +28,7 @@ interface DataTablePaginationProps<TData> {
   selection?: DataTableSelection;
   totalColumns: number;
   onSelectAllRowsChange?: (value: boolean) => void;
+  tableLoading?: boolean;
 }
 
 export const DataTablePagination = <TData,>({
@@ -34,6 +36,7 @@ export const DataTablePagination = <TData,>({
   selection,
   onSelectAllRowsChange,
   totalColumns,
+  tableLoading,
 }: DataTablePaginationProps<TData>) => {
   const renderTotal = () => {
     const { rowSelection, cellSelection } = table.getState();
@@ -59,6 +62,7 @@ export const DataTablePagination = <TData,>({
             data-testid="select-all-button"
             variant="link"
             className="h-4"
+            onMouseDown={Events.preventFocus}
             onClick={() => {
               if (onSelectAllRowsChange) {
                 onSelectAllRowsChange(true);
@@ -82,6 +86,7 @@ export const DataTablePagination = <TData,>({
             data-testid="clear-selection-button"
             variant="link"
             className="h-4"
+            onMouseDown={Events.preventFocus}
             onClick={() => {
               if (!isCellSelection) {
                 if (onSelectAllRowsChange) {
@@ -114,6 +119,13 @@ export const DataTablePagination = <TData,>({
   // Ensure unique page sizes
   const pageSizeSet = new Set([5, 10, 25, 50, 100, pageSize]);
   const pageSizes = [...pageSizeSet].sort((a, b) => a - b);
+
+  const handlePageChange = (pageChangeFn: () => void) => {
+    // Frequent page changes can reset the page index, so we wait until the previous change has completed
+    if (!tableLoading) {
+      pageChangeFn();
+    }
+  };
 
   return (
     <div className="flex flex-1 items-center justify-between px-2">
@@ -151,7 +163,8 @@ export const DataTablePagination = <TData,>({
           variant="outline"
           data-testid="first-page-button"
           className="hidden h-6 w-6 p-0 lg:flex"
-          onClick={() => table.setPageIndex(0)}
+          onClick={() => handlePageChange(() => table.setPageIndex(0))}
+          onMouseDown={Events.preventFocus}
           disabled={!table.getCanPreviousPage()}
         >
           <span className="sr-only">Go to first page</span>
@@ -162,7 +175,8 @@ export const DataTablePagination = <TData,>({
           variant="outline"
           data-testid="previous-page-button"
           className="h-6 w-6 p-0"
-          onClick={() => table.previousPage()}
+          onClick={() => handlePageChange(() => table.previousPage())}
+          onMouseDown={Events.preventFocus}
           disabled={!table.getCanPreviousPage()}
         >
           <span className="sr-only">Go to previous page</span>
@@ -173,7 +187,9 @@ export const DataTablePagination = <TData,>({
           <PageSelector
             currentPage={currentPage}
             totalPages={totalPages}
-            onPageChange={(page) => table.setPageIndex(page)}
+            onPageChange={(page) =>
+              handlePageChange(() => table.setPageIndex(page))
+            }
           />
           <span className="flex-shrink-0">of {prettyNumber(totalPages)}</span>
         </div>
@@ -182,7 +198,8 @@ export const DataTablePagination = <TData,>({
           variant="outline"
           data-testid="next-page-button"
           className="h-6 w-6 p-0"
-          onClick={() => table.nextPage()}
+          onClick={() => handlePageChange(() => table.nextPage())}
+          onMouseDown={Events.preventFocus}
           disabled={!table.getCanNextPage()}
         >
           <span className="sr-only">Go to next page</span>
@@ -193,7 +210,10 @@ export const DataTablePagination = <TData,>({
           variant="outline"
           data-testid="last-page-button"
           className="hidden h-6 w-6 p-0 lg:flex"
-          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          onClick={() =>
+            handlePageChange(() => table.setPageIndex(table.getPageCount() - 1))
+          }
+          onMouseDown={Events.preventFocus}
           disabled={!table.getCanNextPage()}
         >
           <span className="sr-only">Go to last page</span>

--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -55,9 +55,11 @@ export function renderTableHeader<TData>(
 
   return (
     <TableHeader>
-      {renderHeaderGroup(table.getLeftHeaderGroups())}
-      {renderHeaderGroup(table.getCenterHeaderGroups())}
-      {renderHeaderGroup(table.getRightHeaderGroups())}
+      <TableRow>
+        {renderHeaderGroup(table.getLeftHeaderGroups())}
+        {renderHeaderGroup(table.getCenterHeaderGroups())}
+        {renderHeaderGroup(table.getRightHeaderGroups())}
+      </TableRow>
     </TableHeader>
   );
 }

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -156,13 +156,18 @@ module.exports = {
           "0%, 100%": { opacity: "0.3" },
           "50%": { opacity: "1" },
         },
+        "slide": {
+          "0%": { transform: "translateX(-100%)" },
+          "100%": { transform: "translateX(400%)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "delayed-show-200": "delayed-show 200ms ease-out",
         "delayed-show-400": "delayed-show 400ms ease-out",
-        'ellipsis-dot': 'ellipsis-dot 400ms ease-in-out infinite'
+        'ellipsis-dot': 'ellipsis-dot 400ms ease-in-out infinite',
+        'slide': 'slide 1.5s ease-in-out infinite',
       },
       gridTemplateColumns: {
         "auto-fit": "repeat(auto-fit, minmax(0, 1fr))",


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
https://github.com/user-attachments/assets/d33b6926-6b77-4666-88d0-79a3b967766a

For slow connections:
- display loading bars
- wait until table has finished loading before allowing page changes (fixes page index being reset when clicked too fast)
- css fix: clicking on the button loses focus on the cell
- html fix: <th> must be inside a <tr>

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka @dmadisetti 
