### PR TITLE
closes 7690, adds:  @app.cell(expanded_output=True)

### DIFF
--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -344,6 +344,7 @@ interface OutputAreaProps {
   cellId: CellId;
   stale: boolean;
   loading: boolean;
+  defaultExpanded?: boolean;
   /**
    * Whether to allow expanding the output
    * This shows the expand button and allows the user to expand the output
@@ -363,6 +364,7 @@ export const OutputArea = React.memo(
     cellId,
     stale,
     loading,
+    defaultExpanded,
     allowExpand,
     forceExpand,
     className,
@@ -379,23 +381,32 @@ export const OutputArea = React.memo(
     // 2. This output is stale (this cell is queued to run)
     // 3. This output is stale (its inputs have changed)
     const title = stale ? "This output is stale" : undefined;
-    const Container = allowExpand ? ExpandableOutput : Div;
+    const sharedProps = {
+      title,
+      id: CellOutputId.create(cellId),
+      className: cn(
+        stale && "marimo-output-stale",
+        loading && "marimo-output-loading",
+        className,
+      ),
+    };
 
     return (
       <ErrorBoundary>
-        <Container
-          title={title}
-          cellId={cellId}
-          forceExpand={forceExpand}
-          id={CellOutputId.create(cellId)}
-          className={cn(
-            stale && "marimo-output-stale",
-            loading && "marimo-output-loading",
-            className,
-          )}
-        >
-          <OutputRenderer cellId={cellId} message={output} />
-        </Container>
+        {allowExpand ? (
+          <ExpandableOutput
+            {...sharedProps}
+            cellId={cellId}
+            defaultExpanded={defaultExpanded}
+            forceExpand={forceExpand}
+          >
+            <OutputRenderer cellId={cellId} message={output} />
+          </ExpandableOutput>
+        ) : (
+          <Div {...sharedProps}>
+            <OutputRenderer cellId={cellId} message={output} />
+          </Div>
+        )}
       </ErrorBoundary>
     );
   },
@@ -415,14 +426,19 @@ const ExpandableOutput = React.memo(
   ({
     cellId,
     children,
+    defaultExpanded,
     forceExpand,
     ...props
   }: React.HTMLProps<HTMLDivElement> & {
     cellId: CellId;
+    defaultExpanded?: boolean;
     forceExpand?: boolean;
   }) => {
     const containerRef = useRef<HTMLDivElement>(null);
-    const [isExpanded, setIsExpanded] = useExpandedOutput(cellId);
+    const [isExpanded, setIsExpanded] = useExpandedOutput(
+      cellId,
+      defaultExpanded,
+    );
     const isOverflowing = useOverflowDetection(containerRef);
     const { hasFullscreen } = useIframeCapabilities();
 

--- a/frontend/src/components/editor/__tests__/Output.test.tsx
+++ b/frontend/src/components/editor/__tests__/Output.test.tsx
@@ -100,6 +100,30 @@ describe("OutputArea null/undefined handling", () => {
   });
 });
 
+describe("OutputArea default expansion", () => {
+  it("starts expanded when defaultExpanded is true", () => {
+    render(
+      <TooltipProvider>
+        <OutputArea
+          output={{
+            channel: "output",
+            data: "Hello World",
+            mimetype: "text/plain",
+            timestamp: 0,
+          }}
+          cellId={cellId("default-expanded")}
+          stale={false}
+          loading={false}
+          allowExpand={true}
+          defaultExpanded={true}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByTestId("expand-output-button")).toBeInTheDocument();
+  });
+});
+
 describe("OutputRenderer image and SVG rendering", () => {
   const plainSvgString =
     '<svg><rect x="0" y="0" width="10" height="10"></rect></svg>';

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -519,6 +519,7 @@ const EditableCellComponent = ({
       <OutputArea
         // Only allow expanding in edit mode
         allowExpand={true}
+        defaultExpanded={cellData.config.expand_output === true}
         // Force expand when markdown is hidden
         forceExpand={isMarkdownCodeHidden}
         className={CSSClasses.outputArea}
@@ -731,6 +732,7 @@ const EditableCellComponent = ({
             <ConsoleOutput
               consoleOutputs={cellRuntime.consoleOutputs}
               stale={consoleOutputStale}
+              defaultExpanded={cellData.config.expand_output === true}
               // Empty name if serialization triggered
               cellName={cellRuntime.serialization ? "_" : cellData.name}
               onRefactorWithAI={handleRefactorWithAI}
@@ -1191,6 +1193,7 @@ const SetupCellComponent = ({
             <ConsoleOutput
               consoleOutputs={cellRuntime.consoleOutputs}
               stale={consoleOutputStale}
+              defaultExpanded={cellData.config.expand_output === true}
               // Don't show name
               cellName={"_"}
               onRefactorWithAI={handleRefactorWithAI}

--- a/frontend/src/components/editor/output/console/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/console/ConsoleOutput.tsx
@@ -86,6 +86,7 @@ interface Props {
   consoleOutputs: WithResponse<OutputMessage>[];
   stale: boolean;
   debuggerActive: boolean;
+  defaultExpanded?: boolean;
   onRefactorWithAI?: OnRefactorWithAI;
   onClear?: () => void;
   onSubmitDebugger: (text: string, index: number) => void;
@@ -102,7 +103,10 @@ export const ConsoleOutput = (props: Props) => {
 const ConsoleOutputInternal = (props: Props): React.ReactNode => {
   const ref = React.useRef<HTMLDivElement>(null);
   const { wrapText, setWrapText } = useWrapText();
-  const [isExpanded, setIsExpanded] = useExpandedConsoleOutput(props.cellId);
+  const [isExpanded, setIsExpanded] = useExpandedConsoleOutput(
+    props.cellId,
+    props.defaultExpanded,
+  );
   const [stdinValue, setStdinValue] = React.useState("");
   const inputHistory = useInputHistory({
     value: stdinValue,

--- a/frontend/src/components/editor/output/console/__tests__/ConsoleOutput.test.tsx
+++ b/frontend/src/components/editor/output/console/__tests__/ConsoleOutput.test.tsx
@@ -51,6 +51,28 @@ describe("ConsoleOutput integration", () => {
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "https://marimo.io");
   });
+
+  it("starts expanded when defaultExpanded is true", () => {
+    const props = {
+      ...defaultProps,
+      defaultExpanded: true,
+      consoleOutputs: [
+        {
+          ...createOutput("console output"),
+          response: undefined,
+        },
+      ],
+    };
+
+    renderWithProvider(<ConsoleOutput {...props} />);
+
+    expect(
+      screen.getByRole("button", { name: "Collapse output" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("console-output-area")).toHaveStyle({
+      maxHeight: "none",
+    });
+  });
 });
 
 describe("ConsoleOutput pdb history", () => {

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -389,6 +389,7 @@ const VerticalCell = memo(
       const outputArea = (
         <OutputArea
           allowExpand={true}
+          defaultExpanded={config.expand_output === true}
           output={output}
           className={CSSClasses.outputArea}
           cellId={cellId}
@@ -420,6 +421,7 @@ const VerticalCell = memo(
           <ConsoleOutput
             consoleOutputs={consoleOutputs}
             stale={outputStale}
+            defaultExpanded={config.expand_output === true}
             cellName={name}
             onSubmitDebugger={() => null}
             cellId={cellId}
@@ -455,6 +457,7 @@ const VerticalCell = memo(
       >
         <OutputArea
           allowExpand={mode === "edit"}
+          defaultExpanded={config.expand_output === true}
           output={output}
           className={CSSClasses.outputArea}
           cellId={cellId}

--- a/frontend/src/core/cells/__tests__/document-changes.test.ts
+++ b/frontend/src/core/cells/__tests__/document-changes.test.ts
@@ -210,6 +210,26 @@ describe("toDocumentChanges", () => {
       `);
     });
 
+    it("maps expand_output to expandOutput in set-config", () => {
+      setup("a");
+      const [a] = state.cellIds.inOrderIds;
+
+      const { changes } = resolve(state, {
+        type: "updateCellConfig",
+        payload: { cellId: a, config: { expand_output: true } },
+      });
+
+      expect(changes).toMatchInlineSnapshot(`
+        [
+          {
+            "cellId": "0",
+            "expandOutput": true,
+            "type": "set-config",
+          },
+        ]
+      `);
+    });
+
     it("includes full CellConfig in create-cell", () => {
       setup("a");
 

--- a/frontend/src/core/cells/__tests__/session.test.ts
+++ b/frontend/src/core/cells/__tests__/session.test.ts
@@ -59,6 +59,7 @@ describe("notebookStateFromSession", () => {
       column: config?.column ?? null,
       disabled: config?.disabled ?? null,
       hide_code: config?.hide_code ?? null,
+      expand_output: config?.expand_output ?? null,
     },
   });
 
@@ -309,6 +310,7 @@ describe("notebookStateFromSession", () => {
           hide_code: true,
           disabled: true,
           column: 1,
+          expand_output: true,
         }),
       ]);
       const result = notebookStateFromSession(null, notebook);
@@ -319,6 +321,7 @@ describe("notebookStateFromSession", () => {
         hide_code: true,
         disabled: true,
         column: 1,
+        expand_output: true,
       });
     });
 

--- a/frontend/src/core/cells/document-changes.ts
+++ b/frontend/src/core/cells/document-changes.ts
@@ -257,7 +257,7 @@ export function toDocumentChanges(
     }
 
     // updateCellConfig → set-config
-    // Maps CellConfig's snake_case hide_code to the change's camelCase hideCode.
+    // Maps CellConfig's snake_case fields to the change's camelCase fields.
     // Only includes fields that were actually specified in the partial config
     // (from the action payload, not the full cell config).
     case "updateCellConfig": {
@@ -267,6 +267,9 @@ export function toDocumentChanges(
           type: "set-config",
           cellId: cellId,
           ...(config.hide_code != null && { hideCode: config.hide_code }),
+          ...(config.expand_output != null && {
+            expandOutput: config.expand_output,
+          }),
           ...(config.disabled != null && { disabled: config.disabled }),
           ...(config.column != null && { column: config.column }),
         },
@@ -410,7 +413,8 @@ export function fromDocumentChanges(
       // Translates the change's before/after anchor into createNewCell's
       // cellId+before pair. The change carries code, name, and a full CellConfig.
       // createNewCell only accepts hideCode, so name and remaining config
-      // (disabled, column) are applied as separate follow-up actions.
+      // (disabled, column, expand_output) are applied as separate follow-up
+      // actions.
       case "create-cell": {
         let cellId: CellId | "__end__" = "__end__";
         let before = false;
@@ -438,12 +442,19 @@ export function fromDocumentChanges(
             payload: { cellId: change.cellId, name: change.name },
           });
         }
-        if (change.config?.disabled != null || change.config?.column != null) {
+        if (
+          change.config?.disabled != null ||
+          change.config?.column != null ||
+          change.config?.expand_output != null
+        ) {
           actions.push({
             type: "updateCellConfig",
             payload: {
               cellId: change.cellId,
               config: {
+                ...(change.config.expand_output != null && {
+                  expand_output: change.config.expand_output,
+                }),
                 ...(change.config.disabled != null && {
                   disabled: change.config.disabled,
                 }),
@@ -537,7 +548,7 @@ export function fromDocumentChanges(
         break;
 
       // set-config → updateCellConfig
-      // Maps the change's camelCase hideCode back to CellConfig's snake_case
+      // Maps the change's camelCase config keys back to CellConfig's snake_case
       // hide_code. Only includes fields that are non-null (null means
       // "not specified" on the wire, not "clear the value").
       case "set-config":
@@ -547,6 +558,9 @@ export function fromDocumentChanges(
             cellId: change.cellId,
             config: {
               ...(change.hideCode != null && { hide_code: change.hideCode }),
+              ...(change.expandOutput != null && {
+                expand_output: change.expandOutput,
+              }),
               ...(change.disabled != null && { disabled: change.disabled }),
               ...(change.column != null && { column: change.column }),
             },

--- a/frontend/src/core/cells/outputs.ts
+++ b/frontend/src/core/cells/outputs.ts
@@ -11,10 +11,7 @@ const expandedConsoleOutputs: Record<CellId, boolean> = {};
 const userExpandedOutputs: Record<CellId, boolean> = {};
 const userExpandedConsoleOutputs: Record<CellId, boolean> = {};
 
-export function useExpandedOutput(
-  cellId: CellId,
-  defaultExpanded = false,
-) {
+export function useExpandedOutput(cellId: CellId, defaultExpanded = false) {
   const [state, setState] = useState(
     expandedOutputs[cellId] ?? defaultExpanded,
   );

--- a/frontend/src/core/cells/outputs.ts
+++ b/frontend/src/core/cells/outputs.ts
@@ -8,27 +8,69 @@ import type { CellId } from "./ids";
 // state in a global map instead of Jotai since state is not shared between cells.
 const expandedOutputs: Record<CellId, boolean> = {};
 const expandedConsoleOutputs: Record<CellId, boolean> = {};
+const userExpandedOutputs: Record<CellId, boolean> = {};
+const userExpandedConsoleOutputs: Record<CellId, boolean> = {};
 
-export function useExpandedOutput(cellId: CellId) {
-  const [state, setState] = useState(expandedOutputs[cellId] ?? false);
+export function useExpandedOutput(
+  cellId: CellId,
+  defaultExpanded = false,
+) {
+  const [state, setState] = useState(
+    expandedOutputs[cellId] ?? defaultExpanded,
+  );
+
+  useEffect(() => {
+    if (userExpandedOutputs[cellId]) {
+      return;
+    }
+    setState(defaultExpanded);
+    expandedOutputs[cellId] = defaultExpanded;
+  }, [cellId, defaultExpanded]);
 
   // Sync state to external storage
   useEffect(() => {
     expandedOutputs[cellId] = state;
   }, [cellId, state]);
 
-  return [state, setState] as const;
+  const setTrackedState = (
+    nextState: boolean | ((prev: boolean) => boolean),
+  ) => {
+    userExpandedOutputs[cellId] = true;
+    setState(nextState);
+  };
+
+  return [state, setTrackedState] as const;
 }
 
-export function useExpandedConsoleOutput(cellId: CellId) {
-  const [state, setState] = useState(expandedConsoleOutputs[cellId] ?? false);
+export function useExpandedConsoleOutput(
+  cellId: CellId,
+  defaultExpanded = false,
+) {
+  const [state, setState] = useState(
+    expandedConsoleOutputs[cellId] ?? defaultExpanded,
+  );
+
+  useEffect(() => {
+    if (userExpandedConsoleOutputs[cellId]) {
+      return;
+    }
+    setState(defaultExpanded);
+    expandedConsoleOutputs[cellId] = defaultExpanded;
+  }, [cellId, defaultExpanded]);
 
   // Sync state to external storage
   useEffect(() => {
     expandedConsoleOutputs[cellId] = state;
   }, [cellId, state]);
 
-  return [state, setState] as const;
+  const setTrackedState = (
+    nextState: boolean | ((prev: boolean) => boolean),
+  ) => {
+    userExpandedConsoleOutputs[cellId] = true;
+    setState(nextState);
+  };
+
+  return [state, setTrackedState] as const;
 }
 
 export function isOutputEmpty(

--- a/frontend/src/core/cells/session.ts
+++ b/frontend/src/core/cells/session.ts
@@ -177,6 +177,9 @@ function createCellDataFromNotebook(
       column: notebookCell.config?.column ?? null,
       disabled: notebookCell.config?.disabled ?? false,
       hide_code: notebookCell.config?.hide_code ?? false,
+      ...(notebookCell.config?.expand_output === true && {
+        expand_output: true,
+      }),
     },
     serializedEditorState: null,
   };

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -115,11 +115,13 @@ class _SetupContext:
         cell: Cell,
         app: App,
         hide_code: bool,
+        expand_output: bool,
     ):
         super().__init__()
         self._app = app
         self._cell = cell
         self._hide_code = hide_code
+        self._expand_output = expand_output
         self._glbls: dict[str, Any] = {}
         self._frame: FrameType | None = None
         self._previous: dict[str, Any] = {}
@@ -170,16 +172,22 @@ class _SetupContext:
         self,
         *,
         hide_code: bool = False,
+        expand_output: bool = False,
         **kwargs: Any,  # noqa: ARG002
     ) -> _SetupContext:
         """When called with parameters, create a new context with those parameters."""
         cell = self._app._cell_manager.cell_context(
             app=InternalApp(self._app),
             frame=inspect.stack()[1].frame,
-            config=CellConfig(hide_code=hide_code),
+            config=CellConfig(
+                hide_code=hide_code, expand_output=expand_output
+            ),
         )
         self._app._setup = _SetupContext(
-            app=self._app, cell=cell, hide_code=hide_code
+            app=self._app,
+            cell=cell,
+            hide_code=hide_code,
+            expand_output=expand_output,
         )
         return self._app._setup
 
@@ -352,6 +360,7 @@ class App:
         column: int | None = None,
         disabled: bool = False,
         hide_code: bool = False,
+        expand_output: bool = False,
         **kwargs: Any,
     ) -> Cell | Callable[[Fn[P, R]], Cell]:
         """A decorator to add a cell to the app.
@@ -378,6 +387,7 @@ class App:
             column: The column number to place this cell in.
             disabled: Whether to disable the cell.
             hide_code: Whether to hide the cell's code.
+            expand_output: Whether to expand the cell's output by default.
             **kwargs: For forward-compatibility with future arguments.
         """
         del kwargs
@@ -385,7 +395,12 @@ class App:
         return cast(
             Cell | Callable[[Fn[P, R]], Cell],
             self._cell_manager.cell_decorator(
-                func, column, disabled, hide_code, app=InternalApp(self)
+                func,
+                column,
+                disabled,
+                hide_code,
+                expand_output,
+                app=InternalApp(self),
             ),
         )
 
@@ -412,6 +427,7 @@ class App:
         column: int | None = None,
         disabled: bool = False,
         hide_code: bool = False,
+        expand_output: bool = False,
         **kwargs: Any,
     ) -> Fn[P, R] | Callable[[Fn[P, R]], Fn[P, R]]:
         """A decorator to wrap a callable function into a marimo cell.
@@ -440,6 +456,7 @@ class App:
             column: The column number to place this cell in.
             disabled: Whether to disable the cell.
             hide_code: Whether to hide the cell's code.
+            expand_output: Whether to expand the cell's output by default.
             **kwargs: For forward-compatibility with future arguments.
         """
         del kwargs
@@ -451,6 +468,7 @@ class App:
                 column,
                 disabled,
                 hide_code,
+                expand_output,
                 app=InternalApp(self),
                 top_level=True,
             ),
@@ -469,6 +487,7 @@ class App:
         column: int | None = None,
         disabled: bool = False,
         hide_code: bool = False,
+        expand_output: bool = False,
         **kwargs: Any,
     ) -> Cls | Callable[[Cls], Cls]:
         """A decorator to wrap a class into a marimo cell.
@@ -495,6 +514,7 @@ class App:
             column: The column number to place this cell in.
             disabled: Whether to disable the cell.
             hide_code: Whether to hide the cell's code.
+            expand_output: Whether to expand the cell's output by default.
             **kwargs: For forward-compatibility with future arguments.
         """
         del kwargs
@@ -506,6 +526,7 @@ class App:
                 column,
                 disabled,
                 hide_code,
+                expand_output,
                 app=InternalApp(self),
                 top_level=True,
             ),
@@ -526,8 +547,8 @@ class App:
 
             CONSTANT = "my constant"
 
-        # As a method with hide_code
-        with app.setup(hide_code=True):
+        # As a method with cell config
+        with app.setup(hide_code=True, expand_output=True):
             import my_libraries
             from typing import Any
 
@@ -536,6 +557,7 @@ class App:
 
         Args (when called as method):
             hide_code: Whether to hide the setup cell's code. Defaults to False.
+            expand_output: Whether to expand the setup cell's output by default.
             **kwargs: For forward-compatibility with future arguments.
         """
         # Get the calling context to extract the location of the cell
@@ -543,7 +565,12 @@ class App:
         cell = self._cell_manager.cell_context(
             app=InternalApp(self), frame=frame
         )
-        self._setup = _SetupContext(app=self, cell=cell, hide_code=False)
+        self._setup = _SetupContext(
+            app=self,
+            cell=cell,
+            hide_code=False,
+            expand_output=False,
+        )
         return self._setup
 
     def _unparsable_cell(

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -47,6 +47,9 @@ class CellConfig(msgspec.Struct):
     # If True, the cell is hidden from the editor.
     hide_code: bool = False
 
+    # If True, the cell's output starts expanded in the editor.
+    expand_output: bool = False
+
     @classmethod
     def from_dict(
         cls, kwargs: dict[str, Any], warn: bool = True

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -85,6 +85,7 @@ class CellManager:
         column: int | None,
         disabled: bool,
         hide_code: bool,
+        expand_output: bool,
         app: InternalApp | None = None,
         *,
         top_level: bool = False,
@@ -94,7 +95,10 @@ class CellManager:
         # path. This code is only called when run as a script or imported as a
         # module.
         cell_config = CellConfig(
-            column=column, disabled=disabled, hide_code=hide_code
+            column=column,
+            disabled=disabled,
+            hide_code=hide_code,
+            expand_output=expand_output,
         )
 
         def _register(obj: Obj[P, R]) -> Cell | Obj[P, R]:

--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -241,8 +241,17 @@ def build_setup_section(setup_cell: CellImpl | None) -> str:
     if has_only_comments:
         block += "\npass"
 
-    if setup_cell.config.hide_code:
-        setup_line = f"{prefix}with app.setup(hide_code=True):"
+    setup_config = {
+        key: value
+        for key, value in setup_cell.config.asdict_without_defaults().items()
+        if key in {"hide_code", "expand_output"}
+    }
+    if setup_config:
+        config = format_tuple_elements(
+            f"{prefix}with app.setup(...):",
+            tuple(f"{key}={value}" for key, value in setup_config.items()),
+        )
+        setup_line = config[:-1] + ":"
     else:
         setup_line = f"{prefix}with app.setup:"
 

--- a/marimo/_convert/ipynb/to_ir.py
+++ b/marimo/_convert/ipynb/to_ir.py
@@ -1300,6 +1300,7 @@ def bind_cell_metadata(
                     hide_code=hide_code,
                     column=marimo_config.get("column"),
                     disabled=marimo_config.get("disabled", False),
+                    expand_output=marimo_config.get("expand_output", False),
                 ),
             )
         )

--- a/marimo/_convert/markdown/to_ir.py
+++ b/marimo/_convert/markdown/to_ir.py
@@ -172,7 +172,7 @@ def get_cell_config_from_tag(tag: Element, **defaults: bool) -> CellConfig:
         **{
             k: v == "true"
             for k, v in tag.attrib.items()
-            if k in ["hide_code", "disabled"]
+            if k in ["hide_code", "disabled", "expand_output"]
         },
     }
     # "Column" is not a boolean attribute.

--- a/marimo/_convert/notebook.py
+++ b/marimo/_convert/notebook.py
@@ -50,6 +50,7 @@ def convert_from_ir_to_notebook_v1(
                     column=data.options.get("column", None),
                     disabled=data.options.get("disabled", False),
                     hide_code=data.options.get("hide_code", False),
+                    expand_output=data.options.get("expand_output", False),
                 ),
             )
         )
@@ -85,6 +86,9 @@ def convert_from_notebook_v1_to_ir(
                     "disabled": cell.get("config", {}).get("disabled", False),
                     "hide_code": cell.get("config", {}).get(
                         "hide_code", False
+                    ),
+                    "expand_output": cell.get("config", {}).get(
+                        "expand_output", False
                     ),
                 },
             )

--- a/marimo/_messaging/notebook/changes.py
+++ b/marimo/_messaging/notebook/changes.py
@@ -80,6 +80,7 @@ class SetConfig(msgspec.Struct, frozen=True, tag="set-config", rename="camel"):
     column: int | None = None
     disabled: bool | None = None
     hide_code: bool | None = None
+    expand_output: bool | None = None
 
 
 DocumentChange = (

--- a/marimo/_messaging/notebook/document.py
+++ b/marimo/_messaging/notebook/document.py
@@ -220,6 +220,9 @@ class NotebookDocument:
                 hide_code=change.hide_code
                 if change.hide_code is not None
                 else cell.config.hide_code,
+                expand_output=change.expand_output
+                if change.expand_output is not None
+                else cell.config.expand_output,
             )
         else:
             assert_never(change)

--- a/marimo/_schemas/generated/notebook.yaml
+++ b/marimo/_schemas/generated/notebook.yaml
@@ -45,6 +45,10 @@ components:
           anyOf:
           - type: boolean
           - type: 'null'
+        expand_output:
+          anyOf:
+          - type: boolean
+          - type: 'null'
       required: []
       title: NotebookCellConfig
       type: object

--- a/marimo/_schemas/generated/notifications.yaml
+++ b/marimo/_schemas/generated/notifications.yaml
@@ -125,6 +125,9 @@ components:
         hide_code:
           default: false
           type: boolean
+        expand_output:
+          default: false
+          type: boolean
       required: []
       title: CellConfig
       type: object

--- a/marimo/_schemas/notebook.py
+++ b/marimo/_schemas/notebook.py
@@ -17,6 +17,7 @@ class NotebookCellConfig(TypedDict, total=False):
     column: int | None
     disabled: bool | None
     hide_code: bool | None
+    expand_output: bool | None
 
 
 class NotebookCell(TypedDict):

--- a/marimo/_session/file_change_handler.py
+++ b/marimo/_session/file_change_handler.py
@@ -123,6 +123,7 @@ class EditModeReloadStrategy(ReloadStrategy):
                             column=cd.config.column,
                             disabled=cd.config.disabled,
                             hide_code=cd.config.hide_code,
+                            expand_output=cd.config.expand_output,
                         )
                     )
 

--- a/marimo/_session/state/serialize.py
+++ b/marimo/_session/state/serialize.py
@@ -316,6 +316,7 @@ def serialize_notebook(
                 column=None,
                 disabled=None,
                 hide_code=None,
+                expand_output=None,
             )
         else:
             name = cell_data.name
@@ -323,6 +324,7 @@ def serialize_notebook(
                 column=cell_data.config.column,
                 disabled=cell_data.config.disabled,
                 hide_code=cell_data.config.hide_code,
+                expand_output=cell_data.config.expand_output,
             )
 
         cells.append(

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -367,6 +367,9 @@ components:
         hide_code:
           default: false
           type: boolean
+        expand_output:
+          default: false
+          type: boolean
       required: []
       title: CellConfig
       type: object
@@ -4444,6 +4447,11 @@ components:
           - type: boolean
           - type: 'null'
           default: null
+        expandOutput:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          default: null
         type:
           enum:
           - set-config
@@ -7014,4 +7022,3 @@ paths:
       summary: Get the auth token for the current session
       tags:
       - auth
-

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -3560,6 +3560,8 @@ export interface components {
       disabled?: boolean;
       /** @default false */
       hide_code?: boolean;
+      /** @default false */
+      expand_output?: boolean;
     };
     /** Format: cell-id */
     CellId: TypedString<"CellId">;
@@ -6014,6 +6016,8 @@ export interface components {
       disabled?: boolean | null;
       /** @default null */
       hideCode?: boolean | null;
+      /** @default null */
+      expandOutput?: boolean | null;
       /** @enum {unknown} */
       type: "set-config";
     };

--- a/packages/openapi/src/notebook.ts
+++ b/packages/openapi/src/notebook.ts
@@ -26,6 +26,7 @@ export interface components {
       column?: number | null;
       disabled?: boolean | null;
       hide_code?: boolean | null;
+      expand_output?: boolean | null;
     };
     /**
      * NotebookMetadata

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -1,15 +1,13 @@
 # Copyright 2026 Marimo. All rights reserved.
 
 from __future__ import annotations
-import os
+
 import pathlib
 import subprocess
 import sys
 import textwrap
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
 
-import click
 import pytest
 
 from marimo._ast.app import (
@@ -27,21 +25,13 @@ from marimo._ast.errors import (
     SetupRootError,
     UnparsableError,
 )
-from marimo._ast.load import load_app
 from marimo._ast.names import SETUP_CELL_NAME
-from marimo._convert.converters import MarimoConvert
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._plugins.stateless.flex import vstack
+from marimo._runtime.commands import UpdateUIElementCommand
 from marimo._runtime.context.types import get_context
-from marimo._runtime.commands import UpdateUIElementCommand, ExecuteCellCommand
-from marimo._schemas.serialization import (
-    AppInstantiation,
-    CellDef,
-    NotebookSerializationV1,
-)
 from marimo._types.ids import CellId_t
-from tests.conftest import ExecReqProvider, MockedKernel
-from tests._messaging.mocks import MockStream
+from tests.conftest import ExecReqProvider
 
 if TYPE_CHECKING:
     from marimo._runtime.runtime import Kernel
@@ -101,7 +91,7 @@ class TestApp:
 
         @app.cell
         def _() -> tuple[object]:
-            doc = __doc__  # noqa: F821
+            doc = __doc__
             return (doc,)
 
         _, defs = app.run()
@@ -114,7 +104,7 @@ class TestApp:
 
         @app.cell
         def _() -> tuple[object]:
-            doc = __doc__  # noqa: F821
+            doc = __doc__
             return (doc,)
 
         _, defs = app.run()
@@ -132,7 +122,9 @@ class TestApp:
             return batch_size, learning_rate
 
         @app.cell
-        def process_data(batch_size: int, learning_rate: float) -> tuple[float]:
+        def process_data(
+            batch_size: int, learning_rate: float
+        ) -> tuple[float]:
             result = batch_size * learning_rate
             return (result,)
 
@@ -149,7 +141,9 @@ class TestApp:
         assert defs["message"] == "independent"
 
         # Test 2: Run with overridden values
-        outputs, defs = app.run(defs={"batch_size": 64, "learning_rate": 0.001})
+        outputs, defs = app.run(
+            defs={"batch_size": 64, "learning_rate": 0.001}
+        )
         assert defs["batch_size"] == 64
         assert defs["learning_rate"] == 0.001
         assert defs["result"] == 64 * 0.001
@@ -202,7 +196,6 @@ class TestApp:
         app = App()
 
         with app.setup:
-            import os
             setup_var = "from_setup"
 
         @app.cell
@@ -231,7 +224,6 @@ class TestApp:
         app = App()
 
         with app.setup:
-            import os
             a = 1
             if a > 2:
                 setup_var = "from_setup"
@@ -246,7 +238,6 @@ class TestApp:
         with pytest.raises(NameError) as exc_info:
             app.run()
         assert "setup_var" in str(exc_info.value)
-
 
     @staticmethod
     def test_setup() -> None:
@@ -290,7 +281,6 @@ class TestApp:
         assert (defs["y"], defs["z"]) == (1, 2)
         assert defs["a"] == 2
 
-
     @staticmethod
     def test_cycle() -> None:
         app = App()
@@ -314,11 +304,11 @@ class TestApp:
 
         @app.cell
         def one() -> None:
-            x = y  # noqa: F841, F821
+            x = y  # noqa: F821
 
         @app.cell
         def two() -> None:
-            y = x  # noqa: F841, F821
+            y = x  # noqa: F821
 
         with pytest.raises(CycleError):
             app.run()
@@ -346,11 +336,11 @@ class TestApp:
 
         @app.cell
         def one() -> None:
-            x = 0  # noqa: F841
+            x = 0
 
         @app.cell
         def two() -> None:
-            x = 0  # noqa: F841
+            x = 0
 
         with pytest.raises(MultipleDefinitionError):
             app.run()
@@ -361,11 +351,11 @@ class TestApp:
 
         @app.cell
         def one() -> None:
-            x = 0  # noqa: F841
+            x = 0
 
         @app.cell
         def two() -> None:
-            del x  # noqa: F841, F821
+            del x  # noqa: F821
 
         # smoke test, no error raised
         app.run()
@@ -425,7 +415,7 @@ class TestApp:
 
         @app.cell
         def _() -> tuple[str]:
-            _x = 10  # noqa: F841
+            _x = 10
 
             def _f() -> str:
                 _x = "nested"
@@ -453,7 +443,7 @@ class TestApp:
 
         @app.cell
         def _() -> None:
-            _x  # type: ignore  # noqa: F821
+            _x  # type: ignore
             return
 
         with pytest.raises(NameError) as e:
@@ -467,7 +457,7 @@ class TestApp:
 
         @app.cell
         def _() -> None:
-            _x = 0  # noqa: F841
+            _x = 0
             return
 
         @app.cell
@@ -502,7 +492,7 @@ class TestApp:
 
         @app.cell
         def _() -> None:
-            __ = 1  # noqa: F841
+            __ = 1
             return
 
         @app.cell
@@ -547,7 +537,7 @@ class TestApp:
             __x__ = 0
             return (__x__,)
 
-        @app.cell(hide_code=True)
+        @app.cell(hide_code=True, expand_output=True)
         def _(__x__: int) -> None:
             assert __x__ == 0
             return
@@ -557,6 +547,7 @@ class TestApp:
         assert configs[0].disabled
         assert configs[0].column is not None
         assert configs[1].hide_code
+        assert configs[1].expand_output
 
     @staticmethod
     def test_conditional_definition() -> None:
@@ -647,6 +638,7 @@ class TestApp:
         @app.cell
         def _() -> Any:
             import marimo as mo
+
             return (mo,)
 
         @app.cell
@@ -671,6 +663,7 @@ class TestApp:
         @app.cell
         def _() -> Any:
             import marimo as mo
+
             return (mo,)
 
         @app.cell
@@ -696,6 +689,7 @@ class TestApp:
         @app.cell
         def _() -> Any:
             import marimo as mo
+
             return (mo,)
 
         @app.cell
@@ -710,7 +704,6 @@ class TestApp:
             y = 0
             return (y,)
 
-
         @app.cell
         def _(x) -> tuple[int]:
             x
@@ -723,13 +716,11 @@ class TestApp:
             b = 0
             return
 
-
         _, defs = app.run()
         assert "x" not in defs
         assert "y" not in defs
         assert "a" not in defs
         assert "b" not in defs
-
 
     @staticmethod
     def test_run_mo_stop_async() -> None:
@@ -738,6 +729,7 @@ class TestApp:
         @app.cell
         def _() -> Any:
             import marimo as mo
+
             return (mo,)
 
         @app.cell
@@ -762,6 +754,7 @@ class TestApp:
         @app.cell
         def _() -> Any:
             import marimo as mo
+
             return (mo,)
 
         @app.cell
@@ -779,7 +772,6 @@ class TestApp:
         _, defs = app.run()
         assert "x" not in defs
         assert "y" not in defs
-
 
     @pytest.mark.skipif(
         condition=not DependencyManager.matplotlib.has(),
@@ -954,11 +946,16 @@ class TestApp:
 
         # Public mutable fields should be deep-copied, not shared
         assert original_impl.config is not cloned_impl.config
-        assert original_impl.import_workspace is not cloned_impl.import_workspace
+        assert (
+            original_impl.import_workspace is not cloned_impl.import_workspace
+        )
 
         # Private mutable runtime state fields should also be independent
         assert original_impl._status is not cloned_impl._status
-        assert original_impl._run_result_status is not cloned_impl._run_result_status
+        assert (
+            original_impl._run_result_status
+            is not cloned_impl._run_result_status
+        )
         assert original_impl._stale is not cloned_impl._stale
         assert original_impl._output is not cloned_impl._output
 
@@ -1029,8 +1026,7 @@ class TestInvalidSetup:
     @staticmethod
     def test_initial_setup() -> None:
         app = App()
-        app._unparsable_cell(";",
-                             name="setup")
+        app._unparsable_cell(";", name="setup")
 
         assert app._cell_manager.has_cell("setup")
         assert app._cell_manager.cell_name("setup") == "setup"
@@ -1038,22 +1034,21 @@ class TestInvalidSetup:
     @staticmethod
     def test_not_initial_setup() -> None:
         app = App()
-        app._unparsable_cell(";",
-                             name="other")
-        app._unparsable_cell(";",
-                             name="setup")
+        app._unparsable_cell(";", name="other")
+        app._unparsable_cell(";", name="setup")
 
         assert not app._cell_manager.has_cell("setup")
 
     @staticmethod
     def test_not_initial_setup_cell() -> None:
         app = App()
+
         @app.cell
         def _():
             def B() -> float:
                 return 1.0
-        app._unparsable_cell(";",
-                             name="setup")
+
+        app._unparsable_cell(";", name="setup")
         assert not app._cell_manager.has_cell("setup")
 
 
@@ -1198,7 +1193,9 @@ class TestAppComposition:
         with pytest.raises(ValueError) as excinfo:
             await app.embed(defs={"x": mo.ui.slider(1, 10)})
 
-        assert "Substituting UI Elements for variables is not allowed" in str(excinfo.value)
+        assert "Substituting UI Elements for variables is not allowed" in str(
+            excinfo.value
+        )
 
     async def test_app_embed_with_defs_multiple_vars(self) -> None:
         """Test embed() with defs overriding a cell that defines multiple variables."""
@@ -1522,8 +1519,6 @@ class TestAppComposition:
             with app.setup:
                 app = 1
 
-
-
     @staticmethod
     def test_setup_not_exposed() -> None:
         app = App()
@@ -1534,7 +1529,6 @@ class TestAppComposition:
                     x = app is not None
                 except NameError:
                     x = False
-
 
     @staticmethod
     def test_setup_in_memory() -> None:
@@ -1588,11 +1582,20 @@ class TestAppComposition:
         assert setup_cell is not None
         assert setup_cell.config.hide_code is False
 
+    @staticmethod
+    def test_setup_expand_output() -> None:
+        setup_cell_id = CellId_t("setup")
+
+        app = App()
+        with app.setup(expand_output=True):
+            x = 1
+
+        setup_cell = app._cell_manager._cell_data.get(setup_cell_id)
+        assert setup_cell is not None
+        assert setup_cell.config.expand_output is True
 
     @staticmethod
-    async def test_app_embed_preserves_file_path(
-        app: App
-    ) -> None:
+    async def test_app_embed_preserves_file_path(app: App) -> None:
         with app.setup:
             from tests._ast.app_data import notebook_filename
 
@@ -1613,7 +1616,6 @@ class TestAppComposition:
         def _(cloned: AppEmbedResult, filename: str, directory: str) -> None:
             assert cloned.defs.get("this_is_foo_file").endswith(filename)
             assert cloned.defs.get("this_is_foo_path").stem == directory
-
 
     @staticmethod
     async def test_app_embed_in_kernel(
@@ -1638,10 +1640,13 @@ class TestAppComposition:
         filename = "notebook_filename.py"
         directory = "app_data"
         assert k.globals["app"].defs.get("this_is_foo_file").endswith(filename)
-        assert k.globals["cloned"].defs.get("this_is_foo_file").endswith(filename)
+        assert (
+            k.globals["cloned"].defs.get("this_is_foo_file").endswith(filename)
+        )
         assert k.globals["app"].defs.get("this_is_foo_path").stem == directory
-        assert k.globals["cloned"].defs.get("this_is_foo_path").stem == directory
-
+        assert (
+            k.globals["cloned"].defs.get("this_is_foo_path").stem == directory
+        )
 
     @staticmethod
     async def test_app_embed_same_cell_in_kernel(
@@ -1683,8 +1688,9 @@ class TestAppComposition:
 
         This tests the fix where setup cells get the prefix like other cells.
         """
-        await k.run([
-            exec_req.get("""
+        await k.run(
+            [
+                exec_req.get("""
             # Import in kernel context; the prefix the app gets
             # depends on whether it was first imported in a kernel context,
             # so we reload it in case notebook_filename was loaded elsewhere
@@ -1695,11 +1701,14 @@ class TestAppComposition:
             importlib.reload(mod)
             app = mod.app
             """)
-        ])
+            ]
+        )
         assert not k.errors
         nb_app = k.globals["app"]
         cell_ids = list(InternalApp(nb_app).cell_manager.cell_ids())
-        setup_cell_ids = [cid for cid in cell_ids if cid.endswith(SETUP_CELL_NAME)]
+        setup_cell_ids = [
+            cid for cid in cell_ids if cid.endswith(SETUP_CELL_NAME)
+        ]
         assert len(setup_cell_ids) == 1
         assert is_external_cell_id(setup_cell_ids[0])
 
@@ -1822,8 +1831,6 @@ class TestInternalAppOverrides:
         )
         assert not k.errors
         assert k.globals["overrides"] == {"a": 10, "b": 20}
-
-
 
 
 class TestAppKernelRunnerRegistry:

--- a/tests/_ast/test_app_cell.py
+++ b/tests/_ast/test_app_cell.py
@@ -52,6 +52,17 @@ def test_decorator_with_args() -> None:
     assert cell.run(x=1) == (None, {"y": 3})
 
 
+def test_decorator_with_expand_output() -> None:
+    def mock_func() -> tuple[int]:
+        x = 1
+        return (x,)
+
+    app = App()
+    cell = app.cell(expand_output=True)(mock_func)
+    assert cell is not None
+    assert cell._cell.config.expand_output is True
+
+
 def test_decorator_with_unknown_args() -> None:
     # Decorator with unknown args
     def __() -> tuple[int]:

--- a/tests/_ast/test_cell.py
+++ b/tests/_ast/test_cell.py
@@ -481,12 +481,18 @@ def test_cell_config_asdict_without_defaults():
     config = CellConfig(hide_code=True)
     assert config.asdict_without_defaults() == {"hide_code": True}
 
+    config = CellConfig(expand_output=True)
+    assert config.asdict_without_defaults() == {"expand_output": True}
+
     config = CellConfig(hide_code=False)
     assert config.asdict_without_defaults() == {}
 
 
 def test_is_different_from_default():
     config = CellConfig(hide_code=True)
+    assert config.is_different_from_default()
+
+    config = CellConfig(expand_output=True)
     assert config.is_different_from_default()
 
     config = CellConfig(hide_code=False)

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -232,13 +232,14 @@ class TestGeneration:
     def test_generate_unparsable_cell_with_config() -> None:
         """Test that generate_unparsable_cell works with non-default CellConfig."""
         code = 'mo.md("markdown in marimo")'
-        config = CellConfig(hide_code=True)
+        config = CellConfig(hide_code=True, expand_output=True)
 
         # This should not raise AttributeError
         raw = codegen.generate_unparsable_cell(code, None, config)
 
         # Verify the config is included in the output
         assert "hide_code=True" in raw
+        assert "expand_output=True" in raw
         # Verify the code is properly included (raw string for code without triple quotes)
         assert 'mo.md("markdown in marimo")' in raw
 
@@ -327,14 +328,19 @@ app._unparsable_cell(
         assert generate(
             "x = 1",
             "named_cell",
-            CellConfig(disabled=True, hide_code=True, column=1),
+            CellConfig(
+                disabled=True,
+                hide_code=True,
+                expand_output=True,
+                column=1,
+            ),
         ) == snapshot(
             '''\
 app._unparsable_cell(
     r"""
     x = 1
     """,
-    column=1, disabled=True, hide_code=True, name="named_cell"
+    column=1, disabled=True, hide_code=True, expand_output=True, name="named_cell"
 )\
 '''
         )
@@ -948,11 +954,13 @@ class TestToFunctionDef:
     def test_with_all_config(self) -> None:
         code = "x = 0"
         cell = compile_cell(code)
-        cell = cell.configure(CellConfig(disabled=True, hide_code=True))
+        cell = cell.configure(
+            CellConfig(disabled=True, hide_code=True, expand_output=True)
+        )
         fndef = codegen.to_functiondef(cell, "foo")
         expected = "\n".join(
             [
-                "@app.cell(disabled=True, hide_code=True)",
+                "@app.cell(disabled=True, hide_code=True, expand_output=True)",
                 "def foo():",
                 "    x = 0",
                 "    return (x,)",
@@ -1039,9 +1047,14 @@ class TestToFunctionDef:
     def test_fn_with_all_config(self) -> None:
         code = "\n".join(["def foo():", "    x = 0", "    return (x,)"])
         cell = compile_cell(code)
-        cell = cell.configure(CellConfig(disabled=True, hide_code=True))
+        cell = cell.configure(
+            CellConfig(disabled=True, hide_code=True, expand_output=True)
+        )
         fndef = codegen.to_top_functiondef(cell)
-        expected = "@app.function(disabled=True, hide_code=True)\n" + code
+        expected = (
+            "@app.function(disabled=True, hide_code=True, expand_output=True)\n"
+            + code
+        )
         assert fndef == expected
 
 

--- a/tests/_code_mode/test_context.py
+++ b/tests/_code_mode/test_context.py
@@ -95,6 +95,7 @@ class TestAddCell:
                             "column": None,
                             "disabled": False,
                             "hide_code": True,
+                            "expand_output": False,
                         },
                         "before": None,
                         "after": None,
@@ -321,6 +322,7 @@ class TestUpdateCell:
                         "column": None,
                         "disabled": False,
                         "hideCode": True,
+                        "expandOutput": None,
                     },
                     {"type": "reorder-cells", "cellIds": ("0",)},
                 ]

--- a/tests/_messaging/notebook/test_document.py
+++ b/tests/_messaging/notebook/test_document.py
@@ -283,6 +283,14 @@ class TestSetConfig:
         cfg = doc.get_cell(CellId_t("a")).config
         assert cfg.hide_code is True
         assert cfg.disabled is False  # unchanged default
+        assert cfg.expand_output is False  # unchanged default
+
+    def test_partial_expand_output(self) -> None:
+        doc = _doc("a")
+        doc.apply(_tx(SetConfig(cell_id=CellId_t("a"), expand_output=True)))
+        cfg = doc.get_cell(CellId_t("a")).config
+        assert cfg.expand_output is True
+        assert cfg.hide_code is False  # unchanged default
 
     def test_partial_disabled(self) -> None:
         doc = _doc("a")
@@ -316,7 +324,9 @@ class TestSetConfig:
                     id=CellId_t("a"),
                     code="",
                     name="__",
-                    config=CellConfig(hide_code=True, column=2),
+                    config=CellConfig(
+                        hide_code=True, expand_output=True, column=2
+                    ),
                 )
             ]
         )
@@ -324,6 +334,7 @@ class TestSetConfig:
         cfg = doc.get_cell(CellId_t("a")).config
         assert cfg.disabled is True
         assert cfg.hide_code is True  # preserved
+        assert cfg.expand_output is True  # preserved
         assert cfg.column == 2  # preserved
 
 

--- a/tests/_session/state/test_serialize_session.py
+++ b/tests/_session/state/test_serialize_session.py
@@ -164,7 +164,12 @@ def test_serialize_notebook_basic(session_view: SessionView):
         cell_id=CELL1,
         code="print('Hello, world!')",
         name="my_cell",
-        config=CellConfig(column=1, disabled=False, hide_code=True),
+        config=CellConfig(
+            column=1,
+            disabled=False,
+            hide_code=True,
+            expand_output=True,
+        ),
     )
 
     view.cell_notifications[CELL1] = _make_cell_notification(
@@ -190,6 +195,7 @@ def test_serialize_notebook_basic(session_view: SessionView):
     assert cell["config"]["column"] == 1
     assert cell["config"]["disabled"] is False
     assert cell["config"]["hide_code"] is True
+    assert cell["config"]["expand_output"] is True
 
 
 def test_serialize_notebook_multiple_cells(session_view: SessionView):

--- a/tests/_session/test_file_change_handler.py
+++ b/tests/_session/test_file_change_handler.py
@@ -299,6 +299,46 @@ def test_edit_mode_reload_sends_config_changes(
     assert config_changes[0].hide_code is True
 
 
+def test_edit_mode_reload_sends_expand_output_changes(
+    tmp_path: Path, mock_session: MagicMock, config_manager_lazy
+) -> None:
+    content = dedent(
+        """\
+        import marimo
+        app = marimo.App()
+
+        @app.cell(expand_output=True)
+        def my_named_cell():
+            x = 1
+            return x
+        """
+    )
+    afm = _make_app(tmp_path, content)
+    cell_ids = list(afm.app.cell_manager.cell_ids())
+    _run_reload(
+        tmp_path,
+        mock_session,
+        config_manager_lazy,
+        content=content,
+        document=NotebookDocument(
+            [
+                NotebookCell(
+                    id=cell_ids[0],
+                    code="x = 1",
+                    name="my_named_cell",
+                    config=CellConfig(expand_output=False),
+                ),
+            ]
+        ),
+    )
+
+    config_changes = _changes_of_type(
+        _get_transaction(mock_session), SetConfig
+    )
+    assert len(config_changes) == 1
+    assert config_changes[0].expand_output is True
+
+
 def test_edit_mode_reload_sends_name_changes(
     tmp_path: Path, mock_session: MagicMock, config_manager_lazy
 ) -> None:


### PR DESCRIPTION

## 📝 Summary

Closes #7690 

This introduces the ability to annotate a cell with `@app.cell(expand_output=True)` to cause that cell's output to be automatically expanded by default when the user loads the notebook.

This PR does not provide a way to cause this behavior from the web UI.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [X] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [X] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Tests have been added for the changes made.

![2026-04-10 23-47-58](https://github.com/user-attachments/assets/a1a5f930-9470-4c3e-b725-ab5b9c581ea8)

I have read the CLA Document and I hereby sign the CLA