### PR TITLE
Fix: `marimo export ipynb` to support command-line arguments

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -409,6 +409,10 @@ Watch for changes and regenerate the script on modification:
 
     marimo export ipynb notebook.py -o notebook.ipynb --watch
 
+Optionally pass CLI args to the notebook:
+
+    marimo export ipynb notebook.py -o notebook.ipynb --include-outputs -- -arg1 foo -arg2 bar
+
 Requires nbformat to be installed.
 """,
 )
@@ -459,6 +463,7 @@ Requires nbformat to be installed.
     required=True,
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
 )
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def ipynb(
     name: str,
     output: Path,
@@ -467,6 +472,7 @@ def ipynb(
     include_outputs: bool,
     sandbox: Optional[bool],
     force: bool,
+    args: tuple[str],
 ) -> None:
     """
     Export a marimo notebook as a Jupyter notebook in topological order.
@@ -498,14 +504,16 @@ def ipynb(
         package = getattr(e, "name", None) or "nbformat"
         raise MarimoCLIMissingDependencyError(str(e), package) from None
 
+    cli_args = parse_args(args) if include_outputs else {}
+
     def export_callback(file_path: MarimoPath) -> ExportResult:
         if include_outputs:
             return asyncio_run(
                 run_app_then_export_as_ipynb(
                     file_path,
                     sort_mode=sort,
-                    cli_args={},
-                    argv=None,
+                    cli_args=cli_args,
+                    argv=list(args),
                 )
             )
         return export_as_ipynb(file_path, sort_mode=sort)

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -837,10 +837,6 @@ class TestExportIpynb:
         not DependencyManager.nbformat.has(),
         reason="This test requires nbformat.",
     )
-    @pytest.mark.skipif(
-        sys.platform != "linux",
-        reason="Plotly template varies across versions; snapshot is linux-only.",
-    )
     def test_export_ipynb_with_media_outputs(
         self, temp_marimo_file_with_media: str
     ) -> None:
@@ -896,6 +892,71 @@ class TestExportIpynb:
         assert "division by zero" in output
         output = delete_lines_with_files(output)
         snapshot(_get_snapshot_path("ipynb", "ipynb_with_errors"), output)
+
+    @pytest.mark.skipif(
+        not DependencyManager.nbformat.has(),
+        reason="This test requires nbformat.",
+    )
+    def test_export_ipynb_with_cli_args(
+        self, temp_marimo_file_with_md: str
+    ) -> None:
+        p = _run_export(
+            "ipynb",
+            temp_marimo_file_with_md,
+            "--include-outputs",
+            "--",
+            "--arg1",
+            "foo",
+            "--arg2",
+            "bar",
+        )
+        _assert_success(p)
+
+    @pytest.mark.skipif(
+        not DependencyManager.nbformat.has(),
+        reason="This test requires nbformat.",
+    )
+    def test_export_ipynb_cli_args_passed_to_export(
+        self, temp_marimo_file_with_md: str
+    ) -> None:
+        from marimo._server.export import ExportResult
+
+        fake_result = ExportResult(
+            contents="{}", download_filename="test.ipynb", did_error=False
+        )
+
+        async def fake_export(*args: Any, **kwargs: Any) -> ExportResult:
+            del args, kwargs
+            return fake_result
+
+        with mock.patch(
+            "marimo._cli.export.commands.run_app_then_export_as_ipynb",
+            side_effect=fake_export,
+        ) as mock_export:
+            p = _run_export(
+                "ipynb",
+                temp_marimo_file_with_md,
+                "--include-outputs",
+                "--",
+                "--arg1",
+                "foo",
+                "--arg2",
+                "bar",
+            )
+            _assert_success(p)
+
+            mock_export.assert_called_once()
+            call_kwargs = mock_export.call_args
+            assert call_kwargs.kwargs["cli_args"] == {
+                "arg1": "foo",
+                "arg2": "bar",
+            }
+            assert call_kwargs.kwargs["argv"] == [
+                "--arg1",
+                "foo",
+                "--arg2",
+                "bar",
+            ]
 
     @staticmethod
     @pytest.mark.skipif(


### PR DESCRIPTION
Closes #8707

## Problem

`marimo export ipynb --include-outputs` did not support passing CLI
arguments to the notebook (e.g. `-- --arg1 foo --arg2 bar`), even though
`marimo export html` and `marimo export pdf` already did. Attempting to
pass arguments resulted in an error about unexpected extra arguments.

## Solution

Added the `@click.argument("args", nargs=-1, type=click.UNPROCESSED)`
decorator and corresponding parameter to the `ipynb` export command,
matching the pattern used by `html` and `pdf` exports. The arguments are
parsed and forwarded to `run_app_then_export_as_ipynb` when
`--include-outputs` is enabled.
