### PR TITLE
fix: handle list-type tooltip encoding in altair chart (#9167)

### DIFF
--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -69,6 +69,8 @@ def _has_binning(spec: VegaSpec) -> bool:
     if "encoding" not in spec:
         return False
     for encoding in spec["encoding"].values():
+        if isinstance(encoding, list):
+            continue
         if "bin" in encoding:
             return True
     return False
@@ -85,6 +87,8 @@ def _get_binned_fields(spec: VegaSpec) -> dict[str, Any]:
         return binned_fields
 
     for encoding in spec["encoding"].values():
+        if isinstance(encoding, list):
+            continue
         if encoding.get("bin"):
             # Get the field name
             field = encoding.get("field")

--- a/tests/_plugins/ui/_impl/test_altair_chart.py
+++ b/tests/_plugins/ui/_impl/test_altair_chart.py
@@ -994,6 +994,62 @@ def test_get_binned_fields() -> None:
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_get_binned_fields_with_tooltip_list() -> None:
+    """Test _get_binned_fields handles tooltip encoded as a list (#9167)."""
+    import altair as alt
+
+    # Tooltip as a list should not crash _get_binned_fields or _has_binning
+    spec = _parse_spec(
+        alt.Chart(pd.DataFrame({"x": range(10), "y": range(10)}))
+        .mark_point()
+        .encode(
+            x="x",
+            y="y",
+            tooltip=["x", "y"],
+        )
+    )
+    assert _get_binned_fields(spec) == {}
+    assert _has_binning(spec) is False
+
+    # Tooltip list with binned fields on other channels
+    spec_with_bins = _parse_spec(
+        alt.Chart(pd.DataFrame({"x": range(10), "y": range(10)}))
+        .mark_bar()
+        .encode(
+            x=alt.X("x", bin=True),
+            y="count()",
+            tooltip=["x", alt.Tooltip("y", format=".2f")],
+        )
+    )
+    binned = _get_binned_fields(spec_with_bins)
+    assert "x" in binned
+    assert _has_binning(spec_with_bins) is True
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_altair_chart_with_tooltip_list() -> None:
+    """Smoke test: altair_chart with tooltip list should not error (#9167)."""
+    import altair as alt
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": ["x", "y", "z"]})
+    chart = (
+        alt.Chart(df)
+        .mark_arc()
+        .encode(
+            theta="a",
+            color="c",
+            tooltip=[
+                "c",
+                alt.Tooltip("a", format=".2f"),
+                alt.Tooltip("b", format="$.2f"),
+            ],
+        )
+    )
+    # This should not raise AttributeError
+    altair_chart(chart)
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 def test_has_geoshape() -> None:
     import altair as alt
 


### PR DESCRIPTION
`_has_binning()` and `_get_binned_fields()` iterated over
`spec["encoding"].values()` and called dict methods (`.get()`, `in`) on
each value. When `tooltip` is defined as a list of multiple tooltips,
the encoding value is a list instead of a dict, causing
`AttributeError: 'list' object has no attribute 'get'`.

Skip list-type encoding values (like tooltip arrays) since they cannot
contain binning configuration.

Closes #9167
