### PR TITLE
Fix cross-view interactions (e.g., brush selections) breaking in concatenated Altair charts when using `mo.ui.altair_chart`.

### DIFF
--- a/frontend/src/plugins/impl/vega/__tests__/make-selectable.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/make-selectable.test.ts
@@ -1194,4 +1194,78 @@ describe("makeSelectable", () => {
     expect(newSpec).toMatchSnapshot();
     expect(parse(newSpec)).toBeDefined();
   });
+
+  it("should preserve vconcat with existing selection params unchanged (issue #7668)", () => {
+    // This test reproduces the issue from #7668:
+    // Altair charts with cross-view interactions (e.g., brush selection)
+    // should not be modified by makeSelectable to preserve the interaction.
+    const spec = {
+      vconcat: [
+        {
+          mark: "area",
+          encoding: {
+            x: {
+              field: "x",
+              type: "quantitative",
+              scale: { domain: { param: "brush", encoding: "x" } },
+            },
+            y: { field: "y", type: "quantitative" },
+          },
+        },
+        {
+          mark: "area",
+          encoding: {
+            x: { field: "x", type: "quantitative" },
+            y: { field: "y", type: "quantitative" },
+          },
+        },
+      ],
+      params: [
+        {
+          name: "brush",
+          select: { type: "interval", encodings: ["x"] },
+          views: ["view_1"],
+        },
+      ],
+    } as VegaLiteSpec;
+
+    const newSpec = makeSelectable(spec, {});
+
+    // The spec should be returned unchanged to preserve cross-view interactions
+    expect(newSpec).toEqual(spec);
+    expect(getSelectionParamNames(newSpec)).toEqual(["brush"]);
+  });
+
+  it("should preserve hconcat with existing selection params unchanged (issue #7668)", () => {
+    const spec = {
+      hconcat: [
+        {
+          mark: "point",
+          encoding: {
+            x: { field: "x", type: "quantitative" },
+            y: { field: "y", type: "quantitative" },
+          },
+        },
+        {
+          mark: "point",
+          encoding: {
+            x: { field: "x", type: "quantitative" },
+            y: { field: "y", type: "quantitative" },
+          },
+        },
+      ],
+      params: [
+        {
+          name: "my_selection",
+          select: { type: "point", encodings: ["x", "y"] },
+        },
+      ],
+    } as VegaLiteSpec;
+
+    const newSpec = makeSelectable(spec, {});
+
+    // The spec should be returned unchanged
+    expect(newSpec).toEqual(spec);
+    expect(getSelectionParamNames(newSpec)).toEqual(["my_selection"]);
+  });
 });

--- a/frontend/src/plugins/impl/vega/make-selectable.ts
+++ b/frontend/src/plugins/impl/vega/make-selectable.ts
@@ -303,6 +303,14 @@ export function makeSelectable<T extends VegaLiteSpec>(
     chartSelection = false;
   }
 
+  // For vconcat/hconcat with existing chart params, return unchanged.
+  // This preserves cross-view interactions (e.g., brush selections in
+  // concatenated charts). See issue #7668.
+  const isCompoundSpec = "vconcat" in spec || "hconcat" in spec;
+  if (hasChartParam && isCompoundSpec) {
+    return spec;
+  }
+
   if ("vconcat" in spec) {
     const subSpecs = spec.vconcat.map((subSpec) =>
       "mark" in subSpec

--- a/marimo/_smoke_tests/issues/7668_altair_concat_interactions.py
+++ b/marimo/_smoke_tests/issues/7668_altair_concat_interactions.py
@@ -1,0 +1,53 @@
+import marimo
+
+__generated_with = "0.18.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import altair as alt
+    import numpy as np
+    import pyarrow
+    import pandas as pd
+    return alt, mo, np, pd
+
+
+@app.cell
+def _(alt, np, pd):
+    source = pd.DataFrame({"x": np.random.rand(100), "y": np.random.rand(100)})
+
+    brush = alt.selection_interval(encodings=["x"], value={"x": [0, 0.5]})
+
+    base = (
+        alt.Chart(source, width=600, height=200)
+        .mark_area()
+        .encode(x="x:Q", y="y:Q")
+    )
+
+    upper = base.encode(alt.X("x:Q").scale(domain=brush))
+
+    lower = base.properties(height=60).add_params(brush)
+
+    # Brush interaction across views works:
+    upper & lower
+    return lower, upper
+
+
+@app.cell
+def _(lower, mo, upper):
+    # Brush interaction (no longer) breaks:
+    mo.ui.altair_chart(upper & lower)
+    return
+
+
+@app.cell
+def _(alt, lower, mo, upper):
+    # Brush interaction works:
+    mo.ui.altair_chart(alt.vconcat(upper & lower))
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_plugins/ui/_impl/test_altair_chart.py
+++ b/tests/_plugins/ui/_impl/test_altair_chart.py
@@ -1408,6 +1408,28 @@ def test_has_selection_param() -> None:
     layered = alt.layer(chart, rule)
     assert _has_selection_param(layered) is True
 
+    # VConcatChart with selection in nested chart (issue #7668)
+    chart_with_selection = (
+        alt.Chart()
+        .mark_point()
+        .add_params(alt.selection_interval(name="brush", encodings=["x"]))
+    )
+    chart_without_selection = alt.Chart().mark_point()
+    vconcat = chart_with_selection & chart_without_selection
+    assert _has_selection_param(vconcat) is True
+
+    # HConcatChart with selection in nested chart
+    hconcat = chart_with_selection | chart_without_selection
+    assert _has_selection_param(hconcat) is True
+
+    # Nested VConcatChart
+    nested_vconcat = alt.vconcat(vconcat, chart_without_selection)
+    assert _has_selection_param(nested_vconcat) is True
+
+    # VConcatChart without any selection
+    vconcat_no_selection = chart_without_selection & chart_without_selection
+    assert _has_selection_param(vconcat_no_selection) is False
+
     # Invalid chart
     chart = None
     assert _has_selection_param(chart) is False
@@ -1440,6 +1462,24 @@ def test_has_legend_param() -> None:
 
     layered = alt.layer(chart, rule)
     assert _has_legend_param(layered) is False
+
+    # VConcatChart with legend param in nested chart
+    chart_with_legend = (
+        alt.Chart()
+        .mark_point()
+        .add_params(alt.selection_point(fields=["color"], bind="legend"))
+    )
+    chart_without_legend = alt.Chart().mark_point()
+    vconcat = chart_with_legend & chart_without_legend
+    assert _has_legend_param(vconcat) is True
+
+    # HConcatChart with legend param in nested chart
+    hconcat = chart_with_legend | chart_without_legend
+    assert _has_legend_param(hconcat) is True
+
+    # VConcatChart without any legend param
+    vconcat_no_legend = chart_without_legend & chart_without_legend
+    assert _has_legend_param(vconcat_no_legend) is False
 
     # Invalid chart
     chart = None


### PR DESCRIPTION
Closes #7668

When using `mo.ui.altair_chart` with concatenated charts (vconcat/hconcat) that have cross-view selections (like brush selections that control the domain of another chart), the interaction would break.

The frontend's `makeSelectable` function was modifying subspecs in vconcat/hconcat charts even when the parent spec already had selection params. This broke cross-view interactions because of pan/zoom params were added to each subspec
