### PR TITLE
improvement: add completion info to SQL table completions

### DIFF
--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -789,7 +789,75 @@ describe("tablesCompletionSource", () => {
             "detail": "public",
             "info": [Function],
             "label": "public",
-            "type": "namespace",
+            "type": "schema",
+          },
+        },
+        "test_db": {
+          "children": {
+            "public": {
+              "children": {
+                "orders": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "order_id",
+                      "type": "column",
+                    },
+                    {
+                      "info": [Function],
+                      "label": "user_id",
+                      "type": "column",
+                    },
+                    {
+                      "info": [Function],
+                      "label": "total",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "orders",
+                    "type": "table",
+                  },
+                },
+                "users": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "id",
+                      "type": "column",
+                    },
+                    {
+                      "info": [Function],
+                      "label": "name",
+                      "type": "column",
+                    },
+                    {
+                      "info": [Function],
+                      "label": "email",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "users",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "test_db.public",
+                "info": [Function],
+                "label": "public",
+                "type": "schema",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_db",
+            "info": [Function],
+            "label": "test_db",
+            "type": "database",
           },
         },
       }
@@ -897,7 +965,7 @@ describe("tablesCompletionSource", () => {
                 "detail": "db1.schema1",
                 "info": [Function],
                 "label": "schema1",
-                "type": "namespace",
+                "type": "schema",
               },
             },
           },
@@ -905,7 +973,7 @@ describe("tablesCompletionSource", () => {
             "detail": "db1",
             "info": [Function],
             "label": "db1",
-            "type": "namespace",
+            "type": "database",
           },
         },
         "db2": {
@@ -931,7 +999,7 @@ describe("tablesCompletionSource", () => {
                 "detail": "db2.schema2",
                 "info": [Function],
                 "label": "schema2",
-                "type": "namespace",
+                "type": "schema",
               },
             },
           },
@@ -939,7 +1007,7 @@ describe("tablesCompletionSource", () => {
             "detail": "db2",
             "info": [Function],
             "label": "db2",
-            "type": "namespace",
+            "type": "database",
           },
         },
       }
@@ -1075,6 +1143,64 @@ describe("tablesCompletionSource", () => {
     );
     expect(completionSource?.schema).toMatchInlineSnapshot(`
       {
+        "db1": {
+          "children": {
+            "schema1": {
+              "children": {
+                "table1": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col1",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "table1",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "db1.schema1",
+                "info": [Function],
+                "label": "schema1",
+                "type": "schema",
+              },
+            },
+            "schema2": {
+              "children": {
+                "table2": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col2",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "table2",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "db1.schema2",
+                "info": [Function],
+                "label": "schema2",
+                "type": "schema",
+              },
+            },
+          },
+          "self": {
+            "detail": "db1",
+            "info": [Function],
+            "label": "db1",
+            "type": "database",
+          },
+        },
         "db2": {
           "children": {
             "schema2": {
@@ -1098,7 +1224,7 @@ describe("tablesCompletionSource", () => {
                 "detail": "db2.schema2",
                 "info": [Function],
                 "label": "schema2",
-                "type": "namespace",
+                "type": "schema",
               },
             },
           },
@@ -1106,7 +1232,7 @@ describe("tablesCompletionSource", () => {
             "detail": "db2",
             "info": [Function],
             "label": "db2",
-            "type": "namespace",
+            "type": "database",
           },
         },
         "db3": {
@@ -1132,7 +1258,7 @@ describe("tablesCompletionSource", () => {
                 "detail": "db3.schema2",
                 "info": [Function],
                 "label": "schema2",
-                "type": "namespace",
+                "type": "schema",
               },
             },
           },
@@ -1140,7 +1266,7 @@ describe("tablesCompletionSource", () => {
             "detail": "db3",
             "info": [Function],
             "label": "db3",
-            "type": "namespace",
+            "type": "database",
           },
         },
         "schema1": {
@@ -1164,7 +1290,7 @@ describe("tablesCompletionSource", () => {
             "detail": "schema1",
             "info": [Function],
             "label": "schema1",
-            "type": "namespace",
+            "type": "schema",
           },
         },
         "schema2": {
@@ -1188,7 +1314,7 @@ describe("tablesCompletionSource", () => {
             "detail": "schema2",
             "info": [Function],
             "label": "schema2",
-            "type": "namespace",
+            "type": "schema",
           },
         },
       }
@@ -1288,7 +1414,51 @@ describe("tablesCompletionSource", () => {
             "detail": "public",
             "info": [Function],
             "label": "public",
-            "type": "namespace",
+            "type": "schema",
+          },
+        },
+        "test_db": {
+          "children": {
+            "public": {
+              "children": {
+                "users": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "id",
+                      "type": "column",
+                    },
+                    {
+                      "info": [Function],
+                      "label": "name",
+                      "type": "column",
+                    },
+                    {
+                      "info": [Function],
+                      "label": "email",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "users",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "test_db.public",
+                "info": [Function],
+                "label": "public",
+                "type": "schema",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_db",
+            "info": [Function],
+            "label": "test_db",
+            "type": "database",
           },
         },
       }
@@ -1421,7 +1591,7 @@ describe("tablesCompletionSource", () => {
             "detail": "test_db",
             "info": [Function],
             "label": "test_db",
-            "type": "namespace",
+            "type": "database",
           },
         },
         "test_db2": {
@@ -1445,7 +1615,7 @@ describe("tablesCompletionSource", () => {
             "detail": "test_db2",
             "info": [Function],
             "label": "test_db2",
-            "type": "namespace",
+            "type": "database",
           },
         },
         "users": {
@@ -1811,6 +1981,40 @@ describe("tablesCompletionSource", () => {
             "type": "table",
           },
         },
+        "test_db": {
+          "children": {
+            "test_schema": {
+              "children": {
+                "dataset2": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col1",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "dataset2",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "test_db.test_schema",
+                "info": [Function],
+                "label": "test_schema",
+                "type": "schema",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_db",
+            "info": [Function],
+            "label": "test_db",
+            "type": "database",
+          },
+        },
         "test_schema": {
           "children": {
             "dataset2": {
@@ -1832,7 +2036,7 @@ describe("tablesCompletionSource", () => {
             "detail": "test_schema",
             "info": [Function],
             "label": "test_schema",
-            "type": "namespace",
+            "type": "schema",
           },
         },
       }
@@ -1848,6 +2052,40 @@ describe("tablesCompletionSource", () => {
     const completionSource = completionStore.getCompletionSource(TEST_ENGINE);
     expect(completionSource?.schema).toMatchInlineSnapshot(`
       {
+        "test_db": {
+          "children": {
+            "test_schema": {
+              "children": {
+                "dataset2": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col1",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "dataset2",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "test_db.test_schema",
+                "info": [Function],
+                "label": "test_schema",
+                "type": "schema",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_db",
+            "info": [Function],
+            "label": "test_db",
+            "type": "database",
+          },
+        },
         "test_schema": {
           "children": {
             "dataset2": {
@@ -1869,7 +2107,7 @@ describe("tablesCompletionSource", () => {
             "detail": "test_schema",
             "info": [Function],
             "label": "test_schema",
-            "type": "namespace",
+            "type": "schema",
           },
         },
       }
@@ -1924,6 +2162,40 @@ describe("tablesCompletionSource", () => {
             "type": "table",
           },
         },
+        "test_db": {
+          "children": {
+            "test_schema": {
+              "children": {
+                "dataset2": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col1",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "dataset2",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "test_db.test_schema",
+                "info": [Function],
+                "label": "test_schema",
+                "type": "schema",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_db",
+            "info": [Function],
+            "label": "test_db",
+            "type": "database",
+          },
+        },
         "test_schema": {
           "children": {
             "dataset2": {
@@ -1945,7 +2217,7 @@ describe("tablesCompletionSource", () => {
             "detail": "test_schema",
             "info": [Function],
             "label": "test_schema",
-            "type": "namespace",
+            "type": "schema",
           },
         },
       }
@@ -1985,6 +2257,40 @@ describe("tablesCompletionSource", () => {
             "type": "table",
           },
         },
+        "test_db": {
+          "children": {
+            "test_schema": {
+              "children": {
+                "dataset2": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col1",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "dataset2",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "test_db.test_schema",
+                "info": [Function],
+                "label": "test_schema",
+                "type": "schema",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_db",
+            "info": [Function],
+            "label": "test_db",
+            "type": "database",
+          },
+        },
         "test_schema": {
           "children": {
             "dataset2": {
@@ -2006,7 +2312,7 @@ describe("tablesCompletionSource", () => {
             "detail": "test_schema",
             "info": [Function],
             "label": "test_schema",
-            "type": "namespace",
+            "type": "schema",
           },
         },
       }

--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -735,16 +735,62 @@ describe("tablesCompletionSource", () => {
     expect(completionSource?.schema).toMatchInlineSnapshot(`
       {
         "public": {
-          "orders": [
-            "order_id",
-            "user_id",
-            "total",
-          ],
-          "users": [
-            "id",
-            "name",
-            "email",
-          ],
+          "children": {
+            "orders": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "order_id",
+                  "type": "column",
+                },
+                {
+                  "info": [Function],
+                  "label": "user_id",
+                  "type": "column",
+                },
+                {
+                  "info": [Function],
+                  "label": "total",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "orders",
+                "type": "table",
+              },
+            },
+            "users": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "id",
+                  "type": "column",
+                },
+                {
+                  "info": [Function],
+                  "label": "name",
+                  "type": "column",
+                },
+                {
+                  "info": [Function],
+                  "label": "email",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "users",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "public",
+            "info": [Function],
+            "label": "public",
+            "type": "namespace",
+          },
         },
       }
     `);
@@ -829,17 +875,71 @@ describe("tablesCompletionSource", () => {
     expect(completionSource?.schema).toMatchInlineSnapshot(`
       {
         "db1": {
-          "schema1": {
-            "table1": [
-              "col1",
-            ],
+          "children": {
+            "schema1": {
+              "children": {
+                "table1": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col1",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "table1",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "db1.schema1",
+                "info": [Function],
+                "label": "schema1",
+                "type": "namespace",
+              },
+            },
+          },
+          "self": {
+            "detail": "db1",
+            "info": [Function],
+            "label": "db1",
+            "type": "namespace",
           },
         },
         "db2": {
-          "schema2": {
-            "table2": [
-              "col2",
-            ],
+          "children": {
+            "schema2": {
+              "children": {
+                "table2": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col2",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "table2",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "db2.schema2",
+                "info": [Function],
+                "label": "schema2",
+                "type": "namespace",
+              },
+            },
+          },
+          "self": {
+            "detail": "db2",
+            "info": [Function],
+            "label": "db2",
+            "type": "namespace",
           },
         },
       }
@@ -976,28 +1076,120 @@ describe("tablesCompletionSource", () => {
     expect(completionSource?.schema).toMatchInlineSnapshot(`
       {
         "db2": {
-          "schema2": {
-            "table2": [
-              "col2",
-            ],
+          "children": {
+            "schema2": {
+              "children": {
+                "table2": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col2",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "table2",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "db2.schema2",
+                "info": [Function],
+                "label": "schema2",
+                "type": "namespace",
+              },
+            },
+          },
+          "self": {
+            "detail": "db2",
+            "info": [Function],
+            "label": "db2",
+            "type": "namespace",
           },
         },
         "db3": {
-          "schema2": {
-            "table2": [
-              "col2",
-            ],
+          "children": {
+            "schema2": {
+              "children": {
+                "table2": {
+                  "children": [
+                    {
+                      "info": [Function],
+                      "label": "col2",
+                      "type": "column",
+                    },
+                  ],
+                  "self": {
+                    "info": [Function],
+                    "label": "table2",
+                    "type": "table",
+                  },
+                },
+              },
+              "self": {
+                "detail": "db3.schema2",
+                "info": [Function],
+                "label": "schema2",
+                "type": "namespace",
+              },
+            },
+          },
+          "self": {
+            "detail": "db3",
+            "info": [Function],
+            "label": "db3",
+            "type": "namespace",
           },
         },
         "schema1": {
-          "table1": [
-            "col1",
-          ],
+          "children": {
+            "table1": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "col1",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "table1",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "schema1",
+            "info": [Function],
+            "label": "schema1",
+            "type": "namespace",
+          },
         },
         "schema2": {
-          "table2": [
-            "col2",
-          ],
+          "children": {
+            "table2": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "col2",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "table2",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "schema2",
+            "info": [Function],
+            "label": "schema2",
+            "type": "namespace",
+          },
         },
       }
     `);
@@ -1066,11 +1258,38 @@ describe("tablesCompletionSource", () => {
     expect(completionSource?.schema).toMatchInlineSnapshot(`
       {
         "public": {
-          "users": [
-            "id",
-            "name",
-            "email",
-          ],
+          "children": {
+            "users": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "id",
+                  "type": "column",
+                },
+                {
+                  "info": [Function],
+                  "label": "name",
+                  "type": "column",
+                },
+                {
+                  "info": [Function],
+                  "label": "email",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "users",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "public",
+            "info": [Function],
+            "label": "public",
+            "type": "namespace",
+          },
         },
       }
     `);
@@ -1196,16 +1415,55 @@ describe("tablesCompletionSource", () => {
     expect(completionSource?.dialect).toBe(PostgreSQL);
     expect(completionSource?.schema).toMatchInlineSnapshot(`
       {
-        "test_db2": {
-          "orders": [
-            "order_id",
-          ],
+        "test_db": {
+          "children": {},
+          "self": {
+            "detail": "test_db",
+            "info": [Function],
+            "label": "test_db",
+            "type": "namespace",
+          },
         },
-        "users": [
-          "id",
-        ],
+        "test_db2": {
+          "children": {
+            "orders": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "order_id",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "orders",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_db2",
+            "info": [Function],
+            "label": "test_db2",
+            "type": "namespace",
+          },
+        },
+        "users": {
+          "children": [
+            {
+              "info": [Function],
+              "label": "id",
+              "type": "column",
+            },
+          ],
+          "self": {
+            "info": [Function],
+            "label": "users",
+            "type": "table",
+          },
+        },
       }
-      `);
+    `);
   });
 
   it("should return local tables", () => {
@@ -1534,14 +1792,48 @@ describe("tablesCompletionSource", () => {
     const completionSource = completionStore.getCompletionSource(TEST_ENGINE);
     expect(completionSource?.schema).toMatchInlineSnapshot(`
       {
-        "dataset1": [
-          "col1",
-          "col2",
-        ],
-        "test_schema": {
-          "dataset2": [
-            "col1",
+        "dataset1": {
+          "children": [
+            {
+              "info": [Function],
+              "label": "col1",
+              "type": "column",
+            },
+            {
+              "info": [Function],
+              "label": "col2",
+              "type": "column",
+            },
           ],
+          "self": {
+            "info": [Function],
+            "label": "dataset1",
+            "type": "table",
+          },
+        },
+        "test_schema": {
+          "children": {
+            "dataset2": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "col1",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "dataset2",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_schema",
+            "info": [Function],
+            "label": "test_schema",
+            "type": "namespace",
+          },
         },
       }
     `);
@@ -1555,13 +1847,32 @@ describe("tablesCompletionSource", () => {
 
     const completionSource = completionStore.getCompletionSource(TEST_ENGINE);
     expect(completionSource?.schema).toMatchInlineSnapshot(`
-    {
-      "test_schema": {
-        "dataset2": [
-          "col1",
-        ],
-      },
-    }
+      {
+        "test_schema": {
+          "children": {
+            "dataset2": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "col1",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "dataset2",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_schema",
+            "info": [Function],
+            "label": "test_schema",
+            "type": "namespace",
+          },
+        },
+      }
     `);
 
     const newConnection: DataSourceConnection = {
@@ -1593,17 +1904,51 @@ describe("tablesCompletionSource", () => {
     mockStore.set(datasetsAtom, { tables: testDatasets } as DatasetsState);
     const completionSource = completionStore.getCompletionSource(TEST_ENGINE);
     expect(completionSource?.schema).toMatchInlineSnapshot(`
-    {
-      "dataset1": [
-        "col1",
-        "col2",
-      ],
-      "test_schema": {
-        "dataset2": [
-          "col1",
-        ],
-      },
-    }
+      {
+        "dataset1": {
+          "children": [
+            {
+              "info": [Function],
+              "label": "col1",
+              "type": "column",
+            },
+            {
+              "info": [Function],
+              "label": "col2",
+              "type": "column",
+            },
+          ],
+          "self": {
+            "info": [Function],
+            "label": "dataset1",
+            "type": "table",
+          },
+        },
+        "test_schema": {
+          "children": {
+            "dataset2": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "col1",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "dataset2",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_schema",
+            "info": [Function],
+            "label": "test_schema",
+            "type": "namespace",
+          },
+        },
+      }
     `);
 
     const newTestDatasets = [
@@ -1620,17 +1965,51 @@ describe("tablesCompletionSource", () => {
     const newCompletionSource =
       completionStore.getCompletionSource(TEST_ENGINE);
     expect(newCompletionSource?.schema).toMatchInlineSnapshot(`
-    {
-      "dataset3": [
-        "col1",
-        "col2",
-      ],
-      "test_schema": {
-        "dataset2": [
-          "col1",
-        ],
-      },
-    }
+      {
+        "dataset3": {
+          "children": [
+            {
+              "info": [Function],
+              "label": "col1",
+              "type": "column",
+            },
+            {
+              "info": [Function],
+              "label": "col2",
+              "type": "column",
+            },
+          ],
+          "self": {
+            "info": [Function],
+            "label": "dataset3",
+            "type": "table",
+          },
+        },
+        "test_schema": {
+          "children": {
+            "dataset2": {
+              "children": [
+                {
+                  "info": [Function],
+                  "label": "col1",
+                  "type": "column",
+                },
+              ],
+              "self": {
+                "info": [Function],
+                "label": "dataset2",
+                "type": "table",
+              },
+            },
+          },
+          "self": {
+            "detail": "test_schema",
+            "info": [Function],
+            "label": "test_schema",
+            "type": "namespace",
+          },
+        },
+      }
     `);
   });
 });

--- a/frontend/src/core/codemirror/language/languages/sql/completion-builder.ts
+++ b/frontend/src/core/codemirror/language/languages/sql/completion-builder.ts
@@ -53,6 +53,7 @@ export class CompletionBuilder {
    * Set a value at a nested path, creating intermediate objects as needed
    */
   private setAt(path: string[], value: SQLNamespace): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let current: any = this.schema;
     for (const key of path.slice(0, -1)) {
       if (!current[key]) {
@@ -66,7 +67,7 @@ export class CompletionBuilder {
   /**
    * Build the final schema
    */
-  build(): Record<string, any> {
+  build(): SQLNamespace {
     return this.schema;
   }
 

--- a/frontend/src/core/codemirror/language/languages/sql/completion-builder.ts
+++ b/frontend/src/core/codemirror/language/languages/sql/completion-builder.ts
@@ -1,0 +1,150 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import type { Completion } from "@codemirror/autocomplete";
+import type { SQLNamespace } from "@codemirror/lang-sql";
+import { DefaultSqlTooltipRenders } from "@marimo-team/codemirror-sql";
+import type { DataTableColumn } from "@/core/kernel/messages";
+
+/**
+ * Simple builder for SQL completion schemas.
+ */
+export class CompletionBuilder {
+  private schema: Record<string, SQLNamespace> = {};
+
+  /**
+   * Add a table with its columns at the specified path
+   */
+  addTable(path: string[], table: string, columns: DataTableColumn[]): this {
+    const tableNamespace: SQLNamespace = {
+      self: tableToCompletion({
+        tableName: table,
+        columns: columns,
+      }),
+      children: columns.map((col) =>
+        columnToCompletion({
+          tableName: table,
+          column: col.name,
+          metadata: { Type: col.external_type },
+        }),
+      ),
+    };
+
+    this.setAt([...path, table], tableNamespace);
+    return this;
+  }
+
+  /**
+   * Add a namespace at the specified path
+   */
+  addNamespace(path: string[], namespace: string): this {
+    const namespaceObject: SQLNamespace = {
+      self: namespaceToCompletion({
+        namespace: namespace,
+        path: path,
+      }),
+      children: {},
+    };
+
+    this.setAt(path, namespaceObject);
+    return this;
+  }
+
+  /**
+   * Set a value at a nested path, creating intermediate objects as needed
+   */
+  private setAt(path: string[], value: SQLNamespace): void {
+    let current: any = this.schema;
+    for (const key of path.slice(0, -1)) {
+      if (!current[key]) {
+        current[key] = { children: {} };
+      }
+      current = current[key].children;
+    }
+    current[path[path.length - 1]] = value;
+  }
+
+  /**
+   * Build the final schema
+   */
+  build(): Record<string, any> {
+    return this.schema;
+  }
+
+  /**
+   * Reset for reuse
+   */
+  reset(): this {
+    this.schema = {};
+    return this;
+  }
+}
+
+function columnToCompletion(opts: {
+  tableName: string;
+  column: string;
+  metadata?: Record<string, string>;
+}): Completion {
+  return {
+    label: opts.column,
+    type: "column",
+    info: () => {
+      // TODO: do our own styling
+      const html = DefaultSqlTooltipRenders.column({
+        tableName: opts.tableName,
+        columnName: opts.column,
+        schema: {},
+        metadata: opts.metadata,
+      });
+      const dom = document.createElement("div");
+      dom.innerHTML = html;
+      return { dom: dom };
+    },
+  };
+}
+
+function tableToCompletion(opts: {
+  tableName: string;
+  columns: DataTableColumn[];
+  metadata?: Record<string, string>;
+}): Completion {
+  return {
+    label: opts.tableName,
+    type: "table",
+    info: () => {
+      // TODO: do our own styling
+      const html = DefaultSqlTooltipRenders.table({
+        tableName: opts.tableName,
+        columns: opts.columns.map(
+          (col) => `${col.name} (${col.external_type})`,
+        ),
+        metadata: opts.metadata,
+      });
+      const dom = document.createElement("div");
+      dom.innerHTML = html;
+      return { dom: dom };
+    },
+  };
+}
+
+function namespaceToCompletion(opts: {
+  namespace: string;
+  path: string[];
+  metadata?: Record<string, string>;
+}): Completion {
+  return {
+    label: opts.namespace,
+    detail: opts.path.join("."),
+    type: "namespace",
+    info: () => {
+      // TODO: do our own styling
+      const html = DefaultSqlTooltipRenders.namespace({
+        path: opts.path,
+        type: "namespace",
+        semanticType: "namespace",
+      });
+      const dom = document.createElement("div");
+      dom.innerHTML = html;
+      return { dom: dom };
+    },
+  };
+}

--- a/frontend/src/core/codemirror/language/languages/sql/completion-sources.tsx
+++ b/frontend/src/core/codemirror/language/languages/sql/completion-sources.tsx
@@ -28,7 +28,12 @@ export function tablesCompletionSource(): CompletionSource {
       return null;
     }
 
-    return schemaCompletionSource(config)(ctx);
+    const completions = schemaCompletionSource(config)(ctx);
+    if (!completions) {
+      return null;
+    }
+
+    return completions;
   };
 }
 

--- a/frontend/src/core/codemirror/language/languages/sql/completion-sources.tsx
+++ b/frontend/src/core/codemirror/language/languages/sql/completion-sources.tsx
@@ -7,6 +7,7 @@ import {
 } from "@codemirror/lang-sql";
 import type { EditorState } from "@codemirror/state";
 import { DefaultSqlTooltipRenders } from "@marimo-team/codemirror-sql";
+import { once } from "@/utils/once";
 import { languageMetadataField } from "../../metadata";
 import { SCHEMA_CACHE } from "./completion-store";
 import type { SQLLanguageAdapterMetadata } from "./sql";
@@ -89,7 +90,7 @@ export function customKeywordCompletionSource(): CompletionSource {
 }
 
 // e.g. lazily load keyword docs
-const getKeywordDocs = async (): Promise<Record<string, unknown>> => {
+const getKeywordDocs = once(async (): Promise<Record<string, unknown>> => {
   const keywords = await import(
     "@marimo-team/codemirror-sql/data/common-keywords.json"
   );
@@ -101,4 +102,4 @@ const getKeywordDocs = async (): Promise<Record<string, unknown>> => {
     ...keywords.default.keywords,
     ...duckdbKeywords.default.keywords,
   };
-};
+});

--- a/frontend/src/core/codemirror/language/languages/sql/completion-store.ts
+++ b/frontend/src/core/codemirror/language/languages/sql/completion-store.ts
@@ -42,7 +42,7 @@ class SQLCompletionStore {
   }
 
   private getConnectionSchema(connection: DataSourceConnection): CachedSchema {
-    const { default_database, databases } = connection;
+    const { default_database, databases, default_schema } = connection;
     const builder = new CompletionBuilder();
 
     // When there is only one database, it is the default
@@ -89,7 +89,7 @@ class SQLCompletionStore {
     }
 
     // Otherwise, we need to use the fully qualified name
-    for (const database of connection.databases) {
+    for (const database of databases) {
       // Skip the default database, since we already added it
       if (database.name === defaultDb?.name) {
         continue;
@@ -112,7 +112,7 @@ class SQLCompletionStore {
     return {
       shouldAddLocalTables: true,
       schema: builder.build(),
-      defaultSchema: connection.default_schema ?? undefined,
+      defaultSchema: default_schema ?? undefined,
     };
   }
 

--- a/frontend/src/core/codemirror/language/languages/sql/renderers.tsx
+++ b/frontend/src/core/codemirror/language/languages/sql/renderers.tsx
@@ -1,8 +1,11 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
 import {
   ColumnsIcon,
   DatabaseIcon,
   EyeIcon,
   HashIcon,
+  InfoIcon,
   KeyIcon,
   LayersIcon,
   TableIcon,
@@ -40,6 +43,8 @@ const SOURCE_TYPE_COLORS = {
   connection: "bg-[var(--green-4)] text-[var(--green-11)]",
   catalog: "bg-[var(--purple-4)] text-[var(--purple-11)]",
 } as const;
+
+const CONTAINER_STYLES = "p-3 min-w-[250px] flex flex-col divide-y";
 
 // Helper components and functions
 const SectionHeader: React.FC<{
@@ -148,8 +153,11 @@ export const renderTableInfo = (table: DataTable): React.ReactNode => {
     );
   });
 
+  const hasPrimaryKeys = table.primary_keys && table.primary_keys.length > 0;
+  const hasIndexes = table.indexes && table.indexes.length > 0;
+
   return (
-    <div className="p-4 min-w-[300px] flex flex-col divide-y">
+    <div className={`${CONTAINER_STYLES} min-w-[300px]`}>
       <SectionHeader icon={tableIcon} title={table.name} badge={typeBadge} />
 
       {/* Metadata */}
@@ -207,50 +215,49 @@ export const renderTableInfo = (table: DataTable): React.ReactNode => {
         </div>
       )}
 
+      {/* Empty Info */}
+      {table.columns.length === 0 && renderEmptyInfo("column")}
+
       {/* Primary Keys & Indexes */}
-      {(table.primary_keys?.length || table.indexes?.length) && (
+      {(hasPrimaryKeys || hasIndexes) && (
         <div className="flex flex-col gap-2 py-2">
-          {table.primary_keys && table.primary_keys.length > 0 && (
-            <div>
-              <div className="flex items-center gap-1 mb-1">
+          {hasPrimaryKeys && (
+            <div className="flex flex-row gap-1">
+              <div className="flex items-center gap-1">
                 <KeyIcon className="w-3 h-3 text-[var(--amber-9)]" />
                 <span className="text-xs font-medium text-[var(--slate-11)]">
                   Primary Keys:
                 </span>
               </div>
-              <div className="flex flex-wrap gap-1">
-                {table.primary_keys.map((key) => (
-                  <Badge
-                    key={key}
-                    variant="outline"
-                    className="text-xs bg-[var(--amber-4)] text-[var(--amber-11)]"
-                  >
-                    {key}
-                  </Badge>
-                ))}
-              </div>
+              {table.primary_keys?.map((key) => (
+                <Badge
+                  key={key}
+                  variant="outline"
+                  className="text-xs bg-[var(--amber-4)] text-[var(--amber-11)]"
+                >
+                  {key}
+                </Badge>
+              ))}
             </div>
           )}
 
-          {table.indexes && table.indexes.length > 0 && (
-            <div>
+          {hasIndexes && (
+            <div className="flex flex-row gap-1">
               <div className="flex items-center gap-1 mb-1">
                 <LayersIcon className="w-3 h-3 text-[var(--purple-9)]" />
                 <span className="text-xs font-medium text-[var(--slate-11)]">
                   Indexes:
                 </span>
               </div>
-              <div className="flex flex-wrap gap-1">
-                {table.indexes.map((index) => (
-                  <Badge
-                    key={index}
-                    variant="outline"
-                    className="text-xs bg-[var(--purple-4)] text-[var(--purple-11)]"
-                  >
-                    {index}
-                  </Badge>
-                ))}
-              </div>
+              {table.indexes?.map((index) => (
+                <Badge
+                  key={index}
+                  variant="outline"
+                  className="text-xs bg-[var(--purple-4)] text-[var(--purple-11)]"
+                >
+                  {index}
+                </Badge>
+              ))}
             </div>
           )}
         </div>
@@ -287,7 +294,7 @@ export const renderColumnInfo = (column: DataTableColumn): React.ReactNode => {
     )) || [];
 
   return (
-    <div className="p-4 min-w-[280px] flex flex-col divide-y">
+    <div className={CONTAINER_STYLES}>
       <SectionHeader
         icon={<TypeIcon className="w-4 h-4 text-[var(--slate-9)]" />}
         title={column.name}
@@ -295,7 +302,7 @@ export const renderColumnInfo = (column: DataTableColumn): React.ReactNode => {
       />
 
       {/* Type Information */}
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 mt-2">
         <MetadataRow
           label="Type"
           value={<span className="font-medium">{column.type}</span>}
@@ -348,13 +355,12 @@ export const renderDatabaseInfo = (database: Database): React.ReactNode => {
   ));
 
   return (
-    <div className="p-4 min-w-[300px] flex flex-col divide-y">
+    <div className={CONTAINER_STYLES}>
       <SectionHeader
         icon={<DatabaseIcon className="w-4 h-4 text-[var(--blue-9)]" />}
         title={database.name}
         badge={dialectBadge}
       />
-
       {/* Metadata */}
       <div className="flex flex-col gap-2 py-2">
         <MetadataRow
@@ -373,14 +379,15 @@ export const renderDatabaseInfo = (database: Database): React.ReactNode => {
           />
         )}
       </div>
-
       {/* Schema Statistics */}
       <div className="py-2">
         <StatisticItem
           icon={<LayersIcon className="w-3 h-3 text-[var(--slate-9)]" />}
-          text={`${database.schemas.length} schema${database.schemas.length !== 1 ? "s" : ""}`}
+          text={`${database.schemas.length} schema${database.schemas.length === 1 ? "" : "s"}`}
         />
       </div>
+      {/* Empty Info */}
+      {database.schemas.length === 0 && renderEmptyInfo("schema")}
 
       {/* Schema Preview */}
       {database.schemas.length > 0 && (
@@ -431,7 +438,7 @@ export const renderSchemaInfo = (schema: DatabaseSchema): React.ReactNode => {
   ));
 
   return (
-    <div className="p-4 min-w-[280px] flex flex-col divide-y">
+    <div className={CONTAINER_STYLES}>
       <SectionHeader
         icon={<LayersIcon className="w-4 h-4 text-[var(--green-9)]" />}
         title={schema.name}
@@ -442,9 +449,12 @@ export const renderSchemaInfo = (schema: DatabaseSchema): React.ReactNode => {
       <div className="py-2">
         <StatisticItem
           icon={<TableIcon className="w-3 h-3 text-[var(--slate-9)]" />}
-          text={`${schema.tables.length} table${schema.tables.length !== 1 ? "s" : ""}`}
+          text={`${schema.tables.length} table${schema.tables.length === 1 ? "" : "s"}`}
         />
       </div>
+
+      {/* Empty Info */}
+      {schema.tables.length === 0 && renderEmptyInfo("table")}
 
       {/* Table Preview */}
       {schema.tables.length > 0 && (
@@ -454,6 +464,22 @@ export const renderSchemaInfo = (schema: DatabaseSchema): React.ReactNode => {
           totalCount={schema.tables.length}
         />
       )}
+    </div>
+  );
+};
+
+export const renderEmptyInfo = (
+  type: "column" | "table" | "schema" | "database",
+) => {
+  return (
+    <div className="flex items-start gap-2 mt-3">
+      <InfoIcon size={10} className="mt-1 text-[var(--slate-10)] shrink-0" />
+      <span className="text-xs text-[var(--slate-11)]">
+        No {type} information available.{" \n"}
+        <span className="text-[var(--blue-10)]">
+          Introspect to see more details.
+        </span>
+      </span>
     </div>
   );
 };

--- a/frontend/src/core/codemirror/language/languages/sql/renderers.tsx
+++ b/frontend/src/core/codemirror/language/languages/sql/renderers.tsx
@@ -233,7 +233,7 @@ export const renderTableInfo = (table: DataTable): React.ReactNode => {
                 <Badge
                   key={key}
                   variant="outline"
-                  className="text-xs bg-[var(--amber-4)] text-[var(--amber-11)]"
+                  className="text-xs text-[var(--slate-11)]"
                 >
                   {key}
                 </Badge>
@@ -253,7 +253,7 @@ export const renderTableInfo = (table: DataTable): React.ReactNode => {
                 <Badge
                   key={index}
                   variant="outline"
-                  className="text-xs bg-[var(--purple-4)] text-[var(--purple-11)]"
+                  className="text-xs text-[var(--slate-11)]"
                 >
                   {index}
                 </Badge>

--- a/frontend/src/core/codemirror/language/languages/sql/renderers.tsx
+++ b/frontend/src/core/codemirror/language/languages/sql/renderers.tsx
@@ -1,0 +1,459 @@
+import {
+  ColumnsIcon,
+  DatabaseIcon,
+  EyeIcon,
+  HashIcon,
+  KeyIcon,
+  LayersIcon,
+  TableIcon,
+} from "lucide-react";
+import type React from "react";
+import { DATA_TYPE_ICON } from "@/components/datasets/icons";
+import { Badge } from "@/components/ui/badge";
+import type {
+  Database,
+  DatabaseSchema,
+  DataTable,
+  DataTableColumn,
+  DataType,
+} from "@/core/kernel/messages";
+
+// Configuration constants
+const PREVIEW_ITEM_LIMIT = 5;
+
+// Color mappings for data types (Tailwind-safe)
+const DATA_TYPE_COLORS: Record<DataType, string> = {
+  boolean: "bg-[var(--orange-4)] text-[var(--orange-11)]",
+  date: "bg-[var(--grass-4)] text-[var(--grass-11)]",
+  time: "bg-[var(--grass-4)] text-[var(--grass-11)]",
+  datetime: "bg-[var(--grass-4)] text-[var(--grass-11)]",
+  number: "bg-[var(--purple-4)] text-[var(--purple-11)]",
+  integer: "bg-[var(--purple-4)] text-[var(--purple-11)]",
+  string: "bg-[var(--blue-4)] text-[var(--blue-11)]",
+  unknown: "bg-[var(--slate-4)] text-[var(--slate-11)]",
+};
+
+// Source type colors
+const SOURCE_TYPE_COLORS = {
+  local: "bg-[var(--blue-4)] text-[var(--blue-11)]",
+  duckdb: "bg-[var(--amber-4)] text-[var(--amber-11)]",
+  connection: "bg-[var(--green-4)] text-[var(--green-11)]",
+  catalog: "bg-[var(--purple-4)] text-[var(--purple-11)]",
+} as const;
+
+// Helper components and functions
+const SectionHeader: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  badge?: React.ReactNode;
+}> = ({ icon, title, badge }) => (
+  <div className="flex items-center gap-2 pb-2">
+    {icon}
+    <h3 className="font-semibold text-sm">{title}</h3>
+    {badge}
+  </div>
+);
+
+const MetadataRow: React.FC<{
+  label: string;
+  value: React.ReactNode;
+}> = ({ label, value }) => (
+  <div className="flex items-center justify-between text-xs">
+    <span className="text-[var(--slate-11)]">{label}:</span>
+    {value}
+  </div>
+);
+
+const StatisticItem: React.FC<{
+  icon: React.ReactNode;
+  text: string;
+}> = ({ icon, text }) => (
+  <div className="flex items-center gap-1">
+    {icon}
+    <span className="text-xs text-[var(--slate-11)]">{text}</span>
+  </div>
+);
+
+const PreviewList: React.FC<{
+  title?: string;
+  items: React.ReactNode[];
+  totalCount: number;
+  limit?: number;
+}> = ({ title = "", items, totalCount, limit = PREVIEW_ITEM_LIMIT }) => {
+  const visibleItems = items.slice(0, limit);
+  const hasMore = totalCount > limit;
+
+  return (
+    <div className="py-2">
+      {title && (
+        <h4 className="text-xs font-medium text-[var(--slate-11)] mb-2">
+          {title}:
+        </h4>
+      )}
+      <div className="flex flex-col gap-1 overflow-y-auto">
+        {visibleItems}
+        {hasMore && (
+          <div className="text-xs text-[var(--slate-10)] text-center py-1">
+            ... and {totalCount - limit} more
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const getDataTypeColorClass = (dataType: DataType): string => {
+  return DATA_TYPE_COLORS[dataType] || DATA_TYPE_COLORS.unknown;
+};
+
+export const renderTableInfo = (table: DataTable): React.ReactNode => {
+  const tableIcon =
+    table.type === "view" ? (
+      <EyeIcon className="w-4 h-4 text-[var(--blue-9)]" />
+    ) : (
+      <TableIcon className="w-4 h-4 text-[var(--green-9)]" />
+    );
+
+  const typeBadge = (
+    <Badge
+      variant="secondary"
+      className={`text-xs ${
+        table.type === "view"
+          ? "bg-[var(--blue-4)] text-[var(--blue-11)]"
+          : "bg-[var(--green-4)] text-[var(--green-11)]"
+      }`}
+    >
+      {table.type}
+    </Badge>
+  );
+
+  const columnItems = table.columns.map((column) => {
+    const TypeIcon = DATA_TYPE_ICON[column.type];
+    return (
+      <div
+        key={column.name}
+        className="flex items-center justify-between text-xs rounded"
+      >
+        <div className="flex items-center gap-2">
+          <TypeIcon className="w-3 h-3 text-[var(--slate-9)]" />
+          <span className="font-mono">{column.name}</span>
+        </div>
+        <Badge
+          variant="outline"
+          className={`text-xs ${getDataTypeColorClass(column.type)}`}
+        >
+          {column.type}
+        </Badge>
+      </div>
+    );
+  });
+
+  return (
+    <div className="p-4 min-w-[300px] flex flex-col divide-y">
+      <SectionHeader icon={tableIcon} title={table.name} badge={typeBadge} />
+
+      {/* Metadata */}
+      <div className="flex flex-col gap-2 py-2">
+        <MetadataRow
+          label="Source"
+          value={
+            <Badge
+              variant="outline"
+              className={`text-xs ${SOURCE_TYPE_COLORS[table.source_type]}`}
+            >
+              {table.source}
+            </Badge>
+          }
+        />
+
+        {table.variable_name && (
+          <MetadataRow
+            label="Variable"
+            value={
+              <code className="text-xs bg-[var(--slate-4)] px-1 rounded">
+                {table.variable_name}
+              </code>
+            }
+          />
+        )}
+
+        {table.engine && (
+          <MetadataRow
+            label="Engine"
+            value={
+              <code className="text-xs bg-[var(--slate-4)] px-1 rounded">
+                {table.engine}
+              </code>
+            }
+          />
+        )}
+      </div>
+
+      {/* Statistics */}
+      {(table.num_columns != null || table.num_rows != null) && (
+        <div className="grid grid-cols-2 gap-2 py-2">
+          {table.num_columns != null && (
+            <StatisticItem
+              icon={<ColumnsIcon className="w-3 h-3 text-[var(--slate-9)]" />}
+              text={`${table.num_columns} columns`}
+            />
+          )}
+          {table.num_rows != null && (
+            <StatisticItem
+              icon={<HashIcon className="w-3 h-3 text-[var(--slate-9)]" />}
+              text={`${table.num_rows} rows`}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Primary Keys & Indexes */}
+      {(table.primary_keys?.length || table.indexes?.length) && (
+        <div className="flex flex-col gap-2 py-2">
+          {table.primary_keys && table.primary_keys.length > 0 && (
+            <div>
+              <div className="flex items-center gap-1 mb-1">
+                <KeyIcon className="w-3 h-3 text-[var(--amber-9)]" />
+                <span className="text-xs font-medium text-[var(--slate-11)]">
+                  Primary Keys:
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {table.primary_keys.map((key) => (
+                  <Badge
+                    key={key}
+                    variant="outline"
+                    className="text-xs bg-[var(--amber-4)] text-[var(--amber-11)]"
+                  >
+                    {key}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {table.indexes && table.indexes.length > 0 && (
+            <div>
+              <div className="flex items-center gap-1 mb-1">
+                <LayersIcon className="w-3 h-3 text-[var(--purple-9)]" />
+                <span className="text-xs font-medium text-[var(--slate-11)]">
+                  Indexes:
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {table.indexes.map((index) => (
+                  <Badge
+                    key={index}
+                    variant="outline"
+                    className="text-xs bg-[var(--purple-4)] text-[var(--purple-11)]"
+                  >
+                    {index}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Sample Columns Preview */}
+      {table.columns.length > 0 && (
+        <PreviewList items={columnItems} totalCount={table.columns.length} />
+      )}
+    </div>
+  );
+};
+
+export const renderColumnInfo = (column: DataTableColumn): React.ReactNode => {
+  const TypeIcon = DATA_TYPE_ICON[column.type];
+
+  const typeBadge = (
+    <Badge
+      variant="outline"
+      className={`text-xs ${getDataTypeColorClass(column.type)}`}
+    >
+      {column.type}
+    </Badge>
+  );
+
+  const sampleItems =
+    column.sample_values?.map((value, index) => (
+      <div
+        key={index}
+        className="text-xs bg-[var(--slate-3)] rounded font-mono"
+      >
+        {value === null || value === undefined ? "null" : String(value)}
+      </div>
+    )) || [];
+
+  return (
+    <div className="p-4 min-w-[280px] flex flex-col divide-y">
+      <SectionHeader
+        icon={<TypeIcon className="w-4 h-4 text-[var(--slate-9)]" />}
+        title={column.name}
+        badge={typeBadge}
+      />
+
+      {/* Type Information */}
+      <div className="flex flex-col gap-2">
+        <MetadataRow
+          label="Type"
+          value={<span className="font-medium">{column.type}</span>}
+        />
+        <MetadataRow
+          label="External Type"
+          value={
+            <code className="text-xs bg-[var(--slate-4)] px-1 rounded">
+              {column.external_type}
+            </code>
+          }
+        />
+      </div>
+
+      {/* Sample Values */}
+      {column.sample_values && column.sample_values.length > 0 && (
+        <PreviewList
+          title="Sample Values"
+          items={sampleItems}
+          totalCount={column.sample_values.length}
+        />
+      )}
+    </div>
+  );
+};
+
+export const renderDatabaseInfo = (database: Database): React.ReactNode => {
+  const dialectBadge = (
+    <Badge
+      variant="outline"
+      className="text-xs bg-[var(--blue-4)] text-[var(--blue-11)]"
+    >
+      {database.dialect}
+    </Badge>
+  );
+
+  const schemaItems = database.schemas.map((schema) => (
+    <div
+      key={schema.name}
+      className="flex items-center justify-between text-xs rounded hover:bg-[var(--slate-3)]"
+    >
+      <div className="flex items-center gap-2">
+        <LayersIcon className="w-3 h-3 text-[var(--slate-9)]" />
+        <span>{schema.name}</span>
+      </div>
+      <Badge variant="outline" className="text-xs">
+        {schema.tables.length} tables
+      </Badge>
+    </div>
+  ));
+
+  return (
+    <div className="p-4 min-w-[300px] flex flex-col divide-y">
+      <SectionHeader
+        icon={<DatabaseIcon className="w-4 h-4 text-[var(--blue-9)]" />}
+        title={database.name}
+        badge={dialectBadge}
+      />
+
+      {/* Metadata */}
+      <div className="flex flex-col gap-2 py-2">
+        <MetadataRow
+          label="Dialect"
+          value={<span className="font-medium">{database.dialect}</span>}
+        />
+
+        {database.engine && (
+          <MetadataRow
+            label="Engine"
+            value={
+              <code className="text-xs bg-[var(--slate-4)] px-1 rounded">
+                {database.engine}
+              </code>
+            }
+          />
+        )}
+      </div>
+
+      {/* Schema Statistics */}
+      <div className="py-2">
+        <StatisticItem
+          icon={<LayersIcon className="w-3 h-3 text-[var(--slate-9)]" />}
+          text={`${database.schemas.length} schema${database.schemas.length !== 1 ? "s" : ""}`}
+        />
+      </div>
+
+      {/* Schema Preview */}
+      {database.schemas.length > 0 && (
+        <PreviewList
+          title="Schemas"
+          items={schemaItems}
+          totalCount={database.schemas.length}
+        />
+      )}
+    </div>
+  );
+};
+
+export const renderSchemaInfo = (schema: DatabaseSchema): React.ReactNode => {
+  const schemaBadge = (
+    <Badge
+      variant="outline"
+      className="text-xs bg-[var(--green-4)] text-[var(--green-11)]"
+    >
+      Schema
+    </Badge>
+  );
+
+  const tableItems = schema.tables.map((table) => (
+    <div
+      key={table.name}
+      className="flex items-center justify-between text-xs rounded hover:bg-[var(--slate-3)]"
+    >
+      <div className="flex items-center gap-2">
+        {table.type === "view" ? (
+          <EyeIcon className="w-3 h-3 text-[var(--blue-9)]" />
+        ) : (
+          <TableIcon className="w-3 h-3 text-[var(--green-9)]" />
+        )}
+        <span>{table.name}</span>
+      </div>
+      <Badge
+        variant="outline"
+        className={`text-xs ${
+          table.type === "view"
+            ? "bg-[var(--blue-4)] text-[var(--blue-11)]"
+            : "bg-[var(--green-4)] text-[var(--green-11)]"
+        }`}
+      >
+        {table.type}
+      </Badge>
+    </div>
+  ));
+
+  return (
+    <div className="p-4 min-w-[280px] flex flex-col divide-y">
+      <SectionHeader
+        icon={<LayersIcon className="w-4 h-4 text-[var(--green-9)]" />}
+        title={schema.name}
+        badge={schemaBadge}
+      />
+
+      {/* Table Statistics */}
+      <div className="py-2">
+        <StatisticItem
+          icon={<TableIcon className="w-3 h-3 text-[var(--slate-9)]" />}
+          text={`${schema.tables.length} table${schema.tables.length !== 1 ? "s" : ""}`}
+        />
+      </div>
+
+      {/* Table Preview */}
+      {schema.tables.length > 0 && (
+        <PreviewList
+          title="Tables"
+          items={tableItems}
+          totalCount={schema.tables.length}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/core/codemirror/language/languages/sql/utils.ts
+++ b/frontend/src/core/codemirror/language/languages/sql/utils.ts
@@ -18,8 +18,11 @@ import {
 } from "@marimo-team/codemirror-sql/dialects";
 import type { DataSourceConnection } from "@/core/kernel/messages";
 
+/**
+ * Guess the CodeMirror SQL dialect from the backend connection dialect.
+ */
 export function guessDialect(
-  connection: DataSourceConnection,
+  connection: Pick<DataSourceConnection, "dialect">,
 ): SQLDialect | undefined {
   switch (connection.dialect) {
     case "postgresql":


### PR DESCRIPTION
This adds a completion info (unstyled for now) to the table completion.

Also
- utilities for building the `SQLNamespace`
- include default DB in name (not just the tables)


<img width="853" height="442" alt="Screenshot 2025-09-25 at 11 20 42 AM" src="https://github.com/user-attachments/assets/1494fdcc-5229-45fa-94d3-973b32b9e296" />

<img width="845" height="320" alt="Screenshot 2025-09-25 at 11 19 48 AM" src="https://github.com/user-attachments/assets/f5adf672-2d6d-4605-a20c-838605f76466" />
<img width="824" height="304" alt="Screenshot 2025-09-25 at 11 19 04 AM" src="https://github.com/user-attachments/assets/3266417a-b5b8-430c-af04-5d4147193041" />
<img width="733" height="302" alt="Screenshot 2025-09-25 at 11 19 00 AM" src="https://github.com/user-attachments/assets/3b20b43e-48f9-4a1e-bde9-21c3ad470787" />
