### PR TITLE
Handle running indicator when only scratchpad is active

### DIFF
--- a/frontend/src/components/editor/header/status.tsx
+++ b/frontend/src/components/editor/header/status.tsx
@@ -5,6 +5,7 @@ import { HourglassIcon, LockIcon, UnlinkIcon } from "lucide-react";
 import React from "react";
 import { Tooltip } from "@/components/ui/tooltip";
 import { notebookScrollToRunning } from "@/core/cells/actions";
+import { onlyScratchpadIsRunningAtom } from "@/core/cells/cells";
 import { viewStateAtom } from "@/core/mode";
 import { type ConnectionStatus, WebSocketState } from "@/core/websocket/types";
 import { cn } from "@/utils/cn";
@@ -52,17 +53,24 @@ const LockedIcon = () => (
   </Tooltip>
 );
 
-const RunningIcon = () => (
-  <Tooltip content="Jump to running cell" side="right">
-    <div
-      className={topLeftStatus}
-      data-testid="loading-indicator"
-      onClick={notebookScrollToRunning}
-    >
-      <HourglassIcon className="running-app-icon" size={30} strokeWidth={1} />
-    </div>
-  </Tooltip>
-);
+const RunningIcon = () => {
+  const scratchpadOnly = useAtomValue(onlyScratchpadIsRunningAtom);
+  const tooltip = scratchpadOnly
+    ? "Scratchpad is running"
+    : "Jump to running cell";
+
+  return (
+    <Tooltip content={tooltip} side="right">
+      <div
+        className={topLeftStatus}
+        data-testid="loading-indicator"
+        onClick={scratchpadOnly ? undefined : notebookScrollToRunning}
+      >
+        <HourglassIcon className="running-app-icon" size={30} strokeWidth={1} />
+      </div>
+    </Tooltip>
+  );
+};
 
 const NoiseBackground = () => (
   <>

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1640,6 +1640,12 @@ export const cellsRuntimeAtom = atom((get) => get(notebookAtom).cellRuntime);
 export const notebookIsRunningAtom = atom((get) =>
   notebookIsRunning(get(notebookAtom)),
 );
+export const onlyScratchpadIsRunningAtom = atom((get) => {
+  const { cellRuntime } = get(notebookAtom);
+  return Object.entries(cellRuntime).every(
+    ([id, rt]) => rt.status !== "running" || id === SCRATCH_CELL_ID,
+  );
+});
 export const notebookQueuedOrRunningCountAtom = atom((get) =>
   notebookQueueOrRunningCount(get(notebookAtom)),
 );

--- a/frontend/src/core/cells/utils.ts
+++ b/frontend/src/core/cells/utils.ts
@@ -11,6 +11,7 @@ export function notebookIsRunning(state: NotebookState) {
     (cell) => cell.status === "running",
   );
 }
+
 export function notebookQueueOrRunningCount(state: NotebookState) {
   return Object.values(state.cellRuntime).filter(
     (cell) => cell.status === "running" || cell.status === "queued",


### PR DESCRIPTION
The scratchpad is a hidden utility cell that doesn't appear in the notebook cell list. When it's the only running cell, "Jump to running cell" is misleading since there's nothing to scroll to. This changes the tooltip to "Scratchpad is running" and disables click-to-scroll in that case.

There is more UI iteration that we should do for code-mode execution... but this is a starting point.
