### PR TITLE
fix: stop mac completion bindings from stealing backticks

### DIFF
--- a/frontend/src/core/codemirror/completion/__tests__/keymap.test.ts
+++ b/frontend/src/core/codemirror/completion/__tests__/keymap.test.ts
@@ -1,60 +1,24 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import {
-  autocompletion,
-  completeFromList,
-  completionKeymap as defaultCompletionKeymap,
-} from "@codemirror/autocomplete";
-import { EditorState } from "@codemirror/state";
-import { EditorView, runScopeHandlers } from "@codemirror/view";
-import { afterEach, describe, expect, it } from "vitest";
-import { completionKeymap } from "../keymap";
+import { completionKeymap as defaultCompletionKeymap } from "@codemirror/autocomplete";
+import { describe, expect, it } from "vitest";
+import { filterCompletionBindings } from "../keymap";
 
 describe("completionKeymap", () => {
-  let view: EditorView | null = null;
-
-  afterEach(() => {
-    view?.destroy();
-    view = null;
-  });
-
-  function createView() {
-    view = new EditorView({
-      state: EditorState.create({
-        extensions: [
-          autocompletion({
-            override: [completeFromList(["completion-option"])],
-          }),
-          completionKeymap(),
-        ],
-      }),
-    });
-    return view;
-  }
-
-  it("does not intercept Alt-backtick on macOS", () => {
-    expect(
-      defaultCompletionKeymap.some((binding) => binding.mac === "Alt-`"),
-    ).toBe(true);
-
-    const cm = createView();
-    const event = new KeyboardEvent("keydown", {
-      key: "`",
-      code: "Backquote",
-      altKey: true,
-      bubbles: true,
-      cancelable: true,
-    });
-
-    expect(runScopeHandlers(cm, event, "editor")).toBe(false);
-  });
-
-  it("only targets the problematic macOS backtick shortcut", () => {
+  it("upstream includes the macOS-only completion bindings we care about", () => {
     expect(
       defaultCompletionKeymap.some((binding) => binding.mac === "Alt-`"),
     ).toBe(true);
     expect(
       defaultCompletionKeymap.some((binding) => binding.mac === "Alt-i"),
     ).toBe(true);
+  });
+
+  it("removes Alt-backtick and Escape while keeping Alt-i", () => {
+    const filtered = filterCompletionBindings(defaultCompletionKeymap);
+
+    expect(filtered.some((binding) => binding.mac === "Alt-`")).toBe(false);
+    expect(filtered.some((binding) => binding.key === "Escape")).toBe(false);
+    expect(filtered.some((binding) => binding.mac === "Alt-i")).toBe(true);
   });
 });

--- a/frontend/src/core/codemirror/completion/keymap.ts
+++ b/frontend/src/core/codemirror/completion/keymap.ts
@@ -28,10 +28,14 @@ function hasRemovedKeybinding(binding: KeyBinding): boolean {
   );
 }
 
+export function filterCompletionBindings(
+  bindings: readonly KeyBinding[],
+): readonly KeyBinding[] {
+  return bindings.filter((binding) => !hasRemovedKeybinding(binding));
+}
+
 export function completionKeymap(): Extension {
-  const withoutKeysToRemove = defaultCompletionKeymap.filter(
-    (binding) => !hasRemovedKeybinding(binding),
-  );
+  const withoutKeysToRemove = filterCompletionBindings(defaultCompletionKeymap);
 
   return Prec.highest(
     keymap.of([


### PR DESCRIPTION
## Summary

Fixes a macOS notebook editor bug where typing a backtick can trigger CodeMirror completion instead of inserting the character.

This affects international layouts that produce backtick through `Alt`/`Option`, including Hungarian `Option+ű`.

## Details

The intended fix was already in place conceptually: marimo tries to remove the problematic <code>Alt-`</code> completion shortcut.

It seems like the bug was that the filter only checked `binding.key`, while upstream CodeMirror currently exposes this shortcut as a mac-specific binding:

```ts
{ mac: "Alt-`", run: startCompletion }
```

So the shortcut was never actually removed.
This PR changes the filter to check all platform-specific keybinding fields:

- `key`
- `mac`
- `linux`
- `win`

## Tests

The follow-up test after GH Copilot review now checks the filtered bindings returned by `completionKeymap()` directly. Chose that over a `jsdom` event test because CodeMirror snapshots platform at module load, so a mac-only shortcut test there would be brittle and could pass for the wrong reason on non-mac CI.