### PR TITLE
fix: save button in multi-col notebooks lighting up

### DIFF
--- a/frontend/src/core/cells/__tests__/utils.test.ts
+++ b/frontend/src/core/cells/__tests__/utils.test.ts
@@ -58,9 +58,9 @@ describe("getCellConfigs", () => {
     // Assert the results
     expect(result).toEqual([
       { hide_code: false, disabled: false, column: 0 },
-      { hide_code: true, disabled: false },
+      { hide_code: true, disabled: false, column: null },
       { hide_code: false, disabled: true, column: 1 },
-      { hide_code: true, disabled: true },
+      { hide_code: true, disabled: true, column: null },
     ]);
 
     // Check that the original state was not modified

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1416,6 +1416,9 @@ function updateCellData({
 export function getCellConfigs(state: NotebookState): CellConfig[] {
   const cells = state.cellData;
 
+  // We set to null by default to prevent inconsistencies between undefined & null
+  const defaultCellConfig: Partial<CellConfig> = { column: null };
+
   // Handle the case where there's only one column
   // We don't want to set the column config
   const hasMultipleColumns = state.cellIds.getColumns().length > 1;
@@ -1424,7 +1427,7 @@ export function getCellConfigs(state: NotebookState): CellConfig[] {
       return column.inOrderIds.map((cellId) => {
         return {
           ...cells[cellId].config,
-          column: null,
+          ...defaultCellConfig,
         };
       });
     });
@@ -1432,7 +1435,7 @@ export function getCellConfigs(state: NotebookState): CellConfig[] {
 
   return state.cellIds.getColumns().flatMap((column, columnIndex) => {
     return column.inOrderIds.map((cellId, cellIndex) => {
-      const config: Partial<CellConfig> = { column: undefined };
+      const config: Partial<CellConfig> = { ...defaultCellConfig };
 
       // Only set the column index for the first cell in the column
       if (cellIndex === 0) {


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
<img width="330" height="457" alt="CleanShot 2025-07-19 at 01 43 40@2x" src="https://github.com/user-attachments/assets/579913b9-ab25-4e13-8cfa-dcda2b036e98" />

In multi-col notebooks, we incorrectly detect the notebook as needs saving eventhough it is saved.

The fix is to set column to null by default, reasoning explained previously: #2631 

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
