### PR TITLE
fix: include html in marimo base

### DIFF
--- a/.github/workflows/release-marimo-base.yml
+++ b/.github/workflows/release-marimo-base.yml
@@ -4,7 +4,7 @@ name: Publish marimo-base release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch: {}
 
 env:
@@ -27,6 +27,19 @@ jobs:
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
+
+      - name: 📦 Build frontend
+        run: make fe
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/scripts/validate_base_wheel_size.sh
+++ b/scripts/validate_base_wheel_size.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if marimo/_static/index.html exists
+if [ ! -f "marimo/_static/index.html" ]; then
+  echo "Error: marimo/_static/index.html does not exist"
+  exit 1
+fi
+
 wheel_file=$(ls dist/*.whl)
 if [[ "$OSTYPE" == "darwin"* ]]; then
   # macOS


### PR DESCRIPTION
For marimo-base releases, we did not include the HTML file which breaks export

Fixes #6650 