### PR TITLE
fix: remove SVG <title> tooltip from marimo icons

### DIFF
--- a/frontend/src/components/icons/marimo-icons.tsx
+++ b/frontend/src/components/icons/marimo-icons.tsx
@@ -81,9 +81,9 @@ export const MarimoIcon = ({
       width={width ?? size}
       height={height ?? size}
       viewBox={viewBox}
+      aria-hidden={true}
       {...props}
     >
-      <title>marimo icon</title>
       <MarimoCirclePaths
         fill={fill}
         stroke={stroke ?? "currentColor"}
@@ -119,9 +119,9 @@ const MarimoMultiIcon = ({
       width={width ?? size}
       height={height ?? size}
       viewBox={viewBox}
+      aria-hidden={true}
       {...props}
     >
-      <title>marimo multi icon</title>
       <defs>
         <mask id={maskId}>
           <rect width="100%" height="100%" fill="white" />


### PR DESCRIPTION
## 📝 Summary

This is a follow-up to PR #8471.

PR #8471 added an inline `<title>` to `MarimoIcon` to satisfy an a11y lint rule. However, browsers render SVG `<title>` as a native hover tooltip, which shows up in the UI (e.g., in the file tree) and breaks the app's look and feel.

## 🔍 Description of Changes

- Remove the inline `<title>` from `MarimoIcon` (prevents the native hover tooltip) 
- Add `aria-hidden={true}` to the `<svg>`

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
