### PR TITLE
feat: add session_ttl parameter to create_asgi_app

### DIFF
--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -297,6 +297,7 @@ def create_asgi_app(
     include_code: bool = False,
     token: Optional[str] = None,
     skew_protection: bool = False,
+    session_ttl: Optional[int] = None,
 ) -> ASGIAppBuilder:
     """Public API to create an ASGI app that can serve multiple notebooks.
     This only works for application that are in Run mode.
@@ -308,6 +309,7 @@ def create_asgi_app(
             If not provided, an empty token is used.
         skew_protection (bool, optional): Enable skew protection middleware to prevent version mismatch issues.
             e.g. if the server is updated, the client will be prompted to reload.
+        session_ttl (int, optional): Time-to-live in seconds for sessions. If not provided, uses default TTL (2 minutes).
 
     Returns:
         ASGIAppBuilder: A builder object to create multiple ASGI apps
@@ -466,7 +468,7 @@ def create_asgi_app(
                 argv=None,
                 auth_token=auth_token,
                 redirect_console_to_browser=False,
-                ttl_seconds=None,
+                ttl_seconds=session_ttl,
             )
             enable_auth = not AuthToken.is_empty(auth_token)
             app = create_starlette_app(

--- a/tests/_server/test_asgi.py
+++ b/tests/_server/test_asgi.py
@@ -267,6 +267,20 @@ class TestASGIAppBuilder(unittest.TestCase):
         assert response.headers["x-middleware-1"] == "applied"
         assert response.headers["x-middleware-2"] == "applied"
 
+    def test_session_ttl_parameter(self):
+        """Test that session_ttl parameter is passed to SessionManager."""
+        builder = create_asgi_app(
+            quiet=True, include_code=True, session_ttl=300
+        )
+        builder = builder.with_app(path="/app1", root=self.app1)
+        builder.build()
+
+        # Access the app state to verify session_ttl was set
+        # We need to get the Starlette app inside the builder
+        starlette_app = builder._app_cache[self.app1]
+        session_manager = starlette_app.state.session_manager
+        assert session_manager.ttl_seconds == 300
+
 
 class TestDynamicDirectoryMiddleware(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
- Introduced `session_ttl` parameter to control session time-to-live in seconds. Defaults to 2 minutes if not provided.
