### PR TITLE
add alert dialog description for accessibility

### DIFF
--- a/frontend/src/plugins/impl/common/error-banner.tsx
+++ b/frontend/src/plugins/impl/common/error-banner.tsx
@@ -6,6 +6,7 @@ import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogContent,
+  AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
@@ -48,9 +49,12 @@ export const ErrorBanner = ({
           <AlertDialogHeader>
             <AlertDialogTitle className="text-error">Error</AlertDialogTitle>
           </AlertDialogHeader>
-          <pre className="text-error text-sm p-2 font-mono overflow-auto whitespace-pre-wrap">
-            {message}
-          </pre>
+          <AlertDialogDescription
+            asChild={true}
+            className="text-error text-sm p-2 font-mono overflow-auto whitespace-pre-wrap"
+          >
+            <pre>{message}</pre>
+          </AlertDialogDescription>
           <AlertDialogFooter>
             <AlertDialogAction autoFocus={true} onClick={() => setOpen(false)}>
               Ok


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

A warning is raised every time there is an error alert due to missing alertDialogDescription. Small fix.
Before and after below is the same.

before:
<img width="857" height="444" alt="Screenshot 2025-11-21 at 9 17 33 PM" src="https://github.com/user-attachments/assets/0c5871df-0ba3-4cfa-82b4-da302a972b4b" />

after:
<img width="857" height="444" alt="Screenshot 2025-11-21 at 9 16 14 PM" src="https://github.com/user-attachments/assets/21d37c52-ad02-4739-8b94-f9b47926b904" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
