### PR TITLE
fix: prevent mermaid LR diagrams from being squished

### DIFF
--- a/frontend/src/plugins/layout/mermaid/mermaid.tsx
+++ b/frontend/src/plugins/layout/mermaid/mermaid.tsx
@@ -22,6 +22,7 @@ const DEFAULT_CONFIG: MermaidConfig = {
   flowchart: {
     htmlLabels: true,
     curve: "linear",
+    useMaxWidth: false,
   },
   sequence: {
     diagramMarginX: 50,
@@ -88,7 +89,11 @@ const Mermaid: React.FC<Props> = ({ diagram }) => {
     return null;
   }
 
-  return <div dangerouslySetInnerHTML={{ __html: svg }} />;
+  return (
+    <div style={{ overflowX: "auto", maxWidth: "100%" }}>
+      <div dangerouslySetInnerHTML={{ __html: svg }} />
+    </div>
+  );
 };
 
 export default Mermaid;


### PR DESCRIPTION
## Summary
LR (left-to-right) mermaid diagrams were compressed to fit the container width because `flowchart.useMaxWidth` defaults to `true`. Sets it to `false` so diagrams render at natural size, and wraps the output in a scrollable container.

Closes #6697

## Test Plan
- Visual: LR flowcharts render at natural width with horizontal scrolling