### PR TITLE
only run sqlglot limit check when user sets a limit

### DIFF
--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -123,9 +123,11 @@ def sql(
     if df is None:
         return None
 
-    has_limit = _query_includes_limit(query)
+    has_limit = False
     try:
         default_result_limit = get_default_result_limit()
+        if default_result_limit is not None:
+            has_limit = _query_includes_limit(query)
     except OSError:
         default_result_limit = None
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

We would unecessarily run sqlglot parse even when a default limit is not specified. 
This improves perf, and is less annoying for fresh notebooks (do not require multiple installation popups)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
