### PR TITLE
Fix: Use cell name to identify setup cells when id is null

### DIFF
--- a/frontend/src/core/cells/__tests__/session.test.ts
+++ b/frontend/src/core/cells/__tests__/session.test.ts
@@ -7,7 +7,7 @@ import { parseOutline } from "@/core/dom/outline";
 import { MultiColumn, visibleForTesting } from "@/utils/id-tree";
 import { invariant } from "@/utils/invariant";
 import { Logger } from "@/utils/Logger";
-import type { CellId } from "../ids";
+import { type CellId, SETUP_CELL_ID } from "../ids";
 import { notebookStateFromSession } from "../session";
 
 // Mock dependencies
@@ -347,6 +347,42 @@ describe("notebookStateFromSession", () => {
         id: "cell-1",
         name: "",
         code: "",
+        edited: false,
+        lastCodeRun: null,
+        lastExecutionTime: null,
+        config: {
+          hide_code: false,
+          disabled: false,
+          column: null,
+        },
+        serializedEditorState: null,
+      });
+    });
+
+    it("uses SETUP_CELL_ID for setup cell with null id", () => {
+      const notebookCell = {
+        id: null,
+        code: "import marimo as mo",
+        name: "setup",
+        code_hash: null,
+        config: {
+          hide_code: null,
+          disabled: null,
+          column: null,
+        },
+      };
+      const notebook = createNotebook([notebookCell as any]);
+      const result = notebookStateFromSession(null, notebook);
+
+      expect(result).not.toBeNull();
+      invariant(result, "result is null");
+      expect(result.cellIds.inOrderIds).toEqual(
+        MultiColumn.from([[SETUP_CELL_ID]]).inOrderIds,
+      );
+      expect(result.cellData[SETUP_CELL_ID]).toEqual({
+        id: SETUP_CELL_ID,
+        name: "setup",
+        code: "import marimo as mo",
         edited: false,
         lastCodeRun: null,
         lastExecutionTime: null,


### PR DESCRIPTION
**Problem**

Setup cells don't appear when initializing from __MARIMO_MOUNT_CONFIG__ because the
  cell data has "id": null with "name": "setup", but the code only checked the id
field and generated random IDs instead of using SETUP_CELL_ID.

**Solution**

Added a getCellId() helper that checks both id and name fields:
- If cell.id exists, use it
- If cell.name === "setup", use SETUP_CELL_ID
- Otherwise, generate a new random ID
