### PR TITLE
claude 4.5

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -3,28 +3,28 @@
 # Anthropic
 
 - name: Claude 4.5 Sonnet
-  model: claude-sonnet-4-5-20250929
+  model: claude-sonnet-4-5
   description: Latest Sonnet model with enhanced capabilities and performance improvements
   providers: [anthropic]
   roles: [chat, edit]
   thinking: true
   
 - name: Claude 4.1 Opus
-  model: claude-opus-4-1-20250805
+  model: claude-opus-4-1
   description: Latest Opus model with enhanced capabilities and performance improvements
   providers: [anthropic]
   roles: [chat, edit]
   thinking: true
 
 - name: Claude 4 Opus
-  model: claude-opus-4-20250514
+  model: claude-opus-4
   description: Most capable model with superior performance on complex tasks and reasoning
   providers: [anthropic]
   roles: [chat, edit]
   thinking: true
 
 - name: Claude 4 Sonnet
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4
   description: Next-generation Sonnet model with advanced reasoning and multimodal capabilities
   providers: [anthropic]
   roles: [chat, edit]


### PR DESCRIPTION
Added the new model, name from [here](https://docs.claude.com/en/docs/about-claude/models/overview)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `Claude 4.5 Sonnet` and updates `Claude 4.1 Opus`, `Claude 4 Opus`, and `Claude 4 Sonnet` model IDs to undated forms.
> 
> - **Anthropic models (`packages/llm-info/data/models.yml`)**:
>   - **New**: `Claude 4.5 Sonnet` (`model: claude-sonnet-4-5`, roles: `chat`, `edit`, `thinking: true`).
>   - **Model ID normalization**:
>     - `Claude 4.1 Opus`: `claude-opus-4-1-20250805` → `claude-opus-4-1`.
>     - `Claude 4 Opus`: `claude-opus-4-20250514` → `claude-opus-4`.
>     - `Claude 4 Sonnet`: `claude-sonnet-4-20250514` → `claude-sonnet-4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d20f644048d9532a77a525ac880965e0bb8cf42d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->