### PR TITLE
fix: expand hidden code on go-to-definition

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -49,7 +49,7 @@ export interface CellEditorProps
   runCell: () => void;
   theme: Theme;
   showPlaceholder: boolean;
-  editorViewRef: React.MutableRefObject<EditorView | null>;
+  editorViewRef: React.RefObject<EditorView | null>;
   setEditorView: (view: EditorView) => void;
   userConfig: UserConfig;
   /**
@@ -65,7 +65,7 @@ export interface CellEditorProps
   >;
   // Props below are not used by scratchpad.
   // DOM node where the editorView will be mounted
-  editorViewParentRef?: React.MutableRefObject<HTMLDivElement | null>;
+  editorViewParentRef?: React.RefObject<HTMLDivElement | null>;
   showHiddenCode: (opts?: { focus?: boolean }) => void;
 }
 
@@ -216,6 +216,12 @@ const CellEditorInternal = ({
             showHiddenCode({ focus: false });
           }
         }
+      }),
+      // Whenever the editor is focused (e.g. via go-to-definition), show the cell if it is hidden.
+      EditorView.domEventHandlers({
+        focus: () => {
+          showHiddenCode({ focus: false });
+        },
       }),
     );
 

--- a/frontend/src/utils/mergeRefs.ts
+++ b/frontend/src/utils/mergeRefs.ts
@@ -7,7 +7,7 @@ export function mergeRefs<T>(
       if (typeof ref === "function") {
         ref(value);
       } else if (ref != null) {
-        (ref as React.MutableRefObject<T | null>).current = value;
+        ref.current = value;
       }
     });
   };


### PR DESCRIPTION
This fixes expanding the cell when doing go-to-definition. It also will fix any other (i don't know of any) and future instances of focusing the editor when the cell is not expanded.