### PR TITLE
fix: allow saving notebooks on /tmp_mnt paths

### DIFF
--- a/frontend/src/core/saving/__tests__/save-component.test.ts
+++ b/frontend/src/core/saving/__tests__/save-component.test.ts
@@ -1,0 +1,20 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { isNamedPersistentFile } from "../save-component";
+
+describe("isNamedPersistentFile", () => {
+  it.each([
+    [null, false],
+    // Temp paths should return false
+    ["/tmp/notebook.py", false],
+    ["/var/folders/ab/cd/T/notebook.py", false],
+    ["C:\\Users\\user\\AppData\\Local\\Temp\\notebook.py", false],
+    // /tmp_mnt is a mount point, not a temp directory (bug fix)
+    ["/tmp_mnt/notebook.py", true],
+    // Normal paths should return true
+    ["/home/user/project/notebook.py", true],
+  ])("isNamedPersistentFile(%s) => %s", (filename, expected) => {
+    expect(isNamedPersistentFile(filename)).toBe(expected);
+  });
+});

--- a/frontend/src/core/saving/save-component.tsx
+++ b/frontend/src/core/saving/save-component.tsx
@@ -193,11 +193,13 @@ export function useSaveNotebook() {
   };
 }
 
-function isNamedPersistentFile(filename: string | null): filename is string {
+export function isNamedPersistentFile(
+  filename: string | null,
+): filename is string {
   return (
     filename !== null &&
     // Linux
-    !filename.startsWith("/tmp") &&
+    !filename.startsWith("/tmp/") &&
     // macOS
     !filename.startsWith("/var/folders") &&
     // Windows


### PR DESCRIPTION
The `isNamedPersistentFile` check was too broad, preventing saves to paths like `/tmp_mnt/...` which are valid mount points, not temporary directories.

Changed the check from `/tmp` to `/tmp/` to only match actual Linux temp directory paths.

Closes #7638
