### PR TITLE
fix: Enhance keyboard handling in editable name cell component

### DIFF
--- a/frontend/src/components/editor/actions/name-cell-input.tsx
+++ b/frontend/src/components/editor/actions/name-cell-input.tsx
@@ -93,11 +93,17 @@ export const NameCellContentEditable: React.FC<{
         onChange={inputProps.onChange}
         onBlur={inputProps.onBlur}
         onFocus={inputProps.onFocus}
-        onKeyDown={Events.onEnter((e) => {
-          if (e.target instanceof HTMLElement) {
-            e.target.blur();
+        onKeyDown={(e) => {
+          // Prevent all key presses from triggering hotkeys
+          e.stopPropagation();
+
+          // On Enter, blur the input to commit the change
+          if (e.key === "Enter") {
+            if (e.target instanceof HTMLElement) {
+              e.target.blur();
+            }
           }
-        })}
+        }}
       >
         {value}
       </span>

--- a/frontend/src/utils/events.ts
+++ b/frontend/src/utils/events.ts
@@ -42,6 +42,7 @@ export const Events = {
       target.tagName === "INPUT" ||
       target.tagName === "TEXTAREA" ||
       target.tagName.startsWith("MARIMO") ||
+      target.isContentEditable ||
       Events.fromCodeMirror(e)
     );
   },


### PR DESCRIPTION
Updated the `onKeyDown` event to prevent key presses from triggering hotkeys
