### PR TITLE
fix(mcp-server): make mcp-server lifespan and startup non-blocking for marimo server

### DIFF
--- a/marimo/_mcp/server/lifespan.py
+++ b/marimo/_mcp/server/lifespan.py
@@ -28,4 +28,5 @@ async def mcp_server_lifespan(app: Starlette) -> AsyncIterator[None]:
         return
     except Exception as e:
         LOGGER.error(f"Failed to start MCP server: {e}")
-        raise
+        yield
+        return


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Update lifespan function for mcp-server to handle errors rather than raising them to the parent server.

Now if an error occurs it won't block marimo backend server from starting, but rather just log it like this:

<img width="896" height="277" alt="Screenshot 2025-09-26 at 7 33 42 PM" src="https://github.com/user-attachments/assets/dcaa5081-c6c8-4453-851b-e7ac5403c6ba" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Update except block in marimo/_mcp/server/lifespan.py to handle unknown errors internally rather than raising it to parent Starlette app.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
