### PR TITLE
chore: default to wedpdf since tex seems to have more issues

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -530,7 +530,7 @@ Requires nbformat and nbconvert to be installed.
 )
 @click.option(
     "--webpdf/--no-webpdf",
-    default=False,
+    default=True,
     show_default=True,
     type=bool,
     help=(


### PR DESCRIPTION
## 📝 Summary

If latex is detected, the default behavior is to use `pandoc` + `tex` (falling back to webpdf). Pandoc seems to be a little flaky in usage, so the user ends up using webpdf anyway. Moreover, some of the tex exports fail to render for now- so default webpdf will provide a better user experience.

See the following attached:
[no_latex.pdf](https://github.com/user-attachments/files/24946120/no_latex.pdf)
[with_latex.pdf](https://github.com/user-attachments/files/24946127/with_latex.pdf)
