### PR TITLE
fix(vim): Show cursor only in last focused cell

### DIFF
--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -22,6 +22,7 @@ import {
   isAtStartOfEditor,
   isInVimNormalMode,
 } from "../utils";
+import { VimCursorVisibilityPlugin } from "../vim/cursor-visibility";
 import { parseVimrc, type VimCommand } from "./vimrc";
 
 export function vimKeymapExtension(): Extension[] {
@@ -94,6 +95,7 @@ export function vimKeymapExtension(): Extension[] {
         },
       };
     }),
+    ViewPlugin.define((view) => new VimCursorVisibilityPlugin({ view })),
   ];
 }
 

--- a/frontend/src/core/codemirror/vim/cursor-visibility.ts
+++ b/frontend/src/core/codemirror/vim/cursor-visibility.ts
@@ -1,0 +1,51 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import type { EditorView, PluginValue } from "@codemirror/view";
+
+let lastFocusedEditorRef: WeakRef<EditorView> | null = null;
+
+/** Options for {@linkcode VimCursorVisibilityPlugin}. */
+interface VimCursorVisibilityPluginOptions {
+  /** The editor view to manage Vim cursor visibility. */
+  view: EditorView;
+}
+
+/**
+ * A CodeMirror plugin that manages vim cursor visibility.
+ *
+ * Ensures that the vim cursor (block cursor in normal mode) is only
+ * visible in the last focused editor. All other editors will have
+ * their vim cursors hidden entirely, preventing multiple cursors
+ * from appearing across all cells when vim mode is enabled.
+ */
+export class VimCursorVisibilityPlugin implements PluginValue {
+  private view: EditorView;
+  private abortController = new AbortController();
+
+  constructor(options: VimCursorVisibilityPluginOptions) {
+    this.view = options.view;
+    this.view.dom.addEventListener(
+      "focus",
+      () => {
+        lastFocusedEditorRef = new WeakRef(this.view);
+      },
+      {
+        signal: this.abortController.signal,
+        capture: true,
+      },
+    );
+    this.update();
+  }
+
+  update() {
+    const vimCursorLayer = this.view.dom.querySelector(".cm-vimCursorLayer");
+    if (vimCursorLayer instanceof HTMLElement) {
+      const isLastFocused = lastFocusedEditorRef?.deref() === this.view;
+      vimCursorLayer.style.display = isLastFocused ? "" : "none";
+    }
+  }
+
+  destroy(): void {
+    this.abortController.abort();
+  }
+}


### PR DESCRIPTION
Fixes #5417 

When vim mode is enabled, the replit/codemirror-vim plugin displays
block cursors in all cells regardless of focus state, creating a
confusing interface where users see multiple cursors across different
cells.

This implementation adds a cursor visibility extension that tracks the
last focused editor, and coordinates cursor visibility across all
EditorViews. Only the most recently focused cell retains vim cursor
behavior while all other cells have their vim cursor layers hidden via
`display:none`.



<img width=500 src="https://github.com/user-attachments/assets/d58efb6a-31d7-49b9-9122-4738e6793279"/>
