### PR TITLE
fix: better jupyter widget warning for unsupported

### DIFF
--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -28,6 +28,7 @@ import {
 import { useExpandedOutput } from "@/core/cells/outputs";
 import { renderHTML } from "@/plugins/core/RenderHTML";
 import { LazyAnyLanguageCodeMirror } from "@/plugins/impl/code/LazyAnyLanguageCodeMirror";
+import { Banner } from "@/plugins/impl/common/error-banner";
 import type { TopLevelFacetedUnitSpec } from "@/plugins/impl/data-explorer/queries/types";
 import { useTheme } from "@/theme/useTheme";
 import { Events } from "@/utils/events";
@@ -184,6 +185,22 @@ export const OutputRenderer: React.FC<{
             parsedJsonData as Record<OutputMessage["mimetype"], OutputMessage>
           }
         />
+      );
+    case "application/vnd.jupyter.widget-view+json":
+      return (
+        <Banner kind="warn">
+          <b>Jupyter widgets are not supported in marimo.</b> <br />
+          Please migrate this widget to{" "}
+          <a
+            href="https://github.com/manzt/anywidget"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-[var(--amber-12)]"
+          >
+            anywidget
+          </a>
+          .
+        </Banner>
       );
     default:
       logNever(mimetype);

--- a/marimo/_messaging/mimetypes.py
+++ b/marimo/_messaging/mimetypes.py
@@ -13,6 +13,7 @@ KnownMimeType = Literal[
     "application/vnd.marimo+mimebundle",
     "application/vnd.vega.v5+json",
     "application/vnd.vegalite.v5+json",
+    "application/vnd.jupyter.widget-view+json",
     "image/png",
     "image/svg+xml",
     "image/tiff",

--- a/marimo/_schemas/generated/session.yaml
+++ b/marimo/_schemas/generated/session.yaml
@@ -94,6 +94,7 @@ components:
           - application/vnd.marimo+mimebundle
           - application/vnd.vega.v5+json
           - application/vnd.vegalite.v5+json
+          - application/vnd.jupyter.widget-view+json
           - image/png
           - image/svg+xml
           - image/tiff

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1920,6 +1920,7 @@ components:
       - application/vnd.marimo+mimebundle
       - application/vnd.vega.v5+json
       - application/vnd.vegalite.v5+json
+      - application/vnd.jupyter.widget-view+json
       - image/png
       - image/svg+xml
       - image/tiff
@@ -2740,7 +2741,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.14.11
+  version: 0.14.13
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -3363,6 +3363,7 @@ export interface components {
       | "application/vnd.marimo+mimebundle"
       | "application/vnd.vega.v5+json"
       | "application/vnd.vegalite.v5+json"
+      | "application/vnd.jupyter.widget-view+json"
       | "image/png"
       | "image/svg+xml"
       | "image/tiff"

--- a/packages/openapi/src/session.ts
+++ b/packages/openapi/src/session.ts
@@ -51,6 +51,7 @@ export interface components {
         | "application/vnd.marimo+mimebundle"
         | "application/vnd.vega.v5+json"
         | "application/vnd.vegalite.v5+json"
+        | "application/vnd.jupyter.widget-view+json"
         | "image/png"
         | "image/svg+xml"
         | "image/tiff"


### PR DESCRIPTION
Better warning for unsupported ipywidgets. Instead redirect them to anywidget

<img width="1204" height="285" alt="Screenshot 2025-07-28 at 11 41 15 AM" src="https://github.com/user-attachments/assets/d6d75ce6-db1e-48f8-86e7-2e6be85e3117" />
