### PR TITLE
Remove handling for deleted `delete-nonlocal` error type

### DIFF
--- a/.github/workflows/test_fe.yaml
+++ b/.github/workflows/test_fe.yaml
@@ -23,8 +23,7 @@ jobs:
           filters: |
             frontend:
               - 'frontend/**'
-              - 'lsp/**'
-              - 'openapi/**'
+              - 'packages/**'
 
   test_frontend:
     needs: changes

--- a/.github/workflows/test_fe_dagger.yaml.skip
+++ b/.github/workflows/test_fe_dagger.yaml.skip
@@ -21,8 +21,7 @@ jobs:
           filters: |
             frontend:
               - 'frontend/**'
-              - 'lsp/**'
-              - 'openapi/**'
+              - 'packages/**'
               - 'dagger/**'
 
   test_frontend:

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -96,10 +96,6 @@ export const MarimoErrorOutput = ({
     (e): e is Extract<MarimoError, { type: "import-star" }> =>
       e.type === "import-star",
   );
-  const deleteNonlocalErrors = errors.filter(
-    (e): e is Extract<MarimoError, { type: "delete-nonlocal" }> =>
-      e.type === "delete-nonlocal",
-  );
   const interruptionErrors = errors.filter(
     (e): e is Extract<MarimoError, { type: "interruption" }> =>
       e.type === "interruption",
@@ -358,30 +354,6 @@ export const MarimoErrorOutput = ({
               </ExternalLink>
               .
             </p>
-          </Tip>
-        </div>,
-      );
-    }
-
-    if (deleteNonlocalErrors.length > 0) {
-      messages.push(
-        <div key="delete-nonlocal">
-          {deleteNonlocalErrors.map((error, idx) => (
-            <div key={`delete-nonlocal-${idx}`}>
-              {`The variable '${error.name}' can't be deleted because it was defined by another cell (`}
-              <CellLinkError cellId={error.cells[0] as CellId} />
-              {")"}
-            </div>
-          ))}
-          {cellId && (
-            <AutoFixButton errors={deleteNonlocalErrors} cellId={cellId} />
-          )}
-          <Tip title="Why can't I delete other cells' variables?">
-            marimo determines how to run your notebook based on variables
-            definitions and references only. When a cell deletes a variable it
-            didn't define, marimo cannot determine an unambiguous execution
-            order. Try refactoring so that you can delete variables in the cells
-            that create them.
           </Tip>
         </div>,
       );


### PR DESCRIPTION
The backend changes in #5966 removed the `delete-nonlocal` error variant from the API schema, but the frontend still had code attempting to handle this error type. This caused TypeScript errors because the type narrowing created a `never` type when filtering for a non-existent variant, making the error object properties inaccessible.