### PR TITLE
cursor agent: Investigate marimo github issue 5135

### DIFF
--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -168,6 +168,7 @@ const ChatMessage: React.FC<ChatMessageProps> = memo(
             key={message.id}
             value={message.content}
             theme={theme}
+            minHeight="2.5rem"
             placeholder="Type your message..."
             onChange={() => {
               // noop
@@ -391,6 +392,7 @@ const ChatInput: React.FC<ChatInputProps> = memo(
             onSubmit={onSubmit}
             onClose={() => inputRef.current?.editor?.blur()}
             theme={theme}
+            minHeight="2.5rem"
             placeholder="Type your message..."
           />
         </div>
@@ -696,6 +698,7 @@ const ChatPanelBody = () => {
                 value={newThreadInput}
                 placeholder="Ask anything, @ to include context about tables or dataframes"
                 theme={theme}
+                minHeight="2.5rem"
                 onClose={handleOnCloseThread}
                 onChange={setNewThreadInput}
                 onSubmit={handleNewThreadSubmit}

--- a/frontend/src/components/editor/ai/add-cell-with-ai.tsx
+++ b/frontend/src/components/editor/ai/add-cell-with-ai.tsx
@@ -127,6 +127,7 @@ export const AddCellWithAI: React.FC<{
       </DropdownMenu>
       <PromptInput
         theme={theme}
+        minHeight="2.5rem"
         onClose={() => {
           setCompletion("");
           onClose();
@@ -226,6 +227,7 @@ interface PromptInputProps {
   additionalCompletions?: AdditionalCompletions;
   theme: ResolvedTheme;
   maxHeight?: string;
+  minHeight?: string;
 }
 
 /**
@@ -239,12 +241,13 @@ export const PromptInput = ({
   placeholder,
   inputRef,
   className,
+  onClose,
   onChange,
   onSubmit,
-  onClose,
   additionalCompletions,
   theme,
   maxHeight,
+  minHeight = "2.5rem",
 }: PromptInputProps) => {
   const handleSubmit = onSubmit;
   const handleEscape = onClose;
@@ -362,6 +365,7 @@ export const PromptInput = ({
       onChange={onChange}
       theme={theme === "dark" ? "dark" : "light"}
       placeholder={placeholder || "Generate with AI"}
+      minHeight={minHeight}
     />
   );
 };

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -153,6 +153,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
             <PromptInput
               inputRef={inputRef}
               theme={theme}
+              minHeight="2.5rem"
               onClose={() => {
                 declineChange();
                 setCompletion("");

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -375,6 +375,7 @@ export const Chatbot: React.FC<Props> = (props) => {
           value={input}
           inputRef={codeMirrorInputRef}
           theme={theme}
+          minHeight="2.5rem"
           maxHeight={props.maxHeight ? `${props.maxHeight / 2}px` : undefined}
           onChange={setInput}
           onSubmit={(_evt, newValue) => {


### PR DESCRIPTION
## 📝 Summary

Fixes #5135. This PR addresses the issue where the "generate with AI" input box was too small and overlapping other UI elements by ensuring it maintains a minimum height.

## 🔍 Description of Changes

The `PromptInput` component, which is used for AI generation and chat inputs, lacked a `minHeight` property. This omission caused the input box to collapse to an unusable size in certain flex layouts, leading to overlapping UI elements as described in issue #5135.

This pull request introduces a `minHeight` prop to the `PromptInputProps` interface and sets a default `minHeight` of `2.5rem` (40px) for the `PromptInput` component. This minimum height is then applied to the underlying `ReactCodeMirror` instance.

All existing usages of `PromptInput` across the codebase, including `AddCellWithAI`, `AiCompletionEditor`, and various chat components (`chat-panel.tsx`, `chat-ui.tsx`), have been updated to explicitly pass `minHeight="2.5rem"`.

These changes ensure that all AI-related input boxes consistently maintain a usable minimum height, preventing them from collapsing and improving the user experience.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.

---
[Slack Thread](https://marimo-io.slack.com/archives/D0922D508JX/p1753866137613009?thread_ts=1753866137.613009&cid=D0922D508JX)

<a href="https://cursor.com/background-agent?bcId=bc-f0925eec-add6-4d5d-9c6d-147e95ef30ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(p