### PR TITLE
Initial hover_template function

### DIFF
--- a/examples/ui/table.py
+++ b/examples/ui/table.py
@@ -33,6 +33,20 @@ def _(mo):
 
 
 @app.cell
+def _(mo):
+    # Per-cell hover: provide a callable for finer control
+    def cell_hover(row_id: str, column_name: str, value) -> str:
+        return f"{row_id}:{column_name}={value}"
+
+    hover_table = mo.ui.table(
+        [{"a": i, "b": i * i} for i in range(8)],
+        hover_template=cell_hover,
+    )
+    hover_table
+    return (hover_table,)
+
+
+@app.cell
 def _(table):
     table.value
     return

--- a/frontend/src/components/data-table/cell-hover-text/feature.ts
+++ b/frontend/src/components/data-table/cell-hover-text/feature.ts
@@ -1,0 +1,40 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+"use no memo";
+
+import type {
+  Cell,
+  Column,
+  InitialTableState,
+  Row,
+  RowData,
+  Table,
+  TableFeature,
+} from "@tanstack/react-table";
+import { getStableRowId } from "../utils";
+import type { CellHoverTextState, CellHoverTextTableState } from "./types";
+
+function getRowId<TData>(row: Row<TData>): string {
+  return getStableRowId(row) ?? row.id;
+}
+
+export const CellHoverTextFeature: TableFeature = {
+  getInitialState: (state?: InitialTableState): CellHoverTextTableState => {
+    return {
+      ...state,
+      cellHoverTexts: {} as CellHoverTextState,
+    };
+  },
+
+  createCell: <TData extends RowData>(
+    cell: Cell<TData, unknown>,
+    column: Column<TData>,
+    row: Row<TData>,
+    table: Table<TData>,
+  ) => {
+    cell.getHoverTitle = () => {
+      const state = table.getState().cellHoverTexts;
+      const rowId = getRowId(row);
+      return state?.[rowId]?.[column.id] ?? undefined;
+    };
+  },
+};

--- a/frontend/src/components/data-table/cell-hover-text/types.ts
+++ b/frontend/src/components/data-table/cell-hover-text/types.ts
@@ -1,0 +1,24 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+import type { RowData } from "@tanstack/react-table";
+
+export type CellHoverTextState = Record<string, Record<string, string>>;
+
+export interface CellHoverTextTableState {
+  cellHoverTexts: CellHoverTextState;
+}
+
+export interface CellHoverTextCell {
+  /**
+   * Returns precomputed hover text for the cell, if any.
+   */
+  getHoverTitle?: () => string | undefined;
+}
+
+// Use declaration merging to add our new feature APIs
+declare module "@tanstack/react-table" {
+  interface TableState extends CellHoverTextTableState {}
+
+  interface Cell<TData extends RowData, TValue> extends CellHoverTextCell {}
+}

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -26,6 +26,7 @@ import type { GetRowIds } from "@/plugins/impl/DataTablePlugin";
 import { cn } from "@/utils/cn";
 import type { PanelType } from "../editor/chrome/panels/context-aware-panel/context-aware-panel";
 import { CellHoverTemplateFeature } from "./cell-hover-template/feature";
+import { CellHoverTextFeature } from "./cell-hover-text/feature";
 import { CellSelectionFeature } from "./cell-selection/feature";
 import type { CellSelectionState } from "./cell-selection/types";
 import { CellStylingFeature } from "./cell-styling/feature";
@@ -67,6 +68,7 @@ interface DataTableProps<TData> extends Partial<DownloadActionProps> {
   cellSelection?: CellSelectionState;
   cellStyling?: CellStyleState | null;
   hoverTemplate?: string | null;
+  cellHoverTexts?: Record<string, Record<string, string>> | null;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   onCellSelectionChange?: OnChangeFn<CellSelectionState>;
   getRowIds?: GetRowIds;
@@ -109,6 +111,7 @@ const DataTableInternal = <TData,>({
   cellSelection,
   cellStyling,
   hoverTemplate,
+  cellHoverTexts,
   paginationState,
   setPaginationState,
   downloadAs,
@@ -183,6 +186,7 @@ const DataTableInternal = <TData,>({
       ColumnFormattingFeature,
       CellSelectionFeature,
       CellStylingFeature,
+      CellHoverTextFeature,
       CellHoverTemplateFeature,
       CopyColumnFeature,
       FocusRowFeature,
@@ -247,6 +251,7 @@ const DataTableInternal = <TData,>({
       cellStyling,
       columnPinning: columnPinning,
       cellHoverTemplate: hoverTemplate,
+      cellHoverTexts: cellHoverTexts ?? {},
     },
   });
 

--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -122,6 +122,7 @@ export const DataTableBody = <TData,>({
         pinningstyle,
       );
 
+      const title = cell.getHoverTitle?.();
       return (
         <TableCell
           tabIndex={0}
@@ -135,6 +136,7 @@ export const DataTableBody = <TData,>({
             className,
           )}
           style={style}
+          title={title}
           onMouseDown={(e) => handleCellMouseDown(e, cell)}
           onMouseUp={handleCellMouseUp}
           onMouseOver={(e) => handleCellMouseOver(e, cell)}

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -192,6 +192,7 @@ interface Data<T> {
   maxColumns: number | "all";
   hasStableRowId: boolean;
   lazy: boolean;
+  cellHoverTexts?: Record<string, Record<string, string>> | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -214,6 +215,7 @@ type DataTableFunctions = {
     data: TableData<T>;
     total_rows: number | TooManyRows;
     cell_styles?: CellStyleState | null;
+    cell_hover_texts?: Record<string, Record<string, string>> | null;
   }>;
   get_data_url?: GetDataUrl;
   get_row_ids?: GetRowIds;
@@ -263,6 +265,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
       maxHeight: z.number().optional(),
       cellStyles: z.record(z.record(z.object({}).passthrough())).optional(),
       hoverTemplate: z.string().optional(),
+      cellHoverTexts: z.record(z.record(z.string())).optional(),
       // Whether to load the data lazily.
       lazy: z.boolean().default(false),
       // If lazy, this will preload the first page of data
@@ -305,6 +308,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
           cell_styles: z
             .record(z.record(z.object({}).passthrough()))
             .nullable(),
+          cell_hover_texts: z.record(z.record(z.string())).nullable(),
         }),
       ),
     get_row_ids: rpc.input(z.object({}).passthrough()).output(
@@ -352,6 +356,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
             data={props.data.data}
             value={props.value}
             setValue={props.setValue}
+            cellHoverTexts={props.data.cellHoverTexts}
           />
         </LazyDataTableComponent>
       </TableProviders>
@@ -393,6 +398,7 @@ interface DataTableProps<T> extends Data<T>, DataTableFunctions {
   enableFilters?: boolean;
   cellStyles?: CellStyleState | null;
   hoverTemplate?: string | null;
+  cellHoverTexts?: Record<string, Record<string, string>> | null;
   toggleDisplayHeader?: () => void;
   host: HTMLElement;
   cellId?: CellId | null;
@@ -461,6 +467,7 @@ export const LoadingDataTableComponent = memo(
       rows: T[];
       totalRows: number | TooManyRows;
       cellStyles: CellStyleState | undefined | null;
+      cellHoverTexts?: Record<string, Record<string, string>> | null;
     }>(async () => {
       // If there is no data, return an empty array
       if (props.totalRows === 0) {
@@ -471,6 +478,7 @@ export const LoadingDataTableComponent = memo(
       let tableData = props.data;
       let totalRows = props.totalRows;
       let cellStyles = props.cellStyles;
+      let cellHoverTexts = props.cellHoverTexts;
 
       const pageSizeChanged = paginationState.pageSize !== props.pageSize;
 
@@ -521,12 +529,14 @@ export const LoadingDataTableComponent = memo(
         tableData = searchResults.data;
         totalRows = searchResults.total_rows;
         cellStyles = searchResults.cell_styles || {};
+        cellHoverTexts = searchResults.cell_hover_texts || {};
       }
       tableData = await loadTableData(tableData);
       return {
         rows: tableData,
         totalRows: totalRows,
         cellStyles,
+        cellHoverTexts,
       };
     }, [
       sorting,
@@ -537,6 +547,7 @@ export const LoadingDataTableComponent = memo(
       props.data,
       props.totalRows,
       props.lazy,
+      props.cellHoverTexts,
       paginationState.pageSize,
       paginationState.pageIndex,
     ]);
@@ -652,6 +663,7 @@ export const LoadingDataTableComponent = memo(
         paginationState={paginationState}
         setPaginationState={setPaginationState}
         cellStyles={data?.cellStyles ?? props.cellStyles}
+        cellHoverTexts={data?.cellHoverTexts ?? props.cellHoverTexts}
         toggleDisplayHeader={toggleDisplayHeader}
         getRow={getRow}
         cellId={cellId}
@@ -718,6 +730,7 @@ const DataTableComponent = ({
   get_row_ids,
   cellStyles,
   hoverTemplate,
+  cellHoverTexts,
   toggleDisplayHeader,
   calculate_top_k_rows,
   preview_column,
@@ -920,6 +933,7 @@ const DataTableComponent = ({
             cellSelection={cellSelection}
             cellStyling={cellStyles}
             hoverTemplate={hoverTemplate}
+            cellHoverTexts={cellHoverTexts}
             downloadAs={showDownload ? downloadAs : undefined}
             enableSearch={enableSearch}
             searchQuery={searchQuery}


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Provides an alternative to `hover_template` for tables.
The main gripe with the template is that is was for the entire row and that turned out to be not flexible enough.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Similar to `style_cell` we accept a callable to construct the hover text for a cell.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). (Chatted with @mscolnick a bit)
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
