### PR TITLE
Add text wrapping toggle for console output

### DIFF
--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -47,8 +47,9 @@ export const OutputRenderer: React.FC<{
   message: Pick<OutputMessage, "channel" | "data" | "mimetype">;
   cellId?: CellId;
   onRefactorWithAI?: (opts: { prompt: string }) => void;
+  wrapText?: boolean;
 }> = memo((props) => {
-  const { message, onRefactorWithAI, cellId } = props;
+  const { message, onRefactorWithAI, cellId, wrapText } = props;
   const { theme } = useTheme();
 
   // Memoize parsing the json data
@@ -85,7 +86,7 @@ export const OutputRenderer: React.FC<{
         typeof data === "string",
         `Expected string data for mime=${mimetype}. Got ${typeof data}`,
       );
-      return <TextOutput channel={channel} text={data} />;
+      return <TextOutput channel={channel} text={data} wrapText={wrapText} />;
 
     case "application/json":
       // TODO: format is 'auto', but should make configurable once cells can

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -1,8 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import { AnsiUp } from "ansi_up";
-import { ChevronRightIcon } from "lucide-react";
+import { ChevronRightIcon, WrapTextIcon } from "lucide-react";
 import React, { useLayoutEffect } from "react";
+import { ToggleButton, Tooltip, TooltipTrigger } from "react-aria-components";
 import { DebuggerControls } from "@/components/debugger/debugger-code";
 import { Input } from "@/components/ui/input";
 import type { CellId } from "@/core/cells/ids";
@@ -15,6 +16,7 @@ import { invariant } from "@/utils/invariant";
 import { NameCellContentEditable } from "../actions/name-cell-input";
 import { ErrorBoundary } from "../boundary/ErrorBoundary";
 import { OutputRenderer } from "../Output";
+import { useWrapText } from "./useWrapText";
 
 const ansiUp = new AnsiUp();
 
@@ -40,6 +42,7 @@ export const ConsoleOutput = (props: Props) => {
 
 const ConsoleOutputInternal = (props: Props): React.ReactNode => {
   const ref = React.useRef<HTMLDivElement>(null);
+  const { wrapText, setWrapText } = useWrapText();
   const {
     consoleOutputs,
     stale,
@@ -106,68 +109,84 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
   );
 
   return (
-    <div
-      title={stale ? "This console output is stale" : undefined}
-      data-testid="console-output-area"
-      ref={ref}
-      // biome-ignore lint/a11y/noNoninteractiveTabindex: Needed to capture keypress events
-      tabIndex={0}
-      className={cn(
-        "console-output-area overflow-hidden rounded-b-lg flex flex-col-reverse w-full gap-1 focus:outline-none",
-        stale && "marimo-output-stale",
-        hasOutputs ? "p-5" : "p-3",
-        className,
-      )}
-    >
-      {reversedOutputs.map((output, idx) => {
-        if (output.channel === "pdb") {
-          return null;
-        }
+    <div className="relative group">
+      <TooltipTrigger>
+        <ToggleButton
+          aria-label="Toggle text wrapping"
+          className="absolute top-1 right-1 h-6 w-6 z-10 rounded flex items-center justify-center opacity-0 group-hover:opacity-100 bg-transparent text-muted-foreground data-[hovered]:text-foreground data-[selected]:text-foreground"
+          isSelected={wrapText}
+          onChange={setWrapText}
+        >
+          <WrapTextIcon className="h-4 w-4" />
+        </ToggleButton>
+        <Tooltip className="z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-xs data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1">
+          {wrapText ? "Disable wrap text" : "Wrap text"}
+        </Tooltip>
+      </TooltipTrigger>
+      <div
+        title={stale ? "This console output is stale" : undefined}
+        data-testid="console-output-area"
+        ref={ref}
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: Needed to capture keypress events
+        tabIndex={0}
+        className={cn(
+          "console-output-area overflow-hidden rounded-b-lg flex flex-col-reverse w-full gap-1 focus:outline-none",
+          stale && "marimo-output-stale",
+          hasOutputs ? "p-5" : "p-3",
+          className,
+        )}
+      >
+        {reversedOutputs.map((output, idx) => {
+          if (output.channel === "pdb") {
+            return null;
+          }
 
-        if (output.channel === "stdin") {
-          invariant(
-            typeof output.data === "string",
-            "Expected data to be a string",
-          );
+          if (output.channel === "stdin") {
+            invariant(
+              typeof output.data === "string",
+              "Expected data to be a string",
+            );
 
-          const originalIdx = consoleOutputs.length - idx - 1;
+            const originalIdx = consoleOutputs.length - idx - 1;
 
-          if (output.response == null && lastStdInputIdx === idx) {
+            if (output.response == null && lastStdInputIdx === idx) {
+              return (
+                <StdInput
+                  key={idx}
+                  output={output.data}
+                  isPdb={isPdb}
+                  onSubmit={(text) => onSubmitDebugger(text, originalIdx)}
+                  onClear={onClear}
+                />
+              );
+            }
+
             return (
-              <StdInput
+              <StdInputWithResponse
                 key={idx}
                 output={output.data}
-                isPdb={isPdb}
-                onSubmit={(text) => onSubmitDebugger(text, originalIdx)}
-                onClear={onClear}
+                response={output.response}
               />
             );
           }
 
           return (
-            <StdInputWithResponse
-              key={idx}
-              output={output.data}
-              response={output.response}
-            />
+            <React.Fragment key={idx}>
+              <OutputRenderer
+                cellId={cellId}
+                onRefactorWithAI={onRefactorWithAI}
+                message={output}
+                wrapText={wrapText}
+              />
+            </React.Fragment>
           );
-        }
-
-        return (
-          <React.Fragment key={idx}>
-            <OutputRenderer
-              cellId={cellId}
-              onRefactorWithAI={onRefactorWithAI}
-              message={output}
-            />
-          </React.Fragment>
-        );
-      })}
-      <NameCellContentEditable
-        value={cellName}
-        cellId={cellId}
-        className="bg-[var(--slate-4)] border-[var(--slate-4)] hover:bg-[var(--slate-5)] dark:border-[var(--sky-5)] dark:bg-[var(--sky-6)] dark:text-[var(--sky-12)] text-[var(--slate-12)] rounded-tl rounded-br-lg absolute right-0 bottom-0 text-xs px-1.5 py-0.5 font-mono"
-      />
+        })}
+        <NameCellContentEditable
+          value={cellName}
+          cellId={cellId}
+          className="bg-[var(--slate-4)] border-[var(--slate-4)] hover:bg-[var(--slate-5)] dark:border-[var(--sky-5)] dark:bg-[var(--sky-6)] dark:text-[var(--sky-12)] text-[var(--slate-12)] rounded-tl rounded-br-lg absolute right-0 bottom-0 text-xs px-1.5 py-0.5 font-mono"
+        />
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/editor/output/TextOutput.tsx
+++ b/frontend/src/components/editor/output/TextOutput.tsx
@@ -10,21 +10,28 @@ const ansiUp = new AnsiUp();
 interface Props {
   text: string;
   channel?: OutputChannel;
+  wrapText?: boolean;
 }
 
-export const TextOutput = ({ text, channel }: Props): JSX.Element => {
+export const TextOutput = ({ text, channel, wrapText }: Props): JSX.Element => {
   const shouldRenderAnsi = channel === "stdout" || channel === "stderr";
 
   const renderAnsiText = (text: string) => {
     return (
-      <span dangerouslySetInnerHTML={{ __html: ansiUp.ansi_to_html(text) }} />
+      <span
+        className={
+          wrapText ? "whitespace-pre-wrap break-words" : "whitespace-pre"
+        }
+        dangerouslySetInnerHTML={{ __html: ansiUp.ansi_to_html(text) }}
+      />
     );
   };
 
   return (
     <span
       className={cn(
-        "whitespace-pre",
+        !shouldRenderAnsi &&
+          (wrapText ? "whitespace-pre-wrap break-words" : "whitespace-pre"),
         channel === "output" && "font-prose",
         channel,
       )}

--- a/frontend/src/components/editor/output/useWrapText.ts
+++ b/frontend/src/components/editor/output/useWrapText.ts
@@ -1,0 +1,14 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+const WRAP_TEXT_KEY = "marimo:console:wrapText";
+
+// Atom for storing wrap text preference - shared across all console outputs
+const wrapTextAtom = atomWithStorage<boolean>(WRAP_TEXT_KEY, false);
+
+export function useWrapText() {
+  const [wrapText, setWrapText] = useAtom(wrapTextAtom);
+  return { wrapText, setWrapText };
+}


### PR DESCRIPTION
Fixes #4968

Adds a button to toggle text wrapping in console outputs, making it easier to read and analyze text without horizontal scrolling.

The toggle appears on hover in the top-right corner of console outputs. Its state is currently persisted in localStorage, making it consistent across cells (and sessions). Alternatively, we could:

- Add a marimo-wide configuration option, or
- Not persist anything and have each output control it's wrapping state


https://github.com/user-attachments/assets/96aa6ccd-96ed-4ece-8d4d-2d9f570946ea

