### PR TITLE
style: hide unsupported codemirror language warning when LLM generated

### DIFF
--- a/frontend/src/components/markdown/markdown-renderer.tsx
+++ b/frontend/src/components/markdown/markdown-renderer.tsx
@@ -25,22 +25,6 @@ interface CodeBlockProps {
   language: string | undefined;
 }
 
-const SUPPORTED_LANGUAGES = new Set([
-  "python",
-  "markdown",
-  "sql",
-  "json",
-  "yaml",
-  "toml",
-  "shell",
-  "javascript",
-  "typescript",
-  "jsx",
-  "tsx",
-  "css",
-  "html",
-]);
-
 function maybeTransform(
   language: string | undefined,
   code: string,
@@ -128,10 +112,9 @@ const CodeBlock = ({ code, language }: CodeBlockProps) => {
       <Suspense>
         <LazyAnyLanguageCodeMirror
           theme={theme === "dark" ? "dark" : "light"}
-          // Only show the language if it's supported
-          language={
-            language && SUPPORTED_LANGUAGES.has(language) ? language : undefined
-          }
+          language={language}
+          // Since this may be LLM generated, we don't want show errors for unsupported languages
+          hideUnsupportedLanguageErrors={true}
           className="cm border rounded overflow-hidden"
           extensions={extensions}
           value={value}

--- a/frontend/src/plugins/impl/code/any-language-editor.tsx
+++ b/frontend/src/plugins/impl/code/any-language-editor.tsx
@@ -17,10 +17,14 @@ import { ErrorBanner } from "../common/error-banner";
 
 export const LANGUAGE_MAP: Record<string, LanguageName | undefined> = {
   python: "py",
+  python3: "py",
   javascript: "js",
   typescript: "ts",
   shell: "sh",
   bash: "sh",
+  // Other fallbacks
+  unknown: "text",
+  undefined: "text",
 };
 
 function isSupportedLanguage(
@@ -41,10 +45,17 @@ function isSupportedLanguage(
 const AnyLanguageCodeMirror: React.FC<
   ReactCodeMirrorProps & {
     language: string | undefined;
+    hideUnsupportedLanguageErrors?: boolean;
     theme: ResolvedTheme;
     showCopyButton?: boolean;
   }
-> = ({ language, showCopyButton, extensions = [], ...props }) => {
+> = ({
+  language,
+  hideUnsupportedLanguageErrors,
+  showCopyButton,
+  extensions = [],
+  ...props
+}) => {
   // Maybe normalize the language to the extension
   language = LANGUAGE_MAP[language || ""] || language;
 
@@ -62,10 +73,10 @@ const AnyLanguageCodeMirror: React.FC<
 
   return (
     <div className="relative w-full group hover-actions-parent">
-      {!isSupported && (
+      {!isSupported && !hideUnsupportedLanguageErrors && (
         <ErrorBanner
           className="mb-1 rounded-sm"
-          error={`Language ${language} not supported. \n\nSupported languages are: ${Object.keys(
+          error={`Language ${language} not supported. Supported languages are: ${Object.keys(
             langs,
           ).join(", ")}`}
         />


### PR DESCRIPTION
- Removed the static set of supported languages from the markdown renderer, just hide the warning since this may be LLM generated
- Updated the AnyLanguageCodeMirror component to handle unsupported languages gracefully by adding a prop to hide error messages.
- Added more fallback mappings languages in the LANGUAGE_MAP.
