### PR TITLE
feat: Output Altair SVG charts as base64-encoded images

### DIFF
--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import base64
 import json
 from typing import Any
 from urllib.request import urlopen
@@ -18,6 +19,7 @@ from marimo._plugins.ui._impl.altair_chart import (
     maybe_fix_vegafusion_background,
     maybe_make_full_width,
 )
+from marimo._utils.data_uri import build_data_url
 
 LOGGER = marimo_logger()
 
@@ -76,6 +78,9 @@ class AltairFormatter(FormatterFactory):
                         data_url = io_to_data_url(mime_response, mime_type)
                         return (mime_type, data_url or "")
                     if isinstance(mime_response, str):
+                        if mime_type == "image/svg+xml":
+                            data = base64.b64encode(mime_response.encode())
+                            return mime_type, build_data_url(mime_type, data)
                         return mime_type, mime_response
                     return mime_type, json.dumps(mime_response)
 

--- a/tests/_output/formatters/test_altair_formatters.py
+++ b/tests/_output/formatters/test_altair_formatters.py
@@ -182,7 +182,7 @@ def test_altair_formatter_svg():
         mime, content = formatter(mock_chart)
 
         assert mime == "image/svg+xml"
-        assert content == "<svg></svg>"
+        assert content == "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="altair not installed")


### PR DESCRIPTION
## 📝 Summary

This pull request modifies the `AltairFormatter` to output SVG charts as base64-encoded data URIs.

Currently, Altair SVG charts are rendered as raw `<svg>` elements, which prevents users from easily saving or dragging the chart as an image file. This change encodes the SVG output into a `data:image/svg+xml;base64,...` URI, which the frontend then renders as an `<img>` tag.

This improves the user experience by allowing Altair SVG charts to be dragged and dropped or saved as image files directly from the browser.

Note: This change only impacts users who explicitly opt-in with `altair.renderers.enable("svg")`. There is no change to the default behavior.

Closes #8400

## 🔍 Description of Changes

- Modified `marimo/_output/formatters/altair_formatters.py` to base64-encode SVG string outputs and format them as a data URI.
- Updated `tests/_output/formatters/test_altair_formatters.py` to assert the new data URI format.

### Current behavior: Altair SVG as raw `<svg>` (lacks image context menu)

<img width="767" height="568" alt="aa" src="https://github.com/user-attachments/assets/f09e33d8-7768-4f46-b048-25cd5c67b101" />

### After this PR: Altair SVG as Base64-encoded `<img>` (provides image context menu)

<img width="762" height="576" alt="bb" src="https://github.com/user-attachments/assets/2c642e11-654d-42ea-9d7a-f8f9ccc63104" />

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
