### PR TITLE
Re-derive language adapter when cell code changes externally

### DIFF
--- a/frontend/src/core/codemirror/language/utils.ts
+++ b/frontend/src/core/codemirror/language/utils.ts
@@ -3,7 +3,11 @@
 import type { EditorState } from "@codemirror/state";
 import type { EditorView } from "@codemirror/view";
 import { replaceEditorContent } from "../replace-editor-content";
-import { languageAdapterState } from "./extension";
+import {
+  languageAdapterFromCode,
+  languageAdapterState,
+  switchLanguage,
+} from "./extension";
 import { languageMetadataField } from "./metadata";
 
 /**
@@ -35,6 +39,17 @@ export function updateEditorCodeFromPython(
   editor: EditorView,
   pythonCode: string,
 ): string {
+  const currentAdapter = editor.state.field(languageAdapterState);
+  const correctAdapter = languageAdapterFromCode(pythonCode);
+
+  // If the language type changed (e.g., markdown → python), switch adapters
+  if (correctAdapter.type !== currentAdapter.type) {
+    switchLanguage(editor, {
+      language: correctAdapter.type,
+      keepCodeAsIs: true,
+    });
+  }
+
   const languageAdapter = editor.state.field(languageAdapterState);
   const [code] = languageAdapter.transformIn(pythonCode);
   // Use replaceEditorContent which preserves cursor position when focused


### PR DESCRIPTION
When `updateEditorCodeFromPython` receives new code (e.g., from a `code_mode` `edit_cell` call), it blindly uses the current language adapter to transform the incoming code. If a markdown cell is edited to contain plain Python (or vice versa), the adapter doesn't switch and the UI renders the cell with the wrong language mode.

This adds a check that compares the current adapter against what `languageAdapterFromCode` detects for the incoming Python code. When they differ, `switchLanguage` is called with `keepCodeAsIs: true` to update the adapter, metadata, and editor extensions before transforming the code.
