### PR TITLE
Fix storybook's missing requestClientAtom dependency

### DIFF
--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -1,18 +1,18 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import type { Meta, StoryObj } from "@storybook/react-vite";
-import { createStore, Provider } from "jotai";
-import { createRef } from "react";
-import { type NotebookState, notebookAtom } from "@/core/cells/cells";
-import {
-  type CellRuntimeState,
-  createCellRuntimeState,
-} from "@/core/cells/types";
+import { notebookAtom, type NotebookState } from "@/core/cells/cells";
+import { type CellRuntimeState, createCellRuntimeState, } from "@/core/cells/types";
 import { defaultUserConfig } from "@/core/config/config-schema";
 import { connectionAtom } from "@/core/network/connection";
+import { requestClientAtom } from "@/core/network/requests";
+import { resolveRequestClient } from "@/core/network/resolve.ts";
 import type { CellConfig } from "@/core/network/types";
+import { store } from "@/core/state/jotai.ts";
 import { WebSocketState } from "@/core/websocket/types";
 import { MultiColumn } from "@/utils/id-tree";
 import type { Milliseconds, Seconds } from "@/utils/time";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { createStore, Provider } from "jotai";
+import { createRef } from "react";
 import { Cell as EditorCell } from "../components/editor/Cell";
 import { TooltipProvider } from "../components/ui/tooltip";
 import type { CellId } from "../core/cells/ids";
@@ -30,7 +30,7 @@ const Cell: React.FC<{
     staleInputs?: boolean;
     config?: CellConfig;
   };
-}> = ({ overrides = {} }) => {
+}> = ({overrides = {}}) => {
   const cellId = "1" as CellId;
   const notebook: NotebookState = {
     cellData: {
@@ -77,7 +77,8 @@ const Cell: React.FC<{
 
   const store = createStore();
   store.set(notebookAtom, notebook);
-  store.set(connectionAtom, { state: WebSocketState.OPEN });
+  store.set(connectionAtom, {state: WebSocketState.OPEN});
+  store.set(requestClientAtom, resolveRequestClient());
   return (
     <Provider store={store}>
       <TooltipProvider>
@@ -106,7 +107,7 @@ export default {
 export const Primary: Story = {
   render: () => (
     <div className="p-20 max-w-4xl">
-      <Cell />
+      <Cell/>
     </div>
   ),
 };


### PR DESCRIPTION
## 📝 Summary

EditorCell component requires `requestClientAtom` deps to render, but it's missing in story setup.

## 🔍 Description of Changes

Added the dep to the store
```
store.set(requestClientAtom, resolveRequestClient())
````