### PR TITLE
Add marimo-lsp compatibility check

### DIFF
--- a/.github/workflows/test_marimo_lsp.yaml
+++ b/.github/workflows/test_marimo_lsp.yaml
@@ -1,0 +1,81 @@
+name: Test marimo-lsp compatibility
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  test_marimo_lsp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout marimo
+        uses: actions/checkout@v4
+
+      - name: ⬇️ Checkout marimo-lsp
+        uses: actions/checkout@v4
+        with:
+          repository: marimo-team/marimo-lsp
+          path: marimo-lsp
+
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: 🔧 Install marimo-lsp with local marimo
+        working-directory: marimo-lsp
+        run: |
+          uv add --editable ../
+
+      - name: 🔍 Typecheck
+        id: typecheck
+        working-directory: marimo-lsp
+        run: uv run ty check
+
+      - name: 🧪 Run tests
+        if: github.event_name == 'workflow_dispatch'
+        id: tests
+        working-directory: marimo-lsp
+        run: uv run pytest
+
+      - name: 🐛 Open issue on failure
+        if: failure() && github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '🚨 marimo-lsp compatibility check failed';
+            // Check if an open issue already exists
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'marimo-lsp',
+            });
+            if (existing.data.some(issue => issue.title === title)) {
+              console.log('Issue already exists, skipping creation');
+              return;
+            }
+            const commit = context.sha.substring(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              labels: ['marimo-lsp'],
+              body: [
+                `The marimo-lsp compatibility check failed after merging commit ${commit} into \`main\`.`,
+                '',
+                `**Workflow run:** ${runUrl}`,
+                '',
+                'The typecheck (`uv run ty check`) in [marimo-team/marimo-lsp](https://github.com/marimo-team/marimo-lsp) failed against the latest marimo.',
+                '',
+                'This likely means a recent change broke the marimo-lsp integration.',
+              ].join('\n'),
+            });


### PR DESCRIPTION
marimo-lsp is coupled to some of marimo's messaging internals, so releases can silently break it marimo-team/marimo-lsp#398. We've been reasonably careful about minimizing this drift, but there hasn't been a good way to catch breakage before cutting a release.

These changes add a CI workflow that checks out marimo-lsp, installs the local marimo as an editable dependency, and runs `uv run ty check` on every push to main. If the typecheck fails it automatically opens a labeled issue (with deduplication to avoid duplicates).

The workflow also supports manual dispatch via `workflow_dispatch`, which runs both the typecheck and the full test suite (`uv run pytest`).

## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
