### PR TITLE
fix: bump ruff version in pytest_changed plugin to 0.15.9

### DIFF
--- a/packages/pytest_changed/__init__.py
+++ b/packages/pytest_changed/__init__.py
@@ -117,7 +117,7 @@ def get_dependency_graph(
                 "uvx",
                 # uv notes `analyze graph` is experimental,
                 # so we fix the ruff version for now
-                "ruff@0.13.2",
+                "ruff@0.15.9",
                 "analyze",
                 "graph",
                 "--detect-string-imports",


### PR DESCRIPTION
 The `pytest_changed` plugin pins `ruff@0.13.2` for `analyze graph`, but the project upgraded ruff to `>=0.15.9`

older version fails to parse the current `pyproject.toml`, causing all CI test jobs to exit before any tests run