### PR TITLE
Add mapping for 'airflow' to 'apache-airflow'

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -9,6 +9,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "AFQ": "pyAFQ",
         "AG_fft_tools": "agpy",
         "Adafruit": "Adafruit-Libraries",
+        "airflow": "apache-airflow",
         "Asterisk": "py-Asterisk",
         "BB_jekyll_hook": "bitbucket-jekyll-hook",
         "Banzai": "Banzai-NGS",


### PR DESCRIPTION
Should make it easier to toy with airflow inside of marimo. 