### PR TITLE
fix: set data-theme attribute on body for third-party dark mode compat

### DIFF
--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -10,8 +10,10 @@ export const ThemeProvider: React.FC<PropsWithChildren> = memo(
     const { theme } = useTheme();
     useLayoutEffect(() => {
       document.body.classList.add(theme, `${theme}-theme`);
+      document.body.dataset.theme = theme;
       return () => {
         document.body.classList.remove(theme, `${theme}-theme`);
+        delete document.body.dataset.theme;
       };
     }, [theme]);
 


### PR DESCRIPTION
## Summary
Third-party libraries like xarray detect dark mode via `body[data-theme="dark"]`, which didn't match marimo's class-only approach (`body.dark`, `body.dark-theme`). Adds `data-theme` attribute on the body element alongside the existing classes.

Closes #6920

## Test Plan
- Theme change is additive (no existing behavior altered)
- xarray HTML repr now correctly renders with dark mode colors