### PR TITLE
fix (gemini): premature client close error when using gemini models in chat

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -855,7 +855,7 @@ class GoogleProvider(
             else:
                 # Try default initialization which may work with environment variables
                 self._client = genai.Client().aio
-            
+
             # Return vertex or default client
             return self._client
 
@@ -870,7 +870,7 @@ class GoogleProvider(
         additional_tools: list[ToolDefinition],
     ) -> AsyncIterator[GenerateContentResponse]:
         client = self.get_client(self.config)
-        stream = await client.models.generate_content_stream(
+        return await client.models.generate_content_stream(  # type: ignore[reportReturnType]
             model=self.model,
             contents=convert_to_google_messages(messages),
             config=self.get_config(
@@ -879,9 +879,6 @@ class GoogleProvider(
                 additional_tools=additional_tools,
             ),
         )
-        # GoogleProvider returns an Awaitable[AsyncIterator[GenerateContentResponse]]
-        # so we need to cast it to AsyncIterator[GenerateContentResponse]
-        return cast("AsyncIterator[GenerateContentResponse]", stream)
 
     def _get_tool_call_id(self, tool_call_id: Optional[str]) -> Optional[str]:
         # Custom tools don't have an id, so we have to generate a random uuid
@@ -1005,8 +1002,7 @@ class BedrockProvider(
             all_tools = tools + additional_tools
             config["tools"] = convert_to_openai_tools(all_tools)
 
-        result = await litellm_completion(**config)
-        return cast("LitellmStream", result)
+        return await litellm_completion(**config)
 
     def extract_content(
         self,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
This PR fixes the issue of premature client closing for all gemini models which is a blocking issue for using gemini with chat.

<img width="504" height="949" alt="Screenshot 2025-10-01 at 8 06 50 PM" src="https://github.com/user-attachments/assets/20c0d243-172a-454a-a65c-866a844aada5" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

- Add _client variable in GoogleProvider
- Update `get_client()` to cache client when first invoked, then reuse the cached client to ensure that between stream iters, the same GoogleClient is used and and the client will not be closed prematurely.
- Also add ignore to return type error for google since it doesn't affect functionality but throws a type error.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
