### PR TITLE
add categories subtext and add min-width for each bar

### DIFF
--- a/frontend/src/components/data-table/column-summary/column-summary.tsx
+++ b/frontend/src/components/data-table/column-summary/column-summary.tsx
@@ -93,7 +93,7 @@ export const TableColumnSummary = <TData, TValue>({
         }
 
         return (
-          <div className="flex justify-between w-full px-2 whitespace-pre">
+          <div className="flex justify-between w-full px-2 whitespace-pre -mt-1.5">
             <span>{renderDate(stats.min, type)}</span>
             {stats.min === stats.max ? null : (
               <span>-{renderDate(stats.max, type)}</span>
@@ -145,15 +145,20 @@ export const TableColumnSummary = <TData, TValue>({
         return null;
       case "time":
         return null;
-      case "string":
-        if (!spec) {
-          return (
-            <div className="flex flex-col whitespace-pre">
-              <span>unique: {prettyNumber(stats.unique, locale)}</span>
-            </div>
-          );
+      case "string": {
+        const lessThan5Categories =
+          typeof stats.unique === "number" && stats.unique <= 5;
+        // Number of categories will be easily visible from the chart, so don't show it here.
+        if (spec && lessThan5Categories) {
+          return null;
         }
-        return null;
+
+        return (
+          <div className="flex flex-col whitespace-pre -mt-1.5">
+            <span>categories: {prettyNumber(stats.unique, locale)}</span>
+          </div>
+        );
+      }
       case "unknown":
         return (
           <div className="flex flex-col whitespace-pre">

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -990,7 +990,10 @@ class table(
                 ):
                     try:
                         val_counts = self._get_value_counts(
-                            column, DEFAULT_VALUE_COUNTS_SIZE, total_rows
+                            column=column,
+                            size=DEFAULT_VALUE_COUNTS_SIZE,
+                            total_rows=total_rows,
+                            others_threshold=1,
                         )
                         if len(val_counts) > 0:
                             value_counts[column] = val_counts
@@ -1043,7 +1046,12 @@ class table(
         )
 
     def _get_value_counts(
-        self, column: ColumnName, size: int, total_rows: int
+        self,
+        *,
+        column: ColumnName,
+        size: int,
+        total_rows: int,
+        others_threshold: int | None = None,
     ) -> list[ValueCount]:
         """Get value counts for a column. The last item will be 'others' with the count of remaining
         unique values. If there are only unique values, we return 'unique values' instead.
@@ -1052,6 +1060,8 @@ class table(
             column (ColumnName): The column to get value counts for.
             size (int): The number of value counts to return.
             total_rows (int): The total number of rows in the table.
+            others_threshold (int | None): The threshold for values to be considered 'others'.
+                If a value has a count less than or equal to this threshold, it will be considered 'others'.
 
         Returns:
             list[ValueCount]: The value counts.
@@ -1076,6 +1086,9 @@ class table(
 
         sum_count = 0
         for value, count in top_k_rows:
+            if others_threshold is not None and count <= others_threshold:
+                break
+
             sum_count += count
             value = str(value) if value is not None else "null"
             value_counts.append(ValueCount(value=value, count=count))

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1100,6 +1100,28 @@ class TestTableGetValueCounts:
         )
         assert value_counts == [ValueCount(value="1", count=2)]
 
+    def test_with_others_threshold(self, table: ui.table) -> None:
+        value_counts = table._get_value_counts(
+            column="repeat",
+            size=2,
+            total_rows=self.total_rows,
+            others_threshold=1,
+        )
+        assert value_counts == [
+            ValueCount(value="1", count=2),
+            ValueCount(value="others", count=3),
+        ]
+
+        value_counts = table._get_value_counts(
+            column="repeat",
+            size=2,
+            total_rows=self.total_rows,
+            others_threshold=2,
+        )
+        assert value_counts == [
+            ValueCount(value="others", count=5),
+        ]
+
 
 def test_table_with_frozen_columns() -> None:
     data = {


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
![CleanShot 2025-11-03 at 14 25 26](https://github.com/user-attachments/assets/821b72f1-e939-4836-b178-c2db5332023b)

- add min-width to all bars by re-proportioning the bar widths
- count=1 is included as "others"
- add `categories: number` as subtext for string charts

if `show_column_summaries="stats"`
![CleanShot 2025-11-03 at 14 26 39](https://github.com/user-attachments/assets/c77eae91-e995-401d-9eac-d048f03e0a34)

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
