### PR TITLE
fix: add suspense for vega charts

### DIFF
--- a/frontend/src/components/data-table/charts/charts.tsx
+++ b/frontend/src/components/data-table/charts/charts.tsx
@@ -29,11 +29,8 @@ import { inferFieldTypes } from "../columns";
 import type { FieldTypesWithExternalType } from "../types";
 import { generateAltairChartSnippet } from "./chart-spec/altair-generator";
 import { createSpecWithoutData } from "./chart-spec/spec";
-import {
-  ChartErrorState,
-  ChartLoadingState,
-  ChartTypeSelect,
-} from "./components/chart-items";
+import { ChartTypeSelect } from "./components/chart-items";
+import { ChartErrorState, ChartLoadingState } from "./components/chart-states";
 import type { Field } from "./components/form-fields";
 import { CodeSnippet, TabContainer } from "./components/layouts";
 import { ChartFormContext } from "./context";

--- a/frontend/src/components/data-table/charts/components/chart-items.tsx
+++ b/frontend/src/components/data-table/charts/components/chart-items.tsx
@@ -2,7 +2,7 @@
 
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { capitalize } from "lodash-es";
-import { ChevronDown, Loader2 } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import React from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import type { z } from "zod";
@@ -14,7 +14,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { DataType } from "@/core/kernel/messages";
-import { ErrorBanner } from "@/plugins/impl/common/error-banner";
 import { isFieldSet } from "../chart-spec/spec";
 import { convertDataTypeToSelectable } from "../chart-spec/types";
 import {
@@ -131,19 +130,6 @@ const ColumnSelectorWithAggregation: React.FC<{
     </div>
   );
 };
-
-export const ChartLoadingState: React.FC = () => (
-  <div className="flex items-center gap-2 justify-center">
-    <Loader2 className="w-10 h-10 animate-spin" strokeWidth={1} />
-    <span>Loading chart...</span>
-  </div>
-);
-
-export const ChartErrorState: React.FC<{ error: Error }> = ({ error }) => (
-  <div className="flex items-center justify-center">
-    <ErrorBanner error={error} />
-  </div>
-);
 
 export const ChartTypeSelect: React.FC<{
   value: ChartType;

--- a/frontend/src/components/data-table/charts/components/chart-states.tsx
+++ b/frontend/src/components/data-table/charts/components/chart-states.tsx
@@ -1,0 +1,37 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { ChartPieIcon, Loader2 } from "lucide-react";
+import { ErrorBanner } from "@/plugins/impl/common/error-banner";
+import { cn } from "@/utils/cn";
+
+export const ChartLoadingState: React.FC = () => (
+  <div className="flex items-center gap-2 justify-center">
+    <Loader2 className="w-10 h-10 animate-spin" strokeWidth={1} />
+    <span>Loading chart...</span>
+  </div>
+);
+
+export const ChartErrorState: React.FC<{ error: Error }> = ({ error }) => (
+  <div className="flex items-center justify-center">
+    <ErrorBanner error={error} />
+  </div>
+);
+
+export const ChartInfoState: React.FC<{
+  children: React.ReactNode;
+  className?: string;
+}> = ({ children, className }) => {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-4",
+        className,
+      )}
+    >
+      <ChartPieIcon className="w-10 h-10 text-muted-foreground" />
+      <span className="text-md font-semibold text-muted-foreground">
+        {children}
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/components/data-table/charts/lazy-chart.tsx
+++ b/frontend/src/components/data-table/charts/lazy-chart.tsx
@@ -1,11 +1,11 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { ChartPieIcon } from "lucide-react";
 import React from "react";
 import type { TopLevelSpec } from "vega-lite";
 import { useTheme } from "@/theme/useTheme";
 import type { ErrorMessage } from "./chart-spec/spec";
 import { augmentSpecWithData } from "./chart-spec/spec";
+import { ChartInfoState } from "./components/chart-states";
 
 const LazyVega = React.lazy(() =>
   import("react-vega").then((m) => ({ default: m.Vega })),
@@ -23,7 +23,7 @@ export const LazyChart: React.FC<{
 
   const renderChart = (specOrMessage: TopLevelSpec | ErrorMessage) => {
     if (typeof specOrMessage === "string") {
-      return <ChartEmptyState>{specOrMessage}</ChartEmptyState>;
+      return <ChartInfoState>{specOrMessage}</ChartInfoState>;
     }
     const spec = augmentSpecWithData(specOrMessage, data);
 
@@ -52,16 +52,5 @@ export const LazyChart: React.FC<{
 };
 
 const LoadingChart = () => {
-  return <ChartEmptyState>Loading chart...</ChartEmptyState>;
-};
-
-const ChartEmptyState = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <div className="flex flex-col items-center justify-center gap-4 mt-14">
-      <ChartPieIcon className="w-10 h-10 text-muted-foreground" />
-      <span className="text-md font-semibold text-muted-foreground">
-        {children}
-      </span>
-    </div>
-  );
+  return <ChartInfoState className="mt-14">Loading chart...</ChartInfoState>;
 };

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -1,5 +1,12 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import React, { memo, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  memo,
+  Suspense,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { type CellId, CellOutputId } from "@/core/cells/ids";
 import type { OutputMessage } from "@/core/kernel/messages";
 import { cn } from "@/utils/cn";
@@ -26,6 +33,7 @@ import { useTheme } from "@/theme/useTheme";
 import { Events } from "@/utils/events";
 import { invariant } from "@/utils/invariant";
 import { Objects } from "@/utils/objects";
+import { ChartLoadingState } from "../data-table/charts/components/chart-states";
 import { Button } from "../ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Tooltip } from "../ui/tooltip";
@@ -161,10 +169,12 @@ export const OutputRenderer: React.FC<{
     case "application/vnd.vegalite.v5+json":
     case "application/vnd.vega.v5+json":
       return (
-        <LazyVegaLite
-          spec={parsedJsonData as TopLevelFacetedUnitSpec}
-          theme={theme === "dark" ? "dark" : undefined}
-        />
+        <Suspense fallback={<ChartLoadingState />}>
+          <LazyVegaLite
+            spec={parsedJsonData as TopLevelFacetedUnitSpec}
+            theme={theme === "dark" ? "dark" : undefined}
+          />
+        </Suspense>
       );
     case "application/vnd.marimo+mimebundle":
       return (
@@ -216,7 +226,7 @@ const MimeBundleOutputRenderer: React.FC<{
 
   const mimeEntries = Objects.entries(mimebundle);
   // Sort HTML first
-  mimeEntries.sort(([mimeA], [mimeB]) => {
+  mimeEntries.sort(([mimeA], [_mimeB]) => {
     if (mimeA === "text/html") {
       return -1;
     }

--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -77,6 +77,9 @@ class AltairFormatter(FormatterFactory):
                         return mime_type, mime_response
                     return mime_type, json.dumps(mime_response)
 
+            chart = _apply_embed_options(chart)
+            chart = maybe_make_full_width(chart)
+
             # If vegafusion is enabled, just wrap in altair_chart
             if alt.data_transformers.active.startswith("vegafusion"):
                 return (
@@ -88,10 +91,6 @@ class AltairFormatter(FormatterFactory):
             # since we are able to handle the larger sizes (default is 5000)
             if "max_rows" not in alt.data_transformers.options:
                 alt.data_transformers.options["max_rows"] = 20_000
-
-            chart = _apply_embed_options(chart)
-
-            chart = maybe_make_full_width(chart)
 
             # Return the chart as a vega-lite chart with embed options
             return (


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
There was an issue with the notebook flickering due to loading vega. This adds a suspense and minor refactor on the frontend.

This also applies some auto-options for vegafusion charts (like making the width full). 

- I wanted to fix the background colour bug (which only happens with vegafusion), but vegafusion by default sets it to white so I'm not keen to overwrite it (we may clash with user specified background). We could 'smartly' check if theme == dark, then set to black, but it's a bit hacky and imo we are interfering with defaults.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
