### PR TITLE
Fix borderless cell dividers after Tailwind v4 migration

### DIFF
--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -214,7 +214,7 @@
   &.borderless {
     border-color: transparent;
     box-shadow: none;
-    
+
     & > * {
       border-bottom: none;
     }
@@ -253,7 +253,7 @@
   &.borderless {
     border-color: transparent;
     box-shadow: none;
-    
+
     & > * {
       border-bottom: none;
     }


### PR DESCRIPTION
Tailwind v4 changed `divide-y` from using `border-top` (v3) to `border-bottom` (v4). Our custom CSS was removing `border-top` to hide dividers, which broke with v4.

Fixed by adding `border-bottom: none` to `.borderless` cells.

<img src="https://github.com/user-attachments/assets/daf8efa2-dcbc-4382-825f-f3e87e3a3bda" />
