### PR TITLE
feat: CLI flag to configure whether a notebook is trusted

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -340,12 +340,12 @@ requirements. These and other issues are described in
 https://github.com/marimo-team/marimo/issues/5219.""",
 )
 @click.option(
-    "--trusted/--no-trusted",
+    "--trusted/--untrusted",
     is_flag=True,
     default=None,
     show_default=False,
     type=bool,
-    help="Run notebooks hosted remotely on the host machine; if --no-trusted, runs marimo in a Docker container.",
+    help="Run notebooks hosted remotely on the host machine; if --untrusted, runs marimo in a Docker container.",
 )
 @click.option("--profile-dir", default=None, type=str, hidden=True)
 @click.option(
@@ -891,12 +891,12 @@ Example:
     help=check_message,
 )
 @click.option(
-    "--trusted/--no-trusted",
+    "--trusted/--untrusted",
     is_flag=True,
     default=None,
     show_default=False,
     type=bool,
-    help="Run notebooks hosted remotely on the host machine; if --no-trusted, runs marimo in a Docker container.",
+    help="Run notebooks hosted remotely on the host machine; if --untrusted, runs marimo in a Docker container.",
 )
 @click.option(
     "--server-startup-command",

--- a/marimo/_cli/run_docker.py
+++ b/marimo/_cli/run_docker.py
@@ -142,7 +142,7 @@ def run_in_docker(
         f"{port}",
         "--host",
         host,
-        file_path,
+        file_path if file_path is not None else "",
     ]
     # Remove empty strings from command
     container_command = [arg for arg in container_command if arg]

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -1368,13 +1368,13 @@ def test_cli_edit_trusted(temp_marimo_file: str) -> None:
     HAS_DOCKER, reason="docker is required to be not installed"
 )
 def test_cli_edit_no_trusted(temp_marimo_file: str) -> None:
-    # --no-trusted should try to use Docker, fail if not installed
+    # --untrusted should try to use Docker, fail if not installed
     p = subprocess.Popen(
         [
             "marimo",
             "edit",
             temp_marimo_file,
-            "--no-trusted",
+            "--untrusted",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -1408,13 +1408,13 @@ def test_cli_run_trusted(temp_marimo_file: str) -> None:
     HAS_DOCKER, reason="docker is required to be not installed"
 )
 def test_cli_run_no_trusted(temp_marimo_file: str) -> None:
-    # --no-trusted should try to use Docker, fail if not installed
+    # --untrusted should try to use Docker, fail if not installed
     p = subprocess.Popen(
         [
             "marimo",
             "run",
             temp_marimo_file,
-            "--no-trusted",
+            "--untrusted",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
This PR adds a new flag to `marimo edit` and `marimo run`: `--trusted`. This flag controls whether marimo is run in a Docker container.

* `marimo edit --trusted ...`: does not run in a container
* `marimo edit --untrusted ...`: runs in a Docker container
* `marimo edit <NOTEBOOK>`: prompts whether to run in Docker if `NOTEBOOK` is determined to be hosted remotely; this behavior is the same as it was before this change.

This enables users to run trusted notebooks that are hosted remotely on the host machine, without having to respond interactive prompts. For example, `uvx marimo edit --trusted --sandbox URL` 