### PR TITLE
fix: add noreferrer to external markdown links to prevent 403 errors

### DIFF
--- a/frontend/src/plugins/core/__test__/sanitize.test.ts
+++ b/frontend/src/plugins/core/__test__/sanitize.test.ts
@@ -64,7 +64,7 @@ describe("sanitizeHtml", () => {
   test("preserves safe anchor with target=_blank", () => {
     const html = '<a href="https://example.com" target="_blank">Link</a>';
     expect(sanitizeHtml(html)).toMatchInlineSnapshot(
-      `"<a href="https://example.com" target="_blank" rel="noopener">Link</a>"`,
+      `"<a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a>"`,
     );
   });
 

--- a/frontend/src/plugins/core/sanitize.ts
+++ b/frontend/src/plugins/core/sanitize.ts
@@ -62,7 +62,7 @@ DOMPurify.addHook("afterSanitizeAttributes", (node) => {
     node.setAttribute("target", node.getAttribute(TEMPORARY_ATTRIBUTE) || "");
     node.removeAttribute(TEMPORARY_ATTRIBUTE);
     if (node.getAttribute("target") === "_blank") {
-      node.setAttribute("rel", "noopener");
+      node.setAttribute("rel", "noopener noreferrer");
     }
   }
 });

--- a/marimo/_output/md_extensions/external_links.py
+++ b/marimo/_output/md_extensions/external_links.py
@@ -28,7 +28,7 @@ class ExternalLinksTreeProcessor(treeprocessors.Treeprocessor):  # type: ignore[
 
             if parsed_url.scheme in ["http", "https"]:
                 element.set("target", "_blank")
-                element.set("rel", "noopener")
+                element.set("rel", "noopener noreferrer")
 
 
 class ExternalLinksExtension(Extension):  # type: ignore[misc]

--- a/tests/_output/test_md.py
+++ b/tests/_output/test_md.py
@@ -73,7 +73,7 @@ def test_md_latex() -> None:
 def test_md_links() -> None:
     # Test external link conversion
     link_input = "[Google](https://google.com)"
-    expected_output = '<span class="paragraph"><a href="https://google.com" rel="noopener" target="_blank">Google</a></span>'  # noqa: E501
+    expected_output = '<span class="paragraph"><a href="https://google.com" rel="noopener noreferrer" target="_blank">Google</a></span>'  # noqa: E501
     assert _md(link_input, apply_markdown_class=False).text == (
         expected_output
     )


### PR DESCRIPTION
## Summary

Fixes #7350 by adding `noreferrer` to the `rel` attribute of external links in markdown cells. This prevents the browser from sending the `Referer` header when clicking links, which was causing some websites (like ScienceDirect) to return 403 errors when detecting `localhost` as the referrer.
