### PR TITLE
Support initial selection in Plotly plots

### DIFF
--- a/marimo/_plugins/ui/_impl/plotly.py
+++ b/marimo/_plugins/ui/_impl/plotly.py
@@ -142,10 +142,44 @@ class plotly(UIElement[PlotlySelection, list[dict[str, Any]]]):
                 hasattr(selection, k) for k in ["x0", "x1", "y0", "y1"]
             ):
                 return
+
             initial_value["range"] = {
                 "x": [selection.x0, selection.x1],
                 "y": [selection.y0, selection.y1],
             }
+
+            # Find points within the selection range
+            selected_points = []
+            selected_indices = []
+
+            x_axes: list[go.layout.XAxis] = []
+            figure.for_each_xaxis(x_axes.append)
+            [x_axis] = x_axes if len(x_axes) == 1 else [None]
+            y_axes: list[go.layout.YAxis] = []
+            figure.for_each_yaxis(y_axes.append)
+            [y_axis] = y_axes if len(y_axes) == 1 else [None]
+
+            for trace in figure.data:
+                x_data = getattr(trace, "x", None)
+                y_data = getattr(trace, "y", None)
+                if x_data is None or y_data is None:
+                    continue
+                for point_idx, (x, y) in enumerate(zip(x_data, y_data)):
+                    if (
+                        selection.x0 <= x <= selection.x1
+                        and selection.y0 <= y <= selection.y1
+                    ):
+                        selected_points.append(
+                            {
+                                axis.title.text: val
+                                for axis, val in [(x_axis, x), (y_axis, y)]
+                                if axis and axis.title.text
+                            }
+                        )
+                        selected_indices.append(point_idx)
+
+            initial_value["points"] = selected_points
+            initial_value["indices"] = selected_indices
 
         figure.for_each_selection(add_selection)
 


### PR DESCRIPTION
## 📝 Summary

Fixes #6746 for Plotly (Altair issue unchanged)

## 🔍 Description of Changes

`mo.ui.plotly` supports plots having an initial selection made by Plotly'a `add_selection` method.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] I have added tests for the changes made.
  - Didn't find a plotly equivalent for `tests/_plugins/ui/_impl/test_altair_chart.py`. If there is one I'll gladly add a test
- [X] I have run the code and verified that it works as expected.