### PR TITLE
fix keyboard shortcuts normalization

### DIFF
--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -174,7 +174,9 @@ export const KeyboardShortcuts: React.FC = () => {
                 return;
               }
 
-              let key = e.key.toLowerCase();
+              // Single character keys are always lowercase (e.g. "a", "b", "c")
+              // But we should preserve the original case for other keys (e.g. "Enter", "Escape")
+              let key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
               // Handle edge cases
               if (e.key === " ") {
                 key = "Space";

--- a/frontend/src/core/hotkeys/__tests__/hotkeys.test.ts
+++ b/frontend/src/core/hotkeys/__tests__/hotkeys.test.ts
@@ -1,6 +1,12 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { describe, expect, it } from "vitest";
-import { type Hotkey, type HotkeyAction, HotkeyProvider } from "../hotkeys";
+import {
+  type Hotkey,
+  type HotkeyAction,
+  HotkeyProvider,
+  normalizeKeyString,
+  OverridingHotkeyProvider,
+} from "../hotkeys";
 
 /**
  * Just a helper.
@@ -70,5 +76,62 @@ describe("HotkeyProvider platform separation", () => {
     expect(mac.getHotkey("cell.format").key).toBe("Cmd-Option-F");
     expect(windows.getHotkey("cell.format").key).toBe("Ctrl-Alt-F");
     expect(linux.getHotkey("cell.format").key).toBe("Ctrl-Shift-L");
+  });
+});
+
+describe("normalizeKeyString", () => {
+  it("should capitalize multi-character base key names", () => {
+    expect(normalizeKeyString("Shift-enter")).toBe("Shift-Enter");
+    expect(normalizeKeyString("Cmd-enter")).toBe("Cmd-Enter");
+    expect(normalizeKeyString("Ctrl-backspace")).toBe("Ctrl-Backspace");
+    expect(normalizeKeyString("Alt-tab")).toBe("Alt-Tab");
+    expect(normalizeKeyString("Cmd-Shift-arrowUp")).toBe("Cmd-Shift-ArrowUp");
+  });
+
+  it("should leave already-correct key names unchanged", () => {
+    expect(normalizeKeyString("Shift-Enter")).toBe("Shift-Enter");
+    expect(normalizeKeyString("Cmd-Enter")).toBe("Cmd-Enter");
+    expect(normalizeKeyString("Mod-Shift-Enter")).toBe("Mod-Shift-Enter");
+  });
+
+  it("should leave single-character keys unchanged", () => {
+    expect(normalizeKeyString("Cmd-a")).toBe("Cmd-a");
+    expect(normalizeKeyString("Ctrl-Shift-z")).toBe("Ctrl-Shift-z");
+    expect(normalizeKeyString("a")).toBe("a");
+  });
+
+  it("should handle keys without modifiers", () => {
+    expect(normalizeKeyString("enter")).toBe("Enter");
+    expect(normalizeKeyString("Escape")).toBe("Escape");
+    expect(normalizeKeyString("F12")).toBe("F12");
+  });
+});
+
+describe("OverridingHotkeyProvider", () => {
+  it("should normalize lowercase key overrides", () => {
+    const provider = new OverridingHotkeyProvider(
+      {
+        "cell.run": "Shift-enter",
+        "cell.runAndNewBelow": "Cmd-enter",
+      },
+      { platform: "mac" },
+    );
+
+    expect(provider.getHotkey("cell.run").key).toBe("Shift-Enter");
+    expect(provider.getHotkey("cell.runAndNewBelow").key).toBe("Cmd-Enter");
+  });
+
+  it("should return defaults when no override is set", () => {
+    const provider = new OverridingHotkeyProvider({}, { platform: "mac" });
+    expect(provider.getHotkey("cell.run").key).toBe("Cmd-Enter");
+    expect(provider.getHotkey("cell.runAndNewBelow").key).toBe("Shift-Enter");
+  });
+
+  it("should pass through correctly-cased overrides unchanged", () => {
+    const provider = new OverridingHotkeyProvider(
+      { "cell.run": "Shift-Enter" },
+      { platform: "mac" },
+    );
+    expect(provider.getHotkey("cell.run").key).toBe("Shift-Enter");
   });
 });

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -535,10 +535,26 @@ export class OverridingHotkeyProvider extends HotkeyProvider {
 
   override getHotkey(action: HotkeyAction): ResolvedHotkey {
     const base = super.getHotkey(action);
-    const key = this.overrides[action] || base.key;
+    const override = this.overrides[action];
     return {
       name: base.name,
-      key,
+      key: override ? normalizeKeyString(override) : base.key,
     };
   }
+}
+
+const MODIFIER_RE = /^(cmd|ctrl|alt|shift|meta|mod)$/i;
+
+/**
+ * Capitalize multi-character base key names so they match the
+ * casing that KeyboardEvent.key (and therefore CodeMirror) uses.
+ * e.g. "Shift-enter" → "Shift-Enter", "Cmd-backspace" → "Cmd-Backspace"
+ */
+export function normalizeKeyString(key: string): string {
+  const parts = key.split("-");
+  const last = parts[parts.length - 1];
+  if (last.length > 1 && !MODIFIER_RE.test(last)) {
+    parts[parts.length - 1] = last.charAt(0).toUpperCase() + last.slice(1);
+  }
+  return parts.join("-");
 }


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Fixes #8570.

The keyboard shortcuts settings dialog was lowercasing all key names (e.g., "Shift-enter" instead of "Shift-Enter"), causing CodeMirror to silently fail to match overridden bindings since its key lookup is case-sensitive

So, my config would look like this
```toml
[keymap.overrides]
"cell.run" = "Shift-enter"
"cell.runAndNewBelow" = "Cmd-enter"
```
Fixes:
- Added normalizeKeyString in the hotkey provider to capitalize multi-character base key names at read time, fixing both existing broken configs and manually edited ones
- Fixed the shortcut recording to preserve original casing for multi-character keys (Enter, Backspace, Tab, etc.) while still lowercasing single-character keys

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
