### PR TITLE
fix: use svg renderer and support enum charts

### DIFF
--- a/frontend/src/components/data-table/column-summary/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary/column-summary.tsx
@@ -47,6 +47,7 @@ export const TableColumnSummary = <TData, TValue>({
             spec={spec}
             width={70}
             height={30}
+            renderer="svg"
             // @ts-expect-error - Our `loader.load` method is broader than VegaLite's typings but is functionally supported.
             loader={batchedLoader}
             style={{ minWidth: "unset", maxHeight: "40px" }}

--- a/marimo/_data/preview_column.py
+++ b/marimo/_data/preview_column.py
@@ -336,7 +336,7 @@ def _sanitize_dtypes(
     """Sanitize dtypes for vegafusion"""
     try:
         dtype = column_data.schema[column_name]
-        if dtype == nw.Categorical:
+        if dtype == nw.Categorical or dtype == nw.Enum:
             column_data = column_data.with_columns(
                 nw.col(column_name).cast(nw.String)
             )

--- a/tests/_data/test_preview_column.py
+++ b/tests/_data/test_preview_column.py
@@ -493,3 +493,23 @@ def test_sanitize_dtypes() -> None:
 
     result = _sanitize_dtypes(nw_df, "int128_col")
     assert result.schema["int128_col"] == nw.Int64
+
+
+@pytest.mark.skipif(
+    not DependencyManager.narwhals.has(), reason="narwhals not installed"
+)
+@pytest.mark.xfail(reason="Sanitizing is failing")  # TODO: Fix this
+def test_sanitize_dtypes_enum() -> None:
+    import narwhals as nw
+    import polars as pl
+
+    df = pl.DataFrame(
+        {
+            "enum_col": ["A", "B", "A"],
+        },
+        schema={"enum_col": pl.Enum(["A", "B"])},
+    )
+    nw_df = nw.from_native(df)
+
+    result = _sanitize_dtypes(nw_df, "enum_col")
+    assert result.schema["enum_col"] == nw.String


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Better resolution vega spec in tables

<img width="220" height="211" alt="CleanShot 2025-07-31 at 11 30 40" src="https://github.com/user-attachments/assets/1e94aeaf-a1d3-4fba-90f1-42f9ed86fe91" />

And enum charts don't raise an error anymore for polars.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
