### PR TITLE
fix: Add script dependencies to data_editor example

### DIFF
--- a/examples/ui/data_editor.py
+++ b/examples/ui/data_editor.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "polars==1.17.1",
+#     "polars==1.39.3",
 #     "vega-datasets==0.9.0",
 # ]
 # ///


### PR DESCRIPTION
## 📝 Summary

Currently, the example at https://docs.marimo.io/api/inputs/data_editor/ doesn't run straight away due to missing packages.

This PR adds script metadata to `examples/ui/data_editor.py` so that the online docs work without requiring installing the missing packages manually.

I haven't opened an issue since this is a very small fix (but happy to do so if required).

## 🔍 Description of Changes

Add script metadata to `examples/ui/data_editor.py`, copied directly from `examples/ui/data_explorer.py` which has the same dependencies. The script now works when running with e.g. `uvx marimo edit --sandbox data_editor.py` so I believe it should work in the online docs.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
