### PR TITLE
feat: Add `date_slider` input widget

### DIFF
--- a/docs/api/inputs/dates.md
+++ b/docs/api/inputs/dates.md
@@ -59,3 +59,27 @@
 
 ::: marimo.ui.date_range
   :members:
+
+## Date slider
+
+/// marimo-embed
+
+```python
+    @app.cell
+    def __():
+        date_slider = mo.ui.date_slider(
+            start="2025-01-01",
+            stop="2025-01-15",
+        )
+        return
+
+    @app.cell
+    def __():
+        mo.hstack([date_slider, mo.md(f"Has value: {date_slider.value}")])
+        return
+```
+
+///
+
+::: marimo.ui.date_slider
+  :members:

--- a/docs/api/inputs/index.md
+++ b/docs/api/inputs/index.md
@@ -16,6 +16,7 @@ powerful notebooks and apps. These elements are available in `marimo.ui`.
 | [`marimo.ui.date`][marimo.ui.date] | Date picker |
 | [`marimo.ui.datetime`][marimo.ui.datetime] | Date and time picker |
 | [`marimo.ui.date_range`][marimo.ui.date_range] | Date range picker |
+| [`marimo.ui.date_slider`][marimo.ui.date_slider] | Date slider |
 | [`marimo.ui.dictionary`][marimo.ui.dictionary] | Dictionary inputs |
 | [`marimo.ui.dropdown`][marimo.ui.dropdown] | Create dropdowns |
 | [`marimo.ui.file`][marimo.ui.file] | File uploads |

--- a/frontend/src/components/ui/date-slider.tsx
+++ b/frontend/src/components/ui/date-slider.tsx
@@ -1,0 +1,101 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import * as React from "react";
+import { cn } from "@/utils/cn";
+import { useBoolean } from "../../hooks/useBoolean";
+import {
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+} from "./tooltip";
+
+const DateSlider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+    valueMap: (sliderValue: number) => string;
+  }
+>(({ className, valueMap, ...props }, ref) => {
+  const [open, openActions] = useBoolean(false);
+
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex touch-none select-none hover:cursor-pointer",
+        "data-[orientation=horizontal]:w-full data-[orientation=horizontal]:items-center",
+        "data-[orientation=vertical]:h-full data-[orientation=vertical]:justify-center",
+        "data-disabled:cursor-not-allowed",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-testid="track"
+        className={cn(
+          "relative grow overflow-hidden rounded-full bg-slate-200 dark:bg-accent/60",
+          "data-[orientation=horizontal]:h-2 data-[orientation=horizontal]:w-full",
+          "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2",
+        )}
+      >
+        <SliderPrimitive.Range
+          data-testid="range"
+          className={cn(
+            "absolute bg-blue-500 dark:bg-primary",
+            "data-[orientation=horizontal]:h-full",
+            "data-[orientation=vertical]:w-full",
+            "data-disabled:opacity-50",
+          )}
+        />
+      </SliderPrimitive.Track>
+      <TooltipProvider>
+        <TooltipRoot delayDuration={0} open={open}>
+          <TooltipTrigger asChild={true}>
+            <SliderPrimitive.Thumb
+              data-testid="thumb"
+              className="block h-4 w-4 rounded-full shadow-xs-solid border border-blue-500 dark:border-primary dark:bg-accent bg-white hover:bg-blue-300 focus:bg-blue-300 transition-colors focus-visible:outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50"
+              onFocus={openActions.setTrue}
+              onBlur={openActions.setFalse}
+              onMouseEnter={openActions.setTrue}
+              onMouseLeave={openActions.setFalse}
+            />
+          </TooltipTrigger>
+          <TooltipPortal>
+            {props.value != null && props.value.length === 2 && (
+              <TooltipContent key={props.value[0]}>
+                {valueMap(props.value[0])}
+              </TooltipContent>
+            )}
+          </TooltipPortal>
+        </TooltipRoot>
+      </TooltipProvider>
+      <TooltipProvider>
+        <TooltipRoot delayDuration={0} open={open}>
+          <TooltipTrigger asChild={true}>
+            <SliderPrimitive.Thumb
+              data-testid="thumb"
+              className="block h-4 w-4 rounded-full shadow-xs-solid border border-blue-500 dark:border-primary dark:bg-accent bg-white hover:bg-blue-300 focus:bg-blue-300 transition-colors focus-visible:outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50"
+              onFocus={openActions.setTrue}
+              onBlur={openActions.setFalse}
+              onMouseEnter={openActions.setTrue}
+              onMouseLeave={openActions.setFalse}
+            />
+          </TooltipTrigger>
+          <TooltipPortal>
+            {props.value != null && props.value.length === 2 && (
+              <TooltipContent key={props.value[1]}>
+                {valueMap(props.value[1])}
+              </TooltipContent>
+            )}
+          </TooltipPortal>
+        </TooltipRoot>
+      </TooltipProvider>
+    </SliderPrimitive.Root>
+  );
+});
+
+DateSlider.displayName = "DateSlider";
+
+export { DateSlider };

--- a/frontend/src/plugins/impl/DateSliderPlugin.tsx
+++ b/frontend/src/plugins/impl/DateSliderPlugin.tsx
@@ -1,0 +1,197 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { isEqual } from "lodash-es";
+import { type JSX, useEffect, useId, useState } from "react";
+import { z } from "zod";
+import { cn } from "@/utils/cn";
+import { RangeSlider } from "../../components/ui/range-slider";
+import type { IPlugin, IPluginProps, Setter } from "../types";
+import { Labeled } from "./common/labeled";
+
+type T = string[];
+
+interface Data {
+  start: number;
+  stop: number;
+  step: number;
+  label: string | null;
+  steps: string[];
+  debounce: boolean;
+  orientation: "horizontal" | "vertical";
+  showValue: boolean;
+  fullWidth: boolean;
+  disabled?: boolean;
+}
+
+export class DateSliderPlugin implements IPlugin<T, Data> {
+  tagName = "marimo-date-slider";
+
+  validator = z.object({
+    initialValue: z.array(z.string()),
+    label: z.string().nullable(),
+    start: z.number(),
+    stop: z.number(),
+    step: z.number(),
+    steps: z.array(z.string()),
+    debounce: z.boolean().default(false),
+    orientation: z.enum(["horizontal", "vertical"]).default("horizontal"),
+    showValue: z.boolean().default(false),
+    fullWidth: z.boolean().default(false),
+    disabled: z.boolean().optional(),
+  });
+
+  render(props: IPluginProps<T, Data>): JSX.Element {
+    const valueMap = (sliderValue: number): string => {
+      if (props.data.steps && props.data.steps.length > 0) {
+        return props.data.steps[sliderValue];
+      }
+      return sliderValue.toString();
+    };
+
+    return (
+      <DateSliderComponent
+        {...props.data}
+        value={props.value}
+        setValue={props.setValue}
+        valueMap={valueMap}
+      />
+    );
+  }
+}
+
+interface DateSliderProps extends Data {
+  value: T;
+  setValue: Setter<T>;
+  valueMap: (sliderValue: number) => string;
+}
+
+const DateSliderComponent = ({
+  label,
+  setValue,
+  value,
+  start,
+  stop,
+  step,
+  steps,
+  debounce,
+  orientation,
+  showValue,
+  fullWidth,
+  disabled,
+  valueMap,
+}: DateSliderProps): JSX.Element => {
+  const id = useId();
+
+  // Convert date strings to indices
+  const dateToIndex = (dateStr: string): number => {
+    const index = steps.indexOf(dateStr);
+    return index !== -1 ? index : 0;
+  };
+
+  // Convert internal slider value (indices) to date strings
+  const internalValueToDates = (indices: number[]): string[] => {
+    return indices.map((idx) => valueMap(idx));
+  };
+
+  // Convert date strings to internal slider value (indices)
+  const datesToInternalValue = (dates: string[]): number[] => {
+    return dates.map((date) => dateToIndex(date));
+  };
+
+  // Hold internal value (as indices)
+  const [internalValue, setInternalValue] = useState<number[]>(
+    datesToInternalValue(value),
+  );
+
+  // Update internal value on prop change
+  useEffect(() => {
+    setInternalValue(datesToInternalValue(value));
+  }, [value]);
+
+  const formatDate = (dateStr: string): string => {
+    try {
+      const date = new Date(dateStr);
+      return date.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    } catch {
+      return dateStr;
+    }
+  };
+
+  const sliderElement = (
+    <Labeled
+      label={label}
+      id={id}
+      align={orientation === "horizontal" ? "left" : "top"}
+      className={cn(fullWidth && "my-1 w-full")}
+      fullWidth={fullWidth}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2",
+          orientation === "vertical" &&
+            "items-end inline-flex justify-center self-center mx-2",
+          fullWidth && "w-full",
+        )}
+      >
+        <RangeSlider
+          id={id}
+          className={cn(
+            "relative flex items-center select-none",
+            !fullWidth && "data-[orientation=horizontal]:w-36 ",
+            "data-[orientation=vertical]:h-36",
+          )}
+          value={internalValue}
+          min={start}
+          max={stop}
+          step={step}
+          orientation={orientation}
+          disabled={disabled}
+          // Triggered on all value changes
+          onValueChange={(nextValue: number[]) => {
+            setInternalValue(nextValue);
+            if (!debounce) {
+              setValue(internalValueToDates(nextValue));
+            }
+          }}
+          // Triggered on mouse up
+          onValueCommit={(nextValue: number[]) => {
+            if (debounce) {
+              setValue(internalValueToDates(nextValue));
+            }
+          }}
+          // Sometimes onValueCommit doesn't trigger
+          // see https://github.com/radix-ui/primitives/issues/1760
+          // So we also set the value on pointer/mouse up
+          onPointerUp={() => {
+            if (
+              debounce &&
+              !isEqual(internalValue, datesToInternalValue(value))
+            ) {
+              setValue(internalValueToDates(internalValue));
+            }
+          }}
+          onMouseUp={() => {
+            if (
+              debounce &&
+              !isEqual(internalValue, datesToInternalValue(value))
+            ) {
+              setValue(internalValueToDates(internalValue));
+            }
+          }}
+          valueMap={(idx: number) => idx}
+        />
+        {showValue && (
+          <div className="text-xs text-muted-foreground min-w-[16px]">
+            {`${formatDate(valueMap(internalValue[0]))}, ${formatDate(valueMap(internalValue[1]))}`}
+          </div>
+        )}
+      </div>
+    </Labeled>
+  );
+
+  return sliderElement;
+};

--- a/frontend/src/plugins/impl/__tests__/DateSliderPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/DateSliderPlugin.test.tsx
@@ -1,0 +1,168 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { initialModeAtom } from "@/core/mode";
+import { store } from "@/core/state/jotai";
+import type { IPluginProps } from "../../types";
+import { DateSliderPlugin } from "../DateSliderPlugin";
+
+interface DateSliderData {
+  label: string | null;
+  start: number;
+  stop: number;
+  step: number;
+  steps: string[];
+  debounce: boolean;
+  orientation: "horizontal" | "vertical";
+  showValue: boolean;
+  fullWidth: boolean;
+  disabled?: boolean;
+}
+
+describe("DateSliderPlugin", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store.set(initialModeAtom, "edit");
+  });
+
+  it("should render with daily steps", () => {
+    const plugin = new DateSliderPlugin();
+    const host = document.createElement("div");
+    const steps = [
+      "2024-01-01",
+      "2024-01-02",
+      "2024-01-03",
+      "2024-01-04",
+      "2024-01-05",
+    ];
+    const props: IPluginProps<string[], DateSliderData> = {
+      host,
+      value: ["2024-01-01", "2024-01-05"],
+      setValue: (valueOrFn) => {
+        if (typeof valueOrFn === "function") {
+          valueOrFn(["2024-01-01", "2024-01-05"]);
+        }
+      },
+      data: {
+        label: "Select date range",
+        start: 0,
+        stop: 4,
+        step: 1,
+        steps: steps,
+        debounce: false,
+        orientation: "horizontal",
+        showValue: true,
+        fullWidth: false,
+        disabled: false,
+      },
+      functions: {},
+    };
+    const { container } = render(plugin.render(props));
+
+    // Check if the component renders
+    expect(container.innerHTML).not.toBe("");
+  });
+
+  it("should render with weekly steps", () => {
+    const plugin = new DateSliderPlugin();
+    const host = document.createElement("div");
+    const steps = [
+      "2024-01-01",
+      "2024-01-08",
+      "2024-01-15",
+      "2024-01-22",
+      "2024-01-29",
+    ];
+    const props: IPluginProps<string[], DateSliderData> = {
+      host,
+      value: ["2024-01-08", "2024-01-22"],
+      setValue: (valueOrFn) => {
+        if (typeof valueOrFn === "function") {
+          valueOrFn(["2024-01-08", "2024-01-22"]);
+        }
+      },
+      data: {
+        label: null,
+        start: 0,
+        stop: 4,
+        step: 1,
+        steps: steps,
+        debounce: true,
+        orientation: "horizontal",
+        showValue: false,
+        fullWidth: true,
+        disabled: false,
+      },
+      functions: {},
+    };
+    const { container } = render(plugin.render(props));
+
+    // Check if the component renders
+    expect(container.innerHTML).not.toBe("");
+  });
+
+  it("should render with vertical orientation", () => {
+    const plugin = new DateSliderPlugin();
+    const host = document.createElement("div");
+    const steps = ["2024-01-01", "2024-02-01", "2024-03-01"];
+    const props: IPluginProps<string[], DateSliderData> = {
+      host,
+      value: ["2024-01-01", "2024-03-01"],
+      setValue: (valueOrFn) => {
+        if (typeof valueOrFn === "function") {
+          valueOrFn(["2024-01-01", "2024-03-01"]);
+        }
+      },
+      data: {
+        label: "Monthly dates",
+        start: 0,
+        stop: 2,
+        step: 1,
+        steps: steps,
+        debounce: false,
+        orientation: "vertical",
+        showValue: true,
+        fullWidth: false,
+        disabled: false,
+      },
+      functions: {},
+    };
+    const { container } = render(plugin.render(props));
+
+    // Check if the component renders
+    expect(container.innerHTML).not.toBe("");
+  });
+
+  it("should handle disabled state", () => {
+    const plugin = new DateSliderPlugin();
+    const host = document.createElement("div");
+    const steps = ["2024-01-01", "2024-01-02"];
+    const props: IPluginProps<string[], DateSliderData> = {
+      host,
+      value: ["2024-01-01", "2024-01-02"],
+      setValue: (valueOrFn) => {
+        if (typeof valueOrFn === "function") {
+          valueOrFn(["2024-01-01", "2024-01-02"]);
+        }
+      },
+      data: {
+        label: null,
+        start: 0,
+        stop: 1,
+        step: 1,
+        steps: steps,
+        debounce: false,
+        orientation: "horizontal",
+        showValue: false,
+        fullWidth: false,
+        disabled: true,
+      },
+      functions: {},
+    };
+    const { container } = render(plugin.render(props));
+
+    // Check if the component renders
+    expect(container.innerHTML).not.toBe("");
+  });
+});

--- a/frontend/src/plugins/plugins.ts
+++ b/frontend/src/plugins/plugins.ts
@@ -14,6 +14,7 @@ import { DataEditorPlugin } from "./impl/DataEditorPlugin";
 import { DataTablePlugin } from "./impl/DataTablePlugin";
 import { DatePickerPlugin } from "./impl/DatePickerPlugin";
 import { DateRangePickerPlugin } from "./impl/DateRangePlugin";
+import { DateSliderPlugin } from "./impl/DateSliderPlugin";
 import { DateTimePickerPlugin } from "./impl/DateTimePickerPlugin";
 import { DictPlugin } from "./impl/DictPlugin";
 import { DropdownPlugin } from "./impl/DropdownPlugin";
@@ -61,6 +62,7 @@ export const UI_PLUGINS: IPlugin<any, unknown>[] = [
   new DatePickerPlugin(),
   new DateTimePickerPlugin(),
   new DateRangePickerPlugin(),
+  new DateSliderPlugin(),
   new DictPlugin(),
   new CodeEditorPlugin(),
   new DropdownPlugin(),

--- a/marimo/_plugins/ui/__init__.py
+++ b/marimo/_plugins/ui/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "data_explorer",
     "dataframe",
     "date_range",
+    "date_slider",
     "date",
     "datetime",
     "experimental_data_editor",
@@ -55,6 +56,7 @@ from marimo._plugins.ui._impl.dataframes.dataframe import dataframe
 from marimo._plugins.ui._impl.dates import (
     date,
     date_range,
+    date_slider,
     datetime,
 )
 from marimo._plugins.ui._impl.dictionary import dictionary

--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -632,10 +632,8 @@ class date_slider(UIElement[list[str], tuple[dt.date, dt.date]]):
             start = convert_str_to_date(start)
         if isinstance(stop, str):
             stop = convert_str_to_date(stop)
-        # TODO(FBruzzesi): Allow step to be in string format (e.g. 1d) instead of timedelta
-        if step is not None and not isinstance(step, dt.timedelta):
-            msg = f"Expected `step` of type datetime.timedelta. Found {type(step)} instead."
-            raise TypeError(msg)
+        # TODO(FBruzzesi): Allow `step` to be in string format (e.g. 1d) instead of timedelta
+        # and parse it into timedelta?
         if value is not None:
             value = (
                 convert_str_to_date(value[0]),
@@ -647,6 +645,10 @@ class date_slider(UIElement[list[str], tuple[dt.date, dt.date]]):
         self._step = dt.timedelta(days=1) if step is None else step
 
         validate_start_stop(self._start, self._stop, "date")
+
+        if not isinstance(self._step, dt.timedelta):
+            msg = f"Expected `step` of type datetime.timedelta. Found {type(self._step)} instead."
+            raise TypeError(msg)
 
         if self._step.total_seconds() <= 0:
             raise ValueError(f"The step ({step}) must be a positive timedelta")

--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -751,7 +751,7 @@ class date_slider(UIElement[list[str], tuple[dt.date, dt.date]]):
 
         Returns:
             datetime.date: The start date, which is either the user-specified minimum date
-                or 0001-01-01 if no start date was specified.
+                or 01-01-0001 if no start date was specified.
         """
         return self._start
 
@@ -761,7 +761,7 @@ class date_slider(UIElement[list[str], tuple[dt.date, dt.date]]):
 
         Returns:
             datetime.date: The stop date, which is either the user-specified maximum date
-                or 9999-12-31 if no stop date was specified.
+                or 12-31-9999 if no stop date was specified.
         """
         return self._stop
 

--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -578,8 +578,8 @@ class date_slider(UIElement[list[str], tuple[dt.date, dt.date]]):
     Examples:
         ```python
         date_slider = mo.ui.date_slider(
-            start=dt.date(2023, 1, 1),
-            stop=dt.date(2023, 12, 31),
+            start=dt.date(2025, 1, 1),
+            stop=dt.date(2025, 1, 31),
             step=dt.timedelta(days=7),
         )
         ```

--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -289,6 +289,9 @@ class date(UIElement[str, dt.date]):
         label = kwargs.pop("label", info.label)
         return date(start=start, stop=stop, label=label, **kwargs)
 
+    def _convert_value(self, value: str) -> dt.date:
+        return convert_str_to_date(value)
+
     @property
     def start(self) -> dt.date:
         """Get the minimum selectable date.
@@ -417,6 +420,9 @@ class datetime(UIElement[Optional[str], Optional[dt.datetime]]):
         label = kwargs.pop("label", info.label)
         return datetime(start=start, stop=stop, label=label, **kwargs)
 
+    def _convert_value(self, value: Optional[str]) -> Optional[dt.datetime]:
+        return convert_str_to_datetime(value)
+
     @property
     def start(self) -> dt.datetime:
         """Get the minimum selectable datetime.
@@ -538,6 +544,11 @@ class date_range(UIElement[tuple[str, str], tuple[dt.date, dt.date]]):
         stop = kwargs.pop("stop", info.max)
         label = kwargs.pop("label", info.label)
         return date_range(start=start, stop=stop, label=label, **kwargs)
+
+    def _convert_value(
+        self, value: tuple[str, str]
+    ) -> tuple[dt.date, dt.date]:
+        return convert_str_to_date(value[0]), convert_str_to_date(value[1])
 
     @property
     def start(self) -> dt.date:
@@ -775,3 +786,6 @@ class date_slider(UIElement[list[str], tuple[dt.date, dt.date]]):
             datetime.timedelta: The step timedelta.
         """
         return self._step
+
+    def _convert_value(self, value: list[str]) -> tuple[dt.date, dt.date]:
+        return convert_str_to_date(value[0]), convert_str_to_date(value[1])


### PR DESCRIPTION
## 📝 Summary

This is a proof of concept (maybe headstart?) to introduce a `date_slider` (edit: actually a `date_range_slider`) widget.

Fixes #6316

## 🔍 Description of Changes

- Adds `date_slider` ui widget
- Arguably too much refactor in the `dates.py` module
- The frontend is 95% AI generated, that's why I am opening this as a draft, and happy to let anyone take it over. My main objective here was to see how feasible it was to add this component.
- TODO: I would like to add the possibility to use a custom formatting that is applied to the dates before 

<details><summary>Screenshot of rendering</summary>
<p>

<img width="422" height="276" alt="image" src="https://github.com/user-attachments/assets/c18b8bc5-a66b-4d79-a071-75d620a00bae" />


</p>
</details> 

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions). [Thread link](https://discord.com/channels/1059888774789730424/1441427087603925083/1441432814732972033).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
