### PR TITLE
[nd 4/5] Emit transactions from `code_mode`

### DIFF
--- a/marimo/_code_mode/__init__.py
+++ b/marimo/_code_mode/__init__.py
@@ -34,12 +34,12 @@ from __future__ import annotations
 
 from marimo._code_mode._context import (
     AsyncCodeModeContext,
-    NotebookCellData,
     get_context,
 )
+from marimo._notebook.document import NotebookCell
 
 __all__ = [
     "AsyncCodeModeContext",
-    "NotebookCellData",
+    "NotebookCell",
     "get_context",
 ]

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -24,9 +24,7 @@ Usage::
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, overload
-from uuid import uuid4
 
 from marimo import _loggers
 from marimo._ast.cell import CellConfig, CellImpl
@@ -49,6 +47,7 @@ from marimo._messaging.notification import (
     UpdateCellCodesNotification,
 )
 from marimo._messaging.notification_utils import broadcast_notification
+from marimo._notebook.document import NotebookCell, NotebookDocument
 from marimo._notebook.ops import (
     CreateCell,
     DeleteCell,
@@ -81,27 +80,7 @@ if TYPE_CHECKING:
     from marimo._runtime.runtime import Kernel
 
 
-# ------------------------------------------------------------------
-# Data types
-# ------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class NotebookCellData:
-    """Read-only snapshot of a notebook cell (returned by ``ctx.cells[...]``)."""
-
-    code: str | None = None
-    config: CellConfig | None = None
-    id: CellId_t = field(default_factory=lambda: CellId_t(str(uuid4())))
-    name: str | None = field(default=None, repr=True, compare=False)
-
-
 LOGGER = _loggers.marimo_logger()
-
-
-# Module-level store for cell names set via code_mode.
-# Persists across context manager invocations within the same kernel.
-_cell_names: dict[CellId_t, str] = {}
 
 
 # ------------------------------------------------------------------
@@ -153,77 +132,55 @@ class _CellsView:
         for cid, cell in ctx.cells.items():
             ...
         ctx.cells.keys()  # list of CellId_t
-        ctx.cells.values()  # list of NotebookCellData
+        ctx.cells.values()  # list of NotebookCell
         "my_cell" in ctx.cells  # membership test
     """
 
     def __init__(self, ctx: AsyncCodeModeContext) -> None:
         self._ctx = ctx
 
+    @property
+    def _doc(self) -> NotebookDocument:
+        return self._ctx._document
+
     def _cell_ids(self) -> list[CellId_t]:
-        return list(self._ctx.graph.cells.keys())
+        return list(self._doc)
 
     def _cell_name(self, cell_id: CellId_t) -> str | None:
-        # Check code_mode's own name store first.
-        name = _cell_names.get(cell_id)
-        if name is not None:
-            return name
-        # Fall back to cell_manager if available.
-        cm = self._ctx._cell_manager
-        if cm is None:
-            return None
-        data = cm.get_cell_data(cell_id)
-        return data.name if data else None
-
-    def _build_at(self, cell_id: CellId_t) -> NotebookCellData:
-        cell_impl = self._ctx.graph.cells[cell_id]
-        meta = self._ctx._kernel.cell_metadata.get(cell_id)
-        return NotebookCellData(
-            code=cell_impl.code,
-            config=meta.config if meta else CellConfig(),
-            name=self._cell_name(cell_id),
-            id=cell_id,
-        )
+        doc_cell = self._doc.get(cell_id)
+        return doc_cell.name or None if doc_cell else None
 
     def _resolve(self, target: str) -> CellId_t:
         """Resolve a cell ID or cell name to a ``CellId_t``.
 
         Raises ``KeyError`` if not found.
         """
-        cell_ids = self._cell_ids()
-
-        # Try cell ID first.
         cell_id_key = CellId_t(target)
-        for cid in cell_ids:
-            if cid == cell_id_key:
-                return cid
+        if cell_id_key in self._doc:
+            return cell_id_key
 
         # Fall back to cell name.
-        for cid in cell_ids:
-            name = self._cell_name(cid)
-            if name == target:
-                return cid
+        for cell in self._doc.cells:
+            if cell.name == target:
+                return cell.id
 
         raise KeyError(target)
 
     def __len__(self) -> int:
-        return len(self._ctx.graph.cells)
+        return len(self._doc)
 
     @overload
-    def __getitem__(self, key: int) -> NotebookCellData: ...
+    def __getitem__(self, key: int) -> NotebookCell: ...
     @overload
-    def __getitem__(self, key: str) -> NotebookCellData: ...
+    def __getitem__(self, key: str) -> NotebookCell: ...
 
-    def __getitem__(self, key: int | str) -> NotebookCellData:
-        cell_ids = self._cell_ids()
-
+    def __getitem__(self, key: int | str) -> NotebookCell:
         if isinstance(key, int):
-            return self._build_at(cell_ids[key])
-
-        return self._build_at(self._resolve(key))
+            return self._doc.cells[key]
+        return self._doc.get_cell(self._resolve(key))
 
     def __iter__(self) -> Iterator[CellId_t]:
-        yield from self._cell_ids()
+        yield from self._doc
 
     def __contains__(self, key: object) -> bool:
         if isinstance(key, int):
@@ -238,15 +195,15 @@ class _CellsView:
 
     def keys(self) -> list[CellId_t]:
         """Return cell IDs in notebook order."""
-        return self._cell_ids()
+        return self._doc.cell_ids
 
-    def values(self) -> list[NotebookCellData]:
+    def values(self) -> list[NotebookCell]:
         """Return cell data in notebook order."""
-        return [self._build_at(cid) for cid in self._cell_ids()]
+        return self._doc.cells
 
-    def items(self) -> list[tuple[CellId_t, NotebookCellData]]:
+    def items(self) -> list[tuple[CellId_t, NotebookCell]]:
         """Return (cell_id, cell_data) pairs in notebook order."""
-        return [(cid, self._build_at(cid)) for cid in self._cell_ids()]
+        return [(c.id, c) for c in self._doc.cells]
 
 
 # ------------------------------------------------------------------
@@ -276,7 +233,17 @@ class AsyncCodeModeContext:
         *,
         skip_validation: bool = False,
     ) -> None:
+        from marimo._notebook.document import get_current_document
+
+        document = get_current_document()
+        if document is None:
+            raise RuntimeError(
+                "NotebookDocument not available — code_mode must be invoked "
+                "via the /api/execute endpoint which sets the document "
+                "context variable"
+            )
         self._kernel = kernel
+        self._document = document
         self._cell_manager = cell_manager
         self._skip_validation = skip_validation
         self._ops: list[_Op] = []
@@ -438,16 +405,9 @@ class AsyncCodeModeContext:
     def _cell_label(self, cell_id: CellId_t) -> str:
         """Return a display label: ``'id' (name)`` or ``'id'``."""
         short = repr(str(cell_id)[:8])
-        name: str | None = None
-        cm = self._cell_manager
-        if cm is not None:
-            data = cm.get_cell_data(cell_id)
-            if data and data.name:
-                name = data.name
-        if name is None:
-            name = _cell_names.get(cell_id)
-        if name:
-            return f"{short} ({name})"
+        doc_cell = self._document.get(cell_id)
+        if doc_cell and doc_cell.name:
+            return f"{short} ({doc_cell.name})"
         return short
 
     # ------------------------------------------------------------------
@@ -992,19 +952,6 @@ class AsyncCodeModeContext:
                 self.graph.cells[cell_id].configure(cfg.asdict())
             self._kernel.cell_metadata[cell_id] = CellMetadata(config=cfg)
 
-        # Persist names from ops into the module-level store.
-        for op in ops:
-            op_name = getattr(op, "name", None)
-            if op_name is not None:
-                target_id = getattr(op, "new_cell_id", None) or op.cell_id
-                _cell_names[target_id] = op_name
-                # Clean up stale entry when cell_id was migrated.
-                if (
-                    getattr(op, "new_cell_id", None) is not None
-                    and op.cell_id in _cell_names
-                ):
-                    del _cell_names[op.cell_id]
-
         # Build document transaction ops from the plan and broadcast
         # a single NotebookDocumentTransactionNotification instead of
         # the legacy UpdateCellCodes / UpdateCellIds notifications.
@@ -1017,6 +964,8 @@ class AsyncCodeModeContext:
         )
         if doc_ops:
             tx = Transaction(ops=tuple(doc_ops), source="kernel")
+            # Apply to local snapshot so _cell_label can read names.
+            self._document.apply(tx)
             self.notify(
                 NotebookDocumentTransactionNotification(transaction=tx)
             )
@@ -1187,13 +1136,10 @@ def _plan_to_document_ops(
             )
         else:
             # Existing cell — emit ops for changed properties.
-            if (
-                entry.code is not None
-                and entry.code != existing_code.get(entry.cell_id)
+            if entry.code is not None and entry.code != existing_code.get(
+                entry.cell_id
             ):
-                doc_ops.append(
-                    SetCode(cell_id=entry.cell_id, code=entry.code)
-                )
+                doc_ops.append(SetCode(cell_id=entry.cell_id, code=entry.code))
 
     # Names from internal ops (covers both add and update).
     for op in internal_ops:
@@ -1209,14 +1155,14 @@ def _plan_to_document_ops(
     # Config updates for existing cells.
     for entry in plan:
         if entry.cell_id in existing_ids and entry.config is not None:
-            cfg = resolved_configs.get(entry.cell_id)
-            if cfg is not None:
+            resolved_cfg = resolved_configs.get(entry.cell_id)
+            if resolved_cfg is not None:
                 doc_ops.append(
                     SetConfig(
                         cell_id=entry.cell_id,
-                        column=cfg.column,
-                        disabled=cfg.disabled,
-                        hide_code=cfg.hide_code,
+                        column=resolved_cfg.column,
+                        disabled=resolved_cfg.disabled,
+                        hide_code=resolved_cfg.hide_code,
                     )
                 )
 

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -22,6 +22,7 @@ from marimo import _loggers
 from marimo._ast.app_config import _AppConfig
 from marimo._config.config import MarimoConfig
 from marimo._data.models import DataTableSource
+from marimo._notebook.document import NotebookCell
 from marimo._types.ids import CellId_t, RequestId, UIElementId, WidgetModelId
 
 LOGGER = _loggers.marimo_logger()
@@ -325,11 +326,16 @@ class ExecuteScratchpadCommand(Command):
     Attributes:
         code: Python code to execute.
         request: HTTP request context if available.
+        notebook_cells: Snapshot of notebook cells from the session document.
+            Used to populate the document ContextVar so code_mode can read
+            cell ordering, code, names, and configs.
     """
 
     code: str
     # incoming request, e.g. from Starlette or FastAPI
     request: Optional[HTTPRequest] = None
+    # Document snapshot — set by the execution endpoint from session.document.
+    notebook_cells: Optional[tuple[NotebookCell, ...]] = None
 
 
 class RenameNotebookCommand(Command):

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -109,6 +109,10 @@ from marimo._messaging.types import (
     Stream,
 )
 from marimo._messaging.variables import create_variable_value
+from marimo._notebook.document import (
+    NotebookDocument,
+    _current_document,
+)
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import MarimoConvertValueException
@@ -2275,8 +2279,17 @@ class Kernel:
         async def handle_execute_scratchpad(
             request: ExecuteScratchpadCommand,
         ) -> None:
-            with http_request_context(request.request):
-                await self.run_scratchpad(request.code)
+            token = None
+            if request.notebook_cells is not None:
+                token = _current_document.set(
+                    NotebookDocument(list(request.notebook_cells))
+                )
+            try:
+                with http_request_context(request.request):
+                    await self.run_scratchpad(request.code)
+            finally:
+                if token is not None:
+                    _current_document.reset(token)
             broadcast_notification(CompletedRunNotification())
 
         async def handle_execute_stale(

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -302,6 +302,7 @@ async def execute_code(
                         ExecuteScratchpadCommand(
                             code=body.code,
                             request=HTTPRequest.from_request(request),
+                            notebook_cells=tuple(session.document.cells),
                         ),
                         from_consumer_id=None,
                     )

--- a/tests/_code_mode/test_cells_view.py
+++ b/tests/_code_mode/test_cells_view.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import pytest
 
-from marimo._code_mode._context import AsyncCodeModeContext, NotebookCellData
+from marimo._code_mode._context import AsyncCodeModeContext
+from marimo._notebook.document import (
+    NotebookCell,
+    NotebookDocument,
+    _current_document,
+)
 from marimo._runtime.commands import ExecuteCellCommand
 from marimo._runtime.runtime import Kernel
 from marimo._types.ids import CellId_t
@@ -11,6 +16,21 @@ from marimo._types.ids import CellId_t
 
 def cmd(cell_id: str, code: str) -> ExecuteCellCommand:
     return ExecuteCellCommand(cell_id=CellId_t(cell_id), code=code)
+
+
+def _ctx(k: Kernel) -> AsyncCodeModeContext:
+    """Build an AsyncCodeModeContext with a document snapshot from the kernel."""
+    _current_document.set(
+        NotebookDocument(
+            [
+                NotebookCell(
+                    id=cid, code=cell.code, name="", config=cell.config
+                )
+                for cid, cell in k.graph.cells.items()
+            ]
+        )
+    )
+    return AsyncCodeModeContext(k)
 
 
 class TestCellsViewIndex:
@@ -24,7 +44,7 @@ class TestCellsViewIndex:
                 cmd(cell_id="c", code="z = 3"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         assert ctx.cells[0].id == "a"
         assert ctx.cells[1].id == "b"
@@ -38,7 +58,7 @@ class TestCellsViewIndex:
                 cmd(cell_id="c", code="z = 3"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         assert ctx.cells[-1].id == "c"
         assert ctx.cells[-2].id == "b"
@@ -46,7 +66,7 @@ class TestCellsViewIndex:
 
     async def test_index_out_of_range(self, k: Kernel) -> None:
         await k.run([cmd(cell_id="a", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         with pytest.raises(IndexError):
             ctx.cells[5]
@@ -65,7 +85,7 @@ class TestCellsViewCellId:
                 cmd(cell_id="def", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         cell = ctx.cells["def"]
         assert cell.id == "def"
@@ -73,7 +93,7 @@ class TestCellsViewCellId:
 
     async def test_lookup_by_cell_id_not_found(self, k: Kernel) -> None:
         await k.run([cmd(cell_id="abc", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         with pytest.raises(KeyError):
             ctx.cells["nonexistent"]
@@ -84,7 +104,7 @@ class TestCellsViewCellName:
 
     async def test_name_lookup_without_cell_manager(self, k: Kernel) -> None:
         await k.run([cmd(cell_id="a", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         # No cell manager → name lookup fails
         with pytest.raises(KeyError):
@@ -92,18 +112,14 @@ class TestCellsViewCellName:
 
 
 class TestCellsViewNameField:
-    """Test that the name field is populated on NotebookCellData."""
+    """Test that the name field is populated on NotebookCell."""
 
-    async def test_name_is_none_without_cell_manager(self, k: Kernel) -> None:
+    async def test_name_is_empty_without_cell_manager(self, k: Kernel) -> None:
         await k.run([cmd(cell_id="a", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         cell = ctx.cells[0]
-        assert cell.name is None
-
-    async def test_name_field_on_constructed_cell(self) -> None:
-        cell = NotebookCellData(code="x = 1", name="my_cell")
-        assert cell.name == "my_cell"
+        assert cell.name == ""
 
 
 class TestCellsViewIteration:
@@ -116,7 +132,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         assert len(ctx.cells) == 2
 
     async def test_iteration_yields_cell_ids(self, k: Kernel) -> None:
@@ -126,7 +142,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         ids = list(ctx.cells)
         assert ids == ["a", "b"]
@@ -138,7 +154,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         assert ctx.cells.keys() == ["a", "b"]
 
     async def test_values(self, k: Kernel) -> None:
@@ -148,7 +164,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         vals = ctx.cells.values()
         assert [v.id for v in vals] == ["a", "b"]
         assert [v.code for v in vals] == ["x = 1", "y = 2"]
@@ -160,7 +176,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         items = ctx.cells.items()
         assert [(cid, cell.code) for cid, cell in items] == [
             ("a", "x = 1"),
@@ -174,7 +190,7 @@ class TestCellsViewIteration:
                 cmd(cell_id="b", code="y = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         assert "a" in ctx.cells
         assert "nonexistent" not in ctx.cells
         assert 0 in ctx.cells

--- a/tests/_code_mode/test_context.py
+++ b/tests/_code_mode/test_context.py
@@ -12,8 +12,28 @@ from marimo._messaging.notification import (
     NotebookDocumentTransactionNotification,
     UpdateCellCodesNotification,
 )
+from marimo._notebook.document import (
+    NotebookCell,
+    NotebookDocument,
+    _current_document,
+)
 from marimo._runtime.commands import ExecuteCellCommand
 from marimo._runtime.runtime import Kernel
+
+
+def _ctx(k: Kernel) -> AsyncCodeModeContext:
+    """Build an AsyncCodeModeContext with a document snapshot from the kernel."""
+    _current_document.set(
+        NotebookDocument(
+            [
+                NotebookCell(
+                    id=cid, code=cell.code, name="", config=cell.config
+                )
+                for cid, cell in k.graph.cells.items()
+            ]
+        )
+    )
+    return AsyncCodeModeContext(k)
 
 
 def _tx_ops(k: Kernel) -> list[dict[str, object]]:
@@ -43,7 +63,7 @@ def _graph_codes(k: Kernel) -> dict[str, str]:
 
 class TestAddCell:
     async def test_add_into_empty(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -81,7 +101,7 @@ class TestAddCell:
                 ExecuteCellCommand(cell_id="1", code="b = 20"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -105,7 +125,7 @@ class TestAddCell:
                 ExecuteCellCommand(cell_id="1", code="b = 20"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -118,7 +138,7 @@ class TestAddCell:
         assert reorder["cellIds"][2] == "1"
 
     async def test_add_without_run_does_not_execute(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -134,7 +154,7 @@ class TestAddCell:
         assert creates[0]["code"] == "x = 999"
 
     async def test_add_returns_cell_id(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             cid = nb.create_cell("x = 1")
@@ -143,7 +163,7 @@ class TestAddCell:
 
     async def test_add_chain_after(self, k: Kernel) -> None:
         """Can reference a just-added cell's ID in a subsequent add."""
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             cid1 = nb.create_cell("x = 1")
@@ -166,7 +186,7 @@ class TestDeleteCell:
         )
         assert len(k.graph.cells) == 3
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -192,7 +212,7 @@ class TestDeleteCell:
         assert k.globals["a"] == 1
         assert k.globals["b"] == 2
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         async with ctx as nb:
             nb.delete_cell("1")
 
@@ -207,7 +227,7 @@ class TestDeleteCell:
                 ExecuteCellCommand(cell_id="2", code="c = 3"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -222,7 +242,7 @@ class TestUpdateCell:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
         assert k.globals["x"] == 1
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -245,7 +265,7 @@ class TestUpdateCell:
         assert k.globals["x"] == 1
         assert k.globals["y"] == 2
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         async with ctx as nb:
             nb.edit_cell("0", code="x = 42")
             nb.run_cell("0")
@@ -258,14 +278,14 @@ class TestUpdateCell:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
 
         # Set hide_code=True on the cell.
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         async with ctx as nb:
             nb.edit_cell("0", hide_code=True)
 
         assert k.cell_metadata["0"].config.hide_code is True
 
         # Update code without touching config — hide_code should stick.
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         async with ctx as nb:
             nb.edit_cell("0", code="x = 42")
             nb.run_cell("0")
@@ -276,7 +296,7 @@ class TestUpdateCell:
     async def test_update_config_only(self, k: Kernel) -> None:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -308,7 +328,7 @@ class TestCombined:
             ]
         )
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -330,7 +350,7 @@ class TestCombined:
         )
         assert k.globals["b"] == 2
 
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         # Delete cell "1" and create a new cell that also defines "b".
@@ -346,7 +366,7 @@ class TestCombined:
     async def test_noop_batch(self, k: Kernel) -> None:
         """An empty context manager does nothing."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:  # noqa: B018
@@ -357,7 +377,7 @@ class TestCombined:
     async def test_exception_discards_ops(self, k: Kernel) -> None:
         """If an exception occurs, queued ops are discarded."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         try:
             async with ctx as nb:
@@ -373,7 +393,7 @@ class TestCombined:
     async def test_rerun_without_structural_ops(self, k: Kernel) -> None:
         """run_cell without any create/edit/delete still executes."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         # Mutate the global so we can detect re-execution.
         k.globals["x"] = 0
@@ -390,7 +410,7 @@ class TestCombined:
                 ExecuteCellCommand(cell_id="1", code="y = x + 1"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         # Mutate so we can detect re-execution of "0".
         k.globals["x"] = 0
@@ -403,7 +423,7 @@ class TestCombined:
     async def test_run_deleted_cell_raises(self, k: Kernel) -> None:
         """Calling run_cell on a cell queued for deletion raises."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             nb.delete_cell("0")
@@ -415,7 +435,7 @@ class TestSummary:
     async def test_create_prints_summary(
         self, k: Kernel, capsys: object
     ) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             nb.create_cell("x = 1", name="my_cell")
@@ -427,7 +447,7 @@ class TestSummary:
         self, k: Kernel, capsys: object
     ) -> None:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             nb.edit_cell("0", code="x = 2")
@@ -439,7 +459,7 @@ class TestSummary:
         self, k: Kernel, capsys: object
     ) -> None:
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             nb.delete_cell("0")
@@ -450,7 +470,7 @@ class TestSummary:
     async def test_noop_prints_nothing(
         self, k: Kernel, capsys: object
     ) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:  # noqa: B018
             pass
@@ -467,7 +487,7 @@ class TestSummary:
                 ExecuteCellCommand(cell_id="2", code="c = 3"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             # delete
@@ -496,7 +516,7 @@ re-ran cell '2'
 class TestResolveTarget:
     async def test_create_after_pending_add_by_name(self, k: Kernel) -> None:
         """Can reference a just-added cell by name in a subsequent add."""
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         async with ctx as nb:
             cid1 = nb.create_cell("x = 1", name="first")
@@ -520,7 +540,7 @@ class TestResolveTarget:
                 ExecuteCellCommand(cell_id="1", code="b = 2"),
             ]
         )
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -539,7 +559,7 @@ class TestResolveTarget:
 
 class TestInstallPackages:
     async def test_install_single(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         pm = k.packages_callbacks.package_manager
         assert pm is not None
 
@@ -556,7 +576,7 @@ class TestInstallPackages:
         assert mock_install.call_args_list[0].kwargs["version"] == ""
 
     async def test_install_multiple_with_specifiers(self, k: Kernel) -> None:
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         pm = k.packages_callbacks.package_manager
         assert pm is not None
 
@@ -583,7 +603,7 @@ class TestAutorunStaleState:
         """Running the root cell should mark reactive descendants as
         non-stale in autorun mode so the frontend doesn't show them
         as 'needs run'."""
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -608,7 +628,7 @@ class TestAutorunStaleState:
         """In lazy mode, only the explicitly run cell should be non-stale.
         Downstream cells stay stale."""
         k = lazy_kernel
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
         _clear_messages(k)
 
         async with ctx as nb:
@@ -631,7 +651,7 @@ class TestAutorunStaleState:
         """edit_cell in one flush, run_cell in a separate flush should
         send code_is_stale=false so the frontend clears the stale state."""
         await k.run([ExecuteCellCommand(cell_id="0", code="x = 1")])
-        ctx = AsyncCodeModeContext(k)
+        ctx = _ctx(k)
 
         # Flush 1: edit only
         async with ctx as nb:
@@ -640,7 +660,7 @@ class TestAutorunStaleState:
         _clear_messages(k)
 
         # Flush 2: run only
-        ctx2 = AsyncCodeModeContext(k)
+        ctx2 = _ctx(k)
         async with ctx2 as nb:
             nb.run_cell("0")
 


### PR DESCRIPTION
Prev #8842, #8843, #8844. This PR closes the kernel → session loop.

**Transaction emission.** `_apply_ops` previously assembled three separate legacy notifications (`UpdateCellCodesNotification` grouped by stale status, plus `UpdateCellIdsNotification`). Now it builds typed `Op`s via `_plan_to_document_ops()` and broadcasts a **single** `NotebookDocumentTransactionNotification`.

**Document context.** The execution endpoint snapshots `session.document.cells` into `ExecuteScratchpadCommand.notebook_cells`. The kernel handler sets a `ContextVar` from it so `AsyncCodeModeContext` can read cell state from the document.`_CellsView` now delegates entirely to the document and returns `NotebookCell` directly, removing the `NotebookCellData` wrapper and the module-level `_cell_names` dict.
