### PR TITLE
Remove global `hatch` CLI as required development dependency

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -44,8 +44,8 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: 🥚 Install Hatch
-        uses: pypa/hatch@install
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
 
       # patch __init__.py version to be of the form
       # X.Y.<Z+1>-dev{n-commits-since-last-tag}
@@ -64,19 +64,19 @@ jobs:
           sed -i "s/__version__ = \".*\"/__version__ = \"$MARIMO_VERSION\"/" marimo/__init__.py
 
       - name: 📦 Build marimo
-        run: hatch build
+        run: uv build
 
       - name: 📤 Upload to TestPyPI (marimo)
         env:
           HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_USER }}
           HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_PASSWORD }}
-        run: hatch publish --repo test
+        run: uvx hatch publish --repo test
 
       - name: Adapt pyproject.toml to build marimo-base
         run: ./scripts/modify_pyproject_for_marimo_base.sh
 
       - name: 📦 Build marimo
-        run: hatch build --clean
+        run: uv build
 
       - name: 📦 Validate wheel under 2mb
         run: ./scripts/validate_base_wheel_size.sh
@@ -85,7 +85,7 @@ jobs:
         env:
           HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_USER }}
           HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_MARIMO_BASE_PASSWORD }}
-        run: hatch publish --repo test
+        run: uvx hatch publish --repo test
 
       - name: 📦 Update package.json version from CLI
         working-directory: frontend

--- a/.github/workflows/marimo-bot.yml
+++ b/.github/workflows/marimo-bot.yml
@@ -88,8 +88,8 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
-      - name: 🥚 Install Hatch
-        uses: pypa/hatch@install
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
 
       - name: Adapt pyproject.toml to build marimo-base
         run: ./scripts/modify_pyproject_for_marimo_base.sh
@@ -112,7 +112,7 @@ jobs:
           sed -i "s/__version__ = \".*\"/__version__ = \"$MARIMO_VERSION\"/" marimo/__init__.py
 
       - name: 📦 Build marimo
-        run: hatch build --clean
+        run: uv build
 
       - name: 📦 Validate wheel under 2mb
         run: ./scripts/validate_base_wheel_size.sh
@@ -121,7 +121,7 @@ jobs:
         env:
           HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_USER }}
           HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_MARIMO_BASE_PASSWORD }}
-        run: hatch publish --repo test
+        run: uvx hatch publish --repo test
 
       - name: 📦 Update package.json version from CLI
         working-directory: frontend

--- a/.github/workflows/release-marimo-base.yml
+++ b/.github/workflows/release-marimo-base.yml
@@ -28,14 +28,14 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
 
-      - name: 🥚 Install Hatch
-        uses: pypa/hatch@install
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
 
       - name: Adapt pyproject.toml to build marimo-base
         run: ./scripts/modify_pyproject_for_marimo_base.sh
 
       - name: 📦 Build marimo-base
-        run: hatch build --clean
+        run: uv build
 
       - name: 📦 Validate wheel under 2mb
         run: ./scripts/validate_base_wheel_size.sh
@@ -44,10 +44,10 @@ jobs:
         env:
           HATCH_INDEX_USER: ${{ secrets.PYPI_USER }}
           HATCH_INDEX_AUTH: ${{ secrets.PYPI_MARIMO_BASE_PASSWORD }}
-        run: hatch publish
+        run: uvx hatch publish
 
       - name: 📤 Upload to TestPyPI
         env:
           HATCH_INDEX_USER: ${{ secrets.TEST_PYPI_USER }}
           HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_MARIMO_BASE_PASSWORD }}
-        run: hatch publish --repo test
+        run: uvx hatch publish --repo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,22 +48,22 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: 🥚 Install Hatch
-        uses: pypa/hatch@install
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
 
       - name: 📦 Build marimo
-        run: hatch build
+        run: uv build
 
       - name: 📤 Upload to PyPI
         env:
           HATCH_INDEX_USER: ${{ secrets.PYPI_USER }}
           HATCH_INDEX_AUTH: ${{ secrets.PYPI_PASSWORD }}
-        run: hatch publish
+        run: uvx hatch publish
 
       - name: 🔨 Get version
         id: get_version
         run: |
-          echo "marimo_version=$(hatch version)" >> $GITHUB_OUTPUT
+          echo "marimo_version=$(uvx hatch version)" >> $GITHUB_OUTPUT
 
       - name: 📦 Update package.json version from CLI
         working-directory: frontend

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -40,11 +40,11 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
 
-      - name: ⬇️ Install Hatch
-        uses: pypa/hatch@install
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
 
       - name: 📚 Build docs
-        run: hatch run docs:build --strict
+        run: uvx hatch run docs:build --strict
 
   test_python:
     needs: changes
@@ -95,8 +95,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: 🥚 Install Hatch
-        uses: pypa/hatch@install
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
 
       # This step is needed since some of our tests rely on the index.html file
       - name: Create assets directory, copy over index.html
@@ -107,23 +107,23 @@ jobs:
 
       - name: Lint
         if: ${{ matrix.python-version == '3.12' }}
-        run: hatch run lint
+        run: uvx hatch run lint
 
       - name: Typecheck
         if: ${{ matrix.python-version == '3.12' }}
-        run: hatch run typecheck:check
+        run: uvx hatch run typecheck:check
 
       # Test with minimal dependencies
       - name: Test with minimal dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |
-          hatch run +py=${{ matrix.python-version }} test:test -v tests/ -k "not test_cli" --durations=10
+          uvx hatch run +py=${{ matrix.python-version }} test:test -v tests/ -k "not test_cli" --durations=10
 
       # Test with optional dependencies
       - name: Test with optional dependencies
         if: ${{ matrix.dependencies == 'core,optional' }}
         run: |
-          hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli" --durations=10
+          uvx hatch run +py=${{ matrix.python-version }} test-optional:test -v tests/ -k "not test_cli" --durations=10
 
   # Only run coverage on `main` so it is not blocking
   test_coverage:
@@ -138,8 +138,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: 🥚 Install Hatch
-        uses: pypa/hatch@install
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
 
       # This step is needed since some of our tests rely on the index.html file
       - name: Create assets directory, copy over index.html
@@ -150,7 +150,7 @@ jobs:
 
       - name: Test with optional dependencies
         run: |
-          hatch run +py=3.12 test-optional:test -v tests/ -k "not test_cli" --durations=10 \
+          uvx hatch run +py=3.12 test-optional:test -v tests/ -k "not test_cli" --durations=10 \
           --cov=marimo --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       # Only upload coverage on `main` so it is not blocking

--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -58,11 +58,11 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           NODE_OPTIONS: '--max_old_space_size=8192'
 
-      - name: 🥚 Install Hatch
-        uses: pypa/hatch@install
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v6
 
       - name: 📦 Build marimo wheel
-        run: hatch build -t wheel
+        run: uv build --wheel
 
       - name: Check for _static/_lsp directory in wheel
         run: |

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ check-prereqs:
 	@command -v pnpm >/dev/null 2>&1 || { echo "pnpm is required. See https://pnpm.io/installation"; exit 1; }
 	@pnpm -v | grep -vq "^[0-8]\." || { echo "pnpm v9+ is required. Current version: $(shell pnpm -v)"; exit 1; }
 	@command -v uv >/dev/null 2>&1 || { echo "uv is required. See https://docs.astral.sh/uv/getting-started/installation/"; exit 1; }
-	@command -v hatch >/dev/null 2>&1 || { echo "hatch is required. See https://hatch.pypa.io/dev/install/"; exit 1; }
 	@command -v node >/dev/null 2>&1 || { echo "Node.js is required. See https://nodejs.org/en/download/"; exit 1; }
 	@node -v | grep -q "v2[0-9]" || { echo "Node.js v20+ is required. Current version: $(shell node -v)"; exit 1; }
 	@echo "✅ All prerequisites are installed!"
@@ -90,7 +89,7 @@ e2e:
 .PHONY: fe-lint
 # 🧹 Lint frontend
 fe-lint:
-	cd frontend/src && hatch run typos && cd - && pnpm --filter @marimo-team/frontend lint
+	cd frontend/src && uvx hatch run typos && cd - && pnpm --filter @marimo-team/frontend lint
 
 .PHONY: fe-typecheck
 # 🔍 Typecheck frontend
@@ -112,18 +111,18 @@ py-check:
 .PHONY: typos
 # 🔍 Check for typos
 typos:
-	hatch run typos
+	uvx hatch run typos
 
 .PHONY: py-test
 # 🧪 Test python
 py-test:
 	@command -v hatch >/dev/null 2>&1 || { echo "hatch is required. See https://hatch.pypa.io/dev/install/"; exit 1; }
-	hatch run typos && hatch run +py=3.12 test-optional:test $(ARGS)
+	uvx hatch run typos && hatch run +py=3.12 test-optional:test $(ARGS)
 
 .PHONY: py-snapshots
 # 📸 Update snapshots
 py-snapshots:
-	hatch run +py=3.12 test:test \
+	uvx hatch run +py=3.12 test:test \
 		tests/_server/templates/test_templates.py \
 		tests/_server/api/endpoints/test_export.py \
 		tests/test_api.py
@@ -135,7 +134,7 @@ py-snapshots:
 .PHONY: wheel
 # 📦 Build wheel
 wheel:
-	hatch build
+	uv build
 
 
 #################
@@ -145,12 +144,12 @@ wheel:
 .PHONY: docs
 # 📚 Build docs
 docs:
-	hatch run docs:build
+	uvx hatch run docs:build
 
 .PHONY: docs-serve
 # 📚 Serve docs
 docs-serve:
-	hatch run docs:serve
+	uvx hatch run docs:serve
 
 .PHONY: storybook
 # 🧩 Start Storybook for UI development


### PR DESCRIPTION
Simplifies the development toolchain by removing the requirement to install `hatch` separately. Devs are still free to install hatch CLI directly (`uv tool install hatch`), but not required.

All hatch commands can now run through `uvx hatch`, and building uses `uv build` directly. This reduces the number of tools required for developers install. 