### PR TITLE
fix: `mo.mpl.interactive` renders blank in `marimo run` mode (#8452)

### DIFF
--- a/marimo/_plugins/stateless/mpl/_mpl.py
+++ b/marimo/_plugins/stateless/mpl/_mpl.py
@@ -14,6 +14,7 @@ import mimetypes
 import os
 import threading
 import time
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -211,10 +212,21 @@ def _convert_scheme_to_ws(url: str) -> str:
 
 
 def _template(fig_id: str, port: int) -> str:
-    base_url = _get_remote_url() or f"http://localhost:{port}/"
-    base_url_and_path = f"{base_url}/mpl/{fig_id}"
-    base_url_and_path_ws = f"{base_url}/mpl/{port}"
-    ws_base_url = _convert_scheme_to_ws(base_url_and_path_ws)
+    remote_url = _get_remote_url()
+    if remote_url:
+        # Route through the marimo server proxy, which expects
+        # /mpl/{fig_id}/... for static assets and /mpl/{port}/ws for
+        # the WebSocket connection.
+        base_url_and_path = f"{remote_url}/mpl/{fig_id}"
+        ws_base = f"{remote_url}/mpl/{port}"
+    else:
+        # Direct access to the embedded matplotlib server.  The server
+        # only has top-level routes (/_static, /ws, /mpl.js, …), so we
+        # must NOT add the /mpl/{fig_id} prefix that the proxy expects.
+        base_url_and_path = f"http://localhost:{port}"
+        ws_base = f"http://localhost:{port}"
+
+    ws_base_url = _convert_scheme_to_ws(ws_base)
 
     return html_content % {
         "ws_uri": f"{ws_base_url}/ws?figure={fig_id}",
@@ -531,7 +543,17 @@ def interactive(figure: Union[Figure, SubFigure, Axes]) -> Html:
         return NonInteractiveMplHtml(figure)
 
     # Figure Manager, Any type because matplotlib doesn't have typings
-    figure_manager = new_figure_manager_given_figure(id(figure), figure)
+    # Suppress the "Starting a Matplotlib GUI outside of the main thread"
+    # warning.  In run mode the kernel executes on a worker thread, but
+    # our WebAgg canvas only renders to an Agg buffer and serves it over
+    # WebSocket — no actual GUI toolkit is involved.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Starting a Matplotlib GUI outside of the main thread",
+            category=UserWarning,
+        )
+        figure_manager = new_figure_manager_given_figure(id(figure), figure)
 
     # TODO(akshayka): Proxy this server through the marimo server to help with
     # deployment.

--- a/tests/_plugins/stateless/test_mpl.py
+++ b/tests/_plugins/stateless/test_mpl.py
@@ -232,15 +232,26 @@ def test_template_with_remote_url() -> None:
 
 
 def test_template_without_remote_url() -> None:
-    """Test _template function without remote URL"""
+    """Test _template function without remote URL.
+
+    When there is no remote URL (e.g. run-mode auto-instantiation via
+    WebSocket which lacks x-runtime-url), the template should generate
+    direct URLs to the embedded mpl server WITHOUT the /mpl/{fig_id}
+    proxy prefix — the embedded server only has top-level routes like
+    /ws, /_static, /mpl.js.
+    """
 
     with patch("marimo._plugins.stateless.mpl._mpl.app_meta") as mock_app_meta:
         mock_app_meta.return_value.request = None
 
         result = _template("test_fig", 8080)
 
-        assert "/mpl/8080/ws?figure=test_fig" in result
-        assert "/mpl/test_fig" in result
+        # WebSocket should connect directly to the embedded server
+        assert "ws://localhost:8080/ws?figure=test_fig" in result
+        # Base URL should be the embedded server root (no /mpl/ prefix)
+        assert "http://localhost:8080" in result
+        # Should NOT contain the proxy-style /mpl/{fig_id} prefix
+        assert "/mpl/test_fig" not in result
 
 
 def test_template_contains_html_structure() -> None:
@@ -257,7 +268,8 @@ def test_template_contains_html_structure() -> None:
         assert "<body>" in result
         assert '<div id="figure"></div>' in result
         assert "12345" in result
-        assert "9000" in result
+        # Port should appear in the WebSocket URL
+        assert "ws://localhost:9000/ws?figure=12345" in result
 
 
 def test_template_contains_visibilitychange_refresh() -> None:
@@ -277,6 +289,48 @@ def test_template_contains_visibilitychange_refresh() -> None:
         assert "visibilitychange" in result
         assert "document.hidden" in result
         assert 'send_message("refresh"' in result
+
+
+def test_template_static_asset_paths_direct() -> None:
+    """Regression test for https://github.com/marimo-team/marimo/issues/8452.
+
+    Without a remote URL the template must use paths that the embedded
+    matplotlib server actually serves (e.g. /_static/…, /mpl.js).
+    The proxy-style /mpl/{fig_id}/… prefix must NOT appear.
+    """
+
+    with patch("marimo._plugins.stateless.mpl._mpl.app_meta") as mock_app_meta:
+        mock_app_meta.return_value.request = None
+
+        result = _template("99999", 11000)
+
+        # base href should be the server root so relative paths resolve
+        # to top-level routes that the embedded server exposes.
+        assert "http://localhost:11000" in result
+        # Static CSS is referenced as %(base_url)s/_static/css/page.css
+        # so the resolved URL must be http://localhost:11000/_static/…
+        assert "http://localhost:11000/_static/css/page.css" in result
+        assert "http://localhost:11000/mpl.js" in result
+        assert "http://localhost:11000/custom.css" in result
+
+
+def test_template_static_asset_paths_proxy() -> None:
+    """With a remote URL the template routes through the marimo server
+    proxy which expects the /mpl/{fig_id}/… prefix."""
+
+    mock_request = MagicMock()
+    mock_request.headers.get.return_value = "http://localhost:2718"
+
+    with patch("marimo._plugins.stateless.mpl._mpl.app_meta") as mock_app_meta:
+        mock_app_meta.return_value.request = mock_request
+
+        result = _template("99999", 11000)
+
+        # Proxy-style paths
+        assert "http://localhost:2718/mpl/99999/_static/css/page.css" in result
+        assert "http://localhost:2718/mpl/99999/mpl.js" in result
+        assert "wss://localhost:2718/mpl/11000/ws?figure=99999" not in result
+        assert "ws://localhost:2718/mpl/11000/ws?figure=99999" in result
 
 
 def test_mpl_server_manager() -> None:


### PR DESCRIPTION
Closes #8452

## Description

Since v0.19.0 `marimo run` executes kernels in threads instead of
subprocesses. In run mode the session is auto-instantiated from the
WebSocket handler, and the browser WebSocket API does not support
custom headers — so the `x-runtime-url` header that `mpl.interactive`
relies on is absent.

When `_get_remote_url()` returned `""`, `_template()` still prepended
the proxy-style `/mpl/{fig_id}` prefix to every URL. But the embedded
matplotlib server only exposes top-level routes (`/ws`, `/_static/…`,
`/mpl.js`), so all static assets and the WebSocket connection 404'd,
producing a blank rectangle.

### Changes

- **`marimo/_plugins/stateless/mpl/_mpl.py`**
  - `_template()`: when there is no remote URL, generate direct URLs
    to the embedded server *without* the `/mpl/{fig_id}` proxy prefix.
  - Suppress the harmless "Starting a Matplotlib GUI outside of the
    main thread" `UserWarning` around WebAgg figure-manager creation
    (the rendering is Agg-based, no actual GUI toolkit is involved).
