### PR TITLE
fix: enable weave tracing on chat widget

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -252,6 +252,7 @@ class DependencyManager:
     )
     pydantic = Dependency("pydantic")
     zmq = Dependency("zmq")  # pyzmq for sandbox IPC kernels
+    weave = Dependency("weave")
 
     # Version requirements to properly support the new superfences introduced in
     # pymdown#2470

--- a/marimo/_plugins/ui/_impl/chat/chat.py
+++ b/marimo/_plugins/ui/_impl/chat/chat.py
@@ -475,6 +475,8 @@ class ChunkSerializer:
 
         # Handle plain text chunks
         if isinstance(chunk, str):
+            # Coerce str subclasses (like weave's BoxedStr) to plain str
+            chunk = str(chunk)
             if self._text_id is None:
                 self._text_id = f"text_{uuid.uuid4().hex}"
                 self.on_send_chunk({"type": "text-start", "id": self._text_id})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,8 @@ test-optional = [
     "mcp>=1.0.0",
     # zeromq
     "pyzmq>=27.1.0",
+    # weave tracing integration
+    "weave>=0.51.0",
 ]
 
 


### PR DESCRIPTION
## 📝 Summary

Currently weave tracing fails on the following code:

```python
chat_client = OpenAI()

@weave.op()
def handle_chat(messages, config):
    """Wrapper that ensures string return for marimo."""
    user_msg = messages[-1].content
    chat_messages = [{"role": "user", "content": user_msg}]

    response = chat_client.chat.completions.create(
        model="gpt-4o-mini",
        messages=[get_system_prompt()] + chat_messages,
        tools=get_robot_tools(),
    )

    msg = response.choices[0].message
    return msg.content

chat = mo.ui.chat(
    handle_chat
)
chat
```

This is because `weave.op` returns a `BoxedStr(str)` which the causes pydantic to fail. As such, we force a conversion to string even if `isinstance(chunk, str)`.