### PR TITLE
Use MarimoPlusIcon for "New notebook" action

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -17,7 +17,6 @@ import {
   EyeOffIcon,
   FastForwardIcon,
   FileIcon,
-  FilePlus2Icon,
   Files,
   FileTextIcon,
   FolderDownIcon,
@@ -44,6 +43,7 @@ import {
 } from "lucide-react";
 import { settingDialogAtom } from "@/components/app-config/state";
 import { MarkdownIcon } from "@/components/editor/cell/code/icons";
+import { MarimoPlusIcon } from "@/components/icons/marimo-icons";
 import { useImperativeModal } from "@/components/modal/ImperativeModal";
 import { renderShortcut } from "@/components/shortcuts/renderShortcut";
 import { PairWithAgentModal } from "@/components/editor/actions/pair-with-agent-modal";
@@ -640,7 +640,7 @@ export function useNotebookActions() {
     },
 
     {
-      icon: <FilePlus2Icon size={14} strokeWidth={1.5} />,
+      icon: <MarimoPlusIcon size={14} strokeWidth={1.5} />,
       label: "New notebook",
       // If file is in the url, then we ran `marimo edit`
       // without a specific file


### PR DESCRIPTION
## 📝 Summary

This is a follow-up to PR #8471.

Currently, the "New notebook" action in the `useNotebookActions` menu uses the generic `FilePlus2Icon`. However, in the File Explorer, we use the custom `MarimoPlusIcon` for notebook creation tasks.

This PR updates the icon in `useNotebookActions.tsx` to use `MarimoPlusIcon` to ensure visual consistency across the application's UI.

## Changes

- Modified `frontend/src/components/editor/actions/useNotebookActions.tsx`:
  - Replaced `FilePlus2Icon` with `MarimoPlusIcon` for the "New notebook" menu item.
  - Added import for `MarimoPlusIcon` from `@/components/icons/marimo-icons`.

## Motivation

- **Visual Consistency**: Aligning the icons used for notebook creation throughout the app.
- **Brand Identity**: Using the marimo-branded icon reinforces that this action creates a native marimo notebook.

<img width="500" src="https://github.com/user-attachments/assets/9f959e1a-6f0c-42a0-a9f3-f99641cf18ea" />


## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
