### PR TITLE
fix: gracefully handle timeouts/input from uv when adding script metadata

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -391,10 +391,16 @@ def _ensure_marimo_in_script_metadata(name: str | None) -> None:
             check=True,
             capture_output=True,
             text=True,
+            # stdin=DEVNULL prevents hanging on Windows when uv might
+            # wait for input
+            stdin=subprocess.DEVNULL,
+            timeout=30,
         )
         LOGGER.info(f"Added marimo to script metadata: {result.stdout}")
     except subprocess.CalledProcessError as e:
         LOGGER.warning(f"Failed to add marimo to script metadata: {e.stderr}")
+    except subprocess.TimeoutExpired:
+        LOGGER.warning("Timed out adding marimo to script metadata")
     except Exception as e:
         LOGGER.warning(f"Failed to add marimo to script metadata: {e}")
 


### PR DESCRIPTION
This pull request improves the robustness of the `_ensure_marimo_in_script_metadata` function in `marimo/_cli/sandbox.py` by preventing potential hangs and handling timeouts when running subprocesses.

Reliability improvements for subprocess execution:

* Added `stdin=subprocess.DEVNULL` to prevent hanging on Windows when `uv` might wait for input.
* Set a `timeout=30` for the subprocess call and added handling for `TimeoutExpired` exceptions to log a warning if the operation times out.