### PR TITLE
Fix spurious "truth value of UIElement" warning for anywidgets

### DIFF
--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -80,7 +80,8 @@ _cache: WeakCache[AnyWidget, UIElement[Any, Any]] = WeakCache()  # type: ignore[
 
 def from_anywidget(widget: AnyWidget) -> UIElement[Any, Any]:
     """Create a UIElement from an AnyWidget."""
-    if not (el := _cache.get(widget)):
+    el = _cache.get(widget)
+    if el is None:
         el = anywidget(widget)
         _cache.add(widget, el)  # type: ignore[no-untyped-call, unused-ignore, assignment]  # noqa: E501
     return el


### PR DESCRIPTION
The `from_anywidget` cache lookup used `if not (el := _cache.get(widget))` which evaluates the truthiness of the cached UIElement on subsequent lookups. Since `UIElement.__bool__` writes a warning to stderr, displaying the same anywidget in multiple cells would trigger the misleading message "The truth value of a UIElement is always True. You probably want to call `.value` instead."

