### PR TITLE
Speed up screenshots for auto-export

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -128,7 +128,7 @@ export function useNotebookActions() {
   const { selectedLayout } = useLayoutState();
   const { setLayoutView } = useLayoutActions();
   const togglePresenting = useTogglePresenting();
-  const takeScreenshots = useEnrichCellOutputs();
+  const takeScreenshots = useEnrichCellOutputs({});
 
   // Fallback: if sharing is undefined, both are enabled by default
   const sharingHtmlEnabled = resolvedConfig.sharing?.html ?? true;

--- a/frontend/src/utils/__tests__/download.test.tsx
+++ b/frontend/src/utils/__tests__/download.test.tsx
@@ -141,7 +141,9 @@ describe("getImageDataUrlForCell", () => {
   });
 
   it("should return undefined if element is not found", async () => {
-    const result = await getImageDataUrlForCell("nonexistent" as CellId);
+    const result = await getImageDataUrlForCell({
+      cellId: "nonexistent" as CellId,
+    });
 
     expect(result).toBeUndefined();
     expect(Logger.error).toHaveBeenCalledWith(
@@ -152,7 +154,7 @@ describe("getImageDataUrlForCell", () => {
   it("should capture screenshot and return data URL with highFidelity options", async () => {
     vi.mocked(toPng).mockResolvedValue(mockDataUrl);
 
-    const result = await getImageDataUrlForCell("cell-1" as CellId);
+    const result = await getImageDataUrlForCell({ cellId: "cell-1" as CellId });
 
     expect(result).toBe(mockDataUrl);
     expect(toPng).toHaveBeenCalledWith(mockElement, {
@@ -164,7 +166,10 @@ describe("getImageDataUrlForCell", () => {
   it("should capture screenshot without options when highFidelity is false", async () => {
     vi.mocked(toPng).mockResolvedValue(mockDataUrl);
 
-    const result = await getImageDataUrlForCell("cell-1" as CellId, false);
+    const result = await getImageDataUrlForCell({
+      cellId: "cell-1" as CellId,
+      highFidelity: false,
+    });
 
     expect(result).toBe(mockDataUrl);
     expect(toPng).toHaveBeenCalledWith(mockElement, {});
@@ -179,13 +184,19 @@ describe("getImageDataUrlForCell", () => {
       return mockDataUrl;
     });
 
-    await getImageDataUrlForCell("cell-1" as CellId, true);
+    await getImageDataUrlForCell({
+      cellId: "cell-1" as CellId,
+      highFidelity: true,
+    });
   });
 
   it("should remove printing classes after capture when highFidelity is true", async () => {
     vi.mocked(toPng).mockResolvedValue(mockDataUrl);
 
-    await getImageDataUrlForCell("cell-1" as CellId, true);
+    await getImageDataUrlForCell({
+      cellId: "cell-1" as CellId,
+      highFidelity: true,
+    });
 
     expect(mockElement.classList.contains("printing-output")).toBe(false);
     expect(document.body.classList.contains("printing")).toBe(false);
@@ -201,14 +212,20 @@ describe("getImageDataUrlForCell", () => {
       return mockDataUrl;
     });
 
-    await getImageDataUrlForCell("cell-1" as CellId, false);
+    await getImageDataUrlForCell({
+      cellId: "cell-1" as CellId,
+      highFidelity: false,
+    });
   });
 
   it("should cleanup printing-output when highFidelity is false", async () => {
     mockElement.style.overflow = "hidden";
     vi.mocked(toPng).mockResolvedValue(mockDataUrl);
 
-    await getImageDataUrlForCell("cell-1" as CellId, false);
+    await getImageDataUrlForCell({
+      cellId: "cell-1" as CellId,
+      highFidelity: false,
+    });
 
     expect(mockElement.classList.contains("printing-output")).toBe(false);
     expect(document.body.classList.contains("printing")).toBe(false);
@@ -219,7 +236,7 @@ describe("getImageDataUrlForCell", () => {
     mockElement.style.overflow = "hidden";
     vi.mocked(toPng).mockResolvedValue(mockDataUrl);
 
-    await getImageDataUrlForCell("cell-1" as CellId);
+    await getImageDataUrlForCell({ cellId: "cell-1" as CellId });
 
     expect(mockElement.style.overflow).toBe("hidden");
   });
@@ -227,16 +244,18 @@ describe("getImageDataUrlForCell", () => {
   it("should throw error on failure", async () => {
     vi.mocked(toPng).mockRejectedValue(new Error("Capture failed"));
 
-    await expect(getImageDataUrlForCell("cell-1" as CellId)).rejects.toThrow(
-      "Capture failed",
-    );
+    await expect(
+      getImageDataUrlForCell({ cellId: "cell-1" as CellId }),
+    ).rejects.toThrow("Capture failed");
   });
 
   it("should cleanup even on failure", async () => {
     mockElement.style.overflow = "scroll";
     vi.mocked(toPng).mockRejectedValue(new Error("Capture failed"));
 
-    await expect(getImageDataUrlForCell("cell-1" as CellId)).rejects.toThrow();
+    await expect(
+      getImageDataUrlForCell({ cellId: "cell-1" as CellId }),
+    ).rejects.toThrow();
 
     expect(mockElement.classList.contains("printing-output")).toBe(false);
     expect(document.body.classList.contains("printing")).toBe(false);
@@ -278,8 +297,14 @@ describe("getImageDataUrlForCell", () => {
     });
 
     // Start both captures concurrently with highFidelity = true
-    const capture1 = getImageDataUrlForCell("cell-1" as CellId, true);
-    const capture2 = getImageDataUrlForCell("cell-2" as CellId, true);
+    const capture1 = getImageDataUrlForCell({
+      cellId: "cell-1" as CellId,
+      highFidelity: true,
+    });
+    const capture2 = getImageDataUrlForCell({
+      cellId: "cell-2" as CellId,
+      highFidelity: true,
+    });
 
     // Let second capture complete first
     resolveSecond!();
@@ -314,8 +339,14 @@ describe("getImageDataUrlForCell", () => {
     });
 
     // Start both captures concurrently with highFidelity = false
-    const capture1 = getImageDataUrlForCell("cell-1" as CellId, false);
-    const capture2 = getImageDataUrlForCell("cell-2" as CellId, false);
+    const capture1 = getImageDataUrlForCell({
+      cellId: "cell-1" as CellId,
+      highFidelity: false,
+    });
+    const capture2 = getImageDataUrlForCell({
+      cellId: "cell-2" as CellId,
+      highFidelity: false,
+    });
 
     await Promise.all([capture1, capture2]);
 

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -99,10 +99,13 @@ interface toPngOptions {
  * @param highFidelity - When true, the screenshot will be taken with high fidelity. This is slower but will produce better results.
  * @returns The PNG as a data URL, or undefined if the cell element wasn't found
  */
-export async function getImageDataUrlForCell(
-  cellId: CellId,
+export async function getImageDataUrlForCell({
+  cellId,
   highFidelity = true,
-): Promise<string | undefined> {
+}: {
+  cellId: CellId;
+  highFidelity?: boolean;
+}): Promise<string | undefined> {
   const element = findElementForCell(cellId);
   if (!element) {
     return;


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
imageToPng can take some time (>500ms), this adds a parameter to speed it up for auto-export.
This isn't foolproof.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
