### PR TITLE
Avoid normalizing cloudpathlib providers

### DIFF
--- a/marimo/_utils/paths.py
+++ b/marimo/_utils/paths.py
@@ -117,7 +117,7 @@ def normalize_path(path: Path) -> Path:
     """
     # Skip normalization for cloud paths (e.g., S3Path, GCSPath, AzurePath)
     # os.path.normpath corrupts URI schemes like s3:// by reducing them to s3:/
-    if path.__class__.__module__.startswith("cloudpathlib"):
+    if "CloudPath" in [cls.__name__ for cls in type(path).__mro__]:
         return path
 
     # Make absolute if relative (relative to current working directory)


### PR DESCRIPTION
Cloudpathlib providers typically have a path like
"s3://my-bucket/folder/" which, when normalized is converted to "s3:/my-bucket/folder/" which will not work.

Instead of checking the module, which prevents external providers, isinstance() is now used to detect regular Path objects.

## 📝 Summary

Closes #8868

## 🔍 Description of Changes

For more details see #8868.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] ruff check and ruff format pass on changed files
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).

I have read the CLA Document and I hereby sign the CLA