### PR TITLE
feat: add concise __repr__ to NotebookCell for better REPL discoverability

### DIFF
--- a/marimo/_messaging/notebook/document.py
+++ b/marimo/_messaging/notebook/document.py
@@ -55,6 +55,19 @@ class NotebookCell(msgspec.Struct):
     name: str
     config: CellConfig
 
+    def __repr__(self) -> str:
+        first_line = self.code.split("\n", 1)[0]
+        if len(first_line) > 80:
+            code_preview = first_line[:80] + "..."
+        elif "\n" in self.code:
+            code_preview = first_line + "..."
+        else:
+            code_preview = first_line
+        name_part = f", name={self.name!r}" if self.name else ""
+        return (
+            f"NotebookCell(id={self.id!r}{name_part}, code={code_preview!r})"
+        )
+
 
 class NotebookDocument:
     """Ordered collection of cells with transactional updates.

--- a/tests/_messaging/notebook/test_document.py
+++ b/tests/_messaging/notebook/test_document.py
@@ -533,6 +533,56 @@ class TestInit:
 
 
 # ------------------------------------------------------------------
+# NotebookCell.__repr__
+# ------------------------------------------------------------------
+
+
+class TestNotebookCellRepr:
+    def test_simple(self) -> None:
+        cell = NotebookCell(
+            id=CellId_t("abc"), code="x = 1", name="", config=CellConfig()
+        )
+        assert repr(cell) == "NotebookCell(id='abc', code='x = 1')"
+
+    def test_with_name(self) -> None:
+        cell = NotebookCell(
+            id=CellId_t("abc"),
+            code="x = 1",
+            name="my_cell",
+            config=CellConfig(),
+        )
+        assert repr(cell) == (
+            "NotebookCell(id='abc', name='my_cell', code='x = 1')"
+        )
+
+    def test_multiline_shows_first_line_with_ellipsis(self) -> None:
+        cell = NotebookCell(
+            id=CellId_t("a"),
+            code="line1\nline2\nline3",
+            name="",
+            config=CellConfig(),
+        )
+        r = repr(cell)
+        assert "line1..." in r
+        assert "line2" not in r
+
+    def test_long_first_line_truncated(self) -> None:
+        long_code = "x = " + "a" * 100
+        cell = NotebookCell(
+            id=CellId_t("a"), code=long_code, name="", config=CellConfig()
+        )
+        r = repr(cell)
+        assert "..." in r
+        assert long_code[:80] in r
+
+    def test_empty_code(self) -> None:
+        cell = NotebookCell(
+            id=CellId_t("a"), code="", name="", config=CellConfig()
+        )
+        assert repr(cell) == "NotebookCell(id='a', code='')"
+
+
+# ------------------------------------------------------------------
 # ReorderCells
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
NotebookCell's default msgspec repr dumped all fields including config,
making REPL exploration of ctx.cells painful. The new repr shows id,
name (when non-empty), and a truncated first line of code.
