### PR TITLE
docs: add Codex agent support to agents guide and update AI completion reference

### DIFF
--- a/docs/guides/editor_features/agents.md
+++ b/docs/guides/editor_features/agents.md
@@ -61,6 +61,35 @@ See login and authentication instructions in the [Gemini CLI documentation](http
     npx stdio-to-ws "cmd /c npx @google/gemini-cli --experimental-acp" --port 3019
     ```
 
+### Codex Agent
+
+OpenAI's Codex agent uses [Codex CLI](https://github.com/openai/codex) via the [`@zed-industries/codex-acp`](https://github.com/zed-industries/codex-acp) adapter.
+
+**Installation and login:**
+
+```bash
+# Install Codex CLI
+npm install -g @openai/codex
+# or: brew install --cask codex
+
+# Login (or set OPENAI_API_KEY / CODEX_API_KEY)
+codex
+```
+
+**Connection command:**
+
+=== "macOS/Linux"
+
+    ```bash
+    npx stdio-to-ws "npx @zed-industries/codex-acp" --port 3021
+    ```
+
+=== "Windows"
+
+    ```bash
+    npx stdio-to-ws "cmd /c npx @zed-industries/codex-acp" --port 3021
+    ```
+
 ## Connecting to an agent
 
 1. **Start the agent server**: Run the connection command for your chosen agent in a terminal

--- a/docs/guides/editor_features/ai_completion.md
+++ b/docs/guides/editor_features/ai_completion.md
@@ -156,7 +156,7 @@ See the [llm_providers](../configuration/llm_providers.md) guide for detailed in
 
 !!! example "Experimental: Agents"
 
-    marimo also supports external AI agents like Claude Code and Gemini CLI that can interact with your notebooks.
+    marimo also supports external AI agents like Claude Code, Codex, and Gemini CLI that can interact with your notebooks.
     Learn more in the [agents](agents.md) guide.
 
 ## Copilots


### PR DESCRIPTION
This commit introduces a new section for the Codex agent in the agents guide, detailing installation, login, and connection commands for both macOS/Linux and Windows. Additionally, the AI completion guide is updated to include Codex as a supported external AI agent alongside Claude Code and Gemini CLI.
