### PR TITLE
improvement: use lazy-frames for multi-step processing, include more tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,19 +157,25 @@ make py-test
 Run a specific test
 
 ```bash
-hatch run test:test tests/_ast/
+hatch run +py=3.13 test:test tests/_ast/
+```
+
+Run all changed tests
+
+```bash
+hatch run +py=3.13 test:test --picked
 ```
 
 Run tests with optional dependencies
 
 ```bash
-hatch run test-optional:test tests/_ast/
+hatch run +py=3.13 test-optional:test tests/_ast/
 ```
 
-Run tests with a specific Python version
+Run tests across all Python versions (omit `+py`)
 
 ```bash
-hatch run +py=3.10 test:test tests/_ast/
+hatch run test:test tests/_ast/
 ```
 
 Run all tests across all Python versions

--- a/marimo/_data/preview_column.py
+++ b/marimo/_data/preview_column.py
@@ -276,7 +276,7 @@ def _get_altair_chart(
     try:
         chart_spec = _get_chart_spec(
             # Downgrade to v1 since altair doesn't support v2 yet
-            # This is valiadted with our tests, so if the tests pass with this
+            # This is validated with our tests, so if the tests pass with this
             # removed, we can remove the downgrade.
             column_data=downgrade_narwhals_df_to_v1(column_data),
             column_type=column_type,
@@ -369,49 +369,49 @@ def _sanitize_data(
                     total_seconds = diff.total_seconds()
                     if total_seconds >= 604800:
                         # Use weeks if range is at least a week
-                        column_data = column_data.with_columns(
+                        column_data = frame.with_columns(
                             (col.dt.total_seconds() / 604800).alias(
                                 column_name
                             )
                         )
                     elif total_seconds >= 86400:
                         # Use days if range is at least a day
-                        column_data = column_data.with_columns(
+                        column_data = frame.with_columns(
                             (col.dt.total_seconds() / 86400).alias(column_name)
                         )
                     elif total_seconds >= 3600:
                         # Use hours if range is at least an hour
-                        column_data = column_data.with_columns(
+                        column_data = frame.with_columns(
                             (col.dt.total_seconds() / 3600).alias(column_name)
                         )
                     elif total_seconds >= 60:
                         # Use minutes if range is at least a minute
-                        column_data = column_data.with_columns(
+                        column_data = frame.with_columns(
                             col.dt.total_minutes().alias(column_name)
                         )
                     elif total_seconds >= 1:
                         # Use seconds if range is at least a second
-                        column_data = column_data.with_columns(
+                        column_data = frame.with_columns(
                             col.dt.total_seconds().alias(column_name)
                         )
                     elif total_seconds >= 0.001:
                         # Use milliseconds if range is at least a millisecond
-                        column_data = column_data.with_columns(
+                        column_data = frame.with_columns(
                             col.dt.total_milliseconds().alias(column_name)
                         )
                     elif total_seconds >= 0.000001:
                         # Use microseconds if range is at least a microsecond
-                        column_data = column_data.with_columns(
+                        column_data = frame.with_columns(
                             col.dt.total_microseconds().alias(column_name)
                         )
                     elif total_seconds >= 0.000000001:
                         # Use nanoseconds if range is at least a nanosecond
-                        column_data = column_data.with_columns(
+                        column_data = frame.with_columns(
                             col.dt.total_nanoseconds().alias(column_name)
                         )
             except Exception as e:
                 LOGGER.warning("Failed to infer duration precision: %s", e)
-                column_data = column_data.with_columns(
+                column_data = frame.with_columns(
                     col.dt.total_seconds().alias(column_name)
                 )
     except Exception as e:

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -178,7 +178,7 @@ def _filter_dataframe(
                     f"Invalid selection: {field}={resolved_values}"
                 )
 
-    if not is_lazy:
+    if not is_lazy and is_narwhals_lazyframe(df):
         # Undo the lazy
         return df.collect().to_native()
 

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -180,7 +180,7 @@ def _filter_dataframe(
 
     if not is_lazy and is_narwhals_lazyframe(df):
         # Undo the lazy
-        return df.collect().to_native()
+        return df.collect().to_native()  # type: ignore[no-any-return]
 
     return df.to_native()
 

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Marimo. All rights reserved.
+
 from __future__ import annotations
 
 import datetime
@@ -29,6 +30,7 @@ from marimo._utils.narwhals_utils import (
     assert_can_narwhalify,
     can_narwhalify,
     empty_df,
+    is_narwhals_lazyframe,
 )
 
 if sys.version_info < (3, 10):
@@ -100,7 +102,11 @@ def _using_vegafusion() -> bool:
 def _filter_dataframe(
     native_df: Union[IntoDataFrame, IntoLazyFrame], selection: ChartSelection
 ) -> Union[IntoDataFrame, IntoLazyFrame]:
-    df = nw.from_native(native_df)
+    # Use lazy evaluation for efficient chained filtering
+    base = nw.from_native(native_df)
+    is_lazy = is_narwhals_lazyframe(base)
+    df = base.lazy()
+
     if not isinstance(selection, dict):
         raise TypeError("Input 'selection' must be a dictionary")
 
@@ -121,10 +127,12 @@ def _filter_dataframe(
             vgsid = fields.get("_vgsid_", [])
             try:
                 indexes = [int(i) - 1 for i in vgsid]
-                df = cast(nw.DataFrame[Any], df)[indexes]
+                # Need to collect for index-based selection
+                non_lazy = df.collect()[indexes]
+                df = non_lazy.lazy()
             except IndexError:
                 # Out of bounds index, return empty dataframe if it's the
-                df = cast(nw.DataFrame[Any], df)[[]]
+                df = df.head(0)
                 LOGGER.error(f"Invalid index in selection: {vgsid}")
             except ValueError:
                 LOGGER.error(f"Invalid index in selection: {vgsid}")
@@ -140,10 +148,12 @@ def _filter_dataframe(
             if field in ("vlPoint", "_vgsid_"):
                 continue
 
-            if field not in df.columns:
+            # Need to collect schema to check columns and dtypes
+            schema = df.collect_schema()
+            if field not in schema.names():
                 raise ValueError(f"Field '{field}' not found in DataFrame")
 
-            dtype = df[field].dtype
+            dtype = schema[field]
             resolved_values = _resolve_values(values, dtype)
             if is_point_selection:
                 df = df.filter(nw.col(field).is_in(resolved_values))
@@ -168,7 +178,11 @@ def _filter_dataframe(
                     f"Invalid selection: {field}={resolved_values}"
                 )
 
-    return nw.to_native(df)
+    if not is_lazy:
+        # Undo the lazy
+        return df.collect().to_native()
+
+    return df.to_native()
 
 
 def _resolve_values(values: Any, dtype: Any) -> list[Any]:

--- a/marimo/_plugins/ui/_impl/charts/altair_transformer.py
+++ b/marimo/_plugins/ui/_impl/charts/altair_transformer.py
@@ -15,7 +15,7 @@ from marimo._plugins.ui._impl.tables.utils import (
     get_table_manager_or_none,
 )
 from marimo._utils.data_uri import build_data_url
-from marimo._utils.narwhals_utils import can_narwhalify
+from marimo._utils.narwhals_utils import can_narwhalify, is_narwhals_lazyframe
 
 LOGGER = _loggers.marimo_logger()
 
@@ -174,7 +174,7 @@ def sanitize_nan_infs(data: Any) -> Any:
                 )
 
         # Collect if input was eager
-        if not is_prev_lazy:
+        if not is_prev_lazy and is_narwhals_lazyframe(narwhals_data):
             narwhals_data = narwhals_data.collect()
 
         return narwhals_data.to_native()

--- a/marimo/_utils/narwhals_utils.py
+++ b/marimo/_utils/narwhals_utils.py
@@ -224,7 +224,10 @@ def downgrade_narwhals_df_to_v1(
     """
     Downgrade a narwhals dataframe to the latest version.
     """
-    return nw1.from_native(df.to_native())  # type: ignore[no-any-return]
+    if is_narwhals_lazyframe(df) or is_narwhals_dataframe(df):
+        return nw1.from_native(df.to_native())  # type: ignore[no-any-return]
+    # Pass through
+    return df
 
 
 def is_narwhals_lazyframe(df: Any) -> TypeIs[nw.LazyFrame[Any]]:

--- a/tests/_plugins/ui/_impl/charts/test_altair_transformers.py
+++ b/tests/_plugins/ui/_impl/charts/test_altair_transformers.py
@@ -18,7 +18,7 @@ from marimo._plugins.ui._impl.charts.altair_transformer import (
     _to_marimo_json,
     register_transformers,
 )
-from tests._data.mocks import create_dataframes
+from tests._data.mocks import DFType, create_dataframes
 
 HAS_DEPS = DependencyManager.pandas.has() and DependencyManager.altair.has()
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize(
     "df",
     create_dataframes(
-        {"A": [1, 2, 3], "B": ["a", "b", "c"]}, exclude=["duckdb"]
+        {"A": [1, 2, 3], "B": ["a", "b", "c"]},
     ),
 )
 def test_to_marimo_json(df: IntoDataFrame):
@@ -46,7 +46,7 @@ def test_to_marimo_json(df: IntoDataFrame):
 @pytest.mark.parametrize(
     "df",
     create_dataframes(
-        {"A": [1, 2, 3], "B": ["a", "b", "c"]}, exclude=["duckdb"]
+        {"A": [1, 2, 3], "B": ["a", "b", "c"]},
     ),
 )
 def test_to_marimo_csv(df: IntoDataFrame):
@@ -62,7 +62,7 @@ def test_to_marimo_csv(df: IntoDataFrame):
 @pytest.mark.parametrize(
     "df",
     create_dataframes(
-        {"A": [1, 2, 3], "B": ["a", "b", "c"]}, exclude=["duckdb"]
+        {"A": [1, 2, 3], "B": ["a", "b", "c"]},
     ),
 )
 def test_to_marimo_inline_csv(df: IntoDataFrame):
@@ -79,7 +79,7 @@ def test_to_marimo_inline_csv(df: IntoDataFrame):
 @pytest.mark.parametrize(
     "df",
     create_dataframes(
-        {"A": [1, 2, 3], "B": ["a", "b", "c"]}, exclude=["duckdb"]
+        {"A": [1, 2, 3], "B": ["a", "b", "c"]},
     ),
 )
 def test_data_to_json_string(df: IntoDataFrame):
@@ -95,9 +95,7 @@ def test_data_to_json_string(df: IntoDataFrame):
 @pytest.mark.parametrize(
     "df",
     # We skip pyarrow because it's csv is formatted differently
-    create_dataframes(
-        {"A": [1, 2, 3], "B": ["a", "b", "c"]}, exclude=["pyarrow", "duckdb"]
-    ),
+    create_dataframes({"A": [1, 2, 3], "B": ["a", "b", "c"]}),
 )
 def test_data_to_csv_string(df: IntoDataFrame):
     result = _data_to_csv_string(df)
@@ -146,7 +144,6 @@ def test_to_marimo_csv_with_missing_values(df: IntoDataFrame):
     "df",
     create_dataframes(
         {"A": range(10000), "B": [f"value_{i}" for i in range(10000)]},
-        exclude=["pyarrow", "duckdb"],
     ),
 )
 def test_to_marimo_inline_csv_large_dataset(df: IntoDataFrame):
@@ -229,7 +226,7 @@ def test_register_transformers(mock_data_transformers: MagicMock):
     )
 
 
-SUPPORTS_ARROW_IPC = ["pandas", "polars", "lazy-polars"]
+SUPPORTS_ARROW_IPC: list[DFType] = ["pandas", "polars", "lazy-polars"]
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")

--- a/tests/_plugins/ui/_impl/test_altair_chart.py
+++ b/tests/_plugins/ui/_impl/test_altair_chart.py
@@ -26,12 +26,13 @@ from marimo._plugins.ui._impl.altair_chart import (
     altair_chart,
 )
 from marimo._runtime.runtime import Kernel
-from tests._data.mocks import NON_EAGER_LIBS, create_dataframes
+from marimo._utils.narwhals_utils import is_narwhals_lazyframe
+from tests._data.mocks import create_dataframes
 from tests.conftest import ExecReqProvider
 from tests.mocks import snapshotter
 
 if TYPE_CHECKING:
-    from narwhals.typing import IntoDataFrame
+    from narwhals.typing import IntoDataFrame, IntoLazyFrame
 
 snapshot = snapshotter(__file__)
 
@@ -51,8 +52,18 @@ else:
     pd = Mock()
 
 
-def get_len(df: IntoDataFrame) -> int:
-    return nw.from_native(df).shape[0]
+def get_len(df: IntoDataFrame | IntoLazyFrame) -> int:
+    df = nw.from_native(df, pass_through=False)
+    if is_narwhals_lazyframe(df):
+        return df.collect().shape[0]
+    return df.shape[0]
+
+
+def maybe_collect(df: IntoDataFrame | IntoLazyFrame) -> nw.DataFrame[Any]:
+    nw_df = nw.from_native(df, pass_through=False)
+    if is_narwhals_lazyframe(nw_df):
+        return nw_df.collect()
+    return nw_df
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
@@ -67,7 +78,6 @@ class TestAltairChart:
                 "field_2": [1, 2, 3, 4],
                 "field_3": [10, 20, 30, 40],
             },
-            exclude=NON_EAGER_LIBS,
         ),
     )
     def test_filter_dataframe(df: ChartDataType) -> None:
@@ -76,7 +86,7 @@ class TestAltairChart:
             "signal_channel_1": {"vlPoint": [1], "field": ["value1", "value2"]}
         }
         # Filter the DataFrame with the point selection
-        assert len(_filter_dataframe(df, point_selection)) == 2
+        assert get_len(_filter_dataframe(df, point_selection)) == 2
 
         # Point selected with a no fields
         point_selection = {
@@ -86,8 +96,9 @@ class TestAltairChart:
             },
         }
         # Filter the DataFrame with the point selection
-        assert len(_filter_dataframe(df, point_selection)) == 2
-        first, second = _filter_dataframe(df, point_selection)["field"]
+        filtered_df = _filter_dataframe(df, point_selection)
+        assert get_len(filtered_df) == 2
+        first, second = maybe_collect(filtered_df)["field"]
         assert str(first) == "value2"
         assert str(second) == "value3"
 
@@ -96,14 +107,16 @@ class TestAltairChart:
             "signal_channel_2": {"field_2": [1, 3]}
         }
         # Filter the DataFrame with the interval selection
-        assert len(_filter_dataframe(df, interval_selection)) == 3
+        filtered_df = _filter_dataframe(df, interval_selection)
+        assert get_len(filtered_df) == 3
 
         # Define an interval selection with multiple fields
         multi_field_selection: ChartSelection = {
             "signal_channel_1": {"field_2": [1, 3], "field_3": [30, 40]}
         }
         # Filter the DataFrame with the multi-field selection
-        assert len(_filter_dataframe(df, multi_field_selection)) == 1
+        filtered_df = _filter_dataframe(df, multi_field_selection)
+        assert get_len(filtered_df) == 1
 
         # Define an interval selection with multiple fields
         interval_and_point_selection: ChartSelection = {
@@ -111,7 +124,8 @@ class TestAltairChart:
             "signal_channel_2": {"vlPoint": [1], "color": ["red"]},
         }
         # Filter the DataFrame with the multi-field selection
-        assert len(_filter_dataframe(df, interval_and_point_selection)) == 1
+        filtered_df = _filter_dataframe(df, interval_and_point_selection)
+        assert get_len(filtered_df) == 1
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -146,7 +160,6 @@ class TestAltairChart:
                     datetime.datetime(2020, 1, 10),
                 ],
             },
-            exclude=NON_EAGER_LIBS,
         ),
     )
     def test_filter_dataframe_with_dates(
@@ -168,8 +181,9 @@ class TestAltairChart:
             }
         }
         # Filter the DataFrame with the interval selection
-        assert get_len(_filter_dataframe(df, interval_selection)) == 2
-        first, second = _filter_dataframe(df, interval_selection)["field"]
+        filtered_df = _filter_dataframe(df, interval_selection)
+        assert get_len(filtered_df) == 2
+        first, second = maybe_collect(filtered_df)["field"]
         assert str(first) == "value1"
         assert str(second) == "value2"
 
@@ -182,8 +196,9 @@ class TestAltairChart:
                 ]
             }
         }
-        assert get_len(_filter_dataframe(df, interval_selection)) == 2
-        first, second = _filter_dataframe(df, interval_selection)["field"]
+        filtered_df = _filter_dataframe(df, interval_selection)
+        assert get_len(filtered_df) == 2
+        first, second = maybe_collect(filtered_df)["field"]
         assert str(first) == "value1"
         assert str(second) == "value2"
 
@@ -202,8 +217,9 @@ class TestAltairChart:
                 ]
             }
         }
-        assert get_len(_filter_dataframe(df, interval_selection)) == 2
-        first, second = _filter_dataframe(df, interval_selection)["field"]
+        filtered_df = _filter_dataframe(df, interval_selection)
+        assert get_len(filtered_df) == 2
+        first, second = maybe_collect(filtered_df)["field"]
         assert str(first) == "value1"
         assert str(second) == "value2"
 
@@ -218,8 +234,9 @@ class TestAltairChart:
             }
         }
         # Filter the DataFrame with the interval selection
-        assert len(_filter_dataframe(df, interval_selection)) == 2
-        first, second = _filter_dataframe(df, interval_selection)["field"]
+        filtered_df = _filter_dataframe(df, interval_selection)
+        assert get_len(filtered_df) == 2
+        first, second = maybe_collect(filtered_df)["field"]
         assert str(first) == "value1"
         assert str(second) == "value2"
 
@@ -244,7 +261,6 @@ class TestAltairChart:
                     datetime.datetime(2020, 1, 1),
                 ],
             },
-            exclude=NON_EAGER_LIBS,
         ),
     )
     def test_filter_dataframe_with_datetimes_as_strings(
@@ -400,7 +416,6 @@ class TestAltairChart:
                     datetime.datetime.fromtimestamp(20000),
                 ],
             },
-            exclude=NON_EAGER_LIBS,
         ),
     )
     def test_filter_dataframe_with_datetimes_as_numbers(
@@ -806,7 +821,7 @@ def test_no_selection_polars() -> None:
     "df",
     create_dataframes(
         {"x": [1, 2, 3], "y1": [4, 5, 6], "y2": [7, 8, 9]},
-        exclude=["ibis", "lazy-polars"],
+        exclude=["lazy-polars"],
     ),
 )
 def test_layered_chart(df: IntoDataFrame):
@@ -851,7 +866,7 @@ def test_chart_with_binning(df: IntoDataFrame):
             "y": [1, 2, 3, 4],
             "category": ["A", "A", "B", "B"],
         },
-        exclude=["ibis", "pyarrow", "duckdb", "lazy-polars"],
+        exclude=["lazy-polars"],
     ),
 )
 def test_apply_selection(df: IntoDataFrame):
@@ -863,8 +878,8 @@ def test_apply_selection(df: IntoDataFrame):
     marimo_chart._chart_selection = {"signal_channel": {"category": ["A"]}}
 
     filtered_data = marimo_chart.apply_selection(df)
-    assert len(filtered_data) == 2
-    assert all(filtered_data["category"] == "A")
+    assert get_len(filtered_data) == 2
+    assert all(maybe_collect(filtered_data)["category"] == "A")
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")

--- a/tests/_plugins/ui/_impl/test_data_explorer.py
+++ b/tests/_plugins/ui/_impl/test_data_explorer.py
@@ -23,7 +23,7 @@ else:
 
 @pytest.mark.parametrize(
     "df",
-    create_dataframes({"A": [1, 2, 3], "B": [4, 5, 6]}, exclude=["duckdb"]),
+    create_dataframes({"A": [1, 2, 3], "B": [4, 5, 6]}),
 )
 def test_data_explorer(df: Any) -> None:
     explorer = data_explorer.data_explorer(df)

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -33,7 +33,7 @@ from marimo._runtime.functions import EmptyArgs
 from marimo._runtime.runtime import Kernel
 from marimo._utils.data_uri import from_data_uri
 from marimo._utils.platform import is_windows
-from tests._data.mocks import create_dataframes
+from tests._data.mocks import NON_EAGER_LIBS, create_dataframes
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -321,7 +321,7 @@ def test_value_with_sorting_then_selection() -> None:
     "df",
     create_dataframes(
         {"a": ["x", "z", "y"]},
-        exclude=["ibis", "duckdb", "lazy-polars"],
+        exclude=NON_EAGER_LIBS,
     ),
 )
 def test_value_with_sorting_then_selection_dfs(df: Any) -> None:
@@ -396,7 +396,7 @@ def test_value_with_search_then_selection() -> None:
     "df",
     create_dataframes(
         {"a": ["foo", "bar", "baz"]},
-        exclude=["ibis", "duckdb", "lazy-polars"],
+        exclude=NON_EAGER_LIBS,
     ),
 )
 def test_value_with_search_then_selection_dfs(df: Any) -> None:
@@ -444,7 +444,7 @@ def test_value_with_search_then_selection_dfs(df: Any) -> None:
     "df",
     create_dataframes(
         {"a": ["foo", "bar", "baz"]},
-        exclude=["ibis", "duckdb", "lazy-polars"],
+        exclude=NON_EAGER_LIBS,
     ),
 )
 def test_value_with_search_then_cell_selection_dfs(df: Any) -> None:
@@ -695,7 +695,7 @@ def test_get_row_ids_for_lists() -> None:
             "fruits": ["banana", "apple", "cherry"] * 3,
             "quantity": [10, 20, 30] * 3,
         },
-        exclude=["ibis", "duckdb", "lazy-polars"],
+        exclude=NON_EAGER_LIBS,
     ),
 )
 def test_get_row_ids_with_df(df: any) -> None:

--- a/tests/_utils/test_narwhals_utils.py
+++ b/tests/_utils/test_narwhals_utils.py
@@ -49,7 +49,7 @@ def test_empty_df(df: IntoDataFrame) -> None:
 
 @pytest.mark.parametrize(
     "df",
-    create_dataframes({"a": [1, 2, 3]}, exclude=["lazy-polars"]),
+    create_dataframes({"a": [1, 2, 3]}),
 )
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 def test_assert_narwhals_dataframe(df: IntoDataFrame) -> None:


### PR DESCRIPTION
After moving to narwhals v2, we can support more dataframe types in certain codepaths and tests.
This also makes multi-step operations lazy to avoid incremental df states