### PR TITLE
fix: use 'uv tree' to list packages if available

### DIFF
--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -382,10 +382,21 @@ class UvPackageManager(PypiPackageManager):
         tree = self.dependency_tree()
         if tree is not None:
             LOGGER.info("Listing packages with 'uv tree'")
-            return [
-                PackageDescription(name=pkg.name, version=pkg.version or "")
-                for pkg in tree.dependencies
-            ]
+            seen: set[str] = set()
+            packages: list[PackageDescription] = []
+            stack = list(tree.dependencies)
+            while stack:
+                pkg = stack.pop()
+                if pkg.name not in seen:
+                    packages.append(
+                        PackageDescription(
+                            name=pkg.name, version=pkg.version or ""
+                        )
+                    )
+                    seen.add(pkg.name)
+                    # Add dependencies to stack for recursion
+                    stack.extend(pkg.dependencies)
+            return sorted(packages, key=lambda pkg: pkg.name)
 
         LOGGER.info("Listing packages with 'uv pip list'")
         cmd = [self._uv_bin, "pip", "list", "--format=json", "-p", PY_EXE]

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -328,13 +328,31 @@ def test_uv_list_packages_with_tree_success(mock_dependency_tree: MagicMock):
         tags=[],
         dependencies=[
             DependencyTreeNode(
-                name="package1", version="1.0.0", tags=[], dependencies=[]
+                name="z-package1",
+                version="1.0.0",
+                tags=[],
+                dependencies=[
+                    DependencyTreeNode(
+                        name="package3",
+                        version="3.0.0",
+                        tags=[],
+                        dependencies=[],
+                    )
+                ],
             ),
             DependencyTreeNode(
                 name="package2",
                 version=None,  # Test None version handling
                 tags=[],
-                dependencies=[],
+                dependencies=[
+                    # Duplicate package
+                    DependencyTreeNode(
+                        name="package3",
+                        version="3.0.0",
+                        tags=[],
+                        dependencies=[],
+                    )
+                ],
             ),
         ],
     )
@@ -347,9 +365,12 @@ def test_uv_list_packages_with_tree_success(mock_dependency_tree: MagicMock):
     mock_dependency_tree.assert_called_once()
 
     # Should return packages from tree
-    assert len(packages) == 2
-    assert packages[0] == PackageDescription(name="package1", version="1.0.0")
-    assert packages[1] == PackageDescription(name="package2", version="")
+    assert len(packages) == 3
+    assert packages[0] == PackageDescription(name="package2", version="")
+    assert packages[1] == PackageDescription(name="package3", version="3.0.0")
+    assert packages[2] == PackageDescription(
+        name="z-package1", version="1.0.0"
+    )
 
 
 @patch("subprocess.run")


### PR DESCRIPTION
Fixes #6122

I _think_ this is correct. `list_packages()` just called `uv pip list` will grab another environment where instead we want to grab all the packages from `pyproject.toml` (using `uv tree`)