### PR TITLE
Use explicit `uv run` for dev build script in CI

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -75,7 +75,7 @@ jobs:
         run: uvx hatch publish --repo test
 
       - name: Adapt pyproject.toml to build marimo-base
-        run: ./scripts/modify_pyproject_for_marimo_base.py
+        run: uv run ./scripts/modify_pyproject_for_marimo_base.py
 
       - name: 📦 Build marimo
         run: uvx hatch build --clean

--- a/.github/workflows/marimo-bot.yml
+++ b/.github/workflows/marimo-bot.yml
@@ -92,7 +92,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Adapt pyproject.toml to build marimo-base
-        run: ./scripts/modify_pyproject_for_marimo_base.py
+        run: uv run ./scripts/modify_pyproject_for_marimo_base.py
 
       # patch pyproject.toml version to be of the form
       # X.Y.Z-dev9{4random digits}

--- a/.github/workflows/release-marimo-base.yml
+++ b/.github/workflows/release-marimo-base.yml
@@ -32,7 +32,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Adapt pyproject.toml to build marimo-base
-        run: ./scripts/modify_pyproject_for_marimo_base.py
+        run: uv run ./scripts/modify_pyproject_for_marimo_base.py
 
       - name: 📦 Build marimo-base
         run: uv build


### PR DESCRIPTION
The shebang in the `scripts/modify_pyproject_for_marimo_base.py` from #5778 is failing in CI. We should just be able to call `uv run`.