### PR TITLE
revert: additional logic for pickable refs

### DIFF
--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -582,29 +582,6 @@ class BlockHasher:
 
             failed = []
             exceptions = []
-            # By rights, could just fail here - but this final attempt should
-            # provide better user experience.
-            #
-            # Get a transitive closure over the object, and attempt to pickle
-            # each dependent object.
-            #
-            # TODO: Maybe just try dill?
-            closure = self.graph.get_transitive_references(
-                unhashable,
-                predicate=build_ref_predicate_for_primitives(
-                    scope, CLONE_PRIMITIVES
-                ),
-            )
-            closure -= set(content_serialization.keys()) | self.execution_refs
-            unhashable_closure, relevant_serialization, _ = (
-                self.serialize_and_dequeue_content_refs(
-                    closure - unhashable, scope
-                )
-            )
-            unhashable |= unhashable_closure
-            content_serialization.update(relevant_serialization)
-            refs |= unhashable_closure
-
             for ref in unhashable:
                 try:
                     _hashed = pickle.dumps(scope[ref])


### PR DESCRIPTION
## 📝 Summary

Partial revert of #5758 which improperly attempted to traverse graph structure in all contexts (should not have traversed in exposed, no runtime context)