### PR TITLE
Remove opt-in note about reactive reference highlighting

### DIFF
--- a/docs/guides/editor_features/dataflow.md
+++ b/docs/guides/editor_features/dataflow.md
@@ -296,8 +296,3 @@ when variables defined by other cells are used in the current cell. These
 
 Hover over any underlined variable and `Cmd/Ctrl-Click` to jump to its
 definition.
-
-This feature is currently **opt-in** and must be enabled via *Settings* > *User
-Settings* > *Display* > *Reference highlighting* or toggled via the command
-palette (`Cmd/Ctrl-K` > *Reference highlighting*).
-


### PR DESCRIPTION
This feature is now on by default in marimo and the docs are outdated.