### PR TITLE
ci: drop down to macos-14 for networking issues

### DIFF
--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -102,7 +102,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.12']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO: update to latest once networking issues on macos-15 are resolved
+        os: [ubuntu-latest, macos-14, windows-latest]
 
     steps:
       - name: 🛑 Cancel Previous Runs


### PR DESCRIPTION
## 📝 Summary

macos ci has been breaking (despite it running fine locally). It seems that the version change of `macos-latest` has networking issues: https://github.com/actions/runner-images/issues/10924 so just fix to macos-14 until this is resolved.