### PR TITLE
fix: update regex in Plotly template parser to handle special characters

### DIFF
--- a/frontend/src/plugins/impl/plotly/__tests__/parse-from-template.test.ts
+++ b/frontend/src/plugins/impl/plotly/__tests__/parse-from-template.test.ts
@@ -70,4 +70,21 @@ describe("createParser", () => {
       Year: "1964",
     });
   });
+
+  it("should handle labels with special characters (brackets, parentheses, spaces)", () => {
+    const hovertemplate =
+      "Horsepower [ps]=%{x}<br>Miles per Gallon=%{y}<br>Weight (lbs)=%{marker.size}<extra></extra>";
+    const parser = createParser(hovertemplate);
+    const data = {
+      x: "110",
+      y: "20.6",
+      "marker.size": "3000",
+    } as unknown as Plotly.PlotDatum;
+    const result = parser.parse(data);
+    expect(result).toEqual({
+      "Horsepower [ps]": "110",
+      "Miles per Gallon": "20.6",
+      "Weight (lbs)": "3000",
+    });
+  });
 });

--- a/frontend/src/plugins/impl/plotly/parse-from-template.ts
+++ b/frontend/src/plugins/impl/plotly/parse-from-template.ts
@@ -24,7 +24,8 @@ export interface PlotlyTemplateParser {
  */
 export function createParser(hovertemplate: string): PlotlyTemplateParser {
   // Regular expression to match the pattern key=%{selector}
-  const regex = /(\w+)=%{([^}]+)}/g;
+  // Match any characters except = for the key (non-greedy to avoid capturing previous content)
+  const regex = /([^=<>]+)=%{([^}]+)}/g;
 
   // Create an object to hold the key-selector pairs
   const keySelectorPairs: Record<string, string> = {};


### PR DESCRIPTION
Fixes #6717

Updated the regular expression in the createParser function to match keys that may contain special characters, ensuring proper parsing of hovertemplate strings.
