### PR TITLE
Document working with marimo notebooks in existing projects

### DIFF
--- a/docs/guides/configuration/runtime_configuration.md
+++ b/docs/guides/configuration/runtime_configuration.md
@@ -86,17 +86,37 @@ Autoreloading comes in two types:
 
 ## Python path
 
-By default, marimo will not add any additional directories to the Python path. This keeps the behavior of `marimo edit nb.py` and `python nb.py` consistent.
+By default, marimo will not add any additional directories to the Python path.
+This keeps the behavior of `marimo edit nb.py` and `python nb.py` consistent.
 
-You can add directories to the Python path by setting the `pythonpath` key in the
-runtime configuration. These directories will be added to the head of `sys.path`,
-similar to how the `PYTHONPATH` environment variable works. This allows Python to
-find and import modules from these directories.
+You can add directories to the Python path by setting the `pythonpath` key in
+the runtime configuration. These directories will be added to the head of
+`sys.path`, similar to how the `PYTHONPATH` environment variable works. This
+allows Python to find and import modules from these directories.
 
 ```toml title="pyproject.toml"
 [tool.marimo.runtime]
 pythonpath = ["project/src"]
 ```
+
+!!! tip "Consider alternatives to path manipulation"
+
+    When possible, it's preferred to avoid path manipulation. If you want to
+    work on a module in a separate directory alongside your notebooks, we
+    recommend creating a _package_ and including marimo as a project dependency.
+
+    ```sh
+    uv init --lib my_package
+    cd my_package
+    uv add --dev marimo
+    uv run marimo edit notebook.py  # my_package is available in notebook environment
+    ```
+
+    This will make it easier to share your library code. For multiple packages,
+    consider confguring [uv workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/).
+
+    See our guide on [notebooks in existing
+    projects](../package_management/notebooks_in_projects.md) for more details.
 
 ## Environment variables
 

--- a/docs/guides/package_management/index.md
+++ b/docs/guides/package_management/index.md
@@ -8,4 +8,5 @@ the Python dependencies of your notebooks.
 | [Importing packages](importing_packages.md)     | How marimo finds packages on import |
 | [Installing packages](installing_packages.md)     | Installing packages with marimo's UI                      |
 | [Inlining dependencies](inlining_dependencies.md)     | Create self-contained notebooks by inlining dependencies in notebook files                      |
+| [Notebooks in existing projects](notebooks_in_projects.md)     | Working with marimo notebooks in existing Python projects                      |
 | [Using uv](using_uv.md)     | A guide to using the uv package manager with marimo                     |

--- a/docs/guides/package_management/notebooks_in_projects.md
+++ b/docs/guides/package_management/notebooks_in_projects.md
@@ -116,6 +116,9 @@ This approach:
 - Shares dependencies between notebooks and your project
 - Follows standard Python project practices
 
+!!! note "Importing from other directories"
+    If your notebooks need to import modules from directories outside your project, marimo supports configuring the Python path via `pyproject.toml`. However, when possible, it's preferred to avoid path manipulation. We recommend creating a package (`uv init --lib`) and including marimo as a development dependency. For multiple packages, consider configuring [uv workspaces](https://docs.astral.sh/uv/concepts/workspaces/). See the [runtime configuration guide](../configuration/runtime_configuration.md#python-path) for details.
+
 ## Examples
 
 ### Library with example notebooks

--- a/docs/guides/package_management/notebooks_in_projects.md
+++ b/docs/guides/package_management/notebooks_in_projects.md
@@ -1,0 +1,180 @@
+# Notebooks in existing projects
+
+When working with notebooks in existing projects, there are two main approaches
+depending on your needs:
+
+1. **Sandbox notebooks** - Self-contained notebooks with isolated dependencies
+2. **Project notebooks** - Notebooks that are part of your project's environment
+
+marimo uses [PEP 723](https://peps.python.org/pep-0723/) inline script metadata
+for sandboxing, managed by uv. While sandboxing is currently exclusive to the
+uv package manager, other package managers may be supported in the future.
+
+For project notebooks, marimo can be added as a project dependency where all
+notebooks share the same environment defined in `pyproject.toml`. This approach
+works with uv and other package managers (Poetry, Pixi, Hatch, etc.).
+
+## Sandbox notebooks (recommended for libraries)
+
+Sandbox notebooks use inline script metadata ([PEP
+723](https://peps.python.org/pep-0723/)) to create isolated environments. This
+is ideal when:
+
+- Building examples for a library that users can run independently
+- Creating notebooks that don't share dependencies with your main project
+- Sharing self-contained notebooks that work anywhere
+
+### Basic sandbox notebook
+
+Sandbox notebooks can be created with:
+
+```bash
+marimo edit --sandbox notebook.py
+```
+
+When working in the notebook, marimo will automatically manage PEP 723 metadata
+for you. This metadata makes the notebook self-contained, meaning you can
+either come back later with marimo or run the notebook as a script directly
+with uv:
+
+```bash
+marimo edit --sandbox notebook.py  # automatically loads deps and launches marimo
+uv run notebook.py                  # run notebook as a script
+```
+
+### Developing against your local package
+
+When developing library examples, tutorials, or exploratory code, it's often
+useful to have notebooks that _use_ your library. In these cases, you can
+create and version sandboxed notebooks with your library as an _editable_
+install.
+
+This approach lets you:
+
+- Test your library changes immediately without reinstalling
+- Add notebook-specific dependencies (like visualization or data processing tools) without polluting your library's requirements
+- Create self-contained examples that users can run without your development dependencies
+
+To add your library to a notebook, use uv:
+
+```bash
+uv add --script notebooks/notebook.py . --editable
+```
+
+This will produce a header that looks like:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "my-package",
+#     "pandas",
+#     "matplotlib",
+# ]
+#
+# [tool.uv.sources]
+# my-package = { path = "../", editable = true }
+# ///
+```
+
+## Project notebooks
+
+For notebooks that are integral to your project, you can manage everything
+through your project's `pyproject.toml`. This approach uses a single
+environment shared between your project and notebooks.
+
+### Adding marimo to your project
+
+```toml
+[project]
+name = "my-project"
+dependencies = [
+    "numpy",
+    "requests",
+]
+
+[dependency-groups]
+dev = [
+    "marimo",
+    "pytest",
+]
+```
+
+Then work with notebooks using your project's environment:
+
+```bash
+# Using uv
+uv run marimo edit notebooks/analysis.py
+
+# Or activate the environment
+source .venv/bin/activate
+marimo edit notebooks/analysis.py
+```
+
+This approach:
+- Uses a single environment for everything
+- Shares dependencies between notebooks and your project
+- Follows standard Python project practices
+
+## Examples
+
+### Library with example notebooks
+
+When building a library, use sandbox notebooks for examples that users can run
+independently:
+
+```
+my-library/
+├── pyproject.toml       # Library dependencies
+├── src/
+│   └── my_library/
+└── examples/
+    ├── quickstart.py    # Sandbox notebook
+    └── advanced.py      # Sandbox notebook
+```
+
+Create example notebooks:
+```bash
+# Initialize the project
+uv init --lib my-library && cd my-library
+
+# Add marimo as development dependency
+uv add --dev marimo
+
+# Create a sandbox notebook
+mkdir examples
+uv run marimo edit --sandbox examples/quickstart.py
+
+# Add your library as editable dependency
+uv add --script examples/quickstart.py . --editable
+```
+
+### Data science project  
+
+When notebooks are part of your analysis workflow, use project notebooks:
+
+```
+analysis-project/
+├── pyproject.toml       # Project + marimo dependencies
+├── README.md
+├── main.py              # Created by uv init
+└── notebook.py          # Your marimo notebook
+```
+
+Set up the project:
+```bash
+# Initialize project
+uv init analysis-project && cd analysis-project
+
+# Add marimo as a project dependency
+uv add marimo pandas scikit-learn
+
+# Edit notebooks using project environment
+uv run marimo edit notebook.py
+```
+
+## Related guides
+
+- [Using uv](using_uv.md) - Detailed guide on uv with marimo
+- [Inlining dependencies](inlining_dependencies.md) - More on self-contained notebooks
+- [Package management overview](index.md) - General package management in marimo

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
           - Importing packages: guides/package_management/importing_packages.md
           - Installing packages: guides/package_management/installing_packages.md
           - Inlining dependencies: guides/package_management/inlining_dependencies.md
+          - Notebooks in existing projects: guides/package_management/notebooks_in_projects.md
           - Using uv: guides/package_management/using_uv.md
       - Generate with AI:
           - Generate with AI: guides/generate_with_ai/index.md


### PR DESCRIPTION
Fixes #3008

Adds a new guide explaining how to use marimo notebooks within existing Python projects. The guide clarifies two approaches: sandbox notebooks for self-contained examples with isolated dependencies, and project notebooks that share the project's environment.

Think there is probably some overlap with the [uv's integration guide](https://docs.astral.sh/uv/guides/integration/marimo/) and our own [using uv](https://docs.marimo.io/guides/package_management/using_uv/) section. Think this could use a pass to make more agnostic of package manager.