### PR TITLE
fix: preserve literal strings in type annotations

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -22,6 +22,7 @@ from marimo._ast.sql_visitor import (
 )
 from marimo._ast.variables import is_local
 from marimo._dependencies.dependencies import DependencyManager
+from marimo._utils.strings import standardize_annotation_quotes
 
 LOGGER = _loggers.marimo_logger()
 
@@ -813,11 +814,8 @@ class ScopedVisitor(ast.NodeVisitor):
             annotation = ast.unparse(node.annotation)
             # It's also possible for multiline types/ strings
             annotation = annotation.replace("\n", "").strip()
-            # ast seems to give single quote strings regardless
-            # but ruff asks for double quotes (unless double quotes are
-            # contained).
-            if annotation.startswith("'") and '"' not in annotation[1:-1]:
-                annotation = f'"{annotation[1:-1]}"'
+            # Standardize quotes to use double quotes consistently
+            annotation = standardize_annotation_quotes(annotation)
 
             self.variable_data[name][0].annotation_data = AnnotationData(
                 annotation, annotation_refs

--- a/marimo/_utils/strings.py
+++ b/marimo/_utils/strings.py
@@ -1,7 +1,7 @@
-# Copyright 2024 Marimo. All rights reserved.
-"""String manipulation utilities."""
-
+# Copyright 2025 Marimo. All rights reserved.
 from __future__ import annotations
+
+import re
 
 
 def standardize_annotation_quotes(annotation: str) -> str:
@@ -24,7 +24,6 @@ def standardize_annotation_quotes(annotation: str) -> str:
         >>> standardize_annotation_quotes("int")
         'int'  # No quotes to standardize
     """
-    import re
 
     # Regex pattern to match string literals within the annotation:
     #
@@ -43,9 +42,11 @@ def standardize_annotation_quotes(annotation: str) -> str:
     #   - )"                      - Closing double quote and end capture group
     #
     # This pattern correctly handles escaped quotes within strings like 'it\'s' or "say \"hello\""
-    string_pattern = r"'([^'\\]*(?:\\.[^'\\]*)*)'|\"([^\"\\]*(?:\\.[^\"\\]*)*)\""
+    string_pattern = (
+        r"'([^'\\]*(?:\\.[^'\\]*)*)'|\"([^\"\\]*(?:\\.[^\"\\]*)*)\""
+    )
 
-    def replace_quotes(match):
+    def replace_quotes(match: re.Match[str]) -> str:
         if match.group(1) is not None:  # Single quoted string matched
             content = match.group(1)
             # Check if the content contains unescaped double quotes
@@ -55,7 +56,9 @@ def standardize_annotation_quotes(annotation: str) -> str:
             else:
                 # Convert to double quotes, handling escaped characters properly
                 content = content.replace("\\'", "'")  # Unescape single quotes
-                content = content.replace('"', '\\"')  # Escape any double quotes
+                content = content.replace(
+                    '"', '\\"'
+                )  # Escape any double quotes
                 return f'"{content}"'
         else:  # Double quoted string matched (group 2)
             return match.group(0)  # Keep as is - already using double quotes

--- a/marimo/_utils/strings.py
+++ b/marimo/_utils/strings.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Marimo. All rights reserved.
+"""String manipulation utilities."""
+
+from __future__ import annotations
+
+
+def standardize_annotation_quotes(annotation: str) -> str:
+    """Standardize quotes in type annotations to use double quotes.
+
+    This handles complex cases like Literal['foo', 'bar'] -> Literal["foo", "bar"]
+    while preserving mixed quote scenarios where double quotes are already present.
+
+    Args:
+        annotation: The type annotation string to standardize
+
+    Returns:
+        The annotation string with standardized double quotes
+
+    Examples:
+        >>> standardize_annotation_quotes("Literal['foo', 'bar']")
+        'Literal["foo", "bar"]'
+        >>> standardize_annotation_quotes("Literal['say \"hello\"']")
+        'Literal[\'say "hello"\']'  # Preserved due to internal double quotes
+        >>> standardize_annotation_quotes("int")
+        'int'  # No quotes to standardize
+    """
+    import re
+
+    # Regex pattern to match string literals within the annotation:
+    #
+    # '([^'\\]*(?:\\.[^'\\]*)*)'  - Matches single-quoted strings:
+    #   - '                       - Opening single quote
+    #   - ([^'\\]*                - Capture group: any chars except ' and \
+    #   - (?:\\.[^'\\]*)*         - Non-capturing group: escaped char followed by non-quote/backslash chars, repeated
+    #   - )'                      - Closing single quote and end capture group
+    #
+    # |                           - OR operator
+    #
+    # "([^"\\]*(?:\\.[^"\\]*)*)"  - Matches double-quoted strings:
+    #   - "                       - Opening double quote
+    #   - ([^"\\]*                - Capture group: any chars except " and \
+    #   - (?:\\.[^"\\]*)*         - Non-capturing group: escaped char followed by non-quote/backslash chars, repeated
+    #   - )"                      - Closing double quote and end capture group
+    #
+    # This pattern correctly handles escaped quotes within strings like 'it\'s' or "say \"hello\""
+    string_pattern = r"'([^'\\]*(?:\\.[^'\\]*)*)'|\"([^\"\\]*(?:\\.[^\"\\]*)*)\""
+
+    def replace_quotes(match):
+        if match.group(1) is not None:  # Single quoted string matched
+            content = match.group(1)
+            # Check if the content contains unescaped double quotes
+            # If so, keep as single quotes to avoid escaping issues
+            if '"' in content and '\\"' not in content:
+                return match.group(0)  # Keep original single-quoted string
+            else:
+                # Convert to double quotes, handling escaped characters properly
+                content = content.replace("\\'", "'")  # Unescape single quotes
+                content = content.replace('"', '\\"')  # Escape any double quotes
+                return f'"{content}"'
+        else:  # Double quoted string matched (group 2)
+            return match.group(0)  # Keep as is - already using double quotes
+
+    return re.sub(string_pattern, replace_quotes, annotation)

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -416,7 +416,7 @@ class TestGeneration:
         assert fndef == expected
 
         # Test nested quotes that should remain single due to containing double quotes
-        referring = 'x: Literal[\'say "hello"\'] = \'say "hello"\''
+        referring = "x: Literal['say \"hello\"'] = 'say \"hello\"'"
         ref_vars = compile_cell(referring).init_variable_data
 
         code = "z = x"
@@ -427,7 +427,7 @@ class TestGeneration:
         expected = "\n".join(
             [
                 "@app.cell",
-                'def foo(x: Literal[\'say "hello"\']):',
+                "def foo(x: Literal['say \"hello\"']):",
                 "    z = x",
                 "    return (z,)",
             ]


### PR DESCRIPTION
## 📝 Summary

fixes #6446

Fixes quotes in complex annotation types, removing ast default of preferring `'`.
e.g.

`Literal["foo", 'bar']` -> `Literal["foo", "bar"]`

where previously

`Literal["foo", 'bar']` -> `Literal['foo', 'bar']`