### PR TITLE
Fix cellname overlap

### DIFF
--- a/frontend/src/components/editor/actions/name-cell-input.tsx
+++ b/frontend/src/components/editor/actions/name-cell-input.tsx
@@ -79,12 +79,15 @@ export const NameCellContentEditable: React.FC<{
       <span
         className={cn(
           "outline-hidden border hover:border-cyan-500/40 focus:border-cyan-500/40",
+          // Prevent layout shift when focusing
+          inputProps.focusing ? "" : "text-ellipsis",
           className,
         )}
         contentEditable={true}
         suppressContentEditableWarning={true}
         onChange={inputProps.onChange}
         onBlur={inputProps.onBlur}
+        onFocus={inputProps.onFocus}
         onKeyDown={Events.onEnter((e) => {
           if (e.target instanceof HTMLElement) {
             e.target.blur();
@@ -99,6 +102,7 @@ export const NameCellContentEditable: React.FC<{
 
 function useCellNameInput(value: string, onChange: (newName: string) => void) {
   const [internalValue, setInternalValue] = useState(value);
+  const [focusing, setFocusing] = useState(false);
 
   const commit = (newValue: string) => {
     // No change
@@ -119,6 +123,7 @@ function useCellNameInput(value: string, onChange: (newName: string) => void) {
 
   return {
     value: isInternalCellName(internalValue) ? "" : internalValue,
+    focusing,
     onChange: (evt: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = evt.target.value;
       const normalized = normalizeName(newValue);
@@ -131,7 +136,14 @@ function useCellNameInput(value: string, onChange: (newName: string) => void) {
       } else if (evt.target instanceof HTMLSpanElement) {
         const newValue = evt.target.innerText.trim();
         commit(normalizeName(newValue));
+
+        // Scroll to the left after committing to make sure showing the start of the cell name
+        evt.target.scrollLeft = 0;
+        setFocusing(false);
       }
+    },
+    onFocus: () => {
+      setFocusing(true);
     },
   };
 }

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -113,38 +113,40 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
 
   return (
     <div className="relative group">
-      <div className="absolute top-1 right-5 z-10 opacity-0 group-hover:opacity-100 flex gap-1">
-        <Tooltip content="Copy all">
-          <span>
-            <button
-              aria-label="Copy all console output"
-              className="p-1 rounded bg-transparent text-muted-foreground hover:text-foreground"
-              type="button"
-              onClick={() => {
-                const text = reversedOutputs
-                  .filter((output) => output.channel !== "pdb")
-                  .map((output) => Strings.asString(output.data))
-                  .join("\n");
-                void copyToClipboard(text);
-              }}
-            >
-              <CopyIcon className="h-4 w-4" />
-            </button>
-          </span>
-        </Tooltip>
-        <Tooltip content={wrapText ? "Disable wrap text" : "Wrap text"}>
-          <span>
-            <ToggleButton
-              aria-label="Toggle text wrapping"
-              className="p-1 rounded bg-transparent text-muted-foreground data-hovered:text-foreground data-selected:text-foreground"
-              isSelected={wrapText}
-              onChange={setWrapText}
-            >
-              <WrapTextIcon className="h-4 w-4" />
-            </ToggleButton>
-          </span>
-        </Tooltip>
-      </div>
+      {hasOutputs && (
+        <div className="absolute top-1 right-5 z-10 opacity-0 group-hover:opacity-100 flex gap-1">
+          <Tooltip content="Copy all">
+            <span>
+              <button
+                aria-label="Copy all console output"
+                className="p-1 rounded bg-transparent text-muted-foreground hover:text-foreground"
+                type="button"
+                onClick={() => {
+                  const text = reversedOutputs
+                    .filter((output) => output.channel !== "pdb")
+                    .map((output) => Strings.asString(output.data))
+                    .join("\n");
+                  void copyToClipboard(text);
+                }}
+              >
+                <CopyIcon className="h-4 w-4" />
+              </button>
+            </span>
+          </Tooltip>
+          <Tooltip content={wrapText ? "Disable wrap text" : "Wrap text"}>
+            <span>
+              <ToggleButton
+                aria-label="Toggle text wrapping"
+                className="p-1 rounded bg-transparent text-muted-foreground data-hovered:text-foreground data-selected:text-foreground"
+                isSelected={wrapText}
+                onChange={setWrapText}
+              >
+                <WrapTextIcon className="h-4 w-4" />
+              </ToggleButton>
+            </span>
+          </Tooltip>
+        </div>
+      )}
       <div
         title={stale ? "This console output is stale" : undefined}
         data-testid="console-output-area"

--- a/frontend/src/components/editor/output/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/ConsoleOutput.tsx
@@ -209,7 +209,7 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
         <NameCellContentEditable
           value={cellName}
           cellId={cellId}
-          className="bg-(--slate-4) border-(--slate-4) hover:bg-(--slate-5) dark:border-(--sky-5) dark:bg-(--sky-6) dark:text-(--sky-12) text-(--slate-12) rounded-tl rounded-br-lg absolute right-0 bottom-0 text-xs px-1.5 py-0.5 font-mono"
+          className="bg-(--slate-4) border-(--slate-4) hover:bg-(--slate-5) dark:border-(--sky-5) dark:bg-(--sky-6) dark:text-(--sky-12) text-(--slate-12) rounded-l rounded-br-lg absolute right-0 bottom-0 text-xs px-1.5 py-0.5 font-mono max-w-[75%] whitespace-nowrap overflow-hidden"
         />
       </div>
     </div>

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -1483,7 +1483,7 @@ except NameError:
                         """
                     try:
                         R = R # Causes error since no def
-                        C = 0 # Unaccessible
+                        C = 0 # Inaccessible
                     except:
                         pass
                     """

--- a/tests/_runtime/test_trace.py
+++ b/tests/_runtime/test_trace.py
@@ -242,7 +242,7 @@ class TestAppTrace:
                         """
                     try:
                         R = R # Causes error since no def
-                        C = 0 # Unaccessible
+                        C = 0 # Inaccessible
                     except:
                         pass
                     """


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #5964 
## 🔍 Description of Changes
### Typo fix
The precommit fixed spell "unaccessible" -> "inaccessible" automatically.

### main change
#### name cell overlap
 I add a Logical AND `&&` to make sure that the 2 button of `Copy all` and `Warp text` only appear when there is any output content.

https://github.com/user-attachments/assets/7fdeac72-9dcd-4afe-a678-5a5426938746


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
