### PR TITLE
add simple auto fix button for sql cell

### DIFF
--- a/frontend/src/components/editor/errors/auto-fix.tsx
+++ b/frontend/src/components/editor/errors/auto-fix.tsx
@@ -1,17 +1,21 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
+import { useSetAtom } from "jotai";
 import { WrenchIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
+import { aiCompletionCellAtom } from "@/core/ai/state";
 import { notebookAtom, useCellActions } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
 import { getAutoFixes } from "@/core/errors/errors";
 import type { MarimoError } from "@/core/kernel/messages";
 import { store } from "@/core/state/jotai";
+import { cn } from "@/utils/cn";
 
 export const AutoFixButton = ({
   errors,
   cellId,
+  className,
 }: {
   errors: MarimoError[];
   cellId: CellId;
@@ -19,6 +23,7 @@ export const AutoFixButton = ({
 }) => {
   const { createNewCell } = useCellActions();
   const autoFixes = errors.flatMap((error) => getAutoFixes(error));
+  const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
 
   if (autoFixes.length === 0) {
     return null;
@@ -33,7 +38,7 @@ export const AutoFixButton = ({
       <Button
         size="xs"
         variant="outline"
-        className="my-2 font-normal"
+        className={cn("my-2 font-normal", className)}
         onClick={() => {
           const editorView =
             store.get(notebookAtom).cellHandles[cellId].current?.editorView;
@@ -48,6 +53,7 @@ export const AutoFixButton = ({
             },
             editor: editorView,
             cellId: cellId,
+            setAiCompletionCell,
           });
           // Focus the editor
           editorView?.focus();

--- a/frontend/src/components/editor/errors/auto-fix.tsx
+++ b/frontend/src/components/editor/errors/auto-fix.tsx
@@ -1,12 +1,13 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { WrenchIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { aiCompletionCellAtom } from "@/core/ai/state";
 import { notebookAtom, useCellActions } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
+import { aiEnabledAtom } from "@/core/config/config";
 import { getAutoFixes } from "@/core/errors/errors";
 import type { MarimoError } from "@/core/kernel/messages";
 import { store } from "@/core/state/jotai";
@@ -22,7 +23,10 @@ export const AutoFixButton = ({
   className?: string;
 }) => {
   const { createNewCell } = useCellActions();
-  const autoFixes = errors.flatMap((error) => getAutoFixes(error));
+  const aiEnabled = useAtomValue(aiEnabledAtom);
+  const autoFixes = errors.flatMap((error) =>
+    getAutoFixes(error, { aiEnabled }),
+  );
   const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
 
   if (autoFixes.length === 0) {

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -533,7 +533,13 @@ export const MarimoErrorOutput = ({
               </div>
             );
           })}
-          {cellId && <AutoFixButton errors={sqlErrors} cellId={cellId} />}
+          {cellId && (
+            <AutoFixButton
+              errors={sqlErrors}
+              cellId={cellId}
+              className="mt-2.5"
+            />
+          )}
         </div>,
       );
     }

--- a/frontend/src/core/errors/__tests__/errors.test.ts
+++ b/frontend/src/core/errors/__tests__/errors.test.ts
@@ -16,6 +16,10 @@ describe("getImportCode", () => {
   });
 });
 
+const opts = {
+  aiEnabled: true,
+};
+
 describe("getAutoFixes", () => {
   it("returns wrap in function fix for multiple-defs error", () => {
     const error: MarimoError = {
@@ -24,7 +28,7 @@ describe("getAutoFixes", () => {
       cells: ["foo"],
     };
 
-    const fixes = getAutoFixes(error);
+    const fixes = getAutoFixes(error, opts);
     expect(fixes).toHaveLength(1);
     expect(fixes[0].title).toBe("Fix: Wrap in a function");
   });
@@ -37,7 +41,7 @@ describe("getAutoFixes", () => {
       raising_cell: null,
     };
 
-    const fixes = getAutoFixes(error);
+    const fixes = getAutoFixes(error, opts);
     expect(fixes).toHaveLength(1);
     expect(fixes[0].title).toBe("Fix: Add 'import numpy as np'");
   });
@@ -49,9 +53,11 @@ describe("getAutoFixes", () => {
       sql_statement: "SELECT * FROM table",
     };
 
-    const fixes = getAutoFixes(error);
+    const fixes = getAutoFixes(error, opts);
     expect(fixes).toHaveLength(1);
-    expect(fixes[0].title).toBe("AI Fix: Fix the SQL error");
+    expect(fixes[0].title).toBe("Fix with AI");
+
+    expect(getAutoFixes(error, { aiEnabled: false })).toHaveLength(0);
   });
 
   it("returns no fixes for NameError with unknown import", () => {
@@ -62,7 +68,7 @@ describe("getAutoFixes", () => {
       raising_cell: null,
     };
 
-    expect(getAutoFixes(error)).toHaveLength(0);
+    expect(getAutoFixes(error, opts)).toHaveLength(0);
   });
 
   it("returns no fixes for other error types", () => {
@@ -71,6 +77,6 @@ describe("getAutoFixes", () => {
       msg: "invalid syntax",
     };
 
-    expect(getAutoFixes(error)).toHaveLength(0);
+    expect(getAutoFixes(error, opts)).toHaveLength(0);
   });
 });

--- a/frontend/src/core/errors/__tests__/errors.test.ts
+++ b/frontend/src/core/errors/__tests__/errors.test.ts
@@ -42,6 +42,18 @@ describe("getAutoFixes", () => {
     expect(fixes[0].title).toBe("Fix: Add 'import numpy as np'");
   });
 
+  it("returns sql fix for sql-error error", () => {
+    const error: MarimoError = {
+      type: "sql-error",
+      msg: "syntax error",
+      sql_statement: "SELECT * FROM table",
+    };
+
+    const fixes = getAutoFixes(error);
+    expect(fixes).toHaveLength(1);
+    expect(fixes[0].title).toBe("AI Fix: Fix the SQL error");
+  });
+
   it("returns no fixes for NameError with unknown import", () => {
     const error: MarimoError = {
       type: "exception",

--- a/frontend/src/core/errors/errors.ts
+++ b/frontend/src/core/errors/errors.ts
@@ -12,6 +12,10 @@ export interface AutoFix {
     addCodeBelow: (code: string) => void;
     editor: EditorView | undefined;
     cellId: CellId;
+    setAiCompletionCell?: (cell: {
+      cellId: CellId;
+      initialPrompt?: string;
+    }) => void;
   }) => Promise<void>;
 }
 
@@ -52,6 +56,21 @@ export function getAutoFixes(error: MarimoError): AutoFix[] {
         description: "Add a new cell for the missing import",
         onFix: async (ctx) => {
           ctx.addCodeBelow(cellCode);
+        },
+      },
+    ];
+  }
+
+  if (error.type === "sql-error") {
+    return [
+      {
+        title: "AI Fix: Fix the SQL error",
+        description: "Fix the SQL statement",
+        onFix: async (ctx) => {
+          ctx.setAiCompletionCell?.({
+            cellId: ctx.cellId,
+            initialPrompt: `Fix the SQL statement: ${error.msg}`,
+          });
         },
       },
     ];

--- a/frontend/src/core/errors/errors.ts
+++ b/frontend/src/core/errors/errors.ts
@@ -64,7 +64,7 @@ export function getAutoFixes(error: MarimoError): AutoFix[] {
   if (error.type === "sql-error") {
     return [
       {
-        title: "AI Fix: Fix the SQL error",
+        title: "Fix with AI",
         description: "Fix the SQL statement",
         onFix: async (ctx) => {
           ctx.setAiCompletionCell?.({

--- a/frontend/src/core/errors/errors.ts
+++ b/frontend/src/core/errors/errors.ts
@@ -19,7 +19,12 @@ export interface AutoFix {
   }) => Promise<void>;
 }
 
-export function getAutoFixes(error: MarimoError): AutoFix[] {
+export function getAutoFixes(
+  error: MarimoError,
+  opts: {
+    aiEnabled: boolean;
+  },
+): AutoFix[] {
   if (error.type === "multiple-defs") {
     return [
       {
@@ -62,6 +67,10 @@ export function getAutoFixes(error: MarimoError): AutoFix[] {
   }
 
   if (error.type === "sql-error") {
+    // Only show AI fix if AI is enabled
+    if (!opts.aiEnabled) {
+      return [];
+    }
     return [
       {
         title: "Fix with AI",

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -29,8 +29,6 @@ language_rules = {
     "markdown": [],
     "sql": [
         "The SQL must use duckdb syntax.",
-        'SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.',
-        "This will automatically display the result in the UI. You do not need to return the dataframe in the cell.",
     ],
 }
 
@@ -194,7 +192,7 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
     if support_multiple_cells:
         system_prompt += "\n\nAgain, just output code wrapped in cells. Each cell is wrapped in backticks with the appropriate language identifier (python, sql, markdown)."
     else:
-        system_prompt += "\n\nAgain, just output the code itself."
+        system_prompt += f"\n\nAgain, just output the code itself and make sure to return the code as just {language}."
 
     return system_prompt
 

--- a/tests/_server/ai/snapshots/chat_system_prompts.txt
+++ b/tests/_server/ai/snapshots/chat_system_prompts.txt
@@ -141,8 +141,6 @@ chart
 
 ## Rules for sql:
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
 ==================== with custom rules ====================
 
@@ -285,8 +283,6 @@ chart
 
 ## Rules for sql:
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
 ## Additional rules:
 Always be polite.
@@ -432,8 +428,6 @@ chart
 
 ## Rules for sql:
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
 ## Available variables from other cells:
 - variable: `var1`- variable: `var2`
@@ -579,8 +573,6 @@ chart
 
 ## Rules for sql:
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
 ## Available variables from other cells:
 - variable: `df`
@@ -732,8 +724,6 @@ chart
 
 ## Rules for sql:
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
 ## Available schema:
 - Table: df_1
@@ -893,8 +883,6 @@ chart
 
 ## Rules for sql:
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
 <code_from_other_cells>
 import pandas as pd
@@ -1042,8 +1030,6 @@ chart
 
 ## Rules for sql:
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
 ## Additional rules:
 Always be polite.

--- a/tests/_server/ai/snapshots/system_prompts.txt
+++ b/tests/_server/ai/snapshots/system_prompts.txt
@@ -22,7 +22,7 @@ Immediately start with the following format. Do NOT comment on the code, just ou
 6. If an import already exists, do not import it again.
 7. If a variable is already defined, use another name, or make it private by adding an underscore at the beginning.
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just python.
 
 ==================== markdown ====================
 
@@ -37,7 +37,7 @@ Immediately start with the following format. Do NOT comment on the code, just ou
 {CELL_CODE}
 ```
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just markdown.
 
 ==================== sql ====================
 
@@ -54,10 +54,8 @@ Immediately start with the following format. Do NOT comment on the code, just ou
 
 ## Rules for sql
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just sql.
 
 ==================== idk ====================
 
@@ -72,7 +70,7 @@ Immediately start with the following format. Do NOT comment on the code, just ou
 {CELL_CODE}
 ```
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just idk.
 
 ==================== with custom rules ====================
 
@@ -99,7 +97,7 @@ Immediately start with the following format. Do NOT comment on the code, just ou
 ## Additional rules:
 Always use type hints.
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just python.
 
 ==================== with context ====================
 
@@ -133,7 +131,7 @@ Immediately start with the following format. Do NOT comment on the code, just ou
     - Sample values: Alice, Bob, Charlie
 
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just python.
 
 ==================== with is_insert=True ====================
 
@@ -164,7 +162,7 @@ Immediately start with the following format. Do NOT comment on the code, just ou
 6. If an import already exists, do not import it again.
 7. If a variable is already defined, use another name, or make it private by adding an underscore at the beginning.
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just python.
 
 ==================== with cell_code ====================
 
@@ -201,7 +199,7 @@ print('Hello, world!')
 6. If an import already exists, do not import it again.
 7. If a variable is already defined, use another name, or make it private by adding an underscore at the beginning.
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just python.
 
 ==================== with selected_text ====================
 
@@ -238,7 +236,7 @@ print('Hello, world!')
 6. If an import already exists, do not import it again.
 7. If a variable is already defined, use another name, or make it private by adding an underscore at the beginning.
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just python.
 
 ==================== with other_cell_codes ====================
 
@@ -279,7 +277,7 @@ import pandas as pd
 import numpy as np
 </code_from_other_cells>
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just python.
 
 ==================== with VariableContext objects ====================
 
@@ -312,7 +310,7 @@ Immediately start with the following format. Do NOT comment on the code, just ou
   - value_preview: <Model object>
 
 
-Again, just output the code itself.
+Again, just output the code itself and make sure to return the code as just python.
 
 ==================== with support_multiple_cells=True ====================
 
@@ -350,8 +348,6 @@ Separate logic into multiple cells to keep the code organized and readable.
 
 ## Rules for sql:
 1. The SQL must use duckdb syntax.
-2. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
-3. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 
 ## Available variables from other cells:
 - variable: `df`


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

<img width="788" height="497" alt="CleanShot 2025-09-30 at 00 25 38" src="https://github.com/user-attachments/assets/2162f753-d2a0-4d41-80da-b0433ed58d96" />

<img width="770" height="253" alt="CleanShot 2025-09-30 at 00 25 58" src="https://github.com/user-attachments/assets/932f9146-328e-4c9e-b80a-9b643f59dc2b" />

Next step:
- The AI provides the entire autocompletion including _df = mo.sql. We should strip away the python code.
- Going to pass in the schema and maybe sample values

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce an AI-driven auto-fix for SQL errors (gated by aiEnabled) and adjust AI prompts to output raw code/SQL; update UI usage and tests.
> 
> - **Frontend**:
>   - **Auto-fix integration**: `AutoFixButton` now considers `aiEnabled` and sets `aiCompletionCell`; accepts optional `className` and uses `cn`.
>   - **Errors API**: `getAutoFixes(error, { aiEnabled })` adds SQL support that triggers AI completion via `setAiCompletionCell`.
>   - **UI tweak**: `MarimoErrorOutput` passes `className="mt-2.5"` to `AutoFixButton` for SQL errors.
> - **AI/Prompts**:
>   - Remove SQL instructions to wrap queries with `mo.sql(...)`; single-cell prompts now end with “return the code as just {language}”.
> - **Tests**:
>   - Update `getAutoFixes` tests to pass `aiEnabled` and cover SQL error fix behavior.
>   - Refresh chat/system prompt snapshots to match new prompt text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a45cdd73001729607d012fb752c7d782cda5bb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->