### PR TITLE
fix: prevent margin collapse between consecutive cell outputs

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -172,11 +172,9 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
   // spacing is handled elsewhere
   return (
     <VerticalLayoutWrapper invisible={invisible} appConfig={appConfig}>
-      {showCode && canShowCode ? (
-        <div className="flex flex-col gap-5"> {renderCells()}</div>
-      ) : (
-        renderCells()
-      )}
+      <div className={cn("flex flex-col", showCode && canShowCode && "gap-5")}>
+        {renderCells()}
+      </div>
       {mode === "read" && (
         <ActionButtons
           canShowCode={canShowCode}


### PR DESCRIPTION
## Summary

Fixes #3063

In run mode, consecutive markdown cell outputs have slightly less vertical spacing than content within a single markdown cell. This happens because CSS margin collapsing merges the `margin-bottom: 1rem` of one cell output with the `margin-top: 1rem` of the next, resulting in only `1rem` of gap instead of `2rem`.

### Changes

Wrapped `renderCells()` in a `flex flex-col` container in `VerticalLayoutRenderer`. Flexbox containers prevent margin collapse between children, so the full `1rem + 1rem` spacing is preserved between adjacent cell outputs. The existing `gap-5` for the "show code" variant is conditionally applied on the same container.

This is a net reduction of 2 lines (removed the ternary branch that only wrapped cells when code was shown).

## Test plan

- [x] Visual: consecutive markdown cells in run mode now have consistent spacing matching single-cell content
- [x] The "show code" mode still applies `gap-5` between cells