### PR TITLE
docs: clarify pixi vs hatch setup guidance in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,11 @@ Install [pixi](https://github.com/prefix-dev/pixi) to manage your development en
 > As an alternative to installing `pixi`, you can try developing in [Gitpod](https://gitpod.io/#https://github.com/marimo-team/marimo).
 > Note that developing in Gitpod is not officially supported by the marimo team.
 
+> [!TIP]
+> New to both `pixi` and `hatch`? Pick `pixi`. It installs and manages both the Python and Node toolchains, then drops you into a ready shell with one command. Choose `hatch` only if you already maintain Node 20+/pnpm 9+ yourself and just want a Python environment manager. Typical flows:
+> - `pixi shell` → `make fe && make py` → `make dev`
+> - `hatch shell` → `make fe && make py` → `make dev`
+
 ```bash
 pixi shell
 ```


### PR DESCRIPTION
## 📝 Summary

Add a short tip in [CONTRIBUTING.md](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md) guiding newcomers to choose pixi when they’re unfamiliar with both pixi and hatch.

## 🔍 Description of Changes

-Insert a tip callout explaining why pixi is the recommended default for new contributors.
-Include quick-start command sequences for both pixi and hatch to set up frontend and backend toolchains.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).

CC: @nojaf 