### PR TITLE
fix: re-encode WebSocket proxy query params so spaces use %20 (#9041)

### DIFF
--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -14,7 +14,7 @@ from typing import (
     Optional,
     Union,
 )
-from urllib.parse import quote, unquote_plus, urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 import starlette.status as status
 from starlette.authentication import (
@@ -511,12 +511,11 @@ class ProxyMiddleware:
         try:
             original_params = websocket.query_params
             if original_params:
-                # Re-encode query params: Starlette may decode spaces as '+'
-                # (application/x-www-form-urlencoded), but upstream servers
-                # like python-lsp-server expect percent-encoded (%20) values.
+                # Re-encode query params from Starlette's already-decoded
+                # values so spaces become %20 while preserving literal plus
+                # signs instead of incorrectly treating them as spaces.
                 encoded_params = [
-                    (k, quote(unquote_plus(v)))
-                    for k, v in original_params.items()
+                    (k, quote(v)) for k, v in original_params.items()
                 ]
                 ws_url = f"{ws_url}?{'&'.join(f'{k}={v}' for k, v in encoded_params)}"
             await websocket.accept()

--- a/tests/_server/api/test_middleware.py
+++ b/tests/_server/api/test_middleware.py
@@ -662,14 +662,14 @@ class TestProxyMiddleware:
         python-lsp-server expect percent-encoding (%20).
         See: https://github.com/marimo-team/marimo/issues/9041
         """
-        from urllib.parse import quote, unquote_plus
+        from urllib.parse import quote
 
         from starlette.datastructures import QueryParams
 
         def _encode_params(query_string: bytes) -> str:
             """Reproduce the encoding logic from _proxy_websocket."""
             params = QueryParams(query_string.decode())
-            encoded = [(k, quote(unquote_plus(v))) for k, v in params.items()]
+            encoded = [(k, quote(v)) for k, v in params.items()]
             return "&".join(f"{k}={v}" for k, v in encoded)
 
         # '+' in query string should be converted to %20
@@ -687,6 +687,10 @@ class TestProxyMiddleware:
         # Path-like values: slashes are preserved (quote's default safe='/')
         result = _encode_params(b"file=/path/to/my+file.py")
         assert result == "file=/path/to/my%20file.py"
+
+        # Literal plus signs (%2B) should be preserved, not turned into spaces
+        result = _encode_params(b"file=a%2Bb.py")
+        assert result == "file=a%2Bb.py"
 
 
 def _mock_lsp_server(server_id: str, port: int):


### PR DESCRIPTION
Filenames with spaces failed LSP connections because Starlette decodes query-string spaces as '+' (form-urlencoded) while python-lsp-server expects percent-encoding (%20). Apply unquote_plus → quote on forwarded query params to normalize the encoding.
