### PR TITLE
Fix matrix widget showing stale values after cell re-execution

### DIFF
--- a/frontend/src/plugins/impl/MatrixPlugin.tsx
+++ b/frontend/src/plugins/impl/MatrixPlugin.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { type JSX, useCallback, useRef, useState } from "react";
+import { type JSX, useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import { cn } from "@/utils/cn";
 import type { IPlugin, IPluginProps, Setter } from "../types";
@@ -90,6 +90,9 @@ const MatrixComponent = ({
   // Outside of a drag we always read from the prop `value` directly,
   // which avoids stale-state bugs when the matrix shape changes.
   const [draft, setDraft] = useState(value);
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
   const displayValue = activeCell == null ? value : draft;
 
   const formatValue = (val: number) =>


### PR DESCRIPTION
The matrix plugin's `draft` state wasn't synced when the kernel sent new `value` after a cell re-execution. Starting a new drag would switch `displayValue` to the stale draft, flashing the previous state. Syncing `draft` from `value` via `useEffect` fixes this.
