### PR TITLE
set all vega renderer to canvas except col header charts

### DIFF
--- a/frontend/src/components/data-table/charts/lazy-chart.tsx
+++ b/frontend/src/components/data-table/charts/lazy-chart.tsx
@@ -40,6 +40,7 @@ export const LazyChart: React.FC<{
               editor: true,
             },
             mode: "vega",
+            renderer: "canvas",
             tooltip: tooltipHandler.call,
           }}
         />

--- a/frontend/src/components/datasources/column-preview.tsx
+++ b/frontend/src/components/datasources/column-preview.tsx
@@ -230,6 +230,7 @@ export function renderChart(chartSpec: string, theme: Theme) {
           height: 100,
           width: "container" as unknown as number,
           actions: false,
+          renderer: "canvas",
         }}
       />
     </Suspense>

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -181,6 +181,7 @@ export const OutputRenderer: React.FC<{
               theme: theme === "dark" ? "dark" : "vox",
               mode: "vega-lite",
               tooltip: tooltipHandler.call,
+              renderer: "canvas",
             }}
           />
         </Suspense>

--- a/frontend/src/components/tracing/tracing.tsx
+++ b/frontend/src/components/tracing/tracing.tsx
@@ -213,6 +213,7 @@ const TraceBlockBody: React.FC<{
       actions: false,
       // Using vega instead of vegaLite as some parts of the spec get interpreted as vega & will throw warnings
       mode: "vega",
+      renderer: "canvas",
     },
   });
 

--- a/frontend/src/plugins/impl/data-explorer/ConnectedDataExplorerComponent.tsx
+++ b/frontend/src/plugins/impl/data-explorer/ConnectedDataExplorerComponent.tsx
@@ -81,6 +81,7 @@ function chartOptions(theme: ResolvedTheme): VegaEmbedProps["options"] {
     },
     theme: theme === "dark" ? "dark" : undefined,
     tooltip: tooltipHandler.call,
+    renderer: "canvas",
   };
 }
 

--- a/frontend/src/plugins/impl/vega/vega-component.tsx
+++ b/frontend/src/plugins/impl/vega/vega-component.tsx
@@ -235,6 +235,7 @@ const LoadedVegaComponent = ({
       actions: actions,
       mode: "vega-lite",
       tooltip: tooltipHandler.call,
+      renderer: "canvas",
     },
     onError: handleError,
     onEmbed: handleNewView,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Due to https://github.com/vega/vega-embed/issues/1460, the default renderer is svg. We set it to canvas for performance.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
