### PR TITLE
Storybook tailwind compatibility fixes

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -2,7 +2,7 @@ import type { Decorator, Preview } from "@storybook/react-vite";
 import "../src/css/index.css";
 import "../src/css/app/App.css";
 import "./sb.css";
-import "tailwindcss/tailwind.css";
+import "tailwindcss";
 import React, { useEffect } from "react";
 import { TailwindIndicator } from "../src/components/debug/indicator";
 import { Toaster } from "../src/components/ui/toaster";

--- a/frontend/.storybook/sb.css
+++ b/frontend/.storybook/sb.css
@@ -11,5 +11,5 @@
 }
 
 .sbdocs.sbdocs-wrapper h1 {
-  @apply text-foreground !important;
+  @apply !text-foreground;
 }


### PR DESCRIPTION
## 📝 Summary

Currently, when I run storybook with `make storybokk`, I see 2 issues in the console related to TailwindCSS 4 compatibility:

Issue 1: Missing "./tailwind.css" specifier
  - The import "tailwindcss/tailwind.css" tried to access a non-existent file
  - TailwindCSS 4 changed its export structure - tailwind.css doesn't exist

Issue 2: Unknown utility class !important
  - TailwindCSS 4 changed how !important works with @apply
  - The syntax @apply text-foreground !important is no longer valid
  -  Fixed by using new syntax !text-foreground;

## 🔍 Description of Changes

Issue 1 is fixed by importing just "tailwindcss" which uses the main entry point
Issue 2 is fixed by using new syntax !text-foreground;

## 📋 Checklist

- [x ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
