### PR TITLE
ci: split labeler workflow to prevent cancellation failures

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,0 +1,19 @@
+name: 🏷️ Enforce Pull Request Label
+
+# Enforces that at least one label is selected on pull requests
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: yogevbd/enforce-label-action@2.2.2
+        with:
+          REQUIRED_LABELS_ANY: "enhancement,bug,documentation,internal,preview,dependencies,other"
+          REQUIRED_LABELS_ANY_DESCRIPTION: "🏷️ Select at least one label: ['enhancement','bug','documentation','internal','preview','dependencies','other']"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,17 +1,10 @@
 name: 🏷️ Pull Request Labeler
 
-# Label pull requests based on config in .github/labeler.yml
-# And enforces that at least one label is selected
+# Auto-label pull requests based on config in .github/labeler.yml
 
 on:
   pull_request_target:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
-  pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -19,18 +12,8 @@ permissions:
 
 jobs:
   auto-label:
-    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-  enforce-label:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
-        with:
-          REQUIRED_LABELS_ANY: "enhancement,bug,documentation,internal,preview,dependencies,other"
-          REQUIRED_LABELS_ANY_DESCRIPTION: "🏷️ Select at least one label: ['enhancement','bug','documentation','internal','preview','dependencies','other']"


### PR DESCRIPTION
The labeler workflow used a shared concurrency group with cancel-in-progress for both auto-labeling (pull_request_target) and label enforcement (pull_request). When both events fired for the same PR, one would cancel the other, causing the enforce-label check to show as failed.

Split into two independent workflow files so they no longer interfere with each other.