### PR TITLE
Disable "Open in Vega Editor" link in `ChartBuilder`

### DIFF
--- a/frontend/src/components/data-table/charts/lazy-chart.tsx
+++ b/frontend/src/components/data-table/charts/lazy-chart.tsx
@@ -37,7 +37,7 @@ export const LazyChart: React.FC<{
               export: true,
               source: false,
               compiled: false,
-              editor: true,
+              editor: false,
             },
             mode: "vega",
             renderer: "canvas",


### PR DESCRIPTION
Fixes #8501

The ChartBuilder generates charts as Vega-Lite specs with the intended workflow being: build a chart visually, then copy the generated Altair code into a cell. Opening the raw Vega JSON in an external editor doesn't fit this flow.
