### PR TITLE
fix: allow builtin functions to be hashed for cache

### DIFF
--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -100,7 +100,11 @@ def hash_wrapped_functions(
     # there is a chance for a circular reference
     # likely manually created, but easy to guard against.
     def process_function(fn: Callable[..., Any]) -> bytes:
-        fn_hash = hash_module(fn.__code__, hash_type)
+        if not inspect.isbuiltin(fn):
+            fn_hash = hash_module(fn.__code__, hash_type)
+        else:
+            # Builtin functions are not hashable, so we use their name.
+            fn_hash = type_sign(bytes(fn.__name__, "utf-8"), "builtin")
         if fn_hash not in seen and hasattr(fn, "__wrapped__"):
             child_hash = hash_wrapped_functions(fn.__wrapped__, hash_type)
             return child_hash + fn_hash

--- a/tests/_save/test_hash.py
+++ b/tests/_save/test_hash.py
@@ -507,9 +507,10 @@ class TestHash:
     def test_builtins(app) -> None:
         @app.cell
         def _():
-            import marimo as mo
-            from time import sleep
             import time
+            from time import sleep
+
+            import marimo as mo
 
             return mo, sleep, time
 
@@ -532,7 +533,7 @@ class TestHash:
             return
 
         @app.cell
-        def _():
+        def _(direct, module):
             assert direct() == module(), "direct() != module()"
 
 

--- a/tests/_save/test_hash.py
+++ b/tests/_save/test_hash.py
@@ -503,6 +503,38 @@ class TestHash:
             assert cache2._cache.hash != cache._cache.hash
             return (cache2,)
 
+    @staticmethod
+    def test_builtins(app) -> None:
+        @app.cell
+        def _():
+            import marimo as mo
+            from time import sleep
+            import time
+
+            return mo, sleep, time
+
+        @app.cell
+        def _(mo, sleep):
+            @mo.cache
+            def direct():
+                _ = sleep
+                return 42
+
+            return
+
+        @app.cell
+        def _(mo, time):
+            @mo.cache
+            def module():
+                _ = time.sleep
+                return 42
+
+            return
+
+        @app.cell
+        def _():
+            assert direct() == module(), "direct() != module()"
+
 
 class TestDataHash:
     @staticmethod


### PR DESCRIPTION
## 📝 Summary

Fixes #5993

the `__code__` attribute does not live on cpython builtin functions, this provides a stub hash in its place. Test provided to capture the broken behavior