### PR TITLE
fix: fetch field types for lazy tables

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -41,7 +41,6 @@ from marimo._plugins.ui._impl.tables.selection import (
 )
 from marimo._plugins.ui._impl.tables.table_manager import (
     ColumnName,
-    FieldTypes,
     RowId,
     TableCell,
     TableCoordinate,
@@ -601,7 +600,7 @@ class table(
 
         search_result_styles: Optional[CellStyles] = None
         search_result_data: JSONType = []
-        field_types: Optional[FieldTypes] = None
+        field_types = self._manager.get_field_types()
         num_columns = 0
 
         if not _internal_lazy:
@@ -627,8 +626,6 @@ class table(
             _validate_column_formatting(
                 text_justify_columns, wrapped_columns, column_names_set
             )
-
-            field_types = self._manager.get_field_types()
 
         super().__init__(
             component_name=table._name,

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1744,7 +1744,10 @@ def test_lazy_dataframe() -> None:
         assert table._component_args["data"] == []
         assert table._component_args["total-columns"] == 0
         assert table._component_args["max-columns"] == DEFAULT_MAX_COLUMNS
-        assert table._component_args["field-types"] is None
+        assert table._component_args["field-types"] == [
+            ("col1", ("integer", "i64")),
+            ("col2", ("string", "str")),
+        ]
         assert table._component_args["show-page-size-selector"] is False
         assert table._component_args["show-column-explorer"] is False
         assert table._component_args["show-chart-builder"] is False


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Previously, we did not fetch field_types for lazy tables, which prevented dtypes from being visible. Fetching dtypes shouldn't be expensive, we use `collect_schema` to fetch for lazy df's.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
