### PR TITLE
Fix duplicate word in OAuth2 example reference

### DIFF
--- a/docs/guides/deploying/authentication.md
+++ b/docs/guides/deploying/authentication.md
@@ -68,4 +68,4 @@ if __name__ == "__main__":
     uvicorn.run(app, host="localhost", port=8000)
 ```
 
-For for a full example on implementing OAuth2 with FastAPI, see the [FastAPI OAuth2 example](https://fastapi.tiangolo.com/tutorial/security/oauth2-jwt/).
+For a full example on implementing OAuth2 with FastAPI, see the [FastAPI OAuth2 example](https://fastapi.tiangolo.com/tutorial/security/oauth2-jwt/).


### PR DESCRIPTION
This pull request contains a minor fix to a documentation typo in `docs/guides/deploying/authentication.md`, correcting a duplicated word in a sentence.

- Fixed a typo by removing the repeated word "For" in the sentence referencing the FastAPI OAuth2 example.