### PR TITLE
allow for __contains__ and __getitem__ in anywidget

### DIFF
--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -330,3 +330,11 @@ class anywidget(UIElement[WireFormat, T]):
             except AttributeError:
                 return None
         return getattr(self.widget, name)
+
+    def __getitem__(self, key: Any) -> Any:
+        """Forward __getitem__ to the wrapped widget."""
+        return self.widget[key]
+
+    def __contains__(self, key: Any) -> bool:
+        """Forward __contains__ to the wrapped widget."""
+        return key in self.widget

--- a/tests/_plugins/ui/_impl/test_anywidget.py
+++ b/tests/_plugins/ui/_impl/test_anywidget.py
@@ -519,6 +519,36 @@ x = as_marimo_element.count
         wrapped._update({"d": 4})
         assert wrapped.value == {"a": 100, "b": 200, "c": 300, "d": 4}
 
+    @staticmethod
+    async def test_getitem_and_contains() -> None:
+        """Test that __getitem__ and __contains__ are forwarded to the widget."""
+        from typing import Any
+
+        class DictLikeWidget(_anywidget.AnyWidget):
+            _esm = ""
+            data = traitlets.Dict({"a": 1, "b": 2}).tag(sync=True)
+
+            def __getitem__(self, key: str) -> Any:
+                return self.data[key]
+
+            def __contains__(self, key: str) -> bool:
+                return key in self.data
+
+        wrapped = anywidget(DictLikeWidget())
+
+        # Test __getitem__ forwarding
+        assert wrapped["a"] == 1
+        assert wrapped["b"] == 2
+
+        # Test __contains__ forwarding
+        assert "a" in wrapped
+        assert "b" in wrapped
+        assert "c" not in wrapped
+
+        # Test KeyError propagation
+        with pytest.raises(KeyError):
+            _ = wrapped["nonexistent"]
+
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 class TestWireFormat:


### PR DESCRIPTION
This change will let me implement widgets with dictionary-like behavior.

<img width="844" height="550" alt="CleanShot 2026-01-15 at 10 51 47" src="https://github.com/user-attachments/assets/36d42c0a-d79b-4e20-8be5-20f2e16b0eb2" />

Right now I am forced to path through `widget.config` in order to get to my own impelementation of `__getitem__` or `__contains__`. 