### PR TITLE
Broadcast document events and close the event loop

### DIFF
--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -758,13 +758,28 @@ createReducerAndAtoms(initialNotebookState, {
   },
   handleCellMessage: (state, message: CellMessage) => {
     const cellId = message.cell_id as CellId;
-    const nextState = updateCellRuntimeState({
+    let nextState = updateCellRuntimeState({
       state,
       cellId,
       cellReducer: (cell) => {
         return transitionCell(cell, message);
       },
     });
+    // When a cell starts execution (queued), snapshot the current code
+    // as lastCodeRun. This clears staleness if the code hasn't changed
+    // by the time execution completes. If the user edits during
+    // execution, code !== lastCodeRun and the cell stays stale.
+    if (message.status === "queued") {
+      nextState = updateCellData({
+        state: nextState,
+        cellId,
+        cellReducer: (cell) => ({
+          ...cell,
+          lastCodeRun: cell.code.trim(),
+          edited: false,
+        }),
+      });
+    }
     return {
       ...nextState,
       cellLogs: [...nextState.cellLogs, ...getCellLogsForMessage(message)],

--- a/frontend/src/core/cells/document-events-middleware.ts
+++ b/frontend/src/core/cells/document-events-middleware.ts
@@ -19,6 +19,22 @@ import type { CellId } from "./ids";
 
 type DocumentEvent = DocumentEventsRequest["events"][number];
 
+/**
+ * Depth counter for suppression. Incremented when applying
+ * server-originated events so the middleware doesn't echo them back.
+ * A counter (not a boolean) so nested calls are safe.
+ */
+let _suppressDepth = 0;
+
+export function suppressDocumentEvents<T>(fn: () => T): T {
+  _suppressDepth++;
+  try {
+    return fn();
+  } finally {
+    _suppressDepth--;
+  }
+}
+
 let pendingEvents: DocumentEvent[] = [];
 
 const flushEvents = debounce(() => {
@@ -31,7 +47,7 @@ const flushEvents = debounce(() => {
 }, 400);
 
 function enqueue(event: DocumentEvent) {
-  if (store.get(kioskModeAtom)) {
+  if (_suppressDepth > 0 || store.get(kioskModeAtom)) {
     return;
   }
   pendingEvents.push(event);

--- a/frontend/src/core/islands/main.ts
+++ b/frontend/src/core/islands/main.ts
@@ -117,6 +117,7 @@ export async function initialize() {
       case "reload":
       case "update-cell-codes":
       case "update-cell-ids":
+      case "document-events":
       case "focus-cell":
       case "variables":
       case "variable-values":

--- a/frontend/src/core/websocket/useMarimoKernelConnection.tsx
+++ b/frontend/src/core/websocket/useMarimoKernelConnection.tsx
@@ -5,8 +5,12 @@ import { useRef } from "react";
 import { useErrorBoundary } from "react-error-boundary";
 import { toast } from "@/components/ui/use-toast";
 import { getNotebook, useCellActions } from "@/core/cells/cells";
+import { suppressDocumentEvents } from "@/core/cells/document-events-middleware";
 import { AUTOCOMPLETER } from "@/core/codemirror/completion/Autocompleter";
-import type { NotificationPayload } from "@/core/kernel/messages";
+import type {
+  NotificationMessageData,
+  NotificationPayload,
+} from "@/core/kernel/messages";
 import { useConnectionTransport } from "@/core/websocket/useWebSocket";
 import { renderHTML } from "@/plugins/core/RenderHTML";
 import {
@@ -92,7 +96,64 @@ export function useMarimoKernelConnection(opts: {
   const { autoInstantiate, sessionId, setCells } = opts;
   const { showBoundary } = useErrorBoundary();
 
-  const { handleCellMessage, setCellCodes, setCellIds } = useCellActions();
+  const {
+    handleCellMessage,
+    setCellCodes,
+    setCellIds,
+    deleteCell,
+    updateCellName,
+  } = useCellActions();
+
+  const handleDocumentEvents = (
+    events: NotificationMessageData<"document-events">["events"],
+  ) => {
+    suppressDocumentEvents(() => {
+      // Collect created/changed cells for a batch setCellCodes call.
+      const codesToSync: { id: CellId; code: string; name: string }[] = [];
+
+      for (const event of events) {
+        switch (event.type) {
+          case "cell-created":
+            codesToSync.push({
+              id: event.id as CellId,
+              code: event.code,
+              name: event.name ?? "",
+            });
+            break;
+          case "cell-deleted":
+            deleteCell({ cellId: event.id as CellId });
+            break;
+          case "cells-reordered":
+            setCellIds({ cellIds: event.cell_ids as CellId[] });
+            break;
+          case "code-changed":
+            codesToSync.push({
+              id: event.id as CellId,
+              code: event.code,
+              name: "",
+            });
+            break;
+          case "name-changed":
+            updateCellName({
+              cellId: event.id as CellId,
+              name: event.name,
+            });
+            break;
+        }
+      }
+
+      // Code changes are always stale — execution results clear
+      // staleness naturally via CellNotification.
+      if (codesToSync.length > 0) {
+        setCellCodes({
+          ids: codesToSync.map((c) => c.id),
+          codes: codesToSync.map((c) => c.code),
+          names: codesToSync.filter((c) => c.name).map((c) => c.name),
+          codeIsStale: true,
+        });
+      }
+    });
+  };
   const { addCellNotification } = useRunsActions();
   const setKernelState = useSetAtom(kernelStateAtom);
   const setAppConfig = useSetAppConfig();
@@ -323,6 +384,9 @@ export function useMarimoKernelConnection(opts: {
         return;
       case "update-cell-ids":
         setCellIds({ cellIds: msg.data.cell_ids as CellId[] });
+        return;
+      case "document-events":
+        handleDocumentEvents(msg.data.events);
         return;
       default:
         logNever(msg.data);

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -44,9 +44,8 @@ from marimo._code_mode._plan import (
     _validate_ops,
 )
 from marimo._messaging.notification import (
+    DocumentEventsNotification,
     Notification,
-    UpdateCellCodesNotification,
-    UpdateCellIdsNotification,
 )
 from marimo._messaging.notification_utils import broadcast_notification
 from marimo._runtime.commands import (
@@ -64,7 +63,9 @@ from marimo._session.state.document import (
     CellDeleted,
     CellsReordered,
     CodeChanged,
+    DocumentEvent,
     NameChanged,
+    get_current_document,
 )
 from marimo._types.ids import CellId_t, UIElementId
 from marimo._utils.formatter import DefaultFormatter
@@ -156,15 +157,13 @@ class _CellsView:
         return list(self._ctx._document)
 
     def _cell_name(self, cell_id: CellId_t) -> str | None:
-        if cell_id in self._ctx._document:
-            return self._ctx._document[cell_id].name or None
-        return None
+        doc_cell = self._ctx._document.get(cell_id)
+        return doc_cell.name or None if doc_cell else None
 
     def _build_at(self, cell_id: CellId_t) -> NotebookCellData:
-        cell_impl = self._ctx.graph.cells[cell_id]
         doc_cell = self._ctx._document.get(cell_id)
         return NotebookCellData(
-            code=cell_impl.code,
+            code=doc_cell.code if doc_cell else "",
             config=doc_cell.config if doc_cell else CellConfig(),
             name=self._cell_name(cell_id),
             id=cell_id,
@@ -261,14 +260,15 @@ class AsyncCodeModeContext:
         *,
         skip_validation: bool = False,
     ) -> None:
-        if kernel._document is None:
+        document = get_current_document()
+        if document is None:
             raise RuntimeError(
                 "NotebookDocument not available — code_mode must be invoked "
-                "via the /api/execute endpoint which attaches the document "
-                "snapshot"
+                "via the /api/execute endpoint which sets the document "
+                "context variable"
             )
         self._kernel = kernel
-        self._document = kernel._document
+        self._document = document
         self._cell_manager = cell_manager
         self._skip_validation = skip_validation
         self._ops: list[_Op] = []
@@ -342,18 +342,25 @@ class AsyncCodeModeContext:
                 self._dry_run_compile(ops)
             await self._apply_ops(ops, cells_to_run)
         elif cells_to_run:
-            # run_cell was called without any structural ops — just re-run.
-            # Notify the frontend that these cells are no longer stale so
-            # it clears edited/lastCodeRun (covers the two-step pattern:
-            # edit_cell in one flush, run_cell in a separate flush).
-            valid = cells_to_run & set(self.graph.cells.keys())
-            if valid:
-                self.notify(
-                    UpdateCellCodesNotification(
-                        cell_ids=list(valid),
-                        codes=[self.graph.cells[cid].code for cid in valid],
-                        code_is_stale=False,
-                    )
+            # run_cell was called without any structural ops.
+            # If any cells have document code that differs from the graph,
+            # sync them via mutate_graph first so the kernel runs the
+            # latest code.
+            sync_requests = []
+            for cid in cells_to_run:
+                doc_cell = self._document.get(cid)
+                if doc_cell is not None:
+                    doc_code = doc_cell.code
+                    graph_cell = self.graph.cells.get(cid)
+                    graph_code = graph_cell.code if graph_cell else ""
+                    if doc_code != graph_code:
+                        sync_requests.append(
+                            ExecuteCellCommand(cell_id=cid, code=doc_code)
+                        )
+            if sync_requests:
+                cells_to_run = cells_to_run | self._kernel.mutate_graph(
+                    execution_requests=sync_requests,
+                    deletion_requests=[],
                 )
             await self._kernel._run_cells(cells_to_run)
 
@@ -430,8 +437,9 @@ class AsyncCodeModeContext:
     def _cell_label(self, cell_id: CellId_t) -> str:
         """Return a display label: ``'id' (name)`` or ``'id'``."""
         short = repr(str(cell_id)[:8])
-        if cell_id in self._document:
-            name = self._document[cell_id].name
+        doc_cell = self._document.get(cell_id)
+        if doc_cell is not None:
+            name = doc_cell.name
             if name:
                 return f"{short} ({name})"
         return short
@@ -980,21 +988,37 @@ class AsyncCodeModeContext:
                 self.graph.cells[cell_id].configure(cfg.asdict())
             self._kernel.cell_metadata[cell_id] = CellMetadata(config=cfg)
 
-        # Sync the document with the plan: add new cells, remove deleted
-        # ones, update code/names, and reorder to match.
-        existing_doc_ids = set(list(self._document))
+        # Build document events from the plan, apply them to the local
+        # document, and broadcast to the frontend + session.
+        _run_set = explicit_run or set()
+        if _run_set and self._kernel.reactive_execution_mode == "autorun":
+            _run_set = _run_set | cells_to_run
+
+        doc_events: list[DocumentEvent] = []
+        existing_doc_ids = set(self._document)
+
+        # Creates and code changes.
         for entry in plan:
             if entry.cell_id not in existing_doc_ids:
-                self._document.apply(
-                    CellCreated(id=entry.cell_id, code=entry.code or "")
+                doc_events.append(
+                    CellCreated(
+                        id=entry.cell_id,
+                        code=entry.code or "",
+                        config=resolved_configs.get(
+                            entry.cell_id, CellConfig()
+                        ),
+                    )
                 )
             elif entry.code is not None:
-                self._document.apply(
+                doc_events.append(
                     CodeChanged(id=entry.cell_id, code=entry.code)
                 )
+
+        # Deletes.
         for cid in existing_doc_ids - plan_ids:
-            self._document.apply(CellDeleted(id=cid))
-        # Apply names from ops.
+            doc_events.append(CellDeleted(id=cid))
+
+        # Names from ops.
         for op in ops:
             if not isinstance(op, (_AddOp, _UpdateOp)) or op.name is None:
                 continue
@@ -1003,81 +1027,17 @@ class AsyncCodeModeContext:
                 if isinstance(op, _UpdateOp) and op.new_cell_id is not None
                 else op.cell_id
             )
-            if target_id in self._document:
-                self._document.apply(NameChanged(id=target_id, name=op.name))
+            doc_events.append(NameChanged(id=target_id, name=op.name))
+
         # Reorder to match the plan.
-        self._document.apply(CellsReordered(cell_ids=target_order))
+        doc_events.append(CellsReordered(cell_ids=target_order))
 
-        # Notify frontend of all changes (code and config-only).
-        # Cells not queued for execution are marked as stale.
-        # Config-only changes are never stale (the code didn't change).
-        #
-        # In autorun mode, when the caller explicitly ran at least one
-        # cell, also include cells_to_run from mutate_graph (reactive
-        # descendants) so the agent sees their execution synchronously
-        # and the frontend isn't left showing stale for cells that are
-        # about to execute.  We only expand when explicit_run is
-        # non-empty to preserve the "suggestion" behavior: creating
-        # cells without run_cell leaves them stale/unexecuted.
-        _run_set = explicit_run or set()
-        if _run_set and self._kernel.reactive_execution_mode == "autorun":
-            _run_set = _run_set | cells_to_run
-        _code_entry_ids = {e.cell_id for e in code_entries}
-        all_entries = code_entries + config_entries
-        by_stale: dict[bool, list[_PlanEntry]] = {}
-        for entry in all_entries:
-            is_stale = (
-                entry.cell_id in _code_entry_ids
-                and entry.cell_id not in _run_set
-            )
-            by_stale.setdefault(is_stale, []).append(entry)
+        # Apply locally.
+        for event in doc_events:
+            self._document.apply(event)
 
-        for is_stale, entries in by_stale.items():
-            names = [
-                dc.name if (dc := self._document.get(e.cell_id)) else ""
-                for e in entries
-            ]
-            codes = [
-                e.code
-                if e.code is not None
-                else self.graph.cells[e.cell_id].code
-                for e in entries
-            ]
-            kwargs: dict[str, Any] = {}
-            if any(names):
-                kwargs["names"] = names
-            self.notify(
-                UpdateCellCodesNotification(
-                    cell_ids=[e.cell_id for e in entries],
-                    codes=codes,
-                    code_is_stale=is_stale,
-                    configs=[resolved_configs[e.cell_id] for e in entries],
-                    **kwargs,
-                )
-            )
-
-        # For name-only updates (no code change), send a notification
-        # with existing code so the frontend picks up the new name.
-        code_entry_id_set = {e.cell_id for e in code_entries}
-        name_only = {
-            op.cell_id: op.name or ""
-            for op in ops
-            if isinstance(op, (_AddOp, _UpdateOp))
-            and op.name is not None
-            and op.cell_id not in code_entry_id_set
-            and op.cell_id in self.graph.cells
-        }
-        if name_only:
-            self.notify(
-                UpdateCellCodesNotification(
-                    cell_ids=list(name_only.keys()),
-                    codes=[self.graph.cells[cid].code for cid in name_only],
-                    code_is_stale=False,
-                    names=list(name_only.values()),
-                )
-            )
-
-        self.notify(UpdateCellIdsNotification(cell_ids=target_order))
+        # Broadcast to frontend + session.
+        self.notify(DocumentEventsNotification(events=doc_events))
 
         # Run queued cells (explicit run_cell + autorun descendants),
         # filtered to cells that still exist after structural ops.

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -34,6 +34,7 @@ from marimo._messaging.context import RUN_ID_CTX, RunId_t
 from marimo._plugins.core.web_component import JSONType
 from marimo._runtime.layout.layout import LayoutConfig
 from marimo._secrets.models import SecretKeysWithProvider
+from marimo._session.state.document import DocumentEvent
 from marimo._sql.parse import SqlCatalogCheckResult, SqlParseResult
 from marimo._types.ids import CellId_t, RequestId, UIElementId, WidgetModelId
 from marimo._utils.msgspec_basestruct import BaseStruct
@@ -785,6 +786,20 @@ class UpdateCellIdsNotification(Notification, tag="update-cell-ids"):
     cell_ids: list[CellId_t]
 
 
+class DocumentEventsNotification(Notification, tag="document-events"):
+    """Broadcasts document events to the frontend.
+
+    Sent by the session or kernel when document structure changes.
+    The frontend applies these to update its local state.
+
+    Attributes:
+        events: List of document events to apply.
+    """
+
+    name: ClassVar[str] = "document-events"
+    events: list[DocumentEvent]
+
+
 NotificationMessage = Union[
     # Cell operations
     CellNotification,
@@ -835,4 +850,6 @@ NotificationMessage = Union[
     FocusCellNotification,
     UpdateCellCodesNotification,
     UpdateCellIdsNotification,
+    # Document
+    DocumentEventsNotification,
 ]

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -197,7 +197,10 @@ from marimo._secrets.load_dotenv import (
 from marimo._secrets.secrets import get_secret_keys
 from marimo._session.model import SessionMode
 from marimo._session.queue import QueueType
-from marimo._session.state.document import NotebookDocument
+from marimo._session.state.document import (
+    NotebookDocument,
+    _current_document,
+)
 from marimo._sql.engines.duckdb import INTERNAL_DUCKDB_ENGINE, DuckDBEngine
 from marimo._sql.engines.types import (
     EngineCatalog,
@@ -570,10 +573,6 @@ class Kernel:
         self.debugger = debugger_override
         if self.debugger is not None:
             patches.patch_pdb(self.debugger)
-
-        # Document snapshot from session, set before scratchpad execution
-        # so code_mode can read cell ordering/code/names/configs.
-        self._document: NotebookDocument | None = None
 
         self._module = module
         if self.app_metadata.filename is not None:
@@ -2280,13 +2279,17 @@ class Kernel:
         async def handle_execute_scratchpad(
             request: ExecuteScratchpadCommand,
         ) -> None:
+            token = None
             if request.notebook_cells is not None:
-                self._document = NotebookDocument(list(request.notebook_cells))
+                token = _current_document.set(
+                    NotebookDocument(list(request.notebook_cells))
+                )
             try:
                 with http_request_context(request.request):
                     await self.run_scratchpad(request.code)
             finally:
-                self._document = None
+                if token is not None:
+                    _current_document.reset(token)
             broadcast_notification(CompletedRunNotification())
 
         async def handle_execute_stale(

--- a/marimo/_server/api/endpoints/document.py
+++ b/marimo/_server/api/endpoints/document.py
@@ -49,6 +49,6 @@ async def document_events(request: Request) -> BaseResponse:
     session = app_state.require_current_session()
 
     for event in body.events:
-        session.session_view.document.apply(event)
+        session.document.apply(event)
 
     return SuccessResponse()

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -302,9 +302,7 @@ async def execute_code(
                         ExecuteScratchpadCommand(
                             code=body.code,
                             request=HTTPRequest.from_request(request),
-                            notebook_cells=tuple(
-                                session.session_view.document.values()
-                            ),
+                            notebook_cells=tuple(session.document.values()),
                         ),
                         from_consumer_id=None,
                     )

--- a/marimo/_session/session.py
+++ b/marimo/_session/session.py
@@ -16,6 +16,7 @@ from marimo import _loggers
 from marimo._cli.sandbox import SandboxMode
 from marimo._config.manager import MarimoConfigManager, ScriptConfigManager
 from marimo._messaging.notification import (
+    DocumentEventsNotification,
     NotificationMessage,
 )
 from marimo._messaging.serde import serialize_kernel_message
@@ -232,7 +233,10 @@ class SessionImpl(Session):
             ttl_seconds if ttl_seconds is not None else _DEFAULT_TTL_SECONDS
         )
         self.session_view = SessionView()
-        self.session_view.document = NotebookDocument.from_cell_manager(
+        # Document lives on the session (not SessionView) because
+        # SessionView may be replaced across reconnections while the
+        # session persists for the lifetime of the kernel.
+        self.document = NotebookDocument.from_cell_manager(
             app_file_manager.app.cell_manager
         )
         self.config_manager = config_manager
@@ -392,6 +396,10 @@ class SessionImpl(Session):
         from_consumer_id: Optional[ConsumerId],
     ) -> None:
         """Write an operation to the session consumer and the session view."""
+        # Apply document events to the session's document.
+        if isinstance(operation, DocumentEventsNotification):
+            for event in operation.events:
+                self.document.apply(event)
         if isinstance(operation, bytes):
             notification = operation
         else:

--- a/marimo/_session/state/document.py
+++ b/marimo/_session/state/document.py
@@ -16,6 +16,7 @@ order they arrive. There is no merging.
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Annotated, Union
 
 import msgspec
@@ -86,7 +87,7 @@ class CellsReordered(msgspec.Struct, tag="cells-reordered"):
 
 
 class CodeChanged(msgspec.Struct, tag="code-changed"):
-    """A cell's code was changed (but not yet executed)."""
+    """A cell's code was changed."""
 
     id: CellId_t
     code: str
@@ -269,16 +270,13 @@ class NotebookDocument:
         self._rebuild_index()
 
     def _apply_code_changed(self, event: CodeChanged) -> None:
-        cell = self._cells[self._require_index(event.id)]
-        cell.code = event.code
+        self._cells[self._require_index(event.id)].code = event.code
 
     def _apply_name_changed(self, event: NameChanged) -> None:
-        cell = self._cells[self._require_index(event.id)]
-        cell.name = event.name
+        self._cells[self._require_index(event.id)].name = event.name
 
     def _apply_config_changed(self, event: ConfigChanged) -> None:
-        cell = self._cells[self._require_index(event.id)]
-        cell.config = event.config
+        self._cells[self._require_index(event.id)].config = event.config
 
     # -- Display ----------------------------------------------------
 
@@ -288,3 +286,21 @@ class NotebookDocument:
             code_preview = c.code[:40].replace("\n", "\\n")
             lines.append(f"  {i}: {c.id} {code_preview!r}")
         return "\n".join(lines)
+
+
+# ------------------------------------------------------------------
+# Context variable
+# ------------------------------------------------------------------
+
+#: Document snapshot for the current scratchpad execution.  Set by
+#: the kernel before running code_mode so that ``AsyncCodeModeContext``
+#: can read cell ordering, code, names, and configs without the kernel
+#: carrying mutable document state.
+_current_document: ContextVar[NotebookDocument | None] = ContextVar(
+    "_current_document", default=None
+)
+
+
+def get_current_document() -> NotebookDocument | None:
+    """Return the document for the current execution, if any."""
+    return _current_document.get()

--- a/marimo/_session/state/session_view.py
+++ b/marimo/_session/state/session_view.py
@@ -41,7 +41,6 @@ from marimo._runtime.commands import (
     SyncGraphCommand,
     UpdateUIElementCommand,
 )
-from marimo._session.state.document import NotebookDocument
 from marimo._sql.connection_utils import (
     update_table_in_connection,
     update_table_list_in_connection,
@@ -143,8 +142,6 @@ class SessionView:
     """
 
     def __init__(self) -> None:
-        # Canonical notebook structure — ordering, codes, names, configs.
-        self.document = NotebookDocument()
         # Last seen notebook-order of cell IDs
         self.cell_ids: Optional[UpdateCellIdsNotification] = None
         # A mapping from cell (IDs) to their last seen notification

--- a/marimo/_session/types.py
+++ b/marimo/_session/types.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     )
     from marimo._session.notebook.file_manager import AppFileManager
     from marimo._session.queue import ProcessLike, QueueType
+    from marimo._session.state.document import NotebookDocument
     from marimo._session.state.session_view import SessionView
     from marimo._types.ids import ConsumerId
     from marimo._utils.typed_connection import TypedConnection
@@ -108,6 +109,7 @@ class Session(Protocol):
 
     initialization_id: str
     app_file_manager: AppFileManager
+    document: NotebookDocument
     config_manager: MarimoConfigManager
     session_view: SessionView
     ttl_seconds: int

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -683,7 +683,7 @@ components:
       title: ClearCacheRequest
       type: object
     CodeChanged:
-      description: A cell's code was changed (but not yet executed).
+      description: A cell's code was changed.
       properties:
         code:
           type: string
@@ -1465,6 +1465,42 @@ components:
       - default_width
       - theme
       title: DisplayConfig
+      type: object
+    DocumentEventsNotification:
+      description: "Broadcasts document events to the frontend.\n\n    Sent by the\
+        \ session or kernel when document structure changes.\n    The frontend applies\
+        \ these to update its local state.\n\n    Attributes:\n        events: List\
+        \ of document events to apply."
+      properties:
+        events:
+          items:
+            anyOf:
+            - $ref: '#/components/schemas/CellCreated'
+            - $ref: '#/components/schemas/CellDeleted'
+            - $ref: '#/components/schemas/CellMoved'
+            - $ref: '#/components/schemas/CellsReordered'
+            - $ref: '#/components/schemas/CodeChanged'
+            - $ref: '#/components/schemas/NameChanged'
+            - $ref: '#/components/schemas/ConfigChanged'
+            discriminator:
+              mapping:
+                cell-created: '#/components/schemas/CellCreated'
+                cell-deleted: '#/components/schemas/CellDeleted'
+                cell-moved: '#/components/schemas/CellMoved'
+                cells-reordered: '#/components/schemas/CellsReordered'
+                code-changed: '#/components/schemas/CodeChanged'
+                config-changed: '#/components/schemas/ConfigChanged'
+                name-changed: '#/components/schemas/NameChanged'
+              propertyName: type
+            title: DocumentEvent
+          type: array
+        op:
+          enum:
+          - document-events
+      required:
+      - op
+      - events
+      title: DocumentEventsNotification
       type: object
     DocumentEventsRequest:
       properties:
@@ -2650,6 +2686,7 @@ components:
           - $ref: '#/components/schemas/FocusCellNotification'
           - $ref: '#/components/schemas/UpdateCellCodesNotification'
           - $ref: '#/components/schemas/UpdateCellIdsNotification'
+          - $ref: '#/components/schemas/DocumentEventsNotification'
           discriminator:
             mapping:
               alert: '#/components/schemas/AlertNotification'
@@ -2662,6 +2699,7 @@ components:
               data-column-preview: '#/components/schemas/DataColumnPreviewNotification'
               data-source-connections: '#/components/schemas/DataSourceConnectionsNotification'
               datasets: '#/components/schemas/DatasetsNotification'
+              document-events: '#/components/schemas/DocumentEventsNotification'
               focus-cell: '#/components/schemas/FocusCellNotification'
               function-call-result: '#/components/schemas/FunctionCallResultNotification'
               installing-package-alert: '#/components/schemas/InstallingPackageAlertNotification'

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -3711,7 +3711,7 @@ export interface components {
     ClearCacheRequest: Record<string, any>;
     /**
      * CodeChanged
-     * @description A cell's code was changed (but not yet executed).
+     * @description A cell's code was changed.
      */
     CodeChanged: {
       code: string;
@@ -4162,6 +4162,29 @@ export interface components {
       reference_highlighting?: boolean;
       /** @enum {unknown} */
       theme: "dark" | "light" | "system";
+    };
+    /**
+     * DocumentEventsNotification
+     * @description Broadcasts document events to the frontend.
+     *
+     *         Sent by the session or kernel when document structure changes.
+     *         The frontend applies these to update its local state.
+     *
+     *         Attributes:
+     *             events: List of document events to apply.
+     */
+    DocumentEventsNotification: {
+      events: (
+        | components["schemas"]["CellCreated"]
+        | components["schemas"]["CellDeleted"]
+        | components["schemas"]["CellMoved"]
+        | components["schemas"]["CellsReordered"]
+        | components["schemas"]["CodeChanged"]
+        | components["schemas"]["NameChanged"]
+        | components["schemas"]["ConfigChanged"]
+      )[];
+      /** @enum {unknown} */
+      op: "document-events";
     };
     /** DocumentEventsRequest */
     DocumentEventsRequest: {
@@ -4892,7 +4915,8 @@ export interface components {
         | components["schemas"]["CacheInfoNotification"]
         | components["schemas"]["FocusCellNotification"]
         | components["schemas"]["UpdateCellCodesNotification"]
-        | components["schemas"]["UpdateCellIdsNotification"];
+        | components["schemas"]["UpdateCellIdsNotification"]
+        | components["schemas"]["DocumentEventsNotification"];
     };
     /**
      * LanguageServersConfig

--- a/tests/_code_mode/test_cells_view.py
+++ b/tests/_code_mode/test_cells_view.py
@@ -6,17 +6,23 @@ import pytest
 from marimo._code_mode._context import AsyncCodeModeContext, NotebookCellData
 from marimo._runtime.commands import ExecuteCellCommand
 from marimo._runtime.runtime import Kernel
-from marimo._session.state.document import NotebookCell, NotebookDocument
+from marimo._session.state.document import (
+    NotebookCell,
+    NotebookDocument,
+    _current_document,
+)
 from marimo._types.ids import CellId_t
 
 
 def _ctx(k: Kernel) -> AsyncCodeModeContext:
     """Build an AsyncCodeModeContext with a document snapshot from the kernel."""
-    k._document = NotebookDocument(
-        [
-            NotebookCell(id=cid, code=cell.code, config=cell.config)
-            for cid, cell in k.graph.cells.items()
-        ]
+    _current_document.set(
+        NotebookDocument(
+            [
+                NotebookCell(id=cid, code=cell.code, config=cell.config)
+                for cid, cell in k.graph.cells.items()
+            ]
+        )
     )
     return AsyncCodeModeContext(k)
 

--- a/tests/_code_mode/test_context.py
+++ b/tests/_code_mode/test_context.py
@@ -9,25 +9,32 @@ from inline_snapshot import snapshot
 
 from marimo._code_mode._context import AsyncCodeModeContext
 from marimo._messaging.notification import (
+    DocumentEventsNotification,
     UpdateCellCodesNotification,
     UpdateCellIdsNotification,
 )
 from marimo._runtime.commands import ExecuteCellCommand
 from marimo._runtime.runtime import Kernel
-from marimo._session.state.document import NotebookCell, NotebookDocument
+from marimo._session.state.document import (
+    NotebookCell,
+    NotebookDocument,
+    _current_document,
+)
 
 
 def _ctx(k: Kernel) -> AsyncCodeModeContext:
     """Build an AsyncCodeModeContext with a document snapshot from the kernel."""
-    k._document = NotebookDocument(
-        [
-            NotebookCell(
-                id=cid,
-                code=cell.code,
-                config=cell.config,
-            )
-            for cid, cell in k.graph.cells.items()
-        ]
+    _current_document.set(
+        NotebookDocument(
+            [
+                NotebookCell(
+                    id=cid,
+                    code=cell.code,
+                    config=cell.config,
+                )
+                for cid, cell in k.graph.cells.items()
+            ]
+        )
     )
     return AsyncCodeModeContext(k)
 
@@ -46,6 +53,15 @@ def _ids_notifs(k: Kernel) -> list[UpdateCellIdsNotification]:
         for op in k.stream.operations
         if isinstance(op, UpdateCellIdsNotification)
     ]
+
+
+def _doc_events(k: Kernel) -> list[dict[str, object]]:
+    """Serialize all document events for snapshot comparison."""
+    events = []
+    for op in k.stream.operations:
+        if isinstance(op, DocumentEventsNotification):
+            events.extend(msgspec.to_builtins(op.events))
+    return events
 
 
 def _clear_messages(k: Kernel) -> None:
@@ -70,14 +86,23 @@ class TestAddCell:
         assert cell.code == "x = 1"
         assert k.globals["x"] == 1
 
-        code_notifs = msgspec.to_builtins(_code_notifs(k))
-        assert len(code_notifs) == 1
-        assert code_notifs[0]["codes"] == ["x = 1"]
-        assert code_notifs[0]["code_is_stale"] is False
-
-        ids_notifs = msgspec.to_builtins(_ids_notifs(k))
-        assert len(ids_notifs) == 1
-        assert len(ids_notifs[0]["cell_ids"]) == 1
+        assert _doc_events(k) == snapshot(
+            [
+                {
+                    "type": "cell-created",
+                    "id": "Hbol",
+                    "code": "x = 1",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {"type": "cells-reordered", "cell_ids": ["Hbol"]},
+            ]
+        )
 
     async def test_add_appends_by_default(self, k: Kernel) -> None:
         await k.run(
@@ -96,12 +121,23 @@ class TestAddCell:
         assert len(k.graph.cells) == 3
         assert k.globals["c"] == 30
 
-        # New cell should be last in the ordering notification.
-        ids_notifs = _ids_notifs(k)
-        assert len(ids_notifs) == 1
-        cell_ids = ids_notifs[0].cell_ids
-        assert cell_ids[:2] == ["0", "1"]
-        assert len(cell_ids) == 3
+        assert _doc_events(k) == snapshot(
+            [
+                {
+                    "type": "cell-created",
+                    "id": "Hbol",
+                    "code": "c = a + b",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {"type": "cells-reordered", "cell_ids": ["0", "1", "Hbol"]},
+            ]
+        )
 
     async def test_add_with_after(self, k: Kernel) -> None:
         await k.run(
@@ -116,11 +152,23 @@ class TestAddCell:
         async with ctx as nb:
             nb.create_cell("c = a + b", after="0")
 
-        ids_notifs = _ids_notifs(k)
-        cell_ids = ids_notifs[0].cell_ids
-        assert cell_ids[0] == "0"
-        # New cell should be after "0", before "1".
-        assert cell_ids[2] == "1"
+        assert _doc_events(k) == snapshot(
+            [
+                {
+                    "type": "cell-created",
+                    "id": "Hbol",
+                    "code": "c = a + b",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {"type": "cells-reordered", "cell_ids": ["0", "Hbol", "1"]},
+            ]
+        )
 
     async def test_add_without_run_does_not_execute(self, k: Kernel) -> None:
         ctx = _ctx(k)
@@ -132,10 +180,23 @@ class TestAddCell:
         assert len(k.graph.cells) == 1
         assert "x" not in k.globals
 
-        code_notifs = msgspec.to_builtins(_code_notifs(k))
-        assert len(code_notifs) == 1
-        assert code_notifs[0]["codes"] == ["x = 999"]
-        assert code_notifs[0]["code_is_stale"] is True
+        assert _doc_events(k) == snapshot(
+            [
+                {
+                    "type": "cell-created",
+                    "id": "Hbol",
+                    "code": "x = 999",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {"type": "cells-reordered", "cell_ids": ["Hbol"]},
+            ]
+        )
 
     async def test_add_returns_cell_id(self, k: Kernel) -> None:
         ctx = _ctx(k)
@@ -178,8 +239,11 @@ class TestDeleteCell:
 
         assert _graph_codes(k) == snapshot({"0": "a = 1", "2": "c = 3"})
 
-        assert msgspec.to_builtins(_ids_notifs(k)) == snapshot(
-            [{"op": "update-cell-ids", "cell_ids": ["0", "2"]}]
+        assert _doc_events(k) == snapshot(
+            [
+                {"type": "cell-deleted", "id": "1"},
+                {"type": "cells-reordered", "cell_ids": ["0", "2"]},
+            ]
         )
 
     async def test_delete_cleans_globals(self, k: Kernel) -> None:
@@ -233,22 +297,10 @@ class TestUpdateCell:
         assert k.globals["x"] == 42
         assert _graph_codes(k) == snapshot({"0": "x = 42"})
 
-        assert msgspec.to_builtins(_code_notifs(k)) == snapshot(
+        assert _doc_events(k) == snapshot(
             [
-                {
-                    "op": "update-cell-codes",
-                    "cell_ids": ["0"],
-                    "codes": ["x = 42"],
-                    "code_is_stale": False,
-                    "names": [],
-                    "configs": [
-                        {
-                            "column": None,
-                            "disabled": False,
-                            "hide_code": False,
-                        }
-                    ],
-                }
+                {"type": "code-changed", "id": "0", "code": "x = 42"},
+                {"type": "cells-reordered", "cell_ids": ["0"]},
             ]
         )
 
@@ -297,23 +349,8 @@ class TestUpdateCell:
 
         assert k.globals["x"] == 1
         assert _graph_codes(k) == snapshot({"0": "x = 1"})
-        assert msgspec.to_builtins(_code_notifs(k)) == snapshot(
-            [
-                {
-                    "op": "update-cell-codes",
-                    "cell_ids": ["0"],
-                    "codes": ["x = 1"],
-                    "code_is_stale": False,
-                    "names": [],
-                    "configs": [
-                        {
-                            "column": None,
-                            "disabled": False,
-                            "hide_code": True,
-                        }
-                    ],
-                }
-            ]
+        assert _doc_events(k) == snapshot(
+            [{"type": "cells-reordered", "cell_ids": ["0"]}]
         )
 
 
@@ -527,9 +564,36 @@ class TestResolveTarget:
         assert k.globals["y"] == 2
 
         # "first" should come before the second cell in ordering.
-        ids_notifs = _ids_notifs(k)
-        cell_ids = ids_notifs[0].cell_ids
-        assert len(cell_ids) == 2
+        assert _doc_events(k) == snapshot(
+            [
+                {
+                    "type": "cell-created",
+                    "id": "Hbol",
+                    "code": "x = 1",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {
+                    "type": "cell-created",
+                    "id": "MJUe",
+                    "code": "y = x + 1",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {"type": "name-changed", "id": "Hbol", "name": "first"},
+                {"type": "cells-reordered", "cell_ids": ["Hbol", "MJUe"]},
+            ]
+        )
 
     async def test_create_after_renamed_cell(self, k: Kernel) -> None:
         """Can reference a cell by its new name after edit_cell renames it."""
@@ -550,10 +614,24 @@ class TestResolveTarget:
         assert k.globals["c"] == 3
 
         # New cell should be after "0" (renamed), before "1".
-        ids_notifs = _ids_notifs(k)
-        cell_ids = ids_notifs[0].cell_ids
-        assert cell_ids[0] == "0"
-        assert cell_ids[2] == "1"
+        assert _doc_events(k) == snapshot(
+            [
+                {
+                    "type": "cell-created",
+                    "id": "Hbol",
+                    "code": "c = a + b",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {"type": "name-changed", "id": "0", "name": "renamed"},
+                {"type": "cells-reordered", "cell_ids": ["0", "Hbol", "1"]},
+            ]
+        )
 
 
 class TestInstallPackages:
@@ -614,18 +692,36 @@ class TestAutorunStaleState:
         assert k.globals["x"] == 1
         assert k.globals["y"] == 2
 
-        # The notification for b should be code_is_stale=False because
-        # autorun will execute it.
-        code_notifs = msgspec.to_builtins(_code_notifs(k))
-        stale_flags = {
-            cid: n["code_is_stale"]
-            for n in code_notifs
-            for cid in n["cell_ids"]
-        }
-        a_id = list(k.graph.cells.keys())[0]
-        b_id = list(k.graph.cells.keys())[1]
-        assert stale_flags[str(a_id)] is False
-        assert stale_flags[str(b_id)] is False
+        # Both cells should have been created in document events.
+        assert _doc_events(k) == snapshot(
+            [
+                {
+                    "type": "cell-created",
+                    "id": "Hbol",
+                    "code": "x = 1",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {
+                    "type": "cell-created",
+                    "id": "MJUe",
+                    "code": "y = x + 1",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {"type": "cells-reordered", "cell_ids": ["Hbol", "MJUe"]},
+            ]
+        )
 
     async def test_dependent_chain_lazy_mode(
         self, lazy_kernel: Kernel
@@ -645,16 +741,35 @@ class TestAutorunStaleState:
         # b should NOT have executed in lazy mode.
         assert "y" not in k.globals
 
-        code_notifs = msgspec.to_builtins(_code_notifs(k))
-        stale_flags = {
-            cid: n["code_is_stale"]
-            for n in code_notifs
-            for cid in n["cell_ids"]
-        }
-        a_id = list(k.graph.cells.keys())[0]
-        b_id = list(k.graph.cells.keys())[1]
-        assert stale_flags[str(a_id)] is False
-        assert stale_flags[str(b_id)] is True
+        assert _doc_events(k) == snapshot(
+            [
+                {
+                    "type": "cell-created",
+                    "id": "Hbol",
+                    "code": "x = 1",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {
+                    "type": "cell-created",
+                    "id": "MJUe",
+                    "code": "y = x + 1",
+                    "name": "",
+                    "config": {
+                        "column": None,
+                        "disabled": False,
+                        "hide_code": True,
+                    },
+                    "after": None,
+                },
+                {"type": "cells-reordered", "cell_ids": ["Hbol", "MJUe"]},
+            ]
+        )
 
     async def test_two_step_edit_then_run(self, k: Kernel) -> None:
         """edit_cell in one flush, run_cell in a separate flush should
@@ -675,6 +790,5 @@ class TestAutorunStaleState:
 
         assert k.globals["x"] == 42
 
-        code_notifs = msgspec.to_builtins(_code_notifs(k))
-        assert len(code_notifs) == 1
-        assert code_notifs[0]["code_is_stale"] is False
+        # The run-only flush sends a CodeChanged event to clear stale state.
+        assert _doc_events(k) == snapshot([])


### PR DESCRIPTION
Broadcast document events and close the event loop

#8817 & #8818 establish frontend → session flow. This PR adds the reverse direction: kernel → frontend.

`_apply_ops` previously assembled `UpdateCellCodesNotification` and `UpdateCellIdsNotification` by hand. Now it builds a list of document events, applies them to the local document, and broadcasts a single `DocumentEventsNotification`. The frontend receives them on the WebSocket and maps each event to the corresponding cell action, with the outgoing middleware suppressed to prevent loopback.

The document moves from `SessionView` to `Session` so it survives reconnections. Cell code is read from the document instead of the graph so unrun edits are visible. The run-only path syncs document code to the kernel graph via `mutate_graph` before executing. Stale state is derived frontend-side: queuing a cell for execution snapshots `lastCodeRun`, and any divergence between the current code and that snapshot keeps the cell marked stale — including edits made during execution.

After this PR the kernel, session, and frontend all speak the same event language for structural changes.