### PR TITLE
Auto-instantiate notebook when run_cell hits empty graph

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -577,6 +577,15 @@ class AsyncCodeModeContext:
                 self._dry_run_compile(ops)
             await self._apply_ops(ops, cells_to_run)
         elif cells_to_run:
+            # If the notebook hasn't been instantiated yet (graph is empty),
+            # register all cells into the graph first so run_cell can
+            # resolve dependencies.
+            if not self._kernel.graph.cells:
+                reqs = list(
+                    self._kernel._uninstantiated_execution_requests.values()
+                )
+                if reqs:
+                    await self._kernel.run(reqs)
             await self._kernel._run_cells(cells_to_run)
 
         # Flush queued UI updates as a single batch.


### PR DESCRIPTION
In edit mode, marimo defers cell registration until the user clicks "Run". This means the dataflow graph is empty and `run_cell` in code_mode fails with a KeyError during transitive closure — the cell IDs exist in the document but aren't registered in the graph.

This fixes it by checking for an empty graph in `__aexit__` when only `run_cell` operations are queued (no structural ops). If the kernel has uninstantiated execution requests, we run them first to populate the graph, then proceed with the requested cells. The kernel already no-ops on `run` for cells that are up-to-date, so this is safe to call unconditionally when the graph is empty.
