### PR TITLE
fix: shelex paths for lsp

### DIFF
--- a/marimo/_cli/envinfo.py
+++ b/marimo/_cli/envinfo.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import platform
 import sys
+from pathlib import Path
 from typing import Any, Union, cast
 
 from marimo import _loggers
@@ -50,9 +51,11 @@ def get_system_info() -> dict[str, Union[str, bool, dict[str, Any]]]:
     if platform.system() == "Windows" and is_win11():
         os_version = "11"
 
+    location = Path(__file__).parent.parent.as_posix()
     info: dict[str, Union[str, bool, dict[str, Any]]] = {
         "marimo": __version__,
         "editable": is_editable("marimo"),
+        "location": location,
         "OS": platform.system(),
         "OS Version": os_version,
         # e.g., x86 or arm

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -326,10 +326,15 @@ class TyServer(BaseLspServer):
         return True
 
     def get_command(self) -> list[str]:
+        import shlex
+
         from ty.__main__ import find_ty_bin  # type: ignore
 
         lsp_bin = marimo_package_path() / "_lsp" / "index.cjs"
         log_file = _loggers.get_log_directory() / "ty-lsp.log"
+
+        # Properly quote the ty binary path to handle spaces and special characters
+        ty_command = f"{shlex.quote(find_ty_bin())} server"
 
         return [
             "node",
@@ -337,7 +342,7 @@ class TyServer(BaseLspServer):
             "--port",
             str(self.port),
             "--lsp",
-            f"{find_ty_bin()} server",
+            ty_command,
             "--log-file",
             str(log_file),
         ]

--- a/marimo/_server/lsp.py
+++ b/marimo/_server/lsp.py
@@ -189,6 +189,8 @@ class CopilotLspServer(BaseLspServer):
         return self._lsp_dir() / "index.cjs"
 
     def get_command(self) -> list[str]:
+        import shlex
+
         lsp_bin = self._lsp_bin()
         # Check if the LSP binary exists
         if not lsp_bin.exists():
@@ -199,13 +201,16 @@ class CopilotLspServer(BaseLspServer):
         copilot_bin = self._lsp_dir() / "copilot" / "language-server.js"
         log_file = _loggers.get_log_directory() / "github-copilot-lsp.log"
 
+        # Properly quote the copilot binary path to handle spaces and special characters
+        copilot_command = f"node {shlex.quote(str(copilot_bin))} --stdio"
+
         return [
             "node",
             str(lsp_bin),
             "--port",
             str(self.port),
             "--lsp",
-            f"node {copilot_bin} --stdio",
+            copilot_command,
             "--log-file",
             str(log_file),
         ]

--- a/tests/_server/test_lsp.py
+++ b/tests/_server/test_lsp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Union, cast
 from unittest import mock
 
@@ -131,17 +132,14 @@ def test_copilot_server():
     assert "GitHub Copilot" in alert.title
 
 
-def test_copilot_server_command_quotes_path():
+def test_copilot_server_command_quotes_path(tmp_path: Path) -> None:
     """Test that paths with spaces are properly quoted in the copilot command."""
-    import tempfile
-    from pathlib import Path
     from unittest import mock
 
     server = CopilotLspServer(port=8000)
 
-    # Mock the LSP directory to contain spaces
-    temp_dir = Path(tempfile.mkdtemp())
-    lsp_dir_with_spaces = temp_dir / "my folder with spaces"
+    # Create LSP directory with spaces
+    lsp_dir_with_spaces = tmp_path / "my folder with spaces"
     lsp_dir_with_spaces.mkdir(parents=True)
 
     # Create the required files
@@ -171,11 +169,6 @@ def test_copilot_server_command_quotes_path():
             or f'"{copilot_bin}"' in lsp_command
         )
         assert "--stdio" in lsp_command
-
-    # Clean up
-    import shutil
-
-    shutil.rmtree(temp_dir)
 
 
 def test_copilot_server_node_version_validation():

--- a/tests/_server/test_lsp.py
+++ b/tests/_server/test_lsp.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Union, cast
 from unittest import mock
 
@@ -28,6 +27,7 @@ from marimo._server.lsp import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
 
 @pytest.fixture


### PR DESCRIPTION
## 📝 Summary

If a user creates a virtual environment in `/a path with spaces/` then the copilot lsp location may not be properly resolved. This adds string release to properly pass in the binary location.

Additionally, added the `location` key to environment to help debug in the future.