### PR TITLE
fix: widen `Html.batch()` type to accept all UIElement subclasses (#9163)

### DIFF
--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -16,7 +16,6 @@ from marimo._utils.methods import getcallable
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from marimo._plugins.core.web_component import JSONType
     from marimo._plugins.ui._core.ui_element import UIElement
     from marimo._plugins.ui._impl.batch import batch as batch_plugin
 
@@ -164,7 +163,7 @@ class Html(MIME):
         )
 
     @mddoc
-    def batch(self, **elements: UIElement[JSONType, object]) -> batch_plugin:
+    def batch(self, **elements: UIElement[Any, Any]) -> batch_plugin:
         """Convert an HTML object with templated text into a UI element.
 
         This method lets you create custom UI elements that are represented

--- a/tests/_ast/test_app_typing.py
+++ b/tests/_ast/test_app_typing.py
@@ -226,3 +226,19 @@ class TestCacheContext:
     assert_type(mo.{cache_func}("cache"), _cache_context)
 """
         )
+
+
+class TestBatchTyping:
+    def test_batch_accepts_slider_and_number(self) -> None:
+        _check_pyright(
+            _PREAMBLE
+            + """
+    parameters = mo.md(
+        "slider: {a} number: {b}"
+    ).batch(
+        a=mo.ui.slider(start=1, stop=50, step=1, value=10),
+        b=mo.ui.number(value=0.2),
+    )
+    assert_type(parameters.value, dict[str, object])
+"""
+        )


### PR DESCRIPTION
`UIElement` type params are invariant, so `UIElement[Numeric, Numeric]`
(slider) wasn't assignable to `UIElement[JSONType, object]`. Changed to
`UIElement[Any, Any]`, matching `batch.__init__` and `array.__init__`.
