### PR TITLE
fix: raise an error for invalid batch usage

### DIFF
--- a/marimo/_plugins/ui/_impl/dictionary.py
+++ b/marimo/_plugins/ui/_impl/dictionary.py
@@ -9,7 +9,7 @@ from marimo._output.rich_help import mddoc
 from marimo._plugins.stateless.flex import hstack, vstack
 from marimo._plugins.stateless.json_output import json_output
 from marimo._plugins.ui._core.ui_element import UIElement
-from marimo._plugins.ui._impl.batch import _batch_base
+from marimo._plugins.ui._impl.batch import _batch_base, validate_and_clone
 
 
 @mddoc
@@ -120,7 +120,7 @@ class dictionary(_batch_base):
         # additional logic were added to the frontend DictPlugin to spy on
         # marimoValueUpdateEvents of children), and in any case will not
         # trigger cells that ref the dictionary to run, leading to confusion
-        elements = {key: element._clone() for key, element in elements.items()}
+        elements = validate_and_clone(elements)
 
         self._label = label
         # slot a JSON tree viewer as the contents of this element

--- a/tests/_plugins/ui/_impl/test_batch.py
+++ b/tests/_plugins/ui/_impl/test_batch.py
@@ -1,8 +1,47 @@
 # Copyright 2024 Marimo. All rights reserved.
 from __future__ import annotations
 
+import pytest
+
+from marimo import md
 from marimo._output.hypertext import Html
 from marimo._plugins import ui
+
+
+def test_batch_rejects_non_ui_elements() -> None:
+    """Test that batch raises ValueError for non-UIElement arguments."""
+    with pytest.raises(
+        ValueError, match="`.batch` only accepts UIElements as arguments"
+    ):
+        md("Example {thing}").batch(thing="thing")  # type: ignore
+
+    with pytest.raises(
+        ValueError, match="`.batch` only accepts UIElements as arguments"
+    ):
+        md("Example {thing}").batch(thing=42)  # type: ignore
+
+    with pytest.raises(
+        ValueError, match="`.batch` only accepts UIElements as arguments"
+    ):
+        md("Example {thing}").batch(thing={"key": "value"})  # type: ignore
+
+
+def test_dictionary_rejects_non_ui_elements() -> None:
+    """Test that dictionary raises ValueError for non-UIElement arguments."""
+    with pytest.raises(
+        ValueError, match="`.batch` only accepts UIElements as arguments"
+    ):
+        ui.dictionary({"hi": 1})  # type: ignore
+
+    with pytest.raises(
+        ValueError, match="`.batch` only accepts UIElements as arguments"
+    ):
+        ui.dictionary({"text": "string"})  # type: ignore
+
+    with pytest.raises(
+        ValueError, match="`.batch` only accepts UIElements as arguments"
+    ):
+        ui.dictionary({"valid": ui.slider(1, 10), "invalid": "string"})  # type: ignore
 
 
 def test_update_on_frontend_value_change_only() -> None:


### PR DESCRIPTION
## 📝 Summary

Prevents footguns like:

```python
mo.md("""hello there

{moar_md}

""").batch(moar_md=mo.as_html("<p>hello</p>"))
""")
```

by raising a value error with invalid arguments