### PR TITLE
fix path resolution for .resolve() and .absolute() for correctness and security

### DIFF
--- a/marimo/_cli/export/cloudflare.py
+++ b/marimo/_cli/export/cloudflare.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from marimo._cli.print import bold, echo, green
 from marimo._server.print import _utf8
+from marimo._utils.paths import normalize_path
 
 
 def create_cloudflare_files(title: str, out_dir: Path) -> None:
@@ -17,7 +18,7 @@ def create_cloudflare_files(title: str, out_dir: Path) -> None:
 
     if index_js.exists():
         echo(
-            f"Cloudflare {index_js.name} already exists at {green(str(index_js.absolute()))}. Skipping..."
+            f"Cloudflare {index_js.name} already exists at {green(str(normalize_path(index_js)))}. Skipping..."
         )
     else:
         created_files = True
@@ -41,7 +42,7 @@ export default {
 
     if wrangler_jsonc.exists():
         echo(
-            f"Cloudflare {wrangler_jsonc.name} already exists at {green(str(wrangler_jsonc.absolute()))}. Skipping..."
+            f"Cloudflare {wrangler_jsonc.name} already exists at {green(str(normalize_path(wrangler_jsonc)))}. Skipping..."
         )
     else:
         created_files = True
@@ -65,7 +66,7 @@ export default {
 
     if created_files:
         echo(
-            f"Cloudflare configuration files created at {green(str(parent_dir.absolute()))}."
+            f"Cloudflare configuration files created at {green(str(normalize_path(parent_dir)))}."
         )
 
     echo(

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -34,7 +34,6 @@ from marimo._session.model import SessionMode
 from marimo._tracer import LOGGER
 from marimo._utils.lifespans import Lifespans
 from marimo._utils.net import find_free_port
-from marimo._utils.paths import marimo_package_path
 
 DEFAULT_PORT = 2718
 PROXY_REGEX = re.compile(r"^(.*):(\d+)$")
@@ -338,17 +337,6 @@ def start(
             app,
             port=port,
             host=host,
-            # TODO: cannot use reload unless the app is an import string
-            # although cannot use import string because it breaks the
-            # session manager
-            # reload=development_mode,
-            reload_dirs=(
-                [
-                    str((marimo_package_path() / "_static").resolve()),
-                ]
-                if development_mode
-                else None
-            ),
             log_level=log_level,
             # uvicorn times out HTTP connections (i.e. TCP sockets) every 5
             # seconds by default; for some reason breaks the server in

--- a/marimo/_session/file_watcher_integration.py
+++ b/marimo/_session/file_watcher_integration.py
@@ -18,6 +18,7 @@ from marimo._session.events import (
 from marimo._session.extensions.types import SessionExtension
 from marimo._session.session import Session
 from marimo._utils.file_watcher import FileWatcherManager
+from marimo._utils.paths import normalize_path
 
 LOGGER = _loggers.marimo_logger()
 
@@ -92,8 +93,8 @@ class SessionFileWatcherExtension(SessionExtension, SessionEventListener):
         )
 
     def _canonicalize_path(self, path: str) -> Path:
-        """Canonicalize a path."""
-        return Path(path).absolute()
+        """Canonicalize a path without resolving symlinks."""
+        return normalize_path(Path(path))
 
     async def on_session_notebook_renamed(
         self, session: Session, old_path: str | None

--- a/marimo/_utils/inline_script_metadata.py
+++ b/marimo/_utils/inline_script_metadata.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 from marimo import _loggers
 from marimo._cli.file_path import FileContentReader
+from marimo._utils.paths import normalize_path
 from marimo._utils.scripts import read_pyproject_from_script
 
 LOGGER = _loggers.marimo_logger()
@@ -184,7 +185,7 @@ def _pyproject_toml_to_requirements_txt(
             # If path is relative and we have a config path, resolve it relative to the config path
             if not source_path.is_absolute() and config_path:
                 config_dir = Path(config_path).parent
-                source_path = (config_dir / source_path).resolve()
+                source_path = normalize_path(config_dir / source_path)
             new_dependency = f"{dependency} @ {str(source_path)}"
 
         # Handle URLs

--- a/marimo/_utils/paths.py
+++ b/marimo/_utils/paths.py
@@ -42,3 +42,31 @@ def maybe_make_dirs(filepath: Path) -> None:
     Create directories if they don't exist.
     """
     filepath.parent.mkdir(parents=True, exist_ok=True)
+
+
+def normalize_path(path: Path) -> Path:
+    """Normalize a path without resolving symlinks.
+
+    This function:
+    - Converts relative paths to absolute paths
+    - Normalizes .. and . components
+    - Does NOT resolve symlinks (unlike Path.resolve())
+
+    Args:
+        path: The path to normalize
+
+    Returns:
+        Normalized absolute path without symlink resolution
+
+    Example:
+        >>> normalize_path(Path("foo/../bar"))
+        Path("/current/working/dir/bar")
+    """
+    # Make absolute if relative (relative to current working directory)
+    if not path.is_absolute():
+        path = Path.cwd() / path
+
+    # Use os.path.normpath to normalize .. and . without resolving symlinks
+    normalized = Path(os.path.normpath(str(path)))
+
+    return normalized

--- a/tests/_utils/test_paths.py
+++ b/tests/_utils/test_paths.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from marimo._utils.paths import normalize_path
+
+
+def test_normalize_path_makes_absolute() -> None:
+    """Test that relative paths are converted to absolute paths."""
+    relative_path = Path("foo") / "bar"
+    result = normalize_path(relative_path)
+
+    assert result.is_absolute()
+    assert result == Path.cwd() / "foo" / "bar"
+
+
+def test_normalize_path_removes_parent_and_current_refs() -> None:
+    """Test that .. and . components are normalized."""
+    path_with_refs = Path("foo") / "bar" / ".." / "baz" / "." / "qux"
+    result = normalize_path(path_with_refs)
+
+    assert result.is_absolute()
+    assert ".." not in str(result)
+    assert str(result) == str(Path.cwd() / "foo" / "baz" / "qux")
+
+
+def test_normalize_path_handles_already_absolute() -> None:
+    """Test that absolute paths stay absolute and get normalized."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        # Create a path with .. in absolute path
+        absolute_with_parents = temp_path / "foo" / "bar" / ".." / "baz"
+        result = normalize_path(absolute_with_parents)
+
+        assert result.is_absolute()
+        assert ".." not in str(result)
+        # Should resolve to temp_path/foo/baz
+        assert result == temp_path / "foo" / "baz"
+
+
+def test_normalize_path_does_not_resolve_symlinks() -> None:
+    """Test that symlinks are NOT resolved (key security feature)."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create a real directory
+        real_dir = temp_path / "real_directory"
+        real_dir.mkdir()
+
+        # Create a file in the real directory
+        real_file = real_dir / "test.txt"
+        real_file.write_text("test content")
+
+        # Create a symlink to the real directory
+        symlink_dir = temp_path / "symlinked_directory"
+        try:
+            symlink_dir.symlink_to(real_dir)
+        except OSError:
+            # On Windows, creating symlinks might require admin privileges
+            pytest.skip("Cannot create symlinks on this system")
+
+        # Path through symlink
+        path_through_symlink = symlink_dir / "test.txt"
+
+        # normalize_path should NOT resolve the symlink
+        normalized = normalize_path(path_through_symlink)
+
+        # Should contain the symlink name, not the real directory
+        assert "symlinked_directory" in str(normalized)
+        assert "real_directory" not in str(normalized)
+
+        # Compare with resolve() which DOES follow symlinks
+        resolved = path_through_symlink.resolve()
+        assert "real_directory" in str(resolved)
+
+        # They should be different
+        assert normalized != resolved


### PR DESCRIPTION
The codebase was using `Path.resolve()` and `Path.absolute()` inconsistently, leading to:

- **Unexpected behavior**: Symlinked directories resolved to their real paths, breaking user expectations
- **Unnormalized paths**: `Path.absolute()` doesn't normalize `..` and `.` components, leaving messy paths in sys.path and other places.
- **Security vulnerability**: `Path.resolve()` follows symlinks, which could allow traveral attacks - however, in these instances, the user already has full access to the system so there was no additional risk.

This PR adds `normalize_path()` utility that converts relative paths to absolute and normalizes `..` and `.` components using `os.path.normpath()`, but does not resolve symlinks.
