### PR TITLE
Avoid dependency on notebook/variables in `usePendingDeleteService`

### DIFF
--- a/frontend/src/core/cells/pending-delete-service.ts
+++ b/frontend/src/core/cells/pending-delete-service.ts
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { atom, useAtom, useAtomValue } from "jotai";
+import { atom, useAtom, useStore } from "jotai";
 import { useCallback, useEffect } from "react";
 import {
   useDeleteCellCallback,
@@ -27,11 +27,12 @@ const pendingDeleteStateAtom = atom<Map<CellId, PendingDeleteEntry>>(new Map());
 
 export function usePendingDeleteService() {
   const [state, setState] = useAtom(pendingDeleteStateAtom);
-  const notebook = useAtomValue(notebookAtom);
-  const variables = useAtomValue(variablesAtom);
+  const store = useStore();
 
   const submit = useCallback(
     (cellIds: CellId[]) => {
+      const notebook = store.get(notebookAtom);
+      const variables = store.get(variablesAtom);
       const emptyCells = new Set(
         notebook.cellIds.inOrderIds.filter(
           (id) => notebook.cellData[id].code.trim() === "",
@@ -82,7 +83,7 @@ export function usePendingDeleteService() {
 
       setState(entries);
     },
-    [notebook, variables, setState],
+    [setState, store],
   );
 
   const clear = useCallback(() => {


### PR DESCRIPTION
Fixes root of #5883 

The `usePendingDeleteService` hook was subscribing to `notebookAtom` and `variablesAtom`, causing all cells to re-render when any cell was edited.

Fixed by using imperative getters (`getNotebook()` and `getVariables()`) _within_ the submit callback instead of reactive subscriptions. This was a perf regression introduced in #5664.