### PR TITLE
feat: add tool-chaining, send back signature (anthropic), add tool ui in chat-panel

### DIFF
--- a/frontend/src/components/chat/tool-call-accordion.tsx
+++ b/frontend/src/components/chat/tool-call-accordion.tsx
@@ -1,0 +1,119 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import {
+  CheckCircleIcon,
+  Loader2,
+  WrenchIcon,
+  XCircleIcon,
+} from "lucide-react";
+import React from "react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { cn } from "@/utils/cn";
+
+interface ToolCallAccordionProps {
+  toolName: string;
+  result?: string | null;
+  error?: string;
+  index?: number;
+  state?: "partial-call" | "call" | "result";
+}
+
+export const ToolCallAccordion: React.FC<ToolCallAccordionProps> = ({
+  toolName,
+  result,
+  error,
+  index = 0,
+  state,
+}) => {
+  // Only show result when complete, otherwise just loading
+  const showResult = state === "result" && (result || error);
+  const status = error ? "error" : showResult ? "success" : "loading";
+
+  const getStatusIcon = () => {
+    switch (status) {
+      case "loading":
+        return <Loader2 className="h-3 w-3 animate-spin" />;
+      case "error":
+        return <XCircleIcon className="h-3 w-3 text-destructive" />;
+      case "success":
+        return <CheckCircleIcon className="h-3 w-3 text-green-600" />;
+      default:
+        return <WrenchIcon className="h-3 w-3" />;
+    }
+  };
+
+  const getStatusText = () => {
+    if (status === "loading") {
+      return "Running: ";
+    }
+    if (error) {
+      return "Failed: ";
+    }
+    if (showResult) {
+      return "Done: ";
+    }
+    return "Tool call";
+  };
+
+  return (
+    <Accordion
+      key={`tool-${index}`}
+      type="single"
+      collapsible={true}
+      className="w-full my-4"
+    >
+      <AccordionItem value="tool-call" className="border-0">
+        <AccordionTrigger
+          className={cn(
+            "h-6 text-xs border-border !shadow-none !ring-0 bg-muted hover:bg-muted/30 py-0 px-2 gap-1 rounded-sm [&[data-state=open]>svg]:rotate-180",
+            status === "error" && "text-destructive/80",
+            status === "success" && "text-green-600/80",
+          )}
+        >
+          <span className="flex items-center gap-1">
+            {getStatusIcon()}
+            {getStatusText()}:{" "}
+            <code className="font-mono text-xs">{toolName}</code>
+          </span>
+        </AccordionTrigger>
+        <AccordionContent className="pb-2 px-2">
+          {/* Only show content when tool is complete */}
+          {showResult && (
+            <div className="space-y-3">
+              {/* Result */}
+              {result && (
+                <div>
+                  <div className="text-xs font-medium text-muted-foreground mt-2 mb-1">
+                    Result:
+                  </div>
+                  <div className="text-xs font-medium text-muted-foreground mb-1">
+                    {typeof result === "string"
+                      ? result
+                      : JSON.stringify(result, null, 2)}
+                  </div>
+                </div>
+              )}
+
+              {/* Error */}
+              {error && (
+                <div>
+                  <div className="text-xs font-medium text-destructive mb-1">
+                    Error:
+                  </div>
+                  <div className="bg-destructive/10 border border-destructive/20 rounded-md p-3 text-sm text-destructive">
+                    {error}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/frontend/src/components/chat/tool-call-accordion.tsx
+++ b/frontend/src/components/chat/tool-call-accordion.tsx
@@ -30,9 +30,8 @@ export const ToolCallAccordion: React.FC<ToolCallAccordionProps> = ({
   index = 0,
   state,
 }) => {
-  // Only show result when complete, otherwise just loading
-  const showResult = state === "result" && (result || error);
-  const status = error ? "error" : showResult ? "success" : "loading";
+  const hasResult = state === "result" && (result || error);
+  const status = error ? "error" : hasResult ? "success" : "loading";
 
   const getStatusIcon = () => {
     switch (status) {
@@ -54,7 +53,7 @@ export const ToolCallAccordion: React.FC<ToolCallAccordionProps> = ({
     if (error) {
       return "Failed: ";
     }
-    if (showResult) {
+    if (hasResult) {
       return "Done: ";
     }
     return "Tool call";
@@ -83,7 +82,7 @@ export const ToolCallAccordion: React.FC<ToolCallAccordionProps> = ({
         </AccordionTrigger>
         <AccordionContent className="pb-2 px-2">
           {/* Only show content when tool is complete */}
-          {showResult && (
+          {hasResult && (
             <div className="space-y-3">
               {/* Result */}
               {result && (

--- a/frontend/src/core/ai/chat-utils.ts
+++ b/frontend/src/core/ai/chat-utils.ts
@@ -7,6 +7,7 @@ import type { ChatState } from "./state";
 export const addMessageToChat = (
   chatState: ChatState,
   chatId: string | null,
+  messageId: string,
   role: "user" | "assistant",
   content: string,
   parts?: AIMessage["parts"],
@@ -15,21 +16,53 @@ export const addMessageToChat = (
     Logger.warn("No active chat");
     return chatState;
   }
+  // Get active chat
+  const activeChat = chatState.chats.find((chat) => chat.id === chatId);
+  if (!activeChat) {
+    Logger.warn("No active chat");
+    return chatState;
+  }
+
+  // Get message
+  const message = activeChat.messages.find(
+    (message) => message.id === messageId,
+  );
+  // Handle new message
+  if (!message) {
+    return {
+      ...chatState,
+      chats: chatState.chats.map((chat) =>
+        chat.id === chatId
+          ? {
+              ...chat,
+              messages: [
+                ...chat.messages,
+                {
+                  id: messageId,
+                  role,
+                  content,
+                  timestamp: Date.now(),
+                  parts,
+                },
+              ],
+              updatedAt: Date.now(),
+            }
+          : chat,
+      ),
+    };
+  }
+  // Handle update message
   return {
     ...chatState,
     chats: chatState.chats.map((chat) =>
       chat.id === chatId
         ? {
             ...chat,
-            messages: [
-              ...chat.messages,
-              {
-                role,
-                content,
-                timestamp: Date.now(),
-                parts,
-              },
-            ],
+            messages: chat.messages.map((message) =>
+              message.id === messageId
+                ? { ...message, content, parts }
+                : message,
+            ),
             updatedAt: Date.now(),
           }
         : chat,

--- a/frontend/src/core/ai/state.ts
+++ b/frontend/src/core/ai/state.ts
@@ -5,7 +5,7 @@ import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import type { CellId } from "../cells/ids";
 
-const KEY = "marimo:ai:chatState:v2";
+const KEY = "marimo:ai:chatState:v3";
 
 export const aiCompletionCellAtom = atom<{
   cellId: CellId;
@@ -14,6 +14,7 @@ export const aiCompletionCellAtom = atom<{
 export const includeOtherCellsAtom = atom<boolean>(false);
 
 export interface Message {
+  id: string;
   role: "user" | "assistant" | "data" | "system";
   content: string;
   timestamp: number;

--- a/marimo/_ai/_convert.py
+++ b/marimo/_ai/_convert.py
@@ -3,10 +3,19 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Union
 
-from marimo._ai._types import ChatMessage
+from marimo import _loggers
+from marimo._ai._types import (
+    ChatMessage,
+    ReasoningPart,
+    TextPart,
+    ToolInvocationPart,
+)
 from marimo._server.ai.tools import Tool
+
+LOGGER = _loggers.marimo_logger()
+
 
 if TYPE_CHECKING:
     from google.genai.types import (  # type: ignore[import-not-found]
@@ -16,21 +25,74 @@ if TYPE_CHECKING:
 
 
 # Message conversions
+def get_openai_messages_from_parts(
+    role: Literal["system", "user", "assistant"],
+    parts: list[Union[TextPart, ReasoningPart, ToolInvocationPart]],
+) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    for part in parts:
+        if isinstance(part, TextPart):
+            message = {"role": role, "content": part.text}
+            messages.append(message)
+        elif isinstance(part, ToolInvocationPart):
+            if part.tool_invocation.state == "result":
+                # Create two messages for the tool result
+                assistant_message = {
+                    "role": role,
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": part.tool_invocation.tool_call_id,
+                            "type": "function",
+                            "function": {
+                                "name": part.tool_invocation.tool_name,
+                                "arguments": str(part.tool_invocation.args)
+                                if part.tool_invocation.args
+                                else "{}",
+                            },
+                        }
+                    ],
+                }
+                messages.append(assistant_message)
+                tool_result_message = {
+                    "role": "tool",
+                    "tool_call_id": part.tool_invocation.tool_call_id,
+                    "name": part.tool_invocation.tool_name,
+                    "content": str(part.tool_invocation.result),
+                }
+                messages.append(tool_result_message)
+    return messages
+
+
 def convert_to_openai_messages(
     messages: list[ChatMessage],
 ) -> list[dict[Any, Any]]:
     openai_messages: list[dict[Any, Any]] = []
+    LOGGER.warning(f"Converting to OpenAI messages: {messages}")
 
     for message in messages:
+        # Handle message without attachments
         if not message.attachments:
-            openai_messages.append(
-                {"role": message.role, "content": message.content}
-            )
+            if not message.parts or len(message.parts) == 0:
+                openai_messages.append(
+                    {"role": message.role, "content": message.content}
+                )
+            else:
+                parts_messages = get_openai_messages_from_parts(
+                    message.role, message.parts
+                )
+                openai_messages.extend(parts_messages)
             continue
 
         # Handle attachments
         parts: list[dict[Any, Any]] = []
-        parts.append({"type": "text", "text": message.content})
+        if not message.parts or len(message.parts) == 0:
+            parts.append({"type": "text", "text": message.content})
+        else:
+            parts.extend(
+                get_openai_messages_from_parts(message.role, message.parts)
+            )
+
         for attachment in message.attachments:
             content_type = attachment.content_type or "text/plain"
 
@@ -53,6 +115,80 @@ def convert_to_openai_messages(
     return openai_messages
 
 
+def get_anthropic_messages_from_parts(
+    role: Literal["system", "user", "assistant"],
+    parts: list[Union[TextPart, ReasoningPart, ToolInvocationPart]],
+) -> list[dict[Any, Any]]:
+    messages: list[dict[Any, Any]] = []
+    content_parts: list[dict[str, Any]] = []
+
+    LOGGER.warning(f"Converting to Anthropic messages: {parts}")
+
+    for part in parts:
+        if isinstance(part, TextPart):
+            content_parts.append({"type": "text", "text": part.text})
+        elif isinstance(part, ReasoningPart):
+            # Handle reasoning parts with proper Anthropic thinking type
+            signature = ""
+            if part.details and len(part.details) > 0:
+                signature = part.details[0].signature or ""
+
+            content_parts.append(
+                {
+                    "type": "thinking",
+                    "thinking": part.reasoning,
+                    "signature": signature,  # This should be the encrypted signature from Claude's response
+                }
+            )
+        elif isinstance(part, ToolInvocationPart):
+            if part.tool_invocation.state == "result":
+                # Add tool use to current message content
+                content_parts.append(
+                    {
+                        "type": "tool_use",
+                        "id": part.tool_invocation.tool_call_id,
+                        "name": part.tool_invocation.tool_name,
+                        "input": part.tool_invocation.args,
+                    }
+                )
+
+                # Create the message with current content (including tool use)
+                if content_parts:
+                    message_content = (
+                        content_parts[0]["text"]
+                        if len(content_parts) == 1
+                        and content_parts[0]["type"] == "text"
+                        else content_parts
+                    )
+                    messages.append({"role": role, "content": message_content})
+                    content_parts = []  # Reset for next message
+
+                # Create separate tool result message
+                tool_result_message = {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": part.tool_invocation.tool_call_id,
+                            "content": str(part.tool_invocation.result),
+                        }
+                    ],
+                }
+                messages.append(tool_result_message)
+
+    # Add remaining content parts as a single message if any
+    if content_parts:
+        # If only one text part, use string format; otherwise use array format
+        if len(content_parts) == 1 and content_parts[0]["type"] == "text":
+            message_content = content_parts[0]["text"]
+        else:
+            message_content = content_parts
+
+        messages.append({"role": role, "content": message_content})
+
+    return messages
+
+
 def convert_to_anthropic_messages(
     messages: list[ChatMessage],
 ) -> list[dict[Any, Any]]:
@@ -60,14 +196,25 @@ def convert_to_anthropic_messages(
 
     for message in messages:
         if not message.attachments:
-            anthropic_messages.append(
-                {"role": message.role, "content": message.content}
-            )
+            if not message.parts or len(message.parts) == 0:
+                anthropic_messages.append(
+                    {"role": message.role, "content": message.content}
+                )
+            else:
+                parts_messages = get_anthropic_messages_from_parts(
+                    message.role, message.parts
+                )
+                anthropic_messages.extend(parts_messages)
             continue
 
         # Handle attachments
         parts: list[dict[Any, Any]] = []
-        parts.append({"type": "text", "text": message.content})
+        if not message.parts or len(message.parts) == 0:
+            parts.append({"type": "text", "text": message.content})
+        else:
+            parts.extend(
+                get_anthropic_messages_from_parts(message.role, message.parts)
+            )
         for attachment in message.attachments:
             content_type = attachment.content_type or "text/plain"
             if content_type.startswith("image"):
@@ -127,17 +274,100 @@ def convert_to_groq_messages(
     return groq_messages
 
 
+def get_google_messages_from_parts(
+    role: Literal["system", "user", "assistant"],
+    parts: list[Union[TextPart, ReasoningPart, ToolInvocationPart]],
+) -> list[Content]:
+    messages: list[Content] = []
+
+    for part in parts:
+        if isinstance(part, TextPart):
+            # Create a message with text content
+            text_message: Content = {
+                "role": "user" if role == "user" else "model",
+                "parts": [{"text": part.text}],
+            }
+            messages.append(text_message)
+        elif isinstance(part, ReasoningPart):
+            # Google uses the "thought" field for reasoning content
+            # According to Google's thinking models documentation
+            reasoning_message: Content = {
+                "role": "user" if role == "user" else "model",
+                "parts": [{"text": part.reasoning, "thought": True}],
+            }
+            messages.append(reasoning_message)
+        elif isinstance(part, ToolInvocationPart):
+            if part.tool_invocation.state == "result":
+                # Create function call message for Google
+                function_call_message: Content = {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "function_call": {
+                                "name": part.tool_invocation.tool_name,
+                                "args": part.tool_invocation.args or {},
+                            }
+                        }
+                    ],
+                }
+                messages.append(function_call_message)
+
+                # Create function response message
+                function_response_message: Content = {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "function_response": {
+                                "name": part.tool_invocation.tool_name,
+                                "response": {
+                                    "result": str(part.tool_invocation.result)
+                                },
+                            }
+                        }
+                    ],
+                }
+                messages.append(function_response_message)
+
+    return messages
+
+
 def convert_to_google_messages(
     messages: list[ChatMessage],
 ) -> list[Content]:
     google_messages: list[Content] = []
 
     for message in messages:
-        parts: list[Part] = [{"text": str(message.content)}]
-        if message.attachments:
-            for attachment in message.attachments:
-                content_type = attachment.content_type or "text/plain"
+        # Handle message without attachments
+        if not message.attachments:
+            if not message.parts or len(message.parts) == 0:
+                google_messages.append(
+                    {
+                        "role": "user" if message.role == "user" else "model",
+                        "parts": [{"text": str(message.content)}],
+                    }
+                )
+            else:
+                parts_messages = get_google_messages_from_parts(
+                    message.role, message.parts
+                )
+                google_messages.extend(parts_messages)
+            continue
 
+        # Handle attachments
+        parts: list[Part] = []
+        if not message.parts or len(message.parts) == 0:
+            parts.append({"text": str(message.content)})
+        else:
+            # Convert internal parts to Google parts format
+            for parts_message in get_google_messages_from_parts(
+                message.role, message.parts
+            ):
+                parts.extend(parts_message["parts"])
+
+        for attachment in message.attachments:
+            content_type = attachment.content_type or "text/plain"
+
+            if content_type.startswith("image"):
                 parts.append(
                     {
                         "inline_data": {
@@ -148,6 +378,19 @@ def convert_to_google_messages(
                         },
                     }
                 )
+            elif content_type.startswith("text"):
+                parts.append(
+                    {
+                        "inline_data": {
+                            "mime_type": content_type,
+                            "data": base64.b64decode(
+                                _extract_data(attachment.url)
+                            ),
+                        },
+                    }
+                )
+            else:
+                raise ValueError(f"Unsupported content type {content_type}")
 
         google_messages.append(
             {
@@ -176,10 +419,11 @@ def _extract_data(url: str) -> str:
 
 
 def convert_to_ai_sdk_messages(
-    content_text: str | dict[str, Any],
+    content_text: Union[str, dict[str, Any]],
     content_type: Literal[
         "text",
         "reasoning",
+        "reasoning_signature",
         "tool_call_start",
         "tool_call_delta",
         "tool_call_end",
@@ -193,6 +437,7 @@ def convert_to_ai_sdk_messages(
     """
     TEXT_PREFIX = "0:"
     REASON_PREFIX = "g:"
+    REASON_SIGNATURE_PREFIX = "j:"
     TOOL_CALL_START_PREFIX = "b:"
     TOOL_CALL_DELTA_PREFIX = "c:"
     TOOL_CALL_PREFIX = "9:"
@@ -223,6 +468,11 @@ def convert_to_ai_sdk_messages(
         # Emit the finishReason as a JSON object with usage (default 0s)
         # TODO: Add usage (promptTokens, completionTokens)
         return f'{FINISH_REASON_PREFIX}{{"finishReason": "{content_text}", "usage": {{"promptTokens": 0, "completionTokens": 0}}}}\n'
+
+    elif content_type == "reasoning_signature" and isinstance(
+        content_text, dict
+    ):
+        return f"{REASON_SIGNATURE_PREFIX}{json.dumps(content_text)}\n"
 
     else:
         # Default to text for unknown types

--- a/marimo/_ai/_types.py
+++ b/marimo/_ai/_types.py
@@ -21,6 +21,13 @@ class TextPartDict(TypedDict):
 class ReasoningPartDict(TypedDict):
     type: Literal["reasoning"]
     reasoning: str
+    details: list[ReasoningDetailsDict]
+
+
+class ReasoningDetailsDict(TypedDict):
+    type: Literal["text"]
+    text: str
+    signature: Optional[str]
 
 
 class ToolInvocationResultDict(TypedDict):
@@ -92,6 +99,14 @@ class ReasoningPart:
 
     type: Literal["reasoning"]
     reasoning: str
+    details: list[ReasoningDetails]
+
+
+@dataclass
+class ReasoningDetails:
+    type: Literal["text"]
+    text: str
+    signature: Optional[str] = None
 
 
 @dataclass

--- a/marimo/_plugins/ui/_impl/chat/utils.py
+++ b/marimo/_plugins/ui/_impl/chat/utils.py
@@ -7,6 +7,7 @@ from marimo._ai._types import (
     ChatAttachment,
     ChatMessage,
     ChatMessageDict,
+    ReasoningDetails,
     ReasoningPart,
     TextPart,
     ToolInvocationPart,
@@ -43,9 +44,34 @@ def from_chat_message_dict(d: ChatMessageDict) -> ChatMessage:
             if part_dict["type"] == "text":
                 parts.append(TextPart(type="text", text=part_dict["text"]))
             elif part_dict["type"] == "reasoning":
+                # Handle ReasoningDetails if present
+                details_list = part_dict.get("details", [])
+                details = []
+
+                if details_list:
+                    for details_dict in details_list:
+                        details.append(
+                            ReasoningDetails(
+                                type=details_dict["type"],
+                                text=details_dict["text"],
+                                signature=details_dict.get("signature"),
+                            )
+                        )
+                else:
+                    # Fallback for backward compatibility
+                    details = [
+                        ReasoningDetails(
+                            type="text",
+                            text=part_dict["reasoning"],
+                            signature=None,
+                        )
+                    ]
+
                 parts.append(
                     ReasoningPart(
-                        type="reasoning", reasoning=part_dict["reasoning"]
+                        type="reasoning",
+                        reasoning=part_dict["reasoning"],
+                        details=details,
                     )
                 )
             elif part_dict["type"] == "tool-invocation":

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -79,7 +79,8 @@ FinishReason = Literal["tool_calls", "stop"]
 
 # Types for extract_content method return
 DictContent = tuple[
-    dict[str, Any], Literal["tool_call_start", "tool_call_end"]
+    dict[str, Any],
+    Literal["tool_call_start", "tool_call_end", "reasoning_signature"],
 ]
 TextContent = tuple[str, Literal["text", "reasoning", "tool_call_delta"]]
 ExtractedContent = Union[TextContent, DictContent]
@@ -90,7 +91,12 @@ FinishContent = tuple[FinishReason, Literal["finish_reason"]]
 StreamTextContent = tuple[str, Literal["text", "reasoning"]]
 StreamDictContent = tuple[
     dict[str, Any],
-    Literal["tool_call_start", "tool_call_end", "tool_call_delta"],
+    Literal[
+        "tool_call_start",
+        "tool_call_end",
+        "tool_call_delta",
+        "reasoning_signature",
+    ],
 ]
 StreamContent = Union[StreamTextContent, StreamDictContent, FinishContent]
 
@@ -267,6 +273,7 @@ class CompletionProvider(Generic[ResponseT, StreamT], ABC):
         if content_type in [
             "text",
             "reasoning",
+            "reasoning_signature",
             "tool_call_start",
             "tool_call_delta",
             "tool_call_end",
@@ -308,6 +315,8 @@ class CompletionProvider(Generic[ResponseT, StreamT], ABC):
                 return (content_data, "tool_call_end")
             elif content_type == "tool_call_delta":
                 return (content_data, "tool_call_delta")
+            elif content_type == "reasoning_signature":
+                return (content_data, "reasoning_signature")
 
         # Fallback - convert to string content
         content_str = self._content_to_string(content_data)
@@ -723,6 +732,7 @@ class AnthropicProvider(
             InputJSONDelta,
             RawContentBlockDeltaEvent,
             RawContentBlockStartEvent,
+            SignatureDelta,
             TextDelta,
             ThinkingDelta,
             ToolUseBlock,
@@ -736,6 +746,11 @@ class AnthropicProvider(
                 return (response.delta.thinking, "reasoning")
             if isinstance(response.delta, InputJSONDelta):
                 return (response.delta.partial_json, "tool_call_delta")
+            if isinstance(response.delta, SignatureDelta):
+                return (
+                    {"signature": response.delta.signature},
+                    "reasoning_signature",
+                )
 
         # For the beginning of a tool use block
         if isinstance(response, RawContentBlockStartEvent):

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -246,6 +246,23 @@ components:
                     - text
                     type: object
                   - properties:
+                      details:
+                        items:
+                          properties:
+                            signature:
+                              nullable: true
+                              type: string
+                            text:
+                              type: string
+                            type:
+                              enum:
+                              - text
+                              type: string
+                          required:
+                          - type
+                          - text
+                          type: object
+                        type: array
                       reasoning:
                         type: string
                       type:
@@ -255,6 +272,7 @@ components:
                     required:
                     - type
                     - reasoning
+                    - details
                     type: object
                   - properties:
                       toolInvocation:
@@ -2701,7 +2719,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.14.7
+  version: 0.14.8
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/openapi/src/api.ts
+++ b/openapi/src/api.ts
@@ -2643,6 +2643,12 @@ export interface components {
                   type: "text";
                 }
               | {
+                  details: {
+                    signature?: string | null;
+                    text: string;
+                    /** @enum {string} */
+                    type: "text";
+                  }[];
                   reasoning: string;
                   /** @enum {string} */
                   type: "reasoning";


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Updated messages conversion functions to use parts instead of content (best practice for ai-sdk). Sending back reasoning signature since its required for anthropic. Added tool call ui accordion with loader in chat-panel.tsx.


https://github.com/user-attachments/assets/0352826b-c559-45c9-b790-915640df346f



## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

- Added get_*_messages_from_parts for all primary providers in _convert.py
- Added tests for all new helper functions
- Send back reasoning signature (for anthropic since its required for tool use with reasoning) in providers.py and _convert.py
- Updated OpenAPI to include ReasoningDetails from the frontend (ai-sdk ui type)
- Updated Message state to include id and updated addMessageToChat function to use id for updating a previous chat message in chat-utils.ts and state.ts (required for tool use since sometimes new parts are sent for the same message)
- Added ToolAccordion to display tool use in chat panel
- Tested all providers with tool use. Fully functional even with multi-part tool chaining

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@mscolnick OR @Light2Dark 
