### PR TITLE
Propagate `Ctrl+[` as `Escape` to enter command mode with vim keybindings

### DIFF
--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -1,7 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import type { Extension } from "@codemirror/state";
-import { type EditorView, keymap, ViewPlugin } from "@codemirror/view";
+import { EditorView, keymap, ViewPlugin } from "@codemirror/view";
 import {
   type CodeMirror,
   type CodeMirrorV,
@@ -84,6 +84,31 @@ export function vimKeymapExtension(): Extension[] {
         },
       },
     ]),
+    // Propagate Ctrl+[ to Escape for vim mode
+    EditorView.domEventHandlers({
+      keydown: (event, view) => {
+        if (
+          event.ctrlKey &&
+          event.key === "[" &&
+          !event.shiftKey &&
+          !event.altKey &&
+          !event.metaKey
+        ) {
+          event.preventDefault();
+          // Dispatch a synthetic Escape event to the editor
+          view.contentDOM.dispatchEvent(
+            new KeyboardEvent("keydown", {
+              key: "Escape",
+              code: "Escape",
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+          return true;
+        }
+        return false;
+      },
+    }),
     ViewPlugin.define((view) => {
       // Wait for the next animation frame so the CodeMirror instance is ready
       requestAnimationFrame(() => {


### PR DESCRIPTION
Adds a CodeMirror event handler that converts `Ctrl+[` to synthetic
`Escape` when vim keybindings are enabled. This allows `Ctrl+[` to work
as `Escape` for all vim operations, including exiting from cell editor
to command mode.
