### PR TITLE
fix: use old logic for steps in tracing-chart

### DIFF
--- a/frontend/src/components/tracing/tracing-spec.ts
+++ b/frontend/src/components/tracing/tracing-spec.ts
@@ -52,7 +52,9 @@ export function createGanttBaseSpec(
         },
       },
     ],
-    height: { step: 23 },
+    height: {
+      step: chartPosition === "sideBySide" ? 26 : 21,
+    },
     encoding: {
       y: {
         field: cellNumField,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #5454. I regressed this bug because i modifed the step height logic without testing with a large tracing chart. I am reverting to the original logic.

<img width="753" height="676" alt="CleanShot 2025-08-08 at 12 51 50" src="https://github.com/user-attachments/assets/825ec686-5636-43a8-ac51-fc314985edb8" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
