### PR TITLE
improvement: add cross-origin authentication token handling for WebSocket URLs

### DIFF
--- a/frontend/src/core/runtime/__tests__/runtime.test.ts
+++ b/frontend/src/core/runtime/__tests__/runtime.test.ts
@@ -185,12 +185,52 @@ describe("RuntimeManager", () => {
       expect(url.pathname).toBe("/lsp/pylsp");
     });
 
-    it("should return copilot URL", () => {
-      const runtime = new RuntimeManager(mockConfig);
+    it("should return copilot URL without non-auth query params", () => {
+      const runtime = new RuntimeManager({
+        url: "https://example.com?foo=bar&baz=qux",
+        lazy: true,
+      });
       const url = runtime.getLSPURL("copilot");
 
       expect(url.protocol).toBe("wss:");
       expect(url.pathname).toBe("/lsp/copilot");
+      expect(url.searchParams.get("foo")).toBeNull();
+      expect(url.searchParams.get("baz")).toBeNull();
+    });
+
+    it("should preserve access_token on copilot URL when cross-origin", () => {
+      const runtime = new RuntimeManager(
+        {
+          url: "https://sandbox.example.com?foo=bar",
+          lazy: true,
+          authToken: "my-secret-token",
+        },
+        true,
+      );
+      const url = runtime.getLSPURL("copilot");
+
+      expect(url.protocol).toBe("wss:");
+      expect(url.pathname).toBe("/lsp/copilot");
+      expect(url.searchParams.get("access_token")).toBe("my-secret-token");
+      // Other params should be stripped
+      expect(url.searchParams.get("foo")).toBeNull();
+    });
+
+    it("should not have access_token on copilot URL when same-origin", () => {
+      const runtime = new RuntimeManager(
+        {
+          url: window.location.origin,
+          lazy: true,
+          authToken: "my-secret-token",
+        },
+        true,
+      );
+      const url = runtime.getLSPURL("copilot");
+
+      expect(url.protocol).toBe("ws:");
+      expect(url.pathname).toBe("/lsp/copilot");
+      expect(url.searchParams.get("access_token")).toBeNull();
+      expect(url.search).toBe("");
     });
   });
 

--- a/frontend/src/core/runtime/runtime.ts
+++ b/frontend/src/core/runtime/runtime.ts
@@ -152,9 +152,15 @@ export class RuntimeManager {
    */
   getLSPURL(lsp: "pylsp" | "basedpyright" | "copilot" | "ty" | "pyrefly"): URL {
     if (lsp === "copilot") {
-      // For copilot, don't include any query parameters
+      // For copilot, strip all query parameters except the auth token.
+      // Copilot doesn't understand arbitrary query params, but we still
+      // need access_token for cross-origin authentication.
       const url = this.formatWsURL(`/lsp/${lsp}`);
+      const accessToken = url.searchParams.get(KnownQueryParams.accessToken);
       url.search = "";
+      if (accessToken) {
+        url.searchParams.set(KnownQueryParams.accessToken, accessToken);
+      }
       return url;
     }
     return this.formatWsURL(`/lsp/${lsp}`);

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -37,7 +37,7 @@ from websockets import ClientConnection, ConnectionClosed, connect
 from marimo import _loggers
 from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._server.api.auth import validate_auth
+from marimo._server.api.auth import TOKEN_QUERY_PARAM, validate_auth
 from marimo._server.api.deps import AppState, AppStateBase
 from marimo._server.codes import WebSocketCodes
 from marimo._server.uvicorn_utils import close_uvicorn
@@ -514,10 +514,16 @@ class ProxyMiddleware:
                 # Re-encode query params from Starlette's already-decoded
                 # values so spaces become %20 while preserving literal plus
                 # signs instead of incorrectly treating them as spaces.
+                # Strip the access_token param — it's only used by marimo
+                # for authentication and should not be forwarded to
+                # upstream LSP servers.
                 encoded_params = [
-                    (k, quote(v)) for k, v in original_params.items()
+                    (k, quote(v))
+                    for k, v in original_params.items()
+                    if k != TOKEN_QUERY_PARAM
                 ]
-                ws_url = f"{ws_url}?{'&'.join(f'{k}={v}' for k, v in encoded_params)}"
+                if encoded_params:
+                    ws_url = f"{ws_url}?{'&'.join(f'{k}={v}' for k, v in encoded_params)}"
             await websocket.accept()
 
             # Try to connect to the upstream WebSocket with retries

--- a/tests/_server/api/test_middleware.py
+++ b/tests/_server/api/test_middleware.py
@@ -8,10 +8,12 @@ import sys
 import time
 from multiprocessing import Process
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 import pytest
 import uvicorn
 from starlette.applications import Starlette
+from starlette.datastructures import QueryParams
 from starlette.responses import Response
 from starlette.routing import Route
 from starlette.testclient import TestClient
@@ -19,6 +21,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 from uvicorn import Config, Server
 
 from marimo._config.manager import MarimoConfigManager, UserConfigManager
+from marimo._server.api.auth import TOKEN_QUERY_PARAM
 from marimo._server.api.middleware import (
     ProxyMiddleware,
     _AsyncHTTPClient,
@@ -654,6 +657,35 @@ class TestProxyMiddleware:
         await middleware(scope, None, None)
         assert proxy_calls[-1] == "wss://example.com/proxy/test"
 
+    def test_proxy_websocket_strips_access_token(self) -> None:
+        """access_token is used for marimo auth and must not leak upstream."""
+
+        def _encode_params_without_token(query_string: bytes) -> str:
+            """Reproduce the encoding logic from _proxy_websocket."""
+            params = QueryParams(query_string.decode())
+            encoded = [
+                (k, quote(v))
+                for k, v in params.items()
+                if k != TOKEN_QUERY_PARAM
+            ]
+            if not encoded:
+                return ""
+            return "&".join(f"{k}={v}" for k, v in encoded)
+
+        # access_token should be stripped
+        result = _encode_params_without_token(
+            b"access_token=secret&file=test.py"
+        )
+        assert result == "file=test.py"
+
+        # Only access_token → empty string
+        result = _encode_params_without_token(b"access_token=secret")
+        assert result == ""
+
+        # No access_token → unchanged
+        result = _encode_params_without_token(b"file=test.py&mode=edit")
+        assert result == "file=test.py&mode=edit"
+
     def test_proxy_websocket_query_params_space_encoding(self) -> None:
         """Spaces in query params encoded as '+' are re-encoded as '%20'.
 
@@ -662,9 +694,6 @@ class TestProxyMiddleware:
         python-lsp-server expect percent-encoding (%20).
         See: https://github.com/marimo-team/marimo/issues/9041
         """
-        from urllib.parse import quote
-
-        from starlette.datastructures import QueryParams
 
         def _encode_params(query_string: bytes) -> str:
             """Reproduce the encoding logic from _proxy_websocket."""


### PR DESCRIPTION
- Implemented logic to append the `access_token` as a query parameter for cross-origin WebSocket connections when an `authToken` is provided.
- Updated tests to verify the correct behavior of `access_token` inclusion based on origin and token presence.
- Enhanced URL handling to strip `/health` from redirected URLs while preserving query parameters.
