### PR TITLE
Add GPT-5.4 Mini and Nano models

### DIFF
--- a/examples/ai/chat/pydantic-ai-chat.py
+++ b/examples/ai/chat/pydantic-ai-chat.py
@@ -49,7 +49,7 @@ def _():
         options={
             "Gemini 2.5 Flash": "gemini-2.5-flash",
             "Claude Haiku 4.5": "claude-haiku-4-5",
-            "GPT 5 Nano": "gpt-5-nano",
+            "GPT 5.4 Nano": "gpt-5.4-nano",
             "GPT 5 (multimodal)": "gpt-5",
         },
         value="Gemini 2.5 Flash",

--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -84,6 +84,20 @@
   roles: [chat, edit]
   thinking: false
 
+- name: GPT-5.4 Mini
+  model: gpt-5.4-mini
+  description: A faster, more efficient model optimized for high-throughput workloads
+  providers: [openai]
+  roles: [chat, edit]
+  thinking: false
+
+- name: GPT-5.4 Nano
+  model: gpt-5.4-nano
+  description: Most lightweight and cost-efficient variant of the GPT-5.4 family
+  providers: [openai]
+  roles: [chat, edit]
+  thinking: false
+
 - name: GPT-5.3 Chat
   model: gpt-5.3-chat
   description: Most-used model that makes everyday conversations smoother and more useful
@@ -98,19 +112,6 @@
   roles: [chat, edit]
   thinking: false
 
-- name: GPT-5 Mini
-  model: gpt-5-mini
-  description: A faster, cost-efficient version of GPT-5 for well-defined tasks
-  providers: [openai, azure, github]
-  roles: [chat, edit]
-  thinking: false
-
-- name: GPT-5 Nano
-  model: gpt-5-nano
-  description: Fastest, most cost-efficient version of GPT-5
-  providers: [openai, azure]
-  roles: [chat, edit]
-  thinking: false
 
 - name: o3
   model: o3


### PR DESCRIPTION
## Summary
- Add `gpt-5.4-mini` and `gpt-5.4-nano` to the OpenAI models in `models.yml`
- Remove older `gpt-5-mini` and `gpt-5-nano` entries
- Update example file reference from `gpt-5-nano` to `gpt-5.4-nano`


Pending pydantic-ai to include these