### PR TITLE
chore(deps): pin vega-lite to 6.3.1 and update related configurations

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,6 +64,8 @@
         "!/.*react-aria.*/",
         // react-hook-form is pinned to 7.54.2
         "!/.*react-hook-form.*/",
+        // vega-lite is pinned to 6.3.1
+        "!/.*vega-lite.*/",
         // pyodide needs to be manually updated
         "!/.*pyodide.*/"
       ],

--- a/.github/workflows/test_fe.yaml
+++ b/.github/workflows/test_fe.yaml
@@ -115,6 +115,10 @@ jobs:
             echo "Error: react-hook-form version in package.json must be exactly 7.54.2. As it breaks mo.ui.dataframe"
             exit 1
           fi
+          if ! grep -q '"vega-lite": "6.3.1"' package.json; then
+            echo "Error: vega-lite version in package.json must be exactly 6.3.1. Newer versions break numeric tooltips"
+            exit 1
+          fi
 
       - name: 📦 Build
         run: pnpm turbo build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -168,7 +168,7 @@
     "typescript-memoize": "^1.1.1",
     "use-acp": "0.2.5",
     "use-resize-observer": "^9.1.0",
-    "vega-lite": "^6.3.1",
+    "vega-lite": "6.3.1",
     "vega-loader": "^5.1.0",
     "vega-parser": "^7.1.0",
     "vega-tooltip": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,7 +491,7 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       vega-lite:
-        specifier: ^6.3.1
+        specifier: 6.3.1
         version: 6.3.1(vega@6.2.0)
       vega-loader:
         specifier: ^5.1.0


### PR DESCRIPTION
This commit pins the vega-lite dependency to version 6.3.1 in package.json and pnpm-lock.yaml

