### PR TITLE
fix: installHook.js:1 In HTML, <tr> cannot be a child of <table>

### DIFF
--- a/frontend/src/plugins/impl/FileBrowserPlugin.tsx
+++ b/frontend/src/plugins/impl/FileBrowserPlugin.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { NativeSelect } from "@/components/ui/native-select";
-import { Table, TableCell, TableRow } from "@/components/ui/table";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { toast } from "@/components/ui/use-toast";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { useInternalStateWithSync } from "@/hooks/useInternalStateWithSync";
@@ -458,7 +458,9 @@ export const FileBrowser = ({
         className="mt-3 overflow-y-auto w-full border"
         style={{ height: "14rem" }}
       >
-        <Table className="cursor-pointer table-fixed">{fileRows}</Table>
+        <Table className="cursor-pointer table-fixed">
+          <TableBody>{fileRows}</TableBody>
+        </Table>
       </div>
       <div className="mt-4">
         {value.length > 0 && (


### PR DESCRIPTION
## 📝 Summary

React validation hook exception fix for the FileBrowser plugin "In HTML, <tr> cannot be a child of <table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by the browser.”

<img width="2484" height="1020" alt="image" src="https://github.com/user-attachments/assets/016cad37-b0a2-4469-8616-6aea8e3d8482" />

## 🔍 Description of Changes

Simply added `tbody` are recommended.
