### PR TITLE
feat: add art-openpipe fallback package

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -181,6 +181,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "armor": "armor-api",
         "armstrong": "armstrong.utils.celery",
         "arstecnica": "arstecnica.sqlalchemy.async",
+        "art": "openpipe-art",
         "article-downloader": "article-downloader",
         "artifactcli": "artifact-cli",
         "arvados": "arvados-python-client",


### PR DESCRIPTION
## 📝 Summary

`ART` is a RL tuning package provided by OpenPipe https://github.com/OpenPipe/ART
`art` is an ascii package with a quarter as many Github stars: https://pypi.org/project/art/

Falling back to `ART` for `import art` is much more likely for our users

cc @danielbolus