### PR TITLE
Fix `Ctrl+Click` to select cell type on Windows/Linux

### DIFF
--- a/frontend/src/components/editor/cell/CreateCellButton.tsx
+++ b/frontend/src/components/editor/cell/CreateCellButton.tsx
@@ -80,11 +80,23 @@ export const CreateCellButton = ({
     return <div className="mr-3 text-muted-foreground">{icon}</div>;
   };
 
+  const openDropdown = () => {
+    setOpen(true);
+    setJustOpened(true);
+    // Allow interactions after a brief delay to prevent the dropdown items immediately being clicked
+    setTimeout(() => setJustOpened(false), 200);
+  };
+
   // We use onPointerDownCapture (not onPointerDown) to intercept events in
   // capture phase before Radix's DropdownMenuTrigger sees them. Radix ignores
   // Ctrl+Click (likely to avoid interfering with browser), so we bypass its
   // trigger entirely and manage the dropdown's open state ourselves.
   const handlePointerDownCapture = (e: React.MouseEvent) => {
+    // Ignore right-clicks, handled by onContextMenuCapture
+    if (e.button === 2) {
+      return;
+    }
+
     // Don't propagate event to Radix
     e.preventDefault();
     e.stopPropagation();
@@ -93,13 +105,16 @@ export const CreateCellButton = ({
       oneClickShortcut === "shift" ? e.shiftKey : e.metaKey || e.ctrlKey;
 
     if (hasModifier) {
-      setOpen(true);
-      setJustOpened(true);
-      // Allow interactions after a brief delay
-      setTimeout(() => setJustOpened(false), 200);
+      openDropdown();
     } else {
       addPythonCell();
     }
+  };
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    openDropdown();
   };
 
   const handleOpenChange = (isOpen: boolean) => {
@@ -130,6 +145,7 @@ export const CreateCellButton = ({
             isAppInteractionDisabled(connectionState) && " inactive-button",
           )}
           onPointerDownCapture={handlePointerDownCapture}
+          onContextMenuCapture={handleContextMenu}
           size="small"
           data-testid="create-cell-button"
         >


### PR DESCRIPTION
Fixes #7547

The desired behavior of the create cell button is to default to adding a Python cell on click, with `Ctrl+Click` (`Cmd+Click` on Mac) opening a dropdown to select other cell types. This worked on Mac but not on Windows/Linux because Radix's `DropdownMenuTrigger` ignores `Ctrl+Click` (likely because browsers historically use `Ctrl+Click` for "open link in new tab" and Radix avoids interfering with that).

The fix bypasses Radix's trigger behavior entirely. We intercept pointer events in the capture phase before Radix sees them, stop propagation, and manage the dropdown's open state ourselves. Open to other ideas if folks have it. I've implemented the fix on my windows machine.


