### PR TITLE
Remove matplotlib stretch effect in `mo.ui.matplotlib` 

### DIFF
--- a/frontend/src/plugins/impl/matplotlib/matplotlib-renderer.ts
+++ b/frontend/src/plugins/impl/matplotlib/matplotlib-renderer.ts
@@ -301,7 +301,9 @@ export class MatplotlibRenderer {
     canvas.width = this.#state.width * dpr;
     canvas.height = this.#state.height * dpr;
     canvas.style.width = `${this.#state.width}px`;
-    canvas.style.height = `${this.#state.height}px`;
+    canvas.style.maxWidth = "100%";
+    canvas.style.height = "auto";
+    canvas.style.aspectRatio = `${this.#state.width} / ${this.#state.height}`;
     canvas.style.touchAction = "none";
     container.append(canvas);
     this.#canvas = canvas;
@@ -343,7 +345,9 @@ export class MatplotlibRenderer {
       this.#canvas.width = state.width * dpr;
       this.#canvas.height = state.height * dpr;
       this.#canvas.style.width = `${state.width}px`;
-      this.#canvas.style.height = `${state.height}px`;
+      this.#canvas.style.maxWidth = "100%";
+      this.#canvas.style.height = "auto";
+      this.#canvas.style.aspectRatio = `${state.width} / ${state.height}`;
       needsRedraw = true;
     }
 


### PR DESCRIPTION
## 📝 Summary

### Before: 

Notice that we're stretching a bit here: 

<img width="2112" height="1616" alt="CleanShot 2026-03-26 at 17 43 06@2x" src="https://github.com/user-attachments/assets/02ee52b6-99b5-4319-ba56-9762732dd6f4" />

Extreme example: 

<img width="2082" height="1528" alt="CleanShot 2026-03-26 at 17 49 00@2x" src="https://github.com/user-attachments/assets/2e7bd0ef-4fb3-43da-8387-ec1da8f6e054" />

Applying CSS rules in hindsight trips up matplotlib. So I figured removing the hardcoded `maxWidth`.

### After:

<img width="2272" height="1682" alt="CleanShot 2026-03-26 at 17 43 16@2x" src="https://github.com/user-attachments/assets/19ad6688-ea89-4fc2-a9a7-7e50a430f6c4" />

This feels better but here is a consequence: the resulting widget may not fit the cell output width anymore if the width is set too high. But that feels like a fair thing for this widget. 