### PR TITLE
Enable TypeScript incremental compilation

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   /* Visit https://aka.ms/tsconfig to read more about this file */
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2019",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
@@ -31,7 +30,11 @@
     },
     "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+
+    /* Perf */
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
   },
   "include": ["src", "playwright.config.ts", "e2e-tests"]
 }


### PR DESCRIPTION
The `tsBuildInfoFile` configuration was present but inactive without the
`incremental` flag. Enabling incremental compilation allows TypeScript
to cache type information between builds, speeding up subsequent type
checks (~4x in my testing).

```sh
❯ hyperfine "pnpm tsc" "pnpm tsc --incremental"
Benchmark 1: pnpm tsc
  Time (mean ± σ):     10.448 s ±  0.459 s    [User: 15.896 s, System: 1.129 s]
  Range (min … max):    9.443 s … 11.088 s    10 runs

Benchmark 2: pnpm tsc --incremental
  Time (mean ± σ):      2.841 s ±  0.138 s    [User: 4.680 s, System: 0.522 s]
  Range (min … max):    2.700 s …  3.076 s    10 runs

Summary
  pnpm tsc --incremental ran
    3.68 ± 0.24 times faster than pnpm tsc
```

An alternative is just to make everyone aware of the `--incremental` flag.
