### PR TITLE
improvement: cache sql parsing

### DIFF
--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -6,6 +6,7 @@ import dataclasses
 import inspect
 import os
 from collections.abc import Awaitable, Mapping
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from marimo import _loggers
@@ -147,11 +148,6 @@ class CellOutput:
     output: Any = None
 
 
-@dataclasses.dataclass
-class ParsedSQLStatements:
-    parsed: Optional[list[str]] = None
-
-
 @dataclasses.dataclass(frozen=True)
 class CellImpl:
     # hash of code
@@ -189,13 +185,6 @@ class CellImpl:
     _stale: CellStaleState = dataclasses.field(default_factory=CellStaleState)
     # cells can optionally hold a reference to their output
     _output: CellOutput = dataclasses.field(default_factory=CellOutput)
-    # parsed sql statements
-    _sqls: ParsedSQLStatements = dataclasses.field(
-        default_factory=ParsedSQLStatements
-    )
-    _raw_sqls: ParsedSQLStatements = dataclasses.field(
-        default_factory=ParsedSQLStatements
-    )
     # Whether this cell can be executed as a test cell.
     _test: bool = False
 
@@ -233,18 +222,14 @@ class CellImpl:
         except Exception:
             return []
 
-    @property
+    @cached_property
     def sqls(self) -> list[str]:
         """Returns parsed SQL statements from this cell.
 
         Returns:
             list[str]: List of SQL statement strings parsed from the cell code.
         """
-        if self._sqls.parsed is not None:
-            return self._sqls.parsed
-
-        self._sqls.parsed = self._get_sqls()
-        return self._sqls.parsed
+        return self._get_sqls()
 
     @property
     def raw_sqls(self) -> list[str]:
@@ -253,11 +238,7 @@ class CellImpl:
         Returns:
             list[str]: List of SQL statements verbatim from the cell code.
         """
-        if self._raw_sqls.parsed is not None:
-            return self._raw_sqls.parsed
-
-        self._raw_sqls.parsed = self._get_sqls(raw=True)
-        return self._raw_sqls.parsed
+        return self._get_sqls(raw=True)
 
     @property
     def stale(self) -> bool:
@@ -270,7 +251,7 @@ class CellImpl:
     @property
     def imports(self) -> Iterable[ImportData]:
         """Return a set of import data for this cell."""
-        import_data = []
+        import_data: list[ImportData] = []
         for data in self.variable_data.values():
             import_data.extend(
                 [

--- a/marimo/_ast/sql_utils.py
+++ b/marimo/_ast/sql_utils.py
@@ -30,7 +30,8 @@ def classify_sql_statement(
 
     sql_statement = sql_statement.strip().lower()
     try:
-        expression_list = parse(sql_statement, dialect=dialect)
+        with _loggers.suppress_warnings_logs("sqlglot"):
+            expression_list = parse(sql_statement, dialect=dialect)
     except ParseError as e:
         LOGGER.debug(f"Unable to parse SQL. Error: {e}")
         return "unknown"

--- a/marimo/_ast/sql_visitor.py
+++ b/marimo/_ast/sql_visitor.py
@@ -351,7 +351,8 @@ def find_sql_refs(
                 refs.append(table.name)
 
     try:
-        expression_list = parse(sql_statement, dialect="duckdb")
+        with _loggers.suppress_warnings_logs("sqlglot"):
+            expression_list = parse(sql_statement, dialect="duckdb")
     except ParseError as e:
         LOGGER.error(f"Unable to parse SQL. Error: {e}")
         return []

--- a/marimo/_loggers.py
+++ b/marimo/_loggers.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from marimo._utils.log_formatter import LogFormatter
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 # This file manages and creates loggers used throughout marimo.
 #
@@ -179,3 +183,15 @@ def _file_handler() -> logging.FileHandler:
     file_handler.setLevel(min(_LOG_LEVEL, logging.INFO))
 
     return file_handler
+
+
+@contextmanager
+def suppress_warnings_logs(name: str) -> Generator[None, None, None]:
+    """Suppress logs for a given logger."""
+    logger = get_logger(name)
+    original_level = logger.level
+    logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        logger.setLevel(original_level)

--- a/tests/_server/api/endpoints/test_ws.py
+++ b/tests/_server/api/endpoints/test_ws.py
@@ -204,6 +204,7 @@ def test_fails_on_multiple_connections_with_same_file(
     client.post("/api/kernel/shutdown", headers=HEADERS)
 
 
+@pytest.mark.flaky(reruns=3)
 async def test_file_watcher_calls_reload(client: TestClient) -> None:
     session_manager: SessionManager = get_session_manager(client)
     session_manager.watch = True


### PR DESCRIPTION
Cache SQL parsing with an LRU of 200 items. Also moves some manual caching in `CellImpl` to `cached_property`.