### PR TITLE
Unify panel actions to work across sidebar and developer panel

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -75,12 +75,8 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
     selectedPanel,
     selectedDeveloperPanelTab,
   } = useChromeState();
-  const {
-    setIsSidebarOpen,
-    setIsDeveloperPanelOpen,
-    setSelectedDeveloperPanelTab,
-    openApplication,
-  } = useChromeActions();
+  const { setIsSidebarOpen, setIsDeveloperPanelOpen, openApplication } =
+    useChromeActions();
   const sidebarRef = React.useRef<ImperativePanelHandle>(null);
   const developerPanelRef = React.useRef<ImperativePanelHandle>(null);
   const { aiPanelTab, setAiPanelTab } = useAiPanelTab();
@@ -123,7 +119,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
     }
 
     // Select the dropped item in developer panel
-    setSelectedDeveloperPanelTab(item.type);
+    openApplication(item.type);
   };
 
   // Get panels available for developer panel context menu
@@ -412,7 +408,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
             ariaLabel="Developer panel tabs"
             className="flex flex-row gap-1"
             minItems={0}
-            onAction={(panel) => setSelectedDeveloperPanelTab(panel.type)}
+            onAction={(panel) => openApplication(panel.type)}
             renderItem={(panel) => (
               <div
                 className={cn(

--- a/frontend/src/components/editor/chrome/wrapper/footer-items/backend-status.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer-items/backend-status.tsx
@@ -125,7 +125,7 @@ export const BackendConnectionStatus: React.FC = () => {
     if (isAppNotStarted(connection)) {
       void connectToRuntime();
     } else {
-      void refetch();
+      refetch();
     }
   };
 

--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -23,10 +23,8 @@ import { RuntimeSettings } from "./footer-items/runtime-settings";
 import { useSetDependencyPanelTab } from "./useDependencyPanelTab";
 
 export const Footer: React.FC = () => {
-  const { isDeveloperPanelOpen, isSidebarOpen, selectedPanel } =
-    useChromeState();
-  const { toggleDeveloperPanel, openApplication, setIsSidebarOpen } =
-    useChromeActions();
+  const { isDeveloperPanelOpen } = useChromeState();
+  const { toggleDeveloperPanel, toggleApplication } = useChromeActions();
   const setDependencyPanelTab = useSetDependencyPanelTab();
 
   const errorCount = useAtomValue(cellErrorCount);
@@ -42,7 +40,7 @@ export const Footer: React.FC = () => {
   const warningCount = 0;
 
   useHotkey("global.toggleTerminal", () => {
-    toggleDeveloperPanel();
+    toggleApplication("terminal");
   });
 
   useHotkey("global.togglePanel", () => {
@@ -50,14 +48,8 @@ export const Footer: React.FC = () => {
   });
 
   useHotkey("global.toggleMinimap", () => {
-    // If already on dependencies panel with minimap tab, close the sidebar
-    if (isSidebarOpen && selectedPanel === "dependencies") {
-      setIsSidebarOpen(false);
-    } else {
-      // Open sidebar with dependencies panel and switch to minimap tab
-      openApplication("dependencies");
-      setDependencyPanelTab("minimap");
-    }
+    toggleApplication("dependencies");
+    setDependencyPanelTab("minimap");
   });
 
   return (

--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -20,8 +20,7 @@ import {
 
 export const Sidebar: React.FC = () => {
   const { selectedPanel, selectedDeveloperPanelTab } = useChromeState();
-  const { toggleApplication, setSelectedDeveloperPanelTab } =
-    useChromeActions();
+  const { toggleApplication, openApplication } = useChromeActions();
   const [panelLayout, setPanelLayout] = useAtom(panelLayoutAtom);
 
   const renderIcon = ({ Icon }: PanelDescriptor, className?: string) => {
@@ -73,7 +72,7 @@ export const Sidebar: React.FC = () => {
           (id) => id !== item.type,
         );
         if (remainingDevPanels.length > 0) {
-          setSelectedDeveloperPanelTab(remainingDevPanels[0]);
+          openApplication(remainingDevPanels[0]);
         }
       }
     }

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -142,7 +142,7 @@ export const MarimoErrorOutput = ({
   );
 
   const openScratchpad = () => {
-    chromeActions.openDeveloperPanelTab("scratchpad");
+    chromeActions.openApplication("scratchpad");
   };
 
   const renderMessages = () => {
@@ -186,7 +186,7 @@ export const MarimoErrorOutput = ({
               size="xs"
               variant="outline"
               className="mt-2 font-normal"
-              onClick={() => chromeActions.openDeveloperPanelTab("terminal")}
+              onClick={() => chromeActions.openApplication("terminal")}
             >
               <TerminalIcon className="h-3.5 w-3.5 mr-1.5" />
               <span>Open terminal</span>

--- a/frontend/src/components/terminal/hooks.ts
+++ b/frontend/src/components/terminal/hooks.ts
@@ -25,11 +25,11 @@ import { useTerminalActions } from "./state";
  */
 export function useTerminalCommands() {
   const { addCommand } = useTerminalActions();
-  const { openDeveloperPanelTab } = useChromeActions();
+  const { openApplication } = useChromeActions();
 
   const sendCommand = (text: string) => {
     // First, ensure the terminal is open
-    openDeveloperPanelTab("terminal");
+    openApplication("terminal");
 
     // Add the command to the queue
     addCommand(text);


### PR DESCRIPTION
Panels can now be moved between the sidebar and developer panel, but the actions for opening/toggling panels previously assumed a fixed location. This caused issues where hotkeys like toggle-terminal or toggle-minimap would stop working after moving those panels to a different section.

This change adds a `resolvePanelLocation` helper that checks the current panel layout to determine where a panel lives, then updates `openApplication` and `toggleApplication` to route to the correct section accordingly. The specialized actions `openDeveloperPanelTab` and `setSelectedDeveloperPanelTab` are removed since `openApplication` now handles both cases.
