### PR TITLE
Fix HTML links in examples index

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -177,7 +177,7 @@ overview.
 
     ---
 
-    <a href=outputs/spinner"><img src="/_static/example-thumbs/spinner.png" /></a>
+    <a href="outputs/spinner"><img src="/_static/example-thumbs/spinner.png" /></a>
 
 </div>
 
@@ -190,7 +190,7 @@ overview.
 
     ---
 
-    <a href=outputs/stacks.md"><img src="/_static/example-thumbs/stacks.png" /></a>
+    <a href="outputs/stacks.md"><img src="/_static/example-thumbs/stacks.png" /></a>
 
 -   📁 [**Accordion toggle**](../api/layouts/accordion.md)
 


### PR DESCRIPTION
This pull request makes minor corrections to the example links in the `docs/examples/index.md` file. The main change is fixing the HTML anchor tags to ensure the `href` attributes are properly quoted, which improves link reliability and HTML validity.

- Documentation fixes:
  * Fixed missing opening quotes in the `href` attributes for the spinner and stacks example links in `docs/examples/index.md`. [[1]](diffhunk://#diff-5e297a681a7f0e124ef51134b519ec471a165f08499fbcb724dfa0e58edd08c1L180-R180) [[2]](diffhunk://#diff-5e297a681a7f0e124ef51134b519ec471a165f08499fbcb724dfa0e58edd08c1L193-R193)fixed 2 invalid html links

## 📝 Summary


## 🔍 Description of Changes

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
