### PR TITLE
feat: replace logo with back button for notebooks in gallery mode

### DIFF
--- a/frontend/src/core/run-app.tsx
+++ b/frontend/src/core/run-app.tsx
@@ -1,11 +1,14 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { useAtomValue } from "jotai";
+import { ArrowLeftIcon } from "lucide-react";
 import { useEffect } from "react";
 import { AppContainer } from "@/components/editor/app-container";
 import { AppHeader } from "@/components/editor/header/app-header";
 import { Spinner } from "@/components/icons/spinner";
+import { buttonVariants } from "@/components/ui/button";
 import { DelayMount } from "@/components/utils/delay-mount";
+import { cn } from "@/utils/cn";
 import { CellsRenderer } from "../components/editor/renderers/cells-renderer";
 import { notebookIsRunningAtom, useCellActions } from "./cells/cells";
 import type { AppConfig } from "./config/config-schema";
@@ -75,15 +78,19 @@ export const RunApp: React.FC<AppProps> = ({ appConfig }) => {
       isRunning={isRunning}
       width={appConfig.width}
     >
-      <AppHeader connection={connection} className={"sm:pt-8"}>
+      <AppHeader connection={connection} className="sm:pt-8">
         {galleryHref && (
-          <div className="flex items-center px-6 pt-4">
+          <div className="flex items-center px-6 pt-4 sm:-mt-8">
             <a
               href={galleryHref}
               aria-label="Back to gallery"
-              className="inline-flex items-center"
+              className={cn(
+                buttonVariants({ variant: "text", size: "sm" }),
+                "gap-2 px-0 text-muted-foreground hover:text-foreground",
+              )}
             >
-              <img src="logo.png" alt="marimo logo" className="h-6 w-auto" />
+              <ArrowLeftIcon className="size-4" aria-hidden={true} />
+              <span>Back</span>
             </a>
           </div>
         )}


### PR DESCRIPTION
## 📝 Summary

Follow-up of #8056

## Changes

**Before**
<img width="755" height="337" alt="Screenshot 2026-02-03 at 16 10 38" src="https://github.com/user-attachments/assets/155fb23d-a764-4301-8f77-952a199a190b" />

**After**
<img width="755" height="337" alt="Screenshot 2026-02-03 at 16 09 46" src="https://github.com/user-attachments/assets/9c10506c-9c59-49a2-8d88-4534cffeba7b" />
