### PR TITLE
types: pin narwhals in typecheck

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,8 @@ dependencies = [
     "leafmap~=0.39.2",
     "panel~=1.5.3",
     "polars~=1.9.0",
-    "narwhals>=1.12.0",
+    # Types in 2.2.0 don't work great with mypy
+    "narwhals>=1.12.0, <2.2.0",
     "matplotlib>=3.8.0",
     "sqlglot>=23.4",
     "sqlalchemy>=2.0.40",


### PR DESCRIPTION
Narwhals in 2.2.0+ breaks mypy. mostly on call overloads, but a few other places too. I am putting an upperbound, just on the typechecking for now.

We we upgrade to 2.0, i can look to remove this. Again, this is only on the type-checking, but not our published package.