### PR TITLE
fix: resolve AI SDK URL and headers lazily to handle runtime redirects

### DIFF
--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -465,7 +465,7 @@ const ChatPanelBody = () => {
     messages: activeChat?.messages || [], // initial messages
     transport: new DefaultChatTransport({
       api: runtimeManager.getAiURL("chat").toString(),
-      headers: runtimeManager.headers(),
+      headers: () => runtimeManager.headers(),
       prepareSendMessagesRequest: async (options) => {
         const completionBody = await buildCompletionRequestBody(
           options.messages,
@@ -476,6 +476,7 @@ const ChatPanelBody = () => {
         const tools = FRONTEND_TOOL_REGISTRY.getToolSchemas(chatMode);
 
         return {
+          api: runtimeManager.getAiURL("chat").toString(),
           body: {
             tools,
             ...options,

--- a/frontend/src/components/editor/ai/add-cell-with-ai.tsx
+++ b/frontend/src/components/editor/ai/add-cell-with-ai.tsx
@@ -122,7 +122,7 @@ export const AddCellWithAI: React.FC<{
     transport: new StreamingChunkTransport(
       {
         api: runtimeManager.getAiURL("completion").toString(),
-        headers: runtimeManager.headers(),
+        headers: () => runtimeManager.headers(),
         prepareSendMessagesRequest: async (options) => {
           const completionBody = await buildCompletionRequestBody(
             options.messages,
@@ -136,6 +136,7 @@ export const AddCellWithAI: React.FC<{
           };
 
           return {
+            api: runtimeManager.getAiURL("completion").toString(),
             body: body,
           };
         },


### PR DESCRIPTION
Use per-request getters so that if the runtime URL changes after a
redirect, subsequent AI requests use the updated URL and headers.
