### PR TITLE
improvement: show up to h6 for Outline

### DIFF
--- a/frontend/src/core/dom/__tests__/outline.test.ts
+++ b/frontend/src/core/dom/__tests__/outline.test.ts
@@ -242,6 +242,74 @@ describe("parseOutline", () => {
       }
     `);
   });
+
+  it("can parse h4, h5, and h6 headings", () => {
+    const html = `
+    <div>
+      <h1 id="chapter">Chapter</h1>
+      <h2 id="section">Section</h2>
+      <h3 id="subsection">Subsection</h3>
+      <h4 id="paragraph">Paragraph</h4>
+      <h5 id="subparagraph">Subparagraph</h5>
+      <h6 id="detail">Detail</h6>
+    </div>
+    `;
+    const outline = parseOutline({
+      mimetype: "text/html",
+      timestamp: 0,
+      channel: "output",
+      data: html,
+    });
+    expect(outline).toMatchInlineSnapshot(`
+      {
+        "items": [
+          {
+            "by": {
+              "id": "chapter",
+            },
+            "level": 1,
+            "name": "Chapter",
+          },
+          {
+            "by": {
+              "id": "section",
+            },
+            "level": 2,
+            "name": "Section",
+          },
+          {
+            "by": {
+              "id": "subsection",
+            },
+            "level": 3,
+            "name": "Subsection",
+          },
+          {
+            "by": {
+              "id": "paragraph",
+            },
+            "level": 4,
+            "name": "Paragraph",
+          },
+          {
+            "by": {
+              "id": "subparagraph",
+            },
+            "level": 5,
+            "name": "Subparagraph",
+          },
+          {
+            "by": {
+              "id": "detail",
+            },
+            "level": 6,
+            "name": "Detail",
+          },
+        ],
+      }
+    `);
+  });
+
   it("excludes headings within excluded tags", () => {
     const html = `
     <div>

--- a/frontend/src/core/dom/outline.ts
+++ b/frontend/src/core/dom/outline.ts
@@ -8,6 +8,10 @@ import type { OutputMessage } from "../kernel/messages";
 // Tags that we don't want to include in the outline
 const excludedTags = ["marimo-carousel", "marimo-tabs", "marimo-accordion"];
 
+// We go up to h6. Previously we did h3 to match Google Docs and Notion, but users have requested more levels.
+// This could be made configurable in the future.
+const HEADER_TAGS = "h1, h2, h3, h4, h5, h6";
+
 /**
  * Extracts a table of contents {@link Outline} from an HTML string.
  *
@@ -28,7 +32,7 @@ function getOutline(html: string): Outline | null {
   const parser = new DOMParser();
   const document = parser.parseFromString(html, "text/html");
 
-  const headings = document.querySelectorAll("h1, h2, h3");
+  const headings = document.querySelectorAll(HEADER_TAGS);
   // eslint-disable-next-line unicorn/prefer-spread
   for (const heading of Array.from(headings)) {
     const name = heading.textContent;


### PR DESCRIPTION
Allows up to h6 in the outline (prev h3)