### PR TITLE
add container charts smoke test

### DIFF
--- a/marimo/_smoke_tests/altair_examples/container_charts.py
+++ b/marimo/_smoke_tests/altair_examples/container_charts.py
@@ -1,0 +1,38 @@
+import marimo
+
+__generated_with = "0.21.0"
+app = marimo.App(width="medium")
+
+with app.setup:
+    import marimo as mo
+    import altair as alt
+    from altair.datasets import data
+
+
+@app.cell
+def _():
+    cars = data.cars()
+
+    chart = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .interactive()
+    )
+    chart.properties(width="container")
+    return (chart,)
+
+
+@app.cell
+def _(chart):
+    # Broken
+    chart.properties(height="container")
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Adds an altair smoke test for us to check for regression on chart widths.

<img width="955" height="753" alt="image" src="https://github.com/user-attachments/assets/7d9d3b85-ffc5-4b5e-b909-965b32b0bd7e" />

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
