### PR TITLE
chore: Replace subprocess in cli tests with click's runner.

### DIFF
--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -11,11 +11,13 @@ import time
 from os import path
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest import mock
 
 import click
 import pytest
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 
+from marimo._cli.cli import main
 from marimo._cli.export.commands import pdf
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._session.state.serialize import get_session_cache_file
@@ -41,29 +43,32 @@ def _is_win32() -> bool:
     return sys.platform == "win32"
 
 
+_runner = CliRunner()
+
+
 def _run_export(
     export_format: str,
     file: str,
     *extra_args: str,
-    capture_output: bool = True,
-    input_data: bytes | None = None,
-) -> subprocess.CompletedProcess[bytes]:
-    """Helper to run marimo export commands."""
-    cmd = ["marimo", "export", export_format, file, *extra_args]
-    return subprocess.run(
-        cmd,
-        check=False,
-        capture_output=capture_output,
-        input=input_data,
+    stdin: str | None = None,
+) -> Result:
+    """Helper to run marimo export commands via CliRunner."""
+    return _runner.invoke(
+        main,
+        ["export", export_format, file, *extra_args],
+        input=stdin,
     )
 
 
-def _assert_success(p: subprocess.CompletedProcess[bytes]) -> None:
-    assert p.returncode == 0, p.stderr.decode()
+def _assert_success(r: Result) -> None:
+    # Re-raise unexpected exceptions so failures are clearly surfaced
+    if r.exception and not isinstance(r.exception, SystemExit):
+        raise r.exception
+    assert r.exit_code == 0, r.output
 
 
-def _assert_failure(p: subprocess.CompletedProcess[bytes]) -> None:
-    assert p.returncode != 0, p.stderr.decode()
+def _assert_failure(r: Result) -> None:
+    assert r.exit_code != 0, r.output
 
 
 def _get_snapshot_path(export_format: str, name: str) -> str:
@@ -82,7 +87,7 @@ class TestExportHTML:
     def test_cli_export_html(temp_marimo_file: str) -> None:
         p = _run_export("html", temp_marimo_file)
         _assert_success(p)
-        html = normalize_index_html(p.stdout.decode())
+        html = normalize_index_html(p.output)
         html = _normalize_html_path(html, temp_marimo_file)
         assert '<marimo-code hidden=""></marimo-code>' not in html
 
@@ -90,7 +95,7 @@ class TestExportHTML:
     def test_cli_export_html_no_code(temp_marimo_file: str) -> None:
         p = _run_export("html", temp_marimo_file, "--no-include-code")
         _assert_success(p)
-        html = normalize_index_html(p.stdout.decode())
+        html = normalize_index_html(p.output)
         html = _normalize_html_path(html, temp_marimo_file)
         assert '<marimo-code hidden=""></marimo-code>' in html
 
@@ -113,6 +118,48 @@ class TestExportHTML:
         assert "<marimo-wasm" in html
         assert '"showAppCode": false' in html
         assert Path(out_dir / ".nojekyll").exists()
+
+    @staticmethod
+    def test_cli_export_html_wasm_no_override(temp_marimo_file: str) -> None:
+        out_dir = Path(temp_marimo_file).parent / "out"
+        out_dir.mkdir()
+        Path(out_dir / "index.html").touch()
+        with mock.patch(
+            "marimo._cli.export.commands.prompt_to_overwrite",
+            return_value=False,
+        ):
+            p = _run_export(
+                "html-wasm",
+                temp_marimo_file,
+                "--mode",
+                "edit",
+                "--output",
+                str(out_dir),
+            )
+            _assert_success(p)
+            html = Path(out_dir / "index.html").read_text()
+            assert "" == html
+
+    @staticmethod
+    def test_cli_export_html_wasm_override(temp_marimo_file: str) -> None:
+        out_dir = Path(temp_marimo_file).parent / "out"
+        out_dir.mkdir()
+        Path(out_dir / "index.html").touch()
+        with mock.patch(
+            "marimo._cli.export.commands.prompt_to_overwrite",
+            return_value=True,
+        ):
+            p = _run_export(
+                "html-wasm",
+                temp_marimo_file,
+                "--mode",
+                "edit",
+                "--output",
+                str(out_dir),
+            )
+            _assert_success(p)
+            html = Path(out_dir / "index.html").read_text()
+            assert "" != html
 
     @staticmethod
     def test_cli_export_html_wasm_public_folder(temp_marimo_file: str) -> None:
@@ -245,10 +292,10 @@ class TestExportHTML:
     def test_cli_export_async(temp_async_marimo_file: str) -> None:
         p = _run_export("html", temp_async_marimo_file)
         _assert_success(p)
-        stderr = p.stderr.decode()
+        stderr = p.stderr or ""
         assert "ValueError" not in stderr
         assert "Traceback" not in stderr
-        html = normalize_index_html(p.stdout.decode())
+        html = normalize_index_html(p.output)
         html = _normalize_html_path(html, temp_async_marimo_file)
         assert '<marimo-code hidden=""></marimo-code>' not in html
 
@@ -258,9 +305,9 @@ class TestExportHTML:
     ) -> None:
         p = _run_export("html", temp_marimo_file_with_errors)
         _assert_failure(p)
-        html = normalize_index_html(p.stdout.decode())
+        html = normalize_index_html(p.output)
         # Errors but still produces HTML
-        assert " division by zero" in p.stderr.decode()
+        assert " division by zero" in p.stderr
         assert "<marimo-code" in html
 
     @staticmethod
@@ -270,8 +317,8 @@ class TestExportHTML:
         p = _run_export("html", temp_marimo_file_with_multiple_definitions)
         _assert_failure(p)
         # Errors but still produces HTML
-        assert "MultipleDefinitionError" in p.stderr.decode()
-        assert "<marimo-code" in p.stdout.decode()
+        assert "MultipleDefinitionError" in p.stderr
+        assert "<marimo-code" in p.output
 
     @pytest.mark.skipif(
         condition=DependencyManager.watchdog.has(),
@@ -345,8 +392,13 @@ class TestExportHTML:
     @staticmethod
     @pytest.mark.skipif(not HAS_UV, reason="uv is required for sandbox tests")
     def test_cli_export_html_sandbox(temp_marimo_file: str) -> None:
-        p = _run_export("html", temp_marimo_file, "--sandbox")
-        _assert_success(p)
+        # Must use subprocess: sandbox re-invokes via uv using sys.argv[1:]
+        p = subprocess.run(
+            ["marimo", "export", "html", temp_marimo_file, "--sandbox"],
+            check=False,
+            capture_output=True,
+        )
+        assert p.returncode == 0, p.stderr.decode()
         output = p.stderr.decode()
         # Check for sandbox message
         assert "Running in a sandbox" in output
@@ -366,18 +418,21 @@ class TestExportHTML:
         Test that the --force/-f flag allows overwriting an existing file
         using a simple, error-free notebook.
         """
-        p1 = _run_export("html", temp_marimo_file)
-        _assert_success(p1)
-        html = normalize_index_html(p1.stdout.decode())
-        html = _normalize_html_path(html, temp_marimo_file)
-        assert '<marimo-code hidden=""></marimo-code>' not in html
         output_path = Path(temp_marimo_file).parent / "output.html"
 
-        p2 = _run_export(
-            "html", temp_marimo_file, "-o", str(output_path), input_data=b"n\n"
-        )
-        assert p2.returncode == 0, "Expected a graceful exit with no errors"
+        # First export creates the file
+        p1 = _run_export("html", temp_marimo_file, "-o", str(output_path))
+        _assert_success(p1)
 
+        # With TTY simulated, "n\n" on stdin causes graceful exit (no overwrite)
+        with mock.patch("marimo._cli.utils.stdout") as mock_stdout:
+            mock_stdout.isatty.return_value = True
+            p2 = _run_export(
+                "html", temp_marimo_file, "-o", str(output_path), stdin="n\n"
+            )
+        assert p2.exit_code == 0, "Expected graceful exit when user answers no"
+
+        # --force skips the prompt entirely
         p3 = _run_export(
             "html", temp_marimo_file, "-o", str(output_path), "--force"
         )
@@ -385,33 +440,25 @@ class TestExportHTML:
 
 
 class TestExportHtmlSmokeTests:
-    def _assert_no_traceback(
-        self, p: subprocess.CompletedProcess[bytes]
-    ) -> None:
+    def _assert_no_traceback(self, p: Result) -> None:
         """Assert no traceback in stdout or stderr."""
         assert not any(
-            line.startswith("Traceback")
-            for line in p.stderr.decode().splitlines()
+            line.startswith("Traceback") for line in p.stderr.splitlines()
         )
         assert not any(
-            line.startswith("Traceback")
-            for line in p.stdout.decode().splitlines()
+            line.startswith("Traceback") for line in p.output.splitlines()
         )
 
-    def _assert_not_errored(
-        self, p: subprocess.CompletedProcess[bytes]
-    ) -> None:
+    def _assert_not_errored(self, p: Result) -> None:
         _assert_success(p)
         self._assert_no_traceback(p)
 
-    def _assert_has_errors(
-        self, p: subprocess.CompletedProcess[bytes]
-    ) -> None:
+    def _assert_has_errors(self, p: Result) -> None:
         _assert_failure(p)
         assert any(
             "Export was successful, but some cells failed to execute" in line
-            for line in p.stderr.decode().splitlines()
-        ), p.stderr.decode()
+            for line in p.stderr.splitlines()
+        ), p.output
         self._assert_no_traceback(p)
 
     def _export_tutorial(
@@ -420,7 +467,7 @@ class TestExportHtmlSmokeTests:
         module_import: str,
         filename: str = "mod.py",
         extra_args: tuple[str, ...] = (),
-    ) -> subprocess.CompletedProcess[bytes]:
+    ) -> Result:
         """Helper to export a tutorial module to HTML."""
         module = __import__(
             f"marimo._tutorials.{module_import}",
@@ -473,15 +520,14 @@ class TestExportScript:
     def test_export_script(temp_marimo_file: str) -> None:
         p = _run_export("script", temp_marimo_file)
         _assert_success(p)
-        snapshot(_get_snapshot_path("script", "script"), p.stdout.decode())
+        snapshot(_get_snapshot_path("script", "script"), p.output)
 
     @staticmethod
     def test_export_script_async(temp_async_marimo_file: str) -> None:
         p = _run_export("script", temp_async_marimo_file)
-        assert p.returncode == 1, p.stderr.decode()
-        assert (
-            "Cannot export a notebook with async code to a flat script"
-            in p.stderr.decode()
+        assert p.exit_code == 1, p.output
+        assert "Cannot export a notebook with async code to a flat script" in (
+            p.output
         )
 
     @staticmethod
@@ -490,11 +536,9 @@ class TestExportScript:
     ) -> None:
         p = _run_export("script", temp_marimo_file_with_multiple_definitions)
         _assert_failure(p)
-        error_message = p.stderr.decode()
-        assert (
-            "MultipleDefinitionError: This app can't be run because it has multiple definitions of the name x"
-            in error_message
-        )
+        # MultipleDefinitionError is uncaught; CliRunner stores it in exception
+        error_message = str(p.exception) if p.exception else p.output
+        assert "multiple definitions of the name x" in error_message
 
     @staticmethod
     def test_export_script_with_errors(
@@ -504,7 +548,7 @@ class TestExportScript:
         _assert_success(p)
         snapshot(
             _get_snapshot_path("script", "script_with_errors"),
-            p.stdout.decode(),
+            p.output,
         )
 
     @pytest.mark.skipif(
@@ -586,19 +630,19 @@ class TestExportMarkdown:
     def test_export_markdown(temp_marimo_file: str) -> None:
         p = _run_export("md", temp_marimo_file)
         _assert_success(p)
-        snapshot(_get_snapshot_path("md", "markdown"), p.stdout.decode())
+        snapshot(_get_snapshot_path("md", "markdown"), p.output)
 
     @staticmethod
     def test_export_markdown_async(temp_async_marimo_file: str) -> None:
         p = _run_export("md", temp_async_marimo_file)
         _assert_success(p)
-        snapshot(_get_snapshot_path("md", "async"), p.stdout.decode())
+        snapshot(_get_snapshot_path("md", "async"), p.output)
 
     @staticmethod
     def test_export_markdown_broken(temp_unparsable_marimo_file: str) -> None:
         p = _run_export("md", temp_unparsable_marimo_file)
         _assert_success(p)
-        snapshot(_get_snapshot_path("md", "broken"), p.stdout.decode())
+        snapshot(_get_snapshot_path("md", "broken"), p.output)
 
     @staticmethod
     def test_export_markdown_with_errors(
@@ -608,7 +652,7 @@ class TestExportMarkdown:
         _assert_success(p)
         snapshot(
             _get_snapshot_path("md", "export_markdown_with_errors"),
-            p.stdout.decode(),
+            p.output,
         )
 
     @pytest.mark.skipif(
@@ -694,7 +738,7 @@ class TestExportIpynb:
         p = _run_export("ipynb", temp_marimo_file_with_md)
         _assert_success(p)
         # ipynb has non-deterministic ids
-        snapshot(_get_snapshot_path("ipynb", "ipynb"), p.stdout.decode())
+        snapshot(_get_snapshot_path("ipynb", "ipynb"), p.output)
 
     @pytest.mark.skipif(
         not DependencyManager.nbformat.has(),
@@ -706,14 +750,14 @@ class TestExportIpynb:
         # Test topological sort (default)
         p = _run_export("ipynb", temp_marimo_file_with_md)
         _assert_success(p)
-        topo_output = p.stdout.decode()
+        topo_output = p.output
 
         # Test top-down sort
         p = _run_export(
             "ipynb", temp_marimo_file_with_md, "--sort", "top-down"
         )
         _assert_success(p)
-        topdown_output = p.stdout.decode()
+        topdown_output = p.output
         snapshot(_get_snapshot_path("ipynb", "ipynb_topdown"), topdown_output)
 
         # Outputs should be different since sorting is different
@@ -729,12 +773,12 @@ class TestExportIpynb:
         # Test without outputs (default)
         p = _run_export("ipynb", temp_marimo_file_with_md)
         _assert_success(p)
-        no_outputs = p.stdout.decode()
+        no_outputs = p.output
 
         # Test with outputs
         p = _run_export("ipynb", temp_marimo_file_with_md, "--include-outputs")
         _assert_success(p)
-        with_outputs = p.stdout.decode()
+        with_outputs = p.output
         snapshot(
             _get_snapshot_path("ipynb", "ipynb_with_outputs"), with_outputs
         )
@@ -757,7 +801,7 @@ class TestExportIpynb:
             "--no-sandbox",
         )
         _assert_success(p)
-        with_outputs = p.stdout.decode()
+        with_outputs = p.output
         with_outputs = simplify_images(with_outputs)
         with_outputs = simplify_plotly(with_outputs)
         with_outputs = _sanitize_version(with_outputs)
@@ -780,7 +824,7 @@ class TestExportIpynb:
         )
         _assert_failure(p)
         # Error is now captured in the ipynb output as a proper Jupyter error
-        output = p.stdout.decode()
+        output = p.output
         assert "multiple-defs" in output
         assert "was defined by another cell" in output
 
@@ -797,7 +841,7 @@ class TestExportIpynb:
         _assert_failure(p)
         # Error is now captured in the ipynb output (stdout) as a proper
         # Jupyter error output, not printed to stderr
-        output = p.stdout.decode()
+        output = p.output
         assert "division by zero" in output
         output = delete_lines_with_files(output)
         snapshot(_get_snapshot_path("ipynb", "ipynb_with_errors"), output)
@@ -809,15 +853,22 @@ class TestExportIpynb:
     )
     def test_cli_export_ipynb_sandbox(temp_marimo_file: str) -> None:
         output_file = temp_marimo_file.replace(".py", "_sandbox.ipynb")
-        p = _run_export(
-            "ipynb",
-            temp_marimo_file,
-            "--sandbox",
-            "--include-outputs",
-            "--output",
-            output_file,
+        # Must use subprocess: sandbox re-invokes via uv using sys.argv[1:]
+        p = subprocess.run(
+            [
+                "marimo",
+                "export",
+                "ipynb",
+                temp_marimo_file,
+                "--sandbox",
+                "--include-outputs",
+                "--output",
+                output_file,
+            ],
+            check=False,
+            capture_output=True,
         )
-        _assert_success(p)
+        assert p.returncode == 0, p.stderr.decode()
         output = p.stderr.decode()
         # Check for sandbox message
         assert "Running in a sandbox" in output
@@ -839,7 +890,7 @@ class TestExportIpynb:
             "--no-include-outputs",
         )
         _assert_success(p)
-        output = p.stdout.decode()
+        output = p.output
         # Should be valid JSON since sandbox is not used
         notebook = json.loads(output)
         assert "cells" in notebook
@@ -885,7 +936,7 @@ class TestExportPDF:
             "--no-include-inputs",
         )
         _assert_failure(p)
-        stderr = p.stderr.decode()
+        stderr = p.output
         assert "nbconvert" in stderr
         assert "pip install" in stderr
 
@@ -904,7 +955,7 @@ class TestExportPDF:
             "--no-sandbox",
         )
         _assert_failure(p)
-        stderr = p.stderr.decode()
+        stderr = p.output
         assert "Rasterization options require --include-outputs." in stderr
 
     @staticmethod
@@ -923,7 +974,7 @@ class TestExportPDF:
             "--no-sandbox",
         )
         _assert_failure(p)
-        stderr = p.stderr.decode()
+        stderr = p.output
         assert "Rasterization options require --include-outputs." in stderr
 
     @staticmethod
@@ -942,7 +993,7 @@ class TestExportPDF:
             "--no-sandbox",
         )
         _assert_failure(p)
-        stderr = p.stderr.decode()
+        stderr = p.output
         assert "Rasterization options require --include-outputs." in stderr
 
     @staticmethod
@@ -1126,7 +1177,7 @@ class TestExportSession:
 
         unchanged = json.loads(session_file.read_text(encoding="utf-8"))
         assert unchanged.get("custom") == "keep-me"
-        assert b"skip" in p.stdout
+        assert "skip" in p.output
 
     @staticmethod
     def test_export_session_force_overwrite_rewrites_up_to_date(
@@ -1281,7 +1332,7 @@ class TestExportSession:
 
         second = _run_export("session", temp_marimo_file_with_errors)
         _assert_success(second)
-        assert b"skip" in second.stdout
+        assert "skip" in second.output
         unchanged = json.loads(session_file.read_text(encoding="utf-8"))
         assert unchanged.get("custom") == "should-be-overwritten"
 


### PR DESCRIPTION
Also add tests for export override.

## 📝 Summary

Move test runner from subprocess to a click Runner.

## 🔍 Description of Changes

Using click's runner means that the export function runs in the same python process as the test so we can patch the behaviour of prompt_to_override. This PR is also adds tests checking that export WASM respects these flags.

## 📋 Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
