### PR TITLE
fix: allow marimo to open the markdown file format over http

### DIFF
--- a/marimo/_cli/file_path.py
+++ b/marimo/_cli/file_path.py
@@ -307,8 +307,14 @@ class RemoteFileHandler(FileHandler):
         LOGGER.info("Creating temporary file")
         path_to_app = Path(temp_dir.name) / name
         # If doesn't end in .py, add it
-        if not path_to_app.suffix == ".py":
-            path_to_app = path_to_app.with_suffix(".py")
+        if path_to_app.suffix not in (".py", ".md", ".qmd"):
+            if "__generated_with" in content:
+                path_to_app = path_to_app.with_suffix(".py")
+            elif "marimo-version" in content:
+                path_to_app = path_to_app.with_suffix(".md")
+            else:
+                # Fallback to .py
+                path_to_app = path_to_app.with_suffix(".py")
         path_to_app.write_text(content, encoding="utf-8")
         LOGGER.info("App saved to %s", path_to_app)
         return str(path_to_app)

--- a/tests/_cli/test_file_path.py
+++ b/tests/_cli/test_file_path.py
@@ -257,6 +257,13 @@ def test_validate_name_with_markdown_file():
     )
 
 
+def test_validate_name_with_markdown_file_remote() -> None:
+    markdown_tutorial = "https://github.com/marimo-team/marimo/blob/main/marimo/_tutorials/markdown_format.md"
+    assert validate_name(
+        markdown_tutorial, allow_new_file=True, allow_directory=False
+    )[0].endswith("markdown_format.md")
+
+
 def test_validate_name_with_jupyter_notebook():
     with pytest.raises(click.ClickException) as excinfo:
         validate_name(


### PR DESCRIPTION
## 📝 Summary

I noticed that opening a remote markdown file didn't work (because it was incorrectly assumed to be a .py).
Added a more inclusive file format detection for unknown files + adds a test