### PR TITLE
faq: interrupt a progress bar

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -372,8 +372,7 @@ def _(cancelled, mo, time):
 
 @app.cell
 def _(mo, progress):
-    t = mo.Thread(target=progress, args=(10,))
-    t.start()
+    mo.Thread(target=progress, args=(10,)).start()
     return
 
 


### PR DESCRIPTION
Add an example that explains how to interrupt a progress bar.

<img width="771" height="819" alt="image" src="https://github.com/user-attachments/assets/897f5130-6eb8-4abf-bd7d-3e99bdeaf21b" />
