### PR TITLE
Add Azure OpenAI provider support for existing models

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -128,77 +128,77 @@
 - name: GPT-5
   model: gpt-5
   description: The best model for coding and agentic tasks across domains
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: false
 
 - name: GPT-5 Mini
   model: gpt-5-mini
   description: A faster, cost-efficient version of GPT-5 for well-defined tasks
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: false
 
 - name: GPT-5 Nano
   model: gpt-5-nano
   description: Fastest, most cost-efficient version of GPT-5
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: false
 
 - name: GPT-4.1
   model: gpt-4.1
   description: Fast, highly intelligent model with largest context window (1 million tokens)
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: false
 
 - name: GPT-4.1 Mini
   model: gpt-4.1-mini
   description: Balanced for intelligence, speed, and cost
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: false
 
 - name: GPT-4o
   model: gpt-4o
   description: Fast, intelligent, flexible GPT model with multimodal capabilities
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: false
 
 - name: GPT-4o Mini
   model: gpt-4o-mini
   description: Fast, affordable small model for focused tasks
-  providers: [openai, github]
+  providers: [openai, azure, github]
   roles: [chat, edit]
   thinking: false
 
 - name: o3
   model: o3
   description: Our most powerful reasoning model with chain-of-thought capabilities
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: true
 
 - name: o3 Mini
   model: o3-mini
   description: A small model alternative to o3 for reasoning tasks
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: true
 
 - name: o3 Pro
   model: o3-pro
   description: Version of o3 designed to think longer and provide most reliable responses
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: true
 
 - name: o4 Mini
   model: o4-mini
   description: Faster, more affordable reasoning model optimized for math, coding, and visual tasks
-  providers: [openai]
+  providers: [openai, azure]
   roles: [chat, edit]
   thinking: true
 


### PR DESCRIPTION
## Summary

Add Azure OpenAI provider support for all existing OpenAI models.

## Changes

- Add 'azure' to providers list for all OpenAI models in models.yml
- Models now available through both OpenAI and Azure OpenAI services
- Updated models: GPT-5, GPT-5 Mini/Nano, GPT-4.1/Mini, GPT-4o/Mini, o3/Mini/Pro, o4 Mini
- Azure provider displays in UI model dropdown with proper categorization

## Testing

- Ran `npm run codegen` to generate updated JSON files
- Verified Azure appears as separate provider in model dropdown