### PR TITLE
fix: better parsing for pep dependencies in pyodide

### DIFF
--- a/tests/_pyodide/test_pyodide_session.py
+++ b/tests/_pyodide/test_pyodide_session.py
@@ -299,6 +299,18 @@ async def test_strip_version_resilience(
             'dependencies = ["package @ https://github.com/user/repo.git"]',
             ["package @ https://github.com/user/repo.git"],
         ),
+        (
+            'dependencies = ["package @ git+https://github.com/user/repo.git"]',
+            ["package @ git+https://github.com/user/repo.git"],
+        ),
+        (
+            'dependencies = ["package @ git+ssh://git@github.com/user/repo.git"]',
+            ["package @ git+ssh://git@github.com/user/repo.git"],
+        ),
+        (
+            'dependencies = ["package @ file:///path/to/local/package"]',
+            ["package @ file:///path/to/local/package"],
+        ),
         # Multiple packages with various specifiers
         (
             'dependencies = ["foo==1.0", "bar>=2.0", "baz~=3.0", "qux[extra]>=4.0"]',


### PR DESCRIPTION
Better parsing for script header in pyodide following `PEP 440`