### PR TITLE
Download table regardless of cell selection

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -786,6 +786,9 @@ class table(
         # behavior: download selected rows if any, otherwise the searched view.
         manager_candidate: Union[TableManager[Any], list[TableCell]]
         if self._selection in ["single-cell", "multi-cell"]:
+            LOGGER.info(
+                "Download of cell selections not supported, downloading everything."
+            )
             manager_candidate = self._searched_manager
         else:
             manager_candidate = (

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -787,7 +787,7 @@ class table(
         manager_candidate: Union[TableManager[Any], list[TableCell]]
         if self._selection in ["single-cell", "multi-cell"]:
             LOGGER.info(
-                "Download of cell selections not supported, downloading everything."
+                "Cell selection downloads aren't supported; downloading all data."
             )
             manager_candidate = self._searched_manager
         else:

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1321,13 +1321,14 @@ def test_download_as_ignores_cell_selection() -> None:
     table = ui.table(data, selection="multi-cell")
     table._search(SearchTableArgs(query="2", page_size=10, page_number=0))
     # Make a cell selection; download should still include the filtered view
-    table._convert_value([{"rowId": "1", "columnName": "a"}])
-    for fmt in DOWNLOAD_FORMATS:
-        url = table._download_as(DownloadAsArgs(format=fmt))
-        if fmt == "csv":
-            df = _convert_data_bytes_to_pandas_df(url, fmt)
-            assert len(df) == 1
-            assert int(df["a"].iloc[0]) == 2
+    table._convert_value([{"rowId": "0", "columnName": "a"}])
+    # Use JSON format to avoid optional dependencies
+    url = table._download_as(DownloadAsArgs(format="json"))
+    data_bytes = from_data_uri(url)[1]
+    rows = json.loads(data_bytes)
+    assert isinstance(rows, list)
+    assert len(rows) == 1
+    assert int(rows[0]["a"]) == 2
 
 
 @pytest.mark.skipif(

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1257,10 +1257,11 @@ def test_download_as_pandas() -> None:
         assert len(filtered_df) == 2
         assert all(filtered_df["cities"].isin(["Newark", "New York"]))
 
-    # Test downloads with selection (includes search from before)
-    table._convert_value(["1"])
+    # Test downloads with row selection (includes search from before)
+    table._convert_value(["1"])  # select one row of the filtered view
     for format_type in DOWNLOAD_FORMATS:
         selected_df = download_and_convert(format_type, table)
+        # For row selection, selection is respected (single row)
         assert len(selected_df) == 1
         assert selected_df["cities"].iloc[0] == "New York"
 
@@ -1305,19 +1306,28 @@ def test_download_as_polars() -> None:
         assert len(filtered_df) == 2
         assert all(filtered_df["cities"].is_in(["Newark", "New York"]))
 
-    # Test downloads with selection (includes search from before)
-    table._convert_value(["1"])
+    # Test downloads with row selection (includes search from before)
+    table._convert_value(["1"])  # select one row of the filtered view
     for format_type in DOWNLOAD_FORMATS:
         selected_df = download_and_convert(format_type, table)
+        # For row selection, selection is respected (single row)
         assert len(selected_df) == 1
         assert selected_df["cities"][0] == "New York"
 
 
-def test_download_as_for_unsupported_cell_selection() -> None:
-    for selection in ["single-cell", "multi-cell"]:
-        table = ui.table(data=[], selection=selection)
-        with pytest.raises(NotImplementedError):
-            table._download_as(DownloadAsArgs(format="csv"))
+def test_download_as_ignores_cell_selection() -> None:
+    # Download should ignore selection when in cell selection modes
+    data = {"a": [1, 2, 3]}
+    table = ui.table(data, selection="multi-cell")
+    table._search(SearchTableArgs(query="2", page_size=10, page_number=0))
+    # Make a cell selection; download should still include the filtered view
+    table._convert_value([{"rowId": "1", "columnName": "a"}])
+    for fmt in DOWNLOAD_FORMATS:
+        url = table._download_as(DownloadAsArgs(format=fmt))
+        if fmt == "csv":
+            df = _convert_data_bytes_to_pandas_df(url, fmt)
+            assert len(df) == 1
+            assert int(df["a"].iloc[0]) == 2
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Related to https://github.com/marimo-team/marimo/pull/3725.
We would like to download the table when selection is `single-cell` or `multi-cell` regardless of the selection.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

Download is now failing, after these changes it works again.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
