### PR TITLE
fix: slider debounce should not block NumberField input updates (issue #8677)

### DIFF
--- a/frontend/src/plugins/impl/SliderPlugin.tsx
+++ b/frontend/src/plugins/impl/SliderPlugin.tsx
@@ -152,9 +152,9 @@ const SliderComponent = ({
                 nextValue = Number(start);
               }
               setInternalValue(nextValue);
-              if (!debounce) {
-                setValue(nextValue);
-              }
+              // Always update value on explicit NumberField input;
+              // debounce only applies to slider drag events (onValueCommit).
+              setValue(nextValue);
             }}
             minValue={start}
             maxValue={stop}


### PR DESCRIPTION
## Summary

Fixes #8677: Slider debounce prevents value updates when using editable input

### Problem
When a slider is configured with `debounce=True` and `include_input=True`, the editable NumberField becomes unusable:
- Pressing Enter after typing a value does NOT trigger a cell update
- Using up/down arrow keys does NOT trigger a cell update
- The slider visually shows the new value but the cell output is not re-run

### Root Cause
In `SliderPlugin.tsx`, the `NumberField`'s `onChange` handler was checking `if (!debounce)` before calling `setValue`. This meant that when `debounce=True`, explicit NumberField input was ignored.

The intent of `debounce` is to suppress expensive computations during *active slider dragging* (handled via `onValueCommit`). But explicit NumberField input (user typed a value and confirmed with Enter or arrow keys) should always propagate immediately.

### Fix
Removed the `if (!debounce)` guard from the `NumberField`'s `onChange` handler. Now `setValue` is always called on NumberField changes, while the slider's `onValueCommit` continues to handle debouncing for drag events.

### Testing
- Manual: Verified the fix works with `mo.ui.slider(0, 10, debounce=True, include_input=True)`
- No existing unit tests for this interaction; e2e test is basic slider drag

### Risk
- **Low** — debounce still applies to slider drag events via `onValueCommit`
- **Low** — no change to the slider drag behavior, only to NumberField input

### Rollback
`git revert <commit-hash>`
