### PR TITLE
fix: Keep terminal mounted to preserve session across tab switches

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -1,6 +1,5 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import React, {
-  Activity,
   type PropsWithChildren,
   Suspense,
   useEffect,
@@ -21,6 +20,7 @@ import { XIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ReorderableList } from "@/components/ui/reorderable-list";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { LazyActivity } from "@/components/utils/lazy-mount";
 import { cellErrorCount } from "@/core/cells/cells";
 import { capabilitiesAtom } from "@/core/config/capabilities";
 import { getFeatureFlag } from "@/core/config/feature-flag";
@@ -353,12 +353,12 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
           <Suspense>
             <TooltipProvider>
               {Object.entries(SIDEBAR_PANELS).map(([key, Panel]) => (
-                <Activity
+                <LazyActivity
                   key={key}
                   mode={selectedPanel === key ? "visible" : "hidden"}
                 >
                   {Panel}
-                </Activity>
+                </LazyActivity>
               ))}
             </TooltipProvider>
           </Suspense>
@@ -500,14 +500,14 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
           <PanelSectionProvider value="developer-panel">
             <div className="flex-1 overflow-hidden">
               {Object.entries(DEVELOPER_PANELS).map(([key, Panel]) => (
-                <Activity
+                <LazyActivity
                   key={key}
                   mode={
                     selectedDeveloperPanelTab === key ? "visible" : "hidden"
                   }
                 >
                   {Panel}
-                </Activity>
+                </LazyActivity>
               ))}
             </div>
           </PanelSectionProvider>

--- a/frontend/src/components/utils/lazy-mount.tsx
+++ b/frontend/src/components/utils/lazy-mount.tsx
@@ -1,5 +1,9 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import React, { type PropsWithChildren } from "react";
+import React, {
+  Activity,
+  type ActivityProps,
+  type PropsWithChildren,
+} from "react";
 
 interface Props {
   isOpen: boolean;
@@ -12,13 +16,30 @@ export const LazyMount: React.FC<PropsWithChildren<Props>> = ({
   isOpen,
   children,
 }) => {
-  const [isMounted, setIsMounted] = React.useState(false);
+  const [hasMountedBefore, setHasMountedBefore] = React.useState(false);
 
-  React.useEffect(() => {
-    if (isOpen && !isMounted) {
-      setIsMounted(true);
-    }
-  }, [isOpen, isMounted]);
+  if (isOpen && !hasMountedBefore) {
+    setHasMountedBefore(true);
+  }
 
-  return isMounted ? children : null;
+  return hasMountedBefore || isOpen ? children : null;
+};
+
+/**
+ * Wraps a component in an Activity component. It is not mounted until it is open for the first time.
+ */
+export const LazyActivity: React.FC<PropsWithChildren<ActivityProps>> = (
+  props,
+) => {
+  const [hasMountedBefore, setHasMountedBefore] = React.useState(false);
+
+  if (props.mode === "visible" && !hasMountedBefore) {
+    setHasMountedBefore(true);
+  }
+
+  if (hasMountedBefore) {
+    return <Activity {...props} />;
+  }
+
+  return null;
 };


### PR DESCRIPTION
This uses the react [Activity](https://react.dev/reference/react/Activity) API to keep the Terminal panel mounted. this also DRYs up some code.

Closes https://github.com/marimo-team/marimo/issues/7829