### PR TITLE
improvement: avoid full width for column faceted charts

### DIFF
--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -612,6 +612,13 @@ def maybe_make_full_width(chart: AltairChartType) -> AltairChartType:
             isinstance(chart, (alt.Chart, alt.LayerChart))
             and chart.width is alt.Undefined
         ):
+            # Don't make full width if chart has column encoding (faceted)
+            if (
+                hasattr(chart, "encoding")
+                and hasattr(chart.encoding, "column")
+                and chart.encoding.column is not alt.Undefined
+            ):
+                return chart
             return chart.properties(width="container")
         return chart
     except Exception:

--- a/marimo/_smoke_tests/altair_examples/column_facet.py
+++ b/marimo/_smoke_tests/altair_examples/column_facet.py
@@ -1,0 +1,52 @@
+import marimo
+
+__generated_with = "0.17.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _():
+    import altair as alt
+    from vega_datasets import data
+
+    source = data.barley()
+    chart = (
+        alt.Chart(source)
+        .mark_bar()
+        .encode(
+            x="year:O",
+            y="sum(yield):Q",
+            color="year:N",
+            column="site:N",
+        )
+    )
+    chart
+    return (chart,)
+
+
+@app.cell
+def _(chart, mo):
+    mo.ui.altair_chart(chart)
+    return
+
+
+@app.cell
+def _(chart):
+    chart.encoding.column
+    return
+
+
+@app.cell
+def _(chart):
+    type(chart).mro()
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_plugins/ui/_impl/test_altair_chart.py
+++ b/tests/_plugins/ui/_impl/test_altair_chart.py
@@ -1069,3 +1069,35 @@ def test_update_vconcat_width() -> None:
     updated_hconcat = _update_vconcat_width(hconcat_chart)
     assert updated_hconcat.hconcat[0].width == "container"
     assert updated_hconcat.hconcat[1].width == "container"
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_chart_with_column_encoding_not_full_width() -> None:
+    import altair as alt
+
+    from marimo._plugins.ui._impl.altair_chart import maybe_make_full_width
+
+    # Create a chart with column encoding (faceted chart)
+    data = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4],
+            "y": [4, 5, 6, 7],
+            "category": ["A", "B", "A", "B"],
+        }
+    )
+    chart = (
+        alt.Chart(data)
+        .mark_point()
+        .encode(x="x:Q", y="y:Q", column="category:N")
+    )
+
+    # Test that chart with column encoding is NOT made full width
+    result = maybe_make_full_width(chart)
+    assert result.width is alt.Undefined
+
+    # Test that chart without column encoding IS made full width
+    chart_without_column = (
+        alt.Chart(data).mark_point().encode(x="x:Q", y="y:Q")
+    )
+    result_without_column = maybe_make_full_width(chart_without_column)
+    assert result_without_column.width == "container"


### PR DESCRIPTION
Fixes #6865

Column faceted charts don't play nicely with `width="container"`, so we should skip adding that as default. 

Can be tested with:

```python
import altair as alt
from vega_datasets import data

source = data.barley()
chart = (
    alt.Chart(source)
    .mark_bar()
    .encode(
        x="year:O",
        y="sum(yield):Q",
        color="year:N",
        column="site:N",
    )
)
chart
```