### PR TITLE
Vertical layout cleanup for read mode rendering pipeline

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -327,7 +327,6 @@ const VerticalCell = memo(
       "hover-actions-parent empty:invisible",
       {
         published: published,
-        interactive: mode === "edit",
         "has-error": errored,
         stopped: stopped,
         borderless: isPureMarkdown && !published,


### PR DESCRIPTION
In my findings, this is how rendering pipeline looks like if marimo is runing as regular notebook (not static):

```
  mode:
      - edit
          runner: EditPage → EditApp
              cells_renderer: CellsRenderer (wraps children when mode="edit")
                  children: CellArray (EditableCellComponent | ReadonlyCellComponent | SetupCellComponent)
      - read
          runner: RunPage → RunApp
              cells_renderer: CellsRenderer (mode="read")
                  plugin: VerticalLayoutPlugin | GridLayoutPlugin | SlidesLayoutPlugin
```

so, vertical-layout.tsx, which is part of `VerticalLayoutPlugin `, where this piece of code is,

```
    const className = cn(
      "marimo-cell",
      "hover-actions-parent empty:invisible",
      {
        published: published,
        interactive: mode === "edit",   <----------------
        "has-error": errored,
        stopped: stopped,
        borderless: isPureMarkdown && !published,
      },
    );
```

 will always only be rendered in the read mode, hence it makes sense to remove the check.