### PR TITLE
fix: sanitize traceback HTML to prevent XSS

### DIFF
--- a/frontend/src/components/editor/errors/traceback-modal.tsx
+++ b/frontend/src/components/editor/errors/traceback-modal.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { CopyIcon } from "lucide-react";
 import { toast } from "@/components/ui/use-toast";
+import { renderHTML } from "@/plugins/core/RenderHTML";
+import { sanitizeHtml } from "@/plugins/core/sanitize-html";
 
 interface TracebackModalProps {
   isOpen: boolean;
@@ -29,7 +31,7 @@ export const TracebackModal: React.FC<TracebackModalProps> = ({
   const handleCopy = async () => {
     // Strip HTML tags for clipboard
     const tempDiv = document.createElement("div");
-    tempDiv.innerHTML = traceback;
+    tempDiv.innerHTML = sanitizeHtml(traceback);
     const textContent = tempDiv.textContent || tempDiv.innerText || "";
 
     try {
@@ -73,10 +75,9 @@ export const TracebackModal: React.FC<TracebackModalProps> = ({
               Copy
             </Button>
           </div>
-          <div
-            className="font-code text-sm p-4 bg-muted rounded border overflow-auto max-h-[50vh] cursor-text select-text"
-            dangerouslySetInnerHTML={{ __html: traceback }}
-          />
+          <div className="font-code text-sm p-4 bg-muted rounded border overflow-auto max-h-[50vh] cursor-text select-text">
+            {renderHTML({ html: traceback })}
+          </div>
         </div>
         <AlertDialogFooter>
           <AlertDialogAction onClick={onClose}>Close</AlertDialogAction>

--- a/frontend/src/components/editor/output/MarimoErrorOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoErrorOutput.tsx
@@ -25,6 +25,7 @@ import { useChromeActions } from "../chrome/state";
 import { AutoFixButton } from "../errors/auto-fix";
 import { CellLinkError } from "../links/cell-link";
 import { processTextForUrls } from "./console/text-rendering";
+import { renderHTML } from "@/plugins/core/RenderHTML";
 
 const Tip = (props: {
   title?: string;
@@ -486,13 +487,9 @@ export const MarimoErrorOutput = ({
                       {processTextForUrls(error.msg, `exception-${idx}`)}
                     </p>
                     {"traceback" in error && error.traceback ? (
-                      <div
-                        className="font-code text-sm mt-2 p-3 bg-muted rounded border overflow-auto max-h-[50vh] cursor-text select-text"
-                        // biome-ignore lint/security/noDangerouslySetInnerHtml: traceback from backend
-                        dangerouslySetInnerHTML={{
-                          __html: error.traceback,
-                        }}
-                      />
+                      <div className="font-code text-sm mt-2 p-3 bg-muted rounded border overflow-auto max-h-[50vh] cursor-text select-text">
+                        {renderHTML({ html: error.traceback })}
+                      </div>
                     ) : (
                       <div className="text-muted-foreground mt-2">
                         See the console area for a traceback.
@@ -504,13 +501,9 @@ export const MarimoErrorOutput = ({
                     {processTextForUrls(error.msg, `exception-${idx}`)}
                     <CellLinkError cellId={error.raising_cell} />
                     {"traceback" in error && error.traceback && (
-                      <div
-                        className="font-code text-sm mt-2 p-3 bg-muted rounded border overflow-auto max-h-[50vh] cursor-text select-text"
-                        // biome-ignore lint/security/noDangerouslySetInnerHtml: traceback from backend
-                        dangerouslySetInnerHTML={{
-                          __html: error.traceback,
-                        }}
-                      />
+                      <div className="font-code text-sm mt-2 p-3 bg-muted rounded border overflow-auto max-h-[50vh] cursor-text select-text">
+                        {renderHTML({ html: error.traceback })}
+                      </div>
                     )}
                   </div>
                 )}

--- a/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
@@ -34,6 +34,7 @@ import { getRequestClient } from "@/core/network/requests";
 import { isStaticNotebook } from "@/core/static/static-state";
 import { isWasm } from "@/core/wasm/utils";
 import { renderHTML } from "@/plugins/core/RenderHTML";
+import { sanitizeHtml } from "@/plugins/core/sanitize-html";
 import { copyToClipboard } from "@/utils/copy";
 import {
   elementContainsMarimoCellFile,
@@ -173,9 +174,9 @@ export const MarimoTracebackOutput = ({
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => {
-                  // Strip HTML from the traceback
+                  // Strip HTML from the traceback (sanitize first to prevent XSS)
                   const div = document.createElement("div");
-                  div.innerHTML = traceback;
+                  div.innerHTML = sanitizeHtml(traceback);
                   const textContent = div.textContent || "";
                   copyToClipboard(textContent);
                 }}
@@ -193,7 +194,7 @@ export const MarimoTracebackOutput = ({
 
 function lastLine(text: string): string {
   const el = document.createElement("div");
-  el.innerHTML = text;
+  el.innerHTML = sanitizeHtml(text);
   const lines = el.textContent?.split("\n").filter(Boolean);
   return lines?.at(-1) || "";
 }


### PR DESCRIPTION
Use renderHTML (which sanitizes via DOMPurify by default) instead of dangerouslySetInnerHTML for traceback rendering in traceback-modal and MarimoErrorOutput. Also sanitize innerHTML assignments used for text extraction in MarimoTracebackOutput and traceback-modal copy handlers.
