### PR TITLE
Switch to `msgspec_m` fork

### DIFF
--- a/marimo/_ai/_types.py
+++ b/marimo/_ai/_types.py
@@ -15,7 +15,7 @@ from typing import (
     cast,
 )
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo import _loggers
 from marimo._utils.parse_dataclass import parse_raw

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Mapping
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo import _loggers
 from marimo._ast.parse import ast_parse

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import click
-import msgspec
-import msgspec.json
+import msgspec_m as msgspec
+import msgspec_m.json
 
 from marimo._cli.print import orange
 from marimo._data.models import DataType
@@ -275,7 +275,7 @@ def _generate_server_api_schema() -> dict[str, Any]:
         error: MarimoError
         data_type: DataType
 
-    specs = msgspec.json.schema_components(
+    specs = msgspec_m.json.schema_components(
         MESSAGES + [KnownUnions],
         ref_template="#/components/schemas/{name}",
     )

--- a/marimo/_ipc/types.py
+++ b/marimo/_ipc/types.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import typing
 
-import msgspec
-import msgspec.json
+import msgspec_m as msgspec
+import msgspec_m.json
 
 from marimo._ast.cell import CellConfig
 from marimo._config.config import MarimoConfig
@@ -40,4 +40,4 @@ class KernelArgs(msgspec.Struct):
 
     @classmethod
     def decode_json(cls, buf: bytes) -> KernelArgs:
-        return msgspec.json.decode(buf, type=cls)
+        return msgspec_m.json.decode(buf, type=cls)

--- a/marimo/_messaging/cell_output.py
+++ b/marimo/_messaging/cell_output.py
@@ -7,7 +7,7 @@ import time
 from enum import Enum
 from typing import Any, Union
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._messaging.errors import Error
 from marimo._messaging.mimetypes import ConsoleMimeType, KnownMimeType

--- a/marimo/_messaging/completion_option.py
+++ b/marimo/_messaging/completion_option.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 
 class CompletionOption(msgspec.Struct):

--- a/marimo/_messaging/errors.py
+++ b/marimo/_messaging/errors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._runtime.dataflow import EdgeWithVar
 from marimo._types.ids import CellId_t

--- a/marimo/_messaging/msgspec_encoder.py
+++ b/marimo/_messaging/msgspec_encoder.py
@@ -10,8 +10,8 @@ from math import isnan
 from pathlib import PurePath
 from typing import Any
 
-import msgspec
-import msgspec.json
+import msgspec_m as msgspec
+import msgspec_m.json
 
 from marimo._dependencies.dependencies import DependencyManager
 
@@ -200,7 +200,7 @@ def enc_hook(obj: Any) -> Any:
     return repr(obj)
 
 
-_encoder = msgspec.json.Encoder(enc_hook=enc_hook, decimal_format="number")
+_encoder = msgspec_m.json.Encoder(enc_hook=enc_hook, decimal_format="number")
 
 
 def encode_json_bytes(obj: Any) -> bytes:

--- a/marimo/_messaging/ops.py
+++ b/marimo/_messaging/ops.py
@@ -19,7 +19,7 @@ from typing import (
 )
 from uuid import uuid4
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo import _loggers as loggers
 from marimo._ast.app_config import _AppConfig

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -7,7 +7,7 @@ import io
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 
-import msgspec
+import msgspec_m as msgspec
 import narwhals.stable.v2 as nw
 from narwhals.typing import IntoDataFrameT, IntoLazyFrameT
 

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -10,7 +10,7 @@ import typing
 from pathlib import Path
 from typing import Any, Callable, TypeVar
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo import _loggers
 from marimo._ast.cell import CellConfig

--- a/marimo/_runtime/packages/package_manager.py
+++ b/marimo/_runtime/packages/package_manager.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from typing import TYPE_CHECKING, Callable, Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo import _loggers
 from marimo._dependencies.dependencies import DependencyManager
@@ -127,7 +127,7 @@ class PackageManager(abc.ABC):
 
         if log_callback is None:
             # Original behavior - just run the command without capturing output
-            completed_process = subprocess.run(command)  # noqa: ASYNC101
+            completed_process = subprocess.run(command)
             return completed_process.returncode == 0
 
         # Stream output to both the callback and the terminal

--- a/marimo/_runtime/requests.py
+++ b/marimo/_runtime/requests.py
@@ -14,7 +14,7 @@ from typing import (
 )
 from uuid import uuid4
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._ast.app_config import _AppConfig
 from marimo._config.config import MarimoConfig

--- a/marimo/_secrets/models.py
+++ b/marimo/_secrets/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Literal
 
-import msgspec
+import msgspec_m as msgspec
 
 SecretProviderType = Literal["env", "dotenv"]
 

--- a/marimo/_server/api/endpoints/home.py
+++ b/marimo/_server/api/endpoints/home.py
@@ -178,7 +178,7 @@ async def tutorial(
                     schema:
                         $ref: "#/components/schemas/MarimoFile"
     """
-    import msgspec
+    import msgspec_m as msgspec
 
     # Create a new tutorial file and return the filepath
     try:

--- a/marimo/_server/errors.py
+++ b/marimo/_server/errors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import msgspec
+import msgspec_m as msgspec
 from starlette.exceptions import HTTPException
 from starlette.responses import JSONResponse
 

--- a/marimo/_server/models/completion.py
+++ b/marimo/_server/models/completion.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Literal, Optional, Union
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._ai._types import ChatMessage
 from marimo._server.ai.tools.types import ToolDefinition

--- a/marimo/_server/models/export.py
+++ b/marimo/_server/models/export.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 
 class ExportAsHTMLRequest(msgspec.Struct, rename="camel"):

--- a/marimo/_server/models/files.py
+++ b/marimo/_server/models/files.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._server.models.models import BaseResponse
 

--- a/marimo/_server/models/home.py
+++ b/marimo/_server/models/home.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._server.models.files import FileInfo
 from marimo._tutorials import Tutorial  # type: ignore

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from typing import Any, Literal, Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._ast.cell import CellConfig
 from marimo._runtime.requests import (

--- a/marimo/_server/models/packages.py
+++ b/marimo/_server/models/packages.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._runtime.packages.package_manager import PackageDescription
 

--- a/marimo/_server/models/secrets.py
+++ b/marimo/_server/models/secrets.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Marimo. All rights reserved.
 from __future__ import annotations
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._secrets.models import SecretKeysWithProvider, SecretProviderType
 

--- a/marimo/_server/responses.py
+++ b/marimo/_server/responses.py
@@ -8,7 +8,7 @@ import starlette.responses
 from marimo._messaging.msgspec_encoder import encode_json_bytes
 
 if TYPE_CHECKING:
-    import msgspec
+    import msgspec_m as msgspec
 
 
 class StructResponse(starlette.responses.Response):

--- a/marimo/_snippets/snippets.py
+++ b/marimo/_snippets/snippets.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Generator
 from pathlib import Path
 from typing import Any, Optional
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo import _loggers
 from marimo._ast.load import load_app

--- a/marimo/_sql/parse.py
+++ b/marimo/_sql/parse.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 from typing import Literal, Optional, Union
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo import _loggers
 from marimo._dependencies.dependencies import DependencyManager

--- a/marimo/_utils/dataclass_to_openapi.py
+++ b/marimo/_utils/dataclass_to_openapi.py
@@ -28,8 +28,8 @@ else:
 
 from typing import Sequence  # noqa: UP035
 
-import msgspec
-import msgspec.json
+import msgspec_m as msgspec
+import msgspec_m.json
 
 
 class PythonTypeToOpenAPI:
@@ -52,7 +52,7 @@ class PythonTypeToOpenAPI:
             Dict[str, Any]: The OpenAPI schema.
         """
         if type(py_type) is type(msgspec.Struct):
-            return msgspec.json.schema(py_type)["$defs"][py_type.__name__]  # type: ignore[no-any-return]
+            return msgspec_m.json.schema(py_type)["$defs"][py_type.__name__]  # type: ignore[no-any-return]
 
         origin = get_origin(py_type)
         optional_name_overrides = self.optional_name_overrides

--- a/marimo/_utils/msgspec_basestruct.py
+++ b/marimo/_utils/msgspec_basestruct.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import msgspec
+import msgspec_m as msgspec
 
 if TYPE_CHECKING:
     from pydantic import GetCoreSchemaHandler

--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -18,8 +18,8 @@ from typing import (
     get_type_hints,
 )
 
-import msgspec
-import msgspec.json
+import msgspec_m as msgspec
+import msgspec_m.json
 
 # Import NotRequired from typing_extensions for Python < 3.11
 if sys.version_info < (3, 11):
@@ -206,7 +206,7 @@ def _parse_msgspec(
     if isinstance(value, dict):
         return msgspec.convert(value, strict=strict, type=cls)
 
-    return msgspec.json.decode(value, strict=strict, type=cls)
+    return msgspec_m.json.decode(value, strict=strict, type=cls)
 
 
 def parse_raw(

--- a/pixi.lock
+++ b/pixi.lock
@@ -111,7 +111,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/48/f97f0920c20bc522c34f1eaec4c62d7a03c95c37da2dec858f65c8cb4325/loro-1.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/51/3f/afe76f8e2246ffbc867440cbcf90525264df0e658f8a5ca1f872b3f6192a/markdown-3.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d0/ef/c5422ce8af73928d194a6606f8ae36e93a52fd5e8df5abd366903a5ca8da/msgspec-0.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/03/13/d7f707a92fce3cfbb5095dea81c94e26fee3fa57a761f396bb1cee6c54a0/msgspec_m-0.19.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/50/3b/0e2c535c3e6970cfc5763b67f6cc31accaab35a7aa3e322fb6a12830450f/narwhals-2.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -208,7 +208,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/ee/7e042a13e93f09c24618dc804f01849735d81740f8b74827124ff7fc8396/loro-1.5.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/89/b0/1b9763938cfae12acf14b682fcf05c92855974d921a5a985ecc197d1c672/msgspec-0.19.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/0e/d6ace44429887a0a8381fbc887dc59061e5f96be8a64ba7ed60d6d581330/msgspec_m-0.19.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/7d/81/1cf7a468ef2f8e88266d5c3e5ab026a045aa76150e6640bfe9c5450a8c11/narwhals-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl
@@ -1101,7 +1101,7 @@ packages:
 - pypi: ./
   name: marimo
   version: 0.16.5
-  sha256: 00660bfd80ed86fe2742590ac0f59cbd50d764290e29293c6a16beb233d9632b
+  sha256: e4c4bc12febc3a8a910657fc38ab6d6bc3c9421af1f8acaa717d601e863d7700
   requires_dist:
   - click>=8.0,<9
   - jedi>=0.18.0
@@ -1120,7 +1120,7 @@ packages:
   - itsdangerous>=2.0.0
   - narwhals>=2.0.0
   - packaging
-  - msgspec>=0.19.0
+  - msgspec-m>=0.19.1
   - duckdb>=1.0.0 ; extra == 'sql'
   - polars[pyarrow]>=1.9.0 ; extra == 'sql'
   - sqlglot[rs]>=26.2.0 ; extra == 'sql'
@@ -1211,10 +1211,10 @@ packages:
   - pkg:pypi/more-itertools?source=hash-mapping
   size: 61359
   timestamp: 1745349566387
-- pypi: https://files.pythonhosted.org/packages/89/b0/1b9763938cfae12acf14b682fcf05c92855974d921a5a985ecc197d1c672/msgspec-0.19.0-cp312-cp312-macosx_11_0_arm64.whl
-  name: msgspec
-  version: 0.19.0
-  sha256: 43bbb237feab761b815ed9df43b266114203f53596f9b6e6f00ebd79d178cdf2
+- pypi: https://files.pythonhosted.org/packages/03/13/d7f707a92fce3cfbb5095dea81c94e26fee3fa57a761f396bb1cee6c54a0/msgspec_m-0.19.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: msgspec-m
+  version: 0.19.1
+  sha256: 1912ad1ab6ab2e29a63ebe22277b60d6da78466d16b2c8300294fd25471cb528
   requires_dist:
   - pyyaml ; extra == 'yaml'
   - tomli ; python_full_version < '3.11' and extra == 'toml'
@@ -1248,10 +1248,10 @@ packages:
   - tomli ; python_full_version < '3.11' and extra == 'dev'
   - tomli-w ; extra == 'dev'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/d0/ef/c5422ce8af73928d194a6606f8ae36e93a52fd5e8df5abd366903a5ca8da/msgspec-0.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: msgspec
-  version: 0.19.0
-  sha256: d911c442571605e17658ca2b416fd8579c5050ac9adc5e00c2cb3126c97f73bc
+- pypi: https://files.pythonhosted.org/packages/dc/0e/d6ace44429887a0a8381fbc887dc59061e5f96be8a64ba7ed60d6d581330/msgspec_m-0.19.1-cp312-cp312-macosx_11_0_arm64.whl
+  name: msgspec-m
+  version: 0.19.1
+  sha256: 073df7c7dac9137bd2e6511e65a029dff5f2252dc35d22b225f8150f89f20708
   requires_dist:
   - pyyaml ; extra == 'yaml'
   - tomli ; python_full_version < '3.11' and extra == 'toml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "narwhals>=2.0.0",
     # for packaging.version; not sure what the lower bound is.
     "packaging",
-    "msgspec>=0.19.0",
+    "msgspec_m>=0.19.1",
 ]
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/_messaging/test_messaging_errors.py
+++ b/tests/_messaging/test_messaging_errors.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._messaging.errors import (
     CycleError,

--- a/tests/_messaging/test_serde.py
+++ b/tests/_messaging/test_serde.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 
-import msgspec
+import msgspec_m as msgspec
 import pytest
 
 from marimo._messaging.ops import (

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-import msgspec
+import msgspec_m as msgspec
 import pytest
 
 from marimo._utils.platform import is_windows

--- a/tests/_server/api/endpoints/test_packages.py
+++ b/tests/_server/api/endpoints/test_packages.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import msgspec
+import msgspec_m as msgspec
 import pytest
 
 from marimo._runtime.packages.package_manager import PackageManager

--- a/tests/_server/test_errors.py
+++ b/tests/_server/test_errors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import msgspec
+import msgspec_m as msgspec
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 

--- a/tests/_utils/snapshots/complex_project_tree_from_raw.json
+++ b/tests/_utils/snapshots/complex_project_tree_from_raw.json
@@ -322,7 +322,7 @@
                 },
                 {
                   "name": "h11",
-                  "version": "0.0.0",
+                  "version": "0.16.0",
                   "tags": [],
                   "dependencies": []
                 }

--- a/tests/_utils/test_msgspec_basestruct.py
+++ b/tests/_utils/test_msgspec_basestruct.py
@@ -1,6 +1,6 @@
 import typing as t
 
-import msgspec
+import msgspec_m as msgspec
 
 from marimo._ai._tools.tools.cells import (
     GetCellRuntimeDataArgs,

--- a/tests/_utils/test_parse_dataclass.py
+++ b/tests/_utils/test_parse_dataclass.py
@@ -17,7 +17,7 @@ from typing import (
     Union,
 )
 
-import msgspec
+import msgspec_m as msgspec
 import pytest
 
 from marimo._config.config import ExperimentalConfigType

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,7 @@ from marimo._utils.parse_dataclass import parse_raw
 if TYPE_CHECKING:
     from typing import Callable
 
-    import msgspec
+    import msgspec_m as msgspec
 
 
 def try_assert_n_times(n: int, assert_fn: Callable[[], None]) -> None:


### PR DESCRIPTION
Switches off `msgspec` to our `msgspec_m` fork. The 3.14 wheels aren't on PyPI yet. I'll follow up with another PR adding a smoke test for running marimo cli without `--no-build`.

