### PR TITLE
Find first directory parent for `__file__` in `mo.notebook_dir`

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -381,7 +381,10 @@ def notebook_dir() -> pathlib.Path | None:
     # NB: __file__ is patched by runner, so always bound to be correct.
     filename = ctx.globals.get("__file__", None) or ctx.filename
     if filename is not None:
-        return pathlib.Path(filename).parent.absolute()
+        path = pathlib.Path(filename).resolve()
+        while not path.is_dir():
+            path = path.parent
+        return path
 
     return None
 


### PR DESCRIPTION
An alternative to our test patches in #5903 and #5854 is to just find
the first parent that is a directory for the edge case where a parent
path is actually a file (like `pytest.exe\__main__.py`).
