### PR TITLE
docs: molab links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ and deployable as apps.
 pip install marimo && marimo tutorial intro
 ```
 
-_Try marimo at [our online playground](https://marimo.app/l/c7h6pz), which runs entirely in the browser!_
-
-_Jump to the [quickstart](#quickstart) for a primer on our CLI._
+_Get started instantly with [**mo**lab, our free online
+notebook](https://molab.marimo.io/notebooks). Or jump to the
+[quickstart](#quickstart) for a primer on our CLI._
 
 ## A reactive programming environment
 
@@ -213,7 +213,7 @@ See the [FAQ](https://docs.marimo.io/faq.html) at our docs.
 
 marimo is easy to get started with, with lots of room for power users.
 For example, here's an embedding visualizer made in marimo
-([video](https://marimo.io/videos/landing/full.mp4)):
+([try the notebook live on molab!](https://molab.marimo.io/notebooks/nb_jJiFFtznAy4BxkrrZA1o9b/app?show-code=true)):
 
 <img src="https://raw.githubusercontent.com/marimo-team/marimo/main/docs/_static/embedding.gif" width="700px" />
 
@@ -259,23 +259,23 @@ Check out our [docs](https://docs.marimo.io),
   </tr>
   <tr>
     <td>
-      <a target="_blank" href="https://marimo.app/l/c7h6pz">
-        <img src="https://marimo.io/shield.svg"/>
+      <a target="_blank" href="https://molab.marimo.io/notebooks/nb_TWVGCgZZK4L8zj5ziUBNVL">
+        <img src="https://marimo.io/molab-shield.svg"/>
       </a>
     </td>
     <td>
-      <a target="_blank" href="https://marimo.app/l/0ue871">
-        <img src="https://marimo.io/shield.svg"/>
+      <a target="_blank" href="https://molab.marimo.io/notebooks/nb_WuoXgs7mjg5yqrMxJXjRpF">
+        <img src="https://marimo.io/molab-shield.svg"/>
       </a>
     </td>
     <td>
-      <a target="_blank" href="https://marimo.app/l/lxp1jk">
-        <img src="https://marimo.io/shield.svg"/>
+      <a target="_blank" href="https://molab.marimo.io/notebooks/nb_vXxD13t2RoMTLjC89qdn6c">
+        <img src="https://marimo.io/molab-shield.svg"/>
       </a>
     </td>
     <td>
-      <a target="_blank" href="https://marimo.app/l/14ovyr">
-        <img src="https://marimo.io/shield.svg"/>
+      <a target="_blank" href="https://molab.marimo.io/notebooks/nb_XpXx8MX99dWAjn4k1b3xiU">
+        <img src="https://marimo.io/molab-shield.svg"/>
       </a>
     </td>
   </tr>
@@ -301,6 +301,7 @@ We're building a community. Come hang out with us!
 - 🦋 [Follow us on Bluesky](https://bsky.app/profile/marimo.io)
 - 🐦 [Follow us on Twitter](https://twitter.com/marimo_io)
 - 🎥 [Subscribe on YouTube](https://www.youtube.com/@marimo-team)
+- 🤖 [Follow us on Reddit](https://www.reddit.com/marimo_notebook)
 - 🕴️ [Follow us on LinkedIn](https://www.linkedin.com/company/marimo-io)
 
 **A NumFOCUS affiliated project.** marimo is a core part of the broader Python

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,11 @@ support for SQL](guides/working_with_data/sql.md).
 marimo was built from the ground up to solve <a href="faq.html#faq-jupyter">well-known problems associated with traditional notebooks</a>.
 ///
 
+_Get started instantly with [**mo**lab, our free online
+notebook](https://molab.marimo.io/notebooks). Or get started
+locally by installing marimo with your favorite package manager:_
+
+
 /// tab | install with pip
 
 ```bash
@@ -54,6 +59,7 @@ conda install -c conda-forge marimo && marimo tutorial intro
 
 Developer experience is core to marimo, with an emphasis on
 reproducibility, maintainability, composability, and shareability.
+
 
 ## Highlights
 
@@ -235,7 +241,7 @@ See our [FAQ](faq.md).
 
 marimo is easy to get started with, with lots of room for power users.
 For example, here's an embedding visualizer made in marimo
-([video](https://marimo.io/videos/landing/full.mp4)):
+([try the notebook live on molab!](https://molab.marimo.io/notebooks/nb_jJiFFtznAy4BxkrrZA1o9b/app?show-code=true)):
 
 <video autoplay muted loop playsinline width="700px" align="center">
   <source src="/_static/embedding.mp4" type="video/mp4">
@@ -296,23 +302,23 @@ and our [gallery](https://marimo.io/gallery) to learn more.
   </tr>
   <tr>
     <td>
-      <a target="_blank" href="https://marimo.app/l/c7h6pz">
-        <img src="https://marimo.io/shield.svg"/>
+      <a target="_blank" href="https://molab.marimo.io/notebooks/nb_TWVGCgZZK4L8zj5ziUBNVL">
+        <img src="https://marimo.io/molab-shield.svg"/>
       </a>
     </td>
     <td>
-      <a target="_blank" href="https://marimo.app/l/0ue871">
-        <img src="https://marimo.io/shield.svg"/>
+      <a target="_blank" href="https://molab.marimo.io/notebooks/nb_WuoXgs7mjg5yqrMxJXjRpF">
+        <img src="https://marimo.io/molab-shield.svg"/>
       </a>
     </td>
     <td>
-      <a target="_blank" href="https://marimo.app/l/lxp1jk">
-        <img src="https://marimo.io/shield.svg"/>
+      <a target="_blank" href="https://molab.marimo.io/notebooks/nb_vXxD13t2RoMTLjC89qdn6c">
+        <img src="https://marimo.io/molab-shield.svg"/>
       </a>
     </td>
     <td>
-      <a target="_blank" href="https://marimo.app/l/14ovyr">
-        <img src="https://marimo.io/shield.svg"/>
+      <a target="_blank" href="https://molab.marimo.io/notebooks/nb_XpXx8MX99dWAjn4k1b3xiU">
+        <img src="https://marimo.io/molab-shield.svg"/>
       </a>
     </td>
   </tr>
@@ -339,6 +345,7 @@ We're building a community. Come hang out with us!
 - 🐦 [Follow us on Twitter](https://twitter.com/marimo_io)
 - 🎥 [Subscribe on YouTube](https://www.youtube.com/@marimo-team)
 - 💬 [Follow us on Mastodon](https://mastodon.social/@marimo_io)
+- 🤖 [Follow us on Reddit](https://www.reddit.com/marimo_notebook)
 - 🕴️ [Follow us on LinkedIn](https://www.linkedin.com/company/marimo-io)
 
 **A NumFOCUS affiliated project.** marimo is a core part of the broader Python


### PR DESCRIPTION
Add molab links to README.md, docs, replacing stale marimo.app links. Replace try our online playground link with molab link in README.