### PR TITLE
fix: --base-url breaks og:thumbnail generation path (marimo-team#8304)

### DIFF
--- a/frontend/src/components/pages/gallery-page.tsx
+++ b/frontend/src/components/pages/gallery-page.tsx
@@ -72,7 +72,7 @@ const GalleryPage: React.FC = () => {
           opengraphImage && isHttpsUrl(opengraphImage)
             ? opengraphImage
             : asURL(
-                `/og/thumbnail?file=${encodeURIComponent(relativePath)}`,
+                `og/thumbnail?file=${encodeURIComponent(relativePath)}`,
               ).toString();
         return {
           ...file,


### PR DESCRIPTION
## 📝 Summary

On a gallery page, the default card thumbnail was using an absolute /og/thumbnail path, which breaks thumbnail generation when the --base-url option is used in run mode.

Closes #8304

## 🔍 Test Plan
- Open marimo in run mode, providing a directory and the --base-url argument.
- Verify that there are no missing default thumbnails for notebooks.

