### PR TITLE
fix: handle blob protocol in runtime manager

### DIFF
--- a/frontend/src/core/runtime/__tests__/config.test.ts
+++ b/frontend/src/core/runtime/__tests__/config.test.ts
@@ -100,6 +100,18 @@ describe("runtime config", () => {
     });
   });
 
+  describe("asRemoteURL with blob", () => {
+    it("should handle blob URLs", () => {
+      const customRuntimeManager = {
+        httpURL: new URL("blob:http://localhost:8080"),
+      } as RuntimeManager;
+      mockedStore.get.mockReturnValue(customRuntimeManager);
+
+      const result = asRemoteURL("./path/to/file.txt");
+      expect(result.toString()).toBe("http://localhost:8080/path/to/file.txt");
+    });
+  });
+
   describe("getRuntimeManager", () => {
     it("should return runtime manager from store", () => {
       const result = getRuntimeManager();

--- a/frontend/src/core/runtime/config.ts
+++ b/frontend/src/core/runtime/config.ts
@@ -36,5 +36,10 @@ export function asRemoteURL(path: string): URL {
   if (path.startsWith("http")) {
     return new URL(path);
   }
-  return new URL(path, getRuntimeManager().httpURL.toString());
+  let base = getRuntimeManager().httpURL.toString();
+  if (base.startsWith("blob:")) {
+    // Remove leading blob:
+    base = base.replace("blob:", "");
+  }
+  return new URL(path, base);
 }


### PR DESCRIPTION
Small fix when the `baseURI` is `blob:https://..`