### PR TITLE
styles: fix Kernel Startup Error modal overflow

### DIFF
--- a/frontend/src/components/editor/KernelStartupErrorModal.tsx
+++ b/frontend/src/components/editor/KernelStartupErrorModal.tsx
@@ -65,7 +65,7 @@ export const KernelStartupErrorModal: React.FC = () => {
             manager can't install your notebook's dependencies.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <div className="my-4">
+        <div className="my-4 overflow-hidden">
           <div className="flex items-center justify-between mb-2">
             <span className="text-sm font-medium text-muted-foreground">
               Error Details
@@ -80,7 +80,7 @@ export const KernelStartupErrorModal: React.FC = () => {
               Copy
             </Button>
           </div>
-          <pre className="bg-muted p-4 rounded-md text-sm font-mono overflow-auto max-h-80 whitespace-pre-wrap break-words">
+          <pre className="bg-muted p-4 rounded-md text-sm font-mono overflow-auto max-h-80">
             {error}
           </pre>
         </div>


### PR DESCRIPTION
## 📝 Summary

Fixes an overflow issue with the kernel failure page:

<img width="731" height="566" alt="image" src="https://github.com/user-attachments/assets/c0a7618c-5fb3-45e3-9f6d-b646ad57ac2f" />
