### PR TITLE
fix: prevent stdout reader thread death from hanging cell execution

### DIFF
--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -186,23 +186,40 @@ class ThreadSafeStream(Stream):
 def _forward_os_stream(
     standard_stream: Stdout | Stderr, fd: int, should_exit: threading.Event
 ) -> None:
-    """Watch a file descriptor and forward it to a stream object."""
+    """Watch a file descriptor and forward it to a stream object.
 
-    # This coarse try/except block silences exceptions; a raised exception
-    # at this point could cause bad errors, such as an infinite stream of data
-    # to be written to the fd/routed through the stream.
-    #
-    # TODO(akshayka): Make this loop bomb-proof, so that exceptions raised are
-    # exceptions we actually want to pay attention to; then store the exception
-    # and print it to the terminal later (outside an execution context).
+    Reads raw bytes from fd and decodes them as UTF-8 before forwarding.
+    Uses an incremental decoder to correctly handle multi-byte characters
+    that may be split across read boundaries (e.g., from C libraries writing
+    output with non-ASCII or ANSI escape codes). Invalid bytes are replaced
+    with U+FFFD rather than raising an exception.
+
+    This function must not exit from transient errors, since a dead reader
+    thread causes the pipe to fill up and block all subsequent writes to the
+    fd, hanging cell execution. See https://github.com/marimo-team/marimo/issues/5536
+    """
+    import codecs
+
+    # Incremental decoder handles multi-byte chars split across reads.
+    # errors="replace" ensures invalid bytes produce U+FFFD instead of
+    # raising UnicodeDecodeError and killing this thread.
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
     try:
         while not should_exit.is_set():
-            data = os.read(fd, 1024)
+            data = os.read(fd, 4096)
             if not data:
                 break
-            standard_stream.write(data.decode())
-    except Exception:
-        ...
+            try:
+                text = decoder.decode(data)
+                if text:
+                    standard_stream.write(text)
+            except Exception:
+                # If write fails (e.g., cell_id is None between cells),
+                # discard the data but keep the thread alive
+                pass
+    except OSError:
+        # fd was closed — normal shutdown
+        pass
 
 
 class _NoOpWatcher:

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -21,11 +21,16 @@ if TYPE_CHECKING:
 
 
 def forward_os_stream(stream_object: Stdout | Stderr, fd: int) -> None:
+    import codecs
+
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
     while True:
-        data = os.read(fd, 1024)
+        data = os.read(fd, 4096)
         if not data:
             break
-        stream_object.write(data.decode())
+        text = decoder.decode(data)
+        if text:
+            stream_object.write(text)
 
 
 def dup2newfd(fd: int) -> tuple[int, int, int]:

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -25,10 +25,14 @@ def forward_os_stream(stream_object: Stdout | Stderr, fd: int) -> None:
 
     decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
     while True:
-        data = os.read(fd, 4096)
-        if not data:
+        try:
+            data = os.read(fd, 4096)
+            if not data:
+                break
+            text = decoder.decode(data)
+        except Exception:
+            # fd is likely invalid or closed; stop reading.
             break
-        text = decoder.decode(data)
         if text:
             stream_object.write(text)
 

--- a/tests/_messaging/test_streams.py
+++ b/tests/_messaging/test_streams.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider, MockedKernel
 
@@ -195,3 +197,148 @@ async def test_import_multiprocessing(
         ]
     )
     assert mocked_kernel.stdout.messages == ["hello", "\n"]
+
+
+class TestFdLevelStdout:
+    """Tests for C library-style writes directly to the OS file descriptor.
+
+    Reproduces https://github.com/marimo-team/marimo/issues/5536
+    where C libraries writing to stdout via the OS file descriptor
+    can kill the reader thread and cause subsequent cells to hang.
+    """
+
+    @staticmethod
+    @pytest.mark.timeout(10)
+    def test_forward_os_stream_survives_split_multibyte_utf8() -> None:
+        """The _forward_os_stream reader thread must not die when a
+        multi-byte UTF-8 character is split across read boundaries.
+
+        This is the root cause of #5536: the reader thread calls
+        data.decode() which raises UnicodeDecodeError for incomplete
+        sequences. The bare except silently kills the thread. Then on
+        the next cell execution, writes to the pipe block forever
+        because nobody is draining it.
+        """
+        import os
+        import threading
+        import time
+
+        from marimo._messaging.streams import _forward_os_stream
+
+        # Collect all data written through the stream
+        received: list[str] = []
+
+        class FakeStream:
+            def write(self, data: str) -> int:
+                received.append(data)
+                return len(data)
+
+        read_fd, write_fd = os.pipe()
+        should_exit = threading.Event()
+
+        thread = threading.Thread(
+            target=_forward_os_stream,
+            args=(FakeStream(), read_fd, should_exit),
+            daemon=True,
+        )
+        thread.start()
+
+        # Write 1023 ASCII bytes + first byte of 'é' (U+00E9 = 0xC3 0xA9)
+        # If os.read returns exactly 1024 bytes, decode() fails on \xc3
+        data = b"A" * 1023 + b"\xc3"
+        os.write(write_fd, data)
+        # Write the second byte of 'é'
+        os.write(write_fd, b"\xa9")
+        # Write a marker so we know the thread processed everything
+        os.write(write_fd, b"DONE")
+
+        time.sleep(0.5)
+
+        # The reader thread should still be alive
+        assert thread.is_alive(), (
+            "Reader thread died (likely from UnicodeDecodeError)"
+        )
+
+        # All data should have been forwarded (possibly merged differently)
+        all_data = "".join(received)
+        assert "DONE" in all_data, (
+            f"Reader thread stopped processing data. Got: {all_data!r}"
+        )
+
+        # Cleanup
+        should_exit.set()
+        os.close(write_fd)
+        thread.join(timeout=2)
+        os.close(read_fd)
+
+    @staticmethod
+    @pytest.mark.timeout(10)
+    def test_forward_os_stream_survives_invalid_utf8() -> None:
+        """The reader thread must not die on completely invalid UTF-8 bytes."""
+        import os
+        import threading
+        import time
+
+        from marimo._messaging.streams import _forward_os_stream
+
+        received: list[str] = []
+
+        class FakeStream:
+            def write(self, data: str) -> int:
+                received.append(data)
+                return len(data)
+
+        read_fd, write_fd = os.pipe()
+        should_exit = threading.Event()
+
+        thread = threading.Thread(
+            target=_forward_os_stream,
+            args=(FakeStream(), read_fd, should_exit),
+            daemon=True,
+        )
+        thread.start()
+
+        # Write invalid UTF-8 bytes (standalone continuation bytes)
+        os.write(write_fd, b"\x80\x81\x82\xff\xfe")
+        # Write valid ASCII after the invalid bytes
+        os.write(write_fd, b"AFTER")
+
+        time.sleep(0.5)
+
+        assert thread.is_alive(), "Reader thread died on invalid UTF-8 bytes"
+        all_data = "".join(received)
+        assert "AFTER" in all_data, (
+            f"Reader thread stopped processing. Got: {all_data!r}"
+        )
+
+        # Cleanup
+        should_exit.set()
+        os.close(write_fd)
+        thread.join(timeout=2)
+        os.close(read_fd)
+
+    @staticmethod
+    @pytest.mark.timeout(10)
+    async def test_fd_write_large_output_does_not_hang(
+        mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+    ) -> None:
+        """Large C library-style fd writes should not hang the cell."""
+        # Get the fd that the watcher redirected (the original stdout fd)
+        watcher = mocked_kernel.stdout._watcher
+        target_fd = watcher.fd  # This is the fd that C libraries write to
+
+        await mocked_kernel.k.run(
+            [
+                exec_req.get(
+                    f"""
+                    import os
+                    # Simulate a C library writing lots of output with ANSI codes
+                    chunk = b'\\x1b[1mBold text\\x1b[0m some output line\\n'
+                    for _ in range(1000):
+                        os.write({target_fd}, chunk)
+                    result = "done"
+                    """
+                )
+            ]
+        )
+        assert mocked_kernel.k.globals["result"] == "done"


### PR DESCRIPTION
Closes #5536

## Summary

- Fixed a bug where C libraries (like JSBSim) writing to stdout via the OS file descriptor could cause marimo cells to hang forever
- The `_forward_os_stream` reader thread used strict `data.decode()` on raw pipe bytes, which raised `UnicodeDecodeError` when a multi-byte UTF-8 character was split across the 1024-byte read boundary — silently killing the thread
- With the reader thread dead, subsequent writes to the pipe filled the buffer with no reader to drain it, blocking cell execution indefinitely
- Replaced with `codecs.getincrementaldecoder("utf-8")(errors="replace")` to correctly handle split multi-byte characters and invalid bytes
- Moved error handling inside the loop so transient failures don't kill the thread
- Increased read buffer from 1024 to 4096 bytes for better throughput
