### PR TITLE
Prefer `QueueType` annotation over concrete `queue.Queue`

### DIFF
--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -29,7 +29,6 @@ from marimo._server.types import QueueType
 from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
-    import queue
     from collections.abc import Iterable, Iterator
 
 LOGGER = _loggers.marimo_logger()
@@ -79,7 +78,7 @@ class PipeProtocol(Protocol):
 
 
 class QueuePipe:
-    def __init__(self, queue: queue.Queue[KernelMessage]):
+    def __init__(self, queue: QueueType[KernelMessage]):
         self._queue = queue
 
     def send(self, obj: Any) -> None:

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -188,7 +188,6 @@ from marimo._utils.signals import restore_signals
 from marimo._utils.typed_connection import TypedConnection
 
 if TYPE_CHECKING:
-    import queue
     from collections.abc import Awaitable, Iterator, Sequence
     from types import ModuleType
 
@@ -2645,7 +2644,7 @@ def launch_kernel(
     set_ui_element_queue: QueueType[SetUIElementValueRequest],
     completion_queue: QueueType[CodeCompletionRequest],
     input_queue: QueueType[str],
-    stream_queue: queue.Queue[KernelMessage] | None,
+    stream_queue: QueueType[KernelMessage] | None,
     socket_addr: tuple[str, int] | None,
     is_edit_mode: bool,
     configs: dict[CellId_t, CellConfig],

--- a/marimo/_runtime/win32_interrupt_handler.py
+++ b/marimo/_runtime/win32_interrupt_handler.py
@@ -1,4 +1,6 @@
 # Copyright 2024 Marimo. All rights reserved.
+from __future__ import annotations
+
 import queue
 import signal
 import threading
@@ -6,11 +8,11 @@ from _thread import interrupt_main
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from multiprocessing import Queue
+    from marimo._server.types import QueueType
 
 
 class Win32InterruptHandler(threading.Thread):
-    def __init__(self, interrupt_queue: "Queue[bool]") -> None:
+    def __init__(self, interrupt_queue: QueueType[bool]) -> None:
         super().__init__()
         self.daemon = True
         self.interrupt_queue = interrupt_queue


### PR DESCRIPTION
Follow up to #6262. Uses `QueueType` protocol over `queue.Queue` in a few other spots. Should help to avoid type-casting.
