### PR TITLE
fix: use TypeVar for Cls in class_definition

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -76,7 +76,7 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 R = TypeVar("R")
 Fn: TypeAlias = Callable[P, R]
-Cls: TypeAlias = type
+Cls = TypeVar("Cls", bound=type)
 LOGGER = _loggers.marimo_logger()
 
 


### PR DESCRIPTION
## 📝 Summary

Fix type hints in `@app.class_definition`, as detailed in #6335 (Note, this is not a fix for the entire issue).

```python
@app.class_definition
class Foo:
    def __init__(self):
        pass

@app.cell
def _():
    foo1: Foo = Foo()  # type: Unknown
    foo2 = Foo()  # type: Any
    # Expected both type to be `Foo`
```

## 🔍 Description of Changes

Changed the `Cls` type alias used by the type hints of `@app.class_definition` to a `TypeVar`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
