### PR TITLE
fix: Use dynamic filename for "Download image" context menu

### DIFF
--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -26,6 +26,7 @@ import { isOutputEmpty } from "@/core/cells/outputs";
 import { goToDefinitionAtCursorPosition } from "@/core/codemirror/go-to-definition/utils";
 import { sendToPanelManager } from "@/core/vscode/vscode-bindings";
 import { copyToClipboard } from "@/utils/copy";
+import { getImageExtension } from "@/utils/filenames";
 import { Logger } from "@/utils/Logger";
 import type { ActionButton } from "../actions/types";
 import {
@@ -151,25 +152,12 @@ export const CellActionsContextMenu = ({
       icon: <ImageIcon size={13} strokeWidth={1.5} />,
       label: "Download image",
       hidden: !imageRightClicked,
-      handle: async () => {
+      handle: () => {
         if (imageRightClicked) {
-          const response = await fetch(imageRightClicked.src);
-          const blob = await response.blob();
-
-          // This list should be kept in sync with the image MIME types
-          // handled in frontend/src/components/editor/Output.tsx
-          const extensions = ["avif", "bmp", "gif", "jpeg", "svg", "tiff"];
-          let fileExtension = "png"; // Default extension
-          for (const extension of extensions) {
-            // Use blob.type (e.g., "image/svg+xml") to check for extension
-            if (blob.type.includes(extension)) {
-              fileExtension = extension;
-              break;
-            }
-          }
           const link = document.createElement("a");
-          link.download = `image.${fileExtension}`;
-          link.href = URL.createObjectURL(blob);
+          link.href = imageRightClicked.src;
+          const ext = getImageExtension(imageRightClicked.src) || "png";
+          link.download = `image.${ext}`;
           link.click();
         }
       },

--- a/frontend/src/utils/filenames.ts
+++ b/frontend/src/utils/filenames.ts
@@ -30,3 +30,45 @@ export const Filenames = {
     return `${Filenames.withoutExtension(filename)}.${extension}`;
   },
 };
+
+const IMAGE_EXTENSIONS: Record<string, string> = {
+  png: "png",
+  jpg: "jpg",
+  jpeg: "jpeg",
+  gif: "gif",
+  webp: "webp",
+  avif: "avif",
+  bmp: "bmp",
+  tiff: "tiff",
+  svg: "svg",
+  "svg+xml": "svg",
+};
+
+/**
+ * Infers the file extension from an image source string (src).
+ * If the extension cannot be determined, it returns `undefined`.
+ *
+ * @param src - The image source string (a URL or a data URI).
+ * @returns The inferred file extension (e.g., "png", "jpeg", "svg"),
+ *          or `undefined` if it cannot be determined.
+ *
+ * @example
+ * getImageExtension("https://example.com/image.png");  // Returns "png"
+ * getImageExtension("../assets/image.gif");            // Returns "gif"
+ * getImageExtension("data:image/svg+xml;base64,...");  // Returns "svg"
+ * getImageExtension("https://example.com/image");      // Returns undefined
+ */
+export function getImageExtension(src: string): string | undefined {
+  const dataUriMatch = src.match(/^data:image\/([^,;]+)/);
+  if (dataUriMatch) {
+    return IMAGE_EXTENSIONS[dataUriMatch[1]];
+  }
+
+  try {
+    const url = new URL(src, window.location.href);
+    const ext = url.pathname.split(".").pop()?.toLowerCase() ?? "";
+    return IMAGE_EXTENSIONS[ext];
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## 📝 Summary

This pull request addresses an issue where the "Download image" option in the cell output context menu would always save the file with the hardcoded name `image.png`. This behavior ignored the actual MIME type of the image, causing formats like SVG, GIF, or JPEG to be saved with an incorrect `.png` extension.

Closes #8405

## 🔍 Description of Changes

The `handle` function for the "Download image" action in `frontend/src/components/editor/cell/cell-context-menu.tsx` has been updated to:
1.  Fetch the image source and create a `blob`.
2.  Inspect the `blob.type` property.
3.  Dynamically determine the correct file extension based on the MIME type.
4.  Set the `download` attribute of the anchor tag to `image.[correct_extension]`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
