### PR TITLE
Enhance SQLAlchemy engine with safe_execute and inspector methods for SnowFlake

### DIFF
--- a/marimo/_sql/engines/sqlalchemy.py
+++ b/marimo/_sql/engines/sqlalchemy.py
@@ -130,7 +130,7 @@ class SQLAlchemyEngine(SQLConnection["Engine"]):
             return identifier
 
         pattern, open_quote, close_quote = dialect_quoting[self.dialect]
-        if pattern.search(identifier):
+        if pattern.search(identifier) or identifier != identifier.lower():
             escaped = identifier.replace(
                 close_quote, close_quote + close_quote
             )
@@ -159,7 +159,7 @@ class SQLAlchemyEngine(SQLConnection["Engine"]):
         from sqlalchemy import inspect, text
 
         _use_database_dialect_command: dict[str, str] = {
-            "snowflake": f"""USE DATABASE {self._quote_identifier(database)}""",
+            "snowflake": f"USE DATABASE {self._quote_identifier(database)}",
         }
         dialect_command = _use_database_dialect_command.get(self.dialect)
 
@@ -334,7 +334,10 @@ class SQLAlchemyEngine(SQLConnection["Engine"]):
             database_names: list[str] = []
             for row in result.fetchall():
                 raw_name = str(row[name_col_index])
-                if _SNOWFLAKE_NEEDS_QUOTING_RE.search(raw_name):
+                if (
+                    _SNOWFLAKE_NEEDS_QUOTING_RE.search(raw_name)
+                    or raw_name != raw_name.upper()
+                ):
                     database_names.append(raw_name)
                 else:
                     database_names.append(raw_name.lower())

--- a/tests/_sql/test_sqlalchemy.py
+++ b/tests/_sql/test_sqlalchemy.py
@@ -951,13 +951,13 @@ def test_get_inspector_executes_use_database():
     with mock.patch(
         "sqlalchemy.inspect", return_value=mock_command
     ) as patched_inspect:
-        with engine._get_inspector("MY_DB") as inspector:
+        with engine._get_inspector("my_db") as inspector:
             assert inspector is mock_command
             patched_inspect.assert_called_once_with(mock_conn)
 
     # Verify USE DATABASE was executed
     executed = mock_conn.execute.call_args[0][0]
-    assert str(executed) == "USE DATABASE MY_DB"
+    assert str(executed) == "USE DATABASE my_db"
 
     with mock.patch(
         "sqlalchemy.inspect", return_value=mock_command
@@ -969,6 +969,17 @@ def test_get_inspector_executes_use_database():
     # Verify USE DATABASE was executed
     executed = mock_conn.execute.call_args[0][0]
     assert str(executed) == 'USE DATABASE "MY_DB@MYDB"'
+
+    with mock.patch(
+        "sqlalchemy.inspect", return_value=mock_command
+    ) as patched_inspect:
+        with engine._get_inspector("MY_db") as inspector:
+            assert inspector is mock_command
+            patched_inspect.assert_called_once_with(mock_conn)
+
+    # Verify USE DATABASE was executed
+    executed = mock_conn.execute.call_args[0][0]
+    assert str(executed) == 'USE DATABASE "MY_db"'
 
 
 @pytest.mark.skipif(not HAS_SQLALCHEMY, reason="SQLAlchemy not installed")


### PR DESCRIPTION
## 📝 Summary

This pull request adds multi-database engine support, starting with Snowflake, and improves type safety and exception handling in the SQLAlchemy engine integration.

Continues the work from [#8824](https://github.com/marimo-team/marimo/pull/8824).
Closes 

## 🔍 Description of Changes

### Multi-Database Support

- **Introduced `_get_inspector` context manager** that yields an appropriate SQLAlchemy `Inspector` for a given database. For dialects that require a `USE DATABASE` command (e.g., Snowflake), it opens a connection, executes the command, and yields an inspector bound to that connection. For all other dialects, it falls back to the existing `self.inspector`.
- **Added `_get_snowflake_database_names`** to fetch all available databases when the target database is not specified or not found.
- **Refactored existing methods** (`_get_schema_names`, `_get_table_names`, `_get_columns`, `_fetch_primary_keys`, `_fetch_indexes`) to accept a `database` parameter and use `_get_inspector`, enabling per-database inspection across all operations.

### Type Safety & Code Quality

- Corrected type annotations for inspector-related methods, using SQLAlchemy's official `ReflectedColumn` and `ReflectedIndex` types to resolve mypy errors.
- Improved exception handling in `_get_snowflake_database_names` by chaining exceptions with `raise ... from err` (B904 compliance).

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes — it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).