### PR TITLE
fix: honor preventDefault in editor hotkeys

### DIFF
--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -31,6 +31,10 @@ export function useHotkey(shortcut: HotkeyAction, callback: HotkeyHandler) {
   const memoizeCallback = useEvent((evt?: KeyboardEvent) => callback(evt));
 
   const listener = useEvent((e: KeyboardEvent) => {
+    if (e.defaultPrevented) {
+      return;
+    }
+
     const key = hotkeys.getHotkey(shortcut).key;
     if (parseShortcut(key)(e)) {
       const response = callback(e);
@@ -62,6 +66,10 @@ export function useKeydownOnElement(
   handlers: Record<string, HotkeyHandler>,
 ) {
   useEventListener(element, "keydown", (e) => {
+    if (e.defaultPrevented) {
+      return;
+    }
+
     for (const [key, callback] of Objects.entries(handlers)) {
       if (parseShortcut(key)(e)) {
         Logger.debug("Satisfied", key, e);


### PR DESCRIPTION
Fixes #7188

Don't run hotkeys if another event called `preventDefault()`. This prevents `Cmd+f` in the file editor (see ticket) from opening the notebook search. 