### PR TITLE
feat: expand cache api to match functools api

### DIFF
--- a/marimo/_save/cache.py
+++ b/marimo/_save/cache.py
@@ -53,7 +53,9 @@ CACHE_PREFIX: dict[CacheType, str] = {
 ValidCacheSha = namedtuple("ValidCacheSha", ("sha", "cache_type"))
 MetaKey = Literal["return", "version", "runtime"]
 # Matches functools
-CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize", "time_saved"])
+CacheInfo = namedtuple(
+    "CacheInfo", ["hits", "misses", "maxsize", "currsize", "time_saved"]
+)
 
 
 class ModuleStub:

--- a/marimo/_save/cache.py
+++ b/marimo/_save/cache.py
@@ -418,6 +418,6 @@ class CacheContext:
             return 0
         # Use current_size if available, otherwise fall back to misses
         if hasattr(self.loader, "current_size"):
-            return self.loader.current_size
+            return int(self.loader.current_size)
         # Assume all misses leave an entry
         return self.misses

--- a/marimo/_save/cache.py
+++ b/marimo/_save/cache.py
@@ -51,9 +51,9 @@ CACHE_PREFIX: dict[CacheType, str] = {
 }
 
 ValidCacheSha = namedtuple("ValidCacheSha", ("sha", "cache_type"))
-MetaKey = Literal["return", "version"]
+MetaKey = Literal["return", "version", "runtime"]
 # Matches functools
-CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize", "time_saved"])
 
 
 class ModuleStub:
@@ -381,6 +381,7 @@ class CacheContext:
             misses=self.misses,
             maxsize=self.maxsize,
             currsize=self.currsize,
+            time_saved=self.time_saved,
         )
 
     @property
@@ -421,3 +422,9 @@ class CacheContext:
             return int(self.loader.current_size)
         # Assume all misses leave an entry
         return self.misses
+
+    @property
+    def time_saved(self) -> float:
+        if self._loader is None:
+            return 0.0
+        return self.loader.time_saved

--- a/marimo/_save/loaders/loader.py
+++ b/marimo/_save/loaders/loader.py
@@ -170,6 +170,10 @@ class Loader(ABC):
     def save_cache(self, cache: Cache) -> bool:
         """Save Cache"""
 
+    @abstractmethod
+    def clear(self) -> None:
+        """Clear all cached items. Default implementation does nothing."""
+
 
 class BasePersistenceLoader(Loader):
     """Abstract base for cache written to disk."""
@@ -215,6 +219,9 @@ class BasePersistenceLoader(Loader):
             return self.restore_cache(key, blob)
         except FileNotFoundError as e:
             raise LoaderError("Unexpected cache miss.") from e
+
+    def clear(self) -> None:
+        self.store.clear.get(str(self.build_path(key)))
 
     @abstractmethod
     def restore_cache(self, key: HashKey, blob: bytes) -> Cache:

--- a/marimo/_save/loaders/loader.py
+++ b/marimo/_save/loaders/loader.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
@@ -109,6 +110,7 @@ class Loader(ABC):
     def __init__(self, name: str) -> None:
         self.name = name
         self._hits = 0
+        self._time_saved = 0.0
 
     def build_path(self, key: HashKey) -> Path:
         prefix = CACHE_PREFIX.get(key.cache_type, "U_")
@@ -120,15 +122,25 @@ class Loader(ABC):
         key: HashKey,
         stateful_refs: set[Name],
     ) -> Cache:
+        start_time = time.time()
         loaded = self.load_cache(key)
         if not loaded:
             return Cache.empty(defs=defs, key=key, stateful_refs=stateful_refs)
+        load_time = time.time() - start_time
+
         # TODO: Consider more robust verification
         if loaded.hash != key.hash:
             raise LoaderError("Hash mismatch in loaded cache.")
         if (defs | stateful_refs) != set(loaded.defs):
             raise LoaderError("Variable mismatch in loaded cache.")
         self._hits += 1
+
+        # Track time savings: original runtime - time to load from cache
+        runtime = loaded.meta.get("runtime", 0)
+        if runtime > 0:
+            time_saved = runtime - load_time
+            self._time_saved += max(0, time_saved)
+
         return Cache.new(
             loaded=loaded,
             key=key,
@@ -138,6 +150,10 @@ class Loader(ABC):
     @property
     def hits(self) -> int:
         return self._hits
+
+    @property
+    def time_saved(self) -> float:
+        return self._time_saved
 
     @classmethod
     def partial(cls, **kwargs: Any) -> LoaderPartial:
@@ -170,9 +186,10 @@ class Loader(ABC):
     def save_cache(self, cache: Cache) -> bool:
         """Save Cache"""
 
-    @abstractmethod
     def clear(self) -> None:
         """Clear all cached items. Default implementation does nothing."""
+        # Default implementation: no-op for loaders that don't support clearing
+        return
 
 
 class BasePersistenceLoader(Loader):

--- a/marimo/_save/loaders/memory.py
+++ b/marimo/_save/loaders/memory.py
@@ -107,3 +107,11 @@ class MemoryLoader(Loader):
     @max_size.setter
     def max_size(self, value: int) -> None:
         self.resize(value)
+
+    @property
+    def current_size(self) -> int:
+        return len(self._cache)
+
+    def clear(self) -> None:
+        """Clear all cached items."""
+        self._maybe_lock(lambda: self._cache.clear())

--- a/marimo/_save/save.py
+++ b/marimo/_save/save.py
@@ -388,7 +388,9 @@ class _cache_call(CacheContext):
             scope = {
                 k: v for k, v in scope.items() if k in attempt.stateful_refs
             }
-            attempt.update(scope, meta={"return": response, "runtime": runtime})
+            attempt.update(
+                scope, meta={"return": response, "runtime": runtime}
+            )
             self.loader.save_cache(attempt)
         except Exception as e:
             failed = True

--- a/marimo/_save/stores/file.py
+++ b/marimo/_save/stores/file.py
@@ -47,3 +47,11 @@ class FileStore(Store):
     def hit(self, key: str) -> bool:
         path = self.save_path / key
         return _valid_path(path)
+
+    def clear(self, key: str) -> bool:
+        path = self.save_path / key
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not _valid_path(path):
+            return False
+        path.unlink()
+        return True

--- a/marimo/_save/stores/store.py
+++ b/marimo/_save/stores/store.py
@@ -23,4 +23,5 @@ class Store(ABC):
         del key
         return False
 
+
 StoreType = type[Store]

--- a/marimo/_save/stores/store.py
+++ b/marimo/_save/stores/store.py
@@ -18,5 +18,9 @@ class Store(ABC):
     def hit(self, key: str) -> bool:
         """Check if the cache is in the store"""
 
+    def clear(self, key: str) -> bool:
+        """Check if the cache is in the store"""
+        del key
+        return False
 
 StoreType = type[Store]

--- a/tests/_save/stores/test_file.py
+++ b/tests/_save/stores/test_file.py
@@ -22,3 +22,23 @@ class TestFileStore:
         # Store is actually created
         assert (tmp_path / "test_store").exists()
         assert (tmp_path / "test_store" / "key").exists()
+
+    def test_clear(self, tmp_path) -> None:
+        """Test clear functionality of FileStore."""
+        store = FileStore(tmp_path / "test_store")
+        data = b"test data"
+
+        # Put some data
+        store.put("key1", data)
+        assert store.hit("key1")
+        assert store.get("key1") == data
+
+        # Clear the key
+        result = store.clear("key1")
+        assert result is True
+        assert not store.hit("key1")
+        assert store.get("key1") is None
+
+        # Clear non-existent key
+        result = store.clear("nonexistent")
+        assert result is False


### PR DESCRIPTION
## 📝 Summary

Adds `cache_clear` and `cache_info` functions to relevant cache objects, exposing cache `hits`, `misses`, `time` saved and some of the other defaults present on `functools.cache`