### PR TITLE
fix: skip row limit enforcement for EXPLAIN queries

### DIFF
--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -106,7 +106,11 @@ def sql(
     except OSError:
         default_result_limit = None
 
-    enforce_own_limit = not has_limit and default_result_limit is not None and not is_explain_query(query)
+    enforce_own_limit = (
+        not has_limit
+        and default_result_limit is not None
+        and not is_explain_query(query)
+    )
 
     custom_total_count: Optional[Literal["too_many"]] = None
     if enforce_own_limit:

--- a/tests/_sql/test_duckdb.py
+++ b/tests/_sql/test_duckdb.py
@@ -295,13 +295,14 @@ def test_duckdb_engine_sql_output_formats(
 @pytest.mark.skipif(not HAS_DUCKDB, reason="requires duckdb")
 @pytest.mark.skipif(not HAS_POLARS, reason="requires polars")
 def test_explain_query_not_truncated_by_limit(
-    duckdb_connection: "duckdb.DuckDBPyConnection",
+    duckdb_connection: duckdb.DuckDBPyConnection,
 ) -> None:
     """EXPLAIN queries should not be truncated by the default result limit.
 
     Regression test for https://github.com/marimo-team/marimo/issues/8328
     """
     import os
+
     from marimo._sql.engines.duckdb import DuckDBEngine
 
     engine = DuckDBEngine(duckdb_connection, engine_name="duckdb")
@@ -321,6 +322,7 @@ def test_explain_query_not_truncated_by_limit(
         df, _ = result
         # EXPLAIN output should have more than 5 rows
         import polars as pl
+
         if isinstance(df, pl.DataFrame):
             assert len(df) > 5, (
                 "EXPLAIN query output was truncated by MARIMO_SQL_DEFAULT_LIMIT"


### PR DESCRIPTION
Fixes #8328

## Root Cause

EXPLAIN queries were being truncated to the default result limit (e.g. 10 rows) before the EXPLAIN-specific display logic ran.

`enforce_own_limit` was `True` for EXPLAIN queries, so `df.limit()` / `df.head()` truncated the dataframe first. Then `extract_explain_content()` only saw the truncated data — and since `plain_text()` has no pagination, users had no way to scroll through the full output.

## Fix

One-line change: add `not is_explain_query(query)` to the `enforce_own_limit` condition:
```python
enforce_own_limit = not has_limit and default_result_limit is not None and not is_explain_query(query)
```

EXPLAIN queries now bypass the row limit entirely, so all rows are passed to `extract_explain_content()`.

## Testing

Added `test_explain_query_not_truncated_by_limit` to `tests/_sql/test_duckdb.py`: verifies that EXPLAIN output is not truncated when `MARIMO_SQL_DEFAULT_LIMIT` is set.