### PR TITLE
improvement: add config override detection and UI components

### DIFF
--- a/frontend/src/components/app-config/is-overridden.tsx
+++ b/frontend/src/components/app-config/is-overridden.tsx
@@ -1,0 +1,70 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { useAtomValue } from "jotai";
+import { get } from "lodash-es";
+import type { FieldPath } from "react-hook-form";
+import { Tooltip } from "@/components/ui/tooltip";
+import { configOverridesAtom, useUserConfig } from "@/core/config/config";
+import type { UserConfig } from "@/core/config/config-schema";
+import { Kbd } from "../ui/kbd";
+
+/**
+ * Hook to determine if a user config value is overridden by project config.
+ * Returns { isOverridden, currentValue, overriddenValue }
+ */
+export function useIsConfigOverridden(
+  userConfig: UserConfig,
+  name: FieldPath<UserConfig>,
+): {
+  isOverridden: boolean;
+  currentValue: unknown;
+  overriddenValue: unknown;
+} {
+  const currentValue = get(userConfig, name);
+  const overrides = useAtomValue(configOverridesAtom);
+  const overriddenValue = get(overrides as UserConfig, name);
+
+  const isOverridden =
+    overriddenValue != null && currentValue !== overriddenValue;
+
+  return { isOverridden, currentValue, overriddenValue };
+}
+
+/**
+ * Wraps a component and shows a tooltip if the user config is overridden by the
+ * project config.
+ */
+export const DisableIfOverridden = ({
+  name,
+  children,
+}: {
+  name: FieldPath<UserConfig>;
+  children: React.ReactNode;
+}) => {
+  const [userConfig] = useUserConfig();
+  const { isOverridden } = useIsConfigOverridden(userConfig, name);
+  return isOverridden ? (
+    <Tooltip
+      delayDuration={200}
+      content={
+        <div className="flex flex-col gap-2">
+          <p>
+            This setting is overridden by the{" "}
+            <Kbd className="inline mx-[1px]">pyproject.toml</Kbd> config.
+          </p>
+          <p>
+            To change it, edit the project config{" "}
+            <Kbd className="inline mx-[1px]">pyproject.toml</Kbd>
+            directly.
+          </p>
+        </div>
+      }
+    >
+      <div className="text-muted-foreground opacity-80 cursor-not-allowed *:pointer-events-none">
+        {children}
+      </div>
+    </Tooltip>
+  ) : (
+    children
+  );
+};

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
-import { get } from "lodash-es";
 import {
   BrainIcon,
   CpuIcon,
@@ -33,7 +32,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CopilotConfig } from "@/core/codemirror/copilot/copilot-config";
 import { KEYMAP_PRESETS } from "@/core/codemirror/keymaps/keymaps";
 import { capabilitiesAtom } from "@/core/config/capabilities";
-import { configOverridesAtom, useUserConfig } from "@/core/config/config";
+import { useUserConfig } from "@/core/config/config";
 import {
   PackageManagerNames,
   type UserConfig,
@@ -53,6 +52,7 @@ import { Textarea } from "../ui/textarea";
 import { Tooltip } from "../ui/tooltip";
 import { SettingSubtitle, SQL_OUTPUT_SELECT_OPTIONS } from "./common";
 import { AWS_REGIONS, KNOWN_AI_MODELS } from "./constants";
+import { useIsConfigOverridden } from "./is-overridden";
 import { OptionalFeatures } from "./optional-features";
 
 const formItemClasses = "flex flex-row items-center space-x-1 space-y-0";
@@ -1636,14 +1636,12 @@ const IsOverridden = ({
   userConfig: UserConfig;
   name: FieldPath<UserConfig>;
 }) => {
-  const currentValue = get(userConfig, name);
-  const overrides = useAtomValue(configOverridesAtom);
-  const overriddenValue = get(overrides as UserConfig, name);
-  if (overriddenValue == null) {
-    return null;
-  }
+  const { isOverridden, currentValue, overriddenValue } = useIsConfigOverridden(
+    userConfig,
+    name,
+  );
 
-  if (currentValue === overriddenValue) {
+  if (!isOverridden) {
     return null;
   }
 

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/runtime-settings.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/runtime-settings.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import type React from "react";
 import { useEffect, useState } from "react";
+import { DisableIfOverridden } from "@/components/app-config/is-overridden";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -101,109 +102,121 @@ export const RuntimeSettings: React.FC<RuntimeSettingsProps> = ({
     <div className={cn("flex items-center", className)}>
       {/* Shown on larger screens */}
       <div className="hidden md:flex md:items-center">
-        <FooterItem
-          tooltip={
-            config.runtime.auto_instantiate
-              ? "Disable autorun on startup"
-              : "Enable autorun on startup"
-          }
-          selected={false}
-          onClick={() => handleStartupToggle(!config.runtime.auto_instantiate)}
-          data-testid="footer-autorun-startup"
-        >
-          <div className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
-            <span>on startup: </span>
-            {config.runtime.auto_instantiate ? (
-              <ZapIcon size={14} />
-            ) : (
-              <ZapOffIcon size={14} />
-            )}
-            <span>{config.runtime.auto_instantiate ? "autorun" : "lazy"}</span>
-          </div>
-        </FooterItem>
+        <DisableIfOverridden name="runtime.auto_instantiate">
+          <FooterItem
+            tooltip={
+              config.runtime.auto_instantiate
+                ? "Disable autorun on startup"
+                : "Enable autorun on startup"
+            }
+            selected={false}
+            onClick={() =>
+              handleStartupToggle(!config.runtime.auto_instantiate)
+            }
+            data-testid="footer-autorun-startup"
+          >
+            <div className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
+              <span>on startup: </span>
+              {config.runtime.auto_instantiate ? (
+                <ZapIcon size={14} />
+              ) : (
+                <ZapOffIcon size={14} />
+              )}
+              <span>
+                {config.runtime.auto_instantiate ? "autorun" : "lazy"}
+              </span>
+            </div>
+          </FooterItem>
+        </DisableIfOverridden>
 
         <div className="border-r border-border h-6 mx-1" />
 
-        <FooterItem
-          tooltip={
-            config.runtime.on_cell_change === "autorun"
-              ? "Disable autorun"
-              : "Enable autorun"
-          }
-          selected={false}
-          onClick={() =>
-            handleCellChangeToggle(config.runtime.on_cell_change !== "autorun")
-          }
-          data-testid="footer-autorun-cell-change"
-        >
-          <div className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
-            <span>on cell change: </span>
-            {config.runtime.on_cell_change === "autorun" ? (
-              <ZapIcon size={14} />
-            ) : (
-              <ZapOffIcon size={14} />
-            )}
-            <span>{config.runtime.on_cell_change}</span>
-          </div>
-        </FooterItem>
+        <DisableIfOverridden name="runtime.on_cell_change">
+          <FooterItem
+            tooltip={
+              config.runtime.on_cell_change === "autorun"
+                ? "Disable autorun"
+                : "Enable autorun"
+            }
+            selected={false}
+            onClick={() =>
+              handleCellChangeToggle(
+                config.runtime.on_cell_change !== "autorun",
+              )
+            }
+            data-testid="footer-autorun-cell-change"
+          >
+            <div className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
+              <span>on cell change: </span>
+              {config.runtime.on_cell_change === "autorun" ? (
+                <ZapIcon size={14} />
+              ) : (
+                <ZapOffIcon size={14} />
+              )}
+              <span>{config.runtime.on_cell_change}</span>
+            </div>
+          </FooterItem>
+        </DisableIfOverridden>
 
         {!isWasm() && (
           <>
             <div className="border-r border-border h-6 mx-1" />
-            <FooterItem
-              tooltip={null}
-              selected={false}
-              data-testid="footer-module-reload"
-            >
-              <DropdownMenu>
-                <DropdownMenuTrigger className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
-                  <span>on module change: </span>
-                  {config.runtime.auto_reload === "off" && (
-                    <PowerOffIcon size={14} />
-                  )}
-                  {config.runtime.auto_reload === "lazy" && (
-                    <ZapOffIcon size={14} />
-                  )}
-                  {config.runtime.auto_reload === "autorun" && (
-                    <ZapIcon size={14} />
-                  )}
-                  <span>{config.runtime.auto_reload}</span>
-                  <ChevronDownIcon size={14} />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent>
-                  {["off", "lazy", "autorun"].map((option) => (
-                    <DropdownMenuItem
-                      key={option}
-                      onClick={() =>
-                        handleModuleReloadChange(
-                          option as "off" | "lazy" | "autorun",
-                        )
-                      }
-                    >
-                      {option === "off" && (
-                        <PowerOffIcon
-                          size={14}
-                          className="mr-2 text-muted-foreground"
-                        />
-                      )}
-                      {option === "lazy" && (
-                        <ZapOffIcon
-                          size={14}
-                          className="mr-2 text-muted-foreground"
-                        />
-                      )}
-                      {option === "autorun" && (
-                        <ZapIcon
-                          size={14}
-                          className="mr-2 text-muted-foreground"
-                        />
-                      )}
-                      {option}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </FooterItem>
+            <DisableIfOverridden name="runtime.auto_reload">
+              <FooterItem
+                tooltip={null}
+                selected={false}
+                data-testid="footer-module-reload"
+              >
+                <DropdownMenu>
+                  <DropdownMenuTrigger className="font-prose text-sm flex items-center gap-1 whitespace-nowrap">
+                    <span>on module change: </span>
+                    {config.runtime.auto_reload === "off" && (
+                      <PowerOffIcon size={14} />
+                    )}
+                    {config.runtime.auto_reload === "lazy" && (
+                      <ZapOffIcon size={14} />
+                    )}
+                    {config.runtime.auto_reload === "autorun" && (
+                      <ZapIcon size={14} />
+                    )}
+                    <span>{config.runtime.auto_reload}</span>
+                    <ChevronDownIcon size={14} />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    {["off", "lazy", "autorun"].map((option) => (
+                      <DropdownMenuItem
+                        key={option}
+                        onClick={() =>
+                          handleModuleReloadChange(
+                            option as "off" | "lazy" | "autorun",
+                          )
+                        }
+                      >
+                        {option === "off" && (
+                          <PowerOffIcon
+                            size={14}
+                            className="mr-2 text-muted-foreground"
+                          />
+                        )}
+                        {option === "lazy" && (
+                          <ZapOffIcon
+                            size={14}
+                            className="mr-2 text-muted-foreground"
+                          />
+                        )}
+                        {option === "autorun" && (
+                          <ZapIcon
+                            size={14}
+                            className="mr-2 text-muted-foreground"
+                          />
+                        )}
+                        {option}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </FooterItem>
+            </DisableIfOverridden>
           </>
         )}
       </div>
@@ -232,110 +245,120 @@ export const RuntimeSettings: React.FC<RuntimeSettingsProps> = ({
             <DropdownMenuSeparator />
 
             {/* On startup toggle */}
-            <div className="flex items-center justify-between px-2 py-2">
-              <div className="flex items-center space-x-2">
-                {config.runtime.auto_instantiate ? (
-                  <ZapIcon size={14} className="text-amber-500" />
-                ) : (
-                  <ZapOffIcon size={14} className="text-muted-foreground" />
-                )}
-                <div>
-                  <div className="text-sm font-medium">On startup</div>
-                  <div className="text-xs text-muted-foreground">
-                    {config.runtime.auto_instantiate ? "autorun" : "lazy"}
+            <DisableIfOverridden name="runtime.auto_instantiate">
+              <div className="flex items-center justify-between px-2 py-2">
+                <div className="flex items-center space-x-2">
+                  {config.runtime.auto_instantiate ? (
+                    <ZapIcon size={14} className="text-amber-500" />
+                  ) : (
+                    <ZapOffIcon size={14} className="text-muted-foreground" />
+                  )}
+                  <div>
+                    <div className="text-sm font-medium">On startup</div>
+                    <div className="text-xs text-muted-foreground">
+                      {config.runtime.auto_instantiate ? "autorun" : "lazy"}
+                    </div>
                   </div>
                 </div>
+                <Switch
+                  checked={config.runtime.auto_instantiate}
+                  onCheckedChange={handleStartupToggle}
+                  size="sm"
+                />
               </div>
-              <Switch
-                checked={config.runtime.auto_instantiate}
-                onCheckedChange={handleStartupToggle}
-                size="sm"
-              />
-            </div>
+            </DisableIfOverridden>
 
             <DropdownMenuSeparator />
 
             {/* On cell change toggle */}
-            <div className="flex items-center justify-between px-2 py-2">
-              <div className="flex items-center space-x-2">
-                {config.runtime.on_cell_change === "autorun" ? (
-                  <ZapIcon size={14} className="text-amber-500" />
-                ) : (
-                  <ZapOffIcon size={14} className="text-muted-foreground" />
-                )}
-                <div>
-                  <div className="text-sm font-medium">On cell change</div>
-                  <div className="text-xs text-muted-foreground">
-                    {config.runtime.on_cell_change}
+            <DisableIfOverridden name="runtime.on_cell_change">
+              <div className="flex items-center justify-between px-2 py-2">
+                <div className="flex items-center space-x-2">
+                  {config.runtime.on_cell_change === "autorun" ? (
+                    <ZapIcon size={14} className="text-amber-500" />
+                  ) : (
+                    <ZapOffIcon size={14} className="text-muted-foreground" />
+                  )}
+                  <div>
+                    <div className="text-sm font-medium">On cell change</div>
+                    <div className="text-xs text-muted-foreground">
+                      {config.runtime.on_cell_change}
+                    </div>
                   </div>
                 </div>
+                <Switch
+                  checked={config.runtime.on_cell_change === "autorun"}
+                  onCheckedChange={handleCellChangeToggle}
+                  size="sm"
+                />
               </div>
-              <Switch
-                checked={config.runtime.on_cell_change === "autorun"}
-                onCheckedChange={handleCellChangeToggle}
-                size="sm"
-              />
-            </div>
+            </DisableIfOverridden>
 
             {!isWasm() && (
               <>
                 <DropdownMenuSeparator />
 
                 {/* On module change dropdown */}
-                <div className="px-2 py-1">
-                  <div className="flex items-center space-x-2 mb-2">
-                    {config.runtime.auto_reload === "off" && (
-                      <PowerOffIcon
-                        size={14}
-                        className="text-muted-foreground"
-                      />
-                    )}
-                    {config.runtime.auto_reload === "lazy" && (
-                      <ZapOffIcon size={14} className="text-muted-foreground" />
-                    )}
-                    {config.runtime.auto_reload === "autorun" && (
-                      <ZapIcon size={14} className="text-amber-500" />
-                    )}
-                    <div>
-                      <div className="text-sm font-medium">
-                        On module change
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {config.runtime.auto_reload}
+                <DisableIfOverridden name="runtime.auto_reload">
+                  <div className="px-2 py-1">
+                    <div className="flex items-center space-x-2 mb-2">
+                      {config.runtime.auto_reload === "off" && (
+                        <PowerOffIcon
+                          size={14}
+                          className="text-muted-foreground"
+                        />
+                      )}
+                      {config.runtime.auto_reload === "lazy" && (
+                        <ZapOffIcon
+                          size={14}
+                          className="text-muted-foreground"
+                        />
+                      )}
+                      {config.runtime.auto_reload === "autorun" && (
+                        <ZapIcon size={14} className="text-amber-500" />
+                      )}
+                      <div>
+                        <div className="text-sm font-medium">
+                          On module change
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {config.runtime.auto_reload}
+                        </div>
                       </div>
                     </div>
+                    <div className="space-y-1">
+                      {["off", "lazy", "autorun"].map((option) => (
+                        <button
+                          key={option}
+                          onClick={() =>
+                            handleModuleReloadChange(
+                              option as "off" | "lazy" | "autorun",
+                            )
+                          }
+                          className={cn(
+                            "w-full flex items-center px-2 py-1 text-sm rounded hover:bg-accent",
+                            option === config.runtime.auto_reload &&
+                              "bg-accent",
+                          )}
+                        >
+                          {option === "off" && (
+                            <PowerOffIcon size={12} className="mr-2" />
+                          )}
+                          {option === "lazy" && (
+                            <ZapOffIcon size={12} className="mr-2" />
+                          )}
+                          {option === "autorun" && (
+                            <ZapIcon size={12} className="mr-2" />
+                          )}
+                          <span className="capitalize">{option}</span>
+                          {option === config.runtime.auto_reload && (
+                            <span className="ml-auto">✓</span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
                   </div>
-                  <div className="space-y-1">
-                    {["off", "lazy", "autorun"].map((option) => (
-                      <button
-                        key={option}
-                        onClick={() =>
-                          handleModuleReloadChange(
-                            option as "off" | "lazy" | "autorun",
-                          )
-                        }
-                        className={cn(
-                          "w-full flex items-center px-2 py-1 text-sm rounded hover:bg-accent",
-                          option === config.runtime.auto_reload && "bg-accent",
-                        )}
-                      >
-                        {option === "off" && (
-                          <PowerOffIcon size={12} className="mr-2" />
-                        )}
-                        {option === "lazy" && (
-                          <ZapOffIcon size={12} className="mr-2" />
-                        )}
-                        {option === "autorun" && (
-                          <ZapIcon size={12} className="mr-2" />
-                        )}
-                        <span className="capitalize">{option}</span>
-                        {option === config.runtime.auto_reload && (
-                          <span className="ml-auto">✓</span>
-                        )}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+                </DisableIfOverridden>
               </>
             )}
           </DropdownMenuContent>


### PR DESCRIPTION
This adds some visual detection for why you cannot override settings that come the `pyproject.toml`.


- Introduced `useIsConfigOverridden` hook to check if user config values are overridden by project config.
- Added `DisableIfOverridden` component to wrap UI elements, displaying tooltips when settings are overridden.
- Updated `user-config-form` and `runtime-settings` components to utilize the new override detection


<img width="665" height="479" alt="Screenshot 2025-07-15 at 1 52 48 PM" src="https://github.com/user-attachments/assets/af070a56-7d95-47f3-ac69-d0023d68b13f" />
<img width="512" height="546" alt="Screenshot 2025-07-15 at 1 54 32 PM" src="https://github.com/user-attachments/assets/1fda4955-da2f-417f-b25a-89aa7da1670a" />
<img width="565" height="535" alt="Screenshot 2025-07-15 at 1 54 36 PM" src="https://github.com/user-attachments/assets/acc85d83-507c-4412-971a-29c1aa406b98" />