### PR TITLE
Prune redundant traceback item at start of all traces

### DIFF
--- a/marimo/_messaging/tracebacks.py
+++ b/marimo/_messaging/tracebacks.py
@@ -24,11 +24,30 @@ def _highlight_traceback(traceback: str) -> str:
 def write_traceback(traceback: str) -> None:
     if isinstance(sys.stderr, Stderr):
         sys.stderr._write_with_mimetype(
-            _highlight_traceback(traceback),
+            _highlight_traceback(_trim_traceback(traceback)),
             mimetype="application/vnd.marimo+traceback",
         )
     else:
         sys.stderr.write(traceback)
+
+
+def _trim_traceback(traceback: str) -> str:
+    """
+    Skip first DefaultExecutor.execute_cell traceback item which all traces start with.
+    """
+
+    lines = traceback.split("\n")
+    if (
+        len(lines) > 2
+        and lines[0] == "Traceback (most recent call last):"
+        and '/marimo/_runtime/executor.py", line ' in lines[1]
+        and lines[1].endswith(", in execute_cell")
+    ):
+        for i in range(2, len(lines)):
+            if lines[i].startswith("  File "):
+                return "\n".join(lines[:1] + lines[i:])
+
+    return traceback
 
 
 def is_code_highlighting(value: str) -> bool:

--- a/tests/_messaging/test_tracebacks.py
+++ b/tests/_messaging/test_tracebacks.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from marimo._messaging.tracebacks import (
     _highlight_traceback,
+    _trim_traceback,
     is_code_highlighting,
     write_traceback,
 )
@@ -79,3 +80,11 @@ class TestTracebacks:
         assert is_code_highlighting("<span>code</span>") is False
         assert is_code_highlighting("") is False
         assert is_code_highlighting('class="not-codehilite"') is False
+
+    def test_trim(self) -> None:
+        prefix = "Traceback (most recent call last):\n"
+        head = '  File ".../marimo/_runtime/executor.py", line 139, in execute_cell\n    return eval(cell.last_expr, glbls)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n'
+        rest = (
+            '  File ".../__marimo__cell_Hbol_.py", line 2, in <module>\n...\n'
+        )
+        assert _trim_traceback(f"{prefix}{head}{rest}") == f"{prefix}{rest}"


### PR DESCRIPTION
## 📝 Summary

Fixse #6576

## 🔍 Description of Changes

When sending tracebacks to the front-end, the backend prunes the first redundant traceback item in marimo's own engine

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.
