### PR TITLE
fix: format OpenAPI generated files after codegen in build script

### DIFF
--- a/scripts/buildfrontend.sh
+++ b/scripts/buildfrontend.sh
@@ -10,6 +10,8 @@ else
 fi
 
 if $cmd; then
+  echo "Formatting generated OpenAPI client..."
+  pnpm format packages/openapi/
   echo "Removing old static files..."
   rm -rf marimo/_static/
   echo "Copying new static files..."


### PR DESCRIPTION
## Summary
- Adds `pnpm format packages/openapi/` to `buildfrontend.sh` after the turbo build completes
- Ensures generated OpenAPI client files (api.ts, session.ts, notebook.ts) match the formatting of tracked files
- Prevents dirty working tree after running `make fe`

## Background
The `make fe` command runs `buildfrontend.sh`, which invokes `pnpm turbo build`. This triggers the `codegen` task which regenerates OpenAPI client files using `openapi-typescript`. However, these files are output in raw generator style (4-space indentation, unions collapsed to one line), while the tracked versions in the repository are properly formatted.

The `make fe-codegen` target already includes the formatting step (`pnpm format packages/openapi/`), but `make fe` was missing it, causing formatting diffs every time the build ran.

## Testing
- Verified that `make fe` now produces no git diffs for OpenAPI files
- Confirmed the build still completes successfully