### PR TITLE
ci: single release.yml with switch

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,10 +1,7 @@
 name: Publish dev release of marimo-base
 
-# Publish development release to test pypi on pushes to main
 on:
-  push:
-    branches:
-      - main
+  workflow_call: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,0 +1,244 @@
+name: Publish prod release
+
+on:
+  workflow_call: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  TURBO_TEAM: marimo
+  REGISTRY: ghcr.io
+  IMAGE_NAME: marimo-team/marimo
+
+jobs:
+  publish_release:
+    name: 📤 Publish release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    outputs:
+      marimo_version: ${{ steps.get_version.outputs.marimo_version }}
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: 📦 Build frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: 🥚 Install Hatch
+        uses: pypa/hatch@install
+
+      - name: 📦 Build marimo
+        run: hatch build
+
+      - name: 📤 Upload to PyPI
+        env:
+          HATCH_INDEX_USER: ${{ secrets.PYPI_USER }}
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_PASSWORD }}
+        run: hatch publish
+
+      - name: 🔨 Get version
+        id: get_version
+        run: |
+          echo "marimo_version=$(hatch version)" >> $GITHUB_OUTPUT
+
+      - name: 📦 Update package.json version from CLI
+        working-directory: frontend
+        run: |
+          echo "Updating package.json version to ${{ steps.get_version.outputs.marimo_version }}"
+          npm version ${{ steps.get_version.outputs.marimo_version }} --no-git-tag-version
+
+      - name: 📦 Upload frontend artifact for npm publish
+        uses: actions/upload-artifact@v6
+        with:
+          name: frontend
+          path: frontend/
+          retention-days: 1
+
+      - name: 📦 Update package.json name to @marimo-team/islands
+        working-directory: frontend
+        run: |
+          sed -i 's/"name": "@marimo-team\/frontend"/"name": "@marimo-team\/islands"/' package.json
+
+      - name: 📦 Rebuild frontend for islands
+        working-directory: frontend
+        env:
+          NODE_ENV: production
+          VITE_MARIMO_ISLANDS: 'true'
+          VITE_MARIMO_VERSION: ${{ steps.get_version.outputs.marimo_version }}
+        run: |
+          pnpm turbo build:islands
+          ./islands/validate.sh
+
+      - name: 📦 Upload islands artifact for npm publish
+        uses: actions/upload-artifact@v6
+        with:
+          name: frontend-islands
+          path: frontend/
+          retention-days: 1
+
+  publish_wasm:
+    name: 📤 Publish @marimo-team/frontend to npm
+    needs: publish_release
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      package-artifact-name: frontend
+      working-directory: '.'
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
+
+  publish_islands:
+    name: 📤 Publish @marimo-team/islands to npm
+    needs: publish_release
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      package-artifact-name: frontend-islands
+      working-directory: '.'
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
+
+  publish_docker:
+    name: 🐋 Publish Docker images
+    runs-on: ubuntu-latest
+    needs: [publish_release]
+    # Don't error while this is in BETA
+    continue-on-error: true
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: ⏳ Wait for PyPI package availability
+        run: |
+          VERSION="${{ needs.publish_release.outputs.marimo_version }}"
+          echo "Waiting for marimo version $VERSION to be available on PyPI..."
+
+          MAX_ATTEMPTS=30
+          ATTEMPT=0
+          SLEEP_TIME=10
+
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Checking PyPI for version $VERSION..."
+
+            # Check if the version exists on PyPI
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/marimo/$VERSION/json")
+
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✅ Version $VERSION is available on PyPI!"
+              exit 0
+            else
+              echo "Version $VERSION not yet available (HTTP $HTTP_CODE). Waiting ${SLEEP_TIME}s..."
+              sleep $SLEEP_TIME
+            fi
+          done
+
+          echo "❌ Timed out waiting for version $VERSION on PyPI after $((MAX_ATTEMPTS * SLEEP_TIME)) seconds"
+          exit 1
+
+      - name: 🐋 Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐋 Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: 🐋 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 🧪 Build docker image for testing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          # Don't push test image
+          push: false
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
+          target: slim
+          build-args: |
+            marimo_version=${{ needs.publish_release.outputs.marimo_version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: 🧪 Test docker build
+        run: |
+          docker run -d -e PORT=9090 -p 9090:9090 --name test_container ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
+          sleep 2
+          curl -f http://localhost:9090/health || (docker logs test_container && exit 1)
+          docker stop test_container
+          docker rm test_container
+
+      - name: 📦 Build and push Docker images (slim)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          target: slim
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            marimo_version=${{ needs.publish_release.outputs.marimo_version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: 📦 Build and push Docker images (data)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}-data
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-data
+          target: data
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            marimo_version=${{ needs.publish_release.outputs.marimo_version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: 📦 Build and push Docker images (sql)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}-sql
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-sql
+          target: sql
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            marimo_version=${{ needs.publish_release.outputs.marimo_version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
-name: Publish release
+name: Release
 
-# release a new version of marimo on tag push
+# Orchestrates both production and development releases
 on:
   push:
+    branches:
+      - main
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch: {}
@@ -11,238 +13,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
-env:
-  TURBO_TEAM: marimo
-  REGISTRY: ghcr.io
-  IMAGE_NAME: marimo-team/marimo
-
 jobs:
-  publish_release:
-    name: 📤 Publish release
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-
-    outputs:
-      marimo_version: ${{ steps.get_version.outputs.marimo_version }}
-
-    steps:
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
-
-      - name: 📦 Build frontend
-        uses: ./.github/actions/build-frontend
-        with:
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: 🥚 Install Hatch
-        uses: pypa/hatch@install
-
-      - name: 📦 Build marimo
-        run: hatch build
-
-      - name: 📤 Upload to PyPI
-        env:
-          HATCH_INDEX_USER: ${{ secrets.PYPI_USER }}
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_PASSWORD }}
-        run: hatch publish
-
-      - name: 🔨 Get version
-        id: get_version
-        run: |
-          echo "marimo_version=$(hatch version)" >> $GITHUB_OUTPUT
-
-      - name: 📦 Update package.json version from CLI
-        working-directory: frontend
-        run: |
-          echo "Updating package.json version to ${{ steps.get_version.outputs.marimo_version }}"
-          npm version ${{ steps.get_version.outputs.marimo_version }} --no-git-tag-version
-
-      - name: 📦 Upload frontend artifact for npm publish
-        uses: actions/upload-artifact@v6
-        with:
-          name: frontend
-          path: frontend/
-          retention-days: 1
-
-      - name: 📦 Update package.json name to @marimo-team/islands
-        working-directory: frontend
-        run: |
-          sed -i 's/"name": "@marimo-team\/frontend"/"name": "@marimo-team\/islands"/' package.json
-
-      - name: 📦 Rebuild frontend for islands
-        working-directory: frontend
-        env:
-          NODE_ENV: production
-          VITE_MARIMO_ISLANDS: 'true'
-          VITE_MARIMO_VERSION: ${{ steps.get_version.outputs.marimo_version }}
-        run: |
-          pnpm turbo build:islands
-          ./islands/validate.sh
-
-      - name: 📦 Upload islands artifact for npm publish
-        uses: actions/upload-artifact@v6
-        with:
-          name: frontend-islands
-          path: frontend/
-          retention-days: 1
-
-  publish_wasm:
-    name: 📤 Publish @marimo-team/frontend to npm
-    needs: publish_release
-    uses: ./.github/workflows/publish-npm.yml
-    with:
-      package-artifact-name: frontend
-      working-directory: '.'
+  # Publish production release on tag push
+  release_prod:
+    name: 🚀 Production Release
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/release-prod.yml
+    secrets: inherit
     permissions:
-      id-token: write  # Required for OIDC
-      contents: read
+      contents: read # Required for checkout
+      packages: write # Required for Docker image publishing
+      id-token: write # Required for OIDC
 
-  publish_islands:
-    name: 📤 Publish @marimo-team/islands to npm
-    needs: publish_release
-    uses: ./.github/workflows/publish-npm.yml
-    with:
-      package-artifact-name: frontend-islands
-      working-directory: '.'
+  # Publish development release on push to main
+  release_dev:
+    name: 🔧 Development Release
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/release-dev.yml
+    secrets: inherit
     permissions:
-      id-token: write  # Required for OIDC
-      contents: read
-
-  publish_docker:
-    name: 🐋 Publish Docker images
-    runs-on: ubuntu-latest
-    needs: [publish_release]
-    # Don't error while this is in BETA
-    continue-on-error: true
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
-
-      - name: ⏳ Wait for PyPI package availability
-        run: |
-          VERSION="${{ needs.publish_release.outputs.marimo_version }}"
-          echo "Waiting for marimo version $VERSION to be available on PyPI..."
-
-          MAX_ATTEMPTS=30
-          ATTEMPT=0
-          SLEEP_TIME=10
-
-          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-            ATTEMPT=$((ATTEMPT + 1))
-            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Checking PyPI for version $VERSION..."
-
-            # Check if the version exists on PyPI
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/marimo/$VERSION/json")
-
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "✅ Version $VERSION is available on PyPI!"
-              exit 0
-            else
-              echo "Version $VERSION not yet available (HTTP $HTTP_CODE). Waiting ${SLEEP_TIME}s..."
-              sleep $SLEEP_TIME
-            fi
-          done
-
-          echo "❌ Timed out waiting for version $VERSION on PyPI after $((MAX_ATTEMPTS * SLEEP_TIME)) seconds"
-          exit 1
-
-      - name: 🐋 Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 🐋 Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: 🐋 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: 🧪 Build docker image for testing
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          # Don't push test image
-          push: false
-          load: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
-          target: slim
-          build-args: |
-            marimo_version=${{ needs.publish_release.outputs.marimo_version }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: 🧪 Test docker build
-        run: |
-          docker run -d -e PORT=9090 -p 9090:9090 --name test_container ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
-          sleep 2
-          curl -f http://localhost:9090/health || (docker logs test_container && exit 1)
-          docker stop test_container
-          docker rm test_container
-
-      - name: 📦 Build and push Docker images (slim)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          target: slim
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            marimo_version=${{ needs.publish_release.outputs.marimo_version }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: 📦 Build and push Docker images (data)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}-data
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-data
-          target: data
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            marimo_version=${{ needs.publish_release.outputs.marimo_version }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: 📦 Build and push Docker images (sql)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.publish_release.outputs.marimo_version }}-sql
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-sql
-          target: sql
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            marimo_version=${{ needs.publish_release.outputs.marimo_version }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      contents: read # Required for checkout
+      pull-requests: write # Required for PR comment
+      id-token: write # Required for OIDC


### PR DESCRIPTION
Trusted publishing requires a single top-level release script, so moving everything to `release.yml` that switches to dev and prod