### PR TITLE
fix: prevent infinite re-render loop in grid layout read mode (#8644)

### DIFF
--- a/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
@@ -161,7 +161,8 @@ export const GridLayoutRenderer: React.FC<Props> = ({
       onLayoutChange={(cellLayouts) => {
         // Don't update state in read mode — the layout is static and
         // updating triggers a re-render cycle that causes an infinite loop
-        // (React error #185: Maximum update depth exceeded).
+        // (React error https://react.dev/errors/185 Maximum update depth exceeded).
+        // https://github.com/marimo-team/marimo/issues/8644
         if (isReading) {
           return;
         }


### PR DESCRIPTION
## Summary

This is an opportunistic PR to fix #8644, but I was unable to repro myself.

Maybe fix React error (Maximum update depth exceeded) that occurs when
rendering tables or other content in grid layout during `marimo run`.

## Problem

The `onLayoutChange` callback in `GridLayoutRenderer` unconditionally
called `setLayout()` on every layout change, including the initial
render. In read mode (`marimo run`), this created an infinite loop:

1. Component mounts → react-grid-layout fires `onLayoutChange`
2. `setLayout()` updates Jotai atom → new layout object reference
3. Component re-renders with new `layouts` prop
4. react-grid-layout detects prop change → fires `onLayoutChange` again
5. Back to step 2 → infinite loop → React error 

This only manifested in read mode because edit mode bypasses the grid
layout plugin in `CellsRenderer` (returning children directly).

## Fix

Guard `onLayoutChange` to skip state updates in read mode. The layout is
static in read mode (dragging/resizing are disabled), so there is no
reason to persist layout changes from the library's internal
recalculations.
