### PR TITLE
docs: plotly express install needs dependency group

### DIFF
--- a/docs/guides/working_with_data/plotting.md
+++ b/docs/guides/working_with_data/plotting.md
@@ -223,7 +223,7 @@ conda install -c conda-forge "vegafusion-python-embed>=1.4.0" "vegafusion>=1.4.0
 @app.cell(hide_code=True)
 async def __():
     import micropip
-    await micropip.install("plotly")
+    await micropip.install("plotly[express]")
     import plotly.express as px
     return px,
 


### PR DESCRIPTION
Fix a micropip install in the docs.
