### PR TITLE
chore: Add additional contributors for PR issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Your PR will be reviewed more quickly if you can figure out the right person to 
 
 @mscolnick (FE / BE / AI)
 @dmadisetti (BE: Runtime, Caching, Fileformat, AST)
-@mantz (FE: Widgets / BE: Dependency Management, LSP)
+@manzt (Widgets, Dependency Management, LSP)
 @light2dark (FE: Tables, Plots, Layout / BE: SQL)
 @akshayka (docs / BE / Integrations)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,4 +26,9 @@ Tag potential reviewers from the community or maintainers who might be intereste
 
 Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
 
-@akshayka OR @mscolnick
+@mscolnick (FE / BE / AI)
+@dmadisetti (BE: Runtime, Caching, Fileformat, AST)
+@mantz (FE: Widgets / BE: Dependency Management, LSP)
+@light2dark (FE: Tables, Plots, Layout / BE: SQL)
+@akshayka (docs / BE / Integrations)
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,9 +26,8 @@ Tag potential reviewers from the community or maintainers who might be intereste
 
 Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
 
-@mscolnick (FE / BE / AI)
-@dmadisetti (BE: Runtime, Caching, Fileformat, AST)
+@mscolnick (General, AI)
+@dmadisetti (Runtime, Caching, Fileformat, AST)
 @manzt (Widgets, Dependency Management, LSP)
-@light2dark (FE: Tables, Plots, Layout / BE: SQL)
-@akshayka (docs / BE / Integrations)
-
+@light2dark (Tables, Plots, Layouts, SQL)
+@akshayka (Docs, Backend, Integrations)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,10 +24,11 @@ Detail the specific changes made in this pull request. Explain the problem addre
 <!--
 Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.
 
-Your PR will be reviewed more quickly if you can figure out the right person to tag with @ -->
+Your PR will be reviewed more quickly if you can figure out the right person to tag with @
 
 @mscolnick (General, AI)
 @dmadisetti (Runtime, Caching, Fileformat, AST)
 @manzt (Widgets, Dependency Management, LSP)
 @light2dark (Tables, Plots, Layouts, SQL)
 @akshayka (Public API, Dependencies, UX/Styling, Backend, Docs, Integrations)
+ -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,4 +30,4 @@ Your PR will be reviewed more quickly if you can figure out the right person to 
 @dmadisetti (Runtime, Caching, Fileformat, AST)
 @manzt (Widgets, Dependency Management, LSP)
 @light2dark (Tables, Plots, Layouts, SQL)
-@akshayka (Docs, Backend, Integrations)
+@akshayka (Public API, Dependencies, UX/Styling, Backend, Docs, Integrations)


### PR DESCRIPTION
Updating the PR template such that the issues can hopefully become more naturally delegated. I don't want to put anyone in a box, please expand or contract your surface area a as you see fit

--- 

```
<!--
Tag potential reviewers from the community or maintainers who might be interested in reviewing this pull request.

Your PR will be reviewed more quickly if you can figure out the right person to tag with @

@mscolnick (General, AI)
@dmadisetti (Runtime, Caching, Fileformat, AST)
@manzt (Widgets, Dependency Management, LSP)
@light2dark (Tables, Plots, Layouts, SQL)
@akshayka (Public API, Dependencies, UX/Styling, Backend, Docs, Integrations)
 -->
 ```