### PR TITLE
Add contiguous-run merging for batched commands

### DIFF
--- a/marimo/_runtime/utils/set_ui_element_request_manager.py
+++ b/marimo/_runtime/utils/set_ui_element_request_manager.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union
 
 from marimo._runtime.commands import (
     ModelCommand,
@@ -16,6 +16,154 @@ if TYPE_CHECKING:
     import asyncio
 
 BatchableCommand = Union[UpdateUIElementCommand, ModelCommand]
+
+A = TypeVar("A")
+B = TypeVar("B")
+
+
+class _RunAccumulator(Generic[A, B]):
+    """Merges contiguous runs of same-type commands.
+
+    Uses Generic[A, B] for precise merge function typing. If a third
+    command type is needed, this could be generalized to accept a
+    dict[type, Callable] instead.
+
+    Example::
+
+        A A A B B B A A B B  →  A(merged) B(merged) A(merged) B(merged)
+    """
+
+    def __init__(
+        self,
+        a: tuple[type[A], Callable[[list[A]], list[A]]],
+        b: tuple[type[B], Callable[[list[B]], list[B]]],
+    ) -> None:
+        self._type_a = a[0]
+        self._type_b = b[0]
+        self._merge_a = a[1]
+        self._merge_b = b[1]
+        self._current_run: list[A] | list[B] = []
+        self._current_type: type[A] | type[B] | None = None
+        self._result: list[A | B] = []
+
+    def push(self, cmd: A | B) -> None:
+        cmd_type = (
+            self._type_a if isinstance(cmd, self._type_a) else self._type_b
+        )
+        if (
+            self._current_type is not None
+            and cmd_type is not self._current_type
+        ):
+            self._flush()
+        self._current_type = cmd_type
+        self._current_run.append(cmd)  # type: ignore[arg-type]
+
+    def _flush(self) -> None:
+        if not self._current_run:
+            return
+        if self._current_type is self._type_a:
+            self._result.extend(self._merge_a(self._current_run))  # type: ignore[arg-type]
+        else:
+            self._result.extend(self._merge_b(self._current_run))  # type: ignore[arg-type]
+        self._current_run = []
+        self._current_type = None
+
+    def finish(self) -> list[A | B]:
+        self._flush()
+        return self._result
+
+
+def _merge_ui_commands(
+    cmds: list[UpdateUIElementCommand],
+) -> list[UpdateUIElementCommand]:
+    """Merge UI element commands: last-write-wins per element ID."""
+    if not cmds:
+        return []
+
+    merged: dict[UIElementId, Any] = {}
+    last_cmd = cmds[-1]
+    for cmd in cmds:
+        for ui_id, value in cmd.ids_and_values:
+            merged[ui_id] = value
+
+    return [
+        UpdateUIElementCommand(
+            object_ids=list(merged.keys()),
+            values=list(merged.values()),
+            token=last_cmd.token,
+            request=last_cmd.request,
+        )
+    ]
+
+
+BufferPath = tuple[Union[str, int], ...]
+
+
+def _merge_model_commands(
+    cmds: list[ModelCommand],
+) -> list[ModelCommand]:
+    """Merge model commands: last-write-wins per model ID on state keys.
+
+    Custom messages pass through without merging. Uses the same merge
+    strategy as ModelReplayState.apply_update: when a state key is
+    overridden, drop any existing buffers whose root path component
+    matches that key.
+    """
+    result: list[ModelCommand] = []
+    model_state: dict[WidgetModelId, dict[str, Any]] = {}
+    model_buffers: dict[WidgetModelId, dict[BufferPath, bytes]] = {}
+
+    for cmd in cmds:
+        if isinstance(cmd.message, ModelCustomMessage):
+            result.append(cmd)
+        elif isinstance(cmd.message, ModelUpdateMessage):
+            mid = cmd.model_id
+            if mid not in model_state:
+                model_state[mid] = {}
+                model_buffers[mid] = {}
+
+            # Drop buffers whose root key is being overridden
+            updated_keys = set(cmd.message.state.keys())
+            model_buffers[mid] = {
+                path: buf
+                for path, buf in model_buffers[mid].items()
+                if path[0] not in updated_keys
+            }
+            # Merge state and buffers
+            model_state[mid].update(cmd.message.state)
+            for path, buf in zip(cmd.message.buffer_paths, cmd.buffers):
+                model_buffers[mid][tuple(path)] = buf
+
+    for mid in model_state:
+        paths = list(model_buffers[mid].keys())
+        bufs = list(model_buffers[mid].values())
+        result.append(
+            ModelCommand(
+                model_id=mid,
+                message=ModelUpdateMessage(
+                    state=model_state[mid],
+                    buffer_paths=[list(p) for p in paths],
+                ),
+                buffers=bufs,
+            )
+        )
+
+    return result
+
+
+def merge_batchable_commands(
+    commands: list[BatchableCommand],
+) -> list[BatchableCommand]:
+    if not commands:
+        return []
+
+    acc = _RunAccumulator(
+        a=(UpdateUIElementCommand, _merge_ui_commands),
+        b=(ModelCommand, _merge_model_commands),
+    )
+    for cmd in commands:
+        acc.push(cmd)
+    return acc.finish()
 
 
 class SetUIElementRequestManager:
@@ -37,6 +185,9 @@ class SetUIElementRequestManager:
         (last-write-wins).  ModelCommands with update messages are
         merged by model ID (last-write-wins on state keys).  Custom
         model messages pass through without merging.
+
+        Contiguous runs of same-type commands are merged together while
+        preserving the relative interleaving order of different types.
         """
         pending: list[BatchableCommand] = []
 
@@ -62,80 +213,4 @@ class SetUIElementRequestManager:
             else:
                 pending.append(r)
 
-        return self._merge(pending)
-
-    @staticmethod
-    def _merge(
-        commands: list[BatchableCommand],
-    ) -> list[BatchableCommand]:
-        if not commands:
-            return []
-
-        result: list[BatchableCommand] = []
-
-        # --- UI element merging (last-write-wins per element ID) ---
-        ui_merged: dict[UIElementId, Any] = {}
-        last_ui_request: UpdateUIElementCommand | None = None
-        for cmd in commands:
-            if isinstance(cmd, UpdateUIElementCommand):
-                for ui_id, value in cmd.ids_and_values:
-                    ui_merged[ui_id] = value
-                last_ui_request = cmd
-
-        if last_ui_request is not None:
-            result.append(
-                UpdateUIElementCommand(
-                    object_ids=list(ui_merged.keys()),
-                    values=list(ui_merged.values()),
-                    token=last_ui_request.token,
-                    request=last_ui_request.request,
-                )
-            )
-
-        # --- Model command merging (last-write-wins per model ID) ---
-        # Uses the same merge strategy as ModelReplayState.apply_update:
-        # when a state key is overridden, drop any existing buffers whose
-        # root path component matches that key.
-        BufferPath = tuple[Union[str, int], ...]
-        model_state: dict[WidgetModelId, dict[str, Any]] = {}
-        model_buffers: dict[WidgetModelId, dict[BufferPath, bytes]] = {}
-
-        for cmd in commands:
-            if not isinstance(cmd, ModelCommand):
-                continue
-            if isinstance(cmd.message, ModelCustomMessage):
-                # Custom messages are not mergeable
-                result.append(cmd)
-            elif isinstance(cmd.message, ModelUpdateMessage):
-                mid = cmd.model_id
-                if mid not in model_state:
-                    model_state[mid] = {}
-                    model_buffers[mid] = {}
-
-                # Drop buffers whose root key is being overridden
-                updated_keys = set(cmd.message.state.keys())
-                model_buffers[mid] = {
-                    path: buf
-                    for path, buf in model_buffers[mid].items()
-                    if path[0] not in updated_keys
-                }
-                # Merge state and buffers
-                model_state[mid].update(cmd.message.state)
-                for path, buf in zip(cmd.message.buffer_paths, cmd.buffers):
-                    model_buffers[mid][tuple(path)] = buf
-
-        for mid in model_state:
-            paths = list(model_buffers[mid].keys())
-            bufs = list(model_buffers[mid].values())
-            result.append(
-                ModelCommand(
-                    model_id=mid,
-                    message=ModelUpdateMessage(
-                        state=model_state[mid],
-                        buffer_paths=[list(p) for p in paths],
-                    ),
-                    buffers=bufs,
-                )
-            )
-
-        return result
+        return merge_batchable_commands(pending)

--- a/tests/_runtime/utils/test_set_ui_element_request_manager.py
+++ b/tests/_runtime/utils/test_set_ui_element_request_manager.py
@@ -6,15 +6,22 @@ import queue
 import threading
 import time
 
-from marimo._runtime.commands import UpdateUIElementCommand
+from marimo._runtime.commands import (
+    ModelCommand,
+    ModelCustomMessage,
+    ModelUpdateMessage,
+    UpdateUIElementCommand,
+)
 from marimo._runtime.utils.set_ui_element_request_manager import (
+    BatchableCommand,
     SetUIElementRequestManager,
+    merge_batchable_commands,
 )
 
 
 def test_process_request_dedupes_by_token() -> None:
     """Test that duplicate tokens are properly deduplicated."""
-    q: queue.Queue[UpdateUIElementCommand] = queue.Queue()
+    q: queue.Queue[BatchableCommand] = queue.Queue()
     manager = SetUIElementRequestManager(q)
 
     # Create two requests with the same token
@@ -32,14 +39,16 @@ def test_process_request_dedupes_by_token() -> None:
     result = manager.process_request(request1)
 
     # Should only get one request (the second is a duplicate)
-    assert result is not None
-    assert len(result.object_ids) == 1
-    assert result.object_ids[0] == "obj1"
+    assert len(result) == 1
+    cmd = result[0]
+    assert isinstance(cmd, UpdateUIElementCommand)
+    assert len(cmd.object_ids) == 1
+    assert cmd.object_ids[0] == "obj1"
 
 
 def test_process_request_merges_different_tokens() -> None:
     """Test that requests with different tokens are merged."""
-    q: queue.Queue[UpdateUIElementCommand] = queue.Queue()
+    q: queue.Queue[BatchableCommand] = queue.Queue()
     manager = SetUIElementRequestManager(q)
 
     request1 = UpdateUIElementCommand(
@@ -56,14 +65,16 @@ def test_process_request_merges_different_tokens() -> None:
     result = manager.process_request(request1)
 
     # Should merge both requests
-    assert result is not None
-    assert len(result.object_ids) == 2
-    assert set(result.object_ids) == {"obj1", "obj2"}
+    assert len(result) == 1
+    cmd = result[0]
+    assert isinstance(cmd, UpdateUIElementCommand)
+    assert len(cmd.object_ids) == 2
+    assert set(cmd.object_ids) == {"obj1", "obj2"}
 
 
 def test_process_request_keeps_latest_value_per_id() -> None:
     """Test that when multiple requests update the same UI element, the latest value wins."""
-    q: queue.Queue[UpdateUIElementCommand] = queue.Queue()
+    q: queue.Queue[BatchableCommand] = queue.Queue()
     manager = SetUIElementRequestManager(q)
 
     request1 = UpdateUIElementCommand(
@@ -80,10 +91,12 @@ def test_process_request_keeps_latest_value_per_id() -> None:
     result = manager.process_request(request1)
 
     # Should keep the latest value (from request2)
-    assert result is not None
-    assert len(result.object_ids) == 1
-    assert result.object_ids[0] == "obj1"
-    assert result.values[0] == 2
+    assert len(result) == 1
+    cmd = result[0]
+    assert isinstance(cmd, UpdateUIElementCommand)
+    assert len(cmd.object_ids) == 1
+    assert cmd.object_ids[0] == "obj1"
+    assert cmd.values[0] == 2
 
 
 def test_process_request_handles_concurrent_queue_updates() -> None:
@@ -92,7 +105,7 @@ def test_process_request_handles_concurrent_queue_updates() -> None:
     This simulates the race condition that occurs with ZeroMQ IPC where a
     receiver thread continuously adds messages to the queue.
     """
-    q: queue.Queue[UpdateUIElementCommand] = queue.Queue()
+    q: queue.Queue[BatchableCommand] = queue.Queue()
     manager = SetUIElementRequestManager(q)
 
     # Track how many requests were added
@@ -131,10 +144,12 @@ def test_process_request_handles_concurrent_queue_updates() -> None:
     stop_event.set()
     producer_thread.join(timeout=1)
 
-    # Verify that we got a merged result
-    assert result is not None
-    assert len(result.object_ids) > 1  # Should have merged multiple requests
-    assert "obj_initial" in result.object_ids
+    # Verify that we got a merged result (all UI commands in a contiguous run)
+    assert len(result) >= 1
+    cmd = result[0]
+    assert isinstance(cmd, UpdateUIElementCommand)
+    assert len(cmd.object_ids) > 1  # Should have merged multiple requests
+    assert "obj_initial" in cmd.object_ids
 
     # Verify the queue is actually empty after processing
     # (small delay to let any in-flight messages arrive)
@@ -153,7 +168,7 @@ def test_process_request_handles_concurrent_queue_updates() -> None:
 
 async def test_process_request_with_asyncio_queue() -> None:
     """Test that the manager works with asyncio.Queue."""
-    q: asyncio.Queue[UpdateUIElementCommand] = asyncio.Queue()
+    q: asyncio.Queue[BatchableCommand] = asyncio.Queue()
     manager = SetUIElementRequestManager(q)
 
     request1 = UpdateUIElementCommand(
@@ -170,14 +185,16 @@ async def test_process_request_with_asyncio_queue() -> None:
     result = manager.process_request(request1)
 
     # Should merge both requests
-    assert result is not None
-    assert len(result.object_ids) == 2
-    assert set(result.object_ids) == {"obj1", "obj2"}
+    assert len(result) == 1
+    cmd = result[0]
+    assert isinstance(cmd, UpdateUIElementCommand)
+    assert len(cmd.object_ids) == 2
+    assert set(cmd.object_ids) == {"obj1", "obj2"}
 
 
-def test_process_request_returns_none_for_empty_batch() -> None:
-    """Test that None is returned when all requests are duplicates."""
-    q: queue.Queue[UpdateUIElementCommand] = queue.Queue()
+def test_process_request_returns_empty_for_empty_batch() -> None:
+    """Test that an empty list is returned when all requests are duplicates."""
+    q: queue.Queue[BatchableCommand] = queue.Queue()
     manager = SetUIElementRequestManager(q)
 
     # Create a request and process it
@@ -185,9 +202,215 @@ def test_process_request_returns_none_for_empty_batch() -> None:
         object_ids=["obj1"], values=[1], token="token1"
     )
     result1 = manager.process_request(request)
-    assert result1 is not None
+    assert len(result1) == 1
 
     # Process the same token again (duplicate)
     result2 = manager.process_request(request)
-    # Should return None since it's a duplicate
-    assert result2 is None
+    # Should return empty list since it's a duplicate
+    assert result2 == []
+
+
+# --- Model command tests ---
+
+
+def test_model_update_merging_same_model() -> None:
+    """Test that model updates for the same model merge with last-write-wins."""
+    q: queue.Queue[BatchableCommand] = queue.Queue()
+    manager = SetUIElementRequestManager(q)
+
+    cmd1 = ModelCommand(
+        model_id="model-1",
+        message=ModelUpdateMessage(state={"x": 1, "y": 2}, buffer_paths=[]),
+        buffers=[],
+    )
+    cmd2 = ModelCommand(
+        model_id="model-1",
+        message=ModelUpdateMessage(state={"x": 10, "z": 3}, buffer_paths=[]),
+        buffers=[],
+    )
+    q.put(cmd2)
+
+    result = manager.process_request(cmd1)
+
+    assert len(result) == 1
+    cmd = result[0]
+    assert isinstance(cmd, ModelCommand)
+    assert cmd.model_id == "model-1"
+    assert isinstance(cmd.message, ModelUpdateMessage)
+    # x=10 from cmd2 (last-write-wins), y=2 from cmd1, z=3 from cmd2
+    assert cmd.message.state == {"x": 10, "y": 2, "z": 3}
+
+
+def test_model_update_different_models() -> None:
+    """Test that updates to different models produce separate commands."""
+    q: queue.Queue[BatchableCommand] = queue.Queue()
+    manager = SetUIElementRequestManager(q)
+
+    cmd1 = ModelCommand(
+        model_id="model-1",
+        message=ModelUpdateMessage(state={"x": 1}, buffer_paths=[]),
+        buffers=[],
+    )
+    cmd2 = ModelCommand(
+        model_id="model-2",
+        message=ModelUpdateMessage(state={"y": 2}, buffer_paths=[]),
+        buffers=[],
+    )
+    q.put(cmd2)
+
+    result = manager.process_request(cmd1)
+
+    assert len(result) == 2
+    ids = {r.model_id for r in result if isinstance(r, ModelCommand)}
+    assert ids == {"model-1", "model-2"}
+
+
+def test_custom_messages_pass_through() -> None:
+    """Test that custom messages are not merged and each appears individually."""
+    q: queue.Queue[BatchableCommand] = queue.Queue()
+    manager = SetUIElementRequestManager(q)
+
+    cmd1 = ModelCommand(
+        model_id="model-1",
+        message=ModelCustomMessage(content={"action": "ping"}),
+        buffers=[],
+    )
+    cmd2 = ModelCommand(
+        model_id="model-1",
+        message=ModelCustomMessage(content={"action": "pong"}),
+        buffers=[],
+    )
+    q.put(cmd2)
+
+    result = manager.process_request(cmd1)
+
+    assert len(result) == 2
+    assert all(isinstance(r, ModelCommand) for r in result)
+    msgs = [r.message for r in result if isinstance(r, ModelCommand)]
+    assert isinstance(msgs[0], ModelCustomMessage)
+    assert isinstance(msgs[1], ModelCustomMessage)
+    assert msgs[0].content == {"action": "ping"}
+    assert msgs[1].content == {"action": "pong"}
+
+
+def test_buffer_merging_drops_overridden_buffers() -> None:
+    """Test that buffers for overridden state keys are dropped."""
+    q: queue.Queue[BatchableCommand] = queue.Queue()
+    manager = SetUIElementRequestManager(q)
+
+    cmd1 = ModelCommand(
+        model_id="model-1",
+        message=ModelUpdateMessage(
+            state={"data": None},
+            buffer_paths=[["data"]],
+        ),
+        buffers=[b"old-buffer"],
+    )
+    cmd2 = ModelCommand(
+        model_id="model-1",
+        message=ModelUpdateMessage(
+            state={"data": None},
+            buffer_paths=[["data"]],
+        ),
+        buffers=[b"new-buffer"],
+    )
+    q.put(cmd2)
+
+    result = manager.process_request(cmd1)
+
+    assert len(result) == 1
+    cmd = result[0]
+    assert isinstance(cmd, ModelCommand)
+    assert isinstance(cmd.message, ModelUpdateMessage)
+    # Only the new buffer should remain
+    assert cmd.buffers == [b"new-buffer"]
+
+
+def test_mixed_ui_and_model_commands() -> None:
+    """Test that UI and model commands coexist in the result."""
+    q: queue.Queue[BatchableCommand] = queue.Queue()
+    manager = SetUIElementRequestManager(q)
+
+    ui_cmd = UpdateUIElementCommand(
+        object_ids=["obj1"], values=[1], token="token1"
+    )
+    model_cmd = ModelCommand(
+        model_id="model-1",
+        message=ModelUpdateMessage(state={"x": 1}, buffer_paths=[]),
+        buffers=[],
+    )
+    q.put(model_cmd)
+
+    result = manager.process_request(ui_cmd)
+
+    assert len(result) == 2
+    assert isinstance(result[0], UpdateUIElementCommand)
+    assert isinstance(result[1], ModelCommand)
+
+
+def test_contiguous_run_ordering() -> None:
+    """Test that [UI, Model, UI] produces 3 items in that order, not grouped by type."""
+    commands: list[BatchableCommand] = [
+        UpdateUIElementCommand(
+            object_ids=["obj1"], values=[1], token="token1"
+        ),
+        ModelCommand(
+            model_id="model-1",
+            message=ModelUpdateMessage(state={"x": 1}, buffer_paths=[]),
+            buffers=[],
+        ),
+        UpdateUIElementCommand(
+            object_ids=["obj2"], values=[2], token="token2"
+        ),
+    ]
+
+    result = merge_batchable_commands(commands)
+
+    assert len(result) == 3
+    assert isinstance(result[0], UpdateUIElementCommand)
+    assert isinstance(result[1], ModelCommand)
+    assert isinstance(result[2], UpdateUIElementCommand)
+    # Verify values preserved
+    assert result[0].object_ids == ["obj1"]
+    assert result[2].object_ids == ["obj2"]
+
+
+def test_contiguous_runs_merged_within_run() -> None:
+    """Test that contiguous same-type commands are merged within their run."""
+    commands: list[BatchableCommand] = [
+        UpdateUIElementCommand(
+            object_ids=["obj1"], values=[1], token="token1"
+        ),
+        UpdateUIElementCommand(
+            object_ids=["obj2"], values=[2], token="token2"
+        ),
+        ModelCommand(
+            model_id="model-1",
+            message=ModelUpdateMessage(state={"x": 1}, buffer_paths=[]),
+            buffers=[],
+        ),
+        ModelCommand(
+            model_id="model-1",
+            message=ModelUpdateMessage(state={"x": 2}, buffer_paths=[]),
+            buffers=[],
+        ),
+        UpdateUIElementCommand(
+            object_ids=["obj3"], values=[3], token="token3"
+        ),
+    ]
+
+    result = merge_batchable_commands(commands)
+
+    # UI(merged) Model(merged) UI
+    assert len(result) == 3
+    assert isinstance(result[0], UpdateUIElementCommand)
+    assert isinstance(result[1], ModelCommand)
+    assert isinstance(result[2], UpdateUIElementCommand)
+
+    # First UI run merged obj1 and obj2
+    assert set(result[0].object_ids) == {"obj1", "obj2"}
+    # Model run merged x=1 then x=2 → x=2
+    assert isinstance(result[1].message, ModelUpdateMessage)
+    assert result[1].message.state == {"x": 2}
+    # Last UI is standalone
+    assert result[2].object_ids == ["obj3"]


### PR DESCRIPTION
The request manager now handles both UpdateUIElementCommand and ModelCommand through a unified merge path. A _RunAccumulator merges contiguous runs of same-type commands while preserving relative interleaving order between types: `[UI, UI, Model, Model, UI]` becomes `[UI(merged), Model(merged), UI]` rather than grouping all UI commands before all model commands.
