### PR TITLE
fix tests by casting enum to string for polars

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/polars_table.py
+++ b/marimo/_plugins/ui/_impl/tables/polars_table.py
@@ -154,6 +154,15 @@ class PolarsTableManagerFactory(TableManagerFactory):
                                 result, column
                             )
                             converted_columns.append(column.name)
+                        # https://github.com/marimo-team/marimo/issues/5562
+                        elif isinstance(dtype, pl.List) and isinstance(
+                            dtype.inner, (pl.Enum, pl.Categorical)
+                        ):
+                            # Convert each element in the list to a string
+                            result = result.with_columns(
+                                pl.col(column.name).cast(pl.List(pl.String))
+                            )
+                            converted_columns.append(column.name)
 
                     if converted_columns:
                         LOGGER.info(

--- a/tests/_plugins/ui/_impl/tables/test_polars_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_polars_table.py
@@ -982,3 +982,19 @@ class TestPolarsTableManagerFactory(unittest.TestCase):
         )
 
         data.write_json()
+
+    def test_to_json_enum_list_not_supported(self) -> None:
+        # When this is supported, we can remove the casting to string
+        import polars as pl
+
+        data = {"A": [["A", "B", "C"], ["A", "B", "C"], ["A", "B", "C"]]}
+
+        data_enum = pl.DataFrame(
+            data, schema={"A": pl.List(pl.Enum(categories=["A", "B", "C"]))}
+        )
+        with pytest.raises(pl.exceptions.PanicException):
+            data_enum.write_json()
+
+        data_list = pl.DataFrame(data, schema={"A": pl.List(pl.Categorical())})
+        with pytest.raises(pl.exceptions.PanicException):
+            data_list.write_json()


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #5562, casts enum[list] to string. There might be a regression in polars https://github.com/marimo-team/marimo/issues/5562, which caused our CI to fail. Reverting the change to an old fix

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
