### PR TITLE
fix: set base-url if supplied

### DIFF
--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -83,13 +83,14 @@ async def index(request: Request) -> HTMLResponse:
     )
 
     html = index_html.read_text()
+    base_url = app_state.remote_url or app_state.base_url
 
     if not file_key:
         # We don't know which file to use, so we need to render a homepage
         LOGGER.debug("No file key provided, serving homepage")
         html = home_page_template(
             html=html,
-            base_url=app_state.base_url,
+            base_url=base_url,
             user_config=app_state.config_manager.get_user_config(),
             config_overrides=app_state.config_manager.get_config_overrides(),
             server_token=app_state.skew_protection_token,
@@ -104,7 +105,7 @@ async def index(request: Request) -> HTMLResponse:
 
         html = notebook_page_template(
             html=html,
-            base_url=app_state.base_url,
+            base_url=base_url,
             user_config=config_manager.get_user_config(),
             config_overrides=config_manager.get_config_overrides(),
             server_token=app_state.skew_protection_token,

--- a/tests/_server/templates/test_templates.py
+++ b/tests/_server/templates/test_templates.py
@@ -74,7 +74,7 @@ class TestNotebookPageTemplate(unittest.TestCase):
             self.mode,
         )
 
-        assert self.base_url not in result
+        assert f"<base href='{self.base_url}/' />" in result
         assert str(self.server_token) in result
         assert self.filename.name in result
         assert "read" in result
@@ -92,7 +92,7 @@ class TestNotebookPageTemplate(unittest.TestCase):
             self.mode,
         )
 
-        assert self.base_url not in result
+        assert f"<base href='{self.base_url}/' />" in result
         assert str(self.server_token) in result
         assert "<title>marimo</title>" in result
         assert "read" in result
@@ -110,7 +110,7 @@ class TestNotebookPageTemplate(unittest.TestCase):
             SessionMode.EDIT,
         )
 
-        assert self.base_url not in result
+        assert self.base_url in result
         assert str(self.server_token) in result
         assert self.filename.name in result
         assert "edit" in result
@@ -297,7 +297,7 @@ class TestHomePageTemplate(unittest.TestCase):
             self.server_token,
         )
 
-        assert self.base_url not in result
+        assert f"<base href='{self.base_url}/' />" in result
         assert str(self.server_token) in result
         assert json.dumps(self.user_config, sort_keys=True) in result
         assert "marimo" in result


### PR DESCRIPTION
If we have a base-url (subpath or remote), we should include it the html as `<base href>`