### PR TITLE
test patch to fix windows session tests in CI

### DIFF
--- a/tests/_server/test_asgi.py
+++ b/tests/_server/test_asgi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -43,6 +44,11 @@ if __name__ == "__main__":
 
 class TestASGIAppBuilder(unittest.TestCase):
     def setUp(self) -> None:
+        # Kernel threads running in RUN mode may modify sys.modules["__main__"]
+        # via patch_main_module.  Save it so tearDown can restore it and
+        # prevent contamination of later tests (e.g. multiprocessing.Process
+        # on Windows reads __main__.__file__ during spawn).
+        self._saved_main = sys.modules["__main__"]
         # Create a temporary directory for the tests
         self.temp_dir = tempfile.TemporaryDirectory()
         self.app1 = os.path.join(self.temp_dir.name, "app1.py")
@@ -55,6 +61,8 @@ class TestASGIAppBuilder(unittest.TestCase):
     def tearDown(self) -> None:
         # Clean up the temporary directory
         self.temp_dir.cleanup()
+        # Restore __main__ in case a kernel thread modified it
+        sys.modules["__main__"] = self._saved_main
 
     def test_create_asgi_app(self) -> None:
         builder = create_asgi_app(quiet=True, include_code=True)

--- a/tests/_server/test_session_manager.py
+++ b/tests/_server/test_session_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from textwrap import dedent
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, Mock
@@ -22,7 +23,24 @@ from marimo._session.notebook import AppFileManager
 from marimo._types.ids import SessionId
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _preserve_main_module() -> Iterator[None]:
+    """Restore sys.modules["__main__"] after each test.
+
+    Earlier tests (e.g. in test_asgi.py) may start kernel threads in RUN
+    mode that call patch_main_module(), permanently replacing __main__
+    with a module whose __file__ points to a now-deleted temp file.
+    On Windows the multiprocessing 'spawn' start method reads
+    __main__.__file__ to bootstrap the child process, so a stale path
+    causes FileNotFoundError and the parent hangs on listener.accept().
+    """
+    saved = sys.modules["__main__"]
+    yield
+    sys.modules["__main__"] = saved
 
 
 @pytest.fixture


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
These tests were failing in Windows.

<details>

<summary>stack trace</summary>

```python
Timeout (0:00:30)!
Thread 0x00000bd0 (most recent call first):
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 324 in wait
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 607 in wait
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1376 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00001c28 (most recent call first):
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 320 in wait
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\queue.py", line 171 in get
  File "D:\a\marimo\marimo\marimo\_utils\distributor.py", line 139 in _loop
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x000018a8 (most recent call first):
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 324 in wait
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\queue.py", line 180 in get
  File "D:\a\marimo\marimo\marimo\_runtime\runtime.py", line 3540 in control_loop
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\events.py", line 80 in _run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 1909 in _run_once
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 603 in run_forever
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 636 in run_until_complete
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\runners.py", line 44 in run
  File "D:\a\marimo\marimo\marimo\_runtime\runtime.py", line 3573 in launch_kernel
  File "D:\a\marimo\marimo\marimo\_session\managers\kernel.py", line 109 in launch_kernel_with_cleanup
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00002044 (most recent call first):
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\concurrent\futures\thread.py", line 81 in _worker
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x0000095c (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30 in watch_file
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00001efc (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_directory.py", line 54 in watch_directory
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00000a98 (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30 in watch_file
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00000968 (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_directory.py", line 54 in watch_directory
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00000e3c (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_directory.py", line 54 in watch_directory
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00002264 (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30 in watch_file
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00000b70 (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30 in watch_file
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00001d50 (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30 in watch_file
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00002094 (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30 in watch_file
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x000006c8 (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30 in watch_file
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x0000118c (most recent call first):
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30 in watch_file
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x00001e80 (most recent call first):
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\jedi\inference\compiled\subprocess\__init__.py", line 70 in _enqueue_output
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953 in run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016 in _bootstrap_inner
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973 in _bootstrap

Thread 0x000004a4 (most recent call first):
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\socket.py", line 293 in accept
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\multiprocessing\connection.py", line 609 in accept
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\multiprocessing\connection.py", line 463 in accept
  File "D:\a\marimo\marimo\marimo\_session\managers\kernel.py", line 159 in start_kernel
  File "D:\a\marimo\marimo\marimo\_session\session.py", line 194 in __init__
  File "D:\a\marimo\marimo\marimo\_session\session.py", line 159 in create
  File "D:\a\marimo\marimo\marimo\_server\session_manager.py", line 202 in create_session
  File "D:\a\marimo\marimo\tests\_server\test_session_manager.py", line 81 in test_create_session_new
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\tasks.py", line 232 in __step
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\events.py", line 80 in _run
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 1909 in _run_once
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 603 in run_forever
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 636 in run_until_complete
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\backports\asyncio\runner\runner.py", line 175 in run
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pytest_asyncio\plugin.py", line 716 in inner
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\python.py", line 166 in pytest_pyfunc_call
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\python.py", line 1720 in runtest
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pytest_asyncio\plugin.py", line 469 in runtest
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 179 in pytest_runtest_call
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 245 in <lambda>
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 353 in from_call
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 244 in call_and_report
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 137 in runtestprotocol
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 118 in pytest_runtest_protocol
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\main.py", line 396 in pytest_runtestloop
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\main.py", line 372 in _main
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\main.py", line 318 in wrap_session
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\main.py", line 365 in pytest_cmdline_main
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\config\__init__.py", line 199 in main
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\config\__init__.py", line 223 in console_main
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\Scripts\pytest.exe\__main__.py", line 10 in <module>
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\runpy.py", line 86 in _run_code
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\runpy.py", line 196 in _run_module_as_main
tests/_server/test_session_manager.py::test_create_session_new +++++++++++++++++++++++++++++++++++ Timeout +++++++++++++++++++++++++++++++++++
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Captured stderr ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Traceback (most recent call last):

  File "<string>", line 1, in <module>

  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\multiprocessing\spawn.py", line 116, in spawn_main

    exitcode = _main(fd, parent_sentinel)

  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\multiprocessing\spawn.py", line 125, in _main

    prepare(preparation_data)

  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\multiprocessing\spawn.py", line 236, in prepare

    _fixup_main_from_path(data['init_main_from_path'])

  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\multiprocessing\spawn.py", line 287, in _fixup_main_from_path

    main_content = runpy.run_path(main_path,

  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\runpy.py", line 288, in run_path

    code, fname = _get_code_from_file(run_name, path_name)

  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\runpy.py", line 252, in _get_code_from_file

    with io.open_code(decoded_path) as f:

FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmphpj215vm\\app1.py'

~~~~~~~~~~~~~~~~~~~~~ Stack of Thread-7112 (_loop) (7208) ~~~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_utils\distributor.py", line 139, in _loop
    msg = self.queue.get()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\queue.py", line 171, in get
    self.not_empty.wait()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 320, in wait
    waiter.acquire()
~~~~~~~~~~ Stack of Thread-7111 (launch_kernel_with_cleanup) (6312) ~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_session\managers\kernel.py", line 109, in launch_kernel_with_cleanup
    runtime.launch_kernel(*args)
  File "D:\a\marimo\marimo\marimo\_runtime\runtime.py", line 3573, in launch_kernel
    asyncio.run(control_loop(kernel))
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 636, in run_until_complete
    self.run_forever()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 603, in run_forever
    self._run_once()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 1909, in _run_once
    handle._run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "D:\a\marimo\marimo\marimo\_runtime\runtime.py", line 3540, in control_loop
    request: CommandMessage | None = control_queue.get(
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\queue.py", line 180, in get
    self.not_empty.wait(remaining)
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 324, in wait
    gotit = waiter.acquire(True, timeout)
~~~~~~~~~~~~~~~~~~~~~~~~~~ Stack of export_0 (8260) ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\concurrent\futures\thread.py", line 81, in _worker
    work_item = work_queue.get(block=True)
~~~~~~~~~~~~~~~~~~ Stack of Thread-5666 (watch_file) (2396) ~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30, in watch_file
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~ Stack of Thread-5662 (watch_directory) (7932) ~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_directory.py", line 54, in watch_directory
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~~~ Stack of Thread-5658 (watch_file) (2712) ~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30, in watch_file
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~ Stack of Thread-5271 (watch_directory) (2408) ~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_directory.py", line 54, in watch_directory
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~ Stack of Thread-5267 (watch_directory) (3644) ~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_directory.py", line 54, in watch_directory
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~~~ Stack of Thread-5263 (watch_file) (8804) ~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30, in watch_file
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~~~ Stack of Thread-5259 (watch_file) (2928) ~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30, in watch_file
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~~~ Stack of Thread-5255 (watch_file) (7504) ~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30, in watch_file
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~~~ Stack of Thread-5251 (watch_file) (8340) ~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30, in watch_file
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~~~ Stack of Thread-5247 (watch_file) (1736) ~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30, in watch_file
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~~~ Stack of Thread-5243 (watch_file) (4492) ~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "D:\a\marimo\marimo\marimo\_runtime\threads.py", line 167, in run
    super().run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "D:\a\marimo\marimo\marimo\_runtime\watch\_file.py", line 30, in watch_file
    time.sleep(sleep_interval)
~~~~~~~~~~~~~~~~ Stack of Thread-3698 (_enqueue_output) (7808) ~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\jedi\inference\compiled\subprocess\__init__.py", line 70, in _enqueue_output
    for line in iter(out.readline, b''):
~~~~~~~~~~~~~~~~~~~~~~~~~ Stack of MainThread (1188) ~~~~~~~~~~~~~~~~~~~~~~~~~~
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\Scripts\pytest.exe\__main__.py", line 10, in <module>
    sys.exit(console_main())
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\config\__init__.py", line 223, in console_main
    code = main()
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\config\__init__.py", line 199, in main
    ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\main.py", line 365, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\main.py", line 318, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\main.py", line 372, in _main
    config.hook.pytest_runtestloop(session=session)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\main.py", line 396, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 118, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 137, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 244, in call_and_report
    call = CallInfo.from_call(
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 353, in from_call
    result: TResult | None = func()
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 245, in <lambda>
    lambda: runtest_hook(item=item, **kwds),
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\runner.py", line 179, in pytest_runtest_call
    item.runtest()
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pytest_asyncio\plugin.py", line 469, in runtest
    super().runtest()
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pluggy\_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\_pytest\python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\pytest_asyncio\plugin.py", line 716, in inner
    runner.run(coro, context=context)
  File "C:\Users\runneradmin\AppData\Local\hatch\env\virtual\marimo\9kVKMDyf\test.py3.10\lib\site-packages\backports\asyncio\runner\runner.py", line 175, in run
    return self._loop.run_until_complete(task)  # type: ignore[union-attr, no-any-return]
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 636, in run_until_complete
    self.run_forever()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 603, in run_forever
    self._run_once()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\base_events.py", line 1909, in _run_once
    handle._run()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\asyncio\tasks.py", line 232, in __step
    result = coro.send(None)
  File "D:\a\marimo\marimo\tests\_server\test_session_manager.py", line 81, in test_create_session_new
    session = session_manager.create_session(
  File "D:\a\marimo\marimo\marimo\_server\session_manager.py", line 202, in create_session
    session = SessionImpl.create(
  File "D:\a\marimo\marimo\marimo\_session\session.py", line 159, in create
    return cls(
  File "D:\a\marimo\marimo\marimo\_session\session.py", line 194, in __init__
    self._kernel_manager.start_kernel()
  File "D:\a\marimo\marimo\marimo\_session\managers\kernel.py", line 159, in start_kernel
    listener.accept()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\multiprocessing\connection.py", line 463, in accept
    c = self._listener.accept()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\multiprocessing\connection.py", line 609, in accept
    s, self._last_accepted = self._socket.accept()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\socket.py", line 293, in accept
    fd, addr = self._accept()
+++++++++++++++++++++++++++++++++++ Timeout +++++++++++++++++++++++++++++++++++
Error: Process completed with exit code 1.
```
</details

This doesn't solve the root cause, which may be in _session/managers/kernel.py, runtime.py.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
