### PR TITLE
fix: add back floating outline

### DIFF
--- a/frontend/src/core/dom/__tests__/outline.test.ts
+++ b/frontend/src/core/dom/__tests__/outline.test.ts
@@ -137,6 +137,49 @@ describe("parseOutline", () => {
     `);
   });
 
+  it("can parse markdown outline", () => {
+    const markdown = `
+    <span class="markdown">
+      <h1 id="introduction">Introduction</h1>
+      <h2 id="getting-started">Getting Started</h2>
+      <h3 id="installation">Installation</h3>
+    </span>
+    `;
+    const outline = parseOutline({
+      mimetype: "text/markdown",
+      timestamp: 0,
+      channel: "output",
+      data: markdown,
+    });
+    expect(outline).toMatchInlineSnapshot(`
+      {
+        "items": [
+          {
+            "by": {
+              "id": "introduction",
+            },
+            "level": 1,
+            "name": "Introduction",
+          },
+          {
+            "by": {
+              "id": "getting-started",
+            },
+            "level": 2,
+            "name": "Getting Started",
+          },
+          {
+            "by": {
+              "id": "installation",
+            },
+            "level": 3,
+            "name": "Installation",
+          },
+        ],
+      }
+    `);
+  });
+
   it("can handle non-html outline", () => {
     const html = "foo";
     const outline = parseOutline({

--- a/frontend/src/core/dom/outline.ts
+++ b/frontend/src/core/dom/outline.ts
@@ -68,7 +68,7 @@ export function parseOutline(output: OutputMessage | null): Outline | null {
     return null;
   }
 
-  if (output.mimetype !== "text/html") {
+  if (output.mimetype !== "text/html" && output.mimetype !== "text/markdown") {
     return null;
   }
 


### PR DESCRIPTION
Fixes #6932

We moved markdown output from mime type `text/html` to `text/markdown` which broken some downstream logic