### PR TITLE
fix: ignore blank line rules (E302, E305)

### DIFF
--- a/frontend/src/core/codemirror/language/languages/python.ts
+++ b/frontend/src/core/codemirror/language/languages/python.ts
@@ -69,6 +69,10 @@ const pylspClient = once((lspConfig: LSPConfig) => {
     "W292", // No newline at end of file
     // Modules can be imported in any cell
     "E402", // Module level import not at top of file
+    // Blank line rules are not useful in marimo because cells are joined
+    // without extra blank lines, which can trigger these rules at cell boundaries
+    "E302", // Expected 2 blank lines, found 0
+    "E305", // Expected 2 blank lines after class or function definition, found 0
   ];
   const ignoredRuffRules = [
     // Even ruff documentation of this rule explains it is not useful in notebooks


### PR DESCRIPTION
## 📝 Summary

This PR suppresses "blank line" related LSP diagnostics (E302, E305) that occur at cell boundaries in marimo notebooks.

Marimo joins cells with a single `\n` before sending them to the LSP. This triggers PEP 8 violations for missing blank lines between functions/classes.

Closes #8814

## 🔍 Description of Changes

- Modified `frontend/src/core/codemirror/language/languages/python.ts` to add `E302` and `E305` to `ignoredFlakeRules`.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
