### PR TITLE
Fix `Enter` key handling for delete confirmation button

### DIFF
--- a/frontend/src/components/editor/cell/PendingDeleteConfirmation.tsx
+++ b/frontend/src/components/editor/cell/PendingDeleteConfirmation.tsx
@@ -99,7 +99,13 @@ export const PendingDeleteConfirmation: React.FC<{ cellId: CellId }> = ({
                 Are you sure you want to delete?
               </p>
               <FocusScope autoFocus={true}>
-                <div className="flex items-center gap-2">
+                <div
+                  className="flex items-center gap-2"
+                  onKeyDown={(e) => {
+                    // Stop propagation to prevent Cell's resumeCompletionHandler
+                    e.stopPropagation();
+                  }}
+                >
                   <Button
                     size="xs"
                     variant="ghost"


### PR DESCRIPTION
Prevents Cell's keyboard event handler from intercepting Enter key
presses within the delete confirmation UI. The Cell component's
`resumeCompletionHandler` was refocusing the editor on any keypress,
preventing the Delete button from responding to Enter when focused via
Tab navigation.

<img width=500 src="https://github.com/user-attachments/assets/93d99240-d7f6-46a8-bd06-e299d6be1999">

