### PR TITLE
fix: set data-theme attribute on body for third-party dark mode compat

### DIFF
--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -10,8 +10,10 @@ export const ThemeProvider: React.FC<PropsWithChildren> = memo(
     const { theme } = useTheme();
     useLayoutEffect(() => {
       document.body.classList.add(theme, `${theme}-theme`);
+      document.body.dataset.theme = theme;
       return () => {
         document.body.classList.remove(theme, `${theme}-theme`);
+        delete document.body.dataset.theme;
       };
     }, [theme]);
 


### PR DESCRIPTION
## Summary
- Sets `data-theme` attribute on the `<body>` element alongside the existing class-based approach (`body.dark`, `body.dark-theme`)
- Third-party libraries like xarray detect dark mode via `body[data-theme="dark"]`, which didn't match marimo's class-only approach, causing their HTML repr to render with light-mode colors in dark mode

## Details
xarray's CSS uses these selectors for dark mode:
```css
html[theme="dark"],
html[data-theme="dark"],
body[data-theme="dark"],
body.vscode-dark
```

None of these matched marimo's `body.dark` / `body.dark-theme` classes. Adding `data-theme` to the body bridges this gap and also benefits other PyData ecosystem libraries that follow the same convention.

Closes #6920