### PR TITLE
fix: pandas dataframe named index cells showing empty (#7942)

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -151,9 +151,15 @@ class PandasTableManagerFactory(TableManagerFactory):
                     )
 
                 # Flatten row multi-index
+                # Reset index if it's a MultiIndex or a named Index
+                # (including named RangeIndex, which pandas 3.0 uses for sequential integers)
+                # Only skip reset for unnamed default RangeIndex (0, 1, 2, ...)
                 if isinstance(result.index, pd.MultiIndex) or (
                     isinstance(result.index, pd.Index)
-                    and not isinstance(result.index, pd.RangeIndex)
+                    and not (
+                        isinstance(result.index, pd.RangeIndex)
+                        and result.index.name is None
+                    )
                 ):
                     index_names = result.index.names
                     unnamed_indexes = any(


### PR DESCRIPTION
Fixes an issue where pandas DataFrame index columns display empty cells in the marimo UI when using pandas 3.0+.

Fixes #7942

### Problem

In pandas 3.0, when setting a sequential integer column as an index (e.g., `df.set_index('Year')`), pandas optimizes it to a `RangeIndex` with a custom name instead of creating an `Int64Index` (pandas 2.x behavior).

The existing code in `pandas_table.py` excluded ALL `RangeIndex` instances from being reset to columns, including those with custom names. This caused the index values to be missing from the JSON output sent to the frontend, resulting in empty cells.

### Solution

Modified the condition in `to_json_str()` to only skip unnamed `RangeIndex` instances (the default 0,1,2,... index). Named `RangeIndex` instances are now properly reset to columns and included in the JSON output.