### PR TITLE
fix: thread-safe watchdog callbacks and deterministic file watch test

### DIFF
--- a/marimo/_utils/file_watcher.py
+++ b/marimo/_utils/file_watcher.py
@@ -117,9 +117,7 @@ def _create_watchdog(
             | watchdog.events.DirModifiedEvent,
         ) -> None:
             del event
-            asyncio.run_coroutine_threadsafe(
-                self.on_file_changed(), self.loop
-            )
+            asyncio.run_coroutine_threadsafe(self.on_file_changed(), self.loop)
 
         def on_moved(
             self,

--- a/tests/_server/api/endpoints/test_resume_session.py
+++ b/tests/_server/api/endpoints/test_resume_session.py
@@ -325,10 +325,8 @@ def test_resume_session_with_watch(client: TestClient) -> None:
 
         # Directly trigger the file change handler (synchronous) instead
         # of relying on the async file watcher, which is inherently racy.
-        result = (
-            session_manager._file_change_coordinator._handle_file_change_locked(
-                os.path.abspath(filename), session
-            )
+        result = session_manager._file_change_coordinator._handle_file_change_locked(
+            os.path.abspath(filename), session
         )
         assert result.handled
 


### PR DESCRIPTION
This hopefully deflakes `test_resume_session`

Use asyncio.run_coroutine_threadsafe() instead of loop.create_task() in WatchdogFileWatcher, since watchdog Observer callbacks run from a separate thread where create_task() is not safe.

Make test_resume_session_with_watch deterministic by stopping the watcher before writing the file and calling _handle_file_change_locked() directly, removing the async race that caused flakiness.
