### PR TITLE
chore: auto_instantiate=false for our project settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -546,7 +546,6 @@ output_max_bytes = 10_000_000
 std_stream_max_bytes = 2_000_000
 dotenv = [".env"]
 
-
 [tool.marimo.package_management]
 manager = "uv"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -540,10 +540,12 @@ multi_column = true
 dataframes = "rich"
 
 [tool.marimo.runtime]
+auto_instantiate = false
 watcher_on_save = "autorun"
 output_max_bytes = 10_000_000
 std_stream_max_bytes = 2_000_000
 dotenv = [".env"]
+
 
 [tool.marimo.package_management]
 manager = "uv"


### PR DESCRIPTION
We're dogfooding auto instantiation off, and considering making that the default to make onboarding to marimo easier for Jupyter users.