### PR TITLE
issue template: enhancements need discussion

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-issue-forms.json
 name: '🚀 New feature proposal'
 description: Propose a new feature to be added to marimo
-labels: [enhancement]
+labels: [enhancement, needs discussion]
 type: Feature
 body:
   - type: markdown
@@ -26,7 +26,7 @@ body:
   - type: checkboxes
     id: will-submit-pr
     attributes:
-      label: Are you willing to submit a PR?
+      label: Are you willing to submit a PR? (You must receive approval from the team before submitting a PR.)
       description: |
         If you are interested in submitting a PR, please check this box.
         However, please confirm with us on whether your proposed feature


### PR DESCRIPTION
This PR updates the feature request issue template to label the issues with "needs discussion". If and when the team and contributor are aligned on an enhancement, we can remove the needs discussion label and mark it ready for a PR.