### PR TITLE
fix: prompt user to open invalid files

### DIFF
--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -656,6 +656,39 @@ def extract_offsets_post_colon(
     return start_line, col_offset
 
 
+def is_equal_ast(
+    basis: Optional[Union[ast.expr, list[ast.expr]]],
+    other: Optional[Union[ast.expr, list[ast.expr]]],
+) -> bool:
+    """Compare two AST nodes for equality."""
+    if type(basis) is not type(other):
+        return False
+    elif basis is None or other is None:
+        return basis == other
+    elif isinstance(basis, list):
+        assert isinstance(other, list)
+        if len(basis) != len(other):
+            return False
+        return all(is_equal_ast(a, b) for a, b in zip(basis, other))
+
+    for key, value in vars(basis).items():
+        # Scrub positional data not relevant for comparison.
+        if key in {
+            "lineno",
+            "end_lineno",
+            "col_offset",
+            "end_col_offset",
+            "ctx",
+        }:
+            continue
+        other_value = getattr(other, key, None)
+        if isinstance(value, (ast.expr, list, type(None))):
+            return is_equal_ast(value, other_value)
+        elif value != other_value:
+            return False
+    return True
+
+
 def get_valid_decorator(
     node: CellNode,
 ) -> Optional[Union[ast.Attribute, ast.Call]]:
@@ -780,10 +813,8 @@ def is_cell(node: Optional[Node]) -> bool:
 
 
 def is_run_guard(node: Optional[Node]) -> bool:
-    return bool(
-        node
-        and (node == ast.parse('if __name__ == "__main__": app.run()').body[0])
-    )
+    basis = ast.parse('if __name__ == "__main__": app.run()').body[0]
+    return bool(node and is_equal_ast(basis, node))
 
 
 def parse_notebook(contents: str) -> Optional[NotebookSerialization]:

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -14,7 +14,7 @@ import click
 import marimo._cli.cli_validators as validators
 from marimo import __version__, _loggers
 from marimo._ast import codegen
-from marimo._ast.load import notebook_is_openable
+from marimo._ast.load import get_notebook_status
 from marimo._cli.config.commands import config
 from marimo._cli.convert.commands import convert
 from marimo._cli.development.commands import development
@@ -57,7 +57,7 @@ def helpful_usage_error(self: Any, file: Any = None) -> None:
 
 def check_app_correctness(filename: str) -> None:
     try:
-        notebook_is_openable(filename)
+        status = get_notebook_status(filename)
     except SyntaxError:
         import traceback
 
@@ -69,6 +69,21 @@ def check_app_correctness(filename: str) -> None:
         # SyntaxError: invalid syntax
         click.echo(f"Failed to parse notebook: {filename}\n", err=True)
         raise click.ClickException(traceback.format_exc(limit=0)) from None
+
+    if status == "invalid":
+        if not click.confirm(
+            "The notebook is invalid. Do you want to open it anyway?",
+            default=False,
+            abort=True,
+        ):
+            raise click.ClickException(
+                "The notebook is invalid. Please fix the errors before opening it."
+            )
+    if status == "has_errors":
+        # Provide a warning, but allow the user to open the notebook
+        _loggers.marimo_logger().warning(
+            "This notebook has errors, saving may lose data. Continuing anyway."
+        )
 
 
 click.exceptions.UsageError.show = helpful_usage_error  # type: ignore

--- a/tests/_ast/codegen_data/test_get_codes_messy_toplevel.py
+++ b/tests/_ast/codegen_data/test_get_codes_messy_toplevel.py
@@ -1,8 +1,6 @@
 import marimo
 
-__generated_with = '0.1.0'
 app = marimo.App()
-
 
 # We want a wrapper as a proof of concept. Note, that this will not serialize
 # in this form.
@@ -28,7 +26,3 @@ def fn(a,
 @app.cell
 def wrapped():
     return
-
-
-if __name__ == "__main__":
-    app.run()

--- a/tests/_ast/codegen_data/test_main.py
+++ b/tests/_ast/codegen_data/test_main.py
@@ -1,29 +1,27 @@
-from typing import Any, Tuple
-
 import marimo
 
-__generated_with = "0.1.0"
+__generated_with = "0.14.11"
 app = marimo.App()
 
 
 @app.cell
-def one() -> Tuple[Any]:
-    x = 0
+def one():
+    x: int = 0
     return (x,)
 
 
 @app.cell
-def two(x: Any) -> Tuple[Any, Any]:
-    y = x + 1
-    z = y + 1
+def two(x: int):
+    y: int = x + 1
+    z: int = y + 1
     "z"
-    return y, z
+    return (y,)
 
 
 @app.cell
-def three(x: Any, y: Any) -> Tuple[Any]:
-    a = x + y
-    return (a,)
+def three(x: int, y: int):
+    a: int = x + y
+    return
 
 
 if __name__ == "__main__":

--- a/tests/_ast/test_parse.py
+++ b/tests/_ast/test_parse.py
@@ -16,6 +16,12 @@ def get_filepath(name: str) -> Path:
 # Note that loader should cover these cases and more by proxy.
 class TestParser:
     @staticmethod
+    def test_main() -> None:
+        notebook = parse_notebook(get_filepath("test_main").read_text())
+        # Should just work without any violations.
+        assert len(notebook.violations) == 0
+
+    @staticmethod
     def test_parse_codes() -> None:
         parser = Parser.from_file(get_filepath("test_generate_filecontents"))
         body = parser.node_stack()
@@ -99,6 +105,6 @@ class TestParser:
         assert notebook
         # unexpected statements and a missing run guard
         assert len(notebook.violations) == 3
-        assert "statement" in notebook.violations[0].description
+        assert "generated" in notebook.violations[0].description
         assert "statement" in notebook.violations[1].description
         assert "run guard" in notebook.violations[2].description


### PR DESCRIPTION
## 📝 Summary

Previously, we would just overwrite files if they were not recognized as a marimo file.
Now we ask for confirmation if it is not a valid file

<img width="529" height="74" alt="image" src="https://github.com/user-attachments/assets/a53438ce-a437-496e-b331-1d20f709d5d1" />

Otherwise we show a warning

<img width="874" height="112" alt="image" src="https://github.com/user-attachments/assets/db5b8e7f-57e8-4591-b4dd-b701f1476b18" />

Otherwise continue as normal. Also fixed a comparison bug that meant we never detected the run guard properly.