### PR TITLE
don't render data-tooltips for marimo components with tooltips

### DIFF
--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -164,11 +164,20 @@ const wrapDocHoverTargets: TransformFn = (
 // Wrap elements with data-tooltip attribute in a Tooltip component.
 // This renders the tooltip in a portal (top layer), fixing clipping inside
 // containers with overflow:hidden (e.g. grid cells).
+//
+// Marimo custom elements (marimo-button, etc.) are skipped — they handle
+// tooltips via the plugin system inside their Shadow DOM. Wrapping them here
+// would create a duplicate tooltip with incorrect positioning and
+// un-decoded JSON content (the data-* value is JSON-encoded by the backend).
 const wrapTooltipTargets: TransformFn = (
   reactNode: ReactNode,
   domNode: DOMNode,
 ): JSX.Element | undefined => {
   if (domNode instanceof Element && domNode.attribs?.["data-tooltip"]) {
+    const tagName = domNode.name?.toLowerCase() ?? "";
+    if (tagName.startsWith("marimo-")) {
+      return undefined;
+    }
     const tooltipContent = domNode.attribs["data-tooltip"];
     return (
       <Tooltip content={tooltipContent}>{reactNode as JSX.Element}</Tooltip>

--- a/frontend/src/plugins/core/__test__/RenderHTML.test.ts
+++ b/frontend/src/plugins/core/__test__/RenderHTML.test.ts
@@ -240,6 +240,33 @@ describe("wrapTooltipTargets", () => {
       </p>
     `);
   });
+
+  test("data-tooltip on marimo custom elements is not wrapped", () => {
+    const html =
+      '<marimo-button data-tooltip="&quot;Run clicky&quot;">click</marimo-button>';
+    expect(parseHtml({ html })).toMatchInlineSnapshot(`
+      <marimo-button
+        data-tooltip=""Run clicky""
+      >
+        click
+      </marimo-button>
+    `);
+  });
+
+  test("data-tooltip on non-marimo custom elements is still wrapped", () => {
+    const html = '<my-widget data-tooltip="info">content</my-widget>';
+    expect(parseHtml({ html })).toMatchInlineSnapshot(`
+      <Tooltip
+        content="info"
+      >
+        <my-widget
+          data-tooltip="info"
+        >
+          content
+        </my-widget>
+      </Tooltip>
+    `);
+  });
 });
 
 describe("parseHtml with < nad >", () => {

--- a/marimo/_smoke_tests/tooltips.py
+++ b/marimo/_smoke_tests/tooltips.py
@@ -2,25 +2,36 @@
 
 import marimo
 
-__generated_with = "0.15.5"
+__generated_with = "0.23.0"
 app = marimo.App(width="medium")
 
 
 @app.cell
 def _():
     import marimo as mo
+
     return (mo,)
 
 
 @app.cell
 def _(mo):
-    mo.md(
-        """
-        # Tooltips
+    mo.md("""
+    # Tooltips
 
-        <span data-tooltip="Hello world!">Hover me</span>
-        """
-    )
+    ## Markdown tooltips (via data-tooltip attribute)
+
+    <span data-tooltip="Hello world!">Hover me (plain text)</span>
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Button with tooltip in label
+
+    The label contains a `data-tooltip` span — handled by `wrapTooltipTargets` inside the Shadow DOM.
+    """)
     return
 
 
@@ -31,7 +42,89 @@ def _(mo):
 
 
 @app.cell
-def _():
+def _(mo):
+    mo.md("""
+    ## mo.ui.button with tooltip arg
+
+    Tooltip is handled by the plugin (ButtonPlugin) inside the Shadow DOM.
+    Should NOT produce a duplicate tooltip from `wrapTooltipTargets`.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.ui.button(tooltip="Click me!", label="Button with tooltip")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## mo.ui.run_button with tooltip arg
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.ui.run_button(tooltip="Run clicky")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## mo.ui.button with keyboard shortcut (no explicit tooltip)
+
+    Should show the shortcut as a tooltip.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.ui.button(label="Save", keyboard_shortcut="Ctrl-S")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## mo.ui.button with both tooltip and keyboard shortcut
+
+    Explicit tooltip takes precedence over the shortcut tooltip.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.ui.button(
+        label="Submit",
+        tooltip="Submit the form",
+        keyboard_shortcut="Ctrl-Enter",
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## mo.ui.form with submit/clear button tooltips
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.ui.text(label="Name").form(
+        submit_button_label="Go",
+        submit_button_tooltip="Submit the form",
+        show_clear_button=True,
+        clear_button_label="Reset",
+        clear_button_tooltip="Clear all fields",
+    )
     return
 
 


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Should help with #9117 

renderHTML's wrapTooltipTargets transform was wrapping <marimo-button data-tooltip="..."> in a <Tooltip> in the outer DOM, even though ButtonPlugin already renders its own tooltip inside the Shadow DOM. This caused only the outer tooltip to be rendered.

The fix skips marimo-* custom elements in wrapTooltipTargets — they handle tooltips via the plugin system inside their Shadow DOM. User-authored markdown tooltips (<span data-tooltip="...">) are unaffected.

before:
<img width="451" height="126" alt="image" src="https://github.com/user-attachments/assets/b90f4fff-7fdc-4979-ac09-7cce4b7f3240" />

after:
<img width="269" height="110" alt="image" src="https://github.com/user-attachments/assets/78f9ab66-97d5-43bc-b2cf-1d3dd46552fc" />


## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
