### PR TITLE
enh: allow dangerous sandbox to be set with an environment variable

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -488,6 +488,12 @@ def edit(
         )
         return
 
+    # Dangerous sandbox can be forced on by setting an environment variable;
+    # this allows our VS Code extension to force sandbox regardless of the
+    # marimo version.
+    if sandbox and os.getenv("MARIMO_DANGEROUS_SANDBOX"):
+        dangerous_sandbox = True
+
     if dangerous_sandbox and (name is None or os.path.isdir(name)):
         sandbox = True
         click.echo(


### PR DESCRIPTION
This change adds an environment variable, `MARIMO_DANGEROUS_SANDBOX`, that when set upgrades `--sandbox` to `--dangerous-sandbox`. This lets environments that don't know what version of marimo is running to force sandbox for multi-notebook servers (`--dangerous-sandbox` was newly introduced).

example: `MARIMO_DANGEROUS_SANDBOX=1 marimo edit --sandbox`