### PR TITLE
fix: watch for file move with watchdog and Claude Code

### DIFF
--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -1199,6 +1199,11 @@ class SessionFileChangeHandler:
         # Get the latest codes
         codes = list(session.app_file_manager.app.cell_manager.codes())
         cell_ids = list(session.app_file_manager.app.cell_manager.cell_ids())
+
+        LOGGER.info(
+            f"File changed: {file_path}. num_cell_ids: {len(cell_ids)}, num_codes: {len(codes)}, changed_cell_ids: {changed_cell_ids}"
+        )
+
         # Send the updated cell ids and codes to the frontend
         session.write_operation(
             UpdateCellIdsRequest(cell_ids=cell_ids),

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -15,8 +15,6 @@ from textwrap import dedent
 from typing import Any, Callable, TypeVar
 from unittest.mock import MagicMock
 
-import pytest
-
 from marimo._ast.app import App, InternalApp
 from marimo._ast.app_config import _AppConfig
 from marimo._config.manager import (
@@ -438,10 +436,6 @@ def test_session_with_kiosk_consumers() -> None:
     assert session.room.main_consumer is None
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="This test is flaky on Python 3.9",
-)
 @save_and_restore_main
 async def test_session_manager_file_watching(tmp_path: Path) -> None:
     # Create a temporary file
@@ -659,10 +653,6 @@ def test_watch_mode_does_not_override_config(tmp_path: Path) -> None:
         session_manager_no_watch.shutdown()
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="This test is flaky on Python 3.9",
-)
 @save_and_restore_main
 async def test_watch_mode_with_watcher_on_save_config() -> None:
     """Test that watch mode works correctly with watcher_on_save config."""
@@ -814,10 +804,6 @@ def __():
         os.remove(tmp_path)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="This test is flaky on Python 3.9",
-)
 @save_and_restore_main
 async def test_session_manager_file_rename() -> None:
     """Test that file renaming works correctly with file watching."""

--- a/tests/_utils/test_async_path.py
+++ b/tests/_utils/test_async_path.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -416,10 +415,6 @@ class TestAsyncPathThreading:
 
 
 class TestAsyncPathEdgeCases:
-    @pytest.mark.skipif(
-        sys.version_info < (3, 10),
-        reason="Hardlink requires Python 3.10 or higher",
-    )
     async def test_hardlink_to(self):
         """Test hardlink_to creates hard link."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -436,10 +431,6 @@ class TestAsyncPathEdgeCases:
             target_stat = await target.stat()
             assert source_stat.st_ino == target_stat.st_ino
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 10),
-        reason="Hardlink requires Python 3.10 or higher",
-    )
     async def test_write_text_with_newline(self):
         """Test write_text with custom newline parameter."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import difflib
 import re
-import sys
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Callable
@@ -102,15 +101,6 @@ def snapshotter(current_file: str) -> Callable[[str, str], None]:
             )
 
             if result != expected:
-                # Old versions of markdown are allowed to have different
-                # tags and whitespace
-                if sys.version_info < (3, 10):
-                    if ToText.apply(result) == ToText.apply(expected):
-                        pytest.xfail(
-                            "Different tags in older markdown versions"
-                        )
-                        return
-
                 write_result()
                 print("Snapshot updated")
 


### PR DESCRIPTION
This pull request improves the file watching functionality to better support editors that save files by moving temporary files into place, such as Claude Code and some vim configurations. 

Fixes https://github.com/marimo-team/marimo/issues/6784