### PR TITLE
Validate matplotlib scale types as "linear" or "log"

### DIFF
--- a/marimo/_plugins/ui/_impl/mpl.py
+++ b/marimo/_plugins/ui/_impl/mpl.py
@@ -224,6 +224,20 @@ class matplotlib(UIElement[dict[str, JSONType], MatplotlibSelection]):
             (1 - bbox.y0) * fig_height_px,  # bottom
         ]
 
+        _SUPPORTED_SCALES = ("linear", "log")
+        x_scale = axes.get_xscale()
+        y_scale = axes.get_yscale()
+        if x_scale not in _SUPPORTED_SCALES:
+            raise ValueError(
+                f"Unsupported x-axis scale {x_scale!r}. "
+                f"mo.ui.matplotlib supports: {', '.join(_SUPPORTED_SCALES)}."
+            )
+        if y_scale not in _SUPPORTED_SCALES:
+            raise ValueError(
+                f"Unsupported y-axis scale {y_scale!r}. "
+                f"mo.ui.matplotlib supports: {', '.join(_SUPPORTED_SCALES)}."
+            )
+
         super().__init__(
             component_name=matplotlib.name,
             initial_value={},
@@ -236,8 +250,8 @@ class matplotlib(UIElement[dict[str, JSONType], MatplotlibSelection]):
                 "width": fig_width_px,
                 "height": fig_height_px,
                 "debounce": debounce,
-                "x-scale": axes.get_xscale(),
-                "y-scale": axes.get_yscale(),
+                "x-scale": x_scale,
+                "y-scale": y_scale,
             },
             on_change=on_change,
         )

--- a/tests/_plugins/ui/_impl/test_ui_mpl.py
+++ b/tests/_plugins/ui/_impl/test_ui_mpl.py
@@ -54,6 +54,24 @@ def test_construction_no_figure_raises() -> None:
     assert fig is not None
 
 
+def test_unsupported_scale_raises() -> None:
+    fig, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+    ax.set_xscale("symlog")
+    plt.close(fig)
+    with pytest.raises(ValueError, match="Unsupported x-axis scale"):
+        matplotlib(ax)
+
+
+def test_unsupported_yscale_raises() -> None:
+    fig, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+    ax.set_yscale("logit")
+    plt.close(fig)
+    with pytest.raises(ValueError, match="Unsupported y-axis scale"):
+        matplotlib(ax)
+
+
 def test_construction_args() -> None:
     ax = _make_scatter_ax()
     fig = matplotlib(ax)


### PR DESCRIPTION
Raise a ValueError on the Python side for unsupported scales. Only these two scales are currently supported by the frontend coordinate mapping (could add more in the future).
