### PR TITLE
improve: clarify column filtering is only for top 30 values

### DIFF
--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -593,7 +593,7 @@ const PopoverFilterByValues = <TData, TValue>({
       <>
         <Command className="text-sm outline-hidden" shouldFilter={false}>
           <CommandInput
-            placeholder="Search among top 30 values"
+            placeholder={`Search among the top ${data.length} values`}
             autoFocus={true}
             onValueChange={(value) => setQuery(value.trim())}
           />


### PR DESCRIPTION
It was non-obvious that the column filter only applied to the top 30 values. This change updates the placeholder text to make it obvious.

Fixes #6031