### PR TITLE
fix: use millisecond() instead of microsecond()//1000 in ibis time binning

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/ibis_table.py
+++ b/marimo/_plugins/ui/_impl/tables/ibis_table.py
@@ -146,10 +146,10 @@ class IbisTableManagerFactory(TableManagerFactory):
 
                 if dtype.is_time():
                     col_agg = (
-                        col.hour() * 3600000
-                        + col.minute() * 60000
-                        + col.second() * 1000
-                        + col.microsecond() // 1000
+                        col.hour().cast("int64") * 3600000
+                        + col.minute().cast("int64") * 60000
+                        + col.second().cast("int64") * 1000
+                        + col.millisecond().cast("int64")
                     )
                 else:
                     col_agg = col.epoch_seconds()


### PR DESCRIPTION
col.microsecond() // 1000 produces a Floor(Mod/literal) expression tree that fails sqlglot's mypyc type checks because Mod inherits from Binary, not Func. Use ibis's built-in millisecond() method to avoid the floor division entirely, and add int64 casts to prevent potential overflow.