### PR TITLE
Update sandbox documentation link to correct page

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -993,7 +993,7 @@ export const UserConfigForm: React.FC = () => {
                       <br />
                       <br />
                       Running marimo in a{" "}
-                      <ExternalLink href="https://docs.marimo.io/guides/editor_features/package_management.html#running-marimo-in-a-sandbox-environment-uv-only">
+                      <ExternalLink href="https://docs.marimo.io/guides/package_management/inlining_dependencies.html">
                         sandboxed environment
                       </ExternalLink>{" "}
                       is only supported by <Kbd className="inline">uv</Kbd>


### PR DESCRIPTION
Fixes #7887

The "sandboxed environment" link in the settings UI was pointing to a non-existent anchor on the package management page. Updated it to link directly to the inlining dependencies guide, which contains the actual sandbox documentation.