### PR TITLE
fix: use python code when renaming variables

### DIFF
--- a/frontend/src/core/codemirror/lsp/lens.ts
+++ b/frontend/src/core/codemirror/lsp/lens.ts
@@ -81,6 +81,11 @@ export function createNotebookLens(
       const oldLines = mergedText.split("\n");
 
       if (newLines.length !== oldLines.length) {
+        Logger.warn(
+          "[lsp] cannot apply rename with new lines",
+          newLines,
+          oldLines,
+        );
         throw new Error("Cannot apply rename when there are new lines");
       }
 

--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -10,6 +10,10 @@ import { Logger } from "@/utils/Logger";
 import { LRUCache } from "@/utils/lru";
 import { Objects } from "@/utils/objects";
 import { topologicalCodesAtom } from "../copilot/getCodes";
+import {
+  getEditorCodeAsPython,
+  updateEditorCodeFromPython,
+} from "../language/utils";
 import { createNotebookLens, type NotebookLens } from "./lens";
 import {
   CellDocumentUri,
@@ -442,14 +446,9 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
       }
 
       // Only update if it has changed
-      if (ev.state.doc.toString() !== newCode) {
-        ev.dispatch({
-          changes: {
-            from: 0,
-            to: ev.state.doc.length,
-            insert: newCode,
-          },
-        });
+      const code = getEditorCodeAsPython(ev);
+      if (code !== newCode) {
+        updateEditorCodeFromPython(ev, newCode);
       }
     }
 


### PR DESCRIPTION
Fixes #7377 

This uses the smart-cell transformers to transform to/from markdown when updating cell code.