### PR TITLE
fix: don't write snapshots on empty session views

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -25,6 +25,7 @@ from uuid import uuid4
 
 from marimo._ast.app_config import _AppConfig
 from marimo._ast.variables import BUILTINS
+from marimo._convert.converters import MarimoConvert
 from marimo._schemas.serialization import (
     AppInstantiation,
     CellDef,
@@ -826,3 +827,6 @@ class InternalApp:
                 options=self._app._config.asdict(),
             ),
         )
+
+    def to_py(self) -> str:
+        return MarimoConvert.from_ir(self.to_ir()).to_py()

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -330,7 +330,8 @@ class PyodideBridge:
     def export_html(self, request: str) -> str:
         parsed = parse_raw(json.loads(request), ExportAsHTMLRequest)
         html, _filename = Exporter().export_as_html(
-            file_manager=self.session.app_manager,
+            app=self.session.app_manager.app,
+            filename=self.session.app_manager.filename,
             session_view=self.session.session_view,
             display_config=self.session._initial_user_config["display"],
             request=parsed,

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -82,7 +82,7 @@ class Exporter:
 
         virtual_files: dict[str, str] = {}
         for filename_and_length in request.files:
-            if filename_and_length.startswith("/@file/"):
+            if "@file/" in filename_and_length:
                 virtual_file = filename_and_length[7:]
                 try:
                     byte_length, basename = virtual_file.split("-", 1)

--- a/marimo/_server/session/serialize.py
+++ b/marimo/_server/session/serialize.py
@@ -440,10 +440,8 @@ class SessionCacheManager:
             return self.session_view
 
         if not self.is_cache_hit(notebook_session, key):
-            LOGGER.debug("Session view cache miss")
+            LOGGER.info("Session view cache miss")
             return self.session_view
 
-        self.session_view = deserialize_session(
-            json.loads(cache_file.read_text())
-        )
+        self.session_view = deserialize_session(notebook_session)
         return self.session_view

--- a/marimo/_server/session/session_view.py
+++ b/marimo/_server/session/session_view.py
@@ -323,6 +323,9 @@ class SessionView:
                 all_ops.extend(messages)
         return all_ops
 
+    def is_empty(self) -> bool:
+        return len(self.cell_operations) == 0
+
     def mark_auto_export_html(self) -> None:
         self.auto_export_state.mark_exported("html")
 

--- a/marimo/_server/session/session_view.py
+++ b/marimo/_server/session/session_view.py
@@ -324,7 +324,10 @@ class SessionView:
         return all_ops
 
     def is_empty(self) -> bool:
-        return len(self.cell_operations) == 0
+        return all(
+            op.output is None and op.console is None
+            for op in self.cell_operations.values()
+        )
 
     def mark_auto_export_html(self) -> None:
         self.auto_export_state.mark_exported("html")

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -742,6 +742,32 @@ class TestApp:
             InternalApp(app).cell_manager.cell_ids()
         )
 
+    def test_to_py(self) -> None:
+        """Test that InternalApp.to_py() returns the Python code representation."""
+        app = App()
+
+        @app.cell
+        def cell_one():
+            x = 1
+            return (x,)
+
+        @app.cell
+        def cell_two(x):
+            y = x + 1
+            return (y,)
+
+        internal_app = InternalApp(app)
+        python_code = internal_app.to_py()
+
+        # Verify it returns a string containing Python code
+        assert isinstance(python_code, str)
+        assert "import marimo" in python_code
+        assert "app = marimo.App(" in python_code
+        assert "x = 1" in python_code
+        assert "y = x + 1" in python_code
+        assert "cell_one" in python_code
+        assert "cell_two" in python_code
+
 
 class TestInvalidSetup:
     @staticmethod

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -11,6 +11,7 @@ import pytest
 
 from marimo import __version__
 from marimo._dependencies.dependencies import DependencyManager
+from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.ops import CellOp
 from marimo._output.utils import uri_encode_component
 from marimo._types.ids import CellId_t, SessionId
@@ -207,7 +208,11 @@ def test_auto_export_html(client: TestClient, temp_marimo_file: str) -> None:
     session.session_view.add_operation(
         CellOp(
             cell_id=CellId_t("new_cell"),
-            output=None,
+            output=CellOutput(
+                data="hello",
+                mimetype="text/plain",
+                channel=CellChannel.OUTPUT,
+            ),
         )
     )
 
@@ -252,6 +257,7 @@ def test_auto_export_html_no_code(
         CellOp(
             cell_id=CellId_t("new_cell"),
             output=None,
+            console=[CellOutput.stdout("hello")],
         )
     )
 

--- a/tests/_server/session/test_session_view.py
+++ b/tests/_server/session/test_session_view.py
@@ -935,6 +935,14 @@ def test_is_empty() -> None:
     # Initially empty
     assert session_view.is_empty()
 
+    # Add a cell operation without output or console
+    session_view.add_operation(
+        CellOp(
+            cell_id=cell_id,
+            status=initial_status,
+        )
+    )
+
     # Add a cell operation
     session_view.add_operation(
         CellOp(

--- a/tests/_server/session/test_session_view.py
+++ b/tests/_server/session/test_session_view.py
@@ -926,3 +926,44 @@ def test_dataset_filter_by_engine_and_variable() -> None:
     session_view.add_operation(Variables(variables=[]))
     table_names = [t.name for t in session_view.datasets.tables]
     assert table_names == ["table_none"]
+
+
+def test_is_empty() -> None:
+    """Test that SessionView.is_empty() correctly detects empty session views."""
+    session_view = SessionView()
+
+    # Initially empty
+    assert session_view.is_empty()
+
+    # Add a cell operation
+    session_view.add_operation(
+        CellOp(
+            cell_id=cell_id,
+            output=initial_output,
+            status=initial_status,
+        )
+    )
+
+    # No longer empty
+    assert not session_view.is_empty()
+
+    # Clear operations by creating a new session view
+    session_view = SessionView()
+    assert session_view.is_empty()
+
+    # Add multiple operations - should still not be empty
+    session_view.add_operation(
+        CellOp(
+            cell_id="cell1",
+            output=initial_output,
+            status="idle",
+        )
+    )
+    session_view.add_operation(
+        CellOp(
+            cell_id="cell2",
+            output=updated_output,
+            status="idle",
+        )
+    )
+    assert not session_view.is_empty()


### PR DESCRIPTION
If session views are empty, just skip writing it. 

Refactor to clean up the args to just pass down the `App` instead of `AppFileManager`