### PR TITLE
Consolidate TOML reading into a TomlReader class

### DIFF
--- a/marimo/_config/packages.py
+++ b/marimo/_config/packages.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Literal, Optional
 
-from marimo._utils.toml import read_toml
+from marimo._utils.toml import toml_reader
 
 PackageManagerKind = Literal["pip", "rye", "uv", "poetry", "pixi"]
 
@@ -74,7 +74,7 @@ def infer_package_manager_from_pyproject(
 ) -> Optional[PackageManagerKind]:
     """Infer the package manager from a pyproject.toml file."""
     try:
-        data = read_toml(pyproject_toml)
+        data = toml_reader.read(pyproject_toml)
 
         if "tool" not in data:
             return None

--- a/marimo/_config/reader.py
+++ b/marimo/_config/reader.py
@@ -6,21 +6,21 @@ from typing import Any, Optional, Union, cast
 
 from marimo import _loggers
 from marimo._config.config import PartialMarimoConfig
-from marimo._utils.toml import read_toml
+from marimo._utils.toml import toml_reader
 
 LOGGER = _loggers.marimo_logger()
 
 
 def read_marimo_config(path: str) -> PartialMarimoConfig:
     """Read the marimo.toml configuration."""
-    return cast(PartialMarimoConfig, read_toml(path))
+    return cast(PartialMarimoConfig, toml_reader.read(path))
 
 
 def read_pyproject_marimo_config(
     pyproject_path: Union[str, Path],
 ) -> Optional[PartialMarimoConfig]:
     """Read the marimo tool config from a pyproject.toml file."""
-    pyproject_config = read_toml(pyproject_path)
+    pyproject_config = toml_reader.read(pyproject_path)
     marimo_tool_config = get_marimo_config_from_pyproject_dict(
         pyproject_config
     )

--- a/marimo/_utils/config/config.py
+++ b/marimo/_utils/config/config.py
@@ -5,7 +5,7 @@ from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from marimo._utils.parse_dataclass import parse_raw
-from marimo._utils.toml import is_toml_error, read_toml
+from marimo._utils.toml import toml_reader
 from marimo._utils.xdg import marimo_state_dir
 
 if TYPE_CHECKING:
@@ -32,12 +32,10 @@ class ConfigReader:
 
     def read_toml(self, cls: type[T], *, fallback: T) -> T:
         try:
-            data = read_toml(self.filepath)
+            data = toml_reader.read(self.filepath)
             return parse_raw(data, cls, allow_unknown_keys=True)
-        except Exception as e:
-            if is_toml_error(e) or isinstance(e, FileNotFoundError):
-                return fallback
-            raise e
+        except (toml_reader.decode_error, FileNotFoundError):
+            return fallback
 
     def write_toml(self, data: Any) -> None:
         import tomlkit

--- a/marimo/_utils/scripts.py
+++ b/marimo/_utils/scripts.py
@@ -5,7 +5,7 @@ import platform
 import re
 from typing import Any
 
-from marimo._utils.toml import read_toml_string
+from marimo._utils.toml import toml_reader
 
 REGEX = (
     r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
@@ -39,7 +39,7 @@ def read_pyproject_from_script(script: str) -> dict[str, Any] | None:
             for line in matches[0].group("content").splitlines(keepends=True)
         )
 
-        pyproject = read_toml_string(content)
+        pyproject = toml_reader.reads(content)
         return pyproject
     else:
         return None

--- a/marimo/_utils/toml.py
+++ b/marimo/_utils/toml.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, Union
+from typing import IO, TYPE_CHECKING, Any, Callable, Union
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -12,42 +12,35 @@ if TYPE_CHECKING:
 _HAS_TOMLLIB = sys.version_info >= (3, 11)
 
 
-def read_toml(file_path: Union[str, Path]) -> dict[str, Any]:
-    """Read and parse a TOML file."""
+class TomlReader:
+    """TOML reader that prefers tomllib (3.11+) over tomlkit."""
 
-    if _HAS_TOMLLIB:
-        import tomllib
+    decode_error: type[Exception]
+    _load: Callable[[IO[bytes]], dict[str, Any]]
+    _loads: Callable[[str], dict[str, Any]]
 
+    def __init__(self) -> None:
+        if _HAS_TOMLLIB:
+            import tomllib
+
+            self._load = tomllib.load  # type: ignore[assignment]
+            self._loads = tomllib.loads  # type: ignore[assignment]
+            self.decode_error = tomllib.TOMLDecodeError
+        else:
+            import tomlkit
+
+            self._load = lambda f: tomlkit.load(f).unwrap()
+            self._loads = lambda s: tomlkit.loads(s).unwrap()
+            self.decode_error = tomlkit.exceptions.TOMLKitError
+
+    def read(self, file_path: Union[str, Path]) -> dict[str, Any]:
+        """Read and parse a TOML file."""
         with open(file_path, "rb") as file:
-            return tomllib.load(file)
-    else:
-        import tomlkit
+            return self._load(file)
 
-        with open(file_path, "rb") as file:
-            return tomlkit.load(file).unwrap()
-
-
-def read_toml_string(s: str) -> dict[str, Any]:
-    """Read and parse a TOML string."""
-
-    if _HAS_TOMLLIB:
-        import tomllib
-
-        return tomllib.loads(s)
-    else:
-        import tomlkit
-
-        return tomlkit.loads(s).unwrap()
+    def reads(self, s: str) -> dict[str, Any]:
+        """Read and parse a TOML string."""
+        return self._loads(s)
 
 
-def is_toml_error(e: Exception) -> bool:
-    """Check if an exception is a TOML error."""
-
-    if _HAS_TOMLLIB:
-        import tomllib
-
-        return isinstance(e, tomllib.TOMLDecodeError)
-    else:
-        import tomlkit
-
-        return isinstance(e, tomlkit.exceptions.TOMLKitError)
+toml_reader = TomlReader()

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -34,7 +34,7 @@ from marimo._server.file_router import (
 )
 from marimo._server.templates.templates import get_version
 from marimo._utils.platform import is_windows
-from marimo._utils.toml import read_toml
+from marimo._utils.toml import toml_reader
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -160,7 +160,7 @@ def _get_port() -> int:
 def _read_toml(filepath: Path) -> Optional[dict[str, Any]]:
     if not filepath.exists():
         return None
-    return read_toml(filepath)
+    return toml_reader.read(filepath)
 
 
 def _write_temp_notebook(notebook: str, tmp_dir: Path) -> Path:

--- a/tests/_config/test_reader.py
+++ b/tests/_config/test_reader.py
@@ -12,7 +12,7 @@ from marimo._config.reader import (
     read_marimo_config,
     read_pyproject_marimo_config,
 )
-from marimo._utils.toml import is_toml_error, read_toml
+from marimo._utils.toml import toml_reader
 
 
 def test_read_toml():
@@ -21,7 +21,7 @@ def test_read_toml():
     key = "value"
     """
     with patch("builtins.open", mock_open(read_data=toml_content)):
-        result = read_toml("dummy.toml")
+        result = toml_reader.read("dummy.toml")
         assert result == {"section": {"key": "value"}}
 
 
@@ -145,6 +145,5 @@ def test_read_toml_invalid_content():
     """
 
     with patch("builtins.open", mock_open(read_data=invalid_toml)):
-        with pytest.raises(Exception) as e:
-            read_toml("dummy.toml")
-        assert is_toml_error(e.value)
+        with pytest.raises(toml_reader.decode_error):
+            toml_reader.read("dummy.toml")


### PR DESCRIPTION
The free functions `read_toml`, `read_toml_string`, and `is_toml_error` all independently branched on `_HAS_TOMLLIB`, meaning the error-checking logic was decoupled from whichever library actually did the reading. A `TomlReader` class resolves the library choice once in `__init__` and exposes `decode_error` as an attribute, so callers can use it directly in `except` clauses instead of going through a separate predicate.
