### PR TITLE
feat(cli): support -h flag for help in CLI

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -224,7 +224,10 @@ sandbox_message = (
 )
 
 
-@click.group(help=main_help_msg)
+@click.group(
+    help=main_help_msg,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.version_option(version=__version__, message="%(version)s")
 @click.option(
     "-l",


### PR DESCRIPTION
## 📝 Summary

Add support for the `-h` flag as an alias for `--help` in the marimo CLI to improve user experience and follow standard command-line conventions.

Currently, `marimo -h` fails with "No such option: -h", which is unexpected behavior since `-h` is the standard short form for help across most CLI tools.

## 🔍 Description of Changes

**Before:**
```bash
$ marimo -h
Error: No such option: -h
```

**After:**
```bash
$ marimo -h
Usage: marimo [OPTIONS] COMMAND [ARGS]...

  Welcome to marimo!
  # ... rest of help output

$ marimo run -h
Usage: marimo run [OPTIONS] NAME [ARGS]...

  Run a notebook as an app in read-only mode.
  # ... rest of help output
```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
