### PR TITLE
fix: markdown single lines

### DIFF
--- a/packages/smart-cells/src/__tests__/markdown-parser.test.ts
+++ b/packages/smart-cells/src/__tests__/markdown-parser.test.ts
@@ -119,15 +119,13 @@ Count: {str(data["items"][0]["count"])}`.trim(),
         quotePrefix: "",
       });
       expect(pythonCode).toMatchInlineSnapshot(`
-        "mo.md(
-            """
+        "mo.md("""
         # Markdown Title
 
         Some content here.
-        """
-        )"
+        """)"
       `);
-      expect(offset).toBe(16);
+      expect(offset).toBe(11);
     });
 
     it("should preserve r-string prefix", () => {
@@ -146,12 +144,10 @@ Count: {str(data["items"][0]["count"])}`.trim(),
         quotePrefix: "f",
       });
       expect(pythonCode).toMatchInlineSnapshot(`
-        "mo.md(
-            f"""
+        "mo.md(f"""
         # Title
         {some_variable}
-        """
-        )"
+        """)"
       `);
     });
 

--- a/packages/smart-cells/src/parsers/markdown-parser.ts
+++ b/packages/smart-cells/src/parsers/markdown-parser.ts
@@ -114,18 +114,7 @@ export class MarkdownParser implements LanguageParser<MarkdownMetadata> {
     // If it's one line and not bounded by quotes, write it as single line
     const isOneLine = !code.includes("\n");
     const boundedByQuote = code.startsWith('"') || code.endsWith('"');
-    const startQuote = `${quotePrefix}"""`;
     if (isOneLine && !boundedByQuote) {
-      const markdown = `${startQuote}${escapedCode}"""`;
-      const prefix = "mo.md(";
-      if (markdown.length >= 80 - prefix.length) {
-        // Single lines are broken up if they exceed line length
-        const start = `${prefix}"\n    ${startQuote}`;
-        return {
-          code: `${start}${escapedCode}"""\n)`,
-          offset: start.length,
-        };
-      }
       const start = `mo.md(${quotePrefix}"""`;
       const end = `""")`;
       return { code: start + escapedCode + end, offset: start.length };


### PR DESCRIPTION
Reverts a change made in #6969 which breaks a lot of markdown. 

Fixes #6997