### PR TITLE
fix: handle non-ASCII filenames in export Content-Disposition headers

### DIFF
--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -16,7 +16,10 @@ from marimo._messaging.msgspec_encoder import asdict
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
 from marimo._server.export.exporter import AutoExporter, Exporter
-from marimo._server.export.utils import get_download_filename
+from marimo._server.export.utils import (
+    get_download_filename,
+    make_download_headers,
+)
 from marimo._server.models.export import (
     ExportAsHTMLRequest,
     ExportAsMarkdownRequest,
@@ -89,7 +92,7 @@ async def export_as_html(
     )
 
     if body.download:
-        headers = {"Content-Disposition": f"attachment; filename={filename}"}
+        headers = make_download_headers(filename)
     else:
         headers = {}
 
@@ -212,7 +215,7 @@ async def export_as_script(
     )
 
     if body.download:
-        headers = {"Content-Disposition": f"attachment; filename={filename}"}
+        headers = make_download_headers(filename)
     else:
         headers = {}
 
@@ -269,9 +272,7 @@ async def export_as_markdown(
         download_filename = get_download_filename(
             app_file_manager.filename, "md"
         )
-        headers = {
-            "Content-Disposition": f"attachment; filename={download_filename}"
-        }
+        headers = make_download_headers(download_filename)
     else:
         headers = {}
 

--- a/marimo/_server/export/utils.py
+++ b/marimo/_server/export/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 from typing import Optional
+from urllib.parse import quote
 
 
 def get_filename(filename: Optional[str], default: str = "notebook.py") -> str:
@@ -17,3 +18,28 @@ def get_download_filename(filename: Optional[str], extension: str) -> str:
     if basename.endswith(f".{extension}"):
         return basename
     return f"{os.path.splitext(basename)[0]}.{extension}"
+
+
+def make_download_headers(filename: str) -> dict[str, str]:
+    """Create headers for file download with proper Content-Disposition encoding.
+
+    This function handles non-ASCII filenames using RFC 5987 encoding
+    (filename*=UTF-8''...) to avoid UnicodeEncodeError when the filename
+    contains characters outside the Latin-1 range.
+
+    Args:
+        filename: The filename for the download (may contain non-ASCII chars)
+
+    Returns:
+        A dict with the Content-Disposition header properly encoded
+    """
+    # URL-encode the filename for RFC 5987 (preserves safe chars like .)
+    encoded_filename = quote(filename, safe="")
+
+    # Use RFC 5987 encoding: filename*=UTF-8''<url-encoded-filename>
+    # Also provide a fallback ASCII filename for older clients
+    return {
+        "Content-Disposition": (
+            f"attachment; filename*=UTF-8''{encoded_filename}"
+        )
+    }


### PR DESCRIPTION
Fixes #7730 - Exporting HTML/script/markdown fails with `UnicodeEncodeError` when the filename contains non-ASCII characters (Chinese, emojis, etc.).
