### PR TITLE
Fix mo.ui.dataframe showing incorrect column count

### DIFF
--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -202,6 +202,8 @@ export const DataFrameComponent = memo(
       sql_code,
     } = data || {};
 
+    const totalColumns = field_types?.length;
+
     const [internalValue, setInternalValue] = useState<Transformations>(
       value || EMPTY,
     );
@@ -317,7 +319,7 @@ export const DataFrameComponent = memo(
           data={url || ""}
           hasStableRowId={false}
           totalRows={total_rows ?? 0}
-          totalColumns={Object.keys(columns).length}
+          totalColumns={totalColumns ?? 0}
           maxColumns="all"
           pageSize={pageSize}
           pagination={true}


### PR DESCRIPTION
## 📝 Summary

`mo.ui.dataframe` was displaying "0 columns" in the footer, even though the data rendered correctly. After applying transforms like "Select Columns", the column count also didn't update to reflect the filtered columns.

## 🔍 Description of Changes

The column count was being calculated using `Object.keys(columns).length` but because it is a Map, `.keys()` returns an empty array, and hence the zero length. Updated to use `field_types.length` from the `get_dataframe()` response instead. This correctly reflects the actual columns being displayed, including after transforms are applied.

### Screenshot

Before
<img width="730" height="396" alt="image" src="https://github.com/user-attachments/assets/e153fc48-1b2c-4403-a3f5-c2d38ed4d121" />


After
<img width="730" height="396" alt="image" src="https://github.com/user-attachments/assets/06dd9b69-2de6-409f-9120-d17a6f5cedb8" />

Note: I've not added any specific tests for this, since it's a minor bug fix.


## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
