### PR TITLE
perf: grab module css from model-state instead of passing via DOM attributes

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -21,7 +21,6 @@ import { BINDING_MANAGER, WIDGET_DEF_REGISTRY } from "./widget-binding";
 interface Data {
   jsUrl: string;
   jsHash: string;
-  css?: string | null;
 }
 
 type AnyWidgetState = ModelState;
@@ -118,20 +117,17 @@ export const AnyWidgetPlugin = createPlugin<ModelIdRef>("marimo-anywidget")
     z.object({
       jsUrl: z.string(),
       jsHash: z.string(),
-      css: z.string().nullish(),
     }),
   )
   .withFunctions({})
   .renderer((props) => <AnyWidgetSlot {...props} />);
 
 const AnyWidgetSlot = (props: IPluginProps<ModelIdRef, Data>) => {
-  const { css, jsUrl, jsHash } = props.data;
+  const { jsUrl, jsHash } = props.data;
   const { model_id: modelId } = props.value;
   const host = props.host as HTMLElementNotDerivedFromRef;
 
   const { jsModule, error } = useAnyWidgetModule({ jsUrl, jsHash });
-
-  useMountCss(css, host);
 
   if (error) {
     return <ErrorBanner error={error} />;
@@ -160,6 +156,7 @@ const AnyWidgetSlot = (props: IPluginProps<ModelIdRef, Data>) => {
       key={key}
       widget={jsModule.default}
       modelId={modelId}
+      host={host}
     />
   );
 };
@@ -207,11 +204,13 @@ function isAnyWidgetModule(mod: any): mod is { default: AnyWidget } {
 interface Props<T extends AnyWidgetState> {
   widget: AnyWidget<T>;
   modelId: WidgetModelId;
+  host: HTMLElementNotDerivedFromRef;
 }
 
 const LoadedSlot = <T extends AnyWidgetState>({
   widget,
   modelId,
+  host,
 }: Props<T> & { widget: AnyWidget<T> }) => {
   const htmlRef = useRef<HTMLDivElement>(null);
 
@@ -221,6 +220,9 @@ const LoadedSlot = <T extends AnyWidgetState>({
   if (!model) {
     Logger.error("Model not found for modelId", modelId);
   }
+
+  const css = model?.get("_css");
+  useMountCss(css, host);
 
   useEffect(() => {
     if (!htmlRef.current || !model) {

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -167,8 +167,6 @@ class anywidget(UIElement[ModelIdRef, AnyWidgetState]):
         self._initialized = False
 
         js: str = getattr(widget, "_esm", "")  # type: ignore [unused-ignore]
-        css: str = getattr(widget, "_css", "")  # type: ignore [unused-ignore]
-
         js_hash = hash_code(js)
 
         # Trigger comm initialization early to ensure _model_id is set
@@ -186,7 +184,6 @@ class anywidget(UIElement[ModelIdRef, AnyWidgetState]):
             args={
                 "js-url": mo_data.js(js).url if js else "",  # type: ignore [unused-ignore]  # noqa: E501
                 "js-hash": js_hash,
-                "css": css,
             },
             on_change=None,
         )

--- a/tests/_plugins/ui/_impl/test_anywidget.py
+++ b/tests/_plugins/ui/_impl/test_anywidget.py
@@ -193,7 +193,6 @@ x = as_marimo_element.count
         assert len(wrapped._initial_value_frontend) == 1
         assert isinstance(wrapped._initial_value_frontend["model_id"], str)
         assert wrapped._component_args == {
-            "css": "",
             "js-url": "",
             "js-hash": md5(b"").hexdigest(),
         }
@@ -209,7 +208,6 @@ x = as_marimo_element.count
         assert len(wrapped._initial_value_frontend) == 1
         assert isinstance(wrapped._initial_value_frontend["model_id"], str)
         assert wrapped._component_args == {
-            "css": "",
             "js-url": "",
             "js-hash": md5(b"").hexdigest(),
         }
@@ -344,7 +342,7 @@ x = as_marimo_element.count
             _css = "button { color: red; }"
 
         wrapped = anywidget(CSSWidget())
-        assert wrapped._component_args["css"] == "button { color: red; }"
+        assert "css" not in wrapped._component_args
 
     @staticmethod
     async def test_js_hash() -> None:


### PR DESCRIPTION
Unblocked once https://github.com/marimo-team/marimo/pull/8166 is merged.

This avoids passing large css to the DOM dataset for the anywidget element, and instead grabs it from the model state.