### PR TITLE
Checks if sql variable data exists before accessing it

### DIFF
--- a/tests/_runtime/test_dataflow_cases.py
+++ b/tests/_runtime/test_dataflow_cases.py
@@ -483,7 +483,6 @@ SQL_CASES = [
             "3": ["mo", "my_db.my_table"],
         },
         expected_defs={"0": ["my_db"], "1": ["my_table"], "2": [], "3": []},
-        xfail=True,
     ),
     GraphTestCase(
         name="sql table multiple definitions, different order",
@@ -501,7 +500,6 @@ SQL_CASES = [
             "2": ["mo", "my_db.main.my_table"],
         },
         expected_defs={"0": ["my_table"], "1": ["my_db"], "2": []},
-        xfail=True,
     ),
     GraphTestCase(
         name="sql table ordering doesn't cause false positives",


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
For the multiple definitions case, there are 2 cell_ids which defines part of the `name`.

```python
            "0": "_ = mo.sql(f\"ATTACH 'my_db.db' as my_db\")",
            "1": "_ = mo.sql(f'CREATE OR REPLACE TABLE my_db.my_table AS SELECT 1')",
            "2": "_ = mo.sql(f'FROM my_db.main.my_table SELECT *')",
```
cell 0 defines catalog my_db
cell 1 defines table my_table

The error is raised when we do cell_0.variable_data[my_table], this fix is to get the proper variable name and check if the variable exists.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
