### PR TITLE
fix(tests): Use `as_series=False` in `assert_frame_equal` to compare Narwhals dataframes

### DIFF
--- a/tests/_plugins/ui/_impl/tables/test_narwhals.py
+++ b/tests/_plugins/ui/_impl/tables/test_narwhals.py
@@ -5,7 +5,7 @@ import json
 import time
 import unittest
 from math import isnan
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import narwhals.stable.v1 as nw
 import pytest
@@ -31,6 +31,9 @@ from tests._data.mocks import (
 )
 from tests.mocks import snapshotter
 
+if TYPE_CHECKING:
+    from narwhals.stable.v1.typing import DataFrameT
+
 HAS_DEPS = DependencyManager.polars.has()
 
 snapshot = snapshotter(__file__)
@@ -45,8 +48,8 @@ SUPPORTED_LIBS: list[DFType] = [
 ]
 
 
-def assert_frame_equal(a: Any, b: Any) -> None:
-    return a.to_dict() == b.to_dict()
+def assert_frame_equal(a: DataFrameT, b: DataFrameT) -> None:
+    return a.to_dict(as_series=False) == b.to_dict(as_series=False)
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")


### PR DESCRIPTION
## 📝 Summary

As per title: when converting from narwhals dataframe to dict use `as_series=False` to avoid comparing narwhals Series.

## 🔍 Description of Changes

This change is needed since comparing series (and exprs) won't be allowed once https://github.com/narwhals-dev/narwhals/pull/2985 is merged. This emulates the behavior of Polars, pandas and numpy.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
