### PR TITLE
improvement: support cmd+g to cycle through next (simialr to browsers)

### DIFF
--- a/frontend/src/components/find-replace/find-replace.tsx
+++ b/frontend/src/components/find-replace/find-replace.tsx
@@ -148,6 +148,16 @@ export const FindReplace: React.FC = () => {
                     findNext();
                   }
                 }
+                // Override default browser find (Cmd/Ctrl + G)
+                if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "g") {
+                  e.preventDefault();
+                  // Shift for reverse search
+                  if (e.shiftKey) {
+                    findPrev();
+                  } else {
+                    findNext();
+                  }
+                }
               }}
               onChange={(e) => {
                 dispatch({ type: "setFind", find: e.target.value });


### PR DESCRIPTION
`Cmd+G` (and Shift+Cmd+G) in the browser allow you to cycle through matches in native browser find/replace. This change allows you to do the same.