### PR TITLE
Switch to structural typing for `QueueType`

### DIFF
--- a/marimo/_server/types.py
+++ b/marimo/_server/types.py
@@ -1,12 +1,30 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, Union
-
-if TYPE_CHECKING:
-    import multiprocessing as mp
-    from queue import Queue
+from typing import Protocol, TypeVar, Union
 
 T = TypeVar("T")
-# strings for python 3.8 compatibility
-QueueType = Union["mp.Queue[T]", "Queue[T]"]
+
+
+class QueueType(Protocol[T]):
+    """
+    Minimal queue protocol used by Marimo.
+
+    Defines the common subset of methods shared by `multiprocessing.Queue` and
+    `queue.Queue` that Marimo depends on. Keeping this protocol minimal makes it
+    straightforward to stub in `marimo-lsp` and to substitute alternative queue
+    implementations (e.g., wrapping a ZeroMQ socket).
+
+    If additional queue behavior becomes necessary, expand this protocol so that
+    stubs and implementations stay aligned.
+    """
+
+    def get(
+        self, block: bool = True, timeout: Union[float, None] = None
+    ) -> T: ...
+    def put(
+        self, obj: T, /, block: bool = True, timeout: Union[float, None] = None
+    ) -> None: ...
+    def get_nowait(self) -> T: ...
+    def put_nowait(self, item: T, /) -> None: ...
+    def empty(self) -> bool: ...


### PR DESCRIPTION
This change shifts the typing model for `QueueType` from nominal subtyping to structural subtyping. Instead of using a nominal union type (`mp.Queue[T] | queue.Queue[T]`), we define a structural interface via `typing.Protocol[T]`.

The union approach ties type checking to specific classes, even though they expose nearly identical APIs. By introducing a `Protocol`, we specify the minimal structural contract marimo relies on. Any object implementing that contract is valid (including custom queue-like implementations (e.g., a ZeroMQ wrapper) or stubs in marimo-lsp).
