### PR TITLE
fix: replace bare except with except Exception in parse_dataclass

### DIFF
--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -131,7 +131,7 @@ class _DataclassParser:
                 # catch expected exceptions when conversion fails
                 except (TypeError, ValueError):
                     continue
-                except:
+                except BaseException:
                     raise
             raise ValueError(
                 f"Value '{value}' does not fit any type of the union"

--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -131,7 +131,7 @@ class _DataclassParser:
                 # catch expected exceptions when conversion fails
                 except (TypeError, ValueError):
                     continue
-                except BaseException:
+                except Exception:
                     raise
             raise ValueError(
                 f"Value '{value}' does not fit any type of the union"


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except Exception:` in `marimo/_utils/parse_dataclass.py`.

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which should generally not be caught. In this case the handler immediately re-raises, so narrowing to `Exception` preserves the intent while following Python best practices (PEP 8).

**Change:**
```python
# Before
except:
    raise

# After
except Exception:
    raise
```

## Testing
No behavior change — the except clause still catches and re-raises all standard exceptions.