### PR TITLE
Propagate kernel-initiated UI value updates to the frontend

### DIFF
--- a/frontend/src/core/dom/uiregistry.ts
+++ b/frontend/src/core/dom/uiregistry.ts
@@ -10,6 +10,23 @@ import {
 } from "./events";
 import { parseInitialValue } from "./htmlUtils";
 
+/**
+ * Kernel-initiated UI value update, sent via the existing
+ * `send-ui-element-message` channel when `set_ui_value` (code_mode)
+ * changes a widget's value so the frontend can reflect the new state.
+ */
+interface UIValueUpdateMessage {
+  type: "marimo-ui-value-update";
+  value: ValueType;
+}
+
+function isUIValueUpdateMessage(msg: unknown): msg is UIValueUpdateMessage {
+  if (typeof msg !== "object" || msg === null) {
+    return false;
+  }
+  return "type" in msg && msg.type === "marimo-ui-value-update";
+}
+
 interface UIElementEntry {
   objectId: string;
   value: ValueType;
@@ -141,21 +158,38 @@ export class UIElementRegistry {
     const entry = this.entries.get(objectId);
     if (entry === undefined) {
       Logger.warn("UIElementRegistry missing entry", objectId);
-    } else {
+      return;
+    }
+
+    // Kernel-initiated value update — push into DOM elements without
+    // dispatching MarimoValueReadyEvent to avoid a round-trip.
+    if (isUIValueUpdateMessage(message)) {
+      entry.value = message.value;
       entry.elements.forEach((element) => {
         element.dispatchEvent(
-          MarimoIncomingMessageEvent.create({
-            bubbles: false, // only the intended target gets the message
+          MarimoValueUpdateEvent.create({
+            bubbles: false,
             composed: true,
-            detail: {
-              objectId: objectId,
-              message: message,
-              buffers: buffers,
-            },
+            detail: { value: message.value, element: element },
           }),
         );
       });
+      return;
     }
+
+    entry.elements.forEach((element) => {
+      element.dispatchEvent(
+        MarimoIncomingMessageEvent.create({
+          bubbles: false, // only the intended target gets the message
+          composed: true,
+          detail: {
+            objectId: objectId,
+            message: message,
+            buffers: buffers,
+          },
+        }),
+      );
+    });
   }
 
   /**

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -88,6 +88,7 @@ from marimo._messaging.notification import (
     SQLTablePreviewNotification,
     StorageDownloadReadyNotification,
     StorageEntriesNotification,
+    UIElementMessageNotification,
     ValidateSQLResultNotification,
     VariableDeclarationNotification,
     VariablesNotification,
@@ -1951,6 +1952,19 @@ class Kernel:
                     write_traceback(tmpio.read())
                 else:
                     updated_components.append(component)
+                    # Broadcast the new value to the frontend so the
+                    # rendered widget reflects kernel-initiated changes
+                    # (e.g. from code_mode's set_ui_value).
+                    broadcast_notification(
+                        UIElementMessageNotification(
+                            ui_element=object_id,
+                            message={
+                                "type": "marimo-ui-value-update",
+                                "value": value,
+                            },
+                        ),
+                        self.stream,
+                    )
 
             bound_names = {
                 name


### PR DESCRIPTION
When `set_ui_value` is called from code_mode, the kernel updates the element's value but the frontend widget was never notified. Piggyback on the existing `send-ui-element-message` websocket channel to broadcast a `marimo-ui-value-update` message, which the UIElementRegistry intercepts and pushes into the DOM — skipping `MarimoValueReadyEvent` to avoid a round-trip back to the kernel.