### PR TITLE
fix: normalize paths in file router to prevent HTTPException with dotdot paths

### DIFF
--- a/marimo/_server/file_router.py
+++ b/marimo/_server/file_router.py
@@ -177,7 +177,8 @@ class ListOfFilesAppFileRouter(AppFileRouter):
         self._allow_single_file_key = allow_single_file_key
         self._allow_dynamic = allow_dynamic
         self._allowed_paths = {
-            MarimoPath(file.path).absolute_name for file in files
+            str(normalize_path(Path(MarimoPath(file.path).absolute_name)))
+            for file in files
         }
 
     @property
@@ -257,7 +258,9 @@ class ListOfFilesAppFileRouter(AppFileRouter):
         """
         if not self._allow_dynamic:
             return
-        self._allowed_paths.add(MarimoPath(filepath).absolute_name)
+        self._allowed_paths.add(
+            str(normalize_path(Path(MarimoPath(filepath).absolute_name)))
+        )
 
 
 class LazyListOfFilesAppFileRouter(AppFileRouter):


### PR DESCRIPTION
## Summary

Fixes a bug where `create_asgi_app()` fails with `HTTPException` when file paths contain `..` components.

**Problem**: When using `os.path.join(os.path.dirname(__file__), "..", "..", "ui")` (as the FastAPI example does), `_allowed_paths` stored the un-normalized absolute path (preserving `..`), while `resolve_file_path()` normalized it via `os.path.normpath()`. This mismatch caused `HTTPException('File not found')` during `SessionManager` initialization.

**Fix**: Normalize paths consistently using `normalize_path()` when building `_allowed_paths` in `ListOfFilesAppFileRouter.__init__` and in `register_allowed_file()`.

Fixes #8414

## Test Plan

- Added regression test `test_list_of_files_resolves_dotdot_in_path` that creates a file router with a `..` path and verifies `resolve_file_path()` succeeds
- All 50 existing tests in `test_file_router.py` pass