### PR TITLE
Normalize line endings in HTTP responses for Windows generated scripts

### DIFF
--- a/marimo/_utils/requests.py
+++ b/marimo/_utils/requests.py
@@ -49,8 +49,14 @@ class Response:
 
         This assumes the response is UTF-8 encoded.
         In future, we can infer the encoding from the headers.
+        
+        Line endings are normalized to Unix style (\n) to match Python's
+        text mode behavior when reading files.
         """
-        return self.content.decode("utf-8")
+        decoded = self.content.decode("utf-8")
+        # Normalize line endings: \r\n -> \n, \r -> \n
+        # This matches Python's universal newline mode used by Path.read_text()
+        return decoded.replace('\r\n', '\n').replace('\r', '\n')
 
     def raise_for_status(self) -> "Response":
         """Raise an exception for non-2xx status codes.


### PR DESCRIPTION
Fixes #5911

When downloading Python scripts from URLs, Windows line endings (`\r\n`) in inline script metadata (PEP 723) weren't being parsed correctly. The regex pattern used to extract script metadata expected Unix-style line endings (`\n`), which worked fine for local files because Python's `Path.read_text()` automatically normalizes line endings across platforms.

This change updates `Response.text()` to normalize line endings to Unix style, matching Python's universal newline behavior. I implemented the fix at the HTTP response level rather than in the script parsing logic to maintain consistency with how Python reads text files.
