### PR TITLE
Sidebar buttons are accessible now

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -79,12 +79,12 @@ const SidebarItem: React.FC<
     {
       selected: boolean;
       tooltip: React.ReactNode;
-    } & React.HTMLAttributes<HTMLDivElement>
+    } & React.HTMLAttributes<HTMLButtonElement>
   >
 > = ({ children, tooltip, selected, className, ...rest }) => {
   return (
     <Tooltip content={tooltip} side="right" delayDuration={200}>
-      <div
+      <button
         className={cn(
           "flex items-center p-2 text-sm mx-[1px] shadow-inset font-mono cursor-pointer rounded",
           !selected && "hover:bg-[var(--sage-3)]",
@@ -94,7 +94,7 @@ const SidebarItem: React.FC<
         {...rest}
       >
         {children}
-      </div>
+      </button>
     </Tooltip>
   );
 };


### PR DESCRIPTION
I prefer to do everything with a keyboard shortcut instead of using the mouse. And here's a nice example. 

<img width="1508" height="371" alt="CleanShot 2025-07-17 at 14 26 40" src="https://github.com/user-attachments/assets/432f9dd7-97fb-4954-95d9-4e6cb689a15c" />

Notice how there's stuff that I could click here? Well, there's an app called "Homerow" that lets me hit a shortcut and then this appears. 

<img width="1393" height="370" alt="CleanShot 2025-07-17 at 14 26 45" src="https://github.com/user-attachments/assets/da5886d9-59e4-45dd-8364-9c5480e9be47" />

I can then type the two characters to move the mouse and to do the mouse click. This really does wonders because my wrist does not like the trackpad. 

However, the buttons on the sidebar would never really light up. Until now!

<img width="65" height="873" alt="CleanShot 2025-07-17 at 14 30 15" src="https://github.com/user-attachments/assets/b3cebeef-73e4-497e-8ec5-0a558015ca33" />

Major improvement to anyone with a similar wrist issue!