### PR TITLE
fix: Tab in AI chat triggers autocomplete instead of indenting (#5718)

### DIFF
--- a/frontend/src/core/codemirror/ai/resources.ts
+++ b/frontend/src/core/codemirror/ai/resources.ts
@@ -72,6 +72,7 @@ export function resourceExtension(opts: {
       keymap.of([
         {
           key: "Tab",
+          preventDefault: true,
           run: (view: EditorView) => {
             return acceptCompletion(view);
           },


### PR DESCRIPTION
The Tab keymap entry in the chat input's resource extension was missing `preventDefault: true`, so the browser/CodeMirror default Tab behavior (indentation) fired even when the autocomplete handler ran.

Closes #5718

