### PR TITLE
Skip readiness polling in mocked LSP server tests

### DIFF
--- a/tests/_server/test_lsp.py
+++ b/tests/_server/test_lsp.py
@@ -84,9 +84,7 @@ async def test_base_lsp_server_start_stop(
 
     # Skip readiness polling: the mock process doesn't listen on a TCP
     # port, so _wait_until_ready would poll for its full 5 s timeout.
-    with mock.patch.object(
-        server, "_wait_until_ready", return_value=True
-    ):
+    with mock.patch.object(server, "_wait_until_ready", return_value=True):
         alert = await server.start()
     assert alert is None
     mock_popen.assert_called_once()
@@ -115,9 +113,7 @@ async def test_base_lsp_server_stop_force_kill_on_timeout(
 
     # Skip readiness polling: the mock process doesn't listen on a TCP
     # port, so _wait_until_ready would poll for its full 5 s timeout.
-    with mock.patch.object(
-        server, "_wait_until_ready", return_value=True
-    ):
+    with mock.patch.object(server, "_wait_until_ready", return_value=True):
         await server.start()
 
     # Make wait() raise TimeoutExpired to simulate hung process
@@ -149,9 +145,7 @@ async def test_base_lsp_server_start_lock_prevents_concurrent_starts(
 
     # Skip readiness polling: the mock process doesn't listen on a TCP
     # port, so _wait_until_ready would poll for its full 5 s timeout.
-    with mock.patch.object(
-        server, "_wait_until_ready", return_value=True
-    ):
+    with mock.patch.object(server, "_wait_until_ready", return_value=True):
         results = await asyncio.gather(
             server.start(),
             server.start(),


### PR DESCRIPTION
Three LSP tests call `server.start()` with a mock subprocess that never listens on a port, so `_wait_until_ready` burns its full 5s timeout each time. These tests check lifecycle behavior, not readiness so we can patch it out.

15.9 s → 0.66 s.

```sh
hyperfine \
  --warmup 1 --runs 5 \
  -n 'before' 'git stash -q && uv run --group test pytest tests/_server/test_lsp.py -q --timeout=120 -x --no-header -p no:sugar 2>/dev/null; git stash pop -q' \
  -n 'after' 'uv run --group test pytest tests/_server/test_lsp.py -q --timeout=120 -x --no-header -p no:sugar 2>/dev/null'

# Benchmark 1: before
#   Time (mean ± σ):     15.876 s ±  0.052 s    [User: 0.703 s, System: 0.193 s]
#   Range (min … max):   15.818 s … 15.924 s    5 runs
#
# Benchmark 2: after
#   Time (mean ± σ):     661.7 ms ±   0.9 ms    [User: 559.0 ms, System: 92.9 ms]
#   Range (min … max):   660.6 ms … 663.1 ms    5 runs
#
# Summary
#   after ran
#    23.99 ± 0.09 times faster than before
```
