### PR TITLE
enhancement: add a signifier for the create cell context menu

### DIFF
--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -7,6 +7,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import { MarkdownLanguageAdapter } from "@/core/codemirror/language/languages/markdown";
 import { SQLLanguageAdapter } from "@/core/codemirror/language/languages/sql";
 import {
@@ -18,6 +19,7 @@ import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
 import { Tooltip } from "../../ui/tooltip";
 import { MarkdownIcon, PythonIcon } from "./code/icons";
+import { useCellActions } from "@/core/cells/cells";
 
 export const CreateCellButton = ({
   connectionState,
@@ -65,11 +67,16 @@ const CreateCellButtonContextMenu = (props: {
   children: React.ReactNode;
 }) => {
   const { children, onClick } = props;
+  const { createNewCell } = useCellActions();
 
   if (!onClick) {
     return children;
   }
 
+  // NB: When adding the marimo import for markdown and SQL, we run it
+  // automatically regardless of whether autoinstantiate or lazy execution is
+  // enabled; the user experience is confusing otherwise (how does the user
+  // know they need to run import marimo as mo. first?).
   return (
     <ContextMenu>
       <ContextMenuTrigger>{children}</ContextMenuTrigger>
@@ -91,6 +98,7 @@ const CreateCellButtonContextMenu = (props: {
           key="markdown"
           onSelect={(evt) => {
             evt.stopPropagation();
+            maybeAddMarimoImport(true, createNewCell);
             onClick({ code: new MarkdownLanguageAdapter().defaultCode });
           }}
         >
@@ -103,6 +111,7 @@ const CreateCellButtonContextMenu = (props: {
           key="sql"
           onSelect={(evt) => {
             evt.stopPropagation();
+            maybeAddMarimoImport(true, createNewCell);
             onClick({ code: new SQLLanguageAdapter().defaultCode });
           }}
         >

--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -8,6 +8,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
+import { useCellActions } from "@/core/cells/cells";
 import { MarkdownLanguageAdapter } from "@/core/codemirror/language/languages/markdown";
 import { SQLLanguageAdapter } from "@/core/codemirror/language/languages/sql";
 import {
@@ -19,7 +20,6 @@ import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
 import { Tooltip } from "../../ui/tooltip";
 import { MarkdownIcon, PythonIcon } from "./code/icons";
-import { useCellActions } from "@/core/cells/cells";
 
 export const CreateCellButton = ({
   connectionState,
@@ -30,8 +30,11 @@ export const CreateCellButton = ({
   tooltipContent: React.ReactNode;
   onClick: ((opts: { code: string }) => void) | undefined;
 }) => {
-  const baseTooltipContent = getConnectionTooltip(connectionState) || tooltipContent;
-  const finalTooltipContent = isAppInteractionDisabled(connectionState) ? baseTooltipContent : (
+  const baseTooltipContent =
+    getConnectionTooltip(connectionState) || tooltipContent;
+  const finalTooltipContent = isAppInteractionDisabled(connectionState) ? (
+    baseTooltipContent
+  ) : (
     <div className="flex flex-col gap-4">
       <div>{baseTooltipContent}</div>
       <div className="text-xs text-muted-foreground font-medium pt-1 -mt-2 border-t border-border">

--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -28,8 +28,15 @@ export const CreateCellButton = ({
   tooltipContent: React.ReactNode;
   onClick: ((opts: { code: string }) => void) | undefined;
 }) => {
-  const finalTooltipContent =
-    getConnectionTooltip(connectionState) || tooltipContent;
+  const baseTooltipContent = getConnectionTooltip(connectionState) || tooltipContent;
+  const finalTooltipContent = isAppInteractionDisabled(connectionState) ? baseTooltipContent : (
+    <div className="flex flex-col gap-4">
+      <div>{baseTooltipContent}</div>
+      <div className="text-xs text-muted-foreground font-medium pt-1 -mt-2 border-t border-border">
+        Right-click for cell types
+      </div>
+    </div>
+  );
 
   return (
     <CreateCellButtonContextMenu onClick={onClick}>

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -22,7 +22,7 @@ import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import type { CellId } from "@/core/cells/ids";
 import { MarkdownLanguageAdapter } from "@/core/codemirror/language/languages/markdown";
 import { SQLLanguageAdapter } from "@/core/codemirror/language/languages/sql";
-import { aiEnabledAtom, autoInstantiateAtom } from "@/core/config/config";
+import { aiEnabledAtom } from "@/core/config/config";
 import { isConnectedAtom } from "@/core/network/connection";
 import { useBoolean } from "@/hooks/useBoolean";
 import { cn } from "@/utils/cn";
@@ -290,7 +290,6 @@ const AddCellButtons: React.FC<{
   className?: string;
 }> = ({ columnId, className }) => {
   const { createNewCell } = useCellActions();
-  const autoInstantiate = useAtomValue(autoInstantiateAtom);
   const [isAiButtonOpen, isAiButtonOpenActions] = useBoolean(false);
   const aiEnabled = useAtomValue(aiEnabledAtom);
   const isConnected = useAtomValue(isConnectedAtom);
@@ -328,7 +327,7 @@ const AddCellButtons: React.FC<{
           size="sm"
           disabled={!isConnected}
           onClick={() => {
-            maybeAddMarimoImport(autoInstantiate, createNewCell);
+            maybeAddMarimoImport(true, createNewCell);
 
             createNewCell({
               cellId: { type: "__end__", columnId },
@@ -346,7 +345,7 @@ const AddCellButtons: React.FC<{
           size="sm"
           disabled={!isConnected}
           onClick={() => {
-            maybeAddMarimoImport(autoInstantiate, createNewCell);
+            maybeAddMarimoImport(true, createNewCell);
 
             createNewCell({
               cellId: { type: "__end__", columnId },


### PR DESCRIPTION
Users can right-click the create cell button to get a context menu with Python, SQL, and Markdown cell types, but I would guess most users don't know this. This change adds a signifier on hover letting them know about the context menu.

This change also fixes a usability bug in the create markdown and sql actions by importing marimo as needed when the markdown/sql cells are created.

<img width="246" alt="Screenshot 2025-06-29 at 9 44 38 AM" src="https://github.com/user-attachments/assets/faa5ecd3-4c05-4747-a7b9-a31df86b1684" />

This is the context menu (which already existed):

<img width="151" alt="image" src="https://github.com/user-attachments/assets/70078da6-f53f-4244-a823-b7f342c9de57" />
