### PR TITLE
feat: add plotly scattermap/scattermapbox point selection support

### DIFF
--- a/marimo/_smoke_tests/plotly/scattermap_selection.py
+++ b/marimo/_smoke_tests/plotly/scattermap_selection.py
@@ -1,0 +1,64 @@
+import marimo
+
+__generated_with = "0.19.5"
+app = marimo.App(width="medium", auto_download=["html"])
+
+with app.setup:
+    import marimo as mo
+    import pandas as pd
+    import plotly.graph_objects as go
+
+
+@app.cell
+def _():
+    df_mock = pd.DataFrame(
+        {
+            "id": ["WC_0001", "WC_0002", "WC_0003", "WC_0004", "WC_0005"],
+            "Region": ["WC", "WC", "WC", "WC", "WC"],
+            "lon": [18.42, 18.46, 18.50, 18.54, 18.58],
+            "lat": [-33.93, -33.95, -33.91, -33.97, -33.89],
+            "cluster": [0, 1, 0, 2, 1],
+        }
+    )
+
+    figg = go.Figure()
+
+    figg.add_trace(
+        go.Scattermap(
+            lon=df_mock["lon"],
+            lat=df_mock["lat"],
+            mode="markers",
+            marker=dict(size=12, color="red", opacity=0.9),
+            customdata=df_mock[["id", "cluster"]].values,
+            hovertemplate=(
+                "<b>%{customdata[0]}</b><br>"
+                "cluster: %{customdata[1]}<br>"
+                "<extra></extra>"
+            ),
+            name="Mock sites",
+        )
+    )
+
+    figg.update_layout(
+        dragmode="lasso",
+        map=dict(
+            style="open-street-map",
+            zoom=10,
+            center=dict(lat=df_mock["lat"].mean(), lon=df_mock["lon"].mean()),
+        ),
+        margin=dict(l=0, r=0, t=0, b=0),
+    )
+
+    plot = mo.ui.plotly(figg)
+    plot
+    return (plot,)
+
+
+@app.cell
+def _(plot):
+    plot.value
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary

Add support for point selection on Plotly map-based scatter traces:
- `go.Scattermap()` (current recommended trace type)
- `go.Scattermapbox()` (deprecated but still used)
- `go.Scattergeo()` (geographic scatter plots)

Previously, selecting points on these map traces would not return any values in `plot.value` because the backend only handled `scatter`, `heatmap`, and `bar` trace types.

Closes #7970
