### PR TITLE
fix: show which cell defines a variable in multiply-defined error

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -928,10 +928,14 @@ class AsyncCodeModeContext:
             )
             if new_multiply_defined:
                 # Show which existing cell(s) already define each name.
-                batch_ids = {op.cell_id for op in ops}
+                # Only exclude cells that were actually (re)registered
+                # during this dry run.  Moves and config-only updates
+                # do not register code, so their pre-existing
+                # definitions should still appear in the error details.
+                registered_ids = set(registered)
                 details: list[str] = []
                 for name in sorted(new_multiply_defined):
-                    existing = graph.get_defining_cells(name) - batch_ids
+                    existing = graph.get_defining_cells(name) - registered_ids
                     if existing:
                         labels = ", ".join(
                             self._cell_label(cid) for cid in sorted(existing)

--- a/tests/_code_mode/test_context.py
+++ b/tests/_code_mode/test_context.py
@@ -386,6 +386,22 @@ class TestCombined:
             assert "'x' is already defined in" in msg
             assert "'0'" in msg
 
+    async def test_multiply_defined_two_new_cells_in_batch(
+        self, k: Kernel
+    ) -> None:
+        """Two new cells in the same batch defining the same name."""
+
+        async def _create_conflicting_cells() -> None:
+            with _ctx(k) as ctx:
+                async with ctx as nb:
+                    nb.create_cell("y = 1")
+                    nb.create_cell("y = 2")
+
+        # No pre-existing cell owns 'y', so the name appears
+        # without an "already defined in" detail.
+        with pytest.raises(RuntimeError, match=r"'y'"):
+            await _create_conflicting_cells()
+
     async def test_noop_batch(self, k: Kernel) -> None:
         """An empty context manager does nothing."""
         await k.run([ExecuteCellCommand(cell_id=CellId_t("0"), code="x = 1")])


### PR DESCRIPTION
When code mode validation detects a multiply-defined name, the error
message now identifies the existing cell(s) that already define it,
making it actionable instead of requiring the user to search manually.
