### PR TITLE
Fix table cell styles/hover texts when sorting desc

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1238,18 +1238,48 @@ class table(
         )
         return column_preview
 
+    def _resolve_row_ids(
+        self,
+        skip: int,
+        take: int,
+        total_rows: Union[int, Literal["too_many"]],
+    ) -> Union[list[Any], range]:
+        response = self._get_row_ids(EmptyArgs())
+
+        # Clamp take to the available row count for non-lazy tables
+        if total_rows != "too_many" and skip + take > total_rows:
+            take = total_rows - skip
+
+        if response.all_rows or response.error:
+            fallback_row_ids: range = range(skip, skip + take)
+
+            if response.all_rows and self._has_stable_row_id:
+                try:
+                    page = self._searched_manager.take(take, skip)
+                    # Keep provided row IDs as-is to support non-integer IDs.
+                    return page.data[INDEX_COLUMN_NAME].to_list()
+                except Exception as exc:
+                    LOGGER.warning(
+                        "Falling back to positional row IDs after failed "
+                        "stable-row-id lookup: %s",
+                        exc,
+                        exc_info=True,
+                    )
+
+            return fallback_row_ids
+
+        return response.row_ids[skip : skip + take]
+
     def _style_cells(
         self,
         skip: int,
         take: int,
         total_rows: Union[int, Literal["too_many"]],
-        descending: bool = False,
+        row_ids: Optional[Union[list[Any], range]] = None,
     ) -> Optional[CellStyles]:
         """Calculate the styling of the cells in the table."""
         if self._style_cell is None:
             return None
-
-        del descending
 
         def do_style_cell(row: str, col: str) -> dict[str, Any]:
             selected_cells = self._searched_manager.select_cells(
@@ -1260,31 +1290,15 @@ class table(
             return self._style_cell(row, col, selected_cells[0].value)
 
         columns = self._searched_manager.get_column_names()
-        response = self._get_row_ids(EmptyArgs())
-
-        # Clamp the take to the total number of rows
-        if total_rows != "too_many" and skip + take > total_rows:
-            take = total_rows - skip
-
-        # Determine row range
-        row_ids: Union[list[int], range]
-        if response.all_rows or response.error:
-            row_ids = range(skip, skip + take)
-
-            if response.all_rows and self._has_stable_row_id:
-                try:
-                    page = self._searched_manager.take(take, skip)
-                    row_ids = [
-                        int(v) for v in page.data[INDEX_COLUMN_NAME].to_list()
-                    ]
-                except Exception:
-                    row_ids = range(skip, skip + take)
-        else:
-            row_ids = response.row_ids[skip : skip + take]
+        resolved_row_ids = (
+            self._resolve_row_ids(skip, take, total_rows)
+            if row_ids is None
+            else row_ids
+        )
 
         return {
             str(row): {col: do_style_cell(str(row), col) for col in columns}
-            for row in row_ids
+            for row in resolved_row_ids
         }
 
     def _hover_cells(
@@ -1292,13 +1306,11 @@ class table(
         skip: int,
         take: int,
         total_rows: Union[int, Literal["too_many"]],
-        descending: bool = False,
+        row_ids: Optional[Union[list[Any], range]] = None,
     ) -> Optional[dict[RowId, dict[ColumnName, Optional[str]]]]:
         """Calculate hover text for cells in the table (plain strings or None)."""
         if self._hover_cell is None:
             return None
-
-        del descending
 
         def do_hover_cell(row: str, col: str) -> Optional[str]:
             selected_cells = self._searched_manager.select_cells(
@@ -1317,31 +1329,15 @@ class table(
                 return None
 
         columns = self._searched_manager.get_column_names()
-        response = self._get_row_ids(EmptyArgs())
-
-        # Clamp the take to the total number of rows
-        if total_rows != "too_many" and skip + take > total_rows:
-            take = total_rows - skip
-
-        # Determine row range
-        row_ids: Union[list[int], range]
-        if response.all_rows or response.error:
-            row_ids = range(skip, skip + take)
-
-            if response.all_rows and self._has_stable_row_id:
-                try:
-                    page = self._searched_manager.take(take, skip)
-                    row_ids = [
-                        int(v) for v in page.data[INDEX_COLUMN_NAME].to_list()
-                    ]
-                except Exception:
-                    row_ids = range(skip, skip + take)
-        else:
-            row_ids = response.row_ids[skip : skip + take]
+        resolved_row_ids = (
+            self._resolve_row_ids(skip, take, total_rows)
+            if row_ids is None
+            else row_ids
+        )
 
         return {
             str(row): {col: do_hover_cell(str(row), col) for col in columns}
-            for row in row_ids
+            for row in resolved_row_ids
         }
 
     def _search(self, args: SearchTableArgs) -> SearchTableResponse:
@@ -1410,14 +1406,19 @@ class table(
                 total_rows = self._manager.get_num_rows(force=True) or 0
 
             formatted_data, raw_data = clamp_rows_and_columns(self._manager)
+            row_ids = (
+                self._resolve_row_ids(offset, args.page_size, total_rows)
+                if self._style_cell or self._hover_cell
+                else None
+            )
             return SearchTableResponse(
                 data=formatted_data,
                 total_rows=total_rows,
                 cell_styles=self._style_cells(
-                    offset, args.page_size, total_rows
+                    offset, args.page_size, total_rows, row_ids=row_ids
                 ),
                 cell_hover_texts=self._hover_cells(
-                    offset, args.page_size, total_rows
+                    offset, args.page_size, total_rows, row_ids=row_ids
                 ),
                 raw_data=raw_data,
             )
@@ -1436,27 +1437,26 @@ class table(
         # Save the manager to be used for selection
         self._searched_manager = result
 
-        descending = False
-
         if self._lazy:
             total_rows = "too_many"
         else:
             total_rows = result.get_num_rows(force=True) or 0
 
-        if args.sort and (self._style_cell or self._hover_cell):
-            for element in args.sort:
-                if element.descending:
-                    descending = True
+        row_ids = (
+            self._resolve_row_ids(offset, args.page_size, total_rows)
+            if self._style_cell or self._hover_cell
+            else None
+        )
 
         formatted_data, raw_data = clamp_rows_and_columns(result)
         return SearchTableResponse(
             data=formatted_data,
             total_rows=total_rows,
             cell_styles=self._style_cells(
-                offset, args.page_size, total_rows, descending
+                offset, args.page_size, total_rows, row_ids=row_ids
             ),
             cell_hover_texts=self._hover_cells(
-                offset, args.page_size, total_rows, descending
+                offset, args.page_size, total_rows, row_ids=row_ids
             ),
             raw_data=raw_data,
         )

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1249,6 +1249,8 @@ class table(
         if self._style_cell is None:
             return None
 
+        del descending
+
         def do_style_cell(row: str, col: str) -> dict[str, Any]:
             selected_cells = self._searched_manager.select_cells(
                 [TableCoordinate(row_id=row, column_name=col)]
@@ -1268,10 +1270,16 @@ class table(
         row_ids: Union[list[int], range]
         if response.all_rows or response.error:
             row_ids = range(skip, skip + take)
-            if descending and total_rows != "too_many":
-                row_ids = range(
-                    total_rows - 1 - skip, total_rows - 1 - skip - take, -1
-                )
+
+            if response.all_rows and self._has_stable_row_id:
+                try:
+                    page = self._searched_manager.take(take, skip)
+                    row_ids = [
+                        int(v)
+                        for v in page.data[INDEX_COLUMN_NAME].to_list()
+                    ]
+                except Exception:
+                    row_ids = range(skip, skip + take)
         else:
             row_ids = response.row_ids[skip : skip + take]
 
@@ -1290,6 +1298,8 @@ class table(
         """Calculate hover text for cells in the table (plain strings or None)."""
         if self._hover_cell is None:
             return None
+
+        del descending
 
         def do_hover_cell(row: str, col: str) -> Optional[str]:
             selected_cells = self._searched_manager.select_cells(
@@ -1318,10 +1328,16 @@ class table(
         row_ids: Union[list[int], range]
         if response.all_rows or response.error:
             row_ids = range(skip, skip + take)
-            if descending and total_rows != "too_many":
-                row_ids = range(
-                    total_rows - 1 - skip, total_rows - 1 - skip - take, -1
-                )
+
+            if response.all_rows and self._has_stable_row_id:
+                try:
+                    page = self._searched_manager.take(take, skip)
+                    row_ids = [
+                        int(v)
+                        for v in page.data[INDEX_COLUMN_NAME].to_list()
+                    ]
+                except Exception:
+                    row_ids = range(skip, skip + take)
         else:
             row_ids = response.row_ids[skip : skip + take]
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1275,8 +1275,7 @@ class table(
                 try:
                     page = self._searched_manager.take(take, skip)
                     row_ids = [
-                        int(v)
-                        for v in page.data[INDEX_COLUMN_NAME].to_list()
+                        int(v) for v in page.data[INDEX_COLUMN_NAME].to_list()
                     ]
                 except Exception:
                     row_ids = range(skip, skip + take)
@@ -1333,8 +1332,7 @@ class table(
                 try:
                     page = self._searched_manager.take(take, skip)
                     row_ids = [
-                        int(v)
-                        for v in page.data[INDEX_COLUMN_NAME].to_list()
+                        int(v) for v in page.data[INDEX_COLUMN_NAME].to_list()
                     ]
                 except Exception:
                     row_ids = range(skip, skip + take)

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1848,6 +1848,56 @@ def test_cell_search_df_styles_sorted(df: Any):
     }
 
 
+@pytest.mark.skipif(
+    not DependencyManager.pandas.has(), reason="Pandas not installed"
+)
+def test_cell_styles_and_hover_texts_sorted_desc_by_non_index_column() -> None:
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "Name": [f"row-{i}" for i in range(10)],
+            "Score": [10, 1, 9, 2, 8, 3, 7, 4, 6, 5],
+        }
+    )
+
+    def style_cell(_row: str, col: str, value: Any) -> dict[str, Any]:
+        if col != "Score":
+            return {}
+        return {"backgroundColor": "green"} if float(value) >= 6 else {}
+
+    def hover_cell(_row: str, col: str, value: Any) -> str:
+        return f"{col}={value}"
+
+    table = ui.table(df, style_cell=style_cell, hover_template=hover_cell)
+    page = table._search(
+        SearchTableArgs(
+            page_size=5,
+            page_number=0,
+            query="",
+            sort=[SortArgs(by="Score", descending=True)],
+        )
+    )
+
+    visible_rows = json.loads(page.data)
+    visible_row_ids = {str(row[INDEX_COLUMN_NAME]) for row in visible_rows}
+
+    assert page.cell_styles is not None
+    assert page.cell_hover_texts is not None
+    assert set(page.cell_styles.keys()) == visible_row_ids
+    assert set(page.cell_hover_texts.keys()) == visible_row_ids
+
+    for row in visible_rows:
+        row_id = str(row[INDEX_COLUMN_NAME])
+        score = float(row["Score"])
+        expected_style = {"backgroundColor": "green"} if score >= 6 else {}
+        assert page.cell_styles[row_id]["Score"] == expected_style
+        assert (
+            page.cell_hover_texts[row_id]["Score"]
+            == f"Score={row['Score']}"
+        )
+
+
 @pytest.mark.parametrize(
     "df",
     create_dataframes(

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1893,8 +1893,7 @@ def test_cell_styles_and_hover_texts_sorted_desc_by_non_index_column() -> None:
         expected_style = {"backgroundColor": "green"} if score >= 6 else {}
         assert page.cell_styles[row_id]["Score"] == expected_style
         assert (
-            page.cell_hover_texts[row_id]["Score"]
-            == f"Score={row['Score']}"
+            page.cell_hover_texts[row_id]["Score"] == f"Score={row['Score']}"
         )
 
 


### PR DESCRIPTION
Fixes #8847.

When the table has no active filters/search (GetRowIdsResponse.all_rows=True), _style_cells and _hover_cells were generating row id ranges that can diverge from the current sorted view, causing styles/hover texts to disappear (notably for descending sorts by a non-index column).

This change derives row ids from the current page of the searched manager when a stable row id is available, and falls back to positional ranges otherwise.

Adds a pandas regression test for descending sort by a non-index column.