### PR TITLE
fix: katex can't be italics

### DIFF
--- a/frontend/src/css/katex.min.css
+++ b/frontend/src/css/katex.min.css
@@ -4,6 +4,7 @@
   text-rendering: auto;
   font-family: "KaTeX_Main", "Times New Roman", serif;
   font-size: 110%;
+  font-style: normal;
   line-height: inherit;
   text-indent: 0;
 }


### PR DESCRIPTION
Fixes #5909

Katex in blockquotes makes it italics which gives it random/unknown characters. This forces `font-style: normal`.