### PR TITLE
allow converting from sql to markdown with existing hotkey

### DIFF
--- a/frontend/src/core/codemirror/extensions.ts
+++ b/frontend/src/core/codemirror/extensions.ts
@@ -29,14 +29,9 @@ export function formatKeymapExtension(hotkeys: HotkeyProvider) {
       preventDefault: true,
       run: (ev) => {
         const currentLanguage = getCurrentLanguageAdapter(ev);
-        // Early return if not a supported language
-        if (currentLanguage !== "markdown" && currentLanguage !== "python") {
-          return false;
-        }
-
-        // Toggle between markdown and python
         const destinationLanguage =
-          currentLanguage === "python" ? "markdown" : "python";
+          currentLanguage === "markdown" ? "python" : "markdown";
+
         const response = toggleToLanguage(ev, destinationLanguage, {
           force: true,
         });


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
We allow converting a SQL cell to markdown through the UI. However, this fails when using the hotkey. This allows the conversion to happen.

Note that the conversion is "lossy", you can't convert back to SQL from markdown without messing up the cell. The other option is to disable this conversion entirely.

after conversion
<img width="916" height="143" alt="image" src="https://github.com/user-attachments/assets/ef51e1c7-08aa-4a1b-99d4-25216f1f4e56" />

<img width="259" height="404" alt="image" src="https://github.com/user-attachments/assets/c734e1a2-e4e2-422f-b80c-10b375cfef94" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
