### PR TITLE
Add mapping for 'upath' to 'universal-pathlib'

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -743,6 +743,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "umap": "umap-learn",
         "unidecode": "Unidecode",
         "universe": "ansible-universe",
+        "upath": "universal-pathlib",
         "usb": "pyusb",
         "useless": "useless.pipes",
         "userpass": "auth-userpass",


### PR DESCRIPTION
## 📝 Summary

Add a mapping from the `upath` module name to the [`universal-pathlib`](https://pypi.org/project/universal-pathlib/) package on PyPI.  Another package named [`upath`](https://pypi.org/project/upath/) does exist on PyPI, but has not been updated in 6 years, and `universal-pathlib` is far more likely to come up in a modern data science context, as it is a dependency for the [`fsspec`](https://pypi.org/project/fsspec/) library that provides a filesystem-like API for cloud storage backends and is used by pandas, polars and other data science libraries to read and write remote data.

See discussion in [this issue](https://github.com/marimo-team/marimo/issues/6207)

Closes #6207 

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
