### PR TITLE
style: adjust create cell button size, stroke

### DIFF
--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -83,8 +83,8 @@ export const CreateCellButton = ({
         >
           <Tooltip content={finalTooltipContent}>
             <PlusIcon
-              strokeWidth={3.2}
-              size={16}
+              strokeWidth={3}
+              size={14}
               className="opacity-60 hover:opacity-90"
             />
           </Tooltip>

--- a/frontend/src/components/editor/cell/collapse.tsx
+++ b/frontend/src/components/editor/cell/collapse.tsx
@@ -44,9 +44,9 @@ export const CollapseToggle: React.FC<Props> = (props) => {
 
 const Arrow = ({ isCollapsed }: { isCollapsed: boolean }) => {
   return isCollapsed ? (
-    <ChevronRightIcon className="w-5 h-5 shrink-0" />
+    <ChevronRightIcon className="w-5 h-5 shrink-0 opacity-60" strokeWidth={2} />
   ) : (
-    <ChevronDownIcon className="w-5 h-5 shrink-0" />
+    <ChevronDownIcon className="w-5 h-5 shrink-0 opacity-60" strokeWidth={2} />
   );
 };
 

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -489,7 +489,7 @@ const EditableCellComponent = ({
 
   const outputArea = hasOutput && (
     <div className="relative" onDoubleClick={showHiddenCodeIfMarkdown}>
-      <div className="absolute top-5 -left-8 z-20 print:hidden">
+      <div className="absolute top-5 -left-7 z-20 print:hidden">
         <CollapseToggle
           isCollapsed={isCollapsed}
           onClick={() => {


### PR DESCRIPTION
Also adjust markdown heading toggle to make appearance similar to create cell button, since they are shown together

<img width="812" height="182" alt="image" src="https://github.com/user-attachments/assets/73047a33-44a8-49cd-b537-5b1b6856cc87" />
