### PR TITLE
fix: performant charts show for nulls

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -730,7 +730,6 @@ const DataTableComponent = ({
       return ColumnChartSpecModel.EMPTY;
     }
     const fieldTypesWithoutExternalTypes = toFieldTypes(fieldTypes);
-    const performantCharts = getFeatureFlag("performant_table_charts");
 
     return new ColumnChartSpecModel(
       columnSummaries.data || [],
@@ -739,9 +738,8 @@ const DataTableComponent = ({
       columnSummaries.bin_values,
       columnSummaries.value_counts,
       {
-        // If performant charts are enabled, it does not use columnSummaries.data
-        includeCharts: performantCharts || Boolean(columnSummaries.data),
-        usePreComputedValues: performantCharts,
+        includeCharts: Boolean(columnSummaries.data),
+        usePreComputedValues: getFeatureFlag("performant_table_charts"),
       },
     );
   }, [fieldTypes, columnSummaries]);

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1015,6 +1015,24 @@ def test_show_column_summaries_modes():
     assert table_default._component_args["show-column-summaries"] is True
 
 
+class TestTableBinValues:
+    @pytest.mark.skipif(
+        not DependencyManager.pandas.has(), reason="Pandas not installed"
+    )
+    def test_bin_values_all_nulls(self) -> None:
+        import pandas as pd
+
+        data = {"a": [None] * 20}
+        df = pd.DataFrame(data)
+        table = ui.table(df)
+        summaries = table._get_column_summaries(
+            ColumnSummariesArgs(precompute=True)
+        )
+
+        # Returns empty list
+        assert summaries.bin_values == {"a": []}
+
+
 class TestTableGetValueCounts:
     @pytest.fixture
     def table(self) -> ui.table:


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

There is a bug when the feature flag is on where it may not show the statistics beyond row limit.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
