### PR TITLE
fix: set file in compilation for app mode linecache and better stack traces

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -437,6 +437,7 @@ def solve_source_position(
     code: str, filename: str
 ) -> Optional[SourcePosition]:
     entries = _build_source_position_map(filename)
+
     if not entries:
         return None
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -28,7 +28,7 @@ from uuid import uuid4
 
 from marimo import _loggers
 from marimo._ast.cell import CellConfig, CellImpl
-from marimo._ast.compiler import compile_cell
+from marimo._ast.compiler import _build_source_position_map, compile_cell
 from marimo._ast.errors import ImportStarError
 from marimo._ast.names import SETUP_CELL_NAME
 from marimo._ast.variables import BUILTINS, is_local
@@ -851,10 +851,11 @@ class Kernel:
     ) -> tuple[Optional[CellImpl], Optional[Error]]:
         error: Optional[Error] = None
         try:
-            # In run mode, pass the notebook filename so tracebacks
-            # reference the real file instead of synthetic cell files.
+            # In run mode or debugpy, pass the notebook filename so
+            # tracebacks reference the real file instead of synthetic
+            # cell files.
             filename = None
-            if get_mode() == "run":
+            if get_mode() == "run" or os.environ.get("DEBUGPY_RUNNING"):
                 filename = self.app_metadata.filename
             cell = compile_cell(
                 code,
@@ -1170,6 +1171,11 @@ class Kernel:
         """
         LOGGER.debug("Mutating graph.")
         LOGGER.debug("Current set of errors: %s", self.errors)
+        # Invalidate the cached notebook→source position map so that
+        # recompiled cells pick up the current file contents. This
+        # matters for debugpy (edit mode) and `marimo run --watch`
+        # where cells are recompiled after the file changes on disk.
+        _build_source_position_map.cache_clear()
         cells_before_mutation = set(self.graph.cells.keys())
         cells_with_errors_before_mutation = set(self.errors.keys())
         cells_starting_stale = (

--- a/tests/_runtime/test_trace.py
+++ b/tests/_runtime/test_trace.py
@@ -366,6 +366,76 @@ class TestRunModeTrace:
         assert "__marimo__cell_" not in result
         assert "test_notebook.py" in result
 
+    @staticmethod
+    async def test_run_mode_watch_invalidates_cache(
+        run_mode_kernel: MockedKernel,
+        tmp_path: Path,
+    ) -> None:
+        """Source position cache is invalidated on recompilation (--watch)."""
+        from marimo._ast.compiler import _build_source_position_map
+
+        notebook_v1 = textwrap.dedent("""\
+            import marimo
+
+            __generated_with = "0.0.0"
+            app = marimo.App()
+
+
+            @app.cell
+            def _():
+                x = 1
+                return (x,)
+
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook_file = tmp_path / "watch_notebook.py"
+        notebook_file.write_text(notebook_v1)
+
+        k = run_mode_kernel.k
+        k.app_metadata.filename = str(notebook_file)
+
+        # First compile — populates cache
+        await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
+        cached = _build_source_position_map(str(notebook_file))
+        assert len(cached) == 1
+
+        # Simulate file change (--watch): add a second cell
+        notebook_v2 = textwrap.dedent("""\
+            import marimo
+
+            __generated_with = "0.0.0"
+            app = marimo.App()
+
+
+            @app.cell
+            def _():
+                x = 1
+                return (x,)
+
+
+            @app.cell
+            def _(x):
+                y = x + 2
+                return (y,)
+
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook_file.write_text(notebook_v2)
+
+        # Second compile — mutate_graph should clear cache
+        await k.run(
+            [
+                ExecuteCellCommand(cell_id="0", code="x = 1"),
+                ExecuteCellCommand(cell_id="1", code="y = x + 2"),
+            ]
+        )
+        refreshed = _build_source_position_map(str(notebook_file))
+        assert len(refreshed) == 2
+
 
 class TestEmbedTrace:
     @staticmethod


### PR DESCRIPTION
## 📝 Summary

Previously `app/run` mode utilized the default `edit` mode style line caches. By passing in the filename during app mode compilation, we ensure the line cache is set for file level tracebacks. Example:
<img width="755" height="240" alt="image" src="https://github.com/user-attachments/assets/f3ed7bee-312e-438d-a424-e2802ff65bfc" />


Closes #8764 
