### PR TITLE
fix: top-level defs showing up in wasm

### DIFF
--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -35,6 +35,7 @@ from marimo._runtime.commands import (
 from marimo._runtime.context.kernel_context import initialize_kernel_context
 from marimo._runtime.input_override import input_override
 from marimo._runtime.marimo_pdb import MarimoPdb
+from marimo._runtime.runner.hooks_post_execution import render_toplevel_defs
 from marimo._runtime.runtime import Kernel
 from marimo._runtime.utils.set_ui_element_request_manager import (
     SetUIElementRequestManager,
@@ -445,6 +446,9 @@ def _launch_pyodide_kernel(
     stdin = PyodideStdin(stream) if is_edit_mode else None
     debugger = MarimoPdb(stdout=stdout, stdin=stdin) if is_edit_mode else None
 
+    # Run mode kernels do not need additional rendering for toplevel defs
+    render_hook = render_toplevel_defs if is_edit_mode else None
+
     def _enqueue_control_request(req: CommandMessage) -> None:
         control_queue.put_nowait(req)
         if isinstance(req, UpdateUIElementCommand):
@@ -465,6 +469,7 @@ def _launch_pyodide_kernel(
         enqueue_control_request=_enqueue_control_request,
         debugger_override=debugger,
         user_config=user_config,
+        render_hook=render_hook,
     )
     ctx = initialize_kernel_context(
         kernel=kernel,


### PR DESCRIPTION
Top-level defs were not showing up since we didn't pass down the proper hook.

I am doing a refactor in a followup for better hook management