### PR TITLE
refactor: DRY up endpoints that proxy directly to the kernel

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -2095,7 +2095,7 @@ class Kernel:
 
         if self.graph.cells:
             del request
-            LOGGER.debug("App already instantiated.")
+            LOGGER.info("App is already instantiated, skipping instantiation.")
             return
 
         # Handle markdown cells specially during kernel-ready initialization
@@ -2128,6 +2128,7 @@ class Kernel:
         self, execution_requests: dict[CellId_t, ExecutionRequest]
     ) -> None:
         """Handle markdown cells during kernel-ready initialization.
+        Mutates the execution_requests to remove markdown cells.
 
         For cells that contain only markdown (mo.md calls), this method:
         1. Compiles the cells to extract markdown content

--- a/marimo/_server/api/endpoints/cache.py
+++ b/marimo/_server/api/endpoints/cache.py
@@ -9,10 +9,9 @@ from marimo._runtime.requests import (
     ClearCacheRequest,
     GetCacheInfoRequest,
 )
-from marimo._server.api.deps import AppState
+from marimo._server.api.utils import dispatch_control_request
 from marimo._server.models.models import SuccessResponse
 from marimo._server.router import APIRouter
-from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -38,12 +37,7 @@ async def clear_cache(request: Request) -> SuccessResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    app_state.require_current_session().put_control_request(
-        ClearCacheRequest(),
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-    return SuccessResponse(success=True)
+    return await dispatch_control_request(request, ClearCacheRequest())
 
 
 @router.post("/info")
@@ -63,9 +57,4 @@ async def get_cache_info(request: Request) -> SuccessResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    app_state.require_current_session().put_control_request(
-        GetCacheInfoRequest(),
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-    return SuccessResponse(success=True)
+    return await dispatch_control_request(request, GetCacheInfoRequest())

--- a/marimo/_server/api/endpoints/datasources.py
+++ b/marimo/_server/api/endpoints/datasources.py
@@ -12,11 +12,9 @@ from marimo._runtime.requests import (
     PreviewSQLTableListRequest,
     PreviewSQLTableRequest,
 )
-from marimo._server.api.deps import AppState
-from marimo._server.api.utils import parse_request
-from marimo._server.models.models import BaseResponse, SuccessResponse
+from marimo._server.api.utils import dispatch_control_request
+from marimo._server.models.models import BaseResponse
 from marimo._server.router import APIRouter
-from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -46,13 +44,7 @@ async def preview_column(
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, PreviewDatasetColumnRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-    return SuccessResponse()
+    return await dispatch_control_request(request, PreviewDatasetColumnRequest)
 
 
 @router.post("/preview_sql_table")
@@ -72,13 +64,7 @@ async def preview_sql_table(request: Request) -> BaseResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, PreviewSQLTableRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-    return SuccessResponse()
+    return await dispatch_control_request(request, PreviewSQLTableRequest)
 
 
 @router.post("/preview_sql_table_list")
@@ -98,13 +84,7 @@ async def preview_sql_table_list(request: Request) -> BaseResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, PreviewSQLTableListRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-    return SuccessResponse()
+    return await dispatch_control_request(request, PreviewSQLTableListRequest)
 
 
 @router.post("/preview_datasource_connection")
@@ -124,10 +104,6 @@ async def preview_datasource_connection(request: Request) -> BaseResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, PreviewDataSourceConnectionRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
+    return await dispatch_control_request(
+        request, PreviewDataSourceConnectionRequest
     )
-    return SuccessResponse()

--- a/marimo/_server/api/endpoints/editing.py
+++ b/marimo/_server/api/endpoints/editing.py
@@ -13,7 +13,7 @@ from marimo._runtime.requests import (
     SetCellConfigRequest,
 )
 from marimo._server.api.deps import AppState
-from marimo._server.api.utils import parse_request
+from marimo._server.api.utils import dispatch_control_request, parse_request
 from marimo._server.models.models import (
     BaseResponse,
     FormatRequest,
@@ -73,14 +73,7 @@ async def delete_cell(request: Request) -> BaseResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, cls=DeleteCellRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-
-    return SuccessResponse()
+    return await dispatch_control_request(request, DeleteCellRequest)
 
 
 @router.post("/sync/cell_ids")
@@ -149,14 +142,7 @@ async def set_cell_config(request: Request) -> BaseResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, cls=SetCellConfigRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-
-    return SuccessResponse()
+    return await dispatch_control_request(request, SetCellConfigRequest)
 
 
 @router.post("/stdin")
@@ -200,10 +186,6 @@ async def install_missing_packages(request: Request) -> BaseResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, cls=InstallMissingPackagesRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
+    return await dispatch_control_request(
+        request, InstallMissingPackagesRequest
     )
-    return SuccessResponse()

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -20,7 +20,7 @@ from marimo._runtime.requests import (
 )
 from marimo._server.api.deps import AppState
 from marimo._server.api.endpoints.ws import DOC_MANAGER, FILE_QUERY_PARAM_KEY
-from marimo._server.api.utils import parse_request
+from marimo._server.api.utils import dispatch_control_request, parse_request
 from marimo._server.file_router import MarimoFileKey
 from marimo._server.models.models import (
     BaseResponse,
@@ -95,14 +95,7 @@ async def set_model_values(
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, cls=SetModelMessageRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-
-    return SuccessResponse()
+    return await dispatch_control_request(request, SetModelMessageRequest)
 
 
 @router.post("/instantiate")
@@ -153,14 +146,7 @@ async def function_call(
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, cls=FunctionCallRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-
-    return SuccessResponse()
+    return await dispatch_control_request(request, FunctionCallRequest)
 
 
 @router.post("/interrupt")
@@ -235,14 +221,7 @@ async def run_scratchpad(
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """  # noqa: E501
-    app_state = AppState(request)
-    body = await parse_request(request, cls=ExecuteScratchpadRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-
-    return SuccessResponse()
+    return await dispatch_control_request(request, ExecuteScratchpadRequest)
 
 
 @router.post("/pdb/pm")
@@ -265,14 +244,7 @@ async def run_post_mortem(
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """  # noqa: E501
-    app_state = AppState(request)
-    body = await parse_request(request, cls=PdbRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-
-    return SuccessResponse()
+    return await dispatch_control_request(request, PdbRequest)
 
 
 @router.post("/restart_session")

--- a/marimo/_server/api/endpoints/secrets.py
+++ b/marimo/_server/api/endpoints/secrets.py
@@ -12,7 +12,7 @@ from marimo._runtime.requests import (
 )
 from marimo._secrets.secrets import write_secret
 from marimo._server.api.deps import AppState
-from marimo._server.api.utils import parse_request
+from marimo._server.api.utils import dispatch_control_request, parse_request
 from marimo._server.models.models import BaseResponse, SuccessResponse
 from marimo._server.models.secrets import CreateSecretRequest
 from marimo._server.router import APIRouter
@@ -45,13 +45,7 @@ async def list_keys(request: Request) -> SuccessResponse:
                     schema:
                         $ref: "#/components/schemas/ListSecretKeysResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, cls=ListSecretKeysRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-    return SuccessResponse(success=True)
+    return await dispatch_control_request(request, ListSecretKeysRequest)
 
 
 @router.post("/create")

--- a/marimo/_server/api/endpoints/sql.py
+++ b/marimo/_server/api/endpoints/sql.py
@@ -6,11 +6,9 @@ from typing import TYPE_CHECKING
 from starlette.authentication import requires
 
 from marimo._runtime.requests import ValidateSQLRequest
-from marimo._server.api.deps import AppState
-from marimo._server.api.utils import parse_request
-from marimo._server.models.models import BaseResponse, SuccessResponse
+from marimo._server.api.utils import dispatch_control_request
+from marimo._server.models.models import BaseResponse
 from marimo._server.router import APIRouter
-from marimo._types.ids import ConsumerId
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -36,10 +34,4 @@ async def validate_sql(request: Request) -> BaseResponse:
                     schema:
                         $ref: "#/components/schemas/SuccessResponse"
     """
-    app_state = AppState(request)
-    body = await parse_request(request, ValidateSQLRequest)
-    app_state.require_current_session().put_control_request(
-        body,
-        from_consumer_id=ConsumerId(app_state.require_current_session_id()),
-    )
-    return SuccessResponse()
+    return await dispatch_control_request(request, ValidateSQLRequest)

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -3935,3 +3935,21 @@ def _filter_to_error_ops(cell_ops: list[CellOp]) -> list[CellOp]:
         if op.output is not None
         and op.output.channel == CellChannel.MARIMO_ERROR
     ]
+
+
+class TestRequestHandler:
+    async def test_request_handler_only_created_once(
+        self, any_kernel: Kernel
+    ) -> None:
+        """Test that request_handler property is only created once."""
+        k = any_kernel
+
+        # Access request_handler multiple times
+        handler1 = k.request_handler
+        handler2 = k.request_handler
+        handler3 = k.request_handler
+
+        # They should all be the same instance
+        assert handler1 is handler2
+        assert handler2 is handler3
+        assert handler1 is handler3


### PR DESCRIPTION
- Create a `dispatch_control_request` for REST endpoints that just proxy directly to the kernel.