### PR TITLE
marimo/_runtime/packages/module_name_to_pypi_name.py: Add mapping for `sage`

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -663,6 +663,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "rsbackends": "RSFile",
         "ruamel": "ruamel.base",
         "saga": "saga-python",
+        "sage": "passagemath-standard",
         "samtranslator": "aws-sam-translator",
         "sassutils": "libsass",
         "sayhi": "alex-sayhi",


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Map the namespace `sage` to the package https://pypi.org/project/passagemath-standard/

## 🔍 Description of Changes

The default mapping by marimo for the namespace `sage` leads to the uninstallable dummy package https://pypi.org/project/sage/

Following the instructions at https://docs.marimo.io/guides/editor_features/package_management/, this PR provides a mapping of the namespace `sage` to the pip-installable package [passagemath-standard](https://pypi.org/project/passagemath-standard/), which provides this namespace via its numerous dependencies, each pip-installable from binary wheels on PyPI. @akshayka 

For a more fine-grained mapping to the [modularized pip-installable packages of passagemath](https://github.com/passagemath/#passagemath-in-the-mathematical-software-landscape), progress on the following issue will be needed.
- https://github.com/marimo-team/marimo/issues/2841


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
