### PR TITLE
fix: escape special characters in frontend altair chart builder

### DIFF
--- a/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
+++ b/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
@@ -422,4 +422,166 @@ describe("generateAltairChart", () => {
       )"
     `);
   });
+
+  it("should escape dots in field names", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: { field: "name.field" },
+        y: { field: "value.data" },
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='name\\.field'),
+          y=alt.Y(field='value\\.data')
+      )"
+    `);
+  });
+
+  it("should escape brackets in field names", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: { field: "data[0]" },
+        y: { field: "values[key]" },
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='data\\[0\\]'),
+          y=alt.Y(field='values\\[key\\]')
+      )"
+    `);
+  });
+
+  it("should escape colons in field names", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: { field: "time:stamp" },
+        y: { field: "value" },
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='time\\:stamp'),
+          y=alt.Y(field='value')
+      )"
+    `);
+  });
+
+  it("should escape multiple special characters in field names", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: { field: "data[0].name:value" },
+        y: { field: "result" },
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='data\\[0\\]\\.name\\:value'),
+          y=alt.Y(field='result')
+      )"
+    `);
+  });
+
+  it("should escape special characters in color encoding", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: { field: "category" },
+        y: { field: "value" },
+        color: { field: "group.name" },
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value'),
+          color=alt.Color(field='group\\.name')
+      )"
+    `);
+  });
+
+  it("should escape special characters in tooltip", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: { field: "category" },
+        y: { field: "value" },
+        tooltip: { field: "info.details" },
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value'),
+          tooltip=alt.Tooltip(field='info\\.details')
+      )"
+    `);
+  });
+
+  it("should escape special characters in facet encodings", () => {
+    const spec = createSpec({
+      mark: "bar",
+      encoding: {
+        x: { field: "category" },
+        y: { field: "value" },
+        row: { field: "row.label" },
+        column: { field: "col[0]" },
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_bar()
+      .encode(
+          x=alt.X(field='category'),
+          y=alt.Y(field='value'),
+          row=alt.Row(field='row\\.label'),
+          column=alt.Column(field='col\\[0\\]')
+      )"
+    `);
+  });
 });

--- a/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
@@ -8,6 +8,7 @@ import {
   Variable,
   VariableDeclaration,
 } from "@/utils/python-poet/poet";
+import { escapeFieldName } from "./utils";
 
 /**
  * Generates Python code for an Altair chart.
@@ -154,7 +155,12 @@ function makeKwargs<T extends Record<string, any>>(obj: T) {
 
   for (const [key, value] of Object.entries(obj)) {
     if (value !== undefined) {
-      result[key] = new Literal(value);
+      // Escape special characters in field names
+      if (key === "field" && typeof value === "string") {
+        result[key] = new Literal(escapeFieldName(value));
+      } else {
+        result[key] = new Literal(value);
+      }
     }
   }
 

--- a/frontend/src/components/data-table/charts/chart-spec/encodings.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/encodings.ts
@@ -19,6 +19,7 @@ import {
 } from "../types";
 import { isFieldSet } from "./spec";
 import { convertDataTypeToVega } from "./types";
+import { escapeFieldName } from "./utils";
 
 export function getBinEncoding(
   chartType: ChartType,
@@ -123,7 +124,7 @@ export function getColorEncoding(
   const aggregate = colorByColumn?.aggregate;
 
   return {
-    field: colorByColumn.field,
+    field: escapeFieldName(colorByColumn.field),
     type: convertDataTypeToVega(selectedDataType),
     scale: getColorInScale(formValues),
     aggregate: getAggregate(aggregate, selectedDataType),
@@ -143,7 +144,7 @@ export function getOffsetEncoding(
   ) {
     return undefined;
   }
-  return { field: formValues.general?.colorByColumn?.field };
+  return { field: escapeFieldName(formValues.general?.colorByColumn?.field) };
 }
 
 export function getAggregate(

--- a/frontend/src/components/data-table/charts/chart-spec/spec.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/spec.ts
@@ -41,6 +41,7 @@ import {
   convertChartTypeToMark,
   convertDataTypeToVega,
 } from "./types";
+import { escapeFieldName } from "./utils";
 
 /**
  * Convert marimo chart configuration to Vega-Lite specification.
@@ -178,7 +179,7 @@ export function getAxisEncoding(
   }
 
   return {
-    field: column.field,
+    field: escapeFieldName(column.field),
     type: convertDataTypeToVega(column.selectedDataType || "unknown"),
     bin: getBinEncoding(chartType, selectedDataType, binValues),
     title: label,
@@ -211,7 +212,7 @@ export function getFacetEncoding(
   );
 
   return {
-    field: facet.field,
+    field: escapeFieldName(facet.field),
     sort: facet.sort,
     timeUnit: getFacetTimeUnit(facet),
     type: convertDataTypeToVega(facet.selectedDataType || "unknown"),
@@ -244,7 +245,7 @@ function getPieChartSpec(
   );
 
   const colorEncoding: ColorDef<string> = {
-    field: colorByColumn.field,
+    field: escapeFieldName(colorByColumn.field),
     type: convertDataTypeToVega(colorByColumn.selectedDataType || "unknown"),
     scale: getColorInScale(formValues),
     title: getFieldLabel(formValues.yAxis?.label),

--- a/frontend/src/components/data-table/charts/chart-spec/tooltips.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/tooltips.ts
@@ -8,6 +8,7 @@ import type {
 import type { DataType } from "@/core/kernel/messages";
 import type { ChartSchemaType } from "../schemas";
 import { isFieldSet } from "./spec";
+import { escapeFieldName } from "./utils";
 
 function getTooltipFormat(dataType: DataType): string | undefined {
   switch (dataType) {
@@ -60,7 +61,7 @@ export function getTooltips(
       }
 
       const tooltip: StringFieldDef<string> = {
-        field: encoding.field,
+        field: encoding.field, // Already escaped in the encoding
         aggregate: encoding.aggregate,
         timeUnit: encoding.timeUnit,
         format: getTooltipFormat(type),
@@ -159,7 +160,7 @@ export function getTooltips(
     }
 
     const otherTooltip: StringFieldDef<string> = {
-      field: tooltip.field,
+      field: escapeFieldName(tooltip.field),
     };
     tooltips.push(otherTooltip);
   }

--- a/frontend/src/components/data-table/charts/chart-spec/utils.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/utils.ts
@@ -1,0 +1,23 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+/**
+ * Escapes special characters in field names for Altair/Vega-Lite.
+ * Matches the backend implementation in marimo/_data/charts.py
+ *
+ * Special characters that need escaping:
+ * - . (dot)
+ * - [ ] (brackets)
+ * - : (colon)
+ *
+ * See: https://altair-viz.github.io/user_guide/troubleshooting.html#encodings-with-special-characters
+ */
+export function escapeFieldName(field: string | undefined): string | undefined {
+  if (!field) {
+    return field;
+  }
+  return field
+    .replace(/\./g, "\\.")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/:/g, "\\:");
+}

--- a/marimo/_smoke_tests/altair_examples/special_chars.py
+++ b/marimo/_smoke_tests/altair_examples/special_chars.py
@@ -1,0 +1,98 @@
+"""Test Altair chart builder with special characters in column names.
+
+This notebook tests the fix for issue #5956, which ensures that special
+characters like dots, brackets, and colons in column names are properly
+escaped when generating Altair chart code.
+"""
+
+import marimo
+
+__generated_with = "0.17.2"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import pandas as pd
+    import polars as pl
+    import altair as alt
+    return alt, mo, pd, pl
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        """
+    # Testing Altair Charts with Special Characters
+
+    This notebook tests column names with special characters:
+    - Dots: `.`
+    - Brackets: `[`, `]`
+    - Colons: `:`
+
+    These characters need to be escaped in Altair field names.
+    """
+    )
+    return
+
+
+@app.cell
+def _(pd):
+    # Create a Pandas DataFrame with special column names
+    pandas_df = pd.DataFrame(
+        {
+            "category": ["A", "B", "C", "D", "E"],
+            "value.data": [10, 20, 15, 25, 30],
+            "info[0]": [5, 10, 8, 12, 15],
+            "time:stamp": ["2024-01", "2024-02", "2024-03", "2024-04", "2024-05"],
+            "complex.name[1]:value": [100, 200, 150, 250, 300],
+        }
+    )
+    pandas_df
+    return (pandas_df,)
+
+
+@app.cell
+def _(pandas_df, pl):
+    # Create a Polars DataFrame with special column names
+    polars_df = pl.DataFrame(pandas_df)
+    polars_df
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        """
+    Use the data table chart builder to create a chart using `value.data` column.
+    The generated Python code should escape the dot: `field='value\\.data'`
+
+    Repeat for all the other columns
+    """
+    )
+    return
+
+
+@app.cell
+def _(mo, pandas_df):
+    mo.ui.table(pandas_df, selection=None)
+    return
+
+
+@app.cell
+def _(alt, pandas_df):
+    chart = (
+        alt.Chart(pandas_df)
+        .mark_bar()
+        .encode(
+            x=alt.X(field="category"),
+            y=alt.Y(field=r"value\.data"),  # Using escaped field name
+        )
+    )
+    chart
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #5956

This escapes special characters in the chart builder for both the generated python code and generated vega spec.