### PR TITLE
fix: respect holoviews hv.output() settings when rendering in marimo

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -220,6 +220,7 @@ class DependencyManager:
     google_ai = Dependency("google.genai")
     groq = Dependency("groq")
     panel = Dependency("panel")
+    holoviews = Dependency("holoviews")
     sqlalchemy = Dependency("sqlalchemy")
     pylsp = Dependency("pylsp")
     basedpyright = Dependency("basedpyright")

--- a/marimo/_smoke_tests/third_party/holoviews_output_options.py
+++ b/marimo/_smoke_tests/third_party/holoviews_output_options.py
@@ -1,0 +1,49 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "holoviews==1.21.0",
+#     "hvplot==0.12.1",
+#     "netcdf4==1.7.2",
+#     "pooch==1.8.2",
+#     "xarray==2025.9.0",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.15.2"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _():
+    import xarray as xr
+    import hvplot.xarray  # noqa: F401
+    import holoviews as hv
+
+    hv.extension('bokeh')
+    hv.output(widget_location='top')
+
+    air_ds = xr.tutorial.open_dataset('air_temperature').load()
+    air_ds.air.hvplot.image()
+    return air_ds, hv, xr
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #6314

## Summary

HoloViews display output options set via `hv.output(**kwargs)` (like `widget_location='top'`) now apply correctly when rendering HoloViews objects in marimo notebooks.

## Description of Changes

The issue was that `hv.output()` settings were being ignored when marimo rendered HoloViews objects. This happened because marimo uses Panel to render HoloViews objects (via `pn.panel()`), but the HoloViews renderer settings weren't being passed through to Panel.
