### PR TITLE
Improve: error message for missing 'mo' name

### DIFF
--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -395,9 +395,12 @@ export const MarimoErrorOutput = ({
                 <li className="my-2" key={`exception-${idx}`}>
                   <div>
                     <p className="text-muted-foreground">
+                      name 'mo' is not defined.
+                    </p>
+                    <p className="text-muted-foreground mt-2">
                       The marimo module (imported as{" "}
                       <Kbd className="inline">mo</Kbd>) is required for
-                      markdown, SQL, and UI elements.
+                      Markdown, SQL, and UI elements.
                     </p>
                   </div>
                 </li>


### PR DESCRIPTION
This PR improves the error message for name errors on `mo`, which typically suggest that the marimo module has not been imported.

<img width="686" height="139" alt="image" src="https://github.com/user-attachments/assets/001188f5-8935-42a2-8b1b-e779e2e5310f" />

Closes #7143 