### PR TITLE
Ensure output dir is empty for dev release workflow

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -74,11 +74,14 @@ jobs:
           HATCH_INDEX_AUTH: ${{ secrets.TEST_PYPI_PASSWORD }}
         run: uvx hatch publish --repo test
 
+      - name: Clean output dir
+        run: rm -rf dist
+
       - name: Adapt pyproject.toml to build marimo-base
         run: uv run ./scripts/modify_pyproject_for_marimo_base.py
 
-      - name: 📦 Build marimo
-        run: uvx hatch build --clean
+      - name: 📦 Build marimo-base
+        run: uv build
 
       - name: 📦 Validate wheel under 2mb
         run: ./scripts/validate_base_wheel_size.sh


### PR DESCRIPTION
Non-empty `dist` is causing the dev-release workflow to fail when uploading the slimmed `marimo-base` package to the test index. This change clears `dist/` after publishing to Test PyPI for `marimo`. Should fix CI on main.
