### PR TITLE
ci: add UV_EXCLUDE_NEWER to all uv-using workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  UV_EXCLUDE_NEWER: "7 days"
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/marimo-bot.yml
+++ b/.github/workflows/marimo-bot.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   TURBO_TEAM: marimo
+  UV_EXCLUDE_NEWER: "7 days"
 
 jobs:
   # Various jobs that can be triggered by comments

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,7 @@ concurrency:
 
 env:
   UV_SYSTEM_PYTHON: 1
+  UV_EXCLUDE_NEWER: "7 days"
 
 jobs:
   export-notebooks:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   MARIMO_SKIP_UPDATE_CHECK: 1
+  UV_EXCLUDE_NEWER: "7 days"
 
 jobs:
   changes:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   TURBO_TEAM: marimo
+  UV_EXCLUDE_NEWER: "7 days"
 
 jobs:
   publish_dev_release:

--- a/.github/workflows/release-marimo-base.yml
+++ b/.github/workflows/release-marimo-base.yml
@@ -14,6 +14,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  UV_EXCLUDE_NEWER: "7 days"
+
 jobs:
   publish_release:
     name: 📤 Publish release

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   TURBO_TEAM: marimo
+  UV_EXCLUDE_NEWER: "7 days"
 
 jobs:
   publish_release:

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   MARIMO_SKIP_UPDATE_CHECK: 1
+  UV_EXCLUDE_NEWER: "7 days"
 
 jobs:
   changes:

--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -16,6 +16,7 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: marimo
   MARIMO_SKIP_UPDATE_CHECK: 1
+  UV_EXCLUDE_NEWER: "7 days"
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_marimo_lsp.yaml
+++ b/.github/workflows/test_marimo_lsp.yaml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  UV_EXCLUDE_NEWER: "7 days"
+
 jobs:
   test_marimo_lsp:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_no_build.yaml
+++ b/.github/workflows/test_no_build.yaml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  UV_EXCLUDE_NEWER: "7 days"
+
 jobs:
   Test:
     name: Python ${{ matrix.python-version }}


### PR DESCRIPTION
Prevents CI from picking up newly published dependency versions
that may be broken or incompatible, improving build stability.
