### PR TITLE
fix wide notebook banner for column layout

### DIFF
--- a/frontend/src/components/editor/notebook-banner.tsx
+++ b/frontend/src/components/editor/notebook-banner.tsx
@@ -26,7 +26,7 @@ export const NotebookBanner: React.FC<Props> = ({ width }) => {
     <div
       className={cn(
         "flex flex-col gap-4 mb-5 print:hidden",
-        width === "columns" && "sticky left-12 w-full max-w-[80vw]",
+        width === "columns" && "w-full max-w-[80vw]",
       )}
     >
       {banners.map((banner) => (


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #7408 
Previously the notebook banner would stretch the entire notebook (when the panel is open), because the notebook panel is shifted. This PR removes that sticky css, only placing it on the left.

https://github.com/user-attachments/assets/5734f963-0fae-437c-8c87-5f6a89f9d295

I did find another way to make it sticky (using container queries), but I'm not sure if there are side effects of the below change.
```jsx
<Panel id="app-chrome-body" className="[container-type:inline-size]">
```
```jsc
        width === "columns" && "sticky left-12 w-full max-w-[80cqw]",
```

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
