### PR TITLE
fix: suppress RuntimeWarning for all-NaN DataFrame columns

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -517,8 +517,16 @@ class NarwhalsTableManager(
                     }
                 )
 
+        import warnings
+
         stats = frame.select(**exprs)
-        stats_dict = stats.collect().rows(named=True)[0]
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Mean of empty slice|Degrees of freedom",
+                category=RuntimeWarning,
+            )
+            stats_dict = stats.collect().rows(named=True)[0]
 
         # Maybe add units to the stats
         for key, value in stats_dict.items():

--- a/tests/_plugins/ui/_impl/tables/test_narwhals.py
+++ b/tests/_plugins/ui/_impl/tables/test_narwhals.py
@@ -491,6 +491,19 @@ class TestNarwhalsTableManagerFactory(unittest.TestCase):
         assert isinstance(bool_stats.true, int)
         assert isinstance(bool_stats.false, int)
 
+    def test_summary_all_nan_column_no_warning(self) -> None:
+        import warnings
+
+        import polars as pl
+
+        data = pl.DataFrame({"A": [float("nan"), float("nan"), float("nan")]})
+        manager = NarwhalsTableManager.from_dataframe(data)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            stats = manager.get_stats("A")
+        assert stats is not None
+        assert stats.total == 3
+
     def test_sort_values(self) -> None:
         sorted_df = self.manager.sort_values(
             [SortArgs(by="A", descending=True)]


### PR DESCRIPTION
## Summary

- Wraps `stats.collect()` in `warnings.catch_warnings()` to suppress `RuntimeWarning` ("Mean of empty slice" / "Degrees of freedom") when computing column statistics on columns that contain only NaN values
- Adds a test that verifies no warnings are raised when calling `get_stats()` on an all-NaN column

## Test plan

- [x] New test `test_summary_all_nan_column_no_warning` passes with `warnings.simplefilter("error")` — confirms no RuntimeWarning is raised
- [x] Existing summary tests continue to pass
- [x] Lint passes

Closes #7046