### PR TITLE
enable column explorer for run mode

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -563,8 +563,8 @@ class table(
             )
 
         app_mode = get_mode()
-        # These panels are not as useful in non-edit mode and require an external dependency
-        show_column_explorer = app_mode == "edit"
+        # Some panels are not as useful in non-edit mode and require an external dependency
+        show_column_explorer = app_mode == "edit" or app_mode == "run"
         show_chart_builder = app_mode == "edit"
 
         show_page_size_selector = True

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -2162,7 +2162,7 @@ def test_show_toggles_app_mode():
 
     with patch("marimo._plugins.ui._impl.table.get_mode", return_value="run"):
         table_default = ui.table(data)
-        assert table_default._component_args["show-column-explorer"] is False
+        assert table_default._component_args["show-column-explorer"] is True
         assert table_default._component_args["show-chart-builder"] is False
 
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

The original reason for disabling this was there were too many toggles and some weren't useful in run-mode.

<img width="669" height="365" alt="CleanShot 2025-10-01 at 23 46 36" src="https://github.com/user-attachments/assets/1ae235ea-7794-4a03-ad55-c9f9d04b571d" />

Column explorer has been useful so we can enable it, we can also think about how to organize these icons in the future.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
