### PR TITLE
fix: limit private variable rename to current cell

### DIFF
--- a/frontend/src/components/app-config/__tests__/get-dirty-values.test.ts
+++ b/frontend/src/components/app-config/__tests__/get-dirty-values.test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2024 Marimo. All rights reserved. */
+/* Copyright 2026 Marimo. All rights reserved. */
 
 import { describe, expect, test } from "vitest";
 import { getDirtyValues } from "../user-config-form";

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -69,7 +69,7 @@ export function getDirtyValues<T extends FieldValues>(
   dirtyFields: Partial<Record<keyof T, unknown>>,
 ): Partial<T> {
   const result: Partial<T> = {};
-  for (const key of Object.keys(dirtyFields) as Array<keyof T>) {
+  for (const key of Object.keys(dirtyFields) as (keyof T)[]) {
     const dirty = dirtyFields[key];
     if (dirty === true) {
       result[key] = values[key];

--- a/frontend/src/components/editor/chrome/types.ts
+++ b/frontend/src/components/editor/chrome/types.ts
@@ -194,10 +194,8 @@ export function isPanelHidden(
   if (panel.hidden) {
     return true;
   }
-  if (panel.requiredCapability) {
-    if (!capabilities[panel.requiredCapability]) {
-      return true;
-    }
+  if (panel.requiredCapability && !capabilities[panel.requiredCapability]) {
+    return true;
   }
   return false;
 }

--- a/frontend/src/core/kernel/__tests__/handlers.test.ts
+++ b/frontend/src/core/kernel/__tests__/handlers.test.ts
@@ -142,8 +142,8 @@ describe("buildCellData", () => {
         cell2: "y = 2",
       },
       last_execution_time: {
-        cell1: 1234567890,
-        cell2: 1234567891,
+        cell1: 1_234_567_890,
+        cell2: 1_234_567_891,
       },
       app_config: {
         width: "normal",

--- a/frontend/src/core/kernel/state.ts
+++ b/frontend/src/core/kernel/state.ts
@@ -1,3 +1,4 @@
+/* Copyright 2026 Marimo. All rights reserved. */
 import { atom } from "jotai";
 import { waitFor } from "../state/jotai";
 

--- a/frontend/src/core/network/__tests__/requests-lazy.test.ts
+++ b/frontend/src/core/network/__tests__/requests-lazy.test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2024 Marimo. All rights reserved. */
+/* Copyright 2026 Marimo. All rights reserved. */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeManager } from "../../runtime/runtime";

--- a/frontend/src/core/network/requests-lazy.ts
+++ b/frontend/src/core/network/requests-lazy.ts
@@ -1,4 +1,4 @@
-/* Copyright 2024 Marimo. All rights reserved. */
+/* Copyright 2026 Marimo. All rights reserved. */
 
 import { NoKernelConnectedError } from "@/utils/errors";
 import { Logger } from "@/utils/Logger";
@@ -152,7 +152,7 @@ export function createLazyRequests(
             `Dropping request: ${key}, since not connected to a kernel.`,
           );
           // Silently drop the request
-          return Promise.resolve();
+          return;
 
         case "throwError":
           throw new NoKernelConnectedError();

--- a/frontend/src/css/globals.css
+++ b/frontend/src/css/globals.css
@@ -184,8 +184,10 @@
   --shadow-2xl-solid: 10px 12px 0px 0px var(--base-shadow-darker), 0 0px 8px 0px hsl(0deg 0% 90% / 50%);
 
   /* Solid shadows with lighter shade color */
+
   /* biome-ignore format: definition needs to be oneline or breaks variants */
   --shadow-sm-solid-shade: 2px 2px 0px 0px var(--base-shadow), 0px 0px 2px 0px hsl(0deg 0% 50% / 20%);
+
   /* biome-ignore format: definition needs to be oneline or breaks variants */
   --shadow-md-solid-shade: 4px 4px 0px 0px var(--base-shadow), 0 0px 2px 0px hsl(0deg 0% 60% / 50%);
 }


### PR DESCRIPTION
Closes #7810

Private variables (e.g., `_x`) in marimo are cell-local and independent across cell boundaries. However, when using the language server's rename feature, renaming a private variable would change it across all cells.

This fix detects when a private variable is being renamed and limits the rename operation to only the current cell, matching marimo's scoping semantics for private variables.
