### PR TITLE
Move snippets panel to developer panel by default

### DIFF
--- a/frontend/src/components/editor/chrome/state.ts
+++ b/frontend/src/components/editor/chrome/state.ts
@@ -27,11 +27,10 @@ export interface PanelLayout {
 
 const DEFAULT_PANEL_LAYOUT: PanelLayout = {
   sidebar: PANELS.filter(
-    (p) => !p.hidden && !p.defaultHidden && p.defaultSection === "sidebar",
+    (p) => !p.hidden && p.defaultSection === "sidebar",
   ).map((p) => p.type),
   developerPanel: PANELS.filter(
-    (p) =>
-      !p.hidden && !p.defaultHidden && p.defaultSection === "developer-panel",
+    (p) => !p.hidden && p.defaultSection === "developer-panel",
   ).map((p) => p.type),
 };
 

--- a/frontend/src/components/editor/chrome/types.ts
+++ b/frontend/src/components/editor/chrome/types.ts
@@ -54,8 +54,6 @@ export interface PanelDescriptor {
   tooltip: string;
   /** If true, the panel is completely unavailable */
   hidden?: boolean;
-  /** If true, the panel is available but not shown by default */
-  defaultHidden?: boolean;
   /** Which section this panel belongs to by default */
   defaultSection: PanelSection;
 }
@@ -99,8 +97,7 @@ export const PANELS: PanelDescriptor[] = [
     Icon: SquareDashedBottomCodeIcon,
     label: "Snippets",
     tooltip: "Snippets",
-    defaultSection: "sidebar",
-    defaultHidden: true,
+    defaultSection: "developer-panel",
   },
   {
     type: "outline",

--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -22,7 +22,6 @@ import { ReorderableList } from "@/components/ui/reorderable-list";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LazyMount } from "@/components/utils/lazy-mount";
 import { cellErrorCount } from "@/core/cells/cells";
-import { snippetsEnabledAtom } from "@/core/config/config";
 import { getFeatureFlag } from "@/core/config/feature-flag";
 import { cn } from "@/utils/cn";
 import { ErrorBoundary } from "../../boundary/ErrorBoundary";
@@ -81,7 +80,6 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
   const { aiPanelTab, setAiPanelTab } = useAiPanelTab();
   const errorCount = useAtomValue(cellErrorCount);
   const [panelLayout, setPanelLayout] = useAtom(panelLayoutAtom);
-  const snippetsEnabled = useAtomValue(snippetsEnabledAtom);
 
   // Convert current developer panel items to PanelDescriptors
   const devPanelItems = useMemo(() => {
@@ -133,13 +131,9 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
       if (sidebarIds.has(p.type)) {
         return false;
       }
-      // Show defaultHidden panels only if enabled via config
-      if (p.defaultHidden && p.type === "snippets" && !snippetsEnabled) {
-        return false;
-      }
       return true;
     });
-  }, [panelLayout.sidebar, snippetsEnabled]);
+  }, [panelLayout.sidebar]);
 
   // sync sidebar
   useEffect(() => {

--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -8,7 +8,6 @@ import { useMemo } from "react";
 import { ReorderableList } from "@/components/ui/reorderable-list";
 import { Tooltip } from "@/components/ui/tooltip";
 import { notebookQueuedOrRunningCountAtom } from "@/core/cells/cells";
-import { snippetsEnabledAtom } from "@/core/config/config";
 import { cn } from "@/utils/cn";
 import { FeedbackButton } from "../components/feedback-button";
 import { panelLayoutAtom, useChromeActions, useChromeState } from "../state";
@@ -19,7 +18,6 @@ export const Sidebar: React.FC = () => {
   const { toggleApplication, setSelectedDeveloperPanelTab } =
     useChromeActions();
   const [panelLayout, setPanelLayout] = useAtom(panelLayoutAtom);
-  const snippetsEnabled = useAtomValue(snippetsEnabledAtom);
 
   const renderIcon = ({ Icon }: PanelDescriptor, className?: string) => {
     return <Icon className={cn("h-5 w-5", className)} />;
@@ -37,13 +35,9 @@ export const Sidebar: React.FC = () => {
       if (devPanelIds.has(p.type)) {
         return false;
       }
-      // Show defaultHidden panels only if enabled via config
-      if (p.defaultHidden && p.type === "snippets" && !snippetsEnabled) {
-        return false;
-      }
       return true;
     });
-  }, [panelLayout.developerPanel, snippetsEnabled]);
+  }, [panelLayout.developerPanel]);
 
   // Convert current sidebar items to PanelDescriptors
   const sidebarItems = useMemo(() => {


### PR DESCRIPTION
Previously, the snippets panel was special-cased: hidden by default but automatically shown when users enabled snippets in their config. This PR removes that conditional behavior.

The challenge with conditionally showing panels based on config is that we can't distinguish between "user explicitly removed this panel" vs "we hid it by default" (now that they can be rearranged). When a user enables snippets, we'd want to auto-show the panel. But if they later removed it, we'd show it again on next load because we couldn't tell why it was missing.

With the new ability to rearrange panels between sections, we'd also need to track explicitly hidden panels separately, and the logic gets complicated. Maybe there's a cleaner solution, but for now this just moves snippets to the developer panel by default (less magic). Users can drag it to the sidebar if they prefer, but everything has an original "place."

