### PR TITLE
fix: handle null registration.active in service worker registration

### DIFF
--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -234,6 +234,16 @@ def test_inject_service_worker() -> None:
     )
 
 
+def test_inject_service_worker_null_check() -> None:
+    result = _inject_service_worker("<body></body>", "notebook.py")
+    # The helper function should check registration.active before posting
+    assert "function sendNotebookId(registration)" in result
+    assert "if (registration.active)" in result
+    # Should handle installing/waiting workers via statechange listener
+    assert "registration.installing || registration.waiting" in result
+    assert "statechange" in result
+
+
 def test_index_with_missing_local_file_and_asset_url(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #5304

Service worker registration code assumes `registration.active` is immediately available after calling `navigator.serviceWorker.register()`. However, service workers go through lifecycle states (`installing` → `waiting` → `active`), and `registration.active` can be `null` during these transitions. This causes `TypeError: registration.active is null` errors in the browser console on every notebook load.

### Changes

- Added a `sendNotebookId` helper function that safely handles the null case:
  - If `registration.active` exists, posts the message immediately
  - Otherwise, finds the `installing` or `waiting` worker and listens for `statechange` to post the message once the worker reaches the `activated` state
- Replaced both direct `registration.active.postMessage()` calls (after `.register()` and after `.update()`) with the helper
- Added a test to verify the null-check logic is present in the injected script

### Test plan

- [x] Existing `test_inject_service_worker` passes (notebook ID encoding still works)
- [x] New `test_inject_service_worker_null_check` verifies the helper function and statechange listener are present
- [x] `hatch run lint` passes
- [x] `hatch run format` passes (no changes)