### PR TITLE
Revert "remove width param for data editor"

### DIFF
--- a/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
+++ b/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
@@ -616,6 +616,7 @@ export const GlideDataEditor = <T,>({
           allowedFillDirections="vertical" // We can support all directions, but we need to handle datatype logic
           onKeyDown={onKeyDown}
           height={data.length > 10 ? 450 : undefined}
+          width={"100%"}
           rowMarkers={{
             kind: "both",
           }}


### PR DESCRIPTION
This clamps the width for data-editor when it's small. Needs a more robust solution

<img width="943" height="284" alt="image" src="https://github.com/user-attachments/assets/26620308-3d98-49c5-bd91-698331cedde9" />

Reverts marimo-team/marimo#7741