### PR TITLE
docs: correct spelling of 'sqlalchemy' in SQL docs

### DIFF
--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -230,7 +230,7 @@ Define the engine as a Python variable in a cell:
 import sqlalchemy
 
 # Create an in-memory SQLite database with SQLAlchemy
-sqlite_engine = sqlachemy.create_engine("sqlite:///:memory:")
+sqlite_engine = sqlalchemy.create_engine("sqlite:///:memory:")
 ```
 
 ///


### PR DESCRIPTION
## 📝 Summary

Saw @etrotta's message on discord [here](https://discord.com/channels/1059888774789730424/1179936876103225354/1448824804940451870) pointing this typo out.

## 🔍 Description of Changes

Before: sqlachemy
After: sqlalchemy

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.