### PR TITLE
Keep terminal mounted to preserve session across tab switches.

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -341,12 +341,17 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
               {selectedPanel === "tracing" && <LazyTracingPanel />}
               {selectedPanel === "secrets" && <LazySecretsPanel />}
               {selectedPanel === "logs" && <LazyLogsPanel />}
-              {selectedPanel === "terminal" && (
-                <LazyTerminal
-                  visible={isSidebarOpen}
-                  onClose={() => setIsSidebarOpen(false)}
-                />
-              )}
+              {/* LazyMount keeps Terminal mounted to preserve session across panel switches */}
+              <LazyMount isOpen={isSidebarOpen && selectedPanel === "terminal"}>
+                <div
+                  className={selectedPanel === "terminal" ? "h-full" : "hidden"}
+                >
+                  <LazyTerminal
+                    visible={isSidebarOpen && selectedPanel === "terminal"}
+                    onClose={() => setIsSidebarOpen(false)}
+                  />
+                </div>
+              </LazyMount>
               {selectedPanel === "cache" && <LazyCachePanel />}
             </TooltipProvider>
           </Suspense>
@@ -502,15 +507,29 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
               {selectedDeveloperPanelTab === "tracing" && <LazyTracingPanel />}
               {selectedDeveloperPanelTab === "secrets" && <LazySecretsPanel />}
               {selectedDeveloperPanelTab === "logs" && <LazyLogsPanel />}
-              {/* LazyMount needed for Terminal to avoid spurious connection */}
-              {selectedDeveloperPanelTab === "terminal" && (
-                <LazyMount isOpen={isDeveloperPanelOpen}>
+              {/* LazyMount keeps Terminal mounted to preserve session across tab switches */}
+              <LazyMount
+                isOpen={
+                  isDeveloperPanelOpen &&
+                  selectedDeveloperPanelTab === "terminal"
+                }
+              >
+                <div
+                  className={
+                    selectedDeveloperPanelTab === "terminal"
+                      ? "h-full"
+                      : "hidden"
+                  }
+                >
                   <LazyTerminal
-                    visible={isDeveloperPanelOpen}
+                    visible={
+                      isDeveloperPanelOpen &&
+                      selectedDeveloperPanelTab === "terminal"
+                    }
                     onClose={() => setIsDeveloperPanelOpen(false)}
                   />
-                </LazyMount>
-              )}
+                </div>
+              </LazyMount>
               {selectedDeveloperPanelTab === "cache" && <LazyCachePanel />}
             </div>
           </PanelSectionProvider>


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #7829

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

**Problem:** When switching from the Terminal tab to another tab (e.g., Errors) and back, the terminal session was lost and a new shell was created. This was disruptive for users running long-lived processes in the terminal.

**Root cause:** The Terminal component was rendered inside a conditional block (`selectedDeveloperPanelTab === "terminal" && ...`), causing it to unmount when switching tabs. Since the terminal's session history lives in the xterm.js `Terminal` instance (not in external state), unmounting destroyed all session data and closed the WebSocket connection.

**Solution:** Moved the `LazyMount` wrapper outside the conditional rendering so the Terminal stays mounted once initialized. Visibility is now controlled via CSS (`hidden` class) and the `visible` prop instead of conditional mounting. Applied the same fix to both the developer panel and sidebar Terminal instances.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
