### PR TITLE
set back index names

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -314,10 +314,15 @@ class PandasTableManagerFactory(TableManagerFactory):
                     original_names = list(index.names)
 
                     df_with_index = self._original_data.reset_index()
-                    # reset_index() puts index columns at the start
-                    index_columns = list(df_with_index.columns[:num_levels])
-
                     manager = PandasTableManager(df_with_index)
+
+                    # Get index column names AFTER manager init, since
+                    # _handle_non_string_column_names may have converted
+                    # non-string column names to strings
+                    index_columns = list(
+                        manager._original_data.columns[:num_levels]
+                    )
+
                     result = super(PandasTableManager, manager).search(query)
                     native_df: pd.DataFrame = nw.to_native(result.data)
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
reset_index will change the index names. We should set it back so the result doesn't change.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
