### PR TITLE
feat(image): add `normalize` parameter to `mo.image`

### DIFF
--- a/marimo/_plugins/stateless/image.py
+++ b/marimo/_plugins/stateless/image.py
@@ -21,7 +21,7 @@ Tensor = Any
 ImageLike = Union[Image, Tensor]
 
 
-def _normalize_image(src: ImageLike) -> Image:
+def _normalize_image(src: ImageLike, normalize: bool = True) -> Image:
     """Normalize an image-like object to a standard format.
 
     This function handles a variety of input types, including lists, arrays,
@@ -39,6 +39,9 @@ def _normalize_image(src: ImageLike) -> Image:
     Args:
         src: An image-like object. This can be a list, array, tensor, or a
             file-like object.
+        normalize: If True, rescale pixel intensities from [min, max] to
+            [0, 255]. If False, pixel values are clipped to [0, 255] without
+            rescaling.
 
     Returns:
         A BytesIO object or other Image type.
@@ -68,7 +71,21 @@ def _normalize_image(src: ImageLike) -> Image:
             if hasattr(src, "toarray"):
                 src = src.toarray()
             src = numpy.array(src)
-        src = (src - src.min()) / (src.max() - src.min()) * 255.0
+        if normalize:
+            src_min = src.min()
+            src_max = src.max()
+            if src_min != src_max:
+                src = (src - src_min) / (src_max - src_min) * 255.0
+            else:
+                # Avoid division by zero for constant images
+                import numpy
+
+                src = numpy.full_like(src, fill_value=src_min, dtype=float)
+                src = numpy.clip(src, 0, 255)
+        else:
+            import numpy
+
+            src = numpy.clip(src, 0, 255).astype(float)
         img = _Image.fromarray(src.astype("uint8"))
         # io.BytesIO is one of the Image types.
         normalized_src: Image = io.BytesIO()
@@ -102,6 +119,7 @@ def image(
     rounded: bool = False,
     style: Optional[dict[str, Any]] = None,
     caption: Optional[str] = None,
+    normalize: bool = True,
 ) -> Html:
     """Render an image as HTML.
 
@@ -123,6 +141,11 @@ def image(
         )
         ```
 
+        ```python3
+        # Render an array image without normalization
+        mo.image(src=my_array, normalize=False)
+        ```
+
     Args:
         src: a path or URL to an image, a file-like object
             (opened in binary mode), or array-like object.
@@ -132,13 +155,17 @@ def image(
         rounded: whether to round the corners of the image
         style: a dictionary of CSS styles to apply to the image
         caption: the caption of the image
+        normalize: if True (default), rescale array pixel intensities
+            from [min, max] to [0, 255]. Set to False to disable
+            rescaling, which preserves relative intensity differences
+            across images. Only affects array-like inputs.
 
     Returns:
         `Html` object
     """
     # Convert to virtual file
     resolved_src: Optional[str]
-    src = _normalize_image(src)
+    src = _normalize_image(src, normalize=normalize)
     # TODO: Consider downsampling here. This is something matplotlib does
     # implicitly, and can potentially remove the bottle-neck of very large
     # images.

--- a/tests/_plugins/stateless/test_image.py
+++ b/tests/_plugins/stateless/test_image.py
@@ -209,3 +209,57 @@ def test_image_constructor_pil():
         Image.new("RGB", (100, 100), color="red"),
     )
     assert result.text.startswith("<img src='data:image/png;base64,")
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_image_normalize_flag():
+    """Test that normalize=False preserves original pixel values."""
+    import numpy as np
+    from PIL import Image as PILImage
+
+    dark = np.full((10, 10), 50, dtype=np.uint8)
+    light = np.full((10, 10), 200, dtype=np.uint8)
+
+    # With normalize=True (default), both images are rescaled to 0-255 range.
+    # Since each is a constant image, there is no min/max spread to rescale,
+    # but the important test is that normalize=False gives different results.
+    result_dark_norm = image(dark, normalize=True)
+    result_light_norm = image(light, normalize=True)
+
+    # With normalize=False, pixel values are preserved as-is.
+    result_dark_raw = image(dark, normalize=False)
+    result_light_raw = image(light, normalize=False)
+
+    # Decode the images and verify pixel values are preserved
+    # when normalize=False.
+    import base64
+    import re
+
+    def _decode_image(html_text: str) -> np.ndarray:
+        match = re.search(r"base64,([^']+)", html_text)
+        assert match, f"No base64 data found in {html_text[:100]}"
+        data = base64.b64decode(match.group(1))
+        img = PILImage.open(io.BytesIO(data))
+        return np.array(img)
+
+    dark_pixels = _decode_image(result_dark_raw.text)
+    light_pixels = _decode_image(result_light_raw.text)
+
+    # Without normalization, pixel values should be preserved.
+    assert np.all(dark_pixels == 50), (
+        f"Expected all pixels == 50, got unique values: {np.unique(dark_pixels)}"
+    )
+    assert np.all(light_pixels == 200), (
+        f"Expected all pixels == 200, got unique values: {np.unique(light_pixels)}"
+    )
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_image_normalize_constant_image():
+    """Test that normalize=True handles constant images without errors."""
+    import numpy as np
+
+    # A constant image should not cause division by zero
+    constant = np.full((10, 10), 128, dtype=np.uint8)
+    result = image(constant, normalize=True)
+    assert result.text.startswith("<img src='data:image/png;base64,")


### PR DESCRIPTION
## Summary

Adds a `normalize` parameter to `mo.image()` to control whether array pixel intensities are rescaled from `[min, max]` to `[0, 255]`.

- **`normalize=True`** (default): current behavior preserved -- pixel intensities are rescaled to the full `[0, 255]` range
- **`normalize=False`**: pixel values are clipped to `[0, 255]` without rescaling, preserving relative intensity differences across images

This also fixes a division-by-zero warning when displaying constant images (all pixels have the same value).

## Motivation

As reported in #8569, the forced normalization makes it impossible to visually compare different images within a dataset -- a "dark" image and a "light" image both get scaled to the same `0-255` range, destroying the relative physical meaning of pixel intensities.

## Changes

- `marimo/_plugins/stateless/image.py`:
  - Added `normalize` parameter to `_normalize_image()` (internal helper)
  - Added `normalize` parameter to `image()` (public API), defaulting to `True` for backward compatibility
  - Added division-by-zero guard for constant images
  - When `normalize=False`, pixel values are clipped to `[0, 255]` instead of rescaled

- `tests/_plugins/stateless/test_image.py`:
  - Added `test_image_normalize_flag` -- verifies pixel values are preserved when `normalize=False`
  - Added `test_image_normalize_constant_image` -- verifies constant images don't trigger division-by-zero

## Test plan

- [x] All existing tests pass (13/13 in `test_image.py`, 15/15 in `test_image_compare.py`)
- [x] New tests pass (2 new tests)
- [x] `ruff check` passes with no errors

Closes #8569