### PR TITLE
fix(ai): buffer streaming preamble text before code fence appears

### DIFF
--- a/frontend/src/core/ai/__tests__/staged-cells.test.ts
+++ b/frontend/src/core/ai/__tests__/staged-cells.test.ts
@@ -419,7 +419,7 @@ describe("onStream", () => {
     expect(mockUpdateCellEditor).not.toHaveBeenCalled();
   });
 
-  it("should create cells when text-delta is received and a stream has been created", () => {
+  it("should buffer text without fences and create cell on stop", () => {
     const { result } = renderHook(() => useStagedCells(store));
     result.current.onStream({ type: "text-start", id: "test-id" });
 
@@ -433,6 +433,12 @@ describe("onStream", () => {
       delta: "some code",
     });
 
+    // Cell should NOT be created yet — waiting for a fence or stream end
+    expect(mockCreateNewCell).not.toHaveBeenCalled();
+
+    // When the stream ends, the buffered code is flushed as a cell
+    result.current.onStream({ type: "text-end", id: "test-id" });
+
     expect(mockCreateNewCell).toHaveBeenCalledWith({
       cellId: "__end__",
       code: "some code",
@@ -441,7 +447,50 @@ describe("onStream", () => {
     });
   });
 
-  it("should handle delta chunks", () => {
+  it("should not create cell from preamble when fence appears later", () => {
+    const { result } = renderHook(() => useStagedCells(store));
+    result.current.onStream({ type: "text-start", id: "test-id" });
+
+    const mockCellId = cellId("mock-cell-id");
+    vi.mocked(CellId.create).mockReturnValue(mockCellId);
+
+    // Preamble text without fence — should be buffered
+    result.current.onStream({
+      type: "text-delta",
+      id: "test-id",
+      delta: "I'll create a fibonacci function.\n\n",
+    });
+
+    expect(mockCreateNewCell).not.toHaveBeenCalled();
+
+    // Now fence arrives — cell should be created with only the code
+    result.current.onStream({
+      type: "text-delta",
+      id: "test-id",
+      delta: "```python\nsome code",
+    });
+
+    expect(mockCreateNewCell).toHaveBeenCalledWith({
+      cellId: "__end__",
+      code: "some code",
+      before: false,
+      newCellId: "mock-cell-id",
+    });
+
+    // More code arrives — cell should be updated
+    result.current.onStream({
+      type: "text-delta",
+      id: "test-id",
+      delta: "\nmore code\n```",
+    });
+
+    expect(vi.mocked(updateEditorCodeFromPython)).toHaveBeenCalledWith(
+      mockCellHandle.current.editorViewOrNull,
+      "some code\nmore code",
+    );
+  });
+
+  it("should handle delta chunks with fences", () => {
     const { result } = renderHook(() => useStagedCells(store));
     result.current.onStream({ type: "text-start", id: "test-id" });
 
@@ -451,27 +500,15 @@ describe("onStream", () => {
     result.current.onStream({
       type: "text-delta",
       id: "test-id",
-      delta: "``",
+      delta: "```python\nsome code",
     });
 
     expect(mockCreateNewCell).toHaveBeenCalledWith({
       cellId: "__end__",
-      code: "``",
+      code: "some code",
       before: false,
       newCellId: "mock-cell-id",
     });
-
-    result.current.onStream({
-      type: "text-delta",
-      id: "test-id",
-      delta: "```python\nsome code",
-    });
-
-    // Now the cell is recognized and only some code is seen
-    expect(vi.mocked(updateEditorCodeFromPython)).toHaveBeenCalledWith(
-      mockCellHandle.current.editorViewOrNull,
-      "some code",
-    );
 
     result.current.onStream({
       type: "text-delta",

--- a/frontend/src/core/ai/__tests__/staged-cells.test.ts
+++ b/frontend/src/core/ai/__tests__/staged-cells.test.ts
@@ -516,4 +516,37 @@ describe("onStream", () => {
       delta: "\n```",
     });
   });
+
+  it("should buffer partial fence and create cell when fence completes", () => {
+    const { result } = renderHook(() => useStagedCells(store));
+    result.current.onStream({ type: "text-start", id: "test-id" });
+
+    const mockCellId = cellId("mock-cell-id");
+    vi.mocked(CellId.create).mockReturnValue(mockCellId);
+
+    // Chunk 1: partial fence (just two backticks)
+    result.current.onStream({
+      type: "text-delta",
+      id: "test-id",
+      delta: "``",
+    });
+
+    // Cell should NOT be created — fence is incomplete
+    expect(mockCreateNewCell).not.toHaveBeenCalled();
+
+    // Chunk 2: fence completes + code
+    result.current.onStream({
+      type: "text-delta",
+      id: "test-id",
+      delta: "`python\nsome code",
+    });
+
+    // NOW cell is created with actual code
+    expect(mockCreateNewCell).toHaveBeenCalledWith({
+      cellId: "__end__",
+      code: "some code",
+      before: false,
+      newCellId: "mock-cell-id",
+    });
+  });
 });

--- a/frontend/src/core/ai/staged-cells.ts
+++ b/frontend/src/core/ai/staged-cells.ts
@@ -241,6 +241,15 @@ class CellCreationStream {
   stream(chunk: TextDeltaChunk) {
     const delta = chunk.delta;
     this.buffer += delta;
+
+    // If no code fence has appeared yet and no cells have been created,
+    // buffer the content and wait. This prevents conversational preamble
+    // (e.g. "I'll create a cell that...") from becoming a Python cell.
+    // Once a fence appears, codeToCells will correctly extract only the code.
+    if (!this.buffer.includes("```") && this.createdCells.length === 0) {
+      return;
+    }
+
     const completionCells = codeToCells(this.buffer);
 
     // As incoming chunks are appended to the buffer,
@@ -282,6 +291,15 @@ class CellCreationStream {
   }
 
   stop() {
+    // If the stream ended with buffered content but no cells were created
+    // (model returned code without fences), create a cell from the buffer.
+    if (this.buffer.trim() && this.createdCells.length === 0) {
+      const completionCells = codeToCells(this.buffer);
+      for (const cell of completionCells) {
+        const newCellId = this.onCreateCell(cell.code);
+        this.createdCells.push({ cellId: newCellId, cell });
+      }
+    }
     // Clear all state
     this.buffer = "";
   }

--- a/frontend/src/core/ai/staged-cells.ts
+++ b/frontend/src/core/ai/staged-cells.ts
@@ -302,6 +302,8 @@ class CellCreationStream {
     }
     // Clear all state
     this.buffer = "";
+    this.createdCells = [];
+    this.hasMarimoImport = false;
   }
 }
 


### PR DESCRIPTION
## Summary

- Buffer incoming AI stream chunks in `CellCreationStream` until a code fence (` ``` `) appears, preventing conversational preamble from becoming a separate Python cell
- Flush buffered content as a cell in `stop()` if the stream ends without any fence (backward compatibility for models that return code without fences)
- Add tests for: preamble + fence, code without fence, fence from first chunk

## Root cause

`CellCreationStream.stream()` called `codeToCells(buffer)` on every chunk. Before any fence arrived, `codeToCells` treated the entire buffer as Python code (line 166 of `completion-utils.ts`: `if (!code.includes("```")) return [{ language: "python", code }]`), creating a cell from preamble text like "I'll create a fibonacci function...".

## What this does NOT fix

The "Inline AI edit" flow (problem #2 in the issue) uses a different code path through the backend `without_wrapping_backticks` function. That is a separate issue.

## Test plan

- [x] All 25 staged-cells tests pass
- [x] TypeScript clean (no new errors)
- [x] Test: preamble text buffered, cell created only when fence arrives
- [x] Test: code without fence → cell created on stream end (backward compat)
- [x] Test: fence in first chunk → cell created immediately (no delay)

Fixes #8880

🤖 Generated with [Claude Code](https://claude.ai/code)