### PR TITLE
fix wrapping on long text in tables

### DIFF
--- a/frontend/src/components/data-table/column-wrapping/feature.ts
+++ b/frontend/src/components/data-table/column-wrapping/feature.ts
@@ -13,6 +13,8 @@ import type {
   ColumnWrappingTableState,
 } from "./types";
 
+export const COLUMN_WRAPPING_STYLES = "whitespace-pre-wrap min-w-[200px]";
+
 export const ColumnWrappingFeature: TableFeature = {
   getInitialState: (state): ColumnWrappingTableState => {
     return {

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -21,6 +21,7 @@ import { Tooltip } from "../ui/tooltip";
 import { DataTableColumnHeader } from "./column-header";
 import type { ColumnChartSpecModel } from "./column-summary/chart-spec-model";
 import { TableColumnSummary } from "./column-summary/column-summary";
+import { COLUMN_WRAPPING_STYLES } from "./column-wrapping/feature";
 import { DatePopover } from "./date-popover";
 import type { FilterType } from "./filters";
 import { getMimeValues, MimeCell } from "./mime-cell";
@@ -315,6 +316,7 @@ const PopoutColumn = ({
   rawStringValue,
   contentClassName,
   buttonText,
+  wrapped,
   children,
 }: {
   cellStyles?: string;
@@ -322,6 +324,7 @@ const PopoutColumn = ({
   rawStringValue: string;
   contentClassName?: string;
   buttonText?: string;
+  wrapped?: boolean;
   children: React.ReactNode;
 }) => {
   return (
@@ -336,7 +339,10 @@ const PopoutColumn = ({
           }}
         >
           <span
-            className="cursor-pointer hover:text-link"
+            className={cn(
+              "cursor-pointer hover:text-link",
+              wrapped && COLUMN_WRAPPING_STYLES,
+            )}
             title={rawStringValue}
           >
             {rawStringValue}
@@ -408,7 +414,7 @@ function getCellStyleClass(
     "truncate",
     justify === "center" && "text-center",
     justify === "right" && "text-right",
-    wrapped && "whitespace-pre-wrap min-w-[200px] break-words",
+    wrapped && `${COLUMN_WRAPPING_STYLES} break-words`,
   );
 }
 
@@ -517,6 +523,7 @@ export function renderCellValue<TData, TValue>({
         rawStringValue={stringValue}
         contentClassName="max-h-64 overflow-auto whitespace-pre-wrap break-words text-sm"
         buttonText="X"
+        wrapped={column.getColumnWrapping?.() === "wrap"}
       >
         <UrlDetector parts={parts} />
       </PopoutColumn>
@@ -558,6 +565,7 @@ export function renderCellValue<TData, TValue>({
         cellStyles={cellStyles}
         selectCell={selectCell}
         rawStringValue={rawStringValue}
+        wrapped={column.getColumnWrapping?.() === "wrap"}
       >
         <JsonOutput data={value} format="tree" className="max-h-64" />
       </PopoutColumn>

--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { cn } from "@/utils/cn";
+import { COLUMN_WRAPPING_STYLES } from "./column-wrapping/feature";
 import { CellRangeSelectionIndicator } from "./range-focus/cell-selection-indicator";
 import { useCellRangeSelection } from "./range-focus/use-cell-range-selection";
 import { useScrollIntoViewOnFocus } from "./range-focus/use-scroll-into-view";
@@ -130,8 +131,8 @@ export const DataTableBody = <TData,>({
           className={cn(
             "whitespace-pre truncate max-w-[300px] outline-hidden",
             cell.column.getColumnWrapping &&
-              cell.column.getColumnWrapping() === "wrap" &&
-              "whitespace-pre-wrap min-w-[200px]",
+              cell.column.getColumnWrapping?.() === "wrap" &&
+              COLUMN_WRAPPING_STYLES,
             "px-1.5 py-[0.18rem]",
             className,
           )}


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
There is a bug with wrap text on large strings. This fixes it, whenever wrap is turned on, we display normally (not popout component).

Also included is a fix for `w-full` instead of `w-fit`, which ensures long text have ellipsis when overflowed.

https://github.com/user-attachments/assets/10726bcb-2754-4e4c-b00c-cdfa8be413f9

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
