### PR TITLE
fix: append .py extension to markdown notebooks for correct ruff formatting

### DIFF
--- a/marimo/_server/api/endpoints/editing.py
+++ b/marimo/_server/api/endpoints/editing.py
@@ -178,14 +178,13 @@ async def format_cell(request: Request) -> FormatResponse:
     app_state = AppState(request)
     body = await parse_request(request, cls=FormatCellsRequest)
     formatter = DefaultFormatter(line_length=body.line_length)
+    filename = app_state.require_current_session().app_file_manager.path
+    if filename and filename.endswith((".md", ".qmd")):
+        filename = f"{filename}.py"
 
     try:
-        return FormatResponse(
-            codes=await formatter.format(
-                body.codes,
-                stdin_filename=app_state.require_current_session().app_file_manager.path,
-            )
-        )
+        codes = await formatter.format(body.codes, filename)
+        return FormatResponse(codes)
     except ModuleNotFoundError:
         # In multi-sandbox mode each kernel has its own venv, so installing
         # ruff into the server wouldn't help the kernel.  Just surface the

--- a/tests/_server/api/endpoints/test_editing.py
+++ b/tests/_server/api/endpoints/test_editing.py
@@ -90,27 +90,36 @@ def test_format_cell(client: TestClient) -> None:
 def test_format_cell_passes_notebook_path_to_formatter(
     client: TestClient,
 ) -> None:
-    with patch(
-        "marimo._server.api.endpoints.editing.DefaultFormatter.format",
-        new=AsyncMock(return_value={"cell-123": "x = 1"}),
-    ) as mock_format:
-        response = client.post(
-            "/api/kernel/format",
-            headers=HEADERS,
-            json={
-                "codes": {"cell-123": "x=1"},
-                "lineLength": 80,
-            },
-        )
+    # pytest.mark.parametrize doesn't work with @with_session
+    for suffix, filename in (
+        (".py", "notebook.py"),
+        (".md", "notebook.md.py"),
+        (".qmd", "notebook.qmd.py"),
+    ):
+        with (
+            patch(
+                "marimo._server.api.endpoints.editing.DefaultFormatter.format",
+                new=AsyncMock(return_value={"cell-123": "x = 1"}),
+            ) as mock_format,
+            patch(
+                "marimo._server.api.endpoints.editing.AppState.require_current_session"
+            ) as mock_require_session,
+        ):
+            mock_session = MagicMock()
+            mock_session.app_file_manager.path = f"notebook{suffix}"
+            mock_require_session.return_value = mock_session
+            response = client.post(
+                "/api/kernel/format",
+                headers=HEADERS,
+                json={
+                    "codes": {"cell-123": "x=1"},
+                    "lineLength": 80,
+                },
+            )
 
-    assert response.status_code == 200, response.text
-    assert response.json() == {"codes": {"cell-123": "x = 1"}}
-    assert mock_format.await_count == 1
-
-    args, kwargs = mock_format.await_args
-    assert {"cell-123": "x=1"} in args
-    assert isinstance(kwargs["stdin_filename"], str)
-    assert kwargs["stdin_filename"].endswith(".py")
+            assert response.status_code == 200, response.text
+            assert response.json() == {"codes": {"cell-123": "x = 1"}}
+            mock_format.assert_awaited_once_with({"cell-123": "x=1"}, filename)
 
 
 @with_session(SESSION_ID)


### PR DESCRIPTION
## 📝 Summary

This is a follow-up to PR #8609. It ensures that code formatting works correctly for Markdown (`.md`/`.qmd`) notebooks by appending a `.py` extension to the filename passed to the formatter.

While PR #8609 introduced passing the notebook's path to Ruff via `--stdin-filename` to resolve project-level configuration, it didn't account for notebooks with non-Python extensions. 

Ruff uses the file extension to determine the language of the code. When formatting code cells within a Markdown notebook, the formatter receives a path ending in `.md` or `.qmd`, which can lead to it ignoring the code or failing to apply Python-specific rules.

## 🔍 Description of Changes

- modified `marimo/_server/api/endpoints/editing.py` to append a `.py` extension (e.g., `notebook.md.py`) before passing the path to the formatter.
- updated tests in `tests/_server/api/endpoints/test_editing.py` to verify that `.py`, `.md`, and `.qmd` paths are all correctly handled and passed to the formatter with the appropriate suffix.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
