### PR TITLE
show terminal above when there is no space

### DIFF
--- a/frontend/src/components/terminal/terminal.tsx
+++ b/frontend/src/components/terminal/terminal.tsx
@@ -65,7 +65,7 @@ interface TerminalComponentProps {
 interface Position {
   x: number;
   y: number;
-  placement: "bottom" | "top";
+  placement: "bottom" | "top"; // Whether to place the menu above or below the cursor
 }
 
 // Keyboard shortcut handlers


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Fixes context menu displaying above the cursor when at the bottom of the screen. Since there is no space, we can display above instead of below.

Normal placement
<img width="277" height="223" alt="CleanShot 2025-09-17 at 23 49 36" src="https://github.com/user-attachments/assets/5dc4c8a0-6ad3-4854-b209-b9fb8ce90f41" />

Above placement
<img width="247" height="284" alt="CleanShot 2025-09-17 at 23 47 05" src="https://github.com/user-attachments/assets/1e279b24-920f-48e7-813e-5ff2d5f8cecf" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
