### PR TITLE
fix: nested display math

### DIFF
--- a/frontend/src/plugins/layout/TexPlugin.tsx
+++ b/frontend/src/plugins/layout/TexPlugin.tsx
@@ -119,8 +119,7 @@ const TexComponent = ({
   // marimo-tex's textContent includes the nested delimiters (||(||(x||)||))
   // and will render correctly with displayMode: true. We detect this by
   // checking if the parent element is also a marimo-tex.
-  const isNested =
-    host.parentElement?.tagName.toLowerCase() === "marimo-tex";
+  const isNested = host.parentElement?.tagName.toLowerCase() === "marimo-tex";
 
   // Re-render when the text content changes.
   useLayoutEffect(() => {


### PR DESCRIPTION
This fixes rendering of inline display math, such as

My equation is $$f(y) = x$$