### PR TITLE
fix: _repr_mimebundle_ for img and tuple outputs

### DIFF
--- a/docs/guides/integrating_with_marimo/displaying_objects.md
+++ b/docs/guides/integrating_with_marimo/displaying_objects.md
@@ -76,6 +76,8 @@ We support the following methods:
 - `_repr_latex_`
 - `_repr_text_`
 
+**Note:** marimo currently does not handle any optional metadata returned by `_repr_mimebundle_`.
+
 ## Option 3: Implement a `_mime_` method
 
 When displaying an object, marimo's media viewer checks for the presence of a

--- a/marimo/_smoke_tests/ipython/img_mimebundle.py
+++ b/marimo/_smoke_tests/ipython/img_mimebundle.py
@@ -1,0 +1,38 @@
+import marimo
+
+__generated_with = "0.15.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    from io import BytesIO
+    from PIL import Image, ImageDraw
+
+
+    class BlueOnGray:
+        def __init__(self, text, retina=False):
+            self.text = text
+            self.retina = retina
+
+        def _repr_mimebundle_(self, include=None, exclude=None):
+            w, h = 200, 80
+            f = 2 if self.retina else 1
+            img = Image.new("RGB", (w, h), color="lightgray")
+            metadata = {"image/png": {"width": w // f, "height": h // f}}
+            draw = ImageDraw.Draw(img)
+            draw.text((10, 30), self.text, fill="blue")
+            buffer = BytesIO()
+            img.save(buffer, format="PNG")
+            return {
+                "image/png": buffer.getvalue(),
+                "text/html": f"<span style='color: blue; background-color: gray'>{self.text}</span>",
+            }, metadata
+
+
+    BlueOnGray("Blue text on gray background")
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #6162

## Summary

- Fix `_repr_mimebundle_` handling when it returns tuple format
- Add support for Jupyter spec-compliant `(data, metadata)` tuple returns
- Convert binary image data to data URLs for web display
- Add comprehensive tests for both dict and tuple return formats

## Background

Issue #6162 reported that marimo fails to handle `_repr_mimebundle_` output when libraries (like plotnine) return the Jupyter-compliant tuple format `(data_dict, metadata_dict)` instead of just the data dict. Additionally, binary image data wasn't being properly converted for web display.

## Changes

**Core Fix (repr_formatters.py:55-69):**
- Added handling for tuple return format from `_repr_mimebundle_`
- Extract data portion when method returns `(data, metadata)` tuple
- Convert binary image data to data URLs using existing `io_to_data_url` utility
- Maintain backward compatibility with existing dict-only returns
