### PR TITLE
fix: prevent margin collapse between consecutive cell outputs

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -172,11 +172,9 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
   // spacing is handled elsewhere
   return (
     <VerticalLayoutWrapper invisible={invisible} appConfig={appConfig}>
-      {showCode && canShowCode ? (
-        <div className="flex flex-col gap-5"> {renderCells()}</div>
-      ) : (
-        renderCells()
-      )}
+      <div className={cn("flex flex-col", showCode && canShowCode && "gap-5")}>
+        {renderCells()}
+      </div>
       {mode === "read" && (
         <ActionButtons
           canShowCode={canShowCode}


### PR DESCRIPTION
## Summary
Consecutive markdown cell outputs had less vertical spacing than content within a single cell due to CSS margin collapsing. Wrapping the output container in `flex flex-col` prevents margin collapsing between siblings.

Closes #3063

## Test Plan
- Visual: consecutive `mo.md()` cells now have consistent spacing