### PR TITLE
fix: serialize run sessions in cell order

### DIFF
--- a/marimo/_server/sessions/extensions/extensions.py
+++ b/marimo/_server/sessions/extensions/extensions.py
@@ -139,6 +139,7 @@ class CachingExtension(SessionExtension, SessionEventListener):
             session_view=session.session_view,
             path=session.app_file_manager.path,
             interval=self.interval,
+            cell_ids_provider=lambda: session.app_file_manager.app.cell_manager.cell_ids(),
         )
 
         # Serialize the session view based on the current app


### PR DESCRIPTION
## 📝 Summary

When running the notebook with the RUN command, the session gets serialized out of order if the cells execute out of order. This makes the serialized session unusable as it will not be a "cache_hit". The SessionCacheManager doesn't currently have access to the cell_ids to serialize the cells in order.

## 🔍 Description of Changes

The change here adds a `cell_ids_provider` to the SessionCacheManager in order for it to have knowledge of the cell_ids.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
