### PR TITLE
Add light/dark/system settings from command 

### DIFF
--- a/frontend/src/components/editor/actions/useConfigActions.tsx
+++ b/frontend/src/components/editor/actions/useConfigActions.tsx
@@ -35,7 +35,7 @@ export function useConfigActions() {
         },
       })),
     {
-      label: "Config > Set dark mode",
+      label: "Config > Set theme: dark",
       handle: () => {
         handleUserConfig({
           ...config,
@@ -47,7 +47,7 @@ export function useConfigActions() {
       },
     },
     {
-      label: "Config > Set light mode",
+      label: "Config > Set theme: light",
       handle: () => {
         handleUserConfig({
           ...config,
@@ -59,7 +59,7 @@ export function useConfigActions() {
       },
     },
     {
-      label: "Config > Set light/dark mode to system setting",
+      label: "Config > Set theme: system",
       handle: () => {
         handleUserConfig({
           ...config,


### PR DESCRIPTION
When a user types "dark" they will find the dark mode setting, but they won't when they type "light". Figured we should add that extra keyword to make it easy for the user to search for it. 