### PR TITLE
fix: replace bare except with except BaseException in parse_dataclass

### DIFF
--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -131,7 +131,7 @@ class _DataclassParser:
                 # catch expected exceptions when conversion fails
                 except (TypeError, ValueError):
                     continue
-                except:
+                except BaseException:
                     raise
             raise ValueError(
                 f"Value '{value}' does not fit any type of the union"


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except BaseException:` in `marimo/_utils/parse_dataclass.py`.

Per PEP 8, bare `except:` clauses should specify an exception type. Since this handler immediately re-raises the exception, `except BaseException:` preserves the original behavior while being explicit.

**Change:**
```python
# Before
except:
    raise

# After
except BaseException:
    raise
```

## Testing
No behavior change — the catch-and-reraise pattern is preserved. This is a style/correctness fix only.