### PR TITLE
improve: make it possible to close open snippet

### DIFF
--- a/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
@@ -97,7 +97,10 @@ export const SnippetsPanel: React.FC = () => {
   );
 };
 
-const SnippetViewer: React.FC<{ snippet: Snippet; onClose: () => void }> = ({ snippet, onClose }) => {
+const SnippetViewer: React.FC<{ snippet: Snippet; onClose: () => void }> = ({
+  snippet,
+  onClose,
+}) => {
   const { theme } = useTheme();
   const { createNewCell } = useCellActions();
   const lastFocusedCellId = useLastFocusedCellId();

--- a/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
@@ -1,7 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import { CommandList } from "cmdk";
-import { BetweenHorizontalStartIcon, PlusIcon } from "lucide-react";
+import { BetweenHorizontalStartIcon, PlusIcon, XIcon } from "lucide-react";
 import React from "react";
 import {
   Command,
@@ -83,6 +83,7 @@ export const SnippetsPanel: React.FC = () => {
             <SnippetViewer
               key={selectedSnippet.title}
               snippet={selectedSnippet}
+              onClose={() => setSelectedSnippet(undefined)}
             />
           ) : (
             <PanelEmptyState
@@ -96,7 +97,7 @@ export const SnippetsPanel: React.FC = () => {
   );
 };
 
-const SnippetViewer: React.FC<{ snippet: Snippet }> = ({ snippet }) => {
+const SnippetViewer: React.FC<{ snippet: Snippet; onClose: () => void }> = ({ snippet, onClose }) => {
   const { theme } = useTheme();
   const { createNewCell } = useCellActions();
   const lastFocusedCellId = useLastFocusedCellId();
@@ -126,8 +127,16 @@ const SnippetViewer: React.FC<{ snippet: Snippet }> = ({ snippet }) => {
 
   return (
     <>
-      <div className="text-sm font-semibold bg-muted border-y px-2 py-1">
-        {snippet.title}
+      <div className="text-sm font-semibold bg-muted border-y px-2 py-1 flex justify-between items-center">
+        <span>{snippet.title}</span>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onClose}
+          className="h-6 w-6 p-0 hover:bg-muted-foreground/10"
+        >
+          <XIcon className="h-4 w-4" />
+        </Button>
       </div>
       <div className="px-2 py-2 space-y-4 overflow-auto flex-1">
         <div className="flex justify-end">


### PR DESCRIPTION
Previously once a snippet was open, it could not be closed, making it difficult to explore other snippets.

<img width="449" height="756" alt="image" src="https://github.com/user-attachments/assets/169a3e56-356b-46e0-b93c-504d82fb45b2" />