### PR TITLE
fix: remove openai from required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dependencies = [
     # for packaging.version; not sure what the lower bound is.
     "packaging",
     "msgspec>=0.20.0",
-    "openai>=2.15.0",
 ]
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
OpenAI was accidentally added as a required dependency in a previous release.