### PR TITLE
fix: substitute \mbox with \text

### DIFF
--- a/frontend/src/plugins/layout/TexPlugin.tsx
+++ b/frontend/src/plugins/layout/TexPlugin.tsx
@@ -39,7 +39,10 @@ const importMhChem = once(async () => {
 });
 
 // Required, even if empty. (see https://github.com/KaTeX/KaTeX/issues/2513)
-const macros = {};
+const macros = {
+  // KaTeX doesn't support \mbox; map it to the equivalent \text
+  "\\mbox": "\\text{#1}",
+};
 
 async function renderLatex(mount: HTMLElement, tex: string): Promise<void> {
   const [katex] = await Promise.all([importKatex(), importMhChem()]);


### PR DESCRIPTION
KaTeX doesn't support mbox but it does support text, and the two are basically equivalent. This allows us to render math that uses mbox, for example in docstrings or `mo.md`.

<img width="755" height="540" alt="image" src="https://github.com/user-attachments/assets/3b52b278-7d16-486a-83aa-623f1a8ecc52" />
