### PR TITLE
Show smart previews for SQL and markdown cells in minimap

### DIFF
--- a/frontend/src/components/dependency-graph/minimap-content.tsx
+++ b/frontend/src/components/dependency-graph/minimap-content.tsx
@@ -17,6 +17,7 @@ import { cellFocusAtom, useCellFocusActions } from "@/core/cells/focus";
 import type { CellId } from "@/core/cells/ids";
 import { useVariables } from "@/core/variables/state";
 import { cn } from "@/utils/cn";
+import { extractCellPreview } from "./utils/cell-preview";
 
 interface MinimapCellProps {
   cellId: CellId;
@@ -45,6 +46,7 @@ const MinimapCell: React.FC<MinimapCellProps> = (props) => {
   }
 
   const isSelected = selectedCell?.id === cell.id;
+  const preview = extractCellPreview(cell.code);
   const circleRadius = isNonReferenceableCell(cell.graph) ? 1.5 : 3;
 
   const handleClick = () => {
@@ -90,7 +92,7 @@ const MinimapCell: React.FC<MinimapCellProps> = (props) => {
             <VariablesList cell={cell} selectedCell={selectedCell} />
           ) : (
             <span className="overflow-hidden text-ellipsis whitespace-nowrap max-w-full">
-              {codePreview(cell.code) ?? <span className="italic">empty</span>}
+              {preview.text ?? <span className="italic">empty</span>}
             </span>
           )}
         </div>
@@ -122,10 +124,6 @@ const MinimapCell: React.FC<MinimapCellProps> = (props) => {
     </button>
   );
 };
-
-function codePreview(code: string): string | undefined {
-  return code.split("\n")[0].trim() || undefined;
-}
 
 const VariablesList: React.FC<{
   cell: { id: CellId; graph: CellGraph };

--- a/frontend/src/components/dependency-graph/utils/__tests__/cell-preview.test.ts
+++ b/frontend/src/components/dependency-graph/utils/__tests__/cell-preview.test.ts
@@ -1,0 +1,143 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { extractCellPreview } from "../cell-preview";
+
+describe("extractCellPreview", () => {
+  describe("markdown cells", () => {
+    it("extracts heading from f-string triple-double-quoted markdown", () => {
+      expect(extractCellPreview('mo.md(f"""# Heading\nbody""")')).toEqual({
+        text: "# Heading",
+        type: "markdown",
+      });
+    });
+
+    it("extracts text from r-prefixed triple-double-quoted markdown", () => {
+      expect(extractCellPreview('mo.md(r"""text""")')).toEqual({
+        text: "text",
+        type: "markdown",
+      });
+    });
+
+    it("skips leading empty lines", () => {
+      expect(extractCellPreview('mo.md(f"""\n# Heading\n""")')).toEqual({
+        text: "# Heading",
+        type: "markdown",
+      });
+    });
+
+    it("returns undefined text for empty markdown", () => {
+      expect(extractCellPreview('mo.md("")')).toEqual({
+        text: undefined,
+        type: "markdown",
+      });
+    });
+
+    it("works with single-quoted strings", () => {
+      expect(extractCellPreview("mo.md('single line')")).toEqual({
+        text: "single line",
+        type: "markdown",
+      });
+    });
+
+    it("works with triple-single-quoted strings", () => {
+      expect(extractCellPreview("mo.md('''some text''')")).toEqual({
+        text: "some text",
+        type: "markdown",
+      });
+    });
+
+    it("works with fr prefix", () => {
+      expect(extractCellPreview('mo.md(fr"""# Title\n{x}""")')).toEqual({
+        text: "# Title",
+        type: "markdown",
+      });
+    });
+
+    it("works with no prefix", () => {
+      expect(extractCellPreview('mo.md("""plain text""")')).toEqual({
+        text: "plain text",
+        type: "markdown",
+      });
+    });
+  });
+
+  describe("SQL cells", () => {
+    it("extracts SQL from assignment with f-string", () => {
+      expect(
+        extractCellPreview('_df = mo.sql(f"""SELECT * FROM cars""")'),
+      ).toEqual({
+        text: "SELECT * FROM cars",
+        type: "sql",
+      });
+    });
+
+    it("skips leading newlines in SQL", () => {
+      expect(
+        extractCellPreview('_df = mo.sql(f"""\nSELECT * FROM t\n""")'),
+      ).toEqual({
+        text: "SELECT * FROM t",
+        type: "sql",
+      });
+    });
+
+    it("returns first line of multi-line SQL", () => {
+      expect(
+        extractCellPreview(
+          '_df = mo.sql(f"""SELECT *\nFROM users\nWHERE id = 1""")',
+        ),
+      ).toEqual({
+        text: "SELECT *",
+        type: "sql",
+      });
+    });
+
+    it("handles SQL with engine kwarg after string", () => {
+      expect(
+        extractCellPreview('_df = mo.sql(f"""SELECT 1""", engine=my_engine)'),
+      ).toEqual({
+        text: "SELECT 1",
+        type: "sql",
+      });
+    });
+
+    it("returns undefined text for empty SQL string", () => {
+      expect(extractCellPreview('_df = mo.sql(f"""""")')).toEqual({
+        text: undefined,
+        type: "sql",
+      });
+    });
+  });
+
+  describe("Python fallback", () => {
+    it("returns first line of Python code", () => {
+      expect(extractCellPreview("import pandas as pd")).toEqual({
+        text: "import pandas as pd",
+        type: "python",
+      });
+    });
+
+    it("returns first line of multi-line Python", () => {
+      expect(extractCellPreview("x = 1\ny = 2")).toEqual({
+        text: "x = 1",
+        type: "python",
+      });
+    });
+
+    it("returns undefined text for empty string", () => {
+      // MarkdownParser.isSupported("") returns true, so empty cells
+      // are classified as markdown — the text is undefined either way.
+      expect(extractCellPreview("")).toEqual({
+        text: undefined,
+        type: "markdown",
+      });
+    });
+
+    it("returns undefined text for whitespace-only string", () => {
+      expect(extractCellPreview("   \n  ")).toEqual({
+        text: undefined,
+        type: "markdown",
+      });
+    });
+  });
+});

--- a/frontend/src/components/dependency-graph/utils/cell-preview.ts
+++ b/frontend/src/components/dependency-graph/utils/cell-preview.ts
@@ -1,0 +1,46 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { MarkdownParser, SQLParser } from "@marimo-team/smart-cells";
+
+export interface CellPreview {
+  text: string | undefined;
+  type: "python" | "markdown" | "sql";
+}
+
+const markdownParser = new MarkdownParser();
+const sqlParser = new SQLParser();
+
+function firstNonEmptyLine(content: string): string | undefined {
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract a human-readable preview and cell type from raw cell code.
+ *
+ * For markdown cells (`mo.md(...)`) and SQL cells (`mo.sql(...)`),
+ * returns the inner content's first non-empty line instead of the
+ * Python wrapper boilerplate.
+ */
+export function extractCellPreview(code: string): CellPreview {
+  const trimmed = code.trim();
+
+  if (markdownParser.isSupported(trimmed)) {
+    const { code: inner } = markdownParser.transformIn(trimmed);
+    return { text: firstNonEmptyLine(inner), type: "markdown" };
+  }
+
+  if (sqlParser.isSupported(trimmed)) {
+    const { code: inner } = sqlParser.transformIn(trimmed);
+    return { text: firstNonEmptyLine(inner), type: "sql" };
+  }
+
+  // Python fallback: first line of raw code
+  const firstLine = trimmed.split("\n")[0]?.trim();
+  return { text: firstLine || undefined, type: "python" };
+}


### PR DESCRIPTION
Fixes #8457

The dependency minimap previously showed the raw first line of every cell, which meant SQL and markdown cells displayed unhelpful boilerplate like `mo.md(f"""` or `_df = mo.sql(f"""`. These changes extract the inner content (using smart-cells helpers) to show the first meaningful line instead.

We could consider some alternative preview (e.g., a summary comment or visual indicator of cell type), but my experiments led to a lot of visual noise/clutter and if found the stripping simple & effective.

<img width="458" height="407" alt="Screenshot 2026-02-25 at 2 01 49 PM" src="https://github.com/user-attachments/assets/8c9ba8c3-d66a-433d-ab11-7050581a6446" />

