### PR TITLE
set sql footer's background colour and border color

### DIFF
--- a/frontend/src/core/codemirror/theme/dark.ts
+++ b/frontend/src/core/codemirror/theme/dark.ts
@@ -8,7 +8,7 @@ export const darkTheme = [
   createTheme({
     variant: "dark",
     settings: {
-      background: "#282c34",
+      background: "var(--cm-background)",
       foreground: "#abb2bf",
       caret: "#528bff",
       selection: "#3E4451",

--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -67,7 +67,7 @@
 /* -- Panels -- */
 
 .cm .cm-panels {
-  background: transparent;
+  background-color: var(--cm-background);
   color: var(--sky-11);
   font-weight: 700;
 

--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -75,6 +75,10 @@
   margin-right: 30px;
 
   @apply text-xs;
+
+  &.cm-panels-bottom {
+    border-top: 1px solid var(--border);
+  }
 }
 
 /* -- Linting -- */

--- a/frontend/src/css/globals.css
+++ b/frontend/src/css/globals.css
@@ -103,6 +103,9 @@
       hsl(0deg 0% 50% / 60%)
     );
     --base-shadow-opacity: 5%;
+
+    /* Codemirror editor */
+    --cm-background: light-dark(var(--background), #282c34);
   }
 
   .dark,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #6154. Adds background colour and border colour (which is not visible in dark mode)

<img width="654" height="428" alt="CleanShot 2025-09-07 at 00 20 41" src="https://github.com/user-attachments/assets/ada03127-e649-4553-821d-8e8ea102f95a" />

<img width="659" height="321" alt="CleanShot 2025-09-07 at 00 28 38" src="https://github.com/user-attachments/assets/40c4a96b-7249-47f4-a418-09a9d71fb070" />

Before border-colour:
<img width="669" height="71" alt="CleanShot 2025-09-07 at 00 33 56" src="https://github.com/user-attachments/assets/c171f0f5-b11d-4743-a177-22ba364730e8" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
