### PR TITLE
Fix shift-enter not focusing new cell at end

### DIFF
--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -886,8 +886,7 @@ const {
     const isPastLastCell = nextCellIndex === column.length;
     const isBeforeFirstCell = nextCellIndex === -1;
 
-    // Create a new cell at the end; no need to update scrollKey,
-    // because cell will be created with autoScrollIntoView
+    // Create a new cell at the end and set scrollKey to focus it
     if (isPastLastCell && !noCreate) {
       const newCellId = CellId.create();
       return {
@@ -905,9 +904,8 @@ const {
           ...state.cellHandles,
           [newCellId]: createRef(),
         },
+        scrollKey: newCellId,
       };
-      // Create a new cell at the beginning; again, no need to update
-      // scrollKey
     }
 
     if (isBeforeFirstCell && !noCreate) {
@@ -927,6 +925,7 @@ const {
           ...state.cellHandles,
           [newCellId]: createRef(),
         },
+        scrollKey: newCellId,
       };
     }
 


### PR DESCRIPTION
Fixes regression from #5344 where shift-enter on the last cell created a new
cell but didn't focus it. `moveToNextCell` now sets `scrollKey` for new cells
at notebook boundaries, restoring focus behavior without (I think)
reintroducing autoscroll.
