### PR TITLE
Fix Tailwind v4 shadow colors

### DIFF
--- a/frontend/src/components/editor/output/CalloutOutput.styles.ts
+++ b/frontend/src/components/editor/output/CalloutOutput.styles.ts
@@ -6,13 +6,13 @@ export const calloutStyles = cva(
   {
     variants: {
       kind: {
-        neutral: "border-(--slate-9) shadow-(--slate-8)",
+        neutral: "border-(--slate-9) shadow-(color:--slate-8)",
         // @deprecated, use danger instead
-        alert: "bg-(--red-2) border-(--red-9) shadow-(--red-8)",
-        info: "bg-(--sky-1) border-(--sky-8) shadow-(--sky-7)",
-        danger: "bg-(--red-2) border-(--red-9) shadow-(--red-8)",
-        warn: "bg-(--amber-2) border-(--amber-9) shadow-(--amber-8)",
-        success: "bg-(--grass-2) border-(--grass-9) shadow-(--grass-8)",
+        alert: "bg-(--red-2) border-(--red-9) shadow-(color:--red-8)",
+        info: "bg-(--sky-1) border-(--sky-8) shadow-(color:--sky-7)",
+        danger: "bg-(--red-2) border-(--red-9) shadow-(color:--red-8)",
+        warn: "bg-(--amber-2) border-(--amber-9) shadow-(color:--amber-8)",
+        success: "bg-(--grass-2) border-(--grass-9) shadow-(color:--grass-8)",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/editor/renderers/CellArray.tsx
+++ b/frontend/src/components/editor/renderers/CellArray.tsx
@@ -341,7 +341,7 @@ const AddCellButtons: React.FC<{
           "shadow-sm border border-border rounded transition-all duration-200 overflow-hidden divide-x divide-border flex",
           !isAiButtonOpen && "w-fit",
           isAiButtonOpen &&
-            "opacity-100 w-full max-w-4xl shadow-lg shadow-(--blue-3)",
+            "opacity-100 w-full max-w-4xl shadow-lg shadow-(color:--blue-3)",
           className,
         )}
       >


### PR DESCRIPTION
The Tailwind v4 migration tool migrated our shadow styles to `shadow-(--color-var)`, but the correct syntax is
`shadow-(color:--color-var)`.

<img src="https://github.com/user-attachments/assets/93c3ab2b-08fa-4578-afd6-318a35ba2511" />
