### PR TITLE
Refactor pending delete service with reducer pattern

### DIFF
--- a/frontend/src/core/cells/pending-delete-service.ts
+++ b/frontend/src/core/cells/pending-delete-service.ts
@@ -1,15 +1,17 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { atom, useAtom, useStore } from "jotai";
-import { useCallback, useEffect } from "react";
+import { useAtomValue, useStore } from "jotai";
+import { useMemo } from "react";
 import {
   useDeleteCellCallback,
   useDeleteManyCellsCallback,
 } from "@/components/editor/cell/useDeleteCell";
 import { notebookAtom } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
+import type { JotaiStore } from "@/core/state/jotai";
 import { variablesAtom } from "@/core/variables/state";
 import type { VariableName } from "@/core/variables/types";
+import { createReducerAndAtoms } from "@/utils/createReducer";
 
 type PendingDeleteEntry =
   | {
@@ -23,16 +25,30 @@ type PendingDeleteEntry =
       defs: Map<VariableName, readonly CellId[]>;
     };
 
-const pendingDeleteStateAtom = atom<Map<CellId, PendingDeleteEntry>>(new Map());
+interface PendingDeleteState {
+  entries: Map<CellId, PendingDeleteEntry>;
+}
 
-export function usePendingDeleteService() {
-  const [state, setState] = useAtom(pendingDeleteStateAtom);
-  const store = useStore();
+const initialState = (): PendingDeleteState => ({
+  entries: new Map(),
+});
 
-  const submit = useCallback(
-    (cellIds: CellId[]) => {
+const { valueAtom: pendingDeleteStateAtom, useActions } = createReducerAndAtoms(
+  initialState,
+  {
+    submit: (
+      state,
+      action: {
+        cellIds: CellId[];
+        deleteCell: (args: { cellId: CellId }) => void;
+        deleteManyCells: (args: { cellIds: CellId[] }) => void;
+        store: JotaiStore;
+      },
+    ) => {
+      const { cellIds, deleteCell, deleteManyCells, store } = action;
       const notebook = store.get(notebookAtom);
       const variables = store.get(variablesAtom);
+
       const emptyCells = new Set(
         notebook.cellIds.inOrderIds.filter(
           (id) => notebook.cellData[id].code.trim() === "",
@@ -81,53 +97,68 @@ export function usePendingDeleteService() {
         }
       }
 
-      setState(entries);
+      // Auto-delete if all are "simple" cells
+      const allSimple = [...entries.values()].every(
+        (entry) => entry.type === "simple",
+      );
+      if (entries.size > 0 && allSimple) {
+        // Perform the deletion immediately
+        if (entries.size === 1) {
+          deleteCell({ cellId: [...entries.values()][0].cellId });
+        } else {
+          deleteManyCells({
+            cellIds: [...entries.values()].map((e) => e.cellId),
+          });
+        }
+        // Return empty state since we auto-deleted
+        return initialState();
+      }
+
+      return {
+        ...state,
+        entries,
+      };
     },
-    [setState, store],
+
+    clear: () => initialState(),
+  },
+);
+
+export function usePendingDeleteService() {
+  const store = useStore();
+  const { submit, clear } = useActions();
+  const { entries } = useAtomValue(pendingDeleteStateAtom);
+  const deleteCell = useDeleteCellCallback();
+  const deleteManyCells = useDeleteManyCellsCallback();
+  return useMemo(
+    () => ({
+      submit: (cellIds: CellId[]) => {
+        submit({ cellIds, deleteCell, deleteManyCells, store });
+      },
+      clear,
+      get idle() {
+        return entries.size === 0;
+      },
+      get shouldConfirmDelete() {
+        return entries.size > 1;
+      },
+    }),
+    [store, submit, clear, entries, deleteCell, deleteManyCells],
   );
-
-  const clear = useCallback(() => {
-    setState(new Map());
-  }, [setState]);
-
-  return {
-    idle: state.size === 0,
-    shouldConfirmDelete: state.size > 1,
-    submit,
-    clear,
-  };
 }
 
 export function usePendingDelete(cellId: CellId) {
-  const [state, setState] = useAtom(pendingDeleteStateAtom);
-  const deleteCell = useDeleteCellCallback();
+  const state = useAtomValue(pendingDeleteStateAtom);
+  const actions = useActions();
   const deleteManyCells = useDeleteManyCellsCallback();
 
-  const entry = state.get(cellId);
-
-  // Auto-delete if all are "simple" cells
-  useEffect(() => {
-    if (state.size === 0) {
-      return;
-    }
-    const entries = [...state.values()];
-    if (entries.every((entry) => entry.type === "simple")) {
-      setState(() => {
-        if (state.size === 1) {
-          deleteCell({ cellId: entries[0].cellId });
-        } else {
-          deleteManyCells({ cellIds: entries.map((e) => e.cellId) });
-        }
-        return new Map();
-      });
-    }
-  }, [state, deleteCell, deleteManyCells, setState]);
+  const entry = state.entries.get(cellId);
 
   if (!entry) {
     return { isPending: false as const };
   }
 
-  const canConfirmDelete = state.size === 1;
+  const canConfirmDelete = state.entries.size === 1;
 
   if (!canConfirmDelete) {
     return {
@@ -143,10 +174,10 @@ export function usePendingDelete(cellId: CellId) {
     shouldConfirmDelete: true as const,
     confirm: () => {
       deleteManyCells({
-        cellIds: [...state.values()].map((e) => e.cellId),
+        cellIds: [...state.entries.values()].map((e) => e.cellId),
       });
-      setState(new Map());
+      actions.clear();
     },
-    cancel: () => setState(new Map()),
+    cancel: () => actions.clear(),
   };
 }


### PR DESCRIPTION
Replaces React state primitives (`useState`, `useEffect`) with a reducer-based approach, eliminating race conditions from effect-based state synchronization. Auto-deletion of "simple" cells now happens synchronously within the reducer action.

We could move the computed properties into the reducer state, but for now I just wraped the existing API to preserve the computed properties (`idle`, `shouldConfirmDelete`).