### PR TITLE
fix altair not setting to full-width when width: container

### DIFF
--- a/frontend/src/plugins/impl/vega/__tests__/utils.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/utils.test.ts
@@ -33,4 +33,72 @@ describe("getContainerWidth", () => {
   it("should return undefined when width is explicitly undefined", () => {
     expect(getContainerWidth({ width: undefined })).toBeUndefined();
   });
+
+  it("should find width in nested facet spec", () => {
+    expect(
+      getContainerWidth({
+        $schema: "https://vega.github.io/schema/vega-lite/v6.json",
+        facet: { column: { field: "Origin", type: "nominal" } },
+        spec: {
+          mark: "point",
+          encoding: {},
+          width: "container",
+        },
+      }),
+    ).toBe("container");
+  });
+
+  it("should find width in nested repeat spec", () => {
+    expect(
+      getContainerWidth({
+        $schema: "https://vega.github.io/schema/vega-lite/v6.json",
+        repeat: { row: ["A", "B"] },
+        spec: {
+          mark: "point",
+          encoding: {},
+          width: "container",
+        },
+      }),
+    ).toBe("container");
+  });
+
+  it("should return undefined for nested spec without width", () => {
+    expect(
+      getContainerWidth({
+        facet: { column: { field: "Origin" } },
+        spec: { mark: "point", encoding: {} },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should return undefined for hconcat (width on sub-specs)", () => {
+    expect(
+      getContainerWidth({
+        hconcat: [{ width: "container" }, { width: "container" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should return undefined for vconcat (width on sub-specs)", () => {
+    expect(
+      getContainerWidth({
+        vconcat: [{ width: "container" }, { width: "container" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("should return undefined for compiled Vega spec (width as signal)", () => {
+    expect(
+      getContainerWidth({
+        $schema: "https://vega.github.io/schema/vega/v6.json",
+        autosize: { contains: "padding", type: "fit-x" },
+        signals: [
+          {
+            name: "width",
+            init: "isFinite(containerSize()[0]) ? containerSize()[0] : 300",
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/frontend/src/plugins/impl/vega/utils.ts
+++ b/frontend/src/plugins/impl/vega/utils.ts
@@ -6,13 +6,22 @@ import type { DataType, FieldTypes, VegaDataType } from "./vega-loader";
 export type ContainerWidth = number | "container";
 
 /**
- * Get the container width from a VegaLite spec.
- * @param spec - The VegaLite spec.
- * @returns The container width.
+ * Get the container width from a Vega-Lite spec.
+ *
+ * For unit specs, `width` is at the top level. For facet/repeat specs,
+ * `width` is nested inside `spec`. This does not handle hconcat/vconcat and Vega spec
+ * where the width may be a signal. These cases are covered by
+ * the CSS fallback `.vega-embed:has(> .chart-wrapper.fit-x)`.
  */
 export function getContainerWidth(spec: unknown): ContainerWidth | undefined {
-  if (typeof spec === "object" && spec !== null && "width" in spec) {
-    return spec.width as ContainerWidth | undefined;
+  if (typeof spec === "object" && spec !== null) {
+    if ("width" in spec) {
+      return spec.width as ContainerWidth | undefined;
+    }
+    // Faceted/repeated spec
+    if ("spec" in spec) {
+      return getContainerWidth(spec.spec);
+    }
   }
   return undefined;
 }

--- a/frontend/src/plugins/impl/vega/vega.css
+++ b/frontend/src/plugins/impl/vega/vega.css
@@ -5,7 +5,7 @@
 }
 
 .vega-embed[data-container-width="container"],
-.vega-embed:has(.chart-wrapper.fit-x) {
+.vega-embed:has(> .chart-wrapper.fit-x) {
   width: 100%;
 }
 

--- a/marimo/_smoke_tests/altair_examples/container_charts.py
+++ b/marimo/_smoke_tests/altair_examples/container_charts.py
@@ -12,8 +12,7 @@ with app.setup:
 @app.cell
 def _():
     cars = data.cars()
-
-    chart = (
+    base = (
         alt.Chart(cars)
         .mark_point()
         .encode(
@@ -21,17 +20,50 @@ def _():
             y="Miles_per_Gallon",
             color="Origin",
         )
-        .interactive()
-        .properties(width="container")
     )
-    mo.hstack([chart, chart.configure_axis(grid=False)], widths="equal")
-    return (chart,)
+    # 1. Unit chart — width at top level, getContainerWidth works
+    base.properties(width="container")
+    return base, cars
 
 
 @app.cell
-def _(chart):
+def _(base):
+    # facet — width nested under spec
+    base.properties(width="container").facet(column="Origin:N")
+    return
+
+
+@app.cell
+def _(cars):
+    # with vegafusion enabled. This will use vega instead of vega-lite
+    # The chart should be fully expanded
+    alt.data_transformers.enable("vegafusion")
+
+    _base = (
+        alt.Chart(cars)
+        .mark_point()
+        .encode(
+            x="Horsepower",
+            y="Miles_per_Gallon",
+            color="Origin",
+        )
+        .properties(width="container")
+    )
+    _base
+    return
+
+
+@app.cell
+def _(base):
+    # This should not stretch the entire width
+    base.properties(autosize=alt.AutoSizeParams(type="fit-x"))
+    return
+
+
+@app.cell
+def _(base):
     # Broken
-    chart.properties(height="container")
+    base.properties(height="container")
     return
 
 


### PR DESCRIPTION
## 📝 Summary

The existing data-container-width attribute approach only checks for width at the top level of the spec.
There are cases where that may be missing. 

- Use vega-embed's own fit-x class detection and add the width: 100%
- Fix nested/concat charts not setting to full-width

<img width="902" height="866" alt="image" src="https://github.com/user-attachments/assets/4c34b323-f301-47ac-b970-6d1b095b560e" />

### unchanged
<img width="572" height="352" alt="image" src="https://github.com/user-attachments/assets/996898b5-f8e5-41d5-a1e9-e4840a48924a" />

<img width="312" height="573" alt="image" src="https://github.com/user-attachments/assets/dba55074-c3c5-4cab-9b3f-e23c3b501154" />

<img width="383" height="116" alt="image" src="https://github.com/user-attachments/assets/c4a2df54-3f76-4841-9a29-f8eb279c91cf" />

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
