### PR TITLE
improve: bring AI chat style to "generate cell with AI" area

### DIFF
--- a/frontend/src/components/editor/ai/add-cell-with-ai.tsx
+++ b/frontend/src/components/editor/ai/add-cell-with-ai.tsx
@@ -32,12 +32,12 @@ import { useMemo, useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
 import { z } from "zod";
 import { AIModelDropdown } from "@/components/ai/ai-model-dropdown";
+import { FileAttachmentPill } from "@/components/chat/chat-components";
 import {
   buildCompletionRequestBody,
   convertToFileUIPart,
   handleToolCall,
 } from "@/components/chat/chat-utils";
-import { FileAttachmentPill } from "@/components/chat/chat-components";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -53,9 +53,9 @@ import { AiModelId } from "@/core/ai/ids/ids";
 import { stagedAICellsAtom, useStagedCells } from "@/core/ai/staged-cells";
 import type { ToolNotebookContext } from "@/core/ai/tools/base";
 import { useCellActions } from "@/core/cells/cells";
+import { resourceExtension } from "@/core/codemirror/ai/resources";
 import { aiAtom } from "@/core/config/config";
 import { DEFAULT_AI_MODEL } from "@/core/config/config-schema";
-import { resourceExtension } from "@/core/codemirror/ai/resources";
 import { useRequestClient } from "@/core/network/requests";
 import type { AiCompletionRequest } from "@/core/network/types";
 import { useRuntimeManager } from "@/core/runtime/config";
@@ -545,7 +545,8 @@ export const PromptInput = ({
       onKeyDown={onKeyDown}
       theme={theme === "dark" ? "dark" : "light"}
       placeholder={
-        placeholder || `Generate with AI, ${CONTEXT_TRIGGER} to include context about tables or dataframes.\nCode from other cells is automatically included. `
+        placeholder ||
+        `Generate with AI, ${CONTEXT_TRIGGER} to include context about tables or dataframes.\nCode from other cells is automatically included. `
       }
     />
   );


### PR DESCRIPTION
## 📝 Summary

| Before | After |
| -------- | ------- |
| <img width="1180" height="348" alt="image" src="https://github.com/user-attachments/assets/268a0c9c-d159-4755-b203-a62af0b0c7c5" /> | <img width="1221" height="375" alt="image" src="https://github.com/user-attachments/assets/5f15a463-debb-4832-8e90-6663662e8351" /> |

Looking to make the "Generate cell with AI" input area consistent with the AI chat sidebar.

- Brings over "Add context" and "Attach file" buttons to the "Generate cell with AI" area.
- Moves instruction text into placeholder (adds a min-height to the editor to avoid banding when the user starts typing).
- Shifts the model selector and language to the left to have consistent placement.
- Updated the AI sparkles and close button to be pinned as the top row.