### PR TITLE
fix: add "marimo-sidebar" to excluded tags in outline

### DIFF
--- a/frontend/src/core/dom/__tests__/outline.test.ts
+++ b/frontend/src/core/dom/__tests__/outline.test.ts
@@ -323,6 +323,9 @@ describe("parseOutline", () => {
       <marimo-accordion>
         <h2 id="excluded-heading-accordion">Excluded Heading in Accordion</h2>
       </marimo-accordion>
+      <marimo-sidebar>
+        <h2 id="excluded-heading-sidebar">Excluded Heading in Sidebar</h2>
+      </marimo-sidebar>
       <h2 id="another-included-heading">Another Included Heading</h2>
     </div>
     `;

--- a/frontend/src/core/dom/outline.ts
+++ b/frontend/src/core/dom/outline.ts
@@ -6,7 +6,12 @@ import type { Outline, OutlineItem } from "../cells/outline";
 import type { OutputMessage } from "../kernel/messages";
 
 // Tags that we don't want to include in the outline
-const excludedTags = ["marimo-carousel", "marimo-tabs", "marimo-accordion"];
+const excludedTags = [
+  "marimo-carousel",
+  "marimo-tabs",
+  "marimo-accordion",
+  "marimo-sidebar",
+];
 
 // We go up to h6. Previously we did h3 to match Google Docs and Notion, but users have requested more levels.
 // This could be made configurable in the future.


### PR DESCRIPTION
This pull request updates the logic for generating document outlines by expanding the set of HTML tags excluded from outline parsing. The main change is the addition of `marimo-sidebar` to the exclusion list, which ensures that headings inside sidebars are not included in the outline. The test suite is also updated to cover this new behavior.