### PR TITLE
Use `<table>` for `mo.ui.matrix` with right-aligned numbers

### DIFF
--- a/frontend/src/plugins/impl/MatrixPlugin.tsx
+++ b/frontend/src/plugins/impl/MatrixPlugin.tsx
@@ -193,10 +193,13 @@ const MatrixComponent = ({
   const hasRowLabels = rowLabels != null && rowLabels.length > 0;
   const hasColumnLabels = columnLabels != null && columnLabels.length > 0;
 
+  const numRows = internalValue.length;
+  const numCols = internalValue[0]?.length ?? 0;
+
   return (
     <Labeled label={label} align="top" className="items-center">
       <div
-        className="marimo-matrix-bracket relative inline-block px-[14px]"
+        className="relative inline-block"
         data-testid="marimo-plugin-matrix"
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
@@ -214,7 +217,7 @@ const MatrixComponent = ({
                 {columnLabels.map((lbl, j) => (
                   <th
                     key={j}
-                    className="text-center text-xs font-bold text-muted-foreground px-1 pb-1"
+                    className="text-center text-sm font-medium text-foreground px-2 pb-1"
                   >
                     {lbl}
                   </th>
@@ -226,7 +229,7 @@ const MatrixComponent = ({
             {internalValue.map((row, i) => (
               <tr key={i}>
                 {hasRowLabels && (
-                  <th className="text-right text-xs font-bold text-muted-foreground pr-1.5 h-8">
+                  <th className="text-right text-sm font-medium text-foreground pr-3 h-8">
                     {rowLabels[i]}
                   </th>
                 )}
@@ -240,11 +243,15 @@ const MatrixComponent = ({
                     <td
                       key={j}
                       className={cn(
-                        "text-right min-w-14 h-8 px-1 rounded transition-colors touch-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+                        "relative text-right min-w-14 h-8 px-2 transition-colors touch-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
                         isDisabled
                           ? "cursor-default text-muted-foreground"
                           : "cursor-ew-resize text-[var(--link)] hover:bg-accent",
                         isActive && "bg-accent",
+                        j === 0 && "bracket-l",
+                        j === numCols - 1 && "bracket-r",
+                        i === 0 && "bracket-t",
+                        i === numRows - 1 && "bracket-b",
                       )}
                       tabIndex={isDisabled ? -1 : 0}
                       aria-label={`${rowLabel}, ${colLabel}`}

--- a/frontend/src/plugins/impl/__tests__/MatrixPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/MatrixPlugin.test.tsx
@@ -406,7 +406,6 @@ describe("MatrixPlugin", () => {
     const { getByTestId } = render(plugin.render(props));
     const cell = getByTestId("matrix-cell-0-1");
 
-    expect(cell.getAttribute("role")).toBe("spinbutton");
     expect(cell.getAttribute("aria-label")).toBe("x, b");
     expect(cell.getAttribute("aria-valuenow")).toBe("2");
     expect(cell.getAttribute("aria-valuemin")).toBe("0");

--- a/frontend/src/plugins/impl/matrix.css
+++ b/frontend/src/plugins/impl/matrix.css
@@ -1,24 +1,45 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-/* Bracket pseudo-elements for square math bracket notation */
-.marimo-matrix-bracket::before,
-.marimo-matrix-bracket::after {
+/* Left bracket — vertical line + corner ticks via ::before */
+td.bracket-l::before {
   content: "";
   position: absolute;
   top: 0;
   bottom: 0;
-  width: 8px;
+  left: -4px;
+  width: 0;
+  border-left: 2px solid var(--foreground);
   pointer-events: none;
+}
+td.bracket-l.bracket-t::before {
+  top: -1px;
+  width: 8px;
   border-top: 2px solid var(--foreground);
+}
+td.bracket-l.bracket-b::before {
+  bottom: -1px;
+  width: 8px;
   border-bottom: 2px solid var(--foreground);
 }
 
-.marimo-matrix-bracket::before {
-  left: 3px;
-  border-left: 2px solid var(--foreground);
-}
-
-.marimo-matrix-bracket::after {
-  right: 3px;
+/* Right bracket — vertical line + corner ticks via ::after */
+td.bracket-r::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -4px;
+  width: 0;
   border-right: 2px solid var(--foreground);
+  pointer-events: none;
+}
+td.bracket-r.bracket-t::after {
+  top: -1px;
+  width: 8px;
+  border-top: 2px solid var(--foreground);
+}
+td.bracket-r.bracket-b::after {
+  bottom: -1px;
+  width: 8px;
+  border-bottom: 2px solid var(--foreground);
 }


### PR DESCRIPTION
The flex-based layout couldn't right-align numbers within columns because each cell sized to its content independently. Switching to an HTML [`table`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table) gives automatic column-width equalization, so `text-right` on each `<td>` properly aligns numbers like numpy output.  It is also semantically more appropriate here since a matrix is tabular data.

Also adds `tabular-nums` for consistent digit widths.

| before | after |
   |-------------|---------|
   | <img src="https://github.com/user-attachments/assets/99fad98b-8c5e-47e5-98c2-b64cd94d612a" /> | <img src="https://github.com/user-attachments/assets/5f090179-73a8-4388-8d72-484cedd3e295" /> |




https://github.com/user-attachments/assets/e08b905e-73a8-4f1e-8f78-f7b7b67b4acd


