### PR TITLE
ci(fe): fail Test FE when lint/typecheck mutate tracked files

### DIFF
--- a/.github/workflows/test_fe.yaml
+++ b/.github/workflows/test_fe.yaml
@@ -61,12 +61,31 @@ jobs:
         id: lint
         run: pnpm turbo lint
 
+      - name: 🔒 Verify clean git tree after lint
+        id: lint_clean_tree
+        run: |
+          CHANGES="$(git status --porcelain)"
+          if [[ -n "$CHANGES" ]]; then
+            echo "Lint changed tracked files. Commit generated/autofixed files."
+            echo "$CHANGES"
+            git --no-pager diff --stat
+            exit 1
+          fi
+
       - name: Comment on lint failure
         if: failure() && steps.lint.outcome == 'failure'
         uses: ./.github/actions/pr-comment-on-failure
         with:
           check-name: "lint"
           command: "pnpm turbo lint"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on clean-tree failure after lint
+        if: failure() && steps.lint_clean_tree.outcome == 'failure'
+        uses: ./.github/actions/pr-comment-on-failure
+        with:
+          check-name: "clean-tree"
+          command: "pnpm turbo lint && git status --short"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on dedupe failure
@@ -101,6 +120,17 @@ jobs:
         id: typecheck
         run: pnpm turbo typecheck
 
+      - name: 🔒 Verify clean git tree after typecheck
+        id: typecheck_clean_tree
+        run: |
+          CHANGES="$(git status --porcelain)"
+          if [[ -n "$CHANGES" ]]; then
+            echo "Typecheck/codegen changed tracked files. Commit generated files."
+            echo "$CHANGES"
+            git --no-pager diff --stat
+            exit 1
+          fi
+
       - name: 🧪 Test
         id: test
         run: pnpm turbo test
@@ -119,6 +149,14 @@ jobs:
         with:
           check-name: "test"
           command: "pnpm turbo test"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on clean-tree failure after typecheck
+        if: failure() && steps.typecheck_clean_tree.outcome == 'failure'
+        uses: ./.github/actions/pr-comment-on-failure
+        with:
+          check-name: "clean-tree"
+          command: "pnpm turbo typecheck && git status --short"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build_frontend:


### PR DESCRIPTION
## 📝 Summary

Follow-up to [#8332](https://github.com/marimo-team/marimo/pull/8332) to make frontend CI catch cases where checks pass but modify tracked files.

## 🔍 Description of Changes

- Updated `.github/workflows/test_fe.yaml` to add clean-tree verification steps after:
1. `pnpm turbo lint`
2. `pnpm turbo typecheck`

- Each verification step now:
1. Runs `git status --porcelain`
2. Fails the job if any tracked files changed
3. Prints changed files and a diff stat for easier debugging

- Added PR failure comment steps for these new `clean-tree` failures, similar to existing lint/typecheck/test failure comments.

This ensures CI fails when autofix/codegen outputs are not committed, instead of silently passing.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).

CC: @Light2Dark @nojaf 