### PR TITLE
Add mo.image normalization controls and fix constant-array handling

### DIFF
--- a/marimo/_plugins/stateless/image.py
+++ b/marimo/_plugins/stateless/image.py
@@ -21,7 +21,13 @@ Tensor = Any
 ImageLike = Union[Image, Tensor]
 
 
-def _normalize_image(src: ImageLike) -> Image:
+def _normalize_image(
+    src: ImageLike,
+    *,
+    normalize: bool = True,
+    vmin: Optional[float] = None,
+    vmax: Optional[float] = None,
+) -> Image:
     """Normalize an image-like object to a standard format.
 
     This function handles a variety of input types, including lists, arrays,
@@ -39,6 +45,9 @@ def _normalize_image(src: ImageLike) -> Image:
     Args:
         src: An image-like object. This can be a list, array, tensor, or a
             file-like object.
+        normalize: Whether to normalize array-like inputs to the 0-255 range.
+        vmin: Lower bound used for normalization when ``normalize=True``.
+        vmax: Upper bound used for normalization when ``normalize=True``.
 
     Returns:
         A BytesIO object or other Image type.
@@ -68,8 +77,25 @@ def _normalize_image(src: ImageLike) -> Image:
             if hasattr(src, "toarray"):
                 src = src.toarray()
             src = numpy.array(src)
-        src = (src - src.min()) / (src.max() - src.min()) * 255.0
-        img = _Image.fromarray(src.astype("uint8"))
+
+        import numpy as np
+
+        src_array = np.asarray(src, dtype=float)
+
+        if not normalize and (vmin is not None or vmax is not None):
+            raise ValueError("vmin/vmax can only be used when normalize=True")
+
+        if normalize:
+            lower = src_array.min() if vmin is None else float(vmin)
+            upper = src_array.max() if vmax is None else float(vmax)
+            if upper < lower:
+                raise ValueError("vmax must be greater than or equal to vmin")
+            if upper > lower:
+                src_array = (src_array - lower) / (upper - lower) * 255.0
+
+        src_array = np.clip(src_array, 0, 255)
+
+        img = _Image.fromarray(src_array.astype("uint8"))
         # io.BytesIO is one of the Image types.
         normalized_src: Image = io.BytesIO()
         img.save(normalized_src, format="PNG")
@@ -102,6 +128,9 @@ def image(
     rounded: bool = False,
     style: Optional[dict[str, Any]] = None,
     caption: Optional[str] = None,
+    normalize: bool = True,
+    vmin: Optional[float] = None,
+    vmax: Optional[float] = None,
 ) -> Html:
     """Render an image as HTML.
 
@@ -132,13 +161,16 @@ def image(
         rounded: whether to round the corners of the image
         style: a dictionary of CSS styles to apply to the image
         caption: the caption of the image
+        normalize: whether to normalize array-like inputs to the 0-255 range
+        vmin: lower bound used when normalizing array-like inputs
+        vmax: upper bound used when normalizing array-like inputs
 
     Returns:
         `Html` object
     """
     # Convert to virtual file
     resolved_src: Optional[str]
-    src = _normalize_image(src)
+    src = _normalize_image(src, normalize=normalize, vmin=vmin, vmax=vmax)
     # TODO: Consider downsampling here. This is something matplotlib does
     # implicitly, and can potentially remove the bottle-neck of very large
     # images.

--- a/tests/_plugins/stateless/test_image.py
+++ b/tests/_plugins/stateless/test_image.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._plugins.stateless.image import image
+from marimo._plugins.stateless.image import _normalize_image, image
 from marimo._runtime.context import get_context
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
@@ -175,6 +175,59 @@ async def test_image_local_file(k: Kernel, exec_req: ExecReqProvider) -> None:
             ]
         )
         assert len(get_context().virtual_file_registry.registry) == 1
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_normalize_image_constant_array_preserves_values() -> None:
+    import numpy as np
+    from PIL import Image as PILImage
+
+    normalized = _normalize_image(np.full((4, 4), 50, dtype=np.uint8))
+    assert isinstance(normalized, io.BytesIO)
+
+    normalized.seek(0)
+    pixel_values = np.asarray(PILImage.open(normalized))
+    assert pixel_values.min() == 50
+    assert pixel_values.max() == 50
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_normalize_image_can_be_disabled() -> None:
+    import numpy as np
+    from PIL import Image as PILImage
+
+    normalized = _normalize_image(
+        np.array([[10.0, 20.0], [30.0, 40.0]]),
+        normalize=False,
+    )
+    normalized.seek(0)
+
+    pixel_values = np.asarray(PILImage.open(normalized))
+    assert pixel_values.tolist() == [[10, 20], [30, 40]]
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_normalize_image_with_vmin_vmax() -> None:
+    import numpy as np
+    from PIL import Image as PILImage
+
+    normalized = _normalize_image(
+        np.array([[50.0, 200.0]]),
+        vmin=0,
+        vmax=255,
+    )
+    normalized.seek(0)
+
+    pixel_values = np.asarray(PILImage.open(normalized))
+    assert pixel_values.tolist() == [[50, 200]]
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_normalize_image_rejects_vmin_vmax_without_normalization() -> None:
+    import numpy as np
+
+    with pytest.raises(ValueError, match="normalize=True"):
+        _normalize_image(np.array([[1.0, 2.0]]), normalize=False, vmin=0)
 
 
 def test_image_constructor(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add `normalize`, `vmin`, and `vmax` options to `mo.image(...)` for array-like inputs
- avoid divide-by-zero behavior for constant-valued arrays by skipping min-max scaling when bounds collapse
- clip array-like image values into `[0, 255]` before uint8 conversion
- add focused tests for constant arrays, disabling normalization, explicit `vmin`/`vmax`, and invalid argument combinations

## Why
Fixes the issue where `mo.image` always performed per-image min/max normalization and produced unstable results for constant arrays.

Closes #8569

## Validation
- `python3 -m compileall marimo/_plugins/stateless/image.py tests/_plugins/stateless/test_image.py`