### PR TITLE
fix: handle double interruptions

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -758,6 +758,15 @@ class Kernel:
     def _install_execution_context(
         self, cell_id: CellId_t, setting_element_value: bool = False
     ) -> Iterator[ExecutionContext]:
+        """NB: When installed, KeyboardInterrupts may be raised, which MUST be caught.
+
+        try:
+            with self._install_execution_context():
+                # Keyboard interrupts may be raised!
+                ...
+        except KeyboardInterrupt:
+            ...
+        """
         ctx = get_context()
         assert isinstance(ctx, KernelRuntimeContext)
         ctx.execution_context = (


### PR DESCRIPTION
This change makes the cell runner more robust to keyboard interrupts by catching an additional `KeyboardInterrupt` when handling the original `KeyboardInterrupt`.

Interrupting `pl.read_parquet()` raises two `KeyboardInterrupts` (polars may be forwarding signals); without this change, attempting to interrupt this function would kill the kernel.

More work could be done to make the `CellRunner` more robust to `KeyboardInterrupts`, but this fixes the issue with polars in local testing.

Fixes #5888, supersedes #5887