### PR TITLE
Redirect VS Code issue template link to /new/choose

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: VS Code Extension Issues
-    url: https://github.com/marimo-team/marimo-lsp/issues/new
+    url: https://github.com/marimo-team/marimo-lsp/issues/new/choose
     about: For issues with the marimo VS Code extension, please open an issue in the marimo-lsp repository.
   - name: Discord Chat
     url: https://marimo.io/discord?ref=issues


### PR DESCRIPTION
Instead of opening blank issue, this redirects to template options in marimo-lsp.