### PR TITLE
fix: prevent sidebar resize handle from overlapping file explorer buttons  

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -227,6 +227,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
   const helperResizeHandle = (
     <PanelResizeHandle
       onDragging={handleDragging}
+      hitAreaMargins={{ coarse: 15, fine: 2 }}
       className={cn(
         "border-border print:hidden z-10",
         isSidebarOpen ? "resize-handle" : "resize-handle-collapsed",
@@ -281,7 +282,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
   const helpPaneBody = (
     <ErrorBoundary>
       <PanelSectionProvider value="sidebar">
-        <div className="flex flex-col h-full flex-1 overflow-hidden mr-[-4px]">
+        <div className="flex flex-col h-full flex-1 overflow-hidden">
           <div className="p-3 border-b flex justify-between items-center">
             {selectedPanel === "dependencies" ? (
               <div className="flex items-center justify-between flex-1">


### PR DESCRIPTION
## 📝 Summary

Closes #5920

## Description of Changes

The sidebar resize handle's hit area overlapped with the file explorer's three-dot menu button, making it difficult to click "Rename" and other file actions.

Two changes in `frontend/src/components/editor/chrome/wrapper/app-chrome.tsx`:

1. **Removed `mr-[-4px]` negative margin** on the sidebar panel body. This margin was pushing the file list content 4px into the resize handle zone, causing the entire handle to sit on top of interactive elements.

2. **Reduced `hitAreaMargins` on `PanelResizeHandle`** from the library default of `{ coarse: 15, fine: 5 }` to `{ coarse: 15, fine: 2 }`. The `fine` value controls the invisible hit area for mouse pointers — reducing it from 5px to 2px keeps the resize cursor from appearing too far from the actual panel edge. The `coarse` value (touch devices) is kept at the default since larger touch targets are needed there.

## Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
