### PR TITLE
Revert "fix: normalize Html subclasses in as_html for correct f-string formatting (#8223)"

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -304,10 +304,6 @@ def as_html(value: object) -> Html:
         ```
     """
     if isinstance(value, Html):
-        # Normalize Html subclasses (like _md) to plain Html so that
-        # __format__ returns processed HTML instead of raw source text.
-        if type(value) is not Html:
-            return Html(value.text)
         return value
 
     formatter = get_formatter(value)

--- a/tests/_output/formatters/test_formatters.py
+++ b/tests/_output/formatters/test_formatters.py
@@ -689,21 +689,6 @@ def test_as_html_with_html_object() -> None:
     assert result.text == "<h1>Hello</h1>"
 
 
-def test_as_html_with_md_object_formats_as_html() -> None:
-    """Test as_html normalizes md objects so __format__ returns HTML."""
-    from marimo._output.md import md
-
-    md_obj = md("# Title")
-    result = as_html(md_obj)
-
-    # Should be a plain Html, not the _md subclass
-    assert type(result).__name__ == "Html"
-    # When used in an f-string, should produce HTML, not raw markdown
-    formatted = f"{result}"
-    assert "# Title" not in formatted
-    assert "<" in formatted  # Should contain HTML tags
-
-
 def test_as_html_with_repr_html() -> None:
     """Test as_html with objects that have _repr_html_ method."""
     register_formatters()


### PR DESCRIPTION
This reverts commit 2d2f100bc6a130df1fb35a22acba566faf4f686e.

Commit 2d2f100bc changed as_html() to normalize Html subclasses (like Spinner) into
  plain Html objects. This creates a new object, breaking the identity-based comparison (is not) in
   output.remove(). When the spinner's context manager exits and calls remove(self), it can't find
  the spinner in the output list because a different Html object was stored.