### PR TITLE
feat: toggle hidden files file explorer

### DIFF
--- a/frontend/src/components/editor/file-tree/__tests__/file-expolorer.test.ts
+++ b/frontend/src/components/editor/file-tree/__tests__/file-expolorer.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { isDirectoryOrFileHidden, filterHiddenTree } from "../file-explorer";
+import type { FileInfo } from "@/core/network/types";
+
+// Helpers to build FileInfo objects for tests
+const file = (name: string, path: string): FileInfo => ({
+  id: path,
+  name,
+  path,
+  isDirectory: false,
+  isMarimoFile: false,
+  children: [],
+});
+
+const dir = (
+  name: string,
+  path: string,
+  children: FileInfo[] = [],
+): FileInfo => ({
+  id: path,
+  name,
+  path,
+  isDirectory: true,
+  isMarimoFile: false,
+  children,
+});
+
+describe("isDirectoryOrFileHidden", () => {
+  it("should return true for files starting with dot", () => {
+    expect(isDirectoryOrFileHidden(".git")).toBe(true);
+    expect(isDirectoryOrFileHidden(".env")).toBe(true);
+    expect(isDirectoryOrFileHidden(".gitignore")).toBe(true);
+  });
+
+  it("should return false for normal files", () => {
+    expect(isDirectoryOrFileHidden("README.md")).toBe(false);
+    expect(isDirectoryOrFileHidden("package.json")).toBe(false);
+    expect(isDirectoryOrFileHidden("index.ts")).toBe(false);
+  });
+
+  it("should return false for files with dots in the middle", () => {
+    expect(isDirectoryOrFileHidden("file.test.ts")).toBe(false);
+    expect(isDirectoryOrFileHidden("my.config.js")).toBe(false);
+  });
+});
+
+describe("filterHiddenTree", () => {
+  it("should return all items when showHidden is true", () => {
+    const list: FileInfo[] = [
+      dir(".git", "/.git", []),
+      file("README.md", "/README.md"),
+      file(".env", "/.env"),
+    ];
+
+    const result = filterHiddenTree(list, true);
+
+    expect(result).toBe(list); // should be the exact same reference
+    expect(result).toHaveLength(3);
+  });
+
+  it("should filter out hidden files when showHidden is false", () => {
+    const list: FileInfo[] = [
+      dir(".git", "/.git"),
+      file("README.md", "/README.md"),
+      file(".env", "/.env"),
+      file("package.json", "/package.json"),
+    ];
+
+    const result = filterHiddenTree(list, false);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("README.md");
+    expect(result[1].name).toBe("package.json");
+  });
+
+  it("should filter hidden directories recursively", () => {
+    const list: FileInfo[] = [
+      dir("src", "/src", [
+        file("index.ts", "/src/index.ts"),
+        file(".DS_Store", "/src/.DS_Store"),
+        file("utils.ts", "/src/utils.ts"),
+      ]),
+      dir(".git", "/.git", [file("config", "/.git/config")]),
+    ];
+
+    const result = filterHiddenTree(list, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("src");
+    expect(result[0].children).toHaveLength(2);
+    expect(result[0].children?.[0].name).toBe("index.ts");
+    expect(result[0].children?.[1].name).toBe("utils.ts");
+  });
+
+  it("should handle nested hidden files", () => {
+    const list: FileInfo[] = [
+      dir("project", "/project", [
+        dir("src", "/project/src", [
+          file("index.ts", "/project/src/index.ts"),
+          file(".backup", "/project/src/.backup"),
+        ]),
+        file(".env", "/project/.env"),
+      ]),
+    ];
+
+    const result = filterHiddenTree(list, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children?.[0].name).toBe("src");
+    expect(result[0].children?.[0].children).toHaveLength(1);
+    expect(result[0].children?.[0].children?.[0].name).toBe("index.ts");
+  });
+
+  it("should preserve directory structure when no children are filtered", () => {
+    const list: FileInfo[] = [
+      dir("src", "/src", [
+        file("index.ts", "/src/index.ts"),
+        file("utils.ts", "/src/utils.ts"),
+      ]),
+    ];
+
+    const result = filterHiddenTree(list, true);
+
+    // Should return the same reference since nothing changed
+    expect(result[0]).toBe(list[0]);
+  });
+
+  it("should create new object only when children are filtered", () => {
+    const list: FileInfo[] = [
+      dir("src", "/src", [
+        file("index.ts", "/src/index.ts"),
+        file(".hidden", "/src/.hidden"),
+      ]),
+    ];
+
+    const result = filterHiddenTree(list, false);
+
+    // Should be a new object since children changed
+    expect(result[0]).not.toBe(list[0]);
+    expect(result[0].children).not.toBe(list[0].children);
+  });
+
+  it("should handle empty list", () => {
+    const result = filterHiddenTree([], false);
+    expect(result).toEqual([]);
+  });
+
+  it("should handle empty children arrays", () => {
+    const list: FileInfo[] = [dir("empty-dir", "/empty-dir", [])];
+
+    const result = filterHiddenTree(list, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].children).toEqual([]);
+  });
+
+  it("should handle deeply nested structures", () => {
+    const list: FileInfo[] = [
+      dir("level1", "/level1", [
+        dir("level2", "/level1/level2", [
+          dir("level3", "/level1/level2/level3", [
+            file("file.ts", "/level1/level2/level3/file.ts"),
+            file(".hidden", "/level1/level2/level3/.hidden"),
+          ]),
+        ]),
+        file(".ignore", "/level1/.ignore"),
+      ]),
+    ];
+
+    const result = filterHiddenTree(list, false);
+
+    expect(result[0].children?.[0].children?.[0].children).toHaveLength(1);
+    expect(result[0].children?.[0].children?.[0].children?.[0].name).toBe(
+      "file.ts",
+    );
+  });
+});


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
## 🔍 Description of Changes
Fixes #2873, 
Add button to be toggle hidden files/directory in file explorer.

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

I added a Eye-off Button to toggle the hidden files on/off.

Filters Nodes based on if they are hidden or not, then pass that to the Tree to display them.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.
