### PR TITLE
Restore DOM-based metadata for VS Code extension compatibility

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,6 +53,11 @@
       }
     </script>
     <marimo-filename hidden>{{ filename }}</marimo-filename>
+    <!-- TODO(Trevor): Legacy, required by VS Code plugin — remove when plugin is updated (see marimo/server/_templates/template.py) -->
+    <marimo-version data-version="{{ version }}" hidden></marimo-version>
+    <marimo-user-config data-config="{{ user_config }}" hidden></marimo-user-config>
+    <marimo-server-token data-token="{{ server_token }}" hidden></marimo-server-token>
+    <!-- /TODO -->
     <title>{{ title }}</title>
   </head>
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,7 +53,7 @@
       }
     </script>
     <marimo-filename hidden>{{ filename }}</marimo-filename>
-    <!-- TODO(Trevor): Legacy, required by VS Code plugin — remove when plugin is updated (see marimo/server/_templates/template.py) -->
+    <!-- TODO(Trevor): Legacy, required by VS Code plugin. Remove when plugin is updated (see marimo/server/_templates/template.py) -->
     <marimo-version data-version="{{ version }}" hidden></marimo-version>
     <marimo-user-config data-config="{{ user_config }}" hidden></marimo-user-config>
     <marimo-server-token data-token="{{ server_token }}" hidden></marimo-server-token>

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -94,6 +94,14 @@ def home_page_template(
     html = html.replace("{{ title }}", "marimo")
     html = html.replace("{{ filename }}", "")
 
+    # TODO(Trevor): Legacy, required by VS Code plugin — remove when plugin is updated (see frontend/index.html)
+    html = html.replace("{{ version }}", get_version())
+    html = html.replace(
+        "{{ user_config }}", _html_escape(json.dumps(user_config))
+    )
+    html = html.replace("{{ server_token }}", str(server_token))
+    # /TODO
+
     html = html.replace(
         MOUNT_CONFIG_TEMPLATE,
         _get_mount_config(
@@ -137,6 +145,15 @@ def notebook_page_template(
             ).to_notebook_v1()
 
     html = html.replace("{{ filename }}", _html_escape(filename or ""))
+
+    # TODO(Trevor): Legacy, required by VS Code plugin — remove when plugin is updated (see frontend/index.html)
+    html = html.replace("{{ version }}", get_version())
+    html = html.replace(
+        "{{ user_config }}", _html_escape(json.dumps(user_config))
+    )
+    html = html.replace("{{ server_token }}", str(server_token))
+    # /TODO
+
     html = html.replace(
         MOUNT_CONFIG_TEMPLATE,
         _get_mount_config(

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -94,7 +94,7 @@ def home_page_template(
     html = html.replace("{{ title }}", "marimo")
     html = html.replace("{{ filename }}", "")
 
-    # TODO(Trevor): Legacy, required by VS Code plugin — remove when plugin is updated (see frontend/index.html)
+    # TODO(Trevor): Legacy, required by VS Code plugin. Remove when plugin is updated (see frontend/index.html)
     html = html.replace("{{ version }}", get_version())
     html = html.replace(
         "{{ user_config }}", _html_escape(json.dumps(user_config))
@@ -146,7 +146,7 @@ def notebook_page_template(
 
     html = html.replace("{{ filename }}", _html_escape(filename or ""))
 
-    # TODO(Trevor): Legacy, required by VS Code plugin — remove when plugin is updated (see frontend/index.html)
+    # TODO(Trevor): Legacy, required by VS Code plugin. Remove when plugin is updated (see frontend/index.html)
     html = html.replace("{{ version }}", get_version())
     html = html.replace(
         "{{ user_config }}", _html_escape(json.dumps(user_config))


### PR DESCRIPTION
Fixes #5428 

The changes in #5120 removed passing configuration data via HTML DOM
elements. However, the marimo VS Code extension depends on these
DOM-based attributes, leading to a regression.

These changes restore the minimal set of DOM data attributes
(`marimo-version`, `marimo-user-config`, `marimo-server-token`) required
by the extension to function correctly. These additions are marked as
temporary and should be removed once the extension is updated to no
longer rely on them.
