### PR TITLE
Add hotkey to toggle minimap (`Mod-Shift-i`)

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/minimap.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/minimap.tsx
@@ -9,6 +9,7 @@ import { cellFocusAtom, useCellFocusActions } from "@/core/cells/focus";
 import type { CellId } from "@/core/cells/ids";
 import { useVariables } from "@/core/variables/state";
 import type { VariableName } from "@/core/variables/types";
+import { useHotkey } from "@/hooks/useHotkey";
 import { cn } from "@/utils/cn";
 import { useChromeActions, useChromeState } from "../state";
 import {
@@ -186,8 +187,9 @@ const MinimapInternal: React.FC<{
 };
 
 export const Minimap: React.FC = () => {
-  const { setIsMinimapOpen } = useChromeActions();
+  const { setIsMinimapOpen, toggleMinimap } = useChromeActions();
   const { isMinimapOpen } = useChromeState();
+  useHotkey("global.toggleMinimap", () => toggleMinimap());
   return <MinimapInternal open={isMinimapOpen} setOpen={setIsMinimapOpen} />;
 };
 

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -349,6 +349,11 @@ const DEFAULT_HOT_KEY = {
     group: "Editing",
     key: "Mod-Shift-/",
   },
+  "global.toggleMinimap": {
+    name: "Toggle Minimap",
+    group: "Other",
+    key: "Mod-Shift-i",
+  },
 
   // Global Navigation
   "global.focusTop": {


### PR DESCRIPTION
We avoided `Mod-m` (doesn't work Safari), `Mod-Shift-m` (taken for markdown), and `Mod-Shift-n` (browser override for new incognito). The "i" wasn't taken and very loosely stands for "inspect".
