### PR TITLE
fix: recognize class variables used within class scope as non-external dependencies (#7265)

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -531,7 +531,12 @@ class ScopedVisitor(ast.NodeVisitor):
                         # Thus, if it has been declared, it's not "unbounded"
                         class_def.add(var)
                     else:
-                        unbounded_refs |= data.required_refs
+                        # For non-function/non-class variables (e.g., class attributes),
+                        # exclude references to variables already defined in class scope
+                        unbounded_refs |= data.required_refs - class_def
+                        # Add the variable to class_def so that later references
+                        # to it don't create unbounded refs
+                        class_def.add(var)
                 unbounded_refs |= mock_visitor.refs - ignore_refs
 
         # Handle function/class refs that are evaluated in the outer scope

--- a/marimo/_smoke_tests/parse/classes.py
+++ b/marimo/_smoke_tests/parse/classes.py
@@ -1,0 +1,73 @@
+import marimo
+
+__generated_with = "0.18.0"
+app = marimo.App(width="medium")
+
+
+@app.class_definition
+# This should be reusable
+class One:
+    A: int = 1
+
+    def run(a: A = 1) -> int:
+        return a
+
+
+@app.class_definition
+# This should be a pure-class
+class Two:
+    A: int = 1
+
+    def run(a: int = 1) -> int:
+        return a
+
+
+@app.cell
+def _():
+    C = int
+    return (C,)
+
+
+@app.cell
+def _():
+    value = 1
+    return (value,)
+
+
+@app.cell
+def _(C):
+    # This should NOT be reusable (depends on C)
+    class Three:
+        A: int = 1
+        B: int = 1
+
+        def run(a: C = 1) -> int:
+            return a
+    return
+
+
+@app.cell
+def _(C):
+    # This should NOT be reusable (depends on C)
+    class Four:
+        A: int = 1
+        B: C = 1
+
+        def run(a: B = 1) -> int:
+            return a
+    return
+
+
+@app.cell
+def _(value):
+    # This should NOT be reusable (depends on value)
+    class Five:
+        A: int = 1
+
+        def run(a: A = value) -> int:
+            return a
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary

Fixes #7265

When a class had a class variable (like `A: int = 1`) and that variable was referenced within the class scope (e.g., in method default parameters or other class variable definitions), marimo incorrectly concluded the class definition could not be reused. This was because `A` was being treated as an external dependency rather than a class-scoped variable.
