### PR TITLE
Move cell delete ops inside `setState` callback to prevent race condition

### DIFF
--- a/frontend/src/core/cells/pending-delete-service.ts
+++ b/frontend/src/core/cells/pending-delete-service.ts
@@ -111,12 +111,14 @@ export function usePendingDelete(cellId: CellId) {
     }
     const entries = [...state.values()];
     if (entries.every((entry) => entry.type === "simple")) {
-      if (state.size === 1) {
-        deleteCell({ cellId: entries[0].cellId });
-      } else {
-        deleteManyCells({ cellIds: entries.map((e) => e.cellId) });
-      }
-      setState(new Map());
+      setState(() => {
+        if (state.size === 1) {
+          deleteCell({ cellId: entries[0].cellId });
+        } else {
+          deleteManyCells({ cellIds: entries.map((e) => e.cellId) });
+        }
+        return new Map();
+      });
     }
   }, [state, deleteCell, deleteManyCells, setState]);
 


### PR DESCRIPTION
State was being cleared before delete operations completed. Moving deletes inside setState ensures proper sequencing. We should probably refactor to reducer pattern to remove React state from business logic.
