### PR TITLE
fix: handle categorical and enum types in narwhals table search

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -281,7 +281,7 @@ class NarwhalsTableManager(
         for column, dtype in self.nw_schema.items():
             if column == INDEX_COLUMN_NAME:
                 continue
-            if dtype == nw.String:
+            if is_narwhals_string_type(dtype):
                 expressions.append(nw.col(column).str.contains(f"(?i){query}"))
             elif dtype == nw.List(nw.String):
                 # TODO: Narwhals doesn't support list.contains


### PR DESCRIPTION
Previously, the search functionality only checked for `dtype == nw.String`,
which failed to match categorical and enum columns. This caused searches
on categorical columns to return no results.

The fix changes the condition to use `is_narwhals_string_type(dtype)`,
which properly handles String, Categorical, and Enum types.
