### PR TITLE
fix: show dtypes for idexes in tables

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -53,7 +53,6 @@ import { Button } from "@/components/ui/button";
 import { DelayMount } from "@/components/utils/delay-mount";
 import { type CellId, findCellId } from "@/core/cells/ids";
 import { getFeatureFlag } from "@/core/config/feature-flag";
-import { DATA_TYPES } from "@/core/kernel/messages";
 import { slotsController } from "@/core/slots/slots";
 import { store } from "@/core/state/jotai";
 import { isStaticNotebook } from "@/core/static/static-state";
@@ -72,7 +71,11 @@ import { createPlugin } from "../core/builder";
 import { rpc } from "../core/rpc";
 import { Banner } from "./common/error-banner";
 import { Labeled } from "./common/labeled";
-import { ConditionSchema, type ConditionType } from "./data-frames/schema";
+import {
+  ConditionSchema,
+  type ConditionType,
+  columnToFieldTypesSchema,
+} from "./data-frames/schema";
 
 type CsvURL = string;
 export type TableData<T> = T[] | CsvURL;
@@ -163,7 +166,7 @@ interface Data<T> {
   showPageSizeSelector: boolean;
   showColumnExplorer: boolean;
   showChartBuilder: boolean;
-  rowHeaders: string[];
+  rowHeaders: FieldTypesWithExternalType;
   fieldTypes?: FieldTypesWithExternalType | null;
   freezeColumnsLeft?: string[];
   freezeColumnsRight?: string[];
@@ -228,21 +231,14 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
       showPageSizeSelector: z.boolean().default(true),
       showColumnExplorer: z.boolean().default(true),
       showChartBuilder: z.boolean().default(true),
-      rowHeaders: z.array(z.string()),
+      rowHeaders: columnToFieldTypesSchema,
       freezeColumnsLeft: z.array(z.string()).optional(),
       freezeColumnsRight: z.array(z.string()).optional(),
       textJustifyColumns: z
         .record(z.enum(["left", "center", "right"]))
         .optional(),
       wrappedColumns: z.array(z.string()).optional(),
-      fieldTypes: z
-        .array(
-          z.tuple([
-            z.coerce.string(),
-            z.tuple([z.enum(DATA_TYPES), z.string()]),
-          ]),
-        )
-        .nullish(),
+      fieldTypes: columnToFieldTypesSchema.nullish(),
       totalColumns: z.number(),
       maxColumns: z.union([z.number(), z.literal("all")]).default("all"),
       hasStableRowId: z.boolean().default(false),

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -8,7 +8,6 @@ import type { FieldTypesWithExternalType } from "@/components/data-table/types";
 import { ReadonlyCode } from "@/components/editor/code/readonly-python-code";
 import { Spinner } from "@/components/icons/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { DATA_TYPES } from "@/core/kernel/messages";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { createPlugin } from "@/plugins/core/builder";
 import { rpc } from "@/plugins/core/rpc";
@@ -21,6 +20,7 @@ import { TransformPanel } from "./panel";
 import {
   ConditionSchema,
   type ConditionType,
+  columnToFieldTypesSchema,
   type Transformations,
 } from "./schema";
 import type { ColumnDataTypes, ColumnId } from "./types";
@@ -45,7 +45,7 @@ type PluginFunctions = {
   get_dataframe: (req: {}) => Promise<{
     url: string;
     total_rows: number;
-    row_headers: string[];
+    row_headers: FieldTypesWithExternalType;
     field_types: FieldTypesWithExternalType | null;
     python_code?: string | null;
     sql_code?: string | null;
@@ -94,10 +94,8 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
       z.object({
         url: z.string(),
         total_rows: z.number(),
-        row_headers: z.array(z.string()),
-        field_types: z.array(
-          z.tuple([z.string(), z.tuple([z.enum(DATA_TYPES), z.string()])]),
-        ),
+        row_headers: columnToFieldTypesSchema,
+        field_types: columnToFieldTypesSchema,
         python_code: z.string().nullish(),
         sql_code: z.string().nullish(),
       }),

--- a/frontend/src/plugins/impl/data-frames/schema.ts
+++ b/frontend/src/plugins/impl/data-frames/schema.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { FieldOptions, randomNumber } from "@/components/forms/options";
+import { DATA_TYPES } from "@/core/kernel/messages";
 import {
   AGGREGATION_FNS,
   type ColumnId,
@@ -12,6 +13,10 @@ import {
   isConditionValueValid,
   type OperatorType,
 } from "./utils/operators";
+
+export const columnToFieldTypesSchema = z.array(
+  z.tuple([z.coerce.string(), z.tuple([z.enum(DATA_TYPES), z.string()])]),
+);
 
 export const column_id = z
   .string()

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -49,9 +49,9 @@ from marimo._utils.parse_dataclass import parse_raw
 class GetDataFrameResponse:
     url: str
     total_rows: Union[int, Literal["too_many"]]
-    # List of column names that are actually row headers
+    # Columns that are actually row headers
     # This really only applies to Pandas, that has special index columns
-    row_headers: list[str]
+    row_headers: FieldTypes
     field_types: FieldTypes
     python_code: Optional[str] = None
     sql_code: Optional[str] = None

--- a/marimo/_plugins/ui/_impl/tables/default_table.py
+++ b/marimo/_plugins/ui/_impl/tables/default_table.py
@@ -256,7 +256,7 @@ class DefaultTableManager(TableManager[JsonTableData]):
             ]
         )
 
-    def get_row_headers(self) -> list[str]:
+    def get_row_headers(self) -> FieldTypes:
         return []
 
     @functools.lru_cache(maxsize=5)  # noqa: B019

--- a/marimo/_plugins/ui/_impl/tables/ibis_table.py
+++ b/marimo/_plugins/ui/_impl/tables/ibis_table.py
@@ -18,6 +18,7 @@ from marimo._plugins.ui._impl.tables.polars_table import (
 from marimo._plugins.ui._impl.tables.table_manager import (
     ColumnName,
     FieldType,
+    FieldTypes,
     TableCell,
     TableCoordinate,
     TableManager,
@@ -88,9 +89,7 @@ class IbisTableManagerFactory(TableManagerFactory):
             ) -> TableManager[ibis.Table]:
                 return IbisTableManager(self.data.drop(columns))
 
-            def get_row_headers(
-                self,
-            ) -> list[str]:
+            def get_row_headers(self) -> FieldTypes:
                 return []
 
             @staticmethod

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -22,6 +22,7 @@ from marimo._plugins.ui._impl.tables.selection import INDEX_COLUMN_NAME
 from marimo._plugins.ui._impl.tables.table_manager import (
     ColumnName,
     FieldType,
+    FieldTypes,
     TableCell,
     TableCoordinate,
     TableManager,
@@ -155,9 +156,7 @@ class NarwhalsTableManager(
     def drop_columns(self, columns: list[str]) -> TableManager[Any]:
         return self.with_new_data(self.data.drop(columns, strict=False))
 
-    def get_row_headers(
-        self,
-    ) -> list[str]:
+    def get_row_headers(self) -> FieldTypes:
         return []
 
     @functools.lru_cache(maxsize=5)  # noqa: B019

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -130,7 +130,7 @@ class TableManager(abc.ABC, Generic[T]):
         pass
 
     @abc.abstractmethod
-    def get_row_headers(self) -> list[str]:
+    def get_row_headers(self) -> FieldTypes:
         pass
 
     @abc.abstractmethod

--- a/marimo/_smoke_tests/df_index.py
+++ b/marimo/_smoke_tests/df_index.py
@@ -1,11 +1,11 @@
 import marimo
 
-__generated_with = "0.9.15"
+__generated_with = "0.14.12"
 app = marimo.App(width="medium")
 
 
 @app.cell
-def __():
+def _():
     import marimo as mo
     import pandas as pd
     import numpy as np
@@ -13,21 +13,21 @@ def __():
 
 
 @app.cell
-def __(np):
+def _(np):
     data = np.random.randn(100, 2)
     columns = ["A", "B"]
     return columns, data
 
 
 @app.cell
-def __(columns, data, pd):
+def _(columns, data, pd):
     df_no_index = pd.DataFrame(data, columns=columns)
     df_no_index
-    return (df_no_index,)
+    return
 
 
 @app.cell
-def __(columns, data, pd):
+def _(columns, data, pd):
     _dates = pd.date_range(start="2023-01-01", periods=100, freq="D")
     df_date_index = pd.DataFrame(data, index=_dates, columns=columns)
     df_date_index
@@ -35,33 +35,39 @@ def __(columns, data, pd):
 
 
 @app.cell
-def __(columns, data, pd):
+def _(columns, data, pd):
     _dates = pd.date_range(start="2023-01-01", periods=100, freq="D")
     df_date_index_with_name = pd.DataFrame(
         data, index=pd.DatetimeIndex(_dates, name="date"), columns=columns
     )
     df_date_index_with_name
-    return (df_date_index_with_name,)
+    return
 
 
 @app.cell
-def __(columns, data, pd):
+def _(columns, data, pd):
     _dates = pd.date_range(start="2023-01-01", periods=100, freq="D")
     df_category_index = pd.DataFrame(
         data, index=pd.CategoricalIndex(_dates), columns=columns
     )
     df_category_index
-    return (df_category_index,)
+    return
 
 
 @app.cell
-def __(columns, data, pd):
+def _(columns, data, pd):
     index = pd.MultiIndex.from_tuples(
         [(i, j) for i in range(5) for j in range(2)], names=["Level1", "Level2"]
     )
     df_multi_index = pd.DataFrame(data[:10], index=index, columns=columns)
     df_multi_index
-    return df_multi_index, index
+    return
+
+
+@app.cell
+def _(df_date_index, mo):
+    mo.ui.dataframe(df_date_index)
+    return
 
 
 if __name__ == "__main__":

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -375,7 +375,9 @@ class TestPandasTableManager(unittest.TestCase):
             index=pd.to_datetime(["2021-01-01", "2021-06-01", "2021-09-01"]),
         )
         manager = self.factory.create()(data)
-        assert manager.get_row_headers() == [""]
+        assert manager.get_row_headers() == [
+            ("", ("datetime", "datetime64[ns]"))
+        ]
 
     def test_get_row_headers_timedelta_index(self) -> None:
         data = pd.DataFrame(
@@ -387,7 +389,9 @@ class TestPandasTableManager(unittest.TestCase):
             index=pd.to_timedelta(["1 days", "2 days", "3 days"]),
         )
         manager = self.factory.create()(data)
-        assert manager.get_row_headers() == [""]
+        assert manager.get_row_headers() == [
+            ("", ("string", "timedelta64[ns]"))
+        ]
 
     def test_get_row_headers_multi_index(self) -> None:
         data = pd.DataFrame(
@@ -401,7 +405,10 @@ class TestPandasTableManager(unittest.TestCase):
             ),
         )
         manager = self.factory.create()(data)
-        assert manager.get_row_headers() == ["X", "Y"]
+        assert manager.get_row_headers() == [
+            ("X", ("string", "object")),
+            ("Y", ("integer", "int64")),
+        ]
 
     def test_is_type(self) -> None:
         assert self.manager.is_type(self.data)
@@ -1060,7 +1067,10 @@ class TestPandasTableManager(unittest.TestCase):
             index=[["a", "a", "b", "b"], [1, 2, 1, 2]],
         )
         manager = self.factory.create()(df)
-        assert manager.get_row_headers() == ["", ""]
+        assert manager.get_row_headers() == [
+            ("", ("string", "object")),
+            ("", ("integer", "int64")),
+        ]
         assert manager.get_num_rows() == 4
 
     def test_get_field_types_with_datetime(self):


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

With named index:
<img width="940" height="281" alt="CleanShot 2025-07-19 at 16 18 40@2x" src="https://github.com/user-attachments/assets/343990c4-8758-4975-8fcd-fb96382bf5be" />

Unnamed index:
<img width="978" height="220" alt="CleanShot 2025-07-19 at 16 21 46@2x" src="https://github.com/user-attachments/assets/7b0d7c0b-36e9-4835-9f81-a399394c99f8" />

Fixes: #5524 . This surfaces dtypes for indexes in tables, thereby we can render it correctly if the index is of a particular type.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
