### PR TITLE
Intentional sidebar ordering

### DIFF
--- a/frontend/src/components/editor/chrome/types.ts
+++ b/frontend/src/components/editor/chrome/types.ts
@@ -111,7 +111,7 @@ export const PANELS: PanelDescriptor[] = [
   },
   // Scratchpad is the only way users can
   // code without DAG restrictions, so it is
-  // priveleged.
+  // privileged.
   {
     type: "scratchpad",
     Icon: NotebookPenIcon,


### PR DESCRIPTION
Order panels in roughly decreasing order of importance as well as logically group them.

1. Must-have panels first.
2. Panels that can add cells to the editor.
3. Nice-to-have observability panels.

Remove the outline panel, since it is redundant with the floating outline in the editor.


<details>
<summary><strong>Before</strong></summary>
<img width="706" height="576" alt="image" src="https://github.com/user-attachments/assets/5b4e2a71-998b-4003-b931-af00b7604416" />
</details>

**This change:**
<img width="706" height="576" alt="image" src="https://github.com/user-attachments/assets/7e477a98-5676-4389-9e8c-7bd23a76605a" />
