### PR TITLE
fix: datetime UI element rendering in Docker containers

### DIFF
--- a/frontend/src/plugins/impl/__tests__/DateTimePickerPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/DateTimePickerPlugin.test.tsx
@@ -42,4 +42,36 @@ describe("DateTimePickerPlugin", () => {
     const datePicker = container.querySelector('[class*="group"]');
     expect(datePicker).not.toBeNull();
   });
+
+  it("should render with datetime.min and datetime.max edge cases", () => {
+    // Regression test for issue #6700
+    // Ensure the component can handle edge case dates like datetime.min
+    const plugin = new DateTimePickerPlugin();
+    const host = document.createElement("div");
+    const props: IPluginProps<string, DateTimeData> = {
+      host,
+      value: "2024-01-01T12:00:00",
+      setValue: (valueOrFn) => {
+        if (typeof valueOrFn === "function") {
+          valueOrFn("2024-01-01T12:00:00");
+        }
+      },
+      data: {
+        label: null,
+        // These are the exact values that datetime.min and datetime.max produce
+        start: "0001-01-01T00:00:00",
+        stop: "9999-12-31T23:59:59",
+        fullWidth: false,
+      },
+      functions: {},
+    };
+
+    // This should not throw an error
+    const { container } = render(plugin.render(props));
+
+    // Check if the component renders successfully
+    expect(container.innerHTML).not.toBe("");
+    const datePicker = container.querySelector('[class*="group"]');
+    expect(datePicker).not.toBeNull();
+  });
 });

--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -263,8 +263,8 @@ class datetime(UIElement[Optional[str], Optional[dt.datetime]]):
             initial_value=value.isoformat(timespec="seconds"),
             label=label,
             args={
-                "start": self._start.strftime(self.DATETIME_FORMAT),
-                "stop": self._stop.strftime(self.DATETIME_FORMAT),
+                "start": self._start.isoformat(timespec="seconds"),
+                "stop": self._stop.isoformat(timespec="seconds"),
                 "full-width": full_width,
                 "disabled": disabled,
             },


### PR DESCRIPTION
Fixes #6700

## Summary

`mo.ui.datetime` elements now render correctly in Docker containers by using ISO 8601 compliant date formatting instead of platform-dependent `strftime()`.

## Description of Changes

The datetime UI element was failing to render in Docker containers with the error:
```
Uncaught Error: Invalid ISO 8601 date time string: 1-01-01T00:00:00
```

The root cause was in `marimo/_plugins/ui/_impl/dates.py:266-267`, where `strftime()` was used to format `datetime.min` and `datetime.max` values. The `strftime()` function is platform/locale-dependent and doesn't guarantee 4-digit year padding. In some Docker environments, `datetime.min.strftime("%Y-%m-%dT%H:%M:%S")` produced `"1-01-01T00:00:00"` instead of the ISO 8601 compliant `"0001-01-01T00:00:00"`, causing the frontend's `parseDateTime()` to fail.

This PR replaces `strftime()` with `isoformat(timespec="seconds")` for formatting start/stop datetime values, ensuring consistent, platform-independent ISO 8601 formatting across all environments.
