### PR TITLE
fix: preserve return statements inside nested functions when pasting

### DIFF
--- a/frontend/src/core/codemirror/misc/__tests__/paste.test.ts
+++ b/frontend/src/core/codemirror/misc/__tests__/paste.test.ts
@@ -140,6 +140,24 @@ def _(
     expect(extractCells(input)).toEqual(["x = a + b + c"]);
   });
 
+  it("preserves return statements inside nested functions", () => {
+    const input = `
+@app.cell
+def _(mo, px):
+    def make_fig():
+        data = {'category': ['foo', 'bar'], 'value': [10, 20]}
+        fig = px.bar(data, x='category', y='value')
+        return fig
+
+    fig = make_fig()
+    mo.ui.plotly(fig)
+    return
+`;
+    expect(extractCells(input)).toEqual([
+      "def make_fig():\n    data = {'category': ['foo', 'bar'], 'value': [10, 20]}\n    fig = px.bar(data, x='category', y='value')\n    return fig\n\nfig = make_fig()\nmo.ui.plotly(fig)",
+    ]);
+  });
+
   it("handles cells with config", () => {
     const input = `
 @app.cell(hide_code=True, column=2)


### PR DESCRIPTION
## Summary

- When pasting marimo app code, all `return` statements were stripped regardless of indentation, removing returns from nested functions (e.g. `return fig` inside a helper function)
- Now only strips `return` statements at the cell's base indentation level (the top-level return used by marimo cells to expose variables)
- Returns inside nested functions, loops, and conditionals are preserved

## Test plan

- [x] New test verifies nested function returns are preserved when pasting
- [x] All 12 existing paste tests continue to pass
- [x] Frontend tests pass

Closes #6473