### PR TITLE
Do not merge cols when toggling from column width.

### DIFF
--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -1,6 +1,5 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
-import { usePrevious } from "@dnd-kit/utilities";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect } from "react";
@@ -101,13 +100,7 @@ export const EditApp: React.FC<AppProps> = ({
       "Untitled Notebook";
   }, [appConfig.app_title, filename]);
 
-  // Delete column breakpoints if app width changes from "columns"
-  const previousWidth = usePrevious(appConfig.width);
-  useEffect(() => {
-    if (previousWidth === "columns" && appConfig.width !== "columns") {
-      mergeAllColumns();
-    }
-  }, [appConfig.width, previousWidth, mergeAllColumns, numColumns]);
+
 
   const runStaleCells = useRunStaleCells();
   const runAllCells = useRunAllCells();

--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -100,8 +100,6 @@ export const EditApp: React.FC<AppProps> = ({
       "Untitled Notebook";
   }, [appConfig.app_title, filename]);
 
-
-
   const runStaleCells = useRunStaleCells();
   const runAllCells = useRunAllCells();
   const togglePresenting = useTogglePresenting();


### PR DESCRIPTION
## 📝 Summary

Retain column metadata on cells when switching from columns width to another width type in settings

Fixes #3543

## 🔍 Description of Changes

Remove the mergeAllColumn call in edit-app.txt on width change.

after toggling to medium width from columns
<img width="987" height="621" alt="image" src="https://github.com/user-attachments/assets/88a041bb-2f41-4faa-bc53-882b66e32e67" />

after toggling back to columns width

<img width="1314" height="413" alt="image" src="https://github.com/user-attachments/assets/4c870e6b-afea-46e6-976d-93ddf40160ec" />



## 📋 Checklist

- [x ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
