### PR TITLE
improve: contextual docs hint for local variables on NameError

### DIFF
--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -295,9 +295,9 @@ export const MarimoErrorOutput = ({
 
             <p className="py-2">
               Try merging this cell with the mentioned cells or wrapping it in a
-              function. Alternatively, prefix variables with an underscore (e.g., {" "}
-              <Kbd className="inline">_{firstName}</Kbd>). to make them private
-              to this cell.
+              function. Alternatively, prefix variables with an underscore
+              (e.g., <Kbd className="inline">_{firstName}</Kbd>). to make them
+              private to this cell.
             </p>
 
             <p className="py-2">


### PR DESCRIPTION
This change adds a contextual tip and docs link about local variables on `NameError` 

<img width="1209" height="524" alt="image" src="https://github.com/user-attachments/assets/43535c36-c763-4aed-948f-a7776051d356" />
