### PR TITLE
Add proxy_path support for ClickHouse Connections

### DIFF
--- a/frontend/src/components/editor/database/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/database/__tests__/__snapshots__/as-code.test.ts.snap
@@ -461,6 +461,21 @@ engine = clickhouse_connect.get_client(
 )"
 `;
 
+exports[`generateDatabaseCode > edge cases > clickhouse with proxy_path 1`] = `
+"import clickhouse_connect
+import os
+
+_password = os.environ.get("CLICKHOUSE_PASSWORD", "pass")
+engine = clickhouse_connect.get_client(
+  host="localhost",
+  user="user",
+  secure=False,
+  port=8123,
+  password=_password,
+  proxy_path="/clickhouse",
+)"
+`;
+
 exports[`generateDatabaseCode > edge cases > duckdb with relative path 1`] = `
 "import sqlmodel
 

--- a/frontend/src/components/editor/database/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/database/__tests__/as-code.test.ts
@@ -533,6 +533,14 @@ describe("generateDatabaseCode", () => {
         "clickhouse_connect",
       ],
       [
+        "clickhouse with proxy_path",
+        {
+          ...clickhouseConnection,
+          proxy_path: "/clickhouse",
+        },
+        "clickhouse_connect",
+      ],
+      [
         "timeplus with no port",
         {
           ...timeplusConnection,

--- a/frontend/src/components/editor/database/as-code.ts
+++ b/frontend/src/components/editor/database/as-code.ts
@@ -412,6 +412,9 @@ class ClickHouseGenerator extends CodeGenerator<"clickhouse_connect"> {
         ? this.secrets.print("port", this.connection.port)
         : undefined,
       password: this.connection.password ? password : undefined,
+      proxy_path: this.connection.proxy_path
+        ? this.secrets.print("proxy_path", this.connection.proxy_path)
+        : undefined,
     };
 
     return dedent(`

--- a/frontend/src/components/editor/database/schemas.ts
+++ b/frontend/src/components/editor/database/schemas.ts
@@ -267,6 +267,15 @@ export const ClickhouseConnectionSchema = z
       .boolean()
       .default(false)
       .describe(FieldOptions.of({ label: "Use HTTPs" })),
+    proxy_path: z
+      .string()
+      .optional()
+      .describe(
+        FieldOptions.of({
+          label: "Proxy Path",
+          placeholder: "/clickhouse",
+        }),
+      ),
   })
   .describe(FieldOptions.of({ direction: "two-columns" }));
 


### PR DESCRIPTION
## 📝 Summary
Adds support for the `proxy_path` option for the ClickHouse client. This is useful if you have something like `your-database.com/something` 
<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
