### PR TITLE
Bypass delete confirmation for empty cells

### DIFF
--- a/frontend/src/core/cells/pending-delete-service.ts
+++ b/frontend/src/core/cells/pending-delete-service.ts
@@ -32,18 +32,30 @@ export function usePendingDeleteService() {
 
   const submit = useCallback(
     (cellIds: CellId[]) => {
-      const entries = new Map<CellId, PendingDeleteEntry>();
+      const emptyCells = new Set(
+        notebook.cellIds.inOrderIds.filter(
+          (id) => notebook.cellData[id].code.trim() === "",
+        ),
+      );
 
+      const entries = new Map<CellId, PendingDeleteEntry>();
       for (const cellId of cellIds) {
+        if (emptyCells.has(cellId)) {
+          // Empty cells indicate user intent to delete already
+          entries.set(cellId, { cellId, type: "simple" });
+          continue;
+        }
+
         const runtimeInfo = notebook.cellRuntime[cellId];
 
         // Build defs map for this cell
         const defs = new Map<VariableName, readonly CellId[]>();
         for (const variable of Object.values(variables)) {
-          if (
-            variable.declaredBy.includes(cellId) &&
-            variable.usedBy.length > 0
-          ) {
+          const declaredByThisCell = variable.declaredBy.includes(cellId);
+          const usedByNonEmptyCell = variable.usedBy.some(
+            (cellId) => !emptyCells.has(cellId),
+          );
+          if (declaredByThisCell && usedByNonEmptyCell) {
             defs.set(variable.name, variable.usedBy);
           }
         }


### PR DESCRIPTION
An empty cell indicates the users intent to delete the cell, regardless of the runtime state or variables it declares. This change marks empty cells as "cheap" in our pending delete service, as well as only tracks relationships to non-empty cells.

