### PR TITLE
fix: remove unecessary work in scoped state

### DIFF
--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -33,7 +33,7 @@ import {
   useCellSelectionActions,
   useIsCellSelected,
 } from "./selection";
-import { temporarilyShownCodeAtom } from "./state";
+import { useTemporarilyShownCodeActions } from "./state";
 import { handleVimKeybinding } from "./vim-bindings";
 
 interface HotkeyHandler {
@@ -85,7 +85,7 @@ function addSingleHandler(handler: HotkeyHandler["bulkHandle"]): HotkeyHandler {
 function useCellFocusProps(cellId: CellId) {
   const focusActions = useCellFocusActions();
   const actions = useCellActions();
-  const setTemporarilyShownCode = useSetAtom(temporarilyShownCodeAtom);
+  const temporarilyShownCodeActions = useTemporarilyShownCodeActions();
 
   // This occurs at the cell level and descedants.
   const { focusWithinProps } = useFocusWithin({
@@ -95,7 +95,7 @@ function useCellFocusProps(cellId: CellId) {
     },
     onBlurWithin: () => {
       // On blur, hide the code if it was temporarily shown.
-      setTemporarilyShownCode(false);
+      temporarilyShownCodeActions.remove(cellId);
       actions.markTouched({ cellId });
       focusActions.blurCell();
     },
@@ -132,7 +132,7 @@ export function useCellNavigationProps(
   const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
   const actions = useCellActions();
   const store = useStore();
-  const setTemporarilyShownCode = useSetAtom(temporarilyShownCodeAtom);
+  const temporarilyShownCodeActions = useTemporarilyShownCodeActions();
   const runCells = useRunCells();
   const keymapPreset = useAtomValue(keymapPresetAtom);
   const { copyCells, pasteAtCell } = useCellClipboard();
@@ -275,7 +275,7 @@ export function useCellNavigationProps(
         },
         // Enter will focus the cell editor.
         Enter: () => {
-          setTemporarilyShownCode(true);
+          temporarilyShownCodeActions.add(cellId);
           focusCellEditor(store, cellId);
           selectionActions.clear();
           return true;
@@ -608,7 +608,7 @@ export function useCellEditorNavigationProps(
   cellId: CellId,
   editorView: React.RefObject<EditorView | null>,
 ) {
-  const setTemporarilyShownCode = useSetAtom(temporarilyShownCodeAtom);
+  const temporarilyShownCodeActions = useTemporarilyShownCodeActions();
   const keymapPreset = useAtomValue(keymapPresetAtom);
   const hotkeys = useAtomValue(hotkeysAtom);
 
@@ -618,7 +618,7 @@ export function useCellEditorNavigationProps(
   }, [hotkeys]);
 
   const exitToCommandMode = () => {
-    setTemporarilyShownCode(false);
+    temporarilyShownCodeActions.remove(cellId);
     focusCell(cellId);
   };
 

--- a/frontend/src/components/editor/navigation/state.ts
+++ b/frontend/src/components/editor/navigation/state.ts
@@ -1,5 +1,37 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { atom } from "jotai";
+import { atom, useAtomValue } from "jotai";
+import { useMemo } from "react";
+import type { CellId } from "@/core/cells/ids";
+import { createReducerAndAtoms } from "@/utils/createReducer";
 
-export const temporarilyShownCodeAtom = atom<boolean>(false);
+type TemporarilyShownCodeState = Set<CellId>;
+
+// This previously used jotai-scope, but unfortunately this bug creates unnecessary work:
+// https://github.com/jotaijs/jotai-scope/issues/25
+
+const {
+  valueAtom: temporarilyShownCodeAtom,
+  useActions: useTemporarilyShownCodeActions,
+} = createReducerAndAtoms(() => new Set<CellId>(), {
+  add: (state: TemporarilyShownCodeState, cellId: CellId) => {
+    const newState = new Set(state);
+    newState.add(cellId);
+    return newState;
+  },
+  remove: (state: TemporarilyShownCodeState, cellId: CellId) => {
+    const newState = new Set(state);
+    newState.delete(cellId);
+    return newState;
+  },
+});
+
+const createTemporarilyShownCodeAtom = (cellId: CellId) =>
+  atom((get) => get(temporarilyShownCodeAtom).has(cellId));
+
+export function useTemporarilyShownCode(cellId: CellId) {
+  const atom = useMemo(() => createTemporarilyShownCodeAtom(cellId), [cellId]);
+  return useAtomValue(atom);
+}
+
+export { temporarilyShownCodeAtom, useTemporarilyShownCodeActions };


### PR DESCRIPTION
This removes the usage of `jotai-scope` due to this bug https://github.com/jotaijs/jotai-scope/issues/25

This would 1) cause unnecessary work (not terrible), and 2) re-execute side-effectful atoms. 

We probably should not have side-effectful atoms but one was the runtime-manager which would check if it was healthy on creation. So each new cell would trigger a `/healthy` check