### PR TITLE
fix: absolute positioning of button and enable select all rows

### DIFF
--- a/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
+++ b/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
@@ -572,7 +572,7 @@ export const GlideDataEditor = <T,>({
   };
 
   return (
-    <>
+    <div className="relative">
       <ErrorBoundary>
         <DataEditor
           ref={dataEditorRef}
@@ -595,7 +595,6 @@ export const GlideDataEditor = <T,>({
           width={"100%"}
           rowMarkers={{
             kind: "both",
-            headerDisabled: true,
           }}
           rowSelectionMode={"multi"}
           onCellEdited={onCellEdited}
@@ -615,13 +614,13 @@ export const GlideDataEditor = <T,>({
           variant="destructive"
           size="sm"
           disabled={selection.rows.length === 0}
-          className="bottom-1 right-2 h-7"
+          className="right-2 h-7"
           onClick={handleDeleteRows}
         >
           {selection.rows.length <= 1 ? "Delete row" : "Delete rows"}
         </Button>
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

- fixes absolute positioning of delete rows button
- enable select and deselect all rows

Previously:
<img width="600" alt="CleanShot 2025-07-15 at 23 06 19" src="https://github.com/user-attachments/assets/f2a17dd2-718b-4c77-a5f3-187b0891b01f" />

Now:
<img width="600" alt="CleanShot 2025-07-15 at 23 05 26" src="https://github.com/user-attachments/assets/87391c88-fa3f-470f-b077-5eef4219172d" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
