### PR TITLE
Fix `ColumnStats` normalization for msgspec

### DIFF
--- a/marimo/_data/models.py
+++ b/marimo/_data/models.py
@@ -113,10 +113,12 @@ else:
     NonNestedLiteral = Any
 
 
-class ColumnStats(msgspec.Struct):
+class ColumnStats(msgspec.Struct, dict=True):
     """
     Represents stats for a column in a data table.
 
+    The `dict=True` adds a `__dict__` field to the class which is accessed and
+    mutated in marimo/_plugins/ui/_impl/tables/narwhals_table.py
     """
 
     total: Optional[int] = None

--- a/marimo/_data/models.py
+++ b/marimo/_data/models.py
@@ -113,12 +113,9 @@ else:
     NonNestedLiteral = Any
 
 
-class ColumnStats(msgspec.Struct, dict=True):
+class ColumnStats(msgspec.Struct):
     """
     Represents stats for a column in a data table.
-
-    The `dict=True` adds a `__dict__` field to the class which is accessed and
-    mutated in marimo/_plugins/ui/_impl/tables/narwhals_table.py
     """
 
     total: Optional[int] = None

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -7,6 +7,8 @@ import io
 from functools import cached_property
 from typing import Any, Optional, Union, cast
 
+import msgspec
+
 import narwhals.stable.v1 as nw
 from narwhals.stable.v1.typing import IntoFrameT
 
@@ -314,9 +316,12 @@ class NarwhalsTableManager(
                 category=UserWarning,
             )
 
-            for key, value in stats.__dict__.items():
+            # Normalize values to Python builtins
+            for field in msgspec.structs.fields(stats):
+                value = getattr(stats, field.name)
                 if value is not None:
-                    stats.__dict__[key] = unwrap_py_scalar(value)
+                    setattr(stats, field.name, unwrap_py_scalar(value))
+
         return stats
 
     def _get_stats_internal(self, column: str) -> ColumnStats:

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -8,7 +8,6 @@ from functools import cached_property
 from typing import Any, Optional, Union, cast
 
 import msgspec
-
 import narwhals.stable.v1 as nw
 from narwhals.stable.v1.typing import IntoFrameT
 


### PR DESCRIPTION
The narwhals table provider expects `__dict__` on the struct, which must be enabled explicitly. We ideally could just avoid mutation / dunder methods and just normalize the `ColumnStats` directly.
