### PR TITLE
fix: sql explain query with newline

### DIFF
--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -190,7 +190,9 @@ def sql_type_to_data_type(type_str: str) -> DataType:
 
 def is_explain_query(query: str) -> bool:
     """Check if a SQL query is an EXPLAIN query."""
-    return query.lstrip().lower().startswith("explain ")
+    import re
+
+    return bool(re.match(r"\s*explain\s", query, re.IGNORECASE))
 
 
 def wrap_query_with_explain(query: str) -> str:

--- a/tests/_sql/test_sql.py
+++ b/tests/_sql/test_sql.py
@@ -386,6 +386,10 @@ class TestExplainQueries:
         assert is_explain_query("EXPLAIN (FORMAT JSON) SELECT 1")
         assert is_explain_query("EXPLAIN ANALYZE SELECT 1")
         assert is_explain_query("EXPLAIN QUERY PLAN SELECT 1")
+        assert is_explain_query("EXPLAIN\nSELECT 1")
+        assert is_explain_query("EXPLAIN\n  SELECT 1")
+        assert is_explain_query("EXPLAIN\tSELECT 1")
+        assert is_explain_query("explain\nSELECT 1")
 
         # Test non-EXPLAIN queries
         assert not is_explain_query("SELECT 1")


### PR DESCRIPTION
Related to https://github.com/marimo-team/marimo/issues/8416

This pull request improves the detection of EXPLAIN queries in SQL by making the `is_explain_query` function more robust to different whitespace characters and line breaks. It also expands the test coverage to ensure these cases are handled correctly.
