### PR TITLE
perf: lazy-load KaTeX via dynamic import of @streamdown/math

### DIFF
--- a/frontend/src/components/markdown/markdown-renderer.tsx
+++ b/frontend/src/components/markdown/markdown-renderer.tsx
@@ -12,7 +12,7 @@ import { useLastFocusedCellId } from "@/core/cells/focus";
 import { MarkdownLanguageAdapter } from "@/core/codemirror/language/languages/markdown";
 import { SQLLanguageAdapter } from "@/core/codemirror/language/languages/sql/sql";
 import { autoInstantiateAtom } from "@/core/config/config";
-import { useOnMount } from "@/hooks/useLifecycle";
+import { useAsyncData } from "@/hooks/useAsyncData";
 import { LazyAnyLanguageCodeMirror } from "@/plugins/impl/code/LazyAnyLanguageCodeMirror";
 import { useTheme } from "@/theme/useTheme";
 import { copyToClipboard } from "@/utils/copy";
@@ -168,17 +168,16 @@ const COMPONENTS: Components = {
 
 // Lazy-load the math plugin to keep katex (~264 KB) out of the critical path.
 // The first render works without math; once loaded, it re-renders with math support.
-let mathPluginCache: StreamdownProps["plugins"];
+let mathPluginCache: StreamdownProps["plugins"] | undefined;
 const useMathPlugin = () => {
-  const [plugins, setPlugins] = useState(mathPluginCache);
-  useOnMount(() => {
-    if (!mathPluginCache) {
-      import("@streamdown/math").then((mod) => {
-        mathPluginCache = { math: mod.math };
-        setPlugins(mathPluginCache);
-      });
+  const { data: plugins } = useAsyncData(async () => {
+    if (mathPluginCache) {
+      return mathPluginCache;
     }
-  });
+    const mod = await import("@streamdown/math");
+    mathPluginCache = { math: mod.math };
+    return mathPluginCache;
+  }, []);
   return plugins;
 };
 


### PR DESCRIPTION
The math plugin for the markdown renderer was statically imported,
pulling katex (~264 KB) into the critical path. Convert to a dynamic
import so katex loads on demand after the first render.
