### PR TITLE
Fix missing `!pip` transform in notebook converter

### DIFF
--- a/marimo/_convert/ipynb.py
+++ b/marimo/_convert/ipynb.py
@@ -718,6 +718,7 @@ def _transform_sources(
     source_transforms: list[Transform] = [
         transform_strip_whitespace,
         transform_magic_commands,
+        transform_exclamation_mark,
         transform_remove_duplicate_imports,
         transform_fixup_multiple_definitions,
         transform_duplicate_definitions,

--- a/scripts/generate_ipynb_fixtures.py
+++ b/scripts/generate_ipynb_fixtures.py
@@ -156,6 +156,17 @@ for i_1 in range(X_1.shape[0]):
         ],
     )
 
+    create_notebook_fixture(
+        "pip_commands",
+        [
+            "!pip install transformers",
+            "!pip install pandas numpy matplotlib",
+            "# Mixed cell with pip and other commands\n!pip install scikit-learn\nimport numpy as np\n!pip install seaborn",
+            "# Non-pip exclamation commands should remain unchanged\n!ls -la\n!echo 'Hello World'",
+            "# Magic pip command should also be handled\n%pip install requests",
+        ],
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/tests/_convert/ipynb_data/pip_commands.ipynb
+++ b/tests/_convert/ipynb_data/pip_commands.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pandas numpy matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mixed cell with pip and other commands\n",
+    "!pip install scikit-learn\n",
+    "import numpy as np\n",
+    "!pip install seaborn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Non-pip exclamation commands should remain unchanged\n",
+    "!ls -la\n",
+    "!echo 'Hello World'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Magic pip command should also be handled\n",
+    "%pip install requests"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/_convert/snapshots/convert_pip_commands.py.txt
+++ b/tests/_convert/snapshots/convert_pip_commands.py.txt
@@ -1,0 +1,45 @@
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    # (use marimo's built-in package management features instead) !pip install transformers
+    return
+
+
+@app.cell
+def _():
+    # (use marimo's built-in package management features instead) !pip install pandas numpy matplotlib
+    return
+
+
+@app.cell
+def _():
+    # Mixed cell with pip and other commands
+    # (use marimo's built-in package management features instead) !pip install scikit-learn
+    import numpy as np
+    # (use marimo's built-in package management features instead) !pip install seaborn
+    return
+
+
+app._unparsable_cell(
+    r"""
+    # Non-pip exclamation commands should remain unchanged
+    !ls -la
+    !echo 'Hello World'
+    """,
+    name="_"
+)
+
+
+@app.cell
+def _():
+    # Magic pip command should also be handled
+    # '%pip install requests' command supported automatically in marimo
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #5819

The `transform_exclamation_mark` transform was introduced in 59338be but was accidently omitted from the transforms pipeline (`_transform_sources`). The pipeline was later refactored in 92e6a04, but the transform remained missing. This caused `!pip` commands to end up in unparsable cells instead of being properly commented.

Added the missing transform to the pipeline and test coverage. Note: The function name `transform_exclamation_mark` is a little misleading since it only handles `!pip` commands, not all exclamation-mark commands.