### PR TITLE
fix: do not double encode msgspec values

### DIFF
--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -224,11 +224,13 @@ class ModelLifecycleNotification(Notification, tag="model-lifecycle"):
         import base64
 
         d: dict[str, Any] = msgspec.to_builtins(self)
-        # bytes are not JSON-serializable; base64-encode each buffer
         msg = d.get("message", {})
         if "buffers" in msg:
             msg["buffers"] = [
-                base64.b64encode(b).decode("ascii") for b in msg["buffers"]
+                b
+                if isinstance(b, str)
+                else base64.b64encode(b).decode("ascii")
+                for b in msg["buffers"]
             ]
         return d
 

--- a/tests/_messaging/test_notifications.py
+++ b/tests/_messaging/test_notifications.py
@@ -7,6 +7,8 @@ from marimo._ast.toplevel import HINT_UNPARSABLE, TopLevelStatus
 from marimo._messaging.notification import (
     CellNotification,
     InstallingPackageAlertNotification,
+    ModelLifecycleNotification,
+    ModelOpen,
     StartupLogsNotification,
     UIElementMessageNotification,
 )
@@ -137,3 +139,18 @@ def test_send_ui_element_message_broadcast() -> None:
     }
 
     assert stream.parsed_operations[0] == msg
+
+
+def test_model_lifecycle_notification_to_json_serializable() -> None:
+    """to_json_serializable must not double-encode buffers (regression test)."""
+    notif = ModelLifecycleNotification(
+        model_id="model-1",
+        message=ModelOpen(
+            state={"value": 42},
+            buffer_paths=[["data"]],
+            buffers=[b"hello"],
+        ),
+    )
+
+    result = notif.to_json_serializable()
+    assert result["message"]["buffers"] == ["aGVsbG8="]


### PR DESCRIPTION
## 📝 Summary

Closes #9002 

Ensures that b64encode is only called on bytes in anywidget serialization.