### PR TITLE
fix: date rendering to support date formats

### DIFF
--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -429,7 +429,13 @@ export function renderCellValue<TData, TValue>(
   const dataType = column.columnDef.meta?.dataType;
   const dtype = column.columnDef.meta?.dtype;
 
-  if (dataType === "datetime" && typeof value === "string") {
+  if (
+    dataType === "datetime" &&
+    typeof value === "string" &&
+    // 2000-01-01T00:00:00.000 is considered a datetime. We treat shorter values as strings.
+    // Because users may define format_mapping to alter the value.
+    value.length > 12
+  ) {
     try {
       const date = new Date(value);
       return renderDate(date, dataType, dtype);

--- a/frontend/src/utils/__tests__/dates.test.ts
+++ b/frontend/src/utils/__tests__/dates.test.ts
@@ -1,6 +1,12 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { exactDateTime, getShortTimeZone, prettyDate, timeAgo } from "../dates";
+import {
+  exactDateTime,
+  getDateFormat,
+  getShortTimeZone,
+  prettyDate,
+  timeAgo,
+} from "../dates";
 
 describe("dates", () => {
   // Save original timezone
@@ -159,6 +165,24 @@ describe("dates", () => {
 
     it("handles errors gracefully", () => {
       expect(getShortTimeZone("MarimoLand")).toBe("MarimoLand");
+    });
+  });
+
+  describe("getDateFormat", () => {
+    it("returns the correct format for date", () => {
+      expect(getDateFormat("2023-05-15")).toBe("yyyy-MM-dd");
+    });
+
+    it("returns the correct format for year only", () => {
+      expect(getDateFormat("2023")).toBe("yyyy");
+    });
+
+    it("returns the correct format for month only", () => {
+      expect(getDateFormat("2023-05")).toBe("yyyy-MM");
+    });
+
+    it("returns null for invalid date", () => {
+      expect(getDateFormat("2023-05-15T12:00:00Z")).toBeNull();
     });
   });
 });

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -1,7 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import { TZDate } from "@date-fns/tz";
-import { formatDate } from "date-fns";
+import { formatDate, isMatch } from "date-fns";
 import { Logger } from "./Logger";
 
 export function prettyDate(
@@ -127,4 +127,19 @@ export function timeAgo(value: string | number | null | undefined): string {
   }
 
   return value.toString();
+}
+
+export const supportedDateFormats = ["yyyy", "yyyy-MM", "yyyy-MM-dd"] as const;
+export type DateFormat = (typeof supportedDateFormats)[number];
+
+/**
+ * If the string matches one of the supported date formats, return the format.
+ */
+export function getDateFormat(value: string): DateFormat | null {
+  for (const format of supportedDateFormats) {
+    if (isMatch(value, format)) {
+      return format;
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Fixes #5959 . We previously optimistically formed Date based on the dtypes. But format_mapping can alter the value

<img width="467" height="538" alt="CleanShot 2025-08-09 at 01 58 16" src="https://github.com/user-attachments/assets/5c8a0510-6556-4ed1-8158-e639df6ee78c" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
