### PR TITLE
fix: add back LSP snippets, upgrade codemirror-languageserver

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "@lezer/markdown": "^1.6.2",
     "@lezer/python": "^1.1.18",
     "@marimo-team/codemirror-ai": "^0.3.5",
-    "@marimo-team/codemirror-languageserver": "^1.16.10",
+    "@marimo-team/codemirror-languageserver": "^1.16.11",
     "@marimo-team/codemirror-mcp": "^0.1.5",
     "@marimo-team/codemirror-sql": "^0.2.4",
     "@marimo-team/llm-info": "workspace:*",

--- a/frontend/src/core/codemirror/language/languages/python.ts
+++ b/frontend/src/core/codemirror/language/languages/python.ts
@@ -293,7 +293,7 @@ export class PythonLanguageAdapter implements LanguageAdapter<{}> {
             client: client as unknown as LanguageServerClient,
             languageId: "python",
             allowHTMLContent: true,
-            useSnippetOnCompletion: false,
+            useSnippetOnCompletion: true,
             hoverConfig: hoverOptions,
             completionConfig: autocompleteOptions,
             // Default to false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,8 +143,8 @@ importers:
         specifier: ^0.3.5
         version: 0.3.5(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)
       '@marimo-team/codemirror-languageserver':
-        specifier: ^1.16.10
-        version: 1.16.10(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)
+        specifier: ^1.16.11
+        version: 1.16.11(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)
       '@marimo-team/codemirror-mcp':
         specifier: ^0.1.5
         version: 0.1.5(@codemirror/autocomplete@6.20.0)(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)(@modelcontextprotocol/sdk@1.17.2)
@@ -1898,8 +1898,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@marimo-team/codemirror-languageserver@1.16.10':
-    resolution: {integrity: sha512-Rh3ls/zjV0VJ1/V25KFWnXF56iON8L1vhY4YY0rfVSBn26VFJcz6CIreHV/7ZW4AnDy97w6RheJ8Y86V080z/w==}
+  '@marimo-team/codemirror-languageserver@1.16.11':
+    resolution: {integrity: sha512-ZDYg8td8BK7DIYlTJCDeDN21/0HlFWh+63opMXVZ9jHleg7C/yvY8B8pfPmX/UCizkf39OSGJkJPqyMPjL7swg==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -11769,7 +11769,7 @@ snapshots:
       '@codemirror/view': 6.39.9
       diff: 8.0.2
 
-  '@marimo-team/codemirror-languageserver@1.16.10(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)':
+  '@marimo-team/codemirror-languageserver@1.16.11(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)':
     dependencies:
       '@codemirror/autocomplete': 6.20.0
       '@codemirror/lint': 6.9.2


### PR DESCRIPTION
This upgrades `@marimo-team/codemirror-language-server` to pick up a fix for using the `insertText` of completions (instead of the `label`). This allows us to re-enable `useSnippetOnCompletion`

Fixes #7137 