### PR TITLE
OpenAI version 5 models go above 4

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -118,6 +118,27 @@
 
 # OpenAI
 
+- name: GPT-5
+  model: gpt-5
+  description: The best model for coding and agentic tasks across domains
+  providers: [openai]
+  roles: [chat, edit]
+  thinking: false
+
+- name: GPT-5 Mini
+  model: gpt-5-mini
+  description: A faster, cost-efficient version of GPT-5 for well-defined tasks
+  providers: [openai]
+  roles: [chat, edit]
+  thinking: false
+
+- name: GPT-5 Nano
+  model: gpt-5-nano
+  description: Fastest, most cost-efficient version of GPT-5
+  providers: [openai]
+  roles: [chat, edit]
+  thinking: false
+
 - name: GPT-4.1
   model: gpt-4.1
   description: Fast, highly intelligent model with largest context window (1 million tokens)
@@ -143,27 +164,6 @@
   model: gpt-4o-mini
   description: Fast, affordable small model for focused tasks
   providers: [openai, github]
-  roles: [chat, edit]
-  thinking: false
-
-- name: GPT-5
-  model: gpt-5
-  description: The best model for coding and agentic tasks across domains
-  providers: [openai]
-  roles: [chat, edit]
-  thinking: false
-
-- name: GPT-5 Mini
-  model: gpt-5-mini
-  description: A faster, cost-efficient version of GPT-5 for well-defined tasks
-  providers: [openai]
-  roles: [chat, edit]
-  thinking: false
-
-- name: GPT-5 Nano
-  model: gpt-5-nano
-  description: Fastest, most cost-efficient version of GPT-5
-  providers: [openai]
   roles: [chat, edit]
   thinking: false
 


### PR DESCRIPTION
I noticed that the GPT-5 models were below the GPT-4 models. models. While the internet and YouTube suggest that the "5"-models can be worse, it feels very inconsistent to put them below the "4"-models. Hence, this PR. 