### PR TITLE
omit date format for to_csv in pandas

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -77,18 +77,9 @@ class PandasTableManagerFactory(TableManagerFactory):
                 self, format_mapping: Optional[FormatMapping] = None
             ) -> str:
                 has_headers = len(self.get_row_headers()) > 0
-                # Pandas omits H:M:S for datetimes when H:M:S is identically
-                # 0; this doesn't play well with our frontend table component,
-                # so we use an explicit date format.
                 return self.apply_formatting(
                     format_mapping
-                )._original_data.to_csv(
-                    # By adding %H:%M:%S.%f and %z, we ensure that the
-                    # datetime is displayed in the frontend with the
-                    # correct timezone and millisecond precision.
-                    index=has_headers,
-                    date_format="%Y-%m-%d %H:%M:%S.%f%z",
-                )
+                )._original_data.to_csv(index=has_headers)
 
             def to_json_str(
                 self, format_mapping: Optional[FormatMapping] = None

--- a/tests/_plugins/ui/_impl/tables/snapshots/pandas.csv
+++ b/tests/_plugins/ui/_impl/tables/snapshots/pandas.csv
@@ -1,4 +1,4 @@
 strings,bool,int,float,datetime,date,struct,list,nulls,category,set,imaginary,time,duration,mixed_list,bytes
-a,True,1,1.0,2021-01-01 00:00:00.000000,2021-01-01,"{'a': 1, 'b': 2}","[1, 2]",,cat,"{1, 2}",(1+2j),12:30:00,1 days,"[1, 'two']",b'\x00\x00\x00\x00\x01\xc0U\xe8\xb1n1\xc0T@D\xf1?Bc\x95\x83'
-b,False,2,2.0,2021-01-02 00:00:00.000000,2021-01-02,"{'a': 3, 'b': 4}","[3, 4]",data,dog,"{3, 4}",(3+4j),13:45:00,2 days,"[3.0, False]",b'world'
-c,True,3,3.0,2021-01-03 00:00:00.000000,2021-01-03,"{'a': 5, 'b': 6}","[5, 6]",,mouse,"{5, 6}",(5+6j),14:15:00,3 days,"[None, datetime.datetime(2021, 1, 1, 0, 0)]",b'bytes'
+a,True,1,1.0,2021-01-01,2021-01-01,"{'a': 1, 'b': 2}","[1, 2]",,cat,"{1, 2}",(1+2j),12:30:00,1 days,"[1, 'two']",b'\x00\x00\x00\x00\x01\xc0U\xe8\xb1n1\xc0T@D\xf1?Bc\x95\x83'
+b,False,2,2.0,2021-01-02,2021-01-02,"{'a': 3, 'b': 4}","[3, 4]",data,dog,"{3, 4}",(3+4j),13:45:00,2 days,"[3.0, False]",b'world'
+c,True,3,3.0,2021-01-03,2021-01-03,"{'a': 5, 'b': 6}","[5, 6]",,mouse,"{5, 6}",(5+6j),14:15:00,3 days,"[None, datetime.datetime(2021, 1, 1, 0, 0)]",b'bytes'


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

This is more equivalent to the original data from pandas.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
