### PR TITLE
test: progress_bar with iterator and total

### DIFF
--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -129,6 +129,9 @@ def test_progress_without_context():
             assert bar
             bar.update()
 
+    # iterator (no len()) with total
+    assert progress_bar(iter(range(1000)), total=1000)
+
     with pytest.raises(RuntimeError):
         for _ in progress_bar(total=10):
             pass


### PR DESCRIPTION
## 📝 Summary

Add a test for `mo.status.progress_bar()` with an iterator and a `total` argument as noted in #6414.

## 🔍 Description of Changes

See summary.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
