### PR TITLE
snapshot: sql_parsing_errors.txt

### DIFF
--- a/tests/_lint/snapshots/sql_parsing_errors.txt
+++ b/tests/_lint/snapshots/sql_parsing_errors.txt
@@ -1,6 +1,6 @@
-warning[sql-parse-error]: Expecting ). Line 19, Col: 21.
- --> tests/_lint/test_files/sql_parsing_errors.py:36:20
+warning[sql-parse-error]: Expecting ). Line 19, Col: 32.
+ --> tests/_lint/test_files/sql_parsing_errors.py:36:31
   36 |                 AND
   37 |                 descendants NOT NULL
-     |                       ^
+     |                                  ^
   38 |         )


### PR DESCRIPTION
## 📝 Summary

Fixes failing snapshot test. Some discrepancy with the sqlglot and python version, but the test is already restricted to only py313