### PR TITLE
Accept list args in ctx.install_packages

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -1002,7 +1002,9 @@ class AsyncCodeModeContext:
     # Package management
     # ------------------------------------------------------------------
 
-    def install_packages(self, *packages: str | list[str] | tuple[str, ...]) -> None:
+    def install_packages(
+        self, *packages: str | list[str] | tuple[str, ...]
+    ) -> None:
         """Queue packages for installation on context exit.
 
         Installed before cell ops, so newly added cells can import them.


### PR DESCRIPTION
I've seen this hallucinated a couple times in code_mode sessions. `install_packages` now accepts both `*args` and a list/tuple so `ctx.install_packages(["foo", "bar"])` works alongside the existing `ctx.install_packages("foo", "bar")`.
