### PR TITLE
chore: docs CI cannot use pillow 11.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ docs = [
     "mkdocs-redirects>=1.2.2",
     "mkdocs-click>=0.8.1",
     "mike>=2.0.0",  # for versioning
-    "pillow>=10.2.0",  # for social cards
+    "pillow>=10.2.0,!=11.3.0",  # for social cards, 11.3.0 doesn't have manylinux wheels
     "cairosvg>=2.7.1",  # for social cards
     "mdx-include>=1.4.2",
     "pymdown-extensions>=10.7",


### PR DESCRIPTION
Pillow 11.3.0 doesn't have manylinux2014 wheels and was breaking our docs CI.

See https://github.com/python-pillow/Pillow/issues/9057 for context. Future versions will (apparently) restore manylinux2014 support.