### PR TITLE
feat: add asset URL support for templates and server

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -445,6 +445,13 @@ https://github.com/marimo-team/marimo/issues/5219.""",
     hidden=True,
     help="When opening a .py file, enable fallback conversion from pypercent, script, or text.",
 )
+@click.option(
+    "--asset-url",
+    default=None,
+    type=str,
+    hidden=True,
+    help="Custom asset URL for loading static resources. Can include {version} placeholder.",
+)
 @click.argument(
     "name",
     required=False,
@@ -468,6 +475,7 @@ def edit(
     skew_protection: bool,
     remote_url: Optional[str],
     convert: bool,
+    asset_url: Optional[str],
     name: Optional[str],
     args: tuple[str, ...],
 ) -> None:
@@ -595,6 +603,7 @@ def edit(
         redirect_console_to_browser=True,
         ttl_seconds=None,
         remote_url=remote_url,
+        asset_url=asset_url,
     )
 
 
@@ -903,6 +912,13 @@ Example:
     type=bool,
     help=sandbox_message,
 )
+@click.option(
+    "--asset-url",
+    default=None,
+    type=str,
+    hidden=True,
+    help="Custom asset URL for loading static resources. Can include {version} placeholder.",
+)
 @click.argument(
     "name",
     required=True,
@@ -924,6 +940,7 @@ def run(
     allow_origins: tuple[str, ...],
     redirect_console_to_browser: bool,
     sandbox: Optional[bool],
+    asset_url: Optional[str],
     name: str,
     args: tuple[str, ...],
 ) -> None:
@@ -980,6 +997,7 @@ def run(
         argv=list(args),
         auth_token=_resolve_token(token, token_password),
         redirect_console_to_browser=redirect_console_to_browser,
+        asset_url=asset_url,
     )
 
 

--- a/marimo/_server/api/deps.py
+++ b/marimo/_server/api/deps.py
@@ -101,6 +101,10 @@ class AppStateBase:
     def remote_url(self) -> Optional[str]:
         return getattr(self.state, "remote_url", None)
 
+    @property
+    def asset_url(self) -> Optional[str]:
+        return getattr(self.state, "asset_url", None)
+
 
 class AppState(AppStateBase):
     """The app state with a request."""

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -93,6 +93,7 @@ async def index(request: Request) -> HTMLResponse:
             user_config=app_state.config_manager.get_user_config(),
             config_overrides=app_state.config_manager.get_config_overrides(),
             server_token=app_state.skew_protection_token,
+            asset_url=app_state.asset_url,
         )
     else:
         config_manager = app_state.config_manager_at_file(file_key)
@@ -112,6 +113,7 @@ async def index(request: Request) -> HTMLResponse:
             filename=app_manager.filename,
             mode=app_state.mode,
             remote_url=app_state.remote_url,
+            asset_url=app_state.asset_url,
         )
 
         # Inject service worker registration with the notebook ID

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -90,6 +90,7 @@ def start(
     redirect_console_to_browser: bool,
     skew_protection: bool,
     remote_url: Optional[str] = None,
+    asset_url: Optional[str] = None,
 ) -> None:
     """
     Start the server.
@@ -191,6 +192,7 @@ def start(
     app.state.watch = watch
     app.state.session_manager = session_manager
     app.state.base_url = base_url
+    app.state.asset_url = asset_url
     app.state.config_manager = config_reader
     app.state.remote_url = remote_url
 

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -476,7 +476,7 @@ def _inject_custom_css_for_config(
 def _replace_asset_urls(html: str, asset_url: Optional[str]) -> str:
     """Replace asset URLs with the given asset URL.
 
-    These are naturally relative URLs. This can be used load assets
+    These are naturally relative URLs. This can be used to load assets
     from a CDN instead of from the marimo server.
 
     The asset URL can be parameterized with {version}


### PR DESCRIPTION
Hidden url `--asset-url` option in CLI to load assets from a CDN (instead of the marimo server). useful if your server is not set up to be a CDN

`uv run marimo edit notebook.py --asset-url="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"`