### PR TITLE
Fix go-to-definition for function declarations

### DIFF
--- a/frontend/src/core/codemirror/go-to-definition/__tests__/commands.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/commands.test.ts
@@ -6,6 +6,10 @@ import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, test } from "vitest";
 import { goToVariableDefinition } from "../commands";
 
+async function tick(): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
 function createEditor(content: string) {
   const state = EditorState.create({
     doc: content,
@@ -31,30 +35,171 @@ afterEach(() => {
 
 describe("goToVariableDefinition", () => {
   test("selects the variable when it exists", async () => {
-    view = createEditor("#comment\nmyVar = 10\nprint(myVar)");
+    view = createEditor(`\
+#comment
+myVar = 10
+print(myVar)`);
     const result = goToVariableDefinition(view, "myVar");
 
     expect(result).toBe(true);
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-    expect(view.state.selection.main.from).toBe(9);
-    expect(view.state.selection.main.to).toBe(9);
+    await tick();
+    expect(renderEditorView(view)).toMatchInlineSnapshot(`
+      "
+      #comment
+      myVar = 10
+      ^
+      print(myVar)
+      "
+    `);
   });
 
-  test("does not select the variable when it does not exist", () => {
-    view = createEditor("#comment\nmyVar = 10;\nprint(myVar)");
+  test("selects a function declaration", async () => {
+    view = createEditor(`\
+#comment
+def my_func():
+    pass
+
+print(my_func)`);
+    const result = goToVariableDefinition(view, "my_func");
+
+    expect(result).toBe(true);
+    await tick();
+    expect(renderEditorView(view)).toMatchInlineSnapshot(`
+      "
+      #comment
+      def my_func():
+          ^
+          pass
+
+      print(my_func)
+      "
+    `);
+  });
+
+  test("selects outer-scope variable definition", async () => {
+    view = createEditor(`\
+x = 10
+
+def my_func(x):
+    print(x)
+
+print(x)`);
+    const result = goToVariableDefinition(view, "x");
+
+    expect(result).toBe(true);
+    await tick();
+    expect(renderEditorView(view)).toMatchInlineSnapshot(`
+      "
+      x = 10
+      ^
+
+      def my_func(x):
+          print(x)
+
+      print(x)
+      "
+    `);
+  });
+
+  test("selects outer-scope function declaration", async () => {
+    view = createEditor(`\
+def x():
+    print("hi")
+
+def my_func(x):
+    print(x)
+
+print(x)`);
+    const result = goToVariableDefinition(view, "x");
+
+    expect(result).toBe(true);
+    await tick();
+    expect(renderEditorView(view)).toMatchInlineSnapshot(`
+      "
+      def x():
+          ^
+          print("hi")
+
+      def my_func(x):
+          print(x)
+
+      print(x)
+      "
+    `);
+  });
+
+  test("does not select the variable when it does not exist", async () => {
+    view = createEditor(`\
+#comment
+myVar = 10
+print(myVar)`);
     const result = goToVariableDefinition(view, "nonExistentVar");
 
     expect(result).toBe(false);
-    expect(view.state.selection.main.from).toBe(0);
-    expect(view.state.selection.main.to).toBe(0);
+    await tick();
+    expect(renderEditorView(view)).toMatchInlineSnapshot(`
+      "
+      #comment
+      ^
+      myVar = 10
+      print(myVar)
+      "
+    `);
   });
 
-  test("does not select the variable when it exists in a comment or string", () => {
-    view = createEditor("#comment\n# myVar\nprint('myVar')");
+  test("does not select the variable when it exists in a comment or string", async () => {
+    view = createEditor(`\
+#comment
+# myVar
+print('myVar')`);
     const result = goToVariableDefinition(view, "myVar");
-
     expect(result).toBe(false);
-    expect(view.state.selection.main.from).toBe(0);
-    expect(view.state.selection.main.to).toBe(0);
+    await tick();
+    expect(renderEditorView(view)).toMatchInlineSnapshot(`
+      "
+      #comment
+      ^
+      # myVar
+      print('myVar')
+      "
+    `);
   });
 });
+
+/**
+ * Returns a string of the editor's document with the current selection
+ * highlighted using carets (`^`). Used for snapshot testing.
+ *
+ * A single caret marks a cursor; multiple carets mark a selection range.
+ *
+ * @param view - The CodeMirror EditorView instance.
+ * @returns A string with selection markers, suitable for snapshots.
+ */
+function renderEditorView(view: EditorView) {
+  const { from, to } = view.state.selection.main;
+  const lines = view.state.doc.toString().split("\n");
+  let pos = 0;
+  return [
+    "",
+    ...lines.map((line) => {
+      const start = pos;
+      const end = pos + line.length;
+      pos = end + 1;
+
+      if (from >= start && from <= end) {
+        const col = {
+          start: from - start,
+          end: Math.min(to - start, line.length),
+        };
+        const marker =
+          from === to
+            ? "^".padStart(col.start + 1)
+            : "^".repeat(col.end - col.start).padStart(col.end);
+        return `${line}\n${marker}`;
+      }
+
+      return line;
+    }),
+    "",
+  ].join("\n");
+}

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -44,14 +44,6 @@ export function goToVariableDefinition(
         return false;
       } // Stop traversal if found
 
-      // Skip function/lambda bodies entirely
-      if (
-        node.name === "LambdaExpression" ||
-        node.name === "FunctionDefinition"
-      ) {
-        return false;
-      }
-
       // Check if the node is an identifier and matches the variable name
       if (
         node.name === "VariableName" &&


### PR DESCRIPTION
Removed overly aggressive early return introduced in #5415. Adds tests for
variables in different scopes, function declarations.
