### PR TITLE
Use `click.ClickException` for sandbox missing pyzmq error

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -517,7 +517,7 @@ def edit(
         from marimo._dependencies.dependencies import DependencyManager
 
         if not DependencyManager.zmq.has():
-            raise click.UsageError(
+            raise click.ClickException(
                 "pyzmq is required when running the marimo edit server on a directory with --sandbox.\n"
                 "Install it with: pip install 'marimo[sandbox]'\n"
                 "Or: pip install pyzmq"
@@ -1117,7 +1117,7 @@ def run(
         from marimo._dependencies.dependencies import DependencyManager
 
         if not DependencyManager.zmq.has():
-            raise click.UsageError(
+            raise click.ClickException(
                 "pyzmq is required when running a gallery with --sandbox.\n"
                 "Install it with: pip install 'marimo[sandbox]'\n"
                 "Or: pip install pyzmq"


### PR DESCRIPTION
The missing pyzmq dependency check in `marimo edit --sandbox` and `marimo run --sandbox` was raising `click.UsageError`, which triggers a custom handler that prints the full command help text after the error message. This floods the terminal when all the user needs to see is the install instructions.

A missing dependency isn't a exactly a usage error. The user invoked the command correctly. Switching to `click.ClickException` prints just the error message and exits cleanly.