### PR TITLE
chore(frontend): Remove "vega" as top-level dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -150,7 +150,6 @@
     "timestring": "^7.0.0",
     "typescript-memoize": "^1.1.1",
     "use-resize-observer": "^9.1.0",
-    "vega": "^5.33.0",
     "vega-lite": "^5.23.0",
     "vega-loader": "^4.5.3",
     "vscode-languageserver-protocol": "^3.17.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -426,9 +426,6 @@ importers:
       use-resize-observer:
         specifier: ^9.1.0
         version: 9.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      vega:
-        specifier: ^5.33.0
-        version: 5.33.0
       vega-lite:
         specifier: ^5.23.0
         version: 5.23.0(vega@5.33.0)

--- a/frontend/src/components/data-table/charts/chart-spec/encodings.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/encodings.ts
@@ -1,6 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import type { ColorScheme } from "vega";
 import type { Aggregate } from "vega-lite/build/src/aggregate";
 import type { BinParams } from "vega-lite/build/src/bin";
 import type { ColorDef, OffsetDef } from "vega-lite/build/src/channeldef";
@@ -12,6 +11,7 @@ import {
   type AggregationFn,
   BIN_AGGREGATION,
   ChartType,
+  type ColorScheme,
   NONE_AGGREGATION,
   type SelectableDataType,
   STRING_AGGREGATION_FNS,

--- a/frontend/src/components/data-table/charts/chart-spec/spec.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/spec.ts
@@ -1,6 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import type { ExprRef, SignalRef } from "vega";
 import type { TopLevelSpec } from "vega-lite";
 import type {
   ColorDef,
@@ -164,7 +163,7 @@ export function getAxisEncoding(
 export function getFacetEncoding(
   facet: z.infer<typeof RowFacet> | z.infer<typeof ColumnFacet>,
   chartType: ChartType,
-): FacetFieldDef<Field, ExprRef | SignalRef> {
+): FacetFieldDef<Field> {
   const binValues = getBinEncoding(
     chartType,
     facet.selectedDataType || "string",

--- a/frontend/src/components/data-table/charts/constants.ts
+++ b/frontend/src/components/data-table/charts/constants.ts
@@ -18,10 +18,10 @@ import {
   SquareFunctionIcon,
   TableIcon,
 } from "lucide-react";
-import type { ColorScheme } from "vega";
 import type {
   AggregationFn,
   ChartType,
+  ColorScheme,
   SelectableDataType,
   TimeUnit,
 } from "./types";

--- a/frontend/src/components/data-table/charts/types.ts
+++ b/frontend/src/components/data-table/charts/types.ts
@@ -1,4 +1,11 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import type { Scale } from "vega-lite/build/src/scale";
+
+/**
+ * Valid string-based color scheme options from
+ * Vega-Lite `Scale["scheme"]` (aka `vega.ColorScheme`).
+ */
+export type ColorScheme = NonNullable<Scale["scheme"] & string>;
 
 /**
  * Similar to VegaLite's ScaleType, https://vega.github.io/vega-lite/docs/scale.html#type

--- a/frontend/src/components/tracing/tracing-spec.ts
+++ b/frontend/src/components/tracing/tracing-spec.ts
@@ -1,6 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import type { TimeUnit } from "vega";
 import type { TopLevelSpec } from "vega-lite";
 import type { CellId } from "@/core/cells/ids";
 import type { CellRun } from "@/core/cells/runs";
@@ -30,7 +29,7 @@ export function createGanttBaseSpec(
   hiddenInputElementId: string,
   chartPosition: ChartPosition,
   theme: ResolvedTheme,
-): TopLevelSpec {
+): Readonly<TopLevelSpec> {
   return {
     $schema: "https://vega.github.io/schema/vega-lite/v5.json",
     background: theme === "dark" ? "black" : undefined,
@@ -75,13 +74,15 @@ export function createGanttBaseSpec(
         {
           field: startTimestampField,
           type: "temporal",
-          timeUnit: "hoursminutessecondsmilliseconds" as TimeUnit,
+          // @ts-expect-error - Supported by vega/vega-lite but invalid "TimeUnit" option from exported type
+          timeUnit: "hoursminutessecondsmilliseconds",
           title: "Start",
         },
         {
           field: endTimestampField,
           type: "temporal",
-          timeUnit: "hoursminutessecondsmilliseconds" as TimeUnit,
+          // @ts-expect-error - Supported by vega/vega-lite but invalid "TimeUnit" option from exported type
+          timeUnit: "hoursminutessecondsmilliseconds",
           title: "End",
         },
       ],


### PR DESCRIPTION
All runtime uses of "vega" were replaced with "vega-loader" in #5449,
and now the only remaining usage is for types.

This change removes "vega" entirely as a direct dependency and switches
to extracting necessary types from "vega-lite" (which we are using
directly and extensively). It should also simplify future updates, since
we no longer need to keep "vega" and "vega-lite" in sync: all types are
now derived from what "vega-lite" exports. Should also prevent
accidental re-imports from "vega" in the future.
