### PR TITLE
improvement: add file limit, warning, and more performant file detection

### DIFF
--- a/frontend/src/components/pages/home-page.tsx
+++ b/frontend/src/components/pages/home-page.tsx
@@ -169,6 +169,12 @@ const WorkspaceNotebooks: React.FC = () => {
   return (
     <WorkspaceRootContext value={workspace.root}>
       <div className="flex flex-col gap-2">
+        {workspace.hasMore && (
+          <Banner kind="warn" className="rounded p-4">
+            Showing first {workspace.fileCount} files. Your workspace has more
+            files.
+          </Banner>
+        )}
         <Header
           Icon={BookTextIcon}
           control={

--- a/marimo/_server/models/home.py
+++ b/marimo/_server/models/home.py
@@ -43,6 +43,10 @@ class WorkspaceFilesRequest(msgspec.Struct, rename="camel"):
 class WorkspaceFilesResponse(msgspec.Struct, rename="camel"):
     root: str
     files: list[FileInfo]
+    # Indicates if limit was reached
+    has_more: bool = False
+    # Total files found
+    file_count: int = 0
 
 
 class ShutdownSessionRequest(msgspec.Struct, rename="camel"):

--- a/marimo/_utils/marimo_path.py
+++ b/marimo/_utils/marimo_path.py
@@ -85,6 +85,9 @@ class MarimoPath:
     def read_text(self, encoding: str = "utf-8") -> str:
         return self.path.read_text(encoding)
 
+    def read_bytes(self) -> bytes:
+        return self.path.read_bytes()
+
     @property
     def short_name(self) -> str:
         return self.path.name

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -3692,10 +3692,16 @@ components:
       type: object
     WorkspaceFilesResponse:
       properties:
+        fileCount:
+          default: 0
+          type: integer
         files:
           items:
             $ref: '#/components/schemas/FileInfo'
           type: array
+        hasMore:
+          default: false
+          type: boolean
         root:
           type: string
       required:
@@ -3755,7 +3761,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.17.6
+  version: 0.18.1
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4750,7 +4750,11 @@ export interface components {
     };
     /** WorkspaceFilesResponse */
     WorkspaceFilesResponse: {
+      /** @default 0 */
+      fileCount?: number;
       files: components["schemas"]["FileInfo"][];
+      /** @default false */
+      hasMore?: boolean;
       root: string;
     };
     /**

--- a/pixi.lock
+++ b/pixi.lock
@@ -1101,8 +1101,8 @@ packages:
   timestamp: 1727801725384
 - pypi: ./
   name: marimo
-  version: 0.18.0
-  sha256: 38a7a4e5f4bd2017f356d0959dc2b5f0049990f4e416e6bf9ea6d35eeb67c9e7
+  version: 0.18.1
+  sha256: b89cff1b4327d087653d929b56b08026b0b690464da595eb8bb4d5dbadc971e1
   requires_dist:
   - click>=8.0,<9
   - jedi>=0.18.0

--- a/tests/_server/api/endpoints/test_home.py
+++ b/tests/_server/api/endpoints/test_home.py
@@ -35,6 +35,11 @@ def test_workspace_files(client: TestClient) -> None:
     files = body["files"]
     assert len(files) == 1
     assert files[0]["path"] == current_filename
+    # Check that new fields are present
+    assert "hasMore" in body
+    assert "fileCount" in body
+    assert body["hasMore"] is False
+    assert body["fileCount"] == 1
 
 
 @with_session(SESSION_ID)

--- a/tests/_utils/test_marimo_path.py
+++ b/tests/_utils/test_marimo_path.py
@@ -79,6 +79,20 @@ def test_write_text(tmp_path: Path):
     assert tmp_file.read_text() == text
 
 
+def test_read_bytes(tmp_path: Path):
+    # Create a temporary file with binary content
+    tmp_file = tmp_path / "test.py"
+    binary_content = b"import marimo\napp = marimo.App()\n"
+    tmp_file.write_bytes(binary_content)
+
+    mp = MarimoPath(tmp_file)
+
+    # Read bytes and verify
+    content = mp.read_bytes()
+    assert content == binary_content
+    assert isinstance(content, bytes)
+
+
 def test_properties():
     mp = MarimoPath(__file__)
 


### PR DESCRIPTION
Fixes #7317

- add file limit when displaying the workspace (1000 files)
- show a warning when we go over the limit
- more performant file detection by only reading the first `500b` header