### PR TITLE
feat: interactive key completion

### DIFF
--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any, cast
 
 import jedi  # type: ignore # noqa: F401
+import jedi.api  # type: ignore # noqa: F401
 
 from marimo import _loggers as loggers
 from marimo._dependencies.dependencies import DependencyManager

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -373,10 +373,11 @@ def _isinstance_external(obj: Any, *, class_ref: str) -> bool:
 
 
 def _key_options_from_ipython_method(obj: Any) -> list[str]:
-    return obj._ipython_key_completions_()
+    # convention for `_ipython_key_completions_` is to return a list of strings
+    return [str(key) for key in obj._ipython_key_completions_()]
 
 
-def _key_options_from_mapping(obj: Mapping) -> list[str]:
+def _key_options_from_mapping(obj: Mapping[Any, Any]) -> list[str]:
     return [str(key) for key in obj.keys()]
 
 

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -594,7 +594,7 @@ def complete(
                 )
                 return
 
-        if not completions and not key_options:
+        if not completions:
             # If there are still no completions, then bail.
             _write_no_completions(stream, request.id)
             return

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -292,13 +292,25 @@ def test_get_key_completions(
     mock_request.document = code
 
     completions = _maybe_get_key_options(
-        request=mock_request, script=script, glbls=glbls
+        request=mock_request, script=script, glbls=glbls, glbls_lock=glbls_lock
     )
 
     if expects_completions is True:
         assert [c.name for c in completions] == expected_completions
     else:
         assert completions == []
+
+
+def random_dict():
+    """This can't be statically inferred."""
+    import random
+    
+    d = {}
+    for _ in range(5):
+        value = random.randint(0, 100)
+        d[str(value)] = value
+
+    return d
 
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed.")

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 import threading
 from collections.abc import Mapping
 from inspect import signature
@@ -12,11 +13,16 @@ import pytest
 
 import marimo
 from marimo._dependencies.dependencies import DependencyManager
+from marimo._messaging.ops import CompletionResult
+from marimo._messaging.types import Stream
 from marimo._runtime.complete import (
     _build_docstring_cached,
     _maybe_get_key_options,
+    complete,
 )
 from marimo._runtime.patches import patch_jedi_parameter_completion
+from marimo._runtime.requests import CodeCompletionRequest
+from marimo._types.ids import CellId_t
 from tests.mocks import snapshotter
 
 snapshot = snapshotter(__file__)
@@ -215,6 +221,7 @@ def test_parameter_descriptions(obj: Any, runtime_inference: bool):
 
 
 def cases_key_completions_code() -> tuple[tuple[str, bool], ...]:
+    """Text content when key completion is triggered."""
     return (
         ("obj['", True),
         ('obj["', True),
@@ -230,7 +237,7 @@ def cases_key_completions_code() -> tuple[tuple[str, bool], ...]:
 def cases_objects_supporting_key_completion() -> tuple[
     tuple[Any, list[str]], ...
 ]:
-    """Returns globals dictionary containing objects support key completions"""
+    """Values stored in `globals` when key completion is triggered."""
 
     class IPythonImplemented:
         def __init__(self):
@@ -267,10 +274,27 @@ def cases_objects_supporting_key_completion() -> tuple[
         def __len__(self):
             raise NotImplementedError
 
+    static_key_dict = ({"foo": [0, 1], "bar": [1.0, 3.0]}, ["foo", "bar"])
+    # use different ranges to prevent key collisions
+    dynamic_key_1 = str(random.randint(0, 9))
+    dynamic_key_2 = str(random.randint(10, 19))
+    dynamic_key_dict = (
+        {dynamic_key_1: "val1", dynamic_key_2: "val2"},
+        [dynamic_key_1, dynamic_key_2],
+    )
+    mixed_keys_dict = (
+        {"foo": [0, 1], dynamic_key_1: "val2"},
+        ["foo", dynamic_key_1],
+    )
+    ipython_case = (IPythonImplemented(), ["foo", "bar"])
+    custom_mapping_case = (CustomMapping(), ["foo", "bar"])
+
     return (
-        ({"foo": [0, 1], "bar": [1.0, 3.0]}, ["foo", "bar"]),
-        (IPythonImplemented(), ["foo", "bar"]),
-        (CustomMapping(), ["foo", "bar"]),
+        static_key_dict,
+        dynamic_key_dict,
+        mixed_keys_dict,
+        ipython_case,
+        custom_mapping_case,
     )
 
 
@@ -280,10 +304,11 @@ def cases_objects_supporting_key_completion() -> tuple[
 @pytest.mark.parametrize(
     "obj_and_expected_completions", cases_objects_supporting_key_completion()
 )
-def test_get_key_completions(
+def test_maybe_get_key_options(
     code_and_expects_completions: tuple[str, bool],
     obj_and_expected_completions: tuple[Any, list[str]],
 ):
+    """Low-level test for `_maybe_get_key_options()`"""
     code, expects_completions = code_and_expects_completions
     obj, expected_completions = obj_and_expected_completions
 
@@ -303,11 +328,13 @@ def test_get_key_completions(
         assert completions == []
 
 
+# TODO case could be added to `cases_objects_supporting_key_completions()`
+# the test has the same logic of `test_maybe_get_key_options()`
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed.")
 @pytest.mark.parametrize(
     "code_and_expects_completions", cases_key_completions_code()
 )
-def test_get_key_completions_pandas_dataframe(
+def test_maybe_get_key_options_pandas_dataframe(
     code_and_expects_completions: tuple[str, bool],
 ):
     import pandas as pd
@@ -334,3 +361,137 @@ def test_get_key_completions_pandas_dataframe(
         assert [c.name for c in completions] == expected_completions
     else:
         assert completions == []
+
+
+class CaptureStream(Stream):
+    def __init__(self):
+        self.messages: list[tuple[str, dict[Any, Any]]] = []
+
+    def write(self, op: str, data: dict[Any, Any]) -> None:
+        self.messages.append((op, data))
+
+
+# TODO add test cases for all other completion modalities
+# TODO improve coupling between variable name, source code, and assertions
+@pytest.mark.parametrize(
+    "code_and_expects_completions", cases_key_completions_code()
+)
+@pytest.mark.parametrize(
+    "object_name", ["static_key", "dynamic_key", "mixed_keys", "ipython_data"]
+)
+def test_complete_main_entrypoint(
+    code_and_expects_completions: tuple[str, bool],
+    object_name: str,
+) -> None:
+    trigger_code, expects_completions = code_and_expects_completions
+
+    # parameterize the test (object type, trigger code)
+    # `trigger_code` includes different ways to trigger autocompletion (or not)
+    # All `trigger_code` cases trigger completion on variable `obj`
+    # To test different object types, we assign different values to `obj`
+    other_cells_code = f'''\
+import random
+
+class CustomData:
+    def __init__(self):
+        self._table = {{
+            "foo": [0, 1],
+            "bar": [1., 3.],
+            "baz": [True, True],
+        }}
+
+    @property
+    def a_property(self) -> str:
+        """This is a property"""
+        return "prop value"
+
+    def __getitem__(self, key: str) -> list:
+        """Returns a mock column"""
+        return self._table[key]
+
+    def _ipython_key_completions_(self) -> list[str]:
+        return list(self._table.keys())
+
+ipython_data = CustomData()
+static_key = {{"static_key": "foo"}}
+dynamic_key = {{str(random.randint(0, 10)): "foo"}}
+mixed_keys = {{"static_key": "foo", str(random.randint(0, 10)): "bar"}}
+obj = {object_name}\
+'''
+    mock_other_cell = mock.MagicMock()
+    mock_other_cell.code = other_cells_code
+
+    mock_current_cell = mock.MagicMock()
+    mock_current_cell.code = trigger_code
+    current_cell_id = CellId_t("my-request-id")
+
+    mock_graph = mock.MagicMock()
+    mock_graph.cells = {
+        "other-cell-id": mock_other_cell,
+        current_cell_id: mock_current_cell,
+    }
+
+    glbls = {}
+    exec(other_cells_code, {}, glbls)
+    # check existence of variables in globals and their type
+    assert isinstance(
+        glbls.get("ipython_data"), glbls.get("CustomData", Exception)
+    )
+    assert isinstance(glbls.get("static_key"), dict)
+    assert isinstance(glbls.get("dynamic_key"), dict)
+    assert isinstance(glbls.get("mixed_keys"), dict)
+
+    lock = threading.RLock()
+    local_stream = CaptureStream()
+
+    completion_request = CodeCompletionRequest(
+        id="request_id",
+        document=trigger_code,
+        cell_id=current_cell_id,
+    )
+
+    complete(
+        request=completion_request,
+        graph=mock_graph,
+        glbls=glbls,
+        glbls_lock=lock,
+        stream=local_stream,
+    )
+
+    messages = local_stream.messages
+    message_name, content = messages[0]
+    prefix_length = content["prefix_length"]
+    options = content["options"]
+    options_values = [option["name"] for option in options]
+
+    assert len(messages) == 1
+    assert message_name == CompletionResult.name
+    # TODO if `expects_completions=False`, something else than `_maybe_get_key_options()`
+    # could be returning values
+    if expects_completions is False:
+        return
+
+    assert prefix_length == 0
+    assert all(option["type"] == "property" for option in options)
+    assert all(option["completion_info"] == "key" for option in options)
+
+    expected_keys: list[str]
+    if object_name == "static_key":
+        # from source code in variable `other_cells_code`
+        expected_keys = ["static_key"]
+    elif object_name == "dynamic_key":
+        expected_keys = list(glbls["dynamic_key"].keys())
+    elif object_name == "mixed_keys":
+        expected_keys = list(glbls["mixed_keys"].keys())
+    elif object_name == "ipython_data":
+        # from source code in variable `other_cells_code`
+        expected_keys = ["foo", "bar", "baz"]
+    else:
+        RuntimeError(
+            f"Make sure you defined `expected_keys` for `{object_name}`"
+            " Currently, the test is improperly defined."
+        )
+
+    # check `len()` to ensure `set()` operation doesn't deduplicate keys
+    assert len(options_values) == len(expected_keys)
+    assert set(options_values) == set(expected_keys)


### PR DESCRIPTION
## 📝 Summary

Implements key autocompletion (issue #4539). Now, `dataframe["` will suggest column names, dictionaries will suggest keys, etc.

## 🔍 Description of Changes

Existing autocompletion features rely on `jedi`, which is a static analysis tool. It works using the source code / AST or by loading and inspecting an isolated copy of the module. It never accesses the user's namespaces (i.e., where the variable from the notebook live). Key completion requires accessing the object instance in the user namespace. 

`_maybe_get_key_options` was added and is called from the existing `complete()` function (main entrypoint). This identifies the name of the variable being completed, retrieves it from the already available `glbls` namespace and retrieves keys from the instance

### Limitations

- non-`str` dictionary keys aren't show as suggestions. When those are involved (`int`, `float`,  `tuple`), debug mode shows serialization warnings. Even if those values are converted to strings explicitly, something is failing
- the changes explicitly 3 cases to retrieve keys (has `_ipython_key_completions_()`, is `Mapping`, has `.keys()`). However, there's no standard about "how to retrieve valid values to pass to `.__getitem__()`

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## Screenshots

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

<img width="904" height="325" alt="image" src="https://github.com/user-attachments/assets/f5d9ff9a-1f66-4017-8f0e-bea5a8c4a200" />

<img width="921" height="1169" alt="image" src="https://github.com/user-attachments/assets/e2fa8aca-057b-431b-b9f1-751e52084a1e" />

<img width="897" height="816" alt="image" src="https://github.com/user-attachments/assets/010006c6-ac2c-4ccc-b5e0-e232e829400c" />

