### PR TITLE
fix: don't error when writing UI elements values that already exist

### DIFF
--- a/frontend/src/core/dom/uiregistry.ts
+++ b/frontend/src/core/dom/uiregistry.ts
@@ -51,7 +51,10 @@ export class UIElementRegistry {
 
   set(objectId: UIElementId, value: ValueType): void {
     if (this.entries.has(objectId)) {
-      throw new Error(`UIElement ${objectId} already registered`);
+      Logger.debug(
+        "UIElementRegistry overwriting entry for objectId.",
+        objectId,
+      );
     }
     this.entries.set(objectId, {
       objectId: objectId,


### PR DESCRIPTION
Since we now pre-populate the UI with the previous session, this adds/registers previous ui-elements. On refresh, we restore the values with the previous `ui_values`. Previously we would throw if they already existed, but now this is expected.