### PR TITLE
fix: dont show slides PDF when not viewing as slides

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -185,10 +185,6 @@ export function useNotebookActions() {
   };
 
   const handleDocumentPDF = async () => {
-    if (!filename) {
-      toastNotebookMustBeNamed();
-      return;
-    }
     if (serverSidePdfEnabled) {
       await downloadServerSidePDF({
         preset: "document",


### PR DESCRIPTION
This PR updates the frontend menu to only show "Download as slides" when the notebook is configured to be a slide deck. By far the most common case will be to just export the vertical notebook as a PDF, and that should not be buried in a submenu.

**Vertical notebook.**

<img width="574" height="534" alt="image" src="https://github.com/user-attachments/assets/6273d8f2-b8c5-4e4f-ae0b-dc2d3075916b" />

**Slides.**

<img width="571" height="539" alt="image" src="https://github.com/user-attachments/assets/79201509-c396-4fdf-ab2a-a5f2d88aece5" />