### PR TITLE
Change "cell.delete" hotkey description from "Delete empty cell" to "Delete cell"

### DIFF
--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -198,7 +198,7 @@ const DEFAULT_HOT_KEY = {
     key: "Ctrl-Alt-]",
   },
   "cell.delete": {
-    name: "Delete empty cell",
+    name: "Delete cell",
     group: "Editing",
     key: "Shift-Backspace",
   },


### PR DESCRIPTION
Follow up to #5664. We now support deleting cells destructively using
hotkeys.
