### PR TITLE
Ensure logs are scrollable in developer panel

### DIFF
--- a/frontend/src/components/editor/chrome/panels/logs-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/logs-panel.tsx
@@ -35,14 +35,12 @@ const LogsPanel: React.FC = () => {
   }
 
   return (
-    <>
+    <div className="flex flex-col h-full overflow-auto">
       <div className="flex flex-row justify-start px-2 py-1">
         <ClearButton dataTestId="clear-logs-button" onClick={clearLogs} />
       </div>
-      <div className="overflow-auto flex-1">
-        <LogViewer logs={logs} className="min-w-[300px]" />
-      </div>
-    </>
+      <LogViewer logs={logs} className="min-w-[300px]" />
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixes #7992

The logs panel was using a React fragment as its root element, which prevented the flex layout and overflow styles from working correctly when rendered in the developer panel. This replaces the fragment with a flex column container, matching the pattern used by other scrollable panels in the codebase.