### PR TITLE
fix: parsing in python-314

### DIFF
--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -188,9 +188,7 @@ class Extractor:
         if node.lineno - node.body[0].lineno == 0:
             # Quirk where the ellipse token seems to have a line index at
             # the end of the dots ...<
-            if sys.version_info < (3, 14) and isinstance(
-                getattr(node.body[0], "value", None), ast.Ellipsis
-            ):
+            if _is_ellipsis(getattr(node.body[0], "value", None)):
                 col_offset += node.body[0].col_offset - 3
             else:
                 col_offset += node.body[0].col_offset - 1
@@ -910,6 +908,14 @@ def is_body_cell(node: Node) -> bool:
             decorator, allowed=("cell", "function", "class_definition")
         )
     ) or is_unparsable_cell(node)
+
+
+def _is_ellipsis(node: Optional[Node]) -> bool:
+    if node is None:
+        return False
+    if sys.version_info < (3, 14):
+        return isinstance(node, ast.Ellipsis)
+    return isinstance(node, ast.Constant) and node.value == ...
 
 
 def _is_setup_call(node: Node) -> bool:

--- a/tests/_ast/codegen_data/test_get_codes_single_line_fn.py
+++ b/tests/_ast/codegen_data/test_get_codes_single_line_fn.py
@@ -7,6 +7,9 @@ app = marimo.App()
 @app.cell
 def one(a: int, b: int) -> None: c = a + b; print(c); return (c,)
 
+@app.cell
+def two(a: int, b: int) -> None: ...
+
 
 if __name__ == "__main__":
     app.run()

--- a/tests/_ast/test_load.py
+++ b/tests/_ast/test_load.py
@@ -170,8 +170,8 @@ class TestGetCodes:
         app = load_app(get_filepath("test_get_codes_single_line_fn"))
         assert app is not None
         cell_manager = app._cell_manager
-        assert list(cell_manager.names()) == ["one"]
-        assert list(cell_manager.codes()) == ["c = a + b; print(c); "]
+        assert list(cell_manager.names()) == ["one", "two"]
+        assert list(cell_manager.codes()) == ["c = a + b; print(c); ", "..."]
 
     @staticmethod
     def test_get_codes_multiline_string(load_app) -> None:


### PR DESCRIPTION
## 📝 Summary

Noticed these tests breaking on 3.14 with the deprecation of the `ast.Ellipsis` attribute. Easy fix, part of larger effort to stabilize 3.14