### PR TITLE
Prefer type guard over type assertion for Vim macro state

### DIFF
--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -247,21 +247,26 @@ function applyVimCommands(vimCommands: VimCommand[]) {
   }
 }
 
-type VimWithGlobalState = typeof Vim & {
-  getVimGlobalState_?: () => {
+interface ExtendedVim {
+  getVimGlobalState_: () => {
     macroModeState?: {
       isRecording: boolean;
       isPlaying: boolean;
     };
   };
-};
+}
+
+function isExtendedVim(vim: typeof Vim): vim is typeof Vim & ExtendedVim {
+  return (
+    "getVimGlobalState_" in vim && typeof vim.getVimGlobalState_ === "function"
+  );
+}
 
 function isMacroActive() {
-  const getGlobalState = (Vim as VimWithGlobalState).getVimGlobalState_;
-  if (typeof getGlobalState !== "function") {
+  if (!isExtendedVim(Vim)) {
     return false;
   }
-  const macroModeState = getGlobalState()?.macroModeState;
+  const macroModeState = Vim.getVimGlobalState_()?.macroModeState;
   if (!macroModeState) {
     return false;
   }


### PR DESCRIPTION
Quick follow-up to #8470.

Replaces the `Vim as VimWithGlobalState` type assertion with an `isExtendedVim` type guard using runtime `in` checks, avoiding `as` casts and letting TypeScript narrow the type naturally.
