### PR TITLE
use searched manager instead of manager for column charts get value counts

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1060,7 +1060,7 @@ class table(
             LOGGER.warning("Total rows and size is not valid")
             return []
 
-        top_k_rows = self._manager.calculate_top_k_rows(column, size)
+        top_k_rows = self._searched_manager.calculate_top_k_rows(column, size)
         if len(top_k_rows) == 0:
             return []
 

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1088,6 +1088,18 @@ class TestTableGetValueCounts:
             ValueCount(value="others", count=3),
         ]
 
+    def test_with_search(self, table: ui.table) -> None:
+        result = table._search(
+            SearchTableArgs(query="1", page_size=10, page_number=0)
+        )
+        rows = table._searched_manager.get_num_rows(force=True)
+        assert rows is not None
+        assert result.total_rows == 2
+        value_counts = table._get_value_counts(
+            column="repeat", size=2, total_rows=rows
+        )
+        assert value_counts == [ValueCount(value="1", count=2)]
+
 
 def test_table_with_frozen_columns() -> None:
     data = {


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
For column header charts for string/categories, previously even with a filter, it would still calculate value_counts based on all the rows. Leading to the chart not changing.

This fixes ensures the frontend chart changes according to filters.
<img src="https://github.com/user-attachments/assets/e991c5da-ec1b-4a4b-b46e-be476889d0d7" height=300 />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
