### PR TITLE
fix: set initial mode for islands

### DIFF
--- a/frontend/src/core/islands/main.ts
+++ b/frontend/src/core/islands/main.ts
@@ -36,6 +36,7 @@ import {
 } from "../kernel/handlers";
 import { queryParamHandlers } from "../kernel/queryParamHandlers";
 import { RuntimeState } from "../kernel/RuntimeState";
+import { initialModeAtom } from "../mode";
 import type { RequestId } from "../network/DeferredRequestRegistry";
 import { requestClientAtom } from "../network/requests";
 import { store } from "../state/jotai";
@@ -57,6 +58,7 @@ import { dismissIslandsLoadingToast, toastIslandsLoading } from "./toast";
 export async function initialize() {
   // Setup networking
   store.set(requestClientAtom, IslandsPyodideBridge.INSTANCE);
+  store.set(initialModeAtom, "read");
 
   // This will display all the static HTML content.
   initializePlugins();

--- a/frontend/src/plugins/core/sanitize.ts
+++ b/frontend/src/plugins/core/sanitize.ts
@@ -18,7 +18,14 @@ const sanitizeHtmlAtom = atom<boolean>((get) => {
     return false;
   }
 
-  const isInAppMode = getInitialAppMode() === "read";
+  let isInAppMode = true;
+  try {
+    isInAppMode = getInitialAppMode() === "read";
+  } catch {
+    // If it fails to get the initial app mode, we default to sanitizing.
+    return true;
+  }
+
   // Apps need to run javascript and load external resources.
   if (isInAppMode) {
     return false;


### PR DESCRIPTION
Islands started to break without setting the initial app mode.