### PR TITLE
Support hiding code in setup cells

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -1041,6 +1041,14 @@ const SetupCellComponent = ({
   // Callback to get the editor view.
   const getEditorView = useCallback(() => editorView.current, [editorView]);
 
+  const { isCellCodeShown, showHiddenCode } = useCellHiddenLogic({
+    cellId,
+    cellConfig,
+    languageAdapter: "python",
+    editorView,
+    editorViewParentRef,
+  });
+
   // Use the extracted hooks
   const { closeCompletionHandler, resumeCompletionHandler } = useCellCompletion(
     cellRef,
@@ -1108,7 +1116,7 @@ const SetupCellComponent = ({
           title={renderCellTitle()}
           data-setup-cell={true}
         >
-          <div className={cn("tray")} data-hidden={false}>
+          <div className={cn("tray")} data-hidden={!isCellCodeShown}>
             <div className="absolute right-2 -top-4 z-10">
               <CellToolbar
                 edited={edited}
@@ -1123,7 +1131,7 @@ const SetupCellComponent = ({
                 name={name}
                 getEditorView={getEditorView}
                 onRun={runCell}
-                includeCellActions={false}
+                includeCellActions={true}
               />
             </div>
             <CellEditor
@@ -1139,9 +1147,9 @@ const SetupCellComponent = ({
               userConfig={userConfig}
               editorViewRef={editorView}
               editorViewParentRef={editorViewParentRef}
-              hidden={false}
+              hidden={!isCellCodeShown}
               hasOutput={hasOutput}
-              showHiddenCode={Functions.NOOP}
+              showHiddenCode={showHiddenCode}
               languageAdapter={"python"}
               setLanguageAdapter={Functions.NOOP}
               showLanguageToggles={false}

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -111,17 +111,17 @@ class _SetupContext:
 
     def __init__(
         self,
-        app: Optional[App] = None,
-        cell: Optional[Cell] = None,
-        hide_code: bool = False,
+        cell: Cell,
+        app: App,
+        hide_code: bool,
     ):
         super().__init__()
         self._app = app
         self._cell = cell
+        self._hide_code = hide_code
         self._glbls: dict[str, Any] = {}
         self._frame: Optional[FrameType] = None
         self._previous: dict[str, Any] = {}
-        self._hide_code = hide_code
 
     def __enter__(self) -> None:
         if maybe_frame := inspect.currentframe():
@@ -172,11 +172,6 @@ class _SetupContext:
         **kwargs: Any,  # noqa: ARG002
     ) -> _SetupContext:
         """When called with parameters, create a new context with those parameters."""
-        if self._app is None:
-            raise RuntimeError(
-                "Cannot call setup() on an uninitialized context"
-            )
-
         cell = self._app._cell_manager.cell_context(
             app=InternalApp(self._app),
             frame=inspect.stack()[1].frame,

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -192,6 +192,7 @@ class CellManager:
         self,
         frame: FrameType,
         app: InternalApp | None = None,
+        config: Optional[CellConfig] = None,
     ) -> Cell:
         """Registers cells when called through a context block."""
         cell = context_cell_factory(
@@ -199,7 +200,7 @@ class CellManager:
             # NB. carry along the frame from the initial call.
             frame=frame,
         )
-        cell._cell.configure(CellConfig())
+        cell._cell.configure(config or CellConfig())
         self._register_cell(cell, app=app)
         return cell
 

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -158,9 +158,14 @@ def build_setup_section(setup_cell: Optional[CellImpl]) -> str:
     if has_only_comments:
         block += "\npass"
 
+    if setup_cell.config.hide_code:
+        setup_line = f"{prefix}with app.setup(hide_code=True):"
+    else:
+        setup_line = f"{prefix}with app.setup:"
+
     return "\n".join(
         [
-            f"{prefix}with app.setup:",
+            setup_line,
             indent_text(block),
             "\n",
         ]

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -1042,6 +1042,44 @@ class TestAppComposition:
         assert defs["x"] == 0
         assert "app" not in defs
 
+    @staticmethod
+    def test_setup_hide_code() -> None:
+        # Test property access (default behavior, hide_code=False)
+        app1 = App()
+        with app1.setup:
+            x = 1
+        
+        setup_cell = app1._cell_manager._cell_data.get("setup")
+        assert setup_cell is not None
+        assert setup_cell.config.hide_code is False
+        
+        # Test method call with default (hide_code=False)
+        app2 = App()
+        with app2.setup():
+            x2 = 1
+        
+        setup_cell = app2._cell_manager._cell_data.get("setup")
+        assert setup_cell is not None
+        assert setup_cell.config.hide_code is False
+        
+        # Test hide_code=True
+        app3 = App()
+        with app3.setup(hide_code=True):
+            y = 2
+        
+        setup_cell = app3._cell_manager._cell_data.get("setup")
+        assert setup_cell is not None
+        assert setup_cell.config.hide_code is True
+        
+        # Test explicit hide_code=False
+        app4 = App()
+        with app4.setup(hide_code=False):
+            z = 3
+        
+        setup_cell = app4._cell_manager._cell_data.get("setup")
+        assert setup_cell is not None
+        assert setup_cell.config.hide_code is False
+
 
 class TestAppKernelRunnerRegistry:
     def test_get_runner(self, k: Kernel) -> None:

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -1048,29 +1048,29 @@ class TestAppComposition:
         app1 = App()
         with app1.setup:
             x = 1
-        
+
         setup_cell = app1._cell_manager._cell_data.get("setup")
         assert setup_cell is not None
         assert setup_cell.config.hide_code is False
-        
+
         # Test method call with default (hide_code=False)
         app2 = App()
         with app2.setup():
             x2 = 1
-        
+
         setup_cell = app2._cell_manager._cell_data.get("setup")
         assert setup_cell is not None
         assert setup_cell.config.hide_code is False
-        
+
         # Test hide_code=True
         app3 = App()
         with app3.setup(hide_code=True):
             y = 2
-        
+
         setup_cell = app3._cell_manager._cell_data.get("setup")
         assert setup_cell is not None
         assert setup_cell.config.hide_code is True
-        
+
         # Test explicit hide_code=False
         app4 = App()
         with app4.setup(hide_code=False):


### PR DESCRIPTION
Fixes #5727

The setup cell is often used for lengthy imports and configuration that users don't need to see when viewing a notebook. This change allows users to hide the setup cell's code while keeping it functional, just like regular cells.

The implementation maintains backward compatibility by supporting both property access (`with app.setup:`) and method calls (`with app.setup(hide_code=True):`).