### PR TITLE
fix(lsp): add version field when clearing diagnostics

### DIFF
--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -832,6 +832,7 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
               method: "textDocument/publishDiagnostics",
               params: {
                 uri: cellDocumentUri,
+                version: cellVersion,
                 diagnostics: [],
               },
             });


### PR DESCRIPTION
## Summary
LSP diagnostics (e.g. Ruff "Undefined name") are not cleared from the cell editor after fixing the code. The issue occurs because the `textDocument/publishDiagnostics` notification for clearing diagnostics is missing the `version` field.

According to the LSP spec, the client ignores `publishDiagnostics` notifications where the `version` field does not match the current document version. The clear-path code was not including this field, so the diagnostics persisted.

## Fix
Added `version: cellVersion` to the `publishDiagnostics` params in the cells-to-clear loop inside `patchProcessNotification`:

```diff
 for (const cellDocumentUri of cellsToClear) {
   previousProcessNotification({
     method: "textDocument/publishDiagnostics",
     params: {
       uri: cellDocumentUri,
+      version: cellVersion,
       diagnostics: [],
     },
   });
 }
```

This mirrors what the add/update path already does at line ~820.

## Testing
- Verified the fix locally on Windows + WSL2 (issue reporter's environment)
- Fix also resolved persistent diagnostics in basedpyright
- The fix is minimal (1 line) and only affects the clear path

## Risk
- **Low**: Single-line addition, only affects the diagnostics-clear path
- **Rollback**: Revert this single line

## Issue
Fixes marimo-team/marimo#8687