### PR TITLE
ci: add GitHub auto labeler based on file changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,6 +8,6 @@ bash-focus:
 # enhancement:
 #   - title: ['^feat:', '^enhancement:']
 # internal:
-#   - title: ['^chore:', '^internal:', '^ci:']
+#   - title: ['^internal:', '^ci:']
 # preview:
 #   - title: ['^preview:', '^experimental:']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ['docs/**']
+bash-focus:
+  - changed-files:
+      - any-glob-to-any-file: ['openapi/api.yaml', 'frontend/index.html']
+# Only valid once this is merged: https://github.com/actions/labeler/pull/866
+# enhancement:
+#   - title: ['^feat:', '^enhancement:']
+# internal:
+#   - title: ['^chore:', '^internal:', '^ci:']
+# preview:
+#   - title: ['^preview:', '^experimental:']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: 🏷️ Pull Request Labeler
+
+# Label pull requests based on config in .github/labeler.yml
+
+on: [pull_request_target]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Auto-label PRs based on file changes (e.g. `documentation` or `bash-focus`)