### PR TITLE
fix: duplicate notebook when running 'marimo edit <folder>'

### DIFF
--- a/marimo/_server/api/endpoints/files.py
+++ b/marimo/_server/api/endpoints/files.py
@@ -202,9 +202,11 @@ async def copy(
     body = await parse_request(request, cls=CopyNotebookRequest)
 
     # Resolve relative filenames against the file router's directory
-    if body.destination and not Path(body.destination).is_absolute():
-        directory = app_state.session_manager.file_router.directory
-        if directory:
+    directory = app_state.session_manager.file_router.directory
+    if directory:
+        if body.source and not Path(body.source).is_absolute():
+            body.source = str(Path(directory) / body.source)
+        if body.destination and not Path(body.destination).is_absolute():
             body.destination = str(Path(directory) / body.destination)
 
     session = app_state.require_current_session()

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -1,7 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-import os
 from typing import Any, Literal, Optional
 
 import msgspec
@@ -276,19 +275,6 @@ class CopyNotebookRequest(msgspec.Struct, rename="camel"):
     # path to app
     source: str
     destination: str
-
-    # Validate filenames are valid, and destination path does not already exist
-    def __post_init__(self) -> None:
-        destination = os.path.basename(self.destination)
-        assert self.source is not None
-        assert self.destination is not None
-        assert os.path.exists(self.source), (
-            f'File "{self.source}" does not exist.'
-            + "Please save the notebook and try again."
-        )
-        assert not os.path.exists(self.destination), (
-            f'File "{destination}" already exists in this directory.'
-        )
 
 
 class SaveAppConfigurationRequest(msgspec.Struct, rename="camel"):


### PR DESCRIPTION
This PR fixes duplicating notebooks when running from `marimo edit <folder>`