### PR TITLE
optimize for lazy as_frame, fix snapshot tests

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -66,10 +66,14 @@ class NarwhalsTableManager(
     ) -> NarwhalsTableManager[IntoDataFrameT, IntoLazyFrameT]:
         return NarwhalsTableManager(nw.from_native(data, pass_through=False))
 
-    def as_frame(self) -> nw.DataFrame[Any]:
+    @cached_property
+    def _collected_frame(self) -> nw.DataFrame[Any]:
         if is_narwhals_lazyframe(self.data):
             return self.data.collect()
         return self.data
+
+    def as_frame(self) -> nw.DataFrame[Any]:
+        return self._collected_frame
 
     def as_lazy_frame(self) -> nw.LazyFrame[Any]:
         if is_narwhals_lazyframe(self.data):
@@ -544,6 +548,11 @@ class NarwhalsTableManager(
             return []
 
         dtype = self.nw_schema[column]
+
+        # Some backends (e.g. DuckDB) report Unknown for types like Time
+        # until the data is collected. Resolve by checking the collected schema.
+        if dtype == nw.Unknown:
+            dtype = self.as_frame().schema[column]
 
         if dtype.is_temporal():
             return self._get_bin_values_temporal(column, dtype, num_bins)

--- a/tests/_sql/test_sql.py
+++ b/tests/_sql/test_sql.py
@@ -485,9 +485,9 @@ logical_plan
         assert result == snapshot("""\
 physical_plan
 ┌───────────────────────────┐
-│         SEQ_SCAN          │
+│          SEQ_SCAN         │
 │    ────────────────────   │
-│          Table: t         │
+│    Table: memory.main.t   │
 │   Type: Sequential Scan   │
 │      Projections: id      │
 │                           │


### PR DESCRIPTION
These tests were failing in CI, duckdb starts returning unknown backend types since the latest duckdb release.
An optimization was made so that `as_frame` calls doesn't collect for each call, but gets the cached property instead.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
