### PR TITLE
fix: preserve justify on nested stacks when widths/heights are set

### DIFF
--- a/marimo/_plugins/stateless/flex.py
+++ b/marimo/_plugins/stateless/flex.py
@@ -57,7 +57,14 @@ def _flex(
         child_flex = child_flexes[idx]
         if child_flex is None:
             return ""
-        return create_style({"flex": f"{child_flex}"})
+        return create_style(
+            {
+                "flex": f"{child_flex}",
+                "display": "flex",
+                "min-width": "0",
+                "min-height": "0",
+            }
+        )
 
     # If there are no child flexes, don't wrap them in an additional <div>
     if child_flexes is None:

--- a/tests/_plugins/stateless/test_flex.py
+++ b/tests/_plugins/stateless/test_flex.py
@@ -14,7 +14,7 @@ def test_vstack() -> None:
     result = vstack(["item1", "item2"], justify="center", heights=[1, 2])
     assert (
         result.text
-        == "<div style='display: flex;flex: 1;flex-direction: column;justify-content: center;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><div style='flex: 1'><span>item1</span></div><div style='flex: 2'><span>item2</span></div></div>"  # noqa: E501
+        == "<div style='display: flex;flex: 1;flex-direction: column;justify-content: center;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><div style='flex: 1;display: flex;min-width: 0;min-height: 0'><span>item1</span></div><div style='flex: 2;display: flex;min-width: 0;min-height: 0'><span>item2</span></div></div>"  # noqa: E501
     )
 
 
@@ -28,11 +28,11 @@ def test_hstack() -> None:
     result = hstack(["item1", "item2"], align="center", widths=[1, 2])
     assert (
         result.text
-        == "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: center;flex-wrap: nowrap;gap: 0.5rem'><div style='flex: 1'><span>item1</span></div><div style='flex: 2'><span>item2</span></div></div>"  # noqa: E501
+        == "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: center;flex-wrap: nowrap;gap: 0.5rem'><div style='flex: 1;display: flex;min-width: 0;min-height: 0'><span>item1</span></div><div style='flex: 2;display: flex;min-width: 0;min-height: 0'><span>item2</span></div></div>"  # noqa: E501
     )
 
     result = hstack(["item1", "item2"], align="center", widths="equal")
     assert (
         result.text
-        == "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: center;flex-wrap: nowrap;gap: 0.5rem'><div style='flex: 1'><span>item1</span></div><div style='flex: 1'><span>item2</span></div></div>"  # noqa: E501
+        == "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: center;flex-wrap: nowrap;gap: 0.5rem'><div style='flex: 1;display: flex;min-width: 0;min-height: 0'><span>item1</span></div><div style='flex: 1;display: flex;min-width: 0;min-height: 0'><span>item2</span></div></div>"  # noqa: E501
     )


### PR DESCRIPTION
## Summary
Children of `hstack`/`vstack` with `flex: 1` didn't stretch because the wrapper div for width/height constraints wasn't a flex container. Makes the wrapper a flex container with `min-width: 0` / `min-height: 0` to prevent overflow.

Closes #7777

## Test Plan
- Updated existing flex tests to verify flex properties are preserved