### PR TITLE
Hide vim cursor(s) when in command mode

### DIFF
--- a/frontend/src/core/codemirror/vim/cursor-visibility.ts
+++ b/frontend/src/core/codemirror/vim/cursor-visibility.ts
@@ -1,6 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import type { EditorView, PluginValue } from "@codemirror/view";
+import { isAnyCellFocused } from "@/components/editor/navigation/focus-utils";
 
 let lastFocusedEditorRef: WeakRef<EditorView> | null = null;
 
@@ -40,8 +41,14 @@ export class VimCursorVisibilityPlugin implements PluginValue {
   update() {
     const vimCursorLayer = this.view.dom.querySelector(".cm-vimCursorLayer");
     if (vimCursorLayer instanceof HTMLElement) {
-      const isLastFocused = lastFocusedEditorRef?.deref() === this.view;
-      vimCursorLayer.style.display = isLastFocused ? "" : "none";
+      // Hide all vim cursors when in command mode
+      if (isAnyCellFocused()) {
+        vimCursorLayer.style.display = "none";
+      } else {
+        // Show cursor only in the last focused editor when in edit mode
+        const isLastFocused = lastFocusedEditorRef?.deref() === this.view;
+        vimCursorLayer.style.display = isLastFocused ? "" : "none";
+      }
     }
   }
 


### PR DESCRIPTION
#5457 addressed multiple visible cursors with Vim bindings using the last focused editor, but modal editing #5614 introduced new states we didn't account for. This lead to awkward multiple cursors states based on where command mode was entered and exited.

This PR ensures vim block cursors are hidden entirely while in command mode, deferring to blue ring as the indicator of "selected". I find it much less distracting.

**Before**
<img src="https://github.com/user-attachments/assets/58e17414-88ad-4823-9455-f088850aa3ca" width=500>

**After**

<img src="https://github.com/user-attachments/assets/f8a892bb-40d1-4fd2-b753-dd8da5fce95f" width=500>
