### PR TITLE
iframe docs: mention same-origin in sandbox

### DIFF
--- a/docs/guides/publishing/playground.md
+++ b/docs/guides/publishing/playground.md
@@ -230,7 +230,7 @@ You can optionally render embedded notebooks in read-only mode by appending
   width="100%"
   height="500"
   frameborder="0"
-  sandbox="allow-scripts"
+  sandbox="allow-scripts allow-same-origin"
 ></iframe>
 ```
 


### PR DESCRIPTION
I noticed that on my altair sphinx work, iframes would fail to load if I didn't set the [allow-same-origin](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#allow-same-origin) setting in the "sandbox" key of the iframe. 

It's an edge case, because I am serving the marimo notebooks from a static folder that's not part of the path of the page that contains the iframe. It took me a bit to find out about it, figured I'd update this doc so that others can just copy and get on with their day. 
