### PR TITLE
Proper handling of requests to /health, /.well-known and ./assets in the vite dev setup

### DIFF
--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -267,9 +267,9 @@ export default defineConfig({
     },
     headers: isPyodide
       ? {
-        "Cross-Origin-Opener-Policy": "same-origin",
-        "Cross-Origin-Embedder-Policy": "require-corp",
-      }
+          "Cross-Origin-Opener-Policy": "same-origin",
+          "Cross-Origin-Embedder-Policy": "require-corp",
+        }
       : {},
   },
   define: {
@@ -301,8 +301,8 @@ export default defineConfig({
       babel: {
         presets: ["@babel/preset-typescript"],
         plugins: [
-          ["@babel/plugin-proposal-decorators", {legacy: true}],
-          ["@babel/plugin-proposal-class-properties", {loose: true}],
+          ["@babel/plugin-proposal-decorators", { legacy: true }],
+          ["@babel/plugin-proposal-class-properties", { loose: true }],
           ["babel-plugin-react-compiler", ReactCompilerConfig],
         ],
       },


### PR DESCRIPTION
## 📝 Summary

Currently, when you run `pnpm dev` and open a notebook in a browser, there are 2 requests that result in errors causing confusing log. Those requests and the side effects are the following.

For the request:

```
http://127.0.0.1:2718/.well-known/appspecific/com.chrome.devtools.json
```

in the vite log we see this:

```
Failed to connect to a marimo server at http://127.0.0.1:2718/.well-known/appspecific/com.chrome.devtools.json

A marimo server may not be running.
Run marimo edit --no-token --headless in another terminal to start the server.

If the server is already running, make sure it is using port 2718 with --port=2718.
```

For the request:

```
http://127.0.0.1:2718/health
```

we see this:

```
Element title not found.
Element marimo-filename not found.
```

Also, there's a request from the browser to the asset hardcoded in `_static/index.html` produces the following error in the browser console:

```
(index):92  GET http://localhost:3000/assets/index-CVK4EV_D.js net::ERR_ABORTED 404 (Not Found)
```

## 🔍 Description of Changes

For the request to `.../.well-known...` we simply return 404.
For the request to `.../health` we return serverHtml directly without processing.
We avoid the request to `./assets/...` by skipping copying this part to the devHtml.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Not sure what tests apply here.
- [x] I have run the code and verified that it works as expected.
