### PR TITLE
Update multi-cell toolbar labels: "Hide/Show cells" → "Hide/Show code"

### DIFF
--- a/frontend/src/components/editor/navigation/multi-cell-action-toolbar.tsx
+++ b/frontend/src/components/editor/navigation/multi-cell-action-toolbar.tsx
@@ -217,13 +217,13 @@ export function useMultiCellActionButtons(cellIds: CellId[]) {
     [
       {
         icon: <EyeOffIcon size={13} strokeWidth={1.5} />,
-        label: "Hide cells",
+        label: "Hide code",
         handle: (cellIds) =>
           toggleSelectedCellsProperty(cellIds, "hide_code", true),
       },
       {
         icon: <EyeIcon size={13} strokeWidth={1.5} />,
-        label: "Show cells",
+        label: "Show code",
         handle: (cellIds) =>
           toggleSelectedCellsProperty(cellIds, "hide_code", false),
       },


### PR DESCRIPTION
Clarifies that the action targets only the code section of cells, not
the entire cell.
