### PR TITLE
improve: do not trigger UI element warnings for state updates

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1470,6 +1470,16 @@ class Kernel:
         cell_id = ctx.execution_context.cell_id
         with self._state_lock:
             self.state_updates[state] = cell_id
+        # TODO(akshayka): State should not be updated eagerly like this,
+        # the runner already handles state execution. This is a hack
+        # until we figure out how to clean this up.
+        names = ctx.state_registry.bound_names(state)
+        if len(names) == 1 and not (name := list(names)[0]).isidentifier():
+            LOGGER.warning(
+                f"Found 'name' for state object is not an identifier; got name {name}"
+            )
+            return
+
         to_update = self.update_stateful_values(
             ctx.state_registry.bound_names(state), state._value
         )


### PR DESCRIPTION
Right now the runtime eagerly updates states value when a state update
is registered. This should be unnecessary (but maybe was needed
for file watching element, which is when this code was introduced),
and it hits a code path for UI elements that triggers a very loud error.
Instead of fixing the underlying issue, this PR prevents the
code path from being triggered and prints a gentler warning.

Related: #7060 