### PR TITLE
Include an exception in the PDF smoke test

### DIFF
--- a/marimo/_smoke_tests/pdf_export/basic_example.py
+++ b/marimo/_smoke_tests/pdf_export/basic_example.py
@@ -46,6 +46,13 @@ def _():
 
 
 @app.cell
+def _():
+    print("This is console output") 
+    return
+
+
+
+@app.cell
 def _(px):
     df = px.data.iris()
     fig = px.scatter(


### PR DESCRIPTION
We should support displaying exceptions in the exported PDF (and in IPYNB exports)
