### PR TITLE
Preserve whitespaces & new lines when inferring parts during rendering outputs

### DIFF
--- a/frontend/src/utils/__tests__/url-parser.test.ts
+++ b/frontend/src/utils/__tests__/url-parser.test.ts
@@ -76,4 +76,26 @@ describe("parseContent", () => {
       url: "https://avatars.githubusercontent.com/u/123",
     });
   });
+
+  it("preserves newlines between URLs", () => {
+    const parts = parseContent("https://marimo.io\nhttps://github.com\n");
+    expect(parts).toEqual([
+      { type: "url", url: "https://marimo.io" },
+      { type: "text", value: "\n" },
+      { type: "url", url: "https://github.com" },
+      { type: "text", value: "\n" },
+    ]);
+  });
+
+  it("preserves whitespace in mixed content", () => {
+    const parts = parseContent(
+      "Line 1: https://marimo.io\nLine 2: https://github.com",
+    );
+    expect(parts).toEqual([
+      { type: "text", value: "Line 1: " },
+      { type: "url", url: "https://marimo.io" },
+      { type: "text", value: "\nLine 2: " },
+      { type: "url", url: "https://github.com" },
+    ]);
+  });
 });

--- a/frontend/src/utils/url-parser.ts
+++ b/frontend/src/utils/url-parser.ts
@@ -19,7 +19,7 @@ export function parseContent(text: string): ContentPart[] {
     return [{ type: "image", url: text }];
   }
 
-  const parts = text.split(urlRegex).filter((part) => part.trim() !== "");
+  const parts = text.split(urlRegex).filter((part) => part !== "");
   return parts.map((part) => {
     const isUrl = urlRegex.test(part);
     if (isUrl) {


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Links would be concatenated because the \n is removed. I think we should preserve any content anyway since they are user-supplied.
<img width="954" height="286" alt="image" src="https://github.com/user-attachments/assets/2ed9c00a-00b5-47c9-bca2-662bd9a71ab6" />

Fixed
<img width="368" height="134" alt="image" src="https://github.com/user-attachments/assets/b12d2870-59ab-4c8f-8b70-40bf18ee19f5" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
