### PR TITLE
chore: add a script to make running Python tests more convenient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ typos:
 .PHONY: py-test
 # 🧪 Test python
 py-test:
-	@command -v hatch >/dev/null 2>&1 || { echo "hatch is required. See https://hatch.pypa.io/dev/install/"; exit 1; }
-	hatch run typos && hatch run +py=3.12 test-optional:test $(ARGS)
+	uvx hatch run typos
+	./scripts/pytest.sh --optional $(ARGS)
 
 .PHONY: py-snapshots
 # 📸 Update snapshots

--- a/scripts/pytest.sh
+++ b/scripts/pytest.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+usage() {
+    echo "Usage: $0 [--py VERSION] [--optional] [-- PYTEST_ARGS...]"
+    echo ""
+    echo "Options:"
+    echo "  --py VERSION   Python version (e.g. 3.12). Default: 3.12"
+    echo "  --optional     Use test-optional env (includes optional deps)"
+    echo ""
+    echo "Everything after -- is forwarded to pytest."
+    echo "If no -- is used, all unrecognized args are forwarded to pytest."
+    echo ""
+    echo "Examples:"
+    echo "  $0 tests/_runtime/test_threads.py"
+    echo "  $0 --py 3.11 --optional tests/_runtime/test_threads.py -v"
+    echo "  $0 --py 3.13 -- tests/ -k 'test_foo' -x"
+    exit 1
+}
+
+PY_VERSION="3.12"
+ENV="test"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --py)
+            PY_VERSION="$2"
+            shift 2
+            ;;
+        --optional)
+            ENV="test-optional"
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+exec uvx hatch run +py="$PY_VERSION" "$ENV:test" "$@"


### PR DESCRIPTION
It was getting cumbersome to run `uvx hatch run +py=3.12 test:test ...` to invoke tests. This change adds a script the run Python tests, with sensible defaults and arguments to choose the Python version and test matrix. Remaining arguments are forwarded to pytest.

For basic usage with defaults:

`./scripts/pytest.sh tests/_runtime/test_threads.py -v`