### PR TITLE
improvement: drop 'pip install'  when used in the package manager input

### DIFF
--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -23,6 +23,7 @@ import { toast } from "@/components/ui/use-toast";
 import { useResolvedMarimoConfig } from "@/core/config/config";
 import { useRequestClient } from "@/core/network/requests";
 import type { DependencyTreeNode } from "@/core/network/types";
+import { stripPackageManagerPrefix } from "@/core/packages/package-input-utils";
 import {
   showRemovePackageToast,
   showUpgradePackageToast,
@@ -191,8 +192,9 @@ const InstallPackageForm: React.FC<{
   };
 
   const installPackages = () => {
+    const cleanedInput = stripPackageManagerPrefix(input);
     handleInstallPackages(
-      input.split(",").map((p) => p.trim()),
+      cleanedInput.split(",").map((p) => p.trim()),
       onSuccessInstallPackages,
     );
   };

--- a/frontend/src/core/packages/__tests__/package-input-utils.test.ts
+++ b/frontend/src/core/packages/__tests__/package-input-utils.test.ts
@@ -1,0 +1,93 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+import { describe, expect, it } from "vitest";
+import { stripPackageManagerPrefix } from "../package-input-utils";
+
+describe("stripPackageManagerPrefix", () => {
+  it("should remove 'pip install' prefix", () => {
+    expect(stripPackageManagerPrefix("pip install httpx")).toBe("httpx");
+    expect(stripPackageManagerPrefix("pip install httpx requests")).toBe(
+      "httpx requests",
+    );
+  });
+
+  it("should remove 'pip3 install' prefix", () => {
+    expect(stripPackageManagerPrefix("pip3 install pandas")).toBe("pandas");
+  });
+
+  it("should remove 'uv add' prefix", () => {
+    expect(stripPackageManagerPrefix("uv add numpy")).toBe("numpy");
+    expect(stripPackageManagerPrefix("uv add pandas numpy")).toBe(
+      "pandas numpy",
+    );
+  });
+
+  it("should remove 'uv pip install' prefix", () => {
+    expect(stripPackageManagerPrefix("uv pip install scipy")).toBe("scipy");
+  });
+
+  it("should remove 'poetry add' prefix", () => {
+    expect(stripPackageManagerPrefix("poetry add flask")).toBe("flask");
+  });
+
+  it("should remove 'conda install' prefix", () => {
+    expect(stripPackageManagerPrefix("conda install matplotlib")).toBe(
+      "matplotlib",
+    );
+  });
+
+  it("should remove 'pipenv install' prefix", () => {
+    expect(stripPackageManagerPrefix("pipenv install django")).toBe("django");
+  });
+
+  it("should be case insensitive", () => {
+    expect(stripPackageManagerPrefix("PIP INSTALL httpx")).toBe("httpx");
+    expect(stripPackageManagerPrefix("Pip Install requests")).toBe("requests");
+    expect(stripPackageManagerPrefix("UV ADD numpy")).toBe("numpy");
+  });
+
+  it("should handle extra whitespace", () => {
+    expect(stripPackageManagerPrefix("  pip install   httpx  ")).toBe("httpx");
+    expect(stripPackageManagerPrefix("uv add    pandas   ")).toBe("pandas");
+  });
+
+  it("should return input unchanged if no prefix matches", () => {
+    expect(stripPackageManagerPrefix("httpx")).toBe("httpx");
+    expect(stripPackageManagerPrefix("pandas numpy")).toBe("pandas numpy");
+    expect(stripPackageManagerPrefix("httpx==0.27.0")).toBe("httpx==0.27.0");
+  });
+
+  it("should handle package specifications with versions", () => {
+    expect(stripPackageManagerPrefix("pip install httpx==0.27.0")).toBe(
+      "httpx==0.27.0",
+    );
+    expect(stripPackageManagerPrefix("uv add pandas>=2.0.0")).toBe(
+      "pandas>=2.0.0",
+    );
+  });
+
+  it("should handle git URLs", () => {
+    expect(
+      stripPackageManagerPrefix(
+        "pip install git+https://github.com/encode/httpx",
+      ),
+    ).toBe("git+https://github.com/encode/httpx");
+  });
+
+  it("should handle multiple packages", () => {
+    expect(stripPackageManagerPrefix("pip install httpx requests pandas")).toBe(
+      "httpx requests pandas",
+    );
+  });
+
+  it("should only remove the first matching prefix", () => {
+    // Edge case: input contains prefix-like text multiple times
+    expect(stripPackageManagerPrefix("pip install pip install httpx")).toBe(
+      "pip install httpx",
+    );
+  });
+
+  it("should handle empty string", () => {
+    expect(stripPackageManagerPrefix("")).toBe("");
+    expect(stripPackageManagerPrefix("   ")).toBe("");
+  });
+});

--- a/frontend/src/core/packages/package-input-utils.ts
+++ b/frontend/src/core/packages/package-input-utils.ts
@@ -1,0 +1,36 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+/**
+ * Removes common package manager command prefixes from an input string.
+ * This allows users to paste commands like "pip install httpx" and have
+ * the "pip install" prefix automatically removed.
+ *
+ * @param input - The raw input string that may contain a package manager prefix
+ * @returns The input with any recognized prefix removed and trimmed
+ *
+ * @example
+ * stripPackageManagerPrefix("pip install httpx") // returns "httpx"
+ * stripPackageManagerPrefix("uv add pandas numpy") // returns "pandas numpy"
+ * stripPackageManagerPrefix("httpx") // returns "httpx"
+ */
+export function stripPackageManagerPrefix(input: string): string {
+  const trimmedInput = input.trim();
+
+  const prefixes = [
+    "pip install",
+    "pip3 install",
+    "uv add",
+    "uv pip install",
+    "poetry add",
+    "conda install",
+    "pipenv install",
+  ];
+
+  for (const prefix of prefixes) {
+    if (trimmedInput.toLowerCase().startsWith(prefix.toLowerCase())) {
+      return trimmedInput.slice(prefix.length).trim();
+    }
+  }
+
+  return trimmedInput;
+}


### PR DESCRIPTION
Just nice QOL if you are copy-pasting `pip install pkg` into the package installer