### PR TITLE
Skip scratchpad changes in document transaction sync

### DIFF
--- a/frontend/src/core/cells/document-changes.ts
+++ b/frontend/src/core/cells/document-changes.ts
@@ -25,6 +25,7 @@ import type { NotebookDocumentTransactionRequest } from "../network/types";
 import { store } from "../state/jotai";
 import type { CellActions, NotebookState } from "./cells";
 import type { CellId } from "./ids";
+import { SCRATCH_CELL_ID } from "./ids";
 import type { CellData } from "./types";
 
 export type DocumentChange =
@@ -572,8 +573,19 @@ const flushChanges = debounce(() => {
   void getRequestClient().sendDocumentTransaction({ changes });
 }, 400);
 
+function isScratchChange(change: DocumentChange): boolean {
+  if ("cellId" in change && change.cellId === SCRATCH_CELL_ID) {
+    return true;
+  }
+  return false;
+}
+
 function enqueue(change: DocumentChange) {
   if (store.get(kioskModeAtom)) {
+    return;
+  }
+  // The scratchpad cell is local-only — don't sync it to the document.
+  if (isScratchChange(change)) {
     return;
   }
   pendingChanges.push(change);


### PR DESCRIPTION
The scratchpad cell (`__scratch__`) lives only in frontend state and isn't part of the backend `NotebookDocument`. When editing or running the scratchpad, the document transaction middleware was forwarding those changes to the server, which raised `KeyError` because the cell doesn't exist in the document. This surfaced as flickering "Failed to sync document transaction" toasts.

Filtering scratch cell changes out of `enqueue` prevents them from ever reaching the wire while keeping the rest of the middleware untouched.
