### PR TITLE
add run button for floating AI label

### DIFF
--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -50,6 +50,7 @@ interface Props {
   acceptChange: (rightHandCode: string) => void;
   enabled: boolean;
   triggerImmediately?: boolean;
+  runCell: () => void;
   /**
    * Children shown when there is no completion
    */
@@ -73,6 +74,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
   acceptChange,
   enabled,
   triggerImmediately,
+  runCell,
   children,
 }) => {
   const [showInputPrompt, setShowInputPrompt] = useState(false);
@@ -320,6 +322,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
           onReject={handleDeclineCompletion}
           showInputPrompt={showInputPrompt}
           setShowInputPrompt={setShowInputPrompt}
+          runCell={runCell}
           className="mt-4 mb-3 w-128"
         />
       </div>
@@ -333,6 +336,7 @@ interface CompletionBannerProps {
   onReject: () => void;
   showInputPrompt: boolean;
   setShowInputPrompt: (show: boolean) => void;
+  runCell: () => void;
   className?: string;
 }
 
@@ -343,6 +347,7 @@ const CompletionBanner: React.FC<CompletionBannerProps> = ({
   className,
   showInputPrompt,
   setShowInputPrompt,
+  runCell,
 }) => {
   const isLoading = status === "loading";
 
@@ -385,7 +390,9 @@ const CompletionBanner: React.FC<CompletionBannerProps> = ({
           isLoading={isLoading}
           onAccept={onAccept}
           size="xs"
-          className="border-none rounded-md"
+          buttonStyles="border-none rounded-r-none rounded-md"
+          playButtonStyles="border-0 border-l-1 rounded-l-none rounded-md"
+          runCell={runCell}
           // acceptShortcut="Mod-↵"
         />
         <RejectCompletionButton

--- a/frontend/src/components/editor/ai/completion-handlers.tsx
+++ b/frontend/src/components/editor/ai/completion-handlers.tsx
@@ -1,8 +1,10 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
+import { PlayIcon } from "lucide-react";
 import React from "react";
 import { MinimalHotkeys } from "@/components/shortcuts/renderShortcut";
 import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
 import { isPlatformMac } from "@/core/hotkeys/shortcuts";
 
 /**
@@ -113,19 +115,68 @@ export const AcceptCompletionButton: React.FC<{
   isLoading: boolean;
   onAccept: () => void;
   size?: "xs" | "sm";
-  className?: string;
+  buttonStyles?: string;
+  playButtonStyles?: string;
   acceptShortcut?: string;
-}> = ({ isLoading, onAccept, size = "sm", className, acceptShortcut }) => {
+  runCell?: () => void;
+}> = ({
+  isLoading,
+  onAccept,
+  size = "sm",
+  buttonStyles,
+  acceptShortcut,
+  runCell,
+  playButtonStyles,
+}) => {
+  const handleAcceptAndRun = () => {
+    onAccept();
+    if (runCell) {
+      runCell();
+    }
+  };
+
+  const baseClasses = `h-6 text-(--grass-11) bg-(--grass-3)/60
+    hover:bg-(--grass-3) dark:bg-(--grass-4)/80 dark:hover:bg-(--grass-3) font-semibold
+    active:bg-(--grass-5) dark:active:bg-(--grass-4)
+    border-(--green-6) border hover:shadow-xs`;
+
+  if (runCell) {
+    return (
+      <div className="flex">
+        <Button
+          variant="text"
+          size={size}
+          disabled={isLoading}
+          onClick={onAccept}
+          className={`${baseClasses} rounded-r-none ${buttonStyles}`}
+        >
+          Accept
+          {acceptShortcut && (
+            <MinimalHotkeys className="ml-1 inline" shortcut={acceptShortcut} />
+          )}
+        </Button>
+        <Tooltip content="Accept and run cell">
+          <Button
+            variant="text"
+            size={size}
+            disabled={isLoading}
+            onClick={handleAcceptAndRun}
+            className={`${baseClasses} rounded-l-none px-1.5 ${playButtonStyles}`}
+          >
+            <PlayIcon className="h-2.5 w-2.5" />
+          </Button>
+        </Tooltip>
+      </div>
+    );
+  }
+
   return (
     <Button
       variant="text"
       size={size}
       disabled={isLoading}
       onClick={onAccept}
-      className={`h-6 text-(--grass-11) bg-(--grass-3)/60
-    hover:bg-(--grass-3) dark:bg-(--grass-4)/80 dark:hover:bg-(--grass-3) rounded px-3 font-semibold
-    active:bg-(--grass-5) dark:active:bg-(--grass-4)
-    border-(--green-6) border hover:shadow-xs ${className}`}
+      className={`${baseClasses} rounded px-3 ${buttonStyles}`}
     >
       Accept
       {acceptShortcut && (

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -434,6 +434,7 @@ const CellEditorInternal = ({
         editorViewRef.current?.focus();
         setAiCompletionCell(null);
       })}
+      runCell={handleRunCell}
     >
       <div className="relative w-full" {...navigationProps}>
         {showHideButton && (


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Adds a run button to accept and immediately run the cell for an AI completion

https://github.com/user-attachments/assets/24db2501-27e2-4fb3-b0b1-091b9a98a0f2
## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
