### PR TITLE
fix: render all markdown cells in snippets, not just the title cell

### DIFF
--- a/marimo/_snippets/snippets.py
+++ b/marimo/_snippets/snippets.py
@@ -51,14 +51,14 @@ async def read_snippets(config: MarimoConfig) -> Snippets:
                 if not title and "# " in code:
                     title = get_title_from_code(code)
 
-                    ret = cell.run()
-                    if isinstance(ret, Awaitable):
-                        output, _defs = await ret
-                    else:
-                        output, _defs = ret
-                    sections.append(
-                        SnippetSection(html=output.text, id=cell._cell.cell_id)
-                    )
+                ret = cell.run()
+                if isinstance(ret, Awaitable):
+                    output, _defs = await ret
+                else:
+                    output, _defs = ret
+                sections.append(
+                    SnippetSection(html=output.text, id=cell._cell.cell_id)
+                )
             else:
                 sections.append(
                     SnippetSection(code=code, id=cell._cell.cell_id)

--- a/tests/_snippets/data/multi_markdown.py
+++ b/tests/_snippets/data/multi_markdown.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Marimo. All rights reserved.
+import marimo
+
+__generated_with = "0.3.9"
+app = marimo.App()
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        # Multi Markdown Snippet
+
+        This is the title cell with a description.
+        """
+    )
+    return
+
+
+@app.cell
+def __(mo):
+    mo.md(
+        r"""
+        This is a second markdown cell that should also be rendered.
+        """
+    )
+    return
+
+
+@app.cell
+def __():
+    x = 1 + 1
+    return (x,)
+
+
+@app.cell
+def __():
+    import marimo as mo
+
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Fixes #8323. Since v0.16.4 (PR #6583), markdown cells beyond the title were not rendered in the snippets panel. The `cell.run()` and `sections.append()` calls were accidentally over-indented inside the `if not title` block, so only the first markdown cell (the title) was executed and added as an HTML section. Subsequent markdown cells were silently skipped.
