### PR TITLE
fix: remove unreachable deferred call handling in `_cache_call_async`

### DIFF
--- a/marimo/_save/save.py
+++ b/marimo/_save/save.py
@@ -541,18 +541,6 @@ class _cache_call_async(_cache_call[P, R]):
     async def __call__(  # type: ignore[override]
         self, *args: P.args, **kwargs: P.kwargs
     ) -> R:
-        # Capture the deferred call case
-        if self.__wrapped__ is None:
-            if len(args) != 1:
-                raise TypeError(
-                    "cache() takes at most 1 argument (expecting function)"
-                )
-            # Remove the additional frames from singledispatch, because invoking
-            # the function directly.
-            self._frame_offset -= 4
-            self._set_context(cast(Callable[..., Any], args[0]))
-            return self  # type: ignore[return-value]
-
         # Prepare execution context to get cache key
         scope, ctx, attempt = self._prepare_call_execution(args, kwargs)
         cache_key = attempt.hash


### PR DESCRIPTION
## 📝 Summary

This PR removes a dead and logically incorrect code block in `_cache_call_async.__call__`.

Closes #8683 

## 🔍 Description of Changes

- The `async def __call__` in `_cache_call_async` attempted to handle the deferred call case.
- This logic is unreachable because `_cache_call_async` instances always have their `__wrapped__` function set during instantiation.
- Furthermore, an `async` method returns a coroutine, which cannot be used as a decorator return value.
- The initialization and `__wrapped__` function setting are already correctly handled by the synchronous `_cache_call`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
