### PR TITLE
fix(openai): empty tool list error for openai compatible endpoints

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -123,20 +123,23 @@ class AnyProviderConfig:
                 detail="OpenAI config not found",
             )
         key = _get_key(config["open_ai"], "OpenAI")
-        provider_config = {
+
+        kwargs: dict[str, Any] = {
             "base_url": _get_base_url(config["open_ai"]),
             "api_key": key,
             "ssl_verify": config["open_ai"].get("ssl_verify", True),
             "ca_bundle_path": config["open_ai"].get("ca_bundle_path", None),
             "client_pem": config["open_ai"].get("client_pem", None),
         }
+
         # Only include tools if they are available
         # Empty tools list causes an error with deepseek
         # https://discord.com/channels/1059888774789730424/1387766267792068821
         tools = _get_tools(config.get("mode", "manual"))
         if len(tools) > 0:
-            provider_config["tools"] = tools
-        return AnyProviderConfig(**provider_config)
+            kwargs["tools"] = tools
+
+        return AnyProviderConfig(**kwargs)
 
     @staticmethod
     def for_anthropic(config: AiConfig) -> AnyProviderConfig:

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -123,14 +123,20 @@ class AnyProviderConfig:
                 detail="OpenAI config not found",
             )
         key = _get_key(config["open_ai"], "OpenAI")
-        return AnyProviderConfig(
-            base_url=_get_base_url(config["open_ai"]),
-            api_key=key,
-            ssl_verify=config["open_ai"].get("ssl_verify", True),
-            ca_bundle_path=config["open_ai"].get("ca_bundle_path", None),
-            client_pem=config["open_ai"].get("client_pem", None),
-            tools=_get_tools(config.get("mode", "manual")),
-        )
+        provider_config = {
+            "base_url": _get_base_url(config["open_ai"]),
+            "api_key": key,
+            "ssl_verify": config["open_ai"].get("ssl_verify", True),
+            "ca_bundle_path": config["open_ai"].get("ca_bundle_path", None),
+            "client_pem": config["open_ai"].get("client_pem", None),
+        }
+        # Only include tools if they are available
+        # Empty tools list causes an error with deepseek
+        # https://discord.com/channels/1059888774789730424/1387766267792068821
+        tools = _get_tools(config.get("mode", "manual"))
+        if len(tools) > 0:
+            provider_config["tools"] = tools
+        return AnyProviderConfig(**provider_config)
 
     @staticmethod
     def for_anthropic(config: AiConfig) -> AnyProviderConfig:


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixed the deepseek empty tool list error. The error was mentioned [here](https://discord.com/channels/1059888774789730424/1387766267792068821)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Decoupled OpenAIProvider config from AnyProviderConfig class
- Add tools only if the tool list length is 1 or more

_Note: This is only necessary for the OpenAI sdk since it has a broader market of OpenAI compatible endpoints that might error if the tool list is empty. I already tested this with the Google and Anthropic sdks and they don't have this issue_

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers

<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->

@dmadisetti 
