### PR TITLE
fix: add a has_warnings parse enum to indicate formatting errors

### DIFF
--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -1158,6 +1158,21 @@ ONLY_HEADER_EXTRACTED_VIOLATION = "Only able to extract header."
 NON_MARIMO_PYTHON_SCRIPT_VIOLATION = "non-marimo Python content beyond header"
 EXPECTED_RUN_GUARD_VIOLATION = "Expected run guard statement"
 
+# Soft violations are auto-corrected on save with no data loss.
+# Any violation NOT in this set is considered "hard" (potential data loss).
+SOFT_VIOLATIONS: frozenset[str] = frozenset(
+    {
+        MARIMO_ALIAS_VIOLATION,
+        EXPECTED_GENERATED_WITH_VIOLATION,
+        EXPECTED_RUN_GUARD_VIOLATION,
+    }
+)
+
+
+def all_violations_soft(violations: list[Violation]) -> bool:
+    """Check if all violations are soft (auto-corrected on save)."""
+    return all(v.description in SOFT_VIOLATIONS for v in violations)
+
 
 def is_non_marimo_python_script(notebook: NotebookSerialization) -> bool:
     return any(

--- a/marimo/_cli/utils.py
+++ b/marimo/_cli/utils.py
@@ -182,6 +182,10 @@ def check_app_correctness(filename: str, noninteractive: bool = True) -> None:
         _loggers.marimo_logger().warning(
             "This notebook has errors, saving may lose data. Continuing anyway."
         )
+    elif status == "has_warnings":
+        _loggers.marimo_logger().info(
+            "This notebook has minor issues that will be auto-corrected on save."
+        )
 
 
 def check_app_correctness_or_convert(filename: str) -> None:

--- a/marimo/_utils/variable_name.py
+++ b/marimo/_utils/variable_name.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
 import inspect

--- a/tests/_ast/test_load.py
+++ b/tests/_ast/test_load.py
@@ -385,25 +385,28 @@ class TestGetStatus:
             ("test_app_with_only_comments", "invalid"),
             # Invalid (not marimo apps)
             ("test_invalid", "invalid"),
-            # Has errors
+            # Has errors (hard violations — potential data loss)
             ("test_get_codes_messy_toplevel", "has_errors"),
             ("test_get_header_comments_invalid", "has_errors"),
-            ("test_get_bad_kwargs", "has_errors"),
             # Unparsable
             (
                 "test_get_codes_non_marimo_python_script",
                 "invalid",
             ),  # not marimo
-            # Potentially confusing and has_errors
-            ("test_get_alias_import", "has_errors"),  # not official format
-            ("test_get_app_kwargs", "has_errors"),  # Intentionally bad kwargs
+            # Soft violations only (auto-corrected on save)
+            ("test_get_bad_kwargs", "has_warnings"),
+            ("test_get_alias_import", "has_warnings"),  # alias import
+            ("test_get_app_kwargs", "has_warnings"),  # missing version/guard
+            (
+                "test_app_with_no_cells",
+                "has_warnings",
+            ),  # missing version/guard
             # Empty files can still be opened.
             (
                 "test_generate_filecontents_empty_with_config",
                 "has_errors",
             ),  # no body
             ("test_generate_filecontents_empty", "has_errors"),  # no body
-            ("test_app_with_no_cells", "has_errors"),  # No body is an error
             # Invalid decorator order creates an error.
             ("test_decorators", "has_errors"),
             # Syntax errors in code


### PR DESCRIPTION
## 📝 Summary

Previously, all parsing "Violations" would provide a warning indicating the file would change on save. As many of these "Violations" are just formatting issues, we change the warning in these cases.

Previously:

`W: This notebook has errors, saving may lose data. Continuing anyway.`

Now:

`I: This notebook has minor issues that will be auto-corrected on save.`