### PR TITLE
Fix: html-wasm export prompted an overwrite

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -584,12 +584,11 @@ def html_wasm(
 
     out_dir = output
     filename = "index.html"
-    ignore_index_html = False
+    ignore_index_html = True
     # If ends with .html, get the directory
     if output.suffix == ".html":
         out_dir = output.parent
         filename = output.name
-        ignore_index_html = True
 
     marimo_file = MarimoPath(name)
 


### PR DESCRIPTION
## 📝 Summary

Fixes #6012

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
The issue prompted an index.html overwrite whenever an index file is not provided. This lead to a bug where export_assests() exported everything including index.html, which was then overwritten by watch_and_export() to store the actual content.
 
My fix:
The flag "ignore_index_html" should always be true when exporting as html-wasm.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.