### PR TITLE
Move comm payload encoding to model message types

### DIFF
--- a/marimo/_plugins/ui/_impl/anywidget/types.py
+++ b/marimo/_plugins/ui/_impl/anywidget/types.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any, Literal, NewType, TypedDict, Union
+from typing import Any, NewType, Union
 
 # AnyWidget model id
 WidgetModelId = NewType("WidgetModelId", str)
@@ -14,49 +14,3 @@ WidgetModelState = dict[str, Any]
 
 # Widget model state without buffers
 WidgetModelStateWithoutBuffers = dict[str, Any]
-
-
-# AnyWidget model message
-class TypedModelMessage(TypedDict):
-    """
-    A typed message for AnyWidget models.
-
-    Args:
-        state: The state of the model.
-        buffer_paths: The buffer paths to update.
-    """
-
-    state: WidgetModelStateWithoutBuffers
-    buffer_paths: BufferPaths
-
-
-class TypedModelAction(TypedModelMessage):
-    """
-    A typed message for AnyWidget models.
-
-    Args:
-        method: The method to call on the model.
-        state: The state of the model.
-        buffer_paths: The buffer paths to update.
-        content: Content for custom messages (when method is "custom").
-    """
-
-    method: Literal["open", "update", "custom", "echo_update"]
-    content: Any
-
-
-class TypedModelMessageContent(TypedDict):
-    """A typed payload for AnyWidget models."""
-
-    data: TypedModelAction
-
-
-class TypedModelMessagePayload(TypedDict):
-    """
-    A typed payload for AnyWidget models.
-
-    This interface is what AnyWidget's comm.handle_msg expects
-    """
-
-    content: TypedModelMessageContent
-    buffers: list[bytes]

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    TypeAlias,
     TypedDict,
     TypeVar,
     cast,
@@ -20,7 +21,7 @@ from marimo._plugins.ui._impl.comm import MarimoComm
 from marimo._types.ids import WidgetModelId
 from marimo._utils.code import hash_code
 
-AnyWidgetState = TypeAlias = dict[str, Any]
+AnyWidgetState: TypeAlias = dict[str, Any]
 
 
 class WireFormat(TypedDict):

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -693,6 +693,15 @@ class ModelUpdateMessage(
     state: dict[str, Any]
     buffer_paths: list[list[Union[str, int]]]
 
+    def into_comm_payload_content(self) -> dict[str, Any]:
+        return {
+            "data": {
+                "method": "update",
+                "state": self.state,
+                "buffer_paths": self.buffer_paths,
+            }
+        }
+
 
 class ModelCustomMessage(
     msgspec.Struct, tag="custom", tag_field="method", rename="camel"
@@ -704,6 +713,14 @@ class ModelCustomMessage(
     """
 
     content: Any
+
+    def into_comm_payload_content(self) -> dict[str, Any]:
+        return {
+            "data": {
+                "method": "custom",
+                "content": self.content,
+            }
+        }
 
 
 ModelMessage = Union[ModelUpdateMessage, ModelCustomMessage]
@@ -723,6 +740,12 @@ class ModelCommand(Command):
     model_id: WidgetModelId
     message: ModelMessage
     buffers: list[bytes]
+
+    def into_comm_payload(self) -> dict[str, Any]:
+        return {
+            "content": self.message.into_comm_payload_content(),
+            "buffers": self.buffers,
+        }
 
 
 class RefreshSecretsCommand(Command):

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -2278,7 +2278,7 @@ class Kernel:
             request: ModelCommand,
         ) -> None:
             ui_element_id, state = WIDGET_COMM_MANAGER.receive_comm_message(
-                request.model_id, request.message, request.buffers
+                request
             )
 
             # If there's a ui_element_id, trigger a cell re-run


### PR DESCRIPTION
The comm layer was manually building nested dicts to match the ipywidgets handle_msg payload format, duplicating knowledge of each message type's shape across both the command structs and the comm manager. This also required a set of TypedDicts that were difficult to keep in sync and were causing type errors (discriminated union fields that didn't match actual usage).

Instead, each message struct now owns its serialization via `into_comm_payload_content()`, and `ModelCommand.into_comm_payload()` wraps the envelope. This lets `receive_comm_message` accept the whole `ModelCommand` directly, removing the manual dict construction and all the TypedDict definitions that supported it.
