### PR TITLE
Fix lasso selection rendering for self-intersecting paths

### DIFF
--- a/frontend/src/plugins/impl/matplotlib/matplotlib-renderer.ts
+++ b/frontend/src/plugins/impl/matplotlib/matplotlib-renderer.ts
@@ -427,7 +427,7 @@ export class MatplotlibRenderer {
       ctx.save();
       ctx.fillStyle = s.selectionColor;
       ctx.globalAlpha = s.selectionOpacity;
-      ctx.fill();
+      ctx.fill("evenodd");
       ctx.restore();
 
       ctx.strokeStyle = s.selectionColor;


### PR DESCRIPTION
The canvas lasso fill used the default "nonzero" winding rule, which fills the entire interior of a self-intersecting path, including overlapping regions. The point-in-polygon hit test, however, uses a ray-casting algorithm that implements the even-odd rule, so overlapping regions are correctly treated as outside the selection.

Passing "evenodd" to `ctx.fill()` makes the visual rendering match the hit-test logic: when a lasso path crosses over itself, the overlap renders as unselected.

<img width=500 src="https://github.com/user-attachments/assets/bffd4788-22a3-4dcd-ab36-f827648d11d8" />
