### PR TITLE
fix: refresh mpl interactive plots when browser tab becomes visible

### DIFF
--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -606,6 +606,16 @@ html_content = """
               ondownload,
               // The HTML element in which to place the figure
               document.getElementById("figure"));
+
+          // When the browser tab is hidden (minimized or switched away),
+          // browsers throttle or skip canvas rendering. Any canvas updates
+          // sent by matplotlib while hidden are effectively lost, leaving
+          // blank plots. Re-request the full figure when the tab returns.
+          document.addEventListener("visibilitychange", function() {
+            if (!document.hidden && fig.ws.readyState === 1) {
+              fig.send_message("refresh", {});
+            }
+          });
         }
       );
     </script>

--- a/tests/_plugins/stateless/test_mpl.py
+++ b/tests/_plugins/stateless/test_mpl.py
@@ -260,6 +260,25 @@ def test_template_contains_html_structure() -> None:
         assert "9000" in result
 
 
+def test_template_contains_visibilitychange_refresh() -> None:
+    """Test that template includes visibilitychange listener to refresh
+    figures when the browser tab becomes visible again.
+
+    Regression test for https://github.com/marimo-team/marimo/issues/2092:
+    plots rendered while the tab is hidden appear blank because browsers
+    throttle canvas rendering in background tabs.
+    """
+
+    with patch("marimo._plugins.stateless.mpl._mpl.app_meta") as mock_app_meta:
+        mock_app_meta.return_value.request = None
+
+        result = _template("12345", 9000)
+
+        assert "visibilitychange" in result
+        assert "document.hidden" in result
+        assert 'send_message("refresh"' in result
+
+
 def test_mpl_server_manager() -> None:
     """Test MplServerManager basic functionality"""
     from marimo._plugins.stateless.mpl._mpl import MplServerManager


### PR DESCRIPTION
Closes #2092
Closes #4435


## Problem

When `mo.mpl.interactive()` plots are rendered while the browser tab is in the
background (minimized or switched to another tab), the plots appear blank.
This is because browsers throttle or skip canvas rendering in background tabs,
so the image data sent by matplotlib's WebAgg server over WebSocket is
effectively lost.

## Fix

Added a `visibilitychange` event listener in the matplotlib iframe's HTML
template. When the browser tab becomes visible again, it sends a `refresh`
message to the matplotlib WebAgg server. This triggers a full figure redraw
(`_force_full = True` + `draw_idle()`) that sends fresh canvas data back to
the browser, ensuring the plot is always up-to-date when the user returns.
