### PR TITLE
maybe improve windows pytest ci

### DIFF
--- a/marimo/_ast/fast_stack.py
+++ b/marimo/_ast/fast_stack.py
@@ -1,0 +1,56 @@
+# Source - https://stackoverflow.com/a
+# Posted by Kache, modified by community. See post 'Timeline' for change history
+# Retrieved 2026-01-17, License - CC BY-SA 4.0
+from __future__ import annotations
+
+import inspect
+import itertools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from types import FrameType
+
+
+def fast_stack(max_depth: int | None = None) -> list[inspect.FrameInfo]:
+    """Fast alternative to `inspect.stack()`
+
+    Use optional `max_depth` to limit search depth
+    Based on: github.com/python/cpython/blob/3.11/Lib/inspect.py
+
+    Compared to `inspect.stack()`:
+     * Does not read source files to load neighboring context
+     * Less accurate filename determination, still correct for most cases
+     * Does not compute 3.11+ code positions (PEP 657)
+
+    Compare:
+
+    In [3]: %timeit stack_depth(100, lambda: inspect.stack())
+    67.7 ms ± 1.35 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+    In [4]: %timeit stack_depth(100, lambda: inspect.stack(0))
+    22.7 ms ± 747 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+    In [5]: %timeit stack_depth(100, lambda: fast_stack())
+    108 µs ± 180 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+
+    In [6]: %timeit stack_depth(100, lambda: fast_stack(10))
+    14.1 µs ± 33.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
+    """
+
+    def frame_infos(
+        frame: FrameType | None,
+    ) -> Generator[inspect.FrameInfo, None, None]:
+        while frame := frame and frame.f_back:
+            yield inspect.FrameInfo(
+                frame,
+                inspect.getfile(frame),
+                frame.f_lineno,
+                frame.f_code.co_name,
+                None,
+                None,
+            )
+
+    return list(
+        itertools.islice(frame_infos(inspect.currentframe()), max_depth)
+    )

--- a/marimo/_ast/pytest.py
+++ b/marimo/_ast/pytest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeVar, cast
 
 from marimo._ast.cell import Cell
+from marimo._ast.fast_stack import fast_stack
 from marimo._ast.parse import ast_parse
 from marimo._runtime.context import ContextNotInitializedError, get_context
 
@@ -428,7 +429,7 @@ def process_for_pytest(func: Fn, cell: Cell) -> None:
         )
     # Get first frame not in library to insert the class.
     # May be multiple levels if called from pytest or something.
-    frames = inspect.stack(context=0)
+    frames = fast_stack()
 
     cls = build_test_class(
         scope.body, run, inspect.getfile(func), name, cell.defs, frames

--- a/tests/_ast/test_fast_stack.py
+++ b/tests/_ast/test_fast_stack.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import inspect
+
+from marimo._ast.fast_stack import fast_stack
+
+
+class TestFastStack:
+    @staticmethod
+    def test_returns_list_of_frame_info() -> None:
+        result = fast_stack()
+        assert isinstance(result, list)
+        assert all(isinstance(frame, inspect.FrameInfo) for frame in result)
+
+    @staticmethod
+    def test_frame_info_has_expected_fields() -> None:
+        result = fast_stack()
+        assert len(result) > 0
+        frame_info = result[0]
+        assert hasattr(frame_info, "frame")
+        assert hasattr(frame_info, "filename")
+        assert hasattr(frame_info, "lineno")
+        assert hasattr(frame_info, "function")
+
+    @staticmethod
+    def test_contains_caller_function_name() -> None:
+        result = fast_stack()
+        function_names = [f.function for f in result]
+        # The calling test function should be in the stack
+        assert "test_contains_caller_function_name" in function_names
+
+    @staticmethod
+    def test_contains_caller_filename() -> None:
+        result = fast_stack()
+        filenames = [f.filename for f in result]
+        # At least one frame should be from this test file
+        assert any("test_fast_stack.py" in f for f in filenames)
+
+    @staticmethod
+    def test_max_depth_limits_results() -> None:
+        result_limited = fast_stack(max_depth=2)
+        result_full = fast_stack()
+        assert len(result_limited) <= 2
+        assert len(result_limited) <= len(result_full)
+
+    @staticmethod
+    def test_max_depth_none_returns_full_stack() -> None:
+        result = fast_stack(max_depth=None)
+        assert len(result) > 0
+
+    @staticmethod
+    def test_max_depth_zero_returns_empty() -> None:
+        result = fast_stack(max_depth=0)
+        assert result == []
+
+    @staticmethod
+    def test_context_fields_are_none() -> None:
+        # fast_stack does not load context (for performance)
+        result = fast_stack()
+        assert len(result) > 0
+        for frame_info in result:
+            assert frame_info.code_context is None
+            assert frame_info.index is None
+
+    @staticmethod
+    def test_nested_function_call() -> None:
+        def inner() -> list[inspect.FrameInfo]:
+            return fast_stack()
+
+        def outer() -> list[inspect.FrameInfo]:
+            return inner()
+
+        result = outer()
+        function_names = [f.function for f in result]
+        assert "inner" in function_names
+        assert "outer" in function_names
+
+    @staticmethod
+    def test_line_numbers_are_positive() -> None:
+        result = fast_stack()
+        for frame_info in result:
+            assert frame_info.lineno > 0


### PR DESCRIPTION
The pytest runtime test sometimes fails on Windows CI with a timeout. The last time this timeout was triggered was when inspect.stack() was executing. This change uses a reference implementation of a more minimal, faster version of inspect.stack().

It seems unlikely that `inspect.stack()` is really that slow on the Windows runners, but worth a shot. Putting up this PR to trigger CI and observe timing.

EDIT: Tests are green. I might suggest merging and seeing if this fixes the pytest flakiness.