### PR TITLE
prevent layout shift from new cell buttons

### DIFF
--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -113,7 +113,7 @@ export const CreateCellButton = ({
       <DropdownMenuTrigger asChild={true} onPointerDown={handleButtonClick}>
         <Button
           className={cn(
-            "border-none hover-action-hidden shadow-none! bg-transparent focus-visible:outline-none",
+            "border-none hover-action shadow-none! bg-transparent focus-visible:outline-none",
             isAppInteractionDisabled(connectionState) && " inactive-button",
           )}
           onMouseDown={Events.preventFocus}

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -839,7 +839,7 @@ const CellLeftSideActions = memo(
           className,
         )}
       >
-        <div className="-mt-1">
+        <div className="-mt-1 min-h-7">
           <CreateCellButton
             tooltipContent={renderShortcut("cell.createAbove")}
             connectionState={connection.state}
@@ -849,7 +849,7 @@ const CellLeftSideActions = memo(
         </div>
         <div className="flex-1 pointer-events-none w-3" />
         {/* <div className="flex-1 pointer-events-none bg-border w-px mx-auto hover-action opacity-70" /> */}
-        <div className="-mb-2">
+        <div className="-mb-2 min-h-7">
           <CreateCellButton
             tooltipContent={renderShortcut("cell.createBelow")}
             connectionState={connection.state}

--- a/frontend/src/css/common.css
+++ b/frontend/src/css/common.css
@@ -8,21 +8,11 @@
     display: none !important;
   }
 
-  /* Instead of hiding the element, we hide the opacity. Prevents layout shift. */
-  .hover-action-hidden {
-    opacity: 0;
-  }
-
   [data-is-dragging="true"] {
     .hover-actions-parent.hover-actions-parent .hover-action:not(:hover) {
       display: none !important;
     }
   }
-}
-
-.hover-actions-parent:hover .hover-action-hidden,
-.hover-actions-parent:focus .hover-action-hidden {
-  opacity: 1;
 }
 
 .hover-action:hover,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
issue:

https://github.com/user-attachments/assets/0c673e4a-86aa-4cb5-8f2f-c24f60be99af

There is a layout shift because the cell buttons which have `display: none` now appear on hover. This adds a min height to the cell buttons wrapper.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
