### PR TITLE
fix data editor width by setting full width on parent

### DIFF
--- a/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
+++ b/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
@@ -596,7 +596,7 @@ export const GlideDataEditor = <T,>({
   };
 
   return (
-    <div className="relative">
+    <div className="relative w-full min-w-0">
       <ErrorBoundary>
         <DataEditor
           ref={dataEditorRef}


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR fixes any issues, list them here by number (e.g., Fixes #123).
-->
Fixes #7734 

<img width="908" height="706" alt="image" src="https://github.com/user-attachments/assets/5fc434f7-dc32-4c83-b97d-bee90f2e1d2d" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
