### PR TITLE
Fix vim macros duplicating inserted characters

### DIFF
--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -251,28 +251,21 @@ type VimWithGlobalState = typeof Vim & {
   getVimGlobalState_?: () => {
     macroModeState?: {
       isRecording: boolean;
+      isPlaying: boolean;
     };
   };
 };
 
-function withSuspendedMacroRecording(callback: () => void) {
+function isMacroActive() {
   const getGlobalState = (Vim as VimWithGlobalState).getVimGlobalState_;
   if (typeof getGlobalState !== "function") {
-    callback();
-    return;
+    return false;
   }
   const macroModeState = getGlobalState()?.macroModeState;
-  if (!macroModeState || !macroModeState.isRecording) {
-    callback();
-    return;
+  if (!macroModeState) {
+    return false;
   }
-  const prevRecording = macroModeState.isRecording;
-  macroModeState.isRecording = false;
-  try {
-    callback();
-  } finally {
-    macroModeState.isRecording = prevRecording;
-  }
+  return Boolean(macroModeState.isRecording || macroModeState.isPlaying);
 }
 
 class CodeMirrorVimSync {
@@ -303,10 +296,13 @@ class CodeMirrorVimSync {
         return;
       }
       invariant("mode" in e, 'Expected event to have a "mode" property');
+      const skipBroadcast = isMacroActive();
       this.isBroadcasting = true;
       // We use onIdle to keep the focused editor snappy
       onIdle(() => {
-        this.broadcastModeChange(instance, e.mode, e.subMode);
+        if (!skipBroadcast) {
+          this.broadcastModeChange(instance, e.mode, e.subMode);
+        }
         this.isBroadcasting = false;
       });
     });
@@ -358,9 +354,7 @@ class CodeMirrorVimSync {
           case "normal":
             // Only exit insert mode if we're in it
             if (vim.insertMode) {
-              withSuspendedMacroRecording(() => {
-                Vim.exitInsertMode(cm, true);
-              });
+              Vim.exitInsertMode(cm, true);
             }
             // Only exit visual mode if we're in it
             if (vim.visualMode) {
@@ -370,9 +364,7 @@ class CodeMirrorVimSync {
           case "insert":
             // only enter insert mode if we're not already in it
             if (!vim.insertMode) {
-              withSuspendedMacroRecording(() => {
-                Vim.handleKey(cm, "i", "mapping");
-              });
+              Vim.handleKey(cm, "i", "mapping");
             }
             break;
           case "visual":


### PR DESCRIPTION
## 📝 Summary

<!--
-->
Fixes issue with CodeMirror where vim macros would duplicate characters typed in insert mode. 
Closes #8469

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
I believe that the `handleKey` method is called once per editor instance. Thus if we have 3 cells (editors) and enter insert mode, each of the 3 editors insert each character typed. 
By removing the relevant code block I was able to fix this behavior and have not observed any side-effects.
Added comment to explain logic flow for this section
I did not add a test for this issue, but all existing other tests are passing after the change.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
