### PR TITLE
Force exclude `marimo/_lsp` in `marimo-base` build

### DIFF
--- a/scripts/modify_pyproject_for_marimo_base.py
+++ b/scripts/modify_pyproject_for_marimo_base.py
@@ -23,17 +23,17 @@ import tomlkit
 
 root = pathlib.Path(__file__).parent.parent
 
+force_exclude = ["marimo/_lsp"]
 static_dir = root / "marimo/_static"
 
 if static_dir.exists():
-    force_exclude = [
+    force_exclude.extend([
         str(item.relative_to(root))
         for item in static_dir.iterdir()
         if item.name != "index.html"
-    ]
+    ])
 else:
     print("No _static directory found, skipping")
-    force_exclude = []
 
 with (root / "pyproject.toml").open(encoding="utf-8", mode="r") as f:
     data = tomlkit.load(f)


### PR DESCRIPTION
Upgrading to `uv_build` (#5778) included these assets, which we want to ignore in the slimmed down build of marimo. Should fix CI failing for builds >2mb (since the whl is ~900kb now).