### PR TITLE
fix(mcp-server): create dataclass wrapper for VariableValue to resolve Pydantic compatibility

### DIFF
--- a/marimo/_mcp/server/tools/cells.py
+++ b/marimo/_mcp/server/tools/cells.py
@@ -11,7 +11,6 @@ from marimo._mcp.server.exceptions import ToolExecutionError
 from marimo._mcp.server.responses import (
     SuccessResult,
 )
-from marimo._messaging.ops import VariableValue
 from marimo._server.api.deps import AppStateBase
 from marimo._types.ids import CellId_t, SessionId
 
@@ -69,7 +68,14 @@ class CellRuntimeMetadata:
     execution_time: Optional[float]
 
 
-CellVariables = dict[str, VariableValue]
+@dataclass(kw_only=True)
+class CellVariableValue:
+    name: str
+    value: Optional[str] = None
+    datatype: Optional[str] = None
+
+
+CellVariables = dict[str, CellVariableValue]
 
 
 @dataclass(kw_only=True)
@@ -407,6 +413,11 @@ def _get_cell_variables(
     for var_name in cell_defs:
         if var_name in all_variables:
             var_value = all_variables[var_name]
-            cell_variables[var_name] = var_value
+            # Convert VariableValue to pydantic parsable dataclass
+            cell_variables[var_name] = CellVariableValue(
+                name=var_name,
+                value=var_value.value,
+                datatype=var_value.datatype,
+            )
 
     return cell_variables

--- a/tests/_mcp/server/tools/test_cells.py
+++ b/tests/_mcp/server/tools/test_cells.py
@@ -12,6 +12,7 @@ from marimo._mcp.server.tools.cells import (
     CellErrors,
     CellRuntimeMetadata,
     CellVariables,
+    CellVariableValue,
     SupportedCellType,
     _determine_cell_type,
     _get_cell_errors,
@@ -241,7 +242,14 @@ def test_get_cell_variables_with_variables():
 
     result = _get_cell_variables(session, cell_data)
 
-    expected: CellVariables = {"x": var_x, "y": var_y}
+    expected: CellVariables = {
+        "x": CellVariableValue(
+            name="x", value=var_x.value, datatype=var_x.datatype
+        ),
+        "y": CellVariableValue(
+            name="y", value=var_y.value, datatype=var_y.datatype
+        ),
+    }
     assert result == expected
     assert (
         "z" not in result
@@ -262,5 +270,9 @@ def test_get_cell_variables_missing_variables():
     result = _get_cell_variables(session, cell_data)
 
     # Should only include variables that exist in session
-    expected: CellVariables = {"x": var_x}
+    expected: CellVariables = {
+        "x": CellVariableValue(
+            name="x", value=var_x.value, datatype=var_x.datatype
+        )
+    }
     assert result == expected


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

During migration of the mcp-server from TypedDict to dataclass `VariableValue` caused a pydantic parsing error due to `mgspec.Struct` not being a pydantic-compatible type. I resolved this by creating a type called `CellVariableValue` that mirrors `VariableValue` but is pydantic-compatible.



<img width="834" height="363" alt="Screenshot 2025-09-06 at 12 38 18 AM" src="https://github.com/user-attachments/assets/831639e3-09ff-4cc8-b460-2b81b5d1303b" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
