### PR TITLE
fix: Invalid base url in api resolution

### DIFF
--- a/frontend/src/core/network/__tests__/api.test.ts
+++ b/frontend/src/core/network/__tests__/api.test.ts
@@ -1,0 +1,64 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { API } from "../api";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Default mock for getRuntimeManager
+let baseUrl = "http://localhost:8000";
+vi.mock("@/core/runtime/config", () => ({
+  getRuntimeManager: () => ({
+    get httpURL() { return new URL(baseUrl); },
+    headers: () => ({}),
+  }),
+}));
+
+describe("API", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    baseUrl = "http://localhost:8000";
+  });
+
+  it("API.post calls fetch with POST and correct URL", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({ ok: true }),
+    });
+    await API.post("/foo", { bar: 1 });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8000/api/foo",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("API.get calls fetch with GET and correct URL", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({ ok: true }),
+    });
+    await API.get("/bar");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8000/api/bar",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("API.post handles base URL with path correctly", async () => {
+    baseUrl = "http://example.com/e";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({ ok: true }),
+    });
+    await API.post("/foo", { bar: 1 });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://example.com/e/api/foo",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});

--- a/frontend/src/core/network/__tests__/api.test.ts
+++ b/frontend/src/core/network/__tests__/api.test.ts
@@ -63,4 +63,18 @@ describe("API", () => {
       expect.objectContaining({ method: "POST" }),
     );
   });
+
+  it("API.post handles base URL with trailing slash correctly", async () => {
+    baseUrl = "http://example.com/e/";
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({ ok: true }),
+    });
+    await API.post("/foo", { bar: 1 });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://example.com/e/api/foo",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
 });

--- a/frontend/src/core/network/__tests__/api.test.ts
+++ b/frontend/src/core/network/__tests__/api.test.ts
@@ -11,7 +11,9 @@ global.fetch = mockFetch;
 let baseUrl = "http://localhost:8000";
 vi.mock("@/core/runtime/config", () => ({
   getRuntimeManager: () => ({
-    get httpURL() { return new URL(baseUrl); },
+    get httpURL() {
+      return new URL(baseUrl);
+    },
     headers: () => ({}),
   }),
 }));
@@ -31,7 +33,7 @@ describe("API", () => {
     await API.post("/foo", { bar: 1 });
     expect(mockFetch).toHaveBeenCalledWith(
       "http://localhost:8000/api/foo",
-      expect.objectContaining({ method: "POST" })
+      expect.objectContaining({ method: "POST" }),
     );
   });
 
@@ -44,7 +46,7 @@ describe("API", () => {
     await API.get("/bar");
     expect(mockFetch).toHaveBeenCalledWith(
       "http://localhost:8000/api/bar",
-      expect.objectContaining({ method: "GET" })
+      expect.objectContaining({ method: "GET" }),
     );
   });
 
@@ -58,7 +60,7 @@ describe("API", () => {
     await API.post("/foo", { bar: 1 });
     expect(mockFetch).toHaveBeenCalledWith(
       "http://example.com/e/api/foo",
-      expect.objectContaining({ method: "POST" })
+      expect.objectContaining({ method: "POST" }),
     );
   });
 });

--- a/frontend/src/core/network/api.ts
+++ b/frontend/src/core/network/api.ts
@@ -13,6 +13,10 @@ function getBaseUriWithoutQueryParams(): string {
   return url.toString();
 }
 
+function withTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
 /**
  * Wrapper around fetch that adds XSRF token and session ID to the request and
  * strong types.
@@ -26,7 +30,10 @@ export const API = {
       baseUrl?: string;
     } = {},
   ): Promise<RESP> {
-    const baseUrl = opts.baseUrl ?? getBaseUriWithoutQueryParams();
+    const baseUrl = withTrailingSlash(
+      opts.baseUrl ?? getBaseUriWithoutQueryParams(),
+    );
+    // Ensure the URL ends with a slash
     const fullUrl = `${baseUrl}api${url}`;
     return fetch(fullUrl, {
       method: "POST",
@@ -65,7 +72,9 @@ export const API = {
       baseUrl?: string;
     } = {},
   ): Promise<RESP> {
-    const baseUrl = opts.baseUrl ?? getBaseUriWithoutQueryParams();
+    const baseUrl = withTrailingSlash(
+      opts.baseUrl ?? getBaseUriWithoutQueryParams(),
+    );
     const fullUrl = `${baseUrl}api${url}`;
     return fetch(fullUrl, {
       method: "GET",

--- a/frontend/src/core/network/api.ts
+++ b/frontend/src/core/network/api.ts
@@ -2,6 +2,7 @@
 
 import { createMarimoClient } from "@marimo-team/marimo-api";
 import { Logger } from "../../utils/Logger";
+import { Strings } from "../../utils/strings";
 import { getRuntimeManager } from "../runtime/config";
 import type { RuntimeManager } from "../runtime/runtime";
 
@@ -11,10 +12,6 @@ function getBaseUriWithoutQueryParams(): string {
   url.search = "";
   url.hash = "";
   return url.toString();
-}
-
-function withTrailingSlash(url: string): string {
-  return url.endsWith("/") ? url : `${url}/`;
 }
 
 /**
@@ -30,10 +27,9 @@ export const API = {
       baseUrl?: string;
     } = {},
   ): Promise<RESP> {
-    const baseUrl = withTrailingSlash(
+    const baseUrl = Strings.withTrailingSlash(
       opts.baseUrl ?? getBaseUriWithoutQueryParams(),
     );
-    // Ensure the URL ends with a slash
     const fullUrl = `${baseUrl}api${url}`;
     return fetch(fullUrl, {
       method: "POST",
@@ -72,7 +68,7 @@ export const API = {
       baseUrl?: string;
     } = {},
   ): Promise<RESP> {
-    const baseUrl = withTrailingSlash(
+    const baseUrl = Strings.withTrailingSlash(
       opts.baseUrl ?? getBaseUriWithoutQueryParams(),
     );
     const fullUrl = `${baseUrl}api${url}`;

--- a/frontend/src/utils/strings.ts
+++ b/frontend/src/utils/strings.ts
@@ -37,6 +37,9 @@ export const Strings = {
       .replaceAll("\n", " ");
   },
 
+  withTrailingSlash(url: string): string {
+    return url.endsWith("/") ? url : `${url}/`;
+  },
   withoutTrailingSlash(url: string): string {
     return url.endsWith("/") ? url.slice(0, -1) : url;
   },


### PR DESCRIPTION
## 📝 Summary

I traced failing endpoints in WASM to malformed urls (e.g. `marimo.app/eapi`). Quick fix to prevent this, with a sanity check test to prevent regression