### PR TITLE
fix: app embed parametrization

### DIFF
--- a/marimo/_smoke_tests/appcomp/inner.py
+++ b/marimo/_smoke_tests/appcomp/inner.py
@@ -19,8 +19,13 @@ def _(mo):
 
 
 @app.cell
-def _(mo):
-    x = mo.ui.number(1, 10)
+def _():
+    x_initial_value = 1
+    return (x_initial_value,)
+
+@app.cell
+def _(mo, x_initial_value):
+    x = mo.ui.number(x_initial_value, 10)
     return (x,)
 
 
@@ -40,7 +45,6 @@ def _(mo):
 def _(y):
     y
     return
-
 
 @app.cell
 def _(x, y):

--- a/marimo/_smoke_tests/appcomp/main.py
+++ b/marimo/_smoke_tests/appcomp/main.py
@@ -2,7 +2,7 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.18.4"
 app = marimo.App(width="medium")
 
 
@@ -14,7 +14,9 @@ def _():
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md("## Render the same app multiple times")
+    mo.md("""
+    ## Render the same app multiple times
+    """)
     return
 
 
@@ -37,9 +39,53 @@ def _(result):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
-    mo.md("## Render an app inside tabs")
+    mo.md(r"""
+    ## Clone an app
+    """)
+    return
+
+
+@app.cell
+def _(app):
+    clone = app.clone()
+    return (clone,)
+
+
+@app.cell
+async def _(clone):
+    clone_result = await clone.embed()
+    clone_result.output
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Parametrize an app
+    """)
+    return
+
+
+@app.cell
+def _(app):
+    parametrized_app = app.clone()
+    return (parametrized_app,)
+
+
+@app.cell
+async def _(parametrized_app):
+    _result = await parametrized_app.embed(defs={"x_initial_value": 0})
+    _result.output
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Render an app inside tabs
+    """)
     return
 
 
@@ -52,7 +98,9 @@ async def _(app, mo):
 
 @app.cell
 def _(mo):
-    mo.md(rf"## Render an app that uses function calls")
+    mo.md(rf"""
+    ## Render an app that uses function calls
+    """)
     return
 
 

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -1047,6 +1047,21 @@ class TestAppComposition:
         assert result.defs["y"] == 200
         assert "Result: 200" in result.output.text
 
+    async def test_app_embed_with_defs_ui_element_not_allowed(self) -> None:
+        app = App()
+
+        @app.cell
+        def __() -> tuple[int]:
+            x = 10
+            return (x,)
+
+        import marimo as mo
+
+        with pytest.raises(ValueError) as excinfo:
+            await app.embed(defs={"x": mo.ui.slider(1, 10)})
+
+        assert "Substituting UI Elements for variables is not allowed" in str(excinfo.value)
+
     async def test_app_embed_with_defs_multiple_vars(self) -> None:
         """Test embed() with defs overriding a cell that defines multiple variables."""
         app = App()


### PR DESCRIPTION
Invalidate `AppKernelRunner`'s output cache when definitions change.

This change also updates `embed()` to raise a runtime error when attempting to call `embed()` in the same cell that defines the app, similar to UI elements.