### PR TITLE
fix: use mount_config.code and filename as fallback in WASM mode

### DIFF
--- a/frontend/src/core/wasm/__tests__/store.test.ts
+++ b/frontend/src/core/wasm/__tests__/store.test.ts
@@ -1,5 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { describe, expect, it, vi } from "vitest";
+import { codeAtom } from "../../saving/file-state";
+import { store } from "../../state/jotai";
 import {
   CompositeFileStore,
   domElementFileStore,
@@ -7,8 +9,6 @@ import {
   mountConfigFileStore,
   notebookFileStore,
 } from "../store";
-import { store } from "../../state/jotai";
-import { codeAtom } from "../../saving/file-state";
 
 describe("localStorageFileStore", () => {
   it("calls set with correct contents on saveFile", () => {

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -9,7 +9,6 @@ import { Logger } from "@/utils/Logger";
 import { reloadSafe } from "@/utils/reload-safe";
 import { generateUUID } from "@/utils/uuid";
 import { notebookIsRunningAtom } from "../cells/cells";
-import { filenameAtom } from "../saving/file-state";
 import type { CommandMessage } from "../kernel/messages";
 import { getMarimoVersion } from "../meta/globals";
 import { getInitialAppMode } from "../mode";
@@ -30,6 +29,7 @@ import type {
   SaveUserConfigurationRequest,
   Snippets,
 } from "../network/types";
+import { filenameAtom } from "../saving/file-state";
 import { store } from "../state/jotai";
 import { BasicTransport } from "../websocket/transports/basic";
 import type { IConnectionTransport } from "../websocket/transports/transport";

--- a/frontend/src/core/wasm/store.ts
+++ b/frontend/src/core/wasm/store.ts
@@ -4,9 +4,9 @@ import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from "lz-string";
-import { TypedLocalStorage } from "@/utils/storage/typed";
-import { store } from "@/core/state/jotai";
 import { codeAtom } from "@/core/saving/file-state";
+import { store } from "@/core/state/jotai";
+import { TypedLocalStorage } from "@/utils/storage/typed";
 import { PyodideRouter } from "./router";
 
 export interface FileStore {


### PR DESCRIPTION
When embedding marimo in WASM mode without a marimo-code element, the mount config's code and filename options are now used as fallbacks.

Code fallback priority:
1. mount_config.code
2. marimo-code element
3. URL params
4. local storage
5. remote default
6. empty notebook

Filename fallback priority:
1. mount_config.filename
2. URL param (?filename=...)

Fixes #8026
