### PR TITLE
Document stale globals caveat on ctx.globals

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -434,7 +434,12 @@ class AsyncCodeModeContext:
 
     @property
     def globals(self) -> dict[str, Any]:
-        """The kernel's global namespace (all variables defined by cells)."""
+        """The kernel's global namespace (all variables defined by cells).
+
+        Mutations via :meth:`run_cell` update the kernel globals but
+        *not* the scratchpad's copy. Read values through this property
+        (``ctx.globals["x"]``) rather than bare variable names.
+        """
         return self._kernel.globals
 
     @property


### PR DESCRIPTION
When code mode is used from the scratchpad, `run_cell` updates the kernel's globals but not the scratchpad's shallow copy. This means bare variable names read stale values. The docstring now directs callers to use `ctx.globals["x"]` instead.
