### PR TITLE
devops: make dev explicitly uses the port the pnpm expects (fix #6565)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ dev:
 	@echo "Starting development servers..."
 	@# Start both processes, with marimo in background
 	@(trap 'kill %1; exit' INT; \
-	uv run marimo edit --no-token --headless /tmp & \
+	uv run marimo edit --no-token --headless /tmp --port 2718 & \
 	pnpm dev)
 dev-sandbox:
 	@echo "Starting development servers..."


### PR DESCRIPTION
## 📝 Summary

Makes `make dev` fail explicitly when marimo can't get the port `pnpm` expects it to use, instead of telling the user to open a `http://localhost:3000` address that doesn't work.

## 🔍 Description of Changes

Added `--port 2718` to the command `marimo` in `make dev`

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- I have added tests for the changes made.
  - I tested this manually, and am not sure if any other test is needed for such a micro change
- [X] I have run the code and verified that it works as expected.
