### PR TITLE
fix: `progress_bar` type hints

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -350,6 +350,9 @@ class progress_bar(Generic[S]):
                 "`total` is required when using as a context manager"
             )
 
+        else:
+            self.collection = None
+
         self.progress = ProgressBar(
             title=title,
             subtitle=subtitle,
@@ -361,6 +364,10 @@ class progress_bar(Generic[S]):
             output.append(self.progress)
 
     def __iter__(self) -> Iterator[S]:
+        if self.collection is None:
+            raise RuntimeError(
+                "progress_bar can only be iterated over if a collection is provided"
+            )
         for item in self.collection:
             yield item  # type: ignore[misc]
             if not self.disabled:

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -314,7 +314,7 @@ class progress_bar(Generic[S]):
 
     def __init__(
         self,
-        collection: Optional[Collection[S | int]] = None,
+        collection: Optional[Collection[S]] = None,
         *,
         title: Optional[str] = None,
         subtitle: Optional[str] = None,
@@ -360,7 +360,7 @@ class progress_bar(Generic[S]):
         if not disabled:
             output.append(self.progress)
 
-    def __iter__(self) -> Iterator[S | int]:
+    def __iter__(self) -> Iterator[S]:
         for item in self.collection:
             yield item  # type: ignore[misc]
             if not self.disabled:

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Sized
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -9,6 +10,7 @@ from typing import (
     Literal,
     Optional,
     TypeVar,
+    overload,
 )
 
 import marimo._runtime.output._output as output
@@ -300,7 +302,7 @@ class progress_bar(Generic[S]):
         every 150ms.
 
     Args:
-        collection (Collection[Union[S, int]], optional): Optional collection to iterate over.
+        collection (Union[Collection[S], Iterator[S]], optional): Optional collection to iterate over.
         title (str, optional): Optional title.
         subtitle (str, optional): Optional subtitle.
         completion_title (str, optional): Optional title to show during completion.
@@ -312,9 +314,57 @@ class progress_bar(Generic[S]):
         disabled (bool, optional): If True, disable the progress bar.
     """
 
+    @overload
     def __init__(
         self,
-        collection: Optional[Collection[S]] = None,
+        collection: Collection[S] = ...,
+        *,
+        title: Optional[str] = ...,
+        subtitle: Optional[str] = ...,
+        completion_title: Optional[str] = ...,
+        completion_subtitle: Optional[str] = ...,
+        total: Optional[int] = ...,
+        show_rate: bool = ...,
+        show_eta: bool = ...,
+        remove_on_exit: bool = ...,
+        disabled: bool = ...,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        collection: Iterator[S] = ...,
+        *,
+        title: Optional[str] = ...,
+        subtitle: Optional[str] = ...,
+        completion_title: Optional[str] = ...,
+        completion_subtitle: Optional[str] = ...,
+        total: int = ...,
+        show_rate: bool = ...,
+        show_eta: bool = ...,
+        remove_on_exit: bool = ...,
+        disabled: bool = ...,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        collection: None = ...,
+        *,
+        title: Optional[str] = ...,
+        subtitle: Optional[str] = ...,
+        completion_title: Optional[str] = ...,
+        completion_subtitle: Optional[str] = ...,
+        total: int = ...,
+        show_rate: bool = ...,
+        show_eta: bool = ...,
+        remove_on_exit: bool = ...,
+        disabled: bool = ...,
+    ): ...
+
+    def __init__(
+        self,
+        collection: Optional[Collection[S] | Iterator[S]] = None,
         *,
         title: Optional[str] = None,
         subtitle: Optional[str] = None,
@@ -334,12 +384,12 @@ class progress_bar(Generic[S]):
         if collection is not None:
             self.collection = collection
 
-            try:
+            if isinstance(collection, Sized):
                 total = total or len(collection)
                 self.step = (
                     collection.step if isinstance(collection, range) else 1
                 )
-            except TypeError:  # if collection is a generator
+            else:  # if collection is a generator
                 raise TypeError(
                     "fail to determine length of collection, use `total`"
                     + "to specify"

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -5,6 +5,7 @@ import time
 from typing import (
     TYPE_CHECKING,
     Any,
+    Generic,
     Literal,
     Optional,
     TypeVar,
@@ -273,7 +274,7 @@ class spinner:
         return self.spinner._mime_()
 
 
-class progress_bar:
+class progress_bar(Generic[S]):
     """Iterate over a collection and show a progress bar.
 
     Examples:

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -128,3 +128,7 @@ def test_progress_without_context():
         for _ in range(10):
             assert bar
             bar.update()
+
+    with pytest.raises(RuntimeError):
+        for _ in progress_bar(total=10):
+            pass


### PR DESCRIPTION
## 📝 Summary

Well, if I knew I was going to end up issuing a PR anyway, I would have skipped making an issue yesterday. Oh well.

There were a few things I overlooked in #6291, such as how `progress_bar` was not registered properly as a `Generic`, and a few other related typing issues.

## 🔍 Description of Changes

- Made `progress_bar` inherit from `Generic[S]`, as per the [Python docs on Generics](https://typing.python.org/en/latest/spec/generics.html#user-defined-generic-types).
- Remove redundant `int` Union in the `collection` parameter and `__init__()` to fix:
  ```python
  my_list: list[str] = ["a", "b", "c"]
  for s in mo.status.progress_bar(my_list):
      # EXPECTED: s: str
      # ACTUAL:   s: str | int
      pass
  ```
- Add overloads to `progress_bar.__init__()` to support `Iterator[S]` with a specified `total`.
  > I'm not thrilled that I ended up adding 3 overloads to maintain, but I don't think there's an alternative to this in Python.
- Raise an error if iterating over progress_bar when specifying a total without a collection. 
  > Maybe it should default to creating a `range` instead?.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
