### PR TITLE
enhancement: raise a UsageError on marimo edit --sandbox

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -405,13 +405,24 @@ def edit(
         )
         return
 
-    # Set default, if not provided
     if sandbox is None:
+        # When the sandbox flag is omitted we infer whether to
+        # to start in sandbox mode by examining the notebook file and
+        # prompting the user.
         from marimo._cli.sandbox import maybe_prompt_run_in_sandbox
 
         sandbox = maybe_prompt_run_in_sandbox(name)
+    elif sandbox and name is None:
+        raise click.UsageError(
+            """marimo's package sandbox requires a notebook name:
 
-    if sandbox:
+    * marimo edit --sandbox my_notebook.py
+
+  Multi-notebook sandboxed servers (marimo edit --sandbox) are not supported.
+  Follow this issue at: https://github.com/marimo-team/marimo/issues/2598."""
+        )
+
+    elif sandbox:
         from marimo._cli.sandbox import run_in_sandbox
 
         # TODO: consider adding recommended as well

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -582,7 +582,6 @@ def test_cli_sandbox_edit_new_file() -> None:
 @pytest.mark.skipif(not HAS_UV, reason="uv is required for sandbox tests")
 def test_cli_sandbox_edit_not_supported() -> None:
     port = _get_port()
-    d = tempfile.TemporaryDirectory()
     p = subprocess.Popen(
         [
             "marimo",

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -579,6 +579,25 @@ def test_cli_sandbox_edit_new_file() -> None:
     _check_contents(p, b"edit", contents)
 
 
+@pytest.mark.skipif(not HAS_UV, reason="uv is required for sandbox tests")
+def test_cli_sandbox_edit_not_supported() -> None:
+    port = _get_port()
+    d = tempfile.TemporaryDirectory()
+    p = subprocess.Popen(
+        [
+            "marimo",
+            "edit",
+            "-p",
+            str(port),
+            "--headless",
+            "--no-token",
+            "--sandbox",
+        ]
+    )
+    contents = _try_fetch(port)
+    _check_contents(p, b"not supported", contents)
+
+
 @pytest.mark.skipif(is_windows(), reason="Windows will prompt for Docker")
 def test_cli_edit_by_url() -> None:
     port = _get_port()


### PR DESCRIPTION
Today, We (silently) don't support multi-notebook edit servers in sandbox mode. Running

marimo edit --sandbox

yields confusing behavior in which notebooks all share the same environment, even though their inline script metadata is kept separate. This isn't what the users want, and can lead to dependencies missing in notebook metadata.

Instead of failing silently, this change raises a UsageError if the user attempts to run the edit server in sandbox mode without a named notebook argument. It also links to the associated GitHub issue.

Here is the usage error:

```
Error: marimo's package sandbox requires a notebook name:

    * marimo edit --sandbox my_notebook.py

  Multi-notebook sandboxed servers (marimo edit --sandbox) are not supported.
  Follow this issue at: https://github.com/marimo-team/marimo/issues/2598.
```