### PR TITLE
return cell name in run mode

### DIFF
--- a/marimo/_server/api/endpoints/ws/ws_kernel_ready.py
+++ b/marimo/_server/api/endpoints/ws/ws_kernel_ready.py
@@ -127,7 +127,7 @@ def _extract_cell_data(
         codes, names, configs, cell_ids = tuple(
             zip(
                 *tuple(
-                    ("", "", cell_data.config, cell_data.cell_id)
+                    ("", cell_data.name, cell_data.config, cell_data.cell_id)
                     for cell_data in app.cell_manager.cell_data()
                 )
             )

--- a/tests/_server/api/endpoints/test_ws.py
+++ b/tests/_server/api/endpoints/test_ws.py
@@ -303,6 +303,40 @@ async def test_cannot_connect_kiosk_with_run_session(
         assert exc_info.value.reason == "MARIMO_KIOSK_NOT_ALLOWED"
 
 
+async def test_kernel_ready_sends_names_but_not_code_when_include_code_false(
+    client: TestClient,
+) -> None:
+    """Cell names are sent in kernel-ready even when include_code=False.
+
+    This ensures data-cell-name attributes are populated in the DOM when
+    running with marimo run (without --include-code).
+
+    The 4 fields from _extract_cell_data (ws_kernel_ready.py) behave as:
+      - codes    -> blanked ("") to hide source code
+      - names    -> preserved (needed for data-cell-name DOM attribute)
+      - configs  -> preserved (needed for cell rendering)
+      - cell_ids -> preserved (needed for cell identity)
+    """
+    session_manager = get_session_manager(client)
+    session_manager.mode = SessionMode.RUN
+    session_manager.include_code = False
+    with client.websocket_connect(WS_URL) as websocket:
+        data = websocket.receive_json()
+        assert_kernel_ready_response(
+            data,
+            create_response(
+                {
+                    "codes": [""],  # hidden
+                    "names": ["__"],  # preserved
+                    "configs": [
+                        {"disabled": False, "hide_code": False}
+                    ],  # preserved
+                    "cell_ids": ["Hbol"],  # preserved
+                }
+            ),
+        )
+
+
 async def test_connects_to_existing_session_with_same_file(
     client: TestClient,
     temp_marimo_file: str,


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #8100. We previously didn't pass cell names, I think it's okay to pass them to the frontend as it's not source code and not displayed to the user.

<img width="1023" height="284" alt="image" src="https://github.com/user-attachments/assets/39568738-feb8-49d4-8c36-fb70c36a213f" />

fix:
<img width="389" height="55" alt="image" src="https://github.com/user-attachments/assets/c23d50db-2812-465b-9680-0c2f744c8a57" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
