### PR TITLE
Add Minimap/Graph toggle to dependencies panel in developer panel

### DIFF
--- a/frontend/src/components/editor/chrome/panels/dependency-graph-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/dependency-graph-panel.tsx
@@ -7,8 +7,8 @@ import { useVariables } from "@/core/variables/state";
 import { cn } from "@/utils/cn";
 import { DependencyGraph } from "../../../dependency-graph/dependency-graph";
 import { MinimapContent } from "../../../dependency-graph/minimap-content";
-import { usePanelSection } from "./panel-context";
 import { useDependencyPanelTab } from "../wrapper/useDependencyPanelTab";
+import { usePanelSection } from "./panel-context";
 
 const DependencyGraphPanel: React.FC = () => {
   const { dependencyPanelTab, setDependencyPanelTab } = useDependencyPanelTab();


### PR DESCRIPTION
The dependencies panel supports two views (Minimap and Graph) but only the sidebar had the toggle to switch between them. When the panel was moved to the developer panel (bottom drawer), users had no way to change views.

These changes add an inline toggle directly within the panel content when it's rendered in the developer panel. The toggle uses the existing `usePanelSection` context to detect the panel location and only renders when in the developer panel, since the sidebar already has the toggle in its header.

<img width="700" alt="Screenshot 2026-01-26 at 12 23 19 PM" src="https://github.com/user-attachments/assets/45169c9c-1cd1-40fd-8881-80edd46c0199" />

