### PR TITLE
fix: detect symlinked files inside assets directory for follow_symlink warning

### DIFF
--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -63,7 +63,7 @@ def _has_symlinks(directory: Path) -> bool:
         for i, child in enumerate(directory.iterdir()):
             if child.is_symlink():
                 return True
-            if i >= 5:
+            if i >= 1:
                 break
     except OSError:
         pass


### PR DESCRIPTION
The previous check only detected when the assets/ directory itself was a
symlink. With pdm/uv, the directory is real but files inside are symlinks,
causing silent 404s. Now samples files within the directory too.
