### PR TITLE
enforcing labels in PR before merge

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,5 +28,5 @@ jobs:
     steps:
       - uses: yogevbd/enforce-label-action@2.2.2
         with:
-          REQUIRED_LABELS_ANY: "enhancement,bug,documentation,internal,preview"
-          REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['enhancement','bug','documentation','internal','preview']"
+          REQUIRED_LABELS_ANY: "enhancement,bug,documentation,internal,preview,other"
+          REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['enhancement','bug','documentation','internal','preview','other']"


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

PRs must have a label of type: `enhancement','bug','documentation','internal','preview','other`

or an error will be raised with message:
"Select at least one label ['enhancement','bug','documentation','internal','preview','other']"

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
