### PR TITLE
fix: bin step was too small for large bin values

### DIFF
--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -164,7 +164,7 @@ exports[`ColumnChartSpecModel > should expect bin values to be used for number a
         "x": {
           "bin": {
             "binned": true,
-            "step": 2,
+            "step": 10,
           },
           "field": "bin_start",
           "type": "quantitative",
@@ -224,7 +224,7 @@ exports[`ColumnChartSpecModel > should expect bin values to be used for number a
           },
           "bin": {
             "binned": true,
-            "step": 2,
+            "step": 10,
           },
           "field": "bin_start",
           "type": "quantitative",
@@ -485,7 +485,7 @@ exports[`ColumnChartSpecModel > should handle datetime bin values when feat flag
               "axis": null,
               "bin": {
                 "binned": true,
-                "step": 2,
+                "step": 86400000,
               },
               "field": "bin_start",
               "type": "temporal",
@@ -544,7 +544,7 @@ exports[`ColumnChartSpecModel > should handle datetime bin values when feat flag
               "axis": null,
               "bin": {
                 "binned": true,
-                "step": 2,
+                "step": 86400000,
               },
               "field": "bin_start",
               "type": "temporal",
@@ -553,7 +553,7 @@ exports[`ColumnChartSpecModel > should handle datetime bin values when feat flag
               "axis": null,
               "bin": {
                 "binned": true,
-                "step": 2,
+                "step": 86400000,
               },
               "field": "bin_end",
               "type": "temporal",

--- a/frontend/src/components/data-table/column-summary/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/column-summary/chart-spec-model.tsx
@@ -28,7 +28,7 @@ import {
   getLegacyNumericSpec,
   getLegacyTemporalSpec,
 } from "./legacy-chart-spec";
-import { getPartialTimeTooltip } from "./utils";
+import { calculateBinStep, getPartialTimeTooltip } from "./utils";
 
 // We rely on vega's built-in binning to determine bar widths.
 const MAX_BAR_HEIGHT = 20; // px
@@ -198,6 +198,8 @@ export class ColumnChartSpecModel<T> {
           return getLegacyTemporalSpec(column, type, base, scale);
         }
 
+        const binStep = calculateBinStep(binValues || []);
+
         const tooltip = getPartialTimeTooltip(binValues || []);
         const singleValue = binValues?.length === 1;
 
@@ -261,7 +263,7 @@ export class ColumnChartSpecModel<T> {
                 x: {
                   field: "bin_start",
                   type: "temporal",
-                  bin: { binned: true, step: 2 },
+                  bin: { binned: true, step: binStep },
                   axis: null,
                 },
                 x2: {
@@ -295,13 +297,13 @@ export class ColumnChartSpecModel<T> {
                 x: {
                   field: "bin_start",
                   type: "temporal",
-                  bin: { binned: true, step: 2 },
+                  bin: { binned: true, step: binStep },
                   axis: null,
                 },
                 x2: {
                   field: "bin_end",
                   type: "temporal",
-                  bin: { binned: true, step: 2 },
+                  bin: { binned: true, step: binStep },
                   axis: null,
                 },
                 y: {
@@ -428,6 +430,7 @@ export class ColumnChartSpecModel<T> {
       case "number": {
         // Create a histogram spec that properly handles null values
         const format = type === "integer" ? ",d" : ".2f";
+        const binStep = calculateBinStep(binValues || []);
 
         if (!usePreComputedValues) {
           return getLegacyNumericSpec(column, format, base);
@@ -461,7 +464,7 @@ export class ColumnChartSpecModel<T> {
                 x: {
                   field: "bin_start",
                   type: "quantitative",
-                  bin: { binned: true, step: 2 },
+                  bin: { binned: true, step: binStep },
                 },
                 x2: {
                   field: "bin_end",
@@ -493,7 +496,7 @@ export class ColumnChartSpecModel<T> {
                 x: {
                   field: "bin_start",
                   type: "quantitative",
-                  bin: { binned: true, step: 2 },
+                  bin: { binned: true, step: binStep },
                   axis: {
                     title: null,
                     labelFontSize: 8.5,

--- a/frontend/src/components/data-table/column-summary/utils.ts
+++ b/frontend/src/components/data-table/column-summary/utils.ts
@@ -76,3 +76,67 @@ export function getPartialTimeTooltip(
     timeUnit: "yearmonthdate",
   };
 }
+
+/**
+ * Calculate the bin step for a given set of values.
+ * If the bin step is too small for a large range, it can crash the browser.
+ *
+ * @param values - The values to calculate the bin step for.
+ * @returns The bin step.
+ */
+export function calculateBinStep(values: BinValues) {
+  if (values.length === 0) {
+    return 1;
+  }
+
+  const validValues = values.filter(
+    (v) => v.bin_start !== null && v.bin_end !== null,
+  );
+
+  if (validValues.length === 0) {
+    return 1;
+  }
+
+  // Check the data types
+  const firstStart = validValues[0].bin_start;
+  const firstEnd = validValues[0].bin_end;
+
+  // If values are strings or dates, we need to convert them to numbers
+  let min: number;
+  let max: number;
+
+  // Use first and last values since binValues are sorted
+  if (typeof firstStart === "number" && typeof firstEnd === "number") {
+    const firstValue = validValues[0];
+    const lastValue = validValues[validValues.length - 1];
+    min = firstValue.bin_start as number;
+    max = lastValue.bin_end as number;
+  } else if (typeof firstStart === "string" || typeof firstEnd === "string") {
+    // String data (likely dates) - convert to timestamps
+    const firstValue = validValues[0];
+    const lastValue = validValues[validValues.length - 1];
+    const firstStart = new Date(firstValue.bin_start as string).getTime();
+    const lastEnd = new Date(lastValue.bin_end as string).getTime();
+    min = firstStart;
+    max = lastEnd;
+  } else {
+    // Date objects - use first and last values since they're sorted
+    const firstValue = validValues[0];
+    const lastValue = validValues[validValues.length - 1];
+    min = (firstValue.bin_start as Date).getTime();
+    max = (lastValue.bin_end as Date).getTime();
+  }
+
+  const range = max - min;
+
+  // Handle edge case where range is 0
+  if (range === 0) {
+    return 1;
+  }
+
+  const numBins = validValues.length;
+  const step = range / numBins;
+
+  // Ensure minimum step size
+  return Math.max(step, 1);
+}


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

This fixes the browser crash when the binValues were too large, but bin step is too small.

similar issue: https://github.com/vega/vega-lite/issues/9416

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
