### PR TITLE
fix: inline-completions parsing issue

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -299,7 +299,7 @@ class CompletionProvider(Generic[ResponseT, StreamT], ABC):
 
     def collect_stream(self, response: StreamT) -> str:
         """Collect a stream into a single string."""
-        return "".join(self.as_stream_response(response))
+        return "".join(self.as_stream_response(response, StreamOptions(text_only=True)))
 
     def _content_to_string(
         self, content_data: Union[str, dict[str, Any]]

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -299,7 +299,9 @@ class CompletionProvider(Generic[ResponseT, StreamT], ABC):
 
     def collect_stream(self, response: StreamT) -> str:
         """Collect a stream into a single string."""
-        return "".join(self.as_stream_response(response, StreamOptions(text_only=True)))
+        return "".join(
+            self.as_stream_response(response, StreamOptions(text_only=True))
+        )
 
     def _content_to_string(
         self, content_data: Union[str, dict[str, Any]]


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
This PR fixes the inline completions parsing error where `:{"finishReason": "stop", "usage": {"promptTokens": 0, "completionTokens": 0}}` appears at the end of every completion. It is mentioned in a [discord thread](https://discord.com/channels/1059888774789730424/1402597432432263188)

<img width="890" height="387" alt="Screenshot 2025-08-06 at 11 20 15 AM" src="https://github.com/user-attachments/assets/d75edf1f-9ffb-45b4-bfc6-3181849fbd6d" />



## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Add **StreamOptions(text_only=True)** to collect_stream function so that it ignores all formatting and meta data used by the Chat Panel.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
