### PR TITLE
Handle missing `DOMParser` global for VSCode extension

### DIFF
--- a/frontend/src/core/dom/outline.ts
+++ b/frontend/src/core/dom/outline.ts
@@ -8,9 +8,23 @@ import type { OutputMessage } from "../kernel/messages";
 // Tags that we don't want to include in the outline
 const excludedTags = ["marimo-carousel", "marimo-tabs", "marimo-accordion"];
 
-function getOutline(html: string): Outline {
-  const items: Outline["items"] = [];
+/**
+ * Extracts a table of contents {@link Outline} from an HTML string.
+ *
+ * Each {@link OutlineItem} corresponds to a heading (h1–h6) found in the input.
+ *
+ * @param html - The HTML content to parse.
+ * @returns An {@link Outline}, otherwise `null` if parsing via isn't supported in JS runtime (e.g., Node).
+ */
+function getOutline(html: string): Outline | null {
+  // Some JS runtimes (e.g. Node.js for the VSCode extension) do not
+  // expose DOMParser globally. In those environments parsing isn't
+  // possible (without a polyfill), so return just return `null`.
+  if (typeof DOMParser === "undefined") {
+    return null;
+  }
 
+  const items: Outline["items"] = [];
   const parser = new DOMParser();
   const document = parser.parseFromString(html, "text/html");
 


### PR DESCRIPTION
Some of marimo's frontend logic is now reused outside the browser context, including NodeJS for the VS Code extension. Since Node lacks a `DOMParser` global, outline extraction failed in the `transitionCell` path (for maintaining cell state). Returning `null` here avoids the issue and makes the code more interoperable across environments.

We could polyfill `DOMParser` in the future if we wanted/needed the outline in VS Code.
