### PR TITLE
add softer shadows on hovering a cell

### DIFF
--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -79,6 +79,7 @@
      */
 
   &:hover {
+    @apply shadow-sm-solid shadow-shade;
     z-index: 30;
   }
 
@@ -159,6 +160,10 @@
     border: 1px solid var(--red-4);
   }
 
+  &.has-error:not(.needs-run):hover {
+    @apply shadow-sm-solid shadow-error/10;
+  }
+
   &.has-error:not(.needs-run):focus-within {
     @apply shadow-md-solid shadow-error/10;
   }
@@ -174,7 +179,11 @@
   &.needs-run {
     /* TODO(akshayka): Can give this an outline to make more visible. */
     border-color: var(--stale);
-    @apply divide-stale shadow-sm-solid shadow-stale;
+    @apply divide-stale shadow-xs-solid shadow-stale;
+
+    &:hover {
+      @apply divide-stale shadow-sm-solid shadow-stale;
+    }
 
     &:focus-within {
       @apply divide-stale shadow-md-solid shadow-stale;


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Adds a hover shadow over a cell
- hovering over a cell is more distinguishable, 
- a softer transition to thicker shadow when cell is focused.

https://github.com/user-attachments/assets/5cf2d8a5-3615-4a69-8faf-c7e17da8103f

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
