### PR TITLE
Fix flaky hypothesis test for pandas GROUP_BY transforms

### DIFF
--- a/marimo/_internal/__init__.py
+++ b/marimo/_internal/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Marimo. All rights reserved.
 """Internal API - DO NOT USE."""
 
 import marimo._internal.templates as templates

--- a/tests/_plugins/ui/_impl/dataframes/test_print_code.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_print_code.py
@@ -422,11 +422,21 @@ def test_print_code_result_matches_actual_transform_pandas(
             code_result = code_result.to_frame()
         if isinstance(real_result, pd.Series):
             real_result = real_result.to_frame()
-        # Remove index to compare
-        pd.testing.assert_frame_equal(
-            cast(pd.DataFrame, code_result).reset_index(drop=True),
-            real_result.reset_index(drop=True),
-        )
+
+        code_result = cast(pd.DataFrame, code_result).reset_index(drop=True)
+        real_result = real_result.reset_index(drop=True)
+
+        # For group_by transforms, the row order might differ
+        # Sort both dataframes by all columns before comparing
+        if transform.type == TransformType.GROUP_BY:
+            code_result = code_result.sort_values(
+                by=list(code_result.columns)
+            ).reset_index(drop=True)
+            real_result = real_result.sort_values(
+                by=list(real_result.columns)
+            ).reset_index(drop=True)
+
+        pd.testing.assert_frame_equal(code_result, real_result)
 
 
 @given(


### PR DESCRIPTION
The `test_print_code_result_matches_actual_transform_pandas` was failing intermittently because GROUP_BY operations don't guarantee row order. When grouping by a boolean column, the result rows could appear in either `[True, False]` or `[False, True]` order.

The polars version of this test already handled this by sorting both dataframes before comparison, but the pandas test was missing this logic. This fix adds the same sorting behavior for pandas GROUP_BY transforms.