### PR TITLE
fix: don't enable reactive tests in run mode

### DIFF
--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -458,7 +458,7 @@ def _launch_pyodide_kernel(
     )
 
     hooks = create_default_hooks()
-    if user_config["runtime"].get("reactive_tests", False):
+    if is_edit_mode and user_config["runtime"].get("reactive_tests", False):
         hooks.add_post_execution(attempt_pytest, Priority.LATE)
     if is_edit_mode:
         hooks.add_post_execution(render_toplevel_defs, Priority.LATE)

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3210,7 +3210,7 @@ def launch_kernel(
     )
 
     hooks = create_default_hooks()
-    if user_config["runtime"].get("reactive_tests", False):
+    if is_edit_mode and user_config["runtime"].get("reactive_tests", False):
         hooks.add_post_execution(attempt_pytest, Priority.LATE)
     if is_edit_mode:
         hooks.add_post_execution(render_toplevel_defs, Priority.LATE)


### PR DESCRIPTION
Reactive tests don't need to be enabled in run mode. 