### PR TITLE
fix: allow interaction with sidebar behind package alert popup

### DIFF
--- a/frontend/src/components/editor/package-alert.tsx
+++ b/frontend/src/components/editor/package-alert.tsx
@@ -96,10 +96,10 @@ export const PackageAlert: React.FC = () => {
 
   if (isMissingPackageAlert(packageAlert)) {
     return (
-      <div className="flex flex-col gap-4 mb-5 fixed top-5 left-12 min-w-[400px] z-200 opacity-95 max-w-[600px]">
+      <div className="flex flex-col gap-4 mb-5 fixed top-5 left-12 min-w-[400px] z-200 opacity-95 max-w-[600px] pointer-events-none">
         <Banner
           kind="danger"
-          className="flex flex-col rounded py-3 px-5 animate-in slide-in-from-left overflow-auto max-h-[80vh] scrollbar-thin"
+          className="flex flex-col rounded py-3 px-5 animate-in slide-in-from-left overflow-auto max-h-[80vh] scrollbar-thin pointer-events-auto"
         >
           <div className="flex justify-between">
             <span className="font-bold text-lg flex items-center mb-2">
@@ -207,10 +207,10 @@ export const PackageAlert: React.FC = () => {
     }
 
     return (
-      <div className="flex flex-col gap-4 mb-5 fixed top-5 left-12 min-w-[400px] z-200 opacity-95 max-w-[600px] ">
+      <div className="flex flex-col gap-4 mb-5 fixed top-5 left-12 min-w-[400px] z-200 opacity-95 max-w-[600px] pointer-events-none">
         <Banner
           kind={status === "failed" ? "danger" : "info"}
-          className="flex flex-col rounded pt-3 pb-4 px-5 overflow-auto max-h-[80vh] scrollbar-thin"
+          className="flex flex-col rounded pt-3 pb-4 px-5 overflow-auto max-h-[80vh] scrollbar-thin pointer-events-auto"
         >
           <div className="flex justify-between">
             <span className="font-bold text-lg flex items-center mb-2">


### PR DESCRIPTION
## Summary

Fixes #6680

The package alert popup (missing/installing packages banner) uses `fixed` positioning with `z-200` and has `min-w-[400px]`, creating an invisible overlay area that blocks pointer events on elements behind it — most notably the sidebar's search input in the packages panel. This is especially noticeable in Safari.

### Changes

- Added `pointer-events-none` to the outer fixed container so clicks pass through to elements behind the alert
- Added `pointer-events-auto` to the inner `Banner` component so the alert itself remains fully interactive

Both the "missing packages" and "installing packages" alert variants are fixed.

## Test plan

- [x] The alert banner is still clickable (close button, install button, package manager select)
- [x] The sidebar search input is accessible while the alert is visible
- [x] Dropdown menus within the alert still work (extras selector, version picker)