### PR TITLE
Require `Shift+Escape` to enter command mode with vim keybindings

### DIFF
--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -252,7 +252,15 @@ export const KeyboardShortcuts: React.FC = () => {
     renderGroup(
       group,
       <p className="text-xs text-muted-foreground">
-        Press <kbd>Esc</kbd> in a cell to enter command mode
+        Press{" "}
+        {config.keymap.preset === "vim" ? (
+          <>
+            <kbd>Shift</kbd>+<kbd>Esc</kbd>
+          </>
+        ) : (
+          <kbd>Esc</kbd>
+        )}{" "}
+        in a cell to enter command mode
       </p>,
     );
 

--- a/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
@@ -1561,6 +1561,9 @@ describe("useCellNavigationProps", () => {
 describe("useCellEditorNavigationProps", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Reset config overrides
+    store.set(configOverridesAtom, {});
   });
 
   describe("keyboard shortcuts", () => {
@@ -1585,6 +1588,47 @@ describe("useCellEditorNavigationProps", () => {
       );
 
       const mockEvent = Mocks.keyboardEvent({ key: "Enter" });
+
+      act(() => {
+        result.current.onKeyDown?.(mockEvent);
+      });
+
+      expect(focusCell).not.toHaveBeenCalled();
+      expect(mockEvent.continuePropagation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("vim mode", () => {
+    beforeEach(() => {
+      // Set up vim mode in store
+      store.set(configOverridesAtom, {
+        keymap: {
+          preset: "vim",
+        },
+      });
+    });
+
+    it("should focus cell when Shift+Escape is pressed in vim mode", () => {
+      const { result } = renderWithProvider(() =>
+        useCellEditorNavigationProps(mockCellId),
+      );
+
+      const mockEvent = Mocks.keyboardEvent({ key: "Escape", shiftKey: true });
+
+      act(() => {
+        result.current.onKeyDown?.(mockEvent);
+      });
+
+      expect(focusCell).toHaveBeenCalledWith(mockCellId);
+      expect(mockEvent.continuePropagation).not.toHaveBeenCalled();
+    });
+
+    it("should not focus cell when Escape (without Shift) is pressed in vim mode", () => {
+      const { result } = renderWithProvider(() =>
+        useCellEditorNavigationProps(mockCellId),
+      );
+
+      const mockEvent = Mocks.keyboardEvent({ key: "Escape" });
 
       act(() => {
         result.current.onKeyDown?.(mockEvent);

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -602,12 +602,22 @@ export function useCellNavigationProps(
  */
 export function useCellEditorNavigationProps(cellId: CellId) {
   const setTemporarilyShownCode = useSetAtom(temporarilyShownCodeAtom);
+  const keymapPreset = useAtomValue(keymapPresetAtom);
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {
-      if (evt.key === "Escape") {
-        setTemporarilyShownCode(false);
-        focusCell(cellId);
+      // For vim mode, require Shift+Escape to exit to command mode
+      if (keymapPreset === "vim") {
+        if (evt.key === "Escape" && evt.shiftKey) {
+          setTemporarilyShownCode(false);
+          focusCell(cellId);
+        }
+      } else {
+        // For non-vim mode, regular Escape exits to command mode
+        if (evt.key === "Escape") {
+          setTemporarilyShownCode(false);
+          focusCell(cellId);
+        }
       }
 
       evt.continuePropagation();

--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -1,7 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import type { Extension } from "@codemirror/state";
-import { EditorView, keymap, ViewPlugin } from "@codemirror/view";
+import { type EditorView, keymap, ViewPlugin } from "@codemirror/view";
 import {
   type CodeMirror,
   type CodeMirrorV,

--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -84,31 +84,6 @@ export function vimKeymapExtension(): Extension[] {
         },
       },
     ]),
-    // Propagate Ctrl+[ to Escape for vim mode
-    EditorView.domEventHandlers({
-      keydown: (event, view) => {
-        if (
-          event.ctrlKey &&
-          event.key === "[" &&
-          !event.shiftKey &&
-          !event.altKey &&
-          !event.metaKey
-        ) {
-          event.preventDefault();
-          // Dispatch a synthetic Escape event to the editor
-          view.contentDOM.dispatchEvent(
-            new KeyboardEvent("keydown", {
-              key: "Escape",
-              code: "Escape",
-              bubbles: true,
-              cancelable: true,
-            }),
-          );
-          return true;
-        }
-        return false;
-      },
-    }),
     ViewPlugin.define((view) => {
       // Wait for the next animation frame so the CodeMirror instance is ready
       requestAnimationFrame(() => {


### PR DESCRIPTION
Adding an additional mode to vim has proven problematic, both for our team and community members. It's also been reported as confusing in jupyterlab-vim.

Refs:

- https://github.com/marimo-team/marimo/pull/5614#issuecomment-3131185317
- jupyterlab-contrib/jupyterlab-vim#149

This suggests a **poor default experience** for vimmers which we are changing.

Vim keybindings now require `Shift+Escape` to exit to command mode, adding an addition modifier key. This is a breaking change, but should prevent accidently entering **command mode** out of habit of bashing the `Escape` key. Non-vim keybindings continue using regular `Escape` to enter command mode.

This change removes `Ctrl+[` for entering command mode. The `Ctrl+[` keybinding worked previously because `Ctrl+[` _equals_ `Escape` in terminals. However, our command mode requires `Shift+Escape`. Supporting that would mean mapping `Shift+Ctrl+{` to `Shift+Escape`, which feels like a stretch. I'll personally stick with `Shift+Escape` myself but can revisit if there's demand.