### PR TITLE
fix(mcp): disconnect server fix and tests

### DIFF
--- a/marimo/_server/ai/mcp.py
+++ b/marimo/_server/ai/mcp.py
@@ -902,7 +902,7 @@ class MCPClient:
             return True
 
         try:
-            # Signal the connection task to shutdown (instead of cross-task aclose)
+            # Signal the connection task to shutdown
             if connection.disconnect_event:
                 connection.disconnect_event.set()
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fix error where MCP servers don't disconnect during shutdown of Marimo backend. The error happens because the task that connects the MCP server is not the same task that disconnects it.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Created _connection_lifecycle method to handle both connection and disconnection of the same server using the same task in mcp.py
- Updated all connection and disconnection logic to use the new method
- Added disconnect_from_all_servers to lifespans.py after yield
- Added tests for MCP disconnection with edge cases in test_mcp.py

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
