### PR TITLE
Add hover text on table header

### DIFF
--- a/examples/ui/table.py
+++ b/examples/ui/table.py
@@ -22,6 +22,11 @@ def _(mo):
         ],
         # Show full name on hover for each row using column placeholders
         hover_template="{{first_name}} {{last_name}}",
+        # Add hover text (titles) for column headers
+        header_hover_text={
+            "first_name": "Employee's first name",
+            "last_name": "Employee's last name",
+        },
     )
     table
     return (table,)

--- a/frontend/src/components/data-table/__tests__/data-table.test.tsx
+++ b/frontend/src/components/data-table/__tests__/data-table.test.tsx
@@ -95,4 +95,42 @@ describe("DataTable", () => {
     expect(rows[1]).toHaveAttribute("title", "Michael Scott");
     expect(rows[2]).toHaveAttribute("title", "Jim Halpert");
   });
+
+  it("applies headerHoverText mapping to column header titles", () => {
+    interface RowData {
+      id: number;
+      first: string;
+      last: string;
+    }
+
+    const testData: RowData[] = [
+      { id: 1, first: "Michael", last: "Scott" },
+      { id: 2, first: "Jim", last: "Halpert" },
+    ];
+
+    const columns: Array<ColumnDef<RowData>> = [
+      { accessorKey: "first", header: "First" },
+      { accessorKey: "last", header: "Last" },
+    ];
+
+    render(
+      <TooltipProvider>
+        <DataTable
+          data={testData}
+          columns={columns}
+          selection={null}
+          totalRows={2}
+          totalColumns={2}
+          pagination={false}
+          headerHoverText={{ first: "Given name", last: "Family name" }}
+        />
+      </TooltipProvider>,
+    );
+
+    // Header row is role="row" as well; get all headers by role="columnheader"
+    const headers = screen.getAllByRole("columnheader");
+    // Order should correspond to columns array
+    expect(headers[0]).toHaveAttribute("title", "Given name");
+    expect(headers[1]).toHaveAttribute("title", "Family name");
+  });
 });

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -67,12 +67,14 @@ interface DataTableColumnHeaderProps<TData, TValue>
   extends React.HTMLAttributes<HTMLDivElement> {
   column: Column<TData, TValue>;
   header: React.ReactNode;
+  headerTitle?: string;
   calculateTopKRows?: CalculateTopKRows;
 }
 
 export const DataTableColumnHeader = <TData, TValue>({
   column,
   header,
+  headerTitle,
   className,
   calculateTopKRows,
 }: DataTableColumnHeaderProps<TData, TValue>) => {
@@ -86,7 +88,11 @@ export const DataTableColumnHeader = <TData, TValue>({
 
   // No sorting or filtering
   if (!column.getCanSort() && !column.getCanFilter()) {
-    return <div className={cn(className)}>{header}</div>;
+    return (
+      <div className={cn(className)} title={headerTitle}>
+        {header}
+      </div>
+    );
   }
 
   const hasFilter = column.getFilterValue() !== undefined;
@@ -102,6 +108,7 @@ export const DataTableColumnHeader = <TData, TValue>({
               className,
             )}
             data-testid="data-table-sort-button"
+            title={headerTitle}
           >
             <span className="flex-1">{header}</span>
             <span

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -103,6 +103,7 @@ export function generateColumns<T>({
   chartSpecModel,
   textJustifyColumns,
   wrappedColumns,
+  headerHoverText,
   showDataTypes,
   calculateTopKRows,
 }: {
@@ -112,6 +113,7 @@ export function generateColumns<T>({
   chartSpecModel?: ColumnChartSpecModel<unknown>;
   textJustifyColumns?: Record<string, "left" | "center" | "right">;
   wrappedColumns?: string[];
+  headerHoverText?: Record<string, string>;
   showDataTypes?: boolean;
   calculateTopKRows?: CalculateTopKRows;
 }): Array<ColumnDef<T>> {
@@ -165,6 +167,7 @@ export function generateColumns<T>({
       header: ({ column }) => {
         const stats = chartSpecModel?.getColumnStats(key);
         const dtype = column.columnDef.meta?.dtype;
+        const headerTitle = headerHoverText?.[key];
         const dtypeHeader =
           showDataTypes && dtype ? (
             <div className="flex flex-row gap-1">
@@ -188,6 +191,7 @@ export function generateColumns<T>({
           <DataTableColumnHeader
             header={headerWithType}
             column={column}
+            headerTitle={headerTitle}
             calculateTopKRows={calculateTopKRows}
           />
         );

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -66,6 +66,7 @@ interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   cellSelection?: CellSelectionState;
   cellStyling?: CellStyleState | null;
   hoverTemplate?: string | null;
+  headerHoverText?: Record<string, string> | undefined;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   onCellSelectionChange?: OnChangeFn<CellSelectionState>;
   getRowIds?: GetRowIds;
@@ -107,6 +108,7 @@ const DataTableInternal = <TData,>({
   cellSelection,
   cellStyling,
   hoverTemplate,
+  headerHoverText,
   paginationState,
   setPaginationState,
   downloadAs,
@@ -267,7 +269,7 @@ const DataTableInternal = <TData,>({
           {showLoadingBar && (
             <div className="absolute top-0 left-0 h-[3px] w-1/2 bg-primary animate-slide" />
           )}
-          {renderTableHeader(table)}
+          {renderTableHeader(table, headerHoverText)}
           <CellSelectionProvider>
             <DataTableBody
               table={table}

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -182,6 +182,7 @@ interface Data<T> {
   freezeColumnsRight?: string[];
   textJustifyColumns?: Record<string, "left" | "center" | "right">;
   wrappedColumns?: string[];
+  headerHoverText?: Record<string, string>;
   totalColumns: number;
   maxColumns: number | "all";
   hasStableRowId: boolean;
@@ -249,6 +250,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
         .record(z.enum(["left", "center", "right"]))
         .optional(),
       wrappedColumns: z.array(z.string()).optional(),
+      headerHoverText: z.record(z.string()).optional(),
       fieldTypes: columnToFieldTypesSchema.nullish(),
       totalColumns: z.number(),
       maxColumns: z.union([z.number(), z.literal("all")]).default("all"),
@@ -346,6 +348,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
             data={props.data.data}
             value={props.value}
             setValue={props.setValue}
+            headerHoverText={props.data.headerHoverText}
           />
         </LazyDataTableComponent>
       </TableProviders>
@@ -706,6 +709,7 @@ const DataTableComponent = ({
   freezeColumnsRight,
   textJustifyColumns,
   wrappedColumns,
+  headerHoverText,
   totalColumns,
   get_row_ids,
   cellStyles,
@@ -779,6 +783,7 @@ const DataTableComponent = ({
         fieldTypes: memoizedClampedFieldTypes,
         textJustifyColumns: memoizedTextJustifyColumns,
         wrappedColumns: memoizedWrappedColumns,
+        headerHoverText: headerHoverText,
         // Only show data types if they are explicitly set
         showDataTypes: showDataTypes,
         calculateTopKRows: calculate_top_k_rows,
@@ -791,6 +796,7 @@ const DataTableComponent = ({
       memoizedClampedFieldTypes,
       memoizedTextJustifyColumns,
       memoizedWrappedColumns,
+      headerHoverText,
       calculate_top_k_rows,
     ],
   );
@@ -908,6 +914,7 @@ const DataTableComponent = ({
             cellSelection={cellSelection}
             cellStyling={cellStyles}
             hoverTemplate={hoverTemplate}
+            headerHoverText={headerHoverText}
             downloadAs={showDownload ? downloadAs : undefined}
             enableSearch={enableSearch}
             searchQuery={searchQuery}

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -328,6 +328,7 @@ class table(
         text_justify_columns (Dict[str, Literal["left", "center", "right"]], optional):
             Dictionary of column names to text justification options: left, center, right.
         wrapped_columns (List[str], optional): List of column names to wrap.
+        header_hover_text (Dict[str, str], optional): Mapping from column names to header hover text.
         label (str, optional): Markdown label for the element. Defaults to "".
         on_change (Callable[[Union[List[JSONType], Dict[str, List[JSONType]], IntoDataFrame, List[TableCell]]], None], optional):
             Optional callback to run when this element's value changes.
@@ -422,6 +423,7 @@ class table(
             dict[str, Literal["left", "center", "right"]]
         ] = None,
         wrapped_columns: Optional[list[str]] = None,
+        header_hover_text: Optional[dict[str, str]] = None,
         show_download: bool = True,
         max_columns: MaxColumnsType = MAX_COLUMNS_NOT_PROVIDED,
         *,
@@ -634,6 +636,7 @@ class table(
             _validate_column_formatting(
                 text_justify_columns, wrapped_columns, column_names_set
             )
+            _validate_header_hover_text(header_hover_text, column_names_set)
 
             field_types = self._manager.get_field_types()
 
@@ -666,6 +669,7 @@ class table(
                 "freeze-columns-right": freeze_columns_right,
                 "text-justify-columns": text_justify_columns,
                 "wrapped-columns": wrapped_columns,
+                "header-hover-text": header_hover_text,
                 "has-stable-row-id": self._has_stable_row_id,
                 "cell-styles": search_result_styles,
                 "hover-template": hover_template,
@@ -1409,6 +1413,22 @@ def _validate_column_formatting(
     if wrapped_columns:
         wrapped_columns_set = set(wrapped_columns)
         invalid = wrapped_columns_set - column_names_set
+        if invalid:
+            raise ValueError(
+                f"Column '{next(iter(invalid))}' not found in table."
+            )
+
+
+def _validate_header_hover_text(
+    header_hover_text: Optional[dict[str, str]],
+    column_names_set: set[str],
+) -> None:
+    """Validate header hover text mapping.
+
+    Ensures all specified columns exist in the table.
+    """
+    if header_hover_text:
+        invalid = set(header_hover_text.keys()) - column_names_set
         if invalid:
             raise ValueError(
                 f"Column '{next(iter(invalid))}' not found in table."


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

We would like to provide some (static) hover text on table header columns.

<img width="772" height="571" alt="image" src="https://github.com/user-attachments/assets/35bf4783-97aa-4c29-9c91-b6251cb7b68e" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

I went with an approach similar to `text_justify_columns`.
The use-case if to further explain what the table does to other team members.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
