### PR TITLE
dont export marimo specific components

### DIFF
--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -48,10 +48,9 @@ import { renderMimeIcon } from "./renderMimeIcon";
 
 const METADATA_KEY = "__metadata__";
 
-type MimeBundleWithoutMetadata = Record<
-  OutputMessage["mimetype"],
-  { [key: string]: unknown }
->;
+export type MimeType = OutputMessage["mimetype"];
+
+type MimeBundleWithoutMetadata = Record<MimeType, { [key: string]: unknown }>;
 
 type MimeBundle = MimeBundleWithoutMetadata & {
   [METADATA_KEY]?: Record<string, { width?: number; height?: number }>;
@@ -72,7 +71,7 @@ export const OutputRenderer: React.FC<{
   onRefactorWithAI?: OnRefactorWithAI;
   wrapText?: boolean;
   metadata?: { width?: number; height?: number };
-  renderFallback?: (mimetype: OutputMessage["mimetype"]) => React.ReactNode;
+  renderFallback?: (mimetype: MimeType) => React.ReactNode;
 }> = memo((props) => {
   const {
     message,
@@ -222,9 +221,7 @@ export const OutputRenderer: React.FC<{
       return (
         <MimeBundleOutputRenderer
           channel={channel}
-          data={
-            parsedJsonData as Record<OutputMessage["mimetype"], OutputMessage>
-          }
+          data={parsedJsonData as Record<MimeType, OutputMessage>}
         />
       );
     case "application/vnd.jupyter.widget-view+json":
@@ -273,10 +270,7 @@ const MimeBundleOutputRenderer: React.FC<{
   // Filter out metadata from the mime entries and type narrow
   const mimeEntries = Objects.entries(mimebundle as Record<string, unknown>)
     .filter(([key]) => key !== METADATA_KEY)
-    .map(
-      ([mime, data]) =>
-        [mime, data] as [OutputMessage["mimetype"], CellOutput["data"]],
-    );
+    .map(([mime, data]) => [mime, data] as [MimeType, CellOutput["data"]]);
 
   // If there is none, return null
   const first = mimeEntries[0]?.[0];

--- a/frontend/src/core/export/hooks.ts
+++ b/frontend/src/core/export/hooks.ts
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { toPng } from "html-to-image";
 import { atom, useAtom, useAtomValue } from "jotai";
+import type { MimeType } from "@/components/editor/Output";
 import { toast } from "@/components/ui/use-toast";
 import { appConfigAtom } from "@/core/config/config";
 import { useInterval } from "@/hooks/useInterval";
@@ -86,7 +87,7 @@ export function useAutoExport() {
 const richCellsToOutputAtom = atom<Record<CellId, unknown>>({});
 
 // MIME types to capture screenshots for
-const MIME_TYPES_TO_CAPTURE_SCREENSHOTS = new Set([
+const MIME_TYPES_TO_CAPTURE_SCREENSHOTS = new Set<MimeType>([
   "text/html",
   "application/vnd.vegalite.v5+json",
   "application/vnd.vega.v5+json",
@@ -112,7 +113,8 @@ export function useEnrichCellOutputs() {
       // Track latest output for this cell
       trackedCellsOutput[cellId] = outputData;
       if (
-        MIME_TYPES_TO_CAPTURE_SCREENSHOTS.has(runtime.output?.mimetype ?? "") &&
+        runtime.output?.mimetype &&
+        MIME_TYPES_TO_CAPTURE_SCREENSHOTS.has(runtime.output.mimetype) &&
         outputData &&
         outputHasChanged
       ) {

--- a/marimo/_convert/ipynb/from_ir.py
+++ b/marimo/_convert/ipynb/from_ir.py
@@ -198,6 +198,15 @@ def _maybe_extract_dataurl(data: Any) -> Any:
         return data
 
 
+def _is_marimo_component(html_content: Any) -> bool:
+    """Check if the content is a marimo component."""
+    if isinstance(html_content, list):
+        html_content = "".join(html_content)
+    if not isinstance(html_content, str):
+        return False
+    return "<marimo-" in html_content
+
+
 class _HTMLTextExtractor(HTMLParser):
     """Extract plain text from HTML."""
 
@@ -348,6 +357,9 @@ def _convert_marimo_output_to_ipynb(
         for mime, content in mimebundle.items():
             if mime == METADATA_KEY and isinstance(content, dict):
                 metadata = content
+            elif mime == "text/html" and _is_marimo_component(content):
+                # Skip marimo components because they cannot be rendered in IPython notebook format
+                continue
             else:
                 data[mime] = _maybe_extract_dataurl(content)
     else:


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
By default, Jupyter & nbconvert will choose the mimetype to render. Since we include both text/html & image/png in the export, it prefers the text/html and tries to render it but fails since `<marimo>` components don't have a renderer.

nbconvert: https://github.com/jupyter/nbconvert/blob/216550b2aae4c329f4dab597a96ae7cac30de79a/nbconvert/utils/base.py#L16
jupyter: https://github.com/jupyterlab/jupyterlab/blob/main/packages/rendermime/src/registry.ts#L97

<img width="432" height="409" alt="image" src="https://github.com/user-attachments/assets/5beb535c-4284-47d1-b1fc-2a78130fb7e1" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
