### PR TITLE
strips explain, better error output for sql error

### DIFF
--- a/frontend/src/components/editor/Cell.tsx
+++ b/frontend/src/components/editor/Cell.tsx
@@ -451,6 +451,7 @@ const EditableCellComponent = ({
   });
   const canCollapse = canCollapseOutline(cellRuntime.outline);
   const hasOutput = !isOutputEmpty(cellRuntime.output);
+  const isStaleCell = outputIsStale(cellRuntime, cellData.edited);
   const hasConsoleOutput = cellRuntime.consoleOutputs.length > 0;
   const cellOutput = userConfig.display.cell_output;
 
@@ -511,7 +512,7 @@ const EditableCellComponent = ({
         className="output-area"
         cellId={cellId}
         output={cellRuntime.output}
-        stale={outputIsStale(cellRuntime, cellData.edited)}
+        stale={isStaleCell}
         loading={outputIsLoading(cellRuntime.status)}
       />
       {isMarkdownCodeHidden &&
@@ -654,7 +655,10 @@ const EditableCellComponent = ({
                 )}
               </div>
             </div>
-            <SqlValidationErrorBanner cellId={cellId} />
+            <SqlValidationErrorBanner
+              cellId={cellId}
+              hide={cellRuntime.errored && !isStaleCell}
+            />
             {cellOutput === "below" && outputArea}
             {cellRuntime.serialization && (
               <div className="py-1 px-2 flex items-center justify-end gap-2 last:rounded-b">

--- a/frontend/src/components/editor/errors/sql-validation-errors.tsx
+++ b/frontend/src/components/editor/errors/sql-validation-errors.tsx
@@ -18,7 +18,7 @@ export const SqlValidationErrorBanner = ({
   }
 
   return (
-    <div className="p-3 text-sm flex flex-col text-muted-foreground gap-1.5 bg-destructive/5">
+    <div className="p-3 text-sm flex flex-col text-muted-foreground gap-1.5 bg-destructive/4">
       <div className="flex items-start gap-1.5">
         <AlertCircleIcon size={13} className="mt-[3px] text-destructive" />
         <p>
@@ -30,7 +30,7 @@ export const SqlValidationErrorBanner = ({
       {error.codeblock && (
         <pre
           lang="sql"
-          className="text-xs bg-muted rounded p-2 pb-0 mx-3 overflow-x-auto font-mono whitespace-pre-wrap"
+          className="text-xs bg-muted/80 rounded p-2 pb-0 mx-3 font-medium whitespace-pre-wrap"
         >
           {error.codeblock}
         </pre>

--- a/frontend/src/components/editor/errors/sql-validation-errors.tsx
+++ b/frontend/src/components/editor/errors/sql-validation-errors.tsx
@@ -4,10 +4,16 @@ import { AlertCircleIcon } from "lucide-react";
 import type { CellId } from "@/core/cells/ids";
 import { useSqlValidationErrorsForCell } from "@/core/codemirror/language/languages/sql/validation-errors";
 
-export const SqlValidationErrorBanner = ({ cellId }: { cellId: CellId }) => {
+export const SqlValidationErrorBanner = ({
+  cellId,
+  hide,
+}: {
+  cellId: CellId;
+  hide: boolean;
+}) => {
   const error = useSqlValidationErrorsForCell(cellId);
 
-  if (!error) {
+  if (!error || hide) {
     return;
   }
 
@@ -17,7 +23,7 @@ export const SqlValidationErrorBanner = ({ cellId }: { cellId: CellId }) => {
         <AlertCircleIcon size={13} className="mt-[3px] text-destructive" />
         <p>
           <span className="font-bold text-destructive">{error.errorType}:</span>{" "}
-          {error.errorMessage}
+          <span className="whitespace-pre-wrap">{error.errorMessage}</span>
         </p>
       </div>
 

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -77,7 +77,7 @@ export const MarimoErrorOutput = ({
     alertVariant = "default";
     titleColor = "text-secondary-foreground";
   } else if (errors.some((e) => e.type === "sql-error")) {
-    titleContents = "SQL Error in statement";
+    titleContents = "SQL error";
   } else {
     // Check for exception type
     const exceptionError = errors.find((e) => e.type === "exception");
@@ -504,22 +504,26 @@ export const MarimoErrorOutput = ({
             const col =
               error.sql_col == null ? null : Math.trunc(error?.sql_col) + 1;
             return (
-              <div key={`sql-error-${idx}`} className="space-y-2">
-                <p className="text-muted-foreground">{error.msg}</p>
+              <div key={`sql-error-${idx}`} className="space-y-2 mt-2">
+                <p className="text-muted-foreground font-medium">{error.msg}</p>
                 {error.hint && (
                   <div className="flex items-start gap-2">
-                    <InfoIcon className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+                    <InfoIcon
+                      size={11}
+                      className="text-muted-foreground mt-0.5 flex-shrink-0"
+                    />
                     <pre className="whitespace-pre-wrap text-sm text-muted-foreground">
                       {error.hint}
                     </pre>
                   </div>
                 )}
                 {error.sql_statement && (
-                  <div className="bg-muted/50 p-2 rounded text-xs font-mono">
-                    <pre className="whitespace-pre-wrap">
-                      {error.sql_statement}
-                    </pre>
-                  </div>
+                  <pre
+                    lang="sql"
+                    className="text-xs bg-muted/80 rounded p-0 whitespace-pre-wrap"
+                  >
+                    {error.sql_statement}
+                  </pre>
                 )}
                 {line !== null && col !== null && (
                   <p className="text-xs text-muted-foreground">
@@ -530,17 +534,6 @@ export const MarimoErrorOutput = ({
             );
           })}
           {cellId && <AutoFixButton errors={sqlErrors} cellId={cellId} />}
-          <Tip title="How to fix SQL errors">
-            <p className="pb-2">
-              SQL parsing errors often occur due to invalid syntax, missing
-              keywords, or unsupported SQL features.
-            </p>
-            <p className="py-2">
-              Check your SQL syntax and ensure you're using supported SQL
-              dialect features. The error location can help you identify the
-              problematic part of your query.
-            </p>
-          </Tip>
         </div>,
       );
     }

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -510,19 +510,19 @@ export const MarimoErrorOutput = ({
                   <div className="flex items-start gap-2">
                     <InfoIcon
                       size={11}
-                      className="text-muted-foreground mt-0.5 flex-shrink-0"
+                      className="text-muted-foreground mt-1 flex-shrink-0"
                     />
-                    <pre className="whitespace-pre-wrap text-sm text-muted-foreground">
+                    <p className="whitespace-pre-wrap text-sm text-muted-foreground">
                       {error.hint}
-                    </pre>
+                    </p>
                   </div>
                 )}
                 {error.sql_statement && (
                   <pre
                     lang="sql"
-                    className="text-xs bg-muted/80 rounded p-0 whitespace-pre-wrap"
+                    className="text-xs bg-muted/80 rounded whitespace-pre-wrap p-3.5"
                   >
-                    {error.sql_statement}
+                    {error.sql_statement.trim()}
                   </pre>
                 )}
                 {line !== null && col !== null && (

--- a/marimo/_smoke_tests/sql_error_handling.py
+++ b/marimo/_smoke_tests/sql_error_handling.py
@@ -396,12 +396,34 @@ def _(用户表):
     )
     return
 
+@app.cell(hide_code=True)
+def _():
+    mo.md(
+        r"""
+    ## 11. Multiple Statements
+
+    Test sql cells with multiple queries
+    """
+    )
+    return
+
+
+@app.cell
+def _(users):
+    _df = mo.sql(
+        f"""
+        SELECT * FROM users;
+        SELECT names FROM users
+        """
+    )
+    return
+
 
 @app.cell(hide_code=True)
 def _():
     mo.md(
         """
-    ## 10. Successful Query for Comparison
+    ## 12. Successful Query for Comparison
 
     Here's a working query to show the contrast with error handling.
     """

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -13,7 +13,11 @@ from marimo._runtime.context.types import (
     get_context,
     runtime_context_installed,
 )
-from marimo._sql.utils import is_query_empty, wrap_query_with_explain
+from marimo._sql.utils import (
+    is_query_empty,
+    strip_explain_from_error_message,
+    wrap_query_with_explain,
+)
 from marimo._types.ids import VariableName
 
 NO_SCHEMA_NAME = ""
@@ -143,7 +147,7 @@ class QueryEngine(BaseEngine[CONN], ABC):
         except Exception as e:
             if is_query_empty(query):
                 return None, None
-            return None, str(e)
+            return None, strip_explain_from_error_message(str(e))
 
 
 class SQLConnection(EngineCatalog[CONN], QueryEngine[CONN]):

--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -262,3 +262,43 @@ def extract_explain_content(df: Any) -> str:
     except Exception as e:
         LOGGER.debug("Failed to extract explain content: %s", e)
         return repr(df)
+
+
+def strip_explain_from_error_message(error_message: str) -> str:
+    """Strip EXPLAIN from an error message. Also adjusts the caret position
+
+    Example:
+    ```
+    LINE 1: EXPLAIN SELECT * FROM t
+                                  ^
+    ```
+    becomes
+    ```
+    LINE 1: SELECT * FROM t
+                          ^
+    ```
+    """
+    # Find the first occurrence of "EXPLAIN " and replace it
+    explain_pos = error_message.find("EXPLAIN ")
+    if explain_pos == -1:
+        return error_message
+
+    explain_length = len("EXPLAIN ")
+
+    # Replace the first "EXPLAIN " with empty string
+    result = (
+        error_message[:explain_pos]
+        + error_message[explain_pos + explain_length :]
+    )
+
+    # Find the next newline and strip the same amount from the next line
+    next_newline = result.find("\n", explain_pos)
+    if next_newline != -1 and next_newline + explain_length < len(result):
+        # Remove the same length from the beginning of the next line
+        # This is the caret position
+        result = (
+            result[: next_newline + 1]
+            + result[next_newline + 1 + explain_length :]
+        )
+
+    return result


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

marimo error:
<img width="866" height="232" alt="CleanShot 2025-09-25 at 02 37 56@2x" src="https://github.com/user-attachments/assets/5508527e-1042-45e9-a554-dab922019857" />

no more explain for validate mode:
<img width="574" height="159" alt="CleanShot 2025-09-25 at 02 40 15@2x" src="https://github.com/user-attachments/assets/baf1344a-ba4f-491c-85f3-22cab8afbb40" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
