### PR TITLE
fix: suppress RuntimeWarning for all-NaN DataFrame columns

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -517,8 +517,16 @@ class NarwhalsTableManager(
                     }
                 )
 
+        import warnings
+
         stats = frame.select(**exprs)
-        stats_dict = stats.collect().rows(named=True)[0]
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Mean of empty slice|Degrees of freedom",
+                category=RuntimeWarning,
+            )
+            stats_dict = stats.collect().rows(named=True)[0]
 
         # Maybe add units to the stats
         for key, value in stats_dict.items():

--- a/tests/_plugins/ui/_impl/tables/test_narwhals.py
+++ b/tests/_plugins/ui/_impl/tables/test_narwhals.py
@@ -491,6 +491,19 @@ class TestNarwhalsTableManagerFactory(unittest.TestCase):
         assert isinstance(bool_stats.true, int)
         assert isinstance(bool_stats.false, int)
 
+    def test_summary_all_nan_column_no_warning(self) -> None:
+        import warnings
+
+        import polars as pl
+
+        data = pl.DataFrame({"A": [float("nan"), float("nan"), float("nan")]})
+        manager = NarwhalsTableManager.from_dataframe(data)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            stats = manager.get_stats("A")
+        assert stats is not None
+        assert stats.total == 3
+
     def test_sort_values(self) -> None:
         sorted_df = self.manager.sort_values(
             [SortArgs(by="A", descending=True)]


### PR DESCRIPTION
## Summary
Console was spammed with "Mean of empty slice" and "Degrees of freedom <= 0" RuntimeWarnings when computing statistics over all-NaN DataFrame columns. Wraps the computation in a warning suppressor.

Closes #7046

## Test Plan
- Added test verifying no RuntimeWarning is raised for all-NaN columns