### PR TITLE
Add Claude 4.5 Opus model to models.yml

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -2,6 +2,13 @@
 
 # Anthropic
 
+- name: Claude 4.5 Opus
+  model: claude-opus-4-5
+  description: Latest Opus model with enhanced capabilities and performance improvements
+  providers: [anthropic]
+  roles: [chat, edit]
+  thinking: true
+  
 - name: Claude 4.5 Sonnet
   model: claude-sonnet-4-5
   description: Latest Sonnet model with enhanced capabilities and performance improvements


### PR DESCRIPTION
Added Claude 4.5 Opus model. Just saw the [announcement](https://www.anthropic.com/news/claude-opus-4-5), got the model ID from [here](https://platform.claude.com/docs/en/about-claude/models/overview). 