### PR TITLE
Add mapping for 'sky' to 'skypilot'

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -687,7 +687,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "sklearn": "scikit-learn",
         "sklego": "scikit-lego",
         "skvideo": "scikit-video",
-        "sky": "skypilot", 
+        "sky": "skypilot",
         "slack": "slackclient",
         "slugify": "unicode-slugify",
         "smarkets": "smk-python-sdk",


### PR DESCRIPTION
Now, if a user does `import sky` we will install skypilot ... and not a scraping tool from 2018. 