### PR TITLE
fix: resolve relative path sources in `--sandbox` uv export

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -202,7 +202,23 @@ def _uv_export_script_requirements_txt(
         capture_output=True,
         text=True,
     )
-    return result.stdout.split("\n")
+    lines = result.stdout.split("\n")
+
+    # uv export returns local paths relative to the script file, but these
+    # lines get written to a temp requirements file consumed by
+    # `uv run --with-requirements`, which resolves relative paths from CWD.
+    # Convert relative paths to absolute using the script's directory as base.
+    # Applies to both editable (-e ../../) and non-editable (../../) sources.
+    script_dir = Path(name).resolve().parent
+    resolved = []
+    for line in lines:
+        editable = line.startswith("-e ")
+        path = line[3:].strip() if editable else line.strip()
+        if path.startswith("."):
+            path = str((script_dir / path).resolve())
+        prefix = "-e " if editable else ""
+        resolved.append(f"{prefix}{path}")
+    return resolved
 
 
 def _resolve_requirements_txt_lines(pyproject: PyProjectReader) -> list[str]:

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -182,6 +182,22 @@ def _normalize_sandbox_dependencies(
     return filtered + [include_features(chosen, additional_features)]
 
 
+def _resolve_local_path_line(line: str, script_dir: Path) -> str:
+    """Resolve a relative local-path requirement to an absolute path.
+
+    >>> _resolve_local_path_line("-e ../pkg ; py<'3.12' # via foo", Path("/a/b"))
+    '-e /a/pkg ; py<\\'3.12\\' # via foo'
+    """
+    rest = line[3:] if line.startswith("-e ") else line
+    path_and_comment, _, _ = rest.partition(";")
+    path_token, _, _ = path_and_comment.partition(" #")
+    path_token = path_token.rstrip()
+    if not path_token.startswith("."):
+        return line
+    resolved = str((script_dir / path_token).resolve())
+    return line.replace(path_token, resolved, 1)
+
+
 def _uv_export_script_requirements_txt(
     name: str | None,
 ) -> list[str]:
@@ -202,41 +218,11 @@ def _uv_export_script_requirements_txt(
         capture_output=True,
         text=True,
     )
-    lines = result.stdout.split("\n")
-
-    # uv export returns local paths relative to the script file, but these
-    # lines get written to a temp requirements file consumed by
-    # `uv run --with-requirements`, which resolves relative paths from CWD.
-    # Convert relative paths to absolute using the script's directory as base.
-    # Applies to both editable (-e ../../) and non-editable (../../) sources.
     script_dir = Path(name).resolve().parent
-    resolved = []
-    for line in lines:
-        editable = line.startswith("-e ")
-        rest = line[3:].strip() if editable else line.strip()
-        # Split off any environment markers ("; ...") or inline comments ("# ...")
-        # so we only resolve the path token itself.
-        # Preserve the original separator exactly. Environment markers
-        # may appear without a leading space (e.g. ;python_version<"3.12").
-        # Inline comments must be preceded by whitespace to be valid.
-        marker_idx = rest.find(";")
-        comment_idx = -1
-        for i, char in enumerate(rest):
-            if char == "#" and i > 0 and rest[i - 1].isspace():
-                comment_idx = i
-                break
-        split_points = [idx for idx in (marker_idx, comment_idx) if idx != -1]
-        if split_points:
-            split_idx = min(split_points)
-            path_token = rest[:split_idx]
-            remainder = rest[split_idx:]
-        else:
-            path_token, remainder = rest, ""
-        if path_token.startswith("."):
-            path_token = str((script_dir / path_token).resolve())
-        prefix = "-e " if editable else ""
-        resolved.append(f"{prefix}{path_token}{remainder}")
-    return resolved
+    return [
+        _resolve_local_path_line(line, script_dir)
+        for line in result.stdout.split("\n")
+    ]
 
 
 def _resolve_requirements_txt_lines(pyproject: PyProjectReader) -> list[str]:

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -185,10 +185,12 @@ def _normalize_sandbox_dependencies(
 def _resolve_local_path_line(line: str, script_dir: Path) -> str:
     """Resolve a relative local-path requirement to an absolute path.
 
-    >>> _resolve_local_path_line("-e ../pkg ; py<'3.12' # via foo", Path("/a/b"))
+    >>> _resolve_local_path_line(
+    ...     "-e ../pkg ; py<'3.12' # via foo", Path("/a/b")
+    ... )
     '-e /a/pkg ; py<\\'3.12\\' # via foo'
     """
-    rest = line[3:] if line.startswith("-e ") else line
+    rest = line.removeprefix("-e ")
     path_and_comment, _, _ = rest.partition(";")
     path_token, _, _ = path_and_comment.partition(" #")
     path_token = path_token.rstrip()

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -213,11 +213,20 @@ def _uv_export_script_requirements_txt(
     resolved = []
     for line in lines:
         editable = line.startswith("-e ")
-        path = line[3:].strip() if editable else line.strip()
-        if path.startswith("."):
-            path = str((script_dir / path).resolve())
+        rest = line[3:].strip() if editable else line.strip()
+        # Split off any environment markers ("; ...") or inline comments ("# ...")
+        # so we only resolve the path token itself.
+        for sep in (" ;", " #"):
+            if sep in rest:
+                path_token, remainder = rest.split(sep, 1)
+                remainder = sep.lstrip() + remainder
+                break
+        else:
+            path_token, remainder = rest, ""
+        if path_token.startswith("."):
+            path_token = str((script_dir / path_token).resolve())
         prefix = "-e " if editable else ""
-        resolved.append(f"{prefix}{path}")
+        resolved.append(f"{prefix}{path_token}{remainder}")
     return resolved
 
 

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -216,11 +216,20 @@ def _uv_export_script_requirements_txt(
         rest = line[3:].strip() if editable else line.strip()
         # Split off any environment markers ("; ...") or inline comments ("# ...")
         # so we only resolve the path token itself.
-        for sep in (" ;", " #"):
-            if sep in rest:
-                path_token, remainder = rest.split(sep, 1)
-                remainder = sep.lstrip() + remainder
+        # Preserve the original separator exactly. Environment markers
+        # may appear without a leading space (e.g. ;python_version<"3.12").
+        # Inline comments must be preceded by whitespace to be valid.
+        marker_idx = rest.find(";")
+        comment_idx = -1
+        for i, char in enumerate(rest):
+            if char == "#" and i > 0 and rest[i - 1].isspace():
+                comment_idx = i
                 break
+        split_points = [idx for idx in (marker_idx, comment_idx) if idx != -1]
+        if split_points:
+            split_idx = min(split_points)
+            path_token = rest[:split_idx]
+            remainder = rest[split_idx:]
         else:
             path_token, remainder = rest, ""
         if path_token.startswith("."):

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 from unittest.mock import patch
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 import pytest
 
@@ -847,56 +845,30 @@ def test_build_sandbox_venv_with_additional_deps(tmp_path: Path) -> None:
         cleanup_sandbox_dir(sandbox_dir)
 
 
-def test_uv_export_script_requirements_txt_resolves_relative_paths(
-    tmp_path: Path,
-) -> None:
-    """Test that relative paths in uv export output are resolved to absolute paths.
+def test_resolve_local_path_line() -> None:
+    from marimo._cli.sandbox import _resolve_local_path_line
 
-    Regression test for https://github.com/marimo-team/marimo/issues/8980.
-    uv export returns paths relative to the script file, but these get written
-    to a temp requirements file where uv resolves them relative to CWD instead.
-    """
-    from unittest.mock import MagicMock, patch
+    d = Path("/project/notebooks")
+    _r = lambda p: str((d / p).resolve())  # noqa: E731
 
-    from marimo._cli.sandbox import _uv_export_script_requirements_txt
-
-    script_path = tmp_path / "subdir" / "notebook.py"
-    script_path.parent.mkdir(parents=True)
-    script_path.write_text("# placeholder")
-
-    mock_result = MagicMock()
-    mock_result.stdout = (
-        "-e ../../\n"
-        "../other_pkg\n"
-        "../pkg_with_marker ; python_version<'3.12'\n"
-        "numpy==1.26.0\n"
-        "/absolute/path\n"
-        "\n"
-    )
-
-    with patch("marimo._cli.sandbox.subprocess.run", return_value=mock_result):
-        lines = _uv_export_script_requirements_txt(str(script_path))
-
-    script_dir = script_path.resolve().parent
-    expected_editable = str((script_dir / "../../").resolve())
-    expected_non_editable = str((script_dir / "../other_pkg").resolve())
-
-    # Editable relative path resolved to absolute
-    assert any(
-        line.startswith("-e ") and expected_editable in line for line in lines
-    )
-    # Non-editable relative path resolved to absolute
-    assert any(
-        expected_non_editable in line and not line.startswith("-e ")
-        for line in lines
-    )
-    # Relative path with environment marker: path resolved, marker preserved
-    expected_marker_path = str((script_dir / "../pkg_with_marker").resolve())
-    assert any(
-        expected_marker_path in line and "python_version<'3.12'" in line
-        for line in lines
-    )
-    # Regular dep unchanged
-    assert any("numpy==1.26.0" in line for line in lines)
-    # Absolute path unchanged
-    assert any("/absolute/path" in line for line in lines)
+    # Plain relative
+    assert _resolve_local_path_line("../../mylib", d) == _r("../../mylib")
+    # Editable
+    assert _resolve_local_path_line("-e ../pkg", d) == f"-e {_r('../pkg')}"
+    # Env marker
+    result = _resolve_local_path_line("../pkg ; py<'3.12'", d)
+    assert _r("../pkg") in result and "py<'3.12'" in result
+    # Inline comment
+    result = _resolve_local_path_line("../pkg # via foo", d)
+    assert _r("../pkg") in result and "# via foo" in result
+    # Both marker and comment
+    result = _resolve_local_path_line("../pkg ; py<'3.12' # via foo", d)
+    assert _r("../pkg") in result
+    assert "py<'3.12'" in result
+    assert "# via foo" in result
+    # Spaces in path
+    assert _r("../my lib") in _resolve_local_path_line("../my lib", d)
+    # Non-relative unchanged
+    assert _resolve_local_path_line("numpy==1.26.0", d) == "numpy==1.26.0"
+    assert _resolve_local_path_line("/absolute/path", d) == "/absolute/path"
+    assert _resolve_local_path_line("", d) == ""

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -857,6 +857,7 @@ def test_uv_export_script_requirements_txt_resolves_relative_paths(
     to a temp requirements file where uv resolves them relative to CWD instead.
     """
     from unittest.mock import MagicMock, patch
+
     from marimo._cli.sandbox import _uv_export_script_requirements_txt
 
     script_path = tmp_path / "subdir" / "notebook.py"
@@ -864,7 +865,9 @@ def test_uv_export_script_requirements_txt_resolves_relative_paths(
     script_path.write_text("# placeholder")
 
     mock_result = MagicMock()
-    mock_result.stdout = "-e ../../\n../other_pkg\nnumpy==1.26.0\n/absolute/path\n\n"
+    mock_result.stdout = (
+        "-e ../../\n../other_pkg\nnumpy==1.26.0\n/absolute/path\n\n"
+    )
 
     with patch("subprocess.run", return_value=mock_result):
         lines = _uv_export_script_requirements_txt(str(script_path))
@@ -874,10 +877,15 @@ def test_uv_export_script_requirements_txt_resolves_relative_paths(
     expected_non_editable = str((script_dir / "../other_pkg").resolve())
 
     # Editable relative path resolved to absolute
-    assert any(l.startswith("-e ") and expected_editable in l for l in lines)
+    assert any(
+        line.startswith("-e ") and expected_editable in line for line in lines
+    )
     # Non-editable relative path resolved to absolute
-    assert any(expected_non_editable in l and not l.startswith("-e ") for l in lines)
+    assert any(
+        expected_non_editable in line and not line.startswith("-e ")
+        for line in lines
+    )
     # Regular dep unchanged
-    assert any("numpy==1.26.0" in l for l in lines)
+    assert any("numpy==1.26.0" in line for line in lines)
     # Absolute path unchanged
-    assert any("/absolute/path" in l for l in lines)
+    assert any("/absolute/path" in line for line in lines)

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -857,10 +857,12 @@ def test_resolve_local_path_line() -> None:
     assert _resolve_local_path_line("-e ../pkg", d) == f"-e {_r('../pkg')}"
     # Env marker
     result = _resolve_local_path_line("../pkg ; py<'3.12'", d)
-    assert _r("../pkg") in result and "py<'3.12'" in result
+    assert _r("../pkg") in result
+    assert "py<'3.12'" in result
     # Inline comment
     result = _resolve_local_path_line("../pkg # via foo", d)
-    assert _r("../pkg") in result and "# via foo" in result
+    assert _r("../pkg") in result
+    assert "# via foo" in result
     # Both marker and comment
     result = _resolve_local_path_line("../pkg ; py<'3.12' # via foo", d)
     assert _r("../pkg") in result

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -866,10 +866,15 @@ def test_uv_export_script_requirements_txt_resolves_relative_paths(
 
     mock_result = MagicMock()
     mock_result.stdout = (
-        "-e ../../\n../other_pkg\nnumpy==1.26.0\n/absolute/path\n\n"
+        "-e ../../\n"
+        "../other_pkg\n"
+        "../pkg_with_marker ; python_version<'3.12'\n"
+        "numpy==1.26.0\n"
+        "/absolute/path\n"
+        "\n"
     )
 
-    with patch("subprocess.run", return_value=mock_result):
+    with patch("marimo._cli.sandbox.subprocess.run", return_value=mock_result):
         lines = _uv_export_script_requirements_txt(str(script_path))
 
     script_dir = script_path.resolve().parent
@@ -883,6 +888,12 @@ def test_uv_export_script_requirements_txt_resolves_relative_paths(
     # Non-editable relative path resolved to absolute
     assert any(
         expected_non_editable in line and not line.startswith("-e ")
+        for line in lines
+    )
+    # Relative path with environment marker: path resolved, marker preserved
+    expected_marker_path = str((script_dir / "../pkg_with_marker").resolve())
+    assert any(
+        expected_marker_path in line and "python_version<'3.12'" in line
         for line in lines
     )
     # Regular dep unchanged

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -845,3 +845,39 @@ def test_build_sandbox_venv_with_additional_deps(tmp_path: Path) -> None:
         assert os.path.exists(venv_python)
     finally:
         cleanup_sandbox_dir(sandbox_dir)
+
+
+def test_uv_export_script_requirements_txt_resolves_relative_paths(
+    tmp_path: Path,
+) -> None:
+    """Test that relative paths in uv export output are resolved to absolute paths.
+
+    Regression test for https://github.com/marimo-team/marimo/issues/8980.
+    uv export returns paths relative to the script file, but these get written
+    to a temp requirements file where uv resolves them relative to CWD instead.
+    """
+    from unittest.mock import MagicMock, patch
+    from marimo._cli.sandbox import _uv_export_script_requirements_txt
+
+    script_path = tmp_path / "subdir" / "notebook.py"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text("# placeholder")
+
+    mock_result = MagicMock()
+    mock_result.stdout = "-e ../../\n../other_pkg\nnumpy==1.26.0\n/absolute/path\n\n"
+
+    with patch("subprocess.run", return_value=mock_result):
+        lines = _uv_export_script_requirements_txt(str(script_path))
+
+    script_dir = script_path.resolve().parent
+    expected_editable = str((script_dir / "../../").resolve())
+    expected_non_editable = str((script_dir / "../other_pkg").resolve())
+
+    # Editable relative path resolved to absolute
+    assert any(l.startswith("-e ") and expected_editable in l for l in lines)
+    # Non-editable relative path resolved to absolute
+    assert any(expected_non_editable in l and not l.startswith("-e ") for l in lines)
+    # Regular dep unchanged
+    assert any("numpy==1.26.0" in l for l in lines)
+    # Absolute path unchanged
+    assert any("/absolute/path" in l for l in lines)


### PR DESCRIPTION
Fixes #8980

## Problem
`marimo edit --sandbox` fails when a script's inline metadata uses relative `path` sources in `[tool.uv.sources]`. `uv export --script` returns paths relative to the script file, but those lines get written to a temp requirements file. When `uv run --with-requirements` processes that file, it resolves paths relative to CWD - not the script's directory - causing path resolution failures.

## Fix
In `_uv_export_script_requirements_txt` (`marimo/_cli/sandbox.py`), convert any relative paths (`.`-prefixed) to absolute paths using the script's parent directory as the base. Handles both editable (`-e ../../`) and non-editable (`../../`) path sources. Non-path deps and already-absolute paths are left unchanged.

## Test
Added `test_uv_export_script_requirements_txt_resolves_relative_paths` covering:
- Editable relative paths (`-e ../../`) → resolved to absolute
- Non-editable relative paths (`../other_pkg`) → resolved to absolute
- Regular deps (`numpy==1.26.0`) → unchanged
- Already-absolute paths → unchanged