### PR TITLE
fix: hide sidebar content when collapsed instead of squishing

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/sidebar/sidebar.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/sidebar/sidebar.tsx
@@ -22,7 +22,12 @@ export const Sidebar = ({ isOpen, toggle, width }: SidebarProps) => {
       )}
     >
       <SidebarToggle isOpen={isOpen} toggle={toggle} />
-      <div className="relative h-full flex flex-col px-3 pb-16 pt-14 overflow-y-auto shadow-sm border-l">
+      <div
+        className={cn(
+          "relative h-full flex flex-col px-3 pb-16 pt-14 overflow-y-auto shadow-sm border-l",
+          !isOpen && "invisible overflow-hidden",
+        )}
+      >
         <SidebarSlot />
       </div>
     </aside>


### PR DESCRIPTION
## Summary

- When the sidebar is collapsed, the content area was being squeezed into the narrow space, producing unreadable squished text for flex items like `mo.outline()`
- Hides the content div with `invisible overflow-hidden` when collapsed so only the toggle button remains visible

## Test plan

- [x] All 6 existing sidebar tests pass
- [x] Frontend typecheck has no new errors (pre-existing errors in unrelated `model-registry.ts`)

Closes #6852