### PR TITLE
lint: lint commented console statements

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -4,7 +4,8 @@
     "frontend/lint/addEventListenerObject.grit",
     "frontend/lint/removeEventListenerObject.grit",
     "frontend/lint/preferObjectParams.grit",
-    "frontend/lint/atomWithStorageArgs.grit"
+    "frontend/lint/atomWithStorageArgs.grit",
+    "frontend/lint/noCommentedConsole.grit"
   ],
   "files": {
     "includes": ["frontend/**/*", "packages/**/*", "!*.json", "!*.jsonc"]

--- a/frontend/lint/noCommentedConsole.grit
+++ b/frontend/lint/noCommentedConsole.grit
@@ -1,0 +1,10 @@
+language js
+
+// Match commented out console statements
+`// console.$method` where {
+  register_diagnostic(
+    span=.,
+    message="Remove commented out console statement instead of leaving it in the code",
+    severity="error"
+  )
+}


### PR DESCRIPTION
New lint rule to catch console statements that are commented out