### PR TITLE
Define package exports for `@marimo-team/frontend`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,9 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    "./unstable_internal/*": "./src/*"
+  },
   "dependencies": {
     "@ai-sdk/react": "^1.2.12",
     "@anywidget/types": "^0.2.0",


### PR DESCRIPTION
Adds an `./unstable_internal/*` subpath export to allow importing from source within `@marimo-team/frontend`. This package is not published, and the subpath should be considered internal-only.