### PR TITLE
feat: fallback static parsing for completely invalid notebooks

### DIFF
--- a/marimo/_ast/load.py
+++ b/marimo/_ast/load.py
@@ -58,7 +58,7 @@ def _maybe_contents(filename: Optional[Union[str, Path]]) -> Optional[str]:
     if filename is None:
         return None
 
-    return Path(filename).read_text(encoding="utf-8").strip()
+    return Path(filename).read_text(encoding="utf-8", errors="replace").strip()
 
 
 def find_cell(filename: str, lineno: int) -> CellDef | None:

--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -511,14 +511,27 @@ class Parser:
     def __init__(self, contents: str, filepath: str = "<marimo>"):
         self.extractor = Extractor(contents=contents)
         self.filepath = filepath
+        self._scanner_generated_lines: frozenset[int] = frozenset()
 
     def node_stack(self) -> PeekStack[Node]:
-        tree = ast_parse(
-            self.extractor.contents or "",
-            filename=self.filepath,
-            suppress_warnings=False,
-        )
-        return PeekStack(iter(tree.body))
+        try:
+            tree = ast_parse(
+                self.extractor.contents or "",
+                filename=self.filepath,
+                suppress_warnings=False,
+            )
+            return PeekStack(iter(tree.body))
+        except SyntaxError:
+            # File has syntax errors — use scanner to recover individual cells.
+            # Never re-raise: parse_notebook must return a best-effort result
+            # so --watch and IPC are never broken by a syntax error.
+            from marimo._ast.scanner import scan_parse_fallback
+
+            nodes, scanner_lines = scan_parse_fallback(
+                self.extractor.contents or "", self.filepath
+            )
+            self._scanner_generated_lines = scanner_lines
+            return PeekStack(iter(nodes))
 
     def parse_header(self, body: PeekStack[Node]) -> ParseResult[Header]:
         # header? = (docstring | comments)*
@@ -662,7 +675,20 @@ class Parser:
             if is_body_cell(node):
                 cell_result = self.extractor.to_cell(node)
                 violations.extend(cell_result.violations)
-                cells.append(cell_result.unwrap())
+                cell = cell_result.unwrap()
+                # Scanner-generated unparsable cells indicate a syntax
+                # error in the original cell source.
+                if (
+                    isinstance(cell, UnparsableCell)
+                    and node.lineno in self._scanner_generated_lines
+                ):
+                    violations.append(
+                        Violation(
+                            SCANNER_UNPARSABLE_CELL_VIOLATION,
+                            lineno=node.lineno,
+                        )
+                    )
+                cells.append(cell)
             elif is_run_guard(node):
                 break
             else:
@@ -1157,6 +1183,9 @@ UNEXPECTED_KEYWORD_VALUE_VIOLATION = "Unexpected value for keyword argument"
 ONLY_HEADER_EXTRACTED_VIOLATION = "Only able to extract header."
 NON_MARIMO_PYTHON_SCRIPT_VIOLATION = "non-marimo Python content beyond header"
 EXPECTED_RUN_GUARD_VIOLATION = "Expected run guard statement"
+SCANNER_UNPARSABLE_CELL_VIOLATION = (
+    "Cell contains a syntax error and could not be parsed"
+)
 
 # Soft violations are auto-corrected on save with no data loss.
 # Any violation NOT in this set is considered "hard" (potential data loss).

--- a/marimo/_ast/scanner.py
+++ b/marimo/_ast/scanner.py
@@ -1,0 +1,643 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Tokenizer-based cell boundary scanner for marimo notebooks.
+
+Uses Python's tokenize module to find cell boundaries, correctly
+ignoring `@app.cell` inside strings/comments. Falls back to
+line-based scanning when the tokenizer fails (e.g. unterminated strings).
+"""
+
+from __future__ import annotations
+
+import ast
+import enum
+import io
+import re
+import token as token_types
+import tokenize as tokenize_mod
+from dataclasses import dataclass
+from typing import Optional
+
+# Cell boundary types
+CELL_TYPES = frozenset({"cell", "function", "class_definition"})
+
+
+@dataclass
+class ScannedCell:
+    kind: str  # "cell", "function", "class_definition", "setup", "unparsable"
+    name: str | None  # function/class name from def/class line
+    source: str  # full raw source (decorator + def + body)
+    start_line: int  # 1-indexed
+    end_line: int  # 1-indexed
+
+
+@dataclass
+class ScanResult:
+    preamble: str  # everything before first cell boundary
+    cells: list[ScannedCell]  # scanned cells in file order
+    run_guard_line: int | None  # line number of `if __name__` guard
+
+
+class _State(enum.Enum):
+    IDLE = enum.auto()
+    # @app.cell / @app.function / @app.class_definition
+    AT = enum.auto()
+    AT_APP = enum.auto()
+    AT_APP_DOT = enum.auto()
+    AT_APP_DOT_KIND = enum.auto()
+    AT_DECORATOR_ARGS = enum.auto()
+    # with app.setup(...):
+    WITH = enum.auto()
+    WITH_APP = enum.auto()
+    WITH_APP_DOT = enum.auto()
+    WITH_SETUP = enum.auto()
+    # app._unparsable_cell(
+    APP_DIRECT = enum.auto()
+    APP_DIRECT_DOT = enum.auto()
+    APP_DIRECT_UNPARSABLE = enum.auto()
+    # if __name__ == "__main__":
+    IF = enum.auto()
+    IF_NAME = enum.auto()
+
+
+class _BoundaryDetector:
+    """State machine over the token stream to detect cell boundaries.
+
+    Boundaries are identified by token sequences at column 0:
+    - Decorator: @app.cell|function|class_definition [(...)]
+    - Setup: with app.setup(...):
+    - Unparsable: app._unparsable_cell(
+    - Run guard: if __name__ ==
+    """
+
+    def __init__(self) -> None:
+        self.boundaries: list[tuple[int, str, int]] = []
+        # (start_line, kind, end_of_decorator_line)
+        self.run_guard_line: int | None = None
+        self._reset()
+
+    def _reset(self) -> None:
+        self._state = _State.IDLE
+        self._start_line = 0
+        self._kind = ""
+        self._paren_depth = 0
+
+    def feed(self, tok: tokenize_mod.TokenInfo) -> None:
+        ttype = tok.type
+        tstr = tok.string
+        row, col = tok.start
+
+        if self._state is _State.IDLE:
+            if col != 0:
+                return
+            if ttype == token_types.OP and tstr == "@":
+                self._state = _State.AT
+                self._start_line = row
+            elif ttype == token_types.NAME and tstr == "with":
+                self._state = _State.WITH
+                self._start_line = row
+            elif ttype == token_types.NAME and tstr == "app":
+                self._state = _State.APP_DIRECT
+                self._start_line = row
+            elif ttype == token_types.NAME and tstr == "if":
+                self._state = _State.IF
+                self._start_line = row
+            return
+
+        # @app.cell(...) decorator
+        if self._state is _State.AT:
+            if ttype == token_types.NAME and tstr == "app":
+                self._state = _State.AT_APP
+            else:
+                self._reset()
+        elif self._state is _State.AT_APP:
+            if ttype == token_types.OP and tstr == ".":
+                self._state = _State.AT_APP_DOT
+            else:
+                self._reset()
+        elif self._state is _State.AT_APP_DOT:
+            if ttype == token_types.NAME and tstr in CELL_TYPES:
+                self._kind = tstr
+                self._state = _State.AT_APP_DOT_KIND
+            else:
+                self._reset()
+        elif self._state is _State.AT_APP_DOT_KIND:
+            if ttype == token_types.OP and tstr == "(":
+                self._paren_depth = 1
+                self._state = _State.AT_DECORATOR_ARGS
+            elif ttype in (
+                token_types.NEWLINE,
+                token_types.NL,
+                token_types.COMMENT,
+            ):
+                self.boundaries.append((self._start_line, self._kind, row))
+                self._reset()
+            else:
+                self._reset()
+        elif self._state is _State.AT_DECORATOR_ARGS:
+            if ttype == token_types.OP and tstr == "(":
+                self._paren_depth += 1
+            elif ttype == token_types.OP and tstr == ")":
+                self._paren_depth -= 1
+                if self._paren_depth == 0:
+                    self.boundaries.append((self._start_line, self._kind, row))
+                    self._reset()
+
+        # with app.setup(...):
+        elif self._state is _State.WITH:
+            if ttype == token_types.NAME and tstr == "app":
+                self._state = _State.WITH_APP
+            else:
+                self._reset()
+        elif self._state is _State.WITH_APP:
+            if ttype == token_types.OP and tstr == ".":
+                self._state = _State.WITH_APP_DOT
+            else:
+                self._reset()
+        elif self._state is _State.WITH_APP_DOT:
+            if ttype == token_types.NAME and tstr == "setup":
+                self._kind = "setup"
+                self._state = _State.WITH_SETUP
+            else:
+                self._reset()
+        elif self._state is _State.WITH_SETUP:
+            if ttype == token_types.OP and tstr == ":":
+                self.boundaries.append((self._start_line, "setup", row))
+                self._reset()
+            elif ttype in (token_types.NEWLINE, token_types.NL):
+                self._reset()
+
+        # app._unparsable_cell(
+        elif self._state is _State.APP_DIRECT:
+            if ttype == token_types.OP and tstr == ".":
+                self._state = _State.APP_DIRECT_DOT
+            else:
+                self._reset()
+        elif self._state is _State.APP_DIRECT_DOT:
+            if ttype == token_types.NAME and tstr == "_unparsable_cell":
+                self._kind = "unparsable"
+                self._state = _State.APP_DIRECT_UNPARSABLE
+            else:
+                self._reset()
+        elif self._state is _State.APP_DIRECT_UNPARSABLE:
+            if ttype == token_types.OP and tstr == "(":
+                self.boundaries.append((self._start_line, "unparsable", row))
+                self._reset()
+            else:
+                self._reset()
+
+        # if __name__ == "__main__":
+        elif self._state is _State.IF:
+            if ttype == token_types.NAME and tstr == "__name__":
+                self._state = _State.IF_NAME
+            else:
+                self._reset()
+        elif self._state is _State.IF_NAME:
+            if ttype == token_types.OP and tstr == "==":
+                self.run_guard_line = self._start_line
+                self._reset()
+            else:
+                self._reset()
+
+
+def _try_tokenize(
+    source: str,
+) -> tuple[list[tokenize_mod.TokenInfo], Optional[tuple[int, Exception]]]:
+    """Tokenize source, returning tokens produced + optional error info."""
+    tokens: list[tokenize_mod.TokenInfo] = []
+    readline = io.StringIO(source).readline
+    try:
+        for tok in tokenize_mod.generate_tokens(readline):
+            tokens.append(tok)  # noqa: PERF402
+    except tokenize_mod.TokenError as e:
+        return tokens, (
+            e.args[1][0] if len(e.args) > 1 else len(source.splitlines()),
+            e,
+        )
+    except IndentationError as e:
+        line = e.lineno or len(source.splitlines())
+        return tokens, (line, e)
+    return tokens, None
+
+
+# Patterns for line-based recovery scanning
+_BOUNDARY_LINE_RE = re.compile(
+    r"^(?:@app\.|with\s+app\.|app\._unparsable_cell|if\s+__name__\s*==)"
+)
+
+
+def scan_notebook(source: str) -> ScanResult:
+    """Scan a notebook source string for cell boundaries.
+
+    Uses the tokenizer for accurate detection (handles @app.cell
+    inside strings/comments correctly). Falls back to line-based
+    recovery when the tokenizer fails.
+    """
+    if not source.strip():
+        return ScanResult(preamble="", cells=[], run_guard_line=None)
+
+    lines = source.splitlines(keepends=True)
+    total_lines = len(lines)
+
+    # Collect all boundaries by processing chunks
+    all_boundaries: list[tuple[int, str, int]] = []
+    run_guard_line: int | None = None
+
+    offset = 0  # 0-indexed line offset for current chunk
+    while offset < total_lines:
+        chunk = "".join(lines[offset:])
+        tokens, error_info = _try_tokenize(chunk)
+
+        # Process tokens through boundary detector
+        detector = _BoundaryDetector()
+        for tok in tokens:
+            detector.feed(tok)
+
+        # Adjust line numbers by offset (tokens are 1-indexed within chunk)
+        for start, kind, end in detector.boundaries:
+            all_boundaries.append((start + offset, kind, end + offset))
+        if detector.run_guard_line is not None and run_guard_line is None:
+            run_guard_line = detector.run_guard_line + offset
+
+        if error_info is None:
+            break  # Successfully tokenized everything
+
+        # Error recovery: scan forward from error line for boundaries
+        error_line_in_chunk, _exc = error_info
+        error_line_abs = error_line_in_chunk + offset
+        found_restart = False
+
+        for candidate_line_0 in range(error_line_abs, total_lines):
+            line_text = lines[candidate_line_0]
+            if _BOUNDARY_LINE_RE.match(line_text):
+                # Try to tokenize from this candidate
+                candidate_chunk = "".join(lines[candidate_line_0:])
+                test_tokens, _test_err = _try_tokenize(candidate_chunk)
+                # Check if we can find at least one boundary
+                test_det = _BoundaryDetector()
+                for tok in test_tokens:
+                    test_det.feed(tok)
+                    # One boundary is enough to validate
+                    if (
+                        test_det.boundaries
+                        or test_det.run_guard_line is not None
+                    ):
+                        break
+
+                if test_det.boundaries or test_det.run_guard_line is not None:
+                    offset = candidate_line_0
+                    found_restart = True
+                    break
+
+        if not found_restart:
+            break  # No more boundaries to find
+
+    # Sort boundaries by line number
+    all_boundaries.sort(key=lambda b: b[0])
+
+    # For decorator-style boundaries (@app.cell etc.), look backwards
+    # for preceding decorator lines (e.g. @wrapper) that belong to
+    # the same decorated function/class.
+    adjusted_boundaries: list[tuple[int, str, int]] = []
+    for start_line, kind, dec_end in all_boundaries:
+        if kind in CELL_TYPES:
+            # Scan backwards from the @app.* line for decorator lines
+            adjusted_start = start_line
+            line_idx = start_line - 2  # 0-indexed, one line before
+            while line_idx >= 0:
+                line = lines[line_idx].strip()
+                if line.startswith("@"):
+                    adjusted_start = line_idx + 1  # 1-indexed
+                    line_idx -= 1
+                elif not line:
+                    # Skip blank lines between decorators
+                    line_idx -= 1
+                else:
+                    break
+            adjusted_boundaries.append((adjusted_start, kind, dec_end))
+        else:
+            adjusted_boundaries.append((start_line, kind, dec_end))
+    all_boundaries = adjusted_boundaries
+
+    # Build cells from boundaries
+    cells: list[ScannedCell] = []
+
+    # Preamble: everything before the first boundary
+    if all_boundaries:
+        first_boundary_line = all_boundaries[0][0]  # 1-indexed
+        preamble = "".join(lines[: first_boundary_line - 1])
+    else:
+        preamble = source
+
+    for i, (start_line, kind, _dec_end) in enumerate(all_boundaries):
+        # Determine end of this cell: start of next boundary or run guard or EOF
+        if i + 1 < len(all_boundaries):
+            next_start = all_boundaries[i + 1][0]
+        elif run_guard_line is not None:
+            next_start = run_guard_line
+        else:
+            next_start = total_lines + 1
+
+        # Extract source (1-indexed → 0-indexed)
+        cell_source = "".join(lines[start_line - 1 : next_start - 1]).rstrip(
+            "\n"
+        )
+        if not cell_source:
+            cell_source = ""
+
+        end_line = next_start - 1
+        # Strip trailing blank lines from end_line
+        while end_line > start_line and not lines[end_line - 1].strip():
+            end_line -= 1
+
+        # Extract name from the def/class line after decorator
+        name = _extract_name_from_cell(
+            kind, lines, start_line - 1, next_start - 1
+        )
+
+        cells.append(
+            ScannedCell(
+                kind=kind,
+                name=name,
+                source=cell_source,
+                start_line=start_line,
+                end_line=end_line,
+            )
+        )
+
+    return ScanResult(
+        preamble=preamble, cells=cells, run_guard_line=run_guard_line
+    )
+
+
+def _extract_name_from_cell(
+    kind: str,
+    lines: list[str],
+    start_0: int,
+    end_0: int,
+) -> str | None:
+    """Extract the function/class name from lines following a decorator."""
+    if kind in ("setup",):
+        return None
+    if kind == "unparsable":
+        # For unparsable cells, try to find `name="..."` in the call
+        for line in lines[start_0:end_0]:
+            match = re.search(r'name\s*=\s*["\'](\w+)["\']', line)
+            if match:
+                return match.group(1)
+        return None
+
+    # Look for def/class after the decorator line
+    for line_idx in range(start_0 + 1, min(end_0, len(lines))):
+        line = lines[line_idx]
+        match = re.match(r"^\s*(?:async\s+)?(?:def|class)\s+(\w+)", line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _extract_body_code(cell_source: str, kind: str) -> str:
+    """Extract just the body code from a cell source string.
+
+    Strips decorator lines, def/class/with header, and trailing return.
+    Used when a cell fails ast.parse() to get the body for UnparsableCell.
+    """
+    from marimo._ast.parse import fixed_dedent
+
+    if kind == "unparsable":
+        # Already app._unparsable_cell(...) — return as-is
+        return cell_source
+
+    lines = cell_source.splitlines(keepends=True)
+    body_start = _find_body_start(lines, kind)
+
+    if body_start >= len(lines):
+        return ""
+
+    body_lines = list(lines[body_start:])
+
+    # Strip trailing return at body indentation level
+    _strip_trailing_return(body_lines)
+
+    body = "".join(body_lines)
+    return fixed_dedent(body).strip()
+
+
+def _find_body_start(lines: list[str], kind: str) -> int:
+    """Find the line index where the body starts (after header).
+
+    For cell/function/class_definition: skip @decorators, then def/class
+    header (handling multi-line signatures).
+    For setup: skip `with app.setup():` header.
+    """
+    i = 0
+
+    if kind in CELL_TYPES:
+        # Skip decorator lines
+        while i < len(lines):
+            stripped = lines[i].strip()
+            if stripped.startswith("@") or not stripped:
+                i += 1
+            else:
+                break
+
+    # Now find the end of the def/class/with header (the colon at depth 0)
+    paren_depth = 0
+    while i < len(lines):
+        line = lines[i]
+        j = 0
+        while j < len(line):
+            ch = line[j]
+            if ch in ('"', "'"):
+                # Skip string literals
+                quote = ch
+                j += 1
+                if j + 1 < len(line) and line[j : j + 2] == quote * 2:
+                    # Triple quote — skip to closing
+                    j += 2
+                    end = line.find(quote * 3, j)
+                    if end >= 0:
+                        j = end + 3
+                    else:
+                        j = len(line)
+                    continue
+                # Single quote string
+                while j < len(line) and line[j] != quote:
+                    if line[j] == "\\":
+                        j += 1  # skip escaped char
+                    j += 1
+                j += 1  # skip closing quote
+                continue
+            if ch == "#":
+                break  # rest is comment
+            if ch in ("(", "[", "{"):
+                paren_depth += 1
+            elif ch in (")", "]", "}"):
+                paren_depth -= 1
+            elif ch == ":" and paren_depth == 0:
+                # Found the header-ending colon
+                return i + 1
+            j += 1
+        i += 1
+
+    # Couldn't find colon — return all lines as body
+    return 0
+
+
+def _strip_trailing_return(body_lines: list[str]) -> None:
+    """Remove trailing return statement from body lines (in-place).
+
+    Only strips a return at the body's indentation level (top-level
+    within the function), not nested returns.
+    """
+    # Find body indentation from first non-blank line
+    body_indent = ""
+    for line in body_lines:
+        stripped = line.strip()
+        if stripped:
+            body_indent = line[: len(line) - len(line.lstrip())]
+            break
+
+    # From the bottom, skip blank lines, then check for return
+    idx = len(body_lines) - 1
+    while idx >= 0 and not body_lines[idx].strip():
+        idx -= 1
+
+    if idx >= 0:
+        line = body_lines[idx]
+        line_indent = line[: len(line) - len(line.lstrip())]
+        line_stripped = line.strip()
+        if line_indent == body_indent and (
+            line_stripped == "return"
+            or line_stripped.startswith("return ")
+            or line_stripped.startswith("return\t")
+            or line_stripped.startswith("return(")
+        ):
+            # Remove the return line and any trailing blank lines after it
+            del body_lines[idx:]
+
+
+def _build_unparsable_node(
+    code: str,
+    name: str | None,
+    start_line: int,
+) -> ast.Expr:
+    """Build a synthetic app._unparsable_cell(...) AST node.
+
+    Must pass is_unparsable_cell() check in parse.py.
+    """
+    # Build: app._unparsable_cell("code", name="name")
+    keywords = []
+    if name is not None:
+        keywords.append(
+            ast.keyword(
+                arg="name",
+                value=ast.Constant(value=name),
+            )
+        )
+
+    node = ast.Expr(
+        value=ast.Call(
+            func=ast.Attribute(
+                value=ast.Name(id="app", ctx=ast.Load()),
+                attr="_unparsable_cell",
+                ctx=ast.Load(),
+            ),
+            args=[ast.Constant(value=code)],
+            keywords=keywords,
+        )
+    )
+    # Set line numbers
+    ast.fix_missing_locations(node)
+    ast.increment_lineno(node, start_line - 1)
+    return node
+
+
+def _build_run_guard_node(start_line: int) -> ast.If:
+    """Build a synthetic if __name__ == "__main__": app.run() node."""
+    # Equivalent to: if __name__ == "__main__": app.run()
+    node = ast.If(
+        test=ast.Compare(
+            left=ast.Name(id="__name__", ctx=ast.Load()),
+            ops=[ast.Eq()],
+            comparators=[ast.Constant(value="__main__")],
+        ),
+        body=[
+            ast.Expr(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id="app", ctx=ast.Load()),
+                        attr="run",
+                        ctx=ast.Load(),
+                    ),
+                    args=[],
+                    keywords=[],
+                )
+            )
+        ],
+        orelse=[],
+    )
+    ast.fix_missing_locations(node)
+    ast.increment_lineno(node, start_line - 1)
+    return node
+
+
+def _has_cell_boundaries(source: str) -> bool:
+    """Quick check whether source has any cell boundary markers."""
+    return (
+        "@app.cell" in source
+        or "@app.function" in source
+        or "@app.class_definition" in source
+        or "with app.setup" in source
+        or "app._unparsable_cell" in source
+    )
+
+
+def scan_parse_fallback(
+    source: str, filepath: str
+) -> tuple[list[ast.stmt], frozenset[int]]:
+    """Fallback parser: scan for cell boundaries, parse each cell individually.
+
+    Called when ast.parse() on the full file fails due to syntax errors.
+    Returns a tuple of (nodes, scanner_generated_lines) where
+    scanner_generated_lines contains the 1-indexed start line numbers of
+    unparsable cells created by the scanner (vs. pre-existing
+    app._unparsable_cell() calls in the source).
+    Returns ([], frozenset()) if no cell boundaries are found.
+    """
+    from marimo._ast.parse import ast_parse
+
+    if not _has_cell_boundaries(source):
+        return [], frozenset()
+
+    scan = scan_notebook(source)
+
+    nodes: list[ast.stmt] = []
+    scanner_lines: set[int] = set()
+
+    # Preamble
+    if scan.preamble.strip():
+        try:
+            tree = ast_parse(scan.preamble, filename=filepath)
+            nodes.extend(tree.body)
+        except SyntaxError:
+            raise  # Preamble errors are fatal
+
+    # Cells
+    for cell in scan.cells:
+        try:
+            cell_tree = ast_parse(cell.source, filename=filepath)
+            ast.increment_lineno(cell_tree, cell.start_line - 1)
+            nodes.extend(cell_tree.body)
+        except SyntaxError:
+            inner_code = _extract_body_code(cell.source, cell.kind)
+            node = _build_unparsable_node(
+                inner_code, cell.name, cell.start_line
+            )
+            scanner_lines.add(node.lineno)
+            nodes.append(node)
+
+    # Run guard
+    if scan.run_guard_line is not None:
+        nodes.append(_build_run_guard_node(scan.run_guard_line))
+
+    return nodes, frozenset(scanner_lines)

--- a/marimo/_lint/rules/formatting/general.py
+++ b/marimo/_lint/rules/formatting/general.py
@@ -82,6 +82,7 @@ class GeneralFormattingRule(LintRule):
         # Import the violation constants to check for specific types
         from marimo._ast.parse import (
             EXPECTED_GENERATED_WITH_VIOLATION,
+            SCANNER_UNPARSABLE_CELL_VIOLATION,
             UNEXPECTED_STATEMENT_APP_INIT_VIOLATION,
             UNEXPECTED_STATEMENT_CELL_DEF_VIOLATION,
             UNEXPECTED_STATEMENT_MARIMO_IMPORT_VIOLATION,
@@ -89,6 +90,10 @@ class GeneralFormattingRule(LintRule):
 
         # Extract violations from the notebook serialization
         for violation in ctx.notebook.violations:
+            # Skip scanner-generated unparsable cell violations —
+            # already reported by MB001 (unparsable-cells)
+            if violation.description == SCANNER_UNPARSABLE_CELL_VIOLATION:
+                continue
             # Determine if this violation is fixable
             is_fixable = violation.description in [
                 UNEXPECTED_STATEMENT_CELL_DEF_VIOLATION,

--- a/tests/_ast/test_load.py
+++ b/tests/_ast/test_load.py
@@ -409,9 +409,9 @@ class TestGetStatus:
             ("test_generate_filecontents_empty", "has_errors"),  # no body
             # Invalid decorator order creates an error.
             ("test_decorators", "has_errors"),
-            # Syntax errors in code
-            ("_test_not_parsable", "broken"),
-            ("_test_parse_error_in_notebook", "broken"),
+            # Syntax errors in code — non-marimo file returns empty gracefully
+            ("_test_not_parsable", "empty"),
+            ("_test_parse_error_in_notebook", "has_errors"),
             # A script that is not a marimo notebook, but uses marimo is
             # indeterminant, so throws an exception.
             ("test_non_marimo", "broken"),

--- a/tests/_ast/test_scanner.py
+++ b/tests/_ast/test_scanner.py
@@ -1,0 +1,611 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+from marimo._ast.load import get_notebook_status
+from marimo._ast.parse import parse_notebook
+from marimo._ast.scanner import scan_notebook, scan_parse_fallback
+from marimo._lint.rule_engine import RuleEngine
+from marimo._schemas.serialization import UnparsableCell
+
+
+class TestScanNotebook:
+    @staticmethod
+    def test_valid_notebook() -> None:
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def one():
+                x = 1
+                return x,
+
+            @app.cell
+            def two():
+                y = 2
+                return y,
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        result = scan_notebook(source)
+        assert (
+            result.preamble.strip()
+            == textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()""").strip()
+        )
+        assert len(result.cells) == 2
+        assert result.cells[0].kind == "cell"
+        assert result.cells[0].name == "one"
+        assert result.cells[0].start_line == 5
+        assert result.cells[1].kind == "cell"
+        assert result.cells[1].name == "two"
+        assert result.cells[1].start_line == 10
+        assert result.run_guard_line == 15
+
+    @staticmethod
+    def test_various_cell_types() -> None:
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            with app.setup():
+                x = 1
+
+            @app.cell
+            def one():
+                return
+
+            @app.function
+            def add(a, b):
+                return a + b
+
+            @app.class_definition
+            class MyClass:
+                pass
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        result = scan_notebook(source)
+        assert len(result.cells) == 4
+        assert result.cells[0].kind == "setup"
+        assert result.cells[1].kind == "cell"
+        assert result.cells[1].name == "one"
+        assert result.cells[2].kind == "function"
+        assert result.cells[2].name == "add"
+        assert result.cells[3].kind == "class_definition"
+        assert result.cells[3].name == "MyClass"
+
+    @staticmethod
+    def test_decorator_with_args() -> None:
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell(hide_code=True)
+            def one():
+                x = 1
+                return x,
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        result = scan_notebook(source)
+        assert len(result.cells) == 1
+        assert result.cells[0].kind == "cell"
+        assert result.cells[0].name == "one"
+
+    @staticmethod
+    def test_app_cell_inside_string_not_boundary() -> None:
+        source = textwrap.dedent('''\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def one():
+                x = """
+            @app.cell
+            def fake():
+                pass
+            """
+                return x,
+
+            @app.cell
+            def two():
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        ''')
+        result = scan_notebook(source)
+        # The @app.cell inside the string should NOT be a boundary
+        assert len(result.cells) == 2
+        assert result.cells[0].name == "one"
+        assert result.cells[1].name == "two"
+
+    @staticmethod
+    def test_empty_source() -> None:
+        result = scan_notebook("")
+        assert result.preamble == ""
+        assert result.cells == []
+        assert result.run_guard_line is None
+
+    @staticmethod
+    def test_header_only() -> None:
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+        """)
+        result = scan_notebook(source)
+        assert result.preamble.strip() == source.strip()
+        assert result.cells == []
+        assert result.run_guard_line is None
+
+    @staticmethod
+    def test_no_cell_boundaries() -> None:
+        source = "x = 1\ny = 2\nprint(x + y)\n"
+        result = scan_notebook(source)
+        assert result.preamble == source
+        assert result.cells == []
+        assert result.run_guard_line is None
+
+    @staticmethod
+    def test_unparsable_cell_boundary() -> None:
+        source = textwrap.dedent('''\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def one():
+                return
+
+            app._unparsable_cell(
+                r"""
+                _ error
+                """,
+                name="two"
+            )
+
+            if __name__ == "__main__":
+                app.run()
+        ''')
+        result = scan_notebook(source)
+        assert len(result.cells) == 2
+        assert result.cells[0].kind == "cell"
+        assert result.cells[0].name == "one"
+        assert result.cells[1].kind == "unparsable"
+        assert result.cells[1].name == "two"
+
+    @staticmethod
+    def test_unterminated_string_recovery() -> None:
+        """Unterminated string in one cell should not prevent
+        finding subsequent cell boundaries."""
+        source = textwrap.dedent('''\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def broken():
+                x = """unterminated
+                return
+
+            @app.cell
+            def good():
+                y = 1
+                return y,
+
+            if __name__ == "__main__":
+                app.run()
+        ''')
+        result = scan_notebook(source)
+        # Should find at least the second cell via recovery
+        assert len(result.cells) >= 1
+        # The good cell should be found
+        cell_names = [c.name for c in result.cells]
+        assert "good" in cell_names
+
+
+class TestScanParseIntegration:
+    """Integration tests using parse_notebook with the scanner pipeline."""
+
+    @staticmethod
+    def test_syntax_error_in_one_cell() -> None:
+        source = textwrap.dedent('''\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def broken(mo):
+                mo.md("""
+                r"""Markdown cell with error"""
+                """)
+                return
+
+            @app.cell
+            def _():
+                import marimo as mo
+                return (mo,)
+
+            @app.cell
+            def _():
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        ''')
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        # Should have 3 cells total
+        assert len(notebook.cells) == 3
+        # First cell should be unparsable
+        assert isinstance(notebook.cells[0], UnparsableCell)
+        # Other cells should be normal
+        assert not isinstance(notebook.cells[1], UnparsableCell)
+        assert not isinstance(notebook.cells[2], UnparsableCell)
+
+    @staticmethod
+    def test_syntax_errors_in_all_cells() -> None:
+        source = textwrap.dedent('''\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def a():
+                x = """unterminated
+                return
+
+            @app.cell
+            def b():
+                if if if
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        ''')
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        # All cells should be unparsable
+        for cell in notebook.cells:
+            assert isinstance(cell, UnparsableCell)
+
+    @staticmethod
+    def test_non_marimo_file_syntax_error_does_not_raise() -> None:
+        """A file without cell boundaries that has a syntax error should not
+        raise — parse_notebook returns a best-effort result so watch/IPC
+        are never broken by a syntax error."""
+        source = '# Not a marimo file\nprint("hello world\n'
+        # Should not raise; returns a non-valid notebook
+        result = parse_notebook(source)
+        assert result is not None
+        assert not result.valid
+
+    @staticmethod
+    def test_valid_notebook_unchanged() -> None:
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def one():
+                x = 1
+                return x,
+
+            @app.cell
+            def two(x):
+                y = x + 1
+                return y,
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        assert len(notebook.cells) == 2
+        assert notebook.cells[0].code == "x = 1"
+        assert notebook.cells[1].code == "y = x + 1"
+
+    @staticmethod
+    def test_cell_names_preserved() -> None:
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def alpha():
+                x = 1
+                return x,
+
+            @app.cell
+            def beta(x):
+                y = x + 1
+                return y,
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        assert notebook.cells[0].name == "alpha"
+        assert notebook.cells[1].name == "beta"
+
+    @staticmethod
+    def test_unparsable_cell_body_extraction() -> None:
+        """Unparsable cells should contain only body code,
+        not decorator/def/return."""
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def _():
+                x = (1 + 2
+                y = [3, 4
+                return
+
+            @app.cell
+            def _():
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        assert isinstance(notebook.cells[0], UnparsableCell)
+        assert notebook.cells[0].code == "x = (1 + 2\ny = [3, 4"
+
+    @staticmethod
+    def test_unparsable_cell_empty_body() -> None:
+        """A cell with only a broken return becomes empty."""
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def _():
+                if if if
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        assert isinstance(notebook.cells[0], UnparsableCell)
+        assert notebook.cells[0].code == "if if if"
+
+    @staticmethod
+    def test_unparsable_cell_multiline_signature() -> None:
+        """Multi-line def signature is properly stripped."""
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def _(
+                a,
+                b,
+            ):
+                x = (1 + 2
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        assert isinstance(notebook.cells[0], UnparsableCell)
+        assert notebook.cells[0].code == "x = (1 + 2"
+
+    @staticmethod
+    def test_unparsable_cell_decorator_with_args() -> None:
+        """Decorator with arguments is properly stripped."""
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell(hide_code=True)
+            def _():
+                if if if
+                return return return
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        assert isinstance(notebook.cells[0], UnparsableCell)
+        assert notebook.cells[0].code == "if if if\nreturn return return"
+
+    @staticmethod
+    def test_parse_error_in_notebook_file() -> None:
+        """Test the actual _test_parse_error_in_notebook.py file."""
+        filepath = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "codegen_data/_test_parse_error_in_notebook.py",
+        )
+        result = get_notebook_status(filepath)
+        # Should load with errors, not be broken
+        assert result.status == "has_errors"
+        assert result.notebook is not None
+        assert len(result.notebook.cells) == 3
+
+    @staticmethod
+    def test_line_continuation_at_eof_file(tmp_path: object) -> None:
+        """Test a notebook with a backslash continuation at EOF.
+
+        The scanner should recover the cell as unparsable and find
+        the run guard.
+        """
+        filepath = Path(str(tmp_path)) / "line_continuation_at_eof.py"
+        filepath.write_text(
+            textwrap.dedent("""\
+                import marimo
+
+                __generated_with = "0.1.0"
+                app = marimo.App()
+
+
+                @app.cell
+                def _():
+                    x = 1 + \\
+
+
+                if __name__ == "__main__":
+                    app.run()
+            """)
+        )
+        result = get_notebook_status(str(filepath))
+        assert result.status == "has_errors"
+        assert result.notebook is not None
+        assert len(result.notebook.cells) == 1
+        assert isinstance(result.notebook.cells[0], UnparsableCell)
+
+    @staticmethod
+    def test_scanner_generated_lines_typed() -> None:
+        """scan_parse_fallback returns a frozenset of scanner-generated line
+        numbers — no untyped AST attribute is used."""
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def good():
+                x = 1
+                return x,
+
+            @app.cell
+            def broken():
+                x = (1 + 2
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        nodes, scanner_lines = scan_parse_fallback(source, "<test>")
+        # Only the broken cell's start line should be in scanner_lines
+        assert isinstance(scanner_lines, frozenset)
+        assert len(scanner_lines) == 1
+        # The good cell was parsed successfully — not scanner-generated
+        good_lines = {n.lineno for n in nodes if hasattr(n, "lineno")}
+        broken_line = next(iter(scanner_lines))
+        assert broken_line in good_lines  # the line exists in the node list
+        assert len(nodes) > 0
+
+    @staticmethod
+    def test_scanner_generated_lines_existing_unparsable_not_flagged() -> None:
+        """Pre-existing app._unparsable_cell() in source must NOT appear in
+        scanner_generated_lines — only cells the scanner itself created."""
+        # This source parses fine (ast.parse succeeds), so scan_parse_fallback
+        # returns ([], frozenset()) — no scanner-generated lines.
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            app._unparsable_cell(
+                r\"\"\"_ error\"\"\",
+                name="broken"
+            )
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        nodes, scanner_lines = scan_parse_fallback(source, "<test>")
+        # The pre-existing unparsable cell parsed fine through the scanner
+        # (its source is valid Python), so scanner_lines must be empty.
+        assert len(nodes) > 0
+        assert scanner_lines == frozenset()
+
+    @staticmethod
+    def test_line_continuation_no_duplicate_diagnostics() -> None:
+        """Scanner-generated unparsable cells should produce only
+        one diagnostic (MB001), not a duplicate from MF001."""
+        source = textwrap.dedent("""\
+            import marimo
+            __generated_with = "0.1.0"
+            app = marimo.App()
+
+            @app.cell
+            def _():
+                x = 1 + \\
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook = parse_notebook(source)
+        assert notebook is not None
+        assert len(notebook.cells) == 1
+        assert isinstance(notebook.cells[0], UnparsableCell)
+
+        # Run linter rules
+        engine = RuleEngine.create_default()
+        diagnostics = engine.check_notebook_sync(notebook)
+
+        # Should have exactly one diagnostic for the unparsable cell (MB001),
+        # NOT a duplicate from MF001 (general-formatting)
+        unparsable_diags = [d for d in diagnostics if d.code == "MB001"]
+        scanner_format_diags = [
+            d
+            for d in diagnostics
+            if d.code == "MF001" and "syntax error" in d.message.lower()
+        ]
+        assert len(unparsable_diags) == 1
+        assert len(scanner_format_diags) == 0
+
+    @staticmethod
+    def test_encoding_error_file(tmp_path: object) -> None:
+        """Test a notebook with non-UTF-8 bytes (encoding error).
+
+        The file declares ASCII encoding but has a Latin-1 byte (0xe9).
+        Should load gracefully with errors, not crash.
+        """
+        tmp = Path(str(tmp_path))
+        filepath = tmp / "encoding_errors.py"
+        # Write raw bytes: ASCII encoding declaration + Latin-1 byte 0xe9
+        filepath.write_bytes(
+            b"# -*- coding: ascii -*-\n"
+            b"import marimo\n"
+            b"\n"
+            b'__generated_with = "0.0.0"\n'
+            b"app = marimo.App()\n"
+            b"\n"
+            b"\n"
+            b"@app.cell\n"
+            b"def _():\n"
+            b'    x = "caf\xe9"\n'
+            b"    return\n"
+            b"\n"
+            b"\n"
+            b'if __name__ == "__main__":\n'
+            b"    app.run()\n"
+        )
+        result = get_notebook_status(str(filepath))
+        # Should load (not crash), with errors from the encoding issue
+        assert result.status in ("has_errors", "valid")
+        assert result.notebook is not None
+        assert len(result.notebook.cells) >= 1

--- a/tests/_lint/test_json_formatter.py
+++ b/tests/_lint/test_json_formatter.py
@@ -327,7 +327,12 @@ def __():
         assert result["summary"]["errored"] is True
 
     def test_json_format_syntax_error(self, tmp_path):
-        """Test JSON format handling of syntax errors."""
+        """Test JSON format handling of syntax errors.
+
+        A file with a syntax error but no cell boundaries is treated as an
+        empty/unrecognisable notebook and skipped — no JSON issue is emitted.
+        Notebooks with cell boundaries are recovered via scanner fallback.
+        """
         tmpdir = tmp_path
         broken_file = Path(tmpdir) / "broken.py"
         broken_file.write_text("import marimo\ndef broken(\n    pass")
@@ -335,16 +340,11 @@ def __():
         linter = run_check((str(broken_file),), formatter="json")
         result = linter.get_json_result()
 
-        assert len(result["issues"]) == 1
-        error = result["issues"][0]
-        assert error["type"] == "error"
-        assert error["filename"] == str(broken_file)
-        assert "Failed to parse" in error["error"]
-
-        # Check summary includes the error
+        # File has no cell boundaries — skipped, no issues emitted
+        assert len(result["issues"]) == 0
         assert result["summary"]["total_files"] == 1
-        assert result["summary"]["files_with_issues"] == 1
-        assert result["summary"]["errored"] is True
+        assert result["summary"]["files_with_issues"] == 0
+        assert result["summary"]["errored"] is False
 
     def test_json_format_mixed_diagnostics_and_errors(self, tmp_path):
         """Test JSON format with both diagnostics and file errors."""
@@ -380,8 +380,9 @@ if __name__ == "__main__":
         )
         result = linter.get_json_result()
 
-        # Should have 3 issues: 1 diagnostic + 2 errors
-        assert len(result["issues"]) == 3
+        # Should have 2 issues: 1 diagnostic + 1 error (missing.py)
+        # The broken_file has no cell boundaries so is silently skipped
+        assert len(result["issues"]) == 2
 
         # Check diagnostic
         diagnostic_issues = [
@@ -391,15 +392,12 @@ if __name__ == "__main__":
         assert diagnostic_issues[0]["severity"] == "breaking"
         assert "multiple" in diagnostic_issues[0]["message"].lower()
 
-        # Check errors
+        # Check errors — only missing.py, not broken_file (skipped)
         error_issues = [i for i in result["issues"] if i["type"] == "error"]
-        assert len(error_issues) == 2
+        assert len(error_issues) == 1
+        assert error_issues[0]["filename"] == "missing.py"
 
-        filenames = [e["filename"] for e in error_issues]
-        assert str(broken_file) in filenames
-        assert "missing.py" in filenames
-
-        # Check summary
+        # Check summary — broken_file is skipped, not counted as with_issues
         assert result["summary"]["total_files"] == 3
-        assert result["summary"]["files_with_issues"] == 3
+        assert result["summary"]["files_with_issues"] == 2
         assert result["summary"]["errored"] is True

--- a/tests/_lint/test_run_check.py
+++ b/tests/_lint/test_run_check.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 """Unit tests for the run_check CLI integration."""
 
+import asyncio
 from pathlib import Path
 
 from marimo._lint import FileStatus, Linter, run_check
@@ -64,7 +65,13 @@ def __():
         assert isinstance(result.files[0].diagnostics, list)
 
     def test_run_check_with_syntax_error(self, tmpdir):
-        """Test run_check with a file containing syntax errors."""
+        """Test run_check with a file containing syntax errors.
+
+        A file with a syntax error but no cell boundaries is not recognisable
+        as a marimo notebook, so the linter skips it gracefully rather than
+        failing hard.  Notebooks that DO have cell boundaries are recovered via
+        the scanner fallback and reported as diagnostics instead.
+        """
         bad_file = Path(tmpdir) / "bad.py"
         bad_file.write_text(
             "import marimo\napp = marimo.App(\ndef broken(:\n    pass"
@@ -73,9 +80,9 @@ def __():
         result = run_check((str(bad_file),))
 
         assert len(result.files) == 1
-        assert result.files[0].failed is True
-        assert "Failed to parse" in result.files[0].message
-        assert len(result.files[0].details) > 0
+        # File has no cell boundaries — treated as unrecognisable/empty
+        assert result.files[0].failed is False
+        assert result.files[0].skipped is True
 
     def test_run_check_with_glob_patterns(self, tmpdir):
         """Test run_check with glob patterns."""
@@ -322,17 +329,18 @@ def __():
         # Test fixing (if notebook is available)
         if file_status.notebook is not None:
             # Use Linter.fix() method
-            import asyncio
-
             linter = Linter()
             result = asyncio.run(linter.fix(file_status))
             assert isinstance(result, bool)
 
     def test_error_handling_in_run_check(self, tmpdir):
-        """Test error handling in run_check."""
-        # Test by providing invalid content that will cause parsing to fail
+        """Test error handling in run_check.
+
+        A file with a syntax error but no @app.cell boundaries is not
+        recognisable as a marimo notebook.  The linter skips it gracefully;
+        notebooks with cell boundaries are recovered via the scanner fallback.
+        """
         test_file = Path(tmpdir) / "test.py"
-        # Write invalid Python content that will cause an exception
         test_file.write_text(
             "import marimo\napp = marimo.App()\ndef broken(:\n    pass"
         )
@@ -340,9 +348,9 @@ def __():
         result = run_check((str(test_file),))
 
         assert len(result.files) == 1
-        assert result.files[0].failed is True
-        # Note: errored might not be True as we changed error handling
-        assert "Failed to parse" in result.files[0].message
+        # File has no cell boundaries — treated as empty/unrecognisable
+        assert result.files[0].failed is False
+        assert result.files[0].skipped is True
 
     def test_run_check_with_nonexistent_file_pattern(self):
         """Test run_check with a specific nonexistent file."""
@@ -360,3 +368,70 @@ def __():
         assert isinstance(result, Linter)
         assert len(result.files) == 0
         assert result.errored is False
+
+    def test_run_check_encoding_error(self, tmpdir):
+        """Test run_check with a file containing non-UTF-8 bytes.
+
+        Should not crash — the file should be processed gracefully.
+        """
+        bad_file = Path(tmpdir) / "encoding.py"
+        bad_file.write_bytes(
+            b"# -*- coding: ascii -*-\n"
+            b"import marimo\n"
+            b"\n"
+            b'__generated_with = "0.0.0"\n'
+            b"app = marimo.App()\n"
+            b"\n"
+            b"\n"
+            b"@app.cell\n"
+            b"def _():\n"
+            b'    x = "caf\xe9"\n'
+            b"    return\n"
+            b"\n"
+            b"\n"
+            b'if __name__ == "__main__":\n'
+            b"    app.run()\n"
+        )
+
+        result = run_check((str(bad_file),))
+
+        assert len(result.files) == 1
+        assert result.files[0].failed is False
+        assert result.files[0].skipped is False
+
+    def test_run_check_no_duplicate_unparsable_diagnostic(self, tmpdir):
+        """Test that unparsable cells produce only MB001, not a
+        duplicate from MF001 (general-formatting)."""
+        notebook_file = Path(tmpdir) / "broken.py"
+        notebook_file.write_text(
+            "import marimo\n"
+            "\n"
+            '__generated_with = "0.0.0"\n'
+            "app = marimo.App()\n"
+            "\n"
+            "\n"
+            "@app.cell\n"
+            "def _():\n"
+            "    x = 1 + \\\n"
+            "\n"
+            "\n"
+            'if __name__ == "__main__":\n'
+            "    app.run()\n"
+        )
+
+        result = run_check((str(notebook_file),))
+
+        assert len(result.files) == 1
+        file_status = result.files[0]
+        assert not file_status.failed
+
+        # Should have MB001 (unparsable) but NOT a duplicate MF001
+        # for "Cell contains a syntax error"
+        mb001 = [d for d in file_status.diagnostics if d.code == "MB001"]
+        mf001_syntax = [
+            d
+            for d in file_status.diagnostics
+            if d.code == "MF001" and "syntax error" in d.message.lower()
+        ]
+        assert len(mb001) == 1
+        assert len(mf001_syntax) == 0

--- a/tests/_session/test_file_change_handler.py
+++ b/tests/_session/test_file_change_handler.py
@@ -603,18 +603,48 @@ async def test_file_change_coordinator_skips_own_writes(
 async def test_file_change_coordinator_handles_syntax_errors(
     tmp_path: Path, mock_session: MagicMock
 ) -> None:
+    """Test file change coordinator handles syntax errors gracefully."""
+    content = dedent(
+        """\
+        import marimo
+        app = marimo.App()
+
+        @app.cell
+        def cell1():
+            x = 1
+            return x
+        """
+    )
     test_file = tmp_path / "test.py"
-    test_file.write_text(SINGLE_CELL_NOTEBOOK)
-    mock_session.app_file_manager = AppFileManager(filename=str(test_file))
+    test_file.write_text(content)
+
+    app_file_manager = AppFileManager(filename=str(test_file))
+    mock_session.app_file_manager = app_file_manager
 
     strategy = MagicMock()
     coordinator = FileChangeCoordinator(strategy)
 
-    test_file.write_text(SINGLE_CELL_NOTEBOOK.replace("x = 1", "def broken("))
+    # Write invalid syntax
+    test_file.write_text(
+        dedent(
+            """\
+            import marimo
+            app = marimo.App()
+
+            @app.cell
+            def cell1():
+                x = 1
+                # Invalid syntax below
+                def broken(
+            """
+        )
+    )
+
     result = await coordinator.handle_change(test_file, session=mock_session)
 
-    assert not result.handled
-    assert result.error is not None
+    # Should handle using best-effort scanner fallback (never re-raises syntax errors)
+    assert result.handled
+    assert result.error is None
 
 
 async def test_file_change_coordinator_path_mismatch(


### PR DESCRIPTION
## 📝 Summary

Allows notebooks with broken syntax to be parsed by extracting the "cell boundaries" (i.e. @app.cell) and leveraging indentation. Possibly a bit heavy handed, but leverages a simple state machine to work through the tokens to find the boundaries.

NB, this is _ONLY_ a fallback mechanism, but should prevent breakage in vs-code/ watch when the source file breaks.