### PR TITLE
Remove misplaced "AI-assisted coding" from Generate with AI sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,7 +112,6 @@ nav:
           - Generate with AI: guides/generate_with_ai/index.md
           - Skills: guides/generate_with_ai/skills.md
           - Generate entire notebooks: guides/generate_with_ai/text_to_notebook.md
-          - AI-assisted coding: guides/editor_features/ai_completion.md
           - Prompts: guides/generate_with_ai/prompts.md
           - Using Claude Code: guides/generate_with_ai/using_claude_code.md
       - Editor features:


### PR DESCRIPTION
## 📝 Summary
The "AI-assisted coding" page is currently listed under "Generate with AI" in the sidebar, but it belongs to the "Editor features" section.

This creates duplicate navigation and breaks logical grouping.

This PR removes the redundant entry from the "Generate with AI" section while keeping the page accessible under "Editor features".

Redundant link is shown in the image below
<img width="1906" height="837" alt="image" src="https://github.com/user-attachments/assets/3fc9a579-ad4e-4b0e-b448-779e9b11f6cd" />
