### PR TITLE
Change vim mode command entry from `Shift+Escape` to `Ctrl/Cmd+Escape`

### DIFF
--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -44,7 +44,7 @@ editing their contents.
 
 **Enter/Exit:**
 
-- Enter command mode: `Esc` (from cell editor) or `Shift+Esc` (when vim keybindings are enabled)
+- Enter command mode: `Esc` (from cell editor) or `Ctrl+Esc` (when vim keybindings are enabled)
 - Exit command mode: `Enter` or click on a cell
 
 **Shortcuts:**
@@ -63,7 +63,7 @@ When [vim keybindings](#vim-keybindings) are enabled, additional shortcuts are a
 ### Vim keybindings
 
 marimo supports vim keybindings that extend to notebook editing. Within cells,
-use standard vim modes. Press `Shift+Esc` from normal mode to enter [command
+use standard vim modes. Press `Ctrl+Esc` from normal mode to enter [command
 mode](#command-mode) for notebook navigation.
 
 **Cell editing additions:**
@@ -96,7 +96,7 @@ vimrc = relative/path/.vimrc
 
 **Command mode additions:**
 
-When vim keybindings are enabled, press `Shift+Esc` from normal mode to enter
+When vim keybindings are enabled, press `Ctrl+Esc` from normal mode to enter
 [command mode](#command-mode) with additional vim-specific keybindings:
 
 - `j`/`k` - navigate cells

--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -44,7 +44,7 @@ editing their contents.
 
 **Enter/Exit:**
 
-- Enter command mode: `Esc` (from cell editor) or `Ctrl+Esc` (when vim keybindings are enabled)
+- Enter command mode: `Esc` (from cell editor) or `Ctrl+Esc`/`Cmd+Esc` (when vim keybindings are enabled)
 - Exit command mode: `Enter` or click on a cell
 
 **Shortcuts:**
@@ -63,7 +63,7 @@ When [vim keybindings](#vim-keybindings) are enabled, additional shortcuts are a
 ### Vim keybindings
 
 marimo supports vim keybindings that extend to notebook editing. Within cells,
-use standard vim modes. Press `Ctrl+Esc` from normal mode to enter [command
+use standard vim modes. Press `Ctrl+Esc` (or `Cmd+Esc` on macOS) from normal mode to enter [command
 mode](#command-mode) for notebook navigation.
 
 **Cell editing additions:**
@@ -96,7 +96,7 @@ vimrc = relative/path/.vimrc
 
 **Command mode additions:**
 
-When vim keybindings are enabled, press `Ctrl+Esc` from normal mode to enter
+When vim keybindings are enabled, press `Ctrl+Esc` (or `Cmd+Esc` on macOS) from normal mode to enter
 [command mode](#command-mode) with additional vim-specific keybindings:
 
 - `j`/`k` - navigate cells

--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -255,7 +255,7 @@ export const KeyboardShortcuts: React.FC = () => {
         Press{" "}
         {config.keymap.preset === "vim" ? (
           <>
-            <kbd>Shift</kbd>+<kbd>Esc</kbd>
+            <kbd>Ctrl</kbd>+<kbd>Esc</kbd>
           </>
         ) : (
           <kbd>Esc</kbd>

--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -5,6 +5,7 @@ import { EditIcon, XIcon } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Kbd } from "@/components/ui/kbd";
 import { hotkeysAtom, useResolvedMarimoConfig } from "@/core/config/config";
 import type { UserConfig } from "@/core/config/config-schema";
 import {
@@ -251,14 +252,15 @@ export const KeyboardShortcuts: React.FC = () => {
   const renderCommandGroup = (group: HotkeyGroup) =>
     renderGroup(
       group,
-      <p className="text-xs text-muted-foreground">
+      <p className="text-xs text-muted-foreground flex items-center gap-1">
         Press{" "}
         {config.keymap.preset === "vim" ? (
           <>
-            <kbd>Ctrl</kbd>+<kbd>Esc</kbd>
+            <KeyboardHotkeys shortcut={isPlatformMac() ? "Cmd" : "Ctrl"} />
+            <Kbd>Esc</Kbd>
           </>
         ) : (
-          <kbd>Esc</kbd>
+          <Kbd>Esc</Kbd>
         )}{" "}
         in a cell to enter command mode
       </p>,

--- a/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
@@ -1635,6 +1635,21 @@ describe("useCellEditorNavigationProps", () => {
       expect(mockEvent.continuePropagation).not.toHaveBeenCalled();
     });
 
+    it("should focus cell when Cmd+Escape (metaKey) is pressed in vim mode", () => {
+      const { result } = renderWithProvider(() =>
+        useCellEditorNavigationProps(mockCellId),
+      );
+
+      const mockEvent = Mocks.keyboardEvent({ key: "Escape", metaKey: true });
+
+      act(() => {
+        result.current.onKeyDown?.(mockEvent);
+      });
+
+      expect(focusCell).toHaveBeenCalledWith(mockCellId);
+      expect(mockEvent.continuePropagation).not.toHaveBeenCalled();
+    });
+
     it("should not focus cell when Escape (without Ctrl) is pressed in vim mode", () => {
       const { result } = renderWithProvider(() =>
         useCellEditorNavigationProps(mockCellId),

--- a/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
@@ -1620,12 +1620,12 @@ describe("useCellEditorNavigationProps", () => {
       });
     });
 
-    it("should focus cell when Shift+Escape is pressed in vim mode", () => {
+    it("should focus cell when Ctrl+Escape is pressed in vim mode", () => {
       const { result } = renderWithProvider(() =>
         useCellEditorNavigationProps(mockCellId),
       );
 
-      const mockEvent = Mocks.keyboardEvent({ key: "Escape", shiftKey: true });
+      const mockEvent = Mocks.keyboardEvent({ key: "Escape", ctrlKey: true });
 
       act(() => {
         result.current.onKeyDown?.(mockEvent);
@@ -1635,7 +1635,7 @@ describe("useCellEditorNavigationProps", () => {
       expect(mockEvent.continuePropagation).not.toHaveBeenCalled();
     });
 
-    it("should not focus cell when Escape (without Shift) is pressed in vim mode", () => {
+    it("should not focus cell when Escape (without Ctrl) is pressed in vim mode", () => {
       const { result } = renderWithProvider(() =>
         useCellEditorNavigationProps(mockCellId),
       );

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -606,9 +606,9 @@ export function useCellEditorNavigationProps(cellId: CellId) {
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {
-      // For vim mode, require Ctrl+Escape to exit to command mode
+      // For vim mode, require Ctrl+Escape (or Cmd+Escape on Mac) to exit to command mode
       if (keymapPreset === "vim") {
-        if (evt.key === "Escape" && evt.ctrlKey) {
+        if (evt.key === "Escape" && (evt.ctrlKey || evt.metaKey)) {
           setTemporarilyShownCode(false);
           focusCell(cellId);
         }

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -606,9 +606,9 @@ export function useCellEditorNavigationProps(cellId: CellId) {
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {
-      // For vim mode, require Shift+Escape to exit to command mode
+      // For vim mode, require Ctrl+Escape to exit to command mode
       if (keymapPreset === "vim") {
-        if (evt.key === "Escape" && evt.shiftKey) {
+        if (evt.key === "Escape" && evt.ctrlKey) {
           setTemporarilyShownCode(false);
           focusCell(cellId);
         }


### PR DESCRIPTION
On Linux systems, `Shift+Escape` triggers unintended behavior that interferes with marimo's command mode transition. This makes the current keybinding unusable for Linux users trying to exit vim's insert mode to marimo's command mode.

Following the changes from #5815 which introduced `Shift+Escape` to prevent accidental exits from vim mode, we're now switching to `Ctrl+Escape` (or `Cmd+Escape` on macOS) as a more reliable cross-platform solution.