### PR TITLE
improvement: better fill-in-the-middle prompting

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "@lezer/lr": "^1.4.2",
     "@lezer/markdown": "^1.4.3",
     "@lezer/python": "^1.1.18",
-    "@marimo-team/codemirror-ai": "^0.1.11",
+    "@marimo-team/codemirror-ai": "^0.3.1",
     "@marimo-team/codemirror-languageserver": "^1.15.24",
     "@marimo-team/codemirror-mcp": "^0.1.5",
     "@marimo-team/llm-info": "workspace:*",

--- a/frontend/src/core/codemirror/copilot/__tests__/trim-utils.test.ts
+++ b/frontend/src/core/codemirror/copilot/__tests__/trim-utils.test.ts
@@ -1,0 +1,291 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, expect, it } from "vitest";
+import { trimAutocompleteResponse } from "../trim-utils";
+
+const trim = trimAutocompleteResponse;
+
+describe("trimAutocompleteResponse", () => {
+  it("should return the response unchanged when no prefix or suffix", () => {
+    expect(
+      trim({
+        response: "console.log('hello');",
+        prefix: "",
+        suffix: "",
+      }),
+    ).toBe("console.log('hello');");
+  });
+
+  it("should handle empty response", () => {
+    expect(
+      trim({
+        response: "",
+        prefix: "prefix",
+        suffix: "suffix",
+      }),
+    ).toBe("");
+  });
+
+  it("should handle null/undefined inputs gracefully", () => {
+    expect(
+      trim({
+        response: "",
+        prefix: "",
+        suffix: "",
+      }),
+    ).toBe("");
+  });
+
+  describe("basic prefix trimming", () => {
+    it("should trim exact prefix match", () => {
+      expect(
+        trim({
+          response: "const x = 42;",
+          prefix: "const x = ",
+          suffix: "",
+        }),
+      ).toBe("42;");
+    });
+
+    it("should not trim when prefix doesn't match", () => {
+      expect(
+        trim({
+          response: "const x = 42;",
+          prefix: "let x = ",
+          suffix: "",
+        }),
+      ).toBe("const x = 42;");
+    });
+
+    it("should handle empty prefix", () => {
+      expect(
+        trim({
+          response: "const x = 42;",
+          prefix: "",
+          suffix: "",
+        }),
+      ).toBe("const x = 42;");
+    });
+  });
+
+  describe("basic suffix trimming", () => {
+    it("should trim exact suffix match", () => {
+      expect(
+        trim({
+          response: "42 + 1",
+          prefix: "",
+          suffix: " + 1",
+        }),
+      ).toBe("42");
+    });
+
+    it("should not trim when suffix doesn't match", () => {
+      expect(
+        trim({
+          response: "42 + 1",
+          prefix: "",
+          suffix: " + 2",
+        }),
+      ).toBe("42 + 1");
+    });
+
+    it("should handle empty suffix", () => {
+      expect(
+        trim({
+          response: "const x = 42;",
+          prefix: "",
+          suffix: "",
+        }),
+      ).toBe("const x = 42;");
+    });
+  });
+
+  describe("combined prefix and suffix trimming", () => {
+    it("should trim both prefix and suffix", () => {
+      expect(
+        trim({
+          response: "def func():    print('hello')    return",
+          prefix: "def func():",
+          suffix: "    return",
+        }),
+      ).toBe("    print('hello')");
+    });
+
+    it("should handle overlapping prefix and suffix", () => {
+      expect(
+        trim({
+          response: "abcdefabc",
+          prefix: "abc",
+          suffix: "abc",
+        }),
+      ).toBe("def");
+    });
+  });
+
+  describe("multiple occurrences", () => {
+    it("should trim multiple consecutive prefixes", () => {
+      expect(
+        trim({
+          response: ">>>>>>hello",
+          prefix: ">>>",
+          suffix: "",
+        }),
+      ).toBe(">>>hello");
+    });
+
+    it("should trim multiple consecutive suffixes", () => {
+      expect(
+        trim({
+          response: "hello<<<<<<",
+          prefix: "",
+          suffix: "<<<",
+        }),
+      ).toBe("hello<<<");
+    });
+  });
+
+  describe("real-world scenarios", () => {
+    it("should handle multiline Python function completion", () => {
+      expect(
+        trim({
+          response:
+            "def calculate_sum(a, b):\n    result = a + b\n    return result",
+          prefix: "def calculate_sum(a, b):",
+          suffix: "\n    return result",
+        }),
+      ).toBe("\n    result = a + b");
+    });
+
+    it("should handle Python list comprehension", () => {
+      expect(
+        trim({
+          response: "1, 2, 3, 4, 5];",
+          prefix: "const items = [",
+          suffix: "];",
+        }),
+      ).toBe("1, 2, 3, 4, 5");
+    });
+
+    it("should handle HTML tag completion", () => {
+      expect(
+        trim({
+          response: "  <p>Hello World</p></div>",
+          prefix: '<div class="container">',
+          suffix: "</div>",
+        }),
+      ).toBe("  <p>Hello World</p>");
+    });
+
+    it("should handle SQL query completion", () => {
+      expect(
+        trim({
+          response: " age > 18 AND status = 'active' ORDER BY id",
+          prefix: "SELECT * FROM users WHERE",
+          suffix: "ORDER BY id",
+        }),
+      ).toBe(" age > 18 AND status = 'active' ");
+    });
+
+    it("should handle markdown completion", () => {
+      expect(
+        trim({
+          response: "## Introduction\n\nThis is a sample",
+          prefix: "## ",
+          suffix: "",
+        }),
+      ).toBe("Introduction\n\nThis is a sample");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle response that is exactly the prefix", () => {
+      expect(
+        trim({
+          response: "hello",
+          prefix: "hello",
+          suffix: "",
+        }),
+      ).toBe("");
+    });
+
+    it("should handle response that is exactly the suffix", () => {
+      expect(
+        trim({
+          response: "world",
+          prefix: "",
+          suffix: "world",
+        }),
+      ).toBe("");
+    });
+
+    it("should handle response that is exactly prefix + suffix", () => {
+      expect(
+        trim({
+          response: "helloworld",
+          prefix: "hello",
+          suffix: "world",
+        }),
+      ).toBe("");
+    });
+
+    it("should handle very long prefix/suffix", () => {
+      expect(
+        trim({
+          response: `${"a".repeat(1000)}middle${"b".repeat(1000)}`,
+          prefix: "a".repeat(1000),
+          suffix: "b".repeat(1000),
+        }),
+      ).toBe("middle");
+    });
+
+    it("should handle special characters in prefix/suffix", () => {
+      expect(
+        trim({
+          response: "function test() { /* comment */ return 42; /* end */ }",
+          prefix: "function test() { /* comment */",
+          suffix: "/* end */ }",
+        }),
+      ).toBe(" return 42; ");
+    });
+
+    it("should handle unicode characters", () => {
+      expect(
+        trim({
+          response: "const 🚀 = '🎉 Hello World! 🌟';",
+          prefix: "const 🚀 = ",
+          suffix: ";",
+        }),
+      ).toBe("'🎉 Hello World! 🌟'");
+    });
+
+    it("should handle newlines in prefix/suffix", () => {
+      expect(
+        trim({
+          response: "if (condition) {\n  console.log('test');\n}",
+          prefix: "if (condition) {\n",
+          suffix: "\n}",
+        }),
+      ).toBe("  console.log('test');");
+    });
+
+    it("should handle cases where AI response doesn't include context", () => {
+      expect(
+        trim({
+          response: "42",
+          prefix: "const x = ",
+          suffix: ";",
+        }),
+      ).toBe("42");
+    });
+
+    it("should handle partial matches correctly (not trim them)", () => {
+      // Should not trim partial matches
+      expect(
+        trim({
+          response: "function test() hello world return x",
+          prefix: "function test() {",
+          suffix: "return x;",
+        }),
+      ).toBe("function test() hello world return x");
+    });
+  });
+});

--- a/frontend/src/core/codemirror/copilot/trim-utils.ts
+++ b/frontend/src/core/codemirror/copilot/trim-utils.ts
@@ -1,0 +1,33 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+/**
+ * Trims prefix and suffix from an AI completion response.
+ * Handles the basic case where AI might include the original context in the response.
+ */
+export function trimAutocompleteResponse({
+  response,
+  prefix,
+  suffix,
+}: {
+  response: string;
+  prefix: string;
+  suffix: string;
+}): string {
+  if (!response) {
+    return response;
+  }
+
+  let trimmed = response;
+
+  // Trim exact prefix match
+  if (prefix && trimmed.startsWith(prefix)) {
+    trimmed = trimmed.slice(prefix.length);
+  }
+
+  // Trim exact suffix match
+  if (suffix && trimmed.endsWith(suffix)) {
+    trimmed = trimmed.slice(0, -suffix.length);
+  }
+
+  return trimmed;
+}

--- a/frontend/src/core/network/api.ts
+++ b/frontend/src/core/network/api.ts
@@ -25,6 +25,7 @@ export const API = {
     opts: {
       headers?: Record<string, string>;
       baseUrl?: string;
+      signal?: AbortSignal;
     } = {},
   ): Promise<RESP> {
     const baseUrl = Strings.withTrailingSlash(
@@ -39,6 +40,7 @@ export const API = {
         ...opts.headers,
       },
       body: JSON.stringify(body),
+      signal: opts.signal,
     })
       .then(async (response) => {
         const isJson = response.headers

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -11,7 +11,9 @@ from marimo._server.models.completion import (
     VariableContext,
 )
 
-FILL_ME_TAG = "<FILL_ME>"
+FIM_PREFIX_TAG = "<|fim_prefix|>"
+FIM_SUFFIX_TAG = "<|fim_suffix|>"
+FIM_MIDDLE_TAG = "<|fim_middle|>"
 
 language_rules = {
     "python": [
@@ -163,8 +165,9 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
 
 def get_inline_system_prompt(*, language: Language) -> str:
     return (
-        f"You are a {language} programmer that replaces {FILL_ME_TAG} part with the right code. "
-        f"Only output the code that replaces {FILL_ME_TAG} part. Do not add any explanation or markdown."
+        f"You are a {language} code completion assistant. "
+        f"Complete the missing code between the prefix and suffix while maintaining proper syntax, style, and functionality."
+        f"Only output the code that goes after the {FIM_SUFFIX_TAG} part. Do not add any explanation or markdown."
     )
 
 

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -23,7 +23,9 @@ from marimo._server.ai.config import (
     get_max_tokens,
 )
 from marimo._server.ai.prompts import (
-    FILL_ME_TAG,
+    FIM_MIDDLE_TAG,
+    FIM_PREFIX_TAG,
+    FIM_SUFFIX_TAG,
     get_chat_system_prompt,
     get_inline_system_prompt,
     get_refactor_or_insert_notebook_cell_system_prompt,
@@ -216,7 +218,8 @@ async def ai_inline_completion(
     body = await parse_request(
         request, cls=AiInlineCompletionRequest, allow_unknown_keys=True
     )
-    prompt = f"{body.prefix}{FILL_ME_TAG}{body.suffix}"
+    # Use FIM (Fill-In-Middle) format for inline completion
+    prompt = f"{FIM_PREFIX_TAG}{body.prefix}{FIM_SUFFIX_TAG}{body.suffix}{FIM_MIDDLE_TAG}"
     messages = [ChatMessage(role="user", content=prompt)]
     system_prompt = get_inline_system_prompt(language=body.language)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: ^1.1.18
         version: 1.1.18
       '@marimo-team/codemirror-ai':
-        specifier: ^0.1.11
-        version: 0.1.11(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)
+        specifier: ^0.3.1
+        version: 0.3.1(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)
       '@marimo-team/codemirror-languageserver':
         specifier: ^1.15.24
         version: 1.15.24(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)
@@ -1791,8 +1791,8 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@marimo-team/codemirror-ai@0.1.11':
-    resolution: {integrity: sha512-EGFdLmJP5i4fV0Mec0V48Wlav7bvzbC+GWPmOmYmX49v1LLo1ie1x4CcbcM4IC3baH8MP3AdGvzD/7fSXBoupg==}
+  '@marimo-team/codemirror-ai@0.3.1':
+    resolution: {integrity: sha512-mkDM9BVfVCVX9Plf8TsqX36zMLvgzN++dzAR//HF3BhGrT9IvUvcwkzFWHUeN7iZIY8Hb/yh4MuoxrjuBrOZsg==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -5348,6 +5348,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@8.0.2:
+    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -11180,10 +11184,11 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@marimo-team/codemirror-ai@0.1.11(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)':
+  '@marimo-team/codemirror-ai@0.3.1(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)':
     dependencies:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.1
+      diff: 8.0.2
 
   '@marimo-team/codemirror-languageserver@1.15.24(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)':
     dependencies:
@@ -15525,6 +15530,8 @@ snapshots:
   diff-match-patch@1.0.5: {}
 
   diff-sequences@29.6.3: {}
+
+  diff@8.0.2: {}
 
   dir-glob@3.0.1:
     dependencies:

--- a/tests/_server/ai/snapshots/edit_inline_prompts.txt
+++ b/tests/_server/ai/snapshots/edit_inline_prompts.txt
@@ -1,1 +1,1 @@
-You are a python programmer that replaces <FILL_ME> part with the right code. Only output the code that replaces <FILL_ME> part. Do not add any explanation or markdown.
+You are a python code completion assistant. Complete the missing code between the prefix and suffix while maintaining proper syntax, style, and functionality.Only output the code that goes after the <|fim_suffix|> part. Do not add any explanation or markdown.

--- a/tests/_server/ai/test_prompts.py
+++ b/tests/_server/ai/test_prompts.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from marimo._ast.visitor import Language
 from marimo._server.ai.prompts import (
+    FIM_SUFFIX_TAG,
     _format_variables,
     get_chat_system_prompt,
     get_inline_system_prompt,
@@ -172,7 +173,7 @@ def test_empty_rules():
 def test_edit_inline_prompts():
     result = get_inline_system_prompt(language="python")
     snapshot("edit_inline_prompts.txt", result)
-    assert "<|fim_suffix|>" in result
+    assert FIM_SUFFIX_TAG in result
 
 
 def test_chat_system_prompts():

--- a/tests/_server/ai/test_prompts.py
+++ b/tests/_server/ai/test_prompts.py
@@ -5,7 +5,6 @@ from typing import cast
 
 from marimo._ast.visitor import Language
 from marimo._server.ai.prompts import (
-    FILL_ME_TAG,
     _format_variables,
     get_chat_system_prompt,
     get_inline_system_prompt,
@@ -173,9 +172,7 @@ def test_empty_rules():
 def test_edit_inline_prompts():
     result = get_inline_system_prompt(language="python")
     snapshot("edit_inline_prompts.txt", result)
-    # <FILL_ME> is sent from the client, this cannot change without
-    # coordination
-    assert FILL_ME_TAG in result
+    assert "<|fim_suffix|>" in result
 
 
 def test_chat_system_prompts():

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -9,7 +9,11 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._server.ai.prompts import FILL_ME_TAG
+from marimo._server.ai.prompts import (
+    FIM_MIDDLE_TAG,
+    FIM_PREFIX_TAG,
+    FIM_SUFFIX_TAG,
+)
 from marimo._server.ai.providers import (
     AnyProviderConfig,
     OpenAIProvider,
@@ -279,12 +283,18 @@ class TestOpenAiEndpoints:
             prompt = oaiclient.chat.completions.create.call_args.kwargs[
                 "messages"
             ][1]["content"]
-            assert prompt == f"import pandas as pd\n{FILL_ME_TAG}\ndf.head()"
-            # Assert the system prompt includes language-specific instructions
+            assert (
+                prompt
+                == f"{FIM_PREFIX_TAG}import pandas as pd\n{FIM_SUFFIX_TAG}\ndf.head(){FIM_MIDDLE_TAG}"
+            )
+            # Assert the system prompt for FIM models
             system_prompt = oaiclient.chat.completions.create.call_args.kwargs[
                 "messages"
             ][0]["content"]
-            assert "python" in system_prompt
+            assert (
+                system_prompt
+                == "You are a python code completion assistant. Complete the missing code between the prefix and suffix while maintaining proper syntax, style, and functionality.Only output the code that goes after the <|fim_suffix|> part. Do not add any explanation or markdown."
+            )
             # Assert the model it was called with
             model = oaiclient.chat.completions.create.call_args.kwargs["model"]
             assert model == "gpt-marimo-for-inline-completion"
@@ -341,11 +351,14 @@ class TestOpenAiEndpoints:
                 },
             )
             assert response.status_code == 200, response.text
-            # Assert the system prompt includes language-specific instructions
+            # Assert the system prompt for FIM models
             system_prompt = oaiclient.chat.completions.create.call_args.kwargs[
                 "messages"
             ][0]["content"]
-            assert "sql" in system_prompt
+            assert (
+                system_prompt
+                == "You are a sql code completion assistant. Complete the missing code between the prefix and suffix while maintaining proper syntax, style, and functionality.Only output the code that goes after the <|fim_suffix|> part. Do not add any explanation or markdown."
+            )
             # Assert model
             model = oaiclient.chat.completions.create.call_args.kwargs["model"]
             assert model == "gpt-marimo-for-inline-completion"
@@ -452,7 +465,10 @@ class TestAnthropicAiEndpoints:
             prompt: str = anthropic_client.messages.create.call_args.kwargs[
                 "messages"
             ][0]["content"]
-            assert prompt == f"import pandas as pd\n{FILL_ME_TAG}\ndf.head()"
+            assert (
+                prompt
+                == f"{FIM_PREFIX_TAG}import pandas as pd\n{FIM_SUFFIX_TAG}\ndf.head(){FIM_MIDDLE_TAG}"
+            )
             # Assert the model it was called with
             model = anthropic_client.messages.create.call_args.kwargs["model"]
             assert model == "claude-3.5-for-inline-completion"
@@ -585,7 +601,7 @@ class TestGoogleAiEndpoints:
             )
             assert (
                 prompt[0]["parts"][0]["text"]
-                == f"import pandas as pd\n{FILL_ME_TAG}\ndf.head()"
+                == f"{FIM_PREFIX_TAG}import pandas as pd\n{FIM_SUFFIX_TAG}\ndf.head(){FIM_MIDDLE_TAG}"
             )
 
 

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -293,7 +293,7 @@ class TestOpenAiEndpoints:
             ][0]["content"]
             assert (
                 system_prompt
-                == "You are a python code completion assistant. Complete the missing code between the prefix and suffix while maintaining proper syntax, style, and functionality.Only output the code that goes after the <|fim_suffix|> part. Do not add any explanation or markdown."
+                == f"You are a python code completion assistant. Complete the missing code between the prefix and suffix while maintaining proper syntax, style, and functionality.Only output the code that goes after the {FIM_SUFFIX_TAG} part. Do not add any explanation or markdown."
             )
             # Assert the model it was called with
             model = oaiclient.chat.completions.create.call_args.kwargs["model"]
@@ -357,7 +357,7 @@ class TestOpenAiEndpoints:
             ][0]["content"]
             assert (
                 system_prompt
-                == "You are a sql code completion assistant. Complete the missing code between the prefix and suffix while maintaining proper syntax, style, and functionality.Only output the code that goes after the <|fim_suffix|> part. Do not add any explanation or markdown."
+                == f"You are a sql code completion assistant. Complete the missing code between the prefix and suffix while maintaining proper syntax, style, and functionality.Only output the code that goes after the {FIM_SUFFIX_TAG} part. Do not add any explanation or markdown."
             )
             # Assert model
             model = oaiclient.chat.completions.create.call_args.kwargs["model"]


### PR DESCRIPTION
This improves the FIM (fill-in-the-middle) prompting for the common way to prompt these models. 

I used `codegemma` in my testing: https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/codegemma

This also adds some testing and improvements to the codemirror plugin:
- shorter delay on requesting
- ignore if not focused or the cursor has moved