### PR TITLE
fix: hide sidebar content when collapsed instead of squishing

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/sidebar/sidebar.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/sidebar/sidebar.tsx
@@ -22,7 +22,12 @@ export const Sidebar = ({ isOpen, toggle, width }: SidebarProps) => {
       )}
     >
       <SidebarToggle isOpen={isOpen} toggle={toggle} />
-      <div className="relative h-full flex flex-col px-3 pb-16 pt-14 overflow-y-auto shadow-sm border-l">
+      <div
+        className={cn(
+          "relative h-full flex flex-col px-3 pb-16 pt-14 overflow-y-auto shadow-sm border-l",
+          !isOpen && "invisible overflow-hidden",
+        )}
+      >
         <SidebarSlot />
       </div>
     </aside>


### PR DESCRIPTION
## Summary
When the sidebar was collapsed, content was squeezed into a narrow strip instead of being hidden. Adds `invisible overflow-hidden` when collapsed to properly hide the content.

Closes #6852

## Test Plan
- Visual: collapsed sidebar no longer shows squeezed content