### PR TITLE
Increase codecov timeout

### DIFF
--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -230,7 +230,7 @@ jobs:
     if: ${{ needs.changes.outputs.backend == 'true' && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     name: Test coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Running tests with coverage takes a long time. Increase the timeout so it actually finishes, at which point we can see if codecov is useful or not.

Coverage only runs on main so this won't slow down PRs
