### PR TITLE
Add "Notebook Errors" as a context in any AI input

### DIFF
--- a/frontend/src/components/editor/ai/__tests__/completion-utils.test.ts
+++ b/frontend/src/components/editor/ai/__tests__/completion-utils.test.ts
@@ -52,41 +52,36 @@ describe("getAICompletionBody", () => {
     const input = "Use @data://dataset1 and @data://dataset2 for analysis";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [
-          {
-            name: "dataset1",
-            columns: [
-              { name: "col1", type: "number" },
-              { name: "col2", type: "string" },
-            ],
-          },
-          {
-            name: "dataset2",
-            columns: [
-              { name: "col3", type: "boolean" },
-              { name: "col4", type: "date" },
-            ],
-          },
-        ],
-        variables: [],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "<data name="dataset1" source="unknown">
+      Columns:
+        - col1: number
+        - col2: string</data>
+
+      <data name="dataset2" source="unknown">
+      Columns:
+        - col3: boolean
+        - col4: date</data>",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 
   it("should handle input with no mentioned datasets", () => {
     const input = "Perform some analysis without mentioning @data://datasets";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [],
-        variables: [],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 
   it("should handle input with non-existent datasets", () => {
@@ -106,21 +101,17 @@ describe("getAICompletionBody", () => {
       "Use @data://existingDataset and @data://nonExistentDataset for analysis";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [
-          {
-            name: "existingDataset",
-            columns: [
-              { name: "col1", type: "number" },
-              { name: "col2", type: "string" },
-            ],
-          },
-        ],
-        variables: [],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "<data name="existingDataset" source="unknown">
+      Columns:
+        - col1: number
+        - col2: string</data>",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 
   it("should handle dataset names with dots", () => {
@@ -144,25 +135,21 @@ describe("getAICompletionBody", () => {
       "Use @data://dataset.with.dots and @data://regular_dataset for analysis";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [
-          {
-            name: "dataset.with.dots",
-            columns: [
-              { name: "col1", type: "number" },
-              { name: "col2", type: "string" },
-            ],
-          },
-          {
-            name: "regular_dataset",
-            columns: [{ name: "col3", type: "boolean" }],
-          },
-        ],
-        variables: [],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "<data name="dataset.with.dots" source="unknown">
+      Columns:
+        - col1: number
+        - col2: string</data>
+
+      <data name="regular_dataset" source="unknown">
+      Columns:
+        - col3: boolean</data>",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 
   it("should handle connections", () => {
@@ -200,18 +187,16 @@ describe("getAICompletionBody", () => {
     const input = "Use @data://table1 for analysis";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [
-          {
-            name: "table1",
-            columns: [{ name: "col1", type: "number" }],
-          },
-        ],
-        variables: [],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "<data name="table1" source="unknown">
+      Columns:
+        - col1: number</data>",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 
   it("should return the correct completion body with mentioned variables", () => {
@@ -237,24 +222,16 @@ describe("getAICompletionBody", () => {
     const input = "Use @variable://var1 and @variable://var2 for analysis";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [],
-        variables: [
-          {
-            name: "var1",
-            valueType: "string",
-            previewValue: "string value",
-          },
-          {
-            name: "var2",
-            valueType: "number",
-            previewValue: "42",
-          },
-        ],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "<variable name="var1" dataType="string">&quot;string value&quot;</variable>
+
+      <variable name="var2" dataType="number">&quot;42&quot;</variable>",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 
   it("should handle input with both datasets and variables", () => {
@@ -284,27 +261,19 @@ describe("getAICompletionBody", () => {
     const input = "Use @data://dataset1 and @variable://var1 for analysis";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [
-          {
-            name: "dataset1",
-            columns: [
-              { name: "col1", type: "number" },
-              { name: "col2", type: "string" },
-            ],
-          },
-        ],
-        variables: [
-          {
-            name: "var1",
-            valueType: "string",
-            previewValue: "string value",
-          },
-        ],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "<data name="dataset1" source="unknown">
+      Columns:
+        - col1: number
+        - col2: string</data>
+
+      <variable name="var1" dataType="string">&quot;string value&quot;</variable>",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 
   it("should handle non-existent variables", () => {
@@ -324,19 +293,14 @@ describe("getAICompletionBody", () => {
       "Use @variable://existingVar and @variable://nonExistentVar for analysis";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [],
-        variables: [
-          {
-            name: "existingVar",
-            valueType: "string",
-            previewValue: "string value",
-          },
-        ],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "<variable name="existingVar" dataType="string">&quot;string value&quot;</variable>",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 
   it("should prioritize datasets over variables when there's a name conflict", () => {
@@ -363,17 +327,15 @@ describe("getAICompletionBody", () => {
     const input = "Use @data://conflict for analysis";
     const result = getAICompletionBody({ input });
 
-    expect(result).toEqual({
-      includeOtherCode: "// Some other code",
-      context: {
-        schema: [
-          {
-            name: "conflict",
-            columns: [{ name: "col1", type: "number" }],
-          },
-        ],
-        variables: [],
-      },
-    });
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "context": {
+          "plainText": "<data name="conflict" source="unknown">
+      Columns:
+        - col1: number</data>",
+        },
+        "includeOtherCode": "// Some other code",
+      }
+    `);
   });
 });

--- a/frontend/src/components/editor/ai/__tests__/completion-utils.test.ts
+++ b/frontend/src/components/editor/ai/__tests__/completion-utils.test.ts
@@ -64,6 +64,8 @@ describe("getAICompletionBody", () => {
       Columns:
         - col3: boolean
         - col4: date</data>",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }
@@ -78,6 +80,8 @@ describe("getAICompletionBody", () => {
       {
         "context": {
           "plainText": "",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }
@@ -108,6 +112,8 @@ describe("getAICompletionBody", () => {
       Columns:
         - col1: number
         - col2: string</data>",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }
@@ -146,6 +152,8 @@ describe("getAICompletionBody", () => {
       <data name="regular_dataset" source="unknown">
       Columns:
         - col3: boolean</data>",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }
@@ -193,6 +201,8 @@ describe("getAICompletionBody", () => {
           "plainText": "<data name="table1" source="unknown">
       Columns:
         - col1: number</data>",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }
@@ -228,6 +238,8 @@ describe("getAICompletionBody", () => {
           "plainText": "<variable name="var1" dataType="string">&quot;string value&quot;</variable>
 
       <variable name="var2" dataType="number">&quot;42&quot;</variable>",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }
@@ -270,6 +282,8 @@ describe("getAICompletionBody", () => {
         - col2: string</data>
 
       <variable name="var1" dataType="string">&quot;string value&quot;</variable>",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }
@@ -297,6 +311,8 @@ describe("getAICompletionBody", () => {
       {
         "context": {
           "plainText": "<variable name="existingVar" dataType="string">&quot;string value&quot;</variable>",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }
@@ -333,6 +349,8 @@ describe("getAICompletionBody", () => {
           "plainText": "<data name="conflict" source="unknown">
       Columns:
         - col1: number</data>",
+          "schema": [],
+          "variables": [],
         },
         "includeOtherCode": "// Some other code",
       }

--- a/frontend/src/components/editor/ai/__tests__/completion-utils.test.ts
+++ b/frontend/src/components/editor/ai/__tests__/completion-utils.test.ts
@@ -235,9 +235,9 @@ describe("getAICompletionBody", () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "context": {
-          "plainText": "<variable name="var1" dataType="string">&quot;string value&quot;</variable>
+          "plainText": "<variable name="var1" dataType="string">"string value"</variable>
 
-      <variable name="var2" dataType="number">&quot;42&quot;</variable>",
+      <variable name="var2" dataType="number">"42"</variable>",
           "schema": [],
           "variables": [],
         },
@@ -281,7 +281,7 @@ describe("getAICompletionBody", () => {
         - col1: number
         - col2: string</data>
 
-      <variable name="var1" dataType="string">&quot;string value&quot;</variable>",
+      <variable name="var1" dataType="string">"string value"</variable>",
           "schema": [],
           "variables": [],
         },
@@ -310,7 +310,7 @@ describe("getAICompletionBody", () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "context": {
-          "plainText": "<variable name="existingVar" dataType="string">&quot;string value&quot;</variable>",
+          "plainText": "<variable name="existingVar" dataType="string">"string value"</variable>",
           "schema": [],
           "variables": [],
         },

--- a/frontend/src/components/editor/ai/completion-utils.ts
+++ b/frontend/src/components/editor/ai/completion-utils.ts
@@ -26,6 +26,8 @@ export function getAICompletionBody({
     includeOtherCode: getCodes(""),
     context: {
       plainText: contextString,
+      schema: [],
+      variables: [],
     },
   };
 }

--- a/frontend/src/components/editor/ai/completion-utils.ts
+++ b/frontend/src/components/editor/ai/completion-utils.ts
@@ -6,13 +6,9 @@ import type {
   CompletionSource,
 } from "@codemirror/autocomplete";
 import { getAIContextRegistry } from "@/core/ai/context/context";
-import type { TableContextItem } from "@/core/ai/context/providers/tables";
-import type { VariableContextItem } from "@/core/ai/context/providers/variable";
 import { getCodes } from "@/core/codemirror/copilot/getCodes";
-import type { DataTable } from "@/core/kernel/messages";
 import type { AiCompletionRequest } from "@/core/network/types";
 import { store } from "@/core/state/jotai";
-import type { Variable } from "@/core/variables/types";
 import { Logger } from "@/utils/Logger";
 
 /**
@@ -23,26 +19,13 @@ export function getAICompletionBody({
 }: {
   input: string;
 }): Omit<AiCompletionRequest, "language" | "prompt" | "code"> {
-  const { datasets, variables } = extractDatasetsAndVariables(input);
-  Logger.debug("Included datasets", datasets);
-  Logger.debug("Included variables", variables);
+  const contextString = extractDatasetsAndVariables(input);
+  Logger.debug("Included context", contextString);
 
   return {
     includeOtherCode: getCodes(""),
     context: {
-      schema: datasets.map((dataset) => ({
-        name: dataset.name,
-        columns: dataset.columns.map((column) => ({
-          name: column.name,
-          type: column.type,
-          sampleValues: column.sample_values,
-        })),
-      })),
-      variables: variables.map((variable) => ({
-        name: variable.name,
-        valueType: variable.dataType ?? "",
-        previewValue: variable.value,
-      })),
+      plainText: contextString,
     },
   };
 }
@@ -52,21 +35,10 @@ export function getAICompletionBody({
  * References are with @<name> in the input.
  * Prioritizes datasets over variables if there's a name conflict.
  */
-function extractDatasetsAndVariables(input: string): {
-  datasets: DataTable[];
-  variables: Variable[];
-} {
+function extractDatasetsAndVariables(input: string): string {
   const registry = getAIContextRegistry(store);
   const contextIds = registry.parseAllContextIds(input);
-  const contextInfo = registry.getContextInfo(contextIds);
-  const datasets: DataTable[] = contextInfo
-    .filter((info): info is TableContextItem => info.type === "data")
-    .map((info) => info.data);
-  const variables: Variable[] = contextInfo
-    .filter((info): info is VariableContextItem => info.type === "variable")
-    .map((info) => info.data.variable);
-
-  return { datasets, variables };
+  return registry.formatContextForAI(contextIds);
 }
 
 /**

--- a/frontend/src/core/ai/context/__tests__/utils.test.ts
+++ b/frontend/src/core/ai/context/__tests__/utils.test.ts
@@ -1,0 +1,174 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { contextToXml } from "../utils";
+
+describe("contextToXml", () => {
+  it("should convert basic context to XML", () => {
+    const context = {
+      type: "data",
+      data: {
+        name: "dataset1",
+        source: "memory",
+      },
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe('<data name="dataset1" source="memory"></data>');
+  });
+
+  it("should handle context with details", () => {
+    const context = {
+      type: "variable",
+      data: {
+        name: "my_var",
+        dataType: "string",
+      },
+      details: "This is a string variable",
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe(
+      '<variable name="my_var" dataType="string">This is a string variable</variable>',
+    );
+  });
+
+  it("should escape XML characters in attributes", () => {
+    const context = {
+      type: "data",
+      data: {
+        name: "dataset<>&\"'",
+        description: "Contains special chars",
+      },
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe(
+      '<data name="dataset&lt;&gt;&amp;&quot;&#39;" description="Contains special chars"></data>',
+    );
+  });
+
+  it("should escape XML characters in details", () => {
+    const context = {
+      type: "error",
+      data: {
+        name: "error1",
+      },
+      details: "Error message with <tags> & \"quotes\" and 'apostrophes'",
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe(
+      '<error name="error1">Error message with &lt;tags&gt; &amp; &quot;quotes&quot; and &#39;apostrophes&#39;</error>',
+    );
+  });
+
+  it("should handle undefined values in data", () => {
+    const context = {
+      type: "variable",
+      data: {
+        name: "my_var",
+        dataType: undefined,
+        value: "test",
+      },
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe('<variable name="my_var" value="test"></variable>');
+  });
+
+  it("should handle empty data object", () => {
+    const context = {
+      type: "empty",
+      data: {},
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe("<empty></empty>");
+  });
+
+  it("should handle numeric values", () => {
+    const context = {
+      type: "metric",
+      data: {
+        count: 42,
+        percentage: 85.5,
+        isActive: true,
+      },
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe(
+      '<metric count="42" percentage="85.5" isActive="true"></metric>',
+    );
+  });
+
+  it("should handle complex nested data", () => {
+    const context = {
+      type: "complex",
+      data: {
+        name: "test",
+        config: JSON.stringify({ key: "value", nested: { prop: "test" } }),
+      },
+      details: "Complex configuration data",
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe(
+      '<complex name="test" config="{&quot;key&quot;:&quot;value&quot;,&quot;nested&quot;:{&quot;prop&quot;:&quot;test&quot;}}">Complex configuration data</complex>',
+    );
+  });
+
+  it("should handle boolean values", () => {
+    const context = {
+      type: "flags",
+      data: {
+        enabled: true,
+        visible: false,
+      },
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe('<flags enabled="true" visible="false"></flags>');
+  });
+
+  it("should handle null values", () => {
+    const context = {
+      type: "nullable",
+      data: {
+        name: "test",
+        value: null,
+      },
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe('<nullable name="test" value="null"></nullable>');
+  });
+
+  it("should handle multiline details", () => {
+    const context = {
+      type: "multiline",
+      data: {
+        name: "test",
+      },
+      details: "Line 1\nLine 2\nLine 3",
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe(
+      '<multiline name="test">Line 1\nLine 2\nLine 3</multiline>',
+    );
+  });
+
+  it("should handle special characters in type name", () => {
+    const context = {
+      type: "data-source",
+      data: {
+        name: "test",
+      },
+    };
+
+    const result = contextToXml(context);
+    expect(result).toBe('<data-source name="test"></data-source>');
+  });
+});

--- a/frontend/src/core/ai/context/__tests__/utils.test.ts
+++ b/frontend/src/core/ai/context/__tests__/utils.test.ts
@@ -43,8 +43,8 @@ describe("contextToXml", () => {
     };
 
     const result = contextToXml(context);
-    expect(result).toBe(
-      '<data name="dataset&lt;&gt;&amp;&quot;&#39;" description="Contains special chars"></data>',
+    expect(result).toMatchInlineSnapshot(
+      `"<data name="dataset&lt;&gt;&"'" description="Contains special chars"></data>"`,
     );
   });
 
@@ -58,8 +58,8 @@ describe("contextToXml", () => {
     };
 
     const result = contextToXml(context);
-    expect(result).toBe(
-      '<error name="error1">Error message with &lt;tags&gt; &amp; &quot;quotes&quot; and &#39;apostrophes&#39;</error>',
+    expect(result).toMatchInlineSnapshot(
+      `"<error name="error1">Error message with &lt;tags&gt; & "quotes" and 'apostrophes'</error>"`,
     );
   });
 
@@ -114,8 +114,8 @@ describe("contextToXml", () => {
     };
 
     const result = contextToXml(context);
-    expect(result).toBe(
-      '<complex name="test" config="{&quot;key&quot;:&quot;value&quot;,&quot;nested&quot;:{&quot;prop&quot;:&quot;test&quot;}}">Complex configuration data</complex>',
+    expect(result).toMatchInlineSnapshot(
+      `"<complex name="test" config="{"key":"value","nested":{"prop":"test"}}">Complex configuration data</complex>"`,
     );
   });
 

--- a/frontend/src/core/ai/context/context.ts
+++ b/frontend/src/core/ai/context/context.ts
@@ -3,6 +3,7 @@
 import { allTablesAtom } from "@/core/datasets/data-source-connections";
 import type { JotaiStore } from "@/core/state/jotai";
 import { variablesAtom } from "@/core/variables/state";
+import { ErrorContextProvider } from "./providers/error";
 import { TableContextProvider } from "./providers/tables";
 import { VariableContextProvider } from "./providers/variable";
 import { AIContextRegistry } from "./registry";
@@ -12,5 +13,6 @@ export function getAIContextRegistry(store: JotaiStore) {
   const variables = store.get(variablesAtom);
   return new AIContextRegistry()
     .register(new TableContextProvider(tablesMap))
-    .register(new VariableContextProvider(variables, tablesMap));
+    .register(new VariableContextProvider(variables, tablesMap))
+    .register(new ErrorContextProvider(store));
 }

--- a/frontend/src/core/ai/context/providers/__tests__/__snapshots__/error.test.ts.snap
+++ b/frontend/src/core/ai/context/providers/__tests__/__snapshots__/error.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ErrorContextProvider > formatContext > should format context for basic errors > basic-error-context 1`] = `"<error name="Cell 1" description="Invalid syntax"></error>"`;

--- a/frontend/src/core/ai/context/providers/__tests__/__snapshots__/tables.test.ts.snap
+++ b/frontend/src/core/ai/context/providers/__tests__/__snapshots__/tables.test.ts.snap
@@ -1,38 +1,34 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`TableContextProvider > formatContext > should format context for basic table > basic-table-context 1`] = `
-"Table: products
-Source: memory
+"<data name="products" source="memory">
 Shape: 100 rows, 3 columns
 Columns:
   - id: integer
   - name: string
-  - active: boolean"
+  - active: boolean</data>"
 `;
 
 exports[`TableContextProvider > formatContext > should format context for remote database table > remote-table-context 1`] = `
-"Table: remote_table
-Source: postgresql://localhost:5432/mydb
+"<data name="remote_table" source="postgresql://localhost:5432/mydb">
 Shape: 100 rows, 3 columns
 Columns:
   - uuid: string
   - created_at: string
-  - metadata: string"
+  - metadata: string</data>"
 `;
 
 exports[`TableContextProvider > formatContext > should format context for table without columns > no-columns-table-context 1`] = `
-"Table: no_columns
-Source: memory
-Shape: 100 rows, 3 columns"
+"<data name="no_columns" source="memory">
+Shape: 100 rows, 3 columns</data>"
 `;
 
 exports[`TableContextProvider > formatContext > should format context for table without shape info > no-shape-table-context 1`] = `
-"Table: no_shape
-Source: memory
+"<data name="no_shape" source="memory">
 Columns:
   - id: integer
   - name: string
-  - active: boolean"
+  - active: boolean</data>"
 `;
 
 exports[`TableContextProvider > getItems > should handle dataframe tables with variable names > dataframe-table 1`] = `

--- a/frontend/src/core/ai/context/providers/__tests__/__snapshots__/variable.test.ts.snap
+++ b/frontend/src/core/ai/context/providers/__tests__/__snapshots__/variable.test.ts.snap
@@ -1,28 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`VariableContextProvider > formatContext > should format context for basic variable > basic-variable-context 1`] = `
-"Variable: username
-Type: str
-Preview: "\\"alice\\"""
-`;
+exports[`VariableContextProvider > formatContext > should format context for basic variable > basic-variable-context 1`] = `"<variable name="username" dataType="str">&quot;\\&quot;alice\\&quot;&quot;</variable>"`;
 
-exports[`VariableContextProvider > formatContext > should format context for dataframe variable > dataframe-variable-context 1`] = `
-"Variable: sales_df
-Type: pandas.DataFrame
-Preview: "<DataFrame shape: (1000, 8)>\\n   date    product  quantity  price\\n0  2023-01-01  Widget A    10    29.99\\n1  2023-01-02  Widget B     5    49.99\\n...""
-`;
+exports[`VariableContextProvider > formatContext > should format context for dataframe variable > dataframe-variable-context 1`] = `"<variable name="sales_df" dataType="pandas.DataFrame">&quot;&lt;DataFrame shape: (1000, 8)&gt;\\n   date    product  quantity  price\\n0  2023-01-01  Widget A    10    29.99\\n1  2023-01-02  Widget B     5    49.99\\n...&quot;</variable>"`;
 
-exports[`VariableContextProvider > formatContext > should format context for variable with complex value > complex-value-variable-context 1`] = `
-"Variable: complex_data
-Type: dict
-Preview: "{\\"users\\": [{\\"id\\": 1, \\"name\\": \\"Alice\\"}, {\\"id\\": 2, \\"name\\": \\"Bob\\"}], \\"total\\": 2}""
-`;
+exports[`VariableContextProvider > formatContext > should format context for variable with complex value > complex-value-variable-context 1`] = `"<variable name="complex_data" dataType="dict">&quot;{\\&quot;users\\&quot;: [{\\&quot;id\\&quot;: 1, \\&quot;name\\&quot;: \\&quot;Alice\\&quot;}, {\\&quot;id\\&quot;: 2, \\&quot;name\\&quot;: \\&quot;Bob\\&quot;}], \\&quot;total\\&quot;: 2}&quot;</variable>"`;
 
-exports[`VariableContextProvider > formatContext > should format context for variable without dataType > no-datatype-variable-context 1`] = `
-"Variable: mystery_var
-Type: unknown
-Preview: "some_value""
-`;
+exports[`VariableContextProvider > formatContext > should format context for variable without dataType > no-datatype-variable-context 1`] = `"<variable name="mystery_var" dataType="null">&quot;some_value&quot;</variable>"`;
 
 exports[`VariableContextProvider > getItems > should handle complex data types > complex-data-types 1`] = `
 [

--- a/frontend/src/core/ai/context/providers/__tests__/__snapshots__/variable.test.ts.snap
+++ b/frontend/src/core/ai/context/providers/__tests__/__snapshots__/variable.test.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`VariableContextProvider > formatContext > should format context for basic variable > basic-variable-context 1`] = `"<variable name="username" dataType="str">&quot;\\&quot;alice\\&quot;&quot;</variable>"`;
+exports[`VariableContextProvider > formatContext > should format context for basic variable > basic-variable-context 1`] = `"<variable name="username" dataType="str">"\\"alice\\""</variable>"`;
 
-exports[`VariableContextProvider > formatContext > should format context for dataframe variable > dataframe-variable-context 1`] = `"<variable name="sales_df" dataType="pandas.DataFrame">&quot;&lt;DataFrame shape: (1000, 8)&gt;\\n   date    product  quantity  price\\n0  2023-01-01  Widget A    10    29.99\\n1  2023-01-02  Widget B     5    49.99\\n...&quot;</variable>"`;
+exports[`VariableContextProvider > formatContext > should format context for dataframe variable > dataframe-variable-context 1`] = `"<variable name="sales_df" dataType="pandas.DataFrame">"&lt;DataFrame shape: (1000, 8)&gt;\\n   date    product  quantity  price\\n0  2023-01-01  Widget A    10    29.99\\n1  2023-01-02  Widget B     5    49.99\\n..."</variable>"`;
 
-exports[`VariableContextProvider > formatContext > should format context for variable with complex value > complex-value-variable-context 1`] = `"<variable name="complex_data" dataType="dict">&quot;{\\&quot;users\\&quot;: [{\\&quot;id\\&quot;: 1, \\&quot;name\\&quot;: \\&quot;Alice\\&quot;}, {\\&quot;id\\&quot;: 2, \\&quot;name\\&quot;: \\&quot;Bob\\&quot;}], \\&quot;total\\&quot;: 2}&quot;</variable>"`;
+exports[`VariableContextProvider > formatContext > should format context for variable with complex value > complex-value-variable-context 1`] = `"<variable name="complex_data" dataType="dict">"{\\"users\\": [{\\"id\\": 1, \\"name\\": \\"Alice\\"}, {\\"id\\": 2, \\"name\\": \\"Bob\\"}], \\"total\\": 2}"</variable>"`;
 
-exports[`VariableContextProvider > formatContext > should format context for variable without dataType > no-datatype-variable-context 1`] = `"<variable name="mystery_var" dataType="null">&quot;some_value&quot;</variable>"`;
+exports[`VariableContextProvider > formatContext > should format context for variable without dataType > no-datatype-variable-context 1`] = `"<variable name="mystery_var" dataType="null">"some_value"</variable>"`;
 
 exports[`VariableContextProvider > getItems > should handle complex data types > complex-data-types 1`] = `
 [

--- a/frontend/src/core/ai/context/providers/__tests__/error.test.ts
+++ b/frontend/src/core/ai/context/providers/__tests__/error.test.ts
@@ -1,0 +1,329 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { createStore } from "jotai";
+import { beforeEach, describe, expect, it } from "vitest";
+import { MockNotebook } from "@/__mocks__/notebook";
+import { notebookAtom } from "@/core/cells/cells";
+import { CellId as CellIdClass } from "@/core/cells/ids";
+import { ErrorContextProvider } from "../error";
+
+describe("ErrorContextProvider", () => {
+  let provider: ErrorContextProvider;
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    store = createStore();
+    provider = new ErrorContextProvider(store);
+  });
+
+  const createMockNotebookWithErrors = (
+    errors: Parameters<typeof MockNotebook.notebookStateWithErrors>[0],
+  ) => {
+    const notebookState = MockNotebook.notebookStateWithErrors(errors);
+    store.set(notebookAtom, notebookState);
+  };
+
+  describe("provider properties", () => {
+    it("should have correct provider properties", () => {
+      expect(provider.title).toBe("Errors");
+      expect(provider.mentionPrefix).toBe("@");
+      expect(provider.contextType).toBe("error");
+    });
+  });
+
+  describe("getItems", () => {
+    it("should return empty array when no errors", () => {
+      const items = provider.getItems();
+      expect(items).toEqual([]);
+    });
+
+    it("should return error items when errors exist", () => {
+      const cellId1 = CellIdClass.create();
+      const cellId2 = CellIdClass.create();
+
+      createMockNotebookWithErrors([
+        {
+          cellId: cellId1,
+          cellName: "Cell 1",
+          errorData: [MockNotebook.errors.syntax("Invalid syntax")],
+        },
+        {
+          cellId: cellId2,
+          cellName: "Cell 2",
+          errorData: [MockNotebook.errors.exception("Runtime error")],
+        },
+      ]);
+
+      const items = provider.getItems();
+
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({
+        name: "Errors",
+        type: "error",
+        description: "All errors in the notebook",
+        data: {
+          type: "all-errors",
+          errors: [
+            {
+              cellId: cellId1,
+              cellName: "Cell 1",
+              errorData: [{ type: "syntax", msg: "Invalid syntax" }],
+            },
+            {
+              cellId: cellId2,
+              cellName: "Cell 2",
+              errorData: [{ type: "exception", msg: "Runtime error" }],
+            },
+          ],
+        },
+      });
+    });
+
+    it("should handle cells without names", () => {
+      const cellId = CellIdClass.create();
+
+      createMockNotebookWithErrors([
+        {
+          cellId,
+          cellName: "",
+          errorData: [MockNotebook.errors.syntax("Invalid syntax")],
+        },
+      ]);
+
+      const items = provider.getItems();
+      expect(items[0].data.errors[0].cellName).toBe("");
+    });
+  });
+
+  describe("formatCompletion", () => {
+    it("should format completion for all-errors type", () => {
+      const cellId1 = CellIdClass.create();
+      const cellId2 = CellIdClass.create();
+
+      createMockNotebookWithErrors([
+        {
+          cellId: cellId1,
+          cellName: "Cell 1",
+          errorData: [MockNotebook.errors.syntax("Invalid syntax")],
+        },
+        {
+          cellId: cellId2,
+          cellName: "Cell 2",
+          errorData: [MockNotebook.errors.exception("Runtime error")],
+        },
+      ]);
+
+      const items = provider.getItems();
+      const completion = provider.formatCompletion(items[0]);
+
+      expect(completion).toMatchObject({
+        label: "@Errors",
+        displayLabel: "Errors",
+        detail: "2 errors",
+        boost: 2, // Boosts.ERROR
+        type: "error",
+        apply: "@Errors",
+        section: "Errors",
+      });
+
+      // Test the info function
+      expect(completion.info).toBeDefined();
+      if (typeof completion.info === "function") {
+        const infoResult = completion.info(completion);
+        if (
+          infoResult &&
+          typeof infoResult === "object" &&
+          "dom" in infoResult
+        ) {
+          const infoElement = infoResult.dom as HTMLElement;
+          expect(infoElement.tagName).toBe("DIV");
+          expect(infoElement.textContent).toContain("Errors");
+          expect(infoElement.textContent).toContain("2 errors");
+        } else if (infoResult && "tagName" in (infoResult as any)) {
+          const infoElement = infoResult as HTMLElement;
+          expect(infoElement.tagName).toBe("DIV");
+          expect(infoElement.textContent).toContain("Errors");
+          expect(infoElement.textContent).toContain("2 errors");
+        }
+      }
+    });
+
+    it("should handle single error correctly", () => {
+      const cellId = CellIdClass.create();
+
+      createMockNotebookWithErrors([
+        {
+          cellId,
+          cellName: "Cell 1",
+          errorData: [MockNotebook.errors.syntax("Invalid syntax")],
+        },
+      ]);
+
+      const items = provider.getItems();
+      const completion = provider.formatCompletion(items[0]);
+      expect(completion.detail).toBe("1 error");
+    });
+
+    it("should handle fallback for unknown error types", () => {
+      const item = {
+        uri: "error://unknown",
+        name: "Unknown Error",
+        type: "error" as const,
+        data: {
+          type: "unknown" as any,
+          errors: [],
+        },
+        description: "Unknown error type",
+      };
+
+      const completion = provider.formatCompletion(item);
+      expect(completion).toMatchObject({
+        label: "Error",
+        displayLabel: "Error",
+        boost: 2, // Boosts.ERROR
+      });
+    });
+  });
+
+  describe("formatContext", () => {
+    it("should format context for basic errors", () => {
+      const cellId = CellIdClass.create();
+
+      createMockNotebookWithErrors([
+        {
+          cellId,
+          cellName: "Cell 1",
+          errorData: [MockNotebook.errors.syntax("Invalid syntax")],
+        },
+      ]);
+
+      const items = provider.getItems();
+      const context = provider.formatContext(items[0]);
+      expect(context).toMatchSnapshot("basic-error-context");
+    });
+
+    it("should format context for multiple error types", () => {
+      const cellId1 = CellIdClass.create();
+      const cellId2 = CellIdClass.create();
+
+      createMockNotebookWithErrors([
+        {
+          cellId: cellId1,
+          cellName: "Cell 1",
+          errorData: [
+            MockNotebook.errors.syntax("Invalid syntax"),
+            MockNotebook.errors.exception("Runtime error"),
+          ],
+        },
+        {
+          cellId: cellId2,
+          cellName: "",
+          errorData: [
+            MockNotebook.errors.cycle(),
+            MockNotebook.errors.multipleDefs("variable_x"),
+          ],
+        },
+      ]);
+
+      const items = provider.getItems();
+      const context = provider.formatContext(items[0]);
+
+      // Check for expected content instead of exact snapshot match due to random cell IDs
+      expect(context).toContain("Cell 1");
+      expect(context).toContain("Invalid syntax");
+      expect(context).toContain("Runtime error");
+      expect(context).toContain("This cell is in a cycle");
+      expect(context).toContain(
+        "The variable &#39;variable_x&#39; was defined by another cell",
+      );
+      expect(context).toContain("<error");
+      expect(context).toContain("</error>");
+    });
+
+    it("should handle cells without names", () => {
+      const cellId = CellIdClass.create();
+
+      createMockNotebookWithErrors([
+        {
+          cellId,
+          cellName: "",
+          errorData: [MockNotebook.errors.syntax("Invalid syntax")],
+        },
+      ]);
+
+      const items = provider.getItems();
+      const context = provider.formatContext(items[0]);
+      expect(context).toContain(`Cell ${cellId}`);
+    });
+  });
+
+  describe("error description handling", () => {
+    it("should handle all error types correctly", () => {
+      // Note: ancestor-* error types are intentionally filtered out by cellErrorsAtom
+      const errorTypes = [
+        {
+          error: MockNotebook.errors.setupRefs(),
+          expected: "The setup cell cannot have references",
+        },
+        {
+          error: MockNotebook.errors.cycle(),
+          expected: "This cell is in a cycle",
+        },
+        {
+          error: MockNotebook.errors.multipleDefs("var_x"),
+          expected: "The variable &#39;var_x&#39; was defined by another cell",
+        },
+        {
+          error: MockNotebook.errors.importStar("Import star error"),
+          expected: "Import star error",
+        },
+        {
+          error: MockNotebook.errors.exception("Runtime exception"),
+          expected: "Runtime exception",
+        },
+        {
+          error: MockNotebook.errors.strictException("Strict exception", "ref"),
+          expected: "Strict exception",
+        },
+        {
+          error: MockNotebook.errors.interruption(),
+          expected: "This cell was interrupted and needs to be re-run",
+        },
+        {
+          error: MockNotebook.errors.syntax("Syntax error"),
+          expected: "Syntax error",
+        },
+        {
+          error: MockNotebook.errors.unknown("Unknown error"),
+          expected: "Unknown error",
+        },
+      ];
+
+      for (const { error, expected } of errorTypes) {
+        // Create a fresh store and provider for each error type
+        const testStore = createStore();
+        const testProvider = new ErrorContextProvider(testStore);
+
+        const { notebookState } = MockNotebook.cellWithErrors("Cell 1", [
+          error,
+        ]);
+        testStore.set(notebookAtom, notebookState);
+
+        const items = testProvider.getItems();
+        expect(items).toHaveLength(1);
+        const context = testProvider.formatContext(items[0]);
+        expect(context).toContain(expected);
+      }
+    });
+
+    it("should handle unknown error type gracefully", () => {
+      const error = { type: "unknown-type" as any };
+      const { notebookState } = MockNotebook.cellWithErrors("Cell 1", [error]);
+      store.set(notebookAtom, notebookState);
+
+      const items = provider.getItems();
+      const context = provider.formatContext(items[0]);
+      expect(context).toContain("Unknown error");
+    });
+  });
+});

--- a/frontend/src/core/ai/context/providers/__tests__/error.test.ts
+++ b/frontend/src/core/ai/context/providers/__tests__/error.test.ts
@@ -1,4 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { createStore } from "jotai";
 import { beforeEach, describe, expect, it } from "vitest";

--- a/frontend/src/core/ai/context/providers/__tests__/error.test.ts
+++ b/frontend/src/core/ai/context/providers/__tests__/error.test.ts
@@ -5,7 +5,7 @@ import { createStore } from "jotai";
 import { beforeEach, describe, expect, it } from "vitest";
 import { MockNotebook } from "@/__mocks__/notebook";
 import { notebookAtom } from "@/core/cells/cells";
-import { CellId as CellIdClass } from "@/core/cells/ids";
+import { type CellId, CellId as CellIdClass } from "@/core/cells/ids";
 import { ErrorContextProvider } from "../error";
 
 describe("ErrorContextProvider", () => {
@@ -204,8 +204,8 @@ describe("ErrorContextProvider", () => {
     });
 
     it("should format context for multiple error types", () => {
-      const cellId1 = CellIdClass.create();
-      const cellId2 = CellIdClass.create();
+      const cellId1 = "cell-1" as CellId;
+      const cellId2 = "cell-2" as CellId;
 
       createMockNotebookWithErrors([
         {
@@ -230,15 +230,13 @@ describe("ErrorContextProvider", () => {
       const context = provider.formatContext(items[0]);
 
       // Check for expected content instead of exact snapshot match due to random cell IDs
-      expect(context).toContain("Cell 1");
-      expect(context).toContain("Invalid syntax");
-      expect(context).toContain("Runtime error");
-      expect(context).toContain("This cell is in a cycle");
-      expect(context).toContain(
-        "The variable &#39;variable_x&#39; was defined by another cell",
-      );
-      expect(context).toContain("<error");
-      expect(context).toContain("</error>");
+      expect(context).toMatchInlineSnapshot(`
+        "<error name="Cell 1" description="Invalid syntax
+        Runtime error"></error>
+
+        <error name="Cell cell-2" description="This cell is in a cycle
+        The variable 'variable_x' was defined by another cell"></error>"
+      `);
     });
 
     it("should handle cells without names", () => {
@@ -272,7 +270,7 @@ describe("ErrorContextProvider", () => {
         },
         {
           error: MockNotebook.errors.multipleDefs("var_x"),
-          expected: "The variable &#39;var_x&#39; was defined by another cell",
+          expected: "The variable 'var_x' was defined by another cell",
         },
         {
           error: MockNotebook.errors.importStar("Import star error"),

--- a/frontend/src/core/ai/context/providers/common.ts
+++ b/frontend/src/core/ai/context/providers/common.ts
@@ -4,4 +4,5 @@ export const Boosts = {
   LOCAL_TABLE: 5,
   REMOTE_TABLE: 4,
   VARIABLE: 3,
+  ERROR: 2,
 } as const;

--- a/frontend/src/core/ai/context/providers/error.ts
+++ b/frontend/src/core/ai/context/providers/error.ts
@@ -1,0 +1,165 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import type { Completion } from "@codemirror/autocomplete";
+import { cellErrorsAtom } from "@/core/cells/cells";
+import type { CellId } from "@/core/cells/ids";
+import type { MarimoError } from "@/core/kernel/messages";
+import type { JotaiStore } from "@/core/state/jotai";
+import { PluralWord } from "@/utils/pluralize";
+import { type AIContextItem, AIContextProvider } from "../registry";
+import { contextToXml } from "../utils";
+import { Boosts } from "./common";
+
+export interface ErrorContextItem extends AIContextItem {
+  type: "error";
+  data: {
+    type: "all-errors";
+    errors: {
+      cellId: CellId;
+      cellName: string;
+      errorData: MarimoError[];
+    }[];
+  };
+}
+
+function describeError(error: MarimoError): string {
+  if (error.type === "setup-refs") {
+    return "The setup cell cannot have references";
+  }
+  if (error.type === "cycle") {
+    return "This cell is in a cycle";
+  }
+  if (error.type === "multiple-defs") {
+    return `The variable '${error.name}' was defined by another cell`;
+  }
+  if (error.type === "import-star") {
+    return error.msg;
+  }
+  if (error.type === "ancestor-stopped") {
+    return error.msg;
+  }
+  if (error.type === "ancestor-prevented") {
+    return error.msg;
+  }
+  if (error.type === "exception") {
+    return error.msg;
+  }
+  if (error.type === "strict-exception") {
+    return error.msg;
+  }
+  if (error.type === "interruption") {
+    return "This cell was interrupted and needs to be re-run";
+  }
+  if (error.type === "syntax") {
+    return error.msg;
+  }
+  if (error.type === "unknown") {
+    return error.msg;
+  }
+  return "Unknown error";
+}
+
+const errorsTxt = new PluralWord("error", "errors");
+export class ErrorContextProvider extends AIContextProvider<ErrorContextItem> {
+  readonly title = "Errors";
+  readonly mentionPrefix = "@";
+  readonly contextType = "error";
+
+  constructor(private store: JotaiStore) {
+    super();
+  }
+
+  getItems(): ErrorContextItem[] {
+    const errors = this.store.get(cellErrorsAtom);
+    if (errors.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        uri: this.asURI("all"),
+        name: "Errors",
+        type: this.contextType,
+        data: {
+          type: "all-errors",
+          errors: errors.map((error) => ({
+            cellId: error.cellId,
+            cellName: error.cellName,
+            errorData: error.output.data,
+          })),
+        },
+        description: "All errors in the notebook",
+      },
+    ];
+
+    // TODO: maybe handle single errors or grouped by types
+  }
+
+  formatCompletion(item: ErrorContextItem): Completion {
+    if (item.data.type === "all-errors") {
+      return {
+        label: "@Errors",
+        displayLabel: "Errors",
+        detail: `${item.data.errors.length} ${errorsTxt.pluralize(item.data.errors.length)}`,
+        boost: Boosts.ERROR,
+        type: "error",
+        apply: "@Errors",
+        section: "Errors",
+        info: () => {
+          const infoContainer = document.createElement("div");
+          infoContainer.classList.add(
+            "mo-cm-tooltip",
+            "docs-documentation",
+            "min-w-[200px]",
+            "flex",
+            "flex-col",
+            "gap-1",
+            "p-2",
+          );
+
+          const headerDiv = document.createElement("div");
+          headerDiv.classList.add("flex", "flex-col", "gap-1");
+
+          const nameDiv = document.createElement("div");
+          nameDiv.classList.add("font-bold", "text-base");
+          nameDiv.textContent = "Errors";
+          headerDiv.append(nameDiv);
+
+          const descriptionDiv = document.createElement("div");
+          descriptionDiv.classList.add("text-sm", "text-muted-foreground");
+          descriptionDiv.textContent = `${item.data.errors.length} ${errorsTxt.pluralize(item.data.errors.length)}`;
+          headerDiv.append(descriptionDiv);
+
+          infoContainer.append(headerDiv);
+
+          return infoContainer;
+        },
+      };
+    }
+
+    return {
+      label: "Error",
+      displayLabel: "Error",
+      boost: Boosts.ERROR,
+    };
+  }
+
+  formatContext(item: ErrorContextItem): string {
+    const { data } = item;
+
+    const xmls = data.errors.map((err) => {
+      return contextToXml({
+        type: this.contextType,
+        data: {
+          name: err.cellName || `Cell ${err.cellId}`,
+          description: err.errorData
+            .map((err) => describeError(err))
+            .join("\n"),
+        },
+      });
+    });
+
+    const xml = xmls.join("\n\n");
+    return xml;
+  }
+}

--- a/frontend/src/core/ai/context/providers/error.ts
+++ b/frontend/src/core/ai/context/providers/error.ts
@@ -14,11 +14,11 @@ export interface ErrorContextItem extends AIContextItem {
   type: "error";
   data: {
     type: "all-errors";
-    errors: {
+    errors: Array<{
       cellId: CellId;
       cellName: string;
       errorData: MarimoError[];
-    }[];
+    }>;
   };
 }
 

--- a/frontend/src/core/ai/context/providers/tables.ts
+++ b/frontend/src/core/ai/context/providers/tables.ts
@@ -34,7 +34,7 @@ export class TableContextProvider extends AIContextProvider<TableContextItem> {
 
   formatContext(item: TableContextItem): string {
     const { data } = item;
-    const { columns, source, num_rows, num_columns } = data;
+    const { columns, source, num_rows, num_columns, name } = data;
     const shape = [
       num_rows == null ? undefined : `${num_rows} rows`,
       num_columns == null ? undefined : `${num_columns} columns`,
@@ -54,7 +54,7 @@ export class TableContextProvider extends AIContextProvider<TableContextItem> {
     return contextToXml({
       type: this.contextType,
       data: {
-        name: data.name,
+        name: name,
         source: source ?? "unknown",
       },
       details: details,

--- a/frontend/src/core/ai/context/providers/tables.ts
+++ b/frontend/src/core/ai/context/providers/tables.ts
@@ -5,6 +5,7 @@ import type { DatasetTablesMap } from "@/core/datasets/data-source-connections";
 import type { DataTable } from "@/core/kernel/messages";
 import type { AIContextItem } from "../registry";
 import { AIContextProvider } from "../registry";
+import { contextToXml } from "../utils";
 import { Boosts } from "./common";
 
 export interface TableContextItem extends AIContextItem {
@@ -32,7 +33,7 @@ export class TableContextProvider extends AIContextProvider<TableContextItem> {
   }
 
   formatContext(item: TableContextItem): string {
-    const { data, uri: id } = item;
+    const { data } = item;
     const { columns, source, num_rows, num_columns } = data;
     const shape = [
       num_rows == null ? undefined : `${num_rows} rows`,
@@ -41,16 +42,23 @@ export class TableContextProvider extends AIContextProvider<TableContextItem> {
       .filter(Boolean)
       .join(", ");
 
-    let context = `Table: ${id}\nSource: ${source || "unknown"}`;
+    let details = "";
     if (shape) {
-      context += `\nShape: ${shape}`;
+      details += `\nShape: ${shape}`;
     }
 
     if (columns && columns.length > 0) {
-      context += `\nColumns:\n${columns.map((col) => `  - ${col.name}: ${col.type}`).join("\n")}`;
+      details += `\nColumns:\n${columns.map((col) => `  - ${col.name}: ${col.type}`).join("\n")}`;
     }
 
-    return context;
+    return contextToXml({
+      type: this.contextType,
+      data: {
+        name: data.name,
+        source: source ?? "unknown",
+      },
+      details: details,
+    });
   }
 
   formatCompletion(item: TableContextItem): Completion {

--- a/frontend/src/core/ai/context/providers/variable.ts
+++ b/frontend/src/core/ai/context/providers/variable.ts
@@ -5,6 +5,7 @@ import { createVariableInfoElement } from "@/core/codemirror/completion/variable
 import type { DatasetTablesMap } from "@/core/datasets/data-source-connections";
 import type { Variable, Variables } from "@/core/variables/types";
 import { type AIContextItem, AIContextProvider } from "../registry";
+import { contextToXml } from "../utils";
 import { Boosts } from "./common";
 
 export interface VariableContextItem extends AIContextItem {
@@ -65,8 +66,16 @@ export class VariableContextProvider extends AIContextProvider<VariableContextIt
   }
 
   formatContext(item: VariableContextItem): string {
-    const { uri: id, data } = item;
+    const { data } = item;
     const { variable } = data;
-    return `Variable: ${id}\nType: ${variable.dataType || "unknown"}\nPreview: ${JSON.stringify(variable.value)}`;
+    return contextToXml({
+      type: this.contextType,
+      data: {
+        name: variable.name,
+        dataType: variable.dataType,
+      },
+      details:
+        variable.value != null ? JSON.stringify(variable.value) : undefined,
+    });
   }
 }

--- a/frontend/src/core/ai/context/providers/variable.ts
+++ b/frontend/src/core/ai/context/providers/variable.ts
@@ -75,7 +75,7 @@ export class VariableContextProvider extends AIContextProvider<VariableContextIt
         dataType: variable.dataType,
       },
       details:
-        variable.value != null ? JSON.stringify(variable.value) : undefined,
+        variable.value == null ? undefined : JSON.stringify(variable.value),
     });
   }
 }

--- a/frontend/src/core/ai/context/utils.ts
+++ b/frontend/src/core/ai/context/utils.ts
@@ -8,12 +8,15 @@ export interface AiContextPayload {
 
 // XML escaping utility
 function escapeXml(unsafe: string): string {
-  return unsafe
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
+  return (
+    unsafe
+      // We don't escape these characters because this is for an LLM and they can interpret this just fine.
+      // .replaceAll("&", "&amp;")
+      // .replaceAll('"', "&quot;")
+      // .replaceAll("'", "&#39;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+  );
 }
 
 // Convert a single Context object to XML

--- a/frontend/src/core/ai/context/utils.ts
+++ b/frontend/src/core/ai/context/utils.ts
@@ -1,0 +1,44 @@
+export interface AiContextPayload {
+  type: string;
+  data: Record<string, unknown>;
+  details?: string;
+}
+
+// XML escaping utility
+function escapeXml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Convert a single Context object to XML
+export function contextToXml(context: AiContextPayload): string {
+  const { type, data, details } = context;
+
+  // Start with opening tag
+  let xml = `<${type}`;
+
+  // Add data as attributes
+  for (const [key, value] of Object.entries(data)) {
+    const escapedValue = escapeXml(String(value));
+    if (value !== undefined) {
+      xml += ` ${key}="${escapedValue}"`;
+    }
+  }
+
+  // Close the opening tag
+  xml += ">";
+
+  // Add details as content if present
+  if (details) {
+    xml += escapeXml(details);
+  }
+
+  // Add closing tag
+  xml += `</${type}>`;
+
+  return xml;
+}

--- a/frontend/src/core/ai/context/utils.ts
+++ b/frontend/src/core/ai/context/utils.ts
@@ -1,3 +1,5 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
 export interface AiContextPayload {
   type: string;
   data: Record<string, unknown>;
@@ -7,11 +9,11 @@ export interface AiContextPayload {
 // XML escaping utility
 function escapeXml(unsafe: string): string {
   return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }
 
 // Convert a single Context object to XML

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1489,7 +1489,7 @@ export const canUndoDeletesAtom = atom((get) =>
 
 export const needsRunAtom = atom((get) => notebookNeedsRun(get(notebookAtom)));
 
-const cellErrorsAtom = atom((get) => {
+export const cellErrorsAtom = atom((get) => {
   const { cellIds, cellRuntime, cellData } = get(notebookAtom);
   const errors = cellIds.inOrderIds
     .map((cellId) => {

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -99,7 +99,7 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
             "You are an AI assistant integrated into the marimo notebook code editor.\n"
             "You goal is to create a new cell in the notebook.\n"
             f"Your output must be valid {language} code.\n"
-            "The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.\n"
+            "The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.\n"
             "You can reference variables from other cells, but you cannot redefine a variable if it already exists.\n"
             "Immediately start with the following format. Do NOT comment on the code, just output the code itself: \n\n"
             "```\n{CELL_CODE}\n```"
@@ -223,7 +223,7 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -49,6 +49,12 @@ def _format_schema_info(tables: Optional[list[SchemaTable]]) -> str:
     return schema_info
 
 
+def _format_plain_text(plain_text: str) -> str:
+    if not plain_text.strip():
+        return ""
+    return f"If the prompt mentions @kind://name, use the following context to help you answer the question:\n\n{plain_text}"
+
+
 def _format_variables(
     variables: Optional[list[Union[VariableContext, str]]],
 ) -> str:
@@ -93,7 +99,7 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
             "You are an AI assistant integrated into the marimo notebook code editor.\n"
             "You goal is to create a new cell in the notebook.\n"
             f"Your output must be valid {language} code.\n"
-            "You can use the provided context to help you write the new cell.\n"
+            "The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.\n"
             "You can reference variables from other cells, but you cannot redefine a variable if it already exists.\n"
             "Immediately start with the following format. Do NOT comment on the code, just output the code itself: \n\n"
             "```\n{CELL_CODE}\n```"
@@ -150,6 +156,7 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
         system_prompt += f"\n\n## Additional rules:\n{custom_rules}"
 
     if context:
+        system_prompt += _format_plain_text(context.plain_text)
         system_prompt += _format_variables(context.variables)
         system_prompt += _format_schema_info(context.schema)
 
@@ -215,6 +222,8 @@ Your goal is to do one of the following two things:
 2. Answer general-purpose questions unrelated to their particular notebook.
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
+
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -325,6 +334,7 @@ plt.gca()  # Return the current axes to display the plot
         )
 
     if context:
+        system_prompt += _format_plain_text(context.plain_text)
         system_prompt += _format_variables(context.variables)
         system_prompt += _format_schema_info(context.schema)
 

--- a/marimo/_server/models/completion.py
+++ b/marimo/_server/models/completion.py
@@ -31,6 +31,7 @@ class VariableContext:
 class AiCompletionContext:
     schema: list[SchemaTable] = field(default_factory=list)
     variables: list[Union[VariableContext, str]] = field(default_factory=list)
+    plain_text: str = ""
 
 
 Language = Literal["python", "markdown", "sql"]

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -12,6 +12,8 @@ components:
       type: object
     AiCompletionContext:
       properties:
+        plainText:
+          type: string
         schema:
           items:
             $ref: '#/components/schemas/SchemaTable'
@@ -25,6 +27,7 @@ components:
       required:
       - schema
       - variables
+      - plainText
       type: object
     AiCompletionRequest:
       properties:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -2552,6 +2552,7 @@ export interface components {
       upgrade?: boolean | null;
     };
     AiCompletionContext: {
+      plainText: string;
       schema: components["schemas"]["SchemaTable"][];
       variables: (components["schemas"]["VariableContext"] | string)[];
     };

--- a/tests/_server/ai/snapshots/chat_system_prompts.txt
+++ b/tests/_server/ai/snapshots/chat_system_prompts.txt
@@ -20,6 +20,8 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
 
@@ -143,6 +145,8 @@ Your goal is to do one of the following two things:
 2. Answer general-purpose questions unrelated to their particular notebook.
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
+
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -271,6 +275,8 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
 
@@ -397,6 +403,8 @@ Your goal is to do one of the following two things:
 2. Answer general-purpose questions unrelated to their particular notebook.
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
+
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -530,6 +538,8 @@ Your goal is to do one of the following two things:
 2. Answer general-purpose questions unrelated to their particular notebook.
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
+
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -672,6 +682,8 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
 
@@ -800,6 +812,8 @@ Your goal is to do one of the following two things:
 2. Answer general-purpose questions unrelated to their particular notebook.
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
+
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.

--- a/tests/_server/ai/snapshots/chat_system_prompts.txt
+++ b/tests/_server/ai/snapshots/chat_system_prompts.txt
@@ -20,7 +20,7 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -146,7 +146,7 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -275,7 +275,7 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -404,7 +404,7 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -539,7 +539,7 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -682,7 +682,7 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.
@@ -813,7 +813,7 @@ Your goal is to do one of the following two things:
 
 It will be up to you to decide which of these you are doing based on what the user has told you. When unclear, ask clarifying questions to understand the user's intent before proceeding.
 
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 
 You can respond with markdown, code, or a combination of both. You only work with two languages: Python and SQL.
 When responding in code, think of each block of code as a separate cell in the notebook.

--- a/tests/_server/ai/snapshots/system_prompts.txt
+++ b/tests/_server/ai/snapshots/system_prompts.txt
@@ -5,7 +5,7 @@
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid python code.
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -29,7 +29,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid markdown code.
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -44,7 +44,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid sql code.
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -62,7 +62,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid idk code.
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -77,7 +77,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid python code.
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -104,7 +104,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid python code.
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -284,7 +284,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid python code.
-The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
+The user may reference additional context in the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 

--- a/tests/_server/ai/snapshots/system_prompts.txt
+++ b/tests/_server/ai/snapshots/system_prompts.txt
@@ -5,7 +5,7 @@
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid python code.
-You can use the provided context to help you write the new cell.
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -29,7 +29,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid markdown code.
-You can use the provided context to help you write the new cell.
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -44,7 +44,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid sql code.
-You can use the provided context to help you write the new cell.
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -62,7 +62,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid idk code.
-You can use the provided context to help you write the new cell.
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -77,7 +77,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid python code.
-You can use the provided context to help you write the new cell.
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -104,7 +104,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid python code.
-You can use the provided context to help you write the new cell.
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 
@@ -284,7 +284,7 @@ Again, just output the code itself.
 You are an AI assistant integrated into the marimo notebook code editor.
 You goal is to create a new cell in the notebook.
 Your output must be valid python code.
-You can use the provided context to help you write the new cell.
+The user maybe reference additional context of the form @kind://name. You can use this context to help you with the current task.
 You can reference variables from other cells, but you cannot redefine a variable if it already exists.
 Immediately start with the following format. Do NOT comment on the code, just output the code itself: 
 

--- a/tests/_server/ai/test_prompts.py
+++ b/tests/_server/ai/test_prompts.py
@@ -6,6 +6,7 @@ from typing import cast
 from marimo._ast.visitor import Language
 from marimo._server.ai.prompts import (
     FIM_SUFFIX_TAG,
+    _format_plain_text,
     _format_variables,
     get_chat_system_prompt,
     get_inline_system_prompt,
@@ -341,3 +342,12 @@ def test_format_variables():
         "  - value_preview: <DataFrame with 100 rows and 5 columns>\n"
     )
     assert _format_variables(variables) == expected
+
+
+def test_format_plain_text():
+    assert _format_plain_text("") == ""
+    assert _format_plain_text("  ") == ""
+    assert (
+        _format_plain_text("Hello, world!")
+        == "If the prompt mentions @kind://name, use the following context to help you answer the question:\n\nHello, world!"
+    )


### PR DESCRIPTION
This adds a new context provider for Notebook Errors. It currently grabs all errors as a single entry. In the future we could group errors by type or single errors, but i don't think we need to explode out the errors into more choices.

<img width="1474" height="958" alt="Screenshot 2025-08-25 at 11 04 09 PM" src="https://github.com/user-attachments/assets/280b6cbf-28cc-49e1-90e7-567c4e14a78f" />

<img width="719" height="402" alt="Screenshot 2025-08-25 at 11 03 55 PM" src="https://github.com/user-attachments/assets/58fe417c-7e5b-43a4-bae0-3d2f98700ff9" />
