### PR TITLE
don't show sql bottom panel when cell is hidden

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -397,8 +397,8 @@ const CellEditorInternal = ({
     editorClassName = "h-0 overflow-hidden";
   } else if (hidden) {
     // Shortens the editor and hides the cell panels
-    editorClassName = `opacity-20 h-8 [&>div.cm-editor]:h-full [&>div.cm-editor]:overflow-hidden 
-      [&>div.cm-editor>div.cm-panels]:hidden`;
+    editorClassName =
+      "opacity-20 h-8 [&>div.cm-editor]:h-full [&>div.cm-editor]:overflow-hidden [&_.cm-panels]:hidden";
   }
 
   return (

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -396,8 +396,9 @@ const CellEditorInternal = ({
   if (isMarkdown && hidden && hasOutput) {
     editorClassName = "h-0 overflow-hidden";
   } else if (hidden) {
-    editorClassName =
-      "opacity-20 h-8 [&>div.cm-editor]:h-full [&>div.cm-editor]:overflow-hidden";
+    // Shortens the editor and hides the cell panels
+    editorClassName = `opacity-20 h-8 [&>div.cm-editor]:h-full [&>div.cm-editor]:overflow-hidden 
+      [&>div.cm-editor>div.cm-panels]:hidden`;
   }
 
   return (


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
The bottom panels show up when the cell is hidden

Before:
<img height="186" alt="CleanShot 2025-07-30 at 16 26 27" src="https://github.com/user-attachments/assets/e40bc5bc-b4fd-49cd-8caf-b9793be822df" />

Now:
<img height="186" alt="CleanShot 2025-07-30 at 16 25 30" src="https://github.com/user-attachments/assets/864c536f-8970-4983-a2ea-1792beacb7d6" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
