### PR TITLE
Fix cell movement shortcuts on non-Mac keyboards

### DIFF
--- a/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
@@ -645,6 +645,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "9",
+        code: "Digit9",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -667,6 +668,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "9",
+        code: "Digit9",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -686,6 +688,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "0",
+        code: "Digit0",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -761,6 +764,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "9",
+        code: "Digit9",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -795,6 +799,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "0",
+        code: "Digit0",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -830,6 +835,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "1",
+        code: "Digit1",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -862,6 +868,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "2",
+        code: "Digit2",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -1365,6 +1372,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "7",
+        code: "Digit7",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -1389,6 +1397,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "8",
+        code: "Digit8",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -1411,6 +1420,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "7",
+        code: "Digit7",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -1430,6 +1440,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "8",
+        code: "Digit8",
         ctrlKey: true,
         shiftKey: true,
       });
@@ -1459,6 +1470,7 @@ describe("useCellNavigationProps", () => {
 
       const mockEvent = Mocks.keyboardEvent({
         key: "7",
+        code: "Digit7",
         ctrlKey: true,
         shiftKey: true,
       });

--- a/frontend/src/core/hotkeys/shortcuts.ts
+++ b/frontend/src/core/hotkeys/shortcuts.ts
@@ -50,7 +50,17 @@ function areKeysPressed(keys: string[], e: IKeyboardEvent): boolean {
         satisfied &&= e.code === "Space";
         break;
       default:
-        satisfied &&= e.key.toLowerCase() === key;
+        // Handle digit keys specially when shift is pressed
+        // Shift+7 produces different characters across keyboards/platforms:
+        // - US keyboards: "&"
+        // - Some layouts: "7"
+        // Using e.code (physical key) instead of e.key (produced character)
+        // eslint-disable-next-line unicorn/prefer-ternary
+        if (/^\d$/.test(key) && e.shiftKey) {
+          satisfied &&= e.code === `Digit${key}`;
+        } else {
+          satisfied &&= e.key.toLowerCase() === key;
+        }
         break;
     }
 


### PR DESCRIPTION
Cell movement shortcuts (`Ctrl+Shift+7/8/9/0`) weren't working on Windows and Linux because these keyboards produce shifted characters like "&" instead of "7" when Shift is held. The shortcut parser was comparing against the literal digit, causing matches to fail.

This fix uses the physical key code for shifted digit combinations, making the shortcuts work consistently across keyboard layouts. Note: `Ctrl+Shift+0` may still be intercepted at the system-level Windows.