### PR TITLE
Remove auto-instantiate from /api/execute endpoint

### DIFF
--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -272,14 +272,6 @@ async def execute_code(
     body = await parse_request(request, cls=ExecuteScratchpadRequest)
     session = app_state.require_current_session()
 
-    # Auto-instantiate so headless /api/execute works without a prior
-    # /api/instantiate call. The kernel no-ops if already instantiated,
-    # and queue ordering guarantees it completes before the scratchpad runs.
-    session.instantiate(
-        InstantiateNotebookRequest(object_ids=[], values=[], auto_run=True),
-        http_request=HTTPRequest.from_request(request),
-    )
-
     async def _watch_disconnect() -> None:
         """Wait for client disconnect and interrupt the kernel."""
         while True:


### PR DESCRIPTION
Code mode now builds its execution plan from the NotebookDocument and calls mutate_graph/_run_cells on the kernel directly, so the notebook no longer needs to be pre-instantiated before scratchpad execution. The _apply_ops diff source also switches from the graph to the document to stay consistent with this approach.
