### PR TITLE
fix: change input type to password for ApiKey and WriteSecretModal components

### DIFF
--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -133,6 +133,7 @@ export const ApiKey: React.FC<ApiKeyProps> = ({
                 rootClassName="flex-1"
                 className="m-0 inline-flex h-7"
                 placeholder={placeholder}
+                type="password"
                 {...field}
                 value={asStringOrUndefined(field.value)}
                 onChange={(e) => {

--- a/frontend/src/components/editor/chrome/panels/write-secret-modal.tsx
+++ b/frontend/src/components/editor/chrome/panels/write-secret-modal.tsx
@@ -121,7 +121,7 @@ export const WriteSecretModal: React.FC<{
             <Label htmlFor="value">Value</Label>
             <Input
               id="value"
-              type="text"
+              type="password"
               value={value}
               onChange={(e) => setValue(e.target.value)}
               required={true}


### PR DESCRIPTION
Change input type to password for ApiKey and WriteSecretModal components 