### PR TITLE
Add CI workflow to test pre-built wheel installation

### DIFF
--- a/.github/workflows/test_no_build.yaml
+++ b/.github/workflows/test_no_build.yaml
@@ -7,10 +7,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/test_no_build.yaml
+      - pyproject.toml
+      - marimo/_cli/**
   pull_request:
     branches:
       - main
-  workflow_dispatch:
+    paths:
+      - .github/workflows/test_no_build.yaml
+      - pyproject.toml
+      - marimo/_cli/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This workflow verifies that marimo's wheel can be installed and run without requiring any build from source across Python 3.10-3.14. It uses `uv tool run --no-build` to ensure the wheel is truly standalone and doesn't depend on build tools being available at install time (only on ubuntu for now).
