### PR TITLE
Add additional vim keybindings for cell operations

### DIFF
--- a/frontend/src/components/editor/navigation/clipboard.ts
+++ b/frontend/src/components/editor/navigation/clipboard.ts
@@ -99,7 +99,12 @@ export function useCellClipboard() {
     }
   });
 
-  const pasteAtCell = useEvent(async (cellId: CellId) => {
+  interface PasteOptions {
+    before?: boolean;
+  }
+
+  const pasteAtCell = useEvent(async (cellId: CellId, opts?: PasteOptions) => {
+    const { before = false } = opts ?? {};
     try {
       const clipboardItems = await navigator.clipboard.read();
 
@@ -119,12 +124,12 @@ export function useCellClipboard() {
               break;
             }
 
-            // Create new cells with the copied data after the current cell
+            // Create new cells with the copied data before/after the current cell
             const currentCellId = cellId;
             for (const cell of clipboardData.cells) {
               actions.createNewCell({
                 cellId: currentCellId,
-                before: false,
+                before,
                 code: cell.code,
                 autoFocus: false,
               });
@@ -149,7 +154,7 @@ export function useCellClipboard() {
       if (text.trim()) {
         actions.createNewCell({
           cellId,
-          before: false,
+          before,
           code: text,
           autoFocus: true,
         });

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -486,6 +486,30 @@ export function useCellNavigationProps(
           "g g": keymaps["Mod+ArrowUp"],
           "shift+g": keymaps["Mod+ArrowDown"],
           "d d": () => shortcuts["cell.delete"](),
+          "y y": () => {
+            copyCells(selectedCells.size >= 2 ? [...selectedCells] : [cellId]);
+            return true;
+          },
+          p: () => {
+            pasteAtCell(cellId, { before: false });
+            return true;
+          },
+          "shift+p": () => {
+            pasteAtCell(cellId, { before: true });
+            return true;
+          },
+          o: () => {
+            actions.createNewCell({ cellId, before: false, autoFocus: true });
+            return true;
+          },
+          "shift+o": () => {
+            actions.createNewCell({ cellId, before: true, autoFocus: true });
+            return true;
+          },
+          u: () => {
+            actions.undoDeleteCell();
+            return true;
+          },
         })
       ) {
         evt.preventDefault();


### PR DESCRIPTION
Towards #931

Added vim keymaps in command mode:
- `y y` - Copy cell(s)
- `p` - Paste below
- `P` - Paste above
- `o` - Insert cell below
- `O` - Insert cell above
- `u` - Undo cell deletion
