### PR TITLE
Fix `hide_code` not taking effect on kernel-created cells

### DIFF
--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -247,9 +247,10 @@ const {
         [newCellId]: createRef(),
       },
       scrollKey: autoFocus ? newCellId : null,
-      untouchedNewCells: hideCode && !code
-        ? new Set([...state.untouchedNewCells, newCellId])
-        : state.untouchedNewCells,
+      untouchedNewCells:
+        hideCode && !code
+          ? new Set([...state.untouchedNewCells, newCellId])
+          : state.untouchedNewCells,
     };
   },
   moveCell: (


### PR DESCRIPTION
Cells created via code_mode with `hide_code=True` and non-empty code showed their editor anyway because they were marked "untouched," which overrides `hide_code` in the render logic. That override only makes sense for empty cells the user just created, so gate it on `!code` as well.
