### PR TITLE
fix: improve error handling for pyiceberg list_namespaces permission errors

### DIFF
--- a/marimo/_sql/engines/pyiceberg.py
+++ b/marimo/_sql/engines/pyiceberg.py
@@ -106,8 +106,16 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
                         engine=self._engine_name,
                     )
                 )
-        except Exception:
-            LOGGER.warning("Failed to get databases", exc_info=True)
+        except Exception as e:
+            # Check if this is a permission/auth error (e.g., 403 Forbidden)
+            error_str = str(e).lower()
+            if "403" in error_str or "forbidden" in error_str:
+                LOGGER.debug(
+                    "Cannot list namespaces due to insufficient permissions. "
+                    "You can still access tables if you know the namespace name."
+                )
+            else:
+                LOGGER.warning("Failed to get databases", exc_info=True)
 
         return databases
 


### PR DESCRIPTION
## Summary

Fixes #7790 - Improves error handling when list_namespaces() fails due to insufficient permissions.

## Changes

When list_namespaces() fails with a 403 Forbidden error (common when credentials don't allow access to the /v1/namespaces API), the code now:
- Logs at **debug** level instead of warning
- Provides a helpful message explaining that tables can still be accessed if the namespace name is known
- Only falls back to warning with full traceback for other unexpected errors

## Test Plan

- The change is backward compatible - other errors still log warnings
- Users with restricted permissions will no longer see noisy warnings