### PR TITLE
fix: preserve function return type in live docs panel (#8210)

### DIFF
--- a/tests/_server/api/endpoints/test_resume_session.py
+++ b/tests/_server/api/endpoints/test_resume_session.py
@@ -5,6 +5,8 @@ import time
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional
 
+import pytest
+
 from marimo._config.manager import UserConfigManager
 from marimo._messaging.msgspec_encoder import asdict
 from marimo._messaging.notification import (
@@ -295,6 +297,7 @@ def test_restart_session(client: TestClient) -> None:
     # Shutdown the kernel
 
 
+@pytest.mark.flaky(reruns=3)
 def test_resume_session_with_watch(client: TestClient) -> None:
     session_manager = get_session_manager(client)
     session_manager.watch = True

--- a/tests/_utils/test_format_signature.py
+++ b/tests/_utils/test_format_signature.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import pytest
+
+from marimo._utils.format_signature import format_signature
+
+
+class TestFormatSignature:
+    @pytest.mark.parametrize(
+        ("sig", "expected_return"),
+        [
+            # Short (fits on 1 line)
+            ("f() -> int", "int"),
+            ("f() -> str", "str"),
+            ("f() -> list[int]", "list[int]"),
+            # Medium (multiline)
+            ("f(x: int) -> Optional[str]", "Optional[str]"),
+            ("f(x: int, y: str) -> dict[str, Any]", "dict[str, Any]"),
+            ("medium_func(x: int, y: str) -> float", "float"),
+            ("func(x: int, y: str = None) -> bool", "bool"),
+            # Long (like hstack)
+            (
+                "hstack(items: Sequence[object], *, "
+                'justify: str = "space-between", '
+                "align: str = None, "
+                "wrap: bool = False, "
+                "gap: float = 0.5, "
+                "widths: str = None) -> Html",
+                "Html",
+            ),
+        ],
+    )
+    def test_return_type_preserved(
+        self, sig: str, expected_return: str
+    ) -> None:
+        result = format_signature("def ", sig)
+        assert "->" in result
+        assert result.strip().endswith(expected_return)
+
+    def test_no_return_type(self) -> None:
+        result = format_signature("def ", "func(x: int, y: str)")
+        assert "->" not in result
+        assert "func" in result
+
+    def test_class_prefix(self) -> None:
+        result = format_signature("class ", "MyClass(x: int, y: str)")
+        assert result.startswith("class ")
+        assert "MyClass" in result
+
+    def test_default_values_not_truncated(self) -> None:
+        result = format_signature(
+            "def ", "func(x: int, y: str = None) -> bool"
+        )
+        assert "None" in result


### PR DESCRIPTION
Cloes https://github.com/marimo-team/marimo/issues/8210

## Summary

Fixed `format_signature()` dropping the return type annotation (e.g. `-> Html`) when Black >= 26 is installed. Black 26 changed how it formats stub bodies — keeping `: ...` on the same line as the closing paren instead of a separate indented line — which broke the old line-slicing logic.
