### PR TITLE
Directly create `Response` with encoded JSON instead of `JSONResponse`

### DIFF
--- a/marimo/_messaging/msgspec_encoder.py
+++ b/marimo/_messaging/msgspec_encoder.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import msgspec
 import msgspec.json
-from starlette.responses import Response
 
 from marimo._dependencies.dependencies import DependencyManager
 
@@ -106,10 +105,3 @@ def asdict(obj: msgspec.Struct) -> dict[str, Any]:
     Uses `msgspec.to_builtins` with `enc_hook` to handle unsupported values.
     """
     return msgspec.to_builtins(obj, enc_hook=enc_hook)  # type: ignore[no-any-return]
-
-
-class StructResponse(Response):
-    media_type = "application/json"
-
-    def __init__(self, struct: msgspec.Struct) -> None:
-        super().__init__(content=encode_json_bytes(struct))

--- a/marimo/_messaging/msgspec_encoder.py
+++ b/marimo/_messaging/msgspec_encoder.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import msgspec
 import msgspec.json
+from starlette.responses import Response
 
 from marimo._dependencies.dependencies import DependencyManager
 
@@ -105,3 +106,10 @@ def asdict(obj: msgspec.Struct) -> dict[str, Any]:
     Uses `msgspec.to_builtins` with `enc_hook` to handle unsupported values.
     """
     return msgspec.to_builtins(obj, enc_hook=enc_hook)  # type: ignore[no-any-return]
+
+
+class StructResponse(Response):
+    media_type = "application/json"
+
+    def __init__(self, struct: msgspec.Struct) -> None:
+        super().__init__(content=encode_json_bytes(struct))

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -15,7 +15,6 @@ from marimo import _loggers
 from marimo._ai._convert import convert_to_ai_sdk_messages
 from marimo._ai._types import ChatMessage
 from marimo._config.config import AiConfig, MarimoConfig
-from marimo._messaging.msgspec_encoder import StructResponse
 from marimo._server.ai.config import (
     AnyProviderConfig,
     get_autocomplete_model,
@@ -49,6 +48,7 @@ from marimo._server.models.models import (
     InvokeAiToolRequest,
     InvokeAiToolResponse,
 )
+from marimo._server.responses import StructResponse
 from marimo._server.router import APIRouter
 
 if TYPE_CHECKING:

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -15,7 +15,7 @@ from marimo import _loggers
 from marimo._ai._convert import convert_to_ai_sdk_messages
 from marimo._ai._types import ChatMessage
 from marimo._config.config import AiConfig, MarimoConfig
-from marimo._messaging.msgspec_encoder import encode_json_bytes
+from marimo._messaging.msgspec_encoder import StructResponse
 from marimo._server.ai.config import (
     AnyProviderConfig,
     get_autocomplete_model,
@@ -331,28 +331,23 @@ async def invoke_tool(
             body.tool_name, body.arguments
         )
 
-        # Create and return the response
-        response = InvokeAiToolResponse(
-            success=result.error is None,
-            tool_name=result.tool_name,
-            result=result.result,
-            error=result.error,
+        return StructResponse(
+            InvokeAiToolResponse(
+                success=result.error is None,
+                tool_name=result.tool_name,
+                result=result.result,
+                error=result.error,
+            )
         )
 
-        return Response(
-            content=encode_json_bytes(response),
-            media_type="application/json",
-        )
     except Exception as e:
         LOGGER.error("Error invoking AI tool %s: %s", body.tool_name, str(e))
         # Return error response instead of letting it crash
-        error_response = InvokeAiToolResponse(
-            success=False,
-            tool_name=body.tool_name,
-            result=None,
-            error=f"Tool invocation failed: {str(e)}",
-        )
-        return Response(
-            content=encode_json_bytes(error_response),
-            media_type="application/json",
+        return StructResponse(
+            InvokeAiToolResponse(
+                success=False,
+                tool_name=body.tool_name,
+                result=None,
+                error=f"Tool invocation failed: {str(e)}",
+            )
         )

--- a/marimo/_server/responses.py
+++ b/marimo/_server/responses.py
@@ -1,0 +1,11 @@
+import msgspec
+import starlette.responses
+
+from marimo._messaging.msgspec_encoder import encode_json_bytes
+
+
+class StructResponse(starlette.responses.Response):
+    media_type = "application/json"
+
+    def __init__(self, struct: msgspec.Struct) -> None:
+        super().__init__(content=encode_json_bytes(struct))

--- a/marimo/_server/router.py
+++ b/marimo/_server/router.py
@@ -12,7 +12,7 @@ from starlette.responses import (
 from starlette.routing import Mount, Router
 
 from marimo import _loggers
-from marimo._messaging.msgspec_encoder import encode_json_bytes
+from marimo._messaging.msgspec_encoder import StructResponse
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -52,11 +52,8 @@ class APIRouter(Router):
                 if isinstance(response, Response):
                     return response
 
-                # Otherwise encode as JSON and return Response with proper headers
-                return Response(
-                    content=encode_json_bytes(response),
-                    media_type="application/json",
-                )
+                # Otherwise it's one of our structs that we need to encode
+                return StructResponse(response)
 
             # Set docstring of wrapper_func to the docstring of func
             wrapper_func.__doc__ = func.__doc__
@@ -89,11 +86,8 @@ class APIRouter(Router):
                 if isinstance(response, Response):
                     return response
 
-                # Otherwise encode as JSON and return Response with proper headers
-                return Response(
-                    content=encode_json_bytes(response),
-                    media_type="application/json",
-                )
+                # Otherwise it's one of our structs that we need to encode
+                return StructResponse(response)
 
             # Set docstring of wrapper_func to the docstring of func
             wrapper_func.__doc__ = func.__doc__

--- a/marimo/_server/router.py
+++ b/marimo/_server/router.py
@@ -7,13 +7,12 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 from starlette.responses import (
     FileResponse,
-    JSONResponse,
     Response,
 )
 from starlette.routing import Mount, Router
 
 from marimo import _loggers
-from marimo._messaging.msgspec_encoder import encode_json_str
+from marimo._messaging.msgspec_encoder import encode_json_bytes
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -53,8 +52,11 @@ class APIRouter(Router):
                 if isinstance(response, Response):
                     return response
 
-                # Otherwise encode as JSON
-                return JSONResponse(content=encode_json_str(response))
+                # Otherwise encode as JSON and return Response with proper headers
+                return Response(
+                    content=encode_json_bytes(response),
+                    media_type="application/json",
+                )
 
             # Set docstring of wrapper_func to the docstring of func
             wrapper_func.__doc__ = func.__doc__
@@ -87,8 +89,11 @@ class APIRouter(Router):
                 if isinstance(response, Response):
                     return response
 
-                # Otherwise encode as JSON
-                return JSONResponse(content=encode_json_str(response))
+                # Otherwise encode as JSON and return Response with proper headers
+                return Response(
+                    content=encode_json_bytes(response),
+                    media_type="application/json",
+                )
 
             # Set docstring of wrapper_func to the docstring of func
             wrapper_func.__doc__ = func.__doc__

--- a/marimo/_server/router.py
+++ b/marimo/_server/router.py
@@ -12,7 +12,7 @@ from starlette.responses import (
 from starlette.routing import Mount, Router
 
 from marimo import _loggers
-from marimo._messaging.msgspec_encoder import StructResponse
+from marimo._server.responses import StructResponse
 
 if TYPE_CHECKING:
     from starlette.requests import Request


### PR DESCRIPTION
msgspec takes care of our entire struct -> JSON string pipeline. Using the `JSONResponse` from starlette dual encoded our data structures on the frontend.
