### PR TITLE
enhancement(msgspec): create BaseStruct with __get_pydantic_core_schema__ class method and refactor MCP msgspec.Struct types to use it

### DIFF
--- a/marimo/_ai/_tools/tools/cells.py
+++ b/marimo/_ai/_tools/tools/cells.py
@@ -373,10 +373,6 @@ class GetCellRuntimeData(
         for var_name in cell_defs:
             if var_name in all_variables:
                 var_value = all_variables[var_name]
-                cell_variables[var_name] = VariableValue(
-                    name=var_name,
-                    value=var_value.value,
-                    datatype=var_value.datatype,
-                )
+                cell_variables[var_name] = var_value
 
         return cell_variables

--- a/marimo/_ai/_tools/tools/cells.py
+++ b/marimo/_ai/_tools/tools/cells.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from marimo._ai._tools.base import ToolBase
 from marimo._ai._tools.types import SuccessResult
 from marimo._ai._tools.utils.exceptions import ToolExecutionError
 from marimo._ast.models import CellData
+from marimo._messaging.ops import VariableValue
 from marimo._types.ids import CellId_t, SessionId
 
 if TYPE_CHECKING:
@@ -67,16 +68,7 @@ class CellRuntimeMetadata:
     execution_time: Optional[float] = None
 
 
-@dataclass
-class CellVariableValue:
-    name: str
-    # Cell variables can be arbitrary Python values (int, str, list, dict, ...),
-    # so we keep this as Any to reflect actual runtime.
-    value: Optional[Any] = None
-    data_type: Optional[str] = None
-
-
-CellVariables = dict[str, CellVariableValue]
+CellVariables = dict[str, VariableValue]
 
 
 @dataclass
@@ -381,10 +373,10 @@ class GetCellRuntimeData(
         for var_name in cell_defs:
             if var_name in all_variables:
                 var_value = all_variables[var_name]
-                cell_variables[var_name] = CellVariableValue(
+                cell_variables[var_name] = VariableValue(
                     name=var_name,
                     value=var_value.value,
-                    data_type=var_value.datatype,
+                    datatype=var_value.datatype,
                 )
 
         return cell_variables

--- a/marimo/_ai/_tools/tools/tables_and_variables.py
+++ b/marimo/_ai/_tools/tools/tables_and_variables.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from marimo._ai._tools.base import ToolBase
-from marimo._ai._tools.tools.cells import CellVariableValue
 from marimo._ai._tools.types import SuccessResult
 from marimo._data.models import DataTableColumn
+from marimo._messaging.ops import VariableValue
 from marimo._server.sessions import Session
 from marimo._types.ids import SessionId
 
@@ -42,7 +42,7 @@ class DataTableMetadata:
 @dataclass
 class TablesAndVariablesOutput(SuccessResult):
     tables: dict[str, DataTableMetadata] = field(default_factory=dict)
-    variables: dict[str, CellVariableValue] = field(default_factory=dict)
+    variables: dict[str, VariableValue] = field(default_factory=dict)
 
 
 class GetTablesAndVariables(
@@ -98,13 +98,13 @@ class GetTablesAndVariables(
                 engine=table.engine,
             )
 
-        notebook_variables: dict[str, CellVariableValue] = {}
+        notebook_variables: dict[str, VariableValue] = {}
         for variable_name in filtered_variables:
             value = variables[variable_name]
-            notebook_variables[variable_name] = CellVariableValue(
+            notebook_variables[variable_name] = VariableValue(
                 name=variable_name,
                 value=value.value,
-                data_type=value.datatype,
+                datatype=value.datatype,
             )
 
         return TablesAndVariablesOutput(

--- a/marimo/_data/models.py
+++ b/marimo/_data/models.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta  # noqa: TCH003
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
-from marimo._utils.msgspec_basestruct import BaseStruct
-
-import msgspec
 
 from marimo._types.ids import VariableName
+from marimo._utils.msgspec_basestruct import BaseStruct
 
 DataType = Literal[
     "string",

--- a/marimo/_data/models.py
+++ b/marimo/_data/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta  # noqa: TCH003
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from marimo._utils.msgspec_basestruct import BaseStruct
 
 import msgspec
 
@@ -23,7 +24,7 @@ DataType = Literal[
 ExternalDataType = str
 
 
-class DataTableColumn(msgspec.Struct):
+class DataTableColumn(BaseStruct):
     """
     Represents a column in a data table.
 
@@ -54,7 +55,7 @@ DataTableSource = Literal["local", "duckdb", "connection", "catalog"]
 DataTableType = Literal["table", "view"]
 
 
-class DataTable(msgspec.Struct):
+class DataTable(BaseStruct):
     """
     Represents a data table.
 
@@ -85,12 +86,12 @@ class DataTable(msgspec.Struct):
     indexes: Optional[list[str]] = None
 
 
-class Schema(msgspec.Struct):
+class Schema(BaseStruct):
     name: str
     tables: list[DataTable]
 
 
-class Database(msgspec.Struct):
+class Database(BaseStruct):
     """
     Represents a collection of schemas.
 
@@ -119,7 +120,7 @@ else:
     NonNestedLiteral = Any
 
 
-class ColumnStats(msgspec.Struct):
+class ColumnStats(BaseStruct):
     """
     Represents stats for a column in a data table.
     """
@@ -141,7 +142,7 @@ class ColumnStats(msgspec.Struct):
     p95: Optional[NonNestedLiteral] = None
 
 
-class BinValue(msgspec.Struct):
+class BinValue(BaseStruct):
     """
     Represents bin values for a column in a data table. This is used for plotting.
 
@@ -156,7 +157,7 @@ class BinValue(msgspec.Struct):
     count: int
 
 
-class ValueCount(msgspec.Struct):
+class ValueCount(BaseStruct):
     """
     Represents a value and its count in a column in a data table.
     Currently used for string columns.
@@ -170,7 +171,7 @@ class ValueCount(msgspec.Struct):
     count: int
 
 
-class DataSourceConnection(msgspec.Struct):
+class DataSourceConnection(BaseStruct):
     """
     Represents a data source connection.
 

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -54,6 +54,7 @@ from marimo._runtime.context.utils import get_mode
 from marimo._runtime.layout.layout import LayoutConfig
 from marimo._secrets.models import SecretKeysWithProvider
 from marimo._types.ids import CellId_t, RequestId, WidgetModelId
+from marimo._utils.msgspec_basestruct import BaseStruct
 from marimo._utils.platform import is_pyodide, is_windows
 
 LOGGER = loggers.marimo_logger()
@@ -501,7 +502,7 @@ class VariableDeclaration(msgspec.Struct):
     used_by: list[CellId_t]
 
 
-class VariableValue(msgspec.Struct):
+class VariableValue(BaseStruct):
     name: str
     value: Optional[str]
     datatype: Optional[str]

--- a/marimo/_utils/msgspec_basestruct.py
+++ b/marimo/_utils/msgspec_basestruct.py
@@ -1,226 +1,42 @@
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import msgspec
-from msgspec import structs as msf
+
+if TYPE_CHECKING:
+    from pydantic import GetCoreSchemaHandler
+    from pydantic_core import CoreSchema
+
 
 class BaseStruct(msgspec.Struct):
     @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> dict:
-        # 1) build per-field schemas via Pydantic’s handler (we don’t import its type)
-        tdf: dict[str, dict] = {}
-        for f in msf.fields(cls):
-            field_schema = handler.generate_schema(f.type)
-            required = (f.default is msgspec.UNSET and getattr(f, 'default_factory', msgspec.UNSET) is msgspec.UNSET)
-            tdf[f.name] = typed_dict_field(schema=field_schema, required=required)
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
 
-        td = typed_dict_schema(tdf, total=True)
+        # Lazy import pydantic_core
+        from pydantic_core import core_schema
+    
+        # Build per-field schemas
+        tdf: dict[str, core_schema.TypedDictField] = {}
+        for f in msgspec.structs.fields(cls):
+            tdf[f.name] = core_schema.typed_dict_field(
+                schema=handler.generate_schema(f.type),
+                required=(f.default is msgspec.UNSET and getattr(f, "default_factory", msgspec.UNSET) is msgspec.UNSET),
+            )
+        td = core_schema.typed_dict_schema(tdf, total=True)
 
-        # 2) convert dict -> struct using msgspec (single source of truth for defaults & validation)
+        # Create a function to convert a msgspec.Struct to a dictionary.
         def to_struct(values: dict[str, Any]) -> Any:
             return msgspec.convert(values, cls, from_attributes=True)
 
-        chain = chain_schema([td, no_info_plain_validator_function(to_struct)])
+        # Create a chain schema to validate the dictionary and convert to the msgspec.Struct.
+        chain = core_schema.chain_schema([td, core_schema.no_info_plain_validator_function(to_struct)])
 
-        # 3) accept either an instance (fast-path) or dict/JSON
-        return json_or_python_schema(
+        # Return the json or python schema.
+        return core_schema.json_or_python_schema(
             json_schema=chain,
-            python_schema=union_schema([is_instance_schema(cls), chain]),
-            serialization=plain_serializer_function_ser_schema(msgspec.to_builtins),
+            python_schema=core_schema.union_schema([
+                core_schema.is_instance_schema(cls),  # fast-path
+                chain,
+            ]),
+            serialization=core_schema.plain_serializer_function_ser_schema(msgspec.to_builtins),
         )
-
-
-# Tiny helpers that build CoreSchema dicts without importing pydantic_core
-# WARNING: these could break if pydantic_core changes its API
-
-from typing import Any, Iterable
-
-def typed_dict_field(*, schema: dict, required: bool | None = None,
-                     validation_alias: Any = None, serialization_alias: str | None = None,
-                     serialization_exclude: bool | None = None, metadata: dict | None = None) -> dict:
-    out = {
-        'type': 'typed-dict-field',
-        'schema': schema,
-    }
-    if required is not None:
-        out['required'] = required
-    if validation_alias is not None:
-        out['validation_alias'] = validation_alias
-    if serialization_alias is not None:
-        out['serialization_alias'] = serialization_alias
-    if serialization_exclude is not None:
-        out['serialization_exclude'] = serialization_exclude
-    if metadata is not None:
-        out['metadata'] = metadata
-    return out
-
-def typed_dict_schema(
-    fields: dict[str, dict],
-    *,
-    cls: type | None = None,
-    cls_name: str | None = None,
-    computed_fields: list | None = None,
-    strict: bool | None = None,
-    extras_schema: dict | None = None,
-    extra_behavior: str | None = None,
-    total: bool | None = None,
-    ref: str | None = None,
-    metadata: dict | None = None,
-    serialization: dict | None = None,
-    config: dict | None = None,
-) -> dict:
-    out = {
-        "type": "typed-dict",
-        "fields": fields,
-    }
-    if cls is not None:
-        out["cls"] = cls
-    if cls_name is not None:
-        out["cls_name"] = cls_name
-    if computed_fields is not None:
-        out["computed_fields"] = computed_fields
-    if strict is not None:
-        out["strict"] = strict
-    if extras_schema is not None:
-        out["extras_schema"] = extras_schema
-    if extra_behavior is not None:
-        out["extra_behavior"] = extra_behavior
-    if total is not None:
-        out["total"] = total
-    if ref is not None:
-        out["ref"] = ref
-    if metadata is not None:
-        out["metadata"] = metadata
-    if serialization is not None:
-        out["serialization"] = serialization
-    if config is not None:
-        out["config"] = config
-    return out
-
-
-def is_instance_schema(cls: Any, *, cls_repr: str | None = None,
-                       ref: str | None = None, metadata: dict | None = None,
-                       serialization: dict | None = None) -> dict:
-    out = {
-        'type': 'is-instance',
-        'cls': cls,
-    }
-    if cls_repr is not None:
-        out['cls_repr'] = cls_repr
-    if ref is not None:
-        out['ref'] = ref
-    if metadata is not None:
-        out['metadata'] = metadata
-    if serialization is not None:
-        out['serialization'] = serialization
-    return out
-
-def union_schema(choices: list[dict] | list[tuple[dict, str]], *,
-                 auto_collapse: bool | None = None, custom_error_type: str | None = None,
-                 custom_error_message: str | None = None, custom_error_context: dict[str, str | int] | None = None,
-                 mode: str | None = None, ref: str | None = None,
-                 metadata: dict | None = None, serialization: dict | None = None) -> dict:
-    out = {
-        'type': 'union',
-        'choices': choices,
-    }
-    if auto_collapse is not None:
-        out['auto_collapse'] = auto_collapse
-    if custom_error_type is not None:
-        out['custom_error_type'] = custom_error_type
-    if custom_error_message is not None:
-        out['custom_error_message'] = custom_error_message
-    if custom_error_context is not None:
-        out['custom_error_context'] = custom_error_context
-    if mode is not None:
-        out['mode'] = mode
-    if ref is not None:
-        out['ref'] = ref
-    if metadata is not None:
-        out['metadata'] = metadata
-    if serialization is not None:
-        out['serialization'] = serialization
-    return out
-
-def chain_schema(steps: Iterable[dict], *, ref: str | None = None,
-                 metadata: dict | None = None, serialization: dict | None = None) -> dict:
-    out = {
-        'type': 'chain',
-        'steps': list(steps),
-    }
-    if ref is not None:
-        out['ref'] = ref
-    if metadata is not None:
-        out['metadata'] = metadata
-    if serialization is not None:
-        out['serialization'] = serialization
-    return out
-
-def no_info_plain_validator_function(function, *, ref: str | None = None,
-        json_schema_input_schema: dict | None = None,
-        metadata: dict | None = None, serialization: dict | None = None) -> dict:
-    out = {
-        'type': 'function-plain',
-        'function': {'type': 'no-info', 'function': function},
-    }
-    if ref is not None:
-        out['ref'] = ref
-    if json_schema_input_schema is not None:
-        out['json_schema_input_schema'] = json_schema_input_schema
-    if metadata is not None:
-        out['metadata'] = metadata
-    if serialization is not None:
-        out['serialization'] = serialization
-    return out
-
-def no_info_after_validator_function(function, schema: dict, *, ref: str | None = None,
-    json_schema_input_schema: dict | None = None,
-    metadata: dict | None = None, serialization: dict | None = None) -> dict:
-    out = {
-        'type': 'function-after',
-        'function': {'type': 'no-info', 'function': function},
-        'schema': schema,
-    }
-    if ref is not None:
-        out['ref'] = ref
-    if json_schema_input_schema is not None:
-        out['json_schema_input_schema'] = json_schema_input_schema
-    if metadata is not None:
-        out['metadata'] = metadata
-    if serialization is not None:
-        out['serialization'] = serialization
-    return out
-
-def json_or_python_schema(*, json_schema: dict, python_schema: dict,
-    ref: str | None = None, metadata: dict | None = None,
-    serialization: dict | None = None) -> dict:
-    out = {
-        'type': 'json-or-python',
-        'json_schema': json_schema,
-        'python_schema': python_schema,
-    }
-    if ref is not None:
-        out['ref'] = ref
-    if metadata is not None:
-        out['metadata'] = metadata
-    if serialization is not None:
-        out['serialization'] = serialization
-    return out
-
-def plain_serializer_function_ser_schema(function,
-    *, is_field_serializer: bool | None = None,
-    info_arg: bool | None = None,
-    return_schema: dict | None = None,
-    when_used: str = 'always') -> dict:
-    out = {
-        'type': 'function-plain',
-        'function': function,
-    }
-    if is_field_serializer is not None:
-        out['is_field_serializer'] = is_field_serializer
-    if info_arg is not None:
-        out['info_arg'] = info_arg
-    if return_schema is not None:
-        out['return_schema'] = return_schema
-    # Only include when_used if not the default ('always')
-    if when_used != 'always':
-        out['when_used'] = when_used
-    return out

--- a/marimo/_utils/msgspec_basestruct.py
+++ b/marimo/_utils/msgspec_basestruct.py
@@ -1,4 +1,8 @@
-from typing import Any, TYPE_CHECKING
+# Copyright 2025 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import msgspec
 
 if TYPE_CHECKING:
@@ -11,16 +15,19 @@ class BaseStruct(msgspec.Struct):
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
-
         # Lazy import pydantic_core
         from pydantic_core import core_schema
-    
+
         # Build per-field schemas
         tdf: dict[str, core_schema.TypedDictField] = {}
         for f in msgspec.structs.fields(cls):
             tdf[f.name] = core_schema.typed_dict_field(
                 schema=handler.generate_schema(f.type),
-                required=(f.default is msgspec.UNSET and getattr(f, "default_factory", msgspec.UNSET) is msgspec.UNSET),
+                required=(
+                    f.default is msgspec.UNSET
+                    and getattr(f, "default_factory", msgspec.UNSET)
+                    is msgspec.UNSET
+                ),
             )
         td = core_schema.typed_dict_schema(tdf, total=True)
 
@@ -29,14 +36,20 @@ class BaseStruct(msgspec.Struct):
             return msgspec.convert(values, cls, from_attributes=True)
 
         # Create a chain schema to validate the dictionary and convert to the msgspec.Struct.
-        chain = core_schema.chain_schema([td, core_schema.no_info_plain_validator_function(to_struct)])
+        chain = core_schema.chain_schema(
+            [td, core_schema.no_info_plain_validator_function(to_struct)]
+        )
 
         # Return the json or python schema.
         return core_schema.json_or_python_schema(
             json_schema=chain,
-            python_schema=core_schema.union_schema([
-                core_schema.is_instance_schema(cls),  # fast-path
-                chain,
-            ]),
-            serialization=core_schema.plain_serializer_function_ser_schema(msgspec.to_builtins),
+            python_schema=core_schema.union_schema(
+                [
+                    core_schema.is_instance_schema(cls),  # fast-path
+                    chain,
+                ]
+            ),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                msgspec.to_builtins
+            ),
         )

--- a/marimo/_utils/msgspec_basestruct.py
+++ b/marimo/_utils/msgspec_basestruct.py
@@ -1,0 +1,226 @@
+from typing import Any
+import msgspec
+from msgspec import structs as msf
+
+class BaseStruct(msgspec.Struct):
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> dict:
+        # 1) build per-field schemas via Pydantic’s handler (we don’t import its type)
+        tdf: dict[str, dict] = {}
+        for f in msf.fields(cls):
+            field_schema = handler.generate_schema(f.type)
+            required = (f.default is msgspec.UNSET and getattr(f, 'default_factory', msgspec.UNSET) is msgspec.UNSET)
+            tdf[f.name] = typed_dict_field(schema=field_schema, required=required)
+
+        td = typed_dict_schema(tdf, total=True)
+
+        # 2) convert dict -> struct using msgspec (single source of truth for defaults & validation)
+        def to_struct(values: dict[str, Any]) -> Any:
+            return msgspec.convert(values, cls, from_attributes=True)
+
+        chain = chain_schema([td, no_info_plain_validator_function(to_struct)])
+
+        # 3) accept either an instance (fast-path) or dict/JSON
+        return json_or_python_schema(
+            json_schema=chain,
+            python_schema=union_schema([is_instance_schema(cls), chain]),
+            serialization=plain_serializer_function_ser_schema(msgspec.to_builtins),
+        )
+
+
+# pcore_shim.py — tiny helpers that build CoreSchema dicts without importing pydantic_core
+# WARNING: these could break if pydantic_core changes its API
+
+from typing import Any, Iterable
+
+def typed_dict_field(*, schema: dict, required: bool | None = None,
+                     validation_alias: Any = None, serialization_alias: str | None = None,
+                     serialization_exclude: bool | None = None, metadata: dict | None = None) -> dict:
+    out = {
+        'type': 'typed-dict-field',
+        'schema': schema,
+    }
+    if required is not None:
+        out['required'] = required
+    if validation_alias is not None:
+        out['validation_alias'] = validation_alias
+    if serialization_alias is not None:
+        out['serialization_alias'] = serialization_alias
+    if serialization_exclude is not None:
+        out['serialization_exclude'] = serialization_exclude
+    if metadata is not None:
+        out['metadata'] = metadata
+    return out
+
+def typed_dict_schema(
+    fields: dict[str, dict],
+    *,
+    cls: type | None = None,
+    cls_name: str | None = None,
+    computed_fields: list | None = None,
+    strict: bool | None = None,
+    extras_schema: dict | None = None,
+    extra_behavior: str | None = None,
+    total: bool | None = None,
+    ref: str | None = None,
+    metadata: dict | None = None,
+    serialization: dict | None = None,
+    config: dict | None = None,
+) -> dict:
+    out = {
+        "type": "typed-dict",
+        "fields": fields,
+    }
+    if cls is not None:
+        out["cls"] = cls
+    if cls_name is not None:
+        out["cls_name"] = cls_name
+    if computed_fields is not None:
+        out["computed_fields"] = computed_fields
+    if strict is not None:
+        out["strict"] = strict
+    if extras_schema is not None:
+        out["extras_schema"] = extras_schema
+    if extra_behavior is not None:
+        out["extra_behavior"] = extra_behavior
+    if total is not None:
+        out["total"] = total
+    if ref is not None:
+        out["ref"] = ref
+    if metadata is not None:
+        out["metadata"] = metadata
+    if serialization is not None:
+        out["serialization"] = serialization
+    if config is not None:
+        out["config"] = config
+    return out
+
+
+def is_instance_schema(cls: Any, *, cls_repr: str | None = None,
+                       ref: str | None = None, metadata: dict | None = None,
+                       serialization: dict | None = None) -> dict:
+    out = {
+        'type': 'is-instance',
+        'cls': cls,
+    }
+    if cls_repr is not None:
+        out['cls_repr'] = cls_repr
+    if ref is not None:
+        out['ref'] = ref
+    if metadata is not None:
+        out['metadata'] = metadata
+    if serialization is not None:
+        out['serialization'] = serialization
+    return out
+
+def union_schema(choices: list[dict] | list[tuple[dict, str]], *,
+                 auto_collapse: bool | None = None, custom_error_type: str | None = None,
+                 custom_error_message: str | None = None, custom_error_context: dict[str, str | int] | None = None,
+                 mode: str | None = None, ref: str | None = None,
+                 metadata: dict | None = None, serialization: dict | None = None) -> dict:
+    out = {
+        'type': 'union',
+        'choices': choices,
+    }
+    if auto_collapse is not None:
+        out['auto_collapse'] = auto_collapse
+    if custom_error_type is not None:
+        out['custom_error_type'] = custom_error_type
+    if custom_error_message is not None:
+        out['custom_error_message'] = custom_error_message
+    if custom_error_context is not None:
+        out['custom_error_context'] = custom_error_context
+    if mode is not None:
+        out['mode'] = mode
+    if ref is not None:
+        out['ref'] = ref
+    if metadata is not None:
+        out['metadata'] = metadata
+    if serialization is not None:
+        out['serialization'] = serialization
+    return out
+
+def chain_schema(steps: Iterable[dict], *, ref: str | None = None,
+                 metadata: dict | None = None, serialization: dict | None = None) -> dict:
+    out = {
+        'type': 'chain',
+        'steps': list(steps),
+    }
+    if ref is not None:
+        out['ref'] = ref
+    if metadata is not None:
+        out['metadata'] = metadata
+    if serialization is not None:
+        out['serialization'] = serialization
+    return out
+
+def no_info_plain_validator_function(function, *, ref: str | None = None,
+        json_schema_input_schema: dict | None = None,
+        metadata: dict | None = None, serialization: dict | None = None) -> dict:
+    out = {
+        'type': 'function-plain',
+        'function': {'type': 'no-info', 'function': function},
+    }
+    if ref is not None:
+        out['ref'] = ref
+    if json_schema_input_schema is not None:
+        out['json_schema_input_schema'] = json_schema_input_schema
+    if metadata is not None:
+        out['metadata'] = metadata
+    if serialization is not None:
+        out['serialization'] = serialization
+    return out
+
+def no_info_after_validator_function(function, schema: dict, *, ref: str | None = None,
+    json_schema_input_schema: dict | None = None,
+    metadata: dict | None = None, serialization: dict | None = None) -> dict:
+    out = {
+        'type': 'function-after',
+        'function': {'type': 'no-info', 'function': function},
+        'schema': schema,
+    }
+    if ref is not None:
+        out['ref'] = ref
+    if json_schema_input_schema is not None:
+        out['json_schema_input_schema'] = json_schema_input_schema
+    if metadata is not None:
+        out['metadata'] = metadata
+    if serialization is not None:
+        out['serialization'] = serialization
+    return out
+
+def json_or_python_schema(*, json_schema: dict, python_schema: dict,
+    ref: str | None = None, metadata: dict | None = None,
+    serialization: dict | None = None) -> dict:
+    out = {
+        'type': 'json-or-python',
+        'json_schema': json_schema,
+        'python_schema': python_schema,
+    }
+    if ref is not None:
+        out['ref'] = ref
+    if metadata is not None:
+        out['metadata'] = metadata
+    if serialization is not None:
+        out['serialization'] = serialization
+    return out
+
+def plain_serializer_function_ser_schema(function,
+    *, is_field_serializer: bool | None = None,
+    info_arg: bool | None = None,
+    return_schema: dict | None = None,
+    when_used: str = 'always') -> dict:
+    out = {
+        'type': 'function-plain',
+        'function': function,
+    }
+    if is_field_serializer is not None:
+        out['is_field_serializer'] = is_field_serializer
+    if info_arg is not None:
+        out['info_arg'] = info_arg
+    if return_schema is not None:
+        out['return_schema'] = return_schema
+    # Only include when_used if not the default ('always')
+    if when_used != 'always':
+        out['when_used'] = when_used
+    return out

--- a/marimo/_utils/msgspec_basestruct.py
+++ b/marimo/_utils/msgspec_basestruct.py
@@ -28,7 +28,7 @@ class BaseStruct(msgspec.Struct):
         )
 
 
-# pcore_shim.py — tiny helpers that build CoreSchema dicts without importing pydantic_core
+# Tiny helpers that build CoreSchema dicts without importing pydantic_core
 # WARNING: these could break if pydantic_core changes its API
 
 from typing import Any, Iterable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ lsp = [
 
 mcp = [
     "mcp>=1.0.0; python_version >= '3.10'",
+    "pydantic>=2.11.2,<2.12; python_version >= '3.10'",
 ]
 
 
@@ -516,6 +517,7 @@ Ue = "Ue"         # Used in one of the cell IDs
 Nd = "Nd"         # Confused with And
 pn = "pn"         # Panel
 caf = "caf"       # cafe
+ser = "ser"       # Used in pydantic-core package as part of a function name
 
 [tool.typos.files]
 extend-exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ lsp = [
 
 mcp = [
     "mcp>=1.0.0; python_version >= '3.10'",
-    "pydantic>=2.11.2,<2.12; python_version >= '3.10'",
+    "pydantic>2; python_version >= '3.10'",
 ]
 
 

--- a/tests/_utils/test_msgspec_basestruct.py
+++ b/tests/_utils/test_msgspec_basestruct.py
@@ -67,13 +67,17 @@ def test_tool_msgspec_structs_expose_pydantic_hook() -> None:
     offenders: list[str] = []
     for cls in TOOL_IO_CLASSES:
         for ann in (getattr(cls, "__annotations__", {}) or {}).values():
-            for typ in _iter_types(ann):
-                if isinstance(typ, type) and issubclass(typ, msgspec.Struct):
+            for resolved_type in _iter_types(ann):
+                if isinstance(resolved_type, type) and issubclass(
+                    resolved_type, msgspec.Struct
+                ):
                     if not callable(
-                        getattr(typ, "__get_pydantic_core_schema__", None)
+                        getattr(
+                            resolved_type, "__get_pydantic_core_schema__", None
+                        )
                     ):
                         offenders.append(
-                            f"{typ.__module__}.{typ.__name__} (referenced by {cls.__module__}.{cls.__name__})"
+                            f"{resolved_type.__module__}.{resolved_type.__name__} (referenced by {cls.__module__}.{cls.__name__})"
                         )
 
     assert not offenders, (

--- a/tests/_utils/test_msgspec_basestruct.py
+++ b/tests/_utils/test_msgspec_basestruct.py
@@ -1,0 +1,82 @@
+import typing as t
+
+import msgspec
+
+from marimo._ai._tools.tools.cells import (
+    GetCellRuntimeDataArgs,
+    GetCellRuntimeDataOutput,
+    GetLightweightCellMapArgs,
+    GetLightweightCellMapOutput,
+)
+from marimo._ai._tools.tools.datasource import (
+    GetDatabaseTablesArgs,
+    GetDatabaseTablesOutput,
+)
+from marimo._ai._tools.tools.errors import (
+    GetNotebookErrorsArgs,
+    GetNotebookErrorsOutput,
+)
+from marimo._ai._tools.tools.notebooks import (
+    GetActiveNotebooksOutput,
+)
+from marimo._ai._tools.tools.tables_and_variables import (
+    TablesAndVariablesArgs,
+    TablesAndVariablesOutput,
+)
+
+TOOL_IO_CLASSES = [
+    GetCellRuntimeDataArgs,
+    GetCellRuntimeDataOutput,
+    GetLightweightCellMapArgs,
+    GetLightweightCellMapOutput,
+    TablesAndVariablesArgs,
+    TablesAndVariablesOutput,
+    GetDatabaseTablesArgs,
+    GetDatabaseTablesOutput,
+    GetNotebookErrorsArgs,
+    GetNotebookErrorsOutput,
+    GetActiveNotebooksOutput,
+]
+
+
+def _iter_types(ann: t.Any):
+    stack = [ann]
+    seen: set[int] = set()
+    while stack:
+        tp = stack.pop()
+        obj_id = id(tp)
+        if obj_id in seen:
+            continue
+        seen.add(obj_id)
+
+        if isinstance(tp, type):
+            yield tp
+            # Recurse into dataclass-like classes by following their annotations
+            anns = getattr(tp, "__annotations__", None)
+            if anns:
+                stack.extend(anns.values())
+            continue
+
+        origin = t.get_origin(tp)
+        if origin is not None:
+            stack.append(origin)
+            stack.extend(t.get_args(tp))
+
+
+def test_tool_msgspec_structs_expose_pydantic_hook() -> None:
+    offenders: list[str] = []
+    for cls in TOOL_IO_CLASSES:
+        for ann in (getattr(cls, "__annotations__", {}) or {}).values():
+            for typ in _iter_types(ann):
+                if isinstance(typ, type) and issubclass(typ, msgspec.Struct):
+                    if not callable(
+                        getattr(typ, "__get_pydantic_core_schema__", None)
+                    ):
+                        offenders.append(
+                            f"{typ.__module__}.{typ.__name__} (referenced by {cls.__module__}.{cls.__name__})"
+                        )
+
+    assert not offenders, (
+        "These msgspec.Structs referenced by tools must use BaseStruct as their base class: "
+        + ", ".join(offenders)
+    )


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Create BaseStruct to make msgspec.Struct types compatible with pydantic typechecking (for MCP Server tools). Update old code to now use this and remove redundant types.

This PR reverses the temporary fix implemented in #6265 

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Create BaseStruct with __get_pydantic_core_schema__ in marimo/_utils/msgspec_basestruct.py
- Update datatypes in marimo/_data/models.py to use BaseStruct for marimo/_ai/_tools/tools/tables_and_variables.py tool
- Update CellVariableValue -> VariableValue(BaseStruct) in tables_and_variables.py and cells.py
- Update tests to use VariableValue, inherit Session for type saftey, and use correct DataType enums
- Add pydantic >2 as mcp dependency in pyproject.toml
- Add test that checks if all exposed msgspec.Struct classes exposed to tools Args or Output use BaseStruct

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
