### PR TITLE
stop hardcoding us-central1 as vertex ai default location

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -261,9 +261,10 @@ class GoogleProvider(PydanticProvider["PydanticGoogle"]):
         )
         if use_vertex:
             project = os.getenv("GOOGLE_CLOUD_PROJECT")
+            # Upstream (pydantic-ai) defaults to us-central1 if not set
             location = os.getenv("GOOGLE_CLOUD_LOCATION") or None
             if location is None:
-                LOGGER.warning(
+                LOGGER.info(
                     "GOOGLE_CLOUD_LOCATION is not set. "
                     "The upstream provider will default to 'us-central1'. "
                     "Set this env var if your project has region restrictions."


### PR DESCRIPTION
When using Vertex AI without setting `GOOGLE_CLOUD_LOCATION`, marimo hardcodes `us-central1` as the fallback. This silently routes requests to a region that may be blocked by organization policies (like region restriction constraints), giving users a cryptic error with no indication of what went wrong.

This removes the hardcoded default and lets pydantic-ai handle the fallback itself. Also adds a warning log when the env var isn't set, so users in restricted environments actually know they need to configure it.

Fixes #7899