### PR TITLE
feat: support format_mapping for dataframe as table

### DIFF
--- a/docs/guides/working_with_data/dataframes.md
+++ b/docs/guides/working_with_data/dataframes.md
@@ -223,6 +223,32 @@ def __():
 ///
 
 
+### Formatting values
+
+Use `format_mapping` to format values for display in the dataframe UI. This
+affects how values appear in the table but does not change the underlying
+data returned by `.value` or downloads.
+
+```python
+import marimo as mo
+import pandas as pd
+
+df = pd.DataFrame(
+    {"person": ["Alice", "Bob"], "age": [20, 30], "height_cm": [165.2, 180.4]}
+)
+
+def format_height(value: float) -> str:
+    return f"{value:.1f} cm"
+
+mo.ui.dataframe(
+    df,
+    format_mapping={
+        "age": "{:d} years".format,
+        "height_cm": format_height,
+    },
+)
+```
+
 ### Custom filters
 
 Create custom filters with marimo UI elements, like sliders and dropdowns.

--- a/examples/ui/dataframe.py
+++ b/examples/ui/dataframe.py
@@ -33,7 +33,17 @@ def _(mo):
 
 @app.cell
 def _(data, lazy_button, mo):
-    dataframe_transformer = mo.ui.dataframe(data.iris(), lazy=lazy_button.value)
+    def format_length(value: float) -> str:
+        return f"{value:.1f} cm"
+
+    dataframe_transformer = mo.ui.dataframe(
+        data.iris(),
+        lazy=lazy_button.value,
+        format_mapping={
+            "sepal_length": format_length,
+            "sepal_width": "{:.1f}".format,
+        },
+    )
     dataframe_transformer
     return (dataframe_transformer,)
 

--- a/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
@@ -176,6 +176,27 @@ class TestDataframes:
     @staticmethod
     @pytest.mark.parametrize(
         "df",
+        create_dataframes(
+            {"A": [1, 2], "B": ["a", "b"]},
+            exclude=["pyarrow", "duckdb", "lazy-polars"],
+        ),
+    )
+    def test_dataframe_format_mapping(df: IntoDataFrame) -> None:
+        def format_value(value: int) -> str:
+            return f"val-{value}"
+
+        subject = ui.dataframe(df, format_mapping={"A": format_value})
+
+        search_result = subject._search(
+            SearchTableArgs(page_size=2, page_number=0)
+        )
+        data = json.loads(search_result.data)
+        assert {row["A"] for row in data} == {"val-1", "val-2"}
+        assert type(subject.value) is type(df)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "df",
         [
             *create_dataframes(
                 {"A": [], "B": []},


### PR DESCRIPTION
## 📝 Summary

Adds `format_mapping` support to `mo.ui.dataframe` so display formatting is applied in the dataframe UI preview/search payloads, plus docs and tests.

<img width="1046" height="715" alt="image" src="https://github.com/user-attachments/assets/e4989cab-4f26-494e-9e4d-e4e584e0d4e1" />

## 🔍 Description of Changes

- Threaded `format_mapping` through dataframe search serialization so formatted values appear in the UI.
- Added a regression test that asserts formatted values are returned in search results.
- Documented `format_mapping` usage in the interactive dataframes guide.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
