### PR TITLE
fix: clear warning registry before cell execution to prevent suppressed warnings

### DIFF
--- a/marimo/_runtime/executor.py
+++ b/marimo/_runtime/executor.py
@@ -98,6 +98,17 @@ class Executor(ABC):
 
 
 class DefaultExecutor(Executor):
+    @staticmethod
+    def _clear_warning_registry(glbls: dict[str, Any]) -> None:
+        """Clear the warning registry so warnings are shown on every run.
+
+        Python's warnings module stores a ``__warningregistry__`` dict in the
+        caller's global namespace to suppress duplicate warnings.  Because
+        marimo re-executes cells in the same globals dict, previously-seen
+        warnings would be silently suppressed on subsequent runs.
+        """
+        glbls.pop("__warningregistry__", None)
+
     async def execute_cell_async(
         self,
         cell: CellImpl,
@@ -107,6 +118,7 @@ class DefaultExecutor(Executor):
         if cell.body is None:
             return None
         assert cell.last_expr is not None
+        self._clear_warning_registry(glbls)
         try:
             if _is_coroutine(cell.body):
                 await eval(cell.body, glbls)
@@ -130,6 +142,7 @@ class DefaultExecutor(Executor):
         glbls: dict[str, Any],
         graph: DirectedGraph | None = None,
     ) -> Any:
+        self._clear_warning_registry(glbls)
         try:
             if cell.body is None:
                 return None

--- a/tests/_runtime/runner/test_cell_runner.py
+++ b/tests/_runtime/runner/test_cell_runner.py
@@ -259,7 +259,9 @@ async def test_warnings_persist_across_reruns(
     # The cell's snapshot should contain no warning entries.
     await runner.run(er.cell_id)
     snapshot = k.globals["registry_snapshot"]
-    warning_entries = {k: v for k, v in snapshot.items() if k != "version"}
+    warning_entries = {
+        key: val for key, val in snapshot.items() if key != "version"
+    }
     assert warning_entries == {}, (
         f"__warningregistry__ was not cleared before cell re-execution: "
         f"{warning_entries}"

--- a/tests/_runtime/runner/test_cell_runner.py
+++ b/tests/_runtime/runner/test_cell_runner.py
@@ -210,6 +210,62 @@ async def test_ui_element_update_skips_overridden_cells(
     assert embed_result.defs["x"] == 100
 
 
+async def test_warnings_persist_across_reruns(
+    execution_kernel: Kernel, exec_req: ExecReqProvider
+) -> None:
+    """Warnings should appear on every cell run, not just the first.
+
+    Regression test for https://github.com/marimo-team/marimo/issues/4821
+
+    Python's default warning filter records shown warnings in
+    ``__warningregistry__`` (stored in the caller's globals) and suppresses
+    duplicates.  Because marimo re-executes cells in the same globals dict,
+    previously-seen warnings would be silently swallowed on subsequent runs
+    unless the registry is cleared before each execution.
+
+    The cell captures a snapshot of ``__warningregistry__`` at the start of
+    execution. If the executor properly clears the registry, the snapshot
+    should contain no warning entries (only the ``version`` key at most).
+    """
+    k = execution_kernel
+    # The cell records the registry state at the start of execution, then
+    # emits a warning (which populates the registry for the next run).
+    await k.run(
+        [
+            er := exec_req.get(
+                """
+                import warnings
+                registry_snapshot = dict(
+                    globals().get("__warningregistry__", {})
+                )
+                warnings.warn("test warning", UserWarning)
+                """
+            )
+        ]
+    )
+
+    runner = Runner(
+        roots=set(k.graph.cells.keys()),
+        graph=k.graph,
+        glbls=k.globals,
+        debugger=k.debugger,
+        hooks=NotebookCellHooks(),
+    )
+
+    # First run: populates the registry
+    await runner.run(er.cell_id)
+
+    # Second run: the executor should have cleared the registry before exec.
+    # The cell's snapshot should contain no warning entries.
+    await runner.run(er.cell_id)
+    snapshot = k.globals["registry_snapshot"]
+    warning_entries = {k: v for k, v in snapshot.items() if k != "version"}
+    assert warning_entries == {}, (
+        f"__warningregistry__ was not cleared before cell re-execution: "
+        f"{warning_entries}"
+    )
+
+
 async def test_converging_cell_stays_stopped_until_all_branches_trigger(
     k: Kernel, exec_req: ExecReqProvider
 ) -> None:


### PR DESCRIPTION
Python's default warning filter records shown warnings in `__warningregistry__` (stored in the caller's globals dict) and suppresses duplicates. Because marimo re-executes cells in the same globals dict, the registry accumulated entries and caused warnings to disappear on subsequent cell runs.

Clear `__warningregistry__` before each cell execution in `DefaultExecutor`.

Closes #4821
