### PR TITLE
Minor typo fix in uv docs

### DIFF
--- a/docs/guides/package_management/using_uv.md
+++ b/docs/guides/package_management/using_uv.md
@@ -36,7 +36,7 @@ uvx marimo edit --sandbox my_notebook.py
 ```
 
 This command installs marimo in a temporary environment, activates it, then
-runs your marimo notebook. The `--sandbox` flag what tells marimo to keep
+runs your marimo notebook. The `--sandbox` flag is what tells marimo to keep
 track of your dependencies and store them in the notebook file. If there are
 any dependencies already tracked in the file, this command will download
 them and install them in the environment.


### PR DESCRIPTION
## 📝 Summary

Fixing a minor typo in the uv documentation page.

## 🔍 Description of Changes

https://docs.marimo.io/guides/package_management/using_uv/ previously read: "The --sandbox flag what tells marimo to keep track of your dependencies and store them in the notebook file." 

It now reads: ""The --sandbox flag is what tells marimo to keep track of your dependencies and store them in the notebook file." 

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

## 📜 Reviewers


@akshayka 
