### PR TITLE
fix: crash on non-dict YAML frontmatter during markdown conversion

### DIFF
--- a/marimo/_convert/markdown/to_ir.py
+++ b/marimo/_convert/markdown/to_ir.py
@@ -533,7 +533,7 @@ def extract_frontmatter(text: str) -> tuple[dict[str, str], str]:
         try:
             return yaml.load(yaml_content), body
         # If there's an error in parsing YAML, ignore the meta and proceed.
-        except yaml.YAMLError:
+        except (yaml.YAMLError, AssertionError):
             LOGGER.warning(
                 "Error parsing frontmatter YAML. Ignoring frontmatter."
             )

--- a/tests/_convert/markdown/test_markdown_conversion.py
+++ b/tests/_convert/markdown/test_markdown_conversion.py
@@ -172,6 +172,21 @@ def test_markdown_just_frontmatter() -> None:
     assert app.cell_manager.cell_data_at(ids[0]).code == ""
 
 
+def test_non_dict_frontmatter_does_not_crash() -> None:
+    """Non-dict YAML frontmatter (e.g. a list) should be ignored, not crash."""
+    from marimo._convert.markdown.to_ir import extract_frontmatter
+
+    # YAML list — was raising AssertionError before the fix
+    meta, body = extract_frontmatter("---\n- one\n- two\n---\n\nhello\n")
+    assert meta == {}
+    assert body == "hello\n"
+
+    # YAML scalar — also non-dict
+    meta, body = extract_frontmatter("---\njust a string\n---\n\nbody\n")
+    assert meta == {}
+    assert body == "body\n"
+
+
 def test_markdown_frontmatter_metadata_roundtrip() -> None:
     """Frontmatter metadata should survive md -> IR -> md roundtrip."""
     script = dedent(


### PR DESCRIPTION
Converting a markdown file with non-dict YAML frontmatter (e.g. a YAML list) crashes with an unhandled `AssertionError`:

```
AssertionError: Expected dict, got <class 'list'>
```

**Reproduction:**

```bash
cat > test.md <<'EOF'
---
- one
- two
---

hello
EOF

marimo convert test.md
```

**Cause:** `yaml.load()` in `_utils/yaml.py` asserts `isinstance(response, dict)`. `extract_frontmatter()` in `to_ir.py` only catches `yaml.YAMLError`, so the `AssertionError` escapes.

**Fix:** Catch `(yaml.YAMLError, AssertionError)` — matching the sibling code in `from_ir.py:74` which already handles this correctly.

**Checks run:**
- `pytest tests/_convert/markdown/test_markdown_conversion.py` — 12/12 passed
- `ruff check` and `ruff format --check` on changed files — clean