### PR TITLE
fix: don't resolve url provider eagerly

### DIFF
--- a/frontend/src/core/runtime/runtime.ts
+++ b/frontend/src/core/runtime/runtime.ts
@@ -171,6 +171,7 @@ export class RuntimeManager {
       const response = await fetch(this.healthURL().toString());
       // If there is a redirect, update the URL in the config
       if (response.redirected) {
+        Logger.debug(`Runtime redirected to ${response.url}`);
         // strip /health from the URL
         const baseUrl = response.url.replace(/\/health$/, "");
         this.config.url = baseUrl;

--- a/frontend/src/core/websocket/useWebSocket.tsx
+++ b/frontend/src/core/websocket/useWebSocket.tsx
@@ -29,7 +29,8 @@ function createConnectionTransport(
   }
   // Create a connection transport using the ReconnectingWebSocket from partysocket
   // This handles reconnecting when the connection is lost.
-  return new ReconnectingWebSocket(options.url(), undefined, {
+  const urlProvider = options.url; // We don't call the URL provider now since it may change (i.e. if the runtime redirects)
+  return new ReconnectingWebSocket(urlProvider, undefined, {
     // We don't want Infinity retries
     maxRetries: 10,
     debug: false,

--- a/frontend/src/mount.tsx
+++ b/frontend/src/mount.tsx
@@ -231,6 +231,8 @@ const mountOptionsSchema = z.object({
     .array(
       z.looseObject({
         url: z.string(),
+        // Lazy by default, but can be overridden by the runtime config
+        lazy: z.boolean().default(true),
         authToken: z.string().nullish(),
       }),
     )
@@ -300,7 +302,6 @@ function initStore(options: unknown) {
     Logger.debug("⚡ Runtime URL", firstRuntimeConfig.url);
     store.set(runtimeConfigAtom, {
       ...firstRuntimeConfig,
-      lazy: true,
       serverToken: parsedOptions.data.serverToken,
     });
   } else {


### PR DESCRIPTION
We don't want to resolve the websocket url eagerly in case it was redirected/changed.
We also don't want to override the lazy parameter in case it was provided.