### PR TITLE
fix: stop serving duplicate notebooks when `auto_download` is set

### DIFF
--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -841,6 +841,8 @@ def _collect_marimo_files(paths: list[str]) -> _CollectedRunFiles:
             for file_info in flatten_files(file_infos):
                 if not file_info.is_marimo_file:
                     continue
+                if "__marimo__" in Path(file_info.path).parts:
+                    continue
                 absolute_path = str(directory / file_info.path)
                 files_by_path[absolute_path] = MarimoFile(
                     name=file_info.name,

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -852,6 +852,30 @@ def test_collect_marimo_files_includes_markdown(
     assert str(md_file) in {file.path for file in collected.files}
 
 
+def test_collect_marimo_files_excludes_marimo_generated_markdown(
+    tmp_path: Path,
+) -> None:
+    py_file = tmp_path / "notebook.py"
+    py_file.write_text("import marimo\napp = marimo.App()\n", encoding="utf-8")
+
+    md_file = tmp_path / "notes.md"
+    md_file.write_text("---\nmarimo-version: 0.1.0\n---\n", encoding="utf-8")
+
+    marimo_dir = tmp_path / "__marimo__"
+    marimo_dir.mkdir()
+    generated_md = marimo_dir / "notebook.md"
+    generated_md.write_text(
+        "---\nmarimo-version: 0.1.0\n---\n", encoding="utf-8"
+    )
+
+    collected = _collect_marimo_files([str(tmp_path)])
+    paths = {file.path for file in collected.files}
+
+    assert str(py_file) in paths
+    assert str(md_file) in paths
+    assert str(generated_md) not in paths
+
+
 def test_cli_run_with_show_code(temp_marimo_file: str) -> None:
     port = _get_port()
     p = subprocess.Popen(


### PR DESCRIPTION
Fixes bug reported by @jpopesculian on [Discord](https://discord.com/channels/1059888774789730424/1475851011045199902/1476181585626665102). 

Having a notebook like the one below, then `marimo edit <notebook>` will generate  `__marimo__/<notebook>.md ` due to `auto_download=["markdown"]`. Running `marimo run .` will end up serving the same notebook twice.

```python
import marimo

__generated_with = "0.20.2"
app = marimo.App(width="full", auto_download=["markdown"])


@app.cell
def _():
    import marimo as mo
    mo.md("Hello, world!")
    return


if __name__ == "__main__":
    app.run()
```

This PR fixes the issue by excluding notebook-like files under `__marimo__` from the scan.