### PR TITLE
don't override auto-save by when in --watch mode

### DIFF
--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -108,6 +108,10 @@ class MarimoConfigReader:
         return {}
 
     @property
+    def is_auto_save_enabled(self) -> bool:
+        return self._config["save"]["autosave"] == "after_delay"
+
+    @property
     def experimental(self) -> ExperimentalConfigType:
         if "experimental" in self._config:
             return self._config["experimental"]

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -197,7 +197,7 @@ def start(
         )
 
     if watch and config_reader.is_auto_save_enabled:
-        LOGGER.warning("Watch mode enabled and may interfere with auto-save.")
+        LOGGER.warning("Enabling watch mode may interfere with auto-save.")
 
     if GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA:
         config_reader = config_reader.with_overrides(

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -196,19 +196,8 @@ def start(
             min_port=DEFAULT_PORT + 400,
         )
 
-    # If watch is true, disable auto-save and format-on-save,
-    # watch is enabled when they are editing in another editor
-    if watch:
-        config_reader = config_reader.with_overrides(
-            {
-                "save": {
-                    "autosave": "off",
-                    "format_on_save": False,
-                    "autosave_delay": 1000,
-                }
-            }
-        )
-        LOGGER.info("Watch mode enabled, auto-save is disabled")
+    if watch and config_reader.is_auto_save_enabled:
+        LOGGER.warning("Watch mode enabled and may interfere with auto-save.")
 
     if GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA:
         config_reader = config_reader.with_overrides(

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -604,23 +604,14 @@ def __():
 
 
 @save_and_restore_main
-def test_watch_mode_config_override(tmp_path: Path) -> None:
-    """Test that watch mode properly overrides config settings."""
+def test_watch_mode_does_not_override_config(tmp_path: Path) -> None:
+    """Test that watch mode does not override config settings."""
     # Create a temporary file
     tmp_file = tmp_path / "test_watch_mode_config_override.py"
     tmp_file.write_text("import marimo as mo")
 
-    # Create a config with autosave enabled
+    # Create a default config (autosave enabled by default)
     config_reader = get_default_config_manager(current_path=None)
-    config_reader_watch = config_reader.with_overrides(
-        {
-            "save": {
-                "autosave": "off",
-                "format_on_save": False,
-                "autosave_delay": 2000,
-            }
-        }
-    )
 
     # Create a session manager with watch mode enabled
     file_router = AppFileRouter.from_filename(MarimoPath(str(tmp_file)))
@@ -631,7 +622,7 @@ def test_watch_mode_config_override(tmp_path: Path) -> None:
         quiet=True,
         include_code=True,
         lsp_server=MagicMock(),
-        config_manager=config_reader_watch,
+        config_manager=config_reader,
         cli_args={},
         argv=None,
         auth_token=None,
@@ -657,13 +648,8 @@ def test_watch_mode_config_override(tmp_path: Path) -> None:
     )
 
     try:
-        # Verify that the config was overridden
+        # Verify that the config was not overridden for watch mode
         config = session_manager._config_manager.get_config()
-        assert config["save"]["autosave"] == "off"
-        assert config["save"]["format_on_save"] is False
-
-        # Verify that the config was not overridden
-        config = session_manager_no_watch._config_manager.get_config()
         assert config["save"]["autosave"] == "after_delay"
         assert config["save"]["format_on_save"] is True
 


### PR DESCRIPTION
Fixes #6534

Closes https://github.com/marimo-team/marimo/issues/4194
Closes https://github.com/marimo-team/marimo/issues/4196

This updates the behavior of watch mode in the server configuration to ensure that user-defined auto-save is kept, rather than being forcibly overridden. We had this originally enabled to avoid conflicts between the server's view of the file and external changes made from the filesystem. Since the cell matching has improved (https://github.com/marimo-team/marimo/pull/6127), I don't expect this to cause issues.

We can in a followup handle overwrites and show the user (similar to how vscode or other IDEs might handle this)