### PR TITLE
internal: fix import from vitest

### DIFF
--- a/frontend/src/core/codemirror/editing/commands.ts
+++ b/frontend/src/core/codemirror/editing/commands.ts
@@ -2,16 +2,16 @@
 import { foldAll, unfoldAll } from "@codemirror/language";
 import type { Command, EditorView } from "@codemirror/view";
 
-type Nullable<T> = T | null;
+type MaybeEditorView = EditorView | undefined | null;
 
-export type BulkCommand = (targets: Nullable<EditorView>[]) => boolean;
+export type BulkCommand = (targets: MaybeEditorView[]) => boolean;
 
 /**
  * Make a bulk command from a single {@type Command} that applies
  * the given command to all targets.
  */
 export function makeBulkCommand(command: Command) {
-  return (targets: Nullable<EditorView>[]) => {
+  return (targets: MaybeEditorView[]) => {
     let changed = false;
     for (const target of targets) {
       if (target) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace `vitest` `Nullable` with a local `MaybeEditorView` type and update related function signatures.
> 
> - **Type updates in `frontend/src/core/codemirror/editing/commands.ts`**:
>   - Replace `Nullable` from `vitest` with local `MaybeEditorView` (`EditorView | undefined | null`).
>   - Update `BulkCommand` and `makeBulkCommand` signatures to use `MaybeEditorView[]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc0145efa33cc695bda21d57d4f5637e803c6b71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->