### PR TITLE
`NotebookDocument` model and backend integration

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -162,10 +162,10 @@ class _CellsView:
 
     def _build_at(self, cell_id: CellId_t) -> NotebookCellData:
         cell_impl = self._ctx.graph.cells[cell_id]
-        meta = self._ctx._kernel.cell_metadata.get(cell_id)
+        doc_cell = self._ctx._document.get(cell_id)
         return NotebookCellData(
             code=cell_impl.code,
-            config=meta.config if meta else CellConfig(),
+            config=doc_cell.config if doc_cell else CellConfig(),
             name=self._cell_name(cell_id),
             id=cell_id,
         )
@@ -691,8 +691,8 @@ class AsyncCodeModeContext:
         config: CellConfig | None = None
         if hide_code is not None or disabled is not None or column is not None:
             # Start from existing config and override provided fields.
-            meta = self._kernel.cell_metadata.get(cell_id)
-            existing = meta.config if meta else CellConfig()
+            doc_cell = self._document.get(cell_id)
+            existing = doc_cell.config if doc_cell else CellConfig()
             config = CellConfig(
                 hide_code=hide_code
                 if hide_code is not None
@@ -947,9 +947,9 @@ class AsyncCodeModeContext:
             elif entry.cell_id not in existing_id_set:
                 resolved_configs[entry.cell_id] = CellConfig(hide_code=True)
             else:
-                existing_meta = self._kernel.cell_metadata.get(entry.cell_id)
+                doc_cell = self._document.get(entry.cell_id)
                 resolved_configs[entry.cell_id] = (
-                    existing_meta.config if existing_meta else CellConfig()
+                    doc_cell.config if doc_cell else CellConfig()
                 )
 
         # Let mutate_graph handle all graph mutations: it properly

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -151,7 +151,7 @@ class _CellsView:
         self._ctx = ctx
 
     def _cell_ids(self) -> list[CellId_t]:
-        return list(self._ctx.graph.cells.keys())
+        return list(self._ctx._document)
 
     def _cell_name(self, cell_id: CellId_t) -> str | None:
         # Check code_mode's own name store first.
@@ -266,7 +266,14 @@ class AsyncCodeModeContext:
         *,
         skip_validation: bool = False,
     ) -> None:
+        if kernel._document is None:
+            raise RuntimeError(
+                "NotebookDocument not available — code_mode must be invoked "
+                "via the /api/execute endpoint which attaches the document "
+                "snapshot"
+            )
         self._kernel = kernel
+        self._document = kernel._document
         self._cell_manager = cell_manager
         self._skip_validation = skip_validation
         self._ops: list[_Op] = []
@@ -913,7 +920,7 @@ class AsyncCodeModeContext:
         self, ops: list[_Op], explicit_run: set[CellId_t] | None = None
     ) -> None:
         """Validate, plan, format, and apply a batch of operations."""
-        existing_ids = list(self.graph.cells.keys())
+        existing_ids = list(self._document)
         plan = _build_plan(existing_ids, ops)
 
         # Auto-format new/changed code.

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -59,6 +59,13 @@ from marimo._runtime.commands import (
 from marimo._runtime.context import get_context as _get_runtime_context
 from marimo._runtime.context.kernel_context import KernelRuntimeContext
 from marimo._runtime.runtime import CellMetadata
+from marimo._session.state.document import (
+    CellCreated,
+    CellDeleted,
+    CellsReordered,
+    CodeChanged,
+    NameChanged,
+)
 from marimo._types.ids import CellId_t, UIElementId
 from marimo._utils.formatter import DefaultFormatter
 
@@ -87,11 +94,6 @@ class NotebookCellData:
 
 
 LOGGER = _loggers.marimo_logger()
-
-
-# Module-level store for cell names set via code_mode.
-# Persists across context manager invocations within the same kernel.
-_cell_names: dict[CellId_t, str] = {}
 
 
 # ------------------------------------------------------------------
@@ -154,16 +156,9 @@ class _CellsView:
         return list(self._ctx._document)
 
     def _cell_name(self, cell_id: CellId_t) -> str | None:
-        # Check code_mode's own name store first.
-        name = _cell_names.get(cell_id)
-        if name is not None:
-            return name
-        # Fall back to cell_manager if available.
-        cm = self._ctx._cell_manager
-        if cm is None:
-            return None
-        data = cm.get_cell_data(cell_id)
-        return data.name if data else None
+        if cell_id in self._ctx._document:
+            return self._ctx._document[cell_id].name or None
+        return None
 
     def _build_at(self, cell_id: CellId_t) -> NotebookCellData:
         cell_impl = self._ctx.graph.cells[cell_id]
@@ -435,16 +430,10 @@ class AsyncCodeModeContext:
     def _cell_label(self, cell_id: CellId_t) -> str:
         """Return a display label: ``'id' (name)`` or ``'id'``."""
         short = repr(str(cell_id)[:8])
-        name: str | None = None
-        cm = self._cell_manager
-        if cm is not None:
-            data = cm.get_cell_data(cell_id)
-            if data and data.name:
-                name = data.name
-        if name is None:
-            name = _cell_names.get(cell_id)
-        if name:
-            return f"{short} ({name})"
+        if cell_id in self._document:
+            name = self._document[cell_id].name
+            if name:
+                return f"{short} ({name})"
         return short
 
     # ------------------------------------------------------------------
@@ -868,7 +857,9 @@ class AsyncCodeModeContext:
                         graph.delete_cell(cell_id)
                     continue
 
-                code: str | None = getattr(op, "code", None)
+                if not isinstance(op, (_AddOp, _UpdateOp)):
+                    continue
+                code = op.code
                 if code is None:
                     continue
 
@@ -989,18 +980,33 @@ class AsyncCodeModeContext:
                 self.graph.cells[cell_id].configure(cfg.asdict())
             self._kernel.cell_metadata[cell_id] = CellMetadata(config=cfg)
 
-        # Persist names from ops into the module-level store.
+        # Sync the document with the plan: add new cells, remove deleted
+        # ones, update code/names, and reorder to match.
+        existing_doc_ids = set(list(self._document))
+        for entry in plan:
+            if entry.cell_id not in existing_doc_ids:
+                self._document.apply(
+                    CellCreated(id=entry.cell_id, code=entry.code or "")
+                )
+            elif entry.code is not None:
+                self._document.apply(
+                    CodeChanged(id=entry.cell_id, code=entry.code)
+                )
+        for cid in existing_doc_ids - plan_ids:
+            self._document.apply(CellDeleted(id=cid))
+        # Apply names from ops.
         for op in ops:
-            op_name = getattr(op, "name", None)
-            if op_name is not None:
-                target_id = getattr(op, "new_cell_id", None) or op.cell_id
-                _cell_names[target_id] = op_name
-                # Clean up stale entry when cell_id was migrated.
-                if (
-                    getattr(op, "new_cell_id", None) is not None
-                    and op.cell_id in _cell_names
-                ):
-                    del _cell_names[op.cell_id]
+            if not isinstance(op, (_AddOp, _UpdateOp)) or op.name is None:
+                continue
+            target_id = (
+                op.new_cell_id
+                if isinstance(op, _UpdateOp) and op.new_cell_id is not None
+                else op.cell_id
+            )
+            if target_id in self._document:
+                self._document.apply(NameChanged(id=target_id, name=op.name))
+        # Reorder to match the plan.
+        self._document.apply(CellsReordered(cell_ids=target_order))
 
         # Notify frontend of all changes (code and config-only).
         # Cells not queued for execution are marked as stale.
@@ -1027,7 +1033,10 @@ class AsyncCodeModeContext:
             by_stale.setdefault(is_stale, []).append(entry)
 
         for is_stale, entries in by_stale.items():
-            names = [_cell_names.get(e.cell_id, "") for e in entries]
+            names = [
+                dc.name if (dc := self._document.get(e.cell_id)) else ""
+                for e in entries
+            ]
             codes = [
                 e.code
                 if e.code is not None
@@ -1049,15 +1058,14 @@ class AsyncCodeModeContext:
 
         # For name-only updates (no code change), send a notification
         # with existing code so the frontend picks up the new name.
+        code_entry_id_set = {e.cell_id for e in code_entries}
         name_only = {
-            cid: n
-            for cid, n in _cell_names.items()
-            if cid not in {e.cell_id for e in code_entries}
-            and cid in self.graph.cells
-            and any(
-                getattr(op, "name", None) is not None and op.cell_id == cid
-                for op in ops
-            )
+            op.cell_id: op.name or ""
+            for op in ops
+            if isinstance(op, (_AddOp, _UpdateOp))
+            and op.name is not None
+            and op.cell_id not in code_entry_id_set
+            and op.cell_id in self.graph.cells
         }
         if name_only:
             self.notify(

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -22,7 +22,7 @@ from marimo import _loggers
 from marimo._ast.app_config import _AppConfig
 from marimo._config.config import MarimoConfig
 from marimo._data.models import DataTableSource
-from marimo._session.state.document import DocumentCell
+from marimo._session.state.document import NotebookCell
 from marimo._types.ids import CellId_t, RequestId, UIElementId, WidgetModelId
 
 LOGGER = _loggers.marimo_logger()
@@ -335,7 +335,7 @@ class ExecuteScratchpadCommand(Command):
     # Snapshot of notebook document state, attached by the session so
     # code_mode can read cell ordering/code/names/configs.
     # Only populated via /api/execute (code_mode entry point).
-    document_cells: tuple[DocumentCell, ...] | None = None
+    document_cells: tuple[NotebookCell, ...] | None = None
 
 
 class RenameNotebookCommand(Command):

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -22,6 +22,7 @@ from marimo import _loggers
 from marimo._ast.app_config import _AppConfig
 from marimo._config.config import MarimoConfig
 from marimo._data.models import DataTableSource
+from marimo._session.state.document import DocumentCell
 from marimo._types.ids import CellId_t, RequestId, UIElementId, WidgetModelId
 
 LOGGER = _loggers.marimo_logger()
@@ -325,11 +326,16 @@ class ExecuteScratchpadCommand(Command):
     Attributes:
         code: Python code to execute.
         request: HTTP request context if available.
+        document_cells: Snapshot of the notebook document for code_mode reads.
     """
 
     code: str
     # incoming request, e.g. from Starlette or FastAPI
     request: Optional[HTTPRequest] = None
+    # Snapshot of notebook document state, attached by the session so
+    # code_mode can read cell ordering/code/names/configs.
+    # Only populated via /api/execute (code_mode entry point).
+    document_cells: tuple[DocumentCell, ...] | None = None
 
 
 class RenameNotebookCommand(Command):

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -326,7 +326,7 @@ class ExecuteScratchpadCommand(Command):
     Attributes:
         code: Python code to execute.
         request: HTTP request context if available.
-        document_cells: Snapshot of the notebook document for code_mode reads.
+        notebook_cells: Snapshot of the notebook document for code_mode reads.
     """
 
     code: str
@@ -335,7 +335,7 @@ class ExecuteScratchpadCommand(Command):
     # Snapshot of notebook document state, attached by the session so
     # code_mode can read cell ordering/code/names/configs.
     # Only populated via /api/execute (code_mode entry point).
-    document_cells: tuple[NotebookCell, ...] | None = None
+    notebook_cells: tuple[NotebookCell, ...] | None = None
 
 
 class RenameNotebookCommand(Command):

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -2280,8 +2280,8 @@ class Kernel:
         async def handle_execute_scratchpad(
             request: ExecuteScratchpadCommand,
         ) -> None:
-            if request.document_cells is not None:
-                self._document = NotebookDocument(list(request.document_cells))
+            if request.notebook_cells is not None:
+                self._document = NotebookDocument(list(request.notebook_cells))
             try:
                 with http_request_context(request.request):
                     await self.run_scratchpad(request.code)

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -197,6 +197,7 @@ from marimo._secrets.load_dotenv import (
 from marimo._secrets.secrets import get_secret_keys
 from marimo._session.model import SessionMode
 from marimo._session.queue import QueueType
+from marimo._session.state.document import NotebookDocument
 from marimo._sql.engines.duckdb import INTERNAL_DUCKDB_ENGINE, DuckDBEngine
 from marimo._sql.engines.types import (
     EngineCatalog,
@@ -569,6 +570,10 @@ class Kernel:
         self.debugger = debugger_override
         if self.debugger is not None:
             patches.patch_pdb(self.debugger)
+
+        # Document snapshot from session, set before scratchpad execution
+        # so code_mode can read cell ordering/code/names/configs.
+        self._document: NotebookDocument | None = None
 
         self._module = module
         if self.app_metadata.filename is not None:
@@ -2275,8 +2280,13 @@ class Kernel:
         async def handle_execute_scratchpad(
             request: ExecuteScratchpadCommand,
         ) -> None:
-            with http_request_context(request.request):
-                await self.run_scratchpad(request.code)
+            if request.document_cells is not None:
+                self._document = NotebookDocument(list(request.document_cells))
+            try:
+                with http_request_context(request.request):
+                    await self.run_scratchpad(request.code)
+            finally:
+                self._document = None
             broadcast_notification(CompletedRunNotification())
 
         async def handle_execute_stale(

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -302,7 +302,7 @@ async def execute_code(
                         ExecuteScratchpadCommand(
                             code=body.code,
                             request=HTTPRequest.from_request(request),
-                            document_cells=tuple(
+                            notebook_cells=tuple(
                                 session.session_view.document.values()
                             ),
                         ),

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -302,6 +302,9 @@ async def execute_code(
                         ExecuteScratchpadCommand(
                             code=body.code,
                             request=HTTPRequest.from_request(request),
+                            document_cells=tuple(
+                                session.session_view.document.values()
+                            ),
                         ),
                         from_consumer_id=None,
                     )

--- a/marimo/_session/session.py
+++ b/marimo/_session/session.py
@@ -48,6 +48,7 @@ from marimo._session.managers import (
 from marimo._session.model import ConnectionState, SessionMode
 from marimo._session.notebook import AppFileManager
 from marimo._session.room import Room
+from marimo._session.state.document import NotebookDocument
 from marimo._session.state.session_view import SessionView
 from marimo._session.types import (
     KernelManager,
@@ -231,6 +232,9 @@ class SessionImpl(Session):
             ttl_seconds if ttl_seconds is not None else _DEFAULT_TTL_SECONDS
         )
         self.session_view = SessionView()
+        self.session_view.document = NotebookDocument.from_cell_manager(
+            app_file_manager.app.cell_manager
+        )
         self.config_manager = config_manager
         self.extensions = extensions
         self.scratchpad_lock = asyncio.Lock()

--- a/marimo/_session/state/document.py
+++ b/marimo/_session/state/document.py
@@ -1,0 +1,277 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Notebook document model.
+
+The single source of truth for notebook structure. Both the frontend
+and the kernel emit events that mutate this document. The document
+is the canonical ordered list of cells — their IDs, code, names,
+and configs.
+
+Execution is a separate concern. The kernel reads from the document
+to know *what* code a cell contains; the dependency graph determines
+*when* it runs. Cell ordering in the document is purely visual.
+
+Conflict resolution is last-write-wins. Events are applied in the
+order they arrive. There is no merging.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from marimo._ast.cell import CellConfig
+from marimo._types.ids import CellId_t
+
+# ------------------------------------------------------------------
+# Document cell
+# ------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class DocumentCell:
+    """A cell in the notebook document."""
+
+    id: CellId_t
+    code: str
+    name: str = ""
+    config: CellConfig = field(default_factory=CellConfig)
+
+
+# ------------------------------------------------------------------
+# Events
+# ------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CellCreated:
+    """A new cell was added to the notebook."""
+
+    id: CellId_t
+    code: str
+    name: str = ""
+    config: CellConfig = field(default_factory=CellConfig)
+    after: CellId_t | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CellDeleted:
+    """A cell was removed from the notebook."""
+
+    id: CellId_t
+
+
+@dataclass(frozen=True, slots=True)
+class CellMoved:
+    """A cell was moved to a new position.
+
+    ``after=None`` means move to the very beginning.
+    """
+
+    id: CellId_t
+    after: CellId_t | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CellsReordered:
+    """Full cell ordering was set.
+
+    Replaces the entire cell order. Cell IDs that exist in the document
+    but not in the list are left in place at the end. IDs not in the
+    document are ignored.
+    """
+
+    cell_ids: list[CellId_t]
+
+
+@dataclass(frozen=True, slots=True)
+class CodeChanged:
+    """A cell's code was changed (but not yet executed)."""
+
+    id: CellId_t
+    code: str
+
+
+@dataclass(frozen=True, slots=True)
+class NameChanged:
+    """A cell was renamed."""
+
+    id: CellId_t
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigChanged:
+    """A cell's configuration was changed."""
+
+    id: CellId_t
+    config: CellConfig
+
+
+DocumentEvent = Union[
+    CellCreated,
+    CellDeleted,
+    CellMoved,
+    CellsReordered,
+    CodeChanged,
+    NameChanged,
+    ConfigChanged,
+]
+
+
+# ------------------------------------------------------------------
+# Document
+# ------------------------------------------------------------------
+
+
+class NotebookDocument:
+    """Ordered list of notebook cells.
+
+    This is the materialized view of the event log. Both the frontend
+    and the kernel write events to it; it is the single source of truth
+    for document structure.
+    """
+
+    __slots__ = ("_cells", "_index")
+
+    def __init__(self, cells: list[DocumentCell] | None = None) -> None:
+        self._cells: list[DocumentCell] = list(cells) if cells else []
+        self._index: dict[CellId_t, int] = {
+            c.id: i for i, c in enumerate(self._cells)
+        }
+
+    # -- Mapping-style reads ----------------------------------------
+    #
+    # Iteration order is notebook order.  ``list(doc)`` gives cell IDs,
+    # ``list(doc.values())`` gives cells, ``doc[cell_id]`` looks up by
+    # ID (KeyError if missing), ``doc.get(cell_id)`` returns None.
+
+    def __getitem__(self, cell_id: CellId_t) -> DocumentCell:
+        return self._cells[self._require_index(cell_id)]
+
+    def get(self, cell_id: CellId_t) -> DocumentCell | None:
+        idx = self._index.get(cell_id)
+        return self._cells[idx] if idx is not None else None
+
+    def __iter__(self) -> Iterator[CellId_t]:
+        return (c.id for c in self._cells)
+
+    def values(self) -> Iterator[DocumentCell]:
+        """Iterate over cells in notebook order."""
+        return iter(self._cells)
+
+    def __len__(self) -> int:
+        return len(self._cells)
+
+    def __contains__(self, cell_id: object) -> bool:
+        return cell_id in self._index
+
+    # -- Mutation ---------------------------------------------------
+
+    def apply(self, event: DocumentEvent) -> None:
+        """Apply a single event to the document. Mutates in place.
+
+        Raises ``KeyError`` if the event references a cell that does
+        not exist, or ``ValueError`` if the event is invalid (e.g.
+        creating a cell with a duplicate ID).
+        """
+        if isinstance(event, CellCreated):
+            self._apply_created(event)
+        elif isinstance(event, CellDeleted):
+            self._apply_deleted(event)
+        elif isinstance(event, CellMoved):
+            self._apply_moved(event)
+        elif isinstance(event, CellsReordered):
+            self._apply_reordered(event)
+        elif isinstance(event, CodeChanged):
+            self._apply_code_changed(event)
+        elif isinstance(event, NameChanged):
+            self._apply_name_changed(event)
+        elif isinstance(event, ConfigChanged):
+            self._apply_config_changed(event)
+        else:
+            raise TypeError(f"Unknown event type: {type(event)!r}")
+
+    # -- Private ----------------------------------------------------
+
+    def _require_index(self, cell_id: CellId_t) -> int:
+        try:
+            return self._index[cell_id]
+        except KeyError:
+            raise KeyError(f"Cell {cell_id!r} not in document") from None
+
+    def _rebuild_index(self) -> None:
+        self._index = {c.id: i for i, c in enumerate(self._cells)}
+
+    def _insert_at(self, cell: DocumentCell, after: CellId_t | None) -> None:
+        if after is None:
+            self._cells.append(cell)
+        else:
+            idx = self._require_index(after)
+            self._cells.insert(idx + 1, cell)
+        self._rebuild_index()
+
+    def _apply_created(self, event: CellCreated) -> None:
+        if event.id in self._index:
+            raise ValueError(f"Cell {event.id!r} already exists in document")
+        cell = DocumentCell(
+            id=event.id,
+            code=event.code,
+            name=event.name,
+            config=event.config,
+        )
+        self._insert_at(cell, event.after)
+
+    def _apply_deleted(self, event: CellDeleted) -> None:
+        idx = self._require_index(event.id)
+        del self._cells[idx]
+        self._rebuild_index()
+
+    def _apply_moved(self, event: CellMoved) -> None:
+        idx = self._require_index(event.id)
+        cell = self._cells.pop(idx)
+        self._rebuild_index()
+        if event.after is None:
+            self._cells.insert(0, cell)
+        else:
+            after_idx = self._require_index(event.after)
+            self._cells.insert(after_idx + 1, cell)
+        self._rebuild_index()
+
+    def _apply_reordered(self, event: CellsReordered) -> None:
+        by_id = {c.id: c for c in self._cells}
+        seen: set[CellId_t] = set()
+        reordered: list[DocumentCell] = []
+        for cid in event.cell_ids:
+            if cid in by_id and cid not in seen:
+                reordered.append(by_id[cid])
+                seen.add(cid)
+        # Append any cells not in the new ordering.
+        for c in self._cells:
+            if c.id not in seen:
+                reordered.append(c)
+        self._cells = reordered
+        self._rebuild_index()
+
+    def _apply_code_changed(self, event: CodeChanged) -> None:
+        cell = self._cells[self._require_index(event.id)]
+        cell.code = event.code
+
+    def _apply_name_changed(self, event: NameChanged) -> None:
+        cell = self._cells[self._require_index(event.id)]
+        cell.name = event.name
+
+    def _apply_config_changed(self, event: ConfigChanged) -> None:
+        cell = self._cells[self._require_index(event.id)]
+        cell.config = event.config
+
+    # -- Display ----------------------------------------------------
+
+    def __repr__(self) -> str:
+        lines = [f"NotebookDocument({len(self._cells)} cells):"]
+        for i, c in enumerate(self._cells):
+            code_preview = c.code[:40].replace("\n", "\\n")
+            lines.append(f"  {i}: {c.id} {code_preview!r}")
+        return "\n".join(lines)

--- a/marimo/_session/state/document.py
+++ b/marimo/_session/state/document.py
@@ -31,11 +31,11 @@ if TYPE_CHECKING:
 
 
 # ------------------------------------------------------------------
-# Document cell
+# Notebook cell
 # ------------------------------------------------------------------
 
 
-class DocumentCell(msgspec.Struct):
+class NotebookCell(msgspec.Struct):
     """A cell in the notebook document."""
 
     id: CellId_t
@@ -140,8 +140,8 @@ class NotebookDocument:
 
     __slots__ = ("_cells", "_index")
 
-    def __init__(self, cells: list[DocumentCell] | None = None) -> None:
-        self._cells: list[DocumentCell] = list(cells) if cells else []
+    def __init__(self, cells: list[NotebookCell] | None = None) -> None:
+        self._cells: list[NotebookCell] = list(cells) if cells else []
         self._index: dict[CellId_t, int] = {
             c.id: i for i, c in enumerate(self._cells)
         }
@@ -150,7 +150,7 @@ class NotebookDocument:
     def from_cell_manager(cls, cell_manager: CellManager) -> NotebookDocument:
         """Build a document from a CellManager's current state."""
         cells = [
-            DocumentCell(
+            NotebookCell(
                 id=cd.cell_id,
                 code=cd.code,
                 name=cd.name,
@@ -166,17 +166,17 @@ class NotebookDocument:
     # ``list(doc.values())`` gives cells, ``doc[cell_id]`` looks up by
     # ID (KeyError if missing), ``doc.get(cell_id)`` returns None.
 
-    def __getitem__(self, cell_id: CellId_t) -> DocumentCell:
+    def __getitem__(self, cell_id: CellId_t) -> NotebookCell:
         return self._cells[self._require_index(cell_id)]
 
-    def get(self, cell_id: CellId_t) -> DocumentCell | None:
+    def get(self, cell_id: CellId_t) -> NotebookCell | None:
         idx = self._index.get(cell_id)
         return self._cells[idx] if idx is not None else None
 
     def __iter__(self) -> Iterator[CellId_t]:
         return (c.id for c in self._cells)
 
-    def values(self) -> Iterator[DocumentCell]:
+    def values(self) -> Iterator[NotebookCell]:
         """Iterate over cells in notebook order."""
         return iter(self._cells)
 
@@ -223,7 +223,7 @@ class NotebookDocument:
     def _rebuild_index(self) -> None:
         self._index = {c.id: i for i, c in enumerate(self._cells)}
 
-    def _insert_at(self, cell: DocumentCell, after: CellId_t | None) -> None:
+    def _insert_at(self, cell: NotebookCell, after: CellId_t | None) -> None:
         if after is None:
             self._cells.append(cell)
         else:
@@ -234,7 +234,7 @@ class NotebookDocument:
     def _apply_created(self, event: CellCreated) -> None:
         if event.id in self._index:
             raise ValueError(f"Cell {event.id!r} already exists in document")
-        cell = DocumentCell(
+        cell = NotebookCell(
             id=event.id,
             code=event.code,
             name=event.name,
@@ -261,7 +261,7 @@ class NotebookDocument:
     def _apply_reordered(self, event: CellsReordered) -> None:
         by_id = {c.id: c for c in self._cells}
         seen: set[CellId_t] = set()
-        reordered: list[DocumentCell] = []
+        reordered: list[NotebookCell] = []
         for cid in event.cell_ids:
             if cid in by_id and cid not in seen:
                 reordered.append(by_id[cid])

--- a/marimo/_session/state/document.py
+++ b/marimo/_session/state/document.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Union
 
+import msgspec
+
 from marimo._ast.cell import CellConfig
 from marimo._types.ids import CellId_t
 
@@ -27,19 +29,19 @@ if TYPE_CHECKING:
 
     from marimo._ast.cell_manager import CellManager
 
+
 # ------------------------------------------------------------------
 # Document cell
 # ------------------------------------------------------------------
 
 
-@dataclass(slots=True)
-class DocumentCell:
+class DocumentCell(msgspec.Struct):
     """A cell in the notebook document."""
 
     id: CellId_t
     code: str
     name: str = ""
-    config: CellConfig = field(default_factory=CellConfig)
+    config: CellConfig = msgspec.field(default_factory=CellConfig)
 
 
 # ------------------------------------------------------------------

--- a/marimo/_session/state/document.py
+++ b/marimo/_session/state/document.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Union
 
+from marimo._ast.cell import CellConfig
+from marimo._types.ids import CellId_t
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-from marimo._ast.cell import CellConfig
-from marimo._types.ids import CellId_t
+    from marimo._ast.cell_manager import CellManager
 
 # ------------------------------------------------------------------
 # Document cell
@@ -141,6 +143,20 @@ class NotebookDocument:
         self._index: dict[CellId_t, int] = {
             c.id: i for i, c in enumerate(self._cells)
         }
+
+    @classmethod
+    def from_cell_manager(cls, cell_manager: CellManager) -> NotebookDocument:
+        """Build a document from a CellManager's current state."""
+        cells = [
+            DocumentCell(
+                id=cd.cell_id,
+                code=cd.code,
+                name=cd.name,
+                config=cd.config,
+            )
+            for cd in cell_manager.cell_data()
+        ]
+        return cls(cells)
 
     # -- Mapping-style reads ----------------------------------------
     #

--- a/marimo/_session/state/session_view.py
+++ b/marimo/_session/state/session_view.py
@@ -41,6 +41,7 @@ from marimo._runtime.commands import (
     SyncGraphCommand,
     UpdateUIElementCommand,
 )
+from marimo._session.state.document import NotebookDocument
 from marimo._sql.connection_utils import (
     update_table_in_connection,
     update_table_list_in_connection,
@@ -142,6 +143,8 @@ class SessionView:
     """
 
     def __init__(self) -> None:
+        # Canonical notebook structure — ordering, codes, names, configs.
+        self.document = NotebookDocument()
         # Last seen notebook-order of cell IDs
         self.cell_ids: Optional[UpdateCellIdsNotification] = None
         # A mapping from cell (IDs) to their last seen notification

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1359,23 +1359,6 @@ components:
       - theme
       title: DisplayConfig
       type: object
-    DocumentCell:
-      description: A cell in the notebook document.
-      properties:
-        code:
-          type: string
-        config:
-          $ref: '#/components/schemas/CellConfig'
-        id:
-          type: string
-        name:
-          default: ''
-          type: string
-      required:
-      - id
-      - code
-      title: DocumentCell
-      type: object
     ExecuteCellCommand:
       description: "Execute a single cell.\n\n    Executes a cell with the provided\
         \ code. Dependent cells may be\n    re-executed based on the reactive execution\
@@ -1460,15 +1443,15 @@ components:
         \ execution environment that doesn't affect\n    the notebook's cells or dependencies.\
         \ Runs in an isolated cell with a copy\n    of the global namespace, useful\
         \ for experimentation.\n\n    Attributes:\n        code: Python code to execute.\n\
-        \        request: HTTP request context if available.\n        document_cells:\
+        \        request: HTTP request context if available.\n        notebook_cells:\
         \ Snapshot of the notebook document for code_mode reads."
       properties:
         code:
           type: string
-        documentCells:
+        notebookCells:
           anyOf:
           - items:
-              $ref: '#/components/schemas/DocumentCell'
+              $ref: '#/components/schemas/NotebookCell'
             type: array
           - type: 'null'
           default: null
@@ -1489,10 +1472,10 @@ components:
       properties:
         code:
           type: string
-        documentCells:
+        notebookCells:
           anyOf:
           - items:
-              $ref: '#/components/schemas/DocumentCell'
+              $ref: '#/components/schemas/NotebookCell'
             type: array
           - type: 'null'
           default: null
@@ -3362,6 +3345,23 @@ components:
       - name
       - cells
       title: MultipleDefinitionError
+      type: object
+    NotebookCell:
+      description: A cell in the notebook document.
+      properties:
+        code:
+          type: string
+        config:
+          $ref: '#/components/schemas/CellConfig'
+        id:
+          type: string
+        name:
+          default: ''
+          type: string
+      required:
+      - id
+      - code
+      title: NotebookCell
       type: object
     OpenAiConfig:
       description: "Configuration options for OpenAI or OpenAI-compatible services.\n\

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1359,6 +1359,23 @@ components:
       - theme
       title: DisplayConfig
       type: object
+    DocumentCell:
+      description: A cell in the notebook document.
+      properties:
+        code:
+          type: string
+        config:
+          $ref: '#/components/schemas/CellConfig'
+        id:
+          type: string
+        name:
+          default: ''
+          type: string
+      required:
+      - id
+      - code
+      title: DocumentCell
+      type: object
     ExecuteCellCommand:
       description: "Execute a single cell.\n\n    Executes a cell with the provided\
         \ code. Dependent cells may be\n    re-executed based on the reactive execution\
@@ -1443,10 +1460,18 @@ components:
         \ execution environment that doesn't affect\n    the notebook's cells or dependencies.\
         \ Runs in an isolated cell with a copy\n    of the global namespace, useful\
         \ for experimentation.\n\n    Attributes:\n        code: Python code to execute.\n\
-        \        request: HTTP request context if available."
+        \        request: HTTP request context if available.\n        document_cells:\
+        \ Snapshot of the notebook document for code_mode reads."
       properties:
         code:
           type: string
+        documentCells:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/DocumentCell'
+            type: array
+          - type: 'null'
+          default: null
         request:
           anyOf:
           - $ref: '#/components/schemas/HTTPRequest'
@@ -1464,6 +1489,13 @@ components:
       properties:
         code:
           type: string
+        documentCells:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/DocumentCell'
+            type: array
+          - type: 'null'
+          default: null
         request:
           anyOf:
           - $ref: '#/components/schemas/HTTPRequest'

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4053,6 +4053,17 @@ export interface components {
       theme: "dark" | "light" | "system";
     };
     /**
+     * DocumentCell
+     * @description A cell in the notebook document.
+     */
+    DocumentCell: {
+      code: string;
+      config?: components["schemas"]["CellConfig"];
+      id: string;
+      /** @default  */
+      name?: string;
+    };
+    /**
      * ExecuteCellCommand
      * @description Execute a single cell.
      *
@@ -4114,9 +4125,12 @@ export interface components {
      *         Attributes:
      *             code: Python code to execute.
      *             request: HTTP request context if available.
+     *             document_cells: Snapshot of the notebook document for code_mode reads.
      */
     ExecuteScratchpadCommand: {
       code: string;
+      /** @default null */
+      documentCells?: components["schemas"]["DocumentCell"][] | null;
       /** @default null */
       request?: components["schemas"]["HTTPRequest"] | null;
       /** @enum {unknown} */
@@ -4125,6 +4139,8 @@ export interface components {
     /** ExecuteScratchpadRequest */
     ExecuteScratchpadRequest: {
       code: string;
+      /** @default null */
+      documentCells?: components["schemas"]["DocumentCell"][] | null;
       /** @default null */
       request?: components["schemas"]["HTTPRequest"] | null;
     };

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4053,17 +4053,6 @@ export interface components {
       theme: "dark" | "light" | "system";
     };
     /**
-     * DocumentCell
-     * @description A cell in the notebook document.
-     */
-    DocumentCell: {
-      code: string;
-      config?: components["schemas"]["CellConfig"];
-      id: string;
-      /** @default  */
-      name?: string;
-    };
-    /**
      * ExecuteCellCommand
      * @description Execute a single cell.
      *
@@ -4125,12 +4114,12 @@ export interface components {
      *         Attributes:
      *             code: Python code to execute.
      *             request: HTTP request context if available.
-     *             document_cells: Snapshot of the notebook document for code_mode reads.
+     *             notebook_cells: Snapshot of the notebook document for code_mode reads.
      */
     ExecuteScratchpadCommand: {
       code: string;
       /** @default null */
-      documentCells?: components["schemas"]["DocumentCell"][] | null;
+      notebookCells?: components["schemas"]["NotebookCell"][] | null;
       /** @default null */
       request?: components["schemas"]["HTTPRequest"] | null;
       /** @enum {unknown} */
@@ -4140,7 +4129,7 @@ export interface components {
     ExecuteScratchpadRequest: {
       code: string;
       /** @default null */
-      documentCells?: components["schemas"]["DocumentCell"][] | null;
+      notebookCells?: components["schemas"]["NotebookCell"][] | null;
       /** @default null */
       request?: components["schemas"]["HTTPRequest"] | null;
     };
@@ -5220,6 +5209,17 @@ export interface components {
       name: string;
       /** @enum {unknown} */
       type: "multiple-defs";
+    };
+    /**
+     * NotebookCell
+     * @description A cell in the notebook document.
+     */
+    NotebookCell: {
+      code: string;
+      config?: components["schemas"]["CellConfig"];
+      id: string;
+      /** @default  */
+      name?: string;
     };
     /**
      * OpenAiConfig

--- a/tests/_code_mode/test_cells_view.py
+++ b/tests/_code_mode/test_cells_view.py
@@ -6,7 +6,7 @@ import pytest
 from marimo._code_mode._context import AsyncCodeModeContext, NotebookCellData
 from marimo._runtime.commands import ExecuteCellCommand
 from marimo._runtime.runtime import Kernel
-from marimo._session.state.document import DocumentCell, NotebookDocument
+from marimo._session.state.document import NotebookCell, NotebookDocument
 from marimo._types.ids import CellId_t
 
 
@@ -14,7 +14,7 @@ def _ctx(k: Kernel) -> AsyncCodeModeContext:
     """Build an AsyncCodeModeContext with a document snapshot from the kernel."""
     k._document = NotebookDocument(
         [
-            DocumentCell(id=cid, code=cell.code, config=cell.config)
+            NotebookCell(id=cid, code=cell.code, config=cell.config)
             for cid, cell in k.graph.cells.items()
         ]
     )

--- a/tests/_code_mode/test_cells_view.py
+++ b/tests/_code_mode/test_cells_view.py
@@ -6,7 +6,19 @@ import pytest
 from marimo._code_mode._context import AsyncCodeModeContext, NotebookCellData
 from marimo._runtime.commands import ExecuteCellCommand
 from marimo._runtime.runtime import Kernel
+from marimo._session.state.document import DocumentCell, NotebookDocument
 from marimo._types.ids import CellId_t
+
+
+def _ctx(k: Kernel) -> AsyncCodeModeContext:
+    """Build an AsyncCodeModeContext with a document snapshot from the kernel."""
+    k._document = NotebookDocument(
+        [
+            DocumentCell(id=cid, code=cell.code, config=cell.config)
+            for cid, cell in k.graph.cells.items()
+        ]
+    )
+    return AsyncCodeModeContext(k)
 
 
 def cmd(cell_id: str, code: str) -> ExecuteCellCommand:
@@ -24,7 +36,7 @@ class TestCellsViewIndex:
                 cmd(cell_id="c", code="z = 3"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         assert ctx.cells[0].id == "a"
         assert ctx.cells[1].id == "b"
@@ -38,7 +50,7 @@ class TestCellsViewIndex:
                 cmd(cell_id="c", code="z = 3"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         assert ctx.cells[-1].id == "c"
         assert ctx.cells[-2].id == "b"
@@ -46,7 +58,7 @@ class TestCellsViewIndex:
 
     async def test_index_out_of_range(self, k: Kernel) -> None:
         await k.run([cmd(cell_id="a", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         with pytest.raises(IndexError):
             ctx.cells[5]
@@ -65,7 +77,7 @@ class TestCellsViewCellId:
                 cmd(cell_id="def", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         cell = ctx.cells["def"]
         assert cell.id == "def"
@@ -73,7 +85,7 @@ class TestCellsViewCellId:
 
     async def test_lookup_by_cell_id_not_found(self, k: Kernel) -> None:
         await k.run([cmd(cell_id="abc", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         with pytest.raises(KeyError):
             ctx.cells["nonexistent"]
@@ -84,7 +96,7 @@ class TestCellsViewCellName:
 
     async def test_name_lookup_without_cell_manager(self, k: Kernel) -> None:
         await k.run([cmd(cell_id="a", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         # No cell manager → name lookup fails
         with pytest.raises(KeyError):
@@ -96,7 +108,7 @@ class TestCellsViewNameField:
 
     async def test_name_is_none_without_cell_manager(self, k: Kernel) -> None:
         await k.run([cmd(cell_id="a", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         cell = ctx.cells[0]
         assert cell.name is None
@@ -116,7 +128,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         assert len(ctx.cells) == 2
 
     async def test_iteration_yields_cell_ids(self, k: Kernel) -> None:
@@ -126,7 +138,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         ids = list(ctx.cells)
         assert ids == ["a", "b"]
@@ -138,7 +150,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         assert ctx.cells.keys() == ["a", "b"]
 
     async def test_values(self, k: Kernel) -> None:
@@ -148,7 +160,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         vals = ctx.cells.values()
         assert [v.id for v in vals] == ["a", "b"]
         assert [v.code for v in vals] == ["x = 1", "y = 2"]
@@ -160,7 +172,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         items = ctx.cells.items()
         assert [(cid, cell.code) for cid, cell in items] == [
             ("a", "x = 1"),
@@ -174,7 +186,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         assert "a" in ctx.cells
         assert "nonexistent" not in ctx.cells
         assert 0 in ctx.cells

--- a/tests/_code_mode/test_context.py
+++ b/tests/_code_mode/test_context.py
@@ -14,6 +14,22 @@ from marimo._messaging.notification import (
 )
 from marimo._runtime.commands import ExecuteCellCommand
 from marimo._runtime.runtime import Kernel
+from marimo._session.state.document import DocumentCell, NotebookDocument
+
+
+def _ctx(k: Kernel) -> AsyncCodeModeContext:
+    """Build an AsyncCodeModeContext with a document snapshot from the kernel."""
+    k._document = NotebookDocument(
+        [
+            DocumentCell(
+                id=cid,
+                code=cell.code,
+                config=cell.config,
+            )
+            for cid, cell in k.graph.cells.items()
+        ]
+    )
+    return AsyncCodeModeContext(k)
 
 
 def _code_notifs(k: Kernel) -> list[UpdateCellCodesNotification]:
@@ -42,7 +58,7 @@ def _graph_codes(k: Kernel) -> dict[str, str]:
 
 class TestAddCell:
     async def test_add_into_empty(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -70,7 +86,7 @@ class TestAddCell:
                 ExecuteCellCommand(cell_id="1", code="b = 20"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -94,7 +110,7 @@ class TestAddCell:
                 ExecuteCellCommand(cell_id="1", code="b = 20"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -107,7 +123,7 @@ class TestAddCell:
         assert cell_ids[2] == "1"
 
     async def test_add_without_run_does_not_execute(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -122,7 +138,7 @@ class TestAddCell:
         assert code_notifs[0]["code_is_stale"] is True
 
     async def test_add_returns_cell_id(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             cid = nb.create_cell("x = 1")
@@ -131,7 +147,7 @@ class TestAddCell:
 
     async def test_add_chain_after(self, k: Kernel) -> None:
         """Can reference a just-added cell's ID in a subsequent add."""
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             cid1 = nb.create_cell("x = 1")
@@ -154,7 +170,7 @@ class TestDeleteCell:
         )
         assert len(k.graph.cells) == 3
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -177,7 +193,7 @@ class TestDeleteCell:
         assert k.globals["a"] == 1
         assert k.globals["b"] == 2
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         async with ctx as nb:
             nb.delete_cell("1")
 
@@ -192,7 +208,7 @@ class TestDeleteCell:
                 ExecuteCellCommand(cell_id="2", code="c = 3"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -207,7 +223,7 @@ class TestUpdateCell:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
         assert k.globals["x"] == 1
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -242,7 +258,7 @@ class TestUpdateCell:
         assert k.globals["x"] == 1
         assert k.globals["y"] == 2
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         async with ctx as nb:
             nb.edit_cell("0", code="x = 42")
             nb.run_cell("0")
@@ -255,14 +271,14 @@ class TestUpdateCell:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
 
         # Set hide_code=True on the cell.
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         async with ctx as nb:
             nb.edit_cell("0", hide_code=True)
 
         assert k.cell_metadata["0"].config.hide_code is True
 
         # Update code without touching config — hide_code should stick.
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         async with ctx as nb:
             nb.edit_cell("0", code="x = 42")
             nb.run_cell("0")
@@ -273,7 +289,7 @@ class TestUpdateCell:
     async def test_update_config_only(self, k: Kernel) -> None:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -311,7 +327,7 @@ class TestCombined:
             ]
         )
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -333,7 +349,7 @@ class TestCombined:
         )
         assert k.globals["b"] == 2
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         # Delete cell "1" and create a new cell that also defines "b".
@@ -349,7 +365,7 @@ class TestCombined:
     async def test_noop_batch(self, k: Kernel) -> None:
         """An empty context manager does nothing."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:  # noqa: B018
@@ -360,7 +376,7 @@ class TestCombined:
     async def test_exception_discards_ops(self, k: Kernel) -> None:
         """If an exception occurs, queued ops are discarded."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         try:
             async with ctx as nb:
@@ -376,7 +392,7 @@ class TestCombined:
     async def test_rerun_without_structural_ops(self, k: Kernel) -> None:
         """run_cell without any create/edit/delete still executes."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         # Mutate the global so we can detect re-execution.
         k.globals["x"] = 0
@@ -393,7 +409,7 @@ class TestCombined:
                 ExecuteCellCommand(cell_id="1", code="y = x + 1"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         # Mutate so we can detect re-execution of "0".
         k.globals["x"] = 0
@@ -406,7 +422,7 @@ class TestCombined:
     async def test_run_deleted_cell_raises(self, k: Kernel) -> None:
         """Calling run_cell on a cell queued for deletion raises."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             nb.delete_cell("0")
@@ -418,7 +434,7 @@ class TestSummary:
     async def test_create_prints_summary(
         self, k: Kernel, capsys: object
     ) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             nb.create_cell("x = 1", name="my_cell")
@@ -430,7 +446,7 @@ class TestSummary:
         self, k: Kernel, capsys: object
     ) -> None:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             nb.edit_cell("0", code="x = 2")
@@ -442,7 +458,7 @@ class TestSummary:
         self, k: Kernel, capsys: object
     ) -> None:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             nb.delete_cell("0")
@@ -453,7 +469,7 @@ class TestSummary:
     async def test_noop_prints_nothing(
         self, k: Kernel, capsys: object
     ) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:  # noqa: B018
             pass
@@ -470,7 +486,7 @@ class TestSummary:
                 ExecuteCellCommand(cell_id="2", code="c = 3"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             # delete
@@ -499,7 +515,7 @@ re-ran cell '2'
 class TestResolveTarget:
     async def test_create_after_pending_add_by_name(self, k: Kernel) -> None:
         """Can reference a just-added cell by name in a subsequent add."""
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             cid1 = nb.create_cell("x = 1", name="first")
@@ -523,7 +539,7 @@ class TestResolveTarget:
                 ExecuteCellCommand(cell_id="1", code="b = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -542,7 +558,7 @@ class TestResolveTarget:
 
 class TestInstallPackages:
     async def test_install_single(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         pm = k.packages_callbacks.package_manager
         assert pm is not None
 
@@ -559,7 +575,7 @@ class TestInstallPackages:
         assert mock_install.call_args_list[0].kwargs["version"] == ""
 
     async def test_install_multiple_with_specifiers(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         pm = k.packages_callbacks.package_manager
         assert pm is not None
 
@@ -586,7 +602,7 @@ class TestAutorunStaleState:
         """Running the root cell should mark reactive descendants as
         non-stale in autorun mode so the frontend doesn't show them
         as 'needs run'."""
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -617,7 +633,7 @@ class TestAutorunStaleState:
         """In lazy mode, only the explicitly run cell should be non-stale.
         Downstream cells stay stale."""
         k = lazy_kernel
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -644,7 +660,7 @@ class TestAutorunStaleState:
         """edit_cell in one flush, run_cell in a separate flush should
         send code_is_stale=false so the frontend clears the stale state."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         # Flush 1: edit only
         async with ctx as nb:
@@ -653,7 +669,7 @@ class TestAutorunStaleState:
         _clear_messages(k)
 
         # Flush 2: run only
-        ctx2 = AsyncCodeModeContext(k)
+        ctx2 = _ctx(k)
         async with ctx2 as nb:
             nb.run_cell("0")
 

--- a/tests/_code_mode/test_context.py
+++ b/tests/_code_mode/test_context.py
@@ -14,14 +14,14 @@ from marimo._messaging.notification import (
 )
 from marimo._runtime.commands import ExecuteCellCommand
 from marimo._runtime.runtime import Kernel
-from marimo._session.state.document import DocumentCell, NotebookDocument
+from marimo._session.state.document import NotebookCell, NotebookDocument
 
 
 def _ctx(k: Kernel) -> AsyncCodeModeContext:
     """Build an AsyncCodeModeContext with a document snapshot from the kernel."""
     k._document = NotebookDocument(
         [
-            DocumentCell(
+            NotebookCell(
                 id=cid,
                 code=cell.code,
                 config=cell.config,

--- a/tests/_session/state/test_document.py
+++ b/tests/_session/state/test_document.py
@@ -11,10 +11,11 @@ from marimo._session.state.document import (
     CellsReordered,
     CodeChanged,
     ConfigChanged,
-    DocumentCell,
     NameChanged,
+    NotebookCell,
     NotebookDocument,
 )
+from marimo._types.ids import CellId_t
 
 
 def _doc(*codes: str) -> NotebookDocument:
@@ -22,11 +23,13 @@ def _doc(*codes: str) -> NotebookDocument:
 
     Cell IDs are "0", "1", "2", ... matching their initial position.
     """
-    cells = [DocumentCell(id=str(i), code=c) for i, c in enumerate(codes)]
+    cells = [
+        NotebookCell(id=CellId_t(str(i)), code=c) for i, c in enumerate(codes)
+    ]
     return NotebookDocument(cells)
 
 
-def _ids(doc: NotebookDocument) -> list[str]:
+def _ids(doc: NotebookDocument) -> list[CellId_t]:
     return list(doc)
 
 
@@ -65,30 +68,37 @@ class TestConstruction:
 class TestCellCreated:
     def test_append_to_empty(self) -> None:
         doc = NotebookDocument()
-        doc.apply(CellCreated(id="a", code="x = 1"))
-        assert _ids(doc) == ["a"]
-        assert doc["a"].code == "x = 1"
+        cid = CellId_t("a")
+        doc.apply(CellCreated(id=cid, code="x = 1"))
+        assert _ids(doc) == [cid]
+        assert doc[cid].code == "x = 1"
 
     def test_append_to_end(self) -> None:
         doc = _doc("a", "b")
-        doc.apply(CellCreated(id="c", code="new"))
+        cid = CellId_t("c")
+        doc.apply(CellCreated(id=cid, code="new"))
         assert _ids(doc) == ["0", "1", "c"]
 
     def test_insert_after(self) -> None:
         doc = _doc("a", "b", "c")
-        doc.apply(CellCreated(id="x", code="new", after="0"))
+        cid = CellId_t("x")
+        target = CellId_t("0")
+        doc.apply(CellCreated(id=cid, code="new", after=target))
         assert _ids(doc) == ["0", "x", "1", "2"]
 
     def test_insert_after_last(self) -> None:
         doc = _doc("a", "b")
-        doc.apply(CellCreated(id="x", code="new", after="1"))
+        cid = CellId_t("x")
+        target = CellId_t("1")
+        doc.apply(CellCreated(id=cid, code="new", after=target))
         assert _ids(doc) == ["0", "1", "x"]
 
     def test_with_name_and_config(self) -> None:
         cfg = CellConfig(hide_code=True, disabled=True)
+        cid = CellId_t("CellId")
         doc = NotebookDocument()
-        doc.apply(CellCreated(id="a", code="x", name="setup", config=cfg))
-        cell = doc["a"]
+        doc.apply(CellCreated(id=cid, code="x", name="setup", config=cfg))
+        cell = doc[cid]
         assert cell.name == "setup"
         assert cell.config.hide_code is True
         assert cell.config.disabled is True
@@ -96,12 +106,16 @@ class TestCellCreated:
     def test_duplicate_id_raises(self) -> None:
         doc = _doc("a")
         with pytest.raises(ValueError, match="already exists"):
-            doc.apply(CellCreated(id="0", code="dup"))
+            doc.apply(CellCreated(id=CellId_t("0"), code="dup"))
 
     def test_after_nonexistent_raises(self) -> None:
         doc = _doc("a")
         with pytest.raises(KeyError, match="not in document"):
-            doc.apply(CellCreated(id="x", code="new", after="missing"))
+            doc.apply(
+                CellCreated(
+                    id=CellId_t("x"), code="new", after=CellId_t("missing")
+                )
+            )
 
 
 # ------------------------------------------------------------------
@@ -111,30 +125,32 @@ class TestCellCreated:
 
 class TestCellDeleted:
     def test_delete_only_cell(self) -> None:
+        cid = CellId_t("0")
         doc = _doc("a")
-        doc.apply(CellDeleted(id="0"))
+        doc.apply(CellDeleted(id=cid))
         assert len(doc) == 0
-        assert "0" not in doc
+        assert cid not in doc
 
     def test_delete_middle(self) -> None:
+        cid = CellId_t("1")
         doc = _doc("a", "b", "c")
-        doc.apply(CellDeleted(id="1"))
+        doc.apply(CellDeleted(id=cid))
         assert _ids(doc) == ["0", "2"]
 
     def test_delete_first(self) -> None:
         doc = _doc("a", "b", "c")
-        doc.apply(CellDeleted(id="0"))
+        doc.apply(CellDeleted(id=CellId_t("0")))
         assert _ids(doc) == ["1", "2"]
 
     def test_delete_last(self) -> None:
         doc = _doc("a", "b", "c")
-        doc.apply(CellDeleted(id="2"))
+        doc.apply(CellDeleted(id=CellId_t("2")))
         assert _ids(doc) == ["0", "1"]
 
     def test_delete_nonexistent_raises(self) -> None:
         doc = _doc("a")
         with pytest.raises(KeyError, match="not in document"):
-            doc.apply(CellDeleted(id="missing"))
+            doc.apply(CellDeleted(id=CellId_t("missing")))
 
 
 # ------------------------------------------------------------------
@@ -145,33 +161,33 @@ class TestCellDeleted:
 class TestCellMoved:
     def test_move_to_beginning(self) -> None:
         doc = _doc("a", "b", "c")
-        doc.apply(CellMoved(id="2", after=None))
+        doc.apply(CellMoved(id=CellId_t("2"), after=None))
         assert _ids(doc) == ["2", "0", "1"]
 
     def test_move_forward(self) -> None:
         doc = _doc("a", "b", "c", "d")
-        doc.apply(CellMoved(id="0", after="2"))
+        doc.apply(CellMoved(id=CellId_t("0"), after=CellId_t("2")))
         assert _ids(doc) == ["1", "2", "0", "3"]
 
     def test_move_backward(self) -> None:
         doc = _doc("a", "b", "c", "d")
-        doc.apply(CellMoved(id="3", after="0"))
+        doc.apply(CellMoved(id=CellId_t("3"), after=CellId_t("0")))
         assert _ids(doc) == ["0", "3", "1", "2"]
 
     def test_noop(self) -> None:
         doc = _doc("a", "b", "c")
-        doc.apply(CellMoved(id="1", after="0"))
+        doc.apply(CellMoved(id=CellId_t("1"), after=CellId_t("0")))
         assert _ids(doc) == ["0", "1", "2"]
 
     def test_nonexistent_raises(self) -> None:
         doc = _doc("a")
         with pytest.raises(KeyError, match="not in document"):
-            doc.apply(CellMoved(id="missing", after=None))
+            doc.apply(CellMoved(id=CellId_t("missing"), after=None))
 
     def test_after_nonexistent_raises(self) -> None:
         doc = _doc("a", "b")
         with pytest.raises(KeyError, match="not in document"):
-            doc.apply(CellMoved(id="0", after="missing"))
+            doc.apply(CellMoved(id=CellId_t("0"), after=CellId_t("missing")))
 
 
 # ------------------------------------------------------------------
@@ -182,40 +198,47 @@ class TestCellMoved:
 class TestCellsReordered:
     def test_move_to_beginning(self) -> None:
         doc = _doc("a", "b", "c")
-        doc.apply(CellsReordered(cell_ids=["2", "0", "1"]))
+        c0, c1, c2 = doc
+        doc.apply(CellsReordered(cell_ids=[c2, c0, c1]))
         assert _ids(doc) == ["2", "0", "1"]
 
     def test_move_forward(self) -> None:
         doc = _doc("a", "b", "c", "d")
-        doc.apply(CellsReordered(cell_ids=["1", "2", "0", "3"]))
+        c0, c1, c2, c3 = doc
+        doc.apply(CellsReordered(cell_ids=[c1, c2, c0, c3]))
         assert _ids(doc) == ["1", "2", "0", "3"]
 
     def test_move_backward(self) -> None:
         doc = _doc("a", "b", "c", "d")
-        doc.apply(CellsReordered(cell_ids=["0", "3", "1", "2"]))
+        c0, c1, c2, c3 = doc
+        doc.apply(CellsReordered(cell_ids=[c0, c3, c1, c2]))
         assert _ids(doc) == ["0", "3", "1", "2"]
 
     def test_same_order_is_noop(self) -> None:
         doc = _doc("a", "b", "c")
-        doc.apply(CellsReordered(cell_ids=["0", "1", "2"]))
-        assert _ids(doc) == ["0", "1", "2"]
+        ids = list(doc)
+        doc.apply(CellsReordered(cell_ids=ids))
+        assert _ids(doc) == ids
 
     def test_unknown_ids_ignored(self) -> None:
         doc = _doc("a", "b")
-        doc.apply(CellsReordered(cell_ids=["1", "unknown", "0"]))
+        cid0, cid1 = doc
+        doc.apply(CellsReordered(cell_ids=[cid1, CellId_t("unknown"), cid0]))
         assert _ids(doc) == ["1", "0"]
 
     def test_missing_ids_appended(self) -> None:
         """Cells not in the reorder list are appended at the end."""
         doc = _doc("a", "b", "c")
-        doc.apply(CellsReordered(cell_ids=["2", "0"]))
+        cid0, _, cid2 = doc
+        doc.apply(CellsReordered(cell_ids=[cid2, cid0]))
         assert _ids(doc) == ["2", "0", "1"]
 
     def test_preserves_cell_data(self) -> None:
         doc = _doc("code_a", "code_b")
-        doc.apply(CellsReordered(cell_ids=["1", "0"]))
-        assert doc["0"].code == "code_a"
-        assert doc["1"].code == "code_b"
+        cid0, cid1 = doc
+        doc.apply(CellsReordered(cell_ids=[cid1, cid0]))
+        assert doc[cid0].code == "code_a"
+        assert doc[cid1].code == "code_b"
 
 
 # ------------------------------------------------------------------
@@ -226,22 +249,24 @@ class TestCellsReordered:
 class TestCodeChanged:
     def test_change_code(self) -> None:
         doc = _doc("old code")
-        doc.apply(CodeChanged(id="0", code="new code"))
-        assert doc["0"].code == "new code"
+        cid, *_ = doc
+        doc.apply(CodeChanged(id=cid, code="new code"))
+        assert doc[cid].code == "new code"
 
     def test_preserves_other_fields(self) -> None:
+        cid = CellId_t("a")
         doc = NotebookDocument(
             [
-                DocumentCell(
-                    id="a",
+                NotebookCell(
+                    id=cid,
                     code="x",
                     name="setup",
                     config=CellConfig(hide_code=True),
                 )
             ]
         )
-        doc.apply(CodeChanged(id="a", code="y"))
-        cell = doc["a"]
+        doc.apply(CodeChanged(id=cid, code="y"))
+        cell = doc[cid]
         assert cell.code == "y"
         assert cell.name == "setup"
         assert cell.config.hide_code is True
@@ -249,13 +274,14 @@ class TestCodeChanged:
     def test_nonexistent_raises(self) -> None:
         doc = _doc("a")
         with pytest.raises(KeyError, match="not in document"):
-            doc.apply(CodeChanged(id="missing", code="x"))
+            doc.apply(CodeChanged(id=CellId_t("missing"), code="x"))
 
     def test_last_write_wins(self) -> None:
         doc = _doc("v1")
-        doc.apply(CodeChanged(id="0", code="v2"))
-        doc.apply(CodeChanged(id="0", code="v3"))
-        assert doc["0"].code == "v3"
+        cid, *_ = doc
+        doc.apply(CodeChanged(id=cid, code="v2"))
+        doc.apply(CodeChanged(id=cid, code="v3"))
+        assert doc[cid].code == "v3"
 
 
 # ------------------------------------------------------------------
@@ -266,18 +292,20 @@ class TestCodeChanged:
 class TestNameChanged:
     def test_rename(self) -> None:
         doc = _doc("a")
-        doc.apply(NameChanged(id="0", name="setup"))
-        assert doc["0"].name == "setup"
+        cid, *_ = doc
+        doc.apply(NameChanged(id=cid, name="setup"))
+        assert doc[cid].name == "setup"
 
     def test_clear_name(self) -> None:
-        doc = NotebookDocument([DocumentCell(id="a", code="x", name="old")])
-        doc.apply(NameChanged(id="a", name=""))
-        assert doc["a"].name == ""
+        cid = CellId_t("a")
+        doc = NotebookDocument([NotebookCell(id=cid, code="x", name="old")])
+        doc.apply(NameChanged(id=cid, name=""))
+        assert doc[cid].name == ""
 
     def test_nonexistent_raises(self) -> None:
         doc = _doc("a")
         with pytest.raises(KeyError, match="not in document"):
-            doc.apply(NameChanged(id="missing", name="x"))
+            doc.apply(NameChanged(id=CellId_t("missing"), name="x"))
 
 
 # ------------------------------------------------------------------
@@ -288,19 +316,23 @@ class TestNameChanged:
 class TestConfigChanged:
     def test_change_config(self) -> None:
         doc = _doc("a")
-        doc.apply(ConfigChanged(id="0", config=CellConfig(hide_code=True)))
-        assert doc["0"].config.hide_code is True
+        cid, *_ = doc
+        doc.apply(ConfigChanged(id=cid, config=CellConfig(hide_code=True)))
+        assert doc[cid].config.hide_code is True
 
     def test_preserves_code(self) -> None:
         doc = _doc("important code")
-        doc.apply(ConfigChanged(id="0", config=CellConfig(disabled=True)))
-        assert doc["0"].code == "important code"
-        assert doc["0"].config.disabled is True
+        cid, *_ = doc
+        doc.apply(ConfigChanged(id=cid, config=CellConfig(disabled=True)))
+        assert doc[cid].code == "important code"
+        assert doc[cid].config.disabled is True
 
     def test_nonexistent_raises(self) -> None:
         doc = _doc("a")
         with pytest.raises(KeyError, match="not in document"):
-            doc.apply(ConfigChanged(id="missing", config=CellConfig()))
+            doc.apply(
+                ConfigChanged(id=CellId_t("missing"), config=CellConfig())
+            )
 
 
 # ------------------------------------------------------------------
@@ -312,82 +344,100 @@ class TestEventSequences:
     def test_create_move_edit(self) -> None:
         """Full workflow: create cells, reorder, edit."""
         doc = NotebookDocument()
-        doc.apply(CellCreated(id="a", code="import mo"))
-        doc.apply(CellCreated(id="b", code="red"))
-        doc.apply(CellCreated(id="c", code="green"))
+
+        ca = CellCreated(id=CellId_t("a"), code="import mo")
+        doc.apply(ca)
+        cb = CellCreated(id=CellId_t("b"), code="red")
+        doc.apply(cb)
+        cc = CellCreated(id=CellId_t("c"), code="green")
+        doc.apply(cc)
+
         assert _ids(doc) == ["a", "b", "c"]
 
-        doc.apply(CellsReordered(cell_ids=["c", "a", "b"]))
+        doc.apply(CellsReordered(cell_ids=[cc.id, ca.id, cb.id]))
         assert _ids(doc) == ["c", "a", "b"]
 
-        doc.apply(CodeChanged(id="c", code="green (edited)"))
-        assert doc["c"].code == "green (edited)"
+        doc.apply(CodeChanged(id=cc.id, code="green (edited)"))
+        assert doc[cc.id].code == "green (edited)"
         assert _ids(doc) == ["c", "a", "b"]
 
     def test_create_delete_create(self) -> None:
         """Deleting a cell frees the ID for reuse."""
+        cid = CellId_t("a")
         doc = NotebookDocument()
-        doc.apply(CellCreated(id="a", code="v1"))
-        doc.apply(CellDeleted(id="a"))
-        doc.apply(CellCreated(id="a", code="v2"))
-        assert doc["a"].code == "v2"
+        doc.apply(CellCreated(id=cid, code="v1"))
+        doc.apply(CellDeleted(id=cid))
+        doc.apply(CellCreated(id=cid, code="v2"))
+        assert doc[cid].code == "v2"
 
     def test_interleaved_frontend_and_agent(self) -> None:
         """Simulate frontend and code_mode interleaving events."""
         doc = NotebookDocument()
 
+        a, b, c, d = (
+            CellId_t("a"),
+            CellId_t("b"),
+            CellId_t("c"),
+            CellId_t("d"),
+        )
+
         # Agent creates cells
-        doc.apply(CellCreated(id="a", code="import mo"))
-        doc.apply(CellCreated(id="b", code="red"))
-        doc.apply(CellCreated(id="c", code="green"))
+        doc.apply(CellCreated(id=a, code="import mo"))
+        doc.apply(CellCreated(id=b, code="red"))
+        doc.apply(CellCreated(id=c, code="green"))
 
         # User drags green to top
-        doc.apply(CellsReordered(cell_ids=["c", "a", "b"]))
-        assert _ids(doc) == ["c", "a", "b"]
+        doc.apply(CellsReordered(cell_ids=[c, a, b]))
+        assert _ids(doc) == [c, a, b]
 
         # Agent edits red — should NOT change ordering
-        doc.apply(CodeChanged(id="b", code="red (edited)"))
-        assert _ids(doc) == ["c", "a", "b"]
-        assert doc["b"].code == "red (edited)"
+        doc.apply(CodeChanged(id=b, code="red (edited)"))
+        assert _ids(doc) == [c, a, b]
+        assert doc[b].code == "red (edited)"
 
         # User creates a new cell between green and import
-        doc.apply(CellCreated(id="d", code="new", after="c"))
-        assert _ids(doc) == ["c", "d", "a", "b"]
+        doc.apply(CellCreated(id=d, code="new", after=c))
+        assert _ids(doc) == [c, d, a, b]
 
         # Agent deletes the new cell
-        doc.apply(CellDeleted(id="d"))
-        assert _ids(doc) == ["c", "a", "b"]
+        doc.apply(CellDeleted(id=d))
+        assert _ids(doc) == [c, a, b]
 
     def test_multiple_moves(self) -> None:
         doc = _doc("a", "b", "c", "d", "e")
+        c0, c1, c2, c3, c4 = doc
 
-        doc.apply(CellsReordered(cell_ids=["0", "4", "1", "2", "3"]))
-        assert _ids(doc) == ["0", "4", "1", "2", "3"]
+        doc.apply(CellsReordered(cell_ids=[c0, c4, c1, c2, c3]))
+        assert _ids(doc) == [c0, c4, c1, c2, c3]
 
-        doc.apply(CellsReordered(cell_ids=["2", "0", "4", "1", "3"]))
-        assert _ids(doc) == ["2", "0", "4", "1", "3"]
+        doc.apply(CellsReordered(cell_ids=[c2, c0, c4, c1, c3]))
+        assert _ids(doc) == [c2, c0, c4, c1, c3]
 
     def test_index_consistency_after_many_mutations(self) -> None:
         """The internal index must stay consistent through all operations."""
         doc = NotebookDocument()
 
         # Build up
-        for i in range(10):
-            doc.apply(CellCreated(id=str(i), code=f"cell {i}"))
+        ids = [CellId_t(str(i)) for i in range(10)]
+        for i, cid in enumerate(ids):
+            doc.apply(CellCreated(id=cid, code=f"cell {i}"))
 
         # Delete evens
         for i in range(0, 10, 2):
-            doc.apply(CellDeleted(id=str(i)))
-        assert _ids(doc) == ["1", "3", "5", "7", "9"]
+            doc.apply(CellDeleted(id=ids[i]))
+        assert _ids(doc) == [ids[1], ids[3], ids[5], ids[7], ids[9]]
 
         # Move 9 to front
-        doc.apply(CellsReordered(cell_ids=["9", "1", "3", "5", "7"]))
-        assert _ids(doc) == ["9", "1", "3", "5", "7"]
+        doc.apply(
+            CellsReordered(cell_ids=[ids[9], ids[1], ids[3], ids[5], ids[7]])
+        )
+        assert _ids(doc) == [ids[9], ids[1], ids[3], ids[5], ids[7]]
 
         # Create new cells in gaps
-        doc.apply(CellCreated(id="a", code="new", after="1"))
-        doc.apply(CellCreated(id="b", code="new", after="5"))
-        assert _ids(doc) == ["9", "1", "a", "3", "5", "b", "7"]
+        a, b = CellId_t("a"), CellId_t("b")
+        doc.apply(CellCreated(id=a, code="new", after=ids[1]))
+        doc.apply(CellCreated(id=b, code="new", after=ids[5]))
+        assert _ids(doc) == [ids[9], ids[1], a, ids[3], ids[5], b, ids[7]]
 
         # Verify every cell is findable
         for cid in _ids(doc):

--- a/tests/_session/state/test_document.py
+++ b/tests/_session/state/test_document.py
@@ -1,0 +1,394 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import pytest
+
+from marimo._ast.cell import CellConfig
+from marimo._session.state.document import (
+    CellCreated,
+    CellDeleted,
+    CellMoved,
+    CellsReordered,
+    CodeChanged,
+    ConfigChanged,
+    DocumentCell,
+    NameChanged,
+    NotebookDocument,
+)
+
+
+def _doc(*codes: str) -> NotebookDocument:
+    """Helper: build a document from (id, code) pairs.
+
+    Cell IDs are "0", "1", "2", ... matching their initial position.
+    """
+    cells = [DocumentCell(id=str(i), code=c) for i, c in enumerate(codes)]
+    return NotebookDocument(cells)
+
+
+def _ids(doc: NotebookDocument) -> list[str]:
+    return list(doc)
+
+
+# ------------------------------------------------------------------
+# Construction
+# ------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_empty(self) -> None:
+        doc = NotebookDocument()
+        assert len(doc) == 0
+        assert _ids(doc) == []
+
+    def test_from_cells(self) -> None:
+        doc = _doc("a = 1", "b = 2", "c = 3")
+        assert len(doc) == 3
+        assert _ids(doc) == ["0", "1", "2"]
+
+    def test_values_iterates_cells(self) -> None:
+        doc = _doc("a = 1", "b = 2")
+        codes = [c.code for c in doc.values()]
+        assert codes == ["a = 1", "b = 2"]
+
+    def test_contains(self) -> None:
+        doc = _doc("a = 1")
+        assert "0" in doc
+        assert "999" not in doc
+
+
+# ------------------------------------------------------------------
+# CellCreated
+# ------------------------------------------------------------------
+
+
+class TestCellCreated:
+    def test_append_to_empty(self) -> None:
+        doc = NotebookDocument()
+        doc.apply(CellCreated(id="a", code="x = 1"))
+        assert _ids(doc) == ["a"]
+        assert doc["a"].code == "x = 1"
+
+    def test_append_to_end(self) -> None:
+        doc = _doc("a", "b")
+        doc.apply(CellCreated(id="c", code="new"))
+        assert _ids(doc) == ["0", "1", "c"]
+
+    def test_insert_after(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc.apply(CellCreated(id="x", code="new", after="0"))
+        assert _ids(doc) == ["0", "x", "1", "2"]
+
+    def test_insert_after_last(self) -> None:
+        doc = _doc("a", "b")
+        doc.apply(CellCreated(id="x", code="new", after="1"))
+        assert _ids(doc) == ["0", "1", "x"]
+
+    def test_with_name_and_config(self) -> None:
+        cfg = CellConfig(hide_code=True, disabled=True)
+        doc = NotebookDocument()
+        doc.apply(CellCreated(id="a", code="x", name="setup", config=cfg))
+        cell = doc["a"]
+        assert cell.name == "setup"
+        assert cell.config.hide_code is True
+        assert cell.config.disabled is True
+
+    def test_duplicate_id_raises(self) -> None:
+        doc = _doc("a")
+        with pytest.raises(ValueError, match="already exists"):
+            doc.apply(CellCreated(id="0", code="dup"))
+
+    def test_after_nonexistent_raises(self) -> None:
+        doc = _doc("a")
+        with pytest.raises(KeyError, match="not in document"):
+            doc.apply(CellCreated(id="x", code="new", after="missing"))
+
+
+# ------------------------------------------------------------------
+# CellDeleted
+# ------------------------------------------------------------------
+
+
+class TestCellDeleted:
+    def test_delete_only_cell(self) -> None:
+        doc = _doc("a")
+        doc.apply(CellDeleted(id="0"))
+        assert len(doc) == 0
+        assert "0" not in doc
+
+    def test_delete_middle(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc.apply(CellDeleted(id="1"))
+        assert _ids(doc) == ["0", "2"]
+
+    def test_delete_first(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc.apply(CellDeleted(id="0"))
+        assert _ids(doc) == ["1", "2"]
+
+    def test_delete_last(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc.apply(CellDeleted(id="2"))
+        assert _ids(doc) == ["0", "1"]
+
+    def test_delete_nonexistent_raises(self) -> None:
+        doc = _doc("a")
+        with pytest.raises(KeyError, match="not in document"):
+            doc.apply(CellDeleted(id="missing"))
+
+
+# ------------------------------------------------------------------
+# CellMoved
+# ------------------------------------------------------------------
+
+
+class TestCellMoved:
+    def test_move_to_beginning(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc.apply(CellMoved(id="2", after=None))
+        assert _ids(doc) == ["2", "0", "1"]
+
+    def test_move_forward(self) -> None:
+        doc = _doc("a", "b", "c", "d")
+        doc.apply(CellMoved(id="0", after="2"))
+        assert _ids(doc) == ["1", "2", "0", "3"]
+
+    def test_move_backward(self) -> None:
+        doc = _doc("a", "b", "c", "d")
+        doc.apply(CellMoved(id="3", after="0"))
+        assert _ids(doc) == ["0", "3", "1", "2"]
+
+    def test_noop(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc.apply(CellMoved(id="1", after="0"))
+        assert _ids(doc) == ["0", "1", "2"]
+
+    def test_nonexistent_raises(self) -> None:
+        doc = _doc("a")
+        with pytest.raises(KeyError, match="not in document"):
+            doc.apply(CellMoved(id="missing", after=None))
+
+    def test_after_nonexistent_raises(self) -> None:
+        doc = _doc("a", "b")
+        with pytest.raises(KeyError, match="not in document"):
+            doc.apply(CellMoved(id="0", after="missing"))
+
+
+# ------------------------------------------------------------------
+# CellsReordered
+# ------------------------------------------------------------------
+
+
+class TestCellsReordered:
+    def test_move_to_beginning(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc.apply(CellsReordered(cell_ids=["2", "0", "1"]))
+        assert _ids(doc) == ["2", "0", "1"]
+
+    def test_move_forward(self) -> None:
+        doc = _doc("a", "b", "c", "d")
+        doc.apply(CellsReordered(cell_ids=["1", "2", "0", "3"]))
+        assert _ids(doc) == ["1", "2", "0", "3"]
+
+    def test_move_backward(self) -> None:
+        doc = _doc("a", "b", "c", "d")
+        doc.apply(CellsReordered(cell_ids=["0", "3", "1", "2"]))
+        assert _ids(doc) == ["0", "3", "1", "2"]
+
+    def test_same_order_is_noop(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc.apply(CellsReordered(cell_ids=["0", "1", "2"]))
+        assert _ids(doc) == ["0", "1", "2"]
+
+    def test_unknown_ids_ignored(self) -> None:
+        doc = _doc("a", "b")
+        doc.apply(CellsReordered(cell_ids=["1", "unknown", "0"]))
+        assert _ids(doc) == ["1", "0"]
+
+    def test_missing_ids_appended(self) -> None:
+        """Cells not in the reorder list are appended at the end."""
+        doc = _doc("a", "b", "c")
+        doc.apply(CellsReordered(cell_ids=["2", "0"]))
+        assert _ids(doc) == ["2", "0", "1"]
+
+    def test_preserves_cell_data(self) -> None:
+        doc = _doc("code_a", "code_b")
+        doc.apply(CellsReordered(cell_ids=["1", "0"]))
+        assert doc["0"].code == "code_a"
+        assert doc["1"].code == "code_b"
+
+
+# ------------------------------------------------------------------
+# CodeChanged
+# ------------------------------------------------------------------
+
+
+class TestCodeChanged:
+    def test_change_code(self) -> None:
+        doc = _doc("old code")
+        doc.apply(CodeChanged(id="0", code="new code"))
+        assert doc["0"].code == "new code"
+
+    def test_preserves_other_fields(self) -> None:
+        doc = NotebookDocument(
+            [
+                DocumentCell(
+                    id="a",
+                    code="x",
+                    name="setup",
+                    config=CellConfig(hide_code=True),
+                )
+            ]
+        )
+        doc.apply(CodeChanged(id="a", code="y"))
+        cell = doc["a"]
+        assert cell.code == "y"
+        assert cell.name == "setup"
+        assert cell.config.hide_code is True
+
+    def test_nonexistent_raises(self) -> None:
+        doc = _doc("a")
+        with pytest.raises(KeyError, match="not in document"):
+            doc.apply(CodeChanged(id="missing", code="x"))
+
+    def test_last_write_wins(self) -> None:
+        doc = _doc("v1")
+        doc.apply(CodeChanged(id="0", code="v2"))
+        doc.apply(CodeChanged(id="0", code="v3"))
+        assert doc["0"].code == "v3"
+
+
+# ------------------------------------------------------------------
+# NameChanged
+# ------------------------------------------------------------------
+
+
+class TestNameChanged:
+    def test_rename(self) -> None:
+        doc = _doc("a")
+        doc.apply(NameChanged(id="0", name="setup"))
+        assert doc["0"].name == "setup"
+
+    def test_clear_name(self) -> None:
+        doc = NotebookDocument([DocumentCell(id="a", code="x", name="old")])
+        doc.apply(NameChanged(id="a", name=""))
+        assert doc["a"].name == ""
+
+    def test_nonexistent_raises(self) -> None:
+        doc = _doc("a")
+        with pytest.raises(KeyError, match="not in document"):
+            doc.apply(NameChanged(id="missing", name="x"))
+
+
+# ------------------------------------------------------------------
+# ConfigChanged
+# ------------------------------------------------------------------
+
+
+class TestConfigChanged:
+    def test_change_config(self) -> None:
+        doc = _doc("a")
+        doc.apply(ConfigChanged(id="0", config=CellConfig(hide_code=True)))
+        assert doc["0"].config.hide_code is True
+
+    def test_preserves_code(self) -> None:
+        doc = _doc("important code")
+        doc.apply(ConfigChanged(id="0", config=CellConfig(disabled=True)))
+        assert doc["0"].code == "important code"
+        assert doc["0"].config.disabled is True
+
+    def test_nonexistent_raises(self) -> None:
+        doc = _doc("a")
+        with pytest.raises(KeyError, match="not in document"):
+            doc.apply(ConfigChanged(id="missing", config=CellConfig()))
+
+
+# ------------------------------------------------------------------
+# Event sequences
+# ------------------------------------------------------------------
+
+
+class TestEventSequences:
+    def test_create_move_edit(self) -> None:
+        """Full workflow: create cells, reorder, edit."""
+        doc = NotebookDocument()
+        doc.apply(CellCreated(id="a", code="import mo"))
+        doc.apply(CellCreated(id="b", code="red"))
+        doc.apply(CellCreated(id="c", code="green"))
+        assert _ids(doc) == ["a", "b", "c"]
+
+        doc.apply(CellsReordered(cell_ids=["c", "a", "b"]))
+        assert _ids(doc) == ["c", "a", "b"]
+
+        doc.apply(CodeChanged(id="c", code="green (edited)"))
+        assert doc["c"].code == "green (edited)"
+        assert _ids(doc) == ["c", "a", "b"]
+
+    def test_create_delete_create(self) -> None:
+        """Deleting a cell frees the ID for reuse."""
+        doc = NotebookDocument()
+        doc.apply(CellCreated(id="a", code="v1"))
+        doc.apply(CellDeleted(id="a"))
+        doc.apply(CellCreated(id="a", code="v2"))
+        assert doc["a"].code == "v2"
+
+    def test_interleaved_frontend_and_agent(self) -> None:
+        """Simulate frontend and code_mode interleaving events."""
+        doc = NotebookDocument()
+
+        # Agent creates cells
+        doc.apply(CellCreated(id="a", code="import mo"))
+        doc.apply(CellCreated(id="b", code="red"))
+        doc.apply(CellCreated(id="c", code="green"))
+
+        # User drags green to top
+        doc.apply(CellsReordered(cell_ids=["c", "a", "b"]))
+        assert _ids(doc) == ["c", "a", "b"]
+
+        # Agent edits red — should NOT change ordering
+        doc.apply(CodeChanged(id="b", code="red (edited)"))
+        assert _ids(doc) == ["c", "a", "b"]
+        assert doc["b"].code == "red (edited)"
+
+        # User creates a new cell between green and import
+        doc.apply(CellCreated(id="d", code="new", after="c"))
+        assert _ids(doc) == ["c", "d", "a", "b"]
+
+        # Agent deletes the new cell
+        doc.apply(CellDeleted(id="d"))
+        assert _ids(doc) == ["c", "a", "b"]
+
+    def test_multiple_moves(self) -> None:
+        doc = _doc("a", "b", "c", "d", "e")
+
+        doc.apply(CellsReordered(cell_ids=["0", "4", "1", "2", "3"]))
+        assert _ids(doc) == ["0", "4", "1", "2", "3"]
+
+        doc.apply(CellsReordered(cell_ids=["2", "0", "4", "1", "3"]))
+        assert _ids(doc) == ["2", "0", "4", "1", "3"]
+
+    def test_index_consistency_after_many_mutations(self) -> None:
+        """The internal index must stay consistent through all operations."""
+        doc = NotebookDocument()
+
+        # Build up
+        for i in range(10):
+            doc.apply(CellCreated(id=str(i), code=f"cell {i}"))
+
+        # Delete evens
+        for i in range(0, 10, 2):
+            doc.apply(CellDeleted(id=str(i)))
+        assert _ids(doc) == ["1", "3", "5", "7", "9"]
+
+        # Move 9 to front
+        doc.apply(CellsReordered(cell_ids=["9", "1", "3", "5", "7"]))
+        assert _ids(doc) == ["9", "1", "3", "5", "7"]
+
+        # Create new cells in gaps
+        doc.apply(CellCreated(id="a", code="new", after="1"))
+        doc.apply(CellCreated(id="b", code="new", after="5"))
+        assert _ids(doc) == ["9", "1", "a", "3", "5", "b", "7"]
+
+        # Verify every cell is findable
+        for cid in _ids(doc):
+            assert doc[cid].id == cid


### PR DESCRIPTION
Today, notebook structure is scattered across the front end and backend. These diverge silently (now especially with `marimo._code_mode`), and cause inconsistency bugs.

This PR introduces `NotebookDocument`, an event-sourced ordered list of cells that both the frontend and kernel will read from and write to:

```python
@dataclass(slots=True)
class NotebookCell:
    id: CellId_t
    code: str
    name: str = ""
    config: CellConfig = field(default_factory=CellConfig)
```

Seven event types mutate it:

| Event | Fields | Semantics |
| --- | --- | --- |
| `CellCreated` | `id, code, name, config, after` | New cell inserted after `after` (or appended) |
| `CellDeleted` | `id` | Cell removed |
| `CellMoved` | `id, after` | Single cell repositioned |
| `CellsReordered` | `cell_ids` | Full ordering replaced (bulk moves) |
| `CodeChanged` | `id, code` | Cell code updated |
| `NameChanged` | `id, name` | Cell renamed |
| `ConfigChanged` | `id, config` | Cell config changed |

The document is populated from the `CellManager` at session creation and "snapshotted" onto `ExecuteScratchpadCommand` so the kernel process has access.

