### PR TITLE
fix: conditionally show tip for invalid status in interactive terminal

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -70,7 +70,8 @@ def check_app_correctness(filename: str) -> None:
         click.echo(f"Failed to parse notebook: {filename}\n", err=True)
         raise click.ClickException(traceback.format_exc(limit=0)) from None
 
-    if status == "invalid":
+    # Only show the tip if we're in an interactive terminal
+    if status == "invalid" and sys.stdin.isatty():
         click.echo(
             green("tip")
             + ": Use `"


### PR DESCRIPTION
Only display the tip message when the application is running in an interactive terminal, otherwise this will hang