### PR TITLE
Use `Shift+Escape` for Command Mode on Windows with vim bindings

### DIFF
--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -44,7 +44,7 @@ editing their contents.
 
 **Enter/Exit:**
 
-- Enter command mode: `Esc` (from cell editor) or `Ctrl+Esc`/`Cmd+Esc` (when vim keybindings are enabled)
+- Enter command mode: `Esc` (from cell editor) or `Ctrl+Esc`/`Cmd+Esc` (when vim keybindings are enabled, `Shift+Esc` on Windows)
 - Exit command mode: `Enter` or click on a cell
 
 **Shortcuts:**
@@ -63,7 +63,7 @@ When [vim keybindings](#vim-keybindings) are enabled, additional shortcuts are a
 ### Vim keybindings
 
 marimo supports vim keybindings that extend to notebook editing. Within cells,
-use standard vim modes. Press `Ctrl+Esc` (or `Cmd+Esc` on macOS) from normal mode to enter [command
+use standard vim modes. Press `Ctrl+Esc` (or `Cmd+Esc` on macOS, `Shift+Esc` on Windows) from normal mode to enter [command
 mode](#command-mode) for notebook navigation.
 
 **Cell editing additions:**
@@ -96,7 +96,7 @@ vimrc = relative/path/.vimrc
 
 **Command mode additions:**
 
-When vim keybindings are enabled, press `Ctrl+Esc` (or `Cmd+Esc` on macOS) from normal mode to enter
+When vim keybindings are enabled, press `Ctrl+Esc` (or `Cmd+Esc` on macOS, `Shift+Esc` on Windows) from normal mode to enter
 [command mode](#command-mode) with additional vim-specific keybindings:
 
 - `j`/`k` - navigate cells

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -17,7 +17,7 @@ import {
   userConfigAtom,
 } from "@/core/config/config";
 import type { HotkeyAction } from "@/core/hotkeys/hotkeys";
-import { parseShortcut } from "@/core/hotkeys/shortcuts";
+import { parseShortcut, isPlatformWindows } from "@/core/hotkeys/shortcuts";
 import { useRequestClient } from "@/core/network/requests";
 import { useSaveNotebook } from "@/core/saving/save-component";
 import { Events } from "@/utils/events";
@@ -649,10 +649,18 @@ export function useCellEditorNavigationProps(
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {
-      // For vim mode, require Ctrl+Escape (or Cmd+Escape on Mac) to exit to command mode
+      // For vim mode, use different shortcuts based on platform
       if (keymapPreset === "vim") {
-        if (evt.key === "Escape" && (evt.ctrlKey || evt.metaKey)) {
-          handleEscape();
+        if (isPlatformWindows()) {
+          // On Windows, use Shift+Escape since Ctrl+Escape opens Start menu
+          if (evt.key === "Escape" && evt.shiftKey) {
+            handleEscape();
+          }
+        } else {
+          // On Mac/Linux, use Ctrl+Escape (or Cmd+Escape on Mac)
+          if (evt.key === "Escape" && (evt.ctrlKey || evt.metaKey)) {
+            handleEscape();
+          }
         }
       } else {
         // For non-vim mode, regular Escape exits to command mode

--- a/frontend/src/core/hotkeys/shortcuts.ts
+++ b/frontend/src/core/hotkeys/shortcuts.ts
@@ -21,6 +21,24 @@ export function isPlatformMac() {
   return /mac/i.test(platform);
 }
 
+/**
+ * Check if the current platform is Windows
+ */
+export function isPlatformWindows() {
+  if (typeof window === "undefined") {
+    Logger.warn("isPlatformWindows() called without window");
+    return false;
+  }
+
+  // @ts-expect-error typescript does not have types for experimental userAgentData property
+  const platform = window.navigator.userAgentData
+    ? // @ts-expect-error typescript does not have types for experimental userAgentData property
+      window.navigator.userAgentData.platform
+    : window.navigator.platform;
+
+  return /win/i.test(platform);
+}
+
 type IKeyboardEvent = Pick<
   KeyboardEvent,
   "key" | "shiftKey" | "ctrlKey" | "metaKey" | "altKey" | "code"


### PR DESCRIPTION
Fixes #5861

Windows intercepts `Ctrl+Escape` to open the Start menu, breaking Vim mode navigation. This PR adds platform detection to use `Shift+Escape` on Windows, `Ctrl/Cmd+Escape` on other platforms.
