### PR TITLE
feat: add cut cells command (#7423)

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -53,6 +53,7 @@ import {
   canUndoDeletesAtom,
   getNotebook,
   hasDisabledCellsAtom,
+  undoLabelAtom,
   useCellActions,
 } from "@/core/cells/cells";
 import { disabledCellIds } from "@/core/cells/utils";
@@ -137,6 +138,7 @@ export function useNotebookActions() {
 
   const hasDisabledCells = useAtomValue(hasDisabledCellsAtom);
   const canUndoDeletes = useAtomValue(canUndoDeletesAtom);
+  const undoLabel = useAtomValue(undoLabelAtom);
   const { selectedLayout } = useLayoutState();
   const { setLayoutView } = useLayoutActions();
   const togglePresenting = useTogglePresenting();
@@ -512,7 +514,7 @@ export function useNotebookActions() {
     },
     {
       icon: <Undo2Icon size={14} strokeWidth={1.5} />,
-      label: "Undo cell deletion",
+      label: undoLabel,
       hidden: !canUndoDeletes || kioskMode,
       handle: () => {
         undoDeleteCell();

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -270,6 +270,7 @@ const CellEditorInternal = ({
     userConfig.language_servers,
     userConfig.display,
     userConfig.diagnostics,
+    userConfig.ai?.inline_tooltip,
     aiEnabled,
     theme,
     showPlaceholder,

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -270,7 +270,6 @@ const CellEditorInternal = ({
     userConfig.language_servers,
     userConfig.display,
     userConfig.diagnostics,
-    userConfig.ai?.inline_tooltip,
     aiEnabled,
     theme,
     showPlaceholder,

--- a/frontend/src/components/editor/controls/Controls.tsx
+++ b/frontend/src/components/editor/controls/Controls.tsx
@@ -27,6 +27,7 @@ import { Functions } from "@/utils/functions";
 import {
   canUndoDeletesAtom,
   needsRunAtom,
+  undoLabelAtom,
   useCellActions,
 } from "../../../core/cells/cells";
 import { ConfigButton } from "../../app-config/app-config-button";
@@ -56,6 +57,7 @@ export const Controls = ({
   running,
 }: ControlsProps): JSX.Element => {
   const undoAvailable = useAtomValue(canUndoDeletesAtom);
+  const undoLabel = useAtomValue(undoLabelAtom);
   const needsRun = useAtomValue(needsRunAtom);
   const { undoDeleteCell } = useCellActions();
   const closed = connectionState === WebSocketState.CLOSED;
@@ -63,7 +65,7 @@ export const Controls = ({
   let undoControl: JSX.Element | null = null;
   if (!closed && undoAvailable) {
     undoControl = (
-      <Tooltip content="Undo cell deletion">
+      <Tooltip content={undoLabel}>
         <Button
           data-testid="undo-delete-cell"
           size="medium"

--- a/frontend/src/components/editor/navigation/__tests__/clipboard.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/clipboard.test.ts
@@ -20,6 +20,18 @@ vi.mock("@/utils/Logger", () => ({
   Logger: Mocks.quietLogger(),
 }));
 
+const mockClearPendingCut = vi.hoisted(() => vi.fn());
+vi.mock("@/core/cells/pending-cut-service", () => ({
+  usePendingCutActions: () => ({
+    markForCut: vi.fn(),
+    clear: mockClearPendingCut,
+  }),
+  usePendingCutState: () => ({
+    cellIds: new Set(),
+    clipboardData: null,
+  }),
+}));
+
 import { MockNotebook } from "@/__mocks__/notebook";
 import { toast } from "@/components/ui/use-toast";
 import { getNotebook, useCellActions } from "@/core/cells/cells";
@@ -197,6 +209,101 @@ describe("useCellClipboard", () => {
         title: "Cell copied",
         description: "Cell has been copied to clipboard.",
       });
+    });
+
+    it("should clear pending cut when copy succeeds", async () => {
+      const { result } = renderHook(() => useCellClipboard());
+
+      await act(async () => {
+        await result.current.copyCells([mockCellId1]);
+      });
+
+      expect(mockClearPendingCut).toHaveBeenCalled();
+    });
+
+    it("should clear pending cut when copy falls back to writeText", async () => {
+      mockClipboard.write.mockRejectedValue(new Error("Write failed"));
+      mockClipboard.writeText.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useCellClipboard());
+
+      await act(async () => {
+        await result.current.copyCells([mockCellId1]);
+      });
+
+      expect(mockClearPendingCut).toHaveBeenCalled();
+    });
+  });
+
+  describe("cutCells", () => {
+    it("should cut single cell to clipboard with custom mimetype and plain text", async () => {
+      const { result } = renderHook(() => useCellClipboard());
+
+      await act(async () => {
+        await result.current.cutCells([mockCellId1]);
+      });
+
+      expect(mockClipboard.write).toHaveBeenCalledWith([
+        expect.objectContaining({
+          types: ["web application/x-marimo-cell", "text/plain"],
+        }),
+      ]);
+    });
+
+    it("should cut multiple cells to clipboard with custom mimetype and plain text", async () => {
+      const { result } = renderHook(() => useCellClipboard());
+
+      await act(async () => {
+        await result.current.cutCells([mockCellId1, mockCellId2]);
+      });
+
+      expect(mockClipboard.write).toHaveBeenCalledWith([
+        expect.objectContaining({
+          types: ["web application/x-marimo-cell", "text/plain"],
+        }),
+      ]);
+    });
+
+    it("should not write when no cells found", async () => {
+      asMock(getNotebook).mockReturnValue(MockNotebook.notebookState());
+
+      const { result } = renderHook(() => useCellClipboard());
+
+      await act(async () => {
+        await result.current.cutCells([mockCellId1]);
+      });
+
+      expect(mockClipboard.write).not.toHaveBeenCalled();
+    });
+
+    it("should fallback to writeText when clipboard.write fails", async () => {
+      mockClipboard.write.mockRejectedValue(new Error("Write failed"));
+      mockClipboard.writeText.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useCellClipboard());
+
+      await act(async () => {
+        await result.current.cutCells([mockCellId1]);
+      });
+
+      expect(mockClipboard.write).toHaveBeenCalled();
+      expect(mockClipboard.writeText).toHaveBeenCalledWith(mockCellCode1);
+    });
+
+    it("should show error toast when both clipboard methods fail", async () => {
+      mockClipboard.write.mockRejectedValue(new Error("Write failed"));
+      mockClipboard.writeText.mockRejectedValue(new Error("WriteText failed"));
+
+      const { result } = renderHook(() => useCellClipboard());
+
+      await act(async () => {
+        await result.current.cutCells([mockCellId1]);
+      });
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        "Failed to cut cells to clipboard",
+        expect.any(Error),
+      );
     });
   });
 

--- a/frontend/src/components/editor/navigation/clipboard.ts
+++ b/frontend/src/components/editor/navigation/clipboard.ts
@@ -5,15 +5,22 @@ import { z } from "zod";
 import { toast } from "@/components/ui/use-toast";
 import { getNotebook, useCellActions } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
+import {
+  usePendingCutActions,
+  usePendingCutState,
+} from "@/core/cells/pending-cut-service";
+import type { CellConfig } from "@/core/network/types";
 import { copyToClipboard } from "@/utils/copy";
 import { Logger } from "@/utils/Logger";
 
 // According to MDN, custom mimetypes should start with "web "
 const MARIMO_CELL_MIMETYPE = "web application/x-marimo-cell";
 
-interface ClipboardCellData {
+export interface ClipboardCellData {
   cells: {
     code: string;
+    name?: string;
+    config?: CellConfig;
   }[];
   version: "1.0";
 }
@@ -22,19 +29,49 @@ const ClipboardCellDataSchema = z.object({
   cells: z.array(
     z.object({
       code: z.string(),
+      name: z.string().optional(),
+      config: z
+        .object({
+          column: z.union([z.number(), z.null()]).optional(),
+          disabled: z.boolean().optional(),
+          hide_code: z.boolean().optional(),
+        })
+        .optional(),
     }),
   ),
   version: z.literal("1.0"),
 });
 
-// NOTE: We don't support Cut yet. We can wait for feedback before implementing.
-// It is a bit more complex as will need to:
-// - include id, outputs, and name
-// - delete the existing cell, but don't place on the undo stack
-// - don't want to invalidate downstream cells
+function buildClipboardPayload(
+  cells: Array<{ code: string; name?: string; config?: CellConfig }>,
+): { clipboardData: ClipboardCellData; plainText: string } {
+  const clipboardData: ClipboardCellData = {
+    cells: cells.map((cell) => ({
+      code: cell.code,
+      name: cell.name,
+      config: cell.config,
+    })),
+    version: "1.0",
+  };
+  const plainText = cells.map((cell) => cell.code).join("\n\n");
+  return { clipboardData, plainText };
+}
+
+async function writeCellsToClipboard(
+  clipboardData: ClipboardCellData,
+  plainText: string,
+): Promise<void> {
+  const clipboardItem = new ClipboardItemBuilder()
+    .add(MARIMO_CELL_MIMETYPE, clipboardData)
+    .add("text/plain", plainText)
+    .build();
+  await navigator.clipboard.write([clipboardItem]);
+}
 
 export function useCellClipboard() {
   const actions = useCellActions();
+  const pendingCutActions = usePendingCutActions();
+  const pendingCutState = usePendingCutState();
 
   const copyCells = useEvent(async (cellIds: CellId[]) => {
     const notebook = getNotebook();
@@ -47,32 +84,47 @@ export function useCellClipboard() {
       return;
     }
 
+    const { clipboardData, plainText } = buildClipboardPayload(cells);
+
     try {
-      const clipboardData: ClipboardCellData = {
-        cells: cells.map((cell) => ({ code: cell.code })),
-        version: "1.0",
-      };
-
-      // Create plain text representation (joined by newlines)
-      const plainText = cells.map((cell) => cell.code).join("\n\n");
-
-      // Create clipboard item with both custom mimetype and plain text
-      const clipboardItem = new ClipboardItemBuilder()
-        .add(MARIMO_CELL_MIMETYPE, clipboardData)
-        .add("text/plain", plainText)
-        .build();
-
-      await navigator.clipboard.write([clipboardItem]);
-
+      await writeCellsToClipboard(clipboardData, plainText);
+      pendingCutActions.clear();
       toastSuccess(cells.length);
     } catch (error) {
       Logger.error("Failed to copy cells to clipboard", error);
 
       // Fallback to simple text copy
       try {
-        const plainText = cells.map((cell) => cell.code).join("\n\n");
         await copyToClipboard(plainText);
+        pendingCutActions.clear();
         toastSuccess(cells.length);
+      } catch {
+        toastError();
+      }
+    }
+  });
+
+  const cutCells = useEvent(async (cellIds: CellId[]) => {
+    const notebook = getNotebook();
+    const validCellIds = cellIds.filter((cellId) => notebook.cellData[cellId]);
+    const cells = validCellIds.map((cellId) => notebook.cellData[cellId]);
+
+    if (cells.length === 0) {
+      // No cells to cut
+      return;
+    }
+
+    const { clipboardData, plainText } = buildClipboardPayload(cells);
+
+    try {
+      await writeCellsToClipboard(clipboardData, plainText);
+      pendingCutActions.markForCut({ cellIds: validCellIds, clipboardData });
+    } catch (error) {
+      Logger.error("Failed to cut cells to clipboard", error);
+      try {
+        await copyToClipboard(plainText);
+        // Mark cells as pending cut instead of deleting immediately
+        pendingCutActions.markForCut({ cellIds: validCellIds, clipboardData });
       } catch {
         toastError();
       }
@@ -85,6 +137,27 @@ export function useCellClipboard() {
 
   const pasteAtCell = useEvent(async (cellId: CellId, opts?: PasteOptions) => {
     const { before = false } = opts ?? {};
+
+    // Check if we have pending cut cells (internal move)
+    if (pendingCutState.cellIds.size > 0) {
+      const pendingCellIds = [...pendingCutState.cellIds];
+      const notebook = getNotebook();
+      const previousPlacements = pendingCellIds.map((id) => {
+        const column = notebook.cellIds.findWithId(id);
+        return { columnId: column.id, index: column.indexOfOrThrow(id) };
+      });
+
+      actions.moveCellsRelativeTo({
+        cellIds: pendingCellIds,
+        targetCellId: cellId,
+        position: before ? "before" : "after",
+        previousPlacements,
+      });
+
+      pendingCutActions.clear();
+      return;
+    }
+
     try {
       const clipboardItems = await navigator.clipboard.read();
 
@@ -112,6 +185,9 @@ export function useCellClipboard() {
                 cellId: currentCellId,
                 before,
                 code: cell.code,
+                name: cell.name,
+                config: cell.config,
+                hideCode: cell.config?.hide_code,
                 autoFocus: true,
               });
             }
@@ -143,7 +219,9 @@ export function useCellClipboard() {
 
   return {
     copyCells,
+    cutCells,
     pasteAtCell,
+    clearPendingCut: pendingCutActions.clear,
   };
 }
 

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -27,6 +27,7 @@ import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
 import { aiCompletionCellAtom } from "@/core/ai/state";
 import { outputIsLoading, outputIsStale } from "@/core/cells/cell";
 import { isOutputEmpty } from "@/core/cells/outputs";
+import { useIsPendingCut } from "@/core/cells/pending-cut-service";
 import { autocompletionKeymap } from "@/core/codemirror/cm";
 import type { LanguageAdapterType } from "@/core/codemirror/language/types";
 import { CSSClasses } from "@/core/constants";
@@ -387,6 +388,7 @@ const EditableCellComponent = ({
   const deleteCell = useDeleteCellCallback();
   const runCell = useRunCell(cellId);
   const { sendStdin } = useRequestClient();
+  const isPendingCut = useIsPendingCut(cellId);
 
   const [languageAdapter, setLanguageAdapter] = useState<LanguageAdapterType>();
 
@@ -539,6 +541,7 @@ const EditableCellComponent = ({
     stale: cellRuntime.status === "disabled-transitively",
     borderless:
       isMarkdownCodeHidden && hasOutput && !navigationProps["data-selected"],
+    "pending-cut": isPendingCut,
   });
 
   const handleRefactorWithAI: OnRefactorWithAI = useEvent(

--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -209,6 +209,20 @@ describe("cell reducer", () => {
     `);
   });
 
+  it("can add a cell with name and config", () => {
+    actions.createNewCell({
+      cellId: firstCellId,
+      before: false,
+      code: "x = 1",
+      name: "My Cell",
+      config: { hide_code: true, disabled: false },
+    });
+    const newCellId = state.cellIds.inOrderIds[1];
+    expect(state.cellData[newCellId].name).toBe("My Cell");
+    expect(state.cellData[newCellId].config.hide_code).toBe(true);
+    expect(state.cellData[newCellId].config.disabled).toBe(false);
+  });
+
   it("can delete a Python cell and undo delete", () => {
     actions.createNewCell({
       cellId: firstCellId,
@@ -597,6 +611,179 @@ describe("cell reducer", () => {
     });
 
     expect(formatCells(state)).toBe(before);
+  });
+
+  it("can move multiple cells relative to target", () => {
+    actions.createNewCell({
+      cellId: firstCellId,
+      before: false,
+    });
+    actions.createNewCell({
+      cellId: "1" as CellId,
+      before: false,
+    });
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [0] ''
+
+      [1] ''
+
+      [2] ''
+      "
+    `);
+
+    // Move first two cells after the third
+    actions.moveCellsRelativeTo({
+      cellIds: [firstCellId, "1" as CellId],
+      targetCellId: "2" as CellId,
+      position: "after",
+    });
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [2] ''
+
+      [0] ''
+
+      [1] ''
+      "
+    `);
+  });
+
+  it("can undo cut-paste (move with previousPlacements)", () => {
+    actions.createNewCell({
+      cellId: firstCellId,
+      before: false,
+    });
+    actions.createNewCell({
+      cellId: "1" as CellId,
+      before: false,
+    });
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [0] ''
+
+      [1] ''
+
+      [2] ''
+      "
+    `);
+
+    const col = state.cellIds.findWithId(firstCellId);
+    const previousPlacements = [
+      {
+        columnId: col.id,
+        index: col.indexOfOrThrow(
+          firstCellId,
+        ) as import("@/utils/id-tree").CellIndex,
+      },
+      {
+        columnId: col.id,
+        index: col.indexOfOrThrow(
+          "1" as CellId,
+        ) as import("@/utils/id-tree").CellIndex,
+      },
+    ];
+
+    actions.moveCellsRelativeTo({
+      cellIds: [firstCellId, "1" as CellId],
+      targetCellId: "2" as CellId,
+      position: "after",
+      previousPlacements,
+    });
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [2] ''
+
+      [0] ''
+
+      [1] ''
+      "
+    `);
+
+    actions.undoDeleteCell();
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [0] ''
+
+      [1] ''
+
+      [2] ''
+      "
+    `);
+  });
+
+  it("undo order: cut-paste then delete — first undo restores delete, second undo undoes move", () => {
+    actions.createNewCell({
+      cellId: firstCellId,
+      before: false,
+    });
+    actions.createNewCell({
+      cellId: "1" as CellId,
+      before: false,
+    });
+
+    const col = state.cellIds.findWithId(firstCellId);
+    const previousPlacements = [
+      {
+        columnId: col.id,
+        index: col.indexOfOrThrow(
+          firstCellId,
+        ) as import("@/utils/id-tree").CellIndex,
+      },
+      {
+        columnId: col.id,
+        index: col.indexOfOrThrow(
+          "1" as CellId,
+        ) as import("@/utils/id-tree").CellIndex,
+      },
+    ];
+
+    actions.moveCellsRelativeTo({
+      cellIds: [firstCellId, "1" as CellId],
+      targetCellId: "2" as CellId,
+      position: "after",
+      previousPlacements,
+    });
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [2] ''
+
+      [0] ''
+
+      [1] ''
+      "
+    `);
+
+    actions.deleteCell({ cellId: "2" as CellId });
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [0] ''
+
+      [1] ''
+      "
+    `);
+
+    actions.undoDeleteCell();
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [3] ''
+
+      [0] ''
+
+      [1] ''
+      "
+    `);
+
+    actions.undoDeleteCell();
+    expect(formatCells(state)).toMatchInlineSnapshot(`
+      "
+      [0] ''
+
+      [1] ''
+
+      [3] ''
+      "
+    `);
   });
 
   it("can run cell and receive cell messages", () => {

--- a/frontend/src/core/cells/__tests__/pending-cut-service.test.tsx
+++ b/frontend/src/core/cells/__tests__/pending-cut-service.test.tsx
@@ -1,0 +1,145 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { act, renderHook } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import { describe, expect, it } from "vitest";
+import type { CellId } from "@/core/cells/ids";
+import {
+  pendingCutStateAtom,
+  useHasPendingCut,
+  useIsPendingCut,
+  usePendingCutActions,
+  usePendingCutState,
+} from "../pending-cut-service";
+
+function createTestWrapper() {
+  const store = createStore();
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return { wrapper, store };
+}
+
+const mockClipboardData = {
+  cells: [{ code: "x = 1", name: "cell1" }],
+  version: "1.0" as const,
+};
+
+describe("pending-cut-service", () => {
+  it("markForCut sets cellIds and clipboardData", () => {
+    const { wrapper, store } = createTestWrapper();
+    const cellIds: CellId[] = ["cell-1" as CellId, "cell-2" as CellId];
+
+    const { result } = renderHook(
+      () => ({
+        actions: usePendingCutActions(),
+        state: usePendingCutState(),
+      }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.actions.markForCut({
+        cellIds,
+        clipboardData: mockClipboardData,
+      });
+    });
+
+    const state = store.get(pendingCutStateAtom);
+    expect(state.cellIds).toEqual(new Set(cellIds));
+    expect(state.clipboardData).toEqual(mockClipboardData);
+  });
+
+  it("clear resets to initial state", () => {
+    const { wrapper, store } = createTestWrapper();
+    const cellIds: CellId[] = ["cell-1" as CellId];
+
+    const { result } = renderHook(
+      () => ({
+        actions: usePendingCutActions(),
+        state: usePendingCutState(),
+      }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.actions.markForCut({
+        cellIds,
+        clipboardData: mockClipboardData,
+      });
+    });
+    expect(store.get(pendingCutStateAtom).cellIds.size).toBe(1);
+
+    act(() => {
+      result.current.actions.clear();
+    });
+    const state = store.get(pendingCutStateAtom);
+    expect(state.cellIds.size).toBe(0);
+    expect(state.clipboardData).toBeNull();
+  });
+
+  it("useIsPendingCut returns true when cellId is marked for cut", () => {
+    const { wrapper } = createTestWrapper();
+    const cellId = "cell-1" as CellId;
+
+    const { result: actionsResult } = renderHook(() => usePendingCutActions(), {
+      wrapper,
+    });
+    const { result: isPendingResult } = renderHook(
+      () => useIsPendingCut(cellId),
+      { wrapper },
+    );
+
+    expect(isPendingResult.current).toBe(false);
+
+    act(() => {
+      actionsResult.current.markForCut({
+        cellIds: [cellId],
+        clipboardData: mockClipboardData,
+      });
+    });
+
+    expect(isPendingResult.current).toBe(true);
+  });
+
+  it("useIsPendingCut returns false when cellId is not marked for cut", () => {
+    const { wrapper } = createTestWrapper();
+    const { result } = renderHook(
+      () => useIsPendingCut("other-cell" as CellId),
+      { wrapper },
+    );
+
+    const { result: actionsResult } = renderHook(() => usePendingCutActions(), {
+      wrapper,
+    });
+    act(() => {
+      actionsResult.current.markForCut({
+        cellIds: ["cell-1" as CellId],
+        clipboardData: mockClipboardData,
+      });
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("useHasPendingCut returns true when any cells are marked for cut", () => {
+    const { wrapper } = createTestWrapper();
+    const { result: hasPendingResult } = renderHook(() => useHasPendingCut(), {
+      wrapper,
+    });
+    const { result: actionsResult } = renderHook(() => usePendingCutActions(), {
+      wrapper,
+    });
+
+    expect(hasPendingResult.current).toBe(false);
+
+    act(() => {
+      actionsResult.current.markForCut({
+        cellIds: ["cell-1" as CellId],
+        clipboardData: mockClipboardData,
+      });
+    });
+
+    expect(hasPendingResult.current).toBe(true);
+  });
+});

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -259,7 +259,7 @@ const {
           lastCodeRun,
           config: createCellConfig({
             ...config,
-            hide_code: hideCode ?? config?.hide_code,
+            ...(hideCode != null && { hide_code: hideCode }),
           }),
           lastExecutionTime,
           edited: Boolean(code) && code !== lastCodeRun,
@@ -872,7 +872,7 @@ const {
       cellReducer: (cell) => {
         return {
           ...cell,
-          config: { ...cell.config, ...config },
+          config: createCellConfig({ ...cell.config, ...config }),
         };
       },
     });

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -739,7 +739,11 @@ const {
 
     if (last.type === "move") {
       const { cellIds, placements } = last;
-      if (cellIds.length === 0 || placements.length !== cellIds.length) {
+      if (
+        cellIds.length === 0 ||
+        placements.length !== cellIds.length ||
+        cellIds.some((id) => !state.cellData[id])
+      ) {
         return { ...state, history: state.history.slice(0, -1) };
       }
       const toRestore = cellIds.map((id, i) => ({

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -23,6 +23,7 @@ import {
   splitEditor,
   updateEditorCodeFromPython,
 } from "../codemirror/language/utils";
+import type { SerializedEditorState } from "../codemirror/types";
 import { findCollapseRange, mergeOutlines } from "../dom/outline";
 import type { CellMessage } from "../kernel/messages";
 import { isErrorMime } from "../mime";
@@ -49,10 +50,35 @@ import {
   canUndoDeletes,
   disabledCellIds,
   enabledCellIds,
+  getUndoLabel,
   notebookIsRunning,
   notebookNeedsRun,
   notebookQueueOrRunningCount,
 } from "./utils";
+
+/**
+ * History entry for undoing a cell deletion.
+ */
+export interface UndoDeleteEntry {
+  type: "delete";
+  name: string;
+  serializedEditorState: SerializedEditorState;
+  column: CellColumnId;
+  index: CellIndex;
+  isSetupCell: boolean;
+  config: CellConfig;
+}
+
+/**
+ * History entry for undoing a cut-paste (move).
+ */
+export interface UndoMoveEntry {
+  type: "move";
+  cellIds: CellId[];
+  placements: Array<{ columnId: CellColumnId; index: CellIndex }>;
+}
+
+export type HistoryEntry = UndoDeleteEntry | UndoMoveEntry;
 
 /**
  * The state of the notebook.
@@ -75,19 +101,9 @@ export interface NotebookState {
    */
   cellHandles: Record<CellId, React.RefObject<CellHandle | null>>;
   /**
-   * Array of deleted cells (with their data and index) so that cell deletion can be undone
-   *
-   * (CodeMirror types the serialized config as any.)
+   * Undo stack: deleted cells and cut-paste moves, in chronological order.
    */
-  history: {
-    name: string;
-    // oxlint-disable-next-line typescript/no-explicit-any
-    serializedEditorState: any;
-    column: CellColumnId;
-    index: CellIndex;
-    isSetupCell: boolean;
-    config: CellConfig;
-  }[];
+  history: HistoryEntry[];
   /**
    * Key of cell to scroll to; typically set by actions that re-order the cell
    * array. Call the SCROLL_TO_TARGET action to scroll to the specified cell
@@ -157,6 +173,10 @@ export interface CreateNewCellAction {
   before: boolean;
   /** Initial code content for the new cell */
   code?: string;
+  /** Optional name for the new cell */
+  name?: string;
+  /** Optional cell configuration */
+  config?: CellConfig;
   /** The last executed code for the new cell */
   lastCodeRun?: string;
   /** Timestamp of the last execution */
@@ -186,11 +206,13 @@ const {
       cellId,
       before,
       code,
+      name,
+      config,
       lastCodeRun = null,
       lastExecutionTime = null,
       autoFocus = true,
       skipIfCodeExists = false,
-      hideCode = false,
+      hideCode = undefined,
     } = action;
 
     let columnId: CellColumnId;
@@ -233,8 +255,12 @@ const {
         [newCellId]: createCell({
           id: newCellId,
           code,
+          name,
           lastCodeRun,
-          config: createCellConfig({ hide_code: hideCode }),
+          config: createCellConfig({
+            ...config,
+            hide_code: hideCode ?? config?.hide_code,
+          }),
           lastExecutionTime,
           edited: Boolean(code) && code !== lastCodeRun,
         }),
@@ -413,6 +439,40 @@ const {
         toColumn.id,
         overCellId,
       ),
+      scrollKey: null,
+    };
+  },
+  moveCellsRelativeTo: (
+    state,
+    action: {
+      cellIds: CellId[];
+      targetCellId: CellId;
+      position: "before" | "after";
+      previousPlacements?: Array<{ columnId: CellColumnId; index: CellIndex }>;
+    },
+  ) => {
+    const { cellIds, targetCellId, position, previousPlacements } = action;
+    if (cellIds.length === 0) {
+      return state;
+    }
+    const newCellIds = state.cellIds.moveCellsRelativeTo(
+      cellIds,
+      targetCellId,
+      position,
+    );
+    // Only record undo when caller provided full before-state
+    const canUndoMove =
+      previousPlacements && previousPlacements.length === cellIds.length;
+    const history = canUndoMove
+      ? [
+          ...state.history,
+          { type: "move" as const, cellIds, placements: previousPlacements },
+        ]
+      : state.history;
+    return {
+      ...state,
+      cellIds: newCellIds,
+      history,
       scrollKey: null,
     };
   },
@@ -658,6 +718,7 @@ const {
       history: [
         ...state.history,
         {
+          type: "delete",
           name: prevData.name,
           serializedEditorState: serializedEditorState,
           column: column.id,
@@ -674,7 +735,25 @@ const {
       return state;
     }
 
-    const mostRecentlyDeleted = state.history[state.history.length - 1];
+    const last = state.history[state.history.length - 1];
+
+    if (last.type === "move") {
+      const { cellIds, placements } = last;
+      if (cellIds.length === 0 || placements.length !== cellIds.length) {
+        return { ...state, history: state.history.slice(0, -1) };
+      }
+      const toRestore = cellIds.map((id, i) => ({
+        id,
+        columnId: placements[i].columnId,
+        index: placements[i].index,
+      }));
+      return {
+        ...state,
+        cellIds: state.cellIds.placeCells(toRestore),
+        history: state.history.slice(0, -1),
+        scrollKey: cellIds[0] ?? null,
+      };
+    }
 
     const {
       name,
@@ -683,7 +762,7 @@ const {
       index,
       isSetupCell,
       config,
-    } = mostRecentlyDeleted;
+    } = last;
 
     const cellId = isSetupCell ? SETUP_CELL_ID : CellId.create();
     const undoCell = createCell({
@@ -1601,6 +1680,8 @@ export const hasEnabledCellsAtom = atom(
 export const canUndoDeletesAtom = atom((get) =>
   canUndoDeletes(get(notebookAtom)),
 );
+
+export const undoLabelAtom = atom((get) => getUndoLabel(get(notebookAtom)));
 
 export const needsRunAtom = atom((get) => notebookNeedsRun(get(notebookAtom)));
 

--- a/frontend/src/core/cells/document-changes.ts
+++ b/frontend/src/core/cells/document-changes.ts
@@ -215,13 +215,14 @@ export function toDocumentChanges(
       ];
     }
 
-    // dropCellOverCell/dropCellOverColumn/moveCellToIndex → set-config + reorder-cells
+    // dropCellOverCell/dropCellOverColumn/moveCellToIndex/moveCellsRelativeTo → set-config + reorder-cells
     // Drag-and-drop reorders can move cells within or across columns.
     // We emit config changes for cells whose column changed, then
     // the full ordering.
     case "dropCellOverCell":
     case "dropCellOverColumn":
     case "moveCellToIndex":
+    case "moveCellsRelativeTo":
       return columnChanges(prevState, newState);
 
     // updateCellCode → set-code
@@ -296,6 +297,10 @@ export function toDocumentChanges(
     case "undoDeleteCell": {
       const changes = newCellChanges(prevState, newState);
       const colChanges = columnChanges(prevState, newState);
+      // Undo-cut has no new cells — always emit reorder to sync the move.
+      if (changes.length === 0) {
+        return colChanges;
+      }
       // Only include column changes if layout actually changed
       // (colChanges always has at least a reorder-cells change)
       return colChanges.length > 1 ? [...changes, ...colChanges] : changes;

--- a/frontend/src/core/cells/pending-cut-service.ts
+++ b/frontend/src/core/cells/pending-cut-service.ts
@@ -1,0 +1,64 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { atom, useAtomValue } from "jotai";
+import type { ClipboardCellData } from "@/components/editor/navigation/clipboard";
+import type { CellId } from "@/core/cells/ids";
+import { createReducerAndAtoms } from "@/utils/createReducer";
+
+interface PendingCutState {
+  cellIds: Set<CellId>;
+  clipboardData: ClipboardCellData | null;
+}
+
+const initialState = (): PendingCutState => ({
+  cellIds: new Set(),
+  clipboardData: null,
+});
+
+const {
+  valueAtom: pendingCutStateAtom,
+  useActions: usePendingCutActionsInternal,
+} = createReducerAndAtoms(initialState, {
+  markForCut: (
+    _state,
+    action: { cellIds: CellId[]; clipboardData: ClipboardCellData },
+  ) => {
+    return {
+      cellIds: new Set(action.cellIds),
+      clipboardData: action.clipboardData,
+    };
+  },
+  clear: () => {
+    return initialState();
+  },
+});
+
+// Re-export the state atom
+export { pendingCutStateAtom };
+
+// Derived atom just for cell IDs (for easier consumption)
+export const pendingCutCellIdsAtom = atom(
+  (get) => get(pendingCutStateAtom).cellIds,
+);
+
+export const clearPendingCutAtom = atom(null, (_get, set) => {
+  set(pendingCutStateAtom, initialState());
+});
+
+export function usePendingCutActions() {
+  return usePendingCutActionsInternal();
+}
+
+export function useIsPendingCut(cellId: CellId): boolean {
+  const cellIds = useAtomValue(pendingCutCellIdsAtom);
+  return cellIds.has(cellId);
+}
+
+export function usePendingCutState() {
+  return useAtomValue(pendingCutStateAtom);
+}
+
+export function useHasPendingCut(): boolean {
+  const state = useAtomValue(pendingCutStateAtom);
+  return state.cellIds.size > 0;
+}

--- a/frontend/src/core/cells/utils.ts
+++ b/frontend/src/core/cells/utils.ts
@@ -66,6 +66,15 @@ export function canUndoDeletes(state: NotebookState) {
 }
 
 /**
+ * Label for the undo action based on the last history entry type.
+ */
+export function getUndoLabel(state: NotebookState): string {
+  const last = state.history[state.history.length - 1];
+  if (!last) return "Undo cell deletion";
+  return last.type === "move" ? "Undo move" : "Undo cell deletion";
+}
+
+/**
  * Get the status of the descendants of the given cell.
  */
 export function getDescendantsStatus(state: NotebookState, cellId: CellId) {

--- a/frontend/src/core/cells/utils.ts
+++ b/frontend/src/core/cells/utils.ts
@@ -70,7 +70,9 @@ export function canUndoDeletes(state: NotebookState) {
  */
 export function getUndoLabel(state: NotebookState): string {
   const last = state.history[state.history.length - 1];
-  if (!last) {return "Undo cell deletion";}
+  if (!last) {
+    return "Undo cell deletion";
+  }
   return last.type === "move" ? "Undo move" : "Undo cell deletion";
 }
 

--- a/frontend/src/core/cells/utils.ts
+++ b/frontend/src/core/cells/utils.ts
@@ -70,7 +70,7 @@ export function canUndoDeletes(state: NotebookState) {
  */
 export function getUndoLabel(state: NotebookState): string {
   const last = state.history[state.history.length - 1];
-  if (!last) return "Undo cell deletion";
+  if (!last) {return "Undo cell deletion";}
   return last.type === "move" ? "Undo move" : "Undo cell deletion";
 }
 

--- a/frontend/src/core/codemirror/cells/extensions.ts
+++ b/frontend/src/core/codemirror/cells/extensions.ts
@@ -10,6 +10,10 @@ import {
 } from "@codemirror/view";
 import { createTracebackInfoAtom } from "@/core/cells/cells";
 import { type CellId, HTMLCellId, SCRATCH_CELL_ID } from "@/core/cells/ids";
+import {
+  clearPendingCutAtom,
+  pendingCutCellIdsAtom,
+} from "@/core/cells/pending-cut-service";
 import { loroSyncAnnotation } from "@/core/codemirror/rtc/loro/sync";
 import type { KeymapConfig } from "@/core/config/config-schema";
 import type { HotkeyProvider } from "@/core/hotkeys/hotkeys";
@@ -326,6 +330,12 @@ function cellCodeEditing(hotkeys: HotkeyProvider): Extension[] {
         code: nextCode,
         formattingChange: isFormattingChange,
       });
+
+      // Clear pending cut state if this cell was marked for cut
+      const pendingCutCellIds = store.get(pendingCutCellIdsAtom);
+      if (pendingCutCellIds.has(cellId)) {
+        store.set(clearPendingCutAtom);
+      }
     }
   });
 

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -442,6 +442,11 @@ const DEFAULT_HOT_KEY = {
     group: "Command",
     key: "c",
   },
+  "command.cutCell": {
+    name: "Cut cell",
+    group: "Command",
+    key: "x",
+  },
   "command.pasteCell": {
     name: "Paste cell",
     group: "Command",

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -73,6 +73,19 @@
     }
   }
 
+  /* Styling for cells marked for cut */
+  &.pending-cut {
+    opacity: 0.6;
+    border-style: dashed;
+    border-color: var(--amber-7);
+
+    .output-area,
+    .cm-gutters,
+    .cm {
+      background-color: var(--amber-2);
+    }
+  }
+
   &:focus-within {
     z-index: 20;
   }

--- a/frontend/src/utils/__tests__/id-tree.test.ts
+++ b/frontend/src/utils/__tests__/id-tree.test.ts
@@ -957,6 +957,77 @@ describe("MultiColumn", () => {
     expect(inserted.topLevelIds[1]).toEqual(["B1", "D1", "B2"]);
   });
 
+  describe("moveCellsRelativeTo", () => {
+    it("moves a single cell before target in same column", () => {
+      const moved = multiColumn.moveCellsRelativeTo(["A3"], "A1", "before");
+      expect(moved.topLevelIds).toEqual([
+        ["A3", "A1", "A2"],
+        ["B1", "B2"],
+        ["C1", "C2", "C3", "C4"],
+      ]);
+    });
+
+    it("moves a single cell after target in same column", () => {
+      const moved = multiColumn.moveCellsRelativeTo(["A1"], "A3", "after");
+      expect(moved.topLevelIds).toEqual([
+        ["A2", "A3", "A1"],
+        ["B1", "B2"],
+        ["C1", "C2", "C3", "C4"],
+      ]);
+    });
+
+    it("moves multiple cells before target", () => {
+      const moved = multiColumn.moveCellsRelativeTo(
+        ["A1", "A2"],
+        "B2",
+        "before",
+      );
+      expect(moved.topLevelIds).toEqual([
+        ["A3"],
+        ["B1", "A1", "A2", "B2"],
+        ["C1", "C2", "C3", "C4"],
+      ]);
+    });
+
+    it("moves multiple cells after target", () => {
+      const moved = multiColumn.moveCellsRelativeTo(
+        ["A2", "A3"],
+        "B1",
+        "after",
+      );
+      expect(moved.topLevelIds).toEqual([
+        ["A1"],
+        ["B1", "A2", "A3", "B2"],
+        ["C1", "C2", "C3", "C4"],
+      ]);
+    });
+
+    it("returns same MultiColumn when cellIds is empty", () => {
+      const moved = multiColumn.moveCellsRelativeTo([], "A1", "before");
+      expect(moved).toBe(multiColumn);
+    });
+
+    it("inserts at end when target is among moved cells", () => {
+      const moved = multiColumn.moveCellsRelativeTo(
+        ["A1", "A2"],
+        "A2",
+        "after",
+      );
+      // Target A2 was removed; insert at end of column 0
+      expect(moved.topLevelIds).toEqual([
+        ["A3", "A1", "A2"],
+        ["B1", "B2"],
+        ["C1", "C2", "C3", "C4"],
+      ]);
+    });
+
+    it("throws when node not found", () => {
+      expect(() =>
+        multiColumn.moveCellsRelativeTo(["Z1"], "A1", "before"),
+      ).toThrow("Cell Z1 not found in any column");
+    });
+  });
+
   it("deletes by id", () => {
     const deleted = multiColumn.deleteById("B1");
     expect(deleted.topLevelIds[1]).toEqual(["B2"]);

--- a/frontend/src/utils/id-tree.tsx
+++ b/frontend/src/utils/id-tree.tsx
@@ -1033,14 +1033,14 @@ export class MultiColumn<T> {
   placeCells(
     placements: Array<{ id: T; columnId: CellColumnId; index: CellIndex }>,
   ): MultiColumn<T> {
-    if (placements.length === 0) return this;
+    if (placements.length === 0) {return this;}
     let result: MultiColumn<T> = this;
     for (const { id } of placements) {
       result = result.deleteById(id);
     }
-    const sorted = [...placements].sort((a, b) => {
+    const sorted = [...placements].toSorted((a, b) => {
       if (a.columnId !== b.columnId)
-        return a.columnId.localeCompare(b.columnId);
+        {return a.columnId.localeCompare(b.columnId);}
       return (a.index as number) - (b.index as number);
     });
     for (const { id, columnId, index } of sorted) {

--- a/frontend/src/utils/id-tree.tsx
+++ b/frontend/src/utils/id-tree.tsx
@@ -1033,14 +1033,17 @@ export class MultiColumn<T> {
   placeCells(
     placements: Array<{ id: T; columnId: CellColumnId; index: CellIndex }>,
   ): MultiColumn<T> {
-    if (placements.length === 0) {return this;}
+    if (placements.length === 0) {
+      return this;
+    }
     let result: MultiColumn<T> = this;
     for (const { id } of placements) {
       result = result.deleteById(id);
     }
     const sorted = [...placements].toSorted((a, b) => {
-      if (a.columnId !== b.columnId)
-        {return a.columnId.localeCompare(b.columnId);}
+      if (a.columnId !== b.columnId) {
+        return a.columnId.localeCompare(b.columnId);
+      }
       return (a.index as number) - (b.index as number);
     });
     for (const { id, columnId, index } of sorted) {

--- a/frontend/src/utils/id-tree.tsx
+++ b/frontend/src/utils/id-tree.tsx
@@ -1036,8 +1036,8 @@ export class MultiColumn<T> {
     if (placements.length === 0) {
       return this;
     }
-    let result: MultiColumn<T> = this;
-    for (const { id } of placements) {
+    let result = this.deleteById(placements[0].id);
+    for (const { id } of placements.slice(1)) {
       result = result.deleteById(id);
     }
     const sorted = [...placements].toSorted((a, b) => {


### PR DESCRIPTION
 
## 📝 Summary
Added the ability to cut cells in command mode

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Partially addresses #7423
nits / super nits encouraged 🙂
## 🔍 Description of Changes

https://github.com/user-attachments/assets/77ce91cb-bae0-4c52-8286-1be9fb4d3e4b

- `cutCells` function copies cell data (code, name, config) to the clipboard
- `useDeleteManyCellsSilentCallback` hook and `deleteCellSilent` reducer action to delete cells without pushing to the undo stack. 
- `createNewCell` extended to accept optional name and config parameters so that pasted cells retain their original names and configurations.


<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
