### PR TITLE
improvement: dont set --compile-bytecode for uv installation

### DIFF
--- a/marimo/_runtime/packages/package_manager.py
+++ b/marimo/_runtime/packages/package_manager.py
@@ -136,6 +136,8 @@ class PackageManager(abc.ABC):
         if not self.is_manager_installed():
             return False
 
+        LOGGER.info(f"Running command: {command}")
+
         if log_callback is None:
             # Original behavior - just run the command without capturing output
             completed_process = subprocess.run(command)

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -272,8 +272,8 @@ class UvPackageManager(PypiPackageManager):
             install_cmd.append("--upgrade")
 
         return install_cmd + [
-            # trade installation time for faster start time
-            "--compile",
+            # we don't set --compile-bytecode or --no-compile-bytecode because we want
+            # to respect the user's env (e.g. UV_COMPILE_BYTECODE)
             *split_packages(package),
             "-p",
             PY_EXE,
@@ -303,6 +303,8 @@ class UvPackageManager(PypiPackageManager):
 
         # For uv pip install, try with output capture to enable fallback
         cmd = self.install_command(package, upgrade=upgrade, dev=dev)
+
+        LOGGER.info(f"Running command: {cmd}")
 
         # Run the command and capture output
         proc = subprocess.Popen(  # noqa: ASYNC220

--- a/tests/_runtime/packages/test_package_managers.py
+++ b/tests/_runtime/packages/test_package_managers.py
@@ -328,7 +328,7 @@ async def test_uv_pip_install() -> None:
         await pm._install("foo", upgrade=False, dev=False)
 
         assert runs_calls == [
-            ["uv", "pip", "install", "--compile", "foo", "-p", PY_EXE],
+            ["uv", "pip", "install", "foo", "-p", PY_EXE],
         ]
 
 

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -308,7 +308,6 @@ async def test_uv_install_not_in_project(mock_popen: MagicMock):
             "uv",
             "pip",
             "install",
-            "--compile",
             "package1",
             "package2",
             "-p",
@@ -346,7 +345,6 @@ async def test_uv_install_not_in_project_with_target(mock_popen: MagicMock):
             "pip",
             "install",
             "--target=target_path",
-            "--compile",
             "package1",
             "package2",
             "-p",
@@ -370,7 +368,7 @@ async def test_uv_install_in_project(mock_run: MagicMock):
     result = await mgr._install("package1 package2", upgrade=False, dev=False)
 
     mock_run.assert_called_once_with(
-        ["uv", "add", "--compile", "package1", "package2", "-p", PY_EXE],
+        ["uv", "add", "package1", "package2", "-p", PY_EXE],
     )
     assert result is True
 
@@ -389,7 +387,6 @@ async def test_uv_install_dev_dependency_in_project(mock_run: MagicMock):
             "uv",
             "add",
             "--dev",
-            "--compile",
             "package1",
             "package2",
             "-p",
@@ -742,7 +739,6 @@ async def test_uv_install_cache_error_fallback(
             "uv",
             "pip",
             "install",
-            "--compile",
             "datamapplot",
             "-p",
             PY_EXE,
@@ -759,7 +755,6 @@ async def test_uv_install_cache_error_fallback(
             "uv",
             "pip",
             "install",
-            "--compile",
             "datamapplot",
             "-p",
             PY_EXE,
@@ -811,7 +806,7 @@ async def test_uv_install_in_project_no_fallback(mock_run: MagicMock):
 
     # Should only call run once (no fallback for project mode)
     mock_run.assert_called_once_with(
-        ["uv", "add", "--compile", "package1", "-p", PY_EXE],
+        ["uv", "add", "package1", "-p", PY_EXE],
     )
 
     # Should fail without retry


### PR DESCRIPTION
Compiling byte code won't take advantage of lazy imports from packages. For the code path of installing a missing package, we want to get back to executing the code. 

There may be some edge cases where this is slower, but running marimo and progressively showing updates will almost always be better.