### PR TITLE
fix: hide invalid options on setup cell context menu

### DIFF
--- a/frontend/src/components/editor/actions/useCellActionButton.tsx
+++ b/frontend/src/components/editor/actions/useCellActionButton.tsx
@@ -398,9 +398,8 @@ export function useCellActionButtons({ cell, closePopover }: Props) {
         icon: <Columns2Icon size={13} strokeWidth={1.5} />,
         label: "Break into new column",
         hotkey: "cell.addColumnBreakpoint",
-        hidden: appWidth !== "columns",
         handle: () => addColumnBreakpoint({ cellId }),
-        hidden: isSetupCell,
+        hidden: appWidth !== "columns" || isSetupCell,
       },
     ],
 


### PR DESCRIPTION
## 📝 Summary

Closes #5965 

<img width="323" height="341" alt="image" src="https://github.com/user-attachments/assets/2464a89f-bb9b-4494-86da-f09e878843d9" />

Removes actions on setup cell that are invalid (like cell movement)