### PR TITLE
Allow deleting variables defined by other cells

### DIFF
--- a/docs/guides/reactivity.md
+++ b/docs/guides/reactivity.md
@@ -185,6 +185,13 @@ _()
 
 Here, the variables `plt`, `fig`, and `ax` aren't added to the globals.
 
+### Managing memory
+
+Because variable names must be unique, you cannot reassign variables as a means
+of freeing memory. Instead, manage memory by encapsulating code in functions or
+using the `del` operator. See our guide on [expensive
+notebooks](expensive_notebooks.md#manage-memory) to learn more.
+
 ## Configuring how marimo runs cells
 
 Through the notebook settings menu, you can configure how and when marimo runs

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -45,7 +45,6 @@ from marimo._ast.cell import Cell, CellConfig, CellImpl
 from marimo._ast.cell_manager import CellManager
 from marimo._ast.errors import (
     CycleError,
-    DeleteNonlocalError,
     MultipleDefinitionError,
     SetupRootError,
     UnparsableError,
@@ -567,13 +566,6 @@ class App:
                 raise MultipleDefinitionError(
                     "This app can't be run because it has multiple "
                     f"definitions of the name {multiply_defined_names[0]}"
-                )
-            deleted_nonlocal_refs = self._graph.get_deleted_nonlocal_ref()
-            if deleted_nonlocal_refs:
-                raise DeleteNonlocalError(
-                    "This app can't be run because at least one cell "
-                    "deletes one of its refs (the ref's name is "
-                    f"{deleted_nonlocal_refs[0]})"
                 )
             self._execution_order = dataflow.topological_sort(
                 self._graph, list(self._cell_manager.valid_cell_ids())

--- a/marimo/_ast/errors.py
+++ b/marimo/_ast/errors.py
@@ -15,9 +15,5 @@ class MultipleDefinitionError(Exception):
     pass
 
 
-class DeleteNonlocalError(Exception):
-    pass
-
-
 class UnparsableError(Exception):
     pass

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -68,7 +68,6 @@ def _generate_server_api_schema() -> dict[str, Any]:
         errors.CycleError,
         errors.MultipleDefinitionError,
         errors.ImportStarError,
-        errors.DeleteNonlocalError,
         errors.MarimoInterruptionError,
         errors.MarimoInternalError,
         errors.MarimoAncestorStoppedError,

--- a/marimo/_messaging/errors.py
+++ b/marimo/_messaging/errors.py
@@ -46,16 +46,6 @@ class ImportStarError:
 
 
 @dataclass
-class DeleteNonlocalError:
-    name: str
-    cells: tuple[CellId_t, ...]
-    type: Literal["delete-nonlocal"] = "delete-nonlocal"
-
-    def describe(self) -> str:
-        return f"The variable '{self.name}' can't be deleted because it was defined by another cell"
-
-
-@dataclass
 class MarimoInterruptionError:
     type: Literal["interruption"] = "interruption"
 
@@ -174,7 +164,6 @@ Error = Union[
     CycleError,
     MultipleDefinitionError,
     ImportStarError,
-    DeleteNonlocalError,
     MarimoAncestorStoppedError,
     MarimoAncestorPreventedError,
     MarimoExceptionRaisedError,

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -202,6 +202,18 @@ class DirectedGraph:
                     if path:
                         self.cycles.add(tuple([(other_id, cell_id)] + path))
                     self.children[other_id].add(cell_id)
+
+            for name in cell.deleted_refs:
+                referring_cells = self.get_referring_cells(
+                    name, language="python"
+                ) - set((cell_id,))
+                for other_id in referring_cells:
+                    parents.add(other_id)
+                    path = self.get_path(cell_id, other_id)
+                    if path:
+                        self.cycles.add(tuple([(other_id, cell_id)] + path))
+                    self.children[other_id].add(cell_id)
+
         LOGGER.debug("Registered cell %s and released graph lock", cell_id)
         if self.is_any_ancestor_stale(cell_id):
             self.set_stale(set([cell_id]))

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -179,6 +179,8 @@ class DirectedGraph:
                     self.parents[child].add(cell_id)
 
             for name in cell.refs:
+                # First, for each referenced variable, we add cells that define
+                # that variable as parents
                 other_ids_defining_name: set[CellId_t] = (
                     self.definitions[name]
                     if name in self.definitions
@@ -202,6 +204,23 @@ class DirectedGraph:
                     if path:
                         self.cycles.add(tuple([(other_id, cell_id)] + path))
                     self.children[other_id].add(cell_id)
+
+                # Next, any cell that deletes this referenced variable is made
+                # a child of this cell. If two cells delete the same variable,
+                # they form a cycle.
+                other_ids_deleting_name: set[CellId_t] = set(
+                    cid
+                    for cid in self.get_referring_cells(
+                        name, language="python"
+                    )
+                    if name in self.cells[cid].deleted_refs
+                ) - set((cell_id,))
+                for v in other_ids_deleting_name:
+                    path = self.get_path(v, cell_id)
+                    if path:
+                        self.cycles.add(tuple([(cell_id, v)] + path))
+                    self.parents[v].add(cell_id)
+                children.update(other_ids_deleting_name)
 
             for name in cell.deleted_refs:
                 referring_cells = self.get_referring_cells(

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -152,6 +152,11 @@ class DirectedGraph:
             self.children[cell_id] = children
             self.siblings[cell_id] = siblings
             self.parents[cell_id] = parents
+
+            # First, we process the variables that this cell defines. Any cell
+            # that refers to a defined variable becomes a child of this cell;
+            # any cell that defines a variable defined by this cell becomes
+            # a sibling.
             for name, variable_data in cell.variable_data.items():
                 self.definitions.setdefault(name, set()).add(cell_id)
                 for sibling in self.definitions[name]:
@@ -178,6 +183,11 @@ class DirectedGraph:
                 for child in referring_cells:
                     self.parents[child].add(cell_id)
 
+            # Next, we process the cells references. The cell becomes a child
+            # of cells that define its referenced variables. We also have
+            # special logic for handling references that are deleted by this cell,
+            # since cells that delete variables that were defined elsewhere
+            # are made children of cells that reference that variable.
             for name in cell.refs:
                 # First, for each referenced variable, we add cells that define
                 # that variable as parents
@@ -186,9 +196,8 @@ class DirectedGraph:
                     if name in self.definitions
                     else set()
                 ) - set((cell_id,))
-                # if other is empty, this means that the user is going to
-                # get a NameError once the cell is run, unless the symbol
-                # is say a builtin
+                # If other_ids_defining_name is empty, the user will get a
+                # NameError at runtime (unless the symbol is a builtin).
                 for other_id in other_ids_defining_name:
                     language = (
                         self.cells[other_id].variable_data[name][-1].language
@@ -206,8 +215,24 @@ class DirectedGraph:
                     self.children[other_id].add(cell_id)
 
                 # Next, any cell that deletes this referenced variable is made
-                # a child of this cell. If two cells delete the same variable,
-                # they form a cycle.
+                # a child of this cell. In particular, if a cell deletes a
+                # variable, it becomes a child of all other cells that
+                # reference that variable. This means that if two cells delete
+                # the same variable, they form a cycle.
+                #
+                # For example, two cells
+                #
+                #   cell u: x
+                #   cell v: del x
+                #
+                # v becomes a child of u.
+                #
+                # Another example:
+                #
+                #   cell u: del x
+                #   cell v: del x
+                #
+                # u and v form a cycle.
                 other_ids_deleting_name: set[CellId_t] = set(
                     cid
                     for cid in self.get_referring_cells(
@@ -222,6 +247,8 @@ class DirectedGraph:
                     self.parents[v].add(cell_id)
                 children.update(other_ids_deleting_name)
 
+            # Finally, if this cell deletes a variable, we make it a child of
+            # all other cells that reference this variable.
             for name in cell.deleted_refs:
                 referring_cells = self.get_referring_cells(
                     name, language="python"

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -330,7 +330,6 @@ class Runner:
         cell_id: CellId_t,
     ) -> tuple[RunResult, Optional[BaseException]]:
         exception: Optional[ErrorObjects] = unwrapped_exception
-        repr(exception)
         if isinstance(exception, MarimoMissingRefError):
             ref, blamed_cell = self._get_blamed_cell(exception)
             # All MarimoMissingRefErrors should be caused caused by

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -330,6 +330,7 @@ class Runner:
         cell_id: CellId_t,
     ) -> tuple[RunResult, Optional[BaseException]]:
         exception: Optional[ErrorObjects] = unwrapped_exception
+        repr(exception)
         if isinstance(exception, MarimoMissingRefError):
             ref, blamed_cell = self._get_blamed_cell(exception)
             # All MarimoMissingRefErrors should be caused caused by
@@ -354,9 +355,19 @@ class Runner:
                 )
                 exception = output
             elif blamed_cell != cell_id:
+                possibly_deleted = any(
+                    ref in cell.deleted_refs
+                    for cell in self.graph.cells.values()
+                )
+
+                deleted_message = (
+                    " Another cell may have deleted it with the del operator."
+                    if possibly_deleted
+                    else ""
+                )
                 output = MarimoExceptionRaisedError(
-                    f"marimo came across the undefined variable `{ref}` "
-                    "during runtime. Definition expected in cell : ",
+                    f"Name `{ref}` is not defined.{deleted_message} "
+                    "It was expected to be defined in ",
                     "NameError",
                     blamed_cell,
                 )

--- a/marimo/_runtime/runner/hooks_on_finish.py
+++ b/marimo/_runtime/runner/hooks_on_finish.py
@@ -71,12 +71,12 @@ def _send_cancellation_errors(runner: cell_runner.Runner) -> None:
                     blamed_cell=exception.blamed_cell,
                 )
             else:
-                exception_type = type(runner.exceptions[raising_cell]).__name__
+                exception_type = type(exception).__name__
                 data = MarimoExceptionRaisedError(
                     msg=(
                         f"An ancestor raised an exception ({exception_type}): "
                     ),
-                    exception_type=exception_type,
+                    exception_type="Ancestor raised",
                     raising_cell=raising_cell,
                 )
             CellOp.broadcast_error(

--- a/marimo/_runtime/validate_graph.py
+++ b/marimo/_runtime/validate_graph.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from marimo._ast.names import SETUP_CELL_NAME
 from marimo._messaging.errors import (
     CycleError,
-    DeleteNonlocalError,
     Error,
     MultipleDefinitionError,
     SetupRootError,
@@ -78,7 +77,11 @@ def check_for_cycles(graph: DirectedGraph) -> dict[CellId_t, list[CycleError]]:
         cycle_with_vars = tuple(
             (
                 edge[0],
-                sorted(graph.cells[edge[0]].defs & graph.cells[edge[1]].refs),
+                sorted(graph.cells[edge[0]].defs & graph.cells[edge[1]].refs)
+                + sorted(
+                    graph.cells[edge[0]].deleted_refs
+                    & graph.cells[edge[1]].deleted_refs
+                ),
                 edge[1],
             )
             for edge in cycle

--- a/marimo/_runtime/validate_graph.py
+++ b/marimo/_runtime/validate_graph.py
@@ -37,25 +37,6 @@ def check_for_multiple_definitions(
     return errors
 
 
-def check_for_delete_nonlocal(
-    graph: DirectedGraph,
-) -> dict[CellId_t, list[DeleteNonlocalError]]:
-    """Check whether cells delete their refs."""
-    # TODO XXX
-    errors = defaultdict(list)
-    return errors
-    for cid in graph.cells.keys():
-        for name in graph.cells[cid].deleted_refs:
-            if name in graph.definitions:
-                errors[cid].append(
-                    DeleteNonlocalError(
-                        name=str(name),
-                        cells=tuple(graph.definitions[name]),
-                    )
-                )
-    return errors
-
-
 def check_for_invalid_root(
     graph: DirectedGraph,
 ) -> dict[CellId_t, list[SetupRootError]]:
@@ -117,7 +98,6 @@ def check_for_errors(
     that is involved in an error.
     """
     multiple_definition_errors = check_for_multiple_definitions(graph)
-    delete_nonlocal_errors = check_for_delete_nonlocal(graph)
     cycle_errors = check_for_cycles(graph)
     invalid_root_errors = check_for_invalid_root(graph)
 
@@ -125,7 +105,6 @@ def check_for_errors(
     for cid in set(
         itertools.chain(
             multiple_definition_errors.keys(),
-            delete_nonlocal_errors.keys(),
             cycle_errors.keys(),
             invalid_root_errors.keys(),
         )
@@ -134,7 +113,6 @@ def check_for_errors(
             itertools.chain(
                 multiple_definition_errors[cid],
                 cycle_errors[cid],
-                delete_nonlocal_errors[cid],
                 invalid_root_errors[cid],
             )
         )

--- a/marimo/_runtime/validate_graph.py
+++ b/marimo/_runtime/validate_graph.py
@@ -41,7 +41,9 @@ def check_for_delete_nonlocal(
     graph: DirectedGraph,
 ) -> dict[CellId_t, list[DeleteNonlocalError]]:
     """Check whether cells delete their refs."""
+    # TODO XXX
     errors = defaultdict(list)
+    return errors
     for cid in graph.cells.keys():
         for name in graph.cells[cid].deleted_refs:
             if name in graph.definitions:

--- a/marimo/_runtime/validate_graph.py
+++ b/marimo/_runtime/validate_graph.py
@@ -77,10 +77,17 @@ def check_for_cycles(graph: DirectedGraph) -> dict[CellId_t, list[CycleError]]:
         cycle_with_vars = tuple(
             (
                 edge[0],
-                sorted(graph.cells[edge[0]].defs & graph.cells[edge[1]].refs)
-                + sorted(
-                    graph.cells[edge[0]].deleted_refs
-                    & graph.cells[edge[1]].deleted_refs
+                sorted(
+                    set(
+                        list(
+                            graph.cells[edge[0]].defs
+                            & graph.cells[edge[1]].refs
+                        )
+                        + list(
+                            graph.cells[edge[0]].refs
+                            & graph.cells[edge[1]].deleted_refs
+                        )
+                    )
                 ),
                 edge[1],
             )

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -707,23 +707,6 @@ components:
       required:
       - cellId
       type: object
-    DeleteNonlocalError:
-      properties:
-        cells:
-          items:
-            type: string
-          type: array
-        name:
-          type: string
-        type:
-          enum:
-          - delete-nonlocal
-          type: string
-      required:
-      - name
-      - cells
-      - type
-      type: object
     DeleteSecretRequest:
       properties:
         key:
@@ -765,7 +748,6 @@ components:
       - $ref: '#/components/schemas/CycleError'
       - $ref: '#/components/schemas/MultipleDefinitionError'
       - $ref: '#/components/schemas/ImportStarError'
-      - $ref: '#/components/schemas/DeleteNonlocalError'
       - $ref: '#/components/schemas/MarimoAncestorStoppedError'
       - $ref: '#/components/schemas/MarimoAncestorPreventedError'
       - $ref: '#/components/schemas/MarimoExceptionRaisedError'
@@ -2749,7 +2731,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.14.15
+  version: 0.14.16
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -2820,12 +2820,6 @@ export interface components {
     DeleteCellRequest: {
       cellId: string;
     };
-    DeleteNonlocalError: {
-      cells: string[];
-      name: string;
-      /** @enum {string} */
-      type: "delete-nonlocal";
-    };
     DeleteSecretRequest: {
       key: string;
     };
@@ -2845,7 +2839,6 @@ export interface components {
       | components["schemas"]["CycleError"]
       | components["schemas"]["MultipleDefinitionError"]
       | components["schemas"]["ImportStarError"]
-      | components["schemas"]["DeleteNonlocalError"]
       | components["schemas"]["MarimoAncestorStoppedError"]
       | components["schemas"]["MarimoAncestorPreventedError"]
       | components["schemas"]["MarimoExceptionRaisedError"]

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -18,7 +18,6 @@ from marimo._ast.app import (
 from marimo._ast.app_config import _AppConfig
 from marimo._ast.errors import (
     CycleError,
-    DeleteNonlocalError,
     MultipleDefinitionError,
     SetupRootError,
     UnparsableError,
@@ -195,7 +194,7 @@ class TestApp:
             app.run()
 
     @staticmethod
-    def test_delete_nonlocal_missing_args_rets() -> None:
+    def test_delete_nonlocal_ok() -> None:
         app = App()
 
         @app.cell
@@ -206,8 +205,8 @@ class TestApp:
         def two() -> None:
             del x  # noqa: F841, F821
 
-        with pytest.raises(DeleteNonlocalError):
-            app.run()
+        # smoke test, no error raised
+        app.run()
 
     @staticmethod
     def test_unparsable_cell() -> None:

--- a/tests/_messaging/test_messaging_errors.py
+++ b/tests/_messaging/test_messaging_errors.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from marimo._messaging.errors import (
     CycleError,
-    DeleteNonlocalError,
     ImportStarError,
     MarimoAncestorPreventedError,
     MarimoAncestorStoppedError,
@@ -49,14 +48,6 @@ class TestErrorClasses:
         # Test properties
         assert error.type == "import-star"
         assert error.describe() == "Cannot use import * in this context"
-
-    def test_delete_nonlocal_error(self) -> None:
-        error = DeleteNonlocalError(name="test_var", cells=("cell1", "cell2"))
-
-        # Test properties
-        assert error.type == "delete-nonlocal"
-        assert "test_var" in error.describe()
-        assert "can't be deleted" in error.describe()
 
     def test_marimo_interruption_error(self) -> None:
         error = MarimoInterruptionError()

--- a/tests/_runtime/test_dataflow.py
+++ b/tests/_runtime/test_dataflow.py
@@ -974,6 +974,33 @@ def test_cycles() -> None:
     assert not graph.cycles
 
 
+def test_del_cycle():
+    """Two variables that delete the same variable form a cycle."""
+    graph = dataflow.DirectedGraph()
+
+    graph.register_cell("0", parse_cell("del x"))
+    graph.register_cell("1", parse_cell("del x"))
+    assert len(graph.cycles) == 1
+    assert list(graph.cycles)[0] == (("0", "1"), ("1", "0"))
+
+
+def test_del_child_of_ref():
+    """Cells that delete a variable become a child of cells that reference it."""
+    graph = dataflow.DirectedGraph()
+
+    graph.register_cell("0", parse_cell("del x"))
+    graph.register_cell("1", parse_cell("x"))
+    graph.register_cell("2", parse_cell("x = 1"))
+    assert graph.parents["0"] == set(["1", "2"])
+    assert graph.children["0"] == set()
+
+    assert graph.parents["1"] == set(["2"])
+    assert graph.children["1"] == set(["0"])
+
+    assert graph.parents["2"] == set([])
+    assert graph.children["2"] == set(["0", "1"])
+
+
 def test_get_path() -> None:
     """Test the get_path method."""
     graph = dataflow.DirectedGraph()

--- a/tests/_runtime/test_dataflow.py
+++ b/tests/_runtime/test_dataflow.py
@@ -974,14 +974,25 @@ def test_cycles() -> None:
     assert not graph.cycles
 
 
-def test_del_cycle():
+def test_del_del_cycle():
     """Two variables that delete the same variable form a cycle."""
     graph = dataflow.DirectedGraph()
 
     graph.register_cell("0", parse_cell("del x"))
     graph.register_cell("1", parse_cell("del x"))
     assert len(graph.cycles) == 1
-    assert list(graph.cycles)[0] == (("0", "1"), ("1", "0"))
+    assert set(list(graph.cycles)[0]) == set([(("0", "1"), ("1", "0"))])
+
+
+def test_del_ref_cycle():
+    """One cell deletes a variable and defines another, the other refs both."""
+    graph = dataflow.DirectedGraph()
+
+    graph.register_cell("0", parse_cell("x = 1"))
+    graph.register_cell("1", parse_cell("del x; y = 1"))
+    graph.register_cell("2", parse_cell("z = x + y"))
+    assert len(graph.cycles) == 1
+    assert set(list(graph.cycles)[0]) == set([("1", "2"), ("2", "1")])
 
 
 def test_del_child_of_ref():

--- a/tests/_runtime/test_dataflow.py
+++ b/tests/_runtime/test_dataflow.py
@@ -981,7 +981,7 @@ def test_del_del_cycle():
     graph.register_cell("0", parse_cell("del x"))
     graph.register_cell("1", parse_cell("del x"))
     assert len(graph.cycles) == 1
-    assert set(list(graph.cycles)[0]) == set([(("0", "1"), ("1", "0"))])
+    assert set(list(graph.cycles)[0]) == set((("0", "1"), ("1", "0")))
 
 
 def test_del_ref_cycle():

--- a/tests/_runtime/test_trace.py
+++ b/tests/_runtime/test_trace.py
@@ -271,7 +271,7 @@ class TestAppTrace:
             )
         else:
             assert (
-                "marimo came across the undefined variable `C` during runtime."
+                "Name `C` is not defined."
                 in k.stream.messages[-2][1]["output"]["data"][0]["msg"]
             )
             assert "NameError" in k.stderr.messages[0]

--- a/tests/_runtime/test_validate_graph.py
+++ b/tests/_runtime/test_validate_graph.py
@@ -8,7 +8,6 @@ from marimo._ast import compiler
 from marimo._ast.names import SETUP_CELL_NAME
 from marimo._messaging.errors import (
     CycleError,
-    DeleteNonlocalError,
     MultipleDefinitionError,
     SetupRootError,
 )
@@ -68,15 +67,6 @@ def test_underscore_variables_are_private() -> None:
     graph.register_cell("1", parse_cell("del _x"))
     errors = check_for_errors(graph)
     assert not errors
-
-
-def test_delete_nonlocal_error() -> None:
-    graph = dataflow.DirectedGraph()
-    graph.register_cell("0", parse_cell("x = 0"))
-    graph.register_cell("1", parse_cell("del x"))
-    errors = check_for_errors(graph)
-    assert set(errors.keys()) == set(["1"])
-    assert errors["1"] == (DeleteNonlocalError(name="x", cells=("0",)),)
 
 
 def test_two_node_cycle() -> None:


### PR DESCRIPTION
This change makes it possible to delete variables that were defined in another cell.

The motivation for this change is to allow advanced users to reclaim
memory. Especially when dealing with tensors or large datasets, either
reusing a variable name or explicitly deleting it with `del` are
traditionally used to reclaim memory. Reusing variables is not allowed
in marimo, and before this change `del` was not either, since it wasn't
clear how to order cells.

This change allows the `del` operator by introducing the following rule:

  If a cell deletes a variable, it becomes a child of all other cells
  that reference that variable.

For example:

**cell u**
```
x
```

**cell v**
```
del x
```

In this case, **v** becomes a child of **u**.

This has the (desired) consequence that two cells cannot delete the same
variable, as that forms a cycle error.

This change does introduce some path dependency in how cells are
executed. In the above example, if cell u were manually re-run after
cell v ran, the user would get a NameError. We mitigate this by
communicating in the error message that the variable may have been
deleted (if at least one cell deletes the variable).

While the path dependency is unfortunate, using `del` is an advanced pattern that one
only uses when they're in pretty deep (and trying to avoid restarting
their kernel), so trading off execution reproducibility for
unblocking more resource intensive workflows is in my mind worth it.
Without this change, users would need to instead coalesce all
memory-intensive work into a single function (making incremental
computation difficult).