### PR TITLE
feat: add Vim-style autocompletion keybindings (Ctrl-y, Ctrl-n, Ctrl-p)

### DIFF
--- a/frontend/src/core/codemirror/completion/keymap.ts
+++ b/frontend/src/core/codemirror/completion/keymap.ts
@@ -1,8 +1,10 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import {
+  acceptCompletion,
   closeCompletion,
   completionKeymap as defaultCompletionKeymap,
+  moveCompletionSelection,
 } from "@codemirror/autocomplete";
 import { type Extension, Prec } from "@codemirror/state";
 import type { EditorView } from "@codemirror/view";
@@ -36,6 +38,34 @@ export function completionKeymap(): Extension {
       {
         key: "Escape",
         run: closeCompletionAndPropagate,
+      },
+      // Vim-specific completion keybindings
+      {
+        key: "Ctrl-y",
+        run: (view) => {
+          if (isInVimMode(view)) {
+            return acceptCompletion(view);
+          }
+          return false;
+        },
+      },
+      {
+        key: "Ctrl-n",
+        run: (view) => {
+          if (isInVimMode(view)) {
+            return moveCompletionSelection(true)(view);
+          }
+          return false;
+        },
+      },
+      {
+        key: "Ctrl-p",
+        run: (view) => {
+          if (isInVimMode(view)) {
+            return moveCompletionSelection(false)(view);
+          }
+          return false;
+        },
       },
     ]),
   );


### PR DESCRIPTION
This is a bit opinionated... but there is currently no way to configure vim
keybinding navigation for our autocomplete.

This PR adds Ctrl-y (accept), Ctrl-n (next), and Ctrl-p (previous) keybindings
for completion in Vim mode. Does not override Tab-based accept or arrow key
navigation.

These LSP-style keybindings typically aren't defined in vimrc, so they're hard
to configure that way. This adds a familiar, opinionated default for users
expecting neovim-like behavior.

Ref most popular autocomplete plugins share these defaults:

- [`hrsh7th/nvim-cmp`](https://github.com/hrsh7th/nvim-cmp/blob/b5311ab3ed9c846b585c0c15b7559be131ec4be9/lua/cmp/config/mapping.lua#L36-L71)
- [`Saghen/blink.cmp`](https://github.com/Saghen/blink.cmp/blob/dad68b32bc8b91f04b2efd14abc57dd650c51e7e/lua/blink/cmp/keymap/presets.lua#L7-L24)

Which is default set in neovim distros like LazyVim, NvChad, Kickstart Lua
