### PR TITLE
Inherit cell type when creating new cells with Shift+Enter

### DIFF
--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -2288,6 +2288,63 @@ describe("cell reducer", () => {
       expect(focusSpy).not.toHaveBeenCalled();
       expect(state.cellIds.inOrderIds).toEqual(initialState.cellIds.inOrderIds);
     });
+
+    it("creates a new SQL cell when moving after a SQL cell", () => {
+      // Create a SQL cell
+      actions.createNewCell({
+        cellId: "__end__",
+        before: false,
+        code: `_df = mo.sql(f"""SELECT * FROM table""")`,
+      });
+
+      const sqlCellId =
+        state.cellIds.inOrderIds[state.cellIds.inOrderIds.length - 1];
+      const initialCellCount = state.cellIds.inOrderIds.length;
+
+      // Move to next cell (should create a new SQL cell)
+      actions.moveToNextCell({
+        cellId: sqlCellId,
+        before: false,
+        noCreate: false,
+      });
+
+      expect(state.cellIds.inOrderIds.length).toBe(initialCellCount + 1);
+      const newCellId =
+        state.cellIds.inOrderIds[state.cellIds.inOrderIds.length - 1];
+      const newCell = state.cellData[newCellId];
+
+      // The new cell should have SQL code (mo.sql)
+      expect(newCell.code).toContain("mo.sql");
+      expect(newCell.code).toContain("_df");
+    });
+
+    it("creates a new Python cell when moving after a Python cell", () => {
+      // Create a Python cell
+      actions.createNewCell({
+        cellId: "__end__",
+        before: false,
+        code: "x = 1",
+      });
+
+      const pythonCellId =
+        state.cellIds.inOrderIds[state.cellIds.inOrderIds.length - 1];
+      const initialCellCount = state.cellIds.inOrderIds.length;
+
+      // Move to next cell (should create a new Python cell)
+      actions.moveToNextCell({
+        cellId: pythonCellId,
+        before: false,
+        noCreate: false,
+      });
+
+      expect(state.cellIds.inOrderIds.length).toBe(initialCellCount + 1);
+      const newCellId =
+        state.cellIds.inOrderIds[state.cellIds.inOrderIds.length - 1];
+      const newCell = state.cellData[newCellId];
+
+      // The new cell should be empty (default Python cell)
+      expect(newCell.code).toBe("");
+    });
   });
 
   describe("untouched cells functionality", () => {


### PR DESCRIPTION
## 📝 Summary

When pressing Shift+Enter on a SQL cell, the new cell now inherits the SQL type instead of defaulting to Python. This maintains workflow momentum when chaining SQL queries.

Fixes marimo-team/marimo#6790

## 🔍 Description of Changes

Problem: Shift+Enter on SQL cells created Python cells, breaking the flow.

Solution: Modified moveToNextCell in cells.ts to detect SQL cells and create new SQL cells with default boilerplate.

Changes:

* Added getNewCellCode() helper that checks cell type using LanguageAdapters.sql.isSupported()
* SQL cells create SQL cells; Python cells remain empty (unchanged behavior)
* Added two tests for SQL and Python cell behavior
* Before: SQL cell → Shift+Enter → Empty Python cell ❌
* After: SQL cell → Shift+Enter → SQL cell with mo.sql() ✅

## 📋 Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [X] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.