### PR TITLE
fix: include xfailed and xpassed in pytest summary counts

### DIFF
--- a/marimo/_runtime/pytest.py
+++ b/marimo/_runtime/pytest.py
@@ -30,19 +30,35 @@ class MarimoPytestResult:
     failed: int = 0
     errors: int = 0
     skipped: int = 0
+    xfailed: int = 0
+    xpassed: int = 0
     output: Optional[str] = None
 
     @property
     def total(self) -> int:
-        return self.skipped + self.passed + self.failed + self.errors
+        return (
+            self.passed
+            + self.failed
+            + self.errors
+            + self.skipped
+            + self.xfailed
+            + self.xpassed
+        )
 
     @property
     def summary(self) -> str:
-        return (
-            f"Total: {self.total}, Passed: {self.passed}, "
-            f"Failed: {self.failed}, Errors: {self.errors}, "
-            f"Skipped: {self.skipped}"
-        )
+        parts = [
+            f"Total: {self.total}",
+            f"Passed: {self.passed}",
+            f"Failed: {self.failed}",
+            f"Errors: {self.errors}",
+            f"Skipped: {self.skipped}",
+        ]
+        if self.xfailed:
+            parts.append(f"XFailed: {self.xfailed}")
+        if self.xpassed:
+            parts.append(f"XPassed: {self.xpassed}")
+        return ", ".join(parts)
 
 
 def _get_name(default: str = "notebook.py") -> str:
@@ -258,8 +274,15 @@ class ReplaceStubPlugin:
         failed: int = len(stats.get("failed", []))
         skipped: int = len(stats.get("skipped", []))
         errors: int = len(stats.get("error", []))
+        xfailed: int = len(stats.get("xfailed", []))
+        xpassed: int = len(stats.get("xpassed", []))
         self._result = MarimoPytestResult(
-            passed=passed, failed=failed, errors=errors, skipped=skipped
+            passed=passed,
+            failed=failed,
+            errors=errors,
+            skipped=skipped,
+            xfailed=xfailed,
+            xpassed=xpassed,
         )
 
         tr.write_line(self._result.summary)

--- a/tests/_runtime/test_pytest_runtime.py
+++ b/tests/_runtime/test_pytest_runtime.py
@@ -80,3 +80,22 @@ def test_smoke_test():
     # Assert all cases captured, and nothing missed.
     # Total: 0+0+0+2+1+3+2+1+1+3+3+1+2+1+3+1+2+1+0+0+1+1+1 = 30
     assert total == sum(map(sum, def_count.values())) == 30
+
+
+def test_pytest_result_summary_includes_xfail() -> None:
+    from marimo._runtime.pytest import MarimoPytestResult
+
+    result = MarimoPytestResult(
+        passed=2, failed=1, errors=0, skipped=1, xfailed=3, xpassed=1
+    )
+    assert result.total == 8
+    assert "XFailed: 3" in result.summary
+    assert "XPassed: 1" in result.summary
+
+
+def test_pytest_result_summary_omits_zero_xfail() -> None:
+    from marimo._runtime.pytest import MarimoPytestResult
+
+    result = MarimoPytestResult(passed=5, failed=0, errors=0, skipped=0)
+    assert "XFailed" not in result.summary
+    assert "XPassed" not in result.summary


### PR DESCRIPTION
## Summary

- Adds `xfailed` and `xpassed` fields to `MarimoPytestResult` and collects them from pytest's terminal reporter stats
- Includes these counts in `total` so the summary accurately reflects all test outcomes
- Shows XFailed/XPassed conditionally in the summary (only when non-zero) to keep output clean

## Test plan

- [x] New tests verify xfailed/xpassed are included in total and summary string
- [x] New tests verify they are omitted from summary when zero
- [x] Lint passes

Closes #7665