### PR TITLE
style: set combobox to truncate

### DIFF
--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -175,8 +175,8 @@ export const Combobox = <TValue,>({
             )}
             aria-expanded={open}
           >
-            {renderValue()}{" "}
-            <ChevronDownIcon className="ml-3 w-4 h-4 opacity-50" />
+            <span className="truncate flex-1 min-w-0">{renderValue()}</span>
+            <ChevronDownIcon className="ml-3 w-4 h-4 opacity-50 flex-shrink-0" />
           </div>
         </PopoverTrigger>
         <PopoverContent

--- a/frontend/src/plugins/impl/SearchableSelect.tsx
+++ b/frontend/src/plugins/impl/SearchableSelect.tsx
@@ -105,7 +105,9 @@ export const SearchableSelect = (props: SearchableSelectProps): JSX.Element => {
         }}
         placeholder="Select..."
         multiple={false}
-        className={cn("w-full", { "w-full": fullWidth })}
+        className={cn({
+          "w-full": fullWidth,
+        })}
         value={value ?? NONE_KEY}
         onValueChange={handleValueChange}
         shouldFilter={false}

--- a/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
+++ b/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
@@ -36,10 +36,14 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
             data-state="closed"
             type="button"
           >
-            Select columns 
+            <span
+              class="truncate flex-1 min-w-0"
+            >
+              Select columns
+            </span>
             <svg
               aria-hidden="true"
-              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50"
+              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50 flex-shrink-0"
               fill="none"
               height="24"
               stroke="currentColor"
@@ -87,10 +91,14 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
             data-state="closed"
             type="button"
           >
-            Select aggregations 
+            <span
+              class="truncate flex-1 min-w-0"
+            >
+              Select aggregations
+            </span>
             <svg
               aria-hidden="true"
-              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50"
+              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50 flex-shrink-0"
               fill="none"
               height="24"
               stroke="currentColor"
@@ -400,10 +408,14 @@ exports[`renderZodSchema > should render a form explode_columns 1`] = `
             data-state="closed"
             type="button"
           >
-            Select columns 
+            <span
+              class="truncate flex-1 min-w-0"
+            >
+              Select columns
+            </span>
             <svg
               aria-hidden="true"
-              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50"
+              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50 flex-shrink-0"
               fill="none"
               height="24"
               stroke="currentColor"
@@ -591,10 +603,14 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
             data-state="closed"
             type="button"
           >
-            Select columns 
+            <span
+              class="truncate flex-1 min-w-0"
+            >
+              Select columns
+            </span>
             <svg
               aria-hidden="true"
-              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50"
+              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50 flex-shrink-0"
               fill="none"
               height="24"
               stroke="currentColor"
@@ -1007,10 +1023,14 @@ exports[`renderZodSchema > should render a form select_columns 1`] = `
             data-state="closed"
             type="button"
           >
-            Select columns 
+            <span
+              class="truncate flex-1 min-w-0"
+            >
+              Select columns
+            </span>
             <svg
               aria-hidden="true"
-              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50"
+              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50 flex-shrink-0"
               fill="none"
               height="24"
               stroke="currentColor"
@@ -1286,10 +1306,14 @@ exports[`renderZodSchema > should render a form unique 1`] = `
             data-state="closed"
             type="button"
           >
-            Select columns 
+            <span
+              class="truncate flex-1 min-w-0"
+            >
+              Select columns
+            </span>
             <svg
               aria-hidden="true"
-              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50"
+              class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50 flex-shrink-0"
               fill="none"
               height="24"
               stroke="currentColor"
@@ -1441,10 +1465,14 @@ exports[`renders custom forms column_id_array 1`] = `
         data-state="closed"
         type="button"
       >
-        Select columns 
+        <span
+          class="truncate flex-1 min-w-0"
+        >
+          Select columns
+        </span>
         <svg
           aria-hidden="true"
-          class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50"
+          class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50 flex-shrink-0"
           fill="none"
           height="24"
           stroke="currentColor"
@@ -1487,10 +1515,14 @@ exports[`renders custom forms column_id_dot_array 1`] = `
         data-state="closed"
         type="button"
       >
-        -- 
+        <span
+          class="truncate flex-1 min-w-0"
+        >
+          --
+        </span>
         <svg
           aria-hidden="true"
-          class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50"
+          class="lucide lucide-chevron-down ml-3 w-4 h-4 opacity-50 flex-shrink-0"
           fill="none"
           height="24"
           stroke="currentColor"


### PR DESCRIPTION
## 📝 Summary

Fixes #5341 .

Need to do more testing with other components that use combobox, but this allows text in dropdown to be limited to the width set.

By default, it shouldn't wrap
<img width="662" height="243" alt="CleanShot 2025-07-30 at 17 38 03" src="https://github.com/user-attachments/assets/e7d39d16-752e-4dbe-809f-b34ceb8ed6ba" />

If set full_width to True, and style the width, it will truncate the text
<img width="529" height="119" alt="CleanShot 2025-07-30 at 17 38 54" src="https://github.com/user-attachments/assets/920c00c4-dbe0-4ae4-913d-761441830b11" />

## 🔍 Description of Changes

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.