### PR TITLE
Properly focus (and unfocus) multi-cell delete confirmation

### DIFF
--- a/frontend/src/components/editor/navigation/multi-cell-action-toolbar.tsx
+++ b/frontend/src/components/editor/navigation/multi-cell-action-toolbar.tsx
@@ -19,6 +19,7 @@ import {
   ZapOffIcon,
 } from "lucide-react";
 import React from "react";
+import { FocusScope } from "react-aria";
 import useEvent from "react-use-event-hook";
 import { MinimalShortcut } from "@/components/shortcuts/renderShortcut";
 import { Button } from "@/components/ui/button";
@@ -357,6 +358,7 @@ const MultiCellPendingDeleteBar: React.FC<{ cellIds: CellId[] }> = ({
 }) => {
   const pendingDeleteService = usePendingDeleteService();
   const deleteCell = useDeleteManyCellsCallback();
+  const selectionActions = useCellSelectionActions();
 
   if (!pendingDeleteService.shouldConfirmDelete) {
     return null;
@@ -380,27 +382,36 @@ const MultiCellPendingDeleteBar: React.FC<{ cellIds: CellId[] }> = ({
                   Are you sure you want to delete?
                 </p>
               </div>
-              <div className="flex items-center gap-2 mt-3">
-                <Button
-                  size="xs"
-                  variant="ghost"
-                  onClick={() => pendingDeleteService.clear()}
-                  className="text-[var(--amber-11)] hover:bg-[var(--amber-4)] hover:text-[var(--amber-11)]"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  size="xs"
-                  variant="secondary"
-                  onClick={() => {
-                    deleteCell({ cellIds });
-                    pendingDeleteService.clear();
+              <FocusScope restoreFocus autoFocus>
+                <div
+                  className="flex items-center gap-2 mt-3"
+                  onKeyDown={(e) => {
+                    // Stop propagation to prevent Cell's resumeCompletionHandler
+                    e.stopPropagation();
                   }}
-                  className="bg-[var(--amber-11)] hover:bg-[var(--amber-12)] text-white border-[var(--amber-11)]"
                 >
-                  Delete
-                </Button>
-              </div>
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    onClick={() => pendingDeleteService.clear()}
+                    className="text-[var(--amber-11)] hover:bg-[var(--amber-4)] hover:text-[var(--amber-11)]"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="xs"
+                    variant="secondary"
+                    onClick={() => {
+                      deleteCell({ cellIds });
+                      pendingDeleteService.clear();
+                      selectionActions.clear();
+                    }}
+                    className="bg-[var(--amber-11)] hover:bg-[var(--amber-12)] text-white border-[var(--amber-11)]"
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </FocusScope>
             </div>
           </div>
         </div>

--- a/frontend/src/components/editor/navigation/multi-cell-action-toolbar.tsx
+++ b/frontend/src/components/editor/navigation/multi-cell-action-toolbar.tsx
@@ -382,7 +382,7 @@ const MultiCellPendingDeleteBar: React.FC<{ cellIds: CellId[] }> = ({
                   Are you sure you want to delete?
                 </p>
               </div>
-              <FocusScope restoreFocus autoFocus>
+              <FocusScope restoreFocus={true} autoFocus={true}>
                 <div
                   className="flex items-center gap-2 mt-3"
                   onKeyDown={(e) => {

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -81,7 +81,6 @@ function useCellFocusProps(cellId: CellId) {
   const focusActions = useCellFocusActions();
   const actions = useCellActions();
   const setTemporarilyShownCode = useSetAtom(temporarilyShownCodeAtom);
-  const pendingDeleteService = usePendingDeleteService();
 
   // This occurs at the cell level and descedants.
   const { focusWithinProps } = useFocusWithin({
@@ -93,7 +92,6 @@ function useCellFocusProps(cellId: CellId) {
       // On blur, hide the code if it was temporarily shown.
       setTemporarilyShownCode(false);
       actions.markTouched({ cellId });
-      pendingDeleteService.clear();
       focusActions.blurCell();
     },
   });


### PR DESCRIPTION
We didn't support focusing the multi-cell deletion confirmation before
with `FocusScope` because `autoFocus` triggered the cells' blur
handlers, which in turn cleared the pending delete state. When
attempting to focus the confirmation UI, blur events from the selected
cells would clear the pending delete service before the dialog could
render.

The fix removes `pendingDeleteService.clear()` from the cell's
`onBlurWithin` handler to prevent premature clearing and wraps the
confirmation buttons in `FocusScope` with `restoreFocus` to
automatically return focus to the previously focused element when the
dialog is dismissed.

([react-aria](https://react-spectrum.adobe.com/react-aria/index.html) / `FocusScope` is really nice quality of life improvement)

<img width=500 src="https://github.com/user-attachments/assets/5bbc4861-8fac-4f31-9c65-f96f833ca1b7">
