### PR TITLE
ci: handle print code test case failure

### DIFF
--- a/tests/_plugins/ui/_impl/dataframes/test_print_code.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_print_code.py
@@ -497,10 +497,12 @@ def test_print_code_result_matches_actual_transform_pandas(
             ]
             if sortable_cols:
                 code_result = code_result.sort_values(
-                    by=sortable_cols
+                    by=sortable_cols,
+                    key=lambda col: col.astype(str),
                 ).reset_index(drop=True)
                 real_result = real_result.sort_values(
-                    by=sortable_cols
+                    by=sortable_cols,
+                    key=lambda col: col.astype(str),
                 ).reset_index(drop=True)
 
         pd.testing.assert_frame_equal(code_result, real_result)


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
This sort function is only called in tests hence the fix is test fix.

- Fix TypeError: '<' not supported between instances of 'str' and 'float' in test_print_code_result_matches_actual_transform_pandas
- The test's sort_values() call (used to compare group_by results in a stable order) fails when sorting columns with mixed types (e.g. [1, 2.0, "3"])
- Use key=lambda col: col.astype(str) to sort by string representation, which handles mixed types safely

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
