### PR TITLE
Improve error indicators when errors panel is in sidebar

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/footer.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/footer.tsx
@@ -9,7 +9,7 @@ import { cellErrorCount } from "@/core/cells/cells";
 import { isConnectingAtom } from "@/core/network/connection";
 import { useHotkey } from "@/hooks/useHotkey";
 import { ShowInKioskMode } from "../../kiosk-mode";
-import { useChromeActions, useChromeState } from "../state";
+import { panelLayoutAtom, useChromeActions, useChromeState } from "../state";
 import { FooterItem } from "./footer-item";
 import { AIStatusIcon } from "./footer-items/ai-status";
 import {
@@ -29,11 +29,15 @@ export const Footer: React.FC = () => {
 
   const errorCount = useAtomValue(cellErrorCount);
   const connectionStatus = useAtomValue(connectionStatusAtom);
+  const panelLayout = useAtomValue(panelLayoutAtom);
 
   // Show issue count: cell errors + connection issues
+  // Don't include error count if errors panel is in sidebar (it shows there instead)
+  const errorsInSidebar = panelLayout.sidebar.includes("errors");
   const hasConnectionIssue =
     connectionStatus === "unhealthy" || connectionStatus === "disconnected";
-  const issueCount = errorCount + (hasConnectionIssue ? 1 : 0);
+  const issueCount =
+    (errorsInSidebar ? 0 : errorCount) + (hasConnectionIssue ? 1 : 0);
 
   // TODO: Add warning count from diagnostics/linting
   // This can signal warnings/errors with settings up AI / Copilot etc

--- a/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/sidebar.tsx
@@ -7,7 +7,10 @@ import type { PropsWithChildren } from "react";
 import { useMemo } from "react";
 import { ReorderableList } from "@/components/ui/reorderable-list";
 import { Tooltip } from "@/components/ui/tooltip";
-import { notebookQueuedOrRunningCountAtom } from "@/core/cells/cells";
+import {
+  cellErrorCount,
+  notebookQueuedOrRunningCountAtom,
+} from "@/core/cells/cells";
 import { cn } from "@/utils/cn";
 import { FeedbackButton } from "../components/feedback-button";
 import { panelLayoutAtom, useChromeActions, useChromeState } from "../state";
@@ -108,7 +111,11 @@ export const Sidebar: React.FC = () => {
             tooltip={panel.tooltip}
             selected={selectedPanel === panel.type}
           >
-            {renderIcon(panel)}
+            {panel.type === "errors" ? (
+              <ErrorPanelIcon Icon={panel.Icon} />
+            ) : (
+              renderIcon(panel)
+            )}
           </SidebarItem>
         )}
       />
@@ -120,6 +127,15 @@ export const Sidebar: React.FC = () => {
       <div className="flex-1" />
       <QueuedOrRunningStack />
     </div>
+  );
+};
+
+const ErrorPanelIcon: React.FC<{ Icon: PanelDescriptor["Icon"] }> = ({
+  Icon,
+}) => {
+  const errorCount = useAtomValue(cellErrorCount);
+  return (
+    <Icon className={cn("h-5 w-5", errorCount > 0 && "text-destructive")} />
   );
 };
 


### PR DESCRIPTION
The errors panel can be placed either in the sidebar or in the developer panel at the bottom. Previously, we only colored the errors icon red when the panel was in the developer panel. Additionally, the footer toolbar always displayed the notebook error count regardless of where the errors panel lived, which created redundant indicators when it was in the sidebar.

This change ensures users have a single, clear indicator pointing them to notebook errors based on their chosen layout.

When the errors panel is in the sidebar, its icon now turns red if there are errors, and we no longer show the notebook error count in the footer toolbar. When the errors panel is in the developer panel, the behavior remains unchanged: the icon turns red there and the footer shows the count.

The footer toolbar still displays connection issues (disconnected or unhealthy kernel status) regardless of panel placement, since those aren't surfaced in the errors panel.

https://github.com/user-attachments/assets/3e0ea0c6-ac9d-488b-a949-5daa314d1eea



