### PR TITLE
fix: wasm kernels don't have argv

### DIFF
--- a/marimo/_pyodide/bootstrap.py
+++ b/marimo/_pyodide/bootstrap.py
@@ -135,7 +135,7 @@ def create_session(
             query_params=query_params,
             filename=filename,
             cli_args={},
-            argv=[""],
+            argv=[],
             app_config=app.config,
         ),
         user_config,


### PR DESCRIPTION
We were accidentally providing an extra argument to `argv` in WASM, which was breaking the argparse example in the docs.