### PR TITLE
Ensure cell connections render above unselected cells in minimap

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/minimap.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/minimap.tsx
@@ -94,7 +94,8 @@ const MinimapCell: React.FC<MinimapCellProps> = (props) => {
       </div>
       <svg
         className={cn(
-          "absolute z-20 overflow-visible top-[10.5px] left-[calc(var(--spacing-extra-small,8px)_+_17px)] pointer-events-none",
+          "absolute overflow-visible top-[10.5px] left-[calc(var(--spacing-extra-small,8px)_+_17px)] pointer-events-none",
+          isSelected ? "z-30" : "z-20",
           runtime.errored
             ? "text-destructive"
             : selectedCellId === null


### PR DESCRIPTION
The minimap renders connection paths between cells to visualize dependencies, but all SVG elements were at the same z-index level. This caused visual issues where unselected cell indicators could overlap and obscure the selected cell's connection paths.
