### PR TITLE
fix: latex in notebook outline

### DIFF
--- a/frontend/src/components/editor/chrome/panels/outline/floating-outline.tsx
+++ b/frontend/src/components/editor/chrome/panels/outline/floating-outline.tsx
@@ -105,21 +105,33 @@ export const OutlineList: React.FC<{
         const occurrences = seen.get(identifier) ?? 0;
         seen.set(identifier, occurrences + 1);
 
+        const key = `${identifier}-${idx}`;
+        const sharedProps = {
+          className: cn(
+            "px-2 py-1 cursor-pointer hover:bg-accent/50 hover:text-accent-foreground rounded-l",
+            item.level === 1 && "font-semibold",
+            item.level === 2 && "ml-3",
+            item.level === 3 && "ml-6",
+            item.level === 4 && "ml-9",
+            occurrences === activeOccurrences &&
+              activeHeaderId === identifier &&
+              "text-accent-foreground",
+          ),
+          onClick: () => scrollToOutlineItem(item, occurrences),
+        };
+
+        if (item.html) {
+          return (
+            <div
+              key={key}
+              {...sharedProps}
+              dangerouslySetInnerHTML={{ __html: item.html }}
+            />
+          );
+        }
+
         return (
-          <div
-            key={`${identifier}-${idx}`}
-            className={cn(
-              "px-2 py-1 cursor-pointer hover:bg-accent/50 hover:text-accent-foreground rounded-l",
-              item.level === 1 && "font-semibold",
-              item.level === 2 && "ml-3",
-              item.level === 3 && "ml-6",
-              item.level === 4 && "ml-9",
-              occurrences === activeOccurrences &&
-                activeHeaderId === identifier &&
-                "text-accent-foreground",
-            )}
-            onClick={() => scrollToOutlineItem(item, occurrences)}
-          >
+          <div key={key} {...sharedProps}>
             {item.name}
           </div>
         );

--- a/frontend/src/core/cells/outline.ts
+++ b/frontend/src/core/cells/outline.ts
@@ -5,9 +5,15 @@
  */
 export interface OutlineItem {
   /**
-   * The human-readable heading name.
+   * The human-readable heading name (plain text).
    */
   name: string;
+  /**
+   * The heading's inner HTML, preserving rich content like LaTeX.
+   * When present and different from `name`, the outline should
+   * render this instead of the plain-text `name`.
+   */
+  html?: string;
   /**
    * Locator of the item.
    *

--- a/frontend/src/core/dom/__tests__/outline.test.ts
+++ b/frontend/src/core/dom/__tests__/outline.test.ts
@@ -39,6 +39,7 @@ describe("parseOutline", () => {
             "by": {
               "id": "what-is-marimo",
             },
+            "html": "What is <b>marimo</b>?",
             "level": 2,
             "name": "What is marimo?",
           },
@@ -304,6 +305,50 @@ describe("parseOutline", () => {
             },
             "level": 6,
             "name": "Detail",
+          },
+        ],
+      }
+    `);
+  });
+
+  it("preserves LaTeX HTML in headings", () => {
+    const html = `
+    <span class="markdown">
+      <h1 id="intro">Introduction</h1>
+      <h2 id="the-equation">The equation <marimo-tex class="arithmatex">||(E = mc^2||)</marimo-tex></h2>
+      <h2 id="plain">Plain heading</h2>
+    </span>
+    `;
+    const outline = parseOutline({
+      mimetype: "text/html",
+      timestamp: 0,
+      channel: "output",
+      data: html,
+    });
+    expect(outline).toMatchInlineSnapshot(`
+      {
+        "items": [
+          {
+            "by": {
+              "id": "intro",
+            },
+            "level": 1,
+            "name": "Introduction",
+          },
+          {
+            "by": {
+              "id": "the-equation",
+            },
+            "html": "The equation <marimo-tex class="arithmatex">||(E = mc^2||)</marimo-tex>",
+            "level": 2,
+            "name": "The equation ||(E = mc^2||)",
+          },
+          {
+            "by": {
+              "id": "plain",
+            },
+            "level": 2,
+            "name": "Plain heading",
           },
         ],
       }

--- a/frontend/src/core/dom/outline.ts
+++ b/frontend/src/core/dom/outline.ts
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { sanitizeHtml } from "@/plugins/core/sanitize";
 import { invariant } from "@/utils/invariant";
 import { Logger } from "@/utils/Logger";
 import type { Outline, OutlineItem } from "../cells/outline";
@@ -46,7 +47,12 @@ function getOutline(html: string): Outline | null {
     }
 
     const level = Number.parseInt(heading.tagName[1], 10);
-    items.push({ name, level, by: headingToIdentifier(heading) });
+    const innerHTML = heading.innerHTML;
+    const item: OutlineItem = { name, level, by: headingToIdentifier(heading) };
+    if (innerHTML !== name) {
+      item.html = sanitizeHtml(innerHTML);
+    }
+    items.push(item);
   }
 
   return { items };

--- a/marimo/_smoke_tests/markdown/latex_outline.py
+++ b/marimo/_smoke_tests/markdown/latex_outline.py
@@ -1,0 +1,75 @@
+import marimo
+
+__generated_with = "0.20.2"
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Introduction
+
+    This notebook tests that LaTeX renders correctly in the outline panel.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## The equation $E = mc^2$
+
+    Einstein's famous mass-energy equivalence.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Inline math: $\alpha + \beta = \gamma$
+
+    Greek letters in a heading.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Display math
+
+    $$\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}$$
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Mixed: text and $\sum_{i=1}^{n} x_i$
+
+    A heading with both plain text and a summation.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Plain heading (no LaTeX)
+
+    This heading has no math for comparison.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
This pull request enhances the outline panel to support rich content in headings, such as LaTeX and HTML, ensuring that mathematical notation and other formatting are preserved and displayed correctly. The changes introduce a new `html` field to outline items, update rendering logic to use this field when available, and add tests and a smoke test notebook to verify the new behavior.

<img width="390" height="346" alt="image" src="https://github.com/user-attachments/assets/da72a60b-e29c-424b-97bf-b729fef2487f" />
