### PR TITLE
all mo.sql to use rf"""..."" instead of f"""..."""

### DIFF
--- a/frontend/src/components/chat/acp/__tests__/__snapshots__/prompt.test.ts.snap
+++ b/frontend/src/components/chat/acp/__tests__/__snapshots__/prompt.test.ts.snap
@@ -76,7 +76,7 @@ exports[`getAgentPrompt > should generate complete agent prompt with default fil
   </ui_elements>
 
   <sql>
-  - When writing duckdb, prefer using marimo's SQL cells, which start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
+  - When writing duckdb, prefer using marimo's SQL cells, which start with df = mo.sql(rf"""<your query>""") for DuckDB, or df = mo.sql(rf"""<your query>""", engine=engine) for other SQL engines.
   - See the SQL with duckdb example for an example on how to do this
   - Don't add comments in cells that use mo.sql()
   - Consider using \`vega_datasets\` for common example datasets

--- a/frontend/src/components/chat/acp/prompt.ts
+++ b/frontend/src/components/chat/acp/prompt.ts
@@ -1,5 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { SQL_QUOTE_PREFIX } from "@marimo-team/smart-cells";
+
 export function getAgentPrompt(filename: string) {
   return `
   I am currently editing a marimo notebook.
@@ -76,7 +78,7 @@ export function getAgentPrompt(filename: string) {
   </ui_elements>
 
   <sql>
-  - When writing duckdb, prefer using marimo's SQL cells, which start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines.
+  - When writing duckdb, prefer using marimo's SQL cells, which start with df = mo.sql(${SQL_QUOTE_PREFIX}"""<your query>""") for DuckDB, or df = mo.sql(${SQL_QUOTE_PREFIX}"""<your query>""", engine=engine) for other SQL engines.
   - See the SQL with duckdb example for an example on how to do this
   - Don't add comments in cells that use mo.sql()
   - Consider using \`vega_datasets\` for common example datasets

--- a/frontend/src/components/datasources/__tests__/utils.test.ts
+++ b/frontend/src/components/datasources/__tests__/utils.test.ts
@@ -28,7 +28,7 @@ describe("sqlCode", () => {
     it("should generate basic SQL without sqlTableContext", () => {
       const result = sqlCode({ table: mockTable, columnName: mockColumn.name });
       expect(result).toBe(
-        "_df = mo.sql(f'SELECT \"email\" FROM users LIMIT 100')",
+        "_df = mo.sql(rf'SELECT \"email\" FROM users LIMIT 100')",
       );
     });
 
@@ -48,7 +48,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT "email" FROM "users" LIMIT 100\n""")',
+        '_df = mo.sql(rf"""\nSELECT "email" FROM "users" LIMIT 100\n""")',
       );
     });
 
@@ -68,7 +68,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT "email" FROM "analytics"."users" LIMIT 100\n""")',
+        '_df = mo.sql(rf"""\nSELECT "email" FROM "analytics"."users" LIMIT 100\n""")',
       );
     });
 
@@ -88,7 +88,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT email FROM users LIMIT 100\n""", engine=snowflake)',
+        '_df = mo.sql(rf"""\nSELECT email FROM users LIMIT 100\n""", engine=snowflake)',
       );
     });
 
@@ -108,7 +108,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT "email" FROM "remote"."users" LIMIT 100\n""")',
+        '_df = mo.sql(rf"""\nSELECT "email" FROM "remote"."users" LIMIT 100\n""")',
       );
     });
 
@@ -127,7 +127,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT "email" FROM "users" LIMIT 100\n""")',
+        '_df = mo.sql(rf"""\nSELECT "email" FROM "users" LIMIT 100\n""")',
       );
 
       const sqlTableContext2: SQLTableContext = {
@@ -144,7 +144,7 @@ describe("sqlCode", () => {
         sqlTableContext: sqlTableContext2,
       });
       expect(result2).toBe(
-        '_df = mo.sql(f"""\nSELECT "email" FROM "another_db"."users" LIMIT 100\n""")',
+        '_df = mo.sql(rf"""\nSELECT "email" FROM "another_db"."users" LIMIT 100\n""")',
       );
     });
   });
@@ -166,7 +166,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT email FROM `users` LIMIT 100\n""", engine=bigquery)',
+        '_df = mo.sql(rf"""\nSELECT email FROM `users` LIMIT 100\n""", engine=bigquery)',
       );
     });
 
@@ -186,7 +186,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT email FROM `remote.sales.users` LIMIT 100\n""", engine=bigquery)',
+        '_df = mo.sql(rf"""\nSELECT email FROM `remote.sales.users` LIMIT 100\n""", engine=bigquery)',
       );
     });
 
@@ -206,7 +206,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT email FROM `users` LIMIT 100\n""", engine=bigquery)',
+        '_df = mo.sql(rf"""\nSELECT email FROM `users` LIMIT 100\n""", engine=bigquery)',
       );
     });
   });
@@ -228,7 +228,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT TOP 100 email FROM users\n""", engine=mssql)',
+        '_df = mo.sql(rf"""\nSELECT TOP 100 email FROM users\n""", engine=mssql)',
       );
     });
 
@@ -248,7 +248,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT TOP 100 email FROM analytics.sales.users\n""", engine=mssql)',
+        '_df = mo.sql(rf"""\nSELECT TOP 100 email FROM analytics.sales.users\n""", engine=mssql)',
       );
     });
   });
@@ -270,7 +270,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT "email" FROM "users" LIMIT 100\n""", engine=timescaledb)',
+        '_df = mo.sql(rf"""\nSELECT "email" FROM "users" LIMIT 100\n""", engine=timescaledb)',
       );
     });
 
@@ -290,7 +290,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT "email" FROM "remote"."sales"."users" LIMIT 100\n""", engine=timescaledb)',
+        '_df = mo.sql(rf"""\nSELECT "email" FROM "remote"."sales"."users" LIMIT 100\n""", engine=timescaledb)',
       );
     });
 
@@ -309,7 +309,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT "email" FROM "remote"."users" LIMIT 100\n""", engine=postgres)',
+        '_df = mo.sql(rf"""\nSELECT "email" FROM "remote"."users" LIMIT 100\n""", engine=postgres)',
       );
     });
 
@@ -329,7 +329,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT * FROM "users" LIMIT 100\n""", engine=postgres)',
+        '_df = mo.sql(rf"""\nSELECT * FROM "users" LIMIT 100\n""", engine=postgres)',
       );
     });
   });
@@ -351,7 +351,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT email FROM users LIMIT 100\n""", engine=postgres)',
+        '_df = mo.sql(rf"""\nSELECT email FROM users LIMIT 100\n""", engine=postgres)',
       );
     });
 
@@ -371,7 +371,7 @@ describe("sqlCode", () => {
         sqlTableContext,
       });
       expect(result).toBe(
-        '_df = mo.sql(f"""\nSELECT email FROM users LIMIT 100\n""", engine=postgres)',
+        '_df = mo.sql(rf"""\nSELECT email FROM users LIMIT 100\n""", engine=postgres)',
       );
     });
   });

--- a/frontend/src/components/datasources/utils.ts
+++ b/frontend/src/components/datasources/utils.ts
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { BigQueryDialect } from "@marimo-team/codemirror-sql/dialects";
+import { SQL_QUOTE_PREFIX } from "@marimo-team/smart-cells";
 import { isKnownDialect } from "@/core/codemirror/language/languages/sql/utils";
 import type { SQLTableContext } from "@/core/datasets/data-source-connections";
 import { DUCKDB_ENGINE } from "@/core/datasets/engines";
@@ -140,13 +141,13 @@ export function sqlCode({
     );
 
     if (engine === DUCKDB_ENGINE) {
-      return `_df = mo.sql(f"""\n${selectClause}\n""")`;
+      return `_df = mo.sql(${SQL_QUOTE_PREFIX}"""\n${selectClause}\n""")`;
     }
 
-    return `_df = mo.sql(f"""\n${selectClause}\n""", engine=${engine})`;
+    return `_df = mo.sql(${SQL_QUOTE_PREFIX}"""\n${selectClause}\n""", engine=${engine})`;
   }
 
-  return `_df = mo.sql(f'SELECT "${columnName}" FROM ${table.name} LIMIT 100')`;
+  return `_df = mo.sql(${SQL_QUOTE_PREFIX}'SELECT "${columnName}" FROM ${table.name} LIMIT 100')`;
 }
 
 export function convertStatsName(stat: ColumnHeaderStatsKey, type: DataType) {

--- a/frontend/src/core/ai/tools/edit-notebook-tool.ts
+++ b/frontend/src/core/ai/tools/edit-notebook-tool.ts
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import type { EditorView } from "@codemirror/view";
+import { SQL_QUOTE_PREFIX } from "@marimo-team/smart-cells";
 import { z } from "zod";
 import { scrollAndHighlightCell } from "@/components/editor/links/cell-link";
 import {
@@ -49,7 +50,7 @@ const description: ToolDescription = {
 
     For adding code, use the following guidelines:
     - Markdown cells: use mo.md(f"""{content}""") function to insert content.
-    - SQL cells: use mo.sql(f"""{content}""") function to insert content. If a database engine is specified, use mo.sql(f"""{content}""", engine=engine) instead.
+    - SQL cells: use mo.sql(${SQL_QUOTE_PREFIX}"""{content}""") function to insert content. If a database engine is specified, use mo.sql(${SQL_QUOTE_PREFIX}"""{content}""", engine=engine) instead.
 
     Returns:
     - A result object containing standard tool metadata.`,

--- a/frontend/src/core/codemirror/language/__tests__/extension.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/extension.test.ts
@@ -185,7 +185,7 @@ describe("switchLanguage", () => {
     switchLanguage(mockEditor, { language: "python", keepCodeAsIs: false });
     expect(mockEditor.state.doc.toString()).toMatchInlineSnapshot(`
       "_df = mo.sql(
-          f"""
+          rf"""
           mo.md(r\\"""
           print('Hello')
           print('Goodbye')
@@ -214,7 +214,7 @@ describe("switchLanguage", () => {
         "commentLines": [],
         "dataframeName": "_df",
         "engine": "${DUCKDB_ENGINE}",
-        "quotePrefix": "f",
+        "quotePrefix": "rf",
         "showOutput": true,
       }
     `);
@@ -252,7 +252,7 @@ describe("switchLanguage", () => {
       commentLines: [],
       dataframeName: "_df",
       engine: DUCKDB_ENGINE,
-      quotePrefix: "f",
+      quotePrefix: "rf",
       showOutput: true,
     });
 

--- a/frontend/src/core/codemirror/language/__tests__/sql.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/sql.test.ts
@@ -53,8 +53,8 @@ describe("SQLLanguageAdapter", () => {
         {
           "commentLines": [],
           "dataframeName": "_df",
-          "engine": "${DUCKDB_ENGINE}",
-          "quotePrefix": "f",
+          "engine": "__marimo_duckdb",
+          "quotePrefix": "rf",
           "showOutput": true,
         }
       `);
@@ -70,11 +70,11 @@ describe("SQLLanguageAdapter", () => {
       expect(out).toMatchInlineSnapshot(`
         [
           "_df = mo.sql(
-            f"""
+            rf"""
 
             """
         )",
-          24,
+          25,
         ]
       `);
     });
@@ -210,7 +210,7 @@ describe("SQLLanguageAdapter", () => {
     it("should handle parametrized sql", () => {
       const pythonCode = `
 _df = mo.sql(
-    f"""
+    rf"""
     SELECT name, price, category
     FROM products
     WHERE price < {price_threshold.value}
@@ -228,7 +228,7 @@ WHERE price < {price_threshold.value}
 ORDER BY price DESC
         `.trim(),
       );
-      expect(offset).toBe(22);
+      expect(offset).toBe(23);
       expect(metadata.showOutput).toBe(true);
       expect(metadata.engine).toBe("sqlite");
     });
@@ -358,12 +358,12 @@ _df = mo.sql(
       expect(wrappedCode).toMatchInlineSnapshot(`
         "# hello
         my_df = mo.sql(
-            f"""
+            rf"""
             SELECT * FROM {df}
             """
         )"
       `);
-      expect(offset).toBe(26);
+      expect(offset).toBe(27);
     });
 
     it("should add engine connection when provided", () => {
@@ -481,7 +481,7 @@ _df = mo.sql(
         adapter.isSupported(
           `
         countries = mo.sql(
-            f"""
+            rf"""
             SELECT * from "https://raw.githubusercontent.com/data.csv"
             """,
             output=False
@@ -492,7 +492,7 @@ _df = mo.sql(
         adapter.isSupported(
           `
         countries = mo.sql(
-            f"""
+            rf"""
             SELECT * from "https://raw.githubusercontent.com/data.csv"
             """,
             output=False,
@@ -503,7 +503,7 @@ _df = mo.sql(
         adapter.isSupported(
           `
         countries = mo.sql(
-            f"""
+            rf"""
             SELECT * from "https://raw.githubusercontent.com/data.csv"
             """,
             output=False)`.trim(),
@@ -623,13 +623,13 @@ _df = mo.sql(
       const engine = "postgres_engine" as ConnectionName;
       setLatestEngineSelected(engine);
       expect(adapter.defaultCode).toBe(
-        `_df = mo.sql(f"""SELECT * FROM """, engine=${engine})`,
+        `_df = mo.sql(rf"""SELECT * FROM """, engine=${engine})`,
       );
     });
 
     it("should not include engine in defaultCode when using default engine", () => {
       setLatestEngineSelected(DUCKDB_ENGINE);
-      expect(adapter.defaultCode).toBe(`_df = mo.sql(f"""SELECT * FROM """)`);
+      expect(adapter.defaultCode).toBe(`_df = mo.sql(rf"""SELECT * FROM """)`);
     });
   });
 });

--- a/frontend/src/core/codemirror/language/languages/sql/sql.ts
+++ b/frontend/src/core/codemirror/language/languages/sql/sql.ts
@@ -15,7 +15,11 @@ import {
   sqlExtension,
 } from "@marimo-team/codemirror-sql";
 import { DuckDBDialect } from "@marimo-team/codemirror-sql/dialects";
-import { type SQLMetadata, SQLParser } from "@marimo-team/smart-cells";
+import {
+  SQL_QUOTE_PREFIX,
+  type SQLMetadata,
+  SQLParser,
+} from "@marimo-team/smart-cells";
 import type { CellId } from "@/core/cells/ids";
 import { cellIdState } from "@/core/codemirror/cells/state";
 import type { PlaceholderType } from "@/core/codemirror/config/types";
@@ -93,7 +97,7 @@ export class SQLLanguageAdapter
   get defaultCode(): string {
     const engine = getLatestEngine();
     if (engine && engine !== DUCKDB_ENGINE) {
-      return `_df = mo.sql(f"""SELECT * FROM """, engine=${engine})`;
+      return `_df = mo.sql(${SQL_QUOTE_PREFIX}"""SELECT * FROM """, engine=${engine})`;
     }
     return this.parser.defaultCode;
   }

--- a/marimo/_ai/_tools/tools/datasource.py
+++ b/marimo/_ai/_tools/tools/datasource.py
@@ -9,6 +9,7 @@ from marimo import _loggers
 from marimo._ai._tools.base import ToolBase
 from marimo._ai._tools.types import SuccessResult, ToolGuidelines
 from marimo._ai._tools.utils.exceptions import ToolExecutionError
+from marimo._convert.common.format import SQL_QUOTE_PREFIX
 from marimo._data.models import DataTable
 from marimo._sql.engines.duckdb import INTERNAL_DUCKDB_ENGINE
 from marimo._types.ids import SessionId
@@ -169,9 +170,9 @@ class GetDatabaseTables(
         if default_schema:
             sample_query = f"SELECT * FROM {table} LIMIT 100"
         if engine != INTERNAL_DUCKDB_ENGINE:
-            wrapped_query = (
-                f'df = mo.sql(f"""{sample_query}""", engine={engine})'
-            )
+            wrapped_query = f'df = mo.sql({SQL_QUOTE_PREFIX}"""{sample_query}""", engine={engine})'
         else:
-            wrapped_query = f'df = mo.sql(f"""{sample_query}""")'
+            wrapped_query = (
+                f'df = mo.sql({SQL_QUOTE_PREFIX}"""{sample_query}""")'
+            )
         return wrapped_query

--- a/marimo/_convert/common/format.py
+++ b/marimo/_convert/common/format.py
@@ -1,13 +1,22 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Final, Optional, Union
 
 from marimo._ast import codegen
 from marimo._ast.compiler import extract_markdown
 
 if TYPE_CHECKING:
     from marimo._ast.cell import Cell, CellImpl
+
+# Raw f-string prefix for SQL cells.
+# Using rf-strings avoids unicode escape errors when users paste
+# Windows backslash paths (e.g., C:\Users\data\file.csv) into SQL cells.
+# See https://github.com/marimo-team/marimo/issues/8179
+#
+# Keep in sync with SQL_QUOTE_PREFIX in:
+#   packages/smart-cells/src/parsers/sql-parser.ts
+SQL_QUOTE_PREFIX: Final[str] = "rf"
 
 
 def markdown_to_marimo(source: str) -> str:
@@ -37,8 +46,7 @@ def sql_to_marimo(
     return "\n".join(
         [
             f"{table} = mo.sql(",
-            # f-string: expected for sql
-            codegen.indent_text('f"""'),
+            codegen.indent_text(f'{SQL_QUOTE_PREFIX}"""'),
             codegen.indent_text(source),
             ",\n".join(terminal_options),
             ")",

--- a/marimo/_convert/ipynb/to_ir.py
+++ b/marimo/_convert/ipynb/to_ir.py
@@ -14,7 +14,7 @@ from marimo._ast.compiler import compile_cell
 from marimo._ast.transformers import NameTransformer, RemoveImportTransformer
 from marimo._ast.variables import is_local
 from marimo._ast.visitor import Block, NamedNode, ScopedVisitor
-from marimo._convert.common.format import markdown_to_marimo
+from marimo._convert.common.format import SQL_QUOTE_PREFIX, markdown_to_marimo
 from marimo._runtime.dataflow import DirectedGraph
 from marimo._schemas.serialization import (
     AppInstantiation,
@@ -202,7 +202,7 @@ def transform_magic_commands(sources: list[str]) -> list[str]:
         """
         del command
         source = source.strip()
-        return f'_df = mo.sql("""\n{source}\n""")'
+        return f'_df = mo.sql({SQL_QUOTE_PREFIX}"""\n{source}\n""")'
 
     def magic_remove(source: str, command: str) -> str:
         """

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Optional, Union
 
 from marimo._config.config import CopilotMode
+from marimo._convert.common.format import SQL_QUOTE_PREFIX
 from marimo._server.models.completion import (
     AiCompletionContext,
     Language,
@@ -40,7 +41,7 @@ language_rules: dict[Language, list[str]] = {
 
 language_rules_multiple_cells: dict[Language, list[str]] = {
     "sql": [
-        'SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines. You should always write queries inline as the code snippet above, do not use variables to store queries.',
+        f'SQL cells start with df = mo.sql({SQL_QUOTE_PREFIX}"""<your query>""") for DuckDB, or df = mo.sql({SQL_QUOTE_PREFIX}"""<your query>""", engine=engine) for other SQL engines. You should always write queries inline as the code snippet above, do not use variables to store queries.',
         "This will automatically display the result in the UI. You do not need to return the dataframe in the cell.",
         "The SQL must use the syntax of the database engine specified in the `engine` variable. If no engine, then use duckdb syntax.",
     ]
@@ -119,7 +120,7 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
             "You can reference variables from other cells, but you cannot redefine a variable if it already exists.\n"
             "Immediately start with the following format. Do NOT comment on the code, just output the code itself: \n\n"
             "```python\n{PYTHON_CODE}\n```\n\n"
-            '```sql\ndf_name = mo.sql(f"""{SQL_QUERY}""")\n```\n\n'
+            f'```sql\ndf_name = mo.sql({SQL_QUOTE_PREFIX}"""{"{SQL_QUERY}"}""")\n```\n\n'
             '```markdown\nmo.md(f"""{MARKDOWN_CONTENT}""")\n```\n\n'
             "You can have multiple cells of any type. Each cell is wrapped in backticks with the appropriate language identifier.\n"
             "Create clear variable names if they will be used in other cells. Do not prefix with underscore.\n"
@@ -416,7 +417,7 @@ chart
 
         system_prompt += "\n\n## Rules for inserting cells:\n"
         system_prompt += 'For markdown cells, use `mo.md(f"""{content}""")`\n'
-        system_prompt += 'For sql cells, use `mo.sql(f"""{content}""")`. If a database engine is specified, use `mo.sql(f"""{content}""", engine=engine)` instead.\n'
+        system_prompt += f'For sql cells, use `mo.sql({SQL_QUOTE_PREFIX}"""{"{content}"}""")`. If a database engine is specified, use `mo.sql({SQL_QUOTE_PREFIX}"""{"{content}"}""", engine=engine)` instead.\n'
     else:
         for language in language_rules:
             if len(language_rules[language]) == 0:

--- a/packages/smart-cells/src/__tests__/index.test.ts
+++ b/packages/smart-cells/src/__tests__/index.test.ts
@@ -8,6 +8,7 @@ it("index.ts should export the correct modules", () => {
       "MarkdownParser",
       "PythonParser",
       "SQLParser",
+      "SQL_QUOTE_PREFIX",
     ]
   `);
 });

--- a/packages/smart-cells/src/index.ts
+++ b/packages/smart-cells/src/index.ts
@@ -4,7 +4,7 @@ export type { MarkdownMetadata } from "./parsers/markdown-parser.js";
 export { MarkdownParser } from "./parsers/markdown-parser.js";
 export { PythonParser } from "./parsers/python-parser.js";
 export type { SQLMetadata } from "./parsers/sql-parser.js";
-export { SQLParser } from "./parsers/sql-parser.js";
+export { SQL_QUOTE_PREFIX, SQLParser } from "./parsers/sql-parser.js";
 export type {
   FormatResult,
   LanguageParser,

--- a/packages/smart-cells/src/parsers/sql-parser.ts
+++ b/packages/smart-cells/src/parsers/sql-parser.ts
@@ -26,6 +26,17 @@ export interface SQLMetadata {
 
 const DEFAULT_ENGINE = "__marimo_duckdb";
 
+/**
+ * Raw f-string prefix for SQL cells.
+ * Using rf-strings avoids unicode escape errors when users paste
+ * Windows backslash paths (e.g., C:\Users\data\file.csv) into SQL cells.
+ * See https://github.com/marimo-team/marimo/issues/8179
+ *
+ * Keep in sync with SQL_QUOTE_PREFIX in:
+ *   marimo/_convert/common/format.py
+ */
+export const SQL_QUOTE_PREFIX = "rf" as const;
+
 interface SQLParseInfo {
   dfName: string;
   sqlString: string;
@@ -45,21 +56,21 @@ export class SQLParser implements LanguageParser<SQLMetadata> {
 
   readonly defaultMetadata: SQLMetadata = {
     dataframeName: "_df",
-    quotePrefix: "f",
+    quotePrefix: SQL_QUOTE_PREFIX,
     commentLines: [],
     showOutput: true,
     engine: DEFAULT_ENGINE,
   };
 
   get defaultCode(): string {
-    return `_df = mo.sql(f"""SELECT * FROM """)`;
+    return `_df = mo.sql(${SQL_QUOTE_PREFIX}"""SELECT * FROM """)`;
   }
 
   /**
    * Create a SQL cell from a SQL query.
    */
   static fromQuery(query: string): string {
-    return `_df = mo.sql(f"""${query.trim()}""")`;
+    return `_df = mo.sql(${SQL_QUOTE_PREFIX}"""${query.trim()}""")`;
   }
 
   transformIn(pythonCode: string): ParseResult<SQLMetadata> {

--- a/tests/_ai/tools/tools/test_datasource_tool.py
+++ b/tests/_ai/tools/tools/test_datasource_tool.py
@@ -569,7 +569,7 @@ def test_form_sample_query_full_qualified(tool: GetDatabaseTables):
 
     assert (
         query
-        == 'df = mo.sql(f"""SELECT * FROM mydb.myschema.mytable LIMIT 100""", engine=postgres_conn)'
+        == 'df = mo.sql(rf"""SELECT * FROM mydb.myschema.mytable LIMIT 100""", engine=postgres_conn)'
     )
 
 
@@ -586,7 +586,7 @@ def test_form_sample_query_default_database(tool: GetDatabaseTables):
 
     assert (
         query
-        == 'df = mo.sql(f"""SELECT * FROM myschema.mytable LIMIT 100""", engine=mysql_conn)'
+        == 'df = mo.sql(rf"""SELECT * FROM myschema.mytable LIMIT 100""", engine=mysql_conn)'
     )
 
 
@@ -603,7 +603,7 @@ def test_form_sample_query_default_schema(tool: GetDatabaseTables):
 
     assert (
         query
-        == 'df = mo.sql(f"""SELECT * FROM mytable LIMIT 100""", engine=postgres_conn)'
+        == 'df = mo.sql(rf"""SELECT * FROM mytable LIMIT 100""", engine=postgres_conn)'
     )
 
 
@@ -620,7 +620,7 @@ def test_form_sample_query_both_defaults(tool: GetDatabaseTables):
 
     assert (
         query
-        == 'df = mo.sql(f"""SELECT * FROM mytable LIMIT 100""", engine=mysql_conn)'
+        == 'df = mo.sql(rf"""SELECT * FROM mytable LIMIT 100""", engine=mysql_conn)'
     )
 
 
@@ -640,7 +640,7 @@ def test_form_sample_query_internal_duckdb_no_defaults(
 
     assert (
         query
-        == 'df = mo.sql(f"""SELECT * FROM mydb.myschema.mytable LIMIT 100""")'
+        == 'df = mo.sql(rf"""SELECT * FROM mydb.myschema.mytable LIMIT 100""")'
     )
 
 
@@ -658,4 +658,4 @@ def test_form_sample_query_internal_duckdb_with_defaults(
         engine=INTERNAL_DUCKDB_ENGINE,
     )
 
-    assert query == 'df = mo.sql(f"""SELECT * FROM mytable LIMIT 100""")'
+    assert query == 'df = mo.sql(rf"""SELECT * FROM mytable LIMIT 100""")'

--- a/tests/_lint/test_files/sql_parsing_errors.py
+++ b/tests/_lint/test_files/sql_parsing_errors.py
@@ -16,7 +16,7 @@ def _():
 @app.cell
 def _(mo):
     # This should trigger an MF005 SQL parsing error due to trailing comma
-    result = mo.sql(f"""
+    result = mo.sql(rf"""
         WITH ranked_stories AS (
             SELECT
                 title,

--- a/tests/_server/ai/snapshots/chat_system_prompts.txt
+++ b/tests/_server/ai/snapshots/chat_system_prompts.txt
@@ -1069,7 +1069,7 @@ chart
 7. If a variable is already defined, use another name, or make it private by adding an underscore at the beginning.
 
 ## Rules for sql:
-1. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines. You should always write queries inline as the code snippet above, do not use variables to store queries.
+1. SQL cells start with df = mo.sql(rf"""<your query>""") for DuckDB, or df = mo.sql(rf"""<your query>""", engine=engine) for other SQL engines. You should always write queries inline as the code snippet above, do not use variables to store queries.
 2. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 3. The SQL must use the syntax of the database engine specified in the `engine` variable. If no engine, then use duckdb syntax.
 
@@ -1080,7 +1080,7 @@ chart
 
 ## Rules for inserting cells:
 For markdown cells, use `mo.md(f"""{content}""")`
-For sql cells, use `mo.sql(f"""{content}""")`. If a database engine is specified, use `mo.sql(f"""{content}""", engine=engine)` instead.
+For sql cells, use `mo.sql(rf"""{content}""")`. If a database engine is specified, use `mo.sql(rf"""{content}""", engine=engine)` instead.
 
 
 ==================== kitchen sink ====================

--- a/tests/_server/ai/snapshots/system_prompts.txt
+++ b/tests/_server/ai/snapshots/system_prompts.txt
@@ -331,7 +331,7 @@ Immediately start with the following format. Do NOT comment on the code, just ou
 ```
 
 ```sql
-df_name = mo.sql(f"""{SQL_QUERY}""")
+df_name = mo.sql(rf"""{SQL_QUERY}""")
 ```
 
 ```markdown
@@ -352,7 +352,7 @@ Separate logic into multiple cells to keep the code organized and readable.
 7. If a variable is already defined, use another name, or make it private by adding an underscore at the beginning.
 
 ## Rules for sql:
-1. SQL cells start with df = mo.sql(f"""<your query>""") for DuckDB, or df = mo.sql(f"""<your query>""", engine=engine) for other SQL engines. You should always write queries inline as the code snippet above, do not use variables to store queries.
+1. SQL cells start with df = mo.sql(rf"""<your query>""") for DuckDB, or df = mo.sql(rf"""<your query>""", engine=engine) for other SQL engines. You should always write queries inline as the code snippet above, do not use variables to store queries.
 2. This will automatically display the result in the UI. You do not need to return the dataframe in the cell.
 3. The SQL must use the syntax of the database engine specified in the `engine` variable. If no engine, then use duckdb syntax.
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #8179. This supports path strings in queries because the f-string doesn't treat \ characters properly and will error out.

Taken from issue ^:
The rf prefix prevents:

5 types of parsing errors (\U, \u, \x, \N, invalid octal)
7 types of silent corruption (\t, \n, \r, \b, \f, \v, \a)

In my tests, there is no noticeable regression in queries. Complex queries like regex should be more correct. \x for example shouldn't be treated like a special character in a `mo.sql` query, it should be treated literally.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
