### PR TITLE
fix: normalize Html subclasses in as_html for correct f-string formatting

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -304,6 +304,10 @@ def as_html(value: object) -> Html:
         ```
     """
     if isinstance(value, Html):
+        # Normalize Html subclasses (like _md) to plain Html so that
+        # __format__ returns processed HTML instead of raw source text.
+        if type(value) is not Html:
+            return Html(value.text)
         return value
 
     formatter = get_formatter(value)

--- a/tests/_output/formatters/test_formatters.py
+++ b/tests/_output/formatters/test_formatters.py
@@ -689,6 +689,21 @@ def test_as_html_with_html_object() -> None:
     assert result.text == "<h1>Hello</h1>"
 
 
+def test_as_html_with_md_object_formats_as_html() -> None:
+    """Test as_html normalizes md objects so __format__ returns HTML."""
+    from marimo._output.md import md
+
+    md_obj = md("# Title")
+    result = as_html(md_obj)
+
+    # Should be a plain Html, not the _md subclass
+    assert type(result).__name__ == "Html"
+    # When used in an f-string, should produce HTML, not raw markdown
+    formatted = f"{result}"
+    assert "# Title" not in formatted
+    assert "<" in formatted  # Should contain HTML tags
+
+
 def test_as_html_with_repr_html() -> None:
     """Test as_html with objects that have _repr_html_ method."""
     register_formatters()


### PR DESCRIPTION
## Summary
- When `mo.as_html(mo.md("# Title"))` is used in an f-string (e.g., `mo.Html(f"{mo.as_html(mo.md('# Title'))}")`), the result contains raw markdown instead of HTML
- Root cause: `_md` overrides `__format__` to return raw markdown text, and `as_html()` returns `_md` objects unchanged since `_md` is an `Html` subclass
- Fix: in `as_html()`, normalize `Html` subclasses to plain `Html` objects so `__format__` returns processed HTML

## Test plan
- [x] Added test `test_as_html_with_md_object_formats_as_html` verifying that `as_html(md(...))` produces HTML when used in f-strings
- [x] Existing `test_as_html_with_html_object` confirms plain `Html` objects are still returned as-is
- [x] All `tests/_output/` tests pass

Closes #7931