### PR TITLE
Convert import helpers to use named parameters

### DIFF
--- a/frontend/src/components/chat/markdown-renderer.tsx
+++ b/frontend/src/components/chat/markdown-renderer.tsx
@@ -95,7 +95,11 @@ const CodeBlock = ({ code, language }: CodeBlockProps) => {
     const result = maybeTransform(language, value);
 
     if (language === "sql") {
-      maybeAddMarimoImport(autoInstantiate, createNewCell, lastFocusedCellId);
+      maybeAddMarimoImport({
+        autoInstantiate,
+        createNewCell,
+        fromCellId: lastFocusedCellId,
+      });
     }
     createNewCell({
       code: result.code,

--- a/frontend/src/components/datasources/column-preview.tsx
+++ b/frontend/src/components/datasources/column-preview.tsx
@@ -237,7 +237,11 @@ export const AddDataframeChart: React.FC<{
 
   const handleAddColumn = (chartCode: string) => {
     if (chartCode.includes("alt")) {
-      maybeAddAltairImport(autoInstantiate, createNewCell, lastFocusedCellId);
+      maybeAddAltairImport({
+        autoInstantiate,
+        createNewCell,
+        fromCellId: lastFocusedCellId,
+      });
     }
     createNewCell({
       code: chartCode,

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -534,7 +534,11 @@ const DatasetTableItem: React.FC<{
   const addCodeToNewCell = useAddCodeToNewCell();
 
   const handleAddTable = () => {
-    maybeAddMarimoImport(autoInstantiate, createNewCell, lastFocusedCellId);
+    maybeAddMarimoImport({
+      autoInstantiate,
+      createNewCell,
+      fromCellId: lastFocusedCellId,
+    });
     const getCode = () => {
       if (table.source_type === "catalog") {
         const identifier = sqlTableContext?.database

--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -273,7 +273,7 @@ export function useCellActionButtons({ cell }: Props) {
           if (!editorView) {
             return;
           }
-          maybeAddMarimoImport(autoInstantiate, createCell);
+          maybeAddMarimoImport({ autoInstantiate, createNewCell: createCell });
           switchLanguage(editorView, {
             language: "markdown",
             keepCodeAsIs: false,
@@ -288,8 +288,11 @@ export function useCellActionButtons({ cell }: Props) {
           if (!editorView) {
             return;
           }
-          maybeAddMarimoImport(autoInstantiate, createCell);
-          switchLanguage(editorView, { language: "sql", keepCodeAsIs: false });
+          maybeAddMarimoImport({ autoInstantiate, createNewCell: createCell });
+          switchLanguage(editorView, {
+            language: "markdown",
+            keepCodeAsIs: false,
+          });
         },
       },
       {
@@ -300,7 +303,7 @@ export function useCellActionButtons({ cell }: Props) {
           if (!editorView) {
             return;
           }
-          maybeAddMarimoImport(autoInstantiate, createCell);
+          maybeAddMarimoImport({ autoInstantiate, createNewCell: createCell });
           toggleToLanguage(editorView, "python", { force: true });
         },
       },

--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -101,7 +101,7 @@ const CreateCellButtonContextMenu = (props: {
           key="markdown"
           onSelect={(evt) => {
             evt.stopPropagation();
-            maybeAddMarimoImport(true, createNewCell);
+            maybeAddMarimoImport({ autoInstantiate: true, createNewCell });
             onClick({ code: new MarkdownLanguageAdapter().defaultCode });
           }}
         >
@@ -114,7 +114,7 @@ const CreateCellButtonContextMenu = (props: {
           key="sql"
           onSelect={(evt) => {
             evt.stopPropagation();
-            maybeAddMarimoImport(true, createNewCell);
+            maybeAddMarimoImport({ autoInstantiate: true, createNewCell });
             onClick({ code: new SQLLanguageAdapter().defaultCode });
           }}
         >

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -128,7 +128,10 @@ const CellEditorInternal = ({
 
   const autoInstantiate = useAtomValue(autoInstantiateAtom);
   const afterToggleMarkdown = useEvent(() => {
-    maybeAddMarimoImport(autoInstantiate, cellActions.createNewCell);
+    maybeAddMarimoImport({
+      autoInstantiate,
+      createNewCell: cellActions.createNewCell,
+    });
   });
 
   const aiEnabled = isAiEnabled(userConfig);

--- a/frontend/src/components/editor/cell/useAddCell.ts
+++ b/frontend/src/components/editor/cell/useAddCell.ts
@@ -13,7 +13,11 @@ export function useAddCodeToNewCell(): (code: string) => void {
 
   return (code: string) => {
     if (code.includes("alt")) {
-      maybeAddAltairImport(autoInstantiate, createNewCell, lastFocusedCellId);
+      maybeAddAltairImport({
+        autoInstantiate,
+        createNewCell,
+        fromCellId: lastFocusedCellId,
+      });
     }
 
     createNewCell({

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -327,7 +327,7 @@ const AddCellButtons: React.FC<{
           size="sm"
           disabled={!isConnected}
           onClick={() => {
-            maybeAddMarimoImport(true, createNewCell);
+            maybeAddMarimoImport({ autoInstantiate: true, createNewCell });
 
             createNewCell({
               cellId: { type: "__end__", columnId },
@@ -345,7 +345,7 @@ const AddCellButtons: React.FC<{
           size="sm"
           disabled={!isConnected}
           onClick={() => {
-            maybeAddMarimoImport(true, createNewCell);
+            maybeAddMarimoImport({ autoInstantiate: true, createNewCell });
 
             createNewCell({
               cellId: { type: "__end__", columnId },

--- a/frontend/src/core/cells/__tests__/add-missing-import.test.ts
+++ b/frontend/src/core/cells/__tests__/add-missing-import.test.ts
@@ -17,7 +17,12 @@ describe("maybeAddMissingImport", () => {
     const appStore = createStore();
     appStore.set(variablesAtom, { mo: {} } as Variables);
     const onAddImport = vi.fn();
-    maybeAddMissingImport("marimo", "mo", onAddImport, appStore);
+    maybeAddMissingImport({
+      moduleName: "marimo",
+      variableName: "mo",
+      onAddImport,
+      appStore,
+    });
     expect(onAddImport).not.toHaveBeenCalled();
   });
 
@@ -40,7 +45,12 @@ describe("maybeAddMissingImport", () => {
         cellIds: CELL_IDS,
       } as NotebookState);
       const onAddImport = vi.fn();
-      maybeAddMissingImport("marimo", "mo", onAddImport, appStore);
+      maybeAddMissingImport({
+        moduleName: "marimo",
+        variableName: "mo",
+        onAddImport,
+        appStore,
+      });
       expect(onAddImport).not.toHaveBeenCalled();
     },
   );
@@ -57,7 +67,12 @@ describe("maybeAddMissingImport", () => {
       cellIds: CELL_IDS,
     } as NotebookState);
     const onAddImport = vi.fn();
-    maybeAddMissingImport("marimo", "mo", onAddImport, appStore);
+    maybeAddMissingImport({
+      moduleName: "marimo",
+      variableName: "mo",
+      onAddImport,
+      appStore,
+    });
     expect(onAddImport).toHaveBeenCalledWith("import marimo as mo");
   });
 });

--- a/frontend/src/core/cells/add-missing-import.ts
+++ b/frontend/src/core/cells/add-missing-import.ts
@@ -10,12 +10,17 @@ import { CellId } from "./ids";
  * @param moduleName The name of the module to import.
  * @param variableName The name of the variable to import.
  */
-export function maybeAddMissingImport(
-  moduleName: string,
-  variableName: string,
-  onAddImport: (importStatement: string) => void,
-  appStore: typeof store = store,
-): boolean {
+export function maybeAddMissingImport({
+  moduleName,
+  variableName,
+  onAddImport,
+  appStore = store,
+}: {
+  moduleName: string;
+  variableName: string;
+  onAddImport: (importStatement: string) => void;
+  appStore?: typeof store;
+}): boolean {
   // If variableName is already in the variables state,
   // then the import is not missing (or the name has been taken).
   const variables = appStore.get(variablesAtom);
@@ -41,44 +46,60 @@ export function maybeAddMissingImport(
   return true;
 }
 
-export function maybeAddMarimoImport(
-  autoRun: boolean,
-  createNewCell: CellActions["createNewCell"],
-  fromCellId?: CellId | null,
-): boolean {
-  return maybeAddMissingImport("marimo", "mo", (importStatement) => {
-    const newCellId = CellId.create();
-    createNewCell({
-      cellId: fromCellId ?? "__end__",
-      before: false,
-      code: importStatement,
-      lastCodeRun: autoRun ? importStatement : undefined,
-      newCellId: newCellId,
-      autoFocus: false,
-    });
-    if (autoRun) {
-      void sendRun({ cellIds: [newCellId], codes: [importStatement] });
-    }
+export function maybeAddMarimoImport({
+  autoInstantiate,
+  createNewCell,
+  fromCellId,
+}: {
+  autoInstantiate: boolean;
+  createNewCell: CellActions["createNewCell"];
+  fromCellId?: CellId | null;
+}): boolean {
+  return maybeAddMissingImport({
+    moduleName: "marimo",
+    variableName: "mo",
+    onAddImport: (importStatement) => {
+      const newCellId = CellId.create();
+      createNewCell({
+        cellId: fromCellId ?? "__end__",
+        before: false,
+        code: importStatement,
+        lastCodeRun: autoInstantiate ? importStatement : undefined,
+        newCellId: newCellId,
+        autoFocus: false,
+      });
+      if (autoInstantiate) {
+        void sendRun({ cellIds: [newCellId], codes: [importStatement] });
+      }
+    },
   });
 }
 
-export function maybeAddAltairImport(
-  autoRun: boolean,
-  createNewCell: CellActions["createNewCell"],
-  fromCellId?: CellId | null,
-): boolean {
-  return maybeAddMissingImport("altair", "alt", (importStatement) => {
-    const newCellId = CellId.create();
-    createNewCell({
-      cellId: fromCellId ?? "__end__",
-      before: false,
-      code: importStatement,
-      lastCodeRun: autoRun ? importStatement : undefined,
-      newCellId: newCellId,
-      autoFocus: false,
-    });
-    if (autoRun) {
-      void sendRun({ cellIds: [newCellId], codes: [importStatement] });
-    }
+export function maybeAddAltairImport({
+  autoInstantiate,
+  createNewCell,
+  fromCellId,
+}: {
+  autoInstantiate: boolean;
+  createNewCell: CellActions["createNewCell"];
+  fromCellId?: CellId | null;
+}): boolean {
+  return maybeAddMissingImport({
+    moduleName: "altair",
+    variableName: "alt",
+    onAddImport: (importStatement) => {
+      const newCellId = CellId.create();
+      createNewCell({
+        cellId: fromCellId ?? "__end__",
+        before: false,
+        code: importStatement,
+        lastCodeRun: autoInstantiate ? importStatement : undefined,
+        newCellId: newCellId,
+        autoFocus: false,
+      });
+      if (autoInstantiate) {
+        void sendRun({ cellIds: [newCellId], codes: [importStatement] });
+      }
+    },
   });
 }


### PR DESCRIPTION
Used TypeScript's "Convert parameters to destructured object" code action to clarify arguments at call sites. Changes:

```ts
maybeAddMarimoImport(true, createNewCell, lastFocusedCellId);
```

to

```ts
maybeAddMarimoImport({
  autoInstantiate: true,
  createNewCell,
  fromCellId: lastFocusedCellId,
});
```

JS's lack of keyword arguments can make reading call sites challenging. I'd prefer to avoid ambiguous arguments. It probably be best to enforce with a lint rule, though, I suspect it would be noisy across the codebase, so just updated these helpers (seen in #5489 review).