### PR TITLE
Variables & Data sources panel improvements

### DIFF
--- a/frontend/src/components/editor/chrome/panels/session-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/session-panel.tsx
@@ -1,7 +1,9 @@
 /* Copyright 2024 Marimo. All rights reserved. */
 
+import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 import { DatabaseIcon, VariableIcon } from "lucide-react";
-import React, { useState } from "react";
+import React from "react";
 import { DataSources } from "@/components/datasources/datasources";
 import {
   Accordion,
@@ -15,11 +17,16 @@ import { useCellIds } from "@/core/cells/cells";
 import { useDatasets } from "@/core/datasets/state";
 import { useVariables } from "@/core/variables/state";
 
+const openSectionsAtom = atomWithStorage<string[]>(
+  "marimo:session-panel:open-sections",
+  ["variables"],
+);
+
 const SessionPanel: React.FC = () => {
   const variables = useVariables();
   const cellIds = useCellIds();
   const datasets = useDatasets();
-  const [openSections, setOpenSections] = useState<string[]>(["variables"]);
+  const [openSections, setOpenSections] = useAtom(openSectionsAtom);
 
   const datasourcesCount = datasets.tables.length;
   const isDatasourcesOpen = openSections.includes("datasources");

--- a/frontend/src/components/editor/chrome/types.ts
+++ b/frontend/src/components/editor/chrome/types.ts
@@ -66,7 +66,7 @@ export const PANELS: PanelDescriptor[] = [
   {
     id: "variables",
     Icon: VariableIcon,
-    tooltip: "Explore variables",
+    tooltip: "Explore variables and data sources",
     position: "sidebar",
   },
   // Every notebook has a package environment that must


### PR DESCRIPTION
Persist open/closed section state in localStorage so users don't need to re-open data sources each time. Update tooltip to "Explore variables and data sources" for command palette discoverability.
