### PR TITLE
fix pdb start message not being sent

### DIFF
--- a/frontend/src/components/editor/output/console/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/console/ConsoleOutput.tsx
@@ -70,6 +70,7 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
     onSubmitDebugger,
     onClear,
     onRefactorWithAI,
+    debuggerActive,
     className,
   } = props;
 
@@ -119,10 +120,12 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
   }
 
   const reversedOutputs = [...consoleOutputs].reverse();
-  const isPdb = reversedOutputs.some(
-    (output) =>
-      typeof output.data === "string" && output.data.includes("(Pdb)"),
-  );
+  const isPdb =
+    debuggerActive ||
+    reversedOutputs.some(
+      (output) =>
+        typeof output.data === "string" && output.data.includes("(Pdb)"),
+    );
 
   // Find the index of the last stdin output since we only want to show
   // the pdb prompt once

--- a/frontend/src/core/cells/cell.ts
+++ b/frontend/src/core/cells/cell.ts
@@ -9,6 +9,8 @@ import type { RuntimeState } from "../network/types";
 import { collapseConsoleOutputs } from "./collapseConsoleOutputs";
 import type { CellRuntimeState } from "./types";
 
+const PDB_START_MESSAGE = "start";
+
 export function transitionCell(
   cell: CellRuntimeState,
   message: CellMessage,
@@ -145,7 +147,10 @@ export function transitionCell(
     (output) => output.channel === "pdb",
   );
   const hasPdbOutput = pdbOutputs.length > 0;
-  if (hasPdbOutput && pdbOutputs.some((output) => output.data === "start")) {
+  if (
+    hasPdbOutput &&
+    pdbOutputs.some((output) => output.data === PDB_START_MESSAGE)
+  ) {
     nextCell.debuggerActive = true;
   }
 

--- a/marimo/_messaging/cell_output.py
+++ b/marimo/_messaging/cell_output.py
@@ -29,6 +29,10 @@ class CellChannel(str, Enum):
         return self.value
 
 
+# Keep in sync with frontend constant PDB_START_MESSAGE
+PDB_START_MESSAGE = "start"
+
+
 class CellOutput(msgspec.Struct):
     # descriptive name about the kind of output: e.g., stdout, stderr, ...
     channel: CellChannel

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -44,7 +44,7 @@ from marimo._dependencies.dependencies import DependencyManager
 from marimo._dependencies.errors import ManyModulesNotFoundError
 from marimo._entrypoints.registry import EntryPointRegistry
 from marimo._lint.validate_graph import check_for_errors
-from marimo._messaging.cell_output import CellChannel
+from marimo._messaging.cell_output import PDB_START_MESSAGE, CellChannel
 from marimo._messaging.context import http_request_context, run_id_context
 from marimo._messaging.errors import (
     Error,
@@ -1685,6 +1685,13 @@ class Kernel:
         ):
             return
 
+        CellNotificationUtils.broadcast_console_output(
+            channel=CellChannel.PDB,
+            mimetype="text/plain",
+            data=PDB_START_MESSAGE,
+            cell_id=cell_id,
+            status=None,
+        )
         with self._install_execution_context(cell_id):
             self.debugger.post_mortem_by_cell_id(cell_id)
 

--- a/tests/_runtime/test_marimo_pdb.py
+++ b/tests/_runtime/test_marimo_pdb.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
+from marimo._messaging.cell_output import PDB_START_MESSAGE, CellChannel
 from marimo._runtime.marimo_pdb import MarimoPdb
 from marimo._runtime.runtime import Kernel
-from tests.conftest import ExecReqProvider
+from tests.conftest import ExecReqProvider, _MockStream
 
 
 async def test_pdb_patched(
@@ -13,3 +16,36 @@ async def test_pdb_patched(
     assert pdb.Pdb == MarimoPdb
     assert k.debugger.stdout is k.stdout
     assert k.debugger.stdin is k.stdin
+
+
+async def test_pdb_request_broadcasts_start(
+    execution_kernel: Kernel, exec_req: ExecReqProvider
+) -> None:
+    k = execution_kernel
+
+    # Run a cell that raises an exception so the debugger stores a traceback
+    er = exec_req.get("raise ValueError('test')")
+    await k.run([er])
+    cell_id = er.cell_id
+
+    assert k.debugger is not None
+    assert cell_id in k.debugger._last_tracebacks
+
+    stream: _MockStream = k.stream  # type: ignore[assignment]
+    notifications_before = len(stream.cell_notifications)
+
+    # Mock post_mortem_by_cell_id to avoid entering the interactive pdb loop
+    with patch.object(k.debugger, "post_mortem_by_cell_id"):
+        await k.pdb_request(cell_id)
+
+    new_notifications = stream.cell_notifications[notifications_before:]
+    pdb_starts = [
+        n
+        for n in new_notifications
+        if not isinstance(n.console, list)
+        and n.console is not None
+        and n.console.channel == CellChannel.PDB
+        and n.console.data == PDB_START_MESSAGE
+    ]
+    assert len(pdb_starts) == 1
+    assert pdb_starts[0].cell_id == cell_id


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
This error causes the debugger controls not to appear at certain times (eg. onClear). So I end up with this, and no way to escape/resolve this. It seems the pdb start message was not being sent.

<img width="558" height="286" alt="Screenshot 2026-03-03 at 6 15 32 PM" src="https://github.com/user-attachments/assets/b2c77f5e-21e3-4de4-83c0-a34f3250e38a" />

fix:
 
<img width="492" height="294" alt="image" src="https://github.com/user-attachments/assets/4b3e1ae7-01c3-42ec-8a0f-5630eef2cf4f" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
