### PR TITLE
fix: include all query params in WebSocket connection

### DIFF
--- a/frontend/src/core/runtime/__tests__/createWsUrl.test.ts
+++ b/frontend/src/core/runtime/__tests__/createWsUrl.test.ts
@@ -38,8 +38,24 @@ describe("RuntimeManager.getWsURL", () => {
     const sessionId = "1234" as SessionId;
     const url = runtime.getWsURL(sessionId);
     expect(url.toString()).toBe(
-      "ws://marimo.app/nested/ws?foo=bar&session_id=1234&file=test.py",
+      "ws://marimo.app/nested/ws?foo=bar&file=test.py&session_id=1234",
     );
+    expect(url.searchParams.get(KnownQueryParams.sessionId)).toBe(sessionId);
+  });
+
+  it("should include all query params from current page", () => {
+    const runtime = new RuntimeManager({
+      url: "http://marimo.app/",
+    });
+    window.history.pushState({}, "", "/?file=test.py&search=test&other=last");
+    const sessionId = "1234" as SessionId;
+    const url = runtime.getWsURL(sessionId);
+    expect(url.toString()).toBe(
+      "ws://marimo.app/ws?file=test.py&search=test&other=last&session_id=1234",
+    );
+    expect(url.searchParams.get("file")).toBe("test.py");
+    expect(url.searchParams.get("search")).toBe("test");
+    expect(url.searchParams.get("other")).toBe("last");
     expect(url.searchParams.get(KnownQueryParams.sessionId)).toBe(sessionId);
   });
 });

--- a/frontend/src/core/runtime/runtime.ts
+++ b/frontend/src/core/runtime/runtime.ts
@@ -89,6 +89,16 @@ export class RuntimeManager {
   getWsURL(sessionId: SessionId): URL {
     const baseUrl = new URL(this.config.url);
     const searchParams = new URLSearchParams(baseUrl.search);
+    
+    // Merge in current page's query parameters
+    const currentParams = new URLSearchParams(window.location.search);
+    currentParams.forEach((value, key) => {
+      // Don't override base URL params
+      if (!searchParams.has(key)) {
+        searchParams.set(key, value);
+      }
+    });
+    
     searchParams.set(KnownQueryParams.sessionId, sessionId);
     return this.formatWsURL("/ws", searchParams);
   }
@@ -99,6 +109,16 @@ export class RuntimeManager {
   getWsSyncURL(sessionId: SessionId): URL {
     const baseUrl = new URL(this.config.url);
     const searchParams = new URLSearchParams(baseUrl.search);
+    
+    // Merge in current page's query parameters
+    const currentParams = new URLSearchParams(window.location.search);
+    currentParams.forEach((value, key) => {
+      // Don't override base URL params
+      if (!searchParams.has(key)) {
+        searchParams.set(key, value);
+      }
+    });
+    
     searchParams.set(KnownQueryParams.sessionId, sessionId);
     return this.formatWsURL("/ws_sync", searchParams);
   }


### PR DESCRIPTION
# Fix: Include all query params in WebSocket connection

## Summary
- Fixed an issue where `mo.query_params()` was only returning the first query parameter
- The frontend now passes all query parameters from the browser URL to the WebSocket connection
- Previously, only special parameters like `session_id` and `file` were being passed through

## What this PR does

When visiting a marimo notebook with multiple query parameters like:
```
http://localhost:2718/?file=test.py&search=test&other=last
```

Previously, `mo.query_params()` would only return:
```python
{"file": "test.py"}
```

Now it correctly returns all parameters:
```python
{
  "file": "test.py",
  "search": "test", 
  "other": "last"
}
```

## How to test

1. Create a simple test notebook:
```python
import marimo as mo

@app.cell
def _(mo):
    params = mo.query_params()
    params
```

2. Run the notebook and open with query parameters:
```
http://localhost:2718/?file=test.py&search=test&other=last
```

3. Verify that all three parameters are displayed

## Design decisions

- Modified both `getWsURL()` and `getWsSyncURL()` for consistency
- Current page query params are merged with base URL params, with base URL params taking precedence
- Added a test case to verify the behavior