### PR TITLE
Don't persist minimap state open/closed state between page reloads

### DIFF
--- a/frontend/src/components/editor/chrome/state.ts
+++ b/frontend/src/components/editor/chrome/state.ts
@@ -10,7 +10,6 @@ export interface ChromeState {
   selectedPanel: PanelType | undefined;
   isSidebarOpen: boolean;
   isTerminalOpen: boolean;
-  isMinimapOpen: boolean;
 }
 
 const KEY = "marimo:sidebar";
@@ -22,7 +21,6 @@ const storage = new ZodLocalStorage<ChromeState>(
       .transform((v) => v as PanelType),
     isSidebarOpen: z.boolean(),
     isTerminalOpen: z.boolean(),
-    isMinimapOpen: z.boolean(),
   }),
   initialState,
 );
@@ -32,7 +30,6 @@ function initialState(): ChromeState {
     selectedPanel: "variables", // initial panel
     isSidebarOpen: false,
     isTerminalOpen: false,
-    isMinimapOpen: false,
   };
 }
 
@@ -73,14 +70,6 @@ const {
     setIsTerminalOpen: (state, isOpen: boolean) => ({
       ...state,
       isTerminalOpen: isOpen,
-    }),
-    toggleMinimap: (state) => ({
-      ...state,
-      isMinimapOpen: !state.isMinimapOpen,
-    }),
-    setIsMinimapOpen: (state, isOpen: boolean) => ({
-      ...state,
-      isMinimapOpen: isOpen,
     }),
   },
   [(_prevState, newState) => storage.set(KEY, newState)],

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/minimap-status.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/minimap-status.tsx
@@ -1,18 +1,18 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
+import { useAtom } from "jotai";
 import { MapIcon } from "lucide-react";
-import { useChromeActions, useChromeState } from "../../state";
 import { FooterItem } from "../footer-item";
+import { minimapOpenAtom } from "../minimap-state";
 
 export const MinimapStatusIcon: React.FC = () => {
-  const { isMinimapOpen } = useChromeState();
-  const { toggleMinimap } = useChromeActions();
+  const [open, setOpen] = useAtom(minimapOpenAtom);
 
   return (
     <FooterItem
       tooltip="Toggle Minimap"
-      selected={isMinimapOpen}
-      onClick={() => toggleMinimap()}
+      selected={open}
+      onClick={() => setOpen((prev) => !prev)}
       data-testid="footer-minimap"
     >
       <MapIcon className="h-4 w-4" />

--- a/frontend/src/components/editor/chrome/wrapper/minimap-state.ts
+++ b/frontend/src/components/editor/chrome/wrapper/minimap-state.ts
@@ -6,6 +6,8 @@ import type { CellId } from "@/core/cells/ids";
 import { variablesAtom } from "@/core/variables/state";
 import type { Variable, VariableName, Variables } from "@/core/variables/types";
 
+export const minimapOpenAtom = atom(false);
+
 export interface CellGraph {
   variables: readonly VariableName[];
 

--- a/frontend/src/components/editor/chrome/wrapper/minimap.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/minimap.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { XIcon } from "lucide-react";
 import * as React from "react";
 import { Button } from "@/components/ui/button";
@@ -10,11 +10,11 @@ import type { CellId } from "@/core/cells/ids";
 import { useVariables } from "@/core/variables/state";
 import { useHotkey } from "@/hooks/useHotkey";
 import { cn } from "@/utils/cn";
-import { useChromeActions, useChromeState } from "../state";
 import {
   type CellGraph,
   cellGraphsAtom,
   isVariableAffectedBySelectedCell,
+  minimapOpenAtom,
 } from "./minimap-state";
 
 interface MinimapCellProps {
@@ -182,10 +182,9 @@ const MinimapInternal: React.FC<{
 };
 
 export const Minimap: React.FC = () => {
-  const { setIsMinimapOpen, toggleMinimap } = useChromeActions();
-  const { isMinimapOpen } = useChromeState();
-  useHotkey("global.toggleMinimap", () => toggleMinimap());
-  return <MinimapInternal open={isMinimapOpen} setOpen={setIsMinimapOpen} />;
+  const [open, setOpen] = useAtom(minimapOpenAtom);
+  useHotkey("global.toggleMinimap", () => setOpen((prev) => !prev));
+  return <MinimapInternal open={open} setOpen={setOpen} />;
 };
 
 function codePreview(code: string): string | undefined {


### PR DESCRIPTION
Because it hides parts of the UI when open, persisting minimap open/closed state to localStorage is a bit awkward. Sometimes you close a notebook with a complex minimap, then open a fresh one with no cells (empty minimap). I think a better UX is to just have global state per page reload.