### PR TITLE
Fix handling of class attribute references for reactive variables

### DIFF
--- a/frontend/src/core/codemirror/reactive-references/__tests__/analyzer.test.ts
+++ b/frontend/src/core/codemirror/reactive-references/__tests__/analyzer.test.ts
@@ -1072,6 +1072,71 @@ b)
       "
     `);
   });
+
+  test("should not highlight class property", () => {
+    expect(
+      runHighlight(
+        ["bar"],
+        `
+class Foo:
+    bar = 10
+    baz = bar
+`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      class Foo:
+          bar = 10
+          baz = bar
+      "
+    `);
+  });
+
+  test("class property referencing undefined then defined", () => {
+    expect(
+      runHighlight(
+        ["bar"],
+        `
+class Foo:
+    baz = bar
+    bar = bar
+    bar = 10
+`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      class Foo:
+          baz = bar
+                ^^^
+          bar = bar
+                ^^^
+          bar = 10
+      "
+    `);
+  });
+
+  test("class property self-reference", () => {
+    expect(
+      runHighlight(
+        ["bar"],
+        `
+class Foo:
+    baz = bar
+    bar = bar
+    bar = bar
+`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      class Foo:
+          baz = bar
+                ^^^
+          bar = bar
+                ^^^
+          bar = bar
+      "
+    `);
+  });
 });
 
 /**


### PR DESCRIPTION
Improves how class-scoped assignments are resolved when analyzing
reactive references. Previously, class attributes like `bar = 10` could
be incorrectly highlighted as reactive if a global `bar` existed, due to
improper scoping resolution. The fix ensures that class-level variables
are interpreted in declaration order, mirroring Python's evaluation
semantics. This avoids false positives in cases involving
self-references or forward references within the class body. Additional
tests cover sequential assignment, references to undefined variables,
and repeated assignments. If anyone has more pathological examples, I'm
happy to add them to the test suite.
