### PR TITLE
Clear selection or autocomplete popup first before exiting command mode

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -386,7 +386,7 @@ const CellEditorInternal = ({
     };
   }, [editorViewRef]);
 
-  const navigationProps = useCellEditorNavigationProps(cellId);
+  const navigationProps = useCellEditorNavigationProps(cellId, editorViewRef);
 
   // Completely hide the editor & icons if it's markdown and hidden. If there is output, we show.
   const showHideButton =

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -1,5 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
+import { closeCompletion, completionStatus } from "@codemirror/autocomplete";
+import { EditorSelection } from "@codemirror/state";
 import type { EditorView } from "@codemirror/view";
 import { useAtomValue, useSetAtom, useStore } from "jotai";
 import { mergeProps, useFocusWithin, useKeyboard } from "react-aria";
@@ -600,23 +602,59 @@ export function useCellNavigationProps(
  *
  * Handles both keyboard and mouse navigation.
  */
-export function useCellEditorNavigationProps(cellId: CellId) {
+export function useCellEditorNavigationProps(
+  cellId: CellId,
+  editorView: React.RefObject<EditorView | null>,
+) {
   const setTemporarilyShownCode = useSetAtom(temporarilyShownCodeAtom);
   const keymapPreset = useAtomValue(keymapPresetAtom);
 
+  const exitToCommandMode = () => {
+    setTemporarilyShownCode(false);
+    focusCell(cellId);
+  };
+
+  const handleEscape = () => {
+    // If there is a selection / autocomplete popup in the editor, we clear those and return.
+    // Subsequent 'Escapes' will exit to command mode.
+
+    if (!editorView.current) {
+      // If no editor, we can exit to command mode immediately
+      exitToCommandMode();
+      return;
+    }
+
+    const view = editorView.current;
+    const state = view.state;
+
+    const hasSelection = state.selection.main.from !== state.selection.main.to;
+    if (hasSelection) {
+      view.dispatch({
+        selection: EditorSelection.single(state.selection.main.from), // Cursor to the start of the selection
+      });
+      return;
+    }
+
+    const hasAutocompletePopup = completionStatus(state) !== null;
+    if (hasAutocompletePopup) {
+      closeCompletion(view);
+      return;
+    }
+
+    exitToCommandMode();
+  };
+
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {
-      // For vim mode, require Ctrl+Escape (or Cmd+Escape on Mac) to exit to command mode
-      if (keymapPreset === "vim") {
-        if (evt.key === "Escape" && (evt.ctrlKey || evt.metaKey)) {
-          setTemporarilyShownCode(false);
-          focusCell(cellId);
-        }
-      } else {
-        // For non-vim mode, regular Escape exits to command mode
-        if (evt.key === "Escape") {
-          setTemporarilyShownCode(false);
-          focusCell(cellId);
+      if (evt.key === "Escape") {
+        // For vim mode, require Ctrl+Escape (or Cmd+Escape on Mac) to exit to command mode
+        if (keymapPreset === "vim") {
+          if (evt.ctrlKey || evt.metaKey) {
+            handleEscape();
+          }
+        } else {
+          // For non-vim mode, regular Escape exits to command mode
+          handleEscape();
         }
       }
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #5844 .

https://github.com/user-attachments/assets/a0acf508-7f5e-4ce0-86ff-7f97cf82c1ea

This returns early when there is an autocomplete / text selection. Subsequent escapes will exit to command mode.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
