### PR TITLE
runtime fixes for parse_sql, if duckdb not installed

### DIFF
--- a/tests/_sql/test_sql_parse.py
+++ b/tests/_sql/test_sql_parse.py
@@ -421,3 +421,11 @@ class TestEdgeCases:
             assert result is not None
             assert result.success is True
             assert result.errors == []
+
+
+@pytest.mark.skipif(HAS_DUCKDB, reason="DuckDB is installed")
+def test_fails_gracefully_no_duckdb():
+    """Test that the function fails gracefully if DuckDB is not installed."""
+    result, error = parse_sql("SELECT 1", "duckdb")
+    assert result is None
+    assert error is not None


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Adds more try-catch. Also avoids CAST unless duckdb-version is low.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
