### PR TITLE
fix: disallow file access outside directory where 'marimo edit <folder' is run

### DIFF
--- a/marimo/_server/files/path_validator.py
+++ b/marimo/_server/files/path_validator.py
@@ -196,9 +196,17 @@ class PathValidator:
                         directory, Path.cwd()
                     )
                 )
+
+                # If it was an absolute directory, then the base is that directory
+                # otherwise, the base is the current working directory
+                if directory.is_absolute():
+                    filepath_base = directory
+                else:
+                    filepath_base = Path.cwd()
+
                 filepath_normalized = (
                     self._normalize_path_without_resolving_symlinks(
-                        filepath, directory_normalized
+                        filepath, filepath_base
                     )
                 )
                 self._check_containment(


### PR DESCRIPTION
This path validation logic is by no means real Authorization controls (e.g. if a user can open any notebook, they can just use `os` from within the notebook to read anything), but this is still helpful to give a more useful error than rely on the OS error. 