### PR TITLE
Visibility for @ in Generate with AI, also add model dropdown

### DIFF
--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -31,6 +31,7 @@ import { Input } from "@/components/ui/input";
 import { Kbd } from "@/components/ui/kbd";
 import { NativeSelect } from "@/components/ui/native-select";
 import { Textarea } from "@/components/ui/textarea";
+import type { SupportedRole } from "@/core/ai/config";
 import {
   AiModelId,
   PROVIDERS,
@@ -225,6 +226,7 @@ interface ModelSelectorProps {
   description?: React.ReactNode;
   disabled?: boolean;
   label: string;
+  forRole: SupportedRole;
   onSubmit: (values: UserConfig) => void;
 }
 
@@ -237,6 +239,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   description,
   disabled = false,
   label,
+  forRole,
   onSubmit,
 }) => {
   return (
@@ -289,6 +292,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                     </div>
                   </>
                 }
+                forRole={forRole}
               />
             </FormControl>
             <FormMessage />
@@ -420,6 +424,7 @@ const renderCopilotProvider = ({
         testId="custom-model-input"
         description="Model to use for code completion when using a custom provider."
         onSubmit={onSubmit}
+        forRole="autocomplete"
       />
     );
   }
@@ -905,6 +910,7 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
         description={
           <span>Model to use for chat conversations in the Chat panel.</span>
         }
+        forRole="chat"
         onSubmit={onSubmit}
       />
       <ModelSelector
@@ -921,6 +927,7 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
             <Kbd className="inline">Generate with AI</Kbd> button.
           </span>
         }
+        forRole="edit"
         onSubmit={onSubmit}
       />
 

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -2,7 +2,6 @@
 
 import type { UIMessage } from "@ai-sdk/react";
 import { useChat } from "@ai-sdk/react";
-import { startCompletion } from "@codemirror/autocomplete";
 import { storePrompt } from "@marimo-team/codemirror-ai";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import {
@@ -61,7 +60,11 @@ import { Logger } from "@/utils/Logger";
 import { AIModelDropdown } from "../ai/ai-model-dropdown";
 import { useOpenSettingsToTab } from "../app-config/state";
 import { PromptInput } from "../editor/ai/add-cell-with-ai";
-import { getAICompletionBodyWithAttachments } from "../editor/ai/completion-utils";
+import {
+  addContextCompletion,
+  CONTEXT_TRIGGER,
+  getAICompletionBodyWithAttachments,
+} from "../editor/ai/completion-utils";
 import { PanelEmptyState } from "../editor/chrome/panels/empty-state";
 import { CopyClipboardIcon } from "../icons/copy-icon";
 import { Input } from "../ui/input";
@@ -79,8 +82,6 @@ import { ToolCallAccordion } from "./tool-call-accordion";
 
 // Default mode for the AI
 const DEFAULT_MODE = "manual";
-
-const CONTEXT_TRIGGER = "@";
 
 // We need to modify the backend to support attachments for other providers
 // And other types
@@ -337,7 +338,7 @@ const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
     const currentModel = ai?.models?.chat_model || DEFAULT_AI_MODEL;
     const currentProvider = AiModelId.parse(currentModel).providerId;
 
-    const { saveModeChange, saveModelChange } = useModelChange();
+    const { saveModeChange } = useModelChange();
 
     const modeOptions = [
       {
@@ -387,9 +388,7 @@ const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
               </Select>
             </FeatureFlagged>
             <AIModelDropdown
-              value={currentModel}
               placeholder="Model"
-              onSelect={(model) => saveModelChange(model, "chat")}
               triggerClassName="h-6 text-xs shadow-none! ring-0! bg-muted hover:bg-muted/30 rounded-sm"
               iconSize="small"
               showAddCustomModelDocs={true}
@@ -503,28 +502,7 @@ const ChatInput: React.FC<ChatInputProps> = memo(
         </div>
         <ChatInputFooter
           isEmpty={!input.trim()}
-          onAddContext={() => {
-            if (!inputRef.current?.view) {
-              return;
-            }
-            const pos = inputRef.current.view.state.selection.main.from;
-            // Insert @ at the cursor position
-            inputRef.current.view.dispatch({
-              changes: {
-                from: pos,
-                to: pos,
-                insert: CONTEXT_TRIGGER,
-              },
-              selection: {
-                anchor: pos + 1,
-                head: pos + 1,
-              },
-            });
-            // Focus the view
-            inputRef.current.view.focus();
-            // Start completion
-            startCompletion(inputRef.current.view);
-          }}
+          onAddContext={() => addContextCompletion(inputRef)}
           onSendClick={handleSendClick}
           isLoading={isLoading}
           onStop={onStop}
@@ -815,7 +793,7 @@ const ChatPanelBody = () => {
   const chatInput = isNewThread ? (
     <ChatInput
       key="new-thread-input"
-      placeholder="Ask anything, @ to include context about tables or dataframes"
+      placeholder={`Ask anything, ${CONTEXT_TRIGGER} to include context about tables or dataframes`}
       input={newThreadInput}
       inputRef={newThreadInputRef}
       inputClassName="px-1 py-0"

--- a/frontend/src/components/editor/ai/add-cell-with-ai.tsx
+++ b/frontend/src/components/editor/ai/add-cell-with-ai.tsx
@@ -17,7 +17,7 @@ import ReactCodeMirror, {
   minimalSetup,
   type ReactCodeMirrorRef,
 } from "@uiw/react-codemirror";
-import { useAtom, useAtomValue, useStore } from "jotai";
+import { useAtom, useStore } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import {
   ChevronsUpDown,
@@ -40,12 +40,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { toast } from "@/components/ui/use-toast";
-import { useModelChange } from "@/core/ai/config";
 import { resourceExtension } from "@/core/codemirror/ai/resources";
 import { customPythonLanguageSupport } from "@/core/codemirror/language/languages/python";
 import { SQLLanguageAdapter } from "@/core/codemirror/language/languages/sql/sql";
-import { aiAtom } from "@/core/config/config";
-import { DEFAULT_AI_MODEL } from "@/core/config/config-schema";
 import { useRuntimeManager } from "@/core/runtime/config";
 import { useTheme } from "@/theme/useTheme";
 import { cn } from "@/utils/cn";
@@ -58,6 +55,7 @@ import {
   createAiCompletionOnKeydown,
 } from "./completion-handlers";
 import {
+  CONTEXT_TRIGGER,
   getAICompletionBody,
   mentionsCompletionSource,
 } from "./completion-utils";
@@ -90,9 +88,6 @@ export const AddCellWithAI: React.FC<{
   const { theme } = useTheme();
   const runtimeManager = useRuntimeManager();
 
-  const ai = useAtomValue(aiAtom);
-  const editModel = ai?.models?.edit_model || DEFAULT_AI_MODEL;
-  const { saveModelChange } = useModelChange();
   const inputRef = useRef<ReactCodeMirrorRef>(null);
 
   const {
@@ -261,10 +256,6 @@ export const AddCellWithAI: React.FC<{
         <div className="ml-auto flex items-center gap-1">
           {languageDropdown}
           <AIModelDropdown
-            value={editModel}
-            onSelect={(model) => {
-              saveModelChange(model, "edit");
-            }}
             triggerClassName="h-7 text-xs max-w-64"
             iconSize="small"
             forRole="edit"
@@ -437,7 +428,9 @@ export const PromptInput = ({
       onChange={onChange}
       onKeyDown={onKeyDown}
       theme={theme === "dark" ? "dark" : "light"}
-      placeholder={placeholder || "Generate with AI"}
+      placeholder={
+        placeholder || `Generate with AI, ${CONTEXT_TRIGGER} to include context`
+      }
     />
   );
 };

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -2,7 +2,7 @@
 
 import { useCompletion } from "@ai-sdk/react";
 import { EditorView } from "@codemirror/view";
-import { Loader2Icon, SparklesIcon, XIcon } from "lucide-react";
+import { AtSignIcon, Loader2Icon, SparklesIcon, XIcon } from "lucide-react";
 import React, { useEffect, useId, useState } from "react";
 import CodeMirrorMerge from "react-codemirror-merge";
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,7 @@ import "./merge-editor.css";
 import { storePrompt } from "@marimo-team/codemirror-ai";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { useAtom } from "jotai";
+import { AIModelDropdown } from "@/components/ai/ai-model-dropdown";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -30,7 +31,7 @@ import {
   CompletionActions,
   createAiCompletionOnKeydown,
 } from "./completion-handlers";
-import { getAICompletionBody } from "./completion-utils";
+import { addContextCompletion, getAICompletionBody } from "./completion-utils";
 
 const Original = CodeMirrorMerge.Original;
 const Modified = CodeMirrorMerge.Modified;
@@ -164,7 +165,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
             <SparklesIcon className="text-(--blue-10) shrink-0" size={16} />
             <PromptInput
               inputRef={inputRef}
-              className="h-full my-0 py-1.5"
+              className="h-full my-0 py-2"
               onClose={() => {
                 declineChange();
                 setCompletion("");
@@ -209,6 +210,24 @@ export const AiCompletionEditor: React.FC<Props> = ({
                 size="xs"
               />
             )}
+            <div className="flex flex-row items-center gap-0.5 -ml-1.5 -mr-2">
+              <Tooltip content="Add context">
+                <Button
+                  variant="text"
+                  size="icon"
+                  onClick={() => addContextCompletion(inputRef)}
+                >
+                  <AtSignIcon className="h-3 w-3" />
+                </Button>
+              </Tooltip>
+              <AIModelDropdown
+                triggerClassName="h-7"
+                iconSize="small"
+                displayIconOnly={true}
+                forRole="edit"
+              />
+            </div>
+
             <div className="h-full w-px bg-border mx-2" />
             <Tooltip content="Include code from other cells">
               <div className="flex flex-row items-start gap-1 overflow-hidden">

--- a/frontend/src/components/editor/ai/completion-utils.ts
+++ b/frontend/src/components/editor/ai/completion-utils.ts
@@ -1,16 +1,20 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import type {
-  Completion,
-  CompletionContext,
-  CompletionSource,
+import {
+  type Completion,
+  type CompletionContext,
+  type CompletionSource,
+  startCompletion,
 } from "@codemirror/autocomplete";
+import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import type { FileUIPart } from "ai";
 import { getAIContextRegistry } from "@/core/ai/context/context";
 import { getCodes } from "@/core/codemirror/copilot/getCodes";
 import type { AiCompletionRequest } from "@/core/network/types";
 import { store } from "@/core/state/jotai";
 import { Logger } from "@/utils/Logger";
+
+export const CONTEXT_TRIGGER = "@";
 
 interface Opts {
   input: string;
@@ -117,4 +121,27 @@ export function mentionsCompletionSource(
       options: [...data],
     };
   };
+}
+
+export function addContextCompletion(
+  inputRef: React.RefObject<ReactCodeMirrorRef | null>,
+) {
+  if (inputRef.current?.view) {
+    const pos = inputRef.current.view.state.selection.main.from;
+    // Insert @ at the cursor position
+    inputRef.current.view.dispatch({
+      changes: {
+        from: pos,
+        to: pos,
+        insert: CONTEXT_TRIGGER,
+      },
+      selection: {
+        anchor: pos + 1,
+        head: pos + 1,
+      },
+    });
+    inputRef.current.view.focus();
+    // Trigger completion
+    startCompletion(inputRef.current.view);
+  }
 }

--- a/frontend/src/core/ai/config.ts
+++ b/frontend/src/core/ai/config.ts
@@ -8,7 +8,7 @@ import type { AIModelKey, UserConfig } from "@/core/config/config-schema";
 import { useRequestClient } from "@/core/network/requests";
 
 // Extract only the supported roles from the Role type
-type SupportedRole = Extract<Role, "chat" | "autocomplete" | "edit">;
+export type SupportedRole = Extract<Role, "chat" | "autocomplete" | "edit">;
 
 const getModelKeyForRole = (forRole: SupportedRole): AIModelKey | null => {
   switch (forRole) {


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
- Display a icon-only model dropdown for users to switch AI model in the inline Generate with AI
- Add @ button,
- Small refactor for AI model dropdown, so we don't need to call atoms in each component that uses this.

<img width="722" height="111" alt="CleanShot 2025-09-10 at 20 39 17" src="https://github.com/user-attachments/assets/3c6414b6-9cbb-4428-a7f2-055fe2abcaa2" />

<img width="748" height="118" alt="CleanShot 2025-09-10 at 20 39 57" src="https://github.com/user-attachments/assets/5abc267d-3dd8-4e93-9816-52299368f276" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
