### PR TITLE
fix: windows paths for persistent cache

### DIFF
--- a/marimo/_save/loaders/loader.py
+++ b/marimo/_save/loaders/loader.py
@@ -190,8 +190,8 @@ class BasePersistenceLoader(Loader):
             except ContextNotInitializedError:
                 self.store = DEFAULT_STORE()
 
-        # Replace all non-alphanumeric characters in the name with underscores
-        self.name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+        # Limited character set for path for windows compatibility
+        self.name = re.sub(r"[^a-zA-Z0-9 _-]", "_", name)
         self.suffix = suffix
 
     def build_path(self, key: HashKey) -> Path:


### PR DESCRIPTION
## 📝 Summary

Unit tests broke on window 3.9 because toplevel cached functions utilized an invalid path name.

Tests already included (and now hopefully passing!)