### PR TITLE
Pass model_id as data attribute to prevent loss on value update

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -21,17 +21,19 @@ import { BINDING_MANAGER, WIDGET_DEF_REGISTRY } from "./widget-binding";
 interface Data {
   jsUrl: string;
   jsHash: string;
+  modelId: WidgetModelId;
 }
 
 type AnyWidgetState = ModelState;
 
 /**
- * Initial value is a model_id reference.
- * The backend sends just { model_id: string } and the frontend
- * retrieves the actual state from the 'open' message.
+ * Value payload sent by the frontend on state updates.
+ *
+ * The initial value from the backend is empty — `model_id` is passed
+ * via immutable data attributes (`args`) so it survives value overwrites.
  */
 interface ModelIdRef {
-  model_id: WidgetModelId;
+  model_id?: WidgetModelId;
 }
 
 export function useAnyWidgetModule(opts: { jsUrl: string; jsHash: string }) {
@@ -117,14 +119,14 @@ export const AnyWidgetPlugin = createPlugin<ModelIdRef>("marimo-anywidget")
     z.object({
       jsUrl: z.string(),
       jsHash: z.string(),
+      modelId: z.string().transform((v) => v as WidgetModelId),
     }),
   )
   .withFunctions({})
   .renderer((props) => <AnyWidgetSlot {...props} />);
 
 const AnyWidgetSlot = (props: IPluginProps<ModelIdRef, Data>) => {
-  const { jsUrl, jsHash } = props.data;
-  const { model_id: modelId } = props.value;
+  const { jsUrl, jsHash, modelId } = props.data;
   const host = props.host as HTMLElementNotDerivedFromRef;
 
   const { jsModule, error } = useAnyWidgetModule({ jsUrl, jsHash });

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
@@ -29,6 +29,7 @@ describe("LoadedSlot", () => {
     data: {
       jsUrl: "http://example.com/widget.js",
       jsHash: "abc123",
+      modelId: modelId,
     },
     host: document.createElement(
       "div",
@@ -64,6 +65,30 @@ describe("LoadedSlot", () => {
     // Wait a render
     await waitFor(() => {
       expect(mockWidget.render).toHaveBeenCalled();
+    });
+  });
+
+  it("should not remount when value update drops model_id", async () => {
+    // Regression: when the frontend sends a state update (e.g. {zoom_level: 0}),
+    // it overwrites the UIElement value that originally held {model_id: "..."}.
+    // The key must stay stable because modelId comes from data, not value.
+    const { container, rerender } = render(<LoadedSlot {...mockProps} />);
+
+    await waitFor(() => {
+      expect(mockWidget.render).toHaveBeenCalledTimes(1);
+    });
+
+    const divBefore = container.querySelector("div");
+
+    // Simulate a value update that does NOT include model_id
+    // (this is what happens when the widget sends trait state)
+    rerender(<LoadedSlot {...mockProps} />);
+
+    await waitFor(() => {
+      // The div should be the same DOM node (no remount)
+      expect(container.querySelector("div")).toBe(divBefore);
+      // render should not be called again (no remount)
+      expect(mockWidget.render).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/marimo/_output/formatters/repr_formatters.py
+++ b/marimo/_output/formatters/repr_formatters.py
@@ -59,11 +59,12 @@ def _maybe_as_anywidget_html(
 
     inner = build_ui_plugin(
         component_name="marimo-anywidget",
-        initial_value={"model_id": model_id},
+        initial_value={},
         label=None,
         args={
             "js-url": js_url,
             "js-hash": js_hash,
+            "model-id": model_id,
         },
     )
     # Wrap in <marimo-ui-element> so the plugin gets proper lifecycle

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -208,6 +208,7 @@ class anywidget(UIElement[ModelIdRef, AnyWidgetState]):
             args={
                 "js-url": mo_data.js(js).url if js else "",  # type: ignore [unused-ignore]  # noqa: E501
                 "js-hash": js_hash,
+                "model-id": model_id,
             },
             on_change=None,
         )


### PR DESCRIPTION
When a widget sends a state update from the frontend, the runtime calls `set_ui_element_value` with raw trait state (e.g. `{zoom_level: 0}`), which overwrites the UIElement value that originally held `{model_id: "..."}`. This was always happening but was harmless until 2a9f4b182 changed the React key from `randomId` (a stable DOM attribute) to `${jsHash}:${modelId}` — making it depend on the now-clobbered value. When `modelId` becomes `undefined`, the key changes, React remounts the component, and the widget flashes and disappears.

The fix moves `model_id` into the plugin's data attributes (`args`), which are immutable and unaffected by value updates.