### PR TITLE
Fix setup cell name not persisting in code_mode

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -449,8 +449,7 @@ class AsyncCodeModeContext:
                 if self._cell_manager is not None
                 else CellId_t(SETUP_CELL_NAME)
             )
-            # Setup is identified by cell_id, not name — clear the name.
-            return cell_id, None
+            return cell_id, SETUP_CELL_NAME
         cell_id = self._id_generator.create_cell_id()
         return cell_id, name
 


### PR DESCRIPTION
`_resolve_new_cell` was intentionally clearing the name to `None` for setup cells, reasoning that setup is "identified by cell_id, not name." This meant the name never made it into `_cell_names`, so the serializer wrote `def _()` instead of the `app.setup` block. Other cell names (created or renamed via `create_cell`/`edit_cell`) were unaffected because their names flowed through normally.

The fix returns `SETUP_CELL_NAME` instead of `None`, so the name propagates through the same path as every other cell.