### PR TITLE
perf: avoid uncessary duckdb calls in stats and getting db names

### DIFF
--- a/tests/_data/test_preview_column.py
+++ b/tests/_data/test_preview_column.py
@@ -500,6 +500,36 @@ def test_get_column_preview_for_duckdb_over_limit() -> None:
 
 
 @pytest.mark.skipif(
+    not HAS_SQL_DEPS, reason="optional dependencies not installed"
+)
+def test_get_column_preview_for_duckdb_stats_total_none() -> None:
+    """Test that when stats.total is None, no chart is generated and no crash occurs."""
+    from marimo._data.models import ColumnStats
+
+    with (
+        patch(
+            "marimo._data.preview_column.get_sql_stats",
+            return_value=ColumnStats(),
+        ),
+        patch(
+            "marimo._data.preview_column.get_column_type",
+            return_value="integer",
+        ),
+    ):
+        result = get_column_preview_for_duckdb(
+            fully_qualified_table_name="tbl",
+            column_name="id",
+        )
+
+    assert result is not None
+    assert result.stats is not None
+    assert result.stats.total is None
+    # No chart should be generated when total is None
+    assert result.chart_spec is None
+    assert result.error is None
+
+
+@pytest.mark.skipif(
     not DependencyManager.narwhals.has() or not DependencyManager.polars.has(),
     reason="narwhals and polars not installed",
 )


### PR DESCRIPTION
- Eliminate redundant `COUNT(*)` query in get_column_preview_for_duckdb — reuse stats.total
- Skip unnecessary `_get_duckdb_database_names` query in the duckdb_columns() fallback path. avoids an extra SELECT * FROM duckdb_databases() query