### PR TITLE
ci: run check on examples

### DIFF
--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -163,3 +163,9 @@ jobs:
         run: |
           uv add pytest pytest-asyncio
           uv pip install marimo*whl
+
+      - name: Check notebook quality with marimo check
+        shell: bash
+        run: |
+          echo "Checking examples directory..."
+          uv run marimo check --ignore-scripts --strict examples/**.py

--- a/examples/ai/tools/chat_with_tools.py
+++ b/examples/ai/tools/chat_with_tools.py
@@ -16,7 +16,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -86,12 +86,6 @@ def _(input_key, mo, os_key):
 def _(mo):
     get_dataset, set_dataset = mo.state("cars")
     return get_dataset, set_dataset
-
-
-@app.cell
-def _():
-    # data.list_datasets()
-    return
 
 
 @app.cell

--- a/examples/misc/bayes_theorem.py
+++ b/examples/misc/bayes_theorem.py
@@ -106,7 +106,7 @@ def _(
 @app.cell(hide_code=True)
 def _(mo):
     p_h = mo.ui.slider(0.0, 1, label="$P(H)$", value=0.1, step=0.1)
-    p_e_given_h = mo.ui.slider(0.0, 1, label="$P(E \mid H)$", value=0.3, step=0.1)
+    p_e_given_h = mo.ui.slider(0.0, 1, label=r"$P(E \mid H)$", value=0.3, step=0.1)
     p_e_given_not_h = mo.ui.slider(
         0.0, 1, label=r"$P(E \mid \neg H)$", value=0.3, step=0.1
     )

--- a/examples/misc/colliding_blocks_and_pi.py
+++ b/examples/misc/colliding_blocks_and_pi.py
@@ -9,7 +9,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App()
 
 
@@ -139,7 +139,7 @@ class Block:
         self.velocity = new_v1
         other.velocity = new_v2
 
-        return 1  # Return 1 collision
+        return 1
 
 
 @app.function

--- a/examples/misc/compound_interest.py
+++ b/examples/misc/compound_interest.py
@@ -129,14 +129,14 @@ def simulate(
     _prose = f"""
     ## Net Worth
 
-    With an initial investment of **\${initial_investment.value :,.02f}**, an annual
+    With an initial investment of **${{initial_investment.value :,.02f}}**, an annual
     return of **{annual_return.value * 100:.02f}%** with
-    **\${monthly_investment.value:,.02f}** invested monthly, in {years.value} years
-    you will have approximately **\${values[-1]:,.02f}** accumulated in
+    **${{monthly_investment.value:,.02f}}** invested monthly, in {years.value} years
+    you will have approximately **${{values[-1]:,.02f}}** accumulated in
     equities. Assuming a long-term capitals gain tax of
     **{capital_gains_tax_rate.value*100:.02f}%**, the net portfolio value is
-    **\${values_less_taxes[-1]:,.02f}**. Compare that to the
-    **\${investment_principals[-1]:,.02f}** that you contributed in total.
+    **${{values_less_taxes[-1]:,.02f}}**. Compare that to the
+    **${{investment_principals[-1]:,.02f}}** that you contributed in total.
     """
 
     ax = plt.gca()

--- a/examples/misc/mortgage_calculator.py
+++ b/examples/misc/mortgage_calculator.py
@@ -10,7 +10,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App()
 
 
@@ -98,8 +98,8 @@ def _(income, mo, np, retirement_contribution):
 
     mo.md(
         f"""
-        With an after-tax income of **\${income.value*1000:,}**, you'll take home 
-        **\${net_cash_per_month:,.02f}** every month.
+        With an after-tax income of **${{income.value*1000:,}}**, you'll take home
+        **${{net_cash_per_month:,.02f}}** every month.
         """
     )
     return net_cash, net_cash_per_month
@@ -165,12 +165,11 @@ def _(down_payment_pct, home_price, mortgage, rate, years):
     loan = mortgage.Loan(
         principal=principal * 1e3, interest=rate.value / 100, term=years.value
     )
-    return down_payment, loan
+    return (loan,)
 
 
 @app.cell
 def _(
-    down_payment,
     home_insurance,
     home_price,
     loan,
@@ -200,16 +199,16 @@ def _(
 
     mo.md(
         f"""
-        You're purchasing a home worth **\${home_price.value * 1000:,}**, with a 
-        down payment of **\${down_payment*1000:,.02f}**.
+        You're purchasing a home worth **${{home_price.value * 1000:,}}**, with a
+        down payment of **${{down_payment*1000:,.02f}}**.
 
         At a rate of **{rate.value}**%,
-        you will owe **\${annual_home_payment:,.02f}** per year on home expenses.
-        That's **\${monthly_home_payment:,.02f}** per month, which is
+        you will owe **${{annual_home_payment:,.02f}}** per year on home expenses.
+        That's **${{monthly_home_payment:,.02f}}** per month, which is
         **{monthly_home_payment / (net_cash_per_month) * 100:,.02f}%** of
         your take-home pay.
 
-        You'll have **\${cash_less_housing/12:,.02f}** left over per 
+        You'll have **${{cash_less_housing/12:,.02f}}** left over per
         month for expenses and saving.
           """
     ).callout()
@@ -315,10 +314,10 @@ def _(
 
     mo.md(
         f"""
-        Your total monthly expenses are **\${monthly_expenses:,.02f}**.
+        Your total monthly expenses are **${{monthly_expenses:,.02f}}**.
 
-        This means you will save **\${annual_cash_saved/12:,.02f}** per month,
-        or **\${annual_cash_saved:,.02f}** annually.
+        This means you will save **${{annual_cash_saved/12:,.02f}}** per month,
+        or **${{annual_cash_saved:,.02f}}** annually.
         """
     )
     return

--- a/examples/misc/movies_by_the_decade.py
+++ b/examples/misc/movies_by_the_decade.py
@@ -10,7 +10,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="full")
 
 
@@ -396,11 +396,6 @@ def _(end_date, get_previous_date_range, movies, pd, start_date):
         previous_movies,
         previous_start_date,
     )
-
-
-@app.cell
-def _():
-    return
 
 
 if __name__ == "__main__":

--- a/examples/sql/misc/electric_vehicles.py
+++ b/examples/sql/misc/electric_vehicles.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -36,7 +36,7 @@ def _(mo):
         select * from evs
         """
     )
-    return
+    return (evs,)
 
 
 @app.cell
@@ -111,7 +111,7 @@ def _(mo):
 
 
 @app.cell
-def _(mo):
+def _(evs, mo):
     years = mo.sql(
         f"""
         SELECT DISTINCT CAST(evs."Model Year" AS VARCHAR) AS "Model Year" FROM evs;
@@ -121,7 +121,7 @@ def _(mo):
 
 
 @app.cell
-def _(mo):
+def _(evs, mo):
     cities = mo.sql(
         f"""
         SELECT DISTINCT CAST(evs."City" AS VARCHAR) AS "City" FROM evs WHERE "City" != 'null';
@@ -131,7 +131,7 @@ def _(mo):
 
 
 @app.cell
-def _(mo):
+def _(evs, mo):
     makes = mo.sql(
         f"""
         SELECT DISTINCT CAST(evs."Make" AS VARCHAR) AS "Make" FROM evs;
@@ -141,7 +141,7 @@ def _(mo):
 
 
 @app.cell
-def _(cast_to_ints, city_select, make_select, mo, sql_list, year_select):
+def _(cast_to_ints, city_select, evs, make_select, mo, sql_list, year_select):
     grouped_by_city = mo.sql(
         f"""
         SELECT COUNT(*) AS "count", "City", "Model Year"
@@ -161,7 +161,7 @@ def _(cast_to_ints, city_select, make_select, mo, sql_list, year_select):
 
 
 @app.cell
-def _(cast_to_ints, city_select, make_select, mo, sql_list, year_select):
+def _(cast_to_ints, city_select, evs, make_select, mo, sql_list, year_select):
     grouped_by_make = mo.sql(
         f"""
         SELECT COUNT(*) AS "count", "Make", "Model Year" 

--- a/examples/sql/misc/sql_cars.py
+++ b/examples/sql/misc/sql_cars.py
@@ -12,7 +12,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -25,13 +25,13 @@ def _(data):
 
 
 @app.cell
-def _(mo):
+def _(cars_df, mo):
     _df = mo.sql(
         f"""
         CREATE OR REPLACE TABLE cars AS SELECT * FROM cars_df;
         """
     )
-    return
+    return (cars,)
 
 
 @app.cell
@@ -82,7 +82,7 @@ def _(mo):
 
 
 @app.cell
-def _(mo, year_range):
+def _(cars, mo, year_range):
     _df = mo.sql(
         f"""
         WITH ranked_cars AS (
@@ -173,7 +173,7 @@ def _(alt, duckdb, mo, year_range):
 def _(chart, mo):
     mo.stop(chart.value.empty, mo.callout("Select cars from the chart above."))
     selected_cars = chart.value
-    return
+    return (selected_cars,)
 
 
 @app.cell(hide_code=True)
@@ -205,7 +205,7 @@ def _(aggs, aggs_selected, mo):
 
 
 @app.cell(hide_code=True)
-def _(mo):
+def _(cars, mo, selected_cars):
     aggs_selected = mo.sql("""
     SELECT 
         COUNT(*) as count,

--- a/examples/sql/parametrizing_sql_queries.py
+++ b/examples/sql/parametrizing_sql_queries.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -41,7 +41,7 @@ def _():
 
     df = data.iris()
     df
-    return
+    return (df,)
 
 
 @app.cell(hide_code=True)
@@ -92,7 +92,7 @@ def _(mo):
 
 
 @app.cell
-def _(mo, species_dropdown):
+def _(df, mo, species_dropdown):
     result = mo.sql(
         f"""
         SELECT * FROM df where species == '{species_dropdown.value}'

--- a/examples/sql/querying_dataframes.py
+++ b/examples/sql/querying_dataframes.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -41,7 +41,7 @@ def _():
 
     df = data.iris()
     df.head()
-    return
+    return (df,)
 
 
 @app.cell(hide_code=True)
@@ -62,7 +62,7 @@ def _(mo):
 
 
 @app.cell
-def _(mo):
+def _(df, mo):
     result = mo.sql(
         f"""
         SELECT species, mean(petalLength) as meanPetalLength FROM df GROUP BY species ORDER BY meanPetalLength

--- a/examples/sql/read_csv.py
+++ b/examples/sql/read_csv.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -118,11 +118,11 @@ def _(mo):
         CREATE TABLE myTable AS SELECT * FROM "data.csv"
         """
     )
-    return
+    return (mytable,)
 
 
 @app.cell
-def _(mo):
+def _(mo, mytable):
     _df = mo.sql(
         f"""
         SELECT * FROM myTable

--- a/examples/sql/read_json.py
+++ b/examples/sql/read_json.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -128,11 +128,11 @@ def _(mo):
         CREATE OR REPLACE TABLE myTable AS SELECT * FROM 'data.json'
         """
     )
-    return
+    return (mytable,)
 
 
 @app.cell
-def _(mo):
+def _(mo, mytable):
     _df = mo.sql(
         f"""
         SELECT * FROM myTable

--- a/examples/sql/read_parquet.py
+++ b/examples/sql/read_parquet.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -117,11 +117,11 @@ def _(mo):
         CREATE OR REPLACE TABLE myTable AS SELECT * FROM 'data.parquet'
         """
     )
-    return
+    return (mytable,)
 
 
 @app.cell
-def _(mo):
+def _(mo, mytable):
     _df = mo.sql(
         f"""
         SELECT * FROM myTable

--- a/examples/third_party/cvxpy/regularization_and_sparsity.py
+++ b/examples/third_party/cvxpy/regularization_and_sparsity.py
@@ -103,7 +103,7 @@ def _(mo):
     sparsity_parameter = mo.ui.slider(0, 10, step=0.1)
     mo.md(
         f"""
-        Choose the regularization strength $\lambda$: {sparsity_parameter}
+        Choose the regularization strength $\\lambda$: {sparsity_parameter}
         """)
     return (sparsity_parameter,)
 
@@ -113,7 +113,7 @@ def _(mo, n, number_of_zeros, sparsity_parameter, x_l1, x_l2):
     (
         mo.md(
             """
-            **$\lambda$ = 0.**
+            **$\\lambda$ = 0.**
 
             No regularization is applied. The solutions are the same.
             """
@@ -121,15 +121,15 @@ def _(mo, n, number_of_zeros, sparsity_parameter, x_l1, x_l2):
         if sparsity_parameter.value == 0 else
         mo.md(
             f"""
-            **$\lambda$ = {sparsity_parameter.value}.**
+            **$\\lambda$ = {sparsity_parameter.value}.**
 
-            Watch how the fraction of entries of $x$ near $0$ changes as $\lambda$ 
+            Watch how the fraction of entries of $x$ near $0$ changes as $\\lambda$
             increases.
 
-            **$p=1$**: {number_of_zeros(x_l1) / n * 100:.02f}% of the entries of 
+            **$p=1$**: {number_of_zeros(x_l1) / n * 100:.02f}% of the entries of
             $x$ are extremely close to $0$.
 
-            **$p=2$**: {number_of_zeros(x_l2) / n * 100:.02f}% of the entries of 
+            **$p=2$**: {number_of_zeros(x_l2) / n * 100:.02f}% of the entries of
             $x$ are extremely close to $0$.
             """
         )
@@ -150,7 +150,7 @@ def _(cdf, plt, x_l1, x_l2):
 @app.cell
 def _(mo):
     mo.md(
-        """
+        r"""
         ## Sparsity
 
         The $\ell_1$ norm, when used as a regularizer, encourages solutions

--- a/examples/third_party/huggingface/chatbot.py
+++ b/examples/third_party/huggingface/chatbot.py
@@ -8,7 +8,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App(width="medium")
 
 
@@ -146,14 +146,6 @@ def _(client, mo):
         # You can return strings, markdown, charts, tables, dataframes, and more.
         return response.choices[0].message.content
     return max_tokens, respond, system_message, temperature, top_p
-
-
-@app.cell
-def _():
-    # If you need to do anything _reactively_ to the chat messages,
-    # you can access the chat messages using the `chat.value` attribute.
-    # chat.value
-    return
 
 
 if __name__ == "__main__":

--- a/examples/third_party/motherduck/embeddings/embeddings_explorer.py
+++ b/examples/third_party/motherduck/embeddings/embeddings_explorer.py
@@ -19,11 +19,10 @@ import marimo
 __generated_with = "0.15.5"
 app = marimo.App(width="medium")
 
-
-@app.cell
-def _():
-    return
-
+with app.setup:
+    # Use this notebook to follow along with the tutorial at
+    # https://motherduck.com/blog/MotherDuck-Visualize-Embeddings-Marimo/
+    import marimo as mo
 
 if __name__ == "__main__":
     app.run()

--- a/examples/third_party/pymde/complete_graph.py
+++ b/examples/third_party/pymde/complete_graph.py
@@ -53,14 +53,14 @@ def _(complete_graph, mo, n_items, penalty_function):
 
     mo.md(
         f"""
-        Here is a plot of $K_n$ with $n={n_items.value}$, i.e., a complete graph on 
+        Here is a plot of $K_n$ with $n={n_items.value}$, i.e., a complete graph on
         ${n_items.value}$ nodes. This graph has
 
-        \[
+        \\[
         (n)(n-1)/2 = {n_items.value*(n_items.value-1)//2}
-        \]
+        \\]
 
-        edges. The plot was obtained using a 
+        edges. The plot was obtained using a
         {penalty_function.value.__name__.lower()} penalty function.
 
         {mo.as_html(plot)}

--- a/examples/ui/batch_and_form.py
+++ b/examples/ui/batch_and_form.py
@@ -65,8 +65,8 @@ def _(mo, reset, submitted_values, variables):
         submitted_values["x"].add(variables.value["x"])
         submitted_values["y"].add(variables.value["y"])
 
-    x = variables.value["x"] if variables.value else "\ldots"
-    y = variables.value["y"] if variables.value else "\ldots"
+    x = variables.value["x"] if variables.value else r"\ldots"
+    y = variables.value["y"] if variables.value else r"\ldots"
 
 
     mo.md(

--- a/examples/ui/table_advanced.py
+++ b/examples/ui/table_advanced.py
@@ -7,7 +7,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.16.0"
 app = marimo.App()
 
 
@@ -268,11 +268,6 @@ def _(mo):
         },
     ]
     return (office_characters,)
-
-
-@app.cell
-def _():
-    return
 
 
 if __name__ == "__main__":

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -1281,12 +1281,21 @@ def shell_completion() -> None:
     type=bool,
     help="Enable fixes that may change code behavior (e.g., removing empty cells).",
 )
+@click.option(
+    "--ignore-scripts",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    type=bool,
+    help="Ignore files that are not recognizable as marimo notebooks.",
+)
 @click.argument("files", nargs=-1, type=click.UNPROCESSED)
 def check(
     fix: bool,
     strict: bool,
     verbose: bool,
     unsafe_fixes: bool,
+    ignore_scripts: bool,
     files: tuple[str, ...],
 ) -> None:
     if not files:
@@ -1295,7 +1304,13 @@ def check(
 
     # Pass click.echo directly as pipe for streaming output, or None
     pipe = click.echo if verbose else None
-    linter = run_check(files, pipe=pipe, fix=fix, unsafe_fixes=unsafe_fixes)
+    linter = run_check(
+        files,
+        pipe=pipe,
+        fix=fix,
+        unsafe_fixes=unsafe_fixes,
+        ignore_scripts=ignore_scripts,
+    )
 
     # Get counts from linter (fix happens automatically during streaming)
     fixed = linter.fixed_count

--- a/marimo/_lint/__init__.py
+++ b/marimo/_lint/__init__.py
@@ -26,6 +26,7 @@ def run_check(
     pipe: Callable[[str], None] | None = None,
     fix: bool = False,
     unsafe_fixes: bool = False,
+    ignore_scripts: bool = False,
 ) -> Linter:
     """Run linting checks on files matching patterns (CLI entry point).
 
@@ -37,6 +38,7 @@ def run_check(
         pipe: Optional function to call for streaming output
         fix: Whether to fix files automatically
         unsafe_fixes: Whether to enable unsafe fixes that may change behavior
+        ignore_scripts: Whether to ignore files not recognizable as marimo notebooks
 
     Returns:
         Linter with per-file status and diagnostics
@@ -44,7 +46,12 @@ def run_check(
     # Expand patterns to actual files
     files_to_check = expand_file_patterns(file_patterns)
 
-    linter = Linter(pipe=pipe, fix_files=fix, unsafe_fixes=unsafe_fixes)
+    linter = Linter(
+        pipe=pipe,
+        fix_files=fix,
+        unsafe_fixes=unsafe_fixes,
+        ignore_scripts=ignore_scripts,
+    )
     linter.run_streaming(files_to_check)
     return linter
 

--- a/marimo/_smoke_tests/async_iterator.py
+++ b/marimo/_smoke_tests/async_iterator.py
@@ -1,0 +1,41 @@
+import marimo
+
+__generated_with = "0.15.3"
+app = marimo.App(width="medium")
+
+
+@app.function
+async def sleep(seconds):
+    import asyncio
+
+    tasks = [asyncio.create_task(asyncio.sleep(s, s)) for s in seconds]
+    for future in asyncio.as_completed(tasks):
+        yield await future
+
+
+@app.cell
+async def _() -> None:
+    import marimo as mo
+
+    async def test_progress_async() -> None:
+
+        ait = sleep([0.3, 0.2, 0.1])
+        result = [s async for s in mo.status.progress_bar(ait, total=3)]
+        assert result == [0.1, 0.2, 0.3]
+
+    await test_progress_async()
+    return
+
+
+@app.cell
+def _() -> None:
+    return
+
+
+@app.cell
+def _() -> None:
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## 📝 Summary

integrates `marimo check` for examples ci. Highlighted in upcoming post

PR is a little noisy so best examined commit by commit:

https://github.com/marimo-team/marimo/commit/4586e10c878c2c7c574d53245fb024e130e8902b
 - adds `--ignore-scripts` flag, such that clearly non-marimo files do not count as errors
 - changes requirement for updating to ignore `__generated_with` since bumping version numbers is just noise

https://github.com/marimo-team/marimo/commit/b1c42cf409848a00251fa44ed7e276891e2992ef
 - ran `--fix --unsafe-fixes` on examples (cleaning up empty cells)
 - Changed relevant strings to r strings to prevent errors

https://github.com/marimo-team/marimo/commit/2e8ca238d6c894db5b0d0ae2fb7f3de27821d559
 - Added basic CI for examples (We just had a stub for them previously)