### PR TITLE
fix: use python -m pip instead of pip --python for PipPackageManager

### DIFF
--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -126,12 +126,13 @@ class PipPackageManager(PypiPackageManager):
         """Check if pip is available.
 
         On some platforms (e.g. macOS with pip-installed Python from python.org),
-        only `pip3` is available in PATH, not `pip`. We fall back to checking
-        via `python -m pip` to handle these cases.
+        only `pip3` is available in PATH, not `pip`. We first try the method we
+        actually use to invoke pip (`python -m pip`), then fall back to a PATH
+        check for compatibility.
         """
-        if DependencyManager.which(self.name):
-            return True
-        # Fallback: check if `python -m pip` works
+        # Primary check: use the same invocation method we actually use
+        # (python -m pip) rather than relying on PATH pip, which could be
+        # a different Python's pip than self._python_exe
         try:
             proc = subprocess.run(
                 [self._python_exe, "-m", "pip", "--version"],
@@ -141,8 +142,12 @@ class PipPackageManager(PypiPackageManager):
             )
             if proc.returncode == 0:
                 return True
-        except (subprocess.TimeoutExpired, FileNotFoundError):
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
+        # Fallback: check if pip is on PATH (handles cases where pip is
+        # available but python -m pip is not desired/needed)
+        if DependencyManager.which(self.name):
+            return True
         LOGGER.error(
             f"{self.name} is not available. "
             f"Check out the docs for installation instructions: {self.docs_url}"

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -63,6 +63,57 @@ async def test_failed_install_returns_false() -> None:
     assert not await mgr.install("asdfasdfasdfasdfqwerty", version=None)
 
 
+@patch("subprocess.run")
+def test_pip_is_manager_installed_primary_check_success(mock_run: MagicMock):
+    """Primary python -m pip check succeeds → returns True."""
+    mock_run.return_value = MagicMock(returncode=0)
+    mgr = PipPackageManager()
+    assert mgr.is_manager_installed() is True
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args[0][0]
+    assert call_args == [PY_EXE, "-m", "pip", "--version"]
+
+
+@patch("subprocess.run")
+@patch("marimo._dependencies.dependencies.DependencyManager.which")
+def test_pip_is_manager_installed_fallback_check(
+    mock_which: MagicMock, mock_run: MagicMock
+):
+    """Primary python -m pip fails but pip is on PATH → returns True (fallback)."""
+    mock_run.return_value = MagicMock(returncode=1)
+    mock_which.return_value = True
+    mgr = PipPackageManager()
+    assert mgr.is_manager_installed() is True
+    # Primary check was called and failed
+    mock_run.assert_called_once()
+    # Fallback which() was also called
+    mock_which.assert_called_once_with("pip")
+
+
+@patch("subprocess.run")
+@patch("marimo._dependencies.dependencies.DependencyManager.which")
+def test_pip_is_manager_installed_permission_error(
+    mock_which: MagicMock, mock_run: MagicMock
+):
+    """python -m pip raises OSError (e.g. PermissionError) → returns False."""
+    mock_run.side_effect = PermissionError("python not executable")
+    mock_which.return_value = False
+    mgr = PipPackageManager()
+    assert mgr.is_manager_installed() is False
+
+
+@patch("subprocess.run")
+@patch("marimo._dependencies.dependencies.DependencyManager.which")
+def test_pip_is_manager_installed_both_fail(
+    mock_which: MagicMock, mock_run: MagicMock
+):
+    """Both python -m pip and which("pip") fail → returns False."""
+    mock_run.return_value = MagicMock(returncode=1)
+    mock_which.return_value = False
+    mgr = PipPackageManager()
+    assert mgr.is_manager_installed() is False
+
+
 manager = PipPackageManager()
 
 


### PR DESCRIPTION
## Summary

On macOS with pip-installed Python (e.g. python.org installer), only 'pip3' is
available in PATH, not 'pip'. This caused `PipPackageManager.is_manager_installed()`
to return False because `shutil.which('pip')` could not find it, making marimo
fail to detect any optional dependencies.

## Fix

1. **`is_manager_installed()`**: Add fallback check via `python -m pip --version`
   when `pip` is not in PATH.

2. **All pip commands**: Use `python -m pip` instead of `pip --python python_exe`.
   The `-m pip` invocation is the [officially supported way](https://pip.pypa.io/en/stable/user_guide/)
   and works reliably across all platforms.

## Files Changed

- `marimo/_runtime/packages/pypi_package_manager.py`
  - Added `DependencyManager` import
  - Override `is_manager_installed()` with `python -m pip` fallback
  - `install_command()`, `uninstall()`, `list_packages()` now use `python -m pip`
- `tests/_runtime/packages/test_pypi_package_manager.py`
  - Updated test assertions to match new command format

## Testing

- All 70 tests in `test_pypi_package_manager.py` pass
- `ruff check` passes

## CLA

I have read the CLA D