### PR TITLE
fix: do not run create __marimo__/cache by default

### DIFF
--- a/marimo/_save/stores/file.py
+++ b/marimo/_save/stores/file.py
@@ -15,6 +15,8 @@ def _valid_path(path: Path) -> bool:
 class FileStore(Store):
     def __init__(self, save_path: Optional[str] = None) -> None:
         self.save_path = Path(save_path or self._default_save_path())
+        # NB. construction may be called on store import, so do not create
+        # directories until needed.
         self._initialized = False
 
     def _default_save_path(self) -> Path:

--- a/tests/_save/stores/test_file.py
+++ b/tests/_save/stores/test_file.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+from marimo._save.stores.file import FileStore
+
+
+class TestFileStore:
+    def test_init_doesnt_make_file(self, tmp_path) -> None:
+        """Test that initializing FileStore does not create a file."""
+        _store = FileStore(tmp_path / "test_store")
+        # Should not be created just on initialization
+        assert not (tmp_path / "test_store").exists()
+
+    def test_get_put(self, tmp_path) -> None:
+        """Test put and get functionality of FileStore."""
+        store = FileStore(tmp_path / "test_store")
+        assert not (tmp_path / "test_store").exists()
+        data = b"hello world"
+        store.put("key", data)
+        assert store.get("key") == data
+        # Store is actually created
+        assert (tmp_path / "test_store").exists()
+        assert (tmp_path / "test_store" / "key").exists()


### PR DESCRIPTION
## 📝 Summary

fixes #5907

Previously `__marimo__/cache` was created on module load, this PR removes that