### PR TITLE
Migrate LSP from `@sourcegraph/vscode-ws-jsonrpc` to `vscode-ws-jsonrpc`

### DIFF
--- a/packages/lsp/index.ts
+++ b/packages/lsp/index.ts
@@ -1,13 +1,13 @@
 import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import { dirname } from "node:path";
-import type { IWebSocket } from "@sourcegraph/vscode-ws-jsonrpc";
-import { forward } from "@sourcegraph/vscode-ws-jsonrpc/lib/server/connection.js";
+import parseArgs from "minimist";
+import type { IWebSocket } from "vscode-ws-jsonrpc";
 import {
   createServerProcess,
   createWebSocketConnection,
-} from "@sourcegraph/vscode-ws-jsonrpc/lib/server/launch.js";
-import parseArgs from "minimist";
+  forward,
+} from "vscode-ws-jsonrpc/server";
 import type { CloseEvent, Data, ErrorEvent, MessageEvent, WebSocket } from "ws";
 import { WebSocketServer } from "ws";
 
@@ -118,6 +118,10 @@ function handleWebSocketConnection(
     languageServerCommand[0],
     languageServerCommand.slice(1),
   );
+
+  if (!jsonRpcConnection) {
+    throw new Error("Not able to create json-rpc connection.");
+  }
 
   const socket = new WebSocketAdapter(webSocket, logger);
   const connection = createWebSocketConnection(socket);

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0-beta.6",
-    "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
     "@types/minimist": "^1.2.5",
     "@types/node": "^24.0.10",
     "@types/ws": "^8.18.1",
@@ -25,6 +24,7 @@
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4",
+    "vscode-ws-jsonrpc": "^3.4.0",
     "ws": "^8.18.3"
   },
   "packageManager": "pnpm@10.12.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,9 +627,6 @@ importers:
       '@biomejs/biome':
         specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6
-      '@sourcegraph/vscode-ws-jsonrpc':
-        specifier: 0.0.3-fork
-        version: 0.0.3-fork
       '@types/minimist':
         specifier: ^1.2.5
         version: 1.2.5
@@ -657,6 +654,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@1.21.7)(jsdom@24.1.3)(msw@2.10.4(@types/node@24.0.14)(typescript@5.8.3))(terser@5.43.1)(yaml@2.8.0)
+      vscode-ws-jsonrpc:
+        specifier: ^3.4.0
+        version: 3.4.0
       ws:
         specifier: ^8.18.3
         version: 8.18.3
@@ -9191,6 +9191,10 @@ packages:
 
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
+  vscode-ws-jsonrpc@3.4.0:
+    resolution: {integrity: sha512-jkNZvX0LdHt4skPxMw/jFePr3jRCJU6ZmO28oPoQ7RwNSkwU3uN8mgtxACYEbOY68bYmi/b/uJzhxewKCz1P4w==}
+    engines: {node: '>=18.19.0', npm: '>=10.2.3'}
 
   vt-pbf@3.1.3:
     resolution: {integrity: sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==}
@@ -20060,6 +20064,10 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.0.8: {}
+
+  vscode-ws-jsonrpc@3.4.0:
+    dependencies:
+      vscode-jsonrpc: 8.2.1
 
   vt-pbf@3.1.3:
     dependencies:


### PR DESCRIPTION
Bit of a drive-by change, feel free to ignore, but was looking at our LSP deps and found we are on `@sourcegraph/vscode-ws-jsonrpc` which hasn't been updated in 7 years. I noticed `vscode-ws-jsonrpc` exists and has been actively maintained and updated (latest version 3.4.0, updated 7 months ago).

In case there is some reason I'm not aware of (tried digging through the git history and couldn't find anything) maybe worth considering switching over.