### PR TITLE
docs: additional hyprlinks

### DIFF
--- a/docs/guides/editor_features/index.md
+++ b/docs/guides/editor_features/index.md
@@ -20,10 +20,10 @@ Highlights include:
 - a data explorer that lets you inspect dataframes and tables at a glance
 - smart module autoreloading that tells you which cells need to be rerun
 - code completion
-- GitHub Copilot
+- [GitHub Copilot](ai_completion.md#github-copilot)
 - language-model assisted coding
-- language server protocol (LSP) for diagnostics and code intelligence
-- vim keybindings
+- [language server protocol](language_server.md) (LSP) for diagnostics and code intelligence
+- [vim keybindings](overview.md#vim-keybindings)
 - live documentation preiews as you type
 
 and much more.

--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -2,14 +2,14 @@
 
 This guide introduces some of marimo editor's features, including
 a variables panel, dependency graph viewer, table of contents, HTML export,
-GitHub copilot, code formatting, a feedback form, and more.
+[GitHub copilot](ai_completion.md#github-copilot), code formatting, a feedback form, and more.
 
 ## Configuration
 
 The editor exposes of a number of settings for the current notebook,
 as well as user-wide configuration that will apply to all your notebooks.
 These settings include the option to display the current notebook in
-full width, to use vim keybindings, to enable GitHub copilot, and more.
+full width, to use [vim keybindings](#vim-keybindings), to enable [GitHub copilot](ai_completion.md#github-copilot), and more.
 
 To access these settings, click the gear icon in the top-right of the editor:
 
@@ -29,7 +29,7 @@ A non-exhaustive list of settings:
 - Auto-complete
 - Editor font-size
 - Code formatting with ruff/black
-- [GitHub Copilot](ai_completion.md)
+- [GitHub Copilot](ai_completion.md#github-copilot)
 - [LLM coding assistant](ai_completion.md)
 - [Module autoreloading](../configuration/runtime_configuration.md#on-module-change)
 - [Reactive reference highlighting](dataflow.md#reactive-reference-highlighting)
@@ -44,7 +44,7 @@ editing their contents.
 
 **Enter/Exit:**
 
-- Enter command mode: `Esc` (from cell editor) or `Ctrl+Esc`/`Cmd+Esc` (when vim keybindings are enabled, `Shift+Esc` on Windows)
+- Enter command mode: `Esc` (from cell editor) or `Ctrl+Esc`/`Cmd+Esc` (when [vim keybindings](#vim-keybindings) are enabled, `Shift+Esc` on Windows)
 - Exit command mode: `Enter` or click on a cell
 
 **Shortcuts:**

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,9 @@ Python notebook: run a cell or interact with a UI element, and marimo
 automatically runs dependent cells (or [marks them as
 stale](guides/reactivity.md#configuring-how-marimo-runs-cells)), keeping code
 and outputs consistent and preventing bugs before they happen. Every marimo
-notebook is stored as pure Python (Git-friendly), executable as a script, and
-deployable as an app; while stored as Python, marimo notebooks also have native
-support for SQL.
+notebook is stored as pure Python (Git-friendly), [executable as a script](guides/scripts.md), and
+[deployable as an app](guides/apps.md); while stored as Python, marimo notebooks also have [native
+support for SQL](guides/working_with_data/sql.md).
 
 /// admonition | Built from the ground up
     type: tip
@@ -68,7 +68,7 @@ reproducibility, maintainability, composability, and shareability.
 - 🛜 **shareable**: [deploy as an interactive web app](guides/apps.md) or [slides](guides/apps.md#slides-layout), [run in the browser via WASM](guides/wasm.md)
 - 🧩 **reusable:** [import functions and classes](guides/reusing_functions.md) from one notebook to another
 - 🧪 **testable:** [run pytest](guides/testing/index.md) on notebooks
-- ⌨️ **a modern editor**: [GitHub Copilot](guides/editor_features/ai_completion.md#github-copilot), [AI assistants](guides/editor_features/ai_completion.md), vim keybindings, variable explorer, and [more](guides/editor_features/index.md)
+- ⌨️ **a modern editor**: [GitHub Copilot](guides/editor_features/ai_completion.md#github-copilot), [AI assistants](guides/editor_features/ai_completion.md), [vim keybindings](guides/editor_features/overview.md#vim-keybindings), variable explorer, and [more](guides/editor_features/index.md)
 - 🧑‍💻 **use your favorite editor**: run in [VS Code or Cursor](https://marketplace.visualstudio.com/items?itemName=marimo-team.vscode-marimo), or edit in neovim, Zed, [or any other text editor](https://docs.marimo.io/guides/editor_features/watching/)
 
 ## A reactive programming environment
@@ -152,7 +152,7 @@ Organize your notebooks to best fit the stories you'd like to tell.
 **Performant runtime.** marimo runs only those cells that need to be run by
 statically analyzing your code.
 
-**Batteries-included.** marimo comes with GitHub Copilot, AI assistants, Ruff
+**Batteries-included.** marimo comes with [GitHub Copilot](guides/editor_features/ai_completion.md#github-copilot), AI assistants, Ruff
 code formatting, HTML export, fast code completion, a [VS Code
 extension](https://marketplace.visualstudio.com/items?itemName=marimo-team.vscode-marimo),
 an interactive dataframe viewer, and [many more](guides/editor_features/index.md)


### PR DESCRIPTION
## 📝 Summary

This PR adds a few hyperlinks I found to be missing while browsing the docs

## 🔍 Description of Changes

- added hyperlinks on pages:
  - index (https://docs.marimo.io/)
  - overview (https://docs.marimo.io/guides/editor_features/overview/)
  - editor features (https://docs.marimo.io/guides/editor_features/)

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
