### PR TITLE
fix: stub and restore cache meta values 

### DIFF
--- a/marimo/_save/__init__.py
+++ b/marimo/_save/__init__.py
@@ -1,5 +1,12 @@
 # Copyright 2024 Marimo. All rights reserved.
+import marimo._save.cache as _cache_module  # prevent variable shadowing
 from marimo._save.cache import MARIMO_CACHE_VERSION
 from marimo._save.save import cache, lru_cache, persistent_cache
 
-__all__ = ["cache", "lru_cache", "persistent_cache", "MARIMO_CACHE_VERSION"]
+__all__ = [
+    "cache",
+    "lru_cache",
+    "persistent_cache",
+    "MARIMO_CACHE_VERSION",
+    "_cache_module",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from marimo._runtime.input_override import input_override
 from marimo._runtime.marimo_pdb import MarimoPdb
 from marimo._runtime.requests import AppMetadata, ExecutionRequest
 from marimo._runtime.runtime import Kernel
+from marimo._save.cache import ModuleStub
 from marimo._server.model import SessionMode
 from marimo._types.ids import CellId_t
 from marimo._utils.parse_dataclass import parse_raw
@@ -631,6 +632,17 @@ def app() -> Generator[App, None, None]:
     app._pytest_rewrite = True
     yield app
     app.run()
+
+
+class TestableModuleStub(ModuleStub):
+    def __eq__(self, other: Any) -> bool:
+        # Used for testing, equality otherwise not useful.
+        if not isinstance(other, ModuleStub):
+            return False
+        return self.name == other.name
+
+    def __hash__(self) -> int:
+        return hash(self.name) + hash("module")
 
 
 # A pytest hook to fail when raw marimo cells are not collected.


### PR DESCRIPTION
replaces #5933

---

## 📝 Summary

closes https://github.com/marimo-team/marimo/issues/5930

Process `self.meta["return"]` in the same way that `contextual_defs` are handled in `cache.py` so that when caching and restoring UI elements they are re-registered with the `UIElementRegistry`

## 🔍 Description of Changes

https://github.com/marimo-team/marimo/issues/5930 describes a bug from `UIElement`s not being re-registered when they are returned from a caching function.

It seemed like handling `UIElement`s (and some other classes) already handled doing this correctly when it came to "contextual_defs" by using a pattern of storing and loading "stub" classes, so I figured that using that same process for the `return` value of the cached function should work as well. It was either that or explicitly re-register `UIElement`s on cache hit, which seemed like a worse solution.

I tried adding some tests for this but got kinda stuck on how to assert that the old and new ui elements were "the same" since the stub loading process technically creates a new instance. If we need tests for this, I would appreciate some advice.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
