### PR TITLE
perf: better datastructures for kernel Runner

### DIFF
--- a/marimo/_runtime/app/script_runner.py
+++ b/marimo/_runtime/app/script_runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from marimo._ast.names import SETUP_CELL_NAME
@@ -56,12 +57,12 @@ class AppScriptRunner:
             excluded=CellId_t(SETUP_CELL_NAME),
         )
 
-        self.cells_to_run = [
+        self.cells_to_run: deque[CellId_t] = deque(
             cid
             for cid in pruned_execution_order
             if app.cell_manager.cell_data_at(cid).cell is not None
             and not self.app.graph.is_disabled(cid)
-        ]
+        )
         self._executor = get_executor(ExecutionConfig())
 
     def _cancel(self, cell_id: CellId_t) -> None:
@@ -90,7 +91,7 @@ class AppScriptRunner:
 
             outputs: dict[CellId_t, Any] = {}
             while self.cells_to_run:
-                cid = self.cells_to_run.pop(0)
+                cid = self.cells_to_run.popleft()
                 if cid in self.cells_cancelled:
                     continue
                 # Set up has already run in this case.
@@ -133,7 +134,7 @@ class AppScriptRunner:
             outputs: dict[CellId_t, Any] = {}
 
             while self.cells_to_run:
-                cid = self.cells_to_run.pop(0)
+                cid = self.cells_to_run.popleft()
                 if cid in self.cells_cancelled:
                     continue
 

--- a/marimo/_runtime/dataflow/topology.py
+++ b/marimo/_runtime/dataflow/topology.py
@@ -103,18 +103,16 @@ class MutableGraphTopology(GraphTopology):
         if cell_id not in self.cells:
             raise ValueError(f"Cell {cell_id} not found")
 
-        # Remove from cells
+        # Remove this node from its parents' children lists
+        for parent_id in self._parents[cell_id]:
+            self._children[parent_id].discard(cell_id)
+        # Remove this node from its children's parent lists
+        for child_id in self._children[cell_id]:
+            self._parents[child_id].discard(cell_id)
+
         del self._cells[cell_id]
         del self._children[cell_id]
         del self._parents[cell_id]
-
-        # Remove from other nodes' parent/child lists
-        for elems in self.parents.values():
-            if cell_id in elems:
-                elems.remove(cell_id)
-        for elems in self.children.values():
-            if cell_id in elems:
-                elems.remove(cell_id)
 
     def add_edge(self, parent: CellId_t, child: CellId_t) -> None:
         """Add an edge from parent to child."""

--- a/marimo/_runtime/runner/hooks_on_finish.py
+++ b/marimo/_runtime/runner/hooks_on_finish.py
@@ -38,8 +38,8 @@ def _send_interrupt_errors(ctx: OnFinishHookContext) -> None:
 
 @kernel_tracer.start_as_current_span("send_cancellation_errors")
 def _send_cancellation_errors(ctx: OnFinishHookContext) -> None:
-    for raising_cell in ctx.cells_cancelled:
-        for cid in ctx.cells_cancelled[raising_cell]:
+    for raising_cell in ctx.cancelled_cells:
+        for cid in ctx.cancelled_cells[raising_cell]:
             # `cid` was not run
             cell = ctx.graph.cells[cid]
             if cell.runtime_state != "idle":

--- a/marimo/_runtime/runner/hooks_post_execution.py
+++ b/marimo/_runtime/runner/hooks_post_execution.py
@@ -90,7 +90,7 @@ def _set_run_result_status(
 ) -> None:
     if isinstance(run_result.exception, MarimoInterruptionError):
         cell.set_run_result_status("interrupted")
-    elif ctx.cancelled(cell.cell_id):
+    elif cell.cell_id in ctx.cancelled_cells:
         cell.set_run_result_status("cancelled")
     elif run_result.exception is not None:
         cell.set_run_result_status(
@@ -246,11 +246,9 @@ def _store_state_reference(
     # Associate state variables with variable names
     runtime_ctx = get_context()
     runtime_ctx.state_registry.register_scope(ctx.glbls, defs=cell.defs)
-    privates = set().union(
-        *[cell.temporaries for cell in runtime_ctx.graph.cells.values()]
-    )
+    # Use pre-computed all_temporaries
     runtime_ctx.state_registry.retain_active_states(
-        set(ctx.graph.definitions.keys()) | privates
+        set(ctx.graph.definitions.keys()) | ctx.all_temporaries
     )
 
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1471,6 +1471,7 @@ class Kernel:
                 # by object ID (via is operator)
                 if ref in self.globals and self.globals[ref] is state:
                     cells_with_stale_state.add(cid)
+                    break
         self.graph.set_stale(cells_with_stale_state, prune_imports=True)
         if not self.lazy():
             self._execute_stale_cells_callback()

--- a/tests/_runtime/runner/test_cancelled_cells.py
+++ b/tests/_runtime/runner/test_cancelled_cells.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import pytest
+
+from marimo._runtime.runner.hook_context import CancelledCells
+from marimo._types.ids import CellId_t
+
+
+class TestCancelledCells:
+    def test_empty(self) -> None:
+        cc = CancelledCells()
+        assert not cc
+        assert CellId_t("a") not in cc
+        assert list(cc) == []
+
+    def test_add_and_contains(self) -> None:
+        cc = CancelledCells()
+        cc.add(
+            CellId_t("raiser"),
+            {CellId_t("child1"), CellId_t("child2")},
+        )
+        assert cc
+        assert CellId_t("child1") in cc
+        assert CellId_t("child2") in cc
+        assert CellId_t("other") not in cc
+
+    def test_contains_checks_descendants_not_raisers(self) -> None:
+        """The `in` operator checks the flat descendant set, not just raisers."""
+        cc = CancelledCells()
+        cc.add(CellId_t("raiser"), {CellId_t("raiser"), CellId_t("child")})
+        # Both raiser and descendant should be found
+        assert CellId_t("raiser") in cc
+        assert CellId_t("child") in cc
+
+    def test_iter_yields_raising_cells(self) -> None:
+        cc = CancelledCells()
+        cc.add(CellId_t("r1"), {CellId_t("a")})
+        cc.add(CellId_t("r2"), {CellId_t("b")})
+        assert set(cc) == {CellId_t("r1"), CellId_t("r2")}
+
+    def test_getitem(self) -> None:
+        cc = CancelledCells()
+        descendants = {CellId_t("x"), CellId_t("y")}
+        cc.add(CellId_t("r"), descendants)
+        assert cc[CellId_t("r")] == descendants
+
+    def test_getitem_missing_raises(self) -> None:
+        cc = CancelledCells()
+        with pytest.raises(KeyError):
+            cc[CellId_t("missing")]
+
+    def test_multiple_raisers_flat_set_merges(self) -> None:
+        """Flat set is the union of all descendants across raisers."""
+        cc = CancelledCells()
+        cc.add(CellId_t("r1"), {CellId_t("a"), CellId_t("b")})
+        cc.add(CellId_t("r2"), {CellId_t("b"), CellId_t("c")})
+        assert CellId_t("a") in cc
+        assert CellId_t("b") in cc
+        assert CellId_t("c") in cc
+        assert CellId_t("d") not in cc
+
+    def test_shared_reference_semantics(self) -> None:
+        """Mutations after passing to a frozen dataclass are visible."""
+        cc = CancelledCells()
+        # Simulate: PostExecutionHookContext holds a reference,
+        # then Runner.cancel() adds entries after construction.
+        assert CellId_t("x") not in cc
+        cc.add(CellId_t("r"), {CellId_t("x")})
+        assert CellId_t("x") in cc

--- a/tests/_runtime/test_topology.py
+++ b/tests/_runtime/test_topology.py
@@ -102,6 +102,39 @@ class TestMutableGraphTopology:
         assert "cell_2" not in graph.children["cell_1"]
         assert "cell_2" not in graph.parents["cell_3"]
 
+    def test_remove_hub_node_cleans_all_neighbors(self) -> None:
+        """Removing a hub node updates all its parents and children."""
+        graph = MutableGraphTopology()
+        cells = {f"cell_{i}": parse_cell(f"x{i} = {i}") for i in range(1, 6)}
+        for cid, cell in cells.items():
+            graph.add_node(cid, cell)
+
+        # cell_3 is a hub: parents=[cell_1, cell_2], children=[cell_4, cell_5]
+        graph.add_edge("cell_1", "cell_3")
+        graph.add_edge("cell_2", "cell_3")
+        graph.add_edge("cell_3", "cell_4")
+        graph.add_edge("cell_3", "cell_5")
+        # unrelated edge
+        graph.add_edge("cell_1", "cell_2")
+
+        graph.remove_node("cell_3")
+
+        # cell_3 is fully removed
+        assert "cell_3" not in graph.cells
+        assert "cell_3" not in graph.children
+        assert "cell_3" not in graph.parents
+
+        # parents no longer list cell_3 as a child
+        assert "cell_3" not in graph.children["cell_1"]
+        assert "cell_3" not in graph.children["cell_2"]
+        # children no longer list cell_3 as a parent
+        assert "cell_3" not in graph.parents["cell_4"]
+        assert "cell_3" not in graph.parents["cell_5"]
+
+        # unrelated edge is untouched
+        assert "cell_2" in graph.children["cell_1"]
+        assert "cell_1" in graph.parents["cell_2"]
+
     def test_add_edge(self) -> None:
         """Test adding an edge between two nodes."""
         graph = MutableGraphTopology()


### PR DESCRIPTION
Performance improvements to the marimo runtime hot paths, reducing algorithmic complexity in the cell execution loop, graph mutation, and module resolution.

- cells_to_run deque: Replace list.pop(0) (O(n) per pop) with collections.deque.popleft() (O(1)) in Runner and ScriptRunner, eliminating O(n²) total cost across a full run
- CancelledCells dataclass: Encapsulate cancellation tracking into a dedicated class with O(1) membership checks via a flat set, replacing O(k) scans over dict values on every iteration of the run loop
- remove_node targeted removal: Only iterate a node's direct neighbors instead of scanning all nodes in the topology, reducing deletion cost from O(total_cells) to O(neighbors)
- Pre-compute all_temporaries: Compute the union of all cell temporaries once per run and pass via PostExecutionHookContext, eliminating O(cells²) recomputation per run
- register_state_update early exit: Break after finding the first matching ref for a state update instead of continuing to scan all cells
