### PR TITLE
Dm/lint

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import ast
 import base64
 import inspect
 import sys
@@ -25,6 +24,7 @@ from typing import (
 from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell_id import external_prefix
 from marimo._ast.variables import BUILTINS
+from marimo._ast.parse import ast_parse
 from marimo._convert.converters import MarimoConvert
 from marimo._schemas.serialization import (
     AppInstantiation,
@@ -530,7 +530,7 @@ class App:
             errors: list[str] = []
             for code in self._unparsable_code:
                 try:
-                    ast.parse(dedent(code))
+                    ast_parse(dedent(code))
                 except SyntaxError as e:
                     error_line = e.text
                     error_marker: str = (

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 import msgspec
 
 from marimo import _loggers
+from marimo._ast.parse import ast_parse
 from marimo._ast.sql_visitor import SQLRef, SQLVisitor
 from marimo._ast.visitor import ImportData, Language, Name, VariableData
 from marimo._messaging.msgspec_encoder import asdict
@@ -220,7 +221,7 @@ class CellImpl:
     def _get_sqls(self, raw: bool = False) -> list[str]:
         try:
             visitor = SQLVisitor(raw=raw)
-            visitor.visit(ast.parse(self.code))
+            visitor.visit(ast_parse(self.code))
             return visitor.get_sqls()
         except Exception:
             return []
@@ -293,7 +294,7 @@ class CellImpl:
     def toplevel_variable(self) -> Optional[VariableData]:
         """Return the single, scoped, toplevel variable defined if found."""
         try:
-            tree = ast.parse(self.code)
+            tree = ast_parse(self.code)
         except SyntaxError:
             return None
 

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -13,6 +13,7 @@ from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
 from marimo._ast.names import DEFAULT_CELL_NAME, SETUP_CELL_NAME
+from marimo._ast.parse import ast_parse
 from marimo._ast.toplevel import TopLevelExtraction, TopLevelStatus
 from marimo._ast.variables import BUILTINS
 from marimo._ast.visitor import Name, VariableData
@@ -450,7 +451,7 @@ def get_header_comments(filename: str | Path) -> Optional[str]:
     # Ensure the header only contains non-executable code
     # ast parses out single line comments, so we only
     # need to check that every node is not a multiline comment
-    module = ast.parse(header)
+    module = ast_parse(header)
     if any(not is_multiline_comment(node) for node in module.body):
         return None
 

--- a/marimo/_ast/load.py
+++ b/marimo/_ast/load.py
@@ -5,6 +5,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from typing import Literal, Optional, Union
+from dataclasses import dataclass
 
 from marimo import _loggers
 from marimo._ast.app import App, InternalApp
@@ -14,6 +15,8 @@ from marimo._ast.parse import (
     parse_notebook,
 )
 from marimo._schemas.serialization import NotebookSerialization, UnparsableCell
+from marimo._ast.parse import MarimoFileError, parse_notebook
+from marimo._schemas.serialization import UnparsableCell, NotebookSerialization
 
 LOGGER = _loggers.marimo_logger()
 
@@ -27,7 +30,11 @@ LOGGER = _loggers.marimo_logger()
 # However for "managed" marimo (i.e. run/ edit), the expectation is to not fail
 # on startup and defer errors to the runtime.
 
-NotebookStatus = Literal["empty", "has_errors", "invalid", "valid"]
+
+@dataclass
+class LoadResult:
+    status: Literal["empty", "has_errors", "invalid", "valid"] = "empty"
+    notebook: Optional[NotebookSerialization] = None
 
 
 def _maybe_contents(filename: Optional[Union[str, Path]]) -> Optional[str]:
@@ -69,7 +76,7 @@ def _static_load(filepath: Path) -> Optional[App]:
     if not contents:
         return None
 
-    notebook = parse_notebook(contents)
+    notebook = parse_notebook(contents, filepath=str(filepath))
 
     if notebook and is_non_marimo_python_script(notebook):
         # Should fail instead of overriding contents
@@ -80,7 +87,13 @@ def _static_load(filepath: Path) -> Optional[App]:
     if notebook is None or not notebook.valid:
         return None
 
-    app = App(**notebook.app.options, _filename=str(filepath))
+    return load_notebook_ir(notebook, filepath=str(filepath))
+
+
+def load_notebook_ir(
+    notebook: NotebookSerialization, filepath: Optional[str] = None
+) -> App:
+    app = App(**notebook.app.options, _filename=filepath)
     for cell in notebook.cells:
         if isinstance(cell, UnparsableCell):
             app._unparsable_cell(cell.code, **cell.options)
@@ -89,7 +102,42 @@ def _static_load(filepath: Path) -> Optional[App]:
     return app
 
 
-def get_notebook_status(filename: str) -> NotebookStatus:
+def load_notebook(filename: Optional[str]) -> Optional[NotebookSerialization]:
+    """Load and return notebook serialization from a marimo notebook file.
+
+    Args:
+        filename: Path to a marimo notebook file (.py or .md)
+
+    Returns:
+        NotebookSerialization if the file exists and contains valid code,
+        None if the file is empty or contains only comments.
+
+    Raises:
+        MarimoFileError: If the file exists but doesn't define a valid marimo app
+        RuntimeError: If there are issues loading the module
+        SyntaxError: If the file contains a syntax error
+        FileNotFoundError: If the file doesn't exist
+    """
+    path = Path(filename)
+
+    contents = _maybe_contents(filename)
+    if not contents:
+        return True
+
+    if path.suffix in (".md", ".qmd"):
+        from marimo._convert.markdown.markdown import (
+            convert_from_md_to_marimo_ir,
+        )
+
+        return convert_from_md_to_marimo_ir(contents)
+
+    if path.suffix == ".py":
+        return parse_notebook(contents)
+
+    raise MarimoFileError("File must end with .py, .md, or .qmd.")
+
+
+def get_notebook_status(filename: str) -> LoadResult:
     """Attempts to parse an app- should raise SyntaxError on failure.
 
     Args:
@@ -105,7 +153,7 @@ def get_notebook_status(filename: str) -> NotebookStatus:
 
     contents = _maybe_contents(filename)
     if not contents:
-        return "empty"
+        return LoadResult(status="empty")
 
     notebook: Optional[NotebookSerialization] = None
     if path.suffix in (".md", ".qmd"):
@@ -121,16 +169,16 @@ def get_notebook_status(filename: str) -> NotebookStatus:
 
     # NB. A invalid notebook can still be opened.
     if notebook is None:
-        return "empty"
+        return LoadResult(status="empty")
     if not notebook.valid:
-        return "invalid"
+        return LoadResult(status="invalid", notebook=notebook)
     if len(notebook.violations) > 0:
         LOGGER.debug(
             "Notebook has violations: \n%s",
             "\n".join(map(repr, notebook.violations)),
         )
-        return "has_errors"
-    return "valid"
+        return LoadResult(status="has_errors", notebook=notebook)
+    return LoadResult(status="valid", notebook=notebook)
 
 
 def load_app(filename: Optional[str]) -> Optional[App]:

--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -422,14 +422,14 @@ class Parser:
                 if node.names[0].asname:
                     violations.append(
                         Violation(
-                            "`marimo` is typically not imported with an alias. ",
+                            MARIMO_ALIAS_VIOLATION,
                             node.lineno,
                         )
                     )
                 return ParseResult(node, violations=violations)
             violations.append(
                 Violation(
-                    "Unexpected statement (expected marimo import)",
+                    UNEXPECTED_STATEMENT_MARIMO_IMPORT_VIOLATION,
                     lineno=node.lineno,
                 )
             )
@@ -446,7 +446,7 @@ class Parser:
             lineno = node.lineno if node else 0
             violations.append(
                 Violation(
-                    "Expected `__generated_with` assignment for marimo version number.",
+                    EXPECTED_GENERATED_WITH_VIOLATION,
                     lineno=lineno,
                 )
             )
@@ -474,7 +474,7 @@ class Parser:
                 )
             violations.append(
                 Violation(
-                    "Unexpected statement, expected App initialization.",
+                    UNEXPECTED_STATEMENT_APP_INIT_VIOLATION,
                     node.lineno,
                 )
             )
@@ -495,7 +495,7 @@ class Parser:
                 return ParseResult(violations=violations)
             violations.append(
                 Violation(
-                    "Unexpected statement, expected cell definitions.",
+                    UNEXPECTED_STATEMENT_CELL_DEF_VIOLATION,
                     node.lineno,
                 )
             )
@@ -521,7 +521,7 @@ class Parser:
             else:
                 violations.append(
                     Violation(
-                        "Unexpected statement, expected body cell definition.",
+                        UNEXPECTED_STATEMENT_BODY_CELL_VIOLATION,
                         node.lineno,
                     )
                 )
@@ -602,7 +602,7 @@ def _eval_kwargs(
         else:
             violations.append(
                 Violation(
-                    "Unexpected value for keyword argument",
+                    UNEXPECTED_KEYWORD_VALUE_VIOLATION,
                     lineno=kw.lineno,
                     col_offset=kw.col_offset,
                 )
@@ -877,7 +877,7 @@ def parse_notebook(
     if not (import_result := parser.parse_import(body)):
         violations.append(
             Violation(
-                "Only able to extract header.",
+                ONLY_HEADER_EXTRACTED_VIOLATION,
                 lineno=1,
             )
         )
@@ -887,7 +887,7 @@ def parse_notebook(
             # just a header is fine, anything else we would ignore and override
             violations.append(
                 Violation(
-                    _non_marimo_python_script_violation_description,
+                    NON_MARIMO_PYTHON_SCRIPT_VIOLATION,
                     lineno=header.end_lineno + 2 if header.value else 1,
                 )
             )
@@ -947,7 +947,7 @@ def parse_notebook(
 
     # Expected a run guard, but that's OK.
     if not is_run_guard(body.last):
-        violations.append(Violation("Expected run guard statement"))
+        violations.append(Violation(EXPECTED_RUN_GUARD_VIOLATION))
 
     return NotebookSerialization(
         header=header,
@@ -958,13 +958,31 @@ def parse_notebook(
     )
 
 
-_non_marimo_python_script_violation_description = (
-    "non-marimo Python content beyond header"
+# Violation message constants
+MARIMO_ALIAS_VIOLATION = "`marimo` is typically not imported with an alias. "
+UNEXPECTED_STATEMENT_MARIMO_IMPORT_VIOLATION = (
+    "Unexpected statement (expected marimo import)"
 )
+EXPECTED_GENERATED_WITH_VIOLATION = (
+    "Expected `__generated_with` assignment for marimo version number."
+)
+UNEXPECTED_STATEMENT_APP_INIT_VIOLATION = (
+    "Unexpected statement, expected App initialization."
+)
+UNEXPECTED_STATEMENT_CELL_DEF_VIOLATION = (
+    "Unexpected statement, expected cell definitions."
+)
+UNEXPECTED_STATEMENT_BODY_CELL_VIOLATION = (
+    "Unexpected statement, expected body cell definition."
+)
+UNEXPECTED_KEYWORD_VALUE_VIOLATION = "Unexpected value for keyword argument"
+ONLY_HEADER_EXTRACTED_VIOLATION = "Only able to extract header."
+NON_MARIMO_PYTHON_SCRIPT_VIOLATION = "non-marimo Python content beyond header"
+EXPECTED_RUN_GUARD_VIOLATION = "Expected run guard statement"
 
 
 def is_non_marimo_python_script(notebook: NotebookSerialization) -> bool:
     return any(
-        (v.description == _non_marimo_python_script_violation_description)
+        (v.description == NON_MARIMO_PYTHON_SCRIPT_VIOLATION)
         for v in notebook.violations
     )

--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeVar, cast
 
 from marimo._ast.cell import Cell
+from marimo._ast.parse import ast_parse
 from marimo._runtime.context import ContextNotInitializedError, get_context
 
 if TYPE_CHECKING:
@@ -42,7 +43,7 @@ def build_stub_fn(
 ) -> Callable[..., Any]:
     # Avoid declaring the function in the global scope, since it may cause
     # issues with meta-analysis tools like cxfreeze (see #3828).
-    PYTEST_BASE = ast.parse(inspect.getsource(_pytest_scaffold))
+    PYTEST_BASE = ast_parse(inspect.getsource(_pytest_scaffold))
 
     # We modify the signature of the cell function such that pytest
     # does not attempt to use the arguments as fixtures.
@@ -99,7 +100,7 @@ def build_stub_fn(
 
 
 def wrap_fn_for_pytest(func: Fn, cell: Cell) -> Callable[..., Any]:
-    func_ast = ast.parse(inspect.getsource(func))
+    func_ast = ast_parse(inspect.getsource(func))
     func_body = func_ast.body[0]
     assert isinstance(func_body, (ast.FunctionDef, ast.AsyncFunctionDef))
 
@@ -271,7 +272,7 @@ def process_for_pytest(func: Fn, cell: Cell) -> None:
     # Turn off test for the cell itself in this case.
     cell._test_allowed = False
 
-    tree = ast.parse(inspect.getsource(func))
+    tree = ast_parse(inspect.getsource(func))
     run = functools.cache(cell.run)
 
     # Must be a unique name, otherwise won't be injected properly.

--- a/marimo/_ast/transformers.py
+++ b/marimo/_ast/transformers.py
@@ -6,6 +6,7 @@ import inspect
 import textwrap
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
+from marimo._ast.parse import ast_parse
 from marimo._ast.variables import unmangle_local
 
 if TYPE_CHECKING:
@@ -81,7 +82,7 @@ def clean_to_modules(
 def strip_function(fn: Callable[..., Any]) -> ast.Module:
     code, _ = inspect.getsourcelines(fn)
     args = set(fn.__code__.co_varnames)
-    function_ast = ast.parse(textwrap.dedent("".join(code)))
+    function_ast = ast_parse(textwrap.dedent("".join(code)))
     body = function_ast.body.pop()
     assert isinstance(body, (ast.FunctionDef, ast.AsyncFunctionDef)), (
         "Expected a function definition"
@@ -194,7 +195,7 @@ class RemoveImportTransformer(ast.NodeTransformer):
         self.import_name = import_name
 
     def strip_imports(self, code: str) -> str:
-        tree = ast.parse(code)
+        tree = ast_parse(code)
         tree = self.visit(tree)
         return ast.unparse(tree).strip()
 

--- a/marimo/_cli/print.py
+++ b/marimo/_cli/print.py
@@ -71,6 +71,13 @@ def red(text: str, bold: bool = False) -> str:
     return prefix + text + "\033[0m"
 
 
+def cyan(text: str, bold: bool = False) -> str:
+    if not _USE_COLOR:
+        return text
+    prefix = "\033[94m" if not bold else "\033[1;94m"
+    return prefix + text + "\033[0m"
+
+
 def muted(text: str) -> str:
     # Use dark gray (37 is white, 2 is dim) which is more widely supported than 90
     return "\033[37;2m" + text + "\033[0m" if _USE_COLOR else text

--- a/marimo/_lint/__init__.py
+++ b/marimo/_lint/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._lint.base import LintError, LintRule, Severity
+from marimo._lint.checker import LintChecker
+from marimo._lint.formatting import GeneralFormattingRule
+from marimo._lint.runtime import (
+    MultipleDefinitionsRule,
+    CycleDependenciesRule,
+    SetupCellDependenciesRule,
+)
+from marimo._lint.breaking import UnparsableCellsRule
+from marimo._ast.parse import NotebookSerialization
+from typing import List
+
+
+def lint_notebook(notebook: NotebookSerialization) -> List[LintError]:
+    """Lint a notebook and return all errors found.
+
+    Args:
+        notebook: The notebook serialization to lint
+
+    Returns:
+        List of lint errors found in the notebook
+    """
+    checker = LintChecker.create_default()
+    return checker.check_notebook(notebook)
+
+
+__all__ = [
+    "LintError",
+    "LintRule",
+    "Severity",
+    "LintChecker",
+    "GeneralFormattingRule",
+    "MultipleDefinitionsRule",
+    "CycleDependenciesRule",
+    "SetupCellDependenciesRule",
+    "UnparsableCellsRule",
+    "lint_notebook",
+]

--- a/marimo/_lint/base.py
+++ b/marimo/_lint/base.py
@@ -1,0 +1,125 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional
+
+from marimo._types.ids import CellId_t
+from marimo._ast.parse import NotebookSerialization
+
+from marimo._cli.print import red, yellow, bold, cyan
+
+
+class Severity(Enum):
+    """Severity levels for lint errors."""
+
+    FORMATTING = "formatting"
+    RUNTIME = "runtime"
+    BREAKING = "breaking"
+
+
+def line_num(line: int) -> str:
+    """Format line number for display."""
+    return f"{line:4d}"
+
+
+@dataclass
+class LintError:
+    """Represents a lint error found in a notebook."""
+
+    code: str
+    name: str
+    message: str
+    severity: Severity
+    cell_id: list[CellId_t]
+    line: int | list[int]
+    column: int | list[int]
+    fixable: bool
+    fix: Optional[str] = None
+
+    def format(
+        self, filename: str, code_lines: list[str] | None = None
+    ) -> str:
+        """Format the error for display with code context."""
+        severity_color = {
+            Severity.FORMATTING: yellow,
+            Severity.RUNTIME: red,
+            Severity.BREAKING: red,
+        }.get(self.severity, bold)
+        severity_str = {
+            Severity.FORMATTING: "warning",
+            Severity.RUNTIME: "error",
+            Severity.BREAKING: "critical",
+        }.get(self.severity, "info")
+
+        lines = self.line if isinstance(self.line, list) else [self.line]
+        columns = (
+            self.column if isinstance(self.column, list) else [self.column]
+        )
+
+        location = (
+            f"{filename}:{lines[0]}:{columns[0]}"
+            if max(lines + [0]) > 0
+            else filename
+        )
+        header = f"{bold(severity_color(severity_str + '[' + self.name + ']'))}: {bold(self.message)}"
+        header += "\n" + cyan(" --> ") + cyan(location)
+
+        if code_lines is None or not self.line:
+            return header
+
+        context_lines = []
+        previous_line = -1
+        for line, column in sorted(zip(lines, columns)):
+            # Show context: 1 line above, current line, 1 line below
+            start_line = max(1, line - 1)
+            end_line = min(len(code_lines), line + 1)
+            if previous_line != -1 and start_line > previous_line + 2:
+                context_lines.append("   ...")
+
+            for i in range(start_line, end_line + 1):
+                line_content = (
+                    code_lines[i - 1] if i <= len(code_lines) else ""
+                )
+                line_num = cyan(f"{i:4d} |")
+
+                if i == line + 1:
+                    # Current line with error indicator
+                    context_lines.append(f"{line_num} {line_content}")
+                    # Add error indicator line
+                    indicator = " " * 5 + " " * (column - 2) + red("^" * 1)
+                    context_lines.append(f"     {cyan('|')}{indicator}")
+                else:
+                    context_lines.append(f"{line_num} {line_content}")
+            previous_line = end_line
+
+        if self.fix:
+            context_lines.append(
+                cyan("info: ") + bold(self.fix)
+            )
+        return f"{header}\n" + "\n".join(context_lines)
+
+
+class LintRule(ABC):
+    """Base class for lint rules."""
+
+    def __init__(
+        self,
+        code: str,
+        name: str,
+        description: str,
+        severity: Severity,
+        fixable: bool,
+    ):
+        self.code = code
+        self.name = name
+        self.description = description
+        self.severity = severity
+        self.fixable = fixable
+
+    @abstractmethod
+    def check(self, notebook: NotebookSerialization) -> List[LintError]:
+        """Check notebook for violations of this rule."""
+        pass

--- a/marimo/_lint/breaking.py
+++ b/marimo/_lint/breaking.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import List
+
+from marimo._lint.base import LintError, LintRule, Severity
+from marimo._ast.parse import NotebookSerialization
+from marimo._schemas.serialization import UnparsableCell
+
+
+class UnparsableCellsRule(LintRule):
+    """MB001: Cell contains unparseable code."""
+
+    def __init__(self):
+        super().__init__(
+            code="MB001",
+            name="unparsable-cells",
+            description="Cell contains unparseable code",
+            severity=Severity.BREAKING,
+            fixable=False,
+        )
+
+    def check(self, notebook: NotebookSerialization) -> List[LintError]:
+        """Check for unparsable cells."""
+        errors = []
+
+        for cell in notebook.cells:
+            if isinstance(cell, UnparsableCell):  # Unparsable cell
+                # Try to find the line number of the error
+                line_num = cell.lineno
+                col_num = cell.col_offset
+
+                errors.append(
+                    LintError(
+                        code=self.code,
+                        name=self.name,
+                        message=f"Notebook contains unparseable code",
+                        severity=self.severity,
+                        cell_id=None,  # CellDef doesn't have cell_id
+                        line=line_num,
+                        column=col_num,
+                        fixable=False,
+                    )
+                )
+
+        return errors

--- a/marimo/_lint/checker.py
+++ b/marimo/_lint/checker.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import List
+
+from marimo._lint.base import LintError, LintRule, Severity
+from marimo._ast.parse import NotebookSerialization
+
+
+class LintChecker:
+    """Orchestrates lint rules and provides checking and fixing functionality."""
+
+    def __init__(self, rules: List[LintRule]):
+        self.rules = rules
+
+    def check_notebook(
+        self, notebook: NotebookSerialization
+    ) -> List[LintError]:
+        """Check notebook for all lint rule violations."""
+        errors = []
+
+        for rule in self.rules:
+            rule_errors = rule.check(notebook)
+            errors.extend(rule_errors)
+
+        return errors
+
+    @classmethod
+    def create_default(cls) -> LintChecker:
+        """Create a LintChecker with all default rules."""
+        from marimo._lint.formatting import GeneralFormattingRule
+        from marimo._lint.runtime import (
+            MultipleDefinitionsRule,
+            CycleDependenciesRule,
+            SetupCellDependenciesRule,
+        )
+        from marimo._lint.breaking import UnparsableCellsRule
+
+        rules = [
+            GeneralFormattingRule(),
+            MultipleDefinitionsRule(),
+            CycleDependenciesRule(),
+            SetupCellDependenciesRule(),
+            UnparsableCellsRule(),
+        ]
+
+        return cls(rules)

--- a/marimo/_lint/formatting.py
+++ b/marimo/_lint/formatting.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
+import re
+from typing import List
+
+from marimo._lint.base import LintError, LintRule, Severity
+from marimo._ast.parse import NotebookSerialization
+
+
+class GeneralFormattingRule(LintRule):
+    """MF001: General formatting issues."""
+
+    def __init__(self):
+        super().__init__(
+            code="MF001",
+            name="general-formatting",
+            description="General formatting issues (trailing whitespace, inconsistent spacing)",
+            severity=Severity.FORMATTING,
+            fixable=True,
+        )
+
+    def check(self, notebook: NotebookSerialization) -> List[LintError]:
+        """Check for general formatting issues by extracting violations from serialization."""
+        errors = []
+
+        # Import the violation constants to check for specific types
+        from marimo._ast.parse import (
+            UNEXPECTED_STATEMENT_CELL_DEF_VIOLATION,
+            UNEXPECTED_STATEMENT_MARIMO_IMPORT_VIOLATION,
+            EXPECTED_GENERATED_WITH_VIOLATION,
+            UNEXPECTED_STATEMENT_APP_INIT_VIOLATION,
+        )
+
+        # Extract violations from the notebook serialization
+        for violation in notebook.violations:
+            # Determine if this violation is fixable
+            is_fixable = violation.description in [
+                UNEXPECTED_STATEMENT_CELL_DEF_VIOLATION,
+                UNEXPECTED_STATEMENT_MARIMO_IMPORT_VIOLATION,
+                EXPECTED_GENERATED_WITH_VIOLATION,
+                UNEXPECTED_STATEMENT_APP_INIT_VIOLATION,
+            ]
+
+            # Convert Violation to LintError
+            errors.append(
+                LintError(
+                    code=self.code,
+                    name=self.name,
+                    message=violation.description,
+                    severity=self.severity,
+                    cell_id=[],  # Violations don't have cell_id
+                    line=violation.lineno,
+                    column=violation.col_offset
+                    + 1,  # Convert 0-based to 1-based
+                    fixable=is_fixable,
+                )
+            )
+
+        return errors

--- a/marimo/_lint/runtime.py
+++ b/marimo/_lint/runtime.py
@@ -1,0 +1,364 @@
+# Copyright 2025 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import List, Optional
+from abc import abstractmethod
+
+from marimo._lint.base import LintError, LintRule, Severity
+from marimo._lint.validate_graph import (
+    check_for_multiple_definitions,
+    check_for_cycles,
+    check_for_invalid_root,
+)
+from marimo._lint.visitors import VariableLineVisitor
+from marimo._utils.cell_matching import match_cell_ids_by_similarity
+from marimo._ast.parse import NotebookSerialization, ast_parse
+from marimo._ast.load import load_notebook_ir
+
+
+class GraphRule(LintRule):
+    """Base class for graph-based lint rules that analyze the dependency graph.
+
+    This class provides the foundation for runtime lint rules that need to analyze
+    the cell dependency graph to detect issues like cycles, multiple definitions,
+    and setup cell violations. These rules ensure marimo's core constraints are
+    maintained for reproducible, executable notebooks.
+
+    The dependency graph represents how cells depend on each other through variable
+    definitions and references. marimo uses this graph to determine execution order
+    and enforce constraints that make notebooks reliable and shareable.
+
+    See also:
+        - https://docs.marimo.io/guides/understanding_errors/ (Understanding errors)
+        - https://docs.marimo.io/guides/editor_features/understanding_dataflow/ (Dataflow)
+    """
+
+    def __init__(
+        self,
+        code: str,
+        name: str,
+        description: str,
+        severity: Severity,
+        fixable: bool = False,
+    ):
+        super().__init__(code, name, description, severity, fixable)
+
+    def _get_graph(self, notebook: NotebookSerialization):
+        """Get the dependency graph from the notebook."""
+        app = load_notebook_ir(notebook)
+        graph = app._graph
+
+        # Initialize the app to register cells in the graph
+        # Add cells to graph
+        for cell_id, cell in app._cell_manager.valid_cells():
+            graph.register_cell(cell_id, cell._cell)
+        # app._maybe_initialize()
+        return app._graph
+
+    def _get_cell_from_id(self, cell_id: str, notebook: NotebookSerialization):
+        """Get the corresponding CellDef from notebook serialization for a given cell_id."""
+        # For setup cells, use the special setup cell name
+        if cell_id == "setup":
+            for cell in notebook.cells:
+                if cell.name == "setup":
+                    return cell
+            return None
+
+        # Use cell matching to map graph cell IDs to notebook cells
+        graph = self._get_graph(notebook)
+
+        # Build code mappings for cell matching using position numbers
+        graph_codes = {
+            cid: cell.code
+            for cid, cell in graph.cells.items()
+            if cid != "setup"
+        }
+        notebook_codes = {
+            str(i): cell.code
+            for i, cell in enumerate(notebook.cells)
+            if cell.name != "setup"
+        }
+
+        # Match cell IDs using the existing cell matching system
+        cell_mapping = match_cell_ids_by_similarity(
+            graph_codes, notebook_codes
+        )
+
+        # Find the notebook cell that matches this graph cell_id
+        if cell_id in cell_mapping:
+            notebook_position = cell_mapping[cell_id]
+            # Get the cell at the matched position
+            non_setup_cells = [
+                cell for cell in notebook.cells if cell.name != "setup"
+            ]
+            position = int(notebook_position)
+            if 0 <= position < len(non_setup_cells):
+                return non_setup_cells[position]
+
+        return None
+
+    def _get_variable_line_info(
+        self, cell_id: str, variable_name: str, notebook: NotebookSerialization
+    ) -> tuple[int, int]:
+        """Get line and column info for a specific variable within a cell."""
+        target_cell = self._get_cell_from_id(cell_id, notebook)
+
+        if target_cell:
+            # Parse the cell code to find the variable definition
+            tree = ast_parse(target_cell.code)
+            visitor = VariableLineVisitor(variable_name)
+            visitor.visit(tree)
+            if visitor.line_number:
+                return (
+                    target_cell.lineno + visitor.line_number - 1,
+                    target_cell.col_offset + visitor.column_number,
+                )
+            # Fallback to cell line info
+            return target_cell.lineno, target_cell.col_offset + 1
+
+        # Fallback to (0, 0) to indicate unknown line/column
+        return 0, 0
+
+    def check(self, notebook: NotebookSerialization) -> List[LintError]:
+        """Perform graph-based validation.
+
+        Args:
+            notebook: The notebook to check
+
+        Returns:
+            List of LintError objects
+        """
+        # Get the graph using the base class method
+        graph = self._get_graph(notebook)
+
+        # Call the specific validation method
+        return self._validate_graph(graph, notebook)
+
+    @abstractmethod
+    def _validate_graph(
+        self, graph, notebook: NotebookSerialization
+    ) -> List[LintError]:
+        """Abstract method to validate the graph and return LintError objects.
+
+        Args:
+            graph: The dependency graph to validate
+            notebook: The notebook serialization for cell information
+
+        Returns:
+            List of LintError objects
+        """
+        pass
+
+
+class MultipleDefinitionsRule(GraphRule):
+    """MR001: Multiple cells define the same variable.
+
+    marimo requires that each variable be defined in only one cell. This constraint
+    ensures that notebooks are reproducible, executable as scripts, and shareable
+    as web apps with better performance than streamlit.
+
+    When a variable is defined in multiple cells, marimo cannot determine which
+    definition to use, leading to unpredictable behavior and hidden bugs.
+
+    See also:
+        - https://docs.marimo.io/guides/understanding_errors/multiple_definitions/
+        - https://docs.marimo.io/guides/understanding_errors/ (Understanding errors)
+
+    Examples:
+        Violation:
+            Cell 1: x = 1
+            Cell 2: x = 2  # Error: x defined in multiple cells
+
+        Solution:
+            Cell 1: x = 1
+            Cell 2: y = 2  # Use different variable name
+    """
+
+    def __init__(self):
+        super().__init__(
+            code="MR001",
+            name="multiple-definitions",
+            description="Multiple cells define the same variable",
+            severity=Severity.RUNTIME,
+            fixable=False,
+        )
+
+    def _validate_graph(
+        self, graph, notebook: NotebookSerialization
+    ) -> List[LintError]:
+        """Validate the graph for multiple definitions."""
+        errors = []
+        validation_errors = check_for_multiple_definitions(graph)
+
+        names = {}
+        for cell_id, error_list in validation_errors.items():
+            for error in error_list:
+                # Get specific line info for the variable definition
+                line, column = self._get_variable_line_info(
+                    cell_id, error.name, notebook
+                )
+                names.setdefault(error.name, []).append(
+                    {"cell_id": cell_id, "line": line, "column": column}
+                )
+
+        for name in names:
+            lines = [info["line"] for info in names[name]]
+            columns = [info["column"] for info in names[name]]
+            cell_id = [info["cell_id"] for info in names[name]]
+            errors.append(
+                LintError(
+                    code=self.code,
+                    name=self.name,
+                    message=f"Variable '{name}' is defined in multiple cells",
+                    severity=self.severity,
+                    cell_id=cell_id,
+                    line=lines,
+                    column=columns,
+                    fixable=self.fixable,
+                    fix=("Variables must be unique across cells. Alternatively, "
+                    f"they can be private with an underscore prefix (i.e. `_{name}`.)")
+                )
+            )
+
+        return errors
+
+
+class CycleDependenciesRule(GraphRule):
+    """MR002: Cells have circular dependencies.
+
+    marimo prevents circular dependencies between cells to ensure a well-defined
+    execution order. If cell A declares variable 'a' and reads variable 'b', then
+    cell B cannot declare 'b' and read 'a' without creating a cycle.
+
+    Cycles make notebooks non-reproducible and prevent marimo from determining
+    the correct execution order, leading to undefined behavior.
+
+    See also:
+        - https://docs.marimo.io/guides/understanding_errors/cycles/
+        - https://docs.marimo.io/guides/understanding_errors/ (Understanding errors)
+
+    Examples:
+        Violation:
+            Cell 1: a = b + 1  # Reads b
+            Cell 2: b = a + 1  # Reads a -> Cycle!
+
+        Solution:
+            Cell 1: a = 1
+            Cell 2: b = a + 1  # Unidirectional dependency
+    """
+
+    def __init__(self):
+        super().__init__(
+            code="MR002",
+            name="cycle-dependencies",
+            description="Cells have circular dependencies",
+            severity=Severity.RUNTIME,
+            fixable=False,
+        )
+
+    def _validate_graph(
+        self, graph, notebook: NotebookSerialization
+    ) -> List[LintError]:
+        """Validate the graph for circular dependencies."""
+        errors = []
+        validation_errors = check_for_cycles(graph)
+
+        seen = set()
+        for cell_id, error_list in validation_errors.items():
+            for error in error_list:
+                if error.edges_with_vars in seen:
+                    continue
+                seen.add(error.edges_with_vars)
+
+                cells = []
+                lines = []
+                columns = []
+                for cell_id, vars, _ in error.edges_with_vars:
+                    # Get cell from notebook serialization
+                    for v in vars:
+                        line, column = self._get_variable_line_info(
+                            cell_id, v, notebook
+                        )
+                        cells.append(cell_id)
+                        lines.append(line)
+                        columns.append(column)
+
+                errors.append(
+                    LintError(
+                        code=self.code,
+                        name=self.name,
+                        message="Cell is part of a circular dependency",
+                        severity=self.severity,
+                        cell_id=cells,
+                        line=lines,
+                        column=columns,
+                        fixable=self.fixable,
+                    )
+                )
+
+        return errors
+
+
+class SetupCellDependenciesRule(GraphRule):
+    """MR003: Setup cell cannot have dependencies.
+
+    The setup cell in marimo is special - it runs first and can define variables
+    that are available to all other cells. However, the setup cell itself cannot
+    depend on variables defined in other cells, as this would create a dependency
+    cycle and violate marimo's execution model.
+
+    The setup cell is designed for imports, configuration, and other initialization
+    code that should run before any other cells execute.
+
+    See also:
+        - https://docs.marimo.io/guides/understanding_errors/setup/
+        - https://docs.marimo.io/guides/understanding_errors/ (Understanding errors)
+
+    Examples:
+        Violation:
+            Setup cell: y = x + 1  # Error: setup depends on other cells
+            Cell 1: x = 1
+
+        Solution:
+            Setup cell: y = 1  # Setup defines its own variables
+            Cell 1: x = y + 1  # Other cells can use setup variables
+    """
+
+    def __init__(self):
+        super().__init__(
+            code="MR003",
+            name="setup-cell-dependencies",
+            description="Setup cell cannot have dependencies",
+            severity=Severity.RUNTIME,
+            fixable=False,
+        )
+
+    def _validate_graph(
+        self, graph, notebook: NotebookSerialization
+    ) -> List[LintError]:
+        """Validate the graph for setup cell dependency violations."""
+        errors = []
+        validation_errors = check_for_invalid_root(graph)
+
+        for cell_id, error_list in validation_errors.items():
+            for error in error_list:
+                # Get cell from notebook serialization
+                cell = self._get_cell_from_id(cell_id, notebook)
+                line, column = (
+                    (cell.lineno, cell.col_offset + 1) if cell else (0, 0)
+                )
+
+                errors.append(
+                    LintError(
+                        code=self.code,
+                        name=self.name,
+                        message="Setup cell cannot have dependencies",
+                        severity=self.severity,
+                        cell_id=cell_id,
+                        line=line,
+                        column=column,
+                        fixable=self.fixable,
+                    )
+                )
+
+        return errors

--- a/marimo/_lint/validate_graph.py
+++ b/marimo/_lint/validate_graph.py
@@ -15,6 +15,37 @@ from marimo._runtime.dataflow import DirectedGraph
 from marimo._types.ids import CellId_t
 
 
+def check_for_errors(
+    graph: DirectedGraph,
+) -> dict[CellId_t, tuple[Error, ...]]:
+    """
+    Check graph for violations of marimo semantics.
+
+    Return a dict of errors in the graph, with an entry for each cell
+    that is involved in an error.
+    """
+    multiple_definition_errors = check_for_multiple_definitions(graph)
+    cycle_errors = check_for_cycles(graph)
+    invalid_root_errors = check_for_invalid_root(graph)
+
+    errors: dict[CellId_t, tuple[Error, ...]] = {}
+    for cid in set(
+        itertools.chain(
+            multiple_definition_errors.keys(),
+            cycle_errors.keys(),
+            invalid_root_errors.keys(),
+        )
+    ):
+        errors[cid] = tuple(
+            itertools.chain(
+                multiple_definition_errors[cid],
+                cycle_errors[cid],
+                invalid_root_errors[cid],
+            )
+        )
+    return errors
+
+
 def check_for_multiple_definitions(
     graph: DirectedGraph,
 ) -> dict[CellId_t, list[MultipleDefinitionError]]:
@@ -53,9 +84,9 @@ def check_for_invalid_root(
             )
             for ancestor in ancestors
             if (
-                deps := sorted(
+                deps := tuple(sorted(
                     graph.cells[ancestor].defs & graph.cells[setup_id].refs
-                )
+                ))
             )
         )
         errors[setup_id].append(
@@ -77,15 +108,17 @@ def check_for_cycles(graph: DirectedGraph) -> dict[CellId_t, list[CycleError]]:
         cycle_with_vars = tuple(
             (
                 edge[0],
-                sorted(
-                    set(
-                        list(
-                            graph.cells[edge[0]].defs
-                            & graph.cells[edge[1]].refs
-                        )
-                        + list(
-                            graph.cells[edge[0]].refs
-                            & graph.cells[edge[1]].deleted_refs
+                tuple(
+                    sorted(
+                        set(
+                            list(
+                                graph.cells[edge[0]].defs
+                                & graph.cells[edge[1]].refs
+                            )
+                            + list(
+                                graph.cells[edge[0]].refs
+                                & graph.cells[edge[1]].deleted_refs
+                            )
                         )
                     )
                 ),
@@ -95,35 +128,4 @@ def check_for_cycles(graph: DirectedGraph) -> dict[CellId_t, list[CycleError]]:
         )
         for cid in nodes_in_cycle:
             errors[cid].append(CycleError(edges_with_vars=cycle_with_vars))
-    return errors
-
-
-def check_for_errors(
-    graph: DirectedGraph,
-) -> dict[CellId_t, tuple[Error, ...]]:
-    """
-    Check graph for violations of marimo semantics.
-
-    Return a dict of errors in the graph, with an entry for each cell
-    that is involved in an error.
-    """
-    multiple_definition_errors = check_for_multiple_definitions(graph)
-    cycle_errors = check_for_cycles(graph)
-    invalid_root_errors = check_for_invalid_root(graph)
-
-    errors: dict[CellId_t, tuple[Error, ...]] = {}
-    for cid in set(
-        itertools.chain(
-            multiple_definition_errors.keys(),
-            cycle_errors.keys(),
-            invalid_root_errors.keys(),
-        )
-    ):
-        errors[cid] = tuple(
-            itertools.chain(
-                multiple_definition_errors[cid],
-                cycle_errors[cid],
-                invalid_root_errors[cid],
-            )
-        )
     return errors

--- a/marimo/_lint/visitors.py
+++ b/marimo/_lint/visitors.py
@@ -1,0 +1,40 @@
+# Copyright 2025 Marimo. All rights reserved.
+"""AST visitors for linting purposes."""
+
+import ast
+from typing import Optional
+
+
+class VariableLineVisitor(ast.NodeVisitor):
+    """AST visitor to find the line number of a variable definition."""
+
+    def __init__(self, target_variable: str):
+        self.target_variable = target_variable
+        self.line_number: Optional[int] = None
+        self.column_number: int = 1
+
+    def visit_Name(self, node: ast.Name) -> None:
+        """Visit Name nodes to find variable definitions."""
+        if node.id == self.target_variable:
+            # Check if this is a definition (not just a reference)
+            if isinstance(node.ctx, (ast.Store, ast.Del)):
+                self.line_number = node.lineno
+                self.column_number = node.col_offset + 1
+                return
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """Visit function definition nodes."""
+        if node.name == self.target_variable:
+            self.line_number = node.lineno
+            self.column_number = node.col_offset + 1
+            return
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """Visit class definition nodes."""
+        if node.name == self.target_variable:
+            self.line_number = node.lineno
+            self.column_number = node.col_offset + 1
+            return
+        self.generic_visit(node)

--- a/marimo/_runtime/dataflow.py
+++ b/marimo/_runtime/dataflow.py
@@ -30,7 +30,7 @@ Edge = tuple[CellId_t, CellId_t]
 # The first entry is the source node; the second entry is a list of defs from
 # the source read by the destination; and the third entry is the destination
 # node.
-EdgeWithVar = tuple[CellId_t, list[str], CellId_t]
+EdgeWithVar = tuple[CellId_t, tuple[str, ...], CellId_t]
 
 LOGGER = _loggers.marimo_logger()
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -165,7 +165,7 @@ from marimo._runtime.state import State
 from marimo._runtime.utils.set_ui_element_request_manager import (
     SetUIElementRequestManager,
 )
-from marimo._runtime.validate_graph import check_for_errors
+from marimo._lint.validate_graph import check_for_errors
 from marimo._runtime.win32_interrupt_handler import Win32InterruptHandler
 from marimo._secrets.load_dotenv import (
     load_dotenv_with_fallback,

--- a/tests/_ast/test_load.py
+++ b/tests/_ast/test_load.py
@@ -308,16 +308,23 @@ class TestGetCodes:
 class TestGetStatus:
     @staticmethod
     def test_get_status_valid() -> None:
-        assert load.get_notebook_status(get_filepath("test_main")) == "valid"
+        assert (
+            load.get_notebook_status(get_filepath("test_main")).status
+            == "valid"
+        )
 
     @staticmethod
     def test_get_status_empty() -> None:
-        assert load.get_notebook_status(get_filepath("test_empty")) == "empty"
+        assert (
+            load.get_notebook_status(get_filepath("test_empty")).status
+            == "empty"
+        )
 
     @staticmethod
     def test_get_status_invalid() -> None:
         assert (
-            load.get_notebook_status(get_filepath("test_invalid")) == "invalid"
+            load.get_notebook_status(get_filepath("test_invalid")).status
+            == "invalid"
         )
 
     @staticmethod
@@ -325,6 +332,6 @@ class TestGetStatus:
         assert (
             load.get_notebook_status(
                 get_filepath("test_get_codes_messy_toplevel")
-            )
+            ).status
             == "has_errors"
         )

--- a/tests/_lint/test_files/cycle_dependencies.py
+++ b/tests/_lint/test_files/cycle_dependencies.py
@@ -1,23 +1,23 @@
 import marimo
 
-__generated_with = "0.1.0"
+__generated_with = "0.15.2"
 app = marimo.App()
 
 
 @app.cell
-def __():
+def _(z):
     x = 1 + z  # This should trigger MR002 - cycle dependency
     return (x,)
 
 
 @app.cell
-def __():
+def _(x):
     y = x + 1
     return (y,)
 
 
 @app.cell
-def __():
+def _(y):
     z = y + 1
     return (z,)
 

--- a/tests/_lint/test_files/cycle_dependencies.py
+++ b/tests/_lint/test_files/cycle_dependencies.py
@@ -1,0 +1,26 @@
+import marimo
+
+__generated_with = "0.1.0"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    x = 1 + z  # This should trigger MR002 - cycle dependency
+    return (x,)
+
+
+@app.cell
+def __():
+    y = x + 1
+    return (y,)
+
+
+@app.cell
+def __():
+    z = y + 1
+    return (z,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_lint/test_files/multiple_definitions.py
+++ b/tests/_lint/test_files/multiple_definitions.py
@@ -1,0 +1,21 @@
+import marimo
+
+__generated_with = "0.1.0"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    print(1)
+    x = 1
+    return (x,)
+
+
+@app.cell
+def __():
+    x = 2  # This should trigger MR001 - multiple definitions
+    return (x,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_lint/test_files/multiple_definitions.py
+++ b/tests/_lint/test_files/multiple_definitions.py
@@ -1,20 +1,20 @@
 import marimo
 
-__generated_with = "0.1.0"
+__generated_with = "0.15.2"
 app = marimo.App()
 
 
 @app.cell
-def __():
+def _():
     print(1)
     x = 1
-    return (x,)
+    return
 
 
 @app.cell
-def __():
+def _():
     x = 2  # This should trigger MR001 - multiple definitions
-    return (x,)
+    return
 
 
 if __name__ == "__main__":

--- a/tests/_lint/test_files/setup_dependencies.py
+++ b/tests/_lint/test_files/setup_dependencies.py
@@ -1,0 +1,18 @@
+import marimo
+
+__generated_with = "0.13.10"
+
+app = marimo.App()
+
+with app.setup:
+    y = x + 1  # This should trigger MR003 - setup cell dependencies
+
+
+@app.cell
+def _():
+    x = 1
+    return (x,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_lint/test_files/setup_dependencies.py
+++ b/tests/_lint/test_files/setup_dependencies.py
@@ -1,7 +1,6 @@
 import marimo
 
-__generated_with = "0.13.10"
-
+__generated_with = "0.15.2"
 app = marimo.App()
 
 with app.setup:
@@ -11,7 +10,7 @@ with app.setup:
 @app.cell
 def _():
     x = 1
-    return (x,)
+    return
 
 
 if __name__ == "__main__":

--- a/tests/_lint/test_files/unparsable_cell.py
+++ b/tests/_lint/test_files/unparsable_cell.py
@@ -1,12 +1,12 @@
 import marimo
 
-__generated_with = "0.1.0"
+__generated_with = "0.0.0"
 app = marimo.App()
 
 @app.cell
 def _():
     x = 1
-    return (x,)
+    return
 
 # This should create an unparsable cell
 app._unparsable_cell("""
@@ -14,9 +14,9 @@ x = 1 +  # Syntax error
 """)
 
 @app.cell
-def __():
+def _():
     y = 2
-    return (y,)
+    return
 
 if __name__ == "__main__":
     app.run()

--- a/tests/_lint/test_files/unparsable_cell.py
+++ b/tests/_lint/test_files/unparsable_cell.py
@@ -1,0 +1,22 @@
+import marimo
+
+__generated_with = "0.1.0"
+app = marimo.App()
+
+@app.cell
+def _():
+    x = 1
+    return (x,)
+
+# This should create an unparsable cell
+app._unparsable_cell("""
+x = 1 +  # Syntax error
+""")
+
+@app.cell
+def __():
+    y = 2
+    return (y,)
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_lint/test_lint_system.py
+++ b/tests/_lint/test_lint_system.py
@@ -1,0 +1,187 @@
+# Copyright 2025 Marimo. All rights reserved.
+"""Unit tests for the marimo lint system."""
+
+import pytest
+from marimo._lint import lint_notebook
+from marimo._lint.base import Severity
+from marimo._lint.checker import LintChecker
+from marimo._lint.formatting import GeneralFormattingRule
+from marimo._lint.runtime import (
+    MultipleDefinitionsRule,
+    CycleDependenciesRule,
+    SetupCellDependenciesRule,
+)
+from marimo._lint.breaking import UnparsableCellsRule
+from marimo._ast.parse import parse_notebook
+from marimo._schemas.serialization import (
+    CellDef,
+    NotebookSerializationV1,
+    AppInstantiation,
+)
+
+
+class TestLintSystem:
+    """Test the core lint system functionality."""
+
+    def test_lint_notebook_basic(self):
+        """Test basic linting functionality."""
+        code = """
+import marimo
+
+app = marimo.App()
+
+@app.cell
+def __():
+    x = 1
+    return (x,)
+"""
+        notebook = parse_notebook(code)
+        errors = lint_notebook(notebook)
+
+        # Should have formatting error for missing __generated_with
+        assert len(errors) > 0
+        assert any(error.code == "MF001" for error in errors)
+
+    def test_lint_notebook_with_violations(self):
+        """Test linting with parsing violations."""
+        code = """
+import marimo
+
+app = marimo.App()
+
+# This should create a violation
+x = 1
+
+@app.cell
+def __():
+    y = 2
+    return (y,)
+"""
+        notebook = parse_notebook(code)
+        errors = lint_notebook(notebook)
+
+        # Should have formatting errors for violations
+        assert len(errors) > 0
+        assert any(error.code == "MF001" for error in errors)
+
+
+class TestLintRules:
+    """Test individual lint rules."""
+
+    def test_general_formatting_rule(self):
+        """Test the general formatting rule."""
+        rule = GeneralFormattingRule()
+
+        # Create a notebook with violations
+        notebook = NotebookSerializationV1(
+            app=AppInstantiation(),
+            cells=[],
+            violations=[
+                type(
+                    "Violation",
+                    (),
+                    {
+                        "description": "UNEXPECTED_STATEMENT_CELL_DEF_VIOLATION",
+                        "lineno": 1,
+                        "col_offset": 0,
+                    },
+                )()
+            ],
+        )
+
+        errors = rule.check(notebook)
+        assert len(errors) == 1
+        assert errors[0].code == "MF001"
+        assert errors[0].severity == Severity.FORMATTING
+
+    def test_multiple_definitions_rule(self):
+        """Test the multiple definitions rule."""
+        rule = MultipleDefinitionsRule()
+
+        # Create a simple notebook
+        notebook = NotebookSerializationV1(
+            app=AppInstantiation(),
+            cells=[
+                CellDef(code="x = 1", name="cell1", lineno=1, col_offset=0),
+                CellDef(code="x = 2", name="cell2", lineno=2, col_offset=0),
+            ],
+        )
+
+        errors = rule.check(notebook)
+        # The rule should run without errors (even if no multiple definitions found)
+        assert isinstance(errors, list)
+
+    def test_cycle_dependencies_rule(self):
+        """Test the cycle dependencies rule."""
+        rule = CycleDependenciesRule()
+
+        # Create a simple notebook
+        notebook = NotebookSerializationV1(
+            app=AppInstantiation(),
+            cells=[
+                CellDef(code="x = 1", name="cell1", lineno=1, col_offset=0),
+                CellDef(code="y = 2", name="cell2", lineno=2, col_offset=0),
+            ],
+        )
+
+        errors = rule.check(notebook)
+        # The rule should run without errors
+        assert isinstance(errors, list)
+
+    def test_setup_cell_dependencies_rule(self):
+        """Test the setup cell dependencies rule."""
+        rule = SetupCellDependenciesRule()
+
+        # Create a simple notebook
+        notebook = NotebookSerializationV1(
+            app=AppInstantiation(),
+            cells=[
+                CellDef(code="x = 1", name="cell1", lineno=1, col_offset=0),
+            ],
+        )
+
+        errors = rule.check(notebook)
+        # The rule should run without errors
+        assert isinstance(errors, list)
+
+    def test_unparsable_cells_rule(self):
+        """Test the unparsable cells rule."""
+        rule = UnparsableCellsRule()
+
+        # Create a notebook with unparsable cell
+        from marimo._schemas.serialization import UnparsableCell
+
+        notebook = NotebookSerializationV1(
+            app=AppInstantiation(),
+            cells=[
+                UnparsableCell(
+                    code="x = 1 +", name="cell1", lineno=1, col_offset=0
+                ),
+            ],
+        )
+
+        errors = rule.check(notebook)
+        assert len(errors) == 1
+        assert errors[0].code == "MB001"
+        assert errors[0].severity == Severity.BREAKING
+
+
+class TestLintChecker:
+    """Test the LintChecker class."""
+
+    def test_create_default(self):
+        """Test creating a default checker."""
+        checker = LintChecker.create_default()
+        assert checker is not None
+        assert len(checker.rules) > 0
+
+    def test_check_notebook(self):
+        """Test checking a notebook."""
+        checker = LintChecker.create_default()
+
+        notebook = NotebookSerializationV1(
+            app=AppInstantiation(), cells=[], violations=[]
+        )
+
+        errors = checker.check_notebook(notebook)
+        assert isinstance(errors, list)

--- a/tests/_lint/test_runtime_errors_snapshot.py
+++ b/tests/_lint/test_runtime_errors_snapshot.py
@@ -1,0 +1,78 @@
+# Copyright 2025 Marimo. All rights reserved.
+"""Snapshot tests for runtime lint errors."""
+
+import pytest
+from marimo._lint import lint_notebook
+from marimo._ast.parse import parse_notebook
+from tests.mocks import snapshotter
+
+snapshot = snapshotter(__file__)
+
+
+def test_multiple_definitions_snapshot():
+    """Test snapshot for multiple definitions error."""
+    file = "tests/_lint/test_files/multiple_definitions.py"
+    with open(file, "r") as f:
+        code = f.read()
+
+    notebook = parse_notebook(code)
+    errors = lint_notebook(notebook)
+
+    # Format errors for snapshot
+    error_output = []
+    for error in errors:
+        error_output.append(error.format(file))
+
+    snapshot("multiple_definitions_errors.txt", "\n".join(error_output))
+
+
+def test_cycle_dependencies_snapshot():
+    """Test snapshot for cycle dependencies error."""
+    file = "tests/_lint/test_files/cycle_dependencies.py"
+    with open(file, "r") as f:
+        code = f.read()
+
+    notebook = parse_notebook(code)
+    errors = lint_notebook(notebook)
+
+    # Format errors for snapshot
+    error_output = []
+    for error in errors:
+        error_output.append(error.format(file))
+
+    snapshot("cycle_dependencies_errors.txt", "\n".join(error_output))
+
+
+def test_setup_dependencies_snapshot():
+    """Test snapshot for setup dependencies error."""
+    file = "tests/_lint/test_files/setup_dependencies.py"
+    with open(file, "r") as f:
+        code = f.read()
+
+    notebook = parse_notebook(code)
+    errors = lint_notebook(notebook)
+
+    # Format errors for snapshot
+    error_output = []
+    for error in errors:
+        error_output.append(error.format(file))
+
+    snapshot("setup_dependencies_errors.txt", "\n".join(error_output))
+
+
+def test_unparsable_cell_snapshot():
+    """Test snapshot for unparsable cell error."""
+    file = "tests/_lint/test_files/unparsable_cell.py"
+    with open(file, "r") as f:
+        code = f.read()
+
+    notebook = parse_notebook(code)
+    errors = lint_notebook(notebook)
+
+    # Format errors for snapshot
+    error_output = []
+    for error in errors:
+        error_output.append(error.format(file))
+
+    snapshot("unparsable_cell_errors.txt", "\n".join(error_output))
+


### PR DESCRIPTION
## 📝 Summary

closes https://github.com/marimo-team/marimo/issues/1543
related: https://github.com/marimo-team/marimo/discussions/4332

Adds `marimo lint [--fix]` to detect and report on common errors

<img width="557" height="170" alt="image" src="https://github.com/user-attachments/assets/8a7b967a-d1ae-413b-b8b2-a811d7d7f9f8" />


Followup PRS:

   - [] More aggressive formatting for poorly autogenerated code
   - [] Parse bug (unable to detect run guard when no cells)
   - [] More codes
   - [] Jedi type inference for deeper analysis
