### PR TITLE
fix: 'marimo edit' for absolute directory

### DIFF
--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -16,6 +16,7 @@ from marimo._config.manager import get_default_config_manager
 from marimo._output.utils import uri_decode_component, uri_encode_component
 from marimo._runtime.virtual_file import EMPTY_VIRTUAL_FILE, read_virtual_file
 from marimo._server.api.deps import AppState
+from marimo._server.file_router import validate_inside_directory
 from marimo._server.router import APIRouter
 from marimo._server.templates.templates import (
     home_page_template,
@@ -270,8 +271,8 @@ async def serve_public_file(request: Request) -> Response:
 
         # Security check: ensure file is inside public directory
         try:
-            file_path.relative_to(public_dir.resolve())
-        except ValueError:
+            validate_inside_directory(public_dir, file_path)
+        except HTTPException:
             return Response(status_code=403, content="Access denied")
 
         if file_path.is_file() and not file_path.is_symlink():

--- a/marimo/_server/file_router.py
+++ b/marimo/_server/file_router.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import abc
 import os
-import pathlib
 import signal
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from marimo import _loggers
@@ -189,7 +189,7 @@ class ListOfFilesAppFileRouter(AppFileRouter):
 class LazyListOfFilesAppFileRouter(AppFileRouter):
     def __init__(self, directory: str, include_markdown: bool) -> None:
         # pass through Path to canonicalize, strips trailing slashes
-        self._directory = str(pathlib.Path(directory))
+        self._directory = str(Path(directory))
         self.include_markdown = include_markdown
         self._lazy_files: Optional[list[FileInfo]] = None
 
@@ -232,25 +232,18 @@ class LazyListOfFilesAppFileRouter(AppFileRouter):
                 default_sql_output=default_sql_output,
             )
 
-        directory = pathlib.Path(self._directory)
-        filepath = pathlib.Path(key)
+        directory = Path(self._directory)
+        filepath = Path(key)
 
-        # If directory is absolute, ensure the filepath is a child of the directory
-        if directory.is_absolute():
-            # Make filepath absolute if it's not
-            if not filepath.is_absolute():
-                filepath = directory / filepath
-            else:
-                # Ensure the filepath is within the directory
-                try:
-                    filepath.relative_to(directory)
-                except (ValueError, OSError):
-                    raise HTTPException(
-                        status_code=HTTPStatus.FORBIDDEN,
-                        detail=f"Access denied: File {key} is outside the allowed directory",
-                    ) from None
+        # Validate that filepath is inside directory
+        validate_inside_directory(directory, filepath)
 
-        # First try the key as-is (handles absolute paths within directory)
+        # Resolve filepath for use
+        # If directory is absolute and filepath is relative, resolve relative to directory
+        if directory.is_absolute() and not filepath.is_absolute():
+            filepath = directory / filepath
+        # Note: We don't call resolve() here to preserve the original path format
+
         if filepath.exists():
             return AppFileManager(
                 str(filepath),
@@ -386,3 +379,104 @@ def timeout(seconds: int, message: str) -> Generator[None, None, None]:
     finally:
         signal.alarm(0)
         signal.signal(signal.SIGALRM, original_handler)
+
+
+def validate_inside_directory(directory: Path, filepath: Path) -> None:
+    """
+    Validate that a filepath is inside a directory.
+
+    Handles all combinations of absolute/relative paths for both directory
+    and filepath. Resolves symlinks and prevents path traversal attacks.
+
+    Args:
+        directory: The directory path (can be absolute or relative)
+        filepath: The file path to validate (can be absolute or relative)
+
+    Raises:
+        HTTPException: If the filepath is outside the directory or if there's
+            an error resolving paths (e.g., broken symlinks, permission errors)
+    """
+    try:
+        # Handle empty paths - Path("") resolves to ".", so check for that
+        if str(directory) == "." and str(filepath) == ".":
+            # Both are current directory - this is ambiguous
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail="Empty or ambiguous directory or filepath provided",
+            )
+
+        # Resolve directory to absolute path
+        # If directory is relative, resolve it relative to current working directory
+        directory_resolved = directory.resolve(strict=False)
+
+        # If directory doesn't exist, we can't validate - this is an error
+        if not directory_resolved.exists():
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail=f"Directory {directory} does not exist",
+            )
+
+        if not directory_resolved.is_dir():
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail=f"Path {directory} is not a directory",
+            )
+
+        # Resolve filepath to absolute path
+        # If directory is absolute and filepath is relative, resolve relative to directory
+        # (matches behavior in get_file_manager)
+        # Otherwise, resolve relative to current working directory
+        if not filepath.is_absolute() and directory_resolved.is_absolute():
+            # Resolve relative filepath relative to the directory
+            filepath_resolved = (directory_resolved / filepath).resolve(
+                strict=False
+            )
+        elif filepath.is_absolute():
+            # Absolute filepath - resolve it directly (resolves symlinks)
+            filepath_resolved = filepath.resolve(strict=False)
+        else:
+            # Both are relative - resolve relative to current working directory
+            filepath_resolved = filepath.resolve(strict=False)
+
+        # Check if filepath is inside directory
+        # Use resolve() to handle symlinks and normalize paths
+        try:
+            # Ensure both paths are fully resolved (handles symlinks)
+            # resolve(strict=False) resolves symlinks even if final path doesn't exist
+            filepath_absolute = filepath_resolved.resolve(strict=False)
+            directory_absolute = directory_resolved.resolve(strict=False)
+
+            # A directory is not inside itself
+            if filepath_absolute == directory_absolute:
+                raise HTTPException(
+                    status_code=HTTPStatus.FORBIDDEN,
+                    detail=f"Access denied: File {filepath} is the same as directory {directory}",
+                )
+
+            # Check if filepath is inside directory using relative_to
+            # This prevents path traversal attacks
+            try:
+                filepath_absolute.relative_to(directory_absolute)
+            except ValueError:
+                # filepath is not inside directory
+                raise HTTPException(
+                    status_code=HTTPStatus.FORBIDDEN,
+                    detail=f"Access denied: File {filepath} is outside the allowed directory {directory}",
+                ) from None
+
+        except OSError as e:
+            # Handle errors like broken symlinks, permission errors, etc.
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail=f"Error resolving path {filepath}: {str(e)}",
+            ) from e
+
+    except HTTPException:
+        # Re-raise HTTPException as-is
+        raise
+    except Exception as e:
+        # Catch any other unexpected errors
+        raise HTTPException(
+            status_code=HTTPStatus.SERVER_ERROR,
+            detail=f"Unexpected error validating path: {str(e)}",
+        ) from e

--- a/tests/_server/test_file_manager_absolute_path.py
+++ b/tests/_server/test_file_manager_absolute_path.py
@@ -390,7 +390,6 @@ if __name__ == "__main__":
             files = router.files
             assert len(files) > 0
             file_info = files[0]
-            print(f"File path from router.files: {file_info.path}")
 
             # This should work - using the full absolute path
             file_manager = router.get_file_manager(file_info.path)
@@ -400,7 +399,6 @@ if __name__ == "__main__":
             # Now simulate the frontend sending just the basename
             # (This is what might be happening in the bug)
             basename = "notebook.py"
-            print(f"Attempting to open with basename: {basename}")
 
             # This currently fails but should succeed
             # The router should resolve the basename relative to its directory
@@ -408,9 +406,7 @@ if __name__ == "__main__":
                 file_manager_from_basename = router.get_file_manager(basename)
                 assert file_manager_from_basename is not None
                 assert file_manager_from_basename.is_notebook_named
-                print("SUCCESS: Opened file with basename")
             except HTTPException as e:
-                print(f"FAILED: {e.detail}")
                 # This is the bug - it should have resolved relative to router.directory
                 pytest.fail(
                     f"Should be able to open file with basename '{basename}' "
@@ -464,15 +460,12 @@ if __name__ == "__main__":
 
             # Try to open with relative path
             relative_path = "subdir/notebook.py"
-            print(f"Attempting to open with relative path: {relative_path}")
 
             try:
                 file_manager = router.get_file_manager(relative_path)
                 assert file_manager is not None
                 assert file_manager.is_notebook_named
-                print("SUCCESS: Opened file with relative path")
             except HTTPException as e:
-                print(f"FAILED: {e.detail}")
                 pytest.fail(
                     f"Should be able to open file with relative path '{relative_path}' "
                     f"when router has absolute directory '{absolute_dir}'"
@@ -503,7 +496,6 @@ if __name__ == "__main__":
 
         # All paths should be absolute
         for file_info in files:
-            print(f"File: {file_info.name}, Path: {file_info.path}")
             assert Path(file_info.path).is_absolute()
             assert file_info.path.startswith(absolute_dir)
 

--- a/tests/_server/test_file_router.py
+++ b/tests/_server/test_file_router.py
@@ -4,12 +4,17 @@ import os
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 
+import pytest
+
+from marimo._server.api.status import HTTPException, HTTPStatus
 from marimo._server.file_router import (
     AppFileRouter,
     LazyListOfFilesAppFileRouter,
     ListOfFilesAppFileRouter,
     NewFileAppFileRouter,
+    validate_inside_directory,
 )
 from marimo._server.models.home import MarimoFile
 
@@ -151,3 +156,249 @@ class TestAppFileRouter(unittest.TestCase):
         assert os.path.exists(file_manager.filename)
         assert file_manager.filename.startswith(self.test_dir)
         assert "nested" in file_manager.filename
+
+
+class TestValidateInsideDirectory(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory structure
+        self.test_dir = tempfile.mkdtemp()
+        self.test_file = Path(self.test_dir) / "test.py"
+        self.test_file.write_text("test")
+
+        # Create nested directory
+        self.nested_dir = Path(self.test_dir) / "nested"
+        self.nested_dir.mkdir()
+        self.nested_file = self.nested_dir / "nested.py"
+        self.nested_file.write_text("test")
+
+        # Create directory outside test_dir
+        self.outside_dir = tempfile.mkdtemp()
+        self.outside_file = Path(self.outside_dir) / "outside.py"
+        self.outside_file.write_text("test")
+
+        # Save current working directory
+        self.original_cwd = os.getcwd()
+
+    def tearDown(self):
+        # Clean up
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        shutil.rmtree(self.outside_dir, ignore_errors=True)
+        os.chdir(self.original_cwd)
+
+    def test_absolute_directory_absolute_filepath_inside(self):
+        """Test: absolute directory, absolute filepath, file inside directory"""
+        directory = Path(self.test_dir).resolve()
+        filepath = Path(self.test_file).resolve()
+        # Should not raise
+        validate_inside_directory(directory, filepath)
+
+    def test_absolute_directory_absolute_filepath_outside(self):
+        """Test: absolute directory, absolute filepath, file outside directory"""
+        directory = Path(self.test_dir).resolve()
+        filepath = Path(self.outside_file).resolve()
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+
+    def test_absolute_directory_relative_filepath_inside(self):
+        """Test: absolute directory, relative filepath, file inside directory"""
+        directory = Path(self.test_dir).resolve()
+        filepath = Path("test.py")
+        # Change to test_dir so relative path resolves correctly
+        os.chdir(self.test_dir)
+        # Should not raise
+        validate_inside_directory(directory, filepath)
+
+    def test_absolute_directory_relative_filepath_outside(self):
+        """Test: absolute directory, relative filepath, file outside directory"""
+        directory = Path(self.test_dir).resolve()
+        # When directory is absolute and filepath is relative, filepath is resolved
+        # relative to directory. So "outside.py" would resolve to test_dir/outside.py
+        # which doesn't exist but would be inside test_dir. To test outside, we need
+        # to use a path that goes outside even when resolved relative to directory.
+        filepath = Path("..") / ".." / "etc" / "passwd"
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+
+    def test_relative_directory_absolute_filepath_inside(self):
+        """Test: relative directory, absolute filepath, file inside directory"""
+        os.chdir(self.test_dir)
+        directory = Path(".")
+        filepath = Path(self.test_file).resolve()
+        # Should not raise
+        validate_inside_directory(directory, filepath)
+
+    def test_relative_directory_absolute_filepath_outside(self):
+        """Test: relative directory, absolute filepath, file outside directory"""
+        os.chdir(self.test_dir)
+        directory = Path(".")
+        filepath = Path(self.outside_file).resolve()
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+
+    def test_relative_directory_relative_filepath_inside(self):
+        """Test: relative directory, relative filepath, file inside directory"""
+        os.chdir(self.test_dir)
+        directory = Path(".")
+        filepath = Path("test.py")
+        # Should not raise
+        validate_inside_directory(directory, filepath)
+
+    def test_relative_directory_relative_filepath_outside(self):
+        """Test: relative directory, relative filepath, file outside directory"""
+        os.chdir(self.outside_dir)
+        directory = Path(".")
+        # Try to access file in test_dir using relative path
+        relative_path = os.path.relpath(self.test_file, self.outside_dir)
+        filepath = Path(relative_path)
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+
+    def test_path_traversal_dotdot(self):
+        """Test: path traversal attack using .."""
+        directory = Path(self.test_dir).resolve()
+        # Try to escape using ../
+        filepath = Path(self.test_dir) / ".." / ".." / "etc" / "passwd"
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+
+    def test_path_traversal_nested_dotdot(self):
+        """Test: path traversal using nested ../"""
+        directory = Path(self.nested_dir).resolve()
+        # Try to escape to parent directory
+        filepath = (
+            Path(self.nested_dir) / ".." / ".." / ".." / "etc" / "passwd"
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+
+    def test_symlink_inside_directory(self):
+        """Test: symlink pointing to file inside directory"""
+        directory = Path(self.test_dir).resolve()
+        # Create symlink inside directory pointing to file inside directory
+        symlink_path = Path(self.test_dir) / "symlink.py"
+        symlink_path.symlink_to(self.test_file)
+        # Should not raise
+        validate_inside_directory(directory, symlink_path)
+        symlink_path.unlink()
+
+    def test_symlink_outside_directory(self):
+        """Test: symlink pointing to file outside directory"""
+        directory = Path(self.test_dir).resolve()
+        # Create symlink inside directory pointing to file outside directory
+        symlink_path = Path(self.test_dir) / "symlink.py"
+        symlink_path.symlink_to(self.outside_file)
+        # Should raise - symlink resolves to outside file
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, symlink_path)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+        symlink_path.unlink()
+
+    def test_broken_symlink(self):
+        """Test: broken symlink"""
+        directory = Path(self.test_dir).resolve()
+        # Create broken symlink
+        broken_symlink = Path(self.test_dir) / "broken.py"
+        broken_symlink.symlink_to("nonexistent_file")
+        # Broken symlinks can be resolved with resolve(strict=False), but if they
+        # point outside the directory, should still fail
+        # First test: broken symlink inside directory (should work if resolved path is inside)
+        # The symlink itself is inside, so it should pass validation
+        # (the actual file doesn't need to exist for validation)
+        validate_inside_directory(directory, broken_symlink)
+
+        # Test: broken symlink that resolves outside
+        broken_symlink.unlink()
+        broken_symlink = Path(self.test_dir) / "broken.py"
+        # Create symlink that would resolve outside
+        broken_symlink.symlink_to("../../etc/passwd")
+        # Should fail because resolved path is outside
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, broken_symlink)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+        broken_symlink.unlink()
+
+    def test_symlink_to_directory(self):
+        """Test: symlink pointing to directory inside"""
+        directory = Path(self.test_dir).resolve()
+        # Create symlink to nested directory
+        symlink_path = Path(self.test_dir) / "nested_link"
+        symlink_path.symlink_to(self.nested_dir)
+        # Should not raise - symlink resolves to directory inside
+        validate_inside_directory(directory, symlink_path)
+        symlink_path.unlink()
+
+    def test_nested_file(self):
+        """Test: nested file inside directory"""
+        directory = Path(self.test_dir).resolve()
+        filepath = Path(self.nested_file).resolve()
+        # Should not raise
+        validate_inside_directory(directory, filepath)
+
+    def test_nonexistent_directory(self):
+        """Test: directory doesn't exist"""
+        directory = Path(self.test_dir) / "nonexistent"
+        filepath = Path(self.test_file).resolve()
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+
+    def test_file_as_directory(self):
+        """Test: directory path is actually a file"""
+        directory = Path(self.test_file).resolve()
+        filepath = Path(self.test_file).resolve()
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+
+    def test_same_path(self):
+        """Test: filepath is the same as directory"""
+        directory = Path(self.test_dir).resolve()
+        filepath = Path(self.test_dir).resolve()
+        # Directory is not inside itself
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN
+
+    def test_empty_paths(self):
+        """Test: empty paths (Path("") resolves to ".")"""
+        # Path("") resolves to ".", which is ambiguous
+        directory = Path("")
+        filepath = Path("")
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+
+    def test_absolute_path_with_dotdot_resolved(self):
+        """Test: absolute path with .. that resolves inside"""
+        directory = Path(self.test_dir).resolve()
+        # Create path with .. that still resolves inside
+        filepath = Path(self.nested_file).resolve() / ".." / "test.py"
+        # Should not raise - resolves to test.py inside directory
+        validate_inside_directory(directory, filepath.resolve())
+
+    def test_relative_path_with_dotdot(self):
+        """Test: relative path with .. that resolves inside"""
+        directory = Path(self.test_dir).resolve()
+        # When directory is absolute and filepath is relative, filepath is resolved
+        # relative to directory. So "../test.py" from nested_dir would be
+        # resolved as (test_dir / "../test.py") which goes outside.
+        # Instead, test with a path that stays inside when resolved relative to directory
+        nested_rel_path = Path("nested") / ".." / "test.py"
+        filepath = nested_rel_path
+        # Should not raise - resolves to test.py inside directory
+        validate_inside_directory(directory, filepath)
+
+    def test_relative_path_with_dotdot_outside(self):
+        """Test: relative path with .. that goes outside"""
+        os.chdir(self.nested_dir)
+        directory = Path(self.nested_dir).resolve()
+        filepath = Path("..") / ".." / ".." / "etc" / "passwd"
+        with pytest.raises(HTTPException) as exc_info:
+            validate_inside_directory(directory, filepath)
+        assert exc_info.value.status_code == HTTPStatus.FORBIDDEN


### PR DESCRIPTION
`marimo edit /absolute/path/to/dir` would fail to open any notebooks. A relative directory like `marimo edit path/to/dir` would work, but not an absolute directory. This fixes that case.