### PR TITLE
Add mapping for 'sage' to 'sagemath'

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -663,6 +663,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "rsbackends": "RSFile",
         "ruamel": "ruamel.base",
         "saga": "saga-python",
+        "sage": "sagemath",
         "samtranslator": "aws-sam-translator",
         "sassutils": "libsass",
         "sayhi": "alex-sayhi",


### PR DESCRIPTION

## 📝 Summary

Adds the correct upstream [Python package](https://pypi.org/project/sagemath) for the `sage` import. 

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

## 🔍 Description of Changes

Alternative to https://github.com/marimo-team/marimo/pull/7151. Here we use the official upstream package as the target of the mapping, and not an unofficial fork.

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
