### PR TITLE
fix: prevent resize cursor on collapsed panels

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.css
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.css
@@ -4,6 +4,10 @@
   outline: none;
 }
 
+.resize-handle-collapsed {
+  cursor: default;
+}
+
 .resize-handle.horizontal,
 .resize-handle-collapsed.horizontal {
   height: 4px;


### PR DESCRIPTION
## Summary
- When a sidebar or developer panel is collapsed, the resize handle still shows a resize cursor (`col-resize` / `row-resize`), misleading users into thinking they can drag to resize
- Override the cursor to `default` on the `.resize-handle-collapsed` class

## Test plan
- [x] Hover over the border of a collapsed sidebar/developer panel — cursor should be `default` instead of `col-resize`/`row-resize`

Closes #7184