### PR TITLE
Extract sanitizeHtml into a standalone module

### DIFF
--- a/frontend/src/core/dom/outline.ts
+++ b/frontend/src/core/dom/outline.ts
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { sanitizeHtml } from "@/plugins/core/sanitize";
+import { sanitizeHtml } from "@/plugins/core/sanitize-html";
 import { invariant } from "@/utils/invariant";
 import { Logger } from "@/utils/Logger";
 import type { Outline, OutlineItem } from "../cells/outline";

--- a/frontend/src/plugins/core/sanitize-html.ts
+++ b/frontend/src/plugins/core/sanitize-html.ts
@@ -1,0 +1,50 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import DOMPurify, { type Config } from "dompurify";
+
+// preserve target=_blank https://github.com/cure53/DOMPurify/issues/317#issuecomment-912474068
+const TEMPORARY_ATTRIBUTE = "data-temp-href-target";
+DOMPurify.addHook("beforeSanitizeAttributes", (node) => {
+  if (node.tagName === "A") {
+    if (!node.hasAttribute("target")) {
+      node.setAttribute("target", "_self");
+    }
+
+    if (node.hasAttribute("target")) {
+      node.setAttribute(TEMPORARY_ATTRIBUTE, node.getAttribute("target") || "");
+    }
+  }
+});
+
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  if (node.tagName === "A" && node.hasAttribute(TEMPORARY_ATTRIBUTE)) {
+    node.setAttribute("target", node.getAttribute(TEMPORARY_ATTRIBUTE) || "");
+    node.removeAttribute(TEMPORARY_ATTRIBUTE);
+    if (node.getAttribute("target") === "_blank") {
+      node.setAttribute("rel", "noopener noreferrer");
+    }
+  }
+});
+
+/**
+ * This removes script tags, form tags, iframe tags, and other potentially dangerous tags
+ */
+export function sanitizeHtml(html: string) {
+  const sanitizationOptions: Config = {
+    // Default to permit HTML, SVG and MathML, this limits to HTML only
+    USE_PROFILES: { html: true, svg: true, mathMl: true },
+    // Allow SVG <use> elements and their href attributes, which are needed
+    // for SVGs that reference <defs> (e.g., Matplotlib SVG output).
+    ADD_TAGS: ["use"],
+    ADD_ATTR: ["href", "xlink:href"],
+    // glue elements like style, script or others to document.body and prevent unintuitive browser behavior in several edge-cases
+    FORCE_BODY: true,
+    CUSTOM_ELEMENT_HANDLING: {
+      tagNameCheck: /^(marimo-[A-Za-z][\w-]*|iconify-icon)$/,
+      attributeNameCheck: /^[A-Za-z][\w-]*$/,
+    },
+    // This flag means we should sanitize such that is it safe for XML,
+    // but this is only used for HTML content.
+    SAFE_FOR_XML: !html.includes("marimo-mermaid"),
+  };
+  return DOMPurify.sanitize(html, sanitizationOptions);
+}

--- a/frontend/src/plugins/core/sanitize.ts
+++ b/frontend/src/plugins/core/sanitize.ts
@@ -1,9 +1,11 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import DOMPurify, { type Config } from "dompurify";
 import { atom, useAtomValue } from "jotai";
 import { hasRunAnyCellAtom } from "@/components/editor/cell/useRunCells";
 import { autoInstantiateAtom } from "@/core/config/config";
 import { getInitialAppMode } from "@/core/mode";
+
+// Re-export so existing consumers don't break.
+export { sanitizeHtml } from "./sanitize-html";
 
 /**
  * Whether to sanitize the html.
@@ -41,52 +43,4 @@ const sanitizeHtmlAtom = atom<boolean>((get) => {
  */
 export function useSanitizeHtml() {
   return useAtomValue(sanitizeHtmlAtom);
-}
-
-// preserve target=_blank https://github.com/cure53/DOMPurify/issues/317#issuecomment-912474068
-const TEMPORARY_ATTRIBUTE = "data-temp-href-target";
-DOMPurify.addHook("beforeSanitizeAttributes", (node) => {
-  if (node.tagName === "A") {
-    if (!node.hasAttribute("target")) {
-      node.setAttribute("target", "_self");
-    }
-
-    if (node.hasAttribute("target")) {
-      node.setAttribute(TEMPORARY_ATTRIBUTE, node.getAttribute("target") || "");
-    }
-  }
-});
-
-DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-  if (node.tagName === "A" && node.hasAttribute(TEMPORARY_ATTRIBUTE)) {
-    node.setAttribute("target", node.getAttribute(TEMPORARY_ATTRIBUTE) || "");
-    node.removeAttribute(TEMPORARY_ATTRIBUTE);
-    if (node.getAttribute("target") === "_blank") {
-      node.setAttribute("rel", "noopener noreferrer");
-    }
-  }
-});
-
-/**
- * This removes script tags, form tags, iframe tags, and other potentially dangerous tags
- */
-export function sanitizeHtml(html: string) {
-  const sanitizationOptions: Config = {
-    // Default to permit HTML, SVG and MathML, this limits to HTML only
-    USE_PROFILES: { html: true, svg: true, mathMl: true },
-    // Allow SVG <use> elements and their href attributes, which are needed
-    // for SVGs that reference <defs> (e.g., Matplotlib SVG output).
-    ADD_TAGS: ["use"],
-    ADD_ATTR: ["href", "xlink:href"],
-    // glue elements like style, script or others to document.body and prevent unintuitive browser behavior in several edge-cases
-    FORCE_BODY: true,
-    CUSTOM_ELEMENT_HANDLING: {
-      tagNameCheck: /^(marimo-[A-Za-z][\w-]*|iconify-icon)$/,
-      attributeNameCheck: /^[A-Za-z][\w-]*$/,
-    },
-    // This flag means we should sanitize such that is it safe for XML,
-    // but this is only used for HTML content.
-    SAFE_FOR_XML: !html.includes("marimo-mermaid"),
-  };
-  return DOMPurify.sanitize(html, sanitizationOptions);
 }


### PR DESCRIPTION
`sanitize.ts` mixes a pure DOMPurify wrapper with React/jotai state that transitively imports the full editor/codemirror/SQL panel tree, including `.svg`/`.png` database icon assets added in #8528.

This breaks the marimo-lsp VS Code extension build — esbuild bundles `transitionCell` from `core/cells/cell.ts`, which reaches `sanitize.ts` via `outline.ts`, pulling in assets it has no loader for. This has blocked upgrading the frontend dependency in marimo-lsp since 0.20.2.

No logic changes. `sanitizeHtml` and its DOMPurify hooks move to `sanitize-html.ts`, `outline.ts` imports from there directly, and `sanitize.ts` re-exports for backward compat.
