### PR TITLE
Exclude index columns for pivot for count/sum agg

### DIFF
--- a/marimo/_plugins/ui/_impl/dataframes/transforms/handlers.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/handlers.py
@@ -487,7 +487,9 @@ class NarwhalsTransformHandler(TransformHandler[DataFrame]):
         for df_ in dfs:
             result = result.join(df_, on=index_columns, how="left")
         if transform.aggregation in {"count", "sum"}:
-            result = result.select(nw.all().fill_null(0))
+            result = result.with_columns(
+                nw.exclude(*index_columns).fill_null(0)
+            )
         return result.sort(by=index_columns)
 
     @staticmethod

--- a/tests/_plugins/ui/_impl/dataframes/test_handlers.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_handlers.py
@@ -1659,6 +1659,32 @@ class TestTransformHandler:
         )
 
     @staticmethod
+    def test_pivot_count_preserves_boolean_index_dtype() -> None:
+        """fill_null(0) on value columns must not alter boolean index dtypes."""
+        import polars as pl
+
+        df = pl.DataFrame(
+            {
+                "category": ["x", "x", "y"],
+                "id": [1, 2, 1],
+                "flag": [True, False, True],
+                "value": [10, 20, 30],
+            }
+        )
+
+        transform = PivotTransform(
+            type=TransformType.PIVOT,
+            column_ids=["category"],
+            index_column_ids=["id", "flag"],
+            value_column_ids=["value"],
+            aggregation="count",
+        )
+
+        result = apply(df, transform)
+        nw_result = nw.from_native(result)
+        assert nw_result.schema["flag"] == nw.Boolean
+
+    @staticmethod
     @pytest.mark.parametrize(
         ("df", "expected", "expected2"),
         list(


### PR DESCRIPTION
## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
This was caught in CI tests.

Fix pivot fill_null(0) casting boolean index columns

handle_pivot applied nw.all().fill_null(0) to every column — including index columns. On boolean index columns this either silently casts the dtype to Int32 or raises an InvalidOperationError depending on the Polars version. Use nw.exclude(*index_columns).fill_null(0) so only the aggregated value columns are filled.

Adds a regression test in test_handlers.py.

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
