### PR TITLE
fix: flaky resume session watch test

### DIFF
--- a/tests/_server/api/endpoints/test_resume_session.py
+++ b/tests/_server/api/endpoints/test_resume_session.py
@@ -316,7 +316,7 @@ def test_resume_session_after_file_change(client: TestClient) -> None:
         # we write it as the second to last cell
         filename = session_manager.file_router.get_unique_file_key()
         assert filename
-        with open(filename, "r") as f:
+        with open(filename) as f:
             content = f.read()
         last_cell_pos = content.rindex("@app.cell")
         new_content = (


### PR DESCRIPTION
More aggressive deflaking of the test.

The test is supposed to exercise the session resume behavior after
a file is reloaded. Starting the watcher can lead to race conditions,
which make the test flaky which is annoying. So we just simulate
the watcher behavior with synchronous calls instead.