### PR TITLE
fix: initialize run_result to prevent UnboundError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ uv.lock
 
 # WIP files
 .wip/
+wip/
 
 # editors
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,6 @@ uv.lock
 
 # WIP files
 .wip/
-wip/
 
 # editors
 *.swp

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -331,6 +331,8 @@ class Runner:
                 self.debugger._last_traceback = None
 
         cell = self.graph.cells[cell_id]
+        run_result = RunResult(output=None, exception=None)
+
         try:
             if cell.is_coroutine():
                 return_value_future = asyncio.ensure_future(


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

I discovered this when trying to interrupt a long I/O bound process (pl.read_parquet). It threw this error

<details>

<summary>Error trace</summary>

```python
Traceback (most recent call last):
  File "/Users/shahmir/Library/Application Support/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/shahmir/Library/Application Support/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 2811, in launch_kernel
    asyncio.run(control_loop(kernel))
  File "/Users/shahmir/Library/Application Support/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/shahmir/Library/Application Support/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shahmir/Library/Application Support/hatch/env/virtual/.pythons/3.12/python/lib/python3.12/asyncio/base_events.py", line 686, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 2805, in control_loop
    await kernel.handle_message(request)
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 2146, in handle_message
    await self.request_handler.handle(request)
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 2622, in handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 2030, in handle_execute_multiple
    await self.run(request.execution_requests)
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 1529, in run
    await _run_with_uninstantiated_requests(execution_requests)
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 1518, in _run_with_uninstantiated_requests
    await self._run_cells(
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 1329, in _run_cells
    while cell_ids := await self._run_cells_internal(cell_ids):
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runtime.py", line 1408, in _run_cells_internal
    await runner.run_all()
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runner/cell_runner.py", line 604, in run_all
    run_result = await self.run(cell_id)
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shahmir/Development/marimo/marimo/_runtime/runner/cell_runner.py", line 513, in run
    if isinstance(run_result.exception, MarimoInterrupt):
                  ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'run_result' where it is not associated with a value
```

</details>

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
