### PR TITLE
Wait for buffered stdout/stderr before reading MCP execution results

### DIFF
--- a/marimo/_mcp/code_server/main.py
+++ b/marimo/_mcp/code_server/main.py
@@ -193,6 +193,12 @@ def setup_code_mcp_server(
 
                 # Wait for the scratch cell to become idle
                 await asyncio.wait_for(done.wait(), timeout=_EXECUTION_TIMEOUT)
+
+                # FIXME: stdout/stderr are flushed every 10ms by the buffered
+                # writer thread. Wait 50ms so trailing console output arrives
+                # before we read cell_notifications.
+                # See: marimo-team/marimo-lsp ExecutionRegistry.ts
+                await asyncio.sleep(0.05)
             except asyncio.TimeoutError:
                 return CodeExecutionResult(
                     success=False,


### PR DESCRIPTION
The buffered writer thread flushes console output every 10ms, but we were reading cell results immediately after the cell became idle. This caused trailing stdout/stderr to be missed in MCP code execution responses (making agent rely on output).

Adding a short 50ms sleep after the done event gives the flush time to complete before we collect notifications.
