### PR TITLE
fix: clamp memory reported in cgroup v1 reports

### DIFF
--- a/marimo/_utils/health.py
+++ b/marimo/_utils/health.py
@@ -43,6 +43,11 @@ CGROUP_V1_CPU_CFS_PERIOD_US_FILE = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 CGROUP_V1_MEMORY_LIMIT_FILE = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 CGROUP_V1_MEMORY_USAGE_FILE = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
 
+# cgroup v1 uses a value near LONG_MAX to indicate "no limit". Any value >= 1
+# exabyte is treated as unlimited, since no real machine has that much RAM (if
+# you do let us know, that's amazing).
+CGROUP_V1_MEMORY_UNLIMITED_THRESHOLD = 2**60
+
 
 def get_node_version() -> Optional[str]:
     try:
@@ -294,6 +299,8 @@ def get_cgroup_mem_stats() -> Optional[MemoryStats]:
         elif os.path.exists(CGROUP_V1_MEMORY_LIMIT_FILE):
             with open(CGROUP_V1_MEMORY_LIMIT_FILE, encoding="utf-8") as f:
                 total = int(f.read().strip())
+            if total >= CGROUP_V1_MEMORY_UNLIMITED_THRESHOLD:
+                return None
             with open(CGROUP_V1_MEMORY_USAGE_FILE, encoding="utf-8") as f:
                 used = int(f.read().strip())
             available = total - used

--- a/tests/_utils/test_health_utils.py
+++ b/tests/_utils/test_health_utils.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from io import StringIO
+from unittest.mock import patch
+
 from marimo._utils.health import (
+    CGROUP_V1_MEMORY_LIMIT_FILE,
+    CGROUP_V1_MEMORY_USAGE_FILE,
+    CGROUP_V2_MEMORY_CURRENT_FILE,
+    CGROUP_V2_MEMORY_MAX_FILE,
     _get_versions,
     _has_cgroup_cpu_limit,
     get_cgroup_cpu_percent,
@@ -55,3 +62,87 @@ def test_get_container_resources():
         assert "used" in memory_result
         assert "free" in memory_result
         assert "percent" in memory_result
+
+
+def _mock_cgroup_files(file_contents: dict[str, str]):
+    """Return (exists_side_effect, open_side_effect) for mocking cgroup reads."""
+
+    def exists_side_effect(path: str) -> bool:
+        return path in file_contents
+
+    original_open = open
+
+    def open_side_effect(path: str, encoding: str = "utf-8"):
+        if path in file_contents:
+
+            class FakeFile(StringIO):
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *_args: object):
+                    pass
+
+            return FakeFile(file_contents[path])
+        return original_open(path, encoding=encoding)
+
+    return exists_side_effect, open_side_effect
+
+
+def test_cgroup_v1_memory_unlimited_returns_none():
+    """cgroup v1 with LONG_MAX-4096 sentinel (typical WSL2) should be
+    treated as unlimited and return None."""
+    exists_fn, open_fn = _mock_cgroup_files(
+        {CGROUP_V1_MEMORY_LIMIT_FILE: "9223372036854771712\n"}
+    )
+    with (
+        patch("os.path.exists", side_effect=exists_fn),
+        patch("builtins.open", side_effect=open_fn),
+    ):
+        assert get_cgroup_mem_stats() is None
+
+
+def test_cgroup_v1_memory_unlimited_long_max_returns_none():
+    """cgroup v1 with exact LONG_MAX (2^63-1) should also return None."""
+    exists_fn, open_fn = _mock_cgroup_files(
+        {CGROUP_V1_MEMORY_LIMIT_FILE: "9223372036854775807\n"}
+    )
+    with (
+        patch("os.path.exists", side_effect=exists_fn),
+        patch("builtins.open", side_effect=open_fn),
+    ):
+        assert get_cgroup_mem_stats() is None
+
+
+def test_cgroup_v1_memory_with_real_limit():
+    """cgroup v1 with a real 2GB limit should return correct stats."""
+    exists_fn, open_fn = _mock_cgroup_files(
+        {
+            CGROUP_V1_MEMORY_LIMIT_FILE: "2147483648\n",
+            CGROUP_V1_MEMORY_USAGE_FILE: "1073741824\n",
+        }
+    )
+    with (
+        patch("os.path.exists", side_effect=exists_fn),
+        patch("builtins.open", side_effect=open_fn),
+    ):
+        result = get_cgroup_mem_stats()
+        assert result is not None
+        assert result["total"] == 2147483648
+        assert result["used"] == 1073741824
+        assert result["available"] == 1073741824
+        assert result["percent"] == 50.0
+
+
+def test_cgroup_v2_memory_unlimited_returns_none():
+    """cgroup v2 with 'max' (no limit) should return None."""
+    exists_fn, open_fn = _mock_cgroup_files(
+        {
+            CGROUP_V2_MEMORY_MAX_FILE: "max\n",
+            CGROUP_V2_MEMORY_CURRENT_FILE: "1048576\n",
+        }
+    )
+    with (
+        patch("os.path.exists", side_effect=exists_fn),
+        patch("builtins.open", side_effect=open_fn),
+    ):
+        assert get_cgroup_mem_stats() is None


### PR DESCRIPTION
## 📝 Summary

closes #8639

On cgroup v1 (common in older WSL2), `memory.limit_in_bytes` reports a value near LONG_MAX `~9.2×10^18`. This PR clamps the total reported memory to 1 exabyte.

NB cgroup v2 seems to report just `max`. Unable to directly reproduce the reported issue, but this seems like a reasonable work around.