### PR TITLE
add error banner for acp to save the notebook

### DIFF
--- a/frontend/src/components/chat/acp/agent-panel.tsx
+++ b/frontend/src/components/chat/acp/agent-panel.tsx
@@ -662,7 +662,7 @@ function getCwd() {
 
 const AgentPanel: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | string | unknown>(null);
+  const [error, setError] = useState<Error | string | null>(null);
   const [promptValue, setPromptValue] = useState("");
   const [files, setFiles] = useState<File[]>();
   const [sessionModels, setSessionModels] = useState<SessionModelState | null>(
@@ -858,7 +858,7 @@ const AgentPanel: React.FC = () => {
         setError(null);
       } catch (error) {
         logger.error("Failed to create or resume session:", error);
-        setError(error);
+        setError(error instanceof Error ? error : String(error));
       }
     };
 
@@ -1059,7 +1059,7 @@ const AgentPanel: React.FC = () => {
       return (
         <ErrorBanner
           className="w-3/4 mx-auto mt-10"
-          error={error instanceof Error ? error : new Error(String(error))}
+          error={error}
           action={
             <Button
               variant="linkDestructive"


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
adds a dismissable error banner to show that the notebook must be saved.

https://github.com/user-attachments/assets/eaf5f794-9542-428b-abdc-2ce9492f50a1

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
