### PR TITLE
fix empty submits and output area

### DIFF
--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -50,6 +50,7 @@ interface Props {
   enabled: boolean;
   triggerImmediately?: boolean;
   runCell: () => void;
+  outputArea?: "above" | "below";
   /**
    * Children shown when there is no completion
    */
@@ -74,6 +75,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
   enabled,
   triggerImmediately,
   runCell,
+  outputArea,
   children,
 }) => {
   const [showInputPrompt, setShowInputPrompt] = useState(false);
@@ -94,6 +96,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
     setCompletion,
     setInput,
     handleSubmit,
+    complete,
   } = useCompletion({
     api: runtimeManager.getAiURL("completion").toString(),
     headers: runtimeManager.headers(),
@@ -128,7 +131,8 @@ export const AiCompletionEditor: React.FC<Props> = ({
 
   const initialSubmit = useCallback(() => {
     if (triggerImmediately && !isLoading && initialPrompt) {
-      handleSubmit();
+      // Use complete to pass the prompt directly, else input might be empty
+      complete(initialPrompt);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [triggerImmediately]);
@@ -176,6 +180,27 @@ export const AiCompletionEditor: React.FC<Props> = ({
     enabled && triggerImmediately && (completion || isLoading);
 
   const showInput = enabled && (!triggerImmediately || showInputPrompt);
+
+  const completionBanner = (
+    <div
+      className={cn(
+        "w-full bg-(--cm-background) flex justify-center transition-all duration-300 ease-in-out overflow-hidden",
+        showCompletionBanner
+          ? "max-h-20 opacity-100 translate-y-0"
+          : "max-h-0 opacity-0 -translate-y-2",
+      )}
+    >
+      <CompletionBanner
+        status={isLoading ? "loading" : "generated"}
+        onAccept={handleAcceptCompletion}
+        onReject={handleDeclineCompletion}
+        showInputPrompt={showInputPrompt}
+        setShowInputPrompt={setShowInputPrompt}
+        runCell={runCell}
+        className="mt-4 mb-3 w-128"
+      />
+    </div>
+  );
 
   return (
     <div className={cn("flex flex-col w-full rounded-[inherit]", className)}>
@@ -292,6 +317,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
           </>
         )}
       </div>
+      {outputArea === "above" && completionBanner}
       {completion && enabled && (
         <CodeMirrorMerge className="cm" theme={theme}>
           <Original
@@ -308,24 +334,8 @@ export const AiCompletionEditor: React.FC<Props> = ({
         </CodeMirrorMerge>
       )}
       {(!completion || !enabled) && children}
-      <div
-        className={cn(
-          "w-full bg-(--cm-background) flex justify-center transition-all duration-300 ease-in-out overflow-hidden",
-          showCompletionBanner
-            ? "max-h-20 opacity-100 translate-y-0"
-            : "max-h-0 opacity-0 -translate-y-2",
-        )}
-      >
-        <CompletionBanner
-          status={isLoading ? "loading" : "generated"}
-          onAccept={handleAcceptCompletion}
-          onReject={handleDeclineCompletion}
-          showInputPrompt={showInputPrompt}
-          setShowInputPrompt={setShowInputPrompt}
-          runCell={runCell}
-          className="mt-4 mb-3 w-128"
-        />
-      </div>
+      {/* By default, show the completion banner below the code */}
+      {(outputArea === "below" || !outputArea) && completionBanner}
     </div>
   );
 };

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -67,6 +67,7 @@ export interface CellEditorProps
   // DOM node where the editorView will be mounted
   editorViewParentRef?: React.RefObject<HTMLDivElement | null>;
   showHiddenCode: (opts?: { focus?: boolean }) => void;
+  outputArea?: "above" | "below";
 }
 
 const CellEditorInternal = ({
@@ -88,6 +89,7 @@ const CellEditorInternal = ({
   languageAdapter,
   setLanguageAdapter,
   showLanguageToggles = true,
+  outputArea,
 }: CellEditorProps) => {
   const [aiCompletionCell, setAiCompletionCell] = useAtom(aiCompletionCellAtom);
   const deleteCell = useDeleteCellCallback();
@@ -435,6 +437,7 @@ const CellEditorInternal = ({
         setAiCompletionCell(null);
       })}
       runCell={handleRunCell}
+      outputArea={outputArea}
     >
       <div className="relative w-full" {...navigationProps}>
         {showHideButton && (

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -628,6 +628,7 @@ const EditableCellComponent = ({
                 showHiddenCode={showHiddenCode}
                 languageAdapter={languageAdapter}
                 setLanguageAdapter={setLanguageAdapter}
+                outputArea={cellOutput}
               />
               <CellRightSideActions
                 className={cn(


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

There was an issue on browser refresh where `Fix with AI` wouldn't do anything, it's because input is empty. We now use the `complete` API to force set the input state and trigger completion.

Also for outputArea above, we put the banner at the top of the cell instead of at the bottom.

![CleanShot 2025-10-15 at 22 33 26](https://github.com/user-attachments/assets/1fe5cfbe-fbc8-418d-977f-c2d10ffec7a3)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
