### PR TITLE
prevent form rerendering infinitely due to NaNs

### DIFF
--- a/frontend/src/plugins/impl/FormPlugin.tsx
+++ b/frontend/src/plugins/impl/FormPlugin.tsx
@@ -230,7 +230,8 @@ const Form = ({
   // wrapped `elementId`, meaning the value of the wrapped element
   // can change without the plugin generating an event
   const wrappedValue = UI_ELEMENT_REGISTRY.lookupValue(elementId);
-  if (wrappedValue !== internalValue) {
+  // Use Object.is as there can be NaN values
+  if (!Object.is(wrappedValue, internalValue)) {
     setInternalValue(wrappedValue);
   }
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Due to
```
console.log(NaN === NaN); // false
```
we need to use `Object.is` comparator.

I'm not sure where else this is happening, but it's unfortunate. Will check

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
