### PR TITLE
Revert "Revert "don't override auto-save by when in --watch mode" (#7071)"

### DIFF
--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -111,6 +111,10 @@ class MarimoConfigReader:
         return {}
 
     @property
+    def is_auto_save_enabled(self) -> bool:
+        return self._config["save"]["autosave"] == "after_delay"
+
+    @property
     def experimental(self) -> ExperimentalConfigType:
         if "experimental" in self._config:
             return self._config["experimental"]

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -208,19 +208,8 @@ def start(
             min_port=DEFAULT_PORT + 400,
         )
 
-    # If watch is true, disable auto-save and format-on-save,
-    # watch is enabled when they are editing in another editor
-    if watch:
-        config_reader = config_reader.with_overrides(
-            {
-                "save": {
-                    "autosave": "off",
-                    "format_on_save": False,
-                    "autosave_delay": 1000,
-                }
-            }
-        )
-        LOGGER.warning("Watch mode enabled, auto-save is disabled")
+    if watch and config_reader.is_auto_save_enabled:
+        LOGGER.warning("Enabling watch mode may interfere with auto-save.")
 
     if GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA:
         config_reader = config_reader.with_overrides(

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -601,23 +601,14 @@ def __():
 
 
 @save_and_restore_main
-def test_watch_mode_config_override(tmp_path: Path) -> None:
-    """Test that watch mode properly overrides config settings."""
+def test_watch_mode_does_not_override_config(tmp_path: Path) -> None:
+    """Test that watch mode does not override config settings."""
     # Create a temporary file
     tmp_file = tmp_path / "test_watch_mode_config_override.py"
     tmp_file.write_text("import marimo as mo")
 
-    # Create a config with autosave enabled
+    # Create a default config (autosave enabled by default)
     config_reader = get_default_config_manager(current_path=None)
-    config_reader_watch = config_reader.with_overrides(
-        {
-            "save": {
-                "autosave": "off",
-                "format_on_save": False,
-                "autosave_delay": 2000,
-            }
-        }
-    )
 
     # Create a session manager with watch mode enabled
     file_router = AppFileRouter.from_filename(MarimoPath(str(tmp_file)))
@@ -628,7 +619,7 @@ def test_watch_mode_config_override(tmp_path: Path) -> None:
         quiet=True,
         include_code=True,
         lsp_server=MagicMock(),
-        config_manager=config_reader_watch,
+        config_manager=config_reader,
         cli_args={},
         argv=None,
         auth_token=None,
@@ -654,13 +645,8 @@ def test_watch_mode_config_override(tmp_path: Path) -> None:
     )
 
     try:
-        # Verify that the config was overridden
+        # Verify that the config was not overridden for watch mode
         config = session_manager._config_manager.get_config()
-        assert config["save"]["autosave"] == "off"
-        assert config["save"]["format_on_save"] is False
-
-        # Verify that the config was not overridden
-        config = session_manager_no_watch._config_manager.get_config()
         assert config["save"]["autosave"] == "after_delay"
         assert config["save"]["format_on_save"] is True
 


### PR DESCRIPTION
This reverts commit 928e8a0e316e92a9fc1b4f96fedf03911fdaa174.

We can revert this change now and support watch and autosave due to this change: https://github.com/marimo-team/marimo/pull/7099
