### PR TITLE
fix: add version field to publishDiagnostics clear notification

### DIFF
--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -832,6 +832,7 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
               method: "textDocument/publishDiagnostics",
               params: {
                 uri: cellDocumentUri,
+                version: cellVersion,
                 diagnostics: [],
               },
             });


### PR DESCRIPTION
## Summary

- Fixes LSP diagnostics (e.g., Ruff's "Undefined name") persisting after code is fixed, particularly on Windows
- Adds the missing `version` field to the `publishDiagnostics` notification in the "clear diagnostics" loop within `patchProcessNotification`
- The `version` field was already included when forwarding diagnostics to cells with errors, but was omitted when clearing diagnostics for cells without errors, causing LSP clients to ignore the clear notification

## Details

In `notebook-lsp.ts`, the `patchProcessNotification` method processes `textDocument/publishDiagnostics` notifications by splitting merged-document diagnostics into per-cell notifications. When a cell no longer has any diagnostics, a "clear" notification is sent with an empty diagnostics array. However, this clear notification was missing the `version` field, which some LSP clients require to accept the update.

The fix adds `version: cellVersion` to the clear loop (line 833), matching the diagnostic-forwarding loop above it (line 820).

Fixes #8687

## Test plan

- [ ] Open a marimo notebook with a Ruff-detected error (e.g., undefined name)
- [ ] Fix the error in the cell
- [ ] Verify that the diagnostic squiggly line and error message disappear
- [ ] Test on Windows where the issue was originally reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)