### PR TITLE
fix: register Office document mimetypes for cross-platform compatibility

### DIFF
--- a/marimo/_server/utils.py
+++ b/marimo/_server/utils.py
@@ -20,6 +20,21 @@ def initialize_mimetypes() -> None:
     mimetypes.add_type("text/css", ".css")
     mimetypes.add_type("image/svg+xml", ".svg")
 
+    # Office document formats
+    # Ensures these mimetypes are available across all platforms
+    mimetypes.add_type(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ".xlsx",
+    )
+    mimetypes.add_type(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ".docx",
+    )
+    mimetypes.add_type(
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ".pptx",
+    )
+
 
 def initialize_asyncio() -> None:
     """Platform-specific initialization of asyncio.


### PR DESCRIPTION
Fixes #6170

## Summary

Registers xlsx, docx, and pptx mimetypes in `initialize_mimetypes()` to ensure Office documents download with correct file extensions across all platforms, particularly on Windows.
