### PR TITLE
fix: suppress dark-mode hover border on published cells

### DIFF
--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -314,6 +314,11 @@
 
   &.published {
     border: none;
+
+    &:hover {
+      border: none;
+      box-shadow: none;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

In dark-mode app view, hovering over a published cell adds a 1px border that causes layout jiggle. The existing `.dark .marimo-cell:hover` rule (specificity 0,3,0) overrides `.marimo-cell.published:hover` (same specificity, earlier source order). Light mode is unaffected because there's no later light-mode hover rule.

Fix: add `&:hover { border: none; box-shadow: none; }` inside the existing `.dark .marimo-cell` `&.published` block.

## Test plan

- Open any notebook in app view (read mode) with dark theme
- Hover over cells
- Verify no border appears and no layout shift occurs