### PR TITLE
fix: config cell_output prefault "below"

### DIFF
--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -60,7 +60,7 @@ test("default UserConfig - empty", () => {
       },
       "diagnostics": {},
       "display": {
-        "cell_output": "above",
+        "cell_output": "below",
         "code_editor_font_size": 14,
         "dataframes": "rich",
         "default_table_max_columns": 50,
@@ -129,7 +129,7 @@ test("default UserConfig - one level", () => {
       },
       "diagnostics": {},
       "display": {
-        "cell_output": "above",
+        "cell_output": "below",
         "code_editor_font_size": 14,
         "dataframes": "rich",
         "default_table_max_columns": 50,

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -132,7 +132,7 @@ export const UserConfigSchema = z
       .looseObject({
         theme: z.enum(["light", "dark", "system"]).prefault("light"),
         code_editor_font_size: z.number().nonnegative().prefault(14),
-        cell_output: z.enum(["above", "below"]).prefault("above"),
+        cell_output: z.enum(["above", "below"]).prefault("below"),
         dataframes: z.enum(["rich", "plain"]).prefault("rich"),
         default_table_page_size: z.number().prefault(10),
         default_table_max_columns: z.number().prefault(50),


### PR DESCRIPTION
We default to cell output showing below cells. Without this change, in WASM cell output shows above cells, which is inconsistent with molab/OSS.