### PR TITLE
chore: bump loro

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     # websockets for use with starlette, and for lsp
     "websockets >= 14.2.0",
     # loro for collaborative editing
-    "loro>=1.5.0; python_version >= '3.11' and python_version < '3.14'",
+    "loro>=1.10.0",
     # python <=3.10 compatibility
     "typing_extensions>=4.4.0; python_version < '3.11'",
     # for rst parsing; lowerbound determined by awscli requiring < 0.17,


### PR DESCRIPTION
## 📝 Summary

Bumps loro and removes version restrictions since all wheels are packaged (python 3.14t too!)
