### PR TITLE
feat: add `--unsafe-fixes` and example rule

### DIFF
--- a/docs/guides/lint_rules/index.md
+++ b/docs/guides/lint_rules/index.md
@@ -42,10 +42,12 @@ These are style and formatting issues.
 | [MF001](rules/general_formatting.md) | general-formatting | General formatting issues with the notebook format. | 🛠️ |
 | [MF002](rules/parse_stdout.md) | parse-stdout | Parse captured stdout during notebook loading | ❌ |
 | [MF003](rules/parse_stderr.md) | parse-stderr | Parse captured stderr during notebook loading | ❌ |
+| [MF004](rules/empty_cells.md) | empty-cells | Empty cells that can be safely removed. | ⚠️ |
 
 ## Legend
 
 - 🛠️ = Automatically fixable with `marimo check --fix`
+- ⚠️ = Fixable with `marimo check --fix --unsafe-fixes` (may change code behavior)
 - ❌ = Not automatically fixable
 
 ## Configuration

--- a/docs/guides/lint_rules/rules/empty_cells.md
+++ b/docs/guides/lint_rules/rules/empty_cells.md
@@ -1,0 +1,63 @@
+# MF004: empty-cells
+
+✨ **Formatting** ⚠️ Unsafe Fixable
+
+MF004: Empty cells that can be safely removed.
+
+## What it does
+
+Detects cells that contain only:
+- Whitespace characters (spaces, tabs, newlines)
+- Comments (lines starting with #)
+- Pass statements (`pass`)
+- Any combination of the above
+
+## Why is this bad?
+
+Empty cells can:
+- Create clutter in notebook structure
+- Add unnecessary complexity to the execution graph
+- Make notebooks harder to read and maintain
+- Increase file size without adding value
+
+While not functionally breaking, removing empty cells improves code
+clarity and reduces visual noise.
+
+## Examples
+
+**Problematic:**
+```python
+# Cell 1: Only whitespace
+```
+
+**Problematic:**
+```python
+# Cell 2: Only comments
+# This is just a comment
+# Nothing else here
+```
+
+**Problematic:**
+```python
+# Cell 3: Only pass statement
+pass
+```
+
+**Problematic:**
+```python
+# Cell 4: Mix of comments, whitespace, and pass
+# Some comment
+
+pass
+# Another comment
+```
+
+**Note:** This fix requires `--unsafe-fixes` because removing cells changes
+the notebook structure, which could potentially affect cell execution order
+or references in rare edge cases.
+
+## References
+
+- [Understanding Errors](https://docs.marimo.io/guides/understanding_errors/)
+- [Best Practices](https://docs.marimo.io/guides/best_practices/)
+

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -1247,9 +1247,21 @@ def shell_completion() -> None:
     type=bool,
     help="Whether to print detailed messages.",
 )
+@click.option(
+    "--unsafe-fixes",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    type=bool,
+    help="Enable fixes that may change code behavior (e.g., removing empty cells).",
+)
 @click.argument("files", nargs=-1, type=click.UNPROCESSED)
 def check(
-    fix: bool, strict: bool, verbose: bool, files: tuple[str, ...]
+    fix: bool,
+    strict: bool,
+    verbose: bool,
+    unsafe_fixes: bool,
+    files: tuple[str, ...],
 ) -> None:
     if not files:
         # If no files are provided, we lint the current directory
@@ -1257,7 +1269,7 @@ def check(
 
     # Pass click.echo directly as pipe for streaming output, or None
     pipe = click.echo if verbose else None
-    linter = run_check(files, pipe=pipe, fix=fix)
+    linter = run_check(files, pipe=pipe, fix=fix, unsafe_fixes=unsafe_fixes)
 
     # Get counts from linter (fix happens automatically during streaming)
     fixed = linter.fixed_count

--- a/marimo/_lint/__init__.py
+++ b/marimo/_lint/__init__.py
@@ -17,6 +17,7 @@ def run_check(
     file_patterns: tuple[str, ...],
     pipe: Callable[[str], None] | None = None,
     fix: bool = False,
+    unsafe_fixes: bool = False,
 ) -> Linter:
     """Run linting checks on files matching patterns (CLI entry point).
 
@@ -27,6 +28,7 @@ def run_check(
         file_patterns: Glob patterns for file discovery
         pipe: Optional function to call for streaming output
         fix: Whether to fix files automatically
+        unsafe_fixes: Whether to enable unsafe fixes that may change behavior
 
     Returns:
         Linter with per-file status and diagnostics
@@ -34,7 +36,7 @@ def run_check(
     # Expand patterns to actual files
     files_to_check = expand_file_patterns(file_patterns)
 
-    linter = Linter(pipe=pipe, fix_files=fix)
+    linter = Linter(pipe=pipe, fix_files=fix, unsafe_fixes=unsafe_fixes)
     linter.run_streaming(files_to_check)
     return linter
 

--- a/marimo/_lint/diagnostic.py
+++ b/marimo/_lint/diagnostic.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, cast
+from typing import Literal, Optional, cast
 
 from marimo._types.ids import CellId_t
 
@@ -32,7 +32,7 @@ class Diagnostic:
     code: Optional[str] = None
     name: Optional[str] = None
     severity: Optional[Severity] = None
-    fixable: Optional[bool] = None
+    fixable: bool | Literal["unsafe"] | None = None
     fix: Optional[str] = None
     filename: Optional[str] = None
 

--- a/marimo/_lint/rules/base.py
+++ b/marimo/_lint/rules/base.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from marimo._lint.diagnostic import Severity
 
 if TYPE_CHECKING:
     from marimo._lint.context import RuleContext
+    from marimo._lint.diagnostic import Diagnostic
+    from marimo._schemas.serialization import NotebookSerialization
 
 
 class LintRule(ABC):
@@ -18,9 +20,28 @@ class LintRule(ABC):
     name: str
     description: str
     severity: Severity
-    fixable: bool
+    fixable: bool | Literal["unsafe"]
 
     @abstractmethod
     async def check(self, ctx: RuleContext) -> None:
         """Check notebook for violations of this rule using the provided context."""
+        pass
+
+
+class UnsafeFixRule(LintRule):
+    """Base class for rules that can apply unsafe fixes to notebook IR."""
+
+    @abstractmethod
+    def apply_unsafe_fix(
+        self, notebook: NotebookSerialization, diagnostics: list[Diagnostic]
+    ) -> NotebookSerialization:
+        """Apply unsafe fix to notebook IR.
+
+        Args:
+            notebook: The notebook to modify
+            diagnostics: List of diagnostics that triggered this fix
+
+        Returns:
+            Modified notebook serialization
+        """
         pass

--- a/marimo/_lint/rules/formatting/__init__.py
+++ b/marimo/_lint/rules/formatting/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Marimo. All rights reserved.
-from marimo._lint.rules.base import LintRule
+from marimo._lint.rules.base import LintRule, UnsafeFixRule
+from marimo._lint.rules.formatting.empty_cells import EmptyCellRule
 from marimo._lint.rules.formatting.general import GeneralFormattingRule
 from marimo._lint.rules.formatting.parsing import StderrRule, StdoutRule
 
@@ -7,6 +8,7 @@ FORMATTING_RULE_CODES: dict[str, type[LintRule]] = {
     "MF001": GeneralFormattingRule,
     "MF002": StdoutRule,
     "MF003": StderrRule,
+    "MF004": EmptyCellRule,
 }
 
 __all__ = [
@@ -14,4 +16,6 @@ __all__ = [
     "FORMATTING_RULE_CODES",
     "StdoutRule",
     "StderrRule",
+    "EmptyCellRule",
+    "UnsafeFixRule",
 ]

--- a/marimo/_lint/rules/formatting/empty_cells.py
+++ b/marimo/_lint/rules/formatting/empty_cells.py
@@ -1,0 +1,195 @@
+# Copyright 2025 Marimo. All rights reserved.
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+from marimo._ast.parse import ast_parse
+from marimo._lint.diagnostic import Diagnostic, Severity
+from marimo._lint.rules.base import UnsafeFixRule
+from marimo._schemas.serialization import NotebookSerialization
+from marimo._types.ids import CellId_t
+
+if TYPE_CHECKING:
+    from marimo._lint.context import RuleContext
+
+
+class EmptyCellRule(UnsafeFixRule):
+    """MF004: Empty cells that can be safely removed.
+
+    This rule identifies cells that contain only whitespace, comments, or `pass`
+    statements and can be safely removed from the notebook without affecting
+    functionality. Empty cells often accumulate during development and can
+    clutter the notebook structure.
+
+    ## What it does
+
+    Detects cells that contain only:
+    - Whitespace characters (spaces, tabs, newlines)
+    - Comments (lines starting with #)
+    - Pass statements (`pass`)
+    - Any combination of the above
+
+    ## Why is this bad?
+
+    Empty cells can:
+    - Create clutter in notebook structure
+    - Add unnecessary complexity to the execution graph
+    - Make notebooks harder to read and maintain
+    - Increase file size without adding value
+
+    While not functionally breaking, removing empty cells improves code
+    clarity and reduces visual noise.
+
+    ## Examples
+
+    **Problematic:**
+    ```python
+    # Cell 1: Only whitespace
+    ```
+
+    **Problematic:**
+    ```python
+    # Cell 2: Only comments
+    # This is just a comment
+    # Nothing else here
+    ```
+
+    **Problematic:**
+    ```python
+    # Cell 3: Only pass statement
+    pass
+    ```
+
+    **Problematic:**
+    ```python
+    # Cell 4: Mix of comments, whitespace, and pass
+    # Some comment
+
+    pass
+    # Another comment
+    ```
+
+    **Note:** This fix requires `--unsafe-fixes` because removing cells changes
+    the notebook structure, which could potentially affect cell execution order
+    or references in rare edge cases.
+
+    ## References
+
+    - [Understanding Errors](https://docs.marimo.io/guides/understanding_errors/)
+    - [Best Practices](https://docs.marimo.io/guides/best_practices/)
+    """
+
+    code = "MF004"
+    name = "empty-cells"
+    description = "Empty cells that can be safely removed."
+    severity = Severity.FORMATTING
+    fixable = "unsafe"
+
+    async def check(self, ctx: RuleContext) -> None:
+        """Check for empty cells that can be removed."""
+        for i, cell in enumerate(ctx.notebook.cells):
+            if self._is_empty_cell(cell.code):
+                # Create diagnostic for this empty cell
+                idx = CellId_t(str(i))
+                diagnostic = Diagnostic(
+                    message="Empty cell can be removed (contains only whitespace, comments, or pass)",
+                    cell_id=[idx],
+                    line=cell.lineno - 1,  # Convert 1-based to 0-based
+                    column=cell.col_offset,
+                    fixable="unsafe",
+                )
+
+                await ctx.add_diagnostic(diagnostic)
+
+    def apply_unsafe_fix(
+        self, notebook: NotebookSerialization, diagnostics: list[Diagnostic]
+    ) -> NotebookSerialization:
+        """Remove empty cells from the notebook.
+
+        Args:
+            notebook: The notebook to modify
+            diagnostics: List of diagnostics containing cell information
+
+        Returns:
+            Modified notebook with empty cells removed
+        """
+        # Collect all cell IDs to remove from all diagnostics
+        cells_to_remove: set[CellId_t] = set()
+        for diagnostic in diagnostics:
+            if diagnostic.cell_id is not None:
+                (cell_id,) = diagnostic.cell_id
+                cells_to_remove.add(cell_id)
+
+        # Remove cells with matching IDs
+        cells = [
+            cell
+            for i, cell in enumerate(notebook.cells)
+            if CellId_t(str(i)) not in cells_to_remove
+        ]
+        return NotebookSerialization(
+            header=notebook.header,
+            version=notebook.version,
+            app=notebook.app,
+            cells=cells,
+            violations=notebook.violations,
+            valid=notebook.valid,
+            filename=notebook.filename,
+        )
+
+    def _is_empty_cell(self, code: str) -> bool:
+        """Check if a cell is considered empty.
+
+        Args:
+            code: The cell's source code
+
+        Returns:
+            True if the cell is empty (contains only whitespace, comments, or pass)
+        """
+        # Strip whitespace
+        stripped = code.strip()
+
+        # Empty after stripping whitespace
+        if not stripped:
+            return True
+
+        try:
+            # Parse the code to check what statements it contains
+            tree = ast_parse(stripped)
+
+            # If no statements, it's empty
+            if not tree.body:
+                return True
+
+            # Check if all statements are pass statements
+            for node in tree.body:
+                if not isinstance(node, ast.Pass):
+                    return False
+
+            return True
+
+        except SyntaxError:
+            # If it doesn't parse, check if it's only comments
+            return self._is_only_comments(code)
+
+    def _is_only_comments(self, code: str) -> bool:
+        """Check if code contains only comments and whitespace.
+
+        Args:
+            code: The source code to check
+
+        Returns:
+            True if the code contains only comments and whitespace
+        """
+        lines = code.splitlines()
+
+        for line in lines:
+            stripped_line = line.strip()
+            # Skip empty lines
+            if not stripped_line:
+                continue
+            # If line doesn't start with #, it's not just a comment
+            if not stripped_line.startswith("#"):
+                return False
+
+        return True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,10 +100,11 @@ nav:
               - Multiple definitions: guides/lint_rules/rules/multiple_definitions.md
               - Cycle dependencies: guides/lint_rules/rules/cycle_dependencies.md
               - Setup cell dependencies: guides/lint_rules/rules/setup_cell_dependencies.md
-              - Syntax Error: guides/lint_rules/rules/invalid_syntax.md
+              - Syntax error: guides/lint_rules/rules/invalid_syntax.md
               - General formatting: guides/lint_rules/rules/general_formatting.md
               - Parse stdout: guides/lint_rules/rules/parse_stdout.md
               - Parse stderr: guides/lint_rules/rules/parse_stderr.md
+              - Empty cells: guides/lint_rules/rules/empty_cells.md
       - SQL, dataframes, and plots:
           - SQL, dataframes, and plots: guides/working_with_data/index.md
           - DataFrames: guides/working_with_data/dataframes.md

--- a/tests/_lint/snapshots/empty_cells.txt
+++ b/tests/_lint/snapshots/empty_cells.txt
@@ -1,0 +1,30 @@
+warning[empty-cells]: Empty cell can be removed (contains only whitespace, comments, or pass)
+ --> tests/_lint/test_files/empty_cells.py:8:0
+   8 | def _():
+   9 |     return
+     |     ^
+  10 | 
+warning[empty-cells]: Empty cell can be removed (contains only whitespace, comments, or pass)
+ --> tests/_lint/test_files/empty_cells.py:12:0
+  12 | @app.cell
+  13 | def has_pass():
+     |     ^
+  14 |     # This is just a comment
+warning[empty-cells]: Empty cell can be removed (contains only whitespace, comments, or pass)
+ --> tests/_lint/test_files/empty_cells.py:19:0
+  19 | @app.cell
+  20 | def has_comment():
+     |     ^
+  21 |     # Only comment
+warning[empty-cells]: Empty cell can be removed (contains only whitespace, comments, or pass)
+ --> tests/_lint/test_files/empty_cells.py:26:0
+  26 | @app.cell
+  27 | def has_mix():
+     |     ^
+  28 | 
+warning[empty-cells]: Empty cell can be removed (contains only whitespace, comments, or pass)
+ --> tests/_lint/test_files/empty_cells.py:34:0
+  34 | @app.cell
+  35 | def _empty_cell_with_just_whitespace():
+     |     ^
+  36 | 

--- a/tests/_lint/snapshots/formatting.txt
+++ b/tests/_lint/snapshots/formatting.txt
@@ -25,3 +25,9 @@ warning[general-formatting]: Unexpected statement, expected cell definitions.
 warning[general-formatting]: Expected run guard statement
  --> tests/_lint/test_files/formatting.py
    1 | """Example to test formatting issues."""
+warning[empty-cells]: Empty cell can be removed (contains only whitespace, comments, or pass)
+ --> tests/_lint/test_files/formatting.py:13:0
+  13 | @app.cell
+  14 | def _():
+     |     ^
+  15 |     pass

--- a/tests/_lint/test_empty_cells.py
+++ b/tests/_lint/test_empty_cells.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Marimo. All rights reserved.
+"""Snapshot tests for empty cells lint rule."""
+
+from marimo._ast.parse import parse_notebook
+from tests._lint.utils import lint_notebook
+from tests.mocks import snapshotter
+
+snapshot = snapshotter(__file__)
+
+
+def test_empty_cells_detection_snapshot():
+    """Test snapshot for empty cells detection."""
+    file = "tests/_lint/test_files/empty_cells.py"
+    with open(file) as f:
+        code = f.read()
+
+    notebook = parse_notebook(code, filepath=file)
+    errors = lint_notebook(notebook)
+
+    # Format errors for snapshot
+    error_output = []
+    for error in errors:
+        error_output.append(error.format())
+
+    snapshot("empty_cells.txt", "\n".join(error_output))

--- a/tests/_lint/test_files/empty_cells.py
+++ b/tests/_lint/test_files/empty_cells.py
@@ -1,0 +1,50 @@
+import marimo
+
+__generated_with = "0.15.5"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell
+def has_pass():
+    # This is just a comment
+    pass
+    return
+
+
+@app.cell
+def has_comment():
+    # Only comment
+    # Another comment
+    return
+
+
+@app.cell
+def has_mix():
+
+    # Only whitespace and comment
+    pass
+    return
+
+
+@app.cell
+def _empty_cell_with_just_whitespace():
+
+
+
+
+    return
+
+
+@app.cell
+def normal_cell():
+    x = 1
+    return x,
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_lint/test_run_check.py
+++ b/tests/_lint/test_run_check.py
@@ -181,7 +181,8 @@ class TestFileStatus:
             )
 
             # Since no notebook, fix should return False (no changes)
-            result = await Linter.fix(status)
+            linter = Linter()
+            result = await linter.fix(status)
             assert result is False
 
             # File should remain unchanged
@@ -214,7 +215,8 @@ class TestFileStatus:
             )
 
             # Since no notebook, fix should return False (no changes)
-            result = await Linter.fix(status)
+            linter = Linter()
+            result = await linter.fix(status)
             assert result is False
 
             # File should remain unchanged
@@ -269,7 +271,8 @@ class TestFileStatus:
             )
 
             # Since no notebook, fix should return False (no changes)
-            result = await Linter.fix(status)
+            linter = Linter()
+            result = await linter.fix(status)
             assert result is False
 
             # File should remain unchanged
@@ -340,10 +343,11 @@ def __():
 
             # Test fixing (if notebook is available)
             if file_status.notebook is not None:
-                # Use Linter.fix() static method
+                # Use Linter.fix() method
                 import asyncio
 
-                result = asyncio.run(Linter.fix(file_status))
+                linter = Linter()
+                result = asyncio.run(linter.fix(file_status))
                 assert isinstance(result, bool)
 
     def test_error_handling_in_run_check(self):


### PR DESCRIPTION
## 📝 Summary

`--unsafe-fixes` mutates the notebooks in ways that may change the behavior or alter the notebook structure.
As an example, this PR introduces `empty-cells` which strips empty cells from marimo. For example:

```python
...
@app.cell
def _():
    pass

@app.cell
def _():
    # just a comment, will still be removed
    return
```

Trigger errors like:

<img width="807" height="598" alt="image" src="https://github.com/user-attachments/assets/0744dd02-e778-47f3-ba81-0731b9f45e9f" />


Rules with `--unsafe_fixes` hooks should inherit from `UnsafeFixRule` and implement `apply_unsafe_fix`