### PR TITLE
fix: allow syntax errors

### DIFF
--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -236,11 +236,14 @@ class CellManager:
             cell = ir_cell_factory(cell_def, cell_id=cell_id, filename=filename)
         except SyntaxError:
             self.unparsable = True
-            return self.register_unparsable_cell(
+            self.register_cell(
+                cell_id=cell_id,
                 code=cell_def.code,
+                config=cell_config,
                 name=cell_def.name,
-                cell_config=cell_config,
+                cell=None,
             )
+            return
         cell._cell.configure(cell_config)
         self._register_cell(cell, app=app)
 

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -228,10 +228,19 @@ class CellManager:
         else:
             cell_id = self.create_cell_id()
         filename = app.filename if app is not None else None
-        cell = ir_cell_factory(cell_def, cell_id=cell_id, filename=filename)
         cell_config = CellConfig.from_dict(
             cell_def.options,
         )
+
+        try:
+            cell = ir_cell_factory(cell_def, cell_id=cell_id, filename=filename)
+        except SyntaxError:
+            self.unparsable = True
+            return self.register_unparsable_cell(
+                code=cell_def.code,
+                name=cell_def.name,
+                cell_config=cell_config,
+            )
         cell._cell.configure(cell_config)
         self._register_cell(cell, app=app)
 

--- a/tests/_ast/codegen_data/test_syntax_errors.py
+++ b/tests/_ast/codegen_data/test_syntax_errors.py
@@ -1,0 +1,21 @@
+import marimo
+
+__generated_with = "0.15.5"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    tickers = ["AAPL", "GOOGL"]
+    global tickers
+
+@app.cell
+def _(tickers):
+    if tickers is not None:
+        return tickers
+    return
+
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_ast/codegen_data/test_syntax_errors.py
+++ b/tests/_ast/codegen_data/test_syntax_errors.py
@@ -5,12 +5,12 @@ app = marimo.App(width="medium")
 
 
 @app.cell
-def _():
+def global_error():
     tickers = ["AAPL", "GOOGL"]
     global tickers
 
 @app.cell
-def _(tickers):
+def return_error(tickers):
     if tickers is not None:
         return tickers
     return

--- a/tests/_ast/test_parse.py
+++ b/tests/_ast/test_parse.py
@@ -110,6 +110,14 @@ class TestParser:
         assert "run guard" in notebook.violations[2].description
 
     @staticmethod
+    def test_parse_syntax_errors() -> None:
+        notebook = parse_notebook(get_filepath("test_syntax_errors").read_text())
+        assert notebook
+        # Valid currently
+        # TODO: Propagate decorators violations.
+        assert len(notebook.violations) == 0
+
+    @staticmethod
     def test_parse_decorator_permutations() -> None:
         notebook = parse_notebook(get_filepath("test_decorators").read_text())
         assert notebook

--- a/tests/_ast/test_parse.py
+++ b/tests/_ast/test_parse.py
@@ -116,6 +116,10 @@ class TestParser:
         # Valid currently
         # TODO: Propagate decorators violations.
         assert len(notebook.violations) == 0
+        assert [cell.name for cell in notebook.cells] == [
+            "global_error",
+            "return_error",
+        ]
 
     @staticmethod
     def test_parse_decorator_permutations() -> None:


### PR DESCRIPTION
## 📝 Summary

Enables cell level syntax errors e.g.

```python
@app.cell
def _():
    tickers = ["AAPL", "GOOGL"]
    global tickers
```

to be opened. This is a bit more forgiving for `--watch` mode or agent generated code.
NB. Running as a script still fails due to python, but marimo can open these files.