### PR TITLE
columns.tsx LocaleNumber to use maximumFractionDigits

### DIFF
--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -4,7 +4,7 @@
 import { PopoverClose } from "@radix-ui/react-popover";
 import type { Column, ColumnDef } from "@tanstack/react-table";
 import { formatDate } from "date-fns";
-import { useNumberFormatter } from "react-aria";
+import { useLocale, useNumberFormatter } from "react-aria";
 import { WithLocale } from "@/core/i18n/with-locale";
 import type { DataType } from "@/core/kernel/messages";
 import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
@@ -596,7 +596,7 @@ export function renderCellValue<TData, TValue>({
 }
 
 const LocaleNumber = ({ value }: { value: number }) => {
-  const digits = maxFractionalDigits(navigator.language);
+  const digits = maxFractionalDigits(useLocale().locale);
   const format = useNumberFormatter({ maximumFractionDigits: digits });
   return format.format(value);
 };


### PR DESCRIPTION
Default formatting for number data-table columns updated to use calculated maxFractionaldigits based on locale.

## 📝 Summary

By default, a data-table uses `Intl.NumberFormat` with no options to display number types that have no explicit format. This can lead to rounding-when-displayed by default, which is antithetical to the expected behavior when displaying raw data (e.g. without explicit formatting).

## 🔍 Description of Changes

Used the existing `maxFractionalDigits` function from the number utils to invoke the `useNumberFormatter` function with a value for the `maximumSignificantDigits` parameter.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [X] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [X] I have run the code and verified that it works as expected.
