### PR TITLE
Make formatting failure message package-manager agnostic

### DIFF
--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -25,7 +25,7 @@ def ruff(codes: CellCodes, *cmd: str) -> CellCodes:
         process = subprocess.run([*ruff_cmd, "--help"], capture_output=True)
         if process.returncode != 0:
             raise ModuleNotFoundError(
-                "To enable code formatting, install ruff", name="ruff"
+                "To enable code formatting, please install ruff", name="ruff"
             )
 
     formatted_codes: CellCodes = {}
@@ -76,7 +76,8 @@ class DefaultFormatter(Formatter):
             return BlackFormatter(self.line_length).format(codes)
         else:
             raise ModuleNotFoundError(
-                "To enable code formatting, install ruff or black", name="ruff"
+                "To enable code formatting, please install ruff or black",
+                name="ruff",
             )
 
 

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -25,8 +25,7 @@ def ruff(codes: CellCodes, *cmd: str) -> CellCodes:
         process = subprocess.run([*ruff_cmd, "--help"], capture_output=True)
         if process.returncode != 0:
             raise ModuleNotFoundError(
-                "To enable code formatting, install ruff (pip install ruff)",
-                name="ruff",
+                "To enable code formatting, install ruff", name="ruff"
             )
 
     formatted_codes: CellCodes = {}
@@ -77,10 +76,7 @@ class DefaultFormatter(Formatter):
             return BlackFormatter(self.line_length).format(codes)
         else:
             raise ModuleNotFoundError(
-                "To enable code formatting, install ruff (pip install ruff) "
-                "or black (pip install black).",
-                # This asks the frontend to install ruff
-                name="ruff",
+                "To enable code formatting, install ruff or black", name="ruff"
             )
 
 


### PR DESCRIPTION
We integrate with different package managers, so suggesting a specific one
(like `pip`) may not be relevant or helpful for users.

While we could tailor suggestions based on user settings, the simpler approach
is to keep the message package-manager agnostic. In the UI, users are already
prompted with a separate package alert that lets them use their preferred
package manager.


Previously, users would see something like this in sandbox mode: Alert to click (uv) install ruff, suggestion to manually `pip install` ruff or black.

<img width=500 src="https://github.com/user-attachments/assets/be3bfb9c-f561-44c1-9f63-8286a216c150"/>

