### PR TITLE
fix: ensure "async " only appears once in async function signatures

### DIFF
--- a/marimo/_plugins/stateless/inspect.py
+++ b/marimo/_plugins/stateless/inspect.py
@@ -256,9 +256,7 @@ def _get_object_title(obj: object) -> tuple[str, str]:
 
 def _get_signature(obj: object) -> str | None:
     try:
-        sig = inspect_.signature(obj)  # type: ignore
-        prefix = "async " if inspect_.iscoroutinefunction(obj) else ""
-        return f"{prefix}{sig}"
+        return str(inspect_.signature(obj))  # type: ignore
     except (ValueError, TypeError):
         return None
 

--- a/tests/_plugins/stateless/test_inspect.py
+++ b/tests/_plugins/stateless/test_inspect.py
@@ -28,6 +28,11 @@ def simple_function(x: int, y: str = "default") -> str:
     return f"{x} - {y}"
 
 
+async def async_function(a: int) -> int:
+    """Double the value."""
+    return a * 2
+
+
 def test_inspect_basic_object() -> None:
     obj = SimpleClass()
     result = inspect(obj)
@@ -57,6 +62,13 @@ def test_inspect_function() -> None:
     assert "int" in html
     assert "y:" in html
     assert "str" in html
+
+
+def test_inspect_async_function() -> None:
+    result = inspect(async_function)
+    html = result.text
+
+    assert "async def async_function(" in html
 
 
 def test_inspect_with_methods() -> None:


### PR DESCRIPTION
## 📝 Summary

This PR ensures only a single "async" appears in rendered function signatures.
Previously it was being added by both `_get_signature` and it's caller in the `inspect` class.

## 🔍 Description of Changes

Before:
<img width="1119" height="283" alt="Screenshot 2025-11-05 at 22 22 31" src="https://github.com/user-attachments/assets/f6406054-1a4e-41be-92f1-d2e8ea37b479" />

After:
<img width="1129" height="345" alt="Screenshot 2025-11-05 at 22 22 08" src="https://github.com/user-attachments/assets/95df56db-2797-4cf5-afe4-39f0bdb33292" />


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
