### PR TITLE
Make workspace refresh button accessible

### DIFF
--- a/frontend/src/components/pages/home-page.tsx
+++ b/frontend/src/components/pages/home-page.tsx
@@ -195,10 +195,15 @@ const WorkspaceNotebooks: React.FC = () => {
           }
         >
           Workspace
-          <RefreshCcwIcon
-            className="w-4 h-4 ml-1 cursor-pointer opacity-70 hover:opacity-100"
+          <Button
+            variant="text"
+            size="icon"
+            className="w-4 h-4 ml-1 p-0 opacity-70 hover:opacity-100"
             onClick={() => refetch()}
-          />
+            aria-label="Refresh workspace"
+          >
+            <RefreshCcwIcon className="w-4 h-4" />
+          </Button>
           {isFetching && <Spinner size="small" />}
         </Header>
         <div className="flex flex-col divide-y divide-(--slate-3) border rounded overflow-hidden max-h-192 overflow-y-auto shadow-sm bg-background">


### PR DESCRIPTION
## 📝 Summary

Currently it isn't possible to focus the refresh button on the Marimo local server's home page using a keyboard. This change makes the button more accessible by using an actual button tag.

## 🔍 Description of Changes

I changed just the one component from an icon to a button that wraps the icon. This causes the button to inherit the usual browser accessibility features.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
