### PR TITLE
Fix typo introduced during refactoring

### DIFF
--- a/marimo/_server/sessions.py
+++ b/marimo/_server/sessions.py
@@ -194,7 +194,7 @@ class KernelManager:
     def start_kernel(self) -> None:
         # We use a process in edit mode so that we can interrupt the app
         # with a SIGINT; we don't mind the additional memory consumption,
-        # since there's only one client sess
+        # since there's only one client session
         is_edit_mode = self.mode == SessionMode.EDIT
         listener = None
         if is_edit_mode:


### PR DESCRIPTION
Seems like the word got cut off in 3fbee7a7ff4ee100dd7c36b1b9f2422fc859ae87

## 📝 Summary

I found a cut off word in a comment and fixed it.

## 🔍 Description of Changes

I found a cut off word in a comment, wondered if while being cut off, some other important content got cut off along with it. Doesn't seem like it, but I try to fix things when I see them even if it is probably not utterly important.

## 📋 Checklist

No code changed, just comment.

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
