### PR TITLE
style: remove hover border on borderless cells

### DIFF
--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -249,7 +249,6 @@
   }
 
   /* Borderless styles for Cell */
-
   &.borderless {
     border-color: transparent;
 
@@ -258,7 +257,6 @@
     }
 
     /* Apply the original styles */
-    &:hover,
     &:focus {
       border: 1px solid var(--gray-4);
     }


### PR DESCRIPTION
This change removes the on-hover border for borderless cells (i.e., Markdown cells with code hidden).

For context, I have been working on notebooks that are predominantly Markdown. The border that appears on hover added significant noise. This change makes the reading experience more similar to Jupyter/Colab, reducing visual distraction.