### PR TITLE
fix: ignore sql_refs for top level determination

### DIFF
--- a/marimo/_ast/toplevel.py
+++ b/marimo/_ast/toplevel.py
@@ -167,7 +167,12 @@ class TopLevelStatus:
                 self.demote(HINT_HAS_REFS.format(self.dependencies))
             return
 
-        dependent_refs = self._cell.refs - (allowed_refs | toplevel)
+        # SQL refs are runtime dependencies, not definition-time dependencies.
+        # Exclude them from top-level resolution so SQL-using functions are not
+        # incorrectly demoted. General ref tracking in visitor.py is unchanged.
+        dependent_refs = (self._cell.refs - self._cell.sql_refs.keys()) - (
+            allowed_refs | toplevel
+        )
         if not dependent_refs:
             self.type = TopLevelType.TOPLEVEL
             self.hint = HINT_VALID

--- a/tests/_ast/test_toplevel.py
+++ b/tests/_ast/test_toplevel.py
@@ -695,8 +695,12 @@ class TestTopLevelSQL:
 
     @staticmethod
     @pytest.mark.skipif(not HAS_DUCKDB, reason="Requires duckdb")
-    def test_sql_external_refs_not_toplevel(app) -> None:
-        """@app.function referencing genuinely external tables — should remain CELL."""
+    def test_sql_external_refs_toplevel(app) -> None:
+        """@app.function referencing external SQL tables — still TOPLEVEL.
+
+        SQL table references are runtime dependencies, not definition-time
+        dependencies, so they don't prevent a function from being top-level.
+        """
 
         @app.function
         def query_external():
@@ -705,6 +709,6 @@ class TestTopLevelSQL:
             return duckdb.sql("SELECT * FROM some_external_table").df()
 
         extraction = TopLevelExtraction.from_app(InternalApp(app))
-        assert [TopLevelType.CELL] == [s.type for s in extraction], [
+        assert [TopLevelType.TOPLEVEL] == [s.type for s in extraction], [
             s.hint for s in extraction
         ]


### PR DESCRIPTION
## 📝 Summary

We drop `sql_refs` in determination of toplevel functions since they are not passed into the signature and can "live" outside of the runtime graph (e.g. as an external attach or db).