### PR TITLE
fix: splitting when installing multiple packages

### DIFF
--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -194,7 +194,7 @@ const InstallPackageForm: React.FC<{
   const installPackages = () => {
     const cleanedInput = stripPackageManagerPrefix(input);
     handleInstallPackages(
-      cleanedInput.split(",").map((p) => p.trim()),
+      [cleanedInput], // the backend will handle splitting the packages
       onSuccessInstallPackages,
     );
   };


### PR DESCRIPTION
The backend already has the smart logic for splitting multiple packages. This just lets the BE handle that