### PR TITLE
fix: save content when creating a new file via filename input

### DIFF
--- a/frontend/src/components/editor/header/filename-form.tsx
+++ b/frontend/src/components/editor/header/filename-form.tsx
@@ -3,6 +3,7 @@
 import type { JSX } from "react";
 import { FilenameInput } from "@/components/editor/header/filename-input";
 import { useUpdateFilename } from "@/core/saving/filename";
+import { useSaveNotebook } from "@/core/saving/save-component";
 import { Paths } from "@/utils/paths";
 
 export const FilenameForm = ({
@@ -10,14 +11,26 @@ export const FilenameForm = ({
 }: {
   filename: string | null;
 }): JSX.Element => {
-  const setFilename = useUpdateFilename();
+  const updateFilename = useUpdateFilename();
+  const { saveNotebook } = useSaveNotebook();
+
+  const handleNameChange = (newFilename: string) => {
+    const wasUnnamed = filename === null;
+    updateFilename(newFilename).then((name) => {
+      // When creating a new file (was unnamed), also save the content
+      if (name !== null && wasUnnamed) {
+        saveNotebook(name, true);
+      }
+    });
+  };
+
   return (
     <FilenameInput
       placeholderText={
         filename ? Paths.basename(filename) : "untitled marimo notebook"
       }
       initialValue={filename}
-      onNameChange={setFilename}
+      onNameChange={handleNameChange}
       flexibleWidth={true}
       resetOnBlur={true}
       data-testid="filename-input"

--- a/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
@@ -109,6 +109,7 @@ const renderWithProvider = <T>(hook: () => T) => {
 // Shared mock setup
 const mockSaveOrNameNotebook = vi.fn();
 const mockSaveIfNotebookIsPersistent = vi.fn();
+const mockSaveNotebook = vi.fn();
 const mockRunCell = vi.fn();
 const mockCopyCell = vi.fn();
 const mockPasteCell = vi.fn();
@@ -156,6 +157,7 @@ describe("useCellNavigationProps", () => {
     mockUseSaveNotebook.mockReturnValue({
       saveOrNameNotebook: mockSaveOrNameNotebook,
       saveIfNotebookIsPersistent: mockSaveIfNotebookIsPersistent,
+      saveNotebook: mockSaveNotebook,
     });
     mockUseCellActions.mockReturnValue(
       mockCellActions as unknown as CellActions,

--- a/frontend/src/core/saving/save-component.tsx
+++ b/frontend/src/core/saving/save-component.tsx
@@ -190,6 +190,7 @@ export function useSaveNotebook() {
   return {
     saveOrNameNotebook,
     saveIfNotebookIsPersistent,
+    saveNotebook,
   };
 }
 


### PR DESCRIPTION
When creating a new notebook and naming it via the filename input in the
header, the file was created empty because only the rename operation
was performed. The cell content required a separate save action (Ctrl+S).

This change modifies `FilenameForm` to also save the notebook content
after renaming, when the notebook was previously unnamed. This matches
the behavior of the Save dialog (Ctrl+S on unnamed notebooks).

Closes #7981
