### PR TITLE
fix: remove Content-Length from virtual file StreamingResponse

### DIFF
--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -426,12 +426,15 @@ def virtual_file(
 
     chunks = read_virtual_file_chunked(filename, int(byte_length))
     mimetype, _ = mimetypes.guess_type(filename)
+    # Do NOT set Content-Length here. StreamingResponse with an explicit
+    # Content-Length causes h11 LocalProtocolError ("Too little data for
+    # declared Content-Length") for large files. Omitting it lets h11 use
+    # chunked transfer encoding instead. See #8917.
     return StreamingResponse(
         content=chunks,
         media_type=mimetype,
         headers={
             "Cache-Control": "max-age=86400",
-            "Content-Length": byte_length,
         },
     )
 

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -133,6 +133,46 @@ def test_vfile(client: TestClient) -> None:
     assert response.json() == {"detail": "Invalid virtual file request"}
 
 
+def test_vfile_large_streaming(client: TestClient) -> None:
+    """Regression test: large virtual files must stream without
+    Content-Length mismatch (h11 LocalProtocolError).
+
+    See https://github.com/marimo-team/marimo/issues/8917
+    """
+    from marimo._runtime.virtual_file.storage import (
+        InMemoryStorage,
+        VirtualFileStorageManager,
+    )
+
+    manager = VirtualFileStorageManager()
+    original_storage = manager.storage
+    storage = InMemoryStorage()
+    manager.storage = storage
+
+    try:
+        # ~2 MB file, similar to a large anywidget ESM bundle
+        data = b"x" * (2 * 1024 * 1024)
+        filename = "test-large.js"
+        storage.store(filename, data)
+        byte_length = len(data)
+
+        response = client.get(
+            f"/@file/{byte_length}-{filename}",
+            headers=token_header(),
+        )
+        assert response.status_code == 200
+        assert response.content == data
+        assert (
+            response.headers.get("content-type") == "text/javascript"
+            or response.headers.get("content-type") == "application/javascript"
+        )
+        # StreamingResponse must NOT set Content-Length to avoid h11
+        # LocalProtocolError with large files
+        assert "content-length" not in response.headers
+    finally:
+        manager.storage = original_storage
+
+
 def test_public_file_serving(client: TestClient) -> None:
     # Setup app state with a mock notebook
     app_state = AppState.from_app(cast(Any, client.app))


### PR DESCRIPTION
Closes #8917

The `@file/` endpoint set `Content-Length` on a `StreamingResponse`, mixing length-delimited and chunked framing. Starlette's `BaseHTTPMiddleware` re-wraps streaming bodies through memory object streams, which can desynchronize the byte count from the declared length for large responses. This caused h11 `LocalProtocolError` when serving large anywidget ESM bundles (~2MB+).

Fix: drop the `Content-Length` header so h11 uses chunked transfer encoding instead.
