### PR TITLE
Fix terminal not appearing in developer panel

### DIFF
--- a/frontend/src/components/editor/chrome/state.ts
+++ b/frontend/src/components/editor/chrome/state.ts
@@ -8,7 +8,7 @@ import { createReducerAndAtoms } from "@/utils/createReducer";
 import { jotaiJsonStorage } from "@/utils/storage/jotai";
 import { ZodLocalStorage } from "@/utils/storage/typed";
 import type { PanelSection, PanelType } from "./types";
-import { isPanelHidden, PANELS } from "./types";
+import { PANELS } from "./types";
 
 export interface ChromeState {
   selectedPanel: PanelType | undefined;
@@ -28,10 +28,10 @@ export interface PanelLayout {
 
 const DEFAULT_PANEL_LAYOUT: PanelLayout = {
   sidebar: PANELS.filter(
-    (p) => !isPanelHidden(p) && p.defaultSection === "sidebar",
+    (p) => !p.hidden && p.defaultSection === "sidebar",
   ).map((p) => p.type),
   developerPanel: PANELS.filter(
-    (p) => !isPanelHidden(p) && p.defaultSection === "developer-panel",
+    (p) => !p.hidden && p.defaultSection === "developer-panel",
   ).map((p) => p.type),
 };
 

--- a/frontend/src/components/editor/chrome/types.ts
+++ b/frontend/src/components/editor/chrome/types.ts
@@ -18,7 +18,6 @@ import {
   VariableIcon,
   XCircleIcon,
 } from "lucide-react";
-import { hasCapability } from "@/core/config/capabilities";
 import { getFeatureFlag } from "@/core/config/feature-flag";
 import type { Capabilities } from "@/core/kernel/messages";
 import { isWasm } from "@/core/wasm/utils";
@@ -188,12 +187,15 @@ export const PANEL_MAP = new Map<PanelType, PanelDescriptor>(
  * Check if a panel should be hidden based on its `hidden` property
  * and `requiredCapability`.
  */
-export function isPanelHidden(panel: PanelDescriptor): boolean {
+export function isPanelHidden(
+  panel: PanelDescriptor,
+  capabilities: Capabilities,
+): boolean {
   if (panel.hidden) {
     return true;
   }
   if (panel.requiredCapability) {
-    if (!hasCapability(panel.requiredCapability)) {
+    if (!capabilities[panel.requiredCapability]) {
       return true;
     }
   }


### PR DESCRIPTION
`isPanelHidden` was called at module load time when computing `DEFAULT_PANEL_LAYOUT`, before capabilities were received from the backend. This meant terminal was filtered out and never added to the stored layout.

These changes check static `hidden` property at module init, defer capability checks to render time.

