### PR TITLE
fix 6353: enter for renaming a cell not working

### DIFF
--- a/frontend/src/components/editor/actions/name-cell-input.tsx
+++ b/frontend/src/components/editor/actions/name-cell-input.tsx
@@ -19,12 +19,14 @@ interface Props
   value: string;
   onChange: (newName: string) => void;
   placeholder?: string;
+  onEnterKey?: () => void;
 }
 
 export const NameCellInput: React.FC<Props> = ({
   value,
   onChange,
   placeholder,
+  onEnterKey,
   ...props
 }) => {
   const ref = useRef<HTMLInputElement>(null);
@@ -53,7 +55,10 @@ export const NameCellInput: React.FC<Props> = ({
       ref={ref}
       placeholder={placeholder}
       className="shadow-none! hover:shadow-none focus:shadow-none focus-visible:shadow-none"
-      onKeyDown={Events.onEnter(Events.stopPropagation())}
+      onKeyDown={Events.onEnter((e) => {
+        Events.stopPropagation()(e);
+        onEnterKey?.();
+      })}
       {...props}
     />
   );

--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -73,9 +73,10 @@ export interface CellActionButtonProps
 
 interface Props {
   cell: CellActionButtonProps | null;
+  closePopover?: () => void;
 }
 
-export function useCellActionButtons({ cell }: Props) {
+export function useCellActionButtons({ cell, closePopover }: Props) {
   const {
     createNewCell: createCell,
     updateCellConfig,
@@ -177,6 +178,7 @@ export function useCellActionButtons({ cell }: Props) {
             placeholder={"cell name"}
             value={name}
             onChange={(newName) => updateCellName({ cellId, name: newName })}
+            onEnterKey={() => closePopover?.()}
           />
         ),
       },

--- a/frontend/src/components/editor/cell/cell-actions.tsx
+++ b/frontend/src/components/editor/cell/cell-actions.tsx
@@ -56,7 +56,8 @@ const CellActionsDropdownInternal = (
   ref: React.Ref<CellActionsDropdownHandle>,
 ) => {
   const [open, setOpen] = useState(false);
-  const actions = useCellActionButtons({ cell: props });
+  const closePopover = () => setOpen(false);
+  const actions = useCellActionButtons({ cell: props, closePopover });
 
   // store the last focused element so we can restore it when the popover closes
   const restoreFocus = useRestoreFocus();


### PR DESCRIPTION
## 📝 Summary

Pressing enter on the rename cell menu isn't renaming the cell and closing the menu.
Fixes [6353](https://github.com/marimo-team/marimo/issues/6353).


## 🔍 Description of Changes

Pass a callback to close the popover to the cell-name input. Trigger it on ENTER.
