### PR TITLE
fix: safer ends_with_semicolon with token errors

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -11,7 +11,7 @@ import sys
 import textwrap
 import token as token_types
 import warnings
-from tokenize import tokenize
+from tokenize import TokenError, tokenize
 from types import CodeType, FrameType
 from typing import Any, Callable, Optional, TypeAlias, cast
 
@@ -85,8 +85,14 @@ def ends_with_semicolon(code: str) -> bool:
         bool: True if the last non-comment line ends with a semicolon
     """
     # Tokenize to check for semicolon
-    tokens = tokenize(io.BytesIO(code.strip().encode("utf-8")).readline)
-    for token in reversed(list(tokens)):
+    try:
+        tokens = list(
+            tokenize(io.BytesIO(code.strip().encode("utf-8")).readline)
+        )
+    except TokenError:
+        # Fallback for code with syntax errors (e.g., unterminated strings)
+        return code.rstrip().endswith(";")
+    for token in reversed(tokens):
         if token.type in (
             token_types.ENDMARKER,
             token_types.NEWLINE,

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -444,6 +444,57 @@ class TestSemicolon:
         assert eval(cell._cell.last_expr) is None
 
 
+class TestEndsWithSemicolon:
+    @staticmethod
+    def test_simple_semicolon() -> None:
+        assert compiler.ends_with_semicolon("x = 1;") is True
+
+    @staticmethod
+    def test_no_semicolon() -> None:
+        assert compiler.ends_with_semicolon("x = 1") is False
+
+    @staticmethod
+    def test_semicolon_with_trailing_whitespace() -> None:
+        assert compiler.ends_with_semicolon("x = 1;  ") is True
+
+    @staticmethod
+    def test_semicolon_before_comment() -> None:
+        assert compiler.ends_with_semicolon("x = 1; # comment") is True
+
+    @staticmethod
+    def test_no_semicolon_with_comment() -> None:
+        assert compiler.ends_with_semicolon("x = 1  # comment") is False
+
+    @staticmethod
+    def test_semicolon_in_string_not_counted() -> None:
+        assert compiler.ends_with_semicolon('"hello;"') is False
+
+    @staticmethod
+    def test_empty_code() -> None:
+        assert compiler.ends_with_semicolon("") is False
+
+    @staticmethod
+    def test_whitespace_only() -> None:
+        assert compiler.ends_with_semicolon("   ") is False
+
+    @staticmethod
+    def test_token_error_unterminated_string() -> None:
+        # Unterminated string causes TokenError; fallback should handle it
+        assert compiler.ends_with_semicolon('x = "unterminated') is False
+
+    @staticmethod
+    def test_token_error_unterminated_string_with_semicolon() -> None:
+        assert compiler.ends_with_semicolon('x = "unterminated;') is True
+
+    @staticmethod
+    def test_token_error_unterminated_triple_quote() -> None:
+        assert compiler.ends_with_semicolon('x = """unterminated') is False
+
+    @staticmethod
+    def test_token_error_unterminated_triple_quote_with_semicolon() -> None:
+        assert compiler.ends_with_semicolon('x = """unterminated;') is True
+
+
 class TestCompileCellFilename:
     """Test compile_cell function with filename parameter."""
 


### PR DESCRIPTION
This pull request improves the robustness of the `ends_with_semicolon` function in the `marimo/_ast/compiler.py` module by handling tokenization errors and adds comprehensive unit tests to verify its behavior across various edge cases.
