### PR TITLE
fix: add '__class__' as a builtin

### DIFF
--- a/marimo/_ast/variables.py
+++ b/marimo/_ast/variables.py
@@ -23,6 +23,13 @@ BUILTINS = set(
         "__builtin__",
         "__file__",
         "__builtins__",
+        # Only resolved in a class function, i.e.:
+        #   class A:
+        #       @staticmethod
+        #       def f():
+        #           (set(locals().keys()) - BUILTINS) == {'__class__'}
+        # but promote to a global builtin for simplicity
+        "__class__",
     }
 )
 

--- a/tests/_ast/test_toplevel.py
+++ b/tests/_ast/test_toplevel.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import builtins
-
 from marimo._ast import toplevel
 from marimo._ast.app import App, InternalApp
 from marimo._ast.toplevel import (
@@ -11,8 +9,7 @@ from marimo._ast.toplevel import (
     TopLevelStatus,
     TopLevelType,
 )
-
-BUILTINS = set(builtins.__dict__.keys())
+from marimo._ast.variables import BUILTINS
 
 
 class TestTopLevelStatus:
@@ -591,3 +588,16 @@ class TestTopLevelHook:
             TopLevelType.TOPLEVEL,
             TopLevelType.TOPLEVEL,
         ] == [s.type for s in extraction], [s.hint for s in extraction]
+
+    @staticmethod
+    def test_class_builtin_ignored(app) -> None:
+        @app.cell
+        def cell():
+            class Example:
+                @staticmethod
+                def method() -> None:
+                    print(__class__)
+                    return
+
+        status = TopLevelStatus.from_cell(cell._cell, BUILTINS)
+        assert status.type == TopLevelType.TOPLEVEL


### PR DESCRIPTION
## 📝 Summary

closes: #6386

Quick fix to add `__class__` as a builtin for toplevel function resolution. To properly resolve `__class__` in its given context a fair bit more complexity, so this simple fix should suffice.