### PR TITLE
fix: ai endpoints from msgspec migration

### DIFF
--- a/marimo/_ai/_convert.py
+++ b/marimo/_ai/_convert.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import dataclasses
 import json
 import uuid
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
@@ -14,7 +15,6 @@ from marimo._ai._types import (
     TextPart,
     ToolInvocationPart,
 )
-from marimo._messaging.msgspec_encoder import asdict
 from marimo._server.ai.tools.types import Tool
 
 if TYPE_CHECKING:
@@ -109,7 +109,10 @@ def convert_to_openai_messages(
                             f"Unsupported content type {part.media_type}"
                         )
                 else:
-                    parts.append(asdict(part))
+                    if dataclasses.is_dataclass(part):
+                        parts.append(dataclasses.asdict(part))
+                    else:
+                        parts.append(cast(dict[str, Any], part))
 
         openai_messages.append({"role": message.role, "content": parts})
 

--- a/marimo/_ai/_convert.py
+++ b/marimo/_ai/_convert.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import base64
 import json
 import uuid
-from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 
 from marimo._ai._types import (
@@ -15,6 +14,7 @@ from marimo._ai._types import (
     TextPart,
     ToolInvocationPart,
 )
+from marimo._messaging.msgspec_encoder import asdict
 from marimo._server.ai.tools.types import Tool
 
 if TYPE_CHECKING:


### PR DESCRIPTION
We should cast `asdict` using our own encoder which handles both dictionaries and dataclasses