### PR TITLE
update: chalk -> chalk-diagrams

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -329,6 +329,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "cc42": "42qucc",
         "cerberus": "Cerberus",
         "cfnlint": "cfn-lint",
+        "chalk": "chalk-diagrams",
         "chameleon": "Chameleon",
         "charmtools": "charm-tools",
         "chef": "PyChef",


### PR DESCRIPTION
## 📝 Summary

Unlocks chalk (pypi/chalk does not exist) as [chalk-diagrams](https://www.psycopg.org/docs/install.html#install-from-source). Minor unblock for Tensor Puzzle forks (cc @hyjc)