### PR TITLE
Enable TypeScript `erasableSyntaxOnly`

### DIFF
--- a/frontend/src/components/data-table/column-summary/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/column-summary/chart-spec-model.tsx
@@ -64,17 +64,34 @@ export class ColumnChartSpecModel<T> {
   private dataSpec: TopLevelSpec["data"];
   private sourceName: "data_0" | "source_0";
 
+  private readonly data: T[] | string;
+  private readonly fieldTypes: FieldTypes;
+  readonly stats: Record<ColumnName, Partial<ColumnHeaderStats>>;
+  readonly binValues: Record<ColumnName, BinValues>;
+  readonly valueCounts: Record<ColumnName, ValueCounts>;
+  private readonly opts: {
+    includeCharts: boolean;
+    usePreComputedValues?: boolean;
+  };
+
   constructor(
-    private readonly data: T[] | string,
-    private readonly fieldTypes: FieldTypes,
-    readonly stats: Record<ColumnName, Partial<ColumnHeaderStats>>,
-    readonly binValues: Record<ColumnName, BinValues>,
-    readonly valueCounts: Record<ColumnName, ValueCounts>,
-    private readonly opts: {
+    data: T[] | string,
+    fieldTypes: FieldTypes,
+    stats: Record<ColumnName, Partial<ColumnHeaderStats>>,
+    binValues: Record<ColumnName, BinValues>,
+    valueCounts: Record<ColumnName, ValueCounts>,
+    opts: {
       includeCharts: boolean;
       usePreComputedValues?: boolean;
     },
   ) {
+    this.data = data;
+    this.fieldTypes = fieldTypes;
+    this.stats = stats;
+    this.binValues = binValues;
+    this.valueCounts = valueCounts;
+    this.opts = opts;
+
     // Data may come in from a few different sources:
     // - A URL
     // - A CSV data URI (e.g. "data:text/csv;base64,...")

--- a/frontend/src/components/editor/ai/transport/chat-transport.tsx
+++ b/frontend/src/components/editor/ai/transport/chat-transport.tsx
@@ -13,11 +13,14 @@ import {
 export class StreamingChunkTransport<
   UI_MESSAGE extends UIMessage,
 > extends DefaultChatTransport<UI_MESSAGE> {
+  private onChunkReceived: (chunk: UIMessageChunk) => void;
+
   constructor(
     options: HttpChatTransportInitOptions<UI_MESSAGE> = {},
-    private onChunkReceived: (chunk: UIMessageChunk) => void,
+    onChunkReceived: (chunk: UIMessageChunk) => void,
   ) {
     super(options);
+    this.onChunkReceived = onChunkReceived;
   }
 
   protected override processResponseStream(

--- a/frontend/src/components/editor/file-tree/requesting-tree.tsx
+++ b/frontend/src/components/editor/file-tree/requesting-tree.tsx
@@ -13,15 +13,21 @@ import { type FilePath, PathBuilder } from "@/utils/paths";
 
 export class RequestingTree {
   private delegate = new SimpleTree<FileInfo>([]);
+  private callbacks: {
+    listFiles: EditRequests["sendListFiles"];
+    createFileOrFolder: EditRequests["sendCreateFileOrFolder"];
+    deleteFileOrFolder: EditRequests["sendDeleteFileOrFolder"];
+    renameFileOrFolder: EditRequests["sendRenameFileOrFolder"];
+  };
 
-  constructor(
-    private callbacks: {
-      listFiles: EditRequests["sendListFiles"];
-      createFileOrFolder: EditRequests["sendCreateFileOrFolder"];
-      deleteFileOrFolder: EditRequests["sendDeleteFileOrFolder"];
-      renameFileOrFolder: EditRequests["sendRenameFileOrFolder"];
-    },
-  ) {}
+  constructor(callbacks: {
+    listFiles: EditRequests["sendListFiles"];
+    createFileOrFolder: EditRequests["sendCreateFileOrFolder"];
+    deleteFileOrFolder: EditRequests["sendDeleteFileOrFolder"];
+    renameFileOrFolder: EditRequests["sendRenameFileOrFolder"];
+  }) {
+    this.callbacks = callbacks;
+  }
 
   private rootPath: FilePath = "" as FilePath;
   private onChange: (data: FileInfo[]) => void = Functions.NOOP;

--- a/frontend/src/core/ai/context/__tests__/registry.test.ts
+++ b/frontend/src/core/ai/context/__tests__/registry.test.ts
@@ -101,11 +101,13 @@ class AttachmentContextProvider extends AIContextProvider<MockContextItem> {
   readonly mentionPrefix = "@";
   readonly contextType = "attachment";
 
-  constructor(
-    private items: MockContextItem[] = [],
-    private attachments: FileUIPart[] = [],
-  ) {
+  private items: MockContextItem[];
+  private attachments: FileUIPart[];
+
+  constructor(items: MockContextItem[] = [], attachments: FileUIPart[] = []) {
     super();
+    this.items = items;
+    this.attachments = attachments;
   }
 
   getItems(): MockContextItem[] {

--- a/frontend/src/core/ai/context/providers/cell-output.ts
+++ b/frontend/src/core/ai/context/providers/cell-output.ts
@@ -86,9 +86,10 @@ export class CellOutputContextProvider extends AIContextProvider<CellOutputConte
   readonly title = "Cell Outputs";
   readonly mentionPrefix = "@";
   readonly contextType = "cell-output";
-
-  constructor(private store: JotaiStore) {
+  private store: JotaiStore;
+  constructor(store: JotaiStore) {
     super();
+    this.store = store;
   }
 
   getItems(): CellOutputContextItem[] {

--- a/frontend/src/core/ai/context/providers/error.ts
+++ b/frontend/src/core/ai/context/providers/error.ts
@@ -64,9 +64,11 @@ export class ErrorContextProvider extends AIContextProvider<ErrorContextItem> {
   readonly title = "Errors";
   readonly mentionPrefix = "@";
   readonly contextType = "error";
+  private store: JotaiStore;
 
-  constructor(private store: JotaiStore) {
+  constructor(store: JotaiStore) {
     super();
+    this.store = store;
   }
 
   getItems(): ErrorContextItem[] {

--- a/frontend/src/core/ai/context/providers/file.ts
+++ b/frontend/src/core/ai/context/providers/file.ts
@@ -43,11 +43,16 @@ export class FileContextProvider extends AIContextProvider<FileContextItem> {
   readonly mentionPrefix = "#";
   readonly contextType = "file";
 
+  private apiRequests: EditRequests & RunRequests;
+  private config: FileSearchConfig;
+
   constructor(
-    private apiRequests: EditRequests & RunRequests,
-    private config: FileSearchConfig = DEFAULT_FILE_SEARCH_CONFIG,
+    apiRequests: EditRequests & RunRequests,
+    config: FileSearchConfig = DEFAULT_FILE_SEARCH_CONFIG,
   ) {
     super();
+    this.apiRequests = apiRequests;
+    this.config = config;
   }
 
   /**

--- a/frontend/src/core/ai/context/providers/tables.ts
+++ b/frontend/src/core/ai/context/providers/tables.ts
@@ -17,9 +17,10 @@ export class TableContextProvider extends AIContextProvider<TableContextItem> {
   readonly title = "Tables";
   readonly mentionPrefix = "@";
   readonly contextType = "data";
-
-  constructor(private tablesMap: DatasetTablesMap) {
+  private tablesMap: DatasetTablesMap;
+  constructor(tablesMap: DatasetTablesMap) {
     super();
+    this.tablesMap = tablesMap;
   }
 
   getItems(): TableContextItem[] {

--- a/frontend/src/core/ai/context/providers/variable.ts
+++ b/frontend/src/core/ai/context/providers/variable.ts
@@ -20,11 +20,13 @@ export class VariableContextProvider extends AIContextProvider<VariableContextIt
   readonly mentionPrefix = "@";
   readonly contextType = "variable";
 
-  constructor(
-    private variables: Variables,
-    private tablesMap: DatasetTablesMap,
-  ) {
+  private variables: Variables;
+  private tablesMap: DatasetTablesMap;
+
+  constructor(variables: Variables, tablesMap: DatasetTablesMap) {
     super();
+    this.variables = variables;
+    this.tablesMap = tablesMap;
   }
 
   getItems(): VariableContextItem[] {

--- a/frontend/src/core/codemirror/find-replace/search-highlight.ts
+++ b/frontend/src/core/codemirror/find-replace/search-highlight.ts
@@ -91,8 +91,10 @@ const HighlightMargin = 250;
 export const searchHighlighter = ViewPlugin.fromClass(
   class {
     decorations: DecorationSet;
+    readonly view: EditorView;
 
-    constructor(readonly view: EditorView) {
+    constructor(view: EditorView) {
+      this.view = view;
       this.decorations = this.highlight(view.state.field(searchState));
     }
 

--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -18,13 +18,19 @@ import { getLSPDocument } from "./utils";
 
 class Snapshotter {
   private documentVersion = 0;
+  private readonly getNotebookCode: () => {
+    cellIds: CellId[];
+    codes: Record<CellId, string>;
+  };
 
   constructor(
-    private readonly getNotebookCode: () => {
+    getNotebookCode: () => {
       cellIds: CellId[];
       codes: Record<CellId, string>;
     },
-  ) {}
+  ) {
+    this.getNotebookCode = getNotebookCode;
+  }
 
   /**
    * Map from the global document version to the cell id and version.

--- a/frontend/src/core/codemirror/readonly/__tests__/extension.test.ts
+++ b/frontend/src/core/codemirror/readonly/__tests__/extension.test.ts
@@ -9,7 +9,7 @@ import { connectionAtom } from "../../../network/connection";
 import { dynamicReadonly, isEditorReadonly } from "../extension";
 
 function makeStoreWithConnection(
-  state: WebSocketState.CONNECTING | WebSocketState.OPEN,
+  state: typeof WebSocketState.CONNECTING | typeof WebSocketState.OPEN,
 ) {
   const store = createStore();
   store.set(connectionAtom, { state });

--- a/frontend/src/core/codemirror/rtc/loro/awareness.ts
+++ b/frontend/src/core/codemirror/rtc/loro/awareness.ts
@@ -202,13 +202,25 @@ export const createSelectionLayer = (): Extension =>
  * Renders a blinking cursor to indicate the cursor of another user.
  */
 export class RemoteCursorMarker implements LayerMarker {
+  private left: number;
+  private top: number;
+  private height: number;
+  private name: string;
+  private colorClassName: string;
+
   constructor(
-    private left: number,
-    private top: number,
-    private height: number,
-    private name: string,
-    private colorClassName: string,
-  ) {}
+    left: number,
+    top: number,
+    height: number,
+    name: string,
+    colorClassName: string,
+  ) {
+    this.left = left;
+    this.top = top;
+    this.height = height;
+    this.name = name;
+    this.colorClassName = colorClassName;
+  }
 
   draw(): HTMLElement {
     const elt = document.createElement("div");
@@ -353,16 +365,30 @@ export interface CursorPosition {
 
 export class AwarenessPlugin implements PluginValue {
   sub: Subscription;
+  public view: EditorView;
+  public doc: LoroDoc;
+  public user: UserState;
+  public awareness: Awareness<AwarenessState>;
+  private getTextFromDoc: (doc: LoroDoc) => LoroText;
+  private scopeId: ScopeId;
+  private getUserId?: () => Uid;
 
   constructor(
-    public view: EditorView,
-    public doc: LoroDoc,
-    public user: UserState,
-    public awareness: Awareness<AwarenessState>,
-    private getTextFromDoc: (doc: LoroDoc) => LoroText,
-    private scopeId: ScopeId,
-    private getUserId?: () => Uid,
+    view: EditorView,
+    doc: LoroDoc,
+    user: UserState,
+    awareness: Awareness<AwarenessState>,
+    getTextFromDoc: (doc: LoroDoc) => LoroText,
+    scopeId: ScopeId,
+    getUserId?: () => Uid,
   ) {
+    this.view = view;
+    this.doc = doc;
+    this.user = user;
+    this.awareness = awareness;
+    this.getTextFromDoc = getTextFromDoc;
+    this.scopeId = scopeId;
+    this.getUserId = getUserId;
     this.sub = this.doc.subscribe((e) => {
       if (e.by === "local") {
         // update remote cursor position
@@ -435,12 +461,21 @@ export class AwarenessPlugin implements PluginValue {
 }
 export class RemoteAwarenessPlugin implements PluginValue {
   _awarenessListener?: AwarenessListener;
+  public view: EditorView;
+  public doc: LoroDoc;
+  public awareness: Awareness<AwarenessState>;
+  private scopeId: ScopeId;
+
   constructor(
-    public view: EditorView,
-    public doc: LoroDoc,
-    public awareness: Awareness<AwarenessState>,
-    private scopeId: ScopeId,
+    view: EditorView,
+    doc: LoroDoc,
+    awareness: Awareness<AwarenessState>,
+    scopeId: ScopeId,
   ) {
+    this.view = view;
+    this.doc = doc;
+    this.awareness = awareness;
+    this.scopeId = scopeId;
     const listener: AwarenessListener = async (arg, origin) => {
       if (origin === "local") {
         return;

--- a/frontend/src/core/codemirror/rtc/loro/sync.ts
+++ b/frontend/src/core/codemirror/rtc/loro/sync.ts
@@ -40,13 +40,21 @@ export const loroSyncAnnotation = Annotation.define();
 export class LoroSyncPluginValue implements PluginValue {
   sub?: Subscription;
   private isInitDispatch = false;
+  private view: EditorView;
+  private doc: LoroDoc;
+  private docPath: string[];
+  private getTextFromDoc: (doc: LoroDoc) => LoroText;
 
   constructor(
-    private view: EditorView,
-    private doc: LoroDoc,
-    private docPath: string[],
-    private getTextFromDoc: (doc: LoroDoc) => LoroText,
+    view: EditorView,
+    doc: LoroDoc,
+    docPath: string[],
+    getTextFromDoc: (doc: LoroDoc) => LoroText,
   ) {
+    this.view = view;
+    this.doc = doc;
+    this.docPath = docPath;
+    this.getTextFromDoc = getTextFromDoc;
     this.sub = doc.subscribe(this.onRemoteUpdate);
     Promise.resolve().then(() => {
       this.isInitDispatch = true;

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -452,10 +452,13 @@ export class HotkeyProvider implements IHotkeyProvider {
     return new HotkeyProvider(DEFAULT_HOT_KEY, { platform });
   }
 
+  private hotkeys: Record<HotkeyAction, Hotkey>;
+
   constructor(
-    private hotkeys: Record<HotkeyAction, Hotkey>,
+    hotkeys: Record<HotkeyAction, Hotkey>,
     options: HotkeyProviderOptions = {},
   ) {
+    this.hotkeys = hotkeys;
     this.platform = options.platform ?? resolvePlatform();
     this.mod = this.platform === "mac" ? "Cmd" : "Ctrl";
   }
@@ -503,13 +506,14 @@ export class HotkeyProvider implements IHotkeyProvider {
 }
 
 export class OverridingHotkeyProvider extends HotkeyProvider {
+  private readonly overrides: Partial<Record<HotkeyAction, string | undefined>>;
+
   constructor(
-    private readonly overrides: Partial<
-      Record<HotkeyAction, string | undefined>
-    >,
+    overrides: Partial<Record<HotkeyAction, string | undefined>>,
     options: HotkeyProviderOptions = {},
   ) {
     super(DEFAULT_HOT_KEY, options);
+    this.overrides = overrides;
   }
 
   override getHotkey(action: HotkeyAction): ResolvedHotkey {

--- a/frontend/src/core/kernel/RuntimeState.ts
+++ b/frontend/src/core/kernel/RuntimeState.ts
@@ -29,8 +29,11 @@ export class RuntimeState {
    * ObjectIds of UIElements whose values need to be updated in the kernel
    */
   private _sendComponentValues: RunRequests["sendComponentValues"] | undefined;
+  private uiElementRegistry: UIElementRegistry;
 
-  constructor(private uiElementRegistry: UIElementRegistry) {}
+  constructor(uiElementRegistry: UIElementRegistry) {
+    this.uiElementRegistry = uiElementRegistry;
+  }
 
   private get sendComponentValues(): RunRequests["sendComponentValues"] {
     if (!this._sendComponentValues) {

--- a/frontend/src/core/network/DeferredRequestRegistry.ts
+++ b/frontend/src/core/network/DeferredRequestRegistry.ts
@@ -18,17 +18,29 @@ export const RequestId = {
  */
 export class DeferredRequestRegistry<REQ, RES> {
   public requests = new Map<RequestId, Deferred<RES>>();
+  public operation: string;
+  private makeRequest: (id: RequestId, req: REQ) => Promise<void>;
+  private opts: {
+    /**
+     * Resolve existing requests with an empty response.
+     */
+    resolveExistingRequests?: () => RES;
+  };
 
   constructor(
-    public operation: string,
-    private makeRequest: (id: RequestId, req: REQ) => Promise<void>,
-    private opts: {
+    operation: string,
+    makeRequest: (id: RequestId, req: REQ) => Promise<void>,
+    opts: {
       /**
        * Resolve existing requests with an empty response.
        */
       resolveExistingRequests?: () => RES;
     } = {},
-  ) {}
+  ) {
+    this.operation = operation;
+    this.makeRequest = makeRequest;
+    this.opts = opts;
+  }
 
   async request(opts: REQ): Promise<RES> {
     if (this.opts.resolveExistingRequests) {

--- a/frontend/src/core/runtime/runtime.ts
+++ b/frontend/src/core/runtime/runtime.ts
@@ -10,11 +10,12 @@ import type { RuntimeConfig } from "./types";
 
 export class RuntimeManager {
   private initialHealthyCheck = new Deferred<void>();
+  private config: RuntimeConfig;
+  private lazy: boolean;
 
-  constructor(
-    private config: RuntimeConfig,
-    private lazy = false,
-  ) {
+  constructor(config: RuntimeConfig, lazy = false) {
+    this.config = config;
+    this.lazy = lazy;
     // Validate the URL on construction
     try {
       new URL(this.config.url);

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -576,7 +576,11 @@ export class PyodideWebsocket implements IReconnectingWebSocket {
   messageSubscriptions = new Set<(event: MessageEvent) => void>();
   errorSubscriptions = new Set<(event: Event) => void>();
 
-  constructor(private bridge: Pick<PyodideBridge, "consumeMessages">) {}
+  private bridge: Pick<PyodideBridge, "consumeMessages">;
+
+  constructor(bridge: Pick<PyodideBridge, "consumeMessages">) {
+    this.bridge = bridge;
+  }
 
   private consumeMessages() {
     this.bridge.consumeMessages((message) => {

--- a/frontend/src/core/wasm/store.ts
+++ b/frontend/src/core/wasm/store.ts
@@ -87,7 +87,10 @@ const emptyFileStore: FileStore = {
 };
 
 export class CompositeFileStore implements FileStore {
-  constructor(private stores: FileStore[]) {}
+  private stores: FileStore[];
+  constructor(stores: FileStore[]) {
+    this.stores = stores;
+  }
 
   insert(index: number, store: FileStore) {
     this.stores.splice(index, 0, store);

--- a/frontend/src/core/wasm/worker/message-buffer.ts
+++ b/frontend/src/core/wasm/worker/message-buffer.ts
@@ -7,8 +7,9 @@
 export class MessageBuffer<T> {
   private buffer: T[];
   private started = false;
-
-  constructor(private onMessage: (data: T) => void) {
+  private onMessage: (data: T) => void;
+  constructor(onMessage: (data: T) => void) {
+    this.onMessage = onMessage;
     this.buffer = [];
   }
 

--- a/frontend/src/core/websocket/types.ts
+++ b/frontend/src/core/websocket/types.ts
@@ -2,22 +2,28 @@
 
 import type ReconnectingWebSocket from "partysocket/ws";
 
-export enum WebSocketState {
-  CONNECTING = "CONNECTING",
-  OPEN = "CONNECTED",
-  CLOSING = "CLOSING",
-  CLOSED = "CLOSED",
-}
+export const WebSocketState = {
+  CONNECTING: "CONNECTING",
+  OPEN: "OPEN",
+  CLOSING: "CLOSING",
+  CLOSED: "CLOSED",
+} as const;
 
-export enum WebSocketClosedReason {
-  KERNEL_DISCONNECTED = "KERNEL_DISCONNECTED",
-  ALREADY_RUNNING = "ALREADY_RUNNING",
-  MALFORMED_QUERY = "MALFORMED_QUERY",
-}
+export type WebSocketState =
+  (typeof WebSocketState)[keyof typeof WebSocketState];
+
+export const WebSocketClosedReason = {
+  KERNEL_DISCONNECTED: "KERNEL_DISCONNECTED",
+  ALREADY_RUNNING: "ALREADY_RUNNING",
+  MALFORMED_QUERY: "MALFORMED_QUERY",
+} as const;
+
+export type WebSocketClosedReason =
+  (typeof WebSocketClosedReason)[keyof typeof WebSocketClosedReason];
 
 export type ConnectionStatus =
   | {
-      state: WebSocketState.CLOSED;
+      state: typeof WebSocketState.CLOSED;
       code: WebSocketClosedReason;
       /**
        * Human-readable reason for closing the connection.
@@ -31,9 +37,9 @@ export type ConnectionStatus =
     }
   | {
       state:
-        | WebSocketState.CONNECTING
-        | WebSocketState.OPEN
-        | WebSocketState.CLOSING;
+        | typeof WebSocketState.CONNECTING
+        | typeof WebSocketState.OPEN
+        | typeof WebSocketState.CLOSING;
     };
 
 type PublicInterface<T> = {

--- a/frontend/src/plugins/impl/anywidget/model.ts
+++ b/frontend/src/plugins/impl/anywidget/model.ts
@@ -17,8 +17,10 @@ export type EventHandler = (...args: any[]) => void;
 
 class ModelManager {
   private models = new Map<string, Deferred<Model<any>>>();
-
-  constructor(private timeout = 10_000) {}
+  private timeout: number;
+  constructor(timeout = 10_000) {
+    this.timeout = timeout;
+  }
 
   get(key: string): Promise<Model<any>> {
     let deferred = this.models.get(key);
@@ -64,16 +66,25 @@ export class Model<T extends Record<string, any>> implements AnyModel<T> {
   private ANY_CHANGE_EVENT = "change";
   private dirtyFields;
   public static _modelManager: ModelManager = MODEL_MANAGER;
+  private data: T;
+  private onChange: (value: Partial<T>) => void;
+  private sendToWidget: (req: {
+    content?: any;
+    buffers?: ArrayBuffer[] | ArrayBufferView[];
+  }) => Promise<null | undefined>;
 
   constructor(
-    private data: T,
-    private onChange: (value: Partial<T>) => void,
-    private sendToWidget: (req: {
+    data: T,
+    onChange: (value: Partial<T>) => void,
+    sendToWidget: (req: {
       content?: any;
       buffers?: ArrayBuffer[] | ArrayBufferView[];
     }) => Promise<null | undefined>,
     initialDirtyFields: Set<keyof T>,
   ) {
+    this.data = data;
+    this.onChange = onChange;
+    this.sendToWidget = sendToWidget;
     this.dirtyFields = new Set(initialDirtyFields);
   }
 

--- a/frontend/src/plugins/impl/data-editor/types.ts
+++ b/frontend/src/plugins/impl/data-editor/types.ts
@@ -10,11 +10,13 @@ export interface PositionalEdit {
   value: unknown;
 }
 
-export enum BulkEdit {
-  Insert = "insert",
-  Remove = "remove",
-  Rename = "rename",
-}
+export const BulkEdit = {
+  Insert: "insert",
+  Remove: "remove",
+  Rename: "rename",
+} as const;
+
+type BulkEdit = (typeof BulkEdit)[keyof typeof BulkEdit];
 
 export interface RowEdit {
   rowIdx: number;

--- a/frontend/src/plugins/impl/panel/utils.ts
+++ b/frontend/src/plugins/impl/panel/utils.ts
@@ -57,11 +57,13 @@ export class EventBuffer<T> {
   private buffer: T[] = [];
   private isBlocked = false;
   private timeout: number | null = null;
+  private processEvents: () => void;
+  private blockDuration: number;
 
-  constructor(
-    private processEvents: () => void,
-    private blockDuration = 200,
-  ) {}
+  constructor(processEvents: () => void, blockDuration = 200) {
+    this.processEvents = processEvents;
+    this.blockDuration = blockDuration;
+  }
 
   add(event: T) {
     this.buffer.push(event);

--- a/frontend/src/utils/__tests__/edit-distance.test.ts
+++ b/frontend/src/utils/__tests__/edit-distance.test.ts
@@ -7,7 +7,7 @@ import {
   editDistance,
   editDistanceGeneral,
   mergeArray,
-  OperationType,
+  Operation,
 } from "../edit-distance";
 
 describe("editDistance", () => {
@@ -18,9 +18,9 @@ describe("editDistance", () => {
 
     expect(result.distance).toBe(0);
     expect(result.operations).toHaveLength(3);
-    expect(
-      result.operations.every((op) => op.type === OperationType.MATCH),
-    ).toBe(true);
+    expect(result.operations.every((op) => op.type === Operation.MATCH)).toBe(
+      true,
+    );
   });
 
   it("should handle empty arrays", () => {
@@ -31,12 +31,12 @@ describe("editDistance", () => {
     const result2 = editDistance(["a"], []);
     expect(result2.distance).toBe(1);
     expect(result2.operations).toHaveLength(1);
-    expect(result2.operations[0].type).toBe(OperationType.DELETE);
+    expect(result2.operations[0].type).toBe(Operation.DELETE);
 
     const result3 = editDistance([], ["a"]);
     expect(result3.distance).toBe(1);
     expect(result3.operations).toHaveLength(1);
-    expect(result3.operations[0].type).toBe(OperationType.INSERT);
+    expect(result3.operations[0].type).toBe(Operation.INSERT);
   });
 
   it("should handle single element differences", () => {
@@ -46,9 +46,9 @@ describe("editDistance", () => {
 
     expect(result.distance).toBe(1);
     expect(result.operations).toHaveLength(3);
-    expect(result.operations[0].type).toBe(OperationType.MATCH);
-    expect(result.operations[1].type).toBe(OperationType.MATCH);
-    expect(result.operations[2].type).toBe(OperationType.SUBSTITUTE);
+    expect(result.operations[0].type).toBe(Operation.MATCH);
+    expect(result.operations[1].type).toBe(Operation.MATCH);
+    expect(result.operations[2].type).toBe(Operation.SUBSTITUTE);
   });
 
   it("should handle insertions and deletions", () => {
@@ -58,10 +58,10 @@ describe("editDistance", () => {
 
     expect(result.distance).toBe(1);
     expect(result.operations).toHaveLength(4);
-    expect(result.operations[0].type).toBe(OperationType.MATCH);
-    expect(result.operations[1].type).toBe(OperationType.INSERT);
-    expect(result.operations[2].type).toBe(OperationType.MATCH);
-    expect(result.operations[3].type).toBe(OperationType.MATCH);
+    expect(result.operations[0].type).toBe(Operation.MATCH);
+    expect(result.operations[1].type).toBe(Operation.INSERT);
+    expect(result.operations[2].type).toBe(Operation.MATCH);
+    expect(result.operations[3].type).toBe(Operation.MATCH);
   });
 
   it("should work with custom equality function", () => {
@@ -78,8 +78,8 @@ describe("editDistance", () => {
 
     expect(result.distance).toBe(1);
     expect(result.operations).toHaveLength(2);
-    expect(result.operations[0].type).toBe(OperationType.MATCH);
-    expect(result.operations[1].type).toBe(OperationType.SUBSTITUTE);
+    expect(result.operations[0].type).toBe(Operation.MATCH);
+    expect(result.operations[1].type).toBe(Operation.SUBSTITUTE);
   });
 
   // Test the specific example mentioned by the user
@@ -92,12 +92,12 @@ describe("editDistance", () => {
     expect(result.operations).toHaveLength(6);
 
     // Expected operations: match, delete, match, sub, match, insert
-    expect(result.operations[0].type).toBe(OperationType.MATCH); // 'a'
-    expect(result.operations[1].type).toBe(OperationType.DELETE); // 'b'
-    expect(result.operations[2].type).toBe(OperationType.MATCH); // 'c'
-    expect(result.operations[3].type).toBe(OperationType.SUBSTITUTE); // 'd' -> 'z'
-    expect(result.operations[4].type).toBe(OperationType.MATCH); // 'e'
-    expect(result.operations[5].type).toBe(OperationType.INSERT); // 'g'
+    expect(result.operations[0].type).toBe(Operation.MATCH); // 'a'
+    expect(result.operations[1].type).toBe(Operation.DELETE); // 'b'
+    expect(result.operations[2].type).toBe(Operation.MATCH); // 'c'
+    expect(result.operations[3].type).toBe(Operation.SUBSTITUTE); // 'd' -> 'z'
+    expect(result.operations[4].type).toBe(Operation.MATCH); // 'e'
+    expect(result.operations[5].type).toBe(Operation.INSERT); // 'g'
   });
 });
 
@@ -105,9 +105,9 @@ describe("applyOperationsWithStub", () => {
   it("should apply match operations correctly", () => {
     const original = ["a", "b", "c"];
     const operations: EditOperation[] = [
-      { type: OperationType.MATCH, position: 0 },
-      { type: OperationType.MATCH, position: 1 },
-      { type: OperationType.MATCH, position: 2 },
+      { type: Operation.MATCH, position: 0 },
+      { type: Operation.MATCH, position: 1 },
+      { type: Operation.MATCH, position: 2 },
     ];
 
     const result = applyOperationsWithStub(original, operations, "stub");
@@ -117,9 +117,9 @@ describe("applyOperationsWithStub", () => {
   it("should apply delete operations correctly", () => {
     const original = ["a", "b", "c"];
     const operations: EditOperation[] = [
-      { type: OperationType.MATCH, position: 0 },
-      { type: OperationType.DELETE, position: 1 },
-      { type: OperationType.MATCH, position: 2 },
+      { type: Operation.MATCH, position: 0 },
+      { type: Operation.DELETE, position: 1 },
+      { type: Operation.MATCH, position: 2 },
     ];
 
     const result = applyOperationsWithStub(original, operations, "stub");
@@ -129,9 +129,9 @@ describe("applyOperationsWithStub", () => {
   it("should apply insert operations correctly", () => {
     const original = ["a", "c"];
     const operations: EditOperation[] = [
-      { type: OperationType.MATCH, position: 0 },
-      { type: OperationType.INSERT, position: 1 },
-      { type: OperationType.MATCH, position: 1 },
+      { type: Operation.MATCH, position: 0 },
+      { type: Operation.INSERT, position: 1 },
+      { type: Operation.MATCH, position: 1 },
     ];
 
     const result = applyOperationsWithStub(original, operations, "stub");
@@ -141,12 +141,12 @@ describe("applyOperationsWithStub", () => {
   it("should apply substitute operations correctly", () => {
     const original = ["a", "b", "c"];
     const operations: EditOperation[] = [
-      { type: OperationType.MATCH, position: 0 },
+      { type: Operation.MATCH, position: 0 },
       {
-        type: OperationType.SUBSTITUTE,
+        type: Operation.SUBSTITUTE,
         position: 1,
       },
-      { type: OperationType.MATCH, position: 2 },
+      { type: Operation.MATCH, position: 2 },
     ];
 
     const result = applyOperationsWithStub(original, operations, "stub");
@@ -156,11 +156,11 @@ describe("applyOperationsWithStub", () => {
   it("should handle complex operations with position offsets", () => {
     const original = ["a", "b", "c", "d"];
     const operations: EditOperation[] = [
-      { type: OperationType.MATCH, position: 0 },
-      { type: OperationType.DELETE, position: 1 },
-      { type: OperationType.INSERT, position: 1 },
-      { type: OperationType.MATCH, position: 2 },
-      { type: OperationType.DELETE, position: 3 },
+      { type: Operation.MATCH, position: 0 },
+      { type: Operation.DELETE, position: 1 },
+      { type: Operation.INSERT, position: 1 },
+      { type: Operation.MATCH, position: 2 },
+      { type: Operation.DELETE, position: 3 },
     ];
 
     const result = applyOperationsWithStub(original, operations, "stub");
@@ -171,15 +171,15 @@ describe("applyOperationsWithStub", () => {
   it("should handle the specific example: abcde -> ac_e_ (with stub)", () => {
     const original = ["a", "b", "c", "d", "e"];
     const operations: EditOperation[] = [
-      { type: OperationType.MATCH, position: 0 },
-      { type: OperationType.DELETE, position: 1 },
-      { type: OperationType.MATCH, position: 2 },
+      { type: Operation.MATCH, position: 0 },
+      { type: Operation.DELETE, position: 1 },
+      { type: Operation.MATCH, position: 2 },
       {
-        type: OperationType.SUBSTITUTE,
+        type: Operation.SUBSTITUTE,
         position: 3,
       },
-      { type: OperationType.MATCH, position: 4 },
-      { type: OperationType.INSERT, position: 5 },
+      { type: Operation.MATCH, position: 4 },
+      { type: Operation.INSERT, position: 5 },
     ];
 
     const result = applyOperationsWithStub(original, operations, "_");
@@ -189,13 +189,13 @@ describe("applyOperationsWithStub", () => {
   it("should handle multiple consecutive operations correctly", () => {
     const original = ["a", "b", "c"];
     const operations: EditOperation[] = [
-      { type: OperationType.DELETE, position: 0 },
-      { type: OperationType.INSERT, position: 0 },
+      { type: Operation.DELETE, position: 0 },
+      { type: Operation.INSERT, position: 0 },
       {
-        type: OperationType.SUBSTITUTE,
+        type: Operation.SUBSTITUTE,
         position: 1,
       },
-      { type: OperationType.DELETE, position: 2 },
+      { type: Operation.DELETE, position: 2 },
     ];
 
     const result = applyOperationsWithStub(original, operations, "stub");
@@ -209,11 +209,11 @@ describe("applyOperationsWithStub", () => {
   it("should handle operations that affect array length", () => {
     const original = ["a", "b"];
     const operations: EditOperation[] = [
-      { type: OperationType.INSERT, position: 0 },
-      { type: OperationType.INSERT, position: 1 },
-      { type: OperationType.MATCH, position: 2 },
-      { type: OperationType.MATCH, position: 3 },
-      { type: OperationType.INSERT, position: 4 },
+      { type: Operation.INSERT, position: 0 },
+      { type: Operation.INSERT, position: 1 },
+      { type: Operation.MATCH, position: 2 },
+      { type: Operation.MATCH, position: 3 },
+      { type: Operation.INSERT, position: 4 },
     ];
 
     const result = applyOperationsWithStub(original, operations, "stub");

--- a/frontend/src/utils/edit-distance.ts
+++ b/frontend/src/utils/edit-distance.ts
@@ -1,11 +1,13 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-export enum OperationType {
-  INSERT = "insert",
-  DELETE = "delete",
-  SUBSTITUTE = "substitute",
-  MATCH = "match",
-}
+export const Operation = {
+  INSERT: "insert",
+  DELETE: "delete",
+  SUBSTITUTE: "substitute",
+  MATCH: "match",
+};
+
+type OperationType = (typeof Operation)[keyof typeof Operation];
 
 export interface EditOperation {
   type: OperationType;
@@ -52,27 +54,27 @@ export function editDistanceGeneral<T, U>(
   while (i > 0 || j > 0) {
     if (i > 0 && j > 0 && equals(arr1[i - 1], arr2[j - 1])) {
       operations.unshift({
-        type: OperationType.MATCH,
+        type: Operation.MATCH,
         position: i - 1,
       });
       i--;
       j--;
     } else if (i > 0 && j > 0 && dp[i][j] === dp[i - 1][j - 1] + 1) {
       operations.unshift({
-        type: OperationType.SUBSTITUTE,
+        type: Operation.SUBSTITUTE,
         position: i - 1,
       });
       i--;
       j--;
     } else if (i > 0 && dp[i][j] === dp[i - 1][j] + 1) {
       operations.unshift({
-        type: OperationType.DELETE,
+        type: Operation.DELETE,
         position: i - 1,
       });
       i--;
     } else if (j > 0 && dp[i][j] === dp[i][j - 1] + 1) {
       operations.unshift({
-        type: OperationType.INSERT,
+        type: Operation.INSERT,
         position: i,
       });
       j--;
@@ -99,23 +101,23 @@ export function applyOperationsWithStub<T>(
 
   for (const op of operations) {
     switch (op.type) {
-      case OperationType.MATCH:
+      case Operation.MATCH:
         // Copy the original element
         result.push(originalArray[originalIndex]);
         originalIndex++;
         break;
 
-      case OperationType.DELETE:
+      case Operation.DELETE:
         // Skip the original element (don't add to result)
         originalIndex++;
         break;
 
-      case OperationType.INSERT:
+      case Operation.INSERT:
         // Add stub for inserted element
         result.push(stub);
         break;
 
-      case OperationType.SUBSTITUTE:
+      case Operation.SUBSTITUTE:
         // Add stub for substituted element
         result.push(stub);
         originalIndex++;

--- a/frontend/src/utils/id-tree.tsx
+++ b/frontend/src/utils/id-tree.tsx
@@ -23,11 +23,15 @@ export type CellIndex = number & { __brand?: "CellIndex" };
  * Tree data structure for handling ids with nested children
  */
 export class TreeNode<T> {
-  constructor(
-    public value: T,
-    public isCollapsed: boolean,
-    public children: Array<TreeNode<T>>,
-  ) {}
+  public value: T;
+  public isCollapsed: boolean;
+  public children: Array<TreeNode<T>>;
+
+  constructor(value: T, isCollapsed: boolean, children: Array<TreeNode<T>>) {
+    this.value = value;
+    this.isCollapsed = isCollapsed;
+    this.children = children;
+  }
 
   /**
    * Recursively count the number of nodes in the tree
@@ -102,10 +106,13 @@ export class TreeNode<T> {
 let uniqueId = 0;
 
 export class CollapsibleTree<T> {
-  private constructor(
-    public readonly nodes: Array<TreeNode<T>>,
-    public readonly id: CellColumnId,
-  ) {}
+  public readonly nodes: Array<TreeNode<T>>;
+  public readonly id: CellColumnId;
+
+  private constructor(nodes: Array<TreeNode<T>>, id: CellColumnId) {
+    this.nodes = nodes;
+    this.id = id;
+  }
 
   static from<T>(ids: T[]): CollapsibleTree<T> {
     const id = `tree_${uniqueId++}` as CellColumnId;
@@ -592,7 +599,11 @@ export class CollapsibleTree<T> {
 }
 
 export class MultiColumn<T> {
-  constructor(private readonly columns: ReadonlyArray<CollapsibleTree<T>>) {
+  private readonly columns: ReadonlyArray<CollapsibleTree<T>>;
+
+  constructor(columns: ReadonlyArray<CollapsibleTree<T>>) {
+    this.columns = columns;
+
     // Ensure there is always at least one column
     if (columns.length === 0) {
       this.columns = [CollapsibleTree.from([])];

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -12,7 +12,10 @@ interface Storage<T> {
 }
 
 export class TypedLocalStorage<T> implements Storage<T> {
-  constructor(private defaultValue: T) {}
+  private defaultValue: T;
+  constructor(defaultValue: T) {
+    this.defaultValue = defaultValue;
+  }
 
   get(key: string): T {
     try {
@@ -33,10 +36,16 @@ export class TypedLocalStorage<T> implements Storage<T> {
 }
 
 export class ZodLocalStorage<T> implements Storage<T> {
+  private schema: ZodType<T, ZodTypeDef, unknown>;
+  private getDefaultValue: () => T;
+
   constructor(
-    private schema: ZodType<T, ZodTypeDef, unknown>,
-    private getDefaultValue: () => T,
-  ) {}
+    schema: ZodType<T, ZodTypeDef, unknown>,
+    getDefaultValue: () => T,
+  ) {
+    this.schema = schema;
+    this.getDefaultValue = getDefaultValue;
+  }
 
   get(key: string): T {
     try {

--- a/frontend/src/utils/paths.ts
+++ b/frontend/src/utils/paths.ts
@@ -32,7 +32,10 @@ export const Paths = {
 };
 
 export class PathBuilder {
-  constructor(public readonly deliminator: "/" | "\\") {}
+  public readonly deliminator: string;
+  constructor(deliminator: "/" | "\\") {
+    this.deliminator = deliminator;
+  }
 
   static guessDeliminator(path: string): PathBuilder {
     return path.includes("/") ? new PathBuilder("/") : new PathBuilder("\\");

--- a/frontend/src/utils/pluralize.ts
+++ b/frontend/src/utils/pluralize.ts
@@ -1,10 +1,13 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
 export class PluralWord {
-  constructor(
-    public singular: string,
-    public _plural?: string,
-  ) {}
+  public singular: string;
+  public _plural?: string;
+
+  constructor(singular: string, _plural?: string) {
+    this.singular = singular;
+    this._plural = _plural;
+  }
 
   public pluralize(count: number) {
     return count === 1 ? this.singular : this.plural;
@@ -16,7 +19,11 @@ export class PluralWord {
 }
 
 export class PluralWords {
-  constructor(private words: PluralWord[]) {}
+  private words: PluralWord[];
+
+  constructor(words: PluralWord[]) {
+    this.words = words;
+  }
 
   static of(...words: Array<PluralWord | string>) {
     return new PluralWords(

--- a/frontend/src/utils/python-poet/poet.ts
+++ b/frontend/src/utils/python-poet/poet.ts
@@ -25,7 +25,10 @@ function asString(value: string | PythonCode): string {
 }
 
 export class Variable implements PythonCode {
-  constructor(public name: string) {}
+  name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
 
   toCode(): string {
     return this.name;
@@ -38,10 +41,12 @@ interface LiteralOptions {
 }
 
 export class Literal implements PythonCode {
-  constructor(
-    public readonly value: unknown,
-    public readonly opts: LiteralOptions = {},
-  ) {}
+  public readonly value: unknown;
+  public readonly opts: LiteralOptions;
+  constructor(value: unknown, opts: LiteralOptions = {}) {
+    this.value = value;
+    this.opts = opts;
+  }
 
   static from(value: unknown, opts: LiteralOptions = {}): Literal {
     return new Literal(value, opts);
@@ -114,10 +119,13 @@ export class Literal implements PythonCode {
 }
 
 export class VariableDeclaration implements PythonCode {
-  constructor(
-    public name: string,
-    public value: string | PythonCode,
-  ) {}
+  public name: string;
+  public value: string | PythonCode;
+
+  constructor(name: string, value: string | PythonCode) {
+    this.name = name;
+    this.value = value;
+  }
 
   toCode(): string {
     const right = asString(this.value);
@@ -129,10 +137,13 @@ export class VariableDeclaration implements PythonCode {
 }
 
 export class FunctionArg implements PythonCode {
-  constructor(
-    public name: string,
-    public value: string | PythonCode,
-  ) {}
+  public name: string;
+  public value: string | PythonCode;
+
+  constructor(name: string, value: string | PythonCode) {
+    this.name = name;
+    this.value = value;
+  }
 
   toCode(): string {
     return `${this.name}=${asString(this.value)}`;
@@ -141,12 +152,16 @@ export class FunctionArg implements PythonCode {
 
 export class FunctionCall implements PythonCode {
   private args: PythonCode[];
+  public name: string;
+  public multiLine: boolean;
 
   constructor(
-    public name: string,
+    name: string,
     args: PythonCode[] | Record<string, PythonCode>,
-    public multiLine = false,
+    multiLine = false,
   ) {
+    this.name = name;
+    this.multiLine = multiLine;
     this.args = objectToArgs(args);
   }
 

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -5,6 +5,8 @@ export type Milliseconds = number & { __type__: "milliseconds" };
 export type Seconds = number & { __type__: "seconds" };
 
 export class Time {
+  private readonly ms: Milliseconds;
+
   static fromMilliseconds(ms: Milliseconds): Time;
   static fromMilliseconds(ms: Milliseconds | null): Time | null;
   static fromMilliseconds(ms: Milliseconds | null): Time | null {
@@ -27,7 +29,9 @@ export class Time {
     return new Time(Date.now() as Milliseconds);
   }
 
-  private constructor(private readonly ms: Milliseconds) {}
+  private constructor(ms: Milliseconds) {
+    this.ms = ms;
+  }
 
   toMilliseconds(): Milliseconds {
     return this.ms;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,6 +28,7 @@
     "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": true,
     "experimentalDecorators": true,
+    "erasableSyntaxOnly": true,
 
     /* Perf */
     "incremental": true,


### PR DESCRIPTION
Enables `eraseableSyntaxOnly` flag (introduced in TS 5.8), which ensures we won’t use TypeScript features that generate code. It seems common sentiment that some of the features this disables are those which are generally discouraged from TypeScript but kept around for legacy reasons.

The main changes are removing TypeScript's parameter property syntax:

```ts
class Foo {
  constructor(private readonly bar: string) {}
}
```

for explicit field declarations:

```ts
class Foo {
  private readonly bar: string;
  constructor(bar: string) {
    this.bar = bar;
  }
}
```

The second is getting rid of `enums`. Union types are preferred. The most easy migration is just to create a `const` literal and an exported type for the values:

```ts
enum Shape = {
  SQUARE: "square";
  CIRCLE: "circle";
}
```

to

```ts
const Shape = {
  SQUARE: "square";
  CIRCLE: "circle";
} as const;

type Shape = typeof Shape[keyof typeof Shape];
```