### PR TITLE
Add empty markdown cell placeholder

### DIFF
--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -487,6 +487,8 @@ const EditableCellComponent = ({
     isEmptyMarkdownContent &&
     !needsRun && (
       <div
+        role="button"
+        aria-label="Double-click to edit markdown"
         className="relative cursor-pointer px-3 py-2"
         onDoubleClick={showHiddenCodeIfMarkdown}
         onKeyDown={(e) => {


### PR DESCRIPTION
Empty hidden markdown cells now show "Double-click (or enter) to edit" instead of being invisible. The placeholder only appears after the cell has been run.

This was trickier than anticipated. The raw `cellData.code` always contains the `mo.md(...)` wrapper, so checking for empty code doesn't work. Instead, detection reads the editor's inner content directly (the transformed markdown that the user actually edits).

https://github.com/user-attachments/assets/ae9b4b29-382f-43cf-9827-6a047e2118b7

