### PR TITLE
fix: preserve style_cell mapping when table sorted descending

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1421,9 +1421,7 @@ class table(
         return SearchTableResponse(
             data=formatted_data,
             total_rows=total_rows,
-            cell_styles=self._style_cells(
-                offset, args.page_size, total_rows
-            ),
+            cell_styles=self._style_cells(offset, args.page_size, total_rows),
             cell_hover_texts=self._hover_cells(
                 offset, args.page_size, total_rows
             ),


### PR DESCRIPTION
Row styles should be tied to data indices, not display order. The `_style_cells` and `_hover_cells` functions reversed `row_ids` when sorting descending, causing styles to be applied to the wrong rows.

Removes the reversal so style functions always receive the correct data row index regardless of sort direction. Also removes the now-unused `descending` parameter from both functions.

Closes #8847