### PR TITLE
Add vim bindings for top/bottom cell navigation: `gg` and `G`

### DIFF
--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -23,6 +23,7 @@ import {
   useIsCellSelected,
 } from "./selection";
 import { temporarilyShownCodeAtom } from "./state";
+import { handleVimKeybinding } from "./vim-bindings";
 
 interface HotkeyHandler {
   handle: (cellId: CellId) => boolean;
@@ -230,24 +231,20 @@ export function useCellNavigationProps(
       }
 
       // Keymaps when using vim.
-      if (keymapPreset === "vim") {
-        const vimKeymaps = {
+      if (
+        keymapPreset === "vim" &&
+        handleVimKeybinding(evt.nativeEvent || evt, {
           j: keymaps.ArrowDown,
           k: keymaps.ArrowUp,
-          "Shift+j": keymaps["Shift+ArrowDown"],
-          "Shift+k": keymaps["Shift+ArrowUp"],
           i: keymaps.Enter,
-        } satisfies KeymapHandlers;
-
-        for (const [key, handler] of Object.entries(vimKeymaps)) {
-          if (parseShortcut(key)(evt)) {
-            const success = handler();
-            if (success) {
-              evt.preventDefault();
-              return;
-            }
-          }
-        }
+          "shift+j": keymaps["Shift+ArrowDown"],
+          "shift+k": keymaps["Shift+ArrowUp"],
+          "g g": keymaps["Mod+ArrowUp"],
+          "shift+g": keymaps["Mod+ArrowDown"],
+        })
+      ) {
+        evt.preventDefault();
+        return;
       }
 
       // Shortcuts

--- a/frontend/src/components/editor/navigation/vim-bindings.test.ts
+++ b/frontend/src/components/editor/navigation/vim-bindings.test.ts
@@ -1,0 +1,109 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
+import { handleVimKeybinding, testHelpers } from "./vim-bindings";
+
+function createKeyEvent(
+  target: EventTarget,
+  { key, shiftKey = false }: { key: string; shiftKey?: boolean },
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    shiftKey,
+  });
+  // Manually set target since KeyboardEvent constructor doesn't support it
+  Object.defineProperty(event, "target", {
+    value: target,
+    writable: false,
+  });
+  return event;
+}
+
+describe("handleVimKeybinding", () => {
+  let target: EventTarget;
+  let mockActions: Record<string, Mock>;
+  let bindings: Record<string, () => boolean>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    target = new EventTarget();
+    mockActions = {
+      moveDown: vi.fn(() => true),
+      goToTop: vi.fn(() => true),
+    };
+    bindings = {
+      j: mockActions.moveDown,
+      "g g": mockActions.goToTop,
+    };
+  });
+
+  afterEach(() => {
+    testHelpers.clearSequenceTracker(target);
+    vi.useRealTimers();
+  });
+
+  it("handles single key bindings", () => {
+    const result = handleVimKeybinding(
+      createKeyEvent(target, { key: "j" }),
+      bindings,
+    );
+    expect(result).toBe(true);
+    expect(mockActions.moveDown).toHaveBeenCalledOnce();
+  });
+
+  it("handles key sequences", () => {
+    // First 'g' - should not trigger anything, but return true to prevent default
+    const result1 = handleVimKeybinding(
+      createKeyEvent(target, { key: "g" }),
+      bindings,
+    );
+    expect(result1).toBe(true);
+    expect(mockActions.goToTop).not.toHaveBeenCalled();
+
+    // Second 'g' - should trigger the action
+    const result2 = handleVimKeybinding(
+      createKeyEvent(target, { key: "g" }),
+      bindings,
+    );
+    expect(result2).toBe(true);
+    expect(mockActions.goToTop).toHaveBeenCalledOnce();
+  });
+
+  it("times out incomplete sequences", () => {
+    handleVimKeybinding(createKeyEvent(target, { key: "g" }), bindings);
+    vi.advanceTimersByTime(testHelpers.SEQUENCE_TIMEOUT + 1);
+
+    // Press 'g' again - should start a new sequence, not complete "g g"
+    handleVimKeybinding(createKeyEvent(target, { key: "g" }), bindings);
+    expect(mockActions.goToTop).not.toHaveBeenCalled();
+  });
+
+  it("eagerly matches single keys even if they could be part of a sequence", () => {
+    const eagerBindings = {
+      g: vi.fn(() => true),
+      "g g": mockActions.goToTop,
+    };
+
+    // Press 'g' - should immediately trigger single 'g' action
+    const result = handleVimKeybinding(
+      createKeyEvent(target, { key: "g" }),
+      eagerBindings,
+    );
+    expect(result).toBe(true);
+    expect(eagerBindings.g).toHaveBeenCalledOnce();
+    expect(mockActions.goToTop).not.toHaveBeenCalled();
+
+    // Press 'g' again - should trigger single 'g' again, NOT "g g"
+    handleVimKeybinding(createKeyEvent(target, { key: "g" }), eagerBindings);
+    expect(eagerBindings.g).toHaveBeenCalledTimes(2);
+    expect(mockActions.goToTop).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/editor/navigation/vim-bindings.ts
+++ b/frontend/src/components/editor/navigation/vim-bindings.ts
@@ -1,0 +1,90 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+// Track current key sequence per element
+const sequenceTracker = new WeakMap<
+  EventTarget,
+  {
+    sequence: string;
+    timeout: number;
+  }
+>();
+
+const SEQUENCE_TIMEOUT = 500;
+
+function getKeyString(evt: KeyboardEvent): string {
+  // Skip if modifiers are pressed (except shift)
+  if (evt.ctrlKey || evt.metaKey || evt.altKey) {
+    return "";
+  }
+  const key = evt.key.toLowerCase();
+  return evt.shiftKey ? `shift+${key}` : key;
+}
+
+export function handleVimKeybinding(
+  evt: KeyboardEvent,
+  bindings: Record<string, () => boolean>,
+): boolean {
+  const key = getKeyString(evt);
+  const target = evt.target;
+  if (!key || !target) {
+    return false;
+  }
+
+  const tracker = sequenceTracker.get(target);
+  let sequence = key;
+
+  // clear any existing timeout
+  if (tracker?.timeout) {
+    clearTimeout(tracker.timeout);
+  }
+
+  // continue building sequence if we have a previous key
+  if (tracker) {
+    sequence = `${tracker.sequence} ${key}`;
+  }
+
+  // check exact match
+  const action = bindings[sequence];
+  if (action) {
+    sequenceTracker.delete(target);
+    return action();
+  }
+
+  // IMPORTANT: We eagerly match single keys even if they could be part of a sequence
+  // For example, if bindings has both "g" and "g g", pressing "g" will immediately trigger "g"
+  // This means "g g" would never be triggered in that case
+  if (!tracker) {
+    const singleKeyAction = bindings[key];
+    if (singleKeyAction) {
+      return singleKeyAction();
+    }
+  }
+
+  const couldContinue = Object.keys(bindings).some((binding) =>
+    binding.startsWith(`${sequence} `),
+  );
+
+  if (couldContinue) {
+    // store partial sequence
+    const timeout = window.setTimeout(() => {
+      sequenceTracker.delete(target);
+    }, SEQUENCE_TIMEOUT);
+    sequenceTracker.set(target, { sequence, timeout });
+    return true; // prevent default while waiting
+  }
+
+  // No match
+  sequenceTracker.delete(target);
+  return false;
+}
+
+export const testHelpers = {
+  clearSequenceTracker: (target: EventTarget) => {
+    const tracker = sequenceTracker.get(target);
+    if (tracker?.timeout) {
+      clearTimeout(tracker.timeout);
+    }
+    sequenceTracker.delete(target);
+  },
+  SEQUENCE_TIMEOUT,
+};


### PR DESCRIPTION
Adds `gg` to jump to first cell and `G` to jump to last cell in command mode,
matching standard vim behavior. Also refactors vim keybindings into a dedicated
handler with declarative binding definitions, making it easy to add more vim
commands in the future.
