### PR TITLE
improvement: multiple models for different roles 

### DIFF
--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -15,7 +15,7 @@ import { Kbd } from "@/components/ui/kbd";
 import { NativeSelect } from "@/components/ui/native-select";
 import { Textarea } from "@/components/ui/textarea";
 import { CopilotConfig } from "@/core/codemirror/copilot/copilot-config";
-import type { UserConfig } from "@/core/config/config-schema";
+import { DEFAULT_AI_MODEL, type UserConfig } from "@/core/config/config-schema";
 import { isWasm } from "@/core/wasm/utils";
 import {
   AiProviderIcon,
@@ -337,23 +337,15 @@ const renderCopilotProvider = (
         <ModelSelector
           form={form}
           config={config}
-          name="completion.model"
-          placeholder="Qwen2.5-Coder-7B"
+          name="ai.models.autocomplete_model"
+          placeholder="ollama/qwen2.5-coder:1.5b"
           testId="custom-model-input"
-        />
-        <BaseUrl
-          form={form}
-          config={config}
-          name="completion.base_url"
-          placeholder="http://localhost:11434/v1"
-          testId="custom-base-url-input"
-        />
-        <ApiKey
-          form={form}
-          config={config}
-          name="completion.api_key"
-          placeholder="key"
-          testId="custom-api-key-input"
+          description={
+            <>
+              Models should include the provider name and model name separated
+              by a slash.
+            </>
+          }
         />
       </>
     );
@@ -664,7 +656,7 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({ form, config }) => {
         form={form}
         config={config}
         name="ai.models.chat_model"
-        placeholder="openai/gpt-4o"
+        placeholder={DEFAULT_AI_MODEL}
         testId="ai-chat-model-input"
         disabled={isWasmRuntime}
         description={
@@ -687,7 +679,7 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({ form, config }) => {
         form={form}
         config={config}
         name="ai.models.edit_model"
-        placeholder="openai/gpt-4o"
+        placeholder={DEFAULT_AI_MODEL}
         testId="ai-edit-model-input"
         disabled={isWasmRuntime}
         description={
@@ -700,6 +692,27 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({ form, config }) => {
             </p>
             <p className="pt-1">
               You can use a faster, cheaper model for edits if desired.
+            </p>
+          </>
+        }
+      />
+
+      <ModelSelector
+        form={form}
+        config={config}
+        name="ai.models.autocomplete_model"
+        placeholder="ollama/qwen2.5-coder:1.5b"
+        testId="ai-autocomplete-model-input"
+        disabled={isWasmRuntime}
+        description={
+          <>
+            <p>
+              Model to use for code completion when using a custom provider.
+              Models should include the provider name and model name separated
+              by a slash.
+            </p>
+            <p className="pt-1">
+              This will be used when completion.copilot is set to "custom".
             </p>
           </>
         }

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -663,20 +663,43 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({ form, config }) => {
       <ModelSelector
         form={form}
         config={config}
-        name="ai.open_ai.model"
-        placeholder="gpt-4-turbo"
-        testId="ai-model-input"
+        name="ai.models.chat_model"
+        placeholder="openai/gpt-4o"
+        testId="ai-chat-model-input"
         disabled={isWasmRuntime}
         description={
           <>
             <p>
-              Models should include the provider name and model name separated
-              by a slash. For example, "anthropic/claude-3-7-sonnet-latest" or
-              "google/gemini-2.5-flash-preview-05-20".
+              Model to use for chat conversations in the Chat panel. Models
+              should include the provider name and model name separated by a
+              slash. For example, "anthropic/claude-3-5-sonnet-latest" or
+              "google/gemini-2.0-flash-exp".
             </p>
             <p className="pt-1">
               Depending on the provider, we will use the respective API key and
               additional configuration.
+            </p>
+          </>
+        }
+      />
+
+      <ModelSelector
+        form={form}
+        config={config}
+        name="ai.models.edit_model"
+        placeholder="openai/gpt-4o"
+        testId="ai-edit-model-input"
+        disabled={isWasmRuntime}
+        description={
+          <>
+            <p>
+              Model to use for code editing with the{" "}
+              <Kbd className="inline">Generate with AI</Kbd> button. Models
+              should include the provider name and model name separated by a
+              slash.
+            </p>
+            <p className="pt-1">
+              You can use a faster, cheaper model for edits if desired.
             </p>
           </>
         }

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -44,7 +44,7 @@ import {
 } from "@/core/ai/state";
 import { getCodes } from "@/core/codemirror/copilot/getCodes";
 import { aiAtom, aiEnabledAtom, userConfigAtom } from "@/core/config/config";
-import type { UserConfig } from "@/core/config/config-schema";
+import { DEFAULT_AI_MODEL, type UserConfig } from "@/core/config/config-schema";
 import { FeatureFlagged } from "@/core/config/feature-flag";
 import { useRequestClient } from "@/core/network/requests";
 import { useRuntimeManager } from "@/core/runtime/config";
@@ -242,7 +242,6 @@ interface ChatInputFooterProps {
   onStop: () => void;
 }
 
-const DEFAULT_MODEL = "openai/gpt-4o";
 const DEFAULT_MODE = "manual";
 
 const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
@@ -250,7 +249,7 @@ const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
     const ai = useAtomValue(aiAtom);
     const [userConfig, setUserConfig] = useAtom(userConfigAtom);
     const currentMode = ai?.mode || DEFAULT_MODE;
-    const currentModel = ai?.models?.chat_model || DEFAULT_MODEL;
+    const currentModel = ai?.models?.chat_model || DEFAULT_AI_MODEL;
     const { saveUserConfig } = useRequestClient();
 
     const modeOptions = [
@@ -282,9 +281,11 @@ const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
         ...userConfig,
         ai: {
           ...userConfig.ai,
-          open_ai: {
-            ...userConfig.ai?.open_ai,
-            model: newModel,
+          models: {
+            custom_models: [],
+            enabled_models: [],
+            ...userConfig.ai?.models,
+            chat_model: newModel,
           },
         },
       };

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -242,12 +242,15 @@ interface ChatInputFooterProps {
   onStop: () => void;
 }
 
+const DEFAULT_MODEL = "openai/gpt-4o";
+const DEFAULT_MODE = "manual";
+
 const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
   ({ input, onSendClick, isLoading, onStop }) => {
     const ai = useAtomValue(aiAtom);
     const [userConfig, setUserConfig] = useAtom(userConfigAtom);
-    const currentMode = ai?.mode || "manual";
-    const currentModel = ai?.open_ai?.model || "o4-mini";
+    const currentMode = ai?.mode || DEFAULT_MODE;
+    const currentModel = ai?.models?.chat_model || DEFAULT_MODEL;
     const { saveUserConfig } = useRequestClient();
 
     const modeOptions = [

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/ai-status.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/ai-status.tsx
@@ -5,12 +5,13 @@ import { SparklesIcon } from "lucide-react";
 import React from "react";
 import { useOpenSettingsToTab } from "@/components/app-config/state";
 import { aiAtom, aiEnabledAtom } from "@/core/config/config";
+import { DEFAULT_AI_MODEL } from "@/core/config/config-schema";
 import { FooterItem } from "../footer-item";
 
 export const AIStatusIcon: React.FC = () => {
   const ai = useAtomValue(aiAtom);
   const aiEnabled = useAtomValue(aiEnabledAtom);
-  const chatModel = ai?.models?.chat_model;
+  const chatModel = ai?.models?.chat_model || DEFAULT_AI_MODEL;
   const editModel = ai?.models?.edit_model || chatModel;
   const { handleClick } = useOpenSettingsToTab();
 

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/ai-status.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/ai-status.tsx
@@ -10,7 +10,8 @@ import { FooterItem } from "../footer-item";
 export const AIStatusIcon: React.FC = () => {
   const ai = useAtomValue(aiAtom);
   const aiEnabled = useAtomValue(aiEnabledAtom);
-  const model = ai?.open_ai?.model || "gpt-4-turbo";
+  const chatModel = ai?.models?.chat_model;
+  const editModel = ai?.models?.edit_model || chatModel;
   const { handleClick } = useOpenSettingsToTab();
 
   if (!aiEnabled) {
@@ -30,7 +31,9 @@ export const AIStatusIcon: React.FC = () => {
     <FooterItem
       tooltip={
         <>
-          <b>Assist model:</b> {model}
+          <b>Chat model:</b> {chatModel}
+          <br />
+          <b>Edit model:</b> {editModel}
         </>
       }
       onClick={() => handleClick("ai")}

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -37,6 +37,8 @@ const VALID_SQL_OUTPUT_FORMATS = [
 ] as const;
 export type SqlOutputType = (typeof VALID_SQL_OUTPUT_FORMATS)[number];
 
+export const DEFAULT_AI_MODEL = "openai/gpt-4o";
+
 /**
  * Export types for auto download
  */
@@ -142,13 +144,7 @@ export const UserConfigSchema = z
       .object({
         rules: z.string().default(""),
         mode: z.enum(["manual", "ask"]).default("manual"),
-        // TODO: the model currently exists on the open_ai object, but we should
-        // move it to the top level.
-        open_ai: AiConfigSchema.extend({
-          model: z.string().optional(),
-        })
-          .passthrough()
-          .optional(),
+        open_ai: AiConfigSchema.optional(),
         anthropic: AiConfigSchema.optional(),
         google: AiConfigSchema.optional(),
         ollama: AiConfigSchema.optional(),
@@ -162,6 +158,19 @@ export const UserConfigSchema = z
             aws_secret_access_key: z.string().optional(),
           })
           .optional(),
+        models: z
+          .object({
+            chat_model: z.string().default(DEFAULT_AI_MODEL),
+            edit_model: z.string().default(DEFAULT_AI_MODEL),
+            enabled_models: z.array(z.string()).default([]),
+            custom_models: z.array(z.string()).default([]),
+          })
+          .default({
+            chat_model: DEFAULT_AI_MODEL,
+            edit_model: DEFAULT_AI_MODEL,
+            enabled_models: [],
+            custom_models: [],
+          }),
       })
       .passthrough()
       .default({}),
@@ -198,6 +207,7 @@ export const UserConfigSchema = z
       rules: "",
       mode: "manual",
       open_ai: {},
+      models: {},
     },
   });
 export type UserConfig = MarimoConfig;

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -162,6 +162,7 @@ export const UserConfigSchema = z
           .object({
             chat_model: z.string().default(DEFAULT_AI_MODEL),
             edit_model: z.string().default(DEFAULT_AI_MODEL),
+            autocomplete_model: z.string().optional(),
             enabled_models: z.array(z.string()).default([]),
             custom_models: z.array(z.string()).default([]),
           })

--- a/frontend/src/core/config/config.ts
+++ b/frontend/src/core/config/config.ts
@@ -79,6 +79,9 @@ export function isAiEnabled(config: UserConfig) {
     Boolean(config.ai?.open_ai?.api_key) ||
     Boolean(config.ai?.anthropic?.api_key) ||
     Boolean(config.ai?.google?.api_key) ||
+    Boolean(config.ai?.azure?.api_key) ||
+    Boolean(config.ai?.ollama?.api_key) ||
+    Boolean(config.ai?.open_ai_compatible?.api_key) ||
     Boolean(config.ai?.bedrock?.profile_name)
   );
 }

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from marimo._config.packages import infer_package_manager
 from marimo._config.utils import deep_copy
+from marimo._server.ai.constants import DEFAULT_MODEL
 
 if sys.version_info < (3, 11):
     from typing_extensions import NotRequired
@@ -233,6 +234,26 @@ class PackageManagementConfig(TypedDict):
 CopilotMode = Literal["ask", "manual"]
 
 
+@mddoc
+@dataclass
+class AiModelConfig(TypedDict):
+    """Configuration options for an AI model.
+
+    **Keys.**
+
+    - `chat_model`: the model to use for chat completions
+    - `edit_model`: the model to use for edit completions
+    - `enabled_models`: a list of models to enable that are shown in the UI
+    - `custom_models`: a list of custom models to use that are not from the default list
+    """
+
+    chat_model: NotRequired[str]
+    edit_model: NotRequired[str]
+
+    enabled_models: list[str]
+    custom_models: list[str]
+
+
 @dataclass
 class AiConfig(TypedDict, total=False):
     """Configuration options for AI.
@@ -251,6 +272,7 @@ class AiConfig(TypedDict, total=False):
     rules: NotRequired[str]
     max_tokens: NotRequired[int]
     mode: NotRequired[CopilotMode]
+    models: AiModelConfig
 
     # providers
     open_ai: OpenAiConfig
@@ -269,20 +291,21 @@ class OpenAiConfig(TypedDict, total=False):
     **Keys.**
 
     - `api_key`: the OpenAI API key
-    - `model`: the model to use.
-        if model starts with `claude-` we use the AnthropicConfig
     - `base_url`: the base URL for the API
     - `ssl_verify` : Boolean argument for httpx passed to open ai client. httpx defaults to true, but some use cases to let users override to False in some testing scenarios
     - `ca_bundle_path`: custom ca bundle to be used for verifying SSL certificates. Used to create custom SSL context for httpx client
     - `client_pem` : custom path of a client .pem cert used for verifying identity of client server
+    - `model`: the model to use. @deprecated: use `models` instead
     """
 
     api_key: str
-    model: NotRequired[str]
     base_url: NotRequired[str]
     ssl_verify: NotRequired[bool]
     ca_bundle_path: NotRequired[str]
     client_pem: NotRequired[str]
+
+    # @deprecated: use `ai.models.chat_model` instead
+    model: NotRequired[str]
 
 
 @dataclass
@@ -580,6 +603,14 @@ DEFAULT_CONFIG: MarimoConfig = {
             "enable_pydocstyle": False,
             "enable_pylint": False,
             "enable_pyflakes": False,
+        }
+    },
+    "ai": {
+        "models": {
+            "chat_model": DEFAULT_MODEL,
+            "edit_model": DEFAULT_MODEL,
+            "enabled_models": [],
+            "custom_models": [],
         }
     },
     "snippets": {

--- a/marimo/_server/ai/config.py
+++ b/marimo/_server/ai/config.py
@@ -16,12 +16,10 @@ from marimo._config.config import (
     CopilotMode,
     MarimoConfig,
 )
+from marimo._server.ai.constants import DEFAULT_MAX_TOKENS, DEFAULT_MODEL
 from marimo._server.ai.ids import AiModelId
 from marimo._server.ai.tools import Tool, get_tool_manager
 from marimo._server.api.status import HTTPStatus
-
-DEFAULT_MAX_TOKENS = 4096
-DEFAULT_MODEL = "gpt-4o-mini"
 
 
 @dataclass
@@ -162,8 +160,18 @@ def _get_ai_config(config: AiConfig, key: str, name: str) -> dict[str, Any]:
     return cast(dict[str, Any], config.get(key, {}))
 
 
-def get_model(config: AiConfig) -> str:
-    return config.get("open_ai", {}).get("model") or DEFAULT_MODEL
+def get_chat_model(config: AiConfig) -> str:
+    """Get the chat model from the config."""
+    return (
+        config.get("models", {}).get("chat_model")
+        or config.get("open_ai", {}).get("model")
+        or DEFAULT_MODEL
+    )
+
+
+def get_edit_model(config: AiConfig) -> str:
+    """Get the edit model from the config."""
+    return config.get("models", {}).get("edit_model") or get_chat_model(config)
 
 
 def get_max_tokens(config: MarimoConfig) -> int:

--- a/marimo/_server/ai/config.py
+++ b/marimo/_server/ai/config.py
@@ -12,7 +12,6 @@ from starlette.exceptions import HTTPException
 
 from marimo._config.config import (
     AiConfig,
-    CompletionConfig,
     CopilotMode,
     MarimoConfig,
 )
@@ -113,15 +112,6 @@ class AnyProviderConfig:
         )
 
     @classmethod
-    def for_completion(cls, config: CompletionConfig) -> AnyProviderConfig:
-        key = _get_key(config, "AI completion")
-        return cls(
-            base_url=_get_base_url(config),
-            api_key=key,
-            tools=[],  # Inline completion never uses tools
-        )
-
-    @classmethod
     def for_model(cls, model: str, config: AiConfig) -> AnyProviderConfig:
         model_id = AiModelId.from_model(model)
         if model_id.provider == "anthropic":
@@ -163,7 +153,9 @@ def _get_ai_config(config: AiConfig, key: str, name: str) -> dict[str, Any]:
 def get_chat_model(config: AiConfig) -> str:
     """Get the chat model from the config."""
     return (
+        # Current config
         config.get("models", {}).get("chat_model")
+        # Legacy config
         or config.get("open_ai", {}).get("model")
         or DEFAULT_MODEL
     )
@@ -172,6 +164,17 @@ def get_chat_model(config: AiConfig) -> str:
 def get_edit_model(config: AiConfig) -> str:
     """Get the edit model from the config."""
     return config.get("models", {}).get("edit_model") or get_chat_model(config)
+
+
+def get_autocomplete_model(config: AiConfig) -> str:
+    """Get the autocomplete model from the config."""
+    return (
+        # Current config
+        config.get("models", {}).get("autocomplete_model")
+        # Legacy config
+        or config.get("completion", {}).get("model")
+        or DEFAULT_MODEL
+    )
 
 
 def get_max_tokens(config: MarimoConfig) -> int:

--- a/marimo/_server/ai/constants.py
+++ b/marimo/_server/ai/constants.py
@@ -1,0 +1,2 @@
+DEFAULT_MAX_TOKENS = 4096
+DEFAULT_MODEL = "openai/gpt-4o"

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -18,8 +18,9 @@ from marimo._config.config import AiConfig, MarimoConfig
 from marimo._server.ai.config import (
     DEFAULT_MODEL,
     AnyProviderConfig,
+    get_chat_model,
+    get_edit_model,
     get_max_tokens,
-    get_model,
 )
 from marimo._server.ai.prompts import (
     FILL_ME_TAG,
@@ -112,7 +113,7 @@ async def ai_completion(
     )
     prompt = body.prompt
 
-    model = get_model(ai_config)
+    model = get_edit_model(ai_config)
     provider = get_completion_provider(
         AnyProviderConfig.for_model(model, ai_config),
         model=model,
@@ -168,7 +169,7 @@ async def ai_chat(
 
     max_tokens = get_max_tokens(config)
 
-    model = body.model or get_model(ai_config)
+    model = body.model or get_chat_model(ai_config)
     provider = get_completion_provider(
         AnyProviderConfig.for_model(model, ai_config),
         model=model,

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -69,6 +69,24 @@ components:
           - ask
           - manual
           type: string
+        models:
+          properties:
+            chat_model:
+              type: string
+            custom_models:
+              items:
+                type: string
+              type: array
+            edit_model:
+              type: string
+            enabled_models:
+              items:
+                type: string
+              type: array
+          required:
+          - enabled_models
+          - custom_models
+          type: object
         ollama:
           $ref: '#/components/schemas/OpenAiConfig'
         open_ai:

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -71,6 +71,8 @@ components:
           type: string
         models:
           properties:
+            autocomplete_model:
+              type: string
             chat_model:
               type: string
             custom_models:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -2572,6 +2572,12 @@ export interface components {
       max_tokens?: number;
       /** @enum {string} */
       mode?: "ask" | "manual";
+      models?: {
+        chat_model?: string;
+        custom_models: string[];
+        edit_model?: string;
+        enabled_models: string[];
+      };
       ollama?: components["schemas"]["OpenAiConfig"];
       open_ai?: components["schemas"]["OpenAiConfig"];
       open_ai_compatible?: components["schemas"]["OpenAiConfig"];

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -2573,6 +2573,7 @@ export interface components {
       /** @enum {string} */
       mode?: "ask" | "manual";
       models?: {
+        autocomplete_model?: string;
         chat_model?: string;
         custom_models: string[];
         edit_model?: string;

--- a/tests/_config/test_config.py
+++ b/tests/_config/test_config.py
@@ -123,3 +123,149 @@ def test_merge_config_with_keymap_overrides() -> None:
 
     assert new_config["keymap"]["preset"] == "vim"
     assert new_config["keymap"]["overrides"] == {}
+
+
+def test_merge_config_openai_model_fallback() -> None:
+    """Test that openai_model is used as fallback for missing chat_model and edit_model."""
+    base_config = merge_default_config(PartialMarimoConfig())
+
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            ai={
+                "open_ai": {
+                    "api_key": "test_key",
+                    "model": "gpt-4",
+                },
+            }
+        ),
+    )
+
+    # When neither chat_model nor edit_model are present, openai_model should be used for both
+    assert new_config["ai"]["models"]["chat_model"] == "gpt-4"
+    assert new_config["ai"]["models"]["edit_model"] == "gpt-4"
+    assert new_config["ai"]["open_ai"]["model"] == "gpt-4"
+
+
+def test_merge_config_existing_chat_edit_models_no_fallback() -> None:
+    """Test that existing chat_model and edit_model are preserved (no fallback)."""
+    base_config = merge_default_config(PartialMarimoConfig())
+
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            ai={
+                "open_ai": {
+                    "api_key": "test_key",
+                    "model": "gpt-4",
+                },
+                "models": {
+                    "chat_model": "claude-3-sonnet",
+                    "edit_model": "gpt-3.5-turbo",
+                    "enabled_models": [],
+                    "custom_models": [],
+                },
+            }
+        ),
+    )
+
+    # Existing models should be preserved, not overridden by openai_model
+    assert new_config["ai"]["models"]["chat_model"] == "claude-3-sonnet"
+    assert new_config["ai"]["models"]["edit_model"] == "gpt-3.5-turbo"
+    assert new_config["ai"]["open_ai"]["model"] == "gpt-4"
+
+
+def test_merge_config_no_openai_model_no_fallback() -> None:
+    """Test that no fallback happens when openai_model is not present."""
+    base_config = merge_default_config(PartialMarimoConfig())
+
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            ai={
+                "open_ai": {
+                    "api_key": "test_key",
+                },
+            }
+        ),
+    )
+
+    # No models should be set since openai_model is not present
+    assert "chat_model" not in new_config["ai"]["models"]
+    assert "edit_model" not in new_config["ai"]["models"]
+
+
+def test_merge_config_partial_model_config() -> None:
+    """Test fallback when only one of chat_model or edit_model is present."""
+    base_config = merge_default_config(PartialMarimoConfig())
+
+    # Test with only chat_model present
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            ai={
+                "open_ai": {
+                    "api_key": "test_key",
+                    "model": "gpt-4",
+                },
+                "models": {
+                    "chat_model": "claude-3-sonnet",
+                    "enabled_models": [],
+                    "custom_models": [],
+                },
+            }
+        ),
+    )
+
+    # chat_model should be preserved, but no fallback should happen since chat_model exists
+    assert new_config["ai"]["models"]["chat_model"] == "claude-3-sonnet"
+    assert "edit_model" not in new_config["ai"]["models"]
+
+    # Test with only edit_model present
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            ai={
+                "open_ai": {
+                    "api_key": "test_key",
+                    "model": "gpt-4",
+                },
+                "models": {
+                    "edit_model": "gpt-3.5-turbo",
+                    "enabled_models": [],
+                    "custom_models": [],
+                },
+            }
+        ),
+    )
+
+    # edit_model should be preserved, but no fallback should happen since edit_model exists
+    assert new_config["ai"]["models"]["edit_model"] == "gpt-3.5-turbo"
+    assert "chat_model" not in new_config["ai"]["models"]
+
+
+def test_merge_config_empty_models_with_openai_model() -> None:
+    """Test fallback when models config exists but chat_model and edit_model are empty/None."""
+    base_config = merge_default_config(PartialMarimoConfig())
+
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            ai={
+                "open_ai": {
+                    "api_key": "test_key",
+                    "model": "gpt-4",
+                },
+                "models": {
+                    "chat_model": None,
+                    "edit_model": "",
+                    "enabled_models": [],
+                    "custom_models": [],
+                },
+            }
+        ),
+    )
+
+    # Empty/None values should trigger fallback to openai_model
+    assert new_config["ai"]["models"]["chat_model"] == "gpt-4"
+    assert new_config["ai"]["models"]["edit_model"] == "gpt-4"

--- a/tests/_config/test_config.py
+++ b/tests/_config/test_config.py
@@ -57,8 +57,14 @@ def test_merge_config() -> None:
             },
         )
     )
-    assert prev_config["ai"]["open_ai"]["api_key"] == "super_secret"
-    assert prev_config["ai"]["google"]["api_key"] == "google_secret"
+    assert (
+        prev_config.get("ai", {}).get("open_ai", {}).get("api_key")
+        == "super_secret"
+    )
+    assert (
+        prev_config.get("ai", {}).get("google", {}).get("api_key")
+        == "google_secret"
+    )
 
     new_config = merge_config(
         prev_config,
@@ -74,9 +80,17 @@ def test_merge_config() -> None:
         ),
     )
 
-    assert new_config["ai"]["open_ai"]["api_key"] == "super_secret"
-    assert new_config["ai"]["open_ai"]["model"] == "davinci"
-    assert new_config["ai"]["google"]["api_key"] == "google_secret"
+    assert (
+        new_config.get("ai", {}).get("open_ai", {}).get("api_key")
+        == "super_secret"
+    )
+    assert (
+        new_config.get("ai", {}).get("open_ai", {}).get("model") == "davinci"
+    )
+    assert (
+        new_config.get("ai", {}).get("google", {}).get("api_key")
+        == "google_secret"
+    )
 
 
 def test_merge_config_with_keymap_overrides() -> None:
@@ -108,8 +122,11 @@ def test_merge_config_with_keymap_overrides() -> None:
     )
 
     assert new_config["keymap"]["preset"] == "vim"
-    assert "run-all" not in new_config["keymap"]["overrides"]
-    assert new_config["keymap"]["overrides"]["run-cell"] == "ctrl-enter"
+    assert "run-all" not in new_config.get("keymap", {}).get("overrides", {})
+    assert (
+        new_config.get("keymap", {}).get("overrides", {}).get("run-cell")
+        == "ctrl-enter"
+    )
 
     new_config = merge_config(
         prev_config,
@@ -122,7 +139,7 @@ def test_merge_config_with_keymap_overrides() -> None:
     )
 
     assert new_config["keymap"]["preset"] == "vim"
-    assert new_config["keymap"]["overrides"] == {}
+    assert new_config.get("keymap", {}).get("overrides", {}) == {}
 
 
 def test_merge_config_openai_model_fallback() -> None:
@@ -142,9 +159,13 @@ def test_merge_config_openai_model_fallback() -> None:
     )
 
     # When neither chat_model nor edit_model are present, openai_model should be used for both
-    assert new_config["ai"]["models"]["chat_model"] == "gpt-4"
-    assert new_config["ai"]["models"]["edit_model"] == "gpt-4"
-    assert new_config["ai"]["open_ai"]["model"] == "gpt-4"
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("chat_model") == "gpt-4"
+    )
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("edit_model") == "gpt-4"
+    )
+    assert new_config.get("ai", {}).get("open_ai", {}).get("model") == "gpt-4"
 
 
 def test_merge_config_existing_chat_edit_models_no_fallback() -> None:
@@ -170,9 +191,15 @@ def test_merge_config_existing_chat_edit_models_no_fallback() -> None:
     )
 
     # Existing models should be preserved, not overridden by openai_model
-    assert new_config["ai"]["models"]["chat_model"] == "claude-3-sonnet"
-    assert new_config["ai"]["models"]["edit_model"] == "gpt-3.5-turbo"
-    assert new_config["ai"]["open_ai"]["model"] == "gpt-4"
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("chat_model")
+        == "claude-3-sonnet"
+    )
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("edit_model")
+        == "gpt-3.5-turbo"
+    )
+    assert new_config.get("ai", {}).get("open_ai", {}).get("model") == "gpt-4"
 
 
 def test_merge_config_no_openai_model_no_fallback() -> None:
@@ -191,8 +218,8 @@ def test_merge_config_no_openai_model_no_fallback() -> None:
     )
 
     # No models should be set since openai_model is not present
-    assert "chat_model" not in new_config["ai"]["models"]
-    assert "edit_model" not in new_config["ai"]["models"]
+    assert "chat_model" not in new_config.get("ai", {}).get("models", {})
+    assert "edit_model" not in new_config.get("ai", {}).get("models", {})
 
 
 def test_merge_config_partial_model_config() -> None:
@@ -218,8 +245,11 @@ def test_merge_config_partial_model_config() -> None:
     )
 
     # chat_model should be preserved, but no fallback should happen since chat_model exists
-    assert new_config["ai"]["models"]["chat_model"] == "claude-3-sonnet"
-    assert "edit_model" not in new_config["ai"]["models"]
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("chat_model")
+        == "claude-3-sonnet"
+    )
+    assert "edit_model" not in new_config.get("ai", {}).get("models", {})
 
     # Test with only edit_model present
     new_config = merge_config(
@@ -240,8 +270,11 @@ def test_merge_config_partial_model_config() -> None:
     )
 
     # edit_model should be preserved, but no fallback should happen since edit_model exists
-    assert new_config["ai"]["models"]["edit_model"] == "gpt-3.5-turbo"
-    assert "chat_model" not in new_config["ai"]["models"]
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("edit_model")
+        == "gpt-3.5-turbo"
+    )
+    assert "chat_model" not in new_config.get("ai", {}).get("models", {})
 
 
 def test_merge_config_empty_models_with_openai_model() -> None:
@@ -257,7 +290,7 @@ def test_merge_config_empty_models_with_openai_model() -> None:
                     "model": "gpt-4",
                 },
                 "models": {
-                    "chat_model": None,
+                    "chat_model": "",
                     "edit_model": "",
                     "enabled_models": [],
                     "custom_models": [],
@@ -267,5 +300,96 @@ def test_merge_config_empty_models_with_openai_model() -> None:
     )
 
     # Empty/None values should trigger fallback to openai_model
-    assert new_config["ai"]["models"]["chat_model"] == "gpt-4"
-    assert new_config["ai"]["models"]["edit_model"] == "gpt-4"
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("chat_model") == "gpt-4"
+    )
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("edit_model") == "gpt-4"
+    )
+
+
+def test_merge_config_completion_model_migration() -> None:
+    """Test that completion.model is migrated to ai.models.autocomplete_model."""
+    base_config = merge_default_config(PartialMarimoConfig())
+
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            completion={
+                "activate_on_typing": True,
+                "copilot": "custom",
+                "model": "custom-model-v1",
+            }
+        ),
+    )
+
+    # completion.model should be migrated to ai.models.autocomplete_model
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("autocomplete_model")
+        == "custom-model-v1"
+    )
+    # Original completion.model should still exist for backward compatibility
+    assert new_config.get("completion", {}).get("model") == "custom-model-v1"
+
+
+def test_merge_config_completion_model_no_migration_when_autocomplete_exists() -> (
+    None
+):
+    """Test that completion.model is not migrated when ai.models.autocomplete_model already exists."""
+    base_config = merge_default_config(PartialMarimoConfig())
+
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            completion={
+                "activate_on_typing": True,
+                "copilot": "custom",
+                "model": "old-model",
+            },
+            ai={
+                "models": {
+                    "autocomplete_model": "new-model",
+                    "enabled_models": [],
+                    "custom_models": [],
+                }
+            },
+        ),
+    )
+
+    # ai.models.autocomplete_model should not be overridden
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("autocomplete_model")
+        == "new-model"
+    )
+    # Original completion.model should still exist
+    assert new_config.get("completion", {}).get("model") == "old-model"
+
+
+def test_merge_config_completion_model_migration_creates_ai_config() -> None:
+    """Test that completion.model migration creates ai config when it doesn't exist."""
+    base_config = merge_default_config(PartialMarimoConfig())
+
+    new_config = merge_config(
+        base_config,
+        PartialMarimoConfig(
+            completion={
+                "activate_on_typing": True,
+                "copilot": "custom",
+                "model": "custom-model",
+            }
+        ),
+    )
+
+    # Should create ai.models config with the migrated model
+    assert "ai" in new_config
+    assert "models" in new_config.get("ai", {})
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("autocomplete_model")
+        == "custom-model"
+    )
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("enabled_models") == []
+    )
+    assert (
+        new_config.get("ai", {}).get("models", {}).get("custom_models") == []
+    )

--- a/tests/_server/ai/test_ai_config.py
+++ b/tests/_server/ai/test_ai_config.py
@@ -19,8 +19,9 @@ from marimo._server.ai.config import (
     _get_ai_config,
     _get_base_url,
     _get_key,
+    get_chat_model,
+    get_edit_model,
     get_max_tokens,
-    get_model,
 )
 from marimo._server.ai.tools import Tool
 from marimo._server.api.status import HTTPStatus
@@ -450,27 +451,35 @@ class TestUtilityFunctions:
     def test_get_model_with_openai_config(self):
         """Test getting model from OpenAI config."""
         config: AiConfig = {
-            "open_ai": {"model": "gpt-4", "api_key": "test-key"}
+            "models": {
+                "chat_model": "gpt-4",
+                "edit_model": "gpt-5",
+                "enabled_models": [],
+                "custom_models": [],
+            },
+            "open_ai": {"api_key": "test-key"},
         }
 
-        result = get_model(config)
-
+        result = get_chat_model(config)
         assert result == "gpt-4"
+
+        result = get_edit_model(config)
+        assert result == "gpt-5"
 
     def test_get_model_default(self):
         """Test getting default model when not specified."""
-        config: AiConfig = {"open_ai": {"api_key": "test-key"}}
+        config: AiConfig = {
+            "models": {
+                "enabled_models": [],
+                "custom_models": [],
+            },
+            "open_ai": {"api_key": "test-key"},
+        }
 
-        result = get_model(config)
-
+        result = get_chat_model(config)
         assert result == DEFAULT_MODEL
 
-    def test_get_model_no_openai_config(self):
-        """Test getting default model when no OpenAI config."""
-        config: AiConfig = {}
-
-        result = get_model(config)
-
+        result = get_edit_model(config)
         assert result == DEFAULT_MODEL
 
     def test_get_max_tokens_from_config(self):

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -311,9 +311,7 @@ class TestOpenAiEndpoints:
                 },
             )
         assert response.status_code == 400, response.text
-        assert response.json() == {
-            "detail": "AI completion API key not configured"
-        }
+        assert response.json() == {"detail": "OpenAI API key not configured"}
 
     @staticmethod
     @with_session(SESSION_ID)
@@ -486,10 +484,9 @@ class TestGoogleAiEndpoints:
             "ai": {
                 "open_ai": {"model": "gemini-1.5-pro"},
                 "google": {"api_key": "fake-key"},
-            },
-            "completion": {
-                "model": "gemini-1.5-pro-for-inline-completion",
-                "api_key": "fake-key",
+                "models": {
+                    "autocomplete_model": "google/gemini-1.5-pro-for-inline-completion",
+                },
             },
         }
 
@@ -598,11 +595,10 @@ def _openai_config():
             "open_ai": {
                 "api_key": "fake-api",
                 "model": "openai/some-openai-model",
-            }
-        },
-        "completion": {
-            "model": "gpt-marimo-for-inline-completion",
-            "api_key": "fake-api",
+            },
+            "models": {
+                "autocomplete_model": "gpt-marimo-for-inline-completion",
+            },
         },
     }
 
@@ -613,11 +609,10 @@ def _openai_config_custom_model():
             "open_ai": {
                 "api_key": "fake-api",
                 "model": "gpt-marimo",
-            }
-        },
-        "completion": {
-            "model": "gpt-marimo-for-inline-completion",
-            "api_key": "fake-api",
+            },
+            "models": {
+                "autocomplete_model": "gpt-marimo-for-inline-completion",
+            },
         },
     }
 
@@ -629,22 +624,21 @@ def _openai_config_custom_base_url():
                 "api_key": "fake-api",
                 "base_url": "https://my-openai-instance.com",
                 "model": "openai/some-openai-model-with-base-url",
-            }
-        },
-        "completion": {
-            "model": "gpt-marimo-for-inline-completion",
-            "api_key": "fake-api",
-            "base_url": "https://my-openai-instance.com",
+            },
+            "models": {
+                "autocomplete_model": "gpt-marimo-for-inline-completion",
+            },
         },
     }
 
 
 def _no_openai_config():
     return {
-        "ai": {"open_ai": {"api_key": "", "model": ""}},
-        "completion": {
-            "model": "gpt-marimo-for-inline-completion",
-            "api_key": "",
+        "ai": {
+            "open_ai": {"api_key": "", "model": ""},
+            "models": {
+                "autocomplete_model": "gpt-marimo-for-inline-completion",
+            },
         },
     }
 
@@ -654,10 +648,9 @@ def _no_anthropic_config():
         "ai": {
             "open_ai": {"model": "claude-3.5"},
             "anthropic": {"api_key": ""},
-        },
-        "completion": {
-            "model": "claude-3.5-for-inline-completion",
-            "api_key": "",
+            "models": {
+                "autocomplete_model": "claude-3.5-for-inline-completion",
+            },
         },
     }
 
@@ -667,10 +660,9 @@ def _anthropic_config():
         "ai": {
             "open_ai": {"model": "claude-3.5"},
             "anthropic": {"api_key": "fake-key"},
-        },
-        "completion": {
-            "model": "claude-3.5-for-inline-completion",
-            "api_key": "fake-key",
+            "models": {
+                "autocomplete_model": "anthropic/claude-3.5-for-inline-completion",
+            },
         },
     }
 
@@ -680,10 +672,9 @@ def _google_ai_config():
         "ai": {
             "open_ai": {"model": "gemini-1.5-pro"},
             "google": {"api_key": "fake-key"},
-        },
-        "completion": {
-            "model": "gemini-1.5-pro-for-inline-completion",
-            "api_key": "fake-key",
+            "models": {
+                "autocomplete_model": "google/gemini-1.5-pro-for-inline-completion",
+            },
         },
     }
 

--- a/tests/_server/api/endpoints/test_resume_session.py
+++ b/tests/_server/api/endpoints/test_resume_session.py
@@ -6,6 +6,8 @@ from contextlib import contextmanager
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Optional
 
+import pytest
+
 from marimo._config.manager import UserConfigManager
 from marimo._messaging.ops import CellOp, KernelCapabilities, KernelReady
 from marimo._server.sessions import Session
@@ -291,6 +293,7 @@ def test_restart_session(client: TestClient) -> None:
     client.post("/api/kernel/shutdown", headers=HEADERS)
 
 
+@pytest.mark.flaky(reruns=5)
 def test_resume_session_with_watch(client: TestClient) -> None:
     session_manager = get_session_manager(client)
     session_manager.watch = True


### PR DESCRIPTION
This adds a new `ai.models` config for support for different model roles: 

**Chat**: Power conversational interactions about code and provide detailed guidance
**Edit**: Handle complex code transformations and refactoring tasks
**Autocomplete**: Provide real-time suggestions as developers type

Depending on the provider, this will be routed to the correct provider config.