### PR TITLE
fix: prevent mermaid LR diagrams from being squished

### DIFF
--- a/frontend/src/plugins/layout/mermaid/mermaid.tsx
+++ b/frontend/src/plugins/layout/mermaid/mermaid.tsx
@@ -22,6 +22,7 @@ const DEFAULT_CONFIG: MermaidConfig = {
   flowchart: {
     htmlLabels: true,
     curve: "linear",
+    useMaxWidth: false,
   },
   sequence: {
     diagramMarginX: 50,
@@ -88,7 +89,11 @@ const Mermaid: React.FC<Props> = ({ diagram }) => {
     return null;
   }
 
-  return <div dangerouslySetInnerHTML={{ __html: svg }} />;
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <div dangerouslySetInnerHTML={{ __html: svg }} />
+    </div>
+  );
 };
 
 export default Mermaid;


### PR DESCRIPTION
## Summary
- Set `flowchart.useMaxWidth: false` in the default mermaid config so LR flowcharts render at their natural width instead of being compressed to fit the container
- Wrapped the rendered SVG in a scrollable container (`overflow-x: auto`) so wide diagrams remain accessible without overflowing the layout

## Motivation
LR (left-to-right) mermaid diagrams get squished because `useMaxWidth` defaults to `true`, forcing the SVG width to match the container. This works fine for TB layouts which are typically narrower, but compresses wide LR layouts, making text unreadable.

Closes #6697