### PR TITLE
Ensure cell action tooltip appears above sidebar panel

### DIFF
--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -45,7 +45,7 @@ export const CreateCellButton = ({
 
   return (
     <CreateCellButtonContextMenu onClick={onClick}>
-      <Tooltip content={finalTooltipContent} usePortal={false}>
+      <Tooltip content={finalTooltipContent}>
         <Button
           onClick={() => onClick?.({ code: "" })}
           className={cn(


### PR DESCRIPTION
Fixes #5490

The create cell button tooltip was appearing behind the sidebar panel because it had `usePortal={false}`, which kept it within the button's stacking context.

Removing this prop allows the tooltip to render in a portal at the document root, ensuring it appears above all panels. I'm not sure of the original reason for disabling the portal, but in my testing, removing seems to resolve the layering issue and doesn't introduce any obvious regressions.
