### PR TITLE
ci: add wait step for PyPI package availability in Docker release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,34 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
 
+      - name: ⏳ Wait for PyPI package availability
+        run: |
+          VERSION="${{ needs.publish_release.outputs.marimo_version }}"
+          echo "Waiting for marimo version $VERSION to be available on PyPI..."
+
+          MAX_ATTEMPTS=30
+          ATTEMPT=0
+          SLEEP_TIME=10
+
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Checking PyPI for version $VERSION..."
+
+            # Check if the version exists on PyPI
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/marimo/$VERSION/json")
+
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✅ Version $VERSION is available on PyPI!"
+              exit 0
+            else
+              echo "Version $VERSION not yet available (HTTP $HTTP_CODE). Waiting ${SLEEP_TIME}s..."
+              sleep $SLEEP_TIME
+            fi
+          done
+
+          echo "❌ Timed out waiting for version $VERSION on PyPI after $((MAX_ATTEMPTS * SLEEP_TIME)) seconds"
+          exit 1
+
       - name: 🐋 Log in to the Container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This update introduces a new step in the release workflow to wait for the specified version of the marimo package to become available on PyPI. The step checks for the package's availability up to 30 attempts, with a 10-second interval between checks, ensuring that the release process only continues once the package is confirmed to be available.
