### PR TITLE
feat: add disabled parameter to mo.ui.chat

### DIFF
--- a/frontend/src/plugins/impl/chat/ChatPlugin.tsx
+++ b/frontend/src/plugins/impl/chat/ChatPlugin.tsx
@@ -47,6 +47,7 @@ export const ChatPlugin = createPlugin<{ messages: UIMessage[] }>(
       maxHeight: z.number().optional(),
       config: configSchema,
       allowAttachments: z.union([z.boolean(), z.string().array()]),
+      disabled: z.boolean().default(false),
     }),
   )
   .withFunctions<PluginFunctions>({
@@ -76,6 +77,7 @@ export const ChatPlugin = createPlugin<{ messages: UIMessage[] }>(
           showConfigurationControls={props.data.showConfigurationControls}
           maxHeight={props.data.maxHeight}
           allowAttachments={props.data.allowAttachments}
+          disabled={props.data.disabled}
           config={props.data.config}
           get_chat_history={props.functions.get_chat_history}
           delete_chat_history={props.functions.delete_chat_history}

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -67,6 +67,7 @@ interface Props extends PluginFunctions {
   showConfigurationControls: boolean;
   maxHeight: number | undefined;
   allowAttachments: boolean | string[];
+  disabled: boolean;
   value: UIMessage[];
   setValue: (messages: UIMessage[]) => void;
   host: HTMLElement;
@@ -450,6 +451,9 @@ export const Chatbot: React.FC<Props> = (props) => {
       <form
         onSubmit={async (evt) => {
           evt.preventDefault();
+          if (props.disabled) {
+            return;
+          }
 
           const fileParts = files
             ? await convertToFileUIPart(files)
@@ -462,7 +466,12 @@ export const Chatbot: React.FC<Props> = (props) => {
           resetInput();
         }}
         ref={formRef}
-        className="flex w-full border-t border-(--slate-6) px-2 py-1 items-center"
+        // biome-ignore lint/a11y/useSemanticElements: inert is used to disable the entire form
+        inert={props.disabled || undefined}
+        className={cn(
+          "flex w-full border-t border-(--slate-6) px-2 py-1 items-center",
+          props.disabled && "opacity-50 cursor-not-allowed",
+        )}
       >
         {props.showConfigurationControls && (
           <ConfigPopup config={config} onChange={setConfig} />

--- a/marimo/_plugins/ui/_impl/chat/chat.py
+++ b/marimo/_plugins/ui/_impl/chat/chat.py
@@ -184,6 +184,8 @@ class chat(UIElement[dict[str, Any], list[ChatMessage]]):
             attachments types, or pass a list of mime types. Defaults to False.
         max_height (int, optional): Optional maximum height for the chat element.
             Defaults to None.
+        disabled (bool, optional): Whether the chat input is disabled. When True,
+            the user cannot type or send messages. Defaults to False.
     """
 
     _name: Final[str] = "marimo-chatbot"
@@ -198,6 +200,7 @@ class chat(UIElement[dict[str, Any], list[ChatMessage]]):
         config: Optional[ChatModelConfigDict] = DEFAULT_CONFIG,
         allow_attachments: Union[bool, list[str]] = False,
         max_height: Optional[int] = None,
+        disabled: bool = False,
     ) -> None:
         self._model = model
         self._chat_history: list[ChatMessage] = []
@@ -219,6 +222,7 @@ class chat(UIElement[dict[str, Any], list[ChatMessage]]):
                 "config": cast(JSONType, config or {}),
                 "allow-attachments": allow_attachments,
                 "max-height": max_height,
+                "disabled": disabled,
             },
             functions=(
                 Function(

--- a/tests/_plugins/ui/_impl/chat/test_chat.py
+++ b/tests/_plugins/ui/_impl/chat/test_chat.py
@@ -522,6 +522,20 @@ def test_chat_with_show_configuration_controls():
     assert chat._component_args["show-configuration-controls"] is True
 
 
+def test_chat_disabled():
+    def mock_model(
+        messages: list[ChatMessage], config: ChatModelConfig
+    ) -> str:
+        del messages, config
+        return "Mock response"
+
+    chat = ui.chat(mock_model)
+    assert chat._component_args["disabled"] is False
+
+    chat_disabled = ui.chat(mock_model, disabled=True)
+    assert chat_disabled._component_args["disabled"] is True
+
+
 async def test_chat_clear_messages():
     def mock_model(
         messages: list[ChatMessage], config: ChatModelConfig


### PR DESCRIPTION
## Summary
Adds a `disabled` parameter to `mo.ui.chat` that prevents user interaction when set to `True`. Uses the HTML `inert` attribute on the form container so all child inputs, buttons, and links are automatically non-interactive.

Closes #3823

## Test Plan
- Added Python test for disabled parameter serialization
- Visual: `opacity-50 cursor-not-allowed` styling when disabled