### PR TITLE
fix: convert time duration to numeric for column explorer

### DIFF
--- a/marimo/_data/preview_column.py
+++ b/marimo/_data/preview_column.py
@@ -388,6 +388,13 @@ def _sanitize_data(
                             .dt.total_minutes()
                             .alias(column_name)
                         )
+                    elif total_seconds >= 1:
+                        # Use seconds if range is at least a second
+                        column_data = column_data.with_columns(
+                            nw.col(column_name)
+                            .dt.total_seconds()
+                            .alias(column_name)
+                        )
                     elif total_seconds >= 0.001:
                         # Use milliseconds if range is at least a millisecond
                         column_data = column_data.with_columns(
@@ -407,13 +414,6 @@ def _sanitize_data(
                         column_data = column_data.with_columns(
                             nw.col(column_name)
                             .dt.total_nanoseconds()
-                            .alias(column_name)
-                        )
-                    else:
-                        # Use seconds otherwise
-                        column_data = column_data.with_columns(
-                            nw.col(column_name)
-                            .dt.total_seconds()
                             .alias(column_name)
                         )
             except Exception as e:

--- a/marimo/_data/preview_column.py
+++ b/marimo/_data/preview_column.py
@@ -264,10 +264,9 @@ def _get_altair_chart(
 
     # Filter the data to the column we want
     column_data = table.select_columns([column_name]).data
+    column_data = _sanitize_data(column_data, column_name)
     if isinstance(column_data, nw.LazyFrame):
         column_data = column_data.collect()
-
-    column_data = _sanitize_data(column_data, column_name)
 
     error: Optional[str] = None
     missing_packages: Optional[list[str]] = None
@@ -331,95 +330,85 @@ def _get_chart_spec(
 
 
 def _sanitize_data(
-    column_data: nw.DataFrame[Any] | Any, column_name: str
-) -> nw.DataFrame[Any] | Any:
+    column_data: nw.DataFrame[Any] | nw.LazyFrame[Any] | Any, column_name: str
+) -> nw.DataFrame[Any] | nw.LazyFrame[Any] | Any:
     """
     Sanitize data for vegafusion.
     Vegafusion doesn't support all data types so we convert them to supported types.
     """
     try:
-        dtype = column_data.schema[column_name]
+        frame = column_data.lazy()
+        col = nw.col(column_name)
+        dtype = column_data.collect_schema()[column_name]
+
         if dtype == nw.Categorical or dtype == nw.Enum:
-            column_data = column_data.with_columns(
-                nw.col(column_name).cast(nw.String)
-            )
+            column_data = frame.with_columns(col.cast(nw.String))
         # Int128 and UInt128 are not supported by datafusion
         elif dtype == nw.Int128:
-            column_data = column_data.with_columns(
-                nw.col(column_name).cast(nw.Int64)
-            )
+            column_data = frame.with_columns(col.cast(nw.Int64))
         elif dtype == nw.UInt128:
-            column_data = column_data.with_columns(
-                nw.col(column_name).cast(nw.UInt64)
-            )
+            column_data = frame.with_columns(col.cast(nw.UInt64))
         elif dtype == nw.Duration:
             # Convert Duration to numeric values for better charting support
             try:
-                min_value = column_data[column_name].min()
-                max_value = column_data[column_name].max()
+                result = (
+                    frame.select(
+                        col.min().alias("min"), col.max().alias("max")
+                    )
+                    .collect()
+                    .rows(named=True)[0]
+                )
+                min_value = result["min"]
+                max_value = result["max"]
                 if min_value is not None and max_value is not None:
                     diff = max_value - min_value
                     total_seconds = diff.total_seconds()
                     if total_seconds >= 604800:
                         # Use weeks if range is at least a week
                         column_data = column_data.with_columns(
-                            (
-                                nw.col(column_name).dt.total_seconds() / 604800
-                            ).alias(column_name)
+                            (col.dt.total_seconds() / 604800).alias(
+                                column_name
+                            )
                         )
-                    if total_seconds >= 86400:
+                    elif total_seconds >= 86400:
                         # Use days if range is at least a day
                         column_data = column_data.with_columns(
-                            (
-                                nw.col(column_name).dt.total_seconds() / 86400
-                            ).alias(column_name)
+                            (col.dt.total_seconds() / 86400).alias(column_name)
                         )
                     elif total_seconds >= 3600:
                         # Use hours if range is at least an hour
                         column_data = column_data.with_columns(
-                            (
-                                nw.col(column_name).dt.total_seconds() / 3600
-                            ).alias(column_name)
+                            (col.dt.total_seconds() / 3600).alias(column_name)
                         )
                     elif total_seconds >= 60:
                         # Use minutes if range is at least a minute
                         column_data = column_data.with_columns(
-                            nw.col(column_name)
-                            .dt.total_minutes()
-                            .alias(column_name)
+                            col.dt.total_minutes().alias(column_name)
                         )
                     elif total_seconds >= 1:
                         # Use seconds if range is at least a second
                         column_data = column_data.with_columns(
-                            nw.col(column_name)
-                            .dt.total_seconds()
-                            .alias(column_name)
+                            col.dt.total_seconds().alias(column_name)
                         )
                     elif total_seconds >= 0.001:
                         # Use milliseconds if range is at least a millisecond
                         column_data = column_data.with_columns(
-                            nw.col(column_name)
-                            .dt.total_milliseconds()
-                            .alias(column_name)
+                            col.dt.total_milliseconds().alias(column_name)
                         )
                     elif total_seconds >= 0.000001:
                         # Use microseconds if range is at least a microsecond
                         column_data = column_data.with_columns(
-                            nw.col(column_name)
-                            .dt.total_microseconds()
-                            .alias(column_name)
+                            col.dt.total_microseconds().alias(column_name)
                         )
                     elif total_seconds >= 0.000000001:
                         # Use nanoseconds if range is at least a nanosecond
                         column_data = column_data.with_columns(
-                            nw.col(column_name)
-                            .dt.total_nanoseconds()
-                            .alias(column_name)
+                            col.dt.total_nanoseconds().alias(column_name)
                         )
             except Exception as e:
                 LOGGER.warning("Failed to infer duration precision: %s", e)
                 column_data = column_data.with_columns(
-                    nw.col(column_name).dt.total_seconds().alias(column_name)
+                    col.dt.total_seconds().alias(column_name)
                 )
     except Exception as e:
         LOGGER.warning(f"Failed to sanitize dtypes: {e}")

--- a/marimo/_server/ai/constants.py
+++ b/marimo/_server/ai/constants.py
@@ -1,2 +1,3 @@
+# Copyright 2025 Marimo. All rights reserved.
 DEFAULT_MAX_TOKENS = 4096
 DEFAULT_MODEL = "openai/gpt-4o"

--- a/marimo/_server/ai/ids.py
+++ b/marimo/_server/ai/ids.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 from dataclasses import dataclass
 from typing import NewType
 

--- a/tests/_data/test_preview_column.py
+++ b/tests/_data/test_preview_column.py
@@ -489,10 +489,10 @@ def test_sanitize_dtypes() -> None:
 
     # Sanitize the dtypes
     result = _sanitize_data(nw_df, "cat_col")
-    assert result.schema["cat_col"] == nw.String
+    assert result.collect_schema()["cat_col"] == nw.String
 
     result = _sanitize_data(nw_df, "int128_col")
-    assert result.schema["int128_col"] == nw.Int64
+    assert result.collect_schema()["int128_col"] == nw.Int64
 
 
 @pytest.mark.skipif(

--- a/tests/_data/test_preview_column.py
+++ b/tests/_data/test_preview_column.py
@@ -537,10 +537,6 @@ def test_preview_column_duration_dtype() -> None:
                 timedelta(microseconds=1),
                 timedelta(microseconds=2),
             ],
-            "duration_nanoseconds": [
-                timedelta(microseconds=0.001),
-                timedelta(microseconds=0.002),
-            ],
         }
     )
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

previously duration types were not supported, this adds support by converting the column type.

<img width="360" height="191" alt="CleanShot 2025-08-20 at 14 06 10" src="https://github.com/user-attachments/assets/4d701922-7760-4e4b-b79f-41af445f5298" />

<img width="359" height="305" alt="CleanShot 2025-08-20 at 14 06 02" src="https://github.com/user-attachments/assets/cdfb8b33-b740-4686-920f-c64d114ffdf1" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
