### PR TITLE
internal: request utils, make remote file send marimo user-agent

### DIFF
--- a/marimo/_ai/text_to_notebook.py
+++ b/marimo/_ai/text_to_notebook.py
@@ -71,8 +71,7 @@ def text_to_notebook(prompt: str) -> str:
 
         # Create a request with a proper User-Agent header
         headers = {"User-Agent": requests.MARIMO_USER_AGENT}
-        response = requests.get(url, headers=headers)
-        result = response.text()
+        result = requests.get(url, headers=headers).raise_for_status().text()
 
         print_(green("Notebook generated successfully."))
 

--- a/marimo/_ai/text_to_notebook.py
+++ b/marimo/_ai/text_to_notebook.py
@@ -5,9 +5,9 @@ import datetime
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Optional, cast
+from typing import Optional
 
-from marimo import __version__
+import marimo._utils.requests as requests
 from marimo._cli.print import bold, green, muted
 from marimo._config.cli_state import (
     get_cli_state,
@@ -70,11 +70,9 @@ def text_to_notebook(prompt: str) -> str:
         print_(muted("Generating notebook this may take a few seconds..."))
 
         # Create a request with a proper User-Agent header
-        headers = {"User-Agent": f"marimo-cli/{__version__}"}
-        req = urllib.request.Request(url, headers=headers)
-
-        with urllib.request.urlopen(req) as response:
-            result = response.read().decode("utf-8")  # type: ignore[attr-defined]
+        headers = {"User-Agent": requests.MARIMO_USER_AGENT}
+        response = requests.get(url, headers=headers)
+        result = response.text()
 
         print_(green("Notebook generated successfully."))
 
@@ -84,7 +82,7 @@ def text_to_notebook(prompt: str) -> str:
                 "Invalid response from API: missing 'marimo.App' key"
             )
 
-        return cast(str, result)
+        return result
 
     except Exception as e:
         raise RuntimeError(f"Failed to generate notebook: {str(e)}") from e

--- a/marimo/_cli/convert/utils.py
+++ b/marimo/_cli/convert/utils.py
@@ -1,11 +1,11 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import urllib.request
 from pathlib import Path
 
 import click
 
+import marimo._utils.requests as requests
 from marimo._cli.file_path import get_github_src_url, is_github_src
 from marimo._utils.url import is_url
 
@@ -13,13 +13,9 @@ from marimo._utils.url import is_url
 def load_external_file(file_path: str, ext: str) -> str:
     notebook: str = ""
     if is_github_src(file_path, ext=ext):
-        notebook = (
-            urllib.request.urlopen(get_github_src_url(file_path))
-            .read()
-            .decode("utf-8")
-        )
+        notebook = requests.get(get_github_src_url(file_path)).text()
     elif is_url(file_path):
-        notebook = urllib.request.urlopen(file_path).read().decode("utf-8")
+        notebook = requests.get(file_path).text()
     else:
         if not Path(file_path).exists():
             raise click.FileError(file_path, "File does not exist")

--- a/marimo/_cli/convert/utils.py
+++ b/marimo/_cli/convert/utils.py
@@ -13,13 +13,13 @@ from marimo._utils.url import is_url
 def load_external_file(file_path: str, ext: str) -> str:
     notebook: str = ""
     if is_github_src(file_path, ext=ext):
-        response = requests.get(get_github_src_url(file_path))
-        response.raise_for_status()
-        notebook = response.text()
+        notebook = (
+            requests.get(get_github_src_url(file_path))
+            .raise_for_status()
+            .text()
+        )
     elif is_url(file_path):
-        response = requests.get(file_path)
-        response.raise_for_status()
-        notebook = response.text()
+        notebook = requests.get(file_path).raise_for_status().text()
     else:
         if not Path(file_path).exists():
             raise click.FileError(file_path, "File does not exist")

--- a/marimo/_cli/convert/utils.py
+++ b/marimo/_cli/convert/utils.py
@@ -13,9 +13,13 @@ from marimo._utils.url import is_url
 def load_external_file(file_path: str, ext: str) -> str:
     notebook: str = ""
     if is_github_src(file_path, ext=ext):
-        notebook = requests.get(get_github_src_url(file_path)).text()
+        response = requests.get(get_github_src_url(file_path))
+        response.raise_for_status()
+        notebook = response.text()
     elif is_url(file_path):
-        notebook = requests.get(file_path).text()
+        response = requests.get(file_path)
+        response.raise_for_status()
+        notebook = response.text()
     else:
         if not Path(file_path).exists():
             raise click.FileError(file_path, "File does not exist")

--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -129,7 +129,8 @@ class StaticNotebookReader(FileReader):
 
         # Starts with https://static.marimo.app/, append /download
         if url.startswith("https://static.marimo.app/static"):
-            return download(urllib.parse.urljoin(url, "download"))
+            normalized_url = url if url.endswith("/") else url + "/"
+            return download(urllib.parse.urljoin(normalized_url, "download"))
 
         # Other marimo domains
         DOMAINS = [

--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -7,7 +7,7 @@ import re
 import urllib.parse
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Optional
+from typing import Any, Optional, cast
 from urllib.error import HTTPError
 
 import marimo._utils.requests as requests
@@ -74,9 +74,9 @@ class GitHubIssueReader(FileReader):
     def read(self, name: str) -> tuple[str, str]:
         issue_number = name.split("/")[-1]
         api_url = f"https://api.github.com/repos/marimo-team/marimo/issues/{issue_number}"
-        issue_response = requests.get(api_url)
-        issue_response.raise_for_status()
-        issue_response = issue_response.json()
+        response = requests.get(api_url)
+        response.raise_for_status()
+        issue_response = cast(dict[str, Any], response.json())
 
         if "body" not in issue_response:
             raise ValueError(

--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -2,22 +2,23 @@
 from __future__ import annotations
 
 import abc
-import json
 import os
 import re
 import urllib.parse
-import urllib.request
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional
 from urllib.error import HTTPError
 
-from marimo import __version__, _loggers
+import marimo._utils.requests as requests
+from marimo import _loggers
 from marimo._cli.print import green
 from marimo._utils.marimo_path import MarimoPath
 from marimo._utils.url import is_url
 
 LOGGER = _loggers.marimo_logger()
+
+USER_AGENT_HEADER = {"User-Agent": requests.MARIMO_USER_AGENT}
 
 
 def is_github_src(url: str, ext: str) -> bool:
@@ -73,14 +74,22 @@ class GitHubIssueReader(FileReader):
     def read(self, name: str) -> tuple[str, str]:
         issue_number = name.split("/")[-1]
         api_url = f"https://api.github.com/repos/marimo-team/marimo/issues/{issue_number}"
-        issue_response = urllib.request.urlopen(api_url).read().decode("utf-8")
-        issue_json = json.loads(issue_response)
-        body = issue_json["body"]
+        issue_response = requests.get(api_url).json()
+
+        if "body" not in issue_response:
+            raise ValueError(
+                f"Failed to read GitHub issue {name}. No 'body' in response {issue_response}"
+            )
+
+        body = issue_response["body"]
         code = self._find_python_code_in_github_issue(body)
         return code, f"issue_{issue_number}.py"
 
     @staticmethod
     def _find_python_code_in_github_issue(body: str) -> str:
+        if "```python" not in body:
+            raise ValueError(f"No Python code found in GitHub issue {body}")
+
         return body.split("```python")[1].rsplit("```", 1)[0]
 
 
@@ -104,16 +113,10 @@ class StaticNotebookReader(FileReader):
     def _is_static_marimo_notebook_url(url: str) -> tuple[bool, str]:
         def download(url: str) -> tuple[bool, str]:
             LOGGER.info("Downloading %s", url)
-            request = urllib.request.Request(
-                url,
-                # User agent to avoid 403 Forbidden some bot protection
-                headers={"User-Agent": f"marimo/{__version__}"},
-            )
-            file_contents = (
-                urllib.request.urlopen(request).read().decode("utf-8")
-            )
-            return StaticNotebookReader.CODE_TAG in file_contents, str(
-                file_contents
+            file_contents = requests.get(url, headers=USER_AGENT_HEADER).text()
+            return (
+                StaticNotebookReader.CODE_TAG in file_contents,
+                file_contents,
             )
 
         # Not a URL
@@ -126,7 +129,7 @@ class StaticNotebookReader(FileReader):
 
         # Starts with https://static.marimo.app/, append /download
         if url.startswith("https://static.marimo.app/static"):
-            return download(os.path.join(url, "download"))
+            return download(urllib.parse.urljoin(url, "download"))
 
         # Other marimo domains
         DOMAINS = [
@@ -164,7 +167,7 @@ class GitHubSourceReader(FileReader):
 
     def read(self, name: str) -> tuple[str, str]:
         url = get_github_src_url(name)
-        content = urllib.request.urlopen(url).read().decode("utf-8")
+        content = requests.get(url, headers=USER_AGENT_HEADER).text()
         return content, os.path.basename(url)
 
 
@@ -173,7 +176,7 @@ class GenericURLReader(FileReader):
         return is_url(name)
 
     def read(self, name: str) -> tuple[str, str]:
-        content = urllib.request.urlopen(name).read().decode("utf-8")
+        content = requests.get(name, headers=USER_AGENT_HEADER).text()
         # Remove query parameters from the URL
         url_without_query = name.split("?")[0]
         return content, os.path.basename(url_without_query)

--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -74,7 +74,9 @@ class GitHubIssueReader(FileReader):
     def read(self, name: str) -> tuple[str, str]:
         issue_number = name.split("/")[-1]
         api_url = f"https://api.github.com/repos/marimo-team/marimo/issues/{issue_number}"
-        issue_response = requests.get(api_url).json()
+        issue_response = requests.get(api_url)
+        issue_response.raise_for_status()
+        issue_response = issue_response.json()
 
         if "body" not in issue_response:
             raise ValueError(
@@ -113,7 +115,9 @@ class StaticNotebookReader(FileReader):
     def _is_static_marimo_notebook_url(url: str) -> tuple[bool, str]:
         def download(url: str) -> tuple[bool, str]:
             LOGGER.info("Downloading %s", url)
-            file_contents = requests.get(url, headers=USER_AGENT_HEADER).text()
+            response = requests.get(url, headers=USER_AGENT_HEADER)
+            response.raise_for_status()
+            file_contents = response.text()
             return (
                 StaticNotebookReader.CODE_TAG in file_contents,
                 file_contents,
@@ -168,7 +172,9 @@ class GitHubSourceReader(FileReader):
 
     def read(self, name: str) -> tuple[str, str]:
         url = get_github_src_url(name)
-        content = requests.get(url, headers=USER_AGENT_HEADER).text()
+        response = requests.get(url, headers=USER_AGENT_HEADER)
+        response.raise_for_status()
+        content = response.text()
         return content, os.path.basename(url)
 
 
@@ -177,7 +183,9 @@ class GenericURLReader(FileReader):
         return is_url(name)
 
     def read(self, name: str) -> tuple[str, str]:
-        content = requests.get(name, headers=USER_AGENT_HEADER).text()
+        response = requests.get(name, headers=USER_AGENT_HEADER)
+        response.raise_for_status()
+        content = response.text()
         # Remove query parameters from the URL
         url_without_query = name.split("?")[0]
         return content, os.path.basename(url_without_query)

--- a/marimo/_cli/upgrade.py
+++ b/marimo/_cli/upgrade.py
@@ -16,7 +16,6 @@ from marimo._config.cli_state import (
     get_cli_state,
     write_cli_state,
 )
-from marimo._server.api.status import HTTPException
 from marimo._tracer import server_tracer
 
 FETCH_TIMEOUT = 3
@@ -109,14 +108,8 @@ def _update_with_latest_version(state: MarimoCLIState) -> MarimoCLIState:
 def _fetch_data_from_url(url: str) -> dict[str, Any]:
     try:
         response = requests.get(url, timeout=FETCH_TIMEOUT)
-        status = response.status_code
-        if status == 200:
-            return response.json()
-        else:
-            raise HTTPException(
-                status_code=status,
-                detail=f"HTTP request failed with status code {status}",
-            )
+        response.raise_for_status()
+        return response.json()
     except urllib.error.URLError as e:
         LOGGER.warning(
             f"Network error while checking for version updates: {e}"

--- a/marimo/_cli/upgrade.py
+++ b/marimo/_cli/upgrade.py
@@ -6,7 +6,7 @@ import os
 import urllib.error
 import urllib.request
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import marimo._utils.requests as requests
 from marimo import __version__ as current_version, _loggers
@@ -109,7 +109,7 @@ def _fetch_data_from_url(url: str) -> dict[str, Any]:
     try:
         response = requests.get(url, timeout=FETCH_TIMEOUT)
         response.raise_for_status()
-        return response.json()
+        return cast(dict[str, Any], response.json())
     except urllib.error.URLError as e:
         LOGGER.warning(
             f"Network error while checking for version updates: {e}"

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -569,15 +569,14 @@ def _create_notebook_cell(
 
 def get_html_contents() -> str:
     if GLOBAL_SETTINGS.DEVELOPMENT_MODE:
-        import urllib.request
+        import marimo._utils.requests as requests
 
         # Fetch from a CDN
         LOGGER.info(
             "Fetching index.html from jsdelivr because in development mode"
         )
         url = f"https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{__version__}/dist/index.html"
-        with urllib.request.urlopen(url) as response:
-            return cast(str, response.read().decode("utf-8"))
+        return requests.get(url).text()
 
     index_html = Path(ROOT) / "index.html"
     return index_html.read_text(encoding="utf-8")

--- a/marimo/_utils/requests.py
+++ b/marimo/_utils/requests.py
@@ -51,14 +51,19 @@ class Response:
         """
         return self.content.decode("utf-8")
 
-    def raise_for_status(self) -> None:
-        """Raise an exception for non-2xx status codes."""
+    def raise_for_status(self) -> "Response":
+        """Raise an exception for non-2xx status codes.
+
+        Returns:
+            The response object for chaining.
+        """
         if self.status_code >= 300:
             if self.original_error:
                 raise self.original_error
             raise RequestError(
                 f"Request failed: {self.status_code}. {self.text()}"
             )
+        return self
 
 
 def _make_request(

--- a/marimo/_utils/requests.py
+++ b/marimo/_utils/requests.py
@@ -36,11 +36,19 @@ class Response:
         self.original_error = original_error
 
     def json(self) -> Any:
-        """Parse response content as JSON."""
+        """Parse response content as JSON.
+
+        This assumes the response is UTF-8 encoded.
+        In future, we can infer the encoding from the headers.
+        """
         return json.loads(self.text())
 
     def text(self) -> str:
-        """Get response content as text."""
+        """Get response content as text.
+
+        This assumes the response is UTF-8 encoded.
+        In future, we can infer the encoding from the headers.
+        """
         return self.content.decode("utf-8")
 
     def raise_for_status(self) -> None:

--- a/marimo/_utils/requests.py
+++ b/marimo/_utils/requests.py
@@ -1,0 +1,166 @@
+import http.client
+import json
+import urllib.parse
+from typing import Any, Optional, Union
+from urllib.error import HTTPError, URLError
+
+from marimo import __version__
+
+# Utility functions for making HTTP requests,
+# without using the requests library or any other external dependencies.
+
+MARIMO_USER_AGENT = f"marimo/{__version__}"
+
+
+class RequestError(Exception):
+    """Exception raised when a request fails."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
+
+
+class Response:
+    """Simple response object similar to requests.Response."""
+
+    def __init__(
+        self, status_code: int, content: bytes, headers: dict[str, str]
+    ):
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers
+
+    def json(self) -> Any:
+        """Parse response content as JSON."""
+        return json.loads(self.text())
+
+    def text(self) -> str:
+        """Get response content as text."""
+        return self.content.decode("utf-8")
+
+
+def _make_request(
+    method: str,
+    url: str,
+    *,
+    params: Optional[dict[str, str]] = None,
+    headers: Optional[dict[str, str]] = None,
+    data: Optional[Union[dict[str, Any], str]] = None,
+    json_data: Optional[dict[str, Any]] = None,
+    timeout: Optional[float] = None,
+) -> Response:
+    """Make an HTTP request and return a Response object.
+
+    If the URL already contains query parameters and new params are provided,
+    they will be merged with new params taking precedence over existing ones.
+    """
+    assert isinstance(url, str), "url must be a string"
+    has_data = data is not None
+    has_json_data = json_data is not None
+    assert not has_data or not has_json_data, (
+        "cannot pass both data and json_data"
+    )
+
+    parsed = urllib.parse.urlparse(url)
+    path = parsed.path
+    if params:
+        # Parse existing query parameters
+        existing_params = urllib.parse.parse_qs(parsed.query)
+        # Flatten existing params (parse_qs returns lists)
+        flattened_existing = {k: v[0] for k, v in existing_params.items()}
+        # Merge with new params (new params take precedence)
+        merged_params = {**flattened_existing, **params}
+        query = urllib.parse.urlencode(merged_params)
+        path = f"{path}?{query}"
+    elif parsed.query:
+        # Keep existing query if no new params
+        path = f"{path}?{parsed.query}"
+
+    conn = http.client.HTTPSConnection(parsed.netloc, timeout=timeout)
+
+    headers = headers or {}
+    if json_data is not None:
+        headers["Content-Type"] = "application/json"
+        body = json.dumps(json_data).encode("utf-8")
+    elif data is not None:
+        if isinstance(data, dict):
+            body = urllib.parse.urlencode(data).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        else:
+            body = str(data).encode("utf-8")
+    else:
+        body = None
+
+    try:
+        conn.request(method, path, body=body, headers=headers)
+        response = conn.getresponse()
+        return Response(
+            status_code=response.status,
+            content=response.read(),
+            headers=dict(response.getheaders()),
+        )
+    except (HTTPError, URLError, ConnectionRefusedError) as e:
+        raise RequestError(f"Request failed: to {url}: {str(e)}") from None
+    finally:
+        conn.close()
+
+
+def get(
+    url: str,
+    *,
+    params: Optional[dict[str, str]] = None,
+    headers: Optional[dict[str, str]] = None,
+    timeout: Optional[float] = None,
+) -> Response:
+    """Make a GET request."""
+    return _make_request(
+        "GET", url, params=params, headers=headers, timeout=timeout
+    )
+
+
+def post(
+    url: str,
+    *,
+    data: Optional[Union[dict[str, Any], str]] = None,
+    json_data: Optional[dict[str, Any]] = None,
+    headers: Optional[dict[str, str]] = None,
+    timeout: Optional[float] = None,
+) -> Response:
+    """Make a POST request."""
+    return _make_request(
+        "POST",
+        url,
+        data=data,
+        json_data=json_data,
+        headers=headers,
+        timeout=timeout,
+    )
+
+
+def put(
+    url: str,
+    *,
+    data: Optional[Union[dict[str, Any], str]] = None,
+    json_data: Optional[dict[str, Any]] = None,
+    headers: Optional[dict[str, str]] = None,
+    timeout: Optional[float] = None,
+) -> Response:
+    """Make a PUT request."""
+    return _make_request(
+        "PUT",
+        url,
+        data=data,
+        json_data=json_data,
+        headers=headers,
+        timeout=timeout,
+    )
+
+
+def delete(
+    url: str,
+    *,
+    headers: Optional[dict[str, str]] = None,
+    timeout: Optional[float] = None,
+) -> Response:
+    """Make a DELETE request."""
+    return _make_request("DELETE", url, headers=headers, timeout=timeout)

--- a/tests/_utils/test_utils_request.py
+++ b/tests/_utils/test_utils_request.py
@@ -29,6 +29,7 @@ def test_response_raise_for_status():
     # Test that raise_for_status does not raise for success codes
     success_response = Response(200, b"OK", {})
     success_response.raise_for_status()  # Should not raise
+    assert success_response is success_response.raise_for_status()
 
     # Test that raise_for_status raises for error codes
     error_response = Response(404, b"Not Found", {})

--- a/tests/_utils/test_utils_request.py
+++ b/tests/_utils/test_utils_request.py
@@ -1,0 +1,270 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from marimo._utils.requests import (
+    Response,
+    _make_request,
+    delete,
+    get,
+    post,
+    put,
+)
+
+
+def test_response_object():
+    response = Response(
+        200, b'{"key": "value"}', {"Content-Type": "application/json"}
+    )
+    assert response.status_code == 200
+    assert response.content == b'{"key": "value"}'
+    assert response.headers == {"Content-Type": "application/json"}
+    assert response.text() == '{"key": "value"}'
+    assert response.json() == {"key": "value"}
+
+
+@pytest.mark.parametrize(
+    (
+        "method",
+        "url",
+        "params",
+        "headers",
+        "data",
+        "json_data",
+        "expected_body",
+        "expected_headers",
+    ),
+    [
+        # GET request
+        (
+            "GET",
+            "https://api.example.com",
+            {"param": "value"},
+            {"Authorization": "Bearer token"},
+            None,
+            None,
+            None,
+            {"Authorization": "Bearer token"},
+        ),
+        # POST with form data
+        (
+            "POST",
+            "https://api.example.com",
+            None,
+            None,
+            {"key": "value"},
+            None,
+            b"key=value",
+            {"Content-Type": "application/x-www-form-urlencoded"},
+        ),
+        # POST with JSON data
+        (
+            "POST",
+            "https://api.example.com",
+            None,
+            None,
+            None,
+            {"key": "value"},
+            b'{"key": "value"}',
+            {"Content-Type": "application/json"},
+        ),
+        # POST with string data
+        (
+            "POST",
+            "https://api.example.com",
+            None,
+            None,
+            "raw data",
+            None,
+            b"raw data",
+            {},
+        ),
+    ],
+)
+def test_make_request(
+    method: str,
+    url: str,
+    params: dict[str, str] | None,
+    headers: dict[str, str] | None,
+    data: dict[str, Any] | str | None,
+    json_data: dict[str, Any] | None,
+    expected_body: bytes,
+    expected_headers: dict[str, str],
+):
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b'{"key": "value"}'
+    mock_response.getheaders.return_value = [
+        ("Content-Type", "application/json")
+    ]
+
+    mock_conn = MagicMock()
+    mock_conn.getresponse.return_value = mock_response
+
+    with patch("http.client.HTTPSConnection", return_value=mock_conn):
+        response = _make_request(
+            method,
+            url,
+            params=params,
+            headers=headers,
+            data=data,
+            json_data=json_data,
+        )
+
+        # Verify connection was made with correct parameters
+        mock_conn.request.assert_called_once()
+        call_args = mock_conn.request.call_args[0]
+        call_kwargs = mock_conn.request.call_args[1]
+
+        assert call_args[0] == method
+        if params:
+            assert "param=value" in call_args[1]
+        assert call_kwargs["body"] == expected_body
+
+        # Verify headers
+        actual_headers = call_kwargs["headers"]
+        if headers:
+            actual_headers.update(headers)
+        if expected_headers:
+            for key, value in expected_headers.items():
+                assert actual_headers[key] == value
+
+        # Verify response
+        assert response.status_code == 200
+        assert response.content == b'{"key": "value"}'
+        assert response.headers == {"Content-Type": "application/json"}
+
+
+def test_invalid_url():
+    with pytest.raises(AssertionError, match="url must be a string"):
+        _make_request("GET", 123)  # type: ignore
+
+
+def test_conflicting_data_and_json():
+    with pytest.raises(
+        AssertionError, match="cannot pass both data and json_data"
+    ):
+        _make_request(
+            "POST",
+            "https://api.example.com",
+            data={"key": "value"},
+            json_data={"key": "value"},
+        )
+
+
+def test_http_methods():
+    with patch("marimo._utils.requests._make_request") as mock_make_request:
+        # Test GET
+        get("https://api.example.com", params={"key": "value"})
+        mock_make_request.assert_called_with(
+            "GET",
+            "https://api.example.com",
+            params={"key": "value"},
+            headers=None,
+            timeout=None,
+        )
+
+        # Test POST
+        post("https://api.example.com", json_data={"key": "value"})
+        mock_make_request.assert_called_with(
+            "POST",
+            "https://api.example.com",
+            data=None,
+            json_data={"key": "value"},
+            headers=None,
+            timeout=None,
+        )
+
+        # Test PUT
+        put("https://api.example.com", data={"key": "value"})
+        mock_make_request.assert_called_with(
+            "PUT",
+            "https://api.example.com",
+            data={"key": "value"},
+            json_data=None,
+            headers=None,
+            timeout=None,
+        )
+
+        # Test DELETE
+        delete("https://api.example.com")
+        mock_make_request.assert_called_with(
+            "DELETE", "https://api.example.com", headers=None, timeout=None
+        )
+
+
+@pytest.mark.parametrize(
+    ("url", "params", "expected_path"),
+    [
+        # URL with no existing params, add new params
+        ("https://api.example.com", {"new": "value"}, "/path?new=value"),
+        # URL with existing params, add new params (merge)
+        (
+            "https://api.example.com?existing=param",
+            {"new": "value"},
+            "/path?existing=param&new=value",
+        ),
+        # URL with existing params, no new params (preserve existing)
+        (
+            "https://api.example.com?existing=param",
+            None,
+            "/path?existing=param",
+        ),
+        # URL with no params at all
+        ("https://api.example.com", None, "/path"),
+        # URL with existing params, new params override existing
+        (
+            "https://api.example.com?key=old",
+            {"key": "new"},
+            "/path?key=new",
+        ),
+        # URL with multiple existing params, add new params
+        (
+            "https://api.example.com?a=1&b=2",
+            {"c": "3"},
+            "/path?a=1&b=2&c=3",
+        ),
+        # URL with multiple existing params, override some
+        (
+            "https://api.example.com?a=1&b=2",
+            {"b": "new", "c": "3"},
+            "/path?a=1&b=new&c=3",
+        ),
+    ],
+)
+def test_url_parameter_handling(
+    url: str, params: dict[str, str] | None, expected_path: str
+):
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = b'{"success": true}'
+    mock_response.getheaders.return_value = [
+        ("Content-Type", "application/json")
+    ]
+
+    mock_conn = MagicMock()
+    mock_conn.getresponse.return_value = mock_response
+
+    with patch("http.client.HTTPSConnection", return_value=mock_conn):
+        # Replace the actual URL with a test URL that has /path
+        test_url = url.replace("api.example.com", "api.example.com/path")
+        _make_request("GET", test_url, params=params)
+
+        # Verify the path was constructed correctly
+        call_args = mock_conn.request.call_args[0]
+        actual_path = call_args[1]
+
+        # Parse both paths to compare query parameters regardless of order
+        from urllib.parse import parse_qs, urlparse
+
+        actual_parsed = urlparse(actual_path)
+        expected_parsed = urlparse(expected_path)
+
+        assert actual_parsed.path == expected_parsed.path
+        if expected_parsed.query:
+            actual_query = parse_qs(actual_parsed.query)
+            expected_query = parse_qs(expected_parsed.query)
+            assert actual_query == expected_query
+        else:
+            assert actual_parsed.query == ""

--- a/tests/_utils/test_utils_request.py
+++ b/tests/_utils/test_utils_request.py
@@ -25,6 +25,30 @@ def test_response_object():
     assert response.json() == {"key": "value"}
 
 
+def test_response_raise_for_status():
+    # Test that raise_for_status does not raise for success codes
+    success_response = Response(200, b"OK", {})
+    success_response.raise_for_status()  # Should not raise
+
+    # Test that raise_for_status raises for error codes
+    error_response = Response(404, b"Not Found", {})
+    with pytest.raises(RequestError, match="Request failed: 404"):
+        error_response.raise_for_status()
+
+    # Test various error codes
+    for status_code in [300, 400, 401, 403, 404, 500, 502, 503]:
+        error_response = Response(status_code, b"Error", {})
+        with pytest.raises(
+            RequestError, match=f"Request failed: {status_code}"
+        ):
+            error_response.raise_for_status()
+
+    # Test that success codes (2xx) don't raise
+    for status_code in [200, 201, 202, 204]:
+        success_response = Response(status_code, b"Success", {})
+        success_response.raise_for_status()  # Should not raise
+
+
 @pytest.mark.parametrize(
     (
         "method",


### PR DESCRIPTION
Add a few request utils for a better API for fetching (similar to the `requests` lib).
Pass `marimo/__version__` as the user agent when fetching remote notebooks