### PR TITLE
improvement: add tab to configure "Displayed models" in the AI configuration

### DIFF
--- a/frontend/src/components/ai/ai-model-dropdown.tsx
+++ b/frontend/src/components/ai/ai-model-dropdown.tsx
@@ -31,6 +31,7 @@ import {
 } from "../ui/dropdown-menu";
 import { Tooltip } from "../ui/tooltip";
 import { AiProviderIcon } from "./ai-provider-icon";
+import { getCurrentRoleTooltip, getTagColour } from "./display-helpers";
 
 interface AIModelDropdownProps {
   value?: string;
@@ -104,7 +105,7 @@ export const AIModelDropdown = ({
         </div>
 
         <div className="ml-auto flex gap-1">
-          <Tooltip content={getTagTooltip(role)}>
+          <Tooltip content={getCurrentRoleTooltip(role)}>
             <span
               key={role}
               className={`text-xs px-1.5 py-0.5 rounded font-medium ${getTagColour(role)}`}
@@ -248,8 +249,7 @@ const ProviderDropdownContent = ({
             </>
           )}
           {models.map((model) => {
-            const qualifiedModelId =
-              `${provider}/${model.model}` as QualifiedModelId;
+            const qualifiedModelId: QualifiedModelId = `${provider}/${model.model}`;
             return (
               <DropdownMenuSub key={qualifiedModelId}>
                 <DropdownMenuSubTrigger showChevron={false} className="py-2">
@@ -309,7 +309,7 @@ const AiModelDropdownItem = ({
   );
 };
 
-const AiModelInfoDisplay = ({
+export const AiModelInfoDisplay = ({
   model,
   provider,
 }: {
@@ -339,7 +339,7 @@ const AiModelInfoDisplay = ({
               <span
                 key={role}
                 className={`px-2 py-1 text-xs rounded-md font-medium ${getTagColour(role)}`}
-                title={getTagTooltip(role)}
+                title={getCurrentRoleTooltip(role)}
               >
                 {role}
               </span>
@@ -373,33 +373,4 @@ function getProviderLabel(provider: ProviderId): string {
     return providerInfo.name;
   }
   return capitalize(provider);
-}
-
-function getTagColour(role: Role | "thinking"): string {
-  switch (role) {
-    case "chat":
-      return "bg-[var(--purple-3)] text-[var(--purple-11)]";
-    case "autocomplete":
-      return "bg-[var(--green-3)] text-[var(--green-11)]";
-    case "edit":
-      return "bg-[var(--blue-3)] text-[var(--blue-11)]";
-    case "thinking":
-      return "bg-[var(--purple-4)] text-[var(--purple-12)]";
-  }
-  return "bg-[var(--mauve-3)] text-[var(--mauve-11)]";
-}
-
-function getTagTooltip(role: Role): string {
-  switch (role) {
-    case "chat":
-      return "Current model used for chat conversations";
-    case "autocomplete":
-      return "Current model used for autocomplete autocomplete";
-    case "edit":
-      return "Current model used for code edits";
-    case "rerank":
-      return "Current model used for reranking completions";
-    case "embed":
-      return "Current model used for embedding";
-  }
 }

--- a/frontend/src/components/ai/display-helpers.tsx
+++ b/frontend/src/components/ai/display-helpers.tsx
@@ -1,0 +1,32 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import type { Role } from "@marimo-team/llm-info";
+
+export function getTagColour(role: Role | "thinking"): string {
+  switch (role) {
+    case "chat":
+      return "bg-[var(--purple-3)] text-[var(--purple-11)]";
+    case "autocomplete":
+      return "bg-[var(--green-3)] text-[var(--green-11)]";
+    case "edit":
+      return "bg-[var(--blue-3)] text-[var(--blue-11)]";
+    case "thinking":
+      return "bg-[var(--purple-4)] text-[var(--purple-12)]";
+  }
+  return "bg-[var(--mauve-3)] text-[var(--mauve-11)]";
+}
+
+export function getCurrentRoleTooltip(role: Role): string {
+  switch (role) {
+    case "chat":
+      return "Current model used for chat conversations";
+    case "autocomplete":
+      return "Current model used for autocomplete autocomplete";
+    case "edit":
+      return "Current model used for code edits";
+    case "rerank":
+      return "Current model used for reranking completions";
+    case "embed":
+      return "Current model used for embedding";
+  }
+}

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -1,8 +1,13 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { ChevronRightIcon, InfoIcon } from "lucide-react";
+import { BrainIcon, ChevronRightIcon, InfoIcon } from "lucide-react";
 import React, { useMemo } from "react";
-import { Button, Tree, TreeItem, TreeItemContent } from "react-aria-components";
+import {
+  Button as AriaButton,
+  Tree,
+  TreeItem,
+  TreeItemContent,
+} from "react-aria-components";
 import type { FieldPath, UseFormReturn } from "react-hook-form";
 import { useWatch } from "react-hook-form";
 import useEvent from "react-use-event-hook";
@@ -36,6 +41,7 @@ import {
   AiProviderIcon,
   type AiProviderIconProps,
 } from "../ai/ai-provider-icon";
+import { getTagColour } from "../ai/display-helpers";
 import {
   Accordion,
   AccordionContent,
@@ -439,18 +445,49 @@ const ModelListItem: React.FC<ModelListItemProps> = ({
     >
       <TreeItemContent>
         <div className="flex items-center justify-between px-4 py-3 border-b last:border-b-0 cursor-pointer outline-none">
-          <div className="flex items-center gap-3">
-            <div className="flex flex-col">
-              <span className="font-medium">{model.name}</span>
-              <span className="text-sm text-muted-secondary">
-                {qualifiedId}
-              </span>
-            </div>
-          </div>
+          <ModelInfoCard model={model} qualifiedId={qualifiedId} />
           <Switch checked={isEnabled} onClick={handleToggle} size="sm" />
         </div>
       </TreeItemContent>
     </TreeItem>
+  );
+};
+
+const ModelInfoCard = ({
+  model,
+  qualifiedId,
+}: {
+  model: AiModel;
+  qualifiedId: QualifiedModelId;
+}) => {
+  return (
+    <div className="flex items-center gap-3 flex-1">
+      <div className="flex flex-col flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="font-medium">{model.name}</h3>
+        </div>
+        <span className="text-xs text-muted-foreground font-mono">
+          {qualifiedId}
+        </span>
+        {model.description && !model.custom && (
+          <p className="text-sm text-muted-secondary mt-1 line-clamp-2">
+            {model.description}
+          </p>
+        )}
+
+        {model.thinking && (
+          <div
+            className={cn(
+              "flex items-center gap-1 rounded px-1 py-0.5 w-fit mt-1.5",
+              getTagColour("thinking"),
+            )}
+          >
+            <BrainIcon className="h-3 w-3" />
+            <span className="text-xs font-medium">Reasoning</span>
+          </div>
+        )}
+      </div>
+    </div>
   );
 };
 
@@ -939,14 +976,14 @@ const ProviderTreeItem: React.FC<ProviderTreeItemProps> = ({
           />
           <AiProviderIcon provider={providerId} className="h-5 w-5" />
           <div className="flex items-center justify-between w-full">
-            <span className="font-medium">{name}</span>
-            <span className="text-sm text-muted-secondary">
+            <h2 className="font-semibold">{name}</h2>
+            <p className="text-sm text-muted-secondary">
               {enabledCount}/{totalCount} models
-            </span>
+            </p>
           </div>
-          <Button slot="chevron">
+          <AriaButton slot="chevron">
             <ChevronRightIcon className="h-4 w-4 text-muted-foreground shrink-0 transition-transform duration-200 group-data-[expanded]:rotate-90" />
-          </Button>
+          </AriaButton>
         </div>
       </TreeItemContent>
 
@@ -974,6 +1011,7 @@ export const AiModelDisplayConfig: React.FC<AiConfigProps> = ({
     () =>
       AiModelRegistry.create({
         displayedModels: [],
+        customModels: ["openrouter/deepseek-r1-distill-llama-70b"],
       }),
     [],
   );
@@ -1013,8 +1051,7 @@ export const AiModelDisplayConfig: React.FC<AiConfigProps> = ({
   );
 
   return (
-    <SettingGroup className="h-full">
-      <SettingSubtitle>Model Display</SettingSubtitle>
+    <SettingGroup>
       <p className="text-sm text-muted-secondary mb-4">
         Control which AI models are displayed in model selection dropdowns. When
         no models are selected, all available models will be shown.
@@ -1052,7 +1089,7 @@ export const AiConfig: React.FC<AiConfigProps> = ({
       <TabsList className="mb-2">
         <TabsTrigger value="ai-features">AI Features</TabsTrigger>
         <TabsTrigger value="ai-providers">AI Providers</TabsTrigger>
-        <TabsTrigger value="model-display">Model Display</TabsTrigger>
+        <TabsTrigger value="ai-models">AI Models</TabsTrigger>
       </TabsList>
 
       <TabsContent value="ai-features">
@@ -1066,7 +1103,7 @@ export const AiConfig: React.FC<AiConfigProps> = ({
       <TabsContent value="ai-providers">
         <AiProvidersConfig form={form} config={config} onSubmit={onSubmit} />
       </TabsContent>
-      <TabsContent value="model-display">
+      <TabsContent value="ai-models">
         <AiModelDisplayConfig form={form} config={config} onSubmit={onSubmit} />
       </TabsContent>
     </Tabs>

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -966,7 +966,10 @@ const ProviderTreeItem: React.FC<ProviderTreeItemProps> = ({
   );
 };
 
-export const AiModelDisplayConfig: React.FC<AiConfigProps> = ({ form }) => {
+export const AiModelDisplayConfig: React.FC<AiConfigProps> = ({
+  form,
+  onSubmit,
+}) => {
   const aiModelRegistry = useMemo(
     () =>
       AiModelRegistry.create({

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -988,6 +988,7 @@ export const AiModelDisplayConfig: React.FC<AiConfigProps> = ({ form }) => {
       : [...currentDisplayedModels, modelId];
 
     form.setValue("ai.models.displayed_models", newModels);
+    onSubmit(form.getValues());
   });
 
   const toggleProviderModels = useEvent(
@@ -1004,6 +1005,7 @@ export const AiModelDisplayConfig: React.FC<AiConfigProps> = ({ form }) => {
         : currentDisplayedModels.filter((id) => !qualifiedModelIds.has(id));
 
       form.setValue("ai.models.displayed_models", newModels);
+      onSubmit(form.getValues());
     },
   );
 

--- a/frontend/src/components/app-config/app-config-button.tsx
+++ b/frontend/src/components/app-config/app-config-button.tsx
@@ -51,7 +51,7 @@ export const ConfigButton: React.FC<Props> = ({
   );
 
   const userSettingsDialog = (
-    <DialogContent className="w-[80vw] h-[70vh] overflow-hidden sm:max-w-5xl top-[15vh] p-0">
+    <DialogContent className="w-[90vw] h-[90vh] overflow-hidden sm:max-w-5xl top-[5vh] p-0">
       <VisuallyHidden>
         <DialogTitle>User settings</DialogTitle>
       </VisuallyHidden>

--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 import { useForm } from "react-hook-form";
 import {
   Form,
@@ -38,6 +38,8 @@ const FORM_DEBOUNCE = 100; // ms;
 export const AppConfigForm: React.FC = () => {
   const [config, setConfig] = useAppConfig();
   const { saveAppConfig } = useRequestClient();
+  const htmlCheckboxId = useId();
+  const ipynbCheckboxId = useId();
 
   // Create form
   const form = useForm<AppConfig>({
@@ -46,7 +48,6 @@ export const AppConfigForm: React.FC = () => {
   });
 
   const onSubmit = async (values: AppConfig) => {
-    console.log("11111");
     await saveAppConfig({ config: values })
       .then(() => {
         setConfig(values);
@@ -56,8 +57,7 @@ export const AppConfigForm: React.FC = () => {
       });
   };
 
-  const debouncedSubmit = useDebouncedCallback((v) => {
-    console.log("222");
+  const debouncedSubmit = useDebouncedCallback((v: AppConfig) => {
     onSubmit(v);
   }, FORM_DEBOUNCE);
 
@@ -262,23 +262,25 @@ export const AppConfigForm: React.FC = () => {
                       <div className="flex gap-4">
                         <div className="flex items-center space-x-2">
                           <Checkbox
-                            id="html-checkbox"
+                            id={htmlCheckboxId}
+                            data-testid="html-checkbox"
                             checked={field.value.includes("html")}
                             onCheckedChange={() => {
                               field.onChange(arrayToggle(field.value, "html"));
                             }}
                           />
-                          <FormLabel htmlFor="html-checkbox">HTML</FormLabel>
+                          <FormLabel htmlFor={htmlCheckboxId}>HTML</FormLabel>
                         </div>
                         <div className="flex items-center space-x-2">
                           <Checkbox
-                            id="ipynb-checkbox"
+                            id={ipynbCheckboxId}
+                            data-testid="ipynb-checkbox"
                             checked={field.value.includes("ipynb")}
                             onCheckedChange={() => {
                               field.onChange(arrayToggle(field.value, "ipynb"));
                             }}
                           />
-                          <FormLabel htmlFor="ipynb-checkbox">IPYNB</FormLabel>
+                          <FormLabel htmlFor={ipynbCheckboxId}>IPYNB</FormLabel>
                         </div>
                       </div>
                     </FormControl>

--- a/frontend/src/components/app-config/app-config-form.tsx
+++ b/frontend/src/components/app-config/app-config-form.tsx
@@ -14,6 +14,7 @@ import {
 import { useAppConfig } from "@/core/config/config";
 import { getAppWidths } from "@/core/config/widths";
 import { useRequestClient } from "@/core/network/requests";
+import { useDebouncedCallback } from "@/hooks/useDebounce";
 import { arrayToggle } from "@/utils/arrays";
 import {
   type AppConfig,
@@ -32,6 +33,8 @@ import {
   SQL_OUTPUT_SELECT_OPTIONS,
 } from "./common";
 
+const FORM_DEBOUNCE = 100; // ms;
+
 export const AppConfigForm: React.FC = () => {
   const [config, setConfig] = useAppConfig();
   const { saveAppConfig } = useRequestClient();
@@ -43,6 +46,7 @@ export const AppConfigForm: React.FC = () => {
   });
 
   const onSubmit = async (values: AppConfig) => {
+    console.log("11111");
     await saveAppConfig({ config: values })
       .then(() => {
         setConfig(values);
@@ -52,6 +56,11 @@ export const AppConfigForm: React.FC = () => {
       });
   };
 
+  const debouncedSubmit = useDebouncedCallback((v) => {
+    console.log("222");
+    onSubmit(v);
+  }, FORM_DEBOUNCE);
+
   // When width is changed, dispatch a resize event so widgets know to resize
   useEffect(() => {
     window.dispatchEvent(new Event("resize"));
@@ -60,7 +69,7 @@ export const AppConfigForm: React.FC = () => {
   return (
     <Form {...form}>
       <form
-        onChange={form.handleSubmit(onSubmit)}
+        onChange={form.handleSubmit(debouncedSubmit)}
         className="flex flex-col gap-6"
       >
         <div>

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -41,6 +41,7 @@ import { getAppWidths } from "@/core/config/widths";
 import { marimoVersionAtom } from "@/core/meta/state";
 import { useRequestClient } from "@/core/network/requests";
 import { isWasm } from "@/core/wasm/utils";
+import { useDebouncedCallback } from "@/hooks/useDebounce";
 import { Banner } from "@/plugins/impl/common/error-banner";
 import { THEMES } from "@/theme/useTheme";
 import { arrayToggle } from "@/utils/arrays";
@@ -106,6 +107,8 @@ export const activeUserConfigCategoryAtom = atom<SettingCategoryId>(
   categories[0].id,
 );
 
+const FORM_DEBOUNCE = 100; // ms;
+
 export const UserConfigForm: React.FC = () => {
   const [config, setConfig] = useUserConfig();
   const formElement = useRef<HTMLFormElement>(null);
@@ -123,11 +126,12 @@ export const UserConfigForm: React.FC = () => {
     defaultValues: config,
   });
 
-  const onSubmit = async (values: UserConfig) => {
+  const onSubmitNotDebounced = async (values: UserConfig) => {
     await saveUserConfig({ config: values }).then(() => {
       setConfig(values);
     });
   };
+  const onSubmit = useDebouncedCallback(onSubmitNotDebounced, FORM_DEBOUNCE);
 
   const isWasmRuntime = isWasm();
   const htmlCheckboxId = useId();

--- a/frontend/src/core/ai/__tests__/model-registry.test.ts
+++ b/frontend/src/core/ai/__tests__/model-registry.test.ts
@@ -78,20 +78,44 @@ describe("AiModelRegistry", () => {
       const displayedModels = ["openai/gpt-4", "anthropic/claude-3-sonnet"];
       const registry = AiModelRegistry.create({ displayedModels });
 
+      const ids = [...registry.getModelsMap().keys()];
+      expect(ids).toEqual(["openai/gpt-4", "anthropic/claude-3-sonnet"]);
       expect(registry.getCustomModels()).toEqual(new Set());
       expect(registry.getDisplayedModels()).toEqual(new Set(displayedModels));
     });
 
     it("should create registry with both custom and displayed models", () => {
       const customModels = ["openai/custom-gpt"];
-      const displayedModels = ["openai/gpt-4", "anthropic/claude-3-sonnet"];
+      const displayedModels = ["openai/custom-gpt"];
       const registry = AiModelRegistry.create({
         customModels,
         displayedModels,
       });
 
+      const ids = [...registry.getModelsMap().keys()];
+      expect(ids).toEqual(["openai/custom-gpt"]);
       expect(registry.getCustomModels()).toEqual(new Set(customModels));
       expect(registry.getDisplayedModels()).toEqual(new Set(displayedModels));
+    });
+
+    it("should create registry with non-existent displayed_model", () => {
+      const customModels = ["openai/custom-gpt"];
+      const displayedModels = ["something-wrong/model-id"];
+      const registry = AiModelRegistry.create({
+        customModels,
+        displayedModels,
+      });
+
+      const ids = [...registry.getModelsMap().keys()];
+      // Include custom and all default ones.
+      expect(ids).toEqual([
+        "openai/custom-gpt",
+        "openai/gpt-4",
+        "anthropic/claude-3-sonnet",
+        "google/gemini-pro",
+        "openai/multi-model",
+        "anthropic/multi-model",
+      ]);
     });
   });
 

--- a/frontend/src/core/ai/model-registry.ts
+++ b/frontend/src/core/ai/model-registry.ts
@@ -7,6 +7,7 @@ import type {
 } from "@marimo-team/llm-info";
 import { models } from "@marimo-team/llm-info/models.json";
 import { providers } from "@marimo-team/llm-info/providers.json";
+import { Logger } from "@/utils/Logger";
 import { MultiMap } from "@/utils/multi-map";
 import { once } from "@/utils/once";
 import type { ProviderId } from "./ids/ids";
@@ -14,6 +15,7 @@ import { AiModelId, type QualifiedModelId, type ShortModelId } from "./ids/ids";
 
 export interface AiModel extends AiModelType {
   roles: Role[];
+  model: ShortModelId;
   providers: ProviderId[];
   /** Whether this is a custom model. */
   custom: boolean;
@@ -25,6 +27,7 @@ const getKnownModelMap = once((): ReadonlyMap<QualifiedModelId, AiModel> => {
     const modelId = model.model as ShortModelId;
     const modelInfo: AiModel = {
       ...model,
+      model: model.model as ShortModelId,
       roles: model.roles.map((role) => role as Role),
       providers: model.providers as ProviderId[],
       custom: false,
@@ -84,14 +87,42 @@ export class AiModelRegistry {
    * Builds the maps of models by provider and custom models.
    */
   private buildMaps() {
-    const displayedModels = this.displayedModels;
+    let result = AiModelRegistry.buildMapsFromConfig({
+      displayedModels: this.displayedModels,
+      customModels: this.customModels,
+    });
+
+    // If we got zero results, then build the maps with no displayedModels
+    // This can happen if displayedModels is configured to non existent models
+    if (result.modelsMap.size === 0) {
+      Logger.error(
+        "The configured displayed_models have filtered out all registered models. Reverting back to showing all models.",
+        [...this.displayedModels],
+      );
+
+      result = AiModelRegistry.buildMapsFromConfig({
+        displayedModels: new Set(),
+        customModels: this.customModels,
+      });
+    }
+
+    this.modelsByProviderMap = result.modelsByProviderMap;
+    this.modelsMap = result.modelsMap;
+  }
+
+  private static buildMapsFromConfig(opts: {
+    customModels: ReadonlySet<QualifiedModelId>;
+    displayedModels: ReadonlySet<QualifiedModelId>;
+  }) {
+    const { displayedModels, customModels } = opts;
     const hasDisplayedModels = displayedModels.size > 0;
     const knownModelMap = getKnownModelMap();
     const customModelsMap = new Map<QualifiedModelId, AiModel>();
 
     let modelsMap = new Map<QualifiedModelId, AiModel>();
+    const modelsByProviderMap = new MultiMap<ProviderId, AiModel>();
 
-    for (const model of this.customModels) {
+    for (const model of customModels) {
       if (hasDisplayedModels && !displayedModels.has(model)) {
         continue;
       }
@@ -121,15 +152,16 @@ export class AiModelRegistry {
     }
 
     // Set custom models first, then known models
+    // Known models will overwrite custom models (which is desired)
     modelsMap = new Map([...customModelsMap, ...modelsMap]);
 
     // Group by provider
     for (const [qualifiedModelId, model] of modelsMap.entries()) {
       const modelId = AiModelId.parse(qualifiedModelId);
-      this.modelsByProviderMap.add(modelId.providerId, model);
+      modelsByProviderMap.add(modelId.providerId, model);
     }
 
-    this.modelsMap = modelsMap;
+    return { modelsByProviderMap, modelsMap };
   }
 
   getDisplayedModels() {

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -84,7 +84,7 @@ export function useDebounceControlledState<T>(opts: {
   };
 }
 
-export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
+export function useDebouncedCallback<T extends (...args: any[]) => any>(
   callback: T,
   delay: number,
 ) {

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -84,7 +84,8 @@ export function useDebounceControlledState<T>(opts: {
   };
 }
 
-export function useDebouncedCallback<T extends (...args: any[]) => any>(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useDebouncedCallback<T extends (...args: any[]) => unknown>(
   callback: T,
   delay: number,
 ) {


### PR DESCRIPTION
- Add tab to configure "Displayed models" in the AI configuration
- Debounce config to avoid DOS the backend on rapid config changes
- Edge case where displayed models could filter out all models. In this case, we revert to showing all models.

<img width="999" height="1011" alt="image" src="https://github.com/user-attachments/assets/aba90d09-3a7e-4f89-bfab-5d9a4771f9cb" />
