### PR TITLE
Add VS Code extension link to issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: VS Code Extension Issues
+    url: https://github.com/marimo-team/marimo-lsp/issues/new
+    about: For issues with the marimo VS Code extension, please open an issue in the marimo-lsp repository.
   - name: Discord Chat
     url: https://marimo.io/discord?ref=issues
     about: Ask questions and discuss with other marimo users.


### PR DESCRIPTION
Users have been opening VS Code extension issues in the main marimo repo. This adds a contact link to the issue template config that redirects them to marimo-team/marimo-lsp where those issues belong.
