### PR TITLE
ci: remove unnecessary permissions from GitHub workflow

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   TURBO_TEAM: marimo
@@ -20,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This was breaking with:
```
The workflow is
  requesting 'pull-requests: write', but is only allowed 'pull-requests: none'. .github/workflows/release.yml (Line: 52, Col: 3): Error calling workflow
  ```
