### PR TITLE
fix: account for 0 width arrays

### DIFF
--- a/marimo/_plugins/stateless/image.py
+++ b/marimo/_plugins/stateless/image.py
@@ -82,6 +82,12 @@ def _normalize_image(
         is_uint8 = src.__array_interface__["typestr"] == "|u1"
         has_bounds = vmin is not None or vmax is not None
 
+        if 0 in src.__array_interface__.get("shape", (0,)):
+            raise ValueError(
+                f"Cannot render an image from an array with a zero-size "
+                f"dimension (shape {src.__array_interface__['shape']!r})."
+            )
+
         if not is_uint8 or has_bounds:
             lo = float(vmin) if vmin is not None else float(src.min())
             hi = float(vmax) if vmax is not None else float(src.max())

--- a/tests/_plugins/stateless/test_image.py
+++ b/tests/_plugins/stateless/test_image.py
@@ -212,6 +212,14 @@ def test_image_constructor_pil():
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_image_zero_width_array():
+    import numpy as np
+
+    with pytest.raises(ValueError, match="zero-size dimension"):
+        image(np.zeros((100, 0, 3)))
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 def test_image_uint8_no_normalization():
     import numpy as np
     from PIL import Image as PILImage


### PR DESCRIPTION
## 📝 Summary

Quick fix to handle 0 sized arrays in `mo.image`