### PR TITLE
Parentheses for Ibis filter in python code output of marimo.ui.dataframe

### DIFF
--- a/marimo/_plugins/ui/_impl/dataframes/transforms/print_code.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/print_code.py
@@ -386,13 +386,9 @@ def python_print_ibis(
         )
 
         if operator == "==" or operator == "equals":
-            return (
-                f"({df_name}[{_as_literal(column_id)}] == {_as_literal(value)})"
-            )
+            return f"({df_name}[{_as_literal(column_id)}] == {_as_literal(value)})"
         elif operator == "does_not_equal" or operator == "!=":
-            return (
-                f"({df_name}[{_as_literal(column_id)}] != {_as_literal(value)}))"  # noqa: E501
-            )
+            return f"({df_name}[{_as_literal(column_id)}] != {_as_literal(value)}))"  # noqa: E501
         elif operator == "contains":
             return f"({df_name}[{_as_literal(column_id)}].contains({_as_literal(value)}))"  # noqa: E501
         elif operator == "regex":


### PR DESCRIPTION
## 📝 Summary

when applying multiple row filter in the `marimo.ui.dataframe` for an ibis dataset, the generated code does not work.

Applying additional parentheses to the ibis code solves this.

## 🔍 Description of Changes

Every single filter operations will be enclosed in parentheses. So the output code changes like:

before
```Python
df_next = df
df_next = df_next.filter(df_next["category"] == "A" & df_next["id"] == 1)
```

after
```Python
df_next = df
df_next = df_next.filter((df_next["category"] == "A") & (df_next["id"] == 1))
```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
