### PR TITLE
Fix skill detection for marketplace and plugin installs

### DIFF
--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -24,13 +24,21 @@ class AgentConfig:
         )
 
 
+def _claude_skill_dirs() -> list[Path]:
+    """Return all directories where a Claude Code skill may be installed.
+
+    Skills can live under skills/, plugins/, or plugins/marketplaces/ in
+    both the global (~/.claude) and local (.claude) config directories.
+    """
+    roots = [Path.home() / ".claude", Path.cwd() / ".claude"]
+    subdirs = ["skills", "plugins", str(Path("plugins") / "marketplaces")]
+    return [root / sub for root in roots for sub in subdirs]
+
+
 AGENTS: dict[str, AgentConfig] = {
     "claude": AgentConfig(
         name="Claude Code",
-        skill_dirs=[
-            Path.home() / ".claude" / "skills",
-            Path.cwd() / ".claude" / "skills",
-        ],
+        skill_dirs=_claude_skill_dirs(),
     ),
     "codex": AgentConfig(
         name="Codex",


### PR DESCRIPTION
The `marimo pair prompt --claude` check only looked for the marimo-pair skill in `~/.claude/skills/` and `.claude/skills/`, but the standard marketplace install path is `~/.claude/plugins/marketplaces/`. This caused a false "skill not installed" error for anyone who installed via `npx skills add`.

Now checks `skills/`, `plugins/`, and `plugins/marketplaces/` under both the global and local `.claude` directories.
