### PR TITLE
feat: CLI update secure docker to python3.14

### DIFF
--- a/marimo/_cli/run_docker.py
+++ b/marimo/_cli/run_docker.py
@@ -130,7 +130,7 @@ def run_in_docker(
         sys.exit(1)
 
     # Define the container image and command
-    image = "ghcr.io/astral-sh/uv:0.4.21-python3.12-bookworm"
+    image = "ghcr.io/astral-sh/uv:0.9.25-python3.14-bookworm"
     container_command = [
         "uvx",
         "marimo",
@@ -160,7 +160,7 @@ def run_in_docker(
         "-e",
         "MARIMO_IN_SECURE_ENVIRONMENT=true",
         "-w",
-        "/app",
+        "/home",
         image,
     ] + container_command
 


### PR DESCRIPTION
## CLI: update secure docker to python3.14

Use uv:0.9.25-python3.14-bookworm image

Also /app does not exist, so use /home for work directory.

Fixes:

$ `marimo edit --sandbox https://molab.marimo.io/notebooks/nb_g6ygAQ8b1HMSaoszTGEGqy`
```This notebook is hosted on a remote server.
Would you like to run it in a secure docker container? [Y/n]: y 
Starting containerized marimo notebook
Running command: docker run --rm -d -p 8080:8080 -e MARIMO_MANAGE_SCRIPT_METADATA=true -e MARIMO_IN_SECURE_ENVIRONMENT=true -w /app ghcr.io/astral-sh/uv:0.4.21-python3.12-bookworm uvx marimo edit --sandbox --no-token -p 8080 --host 0.0.0.0 https://molab.marimo.io/notebooks/nb_g6ygAQ8b1HMSaoszTGEGqy Failed to start Docker container: Command '['docker', 'run', '--rm', '-d', '-p', '8080:8080', '-e', 'MARIMO_MANAGE_SCRIPT_METADATA=true', '-e', 'MARIMO_IN_SECURE_ENVIRONMENT=true', '-w', '/app', 'ghcr.io/astral-sh/uv:0.4.21-python3.12-bookworm', 'uvx', 'marimo', 'edit', '--sandbox', '--no-token', '-p', '8080', '--host', '0.0.0.0', 'https://molab.marimo.io/notebooks/nb_g6ygAQ8b1HMSaoszTGEGqy']' returned non-zero exit status 126. 
Stopping and removing container...
Container stopped and removed successfully
```

`Error: workdir "/app" does not exist on container...`

and

`error: No interpreter found for Python >=3.14 in virtual environments, managed installations, or system path`


## 📋 Checklist

- [x ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
