### PR TITLE
improve: respect current Python version for sandbox

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import atexit
 import os
+import platform
 import signal
 import subprocess
 import sys
@@ -259,27 +260,26 @@ def construct_uv_flags(
     if len(additional_deps) > 0:
         uv_flags.extend(["--with", ",".join(additional_deps)])
 
-    # Add refresh
     if uv_needs_refresh:
         uv_flags.append("--refresh")
 
-    # Add Python version if specified
+    # We use the specified Python version (if any), otherwise
+    # the current Python version
     python_version = pyproject.python_version
     if python_version:
         uv_flags.extend(["--python", python_version])
+    else:
+        uv_flags.extend(["--python", platform.python_version()])
 
-    # Add index URL if specified
     index_url = pyproject.index_url
     if index_url:
         uv_flags.extend(["--index-url", index_url])
 
-    # Add extra-index-urls if specified
     extra_index_urls = pyproject.extra_index_urls
     if extra_index_urls:
         for url in extra_index_urls:
             uv_flags.extend(["--extra-index-url", url])
 
-    # Add index configs if specified
     index_configs = pyproject.index_configs
     if index_configs:
         for config in index_configs:

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -483,3 +483,28 @@ def test_should_run_in_sandbox_dangerous_sandbox(tmp_path: Path) -> None:
             name=str(dir_path),
         )
         assert result
+
+
+def test_construct_uv_cmd_without_python_version(tmp_path: Path) -> None:
+    """Test that current Python version is used when not specified."""
+    import platform
+
+    # Create a script without requires-python
+    script_path = tmp_path / "test.py"
+    script_path.write_text(
+        """
+# /// script
+# dependencies = ["numpy"]
+# ///
+import marimo
+    """
+    )
+    uv_cmd = construct_uv_command(
+        ["edit", str(script_path)],
+        str(script_path),
+        additional_features=[],
+        additional_deps=[],
+    )
+    assert "--python" in uv_cmd
+    python_idx = uv_cmd.index("--python")
+    assert uv_cmd[python_idx + 1] == platform.python_version()


### PR DESCRIPTION
When --sandbox is used but no Python version is specified in the notebook file, respect the current Python version. This is useful when creating new notebooks with

```
uvx --python 3.13 marimo edit --sandbox my_notebook.py
```

which is itself useful since many packages do not yet work in 3.14.