### PR TITLE
fix double bottom borders for unflushed tables

### DIFF
--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -314,19 +314,19 @@ const DataTableInternal = <TData,>({
               virtualize={virtualize}
             />
           </Table>
+          <TableBottomBar
+            part="table-footer"
+            className="pt-1.5 pb-0.5 border-t border-border"
+            totalColumns={totalColumns}
+            pagination={pagination}
+            selection={selection}
+            onRowSelectionChange={onRowSelectionChange}
+            table={table}
+            getRowIds={getRowIds}
+            showPageSizeSelector={showPageSizeSelector}
+            tableLoading={reloading}
+          />
         </div>
-        <TableBottomBar
-          part="table-footer"
-          className="border-t border-border pt-1.5 pb-0.5"
-          totalColumns={totalColumns}
-          pagination={pagination}
-          selection={selection}
-          onRowSelectionChange={onRowSelectionChange}
-          table={table}
-          getRowIds={getRowIds}
-          showPageSizeSelector={showPageSizeSelector}
-          tableLoading={reloading}
-        />
       </CellSelectionProvider>
     </div>
   );


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
My previous change to add borders resulted in double borders for unflushed table at the bottom

### before
<img width="814" height="302" alt="image" src="https://github.com/user-attachments/assets/1514d1c3-a326-465d-80a3-e2643c5214a5" />

### after
<img width="819" height="307" alt="image" src="https://github.com/user-attachments/assets/755c485a-69b6-42ee-940b-05ca0fab8824" />

flushed is unchanged
<img width="842" height="324" alt="image" src="https://github.com/user-attachments/assets/bbe07ffb-38b2-4d95-83a4-31c12b503703" />

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
