### PR TITLE
support ansi characters in pdf export

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -104,6 +104,7 @@ Best practices:
 - test edge cases
 - use descriptive names
 - group with `describe`
+- prefer complete assertions over individual property checks (e.g., `expect(result).toEqual(expected)` rather than checking each property separately)
 
 ### E2E Tests
 

--- a/marimo/AGENTS.md
+++ b/marimo/AGENTS.md
@@ -109,8 +109,10 @@ def k() -> Generator[Kernel, None, None]:
     yield mocked.k
     mocked.teardown()
 
-# Validate entire object state, not individual attributes
-assert obj == expected # instead of assert obj.attr == expected.attr
+# Prefer complete assertions over individual attribute checks
+# This catches unexpected changes and makes test failures more informative
+assert obj == expected  # GOOD: validates entire object state
+# assert obj.attr == expected.attr  # AVOID: misses other attributes that may have changed
 
 # Snapshot testing for complex outputs
 from tests.mocks import snapshotter


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
PDF exports now can support parsing ANSI logs.
<img width="614" height="371" alt="image" src="https://github.com/user-attachments/assets/f3aba476-5d9d-4b1e-982a-7e1d3099d342" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
