### PR TITLE
Update Gemini2.5 models 

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -123,7 +123,6 @@
   roles: [chat, edit]
   thinking: false
 
-
 # OpenAI
 
 - name: GPT-4.1


### PR DESCRIPTION
<img width="533" height="1027" alt="image" src="https://github.com/user-attachments/assets/9b2262d7-3048-4722-bbab-38daba8aa7c6" />

I noticed that the flash-2.5-preview model was down today while the other models from gemini worked just fine.

I also noticed that the model was removed from [this list](https://ai.google.dev/gemini-api/docs/models) and has seemingly been replaced by the non-preview flash model and a lite variant. So I figured I'd add those models to replace the one that does not work right now.
