### PR TITLE
fix: disable panel resize handles when panels are collapsed

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -226,6 +226,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
 
   const helperResizeHandle = (
     <PanelResizeHandle
+      disabled={!isSidebarOpen}
       onDragging={handleDragging}
       className={cn(
         "border-border print:hidden z-10",
@@ -237,6 +238,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
 
   const panelResizeHandle = (
     <PanelResizeHandle
+      disabled={!isDeveloperPanelOpen}
       onDragging={handleDragging}
       className={cn(
         "border-border print:hidden z-20",


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #7184

## Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

When the left sidebar or bottom developer panel is collapsed, the `PanelResizeHandle` from `react-resizable-panels` remains active. This causes:
- A resize cursor (`col-resize` / `row-resize`) to appear when hovering over the collapsed panel edge
- The panel to be draggable open from the edge, bypassing the sidebar icon toggle

The fix adds the built-in `disabled` prop to both `PanelResizeHandle` components, disabling them when their respective panels are collapsed. When disabled, the handle does not register with the parent `PanelGroup`, so no hit area, cursor, or drag behavior is active.

## Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
