### PR TITLE
fix: add fallback for reactive_tests config

### DIFF
--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -87,6 +87,7 @@ test("default UserConfig - empty", () => {
         "default_auto_download": [],
         "default_sql_output": "auto",
         "on_cell_change": "autorun",
+        "reactive_tests": true,
         "watcher_on_save": "lazy",
       },
       "save": {
@@ -154,6 +155,7 @@ test("default UserConfig - one level", () => {
         "default_auto_download": [],
         "default_sql_output": "auto",
         "on_cell_change": "autorun",
+        "reactive_tests": true,
         "watcher_on_save": "lazy",
       },
       "save": {

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -119,6 +119,7 @@ export const UserConfigSchema = z
         auto_instantiate: z.boolean().prefault(true),
         on_cell_change: z.enum(["lazy", "autorun"]).prefault("autorun"),
         auto_reload: z.enum(["off", "lazy", "autorun"]).prefault("off"),
+        reactive_tests: z.boolean().prefault(true),
         watcher_on_save: z.enum(["lazy", "autorun"]).prefault("lazy"),
         default_sql_output: z.enum(VALID_SQL_OUTPUT_FORMATS).prefault("auto"),
         default_auto_download: z


### PR DESCRIPTION
Fixes the wasm playground when saving user config.