### PR TITLE
fix: opening a notebook from the sidebar when in a subpath

### DIFF
--- a/frontend/src/components/editor/actions/useCopyNotebook.tsx
+++ b/frontend/src/components/editor/actions/useCopyNotebook.tsx
@@ -2,6 +2,7 @@
 import { useImperativeModal } from "@/components/modal/ImperativeModal";
 import { toast } from "@/components/ui/use-toast";
 import { sendCopy } from "@/core/network/requests";
+import { openNotebook } from "@/utils/links";
 import { PathBuilder, Paths } from "@/utils/paths";
 
 export function useCopyNotebook(source: string | null) {
@@ -31,7 +32,7 @@ export function useCopyNotebook(source: string | null) {
             title: "Notebook copied",
             description: "A copy of the notebook has been created.",
           });
-          window.open(`/?file=${destination}`, "_blank");
+          openNotebook(destination);
         });
       },
     });

--- a/frontend/src/components/editor/file-tree/file-explorer.tsx
+++ b/frontend/src/components/editor/file-tree/file-explorer.tsx
@@ -57,6 +57,7 @@ import { ErrorBanner } from "@/plugins/impl/common/error-banner";
 import { cn } from "@/utils/cn";
 import { copyToClipboard } from "@/utils/copy";
 import { downloadBlob } from "@/utils/download";
+import { openNotebook } from "@/utils/links";
 import type { FilePath } from "@/utils/paths";
 import { fileSplit } from "@/utils/pathUtils";
 import { FileViewer } from "./file-viewer";
@@ -675,5 +676,5 @@ function openMarimoNotebook(
 ) {
   event.stopPropagation();
   event.preventDefault();
-  window.open(`/?file=${path}`, "_blank");
+  openNotebook(path);
 }

--- a/frontend/src/components/home/components.tsx
+++ b/frontend/src/components/home/components.tsx
@@ -30,8 +30,8 @@ import {
 import { Constants } from "@/core/constants";
 import { openTutorial } from "@/core/network/requests";
 import type { TutorialId } from "@/core/network/types";
+import { openNotebook } from "@/utils/links";
 import { Objects } from "@/utils/objects";
-import { asURL } from "@/utils/url";
 
 const TUTORIALS: Record<
   TutorialId,
@@ -89,7 +89,7 @@ export const OpenTutorialDropDown: React.FC = () => {
                 if (!file) {
                   return;
                 }
-                window.open(asURL(`?file=${file.path}`).toString(), "_blank");
+                openNotebook(file.path);
               }}
             >
               <Icon

--- a/frontend/src/utils/links.ts
+++ b/frontend/src/utils/links.ts
@@ -1,0 +1,11 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { asURL } from "./url";
+
+/**
+ * Open a notebook in a new tab.
+ * @param path - The path to the notebook.
+ */
+export function openNotebook(path: string) {
+  // There is no leading `/` in the path in order to work when marimo is at a subpath.
+  window.open(asURL(`?file=${path}`).toString(), "_blank");
+}


### PR DESCRIPTION
Fixes #5239

This removes the leading `/` when opening notebooks in a few places, and consolidates the logic.