### PR TITLE
moved marimo import to top in convert command

### DIFF
--- a/marimo/_convert/ipynb.py
+++ b/marimo/_convert/ipynb.py
@@ -119,7 +119,7 @@ def transform_add_marimo_import(sources: list[CodeCell]) -> list[CodeCell]:
         return sources
 
     if any(contains_mo(cell.source) for cell in sources):
-        return sources + [CodeCell("import marimo as mo")]
+        return [CodeCell("import marimo as mo")] + sources
 
     return sources
 

--- a/tests/_convert/test_ipynb.py
+++ b/tests/_convert/test_ipynb.py
@@ -141,7 +141,7 @@ def test_transform_add_marimo_import():
         "print('World')",
     ]
     result = strip_cells(transform_add_marimo_import)(sources)
-    assert "import marimo as mo" in result
+    assert result == ["import marimo as mo"] + sources
 
     # mo.sql
     sources = [
@@ -149,7 +149,7 @@ def test_transform_add_marimo_import():
         "print('World')",
     ]
     result = strip_cells(transform_add_marimo_import)(sources)
-    assert "import marimo as mo" in result
+    assert result == ["import marimo as mo"] + sources
 
     # if `import marimo as mo` is already present
     # it should not be added again
@@ -182,7 +182,7 @@ def test_transform_add_marimo_import_already_but_in_comment_or_definition():
         "# import marimo as mo",
     ]
     result = strip_cells(transform_add_marimo_import)(sources)
-    assert result == sources + ["import marimo as mo"]
+    assert result == ["import marimo as mo"] + sources
 
     # Definition
     sources = [
@@ -190,7 +190,7 @@ def test_transform_add_marimo_import_already_but_in_comment_or_definition():
         "def foo():\n    import marimo as mo",
     ]
     result = strip_cells(transform_add_marimo_import)(sources)
-    assert result == sources + ["import marimo as mo"]
+    assert result == ["import marimo as mo"] + sources
 
 
 def test_transform_magic_commands():


### PR DESCRIPTION
This PR moves the `import marimo as mo` to the top cell when we convert from Jupyter to marimo.  Having the cell at the bottom is bothersome because it may not run at all if the original notebook contains errors. 