### PR TITLE
Generate with AI fix: use update cell code to not wait for cell editor

### DIFF
--- a/frontend/src/core/ai/staged-cells.ts
+++ b/frontend/src/core/ai/staged-cells.ts
@@ -11,8 +11,13 @@ import { CellId } from "@/core/cells/ids";
 import { createReducerAndAtoms } from "@/utils/createReducer";
 import { Logger } from "@/utils/Logger";
 import { maybeAddMarimoImport } from "../cells/add-missing-import";
-import { type CreateNewCellAction, useCellActions } from "../cells/cells";
+import {
+  type CreateNewCellAction,
+  getCellEditorView,
+  useCellActions,
+} from "../cells/cells";
 import type { LanguageAdapterType } from "../codemirror/language/types";
+import { updateEditorCodeFromPython } from "../codemirror/language/utils";
 import type { JotaiStore } from "../state/jotai";
 import type { EditType } from "./tools/edit-notebook-tool";
 
@@ -98,7 +103,14 @@ export function useStagedCells(store: JotaiStore) {
       return;
     }
 
-    updateCellCode({ cellId, code, formattingChange: false });
+    // Update the editor code if the cell is mounted
+    // Else, update the cell code in the notebook
+    const editorView = getCellEditorView(cellId);
+    if (editorView) {
+      updateEditorCodeFromPython(editorView, code);
+    } else {
+      updateCellCode({ cellId, code, formattingChange: false });
+    }
   };
 
   // Delete a staged cell and the corresponding cell in the notebook.


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

Sometimes Generate with AI may not find the cell editor as the EditorView has not been mounted

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
