### PR TITLE
add duplicate selection shortcut to hotkeys as part of editing command

### DIFF
--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -239,13 +239,13 @@ const DEFAULT_HOT_KEY = {
     group: "Editing",
     key: "F2",
   },
-  "cell.copyLinesUp": {
+  "cell.copyLineUp": {
     name: "Copy line(s) up",
     group: "Editing",
     key: "Alt-Shift-ArrowUp",
     editable: false,
   },
-  "cell.copyLinesDown": {
+  "cell.copyLineDown": {
     name: "Copy line(s) down",
     group: "Editing",
     key: "Alt-Shift-ArrowDown",


### PR DESCRIPTION

## 📝 Summary

Fixes #6338 


## 🔍 Description of Changes

Adds an additional keyboard hotkey (that can be modified) for the duplicate selection shortcut and is visible from user settings under Editing (see below for screenshot of the change). The name is modified from copy line down since it technically copies the entire selection and not just a specific line on execution. 

<img width="942" height="125" alt="Screenshot_20251020_121742" src="https://github.com/user-attachments/assets/668687a1-7109-454a-855f-437ebc6c599b" />

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
