### PR TITLE
feat(acp): add dynamic model selection for ACP agents

### DIFF
--- a/frontend/src/components/chat/acp/__tests__/state.test.ts
+++ b/frontend/src/components/chat/acp/__tests__/state.test.ts
@@ -87,6 +87,7 @@ describe("state utility functions", () => {
               "createdAt": 1735689600000,
               "externalAgentSessionId": null,
               "lastUsedAt": 1735689600000,
+              "selectedModel": null,
               "title": "New claude session",
             },
           ],
@@ -103,6 +104,7 @@ describe("state utility functions", () => {
         createdAt: 1_735_689_600_000,
         lastUsedAt: 1_735_689_600_000,
         externalAgentSessionId: null,
+        selectedModel: null,
       };
       const initialState: AgentSessionState = {
         sessions: [existingSession],
@@ -127,6 +129,7 @@ describe("state utility functions", () => {
               "createdAt": 1735689600000,
               "externalAgentSessionId": null,
               "lastUsedAt": 1735689600000,
+              "selectedModel": null,
               "title": "New claude session",
             },
           ],
@@ -142,6 +145,7 @@ describe("state utility functions", () => {
         createdAt: 1_735_689_600_000,
         lastUsedAt: 1_735_689_600_000,
         externalAgentSessionId: null,
+        selectedModel: null,
       };
       const initialState: AgentSessionState = {
         sessions: [existingSession],
@@ -163,6 +167,7 @@ describe("state utility functions", () => {
               "createdAt": 1735689600000,
               "externalAgentSessionId": null,
               "lastUsedAt": 1735689600000,
+              "selectedModel": null,
               "tabId": "tab_existing",
               "title": "Hello",
             },
@@ -180,6 +185,7 @@ describe("state utility functions", () => {
         createdAt: 1_735_689_600_000,
         lastUsedAt: 1_735_689_600_000,
         externalAgentSessionId: "claude-session-123" as ExternalAgentSessionId,
+        selectedModel: null,
       };
       const initialState: AgentSessionState = {
         sessions: [claudeSession],
@@ -208,6 +214,7 @@ describe("state utility functions", () => {
         createdAt: 1_735_689_600_000,
         lastUsedAt: 1_735_689_600_000,
         externalAgentSessionId: "gemini-session-456" as ExternalAgentSessionId,
+        selectedModel: null,
       };
       const initialState: AgentSessionState = {
         sessions: [geminiSession],
@@ -253,6 +260,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
         {
           agentId: "gemini",
@@ -261,6 +269,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
         {
           agentId: "claude",
@@ -269,6 +278,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
       ];
       state = {
@@ -289,6 +299,7 @@ describe("state utility functions", () => {
               "createdAt": 1735689600000,
               "externalAgentSessionId": null,
               "lastUsedAt": 1735689600000,
+              "selectedModel": null,
               "tabId": "tab_1",
               "title": "Claude session 1",
             },
@@ -297,6 +308,7 @@ describe("state utility functions", () => {
               "createdAt": 1735689600000,
               "externalAgentSessionId": null,
               "lastUsedAt": 1735689600000,
+              "selectedModel": null,
               "tabId": "tab_3",
               "title": "Claude session 2",
             },
@@ -323,6 +335,7 @@ describe("state utility functions", () => {
         createdAt: 1_735_689_600_000,
         lastUsedAt: 1_735_689_600_000,
         externalAgentSessionId: null,
+        selectedModel: null,
       };
       const singleSessionState: AgentSessionState = {
         sessions: [singleSession],
@@ -356,6 +369,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
         {
           agentId: "gemini",
@@ -364,6 +378,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
       ];
       state = {
@@ -420,6 +435,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
         {
           agentId: "gemini",
@@ -428,6 +444,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
       ];
       state = {
@@ -483,6 +500,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
         {
           agentId: "gemini",
@@ -491,6 +509,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000,
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
       ];
       state = {
@@ -557,6 +576,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_689_600_000, // 2025-01-01T00:00:00Z
           lastUsedAt: 1_735_689_600_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
         {
           agentId: "gemini",
@@ -565,6 +585,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_693_200_000, // 2025-01-01T01:00:00Z
           lastUsedAt: 1_735_693_200_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
         {
           agentId: "claude",
@@ -573,6 +594,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_696_800_000, // 2025-01-01T02:00:00Z
           lastUsedAt: 1_735_696_800_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
         {
           agentId: "claude",
@@ -581,6 +603,7 @@ describe("state utility functions", () => {
           createdAt: 1_735_700_400_000, // 2025-01-01T03:00:00Z
           lastUsedAt: 1_735_700_400_000,
           externalAgentSessionId: null,
+          selectedModel: null,
         },
       ];
     });

--- a/frontend/src/components/chat/acp/model-selector.tsx
+++ b/frontend/src/components/chat/acp/model-selector.tsx
@@ -1,0 +1,73 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import { memo } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+} from "@/components/ui/select";
+import type { SessionModelState } from "./types";
+
+interface ModelSelectorProps {
+  sessionModels: SessionModelState | null;
+  onModelChange: (modelId: string) => void;
+  disabled?: boolean;
+}
+
+export const ModelSelector = memo<ModelSelectorProps>(
+  ({ sessionModels, onModelChange, disabled }) => {
+    if (!sessionModels || sessionModels.availableModels.length === 0) {
+      return null;
+    }
+
+    const { availableModels, currentModelId } = sessionModels;
+    const currentModel = availableModels.find(
+      (m) => m.modelId === currentModelId,
+    );
+    const displayName = currentModel?.name ?? currentModelId;
+
+    return (
+      <Select
+        value={currentModelId}
+        onValueChange={onModelChange}
+        disabled={disabled}
+      >
+        <SelectTrigger className="h-6 text-xs border-border shadow-none! ring-0! bg-muted hover:bg-muted/30 py-0 px-2 gap-1">
+          {displayName}
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>Model</SelectLabel>
+            {availableModels.map((model, index) => (
+              <SelectItem
+                key={model.modelId}
+                value={model.modelId}
+                className="text-xs"
+              >
+                <div className="flex flex-col">
+                  <span>
+                    {model.name}
+                    {index === 0 && (
+                      <span className="text-muted-foreground ml-1">
+                        (default)
+                      </span>
+                    )}
+                  </span>
+                  {model.description && (
+                    <span className="text-muted-foreground text-xs pt-1 block">
+                      {model.description}
+                    </span>
+                  )}
+                </div>
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    );
+  },
+);
+ModelSelector.displayName = "ModelSelector";

--- a/frontend/src/components/chat/acp/types.ts
+++ b/frontend/src/components/chat/acp/types.ts
@@ -2,6 +2,12 @@
 import type { ContentBlock } from "@zed-industries/agent-client-protocol";
 import type { groupNotifications, useAcpClient } from "use-acp";
 
+// Re-export model types for use in the app
+export type {
+  ModelInfo,
+  SessionModelState,
+} from "@zed-industries/agent-client-protocol";
+
 export type SessionMode = ReturnType<typeof useAcpClient>["sessionMode"];
 
 export type NotificationEvent = Awaited<


### PR DESCRIPTION
## Summary

- Capture available models from agent's `newSession`/`loadSession` response
- Add `ModelSelector` component that displays agent-provided models dynamically
- Call `agent.setSessionModel()` when user changes model selection
- Add `selectedModel` field to `AgentSession` state

Previously, model selection would have required hardcoding model lists per agent. This implementation uses the models returned by the ACP protocol, so it works with any agent that supports the `models` field in their session response.

I couldn't verify whether it works for Codex and for Gemini or OpenCode because I don't have OpenCode installed and Codex doesn't seem to work in dev mode so I couldn't get it to work which is related to issue #7431. My Gemini either hanged or failed because of an `npx` version incompatibility 

## Test plan

- [x] Connect to Claude ACP agent and verify model selector appears with available models (Default, Opus, Haiku)

<img width="580" height="329" alt="Screenshot 2025-12-08 at 11 15 11" src="https://github.com/user-attachments/assets/f0c71187-d021-4c7a-9432-148808b7c004" />

```txt
[Client → Server]: {
  jsonrpc: '2.0',
  id: 6,
  method: 'session/set_model',
  params: {
    sessionId: 'a1900398-de87-4d8d-a215-3d85c5c55ea5',
    modelId: 'haiku'
  }
}
```

<img width="569" height="310" alt="Screenshot 2025-12-08 at 11 16 32" src="https://github.com/user-attachments/assets/410bf69c-6972-48c8-a220-eda4f40644bc" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)