### PR TITLE
register UIElement on change if it is missing from the UIElementRegistry

### DIFF
--- a/frontend/src/core/dom/ui-element.ts
+++ b/frontend/src/core/dom/ui-element.ts
@@ -100,9 +100,12 @@ export function initializeUIElement() {
         // broadcast? that would still let other elements cancel the event
         // while also reducing the number of event listeners on the document
         if (objectId !== null && e.detail.element === this.firstElementChild) {
-          // A UIElement may be missing from the registery if it was returned from a function that caches return values.
+          // A UIElement may be missing from the registry if it was returned from a function that caches return values.
           if (!UI_ELEMENT_REGISTRY.has(objectId)) {
-            UI_ELEMENT_REGISTRY.registerInstance(objectId, child as HTMLElement);
+            UI_ELEMENT_REGISTRY.registerInstance(
+              objectId,
+              child as HTMLElement,
+            );
           }
 
           UI_ELEMENT_REGISTRY.broadcastValueUpdate(


### PR DESCRIPTION
## 📝 Summary

fixes #5465 

When a notebook uses `marimo.cache` for a function that returns UI elements, those UI elements become disconnected from the rest of the notebook after the cell that calls the function re-runs.

I believe this is because UI elements do not end up being disconnected/reconnected in this case, meaning they are never re-added to the UIElementRegistry after they were removed on cell invalidation.

## 🔍 Description of Changes

There may be a more elegant way to solve this, but the best I could come up with was the register the UI element on change if it was missing from the UIElementRegistry.

Before

https://github.com/user-attachments/assets/b0b5c1d2-e999-4ecd-a6bd-049a82914a34

After

https://github.com/user-attachments/assets/a59a6771-a9b7-47ee-8d4e-316feeb209e2


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@akshayka OR @mscolnick
