### PR TITLE
Support `__buffer__` objects in widget comm buffers

### DIFF
--- a/marimo/_plugins/ui/_impl/comm.py
+++ b/marimo/_plugins/ui/_impl/comm.py
@@ -72,19 +72,18 @@ BufferType = Optional[list[Buffer]]
 
 
 def _ensure_bytes(buf: object) -> bytes:
-    """Coerce a buffer to a type msgspec can base64-encode.
+    """Coerce a buffer to plain ``bytes`` for msgspec serialization.
 
     msgspec natively handles ``bytes``, ``memoryview``, and ``bytearray``.
     Some libraries (e.g. obstore) use custom types that hold binary data
     but aren't subclasses of these, so msgspec can't serialize them directly.
+
+    ``bytes()`` handles memoryview/bytearray on all Python versions, and
+    on Python 3.12+ also handles any object implementing ``__buffer__``.
     """
     if isinstance(buf, bytes):
         return buf
-    if hasattr(buf, "__buffer__") or isinstance(buf, (memoryview, bytearray)):
-        return bytes(buf)  # type: ignore[arg-type]
-    raise TypeError(
-        f"Buffer of type {type(buf).__name__} does not support the buffer protocol"
-    )
+    return bytes(buf)  # type: ignore[call-overload,no-any-return]
 
 
 def _create_model_message(

--- a/tests/_plugins/ui/_impl/test_comm.py
+++ b/tests/_plugins/ui/_impl/test_comm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -270,6 +271,10 @@ class TestBroadcastBufferTypes:
         result = self._roundtrip_buffer(comm, bytearray(self.PAYLOAD))
         assert result.message.buffers == [self.PAYLOAD]
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 12),
+        reason="__buffer__ dunder requires Python 3.12+",
+    )
     def test_custom_buffer_protocol(self, comm):
         """Custom buffer-protocol objects (like obstore.Bytes) survive the
         roundtrip."""
@@ -279,9 +284,7 @@ class TestBroadcastBufferTypes:
     def test_unsupported_type_raises(self):
         from marimo._plugins.ui._impl.comm import _ensure_bytes
 
-        with pytest.raises(
-            TypeError, match="does not support the buffer protocol"
-        ):
+        with pytest.raises(TypeError):
             _ensure_bytes("not bytes")
 
 


### PR DESCRIPTION
Libraries like obstore expose a `Bytes` type that implements Python's buffer protocol but isn't a subclass of `bytes`, `memoryview`, or `bytearray`. When these objects ended up in widget comm buffers (e.g. from lonboard map tiles), msgspec didn't recognise them as native binary types and fell through to `enc_hook`, which produced invalid output instead of base64.

This adds `_ensure_bytes()` in the comm layer to coerce any buffer-protocol object to plain `bytes` before building model messages.


Needed to support raster tiles in `lonboard`: 
<img src="https://github.com/user-attachments/assets/0652f406-779d-4db5-bca9-03dd315301a7" />
