### PR TITLE
fix: cloning nested UI elements with on_change

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -529,6 +529,9 @@ class UIElement(Html, Generic[S, T]):
                     "functions": result._args.functions,
                 }
             )
+
+        # Use the newly constructed arguments, instead of the one in the naive deepcopy.
+        result._args = args
         result._initialize(args)
         return result
 

--- a/marimo/_plugins/ui/_impl/batch.py
+++ b/marimo/_plugins/ui/_impl/batch.py
@@ -221,4 +221,8 @@ class batch(_batch_base):
         )
 
     def _clone(self) -> batch:
-        return batch(html=self._html, elements=self.elements)
+        return batch(
+            html=self._html,
+            elements=self.elements,
+            on_change=self._on_change,
+        )

--- a/tests/_plugins/ui/_impl/test_batch.py
+++ b/tests/_plugins/ui/_impl/test_batch.py
@@ -60,3 +60,71 @@ def test_update_on_frontend_value_change_only() -> None:
     b._update({"b": 2})
     b._update({"b": 2})
     assert b.value == {"a": 1, "b": 1}
+
+
+def test_on_change_preserved_through_nested_cloning() -> None:
+    """Test that on_change handlers on child elements work correctly
+    when elements are nested in containers (batch inside array).
+
+    Regression test for https://github.com/marimo-team/marimo/issues/6435
+    """
+    from dataclasses import dataclass
+
+    @dataclass
+    class Model:
+        id: int
+        state: bool = False
+
+        def set_state(self, new_val: bool) -> None:
+            self.state = new_val
+
+    models = [Model(i) for i in range(3)]
+
+    # checkbox in batch in array: the on_change (m.set_state) must
+    # still reference the original Model, not a deep-copied one
+    view = ui.array(
+        [
+            ui.batch(
+                Html("{box}"),
+                elements={
+                    "box": ui.checkbox(on_change=m.set_state),
+                },
+            )
+            for m in models
+        ]
+    )
+
+    # Simulate checking the first checkbox
+    view._update({"0": {"box": True}})
+    assert view.value[0] == {"box": True}
+    # The on_change should have mutated the ORIGINAL model
+    assert models[0].state is True
+    assert models[1].state is False
+    assert models[2].state is False
+
+    # Simulate checking the third checkbox
+    view._update({"2": {"box": True}})
+    assert models[2].state is True
+
+
+def test_on_change_preserved_through_single_cloning() -> None:
+    """Test that on_change handlers work when elements are nested
+    in just a single container (batch only, no array wrapping)."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class Model:
+        id: int
+        state: bool = False
+
+        def set_state(self, new_val: bool) -> None:
+            self.state = new_val
+
+    m = Model(0)
+    b = ui.batch(
+        Html("{box}"),
+        elements={"box": ui.checkbox(on_change=m.set_state)},
+    )
+    b._update({"box": True})
+    assert b.value == {"box": True}
+    assert m.state is True


### PR DESCRIPTION
When UI elements were nested in containers (e.g., checkbox in batch in array), bound method on_change handlers like m.set_state would silently mutate a deep-copied object instead of the original. This happened because deep copying _args created a new bound method targeting a cloned object, and subsequent clones used this stale reference.

With this change, we now update the cloned element's args to point to the newly constructed args so subsequent clones use the correct args.

Fixes #6435