### PR TITLE
fix: handle out-of-bounds tool call index in AI streaming (#7330)

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -632,6 +632,7 @@ class OpenAIProvider(
                     if (
                         tool_call.function
                         and tool_call.function.arguments
+                        and tool_index < len(tool_call_ids)
                         and tool_call_ids[tool_index]
                     ):
                         tool_delta = {
@@ -1193,6 +1194,7 @@ class BedrockProvider(
                         and tool_call.function
                         and hasattr(tool_call.function, "arguments")
                         and tool_call.function.arguments
+                        and tool_index < len(tool_call_ids)
                         and tool_call_ids[tool_index]
                     ):
                         tool_delta = {

--- a/tests/_server/ai/test_providers.py
+++ b/tests/_server/ai/test_providers.py
@@ -500,3 +500,68 @@ async def test_openai_compatible_api_no_reasoning_effort(
     assert "max_completion_tokens" not in call_kwargs, (
         "max_completion_tokens should not be present when reasoning_effort is not used"
     )
+
+
+def test_openai_extract_content_tool_delta_out_of_bounds() -> None:
+    """Test OpenAI handles tool call delta with out-of-bounds index gracefully.
+
+    This reproduces the issue reported in #7330 where some OpenAI-compatible
+    providers (like deepseek) may send tool call deltas before the tool call
+    start, causing an IndexError.
+    """
+    config = AnyProviderConfig(api_key="test-key", base_url="http://test")
+    provider = OpenAIProvider("gpt-4", config)
+
+    mock_response = MagicMock()
+    mock_delta = MagicMock()
+    mock_delta.content = None
+
+    # Create a tool call delta with index 0, but tool_call_ids is empty
+    mock_tool_delta = MagicMock()
+    mock_tool_delta.index = 0
+    mock_tool_delta.id = None  # No id for delta chunks
+    mock_tool_delta.function = MagicMock()
+    mock_tool_delta.function.name = None  # No name for delta chunks
+    mock_tool_delta.function.arguments = '{"location": "SF"}'
+
+    mock_delta.tool_calls = [mock_tool_delta]
+    mock_choice = MagicMock()
+    mock_choice.delta = mock_delta
+    mock_response.choices = [mock_choice]
+
+    # Call with empty tool_call_ids - this should not crash
+    result = provider.extract_content(mock_response, [])
+    # Should return None or empty list since we can't process the delta
+    assert result is None or result == []
+
+
+def test_bedrock_extract_content_tool_delta_out_of_bounds() -> None:
+    """Test Bedrock handles tool call delta with out-of-bounds index gracefully.
+
+    This reproduces the issue reported in #7330 where some providers may send
+    tool call deltas before the tool call start, causing an IndexError.
+    """
+    config = AnyProviderConfig(api_key="test-key", base_url="http://test")
+    provider = BedrockProvider("bedrock/anthropic.claude-3-sonnet", config)
+
+    mock_response = MagicMock()
+    mock_delta = MagicMock()
+    mock_delta.content = None
+
+    # Create a tool call delta with index 0, but tool_call_ids is empty
+    mock_tool_delta = MagicMock()
+    mock_tool_delta.index = 0
+    mock_tool_delta.id = None  # No id for delta chunks
+    mock_tool_delta.function = MagicMock()
+    mock_tool_delta.function.name = None  # No name for delta chunks
+    mock_tool_delta.function.arguments = '{"location": "SF"}'
+
+    mock_delta.tool_calls = [mock_tool_delta]
+    mock_choice = MagicMock()
+    mock_choice.delta = mock_delta
+    mock_response.choices = [mock_choice]
+
+    # Call with empty tool_call_ids - this should not crash
+    result = provider.extract_content(mock_response, [])
+    # Should return None or empty list since we can't process the delta
+    assert result is None or result == []


### PR DESCRIPTION
Fixes #7330

## Summary

Fixes an `IndexError: list index out of range` that occurred when using OpenAI-compatible providers (like DeepSeek) with the "Generate with AI" feature.
