### PR TITLE
enhancement: anywidget dynamic imports in static notebooks

### DIFF
--- a/frontend/src/core/ai/context/providers/file.ts
+++ b/frontend/src/core/ai/context/providers/file.ts
@@ -237,7 +237,7 @@ export class FileContextProvider extends AIContextProvider<FileContextItem> {
                 fileDetails.contents as Base64String,
                 mimeType,
               );
-              blob = await deserializeBlob(dataURL);
+              blob = deserializeBlob(dataURL);
             } catch {
               // Fallback to treating as text
               blob = new Blob([fileDetails.contents], { type: mimeType });

--- a/frontend/src/core/static/files.ts
+++ b/frontend/src/core/static/files.ts
@@ -1,6 +1,8 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import type { Loader } from "@/plugins/impl/vega/vega-loader";
+import { deserializeBlob } from "@/utils/blob";
+import type { DataURLString } from "@/utils/json/base64";
 import { Logger } from "@/utils/Logger";
 import { getStaticVirtualFiles } from "./static-state";
 import type { StaticVirtualFiles } from "./types";
@@ -120,6 +122,24 @@ function withoutLeadingDot(path: string): string {
   return path.startsWith(".") ? path.slice(1) : path;
 }
 
+/**
+ * Resolve a URL to a blob URL if it's a virtual file, for use with dynamic import().
+ * Unlike fetch, import() can't be patched, so we need to convert data URLs to blob URLs.
+ *
+ * @returns The original URL if not a virtual file, or a blob URL if it is
+ */
+export function resolveVirtualFileURL(
+  url: string,
+  files: StaticVirtualFiles = getStaticVirtualFiles(),
+): string {
+  const vfile = maybeGetVirtualFile(url, files);
+  if (!vfile) {
+    return url;
+  }
+  const blob = deserializeBlob(vfile as DataURLString);
+  return URL.createObjectURL(blob);
+}
+
 function maybeGetVirtualFile(
   url: string,
   files: StaticVirtualFiles,
@@ -130,14 +150,11 @@ function maybeGetVirtualFile(
   }
   const pathname = new URL(url, base).pathname;
 
-  // If if the URL starts with file://, then using the document.baseURI
-  // will not work. In this case, should just chop off from /@file/...
-  if (url.startsWith("file://")) {
-    const indexOfFile = url.indexOf("/@file/");
-    if (indexOfFile !== -1) {
-      url = url.slice(indexOfFile);
-    }
-  }
+  // Extract the /@file/... suffix from the URL or pathname
+  // This handles URLs like https://example.com/prefix/@file/foo.js
+  // or file:///path/to/@file/foo.js
+  const filePathFromUrl = extractFilePath(url);
+  const filePathFromPathname = extractFilePath(pathname);
 
   // Few variations to grab the URL.
   // This can happen if a static file was open at file:// or https://
@@ -145,6 +162,19 @@ function maybeGetVirtualFile(
     files[url] ||
     files[withoutLeadingDot(url)] ||
     files[pathname] ||
-    files[withoutLeadingDot(pathname)]
+    files[withoutLeadingDot(pathname)] ||
+    (filePathFromUrl && files[filePathFromUrl]) ||
+    (filePathFromPathname && files[filePathFromPathname])
   );
+}
+
+/**
+ * Extract the /@file/... path from a URL string
+ */
+function extractFilePath(url: string): string | null {
+  const indexOfFile = url.indexOf("/@file/");
+  if (indexOfFile !== -1) {
+    return url.slice(indexOfFile);
+  }
+  return null;
 }

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -8,6 +8,8 @@ import useEvent from "react-use-event-hook";
 import { z } from "zod";
 import { MarimoIncomingMessageEvent } from "@/core/dom/events";
 import { asRemoteURL } from "@/core/runtime/config";
+import { resolveVirtualFileURL } from "@/core/static/files";
+import { isStaticNotebook } from "@/core/static/static-state";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { useDeepCompareMemoize } from "@/hooks/useDeepCompareMemoize";
 import {
@@ -93,7 +95,11 @@ const AnyWidgetSlot = (
     error,
     refetch,
   } = useAsyncData(async () => {
-    const url = asRemoteURL(jsUrl).toString();
+    let url = asRemoteURL(jsUrl).toString();
+    // In static notebooks, resolve virtual files to blob URLs for import()
+    if (isStaticNotebook()) {
+      url = resolveVirtualFileURL(url);
+    }
     return await import(/* @vite-ignore */ url);
     // Re-render on jsHash change (which is a hash of the contents of the file)
     // instead of a jsUrl change because URLs may change without the contents

--- a/frontend/src/utils/__tests__/blob.test.ts
+++ b/frontend/src/utils/__tests__/blob.test.ts
@@ -20,7 +20,7 @@ describe("Blob serialization and deserialization", () => {
 
   test("deserializeBlob should deserialize a base64 string to a Blob", async () => {
     const serialized = await serializeBlob(testBlob);
-    const deserialized = await deserializeBlob(serialized);
+    const deserialized = deserializeBlob(serialized);
     expect(deserialized).toBeDefined();
     expect(deserialized.size).toBe(testBlob.size);
     expect(deserialized.type).toBe(testBlob.type);
@@ -28,7 +28,7 @@ describe("Blob serialization and deserialization", () => {
 
   test("deserialized Blob should contain the original content", async () => {
     const serialized = await serializeBlob(testBlob);
-    const deserialized = await deserializeBlob(serialized);
+    const deserialized = deserializeBlob(serialized);
     const reader = new FileReader();
     // eslint-disable-next-line unicorn/prefer-blob-reading-methods
     reader.readAsText(deserialized);
@@ -45,7 +45,7 @@ describe("Blob serialization and deserialization", () => {
       type: "image/png",
     });
     const serialized = await serializeBlob(imageBlob);
-    const deserialized = await deserializeBlob(serialized);
+    const deserialized = deserializeBlob(serialized);
     expect(deserialized).toBeDefined();
     expect(deserialized.size).toBe(imageBlob.size);
     expect(deserialized.type).toBe(imageBlob.type);

--- a/frontend/src/utils/blob.ts
+++ b/frontend/src/utils/blob.ts
@@ -14,32 +14,19 @@ export function serializeBlob<T>(blob: Blob): Promise<DataURLString> {
   });
 }
 
-export function deserializeBlob(serializedBlob: DataURLString): Promise<Blob> {
-  return new Promise((resolve, reject) => {
-    try {
-      // Extract the base64 data from the data URL
-      const [prefix, base64Data] = serializedBlob.split(",", 2);
-      const mimeType = /^data:(.+);base64$/.exec(prefix)?.[1];
-      // Decode the base64 string
-      const binaryString = atob(base64Data);
-      // Convert the binary string to an array buffer
-      const len = binaryString.length;
-      const bytes = new Uint8Array(len);
-      for (let i = 0; i < len; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-      }
-      // Create a new Blob from the array buffer
-      const blob = new Blob([bytes], { type: mimeType });
-      resolve(blob);
-    } catch (error) {
-      reject(ensureError(error));
-    }
-  });
-}
-
-function ensureError(error: unknown): Error {
-  if (error instanceof Error) {
-    return error;
+export function deserializeBlob(serializedBlob: DataURLString): Blob {
+  // Extract the base64 data from the data URL
+  const [prefix, base64Data] = serializedBlob.split(",", 2);
+  const mimeType = /^data:(.+);base64$/.exec(prefix)?.[1];
+  // Decode the base64 string
+  const binaryString = atob(base64Data);
+  // Convert the binary string to an array buffer
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
   }
-  return new Error(`${error}`);
+  // Create a new Blob from the array buffer
+  const blob = new Blob([bytes], { type: mimeType });
+  return blob;
 }


### PR DESCRIPTION
Adds support for import() of virtual files in static notebooks by resolving /@file/ URLs to blob URLs.

Unlike fetch(), dynamic import() cannot be patched globally. This change enables anywidget JS modules embedded in exported HTML notebooks to load correctly.
