### PR TITLE
fix(ai): prevent duplicated system prompts in PydanticAI completions

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -225,7 +225,6 @@ class PydanticProvider(ABC, Generic[ProviderT]):
         result = await agent.run(
             user_prompt=None,
             message_history=VercelAIAdapter.load_messages(messages),
-            instructions=system_prompt,
         )
 
         return str(result.output)

--- a/tests/_server/ai/test_providers.py
+++ b/tests/_server/ai/test_providers.py
@@ -338,9 +338,6 @@ def test_anthropic_is_extended_thinking_model(
 
 
 @pytest.mark.requires("pydantic_ai")
-@pytest.mark.xfail(
-    reason="System prompt is duplicated when passed to both Agent constructor and run()"
-)
 async def test_completion_does_not_pass_redundant_instructions() -> None:
     from pydantic_ai.messages import ModelResponse, TextPart
     from pydantic_ai.models.openai import OpenAIResponsesModel


### PR DESCRIPTION
I intercepted the outgoing API request and observed the following duplicated content in the system message during tab completion:

```json
{
    "messages": [
        {
            "content": "You are a python code completion assistant... \nYou are a python code completion assistant...",
            "role": "system"
        },
        ...
    ]
}
```

## Cause

This is caused by the internal concatenation logic of `pydantic_ai.agent.__init__.Agent._get_instructions` and how `completion` in `marimo/_server/ai/providers.py` is providing the `system_prompt` to both - the `Agent`'s constructor and the `agent.run` method.

## Fix

The fix removes `instructions=system_prompt` from `agent.run()`, leaving only the constructor-level instructions.

## Notes

A similar duplication issue likely exists in `stream_text()` (also in `providers.py`), where `system_prompt` may be passed to both `create_agent()` and `agent.run_stream()`. I have not verified this e2e though.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Tests have been added for the changes made.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).