### PR TITLE
Clarify markdown section in Jupyter users tutorial

### DIFF
--- a/marimo/_tutorials/for_jupyter_users.py
+++ b/marimo/_tutorials/for_jupyter_users.py
@@ -216,7 +216,15 @@ def _(mo):
     mo.md(rf"""
     ## Markdown
 
-    marimo only has Python cells, but you can still write Markdown: `import marimo as mo` and use `mo.md` to write Markdown.
+    marimo notebooks are stored as pure Python, but you can still write Markdown:
+    `import marimo as mo` and use `mo.md`.
+
+    /// details | What about markdown & SQL "cells"?
+
+    You may notice marimo UI has markdown and SQL cells in the editor. These are
+    conveniences that use `mo.md` and `mo.sql` under the hood, with nicer
+    ergonomics for authoring.
+    ///
     """)
     return
 

--- a/tests/_convert/markdown/snapshots/marimo_for_jupyter_users.md.txt
+++ b/tests/_convert/markdown/snapshots/marimo_for_jupyter_users.md.txt
@@ -130,7 +130,15 @@ If you run into this error, here are your options:
 <!---->
 ## Markdown
 
-marimo only has Python cells, but you can still write Markdown: `import marimo as mo` and use `mo.md` to write Markdown.
+marimo notebooks are stored as pure Python, but you can still write Markdown:
+`import marimo as mo` and use `mo.md`.
+
+/// details | What about markdown & SQL "cells"?
+
+You may notice marimo UI has markdown and SQL cells in the editor. These are
+conveniences that use `mo.md` and `mo.sql` under the hood, with nicer
+ergonomics for authoring.
+///
 
 ```python {.marimo}
 mo.md(


### PR DESCRIPTION
Fixes #8084

The tutorial previously stated "marimo only has Python cells" which confused new users who see markdown and SQL cells in the editor UI.
