### PR TITLE
Make reactivity options in footer responsive for small screen widths

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/footer-items/runtime-settings.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/runtime-settings.tsx
@@ -7,6 +7,7 @@ import {
   ZapOffIcon,
 } from "lucide-react";
 import type React from "react";
+import { useState, useEffect } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,6 +33,22 @@ export const RuntimeSettings: React.FC<RuntimeSettingsProps> = ({
 }) => {
   const [userConfig, setUserConfig] = useUserConfig();
   const config = useResolvedMarimoConfig()[0];
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  // Close dropdown when screen size crosses the md breakpoint
+  useEffect(() => {
+    // 768px matches Tailwind's 'md' breakpoint used in hidden md:flex
+    // TODO: When upgrading to Tailwind v4, use var(--breakpoint-md)
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    const handleChange = () => {
+      if (mediaQuery.matches) {
+        setDropdownOpen(false);
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
 
   const handleStartupToggle = async (checked: boolean) => {
     const newConfig = {
@@ -82,7 +99,7 @@ export const RuntimeSettings: React.FC<RuntimeSettingsProps> = ({
 
   return (
     <div className={cn("flex items-center", className)}>
-      {/* Shown on md and above */}
+      {/* Shown on larger screens */}
       <div className="hidden md:flex md:items-center">
         <FooterItem
           tooltip={
@@ -193,7 +210,7 @@ export const RuntimeSettings: React.FC<RuntimeSettingsProps> = ({
 
       {/* Shown on small screens */}
       <div className="flex md:hidden">
-        <DropdownMenu>
+        <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
           <DropdownMenuTrigger asChild={true}>
             <FooterItem
               tooltip="Runtime reactivity"

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/runtime-settings.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/runtime-settings.tsx
@@ -1,0 +1,329 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import {
+  ChevronDownIcon,
+  PowerOffIcon,
+  ZapIcon,
+  ZapOffIcon,
+} from "lucide-react";
+import type React from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
+import { useResolvedMarimoConfig, useUserConfig } from "@/core/config/config";
+import type { UserConfig } from "@/core/config/config-schema";
+import { saveUserConfig } from "@/core/network/requests";
+import { isWasm } from "@/core/wasm/utils";
+import { cn } from "@/utils/cn";
+import { FooterItem } from "../footer-item";
+
+interface RuntimeSettingsProps {
+  className?: string;
+}
+
+export const RuntimeSettings: React.FC<RuntimeSettingsProps> = ({
+  className,
+}) => {
+  const [userConfig, setUserConfig] = useUserConfig();
+  const config = useResolvedMarimoConfig()[0];
+
+  const handleStartupToggle = async (checked: boolean) => {
+    const newConfig = {
+      ...config,
+      runtime: {
+        ...config.runtime,
+        auto_instantiate: checked,
+      },
+    };
+    await saveUserConfig({ config: newConfig }).then(() =>
+      setUserConfig(newConfig),
+    );
+  };
+
+  const handleCellChangeToggle = async (checked: boolean) => {
+    const newUserConfig: UserConfig = {
+      ...userConfig,
+      runtime: {
+        ...userConfig.runtime,
+        on_cell_change: checked ? "autorun" : "lazy",
+      },
+    };
+    await saveUserConfig({ config: newUserConfig }).then(() =>
+      setUserConfig(newUserConfig),
+    );
+  };
+
+  const handleModuleReloadChange = async (
+    option: "off" | "lazy" | "autorun",
+  ) => {
+    const newUserConfig: UserConfig = {
+      ...userConfig,
+      runtime: {
+        ...userConfig.runtime,
+        auto_reload: option,
+      },
+    };
+    await saveUserConfig({ config: newUserConfig }).then(() =>
+      setUserConfig(newUserConfig),
+    );
+  };
+
+  // Check if all reactivity is disabled
+  const allReactivityDisabled =
+    !config.runtime.auto_instantiate &&
+    config.runtime.on_cell_change === "lazy" &&
+    (isWasm() || config.runtime.auto_reload !== "autorun");
+
+  return (
+    <div className={cn("flex items-center", className)}>
+      {/* Shown on md and above */}
+      <div className="hidden md:flex md:items-center">
+        <FooterItem
+          tooltip={
+            config.runtime.auto_instantiate
+              ? "Disable autorun on startup"
+              : "Enable autorun on startup"
+          }
+          selected={false}
+          onClick={() => handleStartupToggle(!config.runtime.auto_instantiate)}
+          data-testid="footer-autorun-startup"
+        >
+          <div className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
+            <span>on startup: </span>
+            {config.runtime.auto_instantiate ? (
+              <ZapIcon size={14} />
+            ) : (
+              <ZapOffIcon size={14} />
+            )}
+            <span>{config.runtime.auto_instantiate ? "autorun" : "lazy"}</span>
+          </div>
+        </FooterItem>
+
+        <div className="border-r border-border h-6 mx-1" />
+
+        <FooterItem
+          tooltip={
+            config.runtime.on_cell_change === "autorun"
+              ? "Disable autorun"
+              : "Enable autorun"
+          }
+          selected={false}
+          onClick={() =>
+            handleCellChangeToggle(config.runtime.on_cell_change !== "autorun")
+          }
+          data-testid="footer-autorun-cell-change"
+        >
+          <div className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
+            <span>on cell change: </span>
+            {config.runtime.on_cell_change === "autorun" ? (
+              <ZapIcon size={14} />
+            ) : (
+              <ZapOffIcon size={14} />
+            )}
+            <span>{config.runtime.on_cell_change}</span>
+          </div>
+        </FooterItem>
+
+        {!isWasm() && (
+          <>
+            <div className="border-r border-border h-6 mx-1" />
+            <FooterItem
+              tooltip={null}
+              selected={false}
+              data-testid="footer-module-reload"
+            >
+              <DropdownMenu>
+                <DropdownMenuTrigger className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
+                  <span>on module change: </span>
+                  {config.runtime.auto_reload === "off" && (
+                    <PowerOffIcon size={14} />
+                  )}
+                  {config.runtime.auto_reload === "lazy" && (
+                    <ZapOffIcon size={14} />
+                  )}
+                  {config.runtime.auto_reload === "autorun" && (
+                    <ZapIcon size={14} />
+                  )}
+                  <span>{config.runtime.auto_reload}</span>
+                  <ChevronDownIcon size={14} />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  {["off", "lazy", "autorun"].map((option) => (
+                    <DropdownMenuItem
+                      key={option}
+                      onClick={() =>
+                        handleModuleReloadChange(
+                          option as "off" | "lazy" | "autorun",
+                        )
+                      }
+                    >
+                      {option === "off" && (
+                        <PowerOffIcon
+                          size={14}
+                          className="mr-2 text-muted-foreground"
+                        />
+                      )}
+                      {option === "lazy" && (
+                        <ZapOffIcon
+                          size={14}
+                          className="mr-2 text-muted-foreground"
+                        />
+                      )}
+                      {option === "autorun" && (
+                        <ZapIcon
+                          size={14}
+                          className="mr-2 text-muted-foreground"
+                        />
+                      )}
+                      {option}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </FooterItem>
+          </>
+        )}
+      </div>
+
+      {/* Shown on small screens */}
+      <div className="flex md:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild={true}>
+            <FooterItem
+              tooltip="Runtime reactivity"
+              selected={false}
+              data-testid="footer-runtime-settings"
+            >
+              <div className="flex items-center gap-1">
+                {allReactivityDisabled ? (
+                  <ZapOffIcon size={16} className="text-muted-foreground" />
+                ) : (
+                  <ZapIcon size={16} className="text-amber-500" />
+                )}
+                <ChevronDownIcon size={14} />
+              </div>
+            </FooterItem>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-64">
+            <DropdownMenuLabel>Runtime reactivity</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+
+            {/* On startup toggle */}
+            <div className="flex items-center justify-between px-2 py-2">
+              <div className="flex items-center space-x-2">
+                {config.runtime.auto_instantiate ? (
+                  <ZapIcon size={14} className="text-amber-500" />
+                ) : (
+                  <ZapOffIcon size={14} className="text-muted-foreground" />
+                )}
+                <div>
+                  <div className="text-sm font-medium">On startup</div>
+                  <div className="text-xs text-muted-foreground">
+                    {config.runtime.auto_instantiate ? "autorun" : "lazy"}
+                  </div>
+                </div>
+              </div>
+              <Switch
+                checked={config.runtime.auto_instantiate}
+                onCheckedChange={handleStartupToggle}
+                size="sm"
+              />
+            </div>
+
+            <DropdownMenuSeparator />
+
+            {/* On cell change toggle */}
+            <div className="flex items-center justify-between px-2 py-2">
+              <div className="flex items-center space-x-2">
+                {config.runtime.on_cell_change === "autorun" ? (
+                  <ZapIcon size={14} className="text-amber-500" />
+                ) : (
+                  <ZapOffIcon size={14} className="text-muted-foreground" />
+                )}
+                <div>
+                  <div className="text-sm font-medium">On cell change</div>
+                  <div className="text-xs text-muted-foreground">
+                    {config.runtime.on_cell_change}
+                  </div>
+                </div>
+              </div>
+              <Switch
+                checked={config.runtime.on_cell_change === "autorun"}
+                onCheckedChange={handleCellChangeToggle}
+                size="sm"
+              />
+            </div>
+
+            {!isWasm() && (
+              <>
+                <DropdownMenuSeparator />
+
+                {/* On module change dropdown */}
+                <div className="px-2 py-1">
+                  <div className="flex items-center space-x-2 mb-2">
+                    {config.runtime.auto_reload === "off" && (
+                      <PowerOffIcon
+                        size={14}
+                        className="text-muted-foreground"
+                      />
+                    )}
+                    {config.runtime.auto_reload === "lazy" && (
+                      <ZapOffIcon size={14} className="text-muted-foreground" />
+                    )}
+                    {config.runtime.auto_reload === "autorun" && (
+                      <ZapIcon size={14} className="text-amber-500" />
+                    )}
+                    <div>
+                      <div className="text-sm font-medium">
+                        On module change
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {config.runtime.auto_reload}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    {["off", "lazy", "autorun"].map((option) => (
+                      <button
+                        key={option}
+                        onClick={() =>
+                          handleModuleReloadChange(
+                            option as "off" | "lazy" | "autorun",
+                          )
+                        }
+                        className={cn(
+                          "w-full flex items-center px-2 py-1 text-sm rounded hover:bg-accent",
+                          option === config.runtime.auto_reload && "bg-accent",
+                        )}
+                      >
+                        {option === "off" && (
+                          <PowerOffIcon size={12} className="mr-2" />
+                        )}
+                        {option === "lazy" && (
+                          <ZapOffIcon size={12} className="mr-2" />
+                        )}
+                        {option === "autorun" && (
+                          <ZapIcon size={12} className="mr-2" />
+                        )}
+                        <span className="capitalize">{option}</span>
+                        {option === config.runtime.auto_reload && (
+                          <span className="ml-auto">✓</span>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/runtime-settings.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/runtime-settings.tsx
@@ -7,7 +7,7 @@ import {
   ZapOffIcon,
 } from "lucide-react";
 import type React from "react";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -1,27 +1,11 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import { useAtomValue } from "jotai";
-import {
-  ChevronDownIcon,
-  PowerOffIcon,
-  TerminalSquareIcon,
-  ZapIcon,
-  ZapOffIcon,
-} from "lucide-react";
+import { TerminalSquareIcon } from "lucide-react";
 import type React from "react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Tooltip } from "@/components/ui/tooltip";
 import { cellErrorCount } from "@/core/cells/cells";
-import { useResolvedMarimoConfig } from "@/core/config/config";
-import type { UserConfig } from "@/core/config/config-schema";
 import { IfCapability } from "@/core/config/if-capability";
-import { saveUserConfig } from "@/core/network/requests";
-import { isWasm } from "@/core/wasm/utils";
 import { useHotkey } from "@/hooks/useHotkey";
 import { cn } from "@/utils/cn";
 import { invariant } from "@/utils/invariant";
@@ -34,11 +18,11 @@ import { BackendConnection } from "./footer-items/backend-status";
 import { CopilotStatusIcon } from "./footer-items/copilot-status";
 import { MachineStats } from "./footer-items/machine-stats";
 import { RTCStatus } from "./footer-items/rtc-status";
+import { RuntimeSettings } from "./footer-items/runtime-settings";
 
 export const Footer: React.FC = () => {
   const { selectedPanel, isTerminalOpen } = useChromeState();
   const { toggleApplication, toggleTerminal } = useChromeActions();
-  const [config, setConfig] = useResolvedMarimoConfig();
   const errorCount = useAtomValue(cellErrorCount);
 
   const renderIcon = ({ Icon }: PanelDescriptor, className?: string) => {
@@ -53,7 +37,7 @@ export const Footer: React.FC = () => {
   });
 
   return (
-    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md px-1 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50 print:hidden hide-on-fullscreen">
+    <footer className="h-10 py-2 bg-background flex items-center text-muted-foreground text-md px-1 border-t border-border select-none no-print text-sm shadow-[0_0_4px_1px_rgba(0,0,0,0.1)] z-50 print:hidden hide-on-fullscreen overflow-x-auto">
       <FooterItem
         tooltip={errorPanel.tooltip}
         selected={selectedPanel === errorPanel.type}
@@ -75,137 +59,7 @@ export const Footer: React.FC = () => {
         </FooterItem>
       </IfCapability>
 
-      <FooterItem
-        tooltip={
-          config.runtime.auto_instantiate
-            ? "Disable autorun on startup"
-            : "Enable autorun on startup"
-        }
-        selected={false}
-        onClick={async () => {
-          const newConfig = {
-            ...config,
-            runtime: {
-              ...config.runtime,
-              auto_instantiate: !config.runtime.auto_instantiate,
-            },
-          };
-          await saveUserConfig({ config: newConfig }).then(() =>
-            setConfig(newConfig),
-          );
-        }}
-        data-testid="footer-autorun-startup"
-      >
-        <div className="font-prose text-sm flex items-center gap-1">
-          <span>on startup: </span>
-          {config.runtime.auto_instantiate ? (
-            <ZapIcon size={14} />
-          ) : (
-            <ZapOffIcon size={14} />
-          )}
-          <span>{config.runtime.auto_instantiate ? "autorun" : "lazy"}</span>
-        </div>
-      </FooterItem>
-
-      <div className="border-r border-border h-6 mx-1" />
-
-      <FooterItem
-        tooltip={
-          config.runtime.on_cell_change === "autorun"
-            ? "Disable autorun"
-            : "Enable autorun"
-        }
-        selected={false}
-        onClick={async () => {
-          const newConfig: UserConfig = {
-            ...config,
-            runtime: {
-              ...config.runtime,
-              on_cell_change:
-                config.runtime.on_cell_change === "autorun"
-                  ? "lazy"
-                  : "autorun",
-            },
-          };
-          await saveUserConfig({ config: newConfig }).then(() =>
-            setConfig(newConfig),
-          );
-        }}
-        data-testid="footer-autorun-cell-change"
-      >
-        <div className="font-prose text-sm flex items-center gap-1">
-          <span>on cell change: </span>
-          {config.runtime.on_cell_change === "autorun" ? (
-            <ZapIcon size={14} />
-          ) : (
-            <ZapOffIcon size={14} />
-          )}
-          <span>{config.runtime.on_cell_change}</span>
-        </div>
-      </FooterItem>
-
-      <div className="border-r border-border h-6 mx-1" />
-
-      {!isWasm() && (
-        <FooterItem
-          tooltip={null}
-          selected={false}
-          data-testid="footer-module-reload"
-        >
-          <DropdownMenu>
-            <DropdownMenuTrigger className="font-prose text-sm flex items-center gap-1">
-              <span>on module change: </span>
-              {config.runtime.auto_reload === "off" && (
-                <PowerOffIcon size={14} />
-              )}
-              {config.runtime.auto_reload === "lazy" && (
-                <ZapOffIcon size={14} />
-              )}
-              {config.runtime.auto_reload === "autorun" && (
-                <ZapIcon size={14} />
-              )}
-              <span>{config.runtime.auto_reload}</span>
-              <ChevronDownIcon size={14} />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              {["off", "lazy", "autorun"].map((option) => (
-                <DropdownMenuItem
-                  key={option}
-                  onClick={async () => {
-                    const newConfig: UserConfig = {
-                      ...config,
-                      runtime: {
-                        ...config.runtime,
-                        auto_reload: option as "off" | "lazy" | "autorun",
-                      },
-                    };
-                    await saveUserConfig({ config: newConfig }).then(() =>
-                      setConfig(newConfig),
-                    );
-                  }}
-                >
-                  {option === "off" && (
-                    <PowerOffIcon
-                      size={14}
-                      className="mr-2 text-muted-foreground"
-                    />
-                  )}
-                  {option === "lazy" && (
-                    <ZapOffIcon
-                      size={14}
-                      className="mr-2 text-muted-foreground"
-                    />
-                  )}
-                  {option === "autorun" && (
-                    <ZapIcon size={14} className="mr-2 text-muted-foreground" />
-                  )}
-                  {option}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </FooterItem>
-      )}
+      <RuntimeSettings />
 
       <div className="mx-auto" />
 
@@ -222,7 +76,7 @@ export const Footer: React.FC = () => {
         </Tooltip>
       </ShowInKioskMode>
 
-      <div className="flex items-center">
+      <div className="flex items-center flex-shrink-0 min-w-0">
         <MachineStats />
         <AIStatusIcon />
         <CopilotStatusIcon />


### PR DESCRIPTION
Fixes #5495

Fixes bottom toolbar overflow issue on small displays by implementing
responsive design that groups runtime settings into a settings dropdown.
When screen width is below `md` (768px), the footer shows a settings icon
instead of individual runtime controls, preventing text overlap.


https://github.com/user-attachments/assets/805819de-a8b8-4d9e-8ef0-b6c26a72961b


