### PR TITLE
feat: add animated streaming to AI chat panel

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -165,7 +165,7 @@
     "remark-gfm": "^4.0.1",
     "rpc-anywhere": "^1.7.0",
     "sql-formatter": "^15.7.0",
-    "streamdown": "^2.1.0",
+    "streamdown": "^2.2.0",
     "string-dedent": "^3.0.2",
     "swiper": "^12.0.0",
     "tailwind-merge": "^2.6.0",

--- a/frontend/src/components/chat/chat-display.tsx
+++ b/frontend/src/components/chat/chat-display.tsx
@@ -14,10 +14,12 @@ export const renderUIMessage = ({
   message,
   isStreamingReasoning,
   isLast,
+  isLoading,
 }: {
   message: UIMessage;
   isStreamingReasoning: boolean;
   isLast: boolean;
+  isLoading: boolean;
 }) => {
   return (
     <>{message.parts.map((part, index) => renderUIMessagePart(part, index))}</>
@@ -59,7 +61,13 @@ export const renderUIMessage = ({
             </React.Fragment>
           );
         }
-        return <MarkdownRenderer key={index} content={part.text} />;
+        return (
+          <MarkdownRenderer
+            key={index}
+            content={part.text}
+            isStreaming={isLast && isLoading}
+          />
+        );
       case "reasoning":
         return (
           <ReasoningAccordion

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -131,10 +131,11 @@ interface ChatMessageProps {
   onEdit: (index: number, newValue: string) => void;
   isStreamingReasoning: boolean;
   isLast: boolean;
+  isLoading: boolean;
 }
 
 const ChatMessageDisplay: React.FC<ChatMessageProps> = memo(
-  ({ message, index, onEdit, isStreamingReasoning, isLast }) => {
+  ({ message, index, onEdit, isStreamingReasoning, isLast, isLoading }) => {
     const renderUserMessage = (message: UIMessage) => {
       const textParts = message.parts?.filter(
         (p): p is TextUIPart => p.type === "text",
@@ -181,7 +182,7 @@ const ChatMessageDisplay: React.FC<ChatMessageProps> = memo(
           <div className="absolute right-1 top-1 opacity-0 group-hover:opacity-100 transition-opacity">
             <CopyClipboardIcon className="h-3 w-3" value={content || ""} />
           </div>
-          {renderUIMessage({ message, isStreamingReasoning, isLast })}
+          {renderUIMessage({ message, isStreamingReasoning, isLast, isLoading })}
         </div>
       );
     };
@@ -711,6 +712,7 @@ const ChatPanelBody = () => {
             onEdit={handleMessageEdit}
             isStreamingReasoning={isStreamingReasoning}
             isLast={idx === messages.length - 1}
+            isLoading={isLoading}
           />
         ))}
 

--- a/frontend/src/components/markdown/markdown-renderer.tsx
+++ b/frontend/src/components/markdown/markdown-renderer.tsx
@@ -4,8 +4,9 @@ import { EditorView } from "@codemirror/view";
 import { math } from "@streamdown/math";
 import { useAtomValue } from "jotai";
 import { BetweenHorizontalStartIcon } from "lucide-react";
-import { memo, Suspense, useState } from "react";
+import { memo, Suspense, useEffect, useRef, useState } from "react";
 import { Streamdown, type StreamdownProps } from "streamdown";
+import "streamdown/styles.css";
 import { Button, type ButtonProps } from "@/components/ui/button";
 import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import { useCellActions } from "@/core/cells/cells";
@@ -166,15 +167,78 @@ const COMPONENTS: Components = {
   },
 };
 
-export const MarkdownRenderer = memo(({ content }: { content: string }) => {
-  return (
-    <Streamdown
-      components={COMPONENTS}
-      plugins={{ math }}
-      className="mo-markdown-renderer"
-    >
-      {content}
-    </Streamdown>
-  );
-});
+/**
+ * Drip-feeds content word-by-word during streaming so each React commit
+ * adds roughly one word, giving the Streamdown animate plugin a smooth
+ * per-word reveal instead of dumping entire token batches at once.
+ */
+function useWordBuffer(content: string, isStreaming: boolean): string {
+  const [displayLen, setDisplayLen] = useState(content.length);
+  const contentRef = useRef(content);
+  contentRef.current = content;
+
+  useEffect(() => {
+    if (!isStreaming) {
+      // Flush everything when streaming stops
+      setDisplayLen(contentRef.current.length);
+      return;
+    }
+
+    // Snapshot the already-visible length so we only drip new words
+    setDisplayLen(contentRef.current.length);
+
+    const timer = setInterval(() => {
+      setDisplayLen((prev) => {
+        const target = contentRef.current;
+        if (prev >= target.length) {
+          return prev;
+        }
+        // Advance past the next word (non-whitespace then whitespace)
+        const remaining = target.slice(prev);
+        const match = remaining.match(/^\S*\s*/);
+        return prev + (match ? match[0].length : remaining.length);
+      });
+    }, 25);
+
+    return () => clearInterval(timer);
+  }, [isStreaming]);
+
+  if (!isStreaming) {
+    return content;
+  }
+
+  return content.slice(0, Math.min(displayLen, content.length));
+}
+
+const ANIMATED = {
+  animation: "blurIn" as const,
+  duration: 200,
+  easing: "ease-out",
+  sep: "word" as const,
+};
+
+export const MarkdownRenderer = memo(
+  ({
+    content,
+    isStreaming,
+  }: {
+    content: string;
+    isStreaming?: boolean;
+  }) => {
+    const buffered = useWordBuffer(content, isStreaming ?? false);
+
+    return (
+      <Streamdown
+        components={COMPONENTS}
+        plugins={{ math }}
+        className="mo-markdown-renderer"
+        animated={ANIMATED}
+        isAnimating={isStreaming}
+        caret={isStreaming ? "block" : undefined}
+      >
+        {buffered}
+      </Streamdown>
+    );
+  },
+);
 MarkdownRenderer.displayName = "MarkdownRenderer";

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -405,6 +405,7 @@ export const Chatbot: React.FC<Props> = (props) => {
                   message,
                   isStreamingReasoning: status === "streaming",
                   isLast,
+                  isLoading: false,
                 })}
               </div>
               <div className="flex justify-end text-xs gap-2 invisible group-hover:visible">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,8 +470,8 @@ importers:
         specifier: ^15.7.0
         version: 15.7.0
       streamdown:
-        specifier: ^2.1.0
-        version: 2.1.0(react@19.2.4)
+        specifier: ^2.2.0
+        version: 2.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       string-dedent:
         specifier: ^3.0.2
         version: 3.0.2
@@ -8644,8 +8644,8 @@ packages:
   regl@2.1.1:
     resolution: {integrity: sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==}
 
-  rehype-harden@1.1.7:
-    resolution: {integrity: sha512-j5DY0YSK2YavvNGV+qBHma15J9m0WZmRe8posT5AtKDS6TNWtMVTo6RiqF8SidfcASYz8f3k2J/1RWmq5zTXUw==}
+  rehype-harden@1.1.8:
+    resolution: {integrity: sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==}
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
@@ -8671,8 +8671,8 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  remend@1.1.0:
-    resolution: {integrity: sha512-JENGyuIhTwzUfCarW43X4r9cehoqTo9QyYxfNDZSud2AmqeuWjZ5pfybasTa4q0dxTJAj5m8NB+wR+YueAFpxQ==}
+  remend@1.2.2:
+    resolution: {integrity: sha512-4ZJgIB9EG9fQE41mOJCRHMmnxDTKHWawQoJWZyUbZuj680wVyogu2ihnj8Edqm7vh2mo/TWHyEZpn2kqeDvS7w==}
 
   request@2.88.2:
     resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
@@ -9034,10 +9034,11 @@ packages:
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
-  streamdown@2.1.0:
-    resolution: {integrity: sha512-u9gWd0AmjKg1d+74P44XaPlGrMeC21oDOSIhjGNEYMAttDMzCzlJO6lpTyJ9JkSinQQF65YcK4eOd3q9iTvULw==}
+  streamdown@2.4.0:
+    resolution: {integrity: sha512-fRk4HEYNznRLmxoVeT8wsGBwHF6/Yrdey6k+ZrE1Qtp4NyKwm7G/6e2Iw8penY4yLx31TlAHWT5Bsg1weZ9FZg==}
     peerDependencies:
       react: ^19.2.4
+      react-dom: ^19.2.4
 
   strict-event-emitter-types@2.0.0:
     resolution: {integrity: sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==}
@@ -20009,7 +20010,7 @@ snapshots:
 
   regl@2.1.1: {}
 
-  rehype-harden@1.1.7:
+  rehype-harden@1.1.8:
     dependencies:
       unist-util-visit: 5.0.0
 
@@ -20077,7 +20078,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remend@1.1.0: {}
+  remend@1.2.2: {}
 
   request@2.88.2:
     dependencies:
@@ -20536,23 +20537,25 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
-  streamdown@2.1.0(react@19.2.4):
+  streamdown@2.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       clsx: 2.1.1
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       marked: 17.0.1
       react: 19.2.4
-      rehype-harden: 1.1.7
+      react-dom: 19.2.4(react@19.2.4)
+      rehype-harden: 1.1.8
       rehype-raw: 7.0.0
       rehype-sanitize: 6.0.0
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
-      remend: 1.1.0
+      remend: 1.2.2
       tailwind-merge: 3.4.0
       unified: 11.0.5
       unist-util-visit: 5.0.0
+      unist-util-visit-parents: 6.0.1
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary
- Enable per-word `blurIn` animation and a streaming block caret in the AI chat panel using streamdown 2.2+ built-in animation support
- Add a `useWordBuffer` hook that drip-feeds content word-by-word at ~25ms intervals for smooth reveals instead of dumping entire token batches
- Thread `isLoading` through chat components so only the last message animates during active streaming

## Changes
- `frontend/package.json` -- bump streamdown minimum to `^2.2.0`
- `frontend/src/components/markdown/markdown-renderer.tsx` -- add `useWordBuffer` hook, `isStreaming` prop, animation/caret config
- `frontend/src/components/chat/chat-display.tsx` -- thread `isLoading` into `renderUIMessage`
- `frontend/src/components/chat/chat-panel.tsx` -- thread `isLoading` through `ChatMessageProps`
- `frontend/src/plugins/impl/chat/chat-ui.tsx` -- pass `isLoading: false` for `mo.ui.chat()` widget (no streaming animation)

## Test plan
- [x] `pnpm exec tsgo --noEmit` -- typecheck passes (only pre-existing R adapter errors)
- [x] `pnpm test src/components/chat` -- all 59 chat tests pass
- [x] `pnpm build` -- build succeeds
- [x] `pnpm test --run` -- 276/277 test files pass (1 pre-existing locale-dependent failure in logs.test.ts)
- [x] Manual QA: streaming text shows per-word blurIn animation and block caret in AI chat panel
- [ ] Verify `mo.ui.chat()` widget renders without animation (isLoading: false)

Closes #8686

🤖 Generated with [Claude Code](https://claude.com/claude-code)