### PR TITLE
simplify logic to only handle duckdb explain

### DIFF
--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -280,66 +280,14 @@ def is_query_empty(query: str) -> bool:
     return False
 
 
-def _format_explain_sections(sections: list[tuple[str, str]]) -> str:
-    """Format explain sections into a readable string.
-
-    If there is a single section, returns just the value text.
-    If there are multiple sections, adds a header for each section.
-    """
-    if len(sections) == 1:
-        return str(sections[0][1])
-
-    parts: list[str] = []
-    for key, value in sections:
-        key_str = str(key)
-        separator = "\u2500" * len(key_str)
-        header = f"{key_str}\n{separator}"
-        parts.append(f"{header}\n{value}")
-    return "\n\n".join(parts)
-
-
-def _extract_from_relation(df: Any) -> Optional[str]:
-    """Try to extract explain content from a DuckDB relation or similar
-    object that has .columns and .fetchall().
-
-    Returns None if the object doesn't quack like a relation.
-    """
-    columns = getattr(df, "columns", None)
-    fetchall = getattr(df, "fetchall", None)
-    if columns is None or fetchall is None:
-        return None
-
-    rows = fetchall()
-    col_list = list(columns)
-    if "explain_key" in col_list and "explain_value" in col_list:
-        key_idx = col_list.index("explain_key")
-        val_idx = col_list.index("explain_value")
-        sections = [(row[key_idx], row[val_idx]) for row in rows]
-        return _format_explain_sections(sections)
-
-    # Fallback: last column
-    if col_list and rows:
-        last_idx = len(col_list) - 1
-        return "\n".join(str(row[last_idx]) for row in rows)
-
-    return None
-
-
 def extract_explain_content(df: Any) -> str:
-    """Extract the query plan text from a DataFrame for EXPLAIN queries.
-
-    For DuckDB, EXPLAIN returns a result with columns 'explain_key'
-    and 'explain_value'. This function extracts just the plan text,
-    presenting it cleanly without DataFrame chrome.
-
-    Supports DuckDB relations, Polars/Pandas DataFrames, and falls
-    back to repr() for unknown types.
+    """Extract all content from a DataFrame for EXPLAIN queries.
 
     Args:
-        df: A DuckDB relation, Polars/Pandas DataFrame, or other object.
+        df: DataFrame (pandas or polars). If not pandas / polars / duckdb relation, return repr(df).
 
     Returns:
-        String containing the query plan text.
+        String containing content of dataframe
     """
     try:
         if DependencyManager.polars.imported():
@@ -348,49 +296,26 @@ def extract_explain_content(df: Any) -> str:
             if isinstance(df, pl.LazyFrame):
                 df = df.collect()
             if isinstance(df, pl.DataFrame):
-                columns = df.columns
-
-                # DuckDB EXPLAIN format: explain_key + explain_value columns
-                if "explain_key" in columns and "explain_value" in columns:
-                    keys = df["explain_key"].to_list()
-                    values = df["explain_value"].to_list()
-                    return _format_explain_sections(list(zip(keys, values)))
-
-                # Generic fallback: use the last column
-                if len(columns) > 0:
-                    last_col_values = df[columns[-1]].to_list()
-                    return "\n".join(str(v) for v in last_col_values)
-
-                # Final fallback
-                with pl.Config(fmt_str_lengths=1000):
+                # Display full strings without truncation
+                with pl.Config(fmt_str_lengths=10000):
                     return str(df)
 
         if DependencyManager.pandas.imported():
             import pandas as pd
 
             if isinstance(df, pd.DataFrame):
-                columns = list(df.columns)
-
-                # DuckDB EXPLAIN format: explain_key + explain_value columns
-                if "explain_key" in columns and "explain_value" in columns:
-                    keys = df["explain_key"].tolist()
-                    values = df["explain_value"].tolist()
-                    return _format_explain_sections(list(zip(keys, values)))
-
-                # Generic fallback: use the last column
-                if len(columns) > 0:
-                    last_col_values = df[columns[-1]].tolist()
-                    return "\n".join(str(v) for v in last_col_values)
-
-                # Final fallback
+                # Preserve newlines in the data
                 all_values = df.values.flatten().tolist()
                 return "\n".join(str(val) for val in all_values)
 
-        # Try duck-typed relation (DuckDB relation, DB-API cursor, etc.)
-        result = _extract_from_relation(df)
-        if result is not None:
-            return result
+        if DependencyManager.duckdb.imported():
+            import duckdb
 
+            if isinstance(df, duckdb.DuckDBPyRelation):
+                rows = df.fetchall()
+                return "\n".join(str(val) for row in rows for val in row)
+
+        # Fallback to repr for other types
         return repr(df)
 
     except Exception as e:

--- a/tests/_sql/test_sql.py
+++ b/tests/_sql/test_sql.py
@@ -408,182 +408,152 @@ class TestExplainQueries:
             "-- EXPLAIN SELECT 1"
         )  # Comment, not actual query
 
-    @pytest.fixture(autouse=True)
-    def duckdb_test_table(self):
-        """Create and clean up a DuckDB test table for EXPLAIN tests."""
-        if DependencyManager.duckdb.has():
-            import duckdb
+    @pytest.fixture
+    def explain_df_data(self) -> dict[str, list[str]]:
+        return {
+            "explain_key": ["physical_plan", "logical_plan"],
+            "explain_value": [
+                "┌─────────────────────────────────────┐\n│              PROJECTION               │\n└─────────────────────────────────────┘",
+                "┌─────────────────────────────────────┐\n│              SELECTION                │\n└─────────────────────────────────────┘",
+            ],
+        }
 
-            duckdb.sql(
-                "CREATE OR REPLACE TABLE test_explain AS SELECT * FROM range(5)"
-            )
-        yield
-        if DependencyManager.duckdb.has():
-            import duckdb
-
-            duckdb.sql("DROP TABLE IF EXISTS test_explain")
-
-    @pytest.mark.requires("polars", "duckdb")
-    @pytest.mark.parametrize(
-        "lazy", [False, True], ids=["dataframe", "lazyframe"]
-    )
-    def test_extract_explain_content_duckdb_polars(self, lazy):
-        """Test extract_explain_content with real DuckDB EXPLAIN as Polars DataFrame/LazyFrame."""
-        import duckdb
-
-        relation = duckdb.sql("EXPLAIN SELECT * FROM test_explain")
-        df = relation.pl()
-        if lazy:
-            df = df.lazy()
-
-        result = extract_explain_content(df)
-        assert result == snapshot("""\
-┌───────────────────────────┐
-│         SEQ_SCAN          │
-│    ────────────────────   │
-│    Table: test_explain    │
-│   Type: Sequential Scan   │
-│     Projections: range    │
-│                           │
-│          ~5 rows          │
-└───────────────────────────┘
-""")
-
-    @pytest.mark.requires("pandas", "duckdb")
-    def test_extract_explain_content_duckdb_pandas(self):
-        """Test extract_explain_content with real DuckDB EXPLAIN as Pandas."""
-        import duckdb
-
-        relation = duckdb.sql("EXPLAIN SELECT * FROM test_explain")
-        df = relation.df()
-
-        result = extract_explain_content(df)
-        assert result == snapshot("""\
-┌───────────────────────────┐
-│         SEQ_SCAN          │
-│    ────────────────────   │
-│    Table: test_explain    │
-│   Type: Sequential Scan   │
-│     Projections: range    │
-│                           │
-│          ~5 rows          │
-└───────────────────────────┘
-""")
-
-    @pytest.mark.requires("polars", "duckdb")
-    def test_extract_explain_analyze_content_duckdb(self):
-        """Test extract_explain_content with DuckDB EXPLAIN ANALYZE output."""
-        import duckdb
-
-        relation = duckdb.sql("EXPLAIN ANALYZE SELECT * FROM test_explain")
-        df = relation.pl()
-
-        result = extract_explain_content(df)
-
-        # EXPLAIN ANALYZE has profiling info; single row so no header label
-        assert "Query Profiling Information" in result
-        assert "analyzed_plan\n" not in result
-
-    @pytest.mark.requires("duckdb")
-    def test_extract_explain_content_duckdb_native_relation(self):
-        """Test extract_explain_content with a native DuckDB relation."""
-        import duckdb
-
-        relation = duckdb.sql("EXPLAIN SELECT * FROM test_explain")
-        result = extract_explain_content(relation)
-        assert result == snapshot("""\
-┌───────────────────────────┐
-│         SEQ_SCAN          │
-│    ────────────────────   │
-│    Table: test_explain    │
-│   Type: Sequential Scan   │
-│     Projections: range    │
-│                           │
-│          ~5 rows          │
-└───────────────────────────┘
-""")
-
-    @pytest.mark.requires("polars")
-    def test_extract_explain_content_multi_section(self):
-        """Test extract_explain_content with multiple sections adds headers."""
+    @pytest.mark.skipif(not HAS_POLARS, reason="Polars not installed")
+    def test_extract_explain_content_polars(
+        self, explain_df_data: dict[str, list[str]]
+    ):
+        """Test extract_explain_content with polars DataFrames."""
         import polars as pl
 
-        df = pl.DataFrame(
-            {
-                "explain_key": ["physical_plan", "logical_plan"],
-                "explain_value": [
-                    "PhysicalPlan\nDetails",
-                    "LogicalPlan\nDetails",
-                ],
-            }
-        )
+        # Test with regular DataFrame
+        df = pl.DataFrame(explain_df_data)
+
+        expected_rendering = """shape: (2, 2)
+┌───────────────┬───────────────────────────────────────────┐
+│ explain_key   ┆ explain_value                             │
+│ ---           ┆ ---                                       │
+│ str           ┆ str                                       │
+╞═══════════════╪═══════════════════════════════════════════╡
+│ physical_plan ┆ ┌─────────────────────────────────────┐   │
+│               ┆ │              PROJECTION               │ │
+│               ┆ └─────────────────────────────────────┘   │
+│ logical_plan  ┆ ┌─────────────────────────────────────┐   │
+│               ┆ │              SELECTION                │ │
+│               ┆ └─────────────────────────────────────┘   │
+└───────────────┴───────────────────────────────────────────┘"""
 
         result = extract_explain_content(df)
+        assert result == expected_rendering
+
+        # Test with LazyFrame
+        lazy_df = df.lazy()
+        result = extract_explain_content(lazy_df)
+        assert result == expected_rendering
+
+    @pytest.mark.skipif(not HAS_PANDAS, reason="Pandas not installed")
+    def test_extract_explain_content_pandas(
+        self, explain_df_data: dict[str, list[str]]
+    ):
+        """Test extract_explain_content with pandas DataFrames."""
+        import pandas as pd
+
+        df = pd.DataFrame(explain_df_data)
+
+        result = extract_explain_content(df)
+        assert (
+            result
+            == """physical_plan
+┌─────────────────────────────────────┐
+│              PROJECTION               │
+└─────────────────────────────────────┘
+logical_plan
+┌─────────────────────────────────────┐
+│              SELECTION                │
+└─────────────────────────────────────┘"""
+        )
+
+    @pytest.mark.skipif(not HAS_DUCKDB, reason="DuckDB not installed")
+    def test_extract_explain_content_duckdb_relation(self):
+        """Test extract_explain_content with a DuckDB relation."""
+        import duckdb
+
+        conn = duckdb.connect(":memory:")
+        conn.sql("CREATE TABLE t AS SELECT * FROM range(5) tbl(id)")
+        relation = conn.sql("EXPLAIN SELECT * FROM t")
+        result = extract_explain_content(relation)
+
         assert result == snapshot("""\
 physical_plan
-─────────────
-PhysicalPlan
-Details
-
-logical_plan
-────────────
-LogicalPlan
-Details\
+┌───────────────────────────┐
+│         SEQ_SCAN          │
+│    ────────────────────   │
+│          Table: t         │
+│   Type: Sequential Scan   │
+│      Projections: id      │
+│                           │
+│          ~5 rows          │
+└───────────────────────────┘
 """)
 
-    @pytest.mark.requires("polars")
-    def test_extract_explain_content_unknown_columns(self):
-        """Test extract_explain_content fallback for unknown column names."""
-        import polars as pl
-
-        df = pl.DataFrame(
-            {
-                "QUERY PLAN": [
-                    "Seq Scan on users",
-                    "  Filter: (age > 21)",
-                ]
-            }
-        )
-
-        result = extract_explain_content(df)
-        assert result == snapshot("""\
-Seq Scan on users
-  Filter: (age > 21)\
-""")
+        conn.close()
 
     def test_extract_explain_content_fallback(self):
         """Test extract_explain_content fallback for non-DataFrame objects."""
-        assert extract_explain_content("not a dataframe") == snapshot(
-            "'not a dataframe'"
-        )
-        assert extract_explain_content(None) == snapshot("None")
+        # Test with non-DataFrame object
+        result = extract_explain_content("not a dataframe")
+        assert isinstance(result, str)
+        assert "not a dataframe" in result
 
-    @pytest.mark.requires("polars")
+        # Test with None
+        result = extract_explain_content(None)
+        assert isinstance(result, str)
+        assert "None" in result
+
+    @pytest.mark.skipif(not HAS_POLARS, reason="Polars not installed")
     def test_extract_explain_content_error_handling(self):
-        """Test extract_explain_content error handling with broken __str__."""
+        """Test extract_explain_content error handling."""
 
+        # Create a mock DataFrame that will raise an error
         class MockDataFrame:
+            def __init__(self):
+                pass
+
             def __str__(self):
                 raise RuntimeError("Test error")
 
-        result = extract_explain_content(MockDataFrame())
+        mock_df = MockDataFrame()
+        result = extract_explain_content(mock_df)
         assert isinstance(result, str)
-        assert "MockDataFrame" in result
+        assert "MockDataFrame" in result  # Should fallback to repr
 
     @patch("marimo._sql.sql.replace")
-    @pytest.mark.requires("polars", "duckdb")
+    @pytest.mark.skipif(
+        not HAS_POLARS or not HAS_DUCKDB, reason="polars and duckdb required"
+    )
     def test_sql_explain_query_display(self, mock_replace):
-        """Test that mo.sql() EXPLAIN queries render as plain text, not a table."""
+        """Test that EXPLAIN queries are displayed as plain text."""
+        import duckdb
         import polars as pl
 
+        # Create a test table
+        duckdb.sql(
+            "CREATE OR REPLACE TABLE test_explain AS SELECT * FROM range(5)"
+        )
+
+        # Test EXPLAIN query
         result = sql("EXPLAIN SELECT * FROM test_explain")
         assert isinstance(result, pl.DataFrame)
 
+        # Should call replace with plain_text
         mock_replace.assert_called_once()
-        html_obj = mock_replace.call_args[0][0]
-        assert hasattr(html_obj, "text")
-        assert "test_explain" in html_obj.text
-        assert "shape:" not in html_obj.text
+        call_args = mock_replace.call_args[0][0]
+
+        # The call should be a plain_text object
+        assert hasattr(call_args, "text")
+        assert isinstance(call_args.text, str)
+
+        # Clean up
+        duckdb.sql("DROP TABLE test_explain")
 
     def test_wrap_query_with_explain(self):
         """Test wrap_query_with_explain function."""


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Simplifies the logic and tests to only handle duckdb. Increase str_format_length to 10_000. I can't make it unlimited

native
<img width="824" height="626" alt="image" src="https://github.com/user-attachments/assets/f1bd2128-1327-4878-9147-3a59cc76d56e" />

polars
<img width="670" height="641" alt="image" src="https://github.com/user-attachments/assets/6eef6b3d-663d-44fc-9849-5f97c20f3dcd" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
