### PR TITLE
fix: support CloudPath subclasses in normalize_path and file_browser

### DIFF
--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -198,11 +198,16 @@ class file_browser(
 
         # Smart default limit based on path type
         if limit is None:
-            # Check if it's a cloud path
-            if self._path_cls.__module__.startswith("cloudpathlib"):
-                limit = 50  # Conservative for cloud storage
-            else:
-                limit = 10000  # High limit for local filesystems
+            # Check if it's a cloud path (supports subclasses of CloudPath)
+            try:
+                from cloudpathlib import CloudPath
+
+                if isinstance(self._initial_path, CloudPath):
+                    limit = 50  # Conservative for cloud storage
+                else:
+                    limit = 10000  # High limit for local filesystems
+            except ImportError:
+                limit = 10000
 
         self._limit = limit
 

--- a/marimo/_utils/paths.py
+++ b/marimo/_utils/paths.py
@@ -73,6 +73,16 @@ def normalize_path(path: Path) -> Path:
     """
     # Skip normalization for cloud paths (e.g., S3Path, GCSPath, AzurePath)
     # os.path.normpath corrupts URI schemes like s3:// by reducing them to s3:/
+    # Use isinstance to support subclasses of CloudPath (e.g., custom providers)
+    try:
+        from cloudpathlib import CloudPath
+
+        if isinstance(path, CloudPath):
+            return path
+    except ImportError:
+        pass
+
+    # Fallback: check module name for backward compatibility
     if path.__class__.__module__.startswith("cloudpathlib"):
         return path
 

--- a/tests/_utils/test_paths.py
+++ b/tests/_utils/test_paths.py
@@ -95,7 +95,7 @@ def test_normalize_path_skips_cloudpathlib_paths() -> None:
     mock_path = MagicMock()
     mock_path.__class__.__module__ = "cloudpathlib.s3.s3path"
 
-    # normalize_path should return the path unchanged
+    # normalize_path should return the path unchanged (module check fallback)
     result = normalize_path(mock_path)
 
     # Should be the exact same object, returned unchanged


### PR DESCRIPTION
## Fix: Support CloudPath subclasses in path normalization

### Problem

Custom cloudpathlib providers (e.g., SMBPath) that subclass CloudPath were not recognized by marimo's path handling because normalize_path and the file browser used a fragile module-name check:

```python
if path.__class__.__module__.startswith("cloudpathlib"):
```

This only matched the built-in S3Path, GSPath, AzurePath etc., but not user-created subclasses whose __module__ would be their own package (e.g., mypackage.smbpath).

As a result, os.path.normpath was called on cloud paths, corrupting URI schemes like smb://server/share into smb:/server/share.

### Solution

Replace the module-name check with isinstance(path, CloudPath), which correctly identifies all subclasses of CloudPath. The old module-name check is kept as a fallback for backward compatibility.

### Changes

- **marimo/_utils/paths.py**: normalize_path() now uses isinstance(path, CloudPath) with a try/except ImportError, falling back to the module-name check
- **marimo/_plugins/ui/_impl/file_browser.py**: Same isinstance-based check for the cloud storage limit heuristic
- **tests/_utils/test_paths.py**: Minor comment update to clarify fallback behavior

### Testing

All 15 tests in tests/_utils/test_paths.py pass.

Fixes #8868.
