### PR TITLE
fix: prevent resize cursor on collapsed panels

### DIFF
--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.css
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.css
@@ -4,6 +4,10 @@
   outline: none;
 }
 
+.resize-handle-collapsed {
+  cursor: default;
+}
+
 .resize-handle.horizontal,
 .resize-handle-collapsed.horizontal {
   height: 4px;


### PR DESCRIPTION
## Summary
Collapsed panels still showed a resize cursor on hover because the resize handle persisted in the DOM. Overrides the cursor via CSS when the panel is collapsed.

Closes #7184

## Test Plan
- Visual: collapsed panels no longer show resize cursor