### PR TITLE
docs: link to docs in language server page

### DIFF
--- a/docs/guides/editor_features/language_server.md
+++ b/docs/guides/editor_features/language_server.md
@@ -86,7 +86,7 @@ uv pip install ty
 enabled = true
 ```
 
-See the [ty repository](https://github.com/astral-sh/ty) for more information.
+See the [ty docs](https://docs.astral.sh/ty/features/language-server/) for more information.
 
 ### pyrefly
 
@@ -106,7 +106,7 @@ uv pip install pyrefly
 enabled = true
 ```
 
-See the [pyrefly repository](https://github.com/facebook/pyrefly) for more information.
+See the [pyrefly docs](https://pyrefly.org/en/docs/IDE-features/) for more information.
 
 ### GitHub Copilot
 


### PR DESCRIPTION
## 📝 Summary

The ty/basedpyright/pyright sections link to their docs, whereas for ty/pyrefly they link to the repos

A pyrefly dev suggested to me that they should link to https://pyrefly.org/en/docs/IDE-features/ so that there's the complete list of IDE features there

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
