### PR TITLE
strip first and last chunks for backtick checking

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -1296,22 +1296,22 @@ async def without_wrapping_backticks(
         # Handle the first chunk
         if first_chunk:
             first_chunk = False
+            stripped_chunk = chunk.lstrip()
             # Check for language-specific fences first
             for lang in langs:
-                if chunk.startswith(f"```{lang}"):
+                if stripped_chunk.startswith(f"```{lang}"):
                     has_starting_backticks = True
-                    chunk = chunk[
-                        3 + len(lang) :
-                    ]  # Remove the starting backticks with lang
+                    # Remove the starting backticks with lang
+                    chunk = stripped_chunk[3 + len(lang) :]
                     # Also remove starting newline if present
                     if chunk.startswith("\n"):
                         chunk = chunk[1:]
                     break
             # If no language-specific fence was found, check for plain backticks
             else:
-                if chunk.startswith("```"):
+                if stripped_chunk.startswith("```"):
                     has_starting_backticks = True
-                    chunk = chunk[3:]  # Remove the starting backticks
+                    chunk = stripped_chunk[3:]  # Remove the starting backticks
                     # Also remove starting newline if present
                     if chunk.startswith("\n"):
                         chunk = chunk[1:]
@@ -1325,9 +1325,13 @@ async def without_wrapping_backticks(
 
     # Handle the last chunk
     if buffer is not None:
+        # Some models add trailing space to the end of the response, so we strip to check for backticks
+        stripped_buffer = buffer.rstrip()
+        trailing_space = buffer[len(stripped_buffer) :]
+
         # Remove ending newline if present
-        if buffer.endswith("\n```"):
-            buffer = buffer[:-4]  # Remove the ending newline and backticks
-        elif has_starting_backticks and buffer.endswith("```"):
-            buffer = buffer[:-3]  # Remove just the ending backticks
+        if stripped_buffer.endswith("\n```"):
+            buffer = stripped_buffer[:-4] + trailing_space
+        elif has_starting_backticks and stripped_buffer.endswith("```"):
+            buffer = stripped_buffer[:-3] + trailing_space
         yield buffer

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -1027,6 +1027,41 @@ class TestGetFinishReason(unittest.TestCase):
             ["```sql\n", "SELECT * FROM table\n", "WHERE id = 1\n```"],
             "SELECT * FROM table\nWHERE id = 1",
         ),
+        # Test trailing whitespace preservation after closing backticks
+        (
+            ["```", "print('hello')", "```  "],
+            "print('hello')  ",
+        ),
+        (
+            ["```python\n", "print('hello')", "\n``` "],
+            "print('hello') ",
+        ),
+        (
+            ["```", "code", "```\t\n"],
+            "code\t\n",
+        ),
+        # Test leading whitespace before opening backticks (whitespace and backticks stripped)
+        (
+            ["  ```", "code", "```"],
+            "code",
+        ),
+        (
+            [" ```python\n", "code", "```"],
+            "code",
+        ),
+        (
+            ["\t```", "code", "```"],
+            "code",
+        ),
+        # Test opening backticks with extra characters after language (language stripped, rest preserved)
+        (
+            ["```python ", "code", "```"],
+            " code",
+        ),
+        (
+            ["```python\t", "code", "```"],
+            "\tcode",
+        ),
     ],
 )
 async def test_without_wrapping_backticks(


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Should help with #7500 . I tested with `ollama/gemma3:1b` model and it would have ending backticks with spaces. But I have not been able to reproduce starting backticks.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
