### PR TITLE
add anthropic vercel adapter to fix extended thinking error

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -940,6 +940,7 @@ class AnthropicProvider(PydanticProvider["PydanticAnthropic"]):
     EXTENDED_THINKING_MODEL_PREFIXES = [
         "claude-opus-4",
         "claude-sonnet-4",
+        "claude-haiku-4-5",
         "claude-3-7-sonnet",
     ]
     # 1024 tokens is the minimum budget for extended thinking
@@ -1032,7 +1033,7 @@ class AnthropicProvider(PydanticProvider["PydanticAnthropic"]):
         from ThinkingPart to ReasoningEndChunk, which breaks Anthropic's extended thinking
         on follow-up messages (Anthropic requires signatures on thinking blocks).
 
-        See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
+        TODO: Remove this once https://github.com/pydantic/pydantic-ai/pull/3754 is released
         """
         from pydantic_ai import DeferredToolRequests
         from pydantic_ai.ui.vercel_ai import VercelAIAdapter


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
This is a temporary fix until https://github.com/pydantic/pydantic-ai/pull/3754 is released.

There is a bug where text after tool calls on extended thinking models abruptly stop.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
