### PR TITLE
feat(completion): add accept_completion_on_enter config option

### DIFF
--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -207,7 +207,7 @@ export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
     foldGutter(),
     stringsAutoCloseBraces(),
     closeBrackets(),
-    completionKeymap(),
+    completionKeymap(completionConfig.accept_completion_on_enter),
     // to avoid clash with charDeleteBackward keymap
     Prec.high(keymap.of(closeBracketsKeymap)),
     bracketMatching(),

--- a/frontend/src/core/codemirror/completion/__tests__/keymap.test.ts
+++ b/frontend/src/core/codemirror/completion/__tests__/keymap.test.ts
@@ -41,4 +41,32 @@ describe("completionKeymap", () => {
 
     view.destroy();
   });
+
+  it("should include Enter key in keymap by default (acceptOnEnter=true)", () => {
+    const ext = completionKeymap(true);
+    // The extension should be a keymap containing Enter
+    const keymapExt = ext as { key?: string }[];
+    const hasEnter = keymapExt.some(
+      (e) =>
+        e &&
+        typeof e === "object" &&
+        "key" in e &&
+        (e as { key: string }).key === "Enter",
+    );
+    expect(hasEnter).toBe(true);
+  });
+
+  it("should exclude Enter key from keymap when acceptOnEnter=false", () => {
+    const ext = completionKeymap(false);
+    // The extension should NOT contain an Enter binding
+    const keymapExt = ext as { key?: string }[];
+    const hasEnter = keymapExt.some(
+      (e) =>
+        e &&
+        typeof e === "object" &&
+        "key" in e &&
+        (e as { key: string }).key === "Enter",
+    );
+    expect(hasEnter).toBe(false);
+  });
 });

--- a/frontend/src/core/codemirror/completion/keymap.ts
+++ b/frontend/src/core/codemirror/completion/keymap.ts
@@ -22,9 +22,15 @@ const KEYS_TO_REMOVE = new Set<string | undefined>([
   "Alt-`",
 ]);
 
-export function completionKeymap(): Extension {
+export function completionKeymap(acceptOnEnter = true): Extension {
+  const keysToRemove = new Set(KEYS_TO_REMOVE);
+  if (!acceptOnEnter) {
+    // Allow users to disable completion acceptance on Enter, similar to VS Code.
+    // Issue: https://github.com/marimo-team/marimo/issues/7435
+    keysToRemove.add("Enter");
+  }
   const withoutKeysToRemove = defaultCompletionKeymap.filter(
-    (binding) => !KEYS_TO_REMOVE.has(binding.key),
+    (binding) => !keysToRemove.has(binding.key),
   );
 
   return Prec.highest(

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -84,6 +84,7 @@ export const UserConfigSchema = z
             }
             return copilot;
           }),
+        accept_completion_on_enter: z.boolean().prefault(true),
         codeium_api_key: z.string().nullish(),
       })
       .prefault({}),


### PR DESCRIPTION
## Summary

Allow users to disable completion acceptance on the Enter key, similar to VS Code's `editor.acceptSuggestionOnEnter` setting.

Fixes https://github.com/marimo-team/marimo/issues/7435

## Changes

1. **Config schema** (`frontend/src/core/config/config-schema.ts`): Added `accept_completion_on_enter: boolean = true` to the completion config. Defaults to `true` for backward compatibility.

2. **Keymap** (`frontend/src/core/codemirror/completion/keymap.ts`): Modified `completionKeymap(acceptOnEnter = true)` to optionally filter out the Enter key from the default CodeMirror completion keymap when disabled.

3. **Editor setup** (`frontend/src/core/codemirror/cm.ts`): Wired the config value through to `completionKeymap()`.

4. **Tests** (`frontend/src/core/codemirror/completion/__tests__/keymap.test.ts`): Added two test cases verifying Enter is present by default and absent when `acceptOnEnter=false`.

## Risk

- **Low**: Defaults to existing behavior (Enter accepts completions). Users must explicitly opt out.
- **No Python changes**: Purely frontend/TypeScript change.

## Rollback

Revert commit 6decd19 or set `completion.accept_completion_on_enter: true` in config.

## Testing

- `make fe-test` / `make py-test` (when CI runs)
- Manual: With `accept_completion_on_enter: false`, pressing Enter in a completion should insert a newline instead of accepting.
