### PR TITLE
Update language links in README_Traditional_Chinese.md

### DIFF
--- a/README_Traditional_Chinese.md
+++ b/README_Traditional_Chinese.md
@@ -14,9 +14,8 @@
 </p>
 
 <p align="center">
-    <b>English | </b>
-    <a href="https://github.com/marimo-team/marimo/blob/main/README_Traditional_Chinese.md" target="_blank"><b>繁體中文</b></a>
-    <b> | </b>
+    <a href="https://github.com/marimo-team/marimo/blob/main/README.md" target="_blank"><b>English</b></a>
+    <b> | 繁體中文 | </b>
     <a href="https://github.com/marimo-team/marimo/blob/main/README_Chinese.md" target="_blank"><b>简体中文</b></a>
     <b> | </b>
     <a href="https://github.com/marimo-team/marimo/blob/main/README_Japanese.md" target="_blank"><b>日本語</b></a>


### PR DESCRIPTION
Fixed improper link in the Traditional Chinese, properly links to English.
