### PR TITLE
refactor: use Command instead of Request in put_control_request

### DIFF
--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -231,7 +231,6 @@ def _generate_server_api_schema() -> dict[str, Any]:
         models.PreviewDatasetColumnRequest,
         models.PreviewSQLTableRequest,
         models.ReadCodeResponse,
-        models.RefreshSecretsRequest,
         models.RenameNotebookRequest,
         models.ExecuteCellsRequest,
         models.SaveAppConfigurationRequest,

--- a/marimo/_server/api/endpoints/config.py
+++ b/marimo/_server/api/endpoints/config.py
@@ -12,6 +12,7 @@ from marimo._config.config import PartialMarimoConfig
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.msgspec_encoder import asdict
 from marimo._messaging.notification import MissingPackageAlertNotification
+from marimo._runtime.commands import UpdateUserConfigCommand
 from marimo._runtime.packages.utils import is_python_isolated
 from marimo._server.ai.mcp.config import is_mcp_config_empty
 from marimo._server.api.deps import AppState
@@ -19,7 +20,6 @@ from marimo._server.api.utils import parse_request
 from marimo._server.models.models import (
     SaveUserConfigurationRequest,
     SuccessResponse,
-    UpdateUserConfigRequest,
 )
 from marimo._server.router import APIRouter
 from marimo._session import send_message_to_consumer
@@ -111,7 +111,7 @@ async def save_user_config(
     # Session could be None if the user is on the home page
     if session is not None:
         session.put_control_request(
-            UpdateUserConfigRequest(config),
+            UpdateUserConfigCommand(config),
             from_consumer_id=ConsumerId(
                 app_state.require_current_session_id()
             ),

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -10,7 +10,7 @@ from starlette.responses import JSONResponse
 
 from marimo import _loggers
 from marimo._messaging.notification import AlertNotification
-from marimo._runtime.commands import HTTPRequest
+from marimo._runtime.commands import HTTPRequest, UpdateUIElementCommand
 from marimo._server.api.deps import AppState
 from marimo._server.api.endpoints.ws.ws_connection_validator import (
     FILE_QUERY_PARAM_KEY,
@@ -26,7 +26,6 @@ from marimo._server.models.models import (
     InstantiateNotebookRequest,
     InvokeFunctionRequest,
     SuccessResponse,
-    UpdateUIElementRequest,
     UpdateUIElementValuesRequest,
     UpdateWidgetModelRequest,
 )
@@ -65,7 +64,7 @@ async def set_ui_element_values(
     app_state = AppState(request)
     body = await parse_request(request, cls=UpdateUIElementValuesRequest)
     app_state.require_current_session().put_control_request(
-        UpdateUIElementRequest(
+        UpdateUIElementCommand(
             object_ids=body.object_ids,
             values=body.values,
             token=str(uuid4()),

--- a/marimo/_server/api/endpoints/files.py
+++ b/marimo/_server/api/endpoints/files.py
@@ -87,11 +87,11 @@ async def rename_file(
     """
     body = await parse_request(request, cls=RenameNotebookRequest)
     app_state = AppState(request)
+    filename = await abspath(body.filename)
 
     # Convert to absolute path
-    command = RenameNotebookCommand(filename=await abspath(body.filename))
     app_state.require_current_session().put_control_request(
-        command,
+        RenameNotebookCommand(filename=filename),
         from_consumer_id=ConsumerId(app_state.require_current_session_id()),
     )
 

--- a/marimo/_server/api/endpoints/secrets.py
+++ b/marimo/_server/api/endpoints/secrets.py
@@ -7,13 +7,13 @@ from starlette.authentication import requires
 from starlette.responses import JSONResponse
 
 from marimo import _loggers
+from marimo._runtime.commands import RefreshSecretsCommand
 from marimo._secrets.secrets import write_secret
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import dispatch_control_request, parse_request
 from marimo._server.models.models import (
     BaseResponse,
     ListSecretKeysRequest,
-    RefreshSecretsRequest,
     SuccessResponse,
 )
 from marimo._server.models.secrets import CreateSecretRequest
@@ -77,7 +77,7 @@ async def create_secret(request: Request) -> BaseResponse:
 
     # Refresh the secrets
     app_state.require_current_session().put_control_request(
-        RefreshSecretsRequest(),
+        RefreshSecretsCommand(),
         from_consumer_id=ConsumerId(session_id),
     )
     return SuccessResponse(success=True)

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -23,7 +23,6 @@ from marimo._runtime.commands import (
     ListSQLTablesCommand,
     PreviewDatasetColumnCommand,
     PreviewSQLTableCommand,
-    RefreshSecretsCommand,
     UpdateCellConfigCommand,
     UpdateUIElementCommand,
     UpdateUserConfigCommand,
@@ -85,11 +84,6 @@ class UpdateWidgetModelRequest(UpdateWidgetModelCommand, tag=False):
             message=self.message,
             buffers=self.buffers,
         )
-
-
-class RefreshSecretsRequest(RefreshSecretsCommand, tag=False):
-    def as_command(self) -> RefreshSecretsCommand:
-        return RefreshSecretsCommand()
 
 
 class ListDataSourceConnectionRequest(

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -3211,11 +3211,6 @@ components:
       - type
       title: RefreshSecretsCommand
       type: object
-    RefreshSecretsRequest:
-      properties: {}
-      required: []
-      title: RefreshSecretsRequest
-      type: object
     ReloadNotification:
       properties:
         op:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4615,8 +4615,6 @@ export interface components {
       /** @enum {unknown} */
       type: "refresh-secrets";
     };
-    /** RefreshSecretsRequest */
-    RefreshSecretsRequest: Record<string, any>;
     /** ReloadNotification */
     ReloadNotification: {
       /** @enum {unknown} */


### PR DESCRIPTION
We need to pass `*Commands` (not `*Requests`) to the kernel. This fixes a few mistakes