### PR TITLE
fix: dont set empty cells as stale

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -2100,8 +2100,13 @@ class Kernel:
             self.reset_ui_initializers()
         else:
             self._uninstantiated_execution_requests = execution_requests
-            for cell_id in self._uninstantiated_execution_requests.keys():
-                CellOp.broadcast_stale(cell_id=cell_id, stale=True)
+            for (
+                cell_id,
+                cell_request,
+            ) in self._uninstantiated_execution_requests.items():
+                # Only mark non-empty cells as stale
+                if cell_request.code.strip():
+                    CellOp.broadcast_stale(cell_id=cell_id, stale=True)
 
     def _handle_markdown_cells_on_instantiate(
         self, execution_requests: dict[CellId_t, ExecutionRequest]

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -537,6 +537,50 @@ class TestExecution:
         assert not k._uninstantiated_execution_requests
         assert k.globals["z"] == 3
 
+    async def test_instantiate_autorun_false_empty_cells_not_stale(
+        self, any_kernel: Kernel
+    ) -> None:
+        """Tests that empty cells are not marked as stale during instantiation."""
+        k = any_kernel
+        await k.instantiate(
+            CreationRequest(
+                execution_requests=(
+                    ExecutionRequest(cell_id="0", code="x=0"),
+                    ExecutionRequest(cell_id="1", code=""),
+                    ExecutionRequest(cell_id="2", code="  \n  "),
+                    ExecutionRequest(cell_id="3", code="y=x+1"),
+                ),
+                set_ui_element_value_request=SetUIElementValueRequest.from_ids_and_values(
+                    []
+                ),
+                auto_run=False,
+            )
+        )
+
+        # Check that all cells are in uninstantiated requests
+        assert len(k._uninstantiated_execution_requests) == 4
+
+        # Check the stream for stale broadcasts
+        stream = MockStream(k.stream)
+        cell_ops = [
+            op for op in stream.parsed_operations if isinstance(op, CellOp)
+        ]
+
+        # Filter for stale broadcasts
+        stale_broadcasts = [
+            op
+            for op in cell_ops
+            if op.stale_inputs is not None and op.stale_inputs
+        ]
+
+        # Only cells 0 and 3 should be marked as stale (non-empty cells)
+        stale_cell_ids = {op.cell_id for op in stale_broadcasts}
+        assert stale_cell_ids == {"0", "3"}
+
+        # Cells 1 and 2 (empty/whitespace) should not be marked as stale
+        assert "1" not in stale_cell_ids
+        assert "2" not in stale_cell_ids
+
     # Test errors in marimo semantics
     async def test_kernel_simultaneous_multiple_definition_error(
         self,


### PR DESCRIPTION
If you start a new notebook with auto-run off, then the first cell is stale, when it should not be until edited. 