### PR TITLE
Update gemini flash models

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -67,6 +67,13 @@
   roles: [chat, edit]
   thinking: false
 
+- name: Gemini 2.5 Flash Lite
+  model: gemini-2.5-flash-lite
+  description: Most cost-efficient model supporting high throughput
+  providers: [google]
+  roles: [chat, edit]
+  thinking: false
+
 - name: Gemini 2.0 Flash
   model: gemini-2.0-flash
   description: Next-generation Flash model with improved performance and capabilities


### PR DESCRIPTION
I noticed that the flash-2.5-preview model was down today while the other models from gemini worked just fine. 

<img width="533" height="1027" alt="CleanShot 2025-09-01 at 15 02 55" src="https://github.com/user-attachments/assets/03aecf8f-77f0-41f9-974d-83bbec12e17c" />

I also noticed that the model was removed from [this list](https://ai.google.dev/gemini-api/docs/models) and has seemingly been replaced by the non-preview flash model and a lite variant. So I figured I'd add those models to replace the one that does not work right now. 