### PR TITLE
fix: the default rendering of ibis tables when interactive should still be lazy

### DIFF
--- a/marimo/_output/formatters/df_formatters.py
+++ b/marimo/_output/formatters/df_formatters.py
@@ -335,8 +335,16 @@ class IbisFormatter(FormatterFactory):
                 mode = _get_display_mode(expr)
 
                 if mode == IbisDisplayMode.INTERACTIVE:
-                    return table(
-                        expr, selection=None, pagination=True
+                    # Even though interactive mode is enabled and the expression may not be unbound,
+                    # it could be an extremely large query (e.g. s3 bucket)
+                    # Without lazy, this tries to load the entire dataframe into memory
+                    #
+                    # If a user does want the full dataframe, they can call .execute() manually
+                    # or use `mo.ui.table(df)`
+                    return table.lazy(
+                        expr,
+                        # Lazy, but preload the first page of data (since interactive is true)
+                        preload=True,
                     )._mime_()
                 else:
                     return _format_lazy_expression(expr, mode)

--- a/marimo/_smoke_tests/formatters/ibis_opinionated_formatters.py
+++ b/marimo/_smoke_tests/formatters/ibis_opinionated_formatters.py
@@ -1,0 +1,81 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "ibis-framework[duckdb]==11.0.0",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.17.7"
+app = marimo.App(width="medium", auto_download=["html", "ipynb"])
+
+
+@app.cell
+def _():
+    import ibis
+    import marimo as mo
+    return ibis, mo
+
+
+@app.cell
+def _(ibis):
+    ibis.options.interactive = True
+
+    con = ibis.duckdb.connect()
+
+    con.raw_sql("INSTALL httpfs; LOAD httpfs;")
+
+    con.raw_sql("SET s3_region='us-west-2'")
+    return (con,)
+
+
+@app.cell
+def _(con):
+    path = "s3://overturemaps-us-west-2/release/2025-10-22.0/theme=base/type=infrastructure/*.parquet"
+
+    t = con.read_parquet(path, hive_partitioning=True, filename=True)
+    return (t,)
+
+
+@app.cell
+def _(t):
+    t.schema()
+    return
+
+
+@app.cell
+def _(t):
+    t._find_backends()
+    return
+
+
+@app.cell
+def _(t):
+    # This should render the opinionated table, somewhat fast, without fetching the full dataframe into memory
+    t
+    return
+
+
+@app.cell
+def _(t):
+    # This should render the opinionated table, somewhat fast, without fetching the full dataframe into memory
+    t.limit(10)
+    return
+
+
+@app.cell
+def _(mo, t):
+    # Should show a plain HTML table from ibis
+    mo.plain(t)
+    return
+
+
+@app.cell
+def _():
+    # t
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_output/formatters/test_ibis_formatters.py
+++ b/tests/_output/formatters/test_ibis_formatters.py
@@ -48,6 +48,9 @@ def test_ibis_formatters_interactive_mode(test_table) -> None:
         mime, content = formatter(test_table)
         assert mime == "text/html"
         assert "<marimo-table" in content
+        assert (
+            "data-lazy='true'" in content
+        )  # Should be lazy in interactive mode
 
         # Test column - should return table widget via as_table()
         column = test_table.struct
@@ -56,6 +59,9 @@ def test_ibis_formatters_interactive_mode(test_table) -> None:
         mime, content = formatter(column)
         assert mime == "text/html"
         assert "<marimo-table" in content
+        assert (
+            "data-lazy='true'" in content
+        )  # Should be lazy in interactive mode
 
         # Test scalar - should return formatted text
         scalar = test_table.floats.min()
@@ -87,6 +93,7 @@ def test_ibis_formatters_lazy_mode(test_table) -> None:
         mime, content = formatter(test_table)
         assert mime == "text/html"
         assert "<marimo-tabs" in content
+        assert "<marimo-table" not in content  # Should not be table widget
 
         # Test column - should return Expression+SQL tabs
         column = test_table.struct
@@ -95,6 +102,7 @@ def test_ibis_formatters_lazy_mode(test_table) -> None:
         mime, content = formatter(column)
         assert mime == "text/html"
         assert "<marimo-tabs" in content
+        assert "<marimo-table" not in content  # Should not be table widget
 
         # Test scalar - should return Expression+SQL tabs
         scalar = test_table.floats.min()
@@ -103,6 +111,7 @@ def test_ibis_formatters_lazy_mode(test_table) -> None:
         mime, content = formatter(scalar)
         assert mime == "text/html"
         assert "<marimo-tabs" in content
+        assert "<marimo-table" not in content  # Should not be table widget
 
     finally:
         ibis.options.interactive = original_interactive
@@ -136,6 +145,7 @@ def test_ibis_unbound_expressions() -> None:
             mime, content = formatter(joined)
             assert mime == "text/html"
             assert "<marimo-tabs" in content
+            assert "<marimo-table" not in content  # Should not be table widget
         finally:
             ibis.options.interactive = original_interactive
 
@@ -194,6 +204,7 @@ def test_ibis_polars_backend() -> None:
         mime, content = formatter(polars_table)
         assert mime == "text/html"
         assert "<marimo-tabs" in content
+        assert "<marimo-table" not in content  # Should not be table widget
 
     finally:
         ibis.options.interactive = original_interactive


### PR DESCRIPTION
Ibis is naturally lazy and even in "interactive" mode, only render the first 10 items. For our opinionated DF renders, we were loading the full table into memory to display with pagination, but this could load large datasets that were not intended. So instead we show a lazy-table which only shows the first 10 items as well (but using our opinionated table).

If users do want to load the full ibis table, they can call `.execute()` or pass the table into `mo.ui.table(df)`