### PR TITLE
Update convert docsting to mention -y and -g global flags. 

### DIFF
--- a/marimo/_cli/convert/commands.py
+++ b/marimo/_cli/convert/commands.py
@@ -62,8 +62,8 @@ def convert(
 
         marimo convert script.py -o your_nb.py
 
-    You can also pass global flags to the command line app.
-    For example, you can add the `-q` flag to make the command quiet or the `-y` flag
+    You can also pass global flags to the main marimo command.
+    For example, use `-q` to suppress output or `-y`
     to automatically accept all prompts of the command.
 
         marimo -q -y convert script.py -o your_nb.py


### PR DESCRIPTION
Replaces https://github.com/marimo-team/marimo/pull/7199. 

No need to add a `--force` flag, but would be nice to make the user more aware. This is a natural place to mention it. 