### PR TITLE
fix: as_html for svg and add tests

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -332,6 +332,8 @@ def mime_to_html(mimetype: KnownMimeType, data: Any) -> Html:
         # Flatten the HTML text to avoid indentation issues
         # when interpolating into markdown/a multiline string
         return Html(flatten_string(f"<span>{escape(data)}</span>"))
+    elif mimetype == "image/svg+xml":
+        return Html(data)
     elif mimetype.startswith("image"):
         return Html(flatten_string(f'<img src="{data}" alt="" />'))
     elif mimetype == "application/json":


### PR DESCRIPTION
Fixes #5946

svg mime starts with `image` but should be treated differently