### PR TITLE
improvement: fallback to png for matplotlib when in a non-interactive environment

### DIFF
--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from marimo import _loggers
+from marimo._messaging.mimetypes import KnownMimeType
 from marimo._output.builder import h
 from marimo._output.formatting import as_html
 from marimo._output.hypertext import Html
@@ -444,6 +445,33 @@ def new_figure_manager_given_figure(
     return manager
 
 
+def png_bytes(figure: Union[Figure, SubFigure, Axes]) -> bytes:
+    """Convert a matplotlib figure to base64-encoded PNG bytes.
+
+    The Html._mime_ method expects _repr_png_ to return bytes that
+    can be decoded to a UTF-8 string, so we return base64-encoded data.
+    """
+    import base64
+
+    from matplotlib.figure import Figure
+
+    buf = io.BytesIO()
+    if isinstance(figure, Figure):
+        figure.savefig(buf, format="png", bbox_inches="tight")
+    else:
+        figure.figure.canvas.print_figure(buf, format="png")
+    return base64.b64encode(buf.getvalue())
+
+
+class NonInteractiveMplHtml(Html):
+    def __init__(self, figure: Union[Figure, SubFigure, Axes]) -> None:
+        self._figure = figure
+        super().__init__(as_html(figure).text)
+
+    def _mime_(self) -> tuple[KnownMimeType, str]:
+        return ("image/png", png_bytes(self._figure).decode())
+
+
 class InteractiveMplHtml(Html):
     """Html subclass that provides PNG fallback for ipynb export."""
 
@@ -452,21 +480,8 @@ class InteractiveMplHtml(Html):
         super().__init__(text)
 
     def _repr_png_(self) -> bytes:
-        """Return base64-encoded PNG bytes for ipynb export fallback.
-
-        The Html._mime_ method expects _repr_png_ to return bytes that
-        can be decoded to a UTF-8 string, so we return base64-encoded data.
-        """
-        import base64
-
-        from matplotlib.figure import Figure
-
-        buf = io.BytesIO()
-        if isinstance(self._figure, Figure):
-            self._figure.savefig(buf, format="png", bbox_inches="tight")
-        else:
-            self._figure.figure.canvas.print_figure(buf, format="png")
-        return base64.b64encode(buf.getvalue())
+        """Return base64-encoded PNG bytes for ipynb export fallback."""
+        return png_bytes(self._figure)
 
 
 @mddoc
@@ -489,14 +504,6 @@ def interactive(figure: Union[Figure, SubFigure, Axes]) -> Html:
     Returns:
         Html: An interactive matplotlib figure as an `Html` object.
     """
-    # We can't support interactive plots in Pyodide
-    # since they require a WebSocket connection
-    if is_pyodide():
-        LOGGER.error(
-            "Interactive plots are not supported in Pyodide/WebAssembly"
-        )
-        return as_html(figure)
-
     # No top-level imports of matplotlib, since it isn't a required
     # dependency
     from matplotlib.axes import Axes
@@ -506,9 +513,22 @@ def interactive(figure: Union[Figure, SubFigure, Axes]) -> Html:
         assert maybe_figure is not None, "Axes object does not have a Figure"
         figure = maybe_figure
 
+    # We can't support interactive plots in Pyodide
+    # since they require a WebSocket connection
+    if is_pyodide():
+        LOGGER.warning(
+            "Interactive plots are not supported in Pyodide/WebAssembly"
+        )
+        return NonInteractiveMplHtml(figure)
+
     ctx = get_context()
     if not isinstance(ctx, KernelRuntimeContext):
-        return as_html(figure)
+        return NonInteractiveMplHtml(figure)
+
+    # When virtual files are not supported (e.g., during HTML export),
+    # fall back to static PNG instead of interactive plot
+    if not ctx.virtual_files_supported:
+        return NonInteractiveMplHtml(figure)
 
     # Figure Manager, Any type because matplotlib doesn't have typings
     figure_manager = new_figure_manager_given_figure(id(figure), figure)


### PR DESCRIPTION
When we are in a non-interactive environment (e.g. `marimo export html`), we fallback to a mime-renderer of png

Fixes #7816 (cc @AnirudhDagar)