### PR TITLE
fix: add new backend tools to basestruct test

### DIFF
--- a/tests/_utils/test_msgspec_basestruct.py
+++ b/tests/_utils/test_msgspec_basestruct.py
@@ -3,12 +3,12 @@ import typing as t
 import msgspec
 
 from marimo._ai._tools.tools.cells import (
+    GetCellOutputArgs,
+    GetCellOutputOutput,
     GetCellRuntimeDataArgs,
     GetCellRuntimeDataOutput,
     GetLightweightCellMapArgs,
     GetLightweightCellMapOutput,
-    GetCellOutputArgs,
-    GetCellOutputOutput,
 )
 from marimo._ai._tools.tools.datasource import (
     GetDatabaseTablesArgs,
@@ -18,16 +18,16 @@ from marimo._ai._tools.tools.errors import (
     GetNotebookErrorsArgs,
     GetNotebookErrorsOutput,
 )
+from marimo._ai._tools.tools.lint import (
+    LintNotebookArgs,
+    LintNotebookOutput,
+)
 from marimo._ai._tools.tools.notebooks import (
     GetActiveNotebooksOutput,
 )
 from marimo._ai._tools.tools.tables_and_variables import (
     TablesAndVariablesArgs,
     TablesAndVariablesOutput,
-)
-from marimo._ai._tools.tools.lint import (
-    LintNotebookArgs,
-    LintNotebookOutput,
 )
 
 TOOL_IO_CLASSES = [


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
This adds new tests backend tools to the basestruct test which checks if any variables in the args or output are using BaseStruct instead of msgspec.Struct (which is not pydantic compatible and will throw a type error)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
