### PR TITLE
Resolve CSS path issues in islands build

### DIFF
--- a/frontend/src/core/islands/islands.css
+++ b/frontend/src/core/islands/islands.css
@@ -1,12 +1,3 @@
-@import url("../../css/common.css");
-@import url("../../css/globals.css");
-@import url("../../css/codehilite.css");
-@import url("../../css/katex.min.css");
-@import url("../../css/md.css");
-@import url("../../css/admonition.css");
-@import url("../../css/md-tooltip.css");
-@import url("../../css/table.css");
-
 @reference "../../css/globals.css";
 
 .marimo {

--- a/frontend/src/core/islands/main.ts
+++ b/frontend/src/core/islands/main.ts
@@ -1,5 +1,14 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 import "./islands.css";
+import "../../css/common.css";
+import "../../css/globals.css";
+import "../../css/codehilite.css";
+import "../../css/katex.min.css";
+import "../../css/md.css";
+import "../../css/admonition.css";
+import "../../css/md-tooltip.css";
+import "../../css/table.css";
+
 import "iconify-icon";
 
 import { toast } from "@/components/ui/use-toast";


### PR DESCRIPTION
The islands build was emitting a warning:

```sh
Error: Can't resolve '../css/globals.css' in '/Users/manzt/github/marimo-team/marimo/frontend/src/core/islands'
```

Which led to tailwind styles not being included in the build.

This happened because when islands.css imports other CSS files (common.css, md.css, etc.), those files each contain `@reference "../css/globals.css"` on line 1. During the islands library build, these @reference paths were being resolved from the wrong context - from /src/core/islands/ instead of from each CSS file's actual location in /src/css/.

The fix changes the import syntax in islands.css from `@import` to `@import url()`, which prevents the bundler from trying to resolve the nested @reference directives during the build process. This allows Tailwind v4's @reference to work correctly while maintaining proper CSS bundling.