### PR TITLE
fix: image dimensions for Altair PNG outputs

### DIFF
--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -120,8 +120,8 @@ def _format_png_mimebundle(
         "image/png": data_url or "",
         METADATA_KEY: {
             "image/png": {
-                "width": int(metadata["width"]),
-                "height": int(metadata["height"]),
+                "width": round(metadata["width"]),
+                "height": round(metadata["height"]),
             }
         },
     }

--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -120,8 +120,8 @@ def _format_png_mimebundle(
         "image/png": data_url or "",
         METADATA_KEY: {
             "image/png": {
-                "width": metadata["width"],
-                "height": metadata["height"],
+                "width": int(metadata["width"]),
+                "height": int(metadata["height"]),
             }
         },
     }

--- a/tests/_output/formatters/test_altair_formatters.py
+++ b/tests/_output/formatters/test_altair_formatters.py
@@ -190,7 +190,7 @@ def test_altair_formatter_png():
         "_repr_mimebundle_",
         return_value=(
             {"image/png": b"png"},
-            {"image/png": {"width": 10, "height": 20}},
+            {"image/png": {"width": 10.2, "height": 19.8}},
         ),
     ):
         formatter = get_formatter(mock_chart)


### PR DESCRIPTION
## 📝 Summary

This PR fixes a bug introduced in #9049.

Altair returns `width` and `height` metadata as float values for PNG. However, these values are used as the `width` and `height` attributes of an `<img>` element in the frontend. These attributes expect integer values.

## Changes

- Cast `width` and `height` to `int` in the Altair formatter's `_format_png_mimebundle` function.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
