### PR TITLE
fix: lsp lensing

### DIFF
--- a/frontend/src/core/codemirror/copilot/__tests__/getCodes.test.ts
+++ b/frontend/src/core/codemirror/copilot/__tests__/getCodes.test.ts
@@ -91,6 +91,47 @@ describe("getTopologicalCellIds", () => {
     // Assert the result
     expect(result).toEqual(["cell1", "cell2", "cell3", "cell4"]);
   });
+
+  it("should return sorted basic cell ids", () => {
+    const cellIds = [Cells.cell1, Cells.cell2];
+    // Cell 1:
+    // mo.
+
+    // Cell 2:
+    // import marimo as mo
+
+    let result = getTopologicalCellIds(cellIds, {
+      [Variables.var1]: {
+        name: Variables.var1,
+        declaredBy: [Cells.cell2],
+        usedBy: [Cells.cell1],
+      },
+    });
+    expect(result).toEqual(["cell2", "cell1"]);
+
+    // Swap them around
+    result = getTopologicalCellIds([Cells.cell2, Cells.cell1], {
+      [Variables.var1]: {
+        name: Variables.var1,
+        declaredBy: [Cells.cell2],
+        usedBy: [Cells.cell1],
+      },
+    });
+    expect(result).toEqual(["cell2", "cell1"]);
+  });
+
+  it("should put new cells (with no dependencies) at the end", () => {
+    const cellIds = [Cells.cell1, Cells.cell2, Cells.cell3, Cells.cell4];
+    const variables: Variables = {
+      [Variables.var1]: {
+        name: Variables.var1,
+        declaredBy: [Cells.cell2],
+        usedBy: [Cells.cell3],
+      },
+    };
+    const result = getTopologicalCellIds(cellIds, variables);
+    expect(result).toEqual(["cell2", "cell1", "cell3", "cell4"]);
+  });
 });
 
 describe("getCodes", () => {

--- a/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
+++ b/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
@@ -37,6 +37,24 @@ describe("createNotebookLens", () => {
     expect(transformed.character).toBe(0);
   });
 
+  it("order of code should not matter", () => {
+    const cellIds: CellId[] = [Cells.cell1, Cells.cell2];
+    let codes: Record<CellId, string> = {
+      [Cells.cell1]: "before\ntext",
+      [Cells.cell2]: "cell1\ncell2",
+    };
+    let lens = createNotebookLens(cellIds, codes);
+    expect(lens.mergedText).toBe("before\ntext\ncell1\ncell2");
+
+    // Swap them around
+    codes = {
+      [Cells.cell2]: "cell1\ncell2",
+      [Cells.cell1]: "before\ntext",
+    };
+    lens = createNotebookLens(cellIds, codes);
+    expect(lens.mergedText).toBe("before\ntext\ncell1\ncell2");
+  });
+
   it("should transform ranges to merged doc", () => {
     const cellIds: CellId[] = [Cells.cell1, Cells.cell2];
     const codes: Record<CellId, string> = {

--- a/frontend/src/core/codemirror/lsp/lens.ts
+++ b/frontend/src/core/codemirror/lsp/lens.ts
@@ -55,7 +55,7 @@ export function createNotebookLens(
     return cellLineOffsets.get(cellId) ?? 0;
   }
 
-  const mergedText = Object.values(codes).join("\n");
+  const mergedText = sortedCellIds.map((cellId) => codes[cellId]).join("\n");
 
   return {
     cellIds: sortedCellIds,


### PR DESCRIPTION
Fixes #5549

This fixes 2 bugs:

1. the LSP lensings was incorrect. The cellIds were ordered, but the text was not. This led to incorrect hover and completions.
2. the topological sort was correct but not as optimal. We now put cells without deps (likely a new cell) at the bottom. This will solve the case for:
	a. `import marimo as mo`
    b. add a cell above
    c. `mo.<completion>`