### PR TITLE
style: do not style stderr as red

### DIFF
--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -51,6 +51,7 @@
   background: #ffc0cb30;
   padding: 3%;
   font-size: 0.8125rem;
+  font-weight: bold;
   border-radius: 20px;
   white-space: pre-wrap; /* respect newlines */
 


### PR DESCRIPTION
Diagnostic output is often written to stderr, and the red color can be alarming.