### PR TITLE
Lower minimap z-index to stay within panel bounds

### DIFF
--- a/frontend/src/components/dependency-graph/minimap-content.tsx
+++ b/frontend/src/components/dependency-graph/minimap-content.tsx
@@ -98,7 +98,7 @@ const MinimapCell: React.FC<MinimapCellProps> = (props) => {
       <svg
         className={cn(
           "absolute overflow-visible top-[10.5px] left-[calc(var(--spacing-extra-small,8px)+17px)] pointer-events-none",
-          isSelected ? "z-30" : "z-20",
+          isSelected ? "z-[1]" : "z-0",
           getTextColor({ cell, selectedCell }),
         )}
         width="1"


### PR DESCRIPTION
The minimap SVG elements were using z-20/z-30 which caused them to appear above overlays like the package install dialog. Since these z-index values only need to ensure selected cells render above unselected ones within the minimap itself, lowering them fixes the stacking issue while preserving the intended behavior.


<img width="600" src="https://github.com/user-attachments/assets/5de9ae5d-97c9-4393-9928-155eb57eaa0f" />



