### PR TITLE
feat(table): add default_sort for mo.ui.table initial ordering

### DIFF
--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -255,6 +255,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
         .nullable()
         .default(null),
       showDownload: z.boolean().default(false),
+      defaultSort: z.string().optional(),
       showFilters: z.boolean().default(false),
       showColumnSummaries: z
         .union([z.boolean(), z.enum(["stats", "chart"])])
@@ -500,8 +501,15 @@ export const LoadingDataTableComponent = memo(
 
     const search = props.search;
     const setValue = props.setValue;
+    const initialSorting = useMemo<SortingState>(
+      () =>
+        props.defaultSort
+          ? [{ id: props.defaultSort, desc: false }]
+          : Arrays.EMPTY,
+      [props.defaultSort],
+    );
     // Sorting/searching state
-    const [sorting, setSorting] = useState<SortingState>([]);
+    const [sorting, setSorting] = useState<SortingState>(initialSorting);
     const [paginationState, setPaginationState] =
       React.useState<PaginationState>({
         pageSize: props.pageSize,

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -571,7 +571,11 @@ export const LoadingDataTableComponent = memo(
         searchQuery === "" &&
         paginationState.pageIndex === 0 &&
         filters.length === 0 &&
-        sorting.length === 0 &&
+        (sorting.length === 0 ||
+          (sorting.length === 1 &&
+            Boolean(props.defaultSort) &&
+            sorting[0]?.id === props.defaultSort &&
+            sorting[0]?.desc === false)) &&
         !props.lazy &&
         !pageSizeChanged;
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -469,9 +469,9 @@ class table(
         wrapped_columns: Optional[list[str]] = None,
         header_tooltip: Optional[dict[str, str]] = None,
         show_download: bool = True,
-        default_sort: Optional[str] = None,
         max_columns: MaxColumnsType = MAX_COLUMNS_NOT_PROVIDED,
         *,
+        default_sort: Optional[str] = None,
         label: str = "",
         on_change: Optional[
             Callable[
@@ -676,14 +676,14 @@ class table(
         field_types: Optional[FieldTypes] = None
         num_columns = 0
 
-        if not _internal_lazy:
-            if default_sort is not None:
-                existing_columns = set(self._manager.get_column_names())
-                if default_sort not in existing_columns:
-                    raise ValueError(
-                        f"default_sort column '{default_sort}' not found in table columns"
-                    )
+        if default_sort is not None:
+            existing_columns = set(self._manager.get_column_names())
+            if default_sort not in existing_columns:
+                raise ValueError(
+                    f"default_sort column '{default_sort}' not found in table columns"
+                )
 
+        if not _internal_lazy:
             default_sort_args = (
                 [SortArgs(by=default_sort, descending=False)]
                 if default_sort is not None

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -355,6 +355,8 @@ class table(
             Defaults to True.
         show_download (bool, optional): Whether to show the download button.
             Defaults to True for dataframes, False otherwise.
+        default_sort (str, optional): Column name to sort by on initial render.
+            Sorting is ascending by default.
         format_mapping (Dict[str, Union[str, Callable[..., Any]]], optional): A mapping from
             column names to formatting strings or functions.
         freeze_columns_left (Sequence[str], optional): List of column names to freeze on the left.
@@ -467,6 +469,7 @@ class table(
         wrapped_columns: Optional[list[str]] = None,
         header_tooltip: Optional[dict[str, str]] = None,
         show_download: bool = True,
+        default_sort: Optional[str] = None,
         max_columns: MaxColumnsType = MAX_COLUMNS_NOT_PROVIDED,
         *,
         label: str = "",
@@ -674,13 +677,26 @@ class table(
         num_columns = 0
 
         if not _internal_lazy:
+            if default_sort is not None:
+                existing_columns = set(self._manager.get_column_names())
+                if default_sort not in existing_columns:
+                    raise ValueError(
+                        f"default_sort column '{default_sort}' not found in table columns"
+                    )
+
+            default_sort_args = (
+                [SortArgs(by=default_sort, descending=False)]
+                if default_sort is not None
+                else None
+            )
+
             # Search first page
             search_result = self._search(
                 SearchTableArgs(
                     page_size=page_size,
                     page_number=0,
                     query=None,
-                    sort=None,
+                    sort=default_sort_args,
                     filters=None,
                 )
             )
@@ -722,6 +738,7 @@ class table(
                 "show-filters": self._manager.supports_filters(),
                 "show-download": show_download
                 and self._manager.supports_download(),
+                "default-sort": default_sort,
                 "show-column-summaries": show_column_summaries,
                 "show-data-types": show_data_types,
                 "show-page-size-selector": show_page_size_selector,

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -2247,6 +2247,18 @@ def test_default_sort_invalid_column_raises() -> None:
         ui.table(data, selection=None, default_sort="missing")
 
 
+def test_default_sort_invalid_column_raises_in_lazy_mode() -> None:
+    data = {"name": ["charlie", "alice", "bob"], "value": [3, 1, 2]}
+
+    with pytest.raises(ValueError, match="default_sort column 'missing'"):
+        ui.table(
+            data,
+            selection=None,
+            default_sort="missing",
+            _internal_lazy=True,
+        )
+
+
 @pytest.mark.parametrize(
     "df",
     create_dataframes(

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -2231,6 +2231,22 @@ def test_max_columns_not_provided_with_sort():
     assert len(result_data[0].keys()) == 100
 
 
+def test_default_sort_applies_on_initial_render() -> None:
+    data = {"name": ["charlie", "alice", "bob"], "value": [3, 1, 2]}
+    table = ui.table(data, selection=None, default_sort="name")
+
+    result_data = json.loads(table._component_args["data"])
+    assert [row["name"] for row in result_data] == ["alice", "bob", "charlie"]
+    assert table._component_args["default-sort"] == "name"
+
+
+def test_default_sort_invalid_column_raises() -> None:
+    data = {"name": ["charlie", "alice", "bob"], "value": [3, 1, 2]}
+
+    with pytest.raises(ValueError, match="default_sort column 'missing'"):
+        ui.table(data, selection=None, default_sort="missing")
+
+
 @pytest.mark.parametrize(
     "df",
     create_dataframes(


### PR DESCRIPTION
Closes #3860

This PR adds support for `default_sort` in `mo.ui.table` to control initial table ordering.

### Summary
- **Backend (`marimo/_plugins/ui/_impl/table.py`)**
  - Adds a `default_sort` argument to `ui.table`.
  - Validates that the requested sort column exists in table columns.
  - Applies initial search sorting with ascending order by default.
  - Exposes `default-sort` in component args for frontend initialization.
- **Frontend (`frontend/src/plugins/impl/DataTablePlugin.tsx`)**
  - Accepts `defaultSort` in plugin schema/data.
  - Initializes table sorting state from `defaultSort` as ascending (`desc: false`).
- **Tests (`tests/_plugins/ui/_impl/test_table.py`)**
  - Adds coverage that initial render uses `default_sort` ordering.
  - Adds validation test that missing `default_sort` column raises an error.

Behavior note: sorting is ascending by default when `default_sort` is provided.