### PR TITLE
fix: specify utf-8 encoding when writing toml files

### DIFF
--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -48,4 +48,4 @@ class ConfigReader:
         # None values is not valid toml, so we remove them
         dict_data = {k: v for k, v in dict_data.items() if v is not None}
 
-        self.filepath.write_text(tomlkit.dumps(dict_data))
+        self.filepath.write_text(tomlkit.dumps(dict_data), encoding="utf-8")


### PR DESCRIPTION
## 📝 Summary

Fixes #6434.
Fixes a `UnicodeEncodeError` on Windows by specifying UTF-8 encoding when writing TOML files.

## 🔍 Description of Changes

This pull request addresses an issue where saving a marimo notebook on Windows with a file path containing non-ASCII characters would result in a `UnicodeEncodeError`.

The error was caused by the `write_toml` function in `marimo/_utils/config/config.py`, which did not specify the file encoding when writing the TOML configuration. This led to issues on operating systems where the default encoding is not UTF-8.

The fix involves explicitly setting the encoding to `utf-8` in the `write_text` method call within the `write_toml` function. This ensures consistent behavior across all platforms and prevents encoding-related errors.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
