### PR TITLE
fix: Expand checks around decorated functions to enable functools usage

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -298,8 +298,15 @@ def get_source_position(
     # Fallback won't capture embedded scripts
     if inspect.isclass(f):
         is_script = f.__module__ == "__main__"
-    else:
+    # Larger catch all than if inspect.isfunction(f):
+    elif hasattr(f, "__globals__"):
         is_script = f.__globals__["__name__"] == "__main__"  # type: ignore
+    # Could be something wrapped in a decorator, like
+    # functools._lru_cache_wrapper.
+    elif hasattr(f, "__wrapped__"):
+        return get_source_position(f.__wrapped__, lineno, col_offset)
+    else:
+        return None
     # TODO: spec is None for markdown notebooks, which is fine for now
     if module := inspect.getmodule(f):
         spec = module.__spec__

--- a/marimo/_utils/requests.py
+++ b/marimo/_utils/requests.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 import json
 import urllib.error
 import urllib.parse

--- a/tests/_ast/codegen_data/test_with_bad_decorator.py
+++ b/tests/_ast/codegen_data/test_with_bad_decorator.py
@@ -1,0 +1,18 @@
+import marimo
+
+__generated_with = "0.0.0"
+app = marimo.App()
+
+
+@app.function
+def wrap(f) -> int:
+    return 100
+
+@app.function
+@wrap
+def hundred(a: int, b: int) -> int:
+    return a + b
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_ast/test_cell.py
+++ b/tests/_ast/test_cell.py
@@ -378,6 +378,26 @@ class TestReusableCell:
         assert defs == {"z": -1}
 
 
+class TestDecoratedCells:
+    @staticmethod
+    def test_functool_wrapped(app) -> None:
+        with app.setup:
+            from functools import cache
+
+        @app.function
+        @cache
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        assert add(1, 2) == 3
+        assert add.cache_info().hits == 0
+        assert add(1, 2) == 3
+        assert add.cache_info().hits == 1
+        assert app._cell_manager.get_cell_data_by_name("add").cell.defs == {
+            "add"
+        }
+
+
 def help_smoke() -> None:
     app = App()
 

--- a/tests/_ast/test_load.py
+++ b/tests/_ast/test_load.py
@@ -271,3 +271,17 @@ class TestGetCodes:
         else:
             assert len(caplog.records) == 1
         assert "kwarg_that_doesnt_exist" in caplog.text
+
+    @staticmethod
+    def test_get_app_with_bad_decorator(static_load) -> None:
+        app = static_load(get_filepath("test_with_bad_decorator"))
+        assert app is not None
+        assert app._cell_manager.get_cell_data_by_name("wrap").cell.defs == {
+            "wrap"
+        }
+        assert app._cell_manager.get_cell_data_by_name(
+            "hundred"
+        ).cell.defs == {"hundred"}
+        from codegen_data.test_with_bad_decorator import hundred
+
+        assert hundred == 100


### PR DESCRIPTION
## 📝 Summary

fixes #5570

## 🔍 Description of Changes

Certain wrapper decorators, like `functools.cache` return an object, not a function - which breaks compilation.
This adds a check that captures the functool case, and also generalizes cell registration to handle any object.
Also added a test to confirm static parsing can in fact load any decorated value.