### PR TITLE
Using XDG_STATE_HOME environment variable to support the Linux XDG Base Directory

### DIFF
--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 
 import os
 from dataclasses import asdict
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Optional, TypeVar
 
 from marimo._utils.parse_dataclass import parse_raw
 from marimo._utils.toml import is_toml_error, read_toml
 
-ROOT_DIR = os.environ.get("MARIMO_ROOT_DIR", ".marimo")
+if os.name == "posix":
+    # for Linux/macOS/Unix
+    _state_home = os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")
+    ROOT_DIR = Path(_state_home) / "marimo"
+elif os.name == "nt":
+    # for Windows
+    ROOT_DIR = Path.home() / ".marimo"
 
 T = TypeVar("T")
 

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -9,10 +9,7 @@ from typing import Any, Optional, TypeVar
 from marimo._utils.parse_dataclass import parse_raw
 from marimo._utils.toml import is_toml_error, read_toml
 
-if (_root_dir := os.environ.get("MARIMO_ROOT_DIR")) is None:
-    ROOT_DIR = ".marimo"
-else:
-    ROOT_DIR = _root_dir
+ROOT_DIR = os.environ.get("MARIMO_ROOT_DIR", ".marimo")
 
 T = TypeVar("T")
 

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -19,6 +19,8 @@ if os.name == "posix":
 elif os.name == "nt":
     # for Windows
     ROOT_DIR = Path.home() / ".marimo"
+else:
+    ROOT_DIR = ".marimo"
 
 T = TypeVar("T")
 

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -12,7 +12,9 @@ from marimo._utils.toml import is_toml_error, read_toml
 
 if os.name == "posix":
     # for Linux/macOS/Unix
-    _state_home = os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")
+    _state_home = os.environ.get(
+        "XDG_STATE_HOME", Path.home() / ".local/state"
+    )
     ROOT_DIR = Path(_state_home) / "marimo"
 elif os.name == "nt":
     # for Windows

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -10,13 +10,20 @@ from typing import Any, Optional, TypeVar
 from marimo._utils.parse_dataclass import parse_raw
 from marimo._utils.toml import is_toml_error, read_toml
 
-if os.name == "posix":
-    # for Linux/macOS/Unix
-    _user_home = Path.home()
-    _state_home = os.environ.get("XDG_STATE_HOME", _user_home / ".local/state")
-    ROOT_DIR = Path(_state_home).relative_to(_user_home) / "marimo"
-else:
-    ROOT_DIR = ".marimo"
+
+def xdg_state_marimo_dir() -> Path:
+    if os.name == "posix":
+        # for Linux/macOS/Unix
+        _user_home = Path.home()
+        _state_home = os.environ.get(
+            "XDG_STATE_HOME", _user_home / ".local/state"
+        )
+        return Path(_state_home).relative_to(_user_home) / "marimo"
+    else:
+        return Path(".marimo")
+
+
+ROOT_DIR = xdg_state_marimo_dir()
 
 T = TypeVar("T")
 

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -12,13 +12,9 @@ from marimo._utils.toml import is_toml_error, read_toml
 
 if os.name == "posix":
     # for Linux/macOS/Unix
-    _state_home = os.environ.get(
-        "XDG_STATE_HOME", Path.home() / ".local/state"
-    )
-    ROOT_DIR = Path(_state_home) / "marimo"
-elif os.name == "nt":
-    # for Windows
-    ROOT_DIR = Path.home() / ".marimo"
+    _user_home = Path.home()
+    _state_home = os.environ.get("XDG_STATE_HOME", _user_home / ".local/state")
+    ROOT_DIR = Path(_state_home).relative_to(_user_home) / "marimo"
 else:
     ROOT_DIR = ".marimo"
 

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -9,7 +9,10 @@ from typing import Any, Optional, TypeVar
 from marimo._utils.parse_dataclass import parse_raw
 from marimo._utils.toml import is_toml_error, read_toml
 
-ROOT_DIR = ".marimo"
+if (_root_dir := os.environ.get("MARIMO_ROOT_DIR")) is None:
+    ROOT_DIR = ".marimo"
+else:
+    ROOT_DIR = _root_dir
 
 T = TypeVar("T")
 


### PR DESCRIPTION
## 📝 Summary

Closes https://github.com/marimo-team/marimo/issues/4572

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

The default root dir is ".marimo" and cannot be modified, it will autocreate ".marimo" folder at the user's home in Linux platform.

Add the environment variable XDG_STATE_HOME to support the Linux XDG Base Directory.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

1. Get XDG_STATE_HOME environment variable as ROOT_DIR value
2. If it is not set by the user, using the default XDG_STATE_HOME value “~/.config/state”.
3. If the user's system is Windows or others, using default value ".marimo".
4. I don't know if there is a standard for Dir in Windows or other systems, so I use the default value and make it easy for other contributors to modify it.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
