### PR TITLE
Fixed storybook setup for static layouts with window.__MARIMO_STATIC__

### DIFF
--- a/frontend/src/stories/layout/vertical/one-column.stories.tsx
+++ b/frontend/src/stories/layout/vertical/one-column.stories.tsx
@@ -1,9 +1,6 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import type { Meta } from "@storybook/react-vite";
-import { createStore, Provider } from "jotai";
-import { createRef, useEffect } from "react";
-import { type NotebookState, notebookAtom } from "@/core/cells/cells";
+import { notebookAtom, type NotebookState } from "@/core/cells/cells";
 import { createCellRuntimeState } from "@/core/cells/types";
 import { defaultUserConfig, parseAppConfig } from "@/core/config/config-schema";
 import { showCodeInRunModeAtom } from "@/core/meta/state";
@@ -13,6 +10,9 @@ import { resolveRequestClient } from "@/core/network/resolve.ts";
 import { WebSocketState } from "@/core/websocket/types";
 import { MultiColumn } from "@/utils/id-tree";
 import type { Milliseconds, Seconds } from "@/utils/time";
+import type { Meta } from "@storybook/react-vite";
+import { createStore, Provider } from "jotai";
+import { createRef } from "react";
 import { CellArray } from "../../../components/editor/renderers/CellArray";
 import { CellsRenderer } from "../../../components/editor/renderers/cells-renderer";
 import { TooltipProvider } from "../../../components/ui/tooltip";
@@ -96,13 +96,15 @@ export default {
   args: {},
 } satisfies Meta<typeof CellsRenderer>;
 
+type W = Window & { __MARIMO_STATIC__?: { files: Record<string, unknown> } };
+
 const EditModeCodeShown = () => {
   const cellId = "Hbol" as CellId;
   const notebook = createLongReprNotebook(cellId);
 
   const store = createStore();
   store.set(notebookAtom, notebook);
-  store.set(connectionAtom, { state: WebSocketState.OPEN });
+  store.set(connectionAtom, {state: WebSocketState.OPEN});
   store.set(requestClientAtom, resolveRequestClient());
   store.set(showCodeInRunModeAtom, true);
 
@@ -127,7 +129,7 @@ const EditModeCodeHidden = () => {
 
   const store = createStore();
   store.set(notebookAtom, notebook);
-  store.set(connectionAtom, { state: WebSocketState.OPEN });
+  store.set(connectionAtom, {state: WebSocketState.OPEN});
   store.set(requestClientAtom, resolveRequestClient());
   store.set(showCodeInRunModeAtom, true);
 
@@ -150,33 +152,16 @@ const ReadModeCodeShown = () => {
   const cellId = "Hbol" as CellId;
   const notebook = createLongReprNotebook(cellId);
 
-  // Set up as static notebook to show code by default
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      (
-        window as Window & {
-          __MARIMO_STATIC__?: { files: Record<string, unknown> };
-        }
-      ).__MARIMO_STATIC__ = { files: {} };
-    }
-  }, []);
-
   const store = createStore();
   store.set(notebookAtom, notebook);
-  store.set(connectionAtom, { state: WebSocketState.OPEN });
+  store.set(connectionAtom, {state: WebSocketState.OPEN});
   store.set(requestClientAtom, resolveRequestClient());
   store.set(showCodeInRunModeAtom, true);
 
   return (
     <Provider store={store}>
       <TooltipProvider>
-        <CellsRenderer appConfig={parseAppConfig({})} mode="read">
-          <CellArray
-            mode="read"
-            userConfig={defaultUserConfig()}
-            appConfig={parseAppConfig({})}
-          />
-        </CellsRenderer>
+        <CellsRenderer appConfig={parseAppConfig({})} mode="read"/>
       </TooltipProvider>
     </Provider>
   );
@@ -186,51 +171,45 @@ const ReadModeCodeHidden = () => {
   const cellId = "Hbol" as CellId;
   const notebook = createLongReprNotebook(cellId);
 
-  // Don't set up static notebook mode so showCode defaults to false
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      delete (
-        window as Window & {
-          __MARIMO_STATIC__?: { files: Record<string, unknown> };
-        }
-      ).__MARIMO_STATIC__;
-    }
-  }, []);
-
   const store = createStore();
   store.set(notebookAtom, notebook);
-  store.set(connectionAtom, { state: WebSocketState.OPEN });
+  store.set(connectionAtom, {state: WebSocketState.OPEN});
   store.set(requestClientAtom, resolveRequestClient());
   store.set(showCodeInRunModeAtom, true);
 
   return (
     <Provider store={store}>
       <TooltipProvider>
-        <CellsRenderer appConfig={parseAppConfig({})} mode="read">
-          <CellArray
-            mode="read"
-            userConfig={defaultUserConfig()}
-            appConfig={parseAppConfig({})}
-          />
-        </CellsRenderer>
+        <CellsRenderer appConfig={parseAppConfig({})} mode="read"/>
       </TooltipProvider>
     </Provider>
   );
 };
 
 export const EditModeCodeShownStory = {
-  render: () => <EditModeCodeShown />,
+  render: () => <EditModeCodeShown/>,
   name: "Edit Mode - Code Shown",
 };
 export const EditModeCodeHiddenStory = {
-  render: () => <EditModeCodeHidden />,
+  render: () => <EditModeCodeHidden/>,
   name: "Edit Mode - Code Hidden",
 };
 export const ReadModeCodeShownStory = {
-  render: () => <ReadModeCodeShown />,
+  render: () => {
+    if (typeof window !== "undefined") {
+      (window as W).__MARIMO_STATIC__ = {files: {}};
+    }
+
+    return <ReadModeCodeShown/>
+  },
   name: "Read Mode - Code Shown",
 };
 export const ReadModeCodeHiddenStory = {
-  render: () => <ReadModeCodeHidden />,
+  render: () => {
+    if (typeof window !== "undefined") {
+      delete (window as W).__MARIMO_STATIC__;
+    }
+    return <ReadModeCodeHidden/>
+  },
   name: "Read Mode - Code Hidden",
 };


### PR DESCRIPTION
## 📝 Summary

In Storybook I need to setup `window.__MARIMO_STATIC__` before the component mounts, so I moved the setup code from useEffect into `render` method of the story.
