### PR TITLE
Add pycap to module name map

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -646,6 +646,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "readability": "readability-lxml",
         "readline": "gnureadline",
         "recaptcha_works": "django-recaptcha-works",
+        "redcap": "pycap",
         "relstorage": "RelStorage",
         "reportapi": "django-reportapi",
         "requests": "Requests",


### PR DESCRIPTION
see `pycap` on pypi

usage is


```python
import redcap
```

## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
