### PR TITLE
Fix example code in `UIElement.form` docstring

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -373,7 +373,7 @@ class UIElement(Html, Generic[S, T]):
             Combine with `HTML.batch` to create a form made out of multiple `UIElements`:
                 ```python
                 form = (
-                    mo.ui.md(
+                    mo.md(
                         '''
                     **Enter your prompt.**
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->

This PR fixes an example code in the docstring of `UIElement.form`.

## 🔍 Description of Changes

The docstring of `UIElement.form` has the following docstring, which is displayed in various places in the marimo docs:


```python
form = (
    mo.ui.md(
        '''
    **Enter your prompt.**

    {prompt}

    **Choose a random seed.**

    {seed}
    '''
    )
    .batch(
        prompt=mo.ui.text_area(),
        seed=mo.ui.number(),
    )
    .form()
)
```

This code, however, raises an `AttributeError` because `md` should be accessed as `mo.md` instead of `mo.ui.md`.

This PR fixes this by replacing `mo.ui.md` with `mo.ui`.

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [ ] I have run the code and verified that it works as expected.
