### PR TITLE
fix: Copy `ExecutionContext.output` to `marimo.Thread`

### DIFF
--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -147,11 +147,18 @@ class Thread(threading.Thread):
                 initialize_context(self._marimo_ctx)
             except RuntimeError:
                 pass
+
+        output = None
+        if (mctx := self._marimo_ctx) is not None and (
+            ectx := mctx.execution_context
+        ) is not None:
+            output = ectx.output
+
         if isinstance(self._marimo_ctx, KernelRuntimeContext):
             self._marimo_ctx.execution_context = ExecutionContext(
                 cell_id=self._marimo_ctx.stream.cell_id,  # type: ignore
                 setting_element_value=False,
-                output=self._marimo_ctx.execution_context.output,
+                output=output,
             )
         thread_id = threading.get_ident()
         THREADS.add(thread_id)


### PR DESCRIPTION
## 📝 Summary

Closes #8402

## 🔍 Description of Changes

The issue is that `ProgressBar` uses the `mo.output.flush()` which relies on the existing `ExecutionContext.output`. For `mo.Thread`, these are left empty. This patch copies over the `output` into the threads `ExecutionContext`.

This is a one-line change to copy over the output.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
