### PR TITLE
fix: optimize table search for wide dataframes

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -329,11 +329,9 @@ class NarwhalsTableManager(
         if not expressions:
             return NarwhalsTableManager(self.data.filter(nw.lit(False)))
 
-        or_expr = expressions[0]
-        for expr in expressions[1:]:
-            or_expr = or_expr | expr
-
-        filtered = self.data.filter(or_expr)
+        filtered = self.data.filter(
+            nw.any_horizontal(*expressions, ignore_nulls=True)
+        )
         return NarwhalsTableManager(filtered)
 
     def get_stats(self, column: str) -> ColumnStats:

--- a/marimo/_plugins/ui/_impl/tables/polars_table.py
+++ b/marimo/_plugins/ui/_impl/tables/polars_table.py
@@ -275,11 +275,9 @@ class PolarsTableManagerFactory(TableManagerFactory):
                 if not expressions:
                     return self
 
-                or_expr = expressions[0]
-                for expr in expressions[1:]:
-                    or_expr = or_expr | expr
-
-                filtered = self._original_data.filter(or_expr)
+                filtered = self._original_data.filter(
+                    pl.any_horizontal(*expressions)
+                )
                 return PolarsTableManager(filtered)
 
             # We override the default implementation to use polars's


### PR DESCRIPTION
## Summary

Fixes #8449 — table search crashes/fails on wide dataframes (400+ columns, kernel crash at 2000+).

## Root Cause

The `search()` method in both `NarwhalsTableManager` and `PolarsTableManager` built the filter expression by iteratively chaining `|` operators:

```python
or_expr = expressions[0]
for expr in expressions[1:]:
    or_expr = or_expr | expr
```

This creates a deeply nested binary expression tree — one level of nesting per column. At ~400 columns the expression tree exceeds recursion/stack limits, causing silent failures or kernel crashes.

## Fix

Replace the iterative OR chaining with `any_horizontal()`, which evaluates all expressions in a single flat call:

- `narwhals_table.py`: `nw.any_horizontal(*expressions, ignore_nulls=True)`
- `polars_table.py`: `pl.any_horizontal(*expressions)`

This is both more efficient and avoids the deep nesting entirely.

## Testing

All existing tests pass (`test_narwhals.py`, `test_polars_table.py`, `test_pandas_table.py`). Verified manually with 500-column DataFrames.