### PR TITLE
remove width param for data editor

### DIFF
--- a/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
+++ b/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
@@ -616,7 +616,6 @@ export const GlideDataEditor = <T,>({
           allowedFillDirections="vertical" // We can support all directions, but we need to handle datatype logic
           onKeyDown={onKeyDown}
           height={data.length > 10 ? 450 : undefined}
-          width={"100%"}
           rowMarkers={{
             kind: "both",
           }}


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #7734 

in hstack
<img width="943" height="653" alt="image" src="https://github.com/user-attachments/assets/28775bc2-f60e-45a4-b1c4-7fd603aeca39" />

normal
<img width="885" height="480" alt="image" src="https://github.com/user-attachments/assets/4b8efb51-b110-42da-a93a-d717d579d794" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
