### PR TITLE
fix(islands): Replace "vega" runtime imports with "vega-loader" to resolve build issues

### DIFF
--- a/frontend/src/components/data-table/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/chart-spec-model.tsx
@@ -1,9 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import { mint, orange, slate } from "@radix-ui/colors";
-// @ts-expect-error vega-typings does not include formats
-import { formats } from "vega";
 import type { TopLevelSpec } from "vega-lite";
+// @ts-expect-error vega-typings does not include formats
+import { formats } from "vega-loader";
 import { asRemoteURL } from "@/core/runtime/config";
 import type { TopLevelFacetedUnitSpec } from "@/plugins/impl/data-explorer/queries/types";
 import { arrow } from "@/plugins/impl/vega/formats";

--- a/frontend/src/plugins/impl/vega/vega-component.tsx
+++ b/frontend/src/plugins/impl/vega/vega-component.tsx
@@ -7,7 +7,7 @@ import { type JSX, useMemo, useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
 import { type SignalListeners, VegaLite, type View } from "react-vega";
 // @ts-expect-error vega-typings does not include formats
-import { formats } from "vega";
+import { formats } from "vega-loader";
 import { Alert, AlertTitle } from "@/components/ui/alert";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useAsyncData } from "@/hooks/useAsyncData";


### PR DESCRIPTION
Replaces direct import from "vega" with "vega-loader" to prevent module
graph issues introduced by chart summary (#5390). Fixes build error
related to island generation.
