### PR TITLE
Formatters for Ibis objects

### DIFF
--- a/marimo/_output/formatters/df_formatters.py
+++ b/marimo/_output/formatters/df_formatters.py
@@ -262,3 +262,26 @@ class IbisFormatter(FormatterFactory):
             table_expr: ir.Table,
         ) -> tuple[KnownMimeType, str]:
             return _format_ibis_expression(table_expr)
+
+        def register_column_formatters():
+            """Register formatters for all Ibis column types.
+            
+            Converts columns to tables using .as_table() then formats them.
+            """
+            column_types = [
+                ir.Column, ir.UnknownColumn, ir.NullColumn,
+                ir.NumericColumn, ir.IntegerColumn, ir.FloatingColumn, 
+                ir.DecimalColumn, ir.BooleanColumn, ir.StringColumn,
+                ir.TimeColumn, ir.DateColumn, ir.TimestampColumn, ir.IntervalColumn,
+                ir.GeoSpatialColumn, ir.PointColumn, ir.LineStringColumn, ir.PolygonColumn,
+                ir.MultiLineStringColumn, ir.MultiPointColumn, ir.MultiPolygonColumn,
+                ir.ArrayColumn, ir.SetColumn, ir.MapColumn, ir.StructColumn, ir.JSONColumn,
+                ir.BinaryColumn, ir.MACADDRColumn, ir.INETColumn, ir.UUIDColumn,
+            ]
+
+            for column_type in column_types:
+                @formatting.opinionated_formatter(column_type)
+                def _show_marimo_ibis_column(column_expr):
+                    return _format_ibis_expression(column_expr.as_table())
+
+        register_column_formatters()

--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -17,6 +17,7 @@ from marimo._output.formatters.arviz_formatters import ArviZFormatter
 from marimo._output.formatters.bokeh_formatters import BokehFormatter
 from marimo._output.formatters.cell import CellFormatter
 from marimo._output.formatters.df_formatters import (
+    IbisFormatter,
     PolarsFormatter,
     PyArrowFormatter,
     PySparkFormatter,
@@ -49,6 +50,7 @@ if TYPE_CHECKING:
 THIRD_PARTY_FACTORIES: dict[str, FormatterFactory] = {
     AltairFormatter.package_name(): AltairFormatter(),
     MatplotlibFormatter.package_name(): MatplotlibFormatter(),
+    IbisFormatter.package_name(): IbisFormatter(),
     PandasFormatter.package_name(): PandasFormatter(),
     PolarsFormatter.package_name(): PolarsFormatter(),
     PyArrowFormatter.package_name(): PyArrowFormatter(),


### PR DESCRIPTION
## 📝 Summary

This change adds custom formatters for Ibis tables, columns and scalars. It closes #5828.

## 🔍 Description of Changes

Ibis uses the Rich library to display tables and scalars. However, doesn't do look great in marimo. It would be better to use the marimo's own table and output formatters.

  What this PR adds:

  - Table formatters: Table, Join, GroupedTable, CachedTable - displays as interactive marimo tables when possible
  - Column formatters: All 24+ column types (numeric, text, temporal, geospatial, etc.) - converts to single-column tables

  - Scalar formatters: Simple scalars (text display) and complex scalars like arrays/maps (JSON widgets)

  Eager execution and unbound expressions:
  - Interactive + bound expressions: Shows data as interactive table widgets or executed values
  - Lazy/unbound expressions: Shows expression representation + generated SQL (when backend supports SQL)
   - Error handling: Graceful fallbacks to increasingly coarse string representations


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
