### PR TITLE
fix: markdown bullets inside of details

### DIFF
--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -374,6 +374,13 @@ button .prose.prose {
   @apply p-4 pt-0;
 }
 
+/* Restore proper list indentation inside details blocks.
+   The p-4 above overrides prose's padding-inline-start for bullet space.
+   This ensures bullets render correctly with list-style-position: outside. */
+.markdown details > :is(ul, ol) {
+  padding-inline-start: 2.5rem;
+}
+
 .markdown .codehilite {
   background-color: var(--slate-2);
   border-radius: 4px;

--- a/marimo/_smoke_tests/markdown/markdown_pymdownx.py
+++ b/marimo/_smoke_tests/markdown/markdown_pymdownx.py
@@ -114,6 +114,20 @@ def _(mo):
 
     This indicates a successful outcome or positive note
     ///
+
+    /// details | Details with lists
+        type: info
+
+    This is a note with bullets:
+    - First item
+    - Second item
+    - Third item
+
+    And an ordered list:
+    1. One
+    2. Two
+    3. Three
+    ///
     """)
     return
 


### PR DESCRIPTION
Closes #8736

fix markdown bullets inside of details

<img width="1153" height="498" alt="Screenshot 2026-03-18 at 4 45 25 PM" src="https://github.com/user-attachments/assets/4ababc05-55cd-4a06-a6c5-c8bc54c898b3" />
