### PR TITLE
send absolute path to frontend for file_browser

### DIFF
--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -211,7 +211,7 @@ class file_browser(
             initial_value=[],
             label=label,
             args={
-                "initial-path": str(initial_path),
+                "initial-path": str(self._initial_path),
                 "selection-mode": selection_mode,
                 "filetypes": filetypes if filetypes is not None else [],
                 "multiple": multiple,
@@ -300,8 +300,7 @@ class file_browser(
 
         if self._restrict_navigation and path in self._initial_path.parents:
             raise RuntimeError(
-                "Navigation is restricted; navigating to a "
-                "parent of initial path is not allowed."
+                "Navigation is restricted; navigating to a parent of initial path is not allowed."
             )
         folders: list[TypedFileBrowserFileInfo] = []
         files: list[TypedFileBrowserFileInfo] = []

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -951,3 +951,33 @@ def test_file_browser_relative_path_normalization(tmp_path: Path) -> None:
     finally:
         # Restore original directory
         os.chdir(original_cwd)
+
+
+def test_file_browser_relative_path_sent_to_frontend_as_absolute(
+    tmp_path: Path,
+) -> None:
+    """Test that the initial-path arg sent to the frontend is always absolute."""
+    sub_dir = tmp_path / "subdir"
+    sub_dir.mkdir()
+    (sub_dir / "file.txt").touch()
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+
+        for rel_path in ["subdir", "./subdir", Path("subdir")]:
+            fb = file_browser(initial_path=rel_path)
+            initial_path_arg = str(fb._component_args["initial-path"])  # pyright: ignore[reportPrivateUsage]
+            assert "/" in initial_path_arg, (
+                f"initial-path sent to frontend must contain '/' "
+                f"(be absolute), got: {initial_path_arg!r}"
+            )
+            assert Path(initial_path_arg).is_absolute()
+
+            # Navigating up from the initial path should work
+            parent = str(Path(initial_path_arg).parent)
+            response = fb._list_directory(ListDirectoryArgs(path=parent))  # pyright: ignore[reportPrivateUsage]
+            assert isinstance(response, ListDirectoryResponse)
+
+    finally:
+        os.chdir(original_cwd)


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Fixes #8665 

In the backend, we passed the relative path to the frontend. We should instead send the normalized absolute path.

The un-normalized path would cause errors with the frontend's guessDeliminator, so passing "." would parse the delimiter as `\\` even on Mac, when it should be `/`

before:
<img width="568" height="491" alt="image" src="https://github.com/user-attachments/assets/b29f3000-bf63-416b-ba7a-f7a0400abc96" />

after:
<img width="801" height="491" alt="image" src="https://github.com/user-attachments/assets/df62c1ff-3f28-4a0a-9e0f-be61e2cd6372" />


## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
