### PR TITLE
docs: removes ploomber deployment

### DIFF
--- a/docs/guides/deploying/deploying_ploomber.md
+++ b/docs/guides/deploying/deploying_ploomber.md
@@ -1,5 +1,0 @@
-# Deploy to Ploomber Cloud
-
-For production deployments, you can use Ploomber Cloud. It allows you to deploy
-marimo in a secure and scalable way. See
-[deployment instructions here](https://docs.cloud.ploomber.io/en/latest/apps/marimo.html)

--- a/docs/guides/deploying/index.md
+++ b/docs/guides/deploying/index.md
@@ -42,7 +42,6 @@ These guides help you deploy marimo notebooks as read-only apps.
 | [authentication](./authentication.md) | Authentication and security                              |
 | [deploying_public_gallery](./deploying_public_gallery.md) | Deploy to our public gallery                             |
 | [deploying_hugging_face](./deploying_hugging_face.md) | Deploy to Hugging Face                                   |
-| [deploying_ploomber](./deploying_ploomber.md) | Deploy to Ploomber Cloud                                 |
 
 ### Health and status endpoints
 


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->

Ploomber was introduced as a deployment option in PR #1426.

The Ploomber cloud platform shut down on 2025-10-31: 

https://ploomber.io/blog/platform-shut-down/

The Marimo deploying guide still has an entry for Ploomber:

https://docs.marimo.io/guides/deploying/

([Permalink](https://github.com/marimo-team/marimo/blob/74561580dd237279de95350be5db57bc2bf46e75/docs/guides/deploying/index.md))

The link for the deployment instructions is broken:

https://docs.cloud.ploomber.io/en/latest/apps/marimo.html

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

Removed the Ploomber page from the deploying guide.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] ~~For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).~~ N/A
- [ ] ~~Tests have been added for the changes made.~~ N/A
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
