### PR TITLE
fix: enable cache at top level

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -298,13 +298,13 @@ def get_source_position(
     # Fallback won't capture embedded scripts
     if inspect.isclass(f):
         is_script = f.__module__ == "__main__"
-    # Larger catch all than if inspect.isfunction(f):
-    elif hasattr(f, "__globals__"):
-        is_script = f.__globals__["__name__"] == "__main__"  # type: ignore
     # Could be something wrapped in a decorator, like
     # functools._lru_cache_wrapper.
     elif hasattr(f, "__wrapped__"):
         return get_source_position(f.__wrapped__, lineno, col_offset)
+    # Larger catch all than if inspect.isfunction(f):
+    elif hasattr(f, "__globals__") and hasattr(f, "__name__"):
+        is_script = f.__globals__["__name__"] == "__main__"  # type: ignore
     else:
         return None
     # TODO: spec is None for markdown notebooks, which is fine for now

--- a/marimo/_runtime/context/__init__.py
+++ b/marimo/_runtime/context/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 __all__ = [
     "get_context",
+    "safe_get_context",
     "get_global_context",
     "ContextNotInitializedError",
     "ExecutionContext",
@@ -15,5 +16,6 @@ from marimo._runtime.context.types import (
     get_context,
     get_global_context,
     runtime_context_installed,
+    safe_get_context,
     teardown_context,
 )

--- a/marimo/_runtime/context/types.py
+++ b/marimo/_runtime/context/types.py
@@ -234,6 +234,11 @@ def get_context() -> RuntimeContext:
     return _THREAD_LOCAL_CONTEXT.runtime_context
 
 
+def safe_get_context() -> Optional[RuntimeContext]:
+    """Return the runtime context if it exists, otherwise None."""
+    return _THREAD_LOCAL_CONTEXT.runtime_context
+
+
 def runtime_context_installed() -> bool:
     try:
         get_context()

--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -667,7 +667,7 @@ class BlockHasher:
 
             # State relevant to the context, should be dependent on it's value-
             # not the object.
-            value: Optional[State[Any]]
+            value: Optional[State[Any]] = None
             # Prefer actual object over reference.
             # Skip if the reference has already been subbed in, or if it is
             # a shadowed reference.
@@ -692,6 +692,7 @@ class BlockHasher:
                         scope[state_name] = scope[ref]
 
             # Likewise, UI objects should be dependent on their value.
+            ui: Optional[UIElement[Any, Any]] = None
             if ref in scope and isinstance(scope[ref], UIElement):
                 ui = scope[ref]
             elif ctx:

--- a/tests/_ast/test_cell.py
+++ b/tests/_ast/test_cell.py
@@ -397,6 +397,26 @@ class TestDecoratedCells:
             "add"
         }
 
+    @staticmethod
+    def test_cache_wrapped() -> None:
+        app = App()
+        with app.setup:
+            from marimo import cache
+
+        @app.function
+        @cache
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        # Calling with the same app yields the same runner
+        assert add(1, 2) == 3
+        assert add.hits == 0
+        assert add(1, 2) == 3
+        assert add.hits == 1
+        assert app._cell_manager.get_cell_data_by_name("add").cell.defs == {
+            "add"
+        }
+
 
 def help_smoke() -> None:
     app = App()


### PR DESCRIPTION
## 📝 Summary

fixes #5156

Now

```
from notebook import cached_function

cached_function(...)
```

will work

Did not require the refactor I initially thought, removes get_context dependence which allows import level modules.