### PR TITLE
Fix OSError when displaying Polars DataFrames with old timestamps on Windows

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -616,9 +616,36 @@ class NarwhalsTableManager(
                     int(hours), int(minutes), int(seconds), int(microseconds)
                 )
             elif dtype == nw.Date:
-                bin_end = datetime.date.fromtimestamp(bin_end / ms_time)
+                # Use timedelta to handle dates before Unix epoch (1970)
+                # which cause OSError on Windows with fromtimestamp
+                try:
+                    bin_end = datetime.date.fromtimestamp(bin_end / ms_time)
+                except (OSError, OverflowError, ValueError):
+                    # Fall back to timedelta calculation for old dates
+                    epoch = datetime.datetime(
+                        1970, 1, 1, tzinfo=datetime.timezone.utc
+                    )
+                    bin_end_dt = epoch + datetime.timedelta(
+                        seconds=bin_end / ms_time
+                    )
+                    bin_end = bin_end_dt.date()
             else:
-                bin_end = datetime.datetime.fromtimestamp(bin_end / ms_time)
+                # Use timedelta to handle datetimes before Unix epoch (1970)
+                # which cause OSError on Windows with fromtimestamp
+                try:
+                    bin_end = datetime.datetime.fromtimestamp(
+                        bin_end / ms_time
+                    )
+                except (OSError, OverflowError, ValueError):
+                    # Fall back to timedelta calculation for old dates
+                    epoch = datetime.datetime(
+                        1970, 1, 1, tzinfo=datetime.timezone.utc
+                    )
+                    bin_end = epoch + datetime.timedelta(
+                        seconds=bin_end / ms_time
+                    )
+                    # Remove timezone to match fromtimestamp behavior
+                    bin_end = bin_end.replace(tzinfo=None)
 
             # Only append if the count is greater than 0
             if count > 0:

--- a/tests/_plugins/ui/_impl/tables/test_narwhals.py
+++ b/tests/_plugins/ui/_impl/tables/test_narwhals.py
@@ -1318,6 +1318,57 @@ class TestGetBinValuesTemporal:
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 @pytest.mark.parametrize(
     "df",
+    create_dataframes(
+        {
+            "old_dates": [
+                datetime.datetime.fromisoformat("1902-01-01 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-01 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-02 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-03 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-04 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-05 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-06 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-07 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-08 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-09 00:00:00"),
+                datetime.datetime.fromisoformat("2020-01-10 00:00:00"),
+            ]
+        },
+        exclude=["ibis"],
+    ),
+)
+class TestOldDates:
+    """Test handling of old dates (pre-1970) that cause OSError on Windows."""
+
+    def test_get_bin_values_with_old_dates(self, df: Any) -> None:
+        """
+        Test that get_bin_values works with timestamps before Unix epoch.
+
+        This reproduces issue #7469 where dates like 1902-01-01 cause
+        OSError: [Errno 22] Invalid argument on Windows when using
+        datetime.fromtimestamp().
+        """
+        manager = NarwhalsTableManager.from_dataframe(df)
+        # Should not raise OSError even with old dates
+        bin_values = manager.get_bin_values("old_dates", 3)
+
+        # Verify we get valid bin values
+        assert len(bin_values) > 0
+        assert all(
+            isinstance(bv.bin_start, (datetime.datetime, type(None)))
+            for bv in bin_values
+        )
+        assert all(
+            isinstance(bv.bin_end, (datetime.datetime, type(None)))
+            for bv in bin_values
+        )
+        # Total count should be 11 (all rows)
+        assert sum(bin_value.count for bin_value in bin_values) == 11
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+@pytest.mark.parametrize(
+    "df",
     create_dataframes({"A": ["apple", "banana", "cherry"]}),
 )
 def test_search_with_regex(df: Any) -> None:


### PR DESCRIPTION
**Fixes #7469**

### Problem
When displaying a Polars DataFrame with timestamps before the Unix epoch (1970) or very old dates (e.g., 1902-01-01), marimo would crash on Windows with:
```
OSError: [Errno 22] Invalid argument
```

This occurred in the `_get_bin_values_temporal()` function when calling `datetime.fromtimestamp()` to convert millisecond timestamps back to datetime/date objects for histogram bin visualization.

### Root Cause
`datetime.fromtimestamp()` has platform-specific limitations on Windows:
- Cannot handle negative timestamps (dates before 1970-01-01)
- Cannot handle very old dates that are out of the platform's supported range
- This is a known Windows limitation with timestamp conversions

### Solution
Modified `_get_bin_values_temporal()` in `narwhals_table.py` to use a more robust approach:
- Wrapped `fromtimestamp()` calls in try-except blocks to catch `OSError`, `OverflowError`, and `ValueError`
- Added fallback logic using `datetime.timedelta`: `epoch + timedelta(seconds=timestamp)`
- This approach works for any date within Python's datetime range (years 1-9999) regardless of platform
