### PR TITLE
Close anywidget comms on cell re-execution and deletion

### DIFF
--- a/marimo/_plugins/ui/_impl/comm.py
+++ b/marimo/_plugins/ui/_impl/comm.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
 from marimo._loggers import marimo_logger
@@ -22,8 +23,9 @@ from marimo._types.ids import WidgetModelId
 LOGGER = marimo_logger()
 
 
+@dataclass
 class MarimoCommManager:
-    comms: dict[WidgetModelId, MarimoComm] = {}
+    comms: dict[WidgetModelId, MarimoComm] = field(default_factory=dict)
 
     def register_comm(self, comm: MarimoComm) -> str:
         comm_id = comm.comm_id


### PR DESCRIPTION
When a cell containing an anywidget is re-executed or deleted, the runtime invalidates cell state and removes UI elements, but no ModelClose message was ever sent to the frontend.

The `MarimoComm.__del__` fallback never fires because `MarimoCommManager.comms` holds a strong reference to every comm, preventing garbage collection. This leaks frontend objects along with their event listeners.

These changes adds a `CommLifecycleItem` that registers with the cell lifecycle registry when a widget comm is created. When the cell is invalidated (re-execution, deletion, or error), `dispose()` calls `comm.close()`, which broadcasts ModelClose to the frontend and unregisters from the comm manager.
