### PR TITLE
feat: add __repr__, find(), and grep() to _CellsView and improve KeyError messages

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -248,14 +248,30 @@ class _CellsView:
     def __repr__(self) -> str:
         cells = self._doc.cells
         n = len(cells)
+        max_shown = 10
         lines = [f"CellsView({n} cell{'s' if n != 1 else ''}):"]
-        for i, c in enumerate(cells):
+
+        def _fmt(i: int, c: NotebookCell) -> str:
             first_line = c.code.split("\n", 1)[0]
             code_preview = first_line[:50]
             if len(first_line) > 50:
                 code_preview += "..."
             name_part = f" ({c.name})" if c.name else ""
-            lines.append(f"  [{i}] {c.id}{name_part} | {code_preview}")
+            return f"  [{i}] {c.id}{name_part} | {code_preview}"
+
+        if n <= max_shown:
+            for i, c in enumerate(cells):
+                lines.append(_fmt(i, c))
+        else:
+            for i, c in enumerate(cells[:max_shown]):
+                lines.append(_fmt(i, c))
+            omitted = n - max_shown - 1
+            if omitted > 0:
+                lines.append(
+                    f"  ... {omitted} more cell"
+                    f"{'s' if omitted != 1 else ''} ..."
+                )
+            lines.append(_fmt(n - 1, cells[-1]))
         return "\n".join(lines)
 
 

--- a/tests/_code_mode/test_cells_view.py
+++ b/tests/_code_mode/test_cells_view.py
@@ -258,6 +258,20 @@ class TestCellsViewRepr:
         v = _view([_cell("a", "x = 1")])
         assert str(v) == repr(v)
 
+    def test_repr_many_cells_truncated(self) -> None:
+        cells = [_cell(f"c{i}", f"x{i} = {i}") for i in range(15)]
+        v = _view(cells)
+        r = repr(v)
+        assert "CellsView(15 cells):" in r
+        # First 10 shown
+        assert "[9]" in r
+        # Last cell shown
+        assert "[14]" in r
+        # Middle omitted
+        assert "... 4 more cells ..." in r
+        # Cell 11 not individually shown
+        assert "[11]" not in r
+
 
 # ------------------------------------------------------------------
 # find()


### PR DESCRIPTION
- __repr__ prints a summary table (index, ID, name, first line of code)
- find(substring) returns cells whose code contains the substring
- grep(pattern) returns cells matching a regex pattern
- KeyError now lists available cell IDs and notes ID stability
