### PR TITLE
chore/fix: parse correct message for anywidget

### DIFF
--- a/frontend/src/plugins/impl/anywidget/__tests__/model.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/model.test.ts
@@ -337,6 +337,20 @@ describe("ModelManager", () => {
     expect(model.get("count")).toBe(1);
   });
 
+  it("should handle custom messages", async () => {
+    const model = new Model({ count: 0 }, vi.fn(), vi.fn(), new Set());
+    const callback = vi.fn();
+    model.on("msg:custom", callback);
+    modelManager.set("test-id", model);
+
+    await handle({
+      modelId: "test-id",
+      message: { method: "custom", content: { count: 1 } },
+      buffers: [],
+    });
+    expect(callback).toHaveBeenCalledWith({ count: 1 }, undefined);
+  });
+
   it("should handle close messages", async () => {
     const model = new Model({ count: 0 }, vi.fn(), vi.fn(), new Set());
     modelManager.set("test-id", model);

--- a/frontend/src/plugins/impl/anywidget/model.ts
+++ b/frontend/src/plugins/impl/anywidget/model.ts
@@ -254,7 +254,7 @@ export async function handleWidgetMessage(
 
   if (msg.method === "custom") {
     const model = await modelManager.get(modelId);
-    model.receiveCustomMessage(msg.content);
+    model.receiveCustomMessage(msg);
     return;
   }
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
anywidgets were logging a lot of errors when I tested with mosaic.
```typescript
Failed to parse message ZodError: [
  {
    "code": "invalid_union_discriminator",
    "options": [
      "open",
      "update",
      "custom",
      "echo_update",
      "close"
    ],
    "path": [
      "method"
    ],
    "message": "Invalid discriminator value. Expected 'open' | 'update' | 'custom' | 'echo_update' | 'close'"
  }
]
```
```typescript
Message
{
    "type": "arrow",
    "uuid": "160ab694-ef1f-475a-b108-adc3fee81267"
}
```

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
