### PR TITLE
improvement: add hotkeys to AI completion

### DIFF
--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -25,6 +25,10 @@ import { cn } from "@/utils/cn";
 import { prettyError } from "@/utils/errors";
 import { retryWithTimeout } from "@/utils/timeout";
 import { PromptInput } from "./add-cell-with-ai";
+import {
+  CompletionActions,
+  createAiCompletionOnKeydown,
+} from "./completion-handlers";
 import { getAICompletionBody } from "./completion-utils";
 
 const Original = CodeMirrorMerge.Original;
@@ -136,6 +140,15 @@ export const AiCompletionEditor: React.FC<Props> = ({
 
   const { theme } = useTheme();
 
+  const handleAcceptCompletion = () => {
+    acceptChange(completion);
+    setCompletion("");
+  };
+
+  const handleDeclineCompletion = () => {
+    setCompletion("");
+  };
+
   return (
     <div className={cn("flex flex-col w-full rounded-[inherit]", className)}>
       <div
@@ -165,6 +178,12 @@ export const AiCompletionEditor: React.FC<Props> = ({
                   handleSubmit();
                 }
               }}
+              onKeyDown={createAiCompletionOnKeydown({
+                handleAcceptCompletion,
+                handleDeclineCompletion,
+                isLoading,
+                completion,
+              })}
             />
             {isLoading && (
               <Button
@@ -179,32 +198,12 @@ export const AiCompletionEditor: React.FC<Props> = ({
               </Button>
             )}
             {completion && (
-              <>
-                <Button
-                  data-testid="accept-completion-button"
-                  variant="text"
-                  size="xs"
-                  className="mb-0"
-                  disabled={isLoading}
-                  onClick={() => {
-                    acceptChange(completion);
-                    setCompletion("");
-                  }}
-                >
-                  <span className="text-(--grass-11) opacity-100">Accept</span>
-                </Button>
-                <Button
-                  data-testid="decline-completion-button"
-                  variant="text"
-                  size="xs"
-                  className="mb-0 pl-1"
-                  onClick={() => {
-                    setCompletion("");
-                  }}
-                >
-                  <span className="text-(--red-10)">Reject</span>
-                </Button>
-              </>
+              <CompletionActions
+                isLoading={isLoading}
+                onAccept={handleAcceptCompletion}
+                onDecline={handleDeclineCompletion}
+                size="xs"
+              />
             )}
             <div className="h-full w-px bg-border mx-2" />
             <Tooltip content="Include code from other cells">

--- a/frontend/src/components/editor/ai/completion-handlers.tsx
+++ b/frontend/src/components/editor/ai/completion-handlers.tsx
@@ -1,0 +1,91 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import React from "react";
+import { MinimalHotkeys } from "@/components/shortcuts/renderShortcut";
+import { Button } from "@/components/ui/button";
+import { isPlatformMac } from "@/core/hotkeys/shortcuts";
+
+/**
+ * Common keyboard shortcut handlers for AI completions
+ */
+export const createAiCompletionOnKeydown = (opts: {
+  handleAcceptCompletion: () => void;
+  handleDeclineCompletion: () => void;
+  isLoading: boolean;
+  completion: string;
+}) => {
+  const {
+    handleAcceptCompletion,
+    handleDeclineCompletion,
+    isLoading,
+    completion,
+  } = opts;
+
+  return (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const metaKey = isPlatformMac() ? e.metaKey : e.ctrlKey;
+
+    // Mod+Enter should accept the completion, if there is one
+    if (metaKey && e.key === "Enter") {
+      if (!isLoading && completion) {
+        handleAcceptCompletion();
+      }
+    }
+
+    // Mod+Shift+Delete should decline the completion
+    const deleteKey = e.key === "Delete" || e.key === "Backspace";
+    if (deleteKey && metaKey && e.shiftKey) {
+      handleDeclineCompletion();
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+};
+
+/**
+ * Common completion action buttons with keyboard shortcuts
+ */
+export const CompletionActions: React.FC<{
+  isLoading: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+  size?: "xs" | "sm";
+  acceptShortcut?: string;
+  declineShortcut?: string;
+}> = ({
+  isLoading,
+  onAccept,
+  onDecline,
+  size = "sm",
+  acceptShortcut = "Mod-↵",
+  declineShortcut = "Shift-Mod-Delete",
+}) => {
+  return (
+    <>
+      <Button
+        data-testid="accept-completion-button"
+        variant="text"
+        size={size}
+        className="mb-0"
+        disabled={isLoading}
+        onClick={onAccept}
+      >
+        <span className="text-(--grass-11) opacity-100">
+          Accept{" "}
+          <MinimalHotkeys className="ml-1 inline" shortcut={acceptShortcut} />
+        </span>
+      </Button>
+      <Button
+        data-testid="decline-completion-button"
+        variant="text"
+        size={size}
+        className="mb-0 pl-1"
+        onClick={onDecline}
+      >
+        <span className="text-(--red-10)">
+          Reject{" "}
+          <MinimalHotkeys className="ml-1 inline" shortcut={declineShortcut} />
+        </span>
+      </Button>
+    </>
+  );
+};


### PR DESCRIPTION
Hotkey for accept/reject. These are not configurable, but do match Cursor's for familiarity. 

<img width="1032" height="393" alt="Screenshot 2025-08-20 at 6 03 27 PM" src="https://github.com/user-attachments/assets/b649b32c-6009-407c-9fa1-998c071d12d8" />
