### PR TITLE
[fix]fixed losing focus of cell name input on context menu

### DIFF
--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -17,6 +17,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { menuItemVariants } from "@/components/ui/menu-items";
 import { Tooltip } from "@/components/ui/tooltip";
 import { toast } from "@/components/ui/use-toast";
 import { useCellData, useCellRuntime } from "@/core/cells/cells";
@@ -219,19 +220,40 @@ export const CellActionsContextMenu = ({
               }
 
               return (
-                <ContextMenuItem
-                  key={action.label}
-                  className={action.disabled ? "opacity-50!" : ""}
-                  onSelect={(evt) => {
-                    if (action.disableClick || action.disabled) {
-                      return;
-                    }
-                    action.handle(evt);
-                  }}
-                  variant={action.variant}
-                >
-                  {body}
-                </ContextMenuItem>
+                <Fragment key={action.label}>
+                  {
+                    // Set disableClick items such as cell name input
+                    // to div to prevent roving focus
+                    action.disableClick ? (
+                      <div
+                        className={menuItemVariants({
+                          className: action.disabled ? "opacity-50!" : "",
+                          variant: action.variant,
+                        })}
+                        onKeyDown={(evt) => {
+                          evt.stopPropagation();
+                        }}
+                        // Prevent keydown propagation, that focus does not jump to shortcut which start with same letter
+                        // e.g. input "C", then focus jump to "Copy"
+                      >
+                        {body}
+                      </div>
+                    ) : (
+                      <ContextMenuItem
+                        className={action.disabled ? "opacity-50!" : ""}
+                        onSelect={(evt) => {
+                          if (action.disableClick || action.disabled) {
+                            return;
+                          }
+                          action.handle(evt);
+                        }}
+                        variant={action.variant}
+                      >
+                        {body}
+                      </ContextMenuItem>
+                    )
+                  }
+                </Fragment>
               );
             })}
             {i < allActions.length - 1 && <ContextMenuSeparator />}


### PR DESCRIPTION
## 📝 Summary
Fixes  #6147
## 🔍 Description of Changes

### Change details

Editing a cell name inside the `CellActionsContextMenu` lost focus when simply moving the mouse over the menu. #6147
This fixes the unintended blur so users can rename without interruption.

My change is to use a `<div>` instead of `ContextMenuItem` to nest disableClick action (such as cell name input) .

### Reason of bug
I found that command palette use a same `NameCellInput` but it does not bug, So I compared them.

`CellActionsContextMenu` put  a `NameCellInput` into a **Radix `ContextMenuItem`, Radix’s roving focus system refocused the parent item on pointer movement (pointerenter / pointermove).** That shifted focus away from the input, triggering blur prematurely.

Root Cause Radix Menu/ContextMenu composes a RovingFocusGroup. Each Item becomes a roving focus target and claims focus on pointer motion. The inline editable input was not excluded from that behavior.

### Side Effection
- Code became complicated because of using `<div>` and `ContextMenuItem` at same time.
- Because of using `<div>`, it loss ContextMenu features, e.g. you can not use keyboard to select cell name input 

### Final result

https://github.com/user-attachments/assets/09733f70-08e7-4834-b344-c8d2c9789814


### Consider
My approach might not be a good way. The command palette which use `cmdk` do not make this bug,  so maybe use `cmdk` will fix this, but I wonder if this bug worth rewriting. 

https://github.com/user-attachments/assets/ab849398-22bc-4eee-9c61-e8d0365c61a9


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
