### PR TITLE
remove manual handling of local iframes, only external iframes

### DIFF
--- a/frontend/src/utils/__tests__/iframe.test.ts
+++ b/frontend/src/utils/__tests__/iframe.test.ts
@@ -1,13 +1,8 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { captureIframeAsImage } from "../iframe";
+import { captureExternalIframes } from "../iframe";
 
-// Mock html-to-image
-vi.mock("html-to-image", () => ({
-  toPng: vi.fn().mockResolvedValue("data:image/png;base64,mock"),
-}));
-
-describe("captureIframeAsImage", () => {
+describe("captureExternalIframes", () => {
   const originalCreateElement = document.createElement.bind(document);
 
   beforeEach(() => {
@@ -53,7 +48,7 @@ describe("captureIframeAsImage", () => {
     const element = document.createElement("div");
     element.innerHTML = "<p>No iframe here</p>";
 
-    const result = await captureIframeAsImage(element);
+    const result = await captureExternalIframes(element);
     expect(result).toBeNull();
   });
 
@@ -61,7 +56,7 @@ describe("captureIframeAsImage", () => {
     const element = document.createElement("div");
     element.innerHTML = '<iframe src="https://external.com/page"></iframe>';
 
-    const result = await captureIframeAsImage(element);
+    const result = await captureExternalIframes(element);
 
     expect(result).not.toBeNull();
     expect(result).toMatch(/^data:image\/png;base64,/);
@@ -72,7 +67,7 @@ describe("captureIframeAsImage", () => {
     element.innerHTML =
       '<iframe src="https://www.openstreetmap.org/export/embed.html"></iframe>';
 
-    const result = await captureIframeAsImage(element);
+    const result = await captureExternalIframes(element);
 
     expect(result).not.toBeNull();
     expect(result).toMatch(/^data:image\/png;base64,/);
@@ -85,7 +80,7 @@ describe("captureIframeAsImage", () => {
     element.append(iframe);
 
     // The iframe has no body accessible in jsdom
-    const result = await captureIframeAsImage(element);
+    const result = await captureExternalIframes(element);
 
     // In jsdom, contentDocument may not be accessible
     expect(result).toBeNull();
@@ -96,7 +91,7 @@ describe("captureIframeAsImage", () => {
     element.innerHTML = '<iframe src="./@file/123.html"></iframe>';
 
     // Same-origin relative URL, but contentDocument not accessible in jsdom
-    const result = await captureIframeAsImage(element);
+    const result = await captureExternalIframes(element);
 
     // Returns null because jsdom can't access contentDocument for file URLs
     expect(result).toBeNull();
@@ -113,7 +108,7 @@ describe("captureIframeAsImage", () => {
       const element = document.createElement("div");
       element.innerHTML = `<iframe src="${url}"></iframe>`;
 
-      const result = await captureIframeAsImage(element);
+      const result = await captureExternalIframes(element);
 
       expect(result).not.toBeNull();
       expect(result).toMatch(/^data:image\/png;base64,/);
@@ -128,7 +123,7 @@ describe("captureIframeAsImage", () => {
       const element = document.createElement("div");
       element.innerHTML = `<iframe src="${url}"></iframe>`;
 
-      const result = await captureIframeAsImage(element);
+      const result = await captureExternalIframes(element);
 
       // In jsdom, these return null because contentDocument isn't accessible
       // but they should NOT return a placeholder (which would indicate external detection)

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -8,7 +8,7 @@ import { Filenames } from "@/utils/filenames";
 import { Paths } from "@/utils/paths";
 import { prettyError } from "./errors";
 import { toPng } from "./html-to-image";
-import { captureIframeAsImage } from "./iframe";
+import { captureExternalIframes } from "./iframe";
 import { Logger } from "./Logger";
 import { ProgressState } from "./progress";
 import { ToastProgress } from "./toast-progress";
@@ -66,9 +66,11 @@ export async function getImageDataUrlForCell(
     return;
   }
 
-  const iframeDataUrl = await captureIframeAsImage(element);
-  if (iframeDataUrl) {
-    return iframeDataUrl;
+  // TODO: This doesn't handle external iframes + normal elements together (eg. in vstack).
+  // It will return the iframe only
+  const externalIframeDataUrl = await captureExternalIframes(element);
+  if (externalIframeDataUrl) {
+    return externalIframeDataUrl;
   }
 
   const startTime = Date.now();

--- a/frontend/src/utils/iframe.ts
+++ b/frontend/src/utils/iframe.ts
@@ -1,7 +1,5 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { toPng } from "./html-to-image";
-
 const PLACEHOLDER_WIDTH = 320;
 const PLACEHOLDER_HEIGHT = 180;
 
@@ -95,11 +93,11 @@ function createPlaceholderImage(url: string | null): string {
 }
 
 /**
- * Capture an iframe as a PNG image. We need to do this because external iframes are not supported by html-to-image.
+ * Capture external iframes as a PNG image. External iframes are not supported by html-to-image.
  * @param element - The element to capture the iframe from
  * @returns The image data URL of the iframe, or a placeholder image if the iframe is external
  */
-export async function captureIframeAsImage(
+export async function captureExternalIframes(
   element: HTMLElement,
 ): Promise<string | null> {
   const iframe = element.querySelector("iframe");
@@ -133,10 +131,5 @@ export async function captureIframeAsImage(
     }
   }
 
-  // Capture the iframe content
-  try {
-    return await toPng(doc.body);
-  } catch {
-    return createPlaceholderImage(null);
-  }
+  return null;
 }


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
html-to-image can handle local iframes. So we only handle for external iframes. This avoids issues if element + local iframes in the same element

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
