### PR TITLE
chore: deflake flaky i/o tests

### DIFF
--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -93,13 +93,18 @@ def test_save_file(client: TestClient) -> None:
         assert "my_cell" in file_contents
 
     n_tries = 0
-    while n_tries <= 5:
+    limit = 5
+    while n_tries <= limit:
         try:
             _assert_contents()
             break
         except Exception:
             n_tries += 1
             time.sleep(0.1)
+
+    if n_tries > limit:
+        _assert_contents()
+
 
     # save back
     response = client.post(

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -5,7 +5,7 @@ import os
 import random
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from tests._server.conftest import get_session_manager
 from tests._server.mocks import (
@@ -22,6 +22,18 @@ HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
     **token_header("fake-token"),
 }
+
+
+def _try_assert_n_times(n: int, assert_fn: Callable[[], None]) -> None:
+    n_tries = 0
+    while n_tries <= n - 1:
+        try:
+            assert_fn()
+            return
+        except Exception:
+            n_tries += 1
+            time.sleep(0.1)
+    assert_fn()
 
 
 @with_session(SESSION_ID)
@@ -47,7 +59,10 @@ def test_rename(client: TestClient) -> None:
     )
     assert response.json() == {"success": True}
 
-    assert new_path.exists()
+    def _new_path_exists():
+        assert new_path.exists()
+
+    _try_assert_n_times(5, _new_path_exists)
 
 
 @with_session(SESSION_ID)
@@ -92,19 +107,7 @@ def test_save_file(client: TestClient) -> None:
         assert "@app.cell(hide_code=True)" in file_contents
         assert "my_cell" in file_contents
 
-    n_tries = 0
-    limit = 5
-    while n_tries <= limit:
-        try:
-            _assert_contents()
-            break
-        except Exception:
-            n_tries += 1
-            time.sleep(0.1)
-
-    if n_tries > limit:
-        _assert_contents()
-
+    _try_assert_n_times(5, _assert_contents)
 
     # save back
     response = client.post(
@@ -158,14 +161,18 @@ def test_save_with_header(client: TestClient) -> None:
 
     assert response.status_code == 200, response.text
     assert "import marimo" in response.text
-    file_contents = path.read_text()
-    assert "import marimo as mo" in file_contents
-    # Race condition with uv (seen in python 3.10)
-    if file_contents.startswith("# ///"):
-        file_contents = file_contents.split("# ///")[2].lstrip()
-    assert file_contents.startswith(header.rstrip()), "Header was removed"
-    assert "@app.cell(hide_code=True)" in file_contents
-    assert "my_cell" in file_contents
+
+    def _assert_contents():
+        file_contents = path.read_text()
+        assert "import marimo as mo" in file_contents
+        # Race condition with uv (seen in python 3.10)
+        if file_contents.startswith("# ///"):
+            file_contents = file_contents.split("# ///")[2].lstrip()
+        assert file_contents.startswith(header.rstrip()), "Header was removed"
+        assert "@app.cell(hide_code=True)" in file_contents
+        assert "my_cell" in file_contents
+
+    _try_assert_n_times(5, _assert_contents)
 
 
 @with_session(SESSION_ID)
@@ -205,14 +212,18 @@ def test_save_with_invalid_file(client: TestClient) -> None:
 
     assert response.status_code == 200, response.text
     assert "import marimo" in response.text
-    file_contents = path.read_text()
-    assert "@app.cell(hide_code=True)" in file_contents
-    assert "my_cell" in file_contents
 
-    # Race condition with uv (seen in python 3.10)
-    if file_contents.startswith("# ///"):
-        file_contents = file_contents.split("# ///")[2].lstrip()
-    assert file_contents.startswith("import marimo"), "Header was not removed"
+    def _assert_contents():
+        file_contents = path.read_text()
+        assert "@app.cell(hide_code=True)" in file_contents
+        assert "my_cell" in file_contents
+
+        # Race condition with uv (seen in python 3.10)
+        if file_contents.startswith("# ///"):
+            file_contents = file_contents.split("# ///")[2].lstrip()
+        assert file_contents.startswith("import marimo"), "Header was not removed"
+
+    _try_assert_n_times(5, _assert_contents)
 
 
 @with_session(SESSION_ID)
@@ -245,8 +256,11 @@ def test_save_app_config(client: TestClient) -> None:
     assert filename
     path = Path(filename)
 
-    file_contents = path.read_text()
-    assert 'marimo.App(width="medium"' not in file_contents
+    def _wait_for_file_reset():
+        file_contents = path.read_text()
+        assert 'marimo.App(width="medium"' not in file_contents
+
+    _try_assert_n_times(5, _wait_for_file_reset)
 
     response = client.post(
         "/api/kernel/save_app_config",
@@ -257,8 +271,12 @@ def test_save_app_config(client: TestClient) -> None:
     )
     assert response.status_code == 200, response.text
     assert "import marimo" in response.text
-    file_contents = path.read_text()
-    assert 'marimo.App(width="medium"' in file_contents
+
+    def _assert_contents():
+        file_contents = path.read_text()
+        assert 'marimo.App(width="medium"' in file_contents
+
+    _try_assert_n_times(5, _assert_contents)
 
 
 @with_session(SESSION_ID)
@@ -283,9 +301,13 @@ def test_copy_file(client: TestClient) -> None:
     )
     assert response.status_code == 200, response.text
     assert filename_copy in response.text
-    file_contents = open(copied_file).read()
-    assert "import marimo as mo" in file_contents
-    assert 'marimo.App(width="full"' in file_contents
+
+    def _assert_contents():
+        file_contents = open(copied_file).read()
+        assert "import marimo as mo" in file_contents
+        assert 'marimo.App(width="full"' in file_contents
+
+    _try_assert_n_times(5, _assert_contents)
 
 
 @with_websocket_session(SESSION_ID)

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -221,7 +221,9 @@ def test_save_with_invalid_file(client: TestClient) -> None:
         # Race condition with uv (seen in python 3.10)
         if file_contents.startswith("# ///"):
             file_contents = file_contents.split("# ///")[2].lstrip()
-        assert file_contents.startswith("import marimo"), "Header was not removed"
+        assert file_contents.startswith("import marimo"), (
+            "Header was not removed"
+        )
 
     _try_assert_n_times(5, _assert_contents)
 

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import random
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -83,11 +84,22 @@ def test_save_file(client: TestClient) -> None:
         },
     )
     assert response.status_code == 200, response.text
-    assert "import marimo" in response.text
-    file_contents = path.read_text()
-    assert "import marimo as mo" in file_contents
-    assert "@app.cell(hide_code=True)" in file_contents
-    assert "my_cell" in file_contents
+
+    def _assert_contents():
+        file_contents = path.read_text()
+        assert "import marimo" in response.text
+        assert "import marimo as mo" in file_contents
+        assert "@app.cell(hide_code=True)" in file_contents
+        assert "my_cell" in file_contents
+
+    n_tries = 0
+    while n_tries <= 5:
+        try:
+            _assert_contents()
+            break
+        except Exception:
+            n_tries += 1
+            time.sleep(0.1)
 
     # save back
     response = client.post(

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -468,13 +468,16 @@ async def test_run_until_completion_with_console_output(mock_echo: MagicMock):
         mock_echo.assert_any_call("hello stderr", file=sys.stderr, nl=False)
 
     n_tries = 0
-    while n_tries <= 5:
+    limit = 5
+    while n_tries <= limit:
         try:
             _assert_contents()
             break
         except Exception:
             n_tries += 1
             await asyncio.sleep(0.1)
+    if n_tries > limit:
+        _assert_contents()
 
     cell_ops = [op for op in session_view.operations if isinstance(op, CellOp)]
     snapshot(


### PR DESCRIPTION
* `test_file.py::test_save_*` tests are flaky because we appear to read before the file is actually written sometimes.
* `test_run_until_completion_with_console_outputs` is flaky for a similar reason

 This change just adds a few retries and sleeps in an attempt to deflake.