### PR TITLE
docs: fix incorrect data sources panel reference in SQL tutorial

### DIFF
--- a/marimo/_tutorials/sql.py
+++ b/marimo/_tutorials/sql.py
@@ -139,10 +139,10 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    /// Tip | "Data sources panel"
+    /// Tip | "Variables panel"
 
-        Click the database "barrel" icon in the left toolbar to see all dataframes and in-
-        memory tables that your notebook has access to.
+        Open the variables panel in the left toolbar to see all dataframes
+        and in-memory tables that your notebook has access to.
     ///
     """)
     return

--- a/tests/_convert/markdown/snapshots/sql.md.txt
+++ b/tests/_convert/markdown/snapshots/sql.md.txt
@@ -108,10 +108,10 @@ elements. This means your SQL statement and results can be reactive! 🚀
 <!---->
 ## Querying dataframes with SQL
 <!---->
-/// Tip | "Data sources panel"
+/// Tip | "Variables panel"
 
-    Click the database "barrel" icon in the left toolbar to see all dataframes and in-
-    memory tables that your notebook has access to.
+    Open the variables panel in the left toolbar to see all dataframes
+    and in-memory tables that your notebook has access to.
 ///
 <!---->
 Let's take a look at a SQL cell. The next cell generates a dataframe called `df`.


### PR DESCRIPTION
## 📝 Summary

Fix incorrect "Data sources panel" tip in the SQL tutorial to reference the variables panel instead.

## 🔍 Description of Changes

#7459 combined the "Variables" and "Data Sources" panels into a single "Variables & Data Sources" panel, but the SQL tutorial was not updated to reflect this change.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
