### PR TITLE
fix: wrap plugin slot in TooltipProvider to fix tooltip regression

### DIFF
--- a/frontend/src/plugins/core/registerReactComponent.tsx
+++ b/frontend/src/plugins/core/registerReactComponent.tsx
@@ -23,6 +23,7 @@ import React, {
 import ReactDOM, { type Root } from "react-dom/client";
 import useEvent from "react-use-event-hook";
 import { type ZodSchema, z } from "zod";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { notebookAtom } from "@/core/cells/cells.ts";
 import { HTMLCellId } from "@/core/cells/ids.ts";
 import { isUninstantiated } from "@/core/cells/utils";
@@ -250,14 +251,16 @@ function PluginSlotInternal<T>(
     <StyleNamespace>
       <div className={`contents ${theme}`}>
         <Suspense fallback={<div />}>
-          {plugin.render({
-            setValue: setValueAndSendInput,
-            value,
-            data: parsedResult.data,
-            children: childNodes,
-            host: hostElement,
-            functions: functionMethods,
-          })}
+          <TooltipProvider>
+            {plugin.render({
+              setValue: setValueAndSendInput,
+              value,
+              data: parsedResult.data,
+              children: childNodes,
+              host: hostElement,
+              functions: functionMethods,
+            })}
+          </TooltipProvider>
         </Suspense>
       </div>
     </StyleNamespace>

--- a/frontend/src/plugins/impl/ButtonPlugin.tsx
+++ b/frontend/src/plugins/impl/ButtonPlugin.tsx
@@ -3,7 +3,7 @@
 import type { JSX } from "react";
 import { z } from "zod";
 import { KeyboardHotkeys } from "@/components/shortcuts/renderShortcut";
-import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/utils/cn";
 import { Button } from "../../components/ui/button";
 import { renderHTML } from "../core/RenderHTML";
@@ -69,11 +69,9 @@ export class ButtonPlugin implements IPlugin<number, Data> {
 
     if (tooltipContent) {
       return (
-        <TooltipProvider>
-          <Tooltip content={tooltipContent} delayDuration={200}>
-            {button}
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip content={tooltipContent} delayDuration={200}>
+          {button}
+        </Tooltip>
       );
     }
 

--- a/frontend/src/plugins/impl/CodeEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/CodeEditorPlugin.tsx
@@ -4,7 +4,6 @@ import { EditorView } from "@codemirror/view";
 import { type JSX, useEffect, useMemo, useState } from "react";
 import useEvent from "react-use-event-hook";
 import { z } from "zod";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { useDebounceControlledState } from "@/hooks/useDebounce";
 import { type Theme, useTheme } from "@/theme/useTheme";
 import type { IPlugin, IPluginProps, Setter } from "../types";
@@ -98,22 +97,20 @@ const CodeEditorComponent = (props: CodeEditorComponentProps) => {
   }, [props.debounce, onBlur]);
 
   return (
-    <TooltipProvider>
-      <Labeled label={props.label} align="top" fullWidth={true}>
-        <LazyAnyLanguageCodeMirror
-          className={`cm *:outline-hidden border rounded overflow-hidden ${finalTheme}`}
-          theme={finalTheme === "dark" ? "dark" : "light"}
-          minHeight={minHeight}
-          maxHeight={maxHeight}
-          placeholder={props.placeholder}
-          editable={!props.disabled}
-          value={localValue}
-          language={props.language}
-          onChange={handleChange}
-          showCopyButton={props.showCopyButton}
-          extensions={extensions}
-        />
-      </Labeled>
-    </TooltipProvider>
+    <Labeled label={props.label} align="top" fullWidth={true}>
+      <LazyAnyLanguageCodeMirror
+        className={`cm *:outline-hidden border rounded overflow-hidden ${finalTheme}`}
+        theme={finalTheme === "dark" ? "dark" : "light"}
+        minHeight={minHeight}
+        maxHeight={maxHeight}
+        placeholder={props.placeholder}
+        editable={!props.disabled}
+        value={localValue}
+        language={props.language}
+        onChange={handleChange}
+        showCopyButton={props.showCopyButton}
+        extensions={extensions}
+      />
+    </Labeled>
   );
 };

--- a/frontend/src/plugins/impl/DataEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/DataEditorPlugin.tsx
@@ -1,10 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import glideCss from "@glideapps/glide-data-grid/dist/index.css?inline";
-import { Tooltip } from "radix-ui";
-
-const TooltipProvider = Tooltip.Provider;
-
 import React, { useState } from "react";
 import { z } from "zod";
 import { inferFieldTypes } from "@/components/data-table/columns";
@@ -63,16 +59,14 @@ export const DataEditorPlugin = createPlugin<Edits>("marimo-data-editor", {
   .withFunctions({})
   .renderer((props) => {
     return (
-      <TooltipProvider>
-        <LoadingDataEditor
-          data={props.data.data}
-          fieldTypes={props.data.fieldTypes}
-          edits={props.value}
-          onEdits={props.setValue}
-          host={props.host}
-          editableColumns={props.data.editableColumns}
-        />
-      </TooltipProvider>
+      <LoadingDataEditor
+        data={props.data.data}
+        fieldTypes={props.data.fieldTypes}
+        edits={props.value}
+        onEdits={props.setValue}
+        host={props.host}
+        editableColumns={props.data.editableColumns}
+      />
     );
   });
 

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -1,9 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { Provider as SlotzProvider } from "@marimo-team/react-slotz";
-import { Tooltip } from "radix-ui";
-
-const TooltipProvider = Tooltip.Provider;
 
 import type {
   ColumnFiltersState,
@@ -1123,9 +1120,7 @@ export const TableProviders: React.FC<{ children: React.ReactNode }> = ({
   return (
     <ErrorBoundary>
       <Provider store={store}>
-        <SlotzProvider controller={slotsController}>
-          <TooltipProvider>{children}</TooltipProvider>
-        </SlotzProvider>
+        <SlotzProvider controller={slotsController}>{children}</SlotzProvider>
       </Provider>
     </ErrorBoundary>
   );

--- a/frontend/src/plugins/impl/FileUploadPlugin.tsx
+++ b/frontend/src/plugins/impl/FileUploadPlugin.tsx
@@ -4,7 +4,7 @@ import { MousePointerSquareDashedIcon, Upload } from "lucide-react";
 import type { JSX } from "react";
 import { useDropzone } from "react-dropzone";
 import { z } from "zod";
-import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip } from "@/components/ui/tooltip";
 import { toast } from "@/components/ui/use-toast";
 import { cn } from "@/utils/cn";
 import { Logger } from "@/utils/Logger";
@@ -184,42 +184,40 @@ export const FileUpload = (props: FileUploadProps): JSX.Element => {
     //   link button to the hidden input element
     const label = props.label ?? "Upload";
     return (
-      <TooltipProvider>
-        <div className="flex flex-row items-center justify-start gap-2">
-          <button
-            data-testid="marimo-plugin-file-upload-button"
-            {...getRootProps({})}
-            className={buttonVariants({
-              variant: "secondary",
-              size: "xs",
-            })}
-          >
-            {renderHTML({ html: label })}
-            <Upload size={14} className="ml-2" />
-          </button>
-          <input {...getInputProps({})} type="file" />
-          {uploaded ? (
-            <>
-              <Tooltip content={uploadedFiles}>
-                <span className="text-xs text-muted-foreground">
-                  Uploaded{" "}
-                  <span className="underline cursor-pointer">
-                    {value.length} {value.length === 1 ? "file" : "files"}.
-                  </span>
+      <div className="flex flex-row items-center justify-start gap-2">
+        <button
+          data-testid="marimo-plugin-file-upload-button"
+          {...getRootProps({})}
+          className={buttonVariants({
+            variant: "secondary",
+            size: "xs",
+          })}
+        >
+          {renderHTML({ html: label })}
+          <Upload size={14} className="ml-2" />
+        </button>
+        <input {...getInputProps({})} type="file" />
+        {uploaded ? (
+          <>
+            <Tooltip content={uploadedFiles}>
+              <span className="text-xs text-muted-foreground">
+                Uploaded{" "}
+                <span className="underline cursor-pointer">
+                  {value.length} {value.length === 1 ? "file" : "files"}.
                 </span>
-              </Tooltip>
+              </span>
+            </Tooltip>
 
-              <button
-                className={cn("text-xs text-destructive hover:underline")}
-                onClick={() => setValue([])}
-                type="button"
-              >
-                Click to clear files.
-              </button>
-            </>
-          ) : null}
-        </div>
-      </TooltipProvider>
+            <button
+              className={cn("text-xs text-destructive hover:underline")}
+              onClick={() => setValue([])}
+              type="button"
+            >
+              Click to clear files.
+            </button>
+          </>
+        ) : null}
+      </div>
     );
   }
 
@@ -274,14 +272,12 @@ export const FileUpload = (props: FileUploadProps): JSX.Element => {
         {uploaded ? (
           <div className="flex flex-row gap-1">
             <div className="text-xs text-muted-foreground">
-              <TooltipProvider>
-                Uploaded{" "}
-                <Tooltip content={uploadedFiles}>
-                  <span className="underline cursor-pointer">
-                    {value.length} {value.length === 1 ? "file" : "files"}.
-                  </span>
-                </Tooltip>
-              </TooltipProvider>
+              Uploaded{" "}
+              <Tooltip content={uploadedFiles}>
+                <span className="underline cursor-pointer">
+                  {value.length} {value.length === 1 ? "file" : "files"}.
+                </span>
+              </Tooltip>
             </div>
             <span className="text-xs text-destructive hover:underline hover:cursor-pointer">
               <button

--- a/frontend/src/plugins/impl/FormPlugin.tsx
+++ b/frontend/src/plugins/impl/FormPlugin.tsx
@@ -3,7 +3,7 @@
 import { Loader2Icon } from "lucide-react";
 import { type JSX, useEffect, useRef, useState } from "react";
 import { z } from "zod";
-import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip } from "@/components/ui/tooltip";
 import type { UIElementId } from "@/core/cells/ids";
 import {
   MarimoValueInputEvent,
@@ -72,11 +72,7 @@ export const FormPlugin = createPlugin("marimo-form")
       .output(z.string().nullish()),
   })
   .renderer(({ data, functions, ...rest }) => {
-    return (
-      <TooltipProvider>
-        <Form {...data} {...rest} {...functions} />
-      </TooltipProvider>
-    );
+    return <Form {...data} {...rest} {...functions} />;
   });
 
 export interface FormWrapperProps<T>

--- a/frontend/src/plugins/impl/chat/ChatPlugin.tsx
+++ b/frontend/src/plugins/impl/chat/ChatPlugin.tsx
@@ -3,7 +3,6 @@
 import type { UIMessage } from "ai";
 import React, { Suspense } from "react";
 import { z } from "zod";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { createPlugin } from "@/plugins/core/builder";
 import { rpc } from "@/plugins/core/rpc";
 import { Arrays } from "@/utils/arrays";
@@ -73,23 +72,21 @@ export const ChatPlugin = createPlugin<{ messages: UIMessage[] }>(
       .output(z.unknown()),
   })
   .renderer((props) => (
-    <TooltipProvider>
-      <Suspense>
-        <LazyChatbot
-          prompts={props.data.prompts}
-          showConfigurationControls={props.data.showConfigurationControls}
-          maxHeight={props.data.maxHeight}
-          allowAttachments={props.data.allowAttachments}
-          disabled={props.data.disabled}
-          config={props.data.config}
-          get_chat_history={props.functions.get_chat_history}
-          delete_chat_history={props.functions.delete_chat_history}
-          delete_chat_message={props.functions.delete_chat_message}
-          send_prompt={props.functions.send_prompt}
-          value={props.value?.messages || Arrays.EMPTY}
-          setValue={(messages) => props.setValue({ messages })}
-          host={props.host}
-        />
-      </Suspense>
-    </TooltipProvider>
+    <Suspense>
+      <LazyChatbot
+        prompts={props.data.prompts}
+        showConfigurationControls={props.data.showConfigurationControls}
+        maxHeight={props.data.maxHeight}
+        allowAttachments={props.data.allowAttachments}
+        disabled={props.data.disabled}
+        config={props.data.config}
+        get_chat_history={props.functions.get_chat_history}
+        delete_chat_history={props.functions.delete_chat_history}
+        delete_chat_message={props.functions.delete_chat_message}
+        send_prompt={props.functions.send_prompt}
+        value={props.value?.messages || Arrays.EMPTY}
+        setValue={(messages) => props.setValue({ messages })}
+        host={props.host}
+      />
+    </Suspense>
   ));

--- a/frontend/src/plugins/impl/data-explorer/DataExplorerPlugin.tsx
+++ b/frontend/src/plugins/impl/data-explorer/DataExplorerPlugin.tsx
@@ -3,7 +3,6 @@ import "../vega/vega.css";
 
 import React from "react";
 import { z } from "zod";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { createPlugin } from "@/plugins/core/builder";
 import type { DataExplorerState } from "./ConnectedDataExplorerComponent";
 
@@ -21,11 +20,9 @@ export const DataExplorerPlugin = createPlugin<DataExplorerState>(
     }),
   )
   .renderer((props) => (
-    <TooltipProvider>
-      <LazyDataExplorerComponent
-        {...props.data}
-        value={props.value}
-        setValue={props.setValue}
-      />
-    </TooltipProvider>
+    <LazyDataExplorerComponent
+      {...props.data}
+      value={props.value}
+      setValue={props.setValue}
+    />
   ));

--- a/frontend/src/plugins/impl/vega/VegaPlugin.tsx
+++ b/frontend/src/plugins/impl/vega/VegaPlugin.tsx
@@ -8,7 +8,6 @@ import type { Data, VegaComponentState } from "./vega-component";
 
 import "./vega.css";
 import React, { type JSX } from "react";
-import { TooltipProvider } from "@/components/ui/tooltip";
 
 const LazyVegaComponent = React.lazy(() => import("./vega-component"));
 
@@ -29,13 +28,11 @@ export class VegaPlugin implements IPlugin<VegaComponentState, Data> {
 
   render(props: IPluginProps<VegaComponentState, Data>): JSX.Element {
     return (
-      <TooltipProvider>
-        <LazyVegaComponent
-          value={props.value}
-          setValue={props.setValue}
-          {...props.data}
-        />
-      </TooltipProvider>
+      <LazyVegaComponent
+        value={props.value}
+        setValue={props.setValue}
+        {...props.data}
+      />
     );
   }
 }

--- a/frontend/src/plugins/layout/NavigationMenuPlugin.tsx
+++ b/frontend/src/plugins/layout/NavigationMenuPlugin.tsx
@@ -11,7 +11,7 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation";
-import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip } from "@/components/ui/tooltip";
 import { renderHTML } from "@/plugins/core/RenderHTML";
 import { cn } from "@/utils/cn";
 import { appendQueryParams } from "@/utils/urls";
@@ -67,11 +67,7 @@ export class NavigationMenuPlugin implements IStatelessPlugin<Data> {
   });
 
   render(props: IStatelessPluginProps<Data>): JSX.Element {
-    return (
-      <TooltipProvider>
-        <NavMenuComponent {...props.data} />
-      </TooltipProvider>
-    );
+    return <NavMenuComponent {...props.data} />;
   }
 }
 


### PR DESCRIPTION
Each plugin mounts its own React root inside a shadow DOM, so there's no
ambient TooltipProvider from the outer app. When user HTML with a Radix
Tooltip was passed as a label/children to a plugin, it threw
"Tooltip must be used within TooltipProvider".

Adds a single TooltipProvider in PluginSlot and removes the now-redundant
per-plugin wrappers.
