### PR TITLE
refactor: Checking if a block is defined should use a set's in operator.

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -129,7 +129,7 @@ class Block:
     is_comprehension: bool = False
 
     def is_defined(self, name: str) -> bool:
-        return any(name == defn for defn in self.defs)
+        return name in self.defs
 
 
 @dataclass


### PR DESCRIPTION
For large blocks this linear scan is wasteful - specially for definitions that don't exist.

Ran the following benchmark:

```python
import timeit
from functools import partial

from marimo._ast.compiler import compile_cell, module_compile
from marimo._ast.visitor import Block


def bench_block_is_defined() -> None:
    block = Block(defs={f"var_{i}" for i in range(200)})

    t1 = timeit.timeit(lambda: any("missing" == d for d in block.defs), number=100_000)
    t2 = timeit.timeit(lambda: "missing" in block.defs, number=100_000)
    print(f"any(name == d for d in defs):  {t1 * 1000:.1f}ms / 100k")
    print(f"name in defs:                  {t2 * 1000:.1f}ms / 100k")
```

Results:

```
any(name == d for d in defs):  311.0ms / 100k
name in defs:                  1.4ms / 100k
```