### PR TITLE
fix: disable shared memory in wasm

### DIFF
--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -19,7 +19,6 @@ from marimo._runtime.dataflow import DirectedGraph
 from marimo._runtime.functions import FunctionRegistry
 from marimo._runtime.params import CLIArgs, QueryParams
 from marimo._session.model import SessionMode
-from marimo._utils.platform import is_pyodide
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -160,10 +159,9 @@ def create_kernel_context(
 
     # Use shared memory in edit mode,
     # in-memory storage in run mode (same process)
-    # Pyodide doesn't support shared memory, so we use in-memory storage.
     storage = (
         SharedMemoryStorage()
-        if mode == SessionMode.EDIT and not is_pyodide()
+        if mode == SessionMode.EDIT
         else InMemoryStorage()
     )
 

--- a/marimo/_runtime/virtual_file/storage.py
+++ b/marimo/_runtime/virtual_file/storage.py
@@ -46,10 +46,6 @@ class SharedMemoryStorage(VirtualFileStorage):
     """
 
     def __init__(self) -> None:
-        if is_pyodide():
-            raise RuntimeError(
-                "SharedMemoryStorage is not supported on Pyodide"
-            )
         self._storage: dict[str, shared_memory.SharedMemory] = {}
         self._shutting_down = False
 


### PR DESCRIPTION
We need to use InMemoryStorage (which may not even get used at all since virtual_files are disabled). 