### PR TITLE
fix: Only trigger cell when ALL its dependencies are unblocked

### DIFF
--- a/marimo/_runtime/runner/hook_context.py
+++ b/marimo/_runtime/runner/hook_context.py
@@ -35,7 +35,10 @@ class CancelledCells:
 
     def add(self, raising_cell: CellId_t, descendants: set[CellId_t]) -> None:
         """Record that raising_cell caused descendants to be cancelled."""
-        self._by_raising_cell[raising_cell] = descendants
+        if raising_cell in self._by_raising_cell:
+            self._by_raising_cell[raising_cell].update(descendants)
+        else:
+            self._by_raising_cell[raising_cell] = descendants
         self._all.update(descendants)
 
     def __contains__(self, cell_id: object) -> bool:

--- a/tests/_runtime/runner/test_cancelled_cells.py
+++ b/tests/_runtime/runner/test_cancelled_cells.py
@@ -60,6 +60,17 @@ class TestCancelledCells:
         assert CellId_t("c") in cc
         assert CellId_t("d") not in cc
 
+    def test_same_raiser_accumulates_descendants(self) -> None:
+        """add() for the same raising cell unions, not overwrites, descendants."""
+        cc = CancelledCells()
+
+        cc.add(CellId_t("r"), {CellId_t("a")})
+        cc.add(CellId_t("r"), {CellId_t("b")})
+
+        assert CellId_t("a") in cc
+        assert CellId_t("b") in cc
+        assert cc[CellId_t("r")] == {CellId_t("a"), CellId_t("b")}
+
     def test_shared_reference_semantics(self) -> None:
         """Mutations after passing to a frozen dataclass are visible."""
         cc = CancelledCells()


### PR DESCRIPTION
## 📝 Summary

I noticed that when one cell depended on two branches that stopped, the dependant cell correctly stopped initially. But one of the two branches getting "unstopped" unfortunately triggered the dependant cell to run too soon, which could lead to issues such as NameError.

This is an attempt at fixing the issue.

## 🔍 Description of Changes

It seems that every new trigger uses clean state, where the whole transitive closure of the triggered cell gets triggered without the rest of the tree being evaluated at all. With this change, I look for any cell that is about to be run for blocked missing refs and I cancel the cell and its transitive closure whenever I find such blocked missing refs.

Unfortunately, I have to assume that a cell found in "exception" state with a None exception was a stop, and re-wrap the None in a MarimoStopError to get the correct "ancestor stopped" message in the frontend. That seems like a separate cleanup that would be good for Marimo: either make MarimoStopError extend Exception rather than BaseException, or let Cell.exception store BaseExceptions.

In CancelledCells, we might now call add with the same `raising_cell` arguments but different `descendants`, in the case where two different cells depend on the same blocked cell. Things workout fine without a change, but it seems more correct to append all descendants in this case for completeness.

Below is a simple notebook to manually reproduce/verify:

```python
import marimo

__generated_with = "0.19.11"
app = marimo.App(width="medium")

@app.cell
def _():
    import marimo as mo

    return (mo,)

@app.cell
def _(mo):
    a = mo.ui.text(value="ha!", label="A:").form()
    a
    return (a,)

@app.cell
def _(a, mo):
    mo.stop(not a.value, "A not submitted")

    aa = a.value.upper()
    return (aa,)

@app.cell
def _(mo):
    b = mo.ui.text(value="beh...", label="B:").form()
    b
    return (b,)

@app.cell
def _(b, mo):
    mo.stop(not b.value, "B not submitted")

    bb = b.value.upper()
    return (bb,)

@app.cell
def _(aa, bb):
    aa + bb
    return

@app.cell
def _(aa, bb):
    bb + aa
    return

if __name__ == "__main__":
    app.run()
```

Before this fix, submitting either form before the other runs the last two cells and fails with a NameError because either `aa` or `bb` is not defined...

A side effect of this fix is that when explicitly trying to run a cell that depends on a stopped ancestor, instead of getting a NameError we now get a clear "stopped ancestor" message.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
