### PR TITLE
fix column names that are not stringed in tables

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -149,8 +149,9 @@ class TableManager(abc.ABC, Generic[T]):
         pass
 
     def get_field_types(self) -> FieldTypes:
+        # Some column names may be non-string (sqlalchemy quoted names), so we convert them to strings
         return [
-            (column_name, self.get_field_type(column_name))
+            (str(column_name), self.get_field_type(column_name))
             for column_name in self.get_column_names()
         ]
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Fixes #6861. 
Couldn't write a test because they pass regardless of this fix.

sqlachemy has a `column_name` type where the column name is an object instead of string.
this change forces it to be a string.

original column type
![CleanShot 2025-10-22 at 13 56 41](https://github.com/user-attachments/assets/54cf8f68-6ac5-4394-b60f-32034e25f52a)

fixed
![CleanShot 2025-10-22 at 13 57 14](https://github.com/user-attachments/assets/823079e6-3b8f-4aff-8b7b-91bc84adae45)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
