### PR TITLE
feat: enhance GitHub Copilot integration with advanced configuration options

### DIFF
--- a/docs/guides/editor_features/ai_completion.md
+++ b/docs/guides/editor_features/ai_completion.md
@@ -161,7 +161,7 @@ See the [llm_providers](../configuration/llm_providers.md) guide for detailed in
 
 ## Copilots
 
-Copilots allow you to tab-complete code based on your notebook's context, similar to editors like Cursor. 
+Copilots allow you to tab-complete code based on your notebook's context, similar to editors like Cursor.
 
 <video autoplay muted loop playsinline width="100%" height="100%" align="center">
   <source src="/_static/docs-ai-completion-preview.mp4" type="video/mp4">
@@ -184,6 +184,39 @@ an AI pair programmer, similar to VS Code:
 
 _GitHUb Copilot is not yet available in our conda distribution; please install
 marimo using `pip`/`uv` if you need Copilot._
+
+#### Advanced configuration
+
+You can customize GitHub Copilot's behavior by adding `copilot_settings` to your `marimo.toml` configuration file:
+
+```toml title="marimo.toml"
+[ai.github]
+copilot_settings = { http = { proxy = "http://proxy.example.com:8888", proxyStrictSSL = true } }
+```
+
+Or in a more readable format:
+
+```toml title="marimo.toml"
+[ai.github.copilot_settings.http]
+proxy = "http://proxy.example.com:8888"
+proxyStrictSSL = true
+
+[ai.github.copilot_settings.github-enterprise]
+uri = "https://github.enterprise.com"  # For GitHub Enterprise users
+```
+
+Available configuration options (these are the same settings directory from the [npm package](https://github.com/orgs/github/packages/npm/package/copilot-language-server):
+
+* **HTTP settings**: Configure proxy settings for network connections
+    * `proxy`: HTTP proxy URL (e.g., `"http://proxy.example.com:8888"`)
+    * `proxyStrictSSL`: Whether to verify SSL certificates for the proxy (default: `false`)
+    * `proxyKerberosServicePrincipal`: Kerberos service principal for proxy authentication
+
+* **Telemetry settings**: Control telemetry data collection
+    * `telemetryLevel`: Level of telemetry to send - `"off"`, `"crash"`, `"error"`, or `"all"` (default: `"off"`)
+
+* **GitHub Enterprise**: Configure GitHub Enterprise Server
+    * `uri`: URL of your GitHub Enterprise Server instance
 
 ### Windsurf Copilot
 

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/copilot-status.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/copilot-status.tsx
@@ -17,6 +17,7 @@ import {
 import { resolvedMarimoConfigAtom } from "@/core/config/config";
 import { useOnMount } from "@/hooks/useLifecycle";
 import { cn } from "@/utils/cn";
+import { prettyError } from "@/utils/errors";
 import { Logger } from "@/utils/Logger";
 import { FooterItem } from "../footer-item";
 
@@ -90,8 +91,19 @@ const GitHubCopilotStatus: React.FC = () => {
         setStep("connectionError");
         toast({
           title: "GitHub Copilot Connection Error",
-          description:
-            "Failed to connect to GitHub Copilot. Check settings and try again.",
+          description: (
+            <>
+              {" "}
+              <div>
+                Failed to connect to GitHub Copilot. Check settings and try
+                again.
+              </div>
+              <br />
+              <div className="text-sm font-mono whitespace-pre-wrap">
+                {prettyError(error)}
+              </div>
+            </>
+          ),
           variant: "danger",
           action: (
             <Button variant="link" onClick={openSettings}>
@@ -120,15 +132,15 @@ const GitHubCopilotStatus: React.FC = () => {
   return (
     <FooterItem
       tooltip={
-        <>
+        <div className="max-w-[200px]">
           <b>GitHub Copilot:</b> {label}
           {status.kind && (
             <>
               <br />
-              <span className="text-xs">Status: {status.kind}</span>
+              <span className="pt-1 text-xs">Status: {status.kind}</span>
             </>
           )}
-        </>
+        </div>
       }
       selected={false}
       onClick={openSettings}

--- a/frontend/src/core/codemirror/copilot/__tests__/language-server.test.ts
+++ b/frontend/src/core/codemirror/copilot/__tests__/language-server.test.ts
@@ -1,0 +1,209 @@
+/* Copyright 2024 Marimo. All rights reserved. */
+
+import type { Transport } from "@open-rpc/client-js/build/transports/Transport";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotLanguageServerClient } from "../language-server";
+
+// Mock transport
+class MockTransport implements Transport {
+  connect = vi.fn().mockResolvedValue(undefined);
+  close = vi.fn();
+  sendData = vi.fn().mockResolvedValue({});
+  subscribe = vi.fn();
+  unsubscribe = vi.fn();
+  transportRequestManager = {} as any;
+  parseData = vi.fn();
+}
+
+describe("CopilotLanguageServerClient", () => {
+  let mockTransport: MockTransport;
+
+  beforeEach(() => {
+    mockTransport = new MockTransport();
+  });
+
+  it("should initialize without copilot settings", () => {
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+    });
+
+    expect(client).toBeDefined();
+  });
+
+  it("should initialize with empty copilot settings", () => {
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+      copilotSettings: {},
+    });
+
+    expect(client).toBeDefined();
+  });
+
+  it("should initialize with copilot settings", () => {
+    const copilotSettings = {
+      http: {
+        proxy: "http://proxy.example.com:8888",
+        proxyStrictSSL: true,
+      },
+      telemetry: {
+        telemetryLevel: "off",
+      },
+    };
+
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+      copilotSettings,
+    });
+
+    expect(client).toBeDefined();
+  });
+
+  it("should send configuration after initialization when settings are provided", async () => {
+    const copilotSettings = {
+      http: {
+        proxy: "http://proxy.example.com:8888",
+        proxyStrictSSL: true,
+      },
+    };
+
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+      copilotSettings,
+    });
+
+    // Spy on the notify method
+    const notifySpy = vi.spyOn(client as any, "notify");
+
+    // Wait for initialization
+    await client.initializePromise;
+
+    // Wait for next tick to let the configuration be sent
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Verify that notify was called with the correct parameters
+    expect(notifySpy).toHaveBeenCalledWith("workspace/didChangeConfiguration", {
+      settings: copilotSettings,
+    });
+  });
+
+  it("should not send configuration after initialization when settings are empty", async () => {
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+      copilotSettings: {},
+    });
+
+    // Spy on the notify method
+    const notifySpy = vi.spyOn(client as any, "notify");
+
+    // Wait for initialization
+    await client.initializePromise;
+
+    // Wait for next tick
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Verify that notify was NOT called with didChangeConfiguration
+    expect(notifySpy).not.toHaveBeenCalledWith(
+      "workspace/didChangeConfiguration",
+      expect.anything(),
+    );
+  });
+
+  it("should not send configuration after initialization when settings are not provided", async () => {
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+    });
+
+    // Spy on the notify method
+    const notifySpy = vi.spyOn(client as any, "notify");
+
+    // Wait for initialization
+    await client.initializePromise;
+
+    // Wait for next tick
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Verify that notify was NOT called with didChangeConfiguration
+    expect(notifySpy).not.toHaveBeenCalledWith(
+      "workspace/didChangeConfiguration",
+      expect.anything(),
+    );
+  });
+
+  it("should accept github-enterprise settings", async () => {
+    const copilotSettings = {
+      "github-enterprise": {
+        uri: "https://github.enterprise.com",
+      },
+    };
+
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+      copilotSettings,
+    });
+
+    // Spy on the notify method
+    const notifySpy = vi.spyOn(client as any, "notify");
+
+    // Wait for initialization
+    await client.initializePromise;
+
+    // Wait for next tick to let the configuration be sent
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Verify that notify was called with the enterprise settings
+    expect(notifySpy).toHaveBeenCalledWith("workspace/didChangeConfiguration", {
+      settings: copilotSettings,
+    });
+  });
+
+  it("should accept all supported settings at once", async () => {
+    const copilotSettings = {
+      http: {
+        proxy: "http://proxy.example.com:8888",
+        proxyStrictSSL: true,
+        proxyKerberosServicePrincipal: "HTTP/proxy.example.com",
+      },
+      telemetry: {
+        telemetryLevel: "all",
+      },
+      "github-enterprise": {
+        uri: "https://github.enterprise.com",
+      },
+    };
+
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+      copilotSettings,
+    });
+
+    // Spy on the notify method
+    const notifySpy = vi.spyOn(client as any, "notify");
+
+    // Wait for initialization
+    await client.initializePromise;
+
+    // Wait for next tick to let the configuration be sent
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Verify that notify was called with all settings
+    expect(notifySpy).toHaveBeenCalledWith("workspace/didChangeConfiguration", {
+      settings: copilotSettings,
+    });
+  });
+});

--- a/frontend/src/core/codemirror/copilot/client.ts
+++ b/frontend/src/core/codemirror/copilot/client.ts
@@ -2,8 +2,10 @@
 
 import { languageServerWithClient } from "@marimo-team/codemirror-languageserver";
 import { toast } from "@/components/ui/use-toast";
+import { resolvedMarimoConfigAtom } from "@/core/config/config";
 import { waitForConnectionOpen } from "@/core/network/connection";
 import { getRuntimeManager } from "@/core/runtime/config";
+import { store } from "@/core/state/jotai";
 import { once } from "@/utils/once";
 import { CopilotLanguageServerClient } from "./language-server";
 import { waitForEnabledCopilot } from "./state";
@@ -32,14 +34,17 @@ export const createWSTransport = once(() => {
   });
 });
 
-export const getCopilotClient = once(
-  () =>
-    new CopilotLanguageServerClient({
-      rootUri: FILE_URI,
-      workspaceFolders: null,
-      transport: createWSTransport(),
-    }),
-);
+export const getCopilotClient = once(() => {
+  const userConfig = store.get(resolvedMarimoConfigAtom);
+  const copilotSettings = userConfig.ai?.github?.copilot_settings ?? {};
+
+  return new CopilotLanguageServerClient({
+    rootUri: FILE_URI,
+    workspaceFolders: null,
+    transport: createWSTransport(),
+    copilotSettings,
+  });
+});
 
 export function copilotServer() {
   return languageServerWithClient({

--- a/frontend/src/core/codemirror/copilot/transport.ts
+++ b/frontend/src/core/codemirror/copilot/transport.ts
@@ -3,6 +3,7 @@
 import { WebSocketTransport } from "@open-rpc/client-js";
 import type { JSONRPCRequestData } from "@open-rpc/client-js/build/Request";
 import { Transport } from "@open-rpc/client-js/build/transports/Transport";
+import { prettyError } from "@/utils/errors";
 import { Logger } from "@/utils/Logger";
 
 export interface LazyWebsocketTransportOptions {
@@ -20,7 +21,7 @@ export interface LazyWebsocketTransportOptions {
   /**
    * Function to show error toast notifications.
    */
-  showError: (title: string, description: string) => void;
+  showError: (title: string, description: string | React.ReactNode) => void;
 
   /**
    * Number of retry attempts for connection.
@@ -159,7 +160,8 @@ export class LazyWebsocketTransport extends Transport {
           // Show error toast on final retry
           this.options.showError(
             "GitHub Copilot Connection Error",
-            "Failed to connect to GitHub Copilot. Please check your settings and try again.",
+            "Failed to connect to GitHub Copilot. Please check your settings and try again.\n\n" +
+              prettyError(error),
           );
           throw error;
         }

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -375,10 +375,14 @@ class GitHubConfig(TypedDict, total=False):
 
     - `api_key`: the GitHub API token
     - `base_url`: the base URL for the API
+    - `copilot_settings`: configuration settings for GitHub Copilot LSP.
+        Supports settings like `http` (proxy configuration), `telemetry`,
+        and `github-enterprise` (enterprise URI).
     """
 
     api_key: str
     base_url: NotRequired[str]
+    copilot_settings: NotRequired[dict[str, Any]]
 
 
 @dataclass

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1628,12 +1628,17 @@ components:
       type: object
     GitHubConfig:
       description: "Configuration options for GitHub.\n\n    **Keys.**\n\n    - `api_key`:\
-        \ the GitHub API token\n    - `base_url`: the base URL for the API"
+        \ the GitHub API token\n    - `base_url`: the base URL for the API\n    -\
+        \ `copilot_settings`: configuration settings for GitHub Copilot LSP.\n   \
+        \     Supports settings like `http` (proxy configuration), `telemetry`,\n\
+        \        and `github-enterprise` (enterprise URI)."
       properties:
         api_key:
           type: string
         base_url:
           type: string
+        copilot_settings:
+          type: object
       required: []
       title: GitHubConfig
       type: object
@@ -3761,7 +3766,7 @@ components:
       type: object
 info:
   title: marimo API
-  version: 0.18.1
+  version: 0.18.4
 openapi: 3.1.0
 paths:
   /@file/{filename_and_length}:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -3664,10 +3664,14 @@ export interface components {
      *
      *         - `api_key`: the GitHub API token
      *         - `base_url`: the base URL for the API
+     *         - `copilot_settings`: configuration settings for GitHub Copilot LSP.
+     *             Supports settings like `http` (proxy configuration), `telemetry`,
+     *             and `github-enterprise` (enterprise URI).
      */
     GitHubConfig: {
       api_key?: string;
       base_url?: string;
+      copilot_settings?: Record<string, any>;
     };
     /**
      * GoogleAiConfig

--- a/tests/_config/test_config.py
+++ b/tests/_config/test_config.py
@@ -93,6 +93,44 @@ def test_merge_config() -> None:
     )
 
 
+def test_configure_github_with_copilot_settings() -> None:
+    """Test GitHub AI configuration with copilot_settings."""
+    config = merge_default_config(
+        PartialMarimoConfig(
+            ai={
+                "github": {
+                    "api_key": "test-github-key",
+                    "copilot_settings": {
+                        "http": {
+                            "proxy": "http://proxy.example.com:8888",
+                            "proxyStrictSSL": True,
+                        },
+                        "telemetry": {"telemetryLevel": "off"},
+                        "github-enterprise": {
+                            "uri": "https://github.enterprise.com"
+                        },
+                    },
+                }
+            }
+        )
+    )
+
+    github_config = config.get("ai", {}).get("github", {})
+    assert github_config.get("api_key") == "test-github-key"
+    assert github_config.get("copilot_settings") is not None
+    copilot_settings = github_config.get("copilot_settings", {})
+    assert (
+        copilot_settings.get("http", {}).get("proxy")
+        == "http://proxy.example.com:8888"
+    )
+    assert copilot_settings.get("http", {}).get("proxyStrictSSL") is True
+    assert copilot_settings.get("telemetry", {}).get("telemetryLevel") == "off"
+    assert (
+        copilot_settings.get("github-enterprise", {}).get("uri")
+        == "https://github.enterprise.com"
+    )
+
+
 def test_merge_config_with_keymap_overrides() -> None:
     prev_config = merge_default_config(
         PartialMarimoConfig(

--- a/tests/_server/ai/test_ai_config.py
+++ b/tests/_server/ai/test_ai_config.py
@@ -217,6 +217,29 @@ class TestAnyProviderConfig:
             provider_config.extra_headers["X-Custom-Header"] == "custom-value"
         )
 
+    def test_for_github_with_copilot_settings(self):
+        """Test GitHub configuration with copilot_settings is accepted."""
+        config: AiConfig = {
+            "github": {
+                "api_key": "test-github-key",
+                "copilot_settings": {
+                    "http": {
+                        "proxy": "http://proxy.example.com:8888",
+                        "proxyStrictSSL": True,
+                    },
+                    "telemetry": {"telemetryLevel": "off"},
+                },
+            }
+        }
+
+        # Should not raise an error - copilot_settings is a valid field
+        provider_config = AnyProviderConfig.for_github(config)
+
+        # Note: copilot_settings is stored in config but not used by AnyProviderConfig
+        # It's used by the frontend LSP client
+        assert provider_config.api_key == "test-github-key"
+        assert provider_config.base_url == "https://api.githubcopilot.com/"
+
     def test_for_openrouter(self):
         """Test OpenRouter configuration."""
         config: AiConfig = {


### PR DESCRIPTION
Fixes #6992 

You can customize GitHub Copilot's behavior by adding `copilot_settings` to your `marimo.toml` configuration file:

```toml title="marimo.toml"
[ai.github]
copilot_settings = { http = { proxy = "http://proxy.example.com:8888", proxyStrictSSL = true } }
```

Or in a more readable format:

```toml title="marimo.toml"
[ai.github.copilot_settings.http]
proxy = "http://proxy.example.com:8888"
proxyStrictSSL = true

[ai.github.copilot_settings.github-enterprise]
uri = "https://github.enterprise.com"  # For GitHub Enterprise users
```

Available configuration options (these are the same settings directory from the [npm package](https://github.com/orgs/github/packages/npm/package/copilot-language-server):

* **HTTP settings**: Configure proxy settings for network connections
    * `proxy`: HTTP proxy URL (e.g., `"http://proxy.example.com:8888"`)
    * `proxyStrictSSL`: Whether to verify SSL certificates for the proxy (default: `false`)
    * `proxyKerberosServicePrincipal`: Kerberos service principal for proxy authentication

* **Telemetry settings**: Control telemetry data collection
    * `telemetryLevel`: Level of telemetry to send - `"off"`, `"crash"`, `"error"`, or `"all"` (default: `"off"`)

* **GitHub Enterprise**: Configure GitHub Enterprise Server
    * `uri`: URL of your GitHub Enterprise Server instance


----------

## PR notes

- Added support for customizing GitHub Copilot's behavior through `copilot_settings` in the `marimo.toml` configuration file.
- Updated UI components to display connection errors with detailed descriptions.

