### PR TITLE
don't allow '.' when creating custom provider names

### DIFF
--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -609,9 +609,13 @@ export const CustomProvidersConfig: React.FC<AiConfigProps> = ({
   const isDuplicate =
     KNOWN_PROVIDERS.includes(normalizedName as KnownProviderId) ||
     (customProviders && Object.keys(customProviders).includes(normalizedName));
+  const hasInvalidChars = normalizedName.includes(".");
 
   const hasValidValues =
-    normalizedName.trim() && newProviderBaseUrl.trim() && !isDuplicate;
+    normalizedName.trim() &&
+    newProviderBaseUrl.trim() &&
+    !isDuplicate &&
+    !hasInvalidChars;
 
   const resetForm = () => {
     setNewProviderName("");
@@ -669,7 +673,12 @@ export const CustomProvidersConfig: React.FC<AiConfigProps> = ({
                   A provider with this name already exists.
                 </p>
               )}
-              {newProviderName && (
+              {hasInvalidChars && (
+                <p className="text-xs text-destructive">
+                  Provider names cannot contain '.' characters.
+                </p>
+              )}
+              {newProviderName && !hasInvalidChars && (
                 <p className="text-xs text-muted-secondary">
                   Use models with prefix:{" "}
                   <Kbd className="inline text-xs">{normalizedName}/</Kbd>


### PR DESCRIPTION
Provider names with `.` breaks saving to our toml, currently we save it as [marimo.ai.provider_name]. This adds a validation on the frontend to avoid saving a provider like this.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
