### PR TITLE
fix: allow test cells in the presence of async cells

### DIFF
--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -6,9 +6,9 @@ import copy
 import functools
 import inspect
 import itertools
+from collections.abc import Awaitable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeVar, cast
-from collections.abc import Awaitable
 
 from marimo._ast.cell import Cell
 from marimo._runtime.context import ContextNotInitializedError, get_context

--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -8,12 +8,13 @@ import inspect
 import itertools
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeVar, cast
+from collections.abc import Awaitable
 
 from marimo._ast.cell import Cell
 from marimo._runtime.context import ContextNotInitializedError, get_context
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Mapping
+    from collections.abc import Mapping
 
 Fn = TypeVar("Fn", bound=Callable[..., Any])
 
@@ -167,7 +168,14 @@ def build_test_class(
 
     def hook(var: str) -> Callable[..., Any] | type[MarimoTest]:
         def _hook(*args: Any, **kwargs: Any) -> Any:
-            _, defs = run()  # type: ignore
+            res = run()
+            if isinstance(res, Awaitable):
+                import asyncio
+
+                loop = asyncio.new_event_loop()
+                _, defs = loop.run_until_complete(res)
+            else:
+                _, defs = res
             return defs[var](*args, **kwargs)
 
         test = tests.get(var, None)

--- a/tests/_ast/test_pytest.py
+++ b/tests/_ast/test_pytest.py
@@ -45,6 +45,7 @@ async def _(pytest, x, y, Z):
         def test_static() -> None:
             assert x + y == Z
 
+    @pytest.mark.asyncio
     async def test_async_cell():
         assert True
 
@@ -67,6 +68,7 @@ def test_cell_is_invoked():
 
 
 @app.cell
+@pytest.mark.asyncio
 async def test_async_cell():
     assert True
 

--- a/tests/_ast/test_pytest.py
+++ b/tests/_ast/test_pytest.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-import pytest
-
 import marimo
 
 app = marimo.App()
 
 
+with app.setup:
+    import pytest
+
+
 @app.cell
-async def _(pytest, x, y, Z):
+async def _(x, y, Z):
     @pytest.mark.xfail(
         reason=("To ensure this doesn't just eval."),
         raises=AssertionError,
@@ -57,9 +59,7 @@ def imports():
     # Suffixed with _fixture should have corresponding definitions in conftest.py
     mo_fixture = None
 
-    import pytest
-
-    return mo, mo_fixture, pytest
+    return mo, mo_fixture
 
 
 @app.cell
@@ -67,9 +67,15 @@ def test_cell_is_invoked():
     assert True
 
 
-@app.cell
 @pytest.mark.asyncio
+@app.cell
 async def test_async_cell():
+    assert True
+
+
+@app.function
+@pytest.mark.asyncio
+async def test_async_function():
     assert True
 
 
@@ -145,7 +151,7 @@ def test_cell_args_resolved_by_name(mo):  # noqa: ARG001
 
 
 @app.cell
-def test_cell_assert_rewritten(pytest):
+def test_cell_assert_rewritten():
     a = 1
     b = 2
 


### PR DESCRIPTION
## 📝 Summary

Enables async tests for in notebook auto-testing, e.g.

```python
async def my_test():
    assert True
```

Previously, this was only caught by pytest, not within the notebook itself

## 🔍 Description of Changes

Instead of ignoring the type of the result of run for a test cell, and assuming that it's synchronous, check for whether it's awaitable, and await it if so.

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
