### PR TITLE
graduate performant table charts and chat modes from experimental

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -1298,34 +1298,6 @@ export const UserConfigForm: React.FC = () => {
             />
             <FormField
               control={form.control}
-              name="experimental.performant_table_charts"
-              render={({ field }) => (
-                <div className="flex flex-col gap-y-1">
-                  <FormItem className={formItemClasses}>
-                    <FormLabel className="font-normal">
-                      Performant Table Charts
-                    </FormLabel>
-                    <FormControl>
-                      <Checkbox
-                        data-testid="performant-table-charts-checkbox"
-                        checked={field.value === true}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                  </FormItem>
-                  <IsOverridden
-                    userConfig={config}
-                    name="experimental.performant_table_charts"
-                  />
-                  <FormDescription>
-                    Enable experimental table charts which are computed on the
-                    backend.
-                  </FormDescription>
-                </div>
-              )}
-            />
-            <FormField
-              control={form.control}
               name="experimental.external_agents"
               render={({ field }) => (
                 <div className="flex flex-col gap-y-1">
@@ -1352,32 +1324,6 @@ export const UserConfigForm: React.FC = () => {
                       docs
                     </ExternalLink>
                     .
-                  </FormDescription>
-                </div>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="experimental.chat_modes"
-              render={({ field }) => (
-                <div className="flex flex-col gap-y-1">
-                  <FormItem className={formItemClasses}>
-                    <FormLabel className="font-normal">Chat Mode</FormLabel>
-                    <FormControl>
-                      <Checkbox
-                        data-testid="chat-mode-checkbox"
-                        checked={field.value === true}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                  </FormItem>
-                  <IsOverridden
-                    userConfig={config}
-                    name="experimental.chat_modes"
-                  />
-                  <FormDescription>
-                    Switch between different modes in the Chat sidebar, to
-                    enable tool use.
                   </FormDescription>
                 </div>
               )}

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -45,7 +45,6 @@ import {
 import { useCellActions } from "@/core/cells/cells";
 import { aiAtom, aiEnabledAtom } from "@/core/config/config";
 import { DEFAULT_AI_MODEL } from "@/core/config/config-schema";
-import { FeatureFlagged } from "@/core/config/feature-flag";
 import { useRequestClient } from "@/core/network/requests";
 import { useRuntimeManager } from "@/core/runtime/config";
 import { ErrorBanner } from "@/plugins/impl/common/error-banner";
@@ -264,32 +263,30 @@ const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
       <TooltipProvider>
         <div className="px-3 py-2 border-t border-border/20 flex flex-row flex-wrap items-center justify-between gap-1">
           <div className="flex items-center gap-2">
-            <FeatureFlagged feature="chat_modes">
-              <Select value={currentMode} onValueChange={saveModeChange}>
-                <SelectTrigger className="h-6 text-xs border-border shadow-none! ring-0! bg-muted hover:bg-muted/30 py-0 px-2 gap-1 capitalize">
-                  {currentMode}
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectLabel>AI Mode</SelectLabel>
-                    {modeOptions.map((option) => (
-                      <SelectItem
-                        key={option.value}
-                        value={option.value}
-                        className="text-xs"
-                      >
-                        <div className="flex flex-col">
-                          {option.label}
-                          <div className="text-muted-foreground text-xs pt-1 block">
-                            {option.subtitle}
-                          </div>
+            <Select value={currentMode} onValueChange={saveModeChange}>
+              <SelectTrigger className="h-6 text-xs border-border shadow-none! ring-0! bg-muted hover:bg-muted/30 py-0 px-2 gap-1 capitalize">
+                {currentMode}
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>AI Mode</SelectLabel>
+                  {modeOptions.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      className="text-xs"
+                    >
+                      <div className="flex flex-col">
+                        {option.label}
+                        <div className="text-muted-foreground text-xs pt-1 block">
+                          {option.subtitle}
                         </div>
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </FeatureFlagged>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
             <AIModelDropdown
               placeholder="Model"
               triggerClassName="h-6 text-xs shadow-none! ring-0! bg-muted hover:bg-muted/30 rounded-sm"

--- a/frontend/src/core/config/feature-flag.tsx
+++ b/frontend/src/core/config/feature-flag.tsx
@@ -9,8 +9,6 @@ export interface ExperimentalFeatures {
   markdown: boolean; // Used in playground (community cloud)
   wasm_layouts: boolean; // Used in playground (community cloud)
   rtc_v2: boolean;
-  performant_table_charts: boolean;
-  chat_modes: boolean;
   cache_panel: boolean;
   external_agents: boolean;
   server_side_pdf_export: boolean;
@@ -21,8 +19,6 @@ const defaultValues: ExperimentalFeatures = {
   markdown: true,
   wasm_layouts: false,
   rtc_v2: false,
-  performant_table_charts: false,
-  chat_modes: false,
   cache_panel: false,
   external_agents: import.meta.env.DEV,
   server_side_pdf_export: true,

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -550,8 +550,6 @@ class ExperimentalConfig(TypedDict, total=False):
     markdown: bool  # Used in playground (community cloud)
     wasm_layouts: bool  # Used in playground (community cloud)
     rtc_v2: bool
-    performant_table_charts: bool
-    chat_modes: bool
 
     # Internal features
     cache: CacheConfig

--- a/marimo/_server/print.py
+++ b/marimo/_server/print.py
@@ -150,6 +150,8 @@ def print_experimental_features(config: MarimoConfig) -> None:
         "mcp_docs",
         "sql_linter",
         "sql_mode",
+        "performant_table_charts",
+        "chat_modes",
     }
     keys = keys - finished_experiments
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -568,7 +568,6 @@ format_on_save = true
 
 [tool.marimo.experimental]
 multi_column = true
-chat_modes = true
 cache_panel = true
 
 [tool.marimo.display]


### PR DESCRIPTION
## Summary

**Frontend:**
- Remove `performant_table_charts` and `chat_modes` from `ExperimentalFeatures` interface and default values
- Remove feature flag toggle controls from user config settings UI
- Remove `FeatureFlagged` wrapper from chat mode selector, making it always visible
- Clean up unused imports

**Backend:**
- Remove `performant_table_charts` and `chat_modes` from `ExperimentalConfig` TypedDict
- Add both flags to `finished_experiments` set in `print.py` to prevent them from being displayed as experimental features on startup

## Impact

- **Performant Table Charts**: Charts in data tables are now always computed using the performant backend implementation
- **Chat Modes**: Users can now always switch between Manual, Ask, and Agent modes in the Chat sidebar without needing to enable a feature flag

These features have been tested and are stable enough for general use.

🤖 Generated with [Claude Code](https://claude.com/claude-code) & me