### PR TITLE
fix: still allow codegen even if there are duplicate defs

### DIFF
--- a/marimo/_ast/toplevel.py
+++ b/marimo/_ast/toplevel.py
@@ -276,7 +276,9 @@ class TopLevelExtraction:
         unresolved: set[Name] = set()
         for status in self.statuses:
             if status.is_unresolved or status.is_cell:
-                self._statuses[status.type].pop(status.name)
+                # Use pop with default to handle duplicate definitions gracefully
+                # If there are duplicates, only the last one is in the dict
+                self._statuses[status.type].pop(status.name, None)
                 status.update(
                     self.allowed_refs,
                     unresolved,

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -281,6 +281,20 @@ class TestGeneration:
             "test_generate_filecontents_shadowed_builtin"
         )
 
+    @staticmethod
+    def test_generate_filecontents_duplicate_definitions() -> None:
+        """Test that duplicate top-level definitions don't cause KeyError during codegen."""
+        cell_one = "def Two(): return 2"
+        cell_two = "def Two(): return 'two'"
+        codes = [cell_one, cell_two]
+        names = ["one", "two"]
+        # This should not raise a KeyError during TopLevelExtraction
+        # (duplicate validation happens at app.run(), not during codegen)
+        contents = wrap_generate_filecontents(codes, names)
+        # Should successfully generate file contents
+        assert "import marimo" in contents
+        assert contents is not None
+
     def test_with_second_type_noop(self) -> None:
         referring = "x = 1; x: int = 0"
         ref_vars = compile_cell(referring).init_variable_data


### PR DESCRIPTION
If you have duplicate top-level functions/classes, `Save` would fail. We should still allow saving otherwise you can lose wasted work.  