### PR TITLE
Simplify ReorderableList and remove `react-stately`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -151,7 +151,6 @@
     "react-markdown": "^9.1.0",
     "react-plotly.js": "^2.6.0",
     "react-resizable-panels": "2.1.9",
-    "react-stately": "^3.42.0",
     "react-use-event-hook": "^0.9.6",
     "react-vega": "^8.0.0",
     "react-virtuoso": "^4.15.0",

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -159,7 +159,7 @@ export const MarimoErrorOutput = ({
         syntaxErrors.some((error) => error.msg.includes("use os.subprocess"));
 
       const openTerminal = () => {
-        chromeActions.setIsTerminalOpen(true);
+        chromeActions.setIsDeveloperPanelOpen(true);
       };
 
       messages.push(


### PR DESCRIPTION
Impl of https://github.com/marimo-team/marimo/pull/7514#discussion_r2627926590

Remove `useListData` and operate directly on external `value`/`setValue` props. This eliminates the internal list state, `needsSync` boolean, and deferred `useEffect` that worked around timing issues between internal and external state.