### PR TITLE
chore: remove nonlocal error types

### DIFF
--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -96,10 +96,6 @@ export const MarimoErrorOutput = ({
     (e): e is Extract<MarimoError, { type: "import-star" }> =>
       e.type === "import-star",
   );
-  const deleteNonlocalErrors = errors.filter(
-    (e): e is Extract<MarimoError, { type: "delete-nonlocal" }> =>
-      e.type === "delete-nonlocal",
-  );
   const interruptionErrors = errors.filter(
     (e): e is Extract<MarimoError, { type: "interruption" }> =>
       e.type === "interruption",
@@ -358,30 +354,6 @@ export const MarimoErrorOutput = ({
               </ExternalLink>
               .
             </p>
-          </Tip>
-        </div>,
-      );
-    }
-
-    if (deleteNonlocalErrors.length > 0) {
-      messages.push(
-        <div key="delete-nonlocal">
-          {deleteNonlocalErrors.map((error, idx) => (
-            <div key={`delete-nonlocal-${idx}`}>
-              {`The variable '${error.name}' can't be deleted because it was defined by another cell (`}
-              <CellLinkError cellId={error.cells[0] as CellId} />
-              {")"}
-            </div>
-          ))}
-          {cellId && (
-            <AutoFixButton errors={deleteNonlocalErrors} cellId={cellId} />
-          )}
-          <Tip title="Why can't I delete other cells' variables?">
-            marimo determines how to run your notebook based on variables
-            definitions and references only. When a cell deletes a variable it
-            didn't define, marimo cannot determine an unambiguous execution
-            order. Try refactoring so that you can delete variables in the cells
-            that create them.
           </Tip>
         </div>,
       );


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Since this is removed in #5966, typecheck will fail until we delete all the referencing types.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
