### PR TITLE
add default focus for cell-links

### DIFF
--- a/frontend/src/components/editor/links/cell-link.tsx
+++ b/frontend/src/components/editor/links/cell-link.tsx
@@ -97,6 +97,7 @@ export function scrollAndHighlightCell(
 ): boolean {
   const cellHtmlId = HTMLCellId.create(cellId);
   const cell: HTMLElement | null = document.getElementById(cellHtmlId);
+  const isCellErrored = cell?.classList.contains("has-error");
 
   if (cell === null) {
     Logger.error(`Cell ${cellHtmlId} not found on page.`);
@@ -106,13 +107,13 @@ export function scrollAndHighlightCell(
     cell.scrollIntoView({ behavior: "smooth", block: "center" });
   }
 
-  if (variant === "destructive") {
+  if (variant === "destructive" || (isCellErrored && variant === undefined)) {
     cell.classList.add("error-outline");
     setTimeout(() => {
       cell.classList.remove("error-outline");
     }, 2000);
   }
-  if (variant === "focus") {
+  if (variant === "focus" || (!isCellErrored && variant === undefined)) {
     cell.classList.add("focus-outline");
     setTimeout(() => {
       cell.classList.remove("focus-outline");


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
This (opinionated) change impacts a few components (variables panel, deps panel, tracing, logs). We add a focus / destructive outline when clicking cell links. This is helpful when cells are small and are hard to pinpoint at a glance.

before

https://github.com/user-attachments/assets/915d5dc5-6b60-4757-a282-9e22952ff389

after

https://github.com/user-attachments/assets/7e1e1002-5e1a-4611-9d09-36e2016f536c

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
