### PR TITLE
fix: SVG data URL rendering in layout elements

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -343,6 +343,8 @@ def mime_to_html(mimetype: KnownMimeType, data: Any) -> Html:
         # when interpolating into markdown/a multiline string
         return Html(flatten_string(f"<span>{escape(data)}</span>"))
     elif mimetype == "image/svg+xml":
+        if isinstance(data, str) and data.startswith("data:image/svg+xml;"):
+            return Html(flatten_string(f'<img src="{data}" alt="" />'))
         return Html(data)
     elif mimetype.startswith("image"):
         return Html(flatten_string(f'<img src="{data}" alt="" />'))

--- a/tests/_output/formatters/test_matplotlib.py
+++ b/tests/_output/formatters/test_matplotlib.py
@@ -280,3 +280,42 @@ async def test_matplotlib_svg_rendering(
     assert mime_type == "image/svg+xml"
     assert isinstance(data, str)
     assert data.startswith("data:image/svg+xml;base64,PD94")
+
+
+@pytest.mark.skipif(not HAS_MPL, reason="optional dependencies not installed")
+async def test_matplotlib_svg_rendering_in_layout(
+    executing_kernel: Kernel, exec_req: ExecReqProvider
+) -> None:
+    """Test that the SVG output can be used in a layout."""
+    from marimo._output.formatters.formatters import register_formatters
+
+    register_formatters(theme="light")
+
+    await executing_kernel.run(
+        [
+            exec_req.get(
+                """
+                import marimo as mo
+                import matplotlib.pyplot as plt
+
+                fmt = plt.rcParams["savefig.format"]
+                plt.rcParams["savefig.format"] = "svg"
+
+                # Create a simple figure
+                fig, ax = plt.subplots(figsize=(4, 3))
+                ax.plot([1, 2, 3], [1, 2, 3])
+                result = mo.hstack([fig])._mime_()
+
+                plt.rcParams["savefig.format"] = fmt
+                """
+            )
+        ]
+    )
+
+    # Get the formatted result from kernel globals
+    mime_type, data = executing_kernel.globals["result"]
+
+    assert mime_type == "text/html"
+    assert isinstance(data, str)
+    assert data.startswith("<div")
+    assert '<img src="data:image/svg+xml;base64,' in data


### PR DESCRIPTION
## 📝 Summary

This PR fixes #9015 where SVG charts (from Altair, Matplotlib, or other sources) would render as raw Base64 strings instead of images when placed inside layout elements like `mo.vstack` or `mo.hstack`.

### Problem

Previously, marimo treated all `image/svg+xml` data as raw HTML. While this works for raw `<svg>` tags, it is incorrect for SVG Data URLs (`data:image/svg+xml;base64,...`). When a Data URL is wrapped in an `Html` object and inserted into a layout, the browser renders it as a plain text string rather than an image.

This issue was observed in:
- **Altair**: When `alt.renderers.enable("svg")` is used.
- **Matplotlib**: When `plt.rcParams["savefig.format"] = "svg"` is set.

### Solution

The fix involves updating `mime_to_html` in `marimo/_output/formatting.py` to distinguish between:
1. **Raw SVG text**: Continues to be returned as `Html` for inline rendering.
2. **SVG Data URLs**: Now wrapped in an `<img>` tag, ensuring they are rendered as images.

Since representing SVG as a Data URL is a valid and common practice, this approach is more robust than the previous assumption that all SVG data is raw HTML.

## Screenshots

- Before

<img width="450" src="https://github.com/user-attachments/assets/9f5a9ca4-10b8-45d3-b380-0fb1199af383" />

- After

<img width="380" src="https://github.com/user-attachments/assets/040df936-e732-4e96-934c-23ca02524c68" />

## Testing

- Added a new test case in `tests/_output/formatters/test_matplotlib.py` that specifically verifies Matplotlib's SVG output behaves correctly inside a marimo layout.



## 📋 Pre-Review Checklist

- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
