### PR TITLE
add docstring to fix jedi test

### DIFF
--- a/marimo/_runtime/watch/_path.py
+++ b/marimo/_runtime/watch/_path.py
@@ -41,7 +41,12 @@ def write_side_effect(data: str | bytes) -> None:
 
 
 class PathState(State[Path]):
-    """Base class for path state."""
+    """Base class for reactive path watchers.
+
+    Args:
+        path: The filesystem path to watch for changes.
+        allow_self_loops: Whether to allow self-referential reactivity.
+    """
 
     _forbidden_attributes: set[str]
     _target: Callable[[Path, Self, threading.Event], None]


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
This test `tests/_runtime/test_complete.py::test_parameter_descriptions` was failing. It checks that all publicly exported callables have Jedi-resolvable parameter docstrings. PathState has no docstring at all, so Jedi returns empty for the path parameter. AssertionError: Empty docstring result: marimo._runtime.watch._directory.DirectoryState(path

fix is to add docstring

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
