### PR TITLE
fix: Escape key should not prevent exiting to Vim mode

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "@lezer/markdown": "^1.6.2",
     "@lezer/python": "^1.1.18",
     "@marimo-team/codemirror-ai": "^0.3.5",
-    "@marimo-team/codemirror-languageserver": "^1.16.8",
+    "@marimo-team/codemirror-languageserver": "^1.16.10",
     "@marimo-team/codemirror-mcp": "^0.1.5",
     "@marimo-team/codemirror-sql": "^0.2.4",
     "@marimo-team/llm-info": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
         specifier: ^0.3.5
         version: 0.3.5(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.16.8
-        version: 1.16.8(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)
+        specifier: ^1.16.10
+        version: 1.16.10(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)
       '@marimo-team/codemirror-mcp':
         specifier: ^0.1.5
         version: 0.1.5(@codemirror/autocomplete@6.20.0)(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)(@modelcontextprotocol/sdk@1.17.2)
@@ -1892,8 +1892,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.16.8':
-    resolution: {integrity: sha512-hpoXFy5C/zEYW14fJfhHyTRCHnFnCwJDkBgHFqpfPdjtHaq69gFHIvy+tEBgwoBrBqI0IrLkWA321kB1f0B4Dw==}
+  '@marimo-team/codemirror-languageserver@1.16.10':
+    resolution: {integrity: sha512-Rh3ls/zjV0VJ1/V25KFWnXF56iON8L1vhY4YY0rfVSBn26VFJcz6CIreHV/7ZW4AnDy97w6RheJ8Y86V080z/w==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -11847,7 +11847,7 @@ snapshots:
       '@codemirror/view': 6.39.9
       diff: 8.0.2
 
-  '@marimo-team/codemirror-languageserver@1.16.8(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)':
+  '@marimo-team/codemirror-languageserver@1.16.10(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)':
     dependencies:
       '@codemirror/autocomplete': 6.20.0
       '@codemirror/lint': 6.9.2


### PR DESCRIPTION
Picking up this commit https://github.com/marimo-team/codemirror-languageserver/commit/a44bd319caeee00df188a65e0bf9c048aa2e0283