### PR TITLE
fix: align table column headers with text_justify_columns setting

### DIFF
--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -69,6 +69,7 @@ interface DataTableColumnHeaderProps<TData, TValue>
   header: React.ReactNode;
   calculateTopKRows?: CalculateTopKRows;
   table?: Table<TData>;
+  justify?: "left" | "center" | "right";
 }
 
 export const DataTableColumnHeader = <TData, TValue>({
@@ -77,6 +78,7 @@ export const DataTableColumnHeader = <TData, TValue>({
   className,
   calculateTopKRows,
   table,
+  justify,
 }: DataTableColumnHeaderProps<TData, TValue>) => {
   const [isFilterValueOpen, setIsFilterValueOpen] = useState(false);
   const { locale } = useLocale();
@@ -101,6 +103,7 @@ export const DataTableColumnHeader = <TData, TValue>({
           <div
             className={cn(
               "group flex items-center my-1 space-between w-full select-none gap-2 border hover:border-border border-transparent hover:bg-(--slate-3) data-[state=open]:bg-(--slate-3) data-[state=open]:border-border rounded px-1 -mx-1",
+              justify === "right" && "flex-row-reverse",
               className,
             )}
             data-testid="data-table-sort-button"

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -208,12 +208,15 @@ export function generateColumns<T>({
           headerWithType
         );
 
+        const headerJustify = textJustifyColumns?.[key];
+
         const dataTableColumnHeader = (
           <DataTableColumnHeader
             header={headerWithTooltip}
             column={column}
             calculateTopKRows={calculateTopKRows}
             table={table}
+            justify={headerJustify}
           />
         );
 
@@ -223,7 +226,16 @@ export function generateColumns<T>({
         }
 
         return (
-          <div className="flex flex-col h-full pt-0.5 pb-3 justify-between items-start">
+          <div
+            className={cn(
+              "flex flex-col h-full pt-0.5 pb-3 justify-between",
+              headerJustify === "right"
+                ? "items-end"
+                : headerJustify === "center"
+                  ? "items-center"
+                  : "items-start",
+            )}
+          >
             {dataTableColumnHeader}
             <TableColumnSummary columnId={key} />
           </div>


### PR DESCRIPTION
## Summary
- Column headers now follow the same alignment as their cell data when `text_justify_columns` is used
- Right-justified columns get right-aligned headers with the sort/filter icon swapped to the left via `flex-row-reverse`
- Center-justified columns get centered headers

## Changes
- `columns.tsx`: Pass `textJustifyColumns` alignment to header wrapper (`items-end`/`items-center`/`items-start`) and to `DataTableColumnHeader` via new `justify` prop
- `column-header.tsx`: Accept optional `justify` prop; apply `flex-row-reverse` when `justify === "right"` to swap header text and sort icon positions

## Test plan
- [x] All 47 existing column tests pass
- [x] TypeScript typecheck passes
- [ ] Create a table with `text_justify_columns={"col": "right"}` and verify the header aligns right with the sort icon on the left

Closes #7967