### PR TITLE
chore(sql-parser): mark `commentLines` as readonly in SQLMetadata

### DIFF
--- a/packages/smart-cells/src/parsers/sql-parser.ts
+++ b/packages/smart-cells/src/parsers/sql-parser.ts
@@ -19,7 +19,7 @@ import {
 export interface SQLMetadata {
   dataframeName: string;
   quotePrefix: QuotePrefixKind;
-  commentLines: string[];
+  commentLines: readonly string[];
   showOutput: boolean;
   engine: string;
 }


### PR DESCRIPTION
This change updates the SQLMetadata interface to accept readonly arrays for `commentLines`. The field isn't mutated, so this relaxes typing without affecting behavior. (works nicer with Effect's structs in VS Code)