### PR TITLE
Implement wrap around feature for `mo.carousel()`

### DIFF
--- a/frontend/src/plugins/layout/carousel/CarouselPlugin.tsx
+++ b/frontend/src/plugins/layout/carousel/CarouselPlugin.tsx
@@ -15,7 +15,6 @@ import type {
 interface Data {
   index?: string | null;
   height?: string | number | null;
-  wrapAround?: boolean;
 }
 
 export class CarouselPlugin implements IStatelessPlugin<Data> {
@@ -24,7 +23,6 @@ export class CarouselPlugin implements IStatelessPlugin<Data> {
   validator = z.object({
     index: z.string().nullish(),
     height: z.union([z.string(), z.number()]).nullish(),
-    wrapAround: z.boolean().optional(),
   });
 
   // TODO: Move async when we support async css
@@ -38,7 +36,7 @@ export class CarouselPlugin implements IStatelessPlugin<Data> {
 
   render(props: IStatelessPluginProps<Data>): JSX.Element {
     return (
-      <LazySlidesComponent {...props.data}>
+      <LazySlidesComponent {...props.data} wrapAround={true}>
         {props.children}
       </LazySlidesComponent>
     );

--- a/marimo/_plugins/stateless/carousel.py
+++ b/marimo/_plugins/stateless/carousel.py
@@ -16,13 +16,11 @@ if TYPE_CHECKING:
 @mddoc
 def carousel(
     items: Sequence[object],
-    wrap_around: bool = False,
 ) -> Html:
     """Create a carousel of items.
 
     Args:
         items: A list of items.
-        wrap_around: Whether carousel jumps back to the start when navigating beyond the last item.
 
     Returns:
         An `Html` object.
@@ -42,7 +40,7 @@ def carousel(
     return Html(
         build_stateless_plugin(
             component_name="marimo-carousel",
-            args={"wrap-around": wrap_around},
+            args={},
             slotted_html=item_content,
         )
     )


### PR DESCRIPTION
## 📝 Summary

This PR implements wrap around functionality to `mo.carousel()` such that a carousel can be allowed to jump back to the start of the array when scrolling beyond the last item (or vice versa, back to last item from the first by clicking the left arrow)

Fixes #5001 


## 🔍 Description of Changes
- Added `wrapAround` prop to `SlideComponent`. This will be used to set `Swiper`'s loop property, which directly gives the ability to wrap around. 
- `wrapAround` is always `True` when using `CarouselPlugin`

Demo:



https://github.com/user-attachments/assets/f3c287e7-cd3a-4e53-8a6b-68abc0c657fd




Note:
- did not implement new tests: assumed no extra tests needed as no existing tests for `mo.carousel()` were found to be added onto


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
