### PR TITLE
chore: fix typo in readme, missing quotes in recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ To install with additional dependencies that unlock SQL cells, AI completion, an
 run
 
 ```bash
-pip install marimo[recommended]
+pip install "marimo[recommended]"
 ```
 
 **Create notebooks.**


### PR DESCRIPTION
## 📝 Summary

Fixes typo in the `README.md` file

## 🔍 Description of Changes

The readme has instructions to install the recommended packages with `pip install marimo[recommended]`

it should have quotes and read:

```bash
pip install "marimo[recommended]"
```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] n/a For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] n/a I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
