### PR TITLE
style: fullscreen icon, collapse icon, focus ring

### DIFF
--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -461,7 +461,10 @@ const ExpandableOutput = React.memo(
                     size="xs"
                     variant="text"
                   >
-                    <ExpandIcon className="size-4" strokeWidth={1.25} />
+                    <ExpandIcon
+                      className="size-4 opacity-60 hover:opacity-80"
+                      strokeWidth={1.25}
+                    />
                   </Button>
                 </Tooltip>
               )}
@@ -483,7 +486,7 @@ const ExpandableOutput = React.memo(
                     </Tooltip>
                   ) : (
                     <Tooltip content="Expand output" side="left">
-                      <ChevronsUpDownIcon className="h-4 w-4" />
+                      <ChevronsUpDownIcon className="h-4 w-4 opacity-60" />
                     </Tooltip>
                   )}
                 </Button>

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -588,7 +588,7 @@ const EditableCellComponent = ({
             className={cn(
               className,
               navigationProps.className,
-              "focus:ring-1 focus:ring-(--blue-7) focus:ring-offset-0",
+              "focus:ring-1 focus:ring-(--slate-7) focus:ring-offset-2",
             )}
             ref={cellContainerRef}
             {...cellDomProps(cellId, cellData.name)}


### PR DESCRIPTION
* Fullscreen icon and collapse icon should use the same opacity as the other editor buttons
* Add a nonzero ring offset to the cell focus ring so it can be seen even on cells with errors; make ring slate to be less jarring, with ring offset keeping it visible

With this change (notice the ring):
<img width="666" height="205" alt="image" src="https://github.com/user-attachments/assets/73249424-7c22-47db-a014-6bd14d15eeac" />

Without this change (no ring):
<img width="722" height="222" alt="image" src="https://github.com/user-attachments/assets/127dda6e-87b4-45d4-a54b-4e0ca9662d73" />
