### PR TITLE
add docs for azure and properly handle endpoint

### DIFF
--- a/docs/guides/configuration/llm_providers.md
+++ b/docs/guides/configuration/llm_providers.md
@@ -191,7 +191,7 @@ chat_model = "azure/gpt-4.1-mini"
 
 [ai.azure]
 api_key = "sk-proj-..."
-base_url = "https://<your-resource-name>.openai.azure.com/<deployment_name>?api-version=<api-version>"
+base_url = "https://<your-resource-name>.openai.azure.com/openai/deployments/<deployment_name>?api-version=<api-version>"
 ```
 
 The deployment name is typically the model name.

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -791,8 +791,8 @@ export const AiProvidersConfig: React.FC<AiConfigProps> = ({
             form={form}
             config={config}
             name="ai.azure.base_url"
-            placeholder="https://<your-resource-name>.openai.azure.com/<deployment-name>?api-version=<api-version>"
-            defaultValue="https://<your-resource-name>.openai.azure.com/<deployment-name>?api-version=<api-version>"
+            placeholder="https://<your-resource-name>.openai.azure.com/openai/deployments/<deployment-name>?api-version=<api-version>"
+            defaultValue="https://<your-resource-name>.openai.azure.com/openai/deployments/<deployment-name>?api-version=<api-version>"
             testId="ai-azure-base-url-input"
           />
         </AccordionFormItem>

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -588,7 +588,7 @@ class AzureOpenAIProvider(OpenAIProvider):
 
     def _handle_azure_openai(self, base_url: str) -> tuple[str, str, str]:
         """Handle Azure OpenAI.
-        Sample base URL: https://<your-resource-name>.openai.azure.com/<deployment_name>?api-version=<api-version>
+        Sample base URL: https://<your-resource-name>.openai.azure.com/openai/deployments/<deployment_name>?api-version=<api-version>
 
         Args:
             base_url (str): The base URL of the Azure OpenAI.
@@ -599,7 +599,7 @@ class AzureOpenAIProvider(OpenAIProvider):
 
         parsed_url = urlparse(base_url)
 
-        deployment_name = parsed_url.path.split("/")[1]
+        deployment_name = parsed_url.path.split("/")[3]
         api_version = parse_qs(parsed_url.query)["api-version"][0]
 
         endpoint = f"{parsed_url.scheme}://{parsed_url.hostname}"

--- a/tests/_server/ai/test_providers.py
+++ b/tests/_server/ai/test_providers.py
@@ -155,19 +155,19 @@ async def test_azure_openai_provider() -> None:
     """Test that Azure OpenAI provider uses correct parameters."""
     config = AnyProviderConfig(
         api_key="test-key",
-        base_url="https://test.openai.azure.com/gpt-4-1?api-version=2023-05-15",
+        base_url="https://test.openai.azure.com/openai/deployments/gpt-4-1?api-version=2023-05-15",
     )
     provider = AzureOpenAIProvider("gpt-4", config)
 
     api_version, deployment_name, endpoint = provider._handle_azure_openai(
-        "https://test.openai.azure.com/gpt-4-1?api-version=2023-05-15"
+        "https://test.openai.azure.com/openai/deployments/gpt-4-1?api-version=2023-05-15"
     )
     assert api_version == "2023-05-15"
     assert deployment_name == "gpt-4-1"
     assert endpoint == "https://test.openai.azure.com"
 
     api_version, deployment_name, endpoint = provider._handle_azure_openai(
-        "https://unknown_domain.openai/gpt-4-1/gpt-4-1?api-version=2023-05-15"
+        "https://unknown_domain.openai/openai/deployments/gpt-4-1?api-version=2023-05-15"
     )
     assert api_version == "2023-05-15"
     assert deployment_name == "gpt-4-1"


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Typically, the base URL is `https://<your-resource-name>.azure.com`

For Azure, we also need the deployment_name and api_version. So we pad that in to the base_url.

We expect: `https://<your-resource-name>.openai.azure.com/openai/deployments/<deployment_name>?api-version=<api-version>`. 

Referenced issue: https://github.com/marimo-team/marimo/issues/3117

Also fixes #6368 by disabling reasoning_mode param. According to [docs](https://learn.microsoft.com/en-us/answers/questions/5519548/does-gpt-5-via-azure-support-reasoning-effort-and), they are only enabled for custom models set up in Azure Foundry. We can expose this as a param in the future.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
