### PR TITLE
fix windows test: use absolute path check in file_browser test

### DIFF
--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -968,11 +968,10 @@ def test_file_browser_relative_path_sent_to_frontend_as_absolute(
         for rel_path in ["subdir", "./subdir", Path("subdir")]:
             fb = file_browser(initial_path=rel_path)
             initial_path_arg = str(fb._component_args["initial-path"])  # pyright: ignore[reportPrivateUsage]
-            assert "/" in initial_path_arg, (
-                f"initial-path sent to frontend must contain '/' "
-                f"(be absolute), got: {initial_path_arg!r}"
+            assert Path(initial_path_arg).is_absolute(), (
+                f"initial-path sent to frontend must be absolute, "
+                f"got: {initial_path_arg!r}"
             )
-            assert Path(initial_path_arg).is_absolute()
 
             # Navigating up from the initial path should work
             parent = str(Path(initial_path_arg).parent)


### PR DESCRIPTION
## Summary

- Fixes `test_file_browser_relative_path_sent_to_frontend_as_absolute` failing on Windows CI
- The test asserted `"/" in path_string` to check absoluteness, but Windows absolute paths use backslashes (e.g., `C:\Users\...`)
- Replaced with `Path(...).is_absolute()` which works on both Unix and Windows

## Context

The production code in `file_browser.py` correctly normalizes relative paths to absolute via `normalize_path()` and sends them to the frontend as `str(self._initial_path)`. On Windows this produces a valid absolute path with backslashes — the bug was purely in the test assertion, not in the component itself.

## Test plan

- [x] Existing test `test_file_browser_relative_path_sent_to_frontend_as_absolute` passes on Unix
- [ ] Same test should now pass on Windows CI (was previously failing)


Made with [Cursor](https://cursor.com)