### PR TITLE
FIx: Dispatch hashChange event manually

### DIFF
--- a/frontend/src/components/ui/query-param-preserving-link.tsx
+++ b/frontend/src/components/ui/query-param-preserving-link.tsx
@@ -20,6 +20,9 @@ export const QueryParamPreservingLink: React.FC<
     currentUrl.hash = href;
     globalThis.history.pushState({}, "", currentUrl.toString());
 
+    //manually dispatch hashchange event
+    globalThis.dispatchEvent(new HashChangeEvent("hashchange"));
+
     // Scroll to the anchor
     const targetId = href.slice(1);
     const targetElement = document.getElementById(targetId);


### PR DESCRIPTION
## 📝 Summary

Fixed `moutils.URLHash()` that broke in v0.17.3.

## Fixes #7055

## 🔍 Description of Changes

Manually dispatches `HashChangeEvent` after `history.pushState()`

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] I have run the code and verified that it works as expected.
