### PR TITLE
fix: infinite loops with query parameters and UI elements (revert "Fix StateRegistry retain_active_states (#5435)")

### DIFF
--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -80,10 +80,7 @@ class DirectedGraph:
 
         This is a singleton for well-formed graphs.
         """
-        if name in self.definitions:
-            return self.definitions[name]
-        else:
-            return set()
+        return self.definitions[name]
 
     def get_referring_cells(
         self, name: Name, language: Literal["python", "sql"]

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -551,11 +551,9 @@ class Runner:
     ) -> tuple[str, Optional[CellId_t]]:
         ref = e.ref
         blamed_cell = None
-
-        definitions = self.graph.get_defining_cells(ref)
-        if definitions:
-            (blamed_cell, *_) = definitions
-        else:
+        try:
+            (blamed_cell, *_) = self.graph.get_defining_cells(ref)
+        except KeyError:
             # The reference is not found anywhere else in the graph
             # but it might be private
             ref, var_cell_id = unmangle_local(ref)

--- a/marimo/_runtime/state.py
+++ b/marimo/_runtime/state.py
@@ -116,7 +116,7 @@ class StateRegistry:
                         del self._inv_states[id_key]
                 del self._states[state_key]
             else:
-                active_state_ids.add(self._states[state_key].id)
+                active_state_ids.add(id(self._states[state_key]))
 
         # Remove all non-active states by id
         for state_id in list(self._inv_states.keys()):

--- a/tests/_runtime/test_state.py
+++ b/tests/_runtime/test_state.py
@@ -1,6 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
 from marimo._runtime.runtime import Kernel
-from marimo._runtime.state import State, StateRegistry
 from tests.conftest import ExecReqProvider
 
 
@@ -219,17 +218,3 @@ async def test_set_state_not_strict_copied(
 
     assert id(k.globals["a"]) == id(k.globals["state"])
     assert id(k.globals["b"]) == id(k.globals["set_state"])
-
-
-def test_retain_active_states() -> None:
-    state_registry = StateRegistry()
-    state = State(None)
-    state_registry.register(state, "state")
-
-    assert state_registry.lookup("state")
-    assert state_registry.bound_names(state) == {"state"}
-
-    state_registry.retain_active_states({"state"})
-
-    assert state_registry.lookup("state")
-    assert state_registry.bound_names(state) == {"state"}


### PR DESCRIPTION
This reverts commit 9ec52a69a7938f2552cdb3b08ccf400157edbafc (PR #5435).

This change introduced a regression in which cells can become involved in infinite loops. While I have not root-caused this, it can be seen in marimo/_smoke_tests/query_params.py. 

The video below shows the regression.


https://github.com/user-attachments/assets/16bd3cc4-00b4-4c6e-a19b-7b752f62466a

