### PR TITLE
Remove ugly new times roman on token form

### DIFF
--- a/marimo/_server/api/endpoints/login.py
+++ b/marimo/_server/api/endpoints/login.py
@@ -47,7 +47,7 @@ LOGIN_PAGE = """
         display: block;
         margin-bottom: 5px;
         font-size: 16px;
-        font-family: Arial;
+        font-family: Arial, sans-serif;
         color: #333;">Access Token / Password</label>
       <input id="password" name="password" type="password" style="
         width: 100%;


### PR DESCRIPTION
We have an unstyled bit of form text when you start marimo in headless mode without a token in the url. This PR tries to fix that. 

## Before: 

<img width="838" height="531" alt="CleanShot 2025-11-04 at 17 08 34" src="https://github.com/user-attachments/assets/575ebd99-e6d2-44a0-88de-707037767f86" />

## After:

<img width="650" height="390" alt="CleanShot 2025-11-04 at 17 12 24" src="https://github.com/user-attachments/assets/7d1bda27-912c-405c-a335-99c18ba3c9ac" />
