### PR TITLE
fix: default runtime configuration for dotenv

### DIFF
--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -632,6 +632,8 @@ DEFAULT_CONFIG: MarimoConfig = {
     },
     "formatting": {"line_length": 79},
     "keymap": {"preset": "default", "overrides": {}},
+    # dotenv's default value is set at runtime, depending on whether a
+    # pyproject.toml is found.
     "runtime": {
         "auto_instantiate": False,
         "auto_reload": "off",

--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -193,7 +193,10 @@ class ProjectConfigManager(PartialMarimoConfigReader):
                 return {}
             project_config = read_pyproject_marimo_config(self.pyproject_path)
             if project_config is None:
-                return {}
+                # Some project configuration defaults (dotenv in particular)
+                # are resolved at runtime, even in the absence of marimo
+                # section in the pyproject.toml.
+                project_config = cast(PartialMarimoConfig, {})
             project_config = self._resolve_pythonpath(project_config)
             project_config = self._resolve_dotenv(project_config)
             project_config = self._resolve_custom_css(project_config)

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -164,6 +164,21 @@ def test_with_multiple_overrides() -> None:
     assert manager.get_config()["package_management"]["manager"] == "pixi"
 
 
+def test_project_config_default_dotenv(tmp_path: Path) -> None:
+    # Even if the pyproject.toml does not have a marimo section,
+    # at runtime the dotenv default should be injected.
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_content = ""
+    pyproject_path.write_text(textwrap.dedent(pyproject_content))
+
+    notebook_path = tmp_path / "notebook.py"
+    notebook_content = "import marimo as mo"
+    notebook_path.write_text(textwrap.dedent(notebook_content))
+    manager = get_default_config_manager(current_path=str(notebook_path))
+    config = manager.get_config(hide_secrets=False)
+    assert config["runtime"]["dotenv"] == [str(tmp_path / ".env")]
+
+
 def test_project_config_manager_with_script_metadata(tmp_path: Path) -> None:
     # Create a notebook file with script metadata
     notebook_path = tmp_path / "notebook.py"


### PR DESCRIPTION
If a `pyproject.toml` is found, and the dotenv runtime configuration is unset, we are supposed to default to the .env file in the directory containing the `pyproject.toml`. This change fixes a bug in which we did not set this default.