### PR TITLE
Fix reactive highlighting of property access names

### DIFF
--- a/frontend/src/core/codemirror/reactive-references/__tests__/analyzer.test.ts
+++ b/frontend/src/core/codemirror/reactive-references/__tests__/analyzer.test.ts
@@ -1115,6 +1115,60 @@ class Foo:
     `);
   });
 
+  test("should not highlight attribute access matching a for-loop variable", () => {
+    // When `tool` is used as a for-loop variable, `mcp.tool` (attribute access)
+    // should NOT have `tool` highlighted — it's a property, not a variable reference.
+    expect(
+      runHighlight(
+        ["mcp", "client"],
+        `
+@mcp.tool
+def roll_dice():
+    pass
+
+async with client:
+    for tool in await client.list_tools():
+        print(tool)
+`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      @mcp.tool
+       ^^^
+      def roll_dice():
+          pass
+
+      async with client:
+                 ^^^^^^
+          for tool in await client.list_tools():
+                            ^^^^^^
+              print(tool)
+      "
+    `);
+  });
+
+  test("should not highlight property name matching a global variable", () => {
+    // `tool` is a global variable, but `mcp.tool` should not highlight `tool`
+    // because it's a property access, not a variable reference.
+    expect(
+      runHighlight(
+        ["mcp", "tool"],
+        `
+@mcp.tool
+def roll_dice():
+    pass
+`,
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      @mcp.tool
+       ^^^
+      def roll_dice():
+          pass
+      "
+    `);
+  });
+
   test("class property self-reference", () => {
     expect(
       runHighlight(

--- a/frontend/src/core/codemirror/reactive-references/analyzer.ts
+++ b/frontend/src/core/codemirror/reactive-references/analyzer.ts
@@ -462,6 +462,7 @@ export function findReactiveVariables(options: {
   ): boolean {
     return (
       allVariableNames.has(varName) &&
+      !isPropertyAccess(cursor) &&
       !isKeywordArgumentName(cursor) &&
       !isAssignmentTarget(cursor)
     );
@@ -526,6 +527,19 @@ function isAssignmentTarget(cursor: TreeCursor): boolean {
     return assignOpPosition !== -1 && cursor.from < assignOpPosition;
   }
 
+  return false;
+}
+
+/** Checks whether a `VariableName` is a property access (e.g. `tool` in `mcp.tool`). */
+function isPropertyAccess(cursor: TreeCursor): boolean {
+  // Check if the previous sibling is a "." node, which means this
+  // VariableName is a property access rather than a standalone variable.
+  // This handles both MemberExpression (e.g. `obj.attr`) and Decorator
+  // (e.g. `@mcp.tool`) where the parser emits flat sibling nodes.
+  const temp = cursor.node.cursor();
+  if (temp.prevSibling() && temp.name === ".") {
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
Reactive variable highlighting was incorrectly decorating property names when they matched a known variable. For example, given variables `mcp` and `tool`, the expression `mcp.tool` would highlight both `mcp` and `tool`, even though `tool` after the dot is a property access, not a variable reference. This was especially confusing with decorator syntax like `@mcp.tool`.

The fix checks whether a `VariableName` node is preceded by a `.` sibling in the syntax tree, and if so, skips it.