### PR TITLE
feat: cell output for `@` context w/ attachments for media output

### DIFF
--- a/frontend/src/components/editor/ai/completion-utils.ts
+++ b/frontend/src/components/editor/ai/completion-utils.ts
@@ -6,23 +6,32 @@ import type {
   CompletionSource,
 } from "@codemirror/autocomplete";
 import { getAIContextRegistry } from "@/core/ai/context/context";
+import type { ChatAttachment } from "@/core/ai/types";
 import { getCodes } from "@/core/codemirror/copilot/getCodes";
 import type { AiCompletionRequest } from "@/core/network/types";
 import { store } from "@/core/state/jotai";
 import { Logger } from "@/utils/Logger";
+
+interface Opts {
+  input: string;
+}
+
+interface AICompletionBodyWithAttachments {
+  body: Omit<AiCompletionRequest, "language" | "prompt" | "code">;
+  attachments: ChatAttachment[];
+}
 
 /**
  * Gets the request body for the AI completion API.
  */
 export function getAICompletionBody({
   input,
-}: {
-  input: string;
-}): Omit<AiCompletionRequest, "language" | "prompt" | "code"> {
+}: Opts): Omit<AiCompletionRequest, "language" | "prompt" | "code"> {
   let contextString = "";
+
   // Skip if no '@' in the input
   if (input.includes("@")) {
-    contextString = extractDatasetsAndVariables(input);
+    contextString = extractTaggedContext(input);
     Logger.debug("Included context", contextString);
   }
 
@@ -37,11 +46,49 @@ export function getAICompletionBody({
 }
 
 /**
- * Extracts datasets and variables from the input.
- * References are with @<name> in the input.
- * Prioritizes datasets over variables if there's a name conflict.
+ * Gets the request body and attachments for the AI completion API.
  */
-function extractDatasetsAndVariables(input: string): string {
+export async function getAICompletionBodyWithAttachments({
+  input,
+}: Opts): Promise<AICompletionBodyWithAttachments> {
+  let contextString = "";
+  let attachments: ChatAttachment[] = [];
+
+  // Skip if no '@' in the input
+  if (input.includes("@")) {
+    const registry = getAIContextRegistry(store);
+    const contextIds = registry.parseAllContextIds(input);
+
+    // Get context string
+    contextString = registry.formatContextForAI(contextIds);
+
+    // Get attachments
+    try {
+      attachments = await registry.getAttachmentsForContext(contextIds);
+      Logger.debug("Included attachments", attachments.length);
+    } catch (error) {
+      Logger.error("Error getting attachments:", error);
+    }
+  }
+
+  return {
+    body: {
+      includeOtherCode: getCodes(""),
+      context: {
+        plainText: contextString,
+        schema: [],
+        variables: [],
+      },
+    },
+    attachments,
+  };
+}
+
+/**
+ * Extracts datasets, variables and other context from the input.
+ * References are with @<name> in the input.
+ */
+function extractTaggedContext(input: string): string {
   const registry = getAIContextRegistry(store);
   const contextIds = registry.parseAllContextIds(input);
   return registry.formatContextForAI(contextIds);

--- a/frontend/src/core/ai/context/__tests__/registry.test.ts
+++ b/frontend/src/core/ai/context/__tests__/registry.test.ts
@@ -118,7 +118,9 @@ class AttachmentContextProvider extends AIContextProvider<MockContextItem> {
     return this.createBasicCompletion(item);
   }
 
-  async getAttachments(items: MockContextItem[]): Promise<ChatAttachment[]> {
+  override async getAttachments(
+    items: MockContextItem[],
+  ): Promise<ChatAttachment[]> {
     // Return attachments for items that need them
     const itemsNeedingAttachments = items.filter(
       (item) => item.data.needsAttachment,

--- a/frontend/src/core/ai/context/__tests__/registry.test.ts
+++ b/frontend/src/core/ai/context/__tests__/registry.test.ts
@@ -20,7 +20,7 @@ import {
 
 // Mock context item for testing
 interface MockContextItem extends AIContextItem {
-  type: "mock";
+  type: "mock" | "attachment";
   data: {
     value: string;
     needsAttachment?: boolean;
@@ -731,7 +731,7 @@ describe("AIContextRegistry", () => {
       const itemWithAttachment: MockContextItem = {
         uri: "attachment://item1" as ContextLocatorId,
         name: "item1",
-        type: "mock",
+        type: "attachment",
         description: "Item with attachment",
         data: { needsAttachment: true, value: "test1" },
       };
@@ -739,7 +739,7 @@ describe("AIContextRegistry", () => {
       const itemWithoutAttachment: MockContextItem = {
         uri: "attachment://item2" as ContextLocatorId,
         name: "item2",
-        type: "mock",
+        type: "attachment",
         description: "Item without attachment",
         data: { needsAttachment: false, value: "test2" },
       };
@@ -820,7 +820,7 @@ describe("AIContextRegistry", () => {
         const multiItem1: MockContextItem = {
           uri: "attachment://multi1" as ContextLocatorId,
           name: "multi1",
-          type: "mock",
+          type: "attachment",
           description: "Multi item 1",
           data: { needsAttachment: true, value: "multi1" },
         };
@@ -828,7 +828,7 @@ describe("AIContextRegistry", () => {
         const multiItem2: MockContextItem = {
           uri: "attachment://multi2" as ContextLocatorId,
           name: "multi2",
-          type: "mock",
+          type: "attachment",
           description: "Multi item 2",
           data: { needsAttachment: true, value: "multi2" },
         };
@@ -860,7 +860,7 @@ describe("AIContextRegistry", () => {
           {
             uri: "attachment://error-item" as ContextLocatorId,
             name: "error-item",
-            type: "mock",
+            type: "attachment",
             description: "Item that causes error",
             data: { needsAttachment: true, value: "error" },
           },

--- a/frontend/src/core/ai/context/__tests__/registry.test.ts
+++ b/frontend/src/core/ai/context/__tests__/registry.test.ts
@@ -2,8 +2,9 @@
 
 import type { Completion } from "@codemirror/autocomplete";
 import { createStore } from "jotai";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MockNotebook } from "@/__mocks__/notebook";
+import type { ChatAttachment } from "@/core/ai/types";
 import { notebookAtom } from "@/core/cells/cells";
 import { CellId as CellIdClass } from "@/core/cells/ids";
 import {
@@ -20,8 +21,24 @@ import {
 // Mock context item for testing
 interface MockContextItem extends AIContextItem {
   type: "mock";
-  data: { value: string };
+  data: {
+    value: string;
+    needsAttachment?: boolean;
+  };
 }
+
+// Mock attachment data for testing
+const mockAttachment1: ChatAttachment = {
+  name: "test-image-1.png",
+  contentType: "image/png",
+  url: "data:image/png;base64,mockdata1",
+};
+
+const mockAttachment2: ChatAttachment = {
+  name: "test-image-2.jpg",
+  contentType: "image/jpeg",
+  url: "data:image/jpeg;base64,mockdata2",
+};
 
 // Concrete implementation of AIContextProvider for testing
 class MockContextProvider extends AIContextProvider<MockContextItem> {
@@ -73,6 +90,42 @@ class MockContextProvider extends AIContextProvider<MockContextItem> {
   // Method to clear items for testing
   clearItems(): void {
     this.items = [];
+  }
+}
+
+// Test provider that supports attachments
+class AttachmentContextProvider extends AIContextProvider<MockContextItem> {
+  readonly title = "Attachment Items";
+  readonly mentionPrefix = "@";
+  readonly contextType = "attachment";
+
+  constructor(
+    private items: MockContextItem[] = [],
+    private attachments: ChatAttachment[] = [],
+  ) {
+    super();
+  }
+
+  getItems(): MockContextItem[] {
+    return this.items;
+  }
+
+  formatContext(item: MockContextItem): string {
+    return `Attachment: ${item.name} (${item.data.value})`;
+  }
+
+  formatCompletion(item: MockContextItem): Completion {
+    return this.createBasicCompletion(item);
+  }
+
+  async getAttachments(items: MockContextItem[]): Promise<ChatAttachment[]> {
+    // Return attachments for items that need them
+    const itemsNeedingAttachments = items.filter(
+      (item) => item.data.needsAttachment,
+    );
+    return itemsNeedingAttachments
+      .map((_, index) => this.attachments[index % this.attachments.length])
+      .filter(Boolean);
   }
 }
 
@@ -665,6 +718,223 @@ describe("AIContextRegistry", () => {
       expect(formattedContext).toContain("Mock:");
       expect(formattedContext).toContain("Cell 1");
       expect(formattedContext).toContain("Item 1");
+    });
+  });
+
+  describe("attachment functionality", () => {
+    let attachmentProvider: AttachmentContextProvider;
+    let attachmentRegistry: AIContextRegistry<MockContextItem>;
+
+    beforeEach(() => {
+      const itemWithAttachment: MockContextItem = {
+        uri: "attachment://item1" as ContextLocatorId,
+        name: "item1",
+        type: "mock",
+        description: "Item with attachment",
+        data: { needsAttachment: true, value: "test1" },
+      };
+
+      const itemWithoutAttachment: MockContextItem = {
+        uri: "attachment://item2" as ContextLocatorId,
+        name: "item2",
+        type: "mock",
+        description: "Item without attachment",
+        data: { needsAttachment: false, value: "test2" },
+      };
+
+      attachmentProvider = new AttachmentContextProvider(
+        [itemWithAttachment, itemWithoutAttachment],
+        [mockAttachment1, mockAttachment2],
+      );
+
+      attachmentRegistry = new AIContextRegistry<MockContextItem>().register(
+        attachmentProvider,
+      );
+    });
+
+    describe("getAttachmentsForContext", () => {
+      it("should return empty array for empty context IDs", async () => {
+        const attachments = await attachmentRegistry.getAttachmentsForContext(
+          [],
+        );
+        expect(attachments).toEqual([]);
+      });
+
+      it("should return empty array for non-existent context IDs", async () => {
+        const nonExistentIds = ["attachment://nonexistent" as ContextLocatorId];
+        const attachments =
+          await attachmentRegistry.getAttachmentsForContext(nonExistentIds);
+        expect(attachments).toEqual([]);
+      });
+
+      it("should get attachments from provider that supports them", async () => {
+        const contextIds = ["attachment://item1" as ContextLocatorId];
+        const attachments =
+          await attachmentRegistry.getAttachmentsForContext(contextIds);
+
+        expect(attachments).toHaveLength(1);
+        expect(attachments[0]).toEqual(mockAttachment1);
+      });
+
+      it("should not get attachments for items that don't need them", async () => {
+        const contextIds = ["attachment://item2" as ContextLocatorId];
+        const attachments =
+          await attachmentRegistry.getAttachmentsForContext(contextIds);
+
+        expect(attachments).toHaveLength(0);
+      });
+
+      it("should not get attachments from providers with default implementation", async () => {
+        const simpleRegistry =
+          new AIContextRegistry<MockContextItem>().register(mockProvider);
+
+        const contextIds = ["mock://item1" as ContextLocatorId];
+        const attachments =
+          await simpleRegistry.getAttachmentsForContext(contextIds);
+
+        expect(attachments).toHaveLength(0);
+      });
+
+      it("should handle multiple context IDs from different providers", async () => {
+        const mixedRegistry = new AIContextRegistry<MockContextItem>()
+          .register(attachmentProvider)
+          .register(mockProvider);
+
+        const contextIds = [
+          "attachment://item1" as ContextLocatorId, // should have attachment
+          "attachment://item2" as ContextLocatorId, // should not have attachment
+          "mock://item1" as ContextLocatorId, // provider doesn't support attachments
+        ];
+
+        const attachments =
+          await mixedRegistry.getAttachmentsForContext(contextIds);
+
+        // Only attachment://item1 should contribute an attachment
+        expect(attachments).toHaveLength(1);
+        expect(attachments[0]).toEqual(mockAttachment1);
+      });
+
+      it("should handle multiple items needing attachments", async () => {
+        const multiItem1: MockContextItem = {
+          uri: "attachment://multi1" as ContextLocatorId,
+          name: "multi1",
+          type: "mock",
+          description: "Multi item 1",
+          data: { needsAttachment: true, value: "multi1" },
+        };
+
+        const multiItem2: MockContextItem = {
+          uri: "attachment://multi2" as ContextLocatorId,
+          name: "multi2",
+          type: "mock",
+          description: "Multi item 2",
+          data: { needsAttachment: true, value: "multi2" },
+        };
+
+        const multiProvider = new AttachmentContextProvider(
+          [multiItem1, multiItem2],
+          [mockAttachment1, mockAttachment2],
+        );
+
+        const multiRegistry = new AIContextRegistry<MockContextItem>().register(
+          multiProvider,
+        );
+
+        const contextIds = [
+          "attachment://multi1" as ContextLocatorId,
+          "attachment://multi2" as ContextLocatorId,
+        ];
+
+        const attachments =
+          await multiRegistry.getAttachmentsForContext(contextIds);
+
+        expect(attachments).toHaveLength(2);
+        expect(attachments).toContainEqual(mockAttachment1);
+        expect(attachments).toContainEqual(mockAttachment2);
+      });
+
+      it("should handle provider errors gracefully", async () => {
+        const errorProvider = new AttachmentContextProvider([
+          {
+            uri: "attachment://error-item" as ContextLocatorId,
+            name: "error-item",
+            type: "mock",
+            description: "Item that causes error",
+            data: { needsAttachment: true, value: "error" },
+          },
+        ]);
+
+        // Override getAttachments to throw an error
+        errorProvider.getAttachments = vi
+          .fn()
+          .mockRejectedValue(new Error("Attachment error"));
+
+        const errorRegistry = new AIContextRegistry<MockContextItem>()
+          .register(errorProvider)
+          .register(mockProvider);
+
+        const contextIds = [
+          "attachment://error-item" as ContextLocatorId,
+          "mock://item1" as ContextLocatorId,
+        ];
+
+        // Should not throw and should handle the error gracefully
+        const attachments =
+          await errorRegistry.getAttachmentsForContext(contextIds);
+        expect(attachments).toEqual([]);
+      });
+    });
+
+    describe("provider batching for attachments", () => {
+      it("should batch multiple items to the same provider", async () => {
+        const getAttachmentsSpy = vi.spyOn(
+          attachmentProvider,
+          "getAttachments",
+        );
+
+        const contextIds = [
+          "attachment://item1" as ContextLocatorId,
+          "attachment://item2" as ContextLocatorId,
+        ];
+
+        await attachmentRegistry.getAttachmentsForContext(contextIds);
+
+        // Should call getAttachments once with both items
+        expect(getAttachmentsSpy).toHaveBeenCalledTimes(1);
+        expect(getAttachmentsSpy).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ uri: "attachment://item1" }),
+            expect.objectContaining({ uri: "attachment://item2" }),
+          ]),
+        );
+      });
+
+      it("should call different providers separately", async () => {
+        const mixedRegistry = new AIContextRegistry<MockContextItem>()
+          .register(attachmentProvider)
+          .register(mockProvider);
+
+        const attachmentSpy = vi.spyOn(attachmentProvider, "getAttachments");
+        const mockSpy = vi.spyOn(mockProvider, "getAttachments");
+
+        const contextIds = [
+          "attachment://item1" as ContextLocatorId,
+          "mock://item1" as ContextLocatorId,
+        ];
+
+        await mixedRegistry.getAttachmentsForContext(contextIds);
+
+        // Should call each provider once
+        expect(attachmentSpy).toHaveBeenCalledTimes(1);
+        expect(mockSpy).toHaveBeenCalledTimes(1);
+
+        expect(attachmentSpy).toHaveBeenCalledWith([
+          expect.objectContaining({ uri: "attachment://item1" }),
+        ]);
+        expect(mockSpy).toHaveBeenCalledWith([
+          expect.objectContaining({ uri: "mock://item1" }),
+        ]);
+      });
     });
   });
 });

--- a/frontend/src/core/ai/context/context.ts
+++ b/frontend/src/core/ai/context/context.ts
@@ -3,6 +3,7 @@
 import { allTablesAtom } from "@/core/datasets/data-source-connections";
 import type { JotaiStore } from "@/core/state/jotai";
 import { variablesAtom } from "@/core/variables/state";
+import { CellOutputContextProvider } from "./providers/cell-output";
 import { ErrorContextProvider } from "./providers/error";
 import { TableContextProvider } from "./providers/tables";
 import { VariableContextProvider } from "./providers/variable";
@@ -14,5 +15,6 @@ export function getAIContextRegistry(store: JotaiStore) {
   return new AIContextRegistry()
     .register(new TableContextProvider(tablesMap))
     .register(new VariableContextProvider(variables, tablesMap))
-    .register(new ErrorContextProvider(store));
+    .register(new ErrorContextProvider(store))
+    .register(new CellOutputContextProvider(store));
 }

--- a/frontend/src/core/ai/context/providers/__tests__/cell-output.test.ts
+++ b/frontend/src/core/ai/context/providers/__tests__/cell-output.test.ts
@@ -1,0 +1,385 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NotebookState } from "@/core/cells/cells";
+import type { CellId } from "@/core/cells/ids";
+import type { OutputMessage } from "@/core/kernel/messages";
+import type { JotaiStore } from "@/core/state/jotai";
+import { CellOutputContextProvider } from "../cell-output";
+
+// Mock the external dependencies
+vi.mock("html-to-image", () => ({
+  toPng: vi.fn().mockResolvedValue("data:image/png;base64,mockbase64data"),
+}));
+
+vi.mock("@/utils/Logger", () => ({
+  Logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/core/cells/names", () => ({
+  displayCellName: vi.fn(
+    (name: string, index: number) => name || `cell-${index + 1}`,
+  ),
+}));
+
+vi.mock("@/core/cells/outputs", () => ({
+  isOutputEmpty: vi.fn(
+    (output) => !output || output.data === null || output.data === undefined,
+  ),
+}));
+
+// Test helper to create mock store
+function createMockStore(notebook: NotebookState): JotaiStore {
+  const store = {
+    get: vi.fn().mockReturnValue(notebook),
+  } as unknown as JotaiStore;
+  return store;
+}
+
+describe("CellOutputContextProvider", () => {
+  let provider: CellOutputContextProvider;
+  let mockStore: JotaiStore;
+  let mockNotebook: NotebookState;
+
+  beforeEach(() => {
+    // Create a basic mock notebook state
+    mockNotebook = {
+      cellIds: {
+        inOrderIds: ["cell1" as CellId, "cell2" as CellId, "cell3" as CellId],
+      },
+      cellData: {
+        cell1: {
+          id: "cell1" as CellId,
+          name: "My Cell",
+          code: "print('hello world')",
+        },
+        cell2: {
+          id: "cell2" as CellId,
+          name: "",
+          code: "import matplotlib.pyplot as plt\nplt.plot([1,2,3])",
+        },
+        cell3: {
+          id: "cell3" as CellId,
+          name: "Empty Cell",
+          code: "# no output",
+        },
+      },
+      cellRuntime: {
+        cell1: {
+          output: {
+            mimetype: "text/plain",
+            data: "hello world",
+          } as OutputMessage,
+        },
+        cell2: {
+          output: {
+            mimetype: "image/png",
+            data: "base64imagedata",
+          } as OutputMessage,
+        },
+        cell3: {
+          output: null,
+        },
+      },
+    } as unknown as NotebookState;
+
+    mockStore = createMockStore(mockNotebook);
+    provider = new CellOutputContextProvider(mockStore);
+  });
+
+  describe("basic properties", () => {
+    it("should have correct title and context type", () => {
+      expect(provider.title).toBe("Cell Outputs");
+      expect(provider.contextType).toBe("cell-output");
+      expect(provider.mentionPrefix).toBe("@");
+    });
+  });
+
+  describe("getItems", () => {
+    it("should return only cells with outputs", () => {
+      const items = provider.getItems();
+
+      // Should have 2 items (cell1 and cell2, but not cell3 which has no output)
+      expect(items).toHaveLength(2);
+
+      const cellIds = items.map((item) => item.data.cellId);
+      expect(cellIds).toContain("cell1");
+      expect(cellIds).toContain("cell2");
+      expect(cellIds).not.toContain("cell3");
+    });
+
+    it("should correctly identify text vs media outputs", () => {
+      const items = provider.getItems();
+
+      const textItem = items.find((item) => item.data.cellId === "cell1");
+      const mediaItem = items.find((item) => item.data.cellId === "cell2");
+
+      expect(textItem?.data.outputType).toBe("text");
+      expect(mediaItem?.data.outputType).toBe("media");
+    });
+
+    it("should process text content correctly", () => {
+      const items = provider.getItems();
+      const textItem = items.find((item) => item.data.cellId === "cell1");
+
+      expect(textItem?.data.processedContent).toBe("hello world");
+    });
+
+    it("should mark media items for download when no direct URL available", () => {
+      const items = provider.getItems();
+      const mediaItem = items.find((item) => item.data.cellId === "cell2");
+
+      expect(mediaItem?.data.shouldDownloadImage).toBe(true);
+      expect(mediaItem?.data.imageUrl).toBeUndefined();
+    });
+
+    it("should include cell code and names", () => {
+      const items = provider.getItems();
+
+      const item1 = items.find((item) => item.data.cellId === "cell1");
+      const item2 = items.find((item) => item.data.cellId === "cell2");
+
+      expect(item1?.data.cellName).toBe("My Cell");
+      expect(item1?.data.cellCode).toBe("print('hello world')");
+
+      expect(item2?.data.cellName).toBe("cell-2");
+      expect(item2?.data.cellCode).toBe(
+        "import matplotlib.pyplot as plt\nplt.plot([1,2,3])",
+      );
+    });
+  });
+
+  describe("formatContext", () => {
+    it("should format text output context correctly", () => {
+      const items = provider.getItems();
+      const textItem = items.find((item) => item.data.cellId === "cell1");
+
+      if (!textItem) throw new Error("Text item not found");
+
+      const context = provider.formatContext(textItem);
+
+      expect(context).toContain("cell-output");
+      expect(context).toContain("My Cell");
+      expect(context).toContain("Cell Code:");
+      expect(context).toContain("print('hello world')");
+      expect(context).toContain("Output:");
+      expect(context).toContain("hello world");
+    });
+
+    it("should format media output context correctly", () => {
+      const items = provider.getItems();
+      const mediaItem = items.find((item) => item.data.cellId === "cell2");
+
+      if (!mediaItem) throw new Error("Media item not found");
+
+      const context = provider.formatContext(mediaItem);
+
+      expect(context).toContain("cell-output");
+      expect(context).toContain("cell-2");
+      expect(context).toContain("Cell Code:");
+      expect(context).toContain("import matplotlib.pyplot as plt");
+      expect(context).toContain("Media Output: Contains image/png content");
+    });
+  });
+
+  describe("formatCompletion", () => {
+    it("should create proper completion object", () => {
+      const items = provider.getItems();
+      const item = items[0];
+
+      const completion = provider.formatCompletion(item);
+
+      expect(completion.label).toMatch(/@.+/);
+      expect(completion.displayLabel).toBe(item.data.cellName);
+      expect(completion.detail).toContain("output");
+      expect(completion.type).toBe("cell-output");
+      expect(completion.section).toBe("Cell Output");
+      expect(typeof completion.info).toBe("function");
+    });
+  });
+});
+
+// Test utility functions separately
+describe("Cell output utility functions", () => {
+  // We need to extract these functions to test them, or make them exported
+  // For now, let's test through the public interface
+
+  describe("media type detection", () => {
+    let provider: CellOutputContextProvider;
+    let mockStore: JotaiStore;
+
+    beforeEach(() => {
+      const mockNotebook = {
+        cellIds: { inOrderIds: [] },
+        cellData: {},
+        cellRuntime: {},
+      } as unknown as NotebookState;
+
+      mockStore = createMockStore(mockNotebook);
+      provider = new CellOutputContextProvider(mockStore);
+    });
+
+    it("should detect image mimetypes as media", () => {
+      const testCases = [
+        { mimetype: "image/png", data: "test", expected: "media" },
+        { mimetype: "image/jpeg", data: "test", expected: "media" },
+        { mimetype: "image/gif", data: "test", expected: "media" },
+        { mimetype: "image/svg+xml", data: "test", expected: "media" },
+      ];
+
+      for (const testCase of testCases) {
+        mockStore = createMockStore({
+          cellIds: { inOrderIds: ["test" as CellId] },
+          cellData: {
+            test: { id: "test" as CellId, name: "", code: "" },
+          },
+          cellRuntime: {
+            test: {
+              output: {
+                mimetype: testCase.mimetype,
+                data: testCase.data,
+              } as OutputMessage,
+            },
+          },
+        } as unknown as NotebookState);
+
+        provider = new CellOutputContextProvider(mockStore);
+        const items = provider.getItems();
+
+        expect(items[0]?.data.outputType).toBe(testCase.expected);
+      }
+    });
+
+    it("should detect HTML with media tags as media", () => {
+      const htmlWithImage = '<div><img src="test.png" /></div>';
+      const htmlWithCanvas = '<canvas width="100" height="100"></canvas>';
+      const htmlWithSvg = '<svg><circle r="50" /></svg>';
+
+      const testCases = [
+        { data: htmlWithImage, expected: "media" },
+        { data: htmlWithCanvas, expected: "media" },
+        { data: htmlWithSvg, expected: "media" },
+        { data: "<p>Just text</p>", expected: "text" },
+      ];
+
+      for (const testCase of testCases) {
+        mockStore = createMockStore({
+          cellIds: { inOrderIds: ["test" as CellId] },
+          cellData: {
+            test: { id: "test" as CellId, name: "", code: "" },
+          },
+          cellRuntime: {
+            test: {
+              output: {
+                mimetype: "text/html",
+                data: testCase.data,
+              } as OutputMessage,
+            },
+          },
+        } as unknown as NotebookState);
+
+        provider = new CellOutputContextProvider(mockStore);
+        const items = provider.getItems();
+
+        expect(items[0]?.data.outputType).toBe(testCase.expected);
+      }
+    });
+
+    it("should detect text mimetypes correctly", () => {
+      const testCases = [
+        { mimetype: "text/plain", expected: "text" },
+        {
+          mimetype: "text/html",
+          data: "<p>No media tags</p>",
+          expected: "text",
+        },
+        { mimetype: "application/json", expected: "text" },
+      ];
+
+      for (const testCase of testCases) {
+        mockStore = createMockStore({
+          cellIds: { inOrderIds: ["test" as CellId] },
+          cellData: {
+            test: { id: "test" as CellId, name: "", code: "" },
+          },
+          cellRuntime: {
+            test: {
+              output: {
+                mimetype: testCase.mimetype,
+                data: testCase.data || "test data",
+              } as OutputMessage,
+            },
+          },
+        } as unknown as NotebookState);
+
+        provider = new CellOutputContextProvider(mockStore);
+        const items = provider.getItems();
+
+        expect(items[0]?.data.outputType).toBe(testCase.expected);
+      }
+    });
+  });
+
+  describe("HTML content parsing", () => {
+    let provider: CellOutputContextProvider;
+    let mockStore: JotaiStore;
+
+    beforeEach(() => {
+      // Mock DOM methods for HTML parsing
+      const mockDiv = {
+        innerHTML: "",
+        textContent: "",
+        innerText: "",
+      };
+
+      global.document = {
+        createElement: vi.fn().mockReturnValue(mockDiv),
+      } as any;
+
+      const mockNotebook = {
+        cellIds: { inOrderIds: [] },
+        cellData: {},
+        cellRuntime: {},
+      } as unknown as NotebookState;
+
+      mockStore = createMockStore(mockNotebook);
+      provider = new CellOutputContextProvider(mockStore);
+    });
+
+    it("should extract text content from HTML", () => {
+      const htmlContent = "<p>Hello <strong>world</strong>!</p>";
+
+      // Mock the DOM parsing result
+      const mockDiv = {
+        innerHTML: "",
+        textContent: "Hello world!",
+        innerText: "Hello world!",
+      };
+
+      (global.document.createElement as any).mockReturnValue(mockDiv);
+
+      mockStore = createMockStore({
+        cellIds: { inOrderIds: ["test" as CellId] },
+        cellData: {
+          test: { id: "test" as CellId, name: "", code: "" },
+        },
+        cellRuntime: {
+          test: {
+            output: {
+              mimetype: "text/html",
+              data: htmlContent,
+            } as OutputMessage,
+          },
+        },
+      } as unknown as NotebookState);
+
+      provider = new CellOutputContextProvider(mockStore);
+      const items = provider.getItems();
+
+      expect(items[0]?.data.processedContent).toBe("Hello world!");
+    });
+  });
+});

--- a/frontend/src/core/ai/context/providers/__tests__/cell-output.test.ts
+++ b/frontend/src/core/ai/context/providers/__tests__/cell-output.test.ts
@@ -1,11 +1,7 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { NotebookState } from "@/core/cells/cells";
-import type { CellId } from "@/core/cells/ids";
-import type { OutputMessage } from "@/core/kernel/messages";
-import type { JotaiStore } from "@/core/state/jotai";
-import { CellOutputContextProvider } from "../cell-output";
+import { Mocks } from "@/__mocks__/common";
 
 // Mock the external dependencies
 vi.mock("html-to-image", () => ({
@@ -13,23 +9,14 @@ vi.mock("html-to-image", () => ({
 }));
 
 vi.mock("@/utils/Logger", () => ({
-  Logger: {
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
+  Logger: Mocks.quietLogger(),
 }));
 
-vi.mock("@/core/cells/names", () => ({
-  displayCellName: vi.fn(
-    (name: string, index: number) => name || `cell-${index + 1}`,
-  ),
-}));
-
-vi.mock("@/core/cells/outputs", () => ({
-  isOutputEmpty: vi.fn(
-    (output) => !output || output.data === null || output.data === undefined,
-  ),
-}));
+import type { NotebookState } from "@/core/cells/cells";
+import type { CellId } from "@/core/cells/ids";
+import type { OutputMessage } from "@/core/kernel/messages";
+import type { JotaiStore } from "@/core/state/jotai";
+import { CellOutputContextProvider } from "../cell-output";
 
 // Test helper to create mock store
 function createMockStore(notebook: NotebookState): JotaiStore {
@@ -145,7 +132,7 @@ describe("CellOutputContextProvider", () => {
       expect(item1?.data.cellName).toBe("My Cell");
       expect(item1?.data.cellCode).toBe("print('hello world')");
 
-      expect(item2?.data.cellName).toBe("cell-2");
+      expect(item2?.data.cellName).toBe("cell-1");
       expect(item2?.data.cellCode).toBe(
         "import matplotlib.pyplot as plt\nplt.plot([1,2,3])",
       );
@@ -178,7 +165,7 @@ describe("CellOutputContextProvider", () => {
       const context = provider.formatContext(mediaItem);
 
       expect(context).toContain("cell-output");
-      expect(context).toContain("cell-2");
+      expect(context).toContain("cell-1");
       expect(context).toContain("Cell Code:");
       expect(context).toContain("import matplotlib.pyplot as plt");
       expect(context).toContain("Media Output: Contains image/png content");
@@ -337,7 +324,7 @@ describe("Cell output utility functions", () => {
 
       global.document = {
         createElement: vi.fn().mockReturnValue(mockDiv),
-      } as any;
+      } as unknown as Document;
 
       const mockNotebook = {
         cellIds: { inOrderIds: [] },
@@ -359,7 +346,9 @@ describe("Cell output utility functions", () => {
         innerText: "Hello world!",
       };
 
-      (global.document.createElement as any).mockReturnValue(mockDiv);
+      (
+        global.document.createElement as ReturnType<typeof vi.fn>
+      ).mockReturnValue(mockDiv);
 
       mockStore = createMockStore({
         cellIds: { inOrderIds: ["test" as CellId] },

--- a/frontend/src/core/ai/context/providers/__tests__/error.test.ts
+++ b/frontend/src/core/ai/context/providers/__tests__/error.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { MockNotebook } from "@/__mocks__/notebook";
 import { notebookAtom } from "@/core/cells/cells";
 import { type CellId, CellId as CellIdClass } from "@/core/cells/ids";
+import { Boosts } from "../common";
 import { ErrorContextProvider } from "../error";
 
 describe("ErrorContextProvider", () => {
@@ -121,7 +122,7 @@ describe("ErrorContextProvider", () => {
         label: "@Errors",
         displayLabel: "Errors",
         detail: "2 errors",
-        boost: 2, // Boosts.ERROR
+        boost: Boosts.ERROR,
         type: "error",
         apply: "@Errors",
         section: "Errors",
@@ -181,7 +182,7 @@ describe("ErrorContextProvider", () => {
       expect(completion).toMatchObject({
         label: "Error",
         displayLabel: "Error",
-        boost: 2, // Boosts.ERROR
+        boost: Boosts.ERROR,
       });
     });
   });

--- a/frontend/src/core/ai/context/providers/cell-output.ts
+++ b/frontend/src/core/ai/context/providers/cell-output.ts
@@ -275,12 +275,12 @@ export class CellOutputContextProvider extends AIContextProvider<CellOutputConte
   formatContext(item: CellOutputContextItem): string {
     const { data } = item;
 
-    const contextData: any = {
+    const contextData = {
       name: data.cellName,
       cellId: data.cellId,
       outputType: data.outputType,
       mimetype: data.output.mimetype,
-    };
+    } as const;
 
     let details = `Cell Code:\n${data.cellCode}\n\n`;
 

--- a/frontend/src/core/ai/context/providers/cell-output.ts
+++ b/frontend/src/core/ai/context/providers/cell-output.ts
@@ -1,0 +1,347 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import type { Completion } from "@codemirror/autocomplete";
+import { toPng } from "html-to-image";
+import type { ChatAttachment } from "@/core/ai/types";
+import { notebookAtom } from "@/core/cells/cells";
+import { type CellId, CellOutputId } from "@/core/cells/ids";
+import { displayCellName } from "@/core/cells/names";
+import { isOutputEmpty } from "@/core/cells/outputs";
+import type { OutputMessage } from "@/core/kernel/messages";
+import type { JotaiStore } from "@/core/state/jotai";
+import { Logger } from "@/utils/Logger";
+import { type AIContextItem, AIContextProvider } from "../registry";
+import { contextToXml } from "../utils";
+import { Boosts } from "./common";
+
+export interface CellOutputContextItem extends AIContextItem {
+  type: "cell-output";
+  data: {
+    cellId: CellId;
+    cellName: string;
+    cellCode: string;
+    output: OutputMessage;
+    outputType: "text" | "media";
+    processedContent?: string;
+    imageUrl?: string;
+    shouldDownloadImage?: boolean;
+  };
+}
+
+function isMediaMimetype(
+  mimetype: OutputMessage["mimetype"] | undefined,
+  htmlString: string,
+): boolean {
+  if (!mimetype) return false;
+
+  const mediaPrefixes = ["image/", "video/", "audio/", "application/pdf"];
+  if (mediaPrefixes.some((prefix) => mimetype.startsWith(prefix))) {
+    return true;
+  }
+  const mediaIncludes = ["svg", "vega"];
+  if (mediaIncludes.some((include) => mimetype.includes(include))) {
+    return true;
+  }
+
+  // If it is HTML, we need to check if it contains a media tag
+  if (mimetype === "text/html") {
+    const mediaTags = [
+      "<img",
+      "<video",
+      "<audio",
+      "<iframe",
+      "<canvas",
+      "<svg",
+      "<marimo-ui-element",
+    ];
+    if (mediaTags.some((tag) => htmlString.includes(tag))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function parseHtmlContent(htmlString: string): string {
+  try {
+    // Create a temporary DOM element to parse HTML
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = htmlString;
+
+    // Extract text content, removing HTML tags
+    const textContent = tempDiv.textContent || tempDiv.innerText || "";
+
+    // Clean up extra whitespace
+    return textContent.replace(/\s+/g, " ").trim();
+  } catch (error) {
+    Logger.error("Error parsing HTML content:", error);
+    // If parsing fails, return the original string
+    return htmlString;
+  }
+}
+
+export class CellOutputContextProvider extends AIContextProvider<CellOutputContextItem> {
+  readonly title = "Cell Outputs";
+  readonly mentionPrefix = "@";
+  readonly contextType = "cell-output";
+
+  constructor(private store: JotaiStore) {
+    super();
+  }
+
+  getItems(): CellOutputContextItem[] {
+    const notebook = this.store.get(notebookAtom);
+    const items: CellOutputContextItem[] = [];
+
+    for (const [cellIndex, cellId] of notebook.cellIds.inOrderIds.entries()) {
+      const cellRuntime = notebook.cellRuntime[cellId];
+
+      // Filter to only cells with output
+      if (!cellRuntime?.output || isOutputEmpty(cellRuntime.output)) {
+        continue;
+      }
+
+      const cellData = notebook.cellData[cellId];
+      const output = cellRuntime.output;
+      const mimetype = output.mimetype;
+
+      // Determine output type
+      const isMedia = isMediaMimetype(mimetype, String(output.data));
+      const outputType = isMedia ? "media" : "text";
+
+      const cellName = displayCellName(cellData.name, cellIndex);
+
+      let processedContent: string | undefined;
+      let imageUrl: string | undefined;
+      let shouldDownloadImage: boolean = false;
+
+      // Process text content
+      if (outputType === "text" && typeof output.data === "string") {
+        if (mimetype === "text/html") {
+          processedContent = parseHtmlContent(output.data);
+        } else {
+          processedContent = output.data;
+        }
+      }
+
+      // Process media content - for now, we'll just note that it's media
+      if (outputType === "media") {
+        if (
+          typeof output.data === "string" &&
+          output.data.startsWith("data:")
+        ) {
+          imageUrl = output.data; // Data URL
+        } else if (
+          typeof output.data === "string" &&
+          output.data.startsWith("http")
+        ) {
+          imageUrl = output.data; // External URL
+        } else {
+          // Download the image from the DOM element
+          shouldDownloadImage = true;
+        }
+      }
+
+      items.push({
+        uri: this.asURI(cellId),
+        name: cellName,
+        type: this.contextType,
+        description: `Cell output (${mimetype || "unknown"})`,
+        data: {
+          cellId,
+          cellName,
+          cellCode: cellData?.code || "",
+          output,
+          outputType,
+          processedContent,
+          imageUrl,
+          shouldDownloadImage,
+        },
+      });
+    }
+
+    return items;
+  }
+
+  formatCompletion(item: CellOutputContextItem): Completion {
+    const { data } = item;
+    return {
+      label: `@${data.cellName}`,
+      displayLabel: data.cellName,
+      detail: `${data.outputType} output`,
+      boost: Boosts.CELL_OUTPUT,
+      type: this.contextType,
+      section: "Cell Output",
+      apply: `@${data.cellName}`,
+      info: () => {
+        const infoContainer = document.createElement("div");
+        infoContainer.classList.add(
+          "mo-cm-tooltip",
+          "docs-documentation",
+          "min-w-[300px]",
+          "max-w-[500px]",
+          "flex",
+          "flex-col",
+          "gap-2",
+        );
+
+        const headerDiv = document.createElement("div");
+        headerDiv.classList.add("flex", "flex-col", "gap-1");
+
+        const nameDiv = document.createElement("div");
+        nameDiv.classList.add("font-bold", "text-base");
+        nameDiv.textContent = data.cellName;
+        headerDiv.append(nameDiv);
+
+        const descriptionDiv = document.createElement("div");
+        descriptionDiv.classList.add("text-sm", "text-muted-foreground");
+        headerDiv.append(descriptionDiv);
+
+        infoContainer.append(headerDiv);
+
+        // Show cell code preview
+        if (data.cellCode) {
+          const codeHeaderDiv = document.createElement("div");
+          codeHeaderDiv.classList.add(
+            "text-xs",
+            "font-medium",
+            "text-muted-foreground",
+          );
+          codeHeaderDiv.textContent = "Code:";
+          infoContainer.append(codeHeaderDiv);
+
+          const codeDiv = document.createElement("div");
+          codeDiv.classList.add(
+            "text-xs",
+            "font-mono",
+            "bg-muted",
+            "p-2",
+            "rounded",
+            "max-h-20",
+            "overflow-y-auto",
+          );
+          codeDiv.textContent =
+            data.cellCode.slice(0, 200) +
+            (data.cellCode.length > 200 ? "..." : "");
+          infoContainer.append(codeDiv);
+        }
+
+        // Show output preview
+        if (data.processedContent) {
+          const outputHeaderDiv = document.createElement("div");
+          outputHeaderDiv.classList.add(
+            "text-xs",
+            "font-medium",
+            "text-muted-foreground",
+            "mt-2",
+          );
+          outputHeaderDiv.textContent = "Output Preview:";
+          infoContainer.append(outputHeaderDiv);
+
+          const outputDiv = document.createElement("div");
+          outputDiv.classList.add(
+            "text-xs",
+            "bg-muted",
+            "p-2",
+            "rounded",
+            "max-h-24",
+            "overflow-y-auto",
+            "mb-2",
+          );
+          outputDiv.textContent =
+            data.processedContent.slice(0, 300) +
+            (data.processedContent.length > 300 ? "..." : "");
+          infoContainer.append(outputDiv);
+        }
+
+        if (data.outputType === "media") {
+          const mediaDiv = document.createElement("div");
+          mediaDiv.classList.add(
+            "text-xs",
+            "text-muted-foreground",
+            "italic",
+            "mb-2",
+          );
+          mediaDiv.textContent =
+            "Contains media content (image, SVG, or canvas)";
+          infoContainer.append(mediaDiv);
+        }
+
+        return infoContainer;
+      },
+    };
+  }
+
+  formatContext(item: CellOutputContextItem): string {
+    const { data } = item;
+
+    const contextData: any = {
+      name: data.cellName,
+      cellId: data.cellId,
+      outputType: data.outputType,
+      mimetype: data.output.mimetype,
+    };
+
+    let details = `Cell Code:\n${data.cellCode}\n\n`;
+
+    if (data.outputType === "text" && data.processedContent) {
+      details += `Output:\n${data.processedContent}`;
+    } else if (data.outputType === "media") {
+      details += `Media Output: Contains ${data.output.mimetype} content`;
+      if (data.imageUrl) {
+        details += `\nImage URL: ${data.imageUrl}`;
+      }
+    }
+
+    return contextToXml({
+      type: this.contextType,
+      data: contextData,
+      details,
+    });
+  }
+
+  /** Get attachments for cell output items that have shouldDownloadImage=true */
+  override async getAttachments(
+    items: CellOutputContextItem[],
+  ): Promise<ChatAttachment[]> {
+    // Filter items that need image downloading
+    const itemsNeedingDownload = items.filter(
+      (item) =>
+        item.data.shouldDownloadImage && item.data.outputType === "media",
+    );
+
+    if (itemsNeedingDownload.length === 0) {
+      return [];
+    }
+
+    // Prepare download requests
+    const downloadRequests = itemsNeedingDownload.flatMap((item) => {
+      const outputElement = document.getElementById(
+        CellOutputId.create(item.data.cellId),
+      );
+      if (!outputElement) {
+        Logger.warn(`Output element not found for cell ${item.data.cellId}`);
+        return [];
+      }
+      return {
+        cellId: item.data.cellId,
+        cellName: item.data.cellName,
+        mimetype: item.data.output.mimetype,
+        element: outputElement,
+      };
+    });
+
+    try {
+      return await Promise.all(
+        downloadRequests.map(async (item) => ({
+          name: `${item.cellName}-output-screenshot`,
+          contentType: "image/png",
+          url: await toPng(item.element),
+        })),
+      );
+    } catch (error) {
+      Logger.error("Error downloading cell output images:", error);
+      return [];
+    }
+  }
+}

--- a/frontend/src/core/ai/context/providers/common.ts
+++ b/frontend/src/core/ai/context/providers/common.ts
@@ -4,5 +4,6 @@ export const Boosts = {
   LOCAL_TABLE: 5,
   REMOTE_TABLE: 4,
   VARIABLE: 3,
-  ERROR: 2,
+  CELL_OUTPUT: 2,
+  ERROR: 1,
 } as const;

--- a/frontend/src/core/ai/context/registry.ts
+++ b/frontend/src/core/ai/context/registry.ts
@@ -225,7 +225,12 @@ export class AIContextRegistry<T extends AIContextItem> {
         if (!provider) {
           return [];
         }
-        return provider.getAttachments(items);
+        try {
+          return await provider.getAttachments(items);
+        } catch (error) {
+          Logger.error("Error getting attachments from provider", error);
+          return [];
+        }
       },
     );
 

--- a/marimo/_ai/_convert.py
+++ b/marimo/_ai/_convert.py
@@ -404,7 +404,12 @@ def _extract_text(url: str) -> str:
     if url.startswith("data:"):
         # extract base64 encoding from url
         data = url.split(",")[1]
-        return base64.b64decode(data).decode("utf-8")
+        raw = base64.b64decode(data)
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            # fallback: try latin1
+            return raw.decode("latin1")
     else:
         return url
 


### PR DESCRIPTION
This PR adds a new `@` context type for cell output. For text or json output, we just include that in the context body. For media types (image, video, charts, tables) we convert from DOM →  PNG and include the attachment.


<img width="1775" height="933" alt="Screenshot 2025-09-04 at 4 27 12 PM" src="https://github.com/user-attachments/assets/638211cd-801b-4bc7-9903-044b013807fd" />
<img width="936" height="511" alt="Screenshot 2025-09-04 at 4 16 30 PM" src="https://github.com/user-attachments/assets/7671012f-9fe4-4ebe-9ce6-0441220b7622" />
<img width="956" height="574" alt="Screenshot 2025-09-04 at 4 16 22 PM" src="https://github.com/user-attachments/assets/177cb0ba-a953-474b-8462-48a0ba7423d5" />
