### PR TITLE
feat: add default_sort and ascending parameters to mo.ui.table

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -665,7 +665,9 @@ class table(
                 raise ValueError(
                     f"default_sort column '{default_sort}' not found in table."
                 )
-            self._default_sort = [SortArgs(by=default_sort, descending=not ascending)]
+            self._default_sort = [
+                SortArgs(by=default_sort, descending=not ascending)
+            ]
         self._style_cell = style_cell
         # Store hover callable vs string template separately
         self._hover_cell: Optional[Callable[[str, str, Any], str]] = None


### PR DESCRIPTION
Adds support for specifying an initial sort column when creating a table.
Closes #3860

## 📝 Summary

Adds default_sort and ascending parameters to mo.ui.table, allowing users to specify an initial sort column on render.
Example:
pythonmo.ui.table(data, default_sort='name', ascending=True)
Closes #3860


## 🔍 Description of Changes

Adds `default_sort` and `ascending` parameters to `mo.ui.table`, 
allowing users to specify an initial sort column when the table renders.

**Example:**
```python
mo.ui.table(
    data=[
        {"name": "Charlie", "age": 30},
        {"name": "Alice", "age": 25},
        {"name": "Bob", "age": 35},
    ],
    default_sort="name",
    ascending=True,
)
```

Closes #3860

## 📋 Checklist
- [x] I have read the contributor guidelines.
- [x] This change was discussed and approved through issue #3860.
- [ ] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes.

