### PR TITLE
storage-inspector: When parent dir is searched, child files should be open too

### DIFF
--- a/frontend/src/components/storage/storage-inspector.tsx
+++ b/frontend/src/components/storage/storage-inspector.tsx
@@ -140,7 +140,6 @@ const StorageEntryChildren: React.FC<{
   depth: number;
   locale: string;
   searchValue: string;
-  parentMatched: boolean;
   onOpenFile: (info: OpenFileInfo) => void;
 }> = ({
   namespace,
@@ -150,7 +149,6 @@ const StorageEntryChildren: React.FC<{
   depth,
   locale,
   searchValue,
-  parentMatched,
   onOpenFile,
 }) => {
   const { entriesByPath } = useStorage();
@@ -191,10 +189,12 @@ const StorageEntryChildren: React.FC<{
     );
   }
 
-  // When a parent directory matches the search, we don't need to filter the children.
-  const filtered = parentMatched
-    ? children
-    : filterEntries(children, namespace, searchValue, entriesByPath);
+  const filtered = filterEntries(
+    children,
+    namespace,
+    searchValue,
+    entriesByPath,
+  );
 
   return (
     <>
@@ -208,7 +208,6 @@ const StorageEntryChildren: React.FC<{
           depth={depth}
           locale={locale}
           searchValue={searchValue}
-          parentMatched={parentMatched}
           onOpenFile={onOpenFile}
         />
       ))}
@@ -224,7 +223,6 @@ const StorageEntryRow: React.FC<{
   depth: number;
   locale: string;
   searchValue: string;
-  parentMatched: boolean;
   onOpenFile: (info: OpenFileInfo) => void;
 }> = ({
   entry,
@@ -234,7 +232,6 @@ const StorageEntryRow: React.FC<{
   depth,
   locale,
   searchValue,
-  parentMatched,
   onOpenFile,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -246,7 +243,6 @@ const StorageEntryRow: React.FC<{
   const selfMatches =
     isDir &&
     hasSearch &&
-    !parentMatched &&
     name.toLowerCase().includes(searchValue.trim().toLowerCase());
 
   // During a search, auto-expand directories whose loaded descendants match
@@ -389,8 +385,7 @@ const StorageEntryRow: React.FC<{
           prefix={entry.path}
           depth={depth + 1}
           locale={locale}
-          searchValue={searchValue}
-          parentMatched={selfMatches || parentMatched}
+          searchValue={selfMatches ? "" : searchValue} // When a parent directory matches the search, we don't need to filter the children.
           onOpenFile={onOpenFile}
         />
       )}
@@ -521,7 +516,6 @@ const StorageNamespaceSection: React.FC<{
               depth={1}
               locale={locale}
               searchValue={searchValue}
-              parentMatched={false}
               onOpenFile={onOpenFile}
             />
           ))}


### PR DESCRIPTION
Previously a search would only match exact files, so if a directory matched, children files would not show.

This fixes that
<img width="437" height="334" alt="image" src="https://github.com/user-attachments/assets/cb7b307c-a057-4a09-96ab-54196a694d90" />

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
