### PR TITLE
fix inf rerender tables col sizing

### DIFF
--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -9,7 +9,6 @@ import {
   type HeaderGroup,
   type Row,
   type Table,
-  type Table as TanStackTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { type JSX, useLayoutEffect, useRef, useState } from "react";
@@ -52,7 +51,7 @@ export function renderTableHeader<TData>(
             )}
             style={style}
             ref={(thead) => {
-              columnSizingHandler(thead, table, header.column);
+              columnSizingHandler({ table, column: header.column, thead });
             }}
           >
             {header.isPlaceholder
@@ -323,23 +322,30 @@ function getPinningStyles<TData>(
 
 // Update column sizes in table state for column pinning offsets
 // https://github.com/TanStack/table/discussions/3947#discussioncomment-9564867
-function columnSizingHandler<TData>(
-  thead: HTMLTableCellElement | null,
-  table: TanStackTable<TData>,
-  column: Column<TData>,
-) {
+function columnSizingHandler<TData>({
+  table,
+  column,
+  thead,
+}: {
+  table: Table<TData>;
+  column: Column<TData>;
+  thead: HTMLTableCellElement | null;
+}): void {
   if (!thead) {
     return;
   }
-  if (
-    table.getState().columnSizing[column.id] ===
-    thead.getBoundingClientRect().width
-  ) {
+  // Round to avoid infinite re-render loops: the browser's table layout
+  // algorithm may render a <th> at a slightly different width than the
+  // CSS `width` we set via column.getSize(), so a strict float === float
+  // comparison never stabilizes. Rounding to integers ensures convergence
+  // after at most one cycle.
+  const measuredWidth = Math.round(thead.getBoundingClientRect().width);
+  if (table.getState().columnSizing[column.id] === measuredWidth) {
     return;
   }
 
   table.setColumnSizing((prevSizes) => ({
     ...prevSizes,
-    [column.id]: thead.getBoundingClientRect().width,
+    [column.id]: measuredWidth,
   }));
 }

--- a/marimo/_smoke_tests/pandas_smoke_tests/dates.py
+++ b/marimo/_smoke_tests/pandas_smoke_tests/dates.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.17.8"
+__generated_with = "0.22.0"
 app = marimo.App(width="medium")
 
 
@@ -9,6 +9,7 @@ def _():
     import marimo as mo
     import pandas as pd
     from datetime import datetime
+
     return datetime, mo, pd
 
 
@@ -103,6 +104,20 @@ def _(mo, pd):
 def _(datetime, pd):
     dates_with_null = pd.DataFrame({"mixed": [datetime.now(), None]})
     dates_with_null
+    return
+
+
+@app.cell
+def _(mo, pd):
+    # Bug with inf re-render https://github.com/marimo-team/marimo/issues/8964
+    df = pd.DataFrame(
+        {
+            "ID_SBSC": [6013949] * 10,
+            "ID_DATE": [20260401] * 10,
+        },
+        index=pd.Index(["2026-04-01"] * 10, name="ID_DATE"),
+    )
+    mo.ui.table(df)
     return
 
 


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Fixes https://github.com/marimo-team/marimo/issues/8964

- "Maximum update depth exceeded" error when rendering tables with narrow columns (e.g., small DataFrames with short numeric values), caused by columnSizingHandler calling setColumnSizing in a ref callback where getBoundingClientRect().width never exactly matches the stored float value due to the browser's table layout algorithm redistributing space.
- Rounds measured widths to integers via Math.round so the comparison stabilizes after one render cycle.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
