### PR TITLE
Properly detect Linux platform for hotkeys

### DIFF
--- a/frontend/e2e-tests/helper.ts
+++ b/frontend/e2e-tests/helper.ts
@@ -82,7 +82,7 @@ export async function takeScreenshot(page: Page, filename: string) {
  */
 export async function pressShortcut(page: Page, action: HotkeyAction) {
   const isMac = await page.evaluate(() => navigator.userAgent.includes("Mac"));
-  const provider = HotkeyProvider.create(isMac);
+  const provider = HotkeyProvider.create();
   const key = provider.getHotkey(action);
   // playwright uses "Meta" for command key on mac, "Control" for windows/linux
   // we also need to capitalize the first letter of each key

--- a/frontend/src/core/hotkeys/__tests__/hotkeys.test.ts
+++ b/frontend/src/core/hotkeys/__tests__/hotkeys.test.ts
@@ -1,0 +1,74 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, expect, it } from "vitest";
+import { type Hotkey, type HotkeyAction, HotkeyProvider } from "../hotkeys";
+
+/**
+ * Just a helper.
+ */
+function createHotkeys(
+  keys: Partial<Record<HotkeyAction, Hotkey>>,
+): Record<HotkeyAction, Hotkey> {
+  return new Proxy(keys as Record<HotkeyAction, Hotkey>, {
+    // biome-ignore lint: ok to have three arguments here (It's a web API)
+    get(target, p, receiver) {
+      const key = Reflect.get(target, p, receiver);
+      if (key === "undefined") {
+        throw new Error("Missing required hotkey.");
+      }
+      return key;
+    },
+  });
+}
+
+describe("HotkeyProvider platform separation", () => {
+  it("should not apply Windows overrides to Linux platform", () => {
+    const hotkeys = createHotkeys({
+      "cell.run": {
+        name: "Run cell",
+        group: "Running Cells",
+        key: {
+          main: "Ctrl-Enter",
+          windows: "Alt-Enter",
+        },
+      },
+      "cell.runAndNewBelow": {
+        name: "Run and new below",
+        group: "Running Cells",
+        key: "Shift-Enter",
+      },
+    });
+
+    // Create providers for each platform
+    const windowsProvider = new HotkeyProvider(hotkeys, "windows");
+    const linuxProvider = new HotkeyProvider(hotkeys, "linux");
+    const macProvider = new HotkeyProvider(hotkeys, "mac");
+
+    expect(windowsProvider.getHotkey("cell.run").key).toBe("Alt-Enter");
+    expect(linuxProvider.getHotkey("cell.run").key).toBe("Ctrl-Enter");
+    expect(macProvider.getHotkey("cell.run").key).toBe("Ctrl-Enter");
+  });
+
+  it("should allow each platform to have distinct keybindings", () => {
+    const hotkeys = createHotkeys({
+      "cell.format": {
+        name: "Format cell",
+        group: "Editing",
+        key: {
+          main: "Mod-Shift-F",
+          mac: "Cmd-Option-F",
+          windows: "Ctrl-Alt-F",
+          linux: "Ctrl-Shift-L",
+        },
+      },
+    });
+
+    const windowsProvider = new HotkeyProvider(hotkeys, "windows");
+    const linuxProvider = new HotkeyProvider(hotkeys, "linux");
+    const macProvider = new HotkeyProvider(hotkeys, "mac");
+
+    // Each platform should get its own specific override
+    expect(macProvider.getHotkey("cell.format").key).toBe("Cmd-Option-F");
+    expect(windowsProvider.getHotkey("cell.format").key).toBe("Ctrl-Alt-F");
+    expect(linuxProvider.getHotkey("cell.format").key).toBe("Ctrl-Shift-L");
+  });
+});

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -1,10 +1,10 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { isPlatformMac } from "@/core/hotkeys/shortcuts";
+import { isPlatformMac, isPlatformWindows } from "@/core/hotkeys/shortcuts";
 import { Objects } from "@/utils/objects";
 
 export const NOT_SET: unique symbol = Symbol("NOT_SET");
 
-interface Hotkey {
+export interface Hotkey {
   name: string;
   /**
    * Grouping for the command palette and keyboard shortcuts page.
@@ -34,6 +34,7 @@ interface ResolvedHotkey {
   key: string;
 }
 
+type ModKey = "Cmd" | "Ctrl";
 type Platform = "mac" | "windows" | "linux";
 
 export type HotkeyGroup =
@@ -432,21 +433,17 @@ export interface IHotkeyProvider {
 }
 
 export class HotkeyProvider implements IHotkeyProvider {
-  private mod: string;
-  private platform: Platform;
+  private mod: ModKey;
 
-  static create(isMac?: boolean): HotkeyProvider {
-    return new HotkeyProvider(DEFAULT_HOT_KEY, isMac);
+  static create(platform?: Platform): HotkeyProvider {
+    return new HotkeyProvider(DEFAULT_HOT_KEY, platform);
   }
 
   constructor(
     private hotkeys: Record<HotkeyAction, Hotkey>,
-    isMac?: boolean,
+    private platform: Platform = resolvePlatform(),
   ) {
-    isMac = isMac ?? isPlatformMac();
-
-    this.mod = isMac ? "Cmd" : "Ctrl";
-    this.platform = isMac ? "mac" : "windows";
+    this.mod = platform === "mac" ? "Cmd" : "Ctrl";
   }
 
   iterate(): HotkeyAction[] {
@@ -508,4 +505,14 @@ export class OverridingHotkeyProvider extends HotkeyProvider {
       key,
     };
   }
+}
+
+function resolvePlatform(): Platform {
+  if (isPlatformMac()) {
+    return "mac";
+  }
+  if (isPlatformWindows()) {
+    return "windows";
+  }
+  return "linux";
 }

--- a/frontend/src/core/hotkeys/shortcuts.ts
+++ b/frontend/src/core/hotkeys/shortcuts.ts
@@ -21,6 +21,23 @@ export function isPlatformMac() {
   return /mac/i.test(platform);
 }
 
+/**
+ * Check if the current platform is Windows
+ */
+export function isPlatformWindows() {
+  if (typeof window === "undefined") {
+    Logger.warn("isPlatformWindows() called without window");
+    return false;
+  }
+  // @ts-expect-error typescript does not have types for experimental userAgentData property
+  const platform = window.navigator.userAgentData
+    ? // @ts-expect-error typescript does not have types for experimental userAgentData property
+      window.navigator.userAgentData.platform
+    : window.navigator.platform;
+
+  return /win/i.test(platform);
+}
+
 type IKeyboardEvent = Pick<
   KeyboardEvent,
   "key" | "shiftKey" | "ctrlKey" | "metaKey" | "altKey" | "code"


### PR DESCRIPTION
Linux was incorrectly treated as Windows for keyboard shortcuts. Now Linux, Windows, and Mac are properly distinguished, allowing platform-specific keybindings to work correctly.

Should be merged before #6092 and that PR rebased on these changes.
