### PR TITLE
fix: chart sizing with nested hconcat in vconcat

### DIFF
--- a/frontend/src/plugins/impl/vega/vega.css
+++ b/frontend/src/plugins/impl/vega/vega.css
@@ -3,6 +3,7 @@
 .vega-embed {
   width: 100%;
   flex: 1;
+  display: inline-block;
 
   @media (min-width: 500px) {
     min-width: 300px;

--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -338,7 +338,9 @@ class altair_chart(UIElement[ChartSelection, ChartDataType]):
         chart = maybe_make_full_width(chart)
 
         # Fix the sizing for vconcat charts
-        if isinstance(chart, alt.VConcatChart):
+        if isinstance(chart, alt.VConcatChart) and _has_no_nested_hconcat(
+            chart
+        ):
             chart = _update_vconcat_width(chart)
 
             # without autosize, vconcat will overflow
@@ -699,3 +701,18 @@ def _update_vconcat_width(chart: AltairChartType) -> AltairChartType:
 
     # Not handled
     return chart
+
+
+def _has_no_nested_hconcat(chart: AltairChartType) -> bool:
+    import altair as alt
+
+    if isinstance(chart, alt.HConcatChart):
+        return False
+    if isinstance(chart, alt.VConcatChart):
+        return all(
+            _has_no_nested_hconcat(subchart) for subchart in chart.vconcat
+        )
+    if isinstance(chart, alt.LayerChart):
+        return all(_has_no_nested_hconcat(layer) for layer in chart.layer)
+
+    return True

--- a/marimo/_smoke_tests/altair_examples/hconcat_vconcat.py
+++ b/marimo/_smoke_tests/altair_examples/hconcat_vconcat.py
@@ -1,0 +1,225 @@
+import marimo
+
+__generated_with = "0.16.2"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    from vega_datasets import data
+    import altair as alt
+    import marimo as mo
+
+    cars = data.cars()
+
+    _chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .properties(height=100)
+    )
+    return alt, cars, mo
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""## vconcat with hconcat inside""")
+    return
+
+
+@app.cell
+def _(alt, cars):
+    _chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .properties(height=100)
+    )
+
+    stacked_chart = alt.vconcat(
+        alt.hconcat(
+            _chart,
+            _chart,
+        ),
+        _chart,
+    )
+    return (stacked_chart,)
+
+
+@app.cell
+def _(stacked_chart):
+    stacked_chart
+    return
+
+
+@app.cell
+def _(mo, stacked_chart):
+    mo.ui.altair_chart(stacked_chart.copy())
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""## Nested vconcat""")
+    return
+
+
+@app.cell
+def _(alt, cars):
+    _chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .properties(height=100)
+    )
+
+    stacked_chart1 = alt.vconcat(
+        _chart,
+        alt.vconcat(
+            _chart,
+            _chart,
+        ),
+    )
+
+    stacked_chart1
+    return (stacked_chart1,)
+
+
+@app.cell
+def _(mo, stacked_chart1):
+    mo.ui.altair_chart(stacked_chart1.copy())
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""## hconcat with vconcat inside""")
+    return
+
+
+@app.cell
+def _(alt, cars):
+    _chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .properties(height=100)
+    )
+
+    h_v_chart = alt.hconcat(
+        alt.vconcat(
+            _chart,
+            _chart,
+        ),
+        _chart,
+    )
+
+    h_v_chart
+    return (h_v_chart,)
+
+
+@app.cell
+def _(h_v_chart, mo):
+    mo.ui.altair_chart(h_v_chart.copy())
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""## Nested hconcat""")
+    return
+
+
+@app.cell
+def _(alt, cars):
+    _chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .properties(height=100)
+    )
+
+    nested_h_chart = alt.hconcat(
+        _chart,
+        alt.hconcat(
+            _chart,
+            _chart,
+        ),
+    )
+
+    nested_h_chart
+    return (nested_h_chart,)
+
+
+@app.cell
+def _(mo, nested_h_chart):
+    mo.ui.altair_chart(nested_h_chart.copy())
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""## Complex nested combination""")
+    return
+
+
+@app.cell
+def _(alt, cars):
+    _chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .properties(height=100)
+    )
+
+    # Complex: vconcat(hconcat(vconcat(...), ...), ...)
+    complex_chart = alt.vconcat(
+        alt.hconcat(
+            alt.vconcat(
+                _chart,
+                _chart,
+            ),
+            _chart,
+        ),
+        alt.hconcat(
+            _chart,
+            _chart,
+        ),
+    )
+
+    complex_chart
+    return (complex_chart,)
+
+
+@app.cell
+def _(complex_chart, mo):
+    mo.ui.altair_chart(complex_chart.copy())
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #6323 

Previously we would add `autosize: fit-x` which made sense for vertical charts, but this breaks when there is an hconcat inside of it. This only adds `autosize: fit-x` to charts with only vconcat charts