### PR TITLE
Make `preview` a priority in release notes generation

### DIFF
--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -182,14 +182,14 @@ def categorize_entries(
 
         if "breaking" in label_names:
             categories["breaking"].append(entry)
+        elif "preview" in label_names:
+            categories["preview"].append(entry)
         elif "bug" in label_names:
             categories["bug"].append(entry)
         elif "enhancement" in label_names:
             categories["enhancement"].append(entry)
         elif "documentation" in label_names:
             categories["documentation"].append(entry)
-        elif "preview" in label_names:
-            categories["preview"].append(entry)
         else:
             categories["other"].append(entry)
 


### PR DESCRIPTION
The `preview` tag now takes priority over `enhancements` in the release notes generation (in case a PR is tagged as both).
