### PR TITLE
improvement: add param to show dtypes in table header

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -160,6 +160,7 @@ interface Data<T> {
   showDownload: boolean;
   showFilters: boolean;
   showColumnSummaries: boolean | "stats" | "chart";
+  showDataTypes: boolean;
   showPageSizeSelector: boolean;
   showColumnExplorer: boolean;
   showChartBuilder: boolean;
@@ -225,6 +226,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
       showColumnSummaries: z
         .union([z.boolean(), z.enum(["stats", "chart"])])
         .default(true),
+      showDataTypes: z.boolean().default(true),
       showPageSizeSelector: z.boolean().default(true),
       showColumnExplorer: z.boolean().default(true),
       showChartBuilder: z.boolean().default(true),
@@ -673,6 +675,7 @@ const DataTableComponent = ({
   showPageSizeSelector,
   showColumnExplorer,
   showChartBuilder,
+  showDataTypes,
   rowHeaders,
   fieldTypes,
   paginationState,
@@ -747,8 +750,12 @@ const DataTableComponent = ({
   const memoizedTextJustifyColumns = useDeepCompareMemoize(textJustifyColumns);
   const memoizedWrappedColumns = useDeepCompareMemoize(wrappedColumns);
   const memoizedChartSpecModel = useDeepCompareMemoize(chartSpecModel);
-  const showDataTypes = Boolean(fieldTypes);
   const shownColumns = memoizedClampedFieldTypes.length;
+
+  // If the field types are not set, we don't show them
+  if (!fieldTypes) {
+    showDataTypes = false;
+  }
 
   const columns = useMemo(
     () =>

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -278,6 +278,7 @@ export const DataFrameComponent = memo(
           showFilters={false}
           search={search}
           showColumnSummaries={false}
+          showDataTypes={true}
           get_column_summaries={getColumnSummaries}
           showPageSizeSelector={(total_rows && total_rows > 5) || false}
           showColumnExplorer={false}

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -315,6 +315,8 @@ class table(
         show_column_summaries (Union[bool, Literal["stats", "chart"]], optional): Whether to show column summaries.
             Defaults to True when the table has less than 40 columns and at least 10 rows, False otherwise.
             If "stats", only show stats. If "chart", only show charts.
+        show_data_types (bool, optional): Whether to show data types of columns in the table header.
+            Defaults to True.
         show_download (bool, optional): Whether to show the download button.
             Defaults to True for dataframes, False otherwise.
         format_mapping (Dict[str, Union[str, Callable[..., Any]]], optional): A mapping from
@@ -409,6 +411,7 @@ class table(
         show_column_summaries: Optional[
             Union[bool, Literal["stats", "chart"]]
         ] = None,
+        show_data_types: bool = True,
         format_mapping: Optional[
             dict[str, Union[str, Callable[..., Any]]]
         ] = None,
@@ -650,6 +653,7 @@ class table(
                 "show-download": show_download
                 and self._manager.supports_download(),
                 "show-column-summaries": show_column_summaries,
+                "show-data-types": show_data_types,
                 "show-page-size-selector": show_page_size_selector,
                 "show-column-explorer": show_column_explorer,
                 "show-chart-builder": show_chart_builder,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #2902 . Pass a `show_data_types` param in mo.ui.table() to control display of dtypes.

<img width="894" height="431" alt="CleanShot 2025-07-19 at 10 15 10@2x" src="https://github.com/user-attachments/assets/8835c0a7-ea00-4552-80c5-a9845369ed66" />

If we are not keen to add another param, we could make this a global config instead.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
