### PR TITLE
fix [6281]: Could not find function given request: FunctionCallReques…

### DIFF
--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -1,4 +1,19 @@
 /* Copyright 2024 Marimo. All rights reserved. */
+import { notebookAtom } from "@/core/cells/cells.ts";
+import { findCellId } from "@/core/cells/ids.ts";
+import { isUninstantiated } from "@/core/cells/utils"
+import { createInputEvent, MarimoValueUpdateEvent } from "@/core/dom/events";
+import { getUIElementObjectId } from "@/core/dom/ui-element";
+import { UIElementRegistry } from "@/core/dom/uiregistry";
+import { FUNCTIONS_REGISTRY } from "@/core/functions/FunctionRegistry";
+import { store } from "@/core/state/jotai";
+import { type HTMLElementNotDerivedFromRef, useEventListener, } from "@/hooks/useEventListener";
+import { StyleNamespace } from "@/theme/namespace";
+import { useTheme } from "@/theme/useTheme";
+import { CellNotInitializedError } from "@/utils/errors.ts";
+import { Functions } from "@/utils/functions";
+import { shallowCompare } from "@/utils/shallow-compare";
+
 /* eslint-disable unicorn/prefer-spread */
 /**
  * WebComponent Factory for React Components
@@ -21,24 +36,8 @@ import React, {
 import ReactDOM, { type Root } from "react-dom/client";
 import useEvent from "react-use-event-hook";
 import type { ZodSchema } from "zod";
-import { createInputEvent, MarimoValueUpdateEvent } from "@/core/dom/events";
-import { getUIElementObjectId } from "@/core/dom/ui-element";
-import { UIElementRegistry } from "@/core/dom/uiregistry";
-import { FUNCTIONS_REGISTRY } from "@/core/functions/FunctionRegistry";
-import {
-  type HTMLElementNotDerivedFromRef,
-  useEventListener,
-} from "@/hooks/useEventListener";
-import { StyleNamespace } from "@/theme/namespace";
-import { useTheme } from "@/theme/useTheme";
-import { Functions } from "@/utils/functions";
-import { shallowCompare } from "@/utils/shallow-compare";
 import { defineCustomElement } from "../../core/dom/defineCustomElement";
-import {
-  parseAttrValue,
-  parseDataset,
-  parseInitialValue,
-} from "../../core/dom/htmlUtils";
+import { parseAttrValue, parseDataset, parseInitialValue, } from "../../core/dom/htmlUtils";
 import { invariant } from "../../utils/invariant";
 import { Logger } from "../../utils/Logger";
 import { Objects } from "../../utils/objects";
@@ -78,14 +77,15 @@ interface PluginSlotProps<T> {
 }
 
 /* Handles synchronization of value on behalf of the component */
+
 // eslint-disable-next-line react/function-component-definition
 function PluginSlotInternal<T>(
-  { hostElement, plugin, children, getInitialValue }: PluginSlotProps<T>,
+  {hostElement, plugin, children, getInitialValue}: PluginSlotProps<T>,
   ref: React.Ref<PluginSlotHandle>,
 ): JSX.Element {
   const [childNodes, setChildNodes] = useState<ReactNode>(children);
   const [value, setValue] = useState<T>(getInitialValue());
-  const { theme } = useTheme();
+  const {theme} = useTheme();
 
   const [parsedResult, setParsedResult] = useState(() => {
     return plugin.validator.safeParse(parseDataset(hostElement));
@@ -161,7 +161,7 @@ function PluginSlotInternal<T>(
 
     const methods: PluginFunctions = {};
     for (const [key, schemas] of Objects.entries(plugin.functions)) {
-      const { input, output } = schemas as {
+      const {input, output} = schemas as {
         input: ZodSchema<Record<string, unknown>>;
         output: ZodSchema<Record<string, unknown>>;
       };
@@ -172,6 +172,26 @@ function PluginSlotInternal<T>(
         );
         const objectId = getUIElementObjectId(hostElement);
         invariant(objectId, "Object ID should exist");
+
+        const cellId = findCellId(hostElement);
+        invariant(cellId, "Cell ID should exist");
+
+        const notebookState = store.get(notebookAtom);
+        const cellRuntime = notebookState.cellRuntime[cellId];
+        const cellData = notebookState.cellData[cellId];
+
+        const cellNotInitialized = isUninstantiated({
+          executionTime: cellRuntime.runElapsedTimeMs ?? cellData.lastExecutionTime,
+          status: cellRuntime.status,
+          errored: cellRuntime.errored,
+          interrupted: cellRuntime.interrupted,
+          stopped: cellRuntime.stopped,
+        })
+
+        if (cellNotInitialized) {
+          throw new CellNotInitializedError();
+        }
+
         const response = await FUNCTIONS_REGISTRY.request({
           args: prettyParse(input, args[0]),
           functionName: key,
@@ -203,7 +223,7 @@ function PluginSlotInternal<T>(
   return (
     <StyleNamespace>
       <div className={`contents ${theme}`}>
-        <Suspense fallback={<div />}>
+        <Suspense fallback={<div/>}>
           {plugin.render({
             setValue: setValueAndSendInput,
             value,
@@ -260,7 +280,7 @@ export function registerReactComponent<T>(plugin: IPlugin<T, unknown>): void {
       super();
       // Create a shadow root so we can store the React tree on the shadow root, while the original
       // element's children are still on the DOM
-      this.attachShadow({ mode: "open" });
+      this.attachShadow({mode: "open"});
       this.copyStyles();
 
       // This observer is used to detect changes to the children and re-render the component
@@ -324,7 +344,7 @@ export function registerReactComponent<T>(plugin: IPlugin<T, unknown>): void {
      * Get the children of the element as React nodes.
      */
     private getChildren(): React.ReactNode {
-      return renderHTML({ html: this.innerHTML });
+      return renderHTML({html: this.innerHTML});
     }
 
     /**

--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -1,18 +1,4 @@
 /* Copyright 2024 Marimo. All rights reserved. */
-import { notebookAtom } from "@/core/cells/cells.ts";
-import { findCellId } from "@/core/cells/ids.ts";
-import { isUninstantiated } from "@/core/cells/utils"
-import { createInputEvent, MarimoValueUpdateEvent } from "@/core/dom/events";
-import { getUIElementObjectId } from "@/core/dom/ui-element";
-import { UIElementRegistry } from "@/core/dom/uiregistry";
-import { FUNCTIONS_REGISTRY } from "@/core/functions/FunctionRegistry";
-import { store } from "@/core/state/jotai";
-import { type HTMLElementNotDerivedFromRef, useEventListener, } from "@/hooks/useEventListener";
-import { StyleNamespace } from "@/theme/namespace";
-import { useTheme } from "@/theme/useTheme";
-import { CellNotInitializedError } from "@/utils/errors.ts";
-import { Functions } from "@/utils/functions";
-import { shallowCompare } from "@/utils/shallow-compare";
 
 /* eslint-disable unicorn/prefer-spread */
 /**
@@ -36,8 +22,29 @@ import React, {
 import ReactDOM, { type Root } from "react-dom/client";
 import useEvent from "react-use-event-hook";
 import type { ZodSchema } from "zod";
+import { notebookAtom } from "@/core/cells/cells.ts";
+import { findCellId } from "@/core/cells/ids.ts";
+import { isUninstantiated } from "@/core/cells/utils";
+import { createInputEvent, MarimoValueUpdateEvent } from "@/core/dom/events";
+import { getUIElementObjectId } from "@/core/dom/ui-element";
+import { UIElementRegistry } from "@/core/dom/uiregistry";
+import { FUNCTIONS_REGISTRY } from "@/core/functions/FunctionRegistry";
+import { store } from "@/core/state/jotai";
+import {
+  type HTMLElementNotDerivedFromRef,
+  useEventListener,
+} from "@/hooks/useEventListener";
+import { StyleNamespace } from "@/theme/namespace";
+import { useTheme } from "@/theme/useTheme";
+import { CellNotInitializedError } from "@/utils/errors.ts";
+import { Functions } from "@/utils/functions";
+import { shallowCompare } from "@/utils/shallow-compare";
 import { defineCustomElement } from "../../core/dom/defineCustomElement";
-import { parseAttrValue, parseDataset, parseInitialValue, } from "../../core/dom/htmlUtils";
+import {
+  parseAttrValue,
+  parseDataset,
+  parseInitialValue,
+} from "../../core/dom/htmlUtils";
 import { invariant } from "../../utils/invariant";
 import { Logger } from "../../utils/Logger";
 import { Objects } from "../../utils/objects";
@@ -80,12 +87,12 @@ interface PluginSlotProps<T> {
 
 // eslint-disable-next-line react/function-component-definition
 function PluginSlotInternal<T>(
-  {hostElement, plugin, children, getInitialValue}: PluginSlotProps<T>,
+  { hostElement, plugin, children, getInitialValue }: PluginSlotProps<T>,
   ref: React.Ref<PluginSlotHandle>,
 ): JSX.Element {
   const [childNodes, setChildNodes] = useState<ReactNode>(children);
   const [value, setValue] = useState<T>(getInitialValue());
-  const {theme} = useTheme();
+  const { theme } = useTheme();
 
   const [parsedResult, setParsedResult] = useState(() => {
     return plugin.validator.safeParse(parseDataset(hostElement));
@@ -161,7 +168,7 @@ function PluginSlotInternal<T>(
 
     const methods: PluginFunctions = {};
     for (const [key, schemas] of Objects.entries(plugin.functions)) {
-      const {input, output} = schemas as {
+      const { input, output } = schemas as {
         input: ZodSchema<Record<string, unknown>>;
         output: ZodSchema<Record<string, unknown>>;
       };
@@ -181,12 +188,13 @@ function PluginSlotInternal<T>(
         const cellData = notebookState.cellData[cellId];
 
         const cellNotInitialized = isUninstantiated({
-          executionTime: cellRuntime.runElapsedTimeMs ?? cellData.lastExecutionTime,
+          executionTime:
+            cellRuntime.runElapsedTimeMs ?? cellData.lastExecutionTime,
           status: cellRuntime.status,
           errored: cellRuntime.errored,
           interrupted: cellRuntime.interrupted,
           stopped: cellRuntime.stopped,
-        })
+        });
 
         if (cellNotInitialized) {
           throw new CellNotInitializedError();
@@ -223,7 +231,7 @@ function PluginSlotInternal<T>(
   return (
     <StyleNamespace>
       <div className={`contents ${theme}`}>
-        <Suspense fallback={<div/>}>
+        <Suspense fallback={<div />}>
           {plugin.render({
             setValue: setValueAndSendInput,
             value,
@@ -280,7 +288,7 @@ export function registerReactComponent<T>(plugin: IPlugin<T, unknown>): void {
       super();
       // Create a shadow root so we can store the React tree on the shadow root, while the original
       // element's children are still on the DOM
-      this.attachShadow({mode: "open"});
+      this.attachShadow({ mode: "open" });
       this.copyStyles();
 
       // This observer is used to detect changes to the children and re-render the component
@@ -344,7 +352,7 @@ export function registerReactComponent<T>(plugin: IPlugin<T, unknown>): void {
      * Get the children of the element as React nodes.
      */
     private getChildren(): React.ReactNode {
-      return renderHTML({html: this.innerHTML});
+      return renderHTML({ html: this.innerHTML });
     }
 
     /**

--- a/frontend/src/plugins/impl/FileBrowserPlugin.tsx
+++ b/frontend/src/plugins/impl/FileBrowserPlugin.tsx
@@ -132,16 +132,16 @@ interface FileBrowserProps extends Data, PluginFunctions {
  * Only works for absolute paths.
  */
 export const FileBrowser = ({
-  value,
-  setValue,
-  initialPath,
-  selectionMode,
-  multiple,
-  label,
-  restrictNavigation,
-  list_directory,
-  host,
-}: FileBrowserProps): JSX.Element | null => {
+                              value,
+                              setValue,
+                              initialPath,
+                              selectionMode,
+                              multiple,
+                              label,
+                              restrictNavigation,
+                              list_directory,
+                              host,
+                            }: FileBrowserProps): JSX.Element | null => {
   const [path, setPath] = useInternalStateWithSync(initialPath);
   const [selectAllLabel, setSelectAllLabel] = useState("Select all");
   const [isUpdatingPath, setIsUpdatingPath] = useState(false);
@@ -150,15 +150,19 @@ export const FileBrowser = ({
   // when the random-id changes, this means the cell was re-rendered
   const randomId = host.closest("[random-id]")?.getAttribute("random-id");
 
-  const { data, error, isPending } = useAsyncData(() => {
-    return list_directory({ path: path });
+  const {data, error, isPending} = useAsyncData(() => {
+    return list_directory({path: path});
   }, [path, randomId]);
 
   if (isPending) {
     return null;
   }
 
-  let { files } = data || {};
+  if (!data && error) {
+    return <Banner kind="danger">{error.message}</Banner>
+  }
+
+  let {files} = data || {};
   if (files === undefined) {
     files = [];
   }
@@ -216,10 +220,10 @@ export const FileBrowser = ({
   }
 
   function createFileInfo({
-    path,
-    name,
-    isDirectory,
-  }: {
+                            path,
+                            name,
+                            isDirectory,
+                          }: {
     path: string;
     name: string;
     isDirectory: boolean;
@@ -233,15 +237,15 @@ export const FileBrowser = ({
   }
 
   function handleSelection({
-    path,
-    name,
-    isDirectory,
-  }: {
+                             path,
+                             name,
+                             isDirectory,
+                           }: {
     path: string;
     name: string;
     isDirectory: boolean;
   }) {
-    const fileInfo = createFileInfo({ path, name, isDirectory });
+    const fileInfo = createFileInfo({path, name, isDirectory});
 
     if (multiple) {
       if (selectedPaths.has(path)) {
@@ -297,7 +301,7 @@ export const FileBrowser = ({
       onClick={() => setNewPath(PARENT_DIRECTORY)}
     >
       <TableCell className="w-[50px] pl-4">
-        <CornerLeftUp size={16} />
+        <CornerLeftUp size={16}/>
       </TableCell>
       <TableCell>{PARENT_DIRECTORY}</TableCell>
     </TableRow>,
@@ -312,7 +316,7 @@ export const FileBrowser = ({
 
     // Click handler
     const handleClick = file.is_directory
-      ? ({ path }: { path: string }) => setNewPath(path)
+      ? ({path}: { path: string }) => setNewPath(path)
       : handleSelection;
 
     // Icon
@@ -355,7 +359,7 @@ export const FileBrowser = ({
         );
       }
 
-      return <Icon size={16} className="mr-2" />;
+      return <Icon size={16} className="mr-2"/>;
     };
 
     fileRows.push(
@@ -387,7 +391,7 @@ export const FileBrowser = ({
   //
   // Assumes that path contains at least one delimiter, which is true
   // only if this is an absolute path.
-  const { parentDirectories } = getProtocolAndParentDirectories({
+  const {parentDirectories} = getProtocolAndParentDirectories({
     path,
     delimiter,
     initialPath,
@@ -403,7 +407,7 @@ export const FileBrowser = ({
 
   const renderHeader = () => {
     label = label ?? `Select ${selectionKindLabel.join(" and ", 2)}...`;
-    const labelText = <Label>{renderHTML({ html: label })}</Label>;
+    const labelText = <Label>{renderHTML({html: label})}</Label>;
 
     if (multiple) {
       return (
@@ -419,7 +423,7 @@ export const FileBrowser = ({
                   : () => deselectAllFiles()
               }
             >
-              {renderHTML({ html: selectAllLabel })}
+              {renderHTML({html: selectAllLabel})}
             </Button>
           </div>
         </div>
@@ -456,7 +460,7 @@ export const FileBrowser = ({
 
       <div
         className="mt-3 overflow-y-auto w-full border"
-        style={{ height: "14rem" }}
+        style={{height: "14rem"}}
       >
         <Table className="cursor-pointer table-fixed">{fileRows}</Table>
       </div>
@@ -480,7 +484,7 @@ export const FileBrowser = ({
             </div>
             <div className="markdown">
               <ul
-                style={{ marginBlock: 0 }}
+                style={{marginBlock: 0}}
                 className="m-0 text-xs text-muted-foreground"
               >
                 {selectedFiles}

--- a/frontend/src/plugins/impl/FileBrowserPlugin.tsx
+++ b/frontend/src/plugins/impl/FileBrowserPlugin.tsx
@@ -132,16 +132,16 @@ interface FileBrowserProps extends Data, PluginFunctions {
  * Only works for absolute paths.
  */
 export const FileBrowser = ({
-                              value,
-                              setValue,
-                              initialPath,
-                              selectionMode,
-                              multiple,
-                              label,
-                              restrictNavigation,
-                              list_directory,
-                              host,
-                            }: FileBrowserProps): JSX.Element | null => {
+  value,
+  setValue,
+  initialPath,
+  selectionMode,
+  multiple,
+  label,
+  restrictNavigation,
+  list_directory,
+  host,
+}: FileBrowserProps): JSX.Element | null => {
   const [path, setPath] = useInternalStateWithSync(initialPath);
   const [selectAllLabel, setSelectAllLabel] = useState("Select all");
   const [isUpdatingPath, setIsUpdatingPath] = useState(false);
@@ -150,8 +150,8 @@ export const FileBrowser = ({
   // when the random-id changes, this means the cell was re-rendered
   const randomId = host.closest("[random-id]")?.getAttribute("random-id");
 
-  const {data, error, isPending} = useAsyncData(() => {
-    return list_directory({path: path});
+  const { data, error, isPending } = useAsyncData(() => {
+    return list_directory({ path: path });
   }, [path, randomId]);
 
   if (isPending) {
@@ -159,10 +159,10 @@ export const FileBrowser = ({
   }
 
   if (!data && error) {
-    return <Banner kind="danger">{error.message}</Banner>
+    return <Banner kind="danger">{error.message}</Banner>;
   }
 
-  let {files} = data || {};
+  let { files } = data || {};
   if (files === undefined) {
     files = [];
   }
@@ -220,10 +220,10 @@ export const FileBrowser = ({
   }
 
   function createFileInfo({
-                            path,
-                            name,
-                            isDirectory,
-                          }: {
+    path,
+    name,
+    isDirectory,
+  }: {
     path: string;
     name: string;
     isDirectory: boolean;
@@ -237,15 +237,15 @@ export const FileBrowser = ({
   }
 
   function handleSelection({
-                             path,
-                             name,
-                             isDirectory,
-                           }: {
+    path,
+    name,
+    isDirectory,
+  }: {
     path: string;
     name: string;
     isDirectory: boolean;
   }) {
-    const fileInfo = createFileInfo({path, name, isDirectory});
+    const fileInfo = createFileInfo({ path, name, isDirectory });
 
     if (multiple) {
       if (selectedPaths.has(path)) {
@@ -301,7 +301,7 @@ export const FileBrowser = ({
       onClick={() => setNewPath(PARENT_DIRECTORY)}
     >
       <TableCell className="w-[50px] pl-4">
-        <CornerLeftUp size={16}/>
+        <CornerLeftUp size={16} />
       </TableCell>
       <TableCell>{PARENT_DIRECTORY}</TableCell>
     </TableRow>,
@@ -316,7 +316,7 @@ export const FileBrowser = ({
 
     // Click handler
     const handleClick = file.is_directory
-      ? ({path}: { path: string }) => setNewPath(path)
+      ? ({ path }: { path: string }) => setNewPath(path)
       : handleSelection;
 
     // Icon
@@ -359,7 +359,7 @@ export const FileBrowser = ({
         );
       }
 
-      return <Icon size={16} className="mr-2"/>;
+      return <Icon size={16} className="mr-2" />;
     };
 
     fileRows.push(
@@ -391,7 +391,7 @@ export const FileBrowser = ({
   //
   // Assumes that path contains at least one delimiter, which is true
   // only if this is an absolute path.
-  const {parentDirectories} = getProtocolAndParentDirectories({
+  const { parentDirectories } = getProtocolAndParentDirectories({
     path,
     delimiter,
     initialPath,
@@ -407,7 +407,7 @@ export const FileBrowser = ({
 
   const renderHeader = () => {
     label = label ?? `Select ${selectionKindLabel.join(" and ", 2)}...`;
-    const labelText = <Label>{renderHTML({html: label})}</Label>;
+    const labelText = <Label>{renderHTML({ html: label })}</Label>;
 
     if (multiple) {
       return (
@@ -423,7 +423,7 @@ export const FileBrowser = ({
                   : () => deselectAllFiles()
               }
             >
-              {renderHTML({html: selectAllLabel})}
+              {renderHTML({ html: selectAllLabel })}
             </Button>
           </div>
         </div>
@@ -460,7 +460,7 @@ export const FileBrowser = ({
 
       <div
         className="mt-3 overflow-y-auto w-full border"
-        style={{height: "14rem"}}
+        style={{ height: "14rem" }}
       >
         <Table className="cursor-pointer table-fixed">{fileRows}</Table>
       </div>
@@ -484,7 +484,7 @@ export const FileBrowser = ({
             </div>
             <div className="markdown">
               <ul
-                style={{marginBlock: 0}}
+                style={{ marginBlock: 0 }}
                 className="m-0 text-xs text-muted-foreground"
               >
                 {selectedFiles}

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -63,7 +63,9 @@ function safeJSONParse(message: string): unknown {
 }
 
 export class CellNotInitializedError extends Error {
-  constructor(message: string = "The cell containing this UI element has not been run yet. Please run the cell first.") {
+  constructor(
+    message: string = "The cell containing this UI element has not been run yet. Please run the cell first.",
+  ) {
     super(message);
     this.name = "CellNotInitializedError";
   }

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -61,3 +61,10 @@ function safeJSONParse(message: string): unknown {
     return message;
   }
 }
+
+export class CellNotInitializedError extends Error {
+  constructor(message: string = "The cell containing this UI element has not been run yet. Please run the cell first.") {
+    super(message);
+    this.name = "CellNotInitializedError";
+  }
+}


### PR DESCRIPTION
## 📝 Summary

The error `Could not find function given request: FunctionCallRequest(...)` is shown for UI elements that have associated server side part, eg mo.ui.file_browser() and with auto_instantiate=false in the config. Fixes [6281](https://github.com/marimo-team/marimo/issues/6281).

## 🔍 Description of Changes

Check if the cell is not yet instantiated (haved run), and show user friendlier error message that tells them they need to re-run the cell. If there's no data (initial run), then don't show directory selector widget in the output, just the message:

<img width="2599" height="764" alt="image" src="https://github.com/user-attachments/assets/fe4e229c-eb16-4b44-bd5d-4db35523b389" />

The original FunctionCallRequest(...) error is caused by the fact, that cell with `auto_instantiate=false` loads the widget from the cache, which immediately calls plugin function (eg list_directories), but the runtime graph is empty and doesn't have any plugin functions registered b/c the cell hasn't run.
