### PR TITLE
fix: use shared memory for virtual files when running with app isolation 

### DIFF
--- a/marimo/_ipc/launch_kernel.py
+++ b/marimo/_ipc/launch_kernel.py
@@ -44,7 +44,7 @@ def main() -> None:
         profile_path=args.profile_path,
         # Virtual files require a web server to serve file URLs. Since we're
         # not running one, content must be embedded as data URLs instead.
-        virtual_files_supported=False,
+        virtual_file_storage=None,
         # NB: IPC kernels are always subprocesses (is_ipc=True) but may be
         # edit or run mode based on is_edit_mode.
         stream_queue=queue_manager.stream_queue,

--- a/marimo/_ipc/types.py
+++ b/marimo/_ipc/types.py
@@ -35,7 +35,6 @@ class KernelArgs(msgspec.Struct):
     # Whether to use run-mode config (autorun) vs edit-mode config (lazy)
     is_run_mode: bool = False
     # Runtime behavior flags
-    virtual_files_supported: bool = True
     redirect_console_to_browser: bool = True
 
     def encode_json(self) -> bytes:

--- a/marimo/_ipc/types.py
+++ b/marimo/_ipc/types.py
@@ -35,6 +35,8 @@ class KernelArgs(msgspec.Struct):
     # Whether to use run-mode config (autorun) vs edit-mode config (lazy)
     is_run_mode: bool = False
     # Runtime behavior flags
+    # virtual_files_supported is ignored, but kept for backward compatibility
+    virtual_files_supported: bool = True
     redirect_console_to_browser: bool = True
 
     def encode_json(self) -> bytes:

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -493,7 +493,7 @@ def _launch_pyodide_kernel(
         stream=stream,
         stdout=stdout,
         stderr=stderr,
-        virtual_files_supported=False,
+        virtual_file_storage=None,
         mode=session_mode,
     )
 

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -140,7 +140,7 @@ class AppKernelRunner:
             stream=ctx.stream,
             stdout=None,
             stderr=None,
-            virtual_files_supported=True,
+            virtual_file_storage="shared_memory",
             mode=SessionMode.EDIT,
             parent=ctx,
         )

--- a/marimo/_runtime/context/kernel_context.py
+++ b/marimo/_runtime/context/kernel_context.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from marimo._messaging.types import Stream
     from marimo._runtime.runtime import Kernel
     from marimo._runtime.state import State
+    from marimo._runtime.virtual_file import VirtualFileStorageType
     from marimo._types.ids import CellId_t
 
 
@@ -143,7 +144,7 @@ def create_kernel_context(
     stream: Stream,
     stdout: Stdout | None,
     stderr: Stderr | None,
-    virtual_files_supported: bool,
+    virtual_file_storage: VirtualFileStorageType | None,
     mode: SessionMode,
     app: InternalApp | None = None,
     parent: KernelRuntimeContext | None = None,
@@ -154,15 +155,17 @@ def create_kernel_context(
         InMemoryStorage,
         SharedMemoryStorage,
         VirtualFileRegistry,
+        VirtualFileStorage,
     )
     from marimo._save.cache import CacheState
     from marimo._save.stores import get_store
 
-    # Use shared memory in edit mode,
-    # in-memory storage in run mode (same process)
-    storage = (
+    # Storage is chosen explicitly by the caller. None means virtual files
+    # are not supported; we still construct an (inert) InMemoryStorage so
+    # the registry has a backend, but ctx.virtual_files_supported is False.
+    storage: VirtualFileStorage = (
         SharedMemoryStorage()
-        if mode == SessionMode.EDIT
+        if virtual_file_storage == "shared_memory"
         else InMemoryStorage()
     )
 
@@ -181,7 +184,7 @@ def create_kernel_context(
             else AppKernelRunnerRegistry()
         ),
         virtual_file_registry=VirtualFileRegistry(storage=storage),
-        virtual_files_supported=virtual_files_supported,
+        virtual_files_supported=virtual_file_storage is not None,
         stream=stream,
         stdout=stdout,
         stderr=stderr,
@@ -198,7 +201,7 @@ def initialize_kernel_context(
     stream: Stream,
     stdout: Stdout | None,
     stderr: Stderr | None,
-    virtual_files_supported: bool,
+    virtual_file_storage: VirtualFileStorageType | None,
     mode: SessionMode,
 ) -> KernelRuntimeContext:
     """Initializes thread-local/session-specific context.
@@ -210,7 +213,7 @@ def initialize_kernel_context(
         stream=stream,
         stdout=stdout,
         stderr=stderr,
-        virtual_files_supported=virtual_files_supported,
+        virtual_file_storage=virtual_file_storage,
         mode=mode,
     )
     initialize_context(runtime_context=ctx)

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -230,6 +230,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from marimo._plugins.ui._core.ui_element import UIElement
+    from marimo._runtime.virtual_file import VirtualFileStorageType
 
 LOGGER = _loggers.marimo_logger()
 
@@ -3502,7 +3503,7 @@ def launch_kernel(
     configs: dict[CellId_t, CellConfig],
     app_metadata: AppMetadata,
     user_config: MarimoConfig,
-    virtual_files_supported: bool,
+    virtual_file_storage: VirtualFileStorageType | None,
     redirect_console_to_browser: bool,
     interrupt_queue: QueueType[bool] | None = None,
     profile_path: str | None = None,
@@ -3636,7 +3637,7 @@ def launch_kernel(
         stream=stream,
         stdout=stdout,
         stderr=stderr,
-        virtual_files_supported=virtual_files_supported,
+        virtual_file_storage=virtual_file_storage,
         mode=SessionMode.EDIT if is_edit_mode else SessionMode.RUN,
     )
 

--- a/marimo/_runtime/virtual_file/__init__.py
+++ b/marimo/_runtime/virtual_file/__init__.py
@@ -12,6 +12,7 @@ from marimo._runtime.virtual_file.storage import (
     SharedMemoryStorage,
     VirtualFileStorage,
     VirtualFileStorageManager,
+    VirtualFileStorageType,
 )
 from marimo._runtime.virtual_file.virtual_file import (
     EMPTY_VIRTUAL_FILE,
@@ -27,6 +28,7 @@ from marimo._runtime.virtual_file.virtual_file import (
 __all__ = [  # noqa: RUF022
     # Storage
     "VirtualFileStorage",
+    "VirtualFileStorageType",
     "SharedMemoryStorage",
     "InMemoryStorage",
     "VirtualFileStorageManager",

--- a/marimo/_runtime/virtual_file/storage.py
+++ b/marimo/_runtime/virtual_file/storage.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 
 from marimo._utils.platform import is_pyodide
 
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
 DEFAULT_CHUNK_SIZE = 256 * 1024  # 256KB
+
+VirtualFileStorageType = Literal["in_memory", "shared_memory"]
 
 if not is_pyodide():
     # the shared_memory module is not supported in the Pyodide distribution

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -518,7 +518,7 @@ async def run_app_until_completion(
         ),
         app_file_manager=file_manager,
         config_manager=config_manager,
-        virtual_files_supported=False,
+        virtual_file_storage=None,
         redirect_console_to_browser=False,
         ttl_seconds=None,
         auto_instantiate=True,

--- a/marimo/_server/session_manager.py
+++ b/marimo/_server/session_manager.py
@@ -227,7 +227,14 @@ class SessionManager:
             ),
             app_file_manager=app_file_manager,
             config_manager=self._config_manager,
-            virtual_files_supported=True,
+            # EDIT mode runs the kernel in a subprocess (SharedMemoryStorage);
+            # RUN mode runs it in a thread in the same process (InMemoryStorage).
+            # AppHost-backed sessions override this with "shared_memory".
+            virtual_file_storage=(
+                "shared_memory"
+                if self.mode == SessionMode.EDIT
+                else "in_memory"
+            ),
             redirect_console_to_browser=self.redirect_console_to_browser,
             ttl_seconds=self.ttl_seconds,
             auto_instantiate=auto_instantiate,

--- a/marimo/_session/app_host/commands.py
+++ b/marimo/_session/app_host/commands.py
@@ -12,6 +12,7 @@ import msgspec.json
 from marimo._ast.cell import CellConfig
 from marimo._config.config import MarimoConfig
 from marimo._runtime.commands import AppMetadata
+from marimo._runtime.virtual_file import VirtualFileStorageType
 from marimo._types.ids import CellId_t
 
 
@@ -23,7 +24,7 @@ class CreateKernelCmd(msgspec.Struct, tag=True):
     configs: dict[CellId_t, CellConfig]
     app_metadata: AppMetadata
     user_config: MarimoConfig
-    virtual_files_supported: bool
+    virtual_file_storage: VirtualFileStorageType | None
     redirect_console_to_browser: bool
     log_level: int
 

--- a/marimo/_session/app_host/host.py
+++ b/marimo/_session/app_host/host.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from marimo._ast.cell import CellConfig
     from marimo._config.config import MarimoConfig
     from marimo._runtime.commands import AppMetadata
+    from marimo._runtime.virtual_file import VirtualFileStorageType
     from marimo._types.ids import CellId_t
 
 LOGGER = _loggers.marimo_logger()
@@ -251,7 +252,7 @@ class AppHost:
         configs: dict[CellId_t, CellConfig],
         app_metadata: AppMetadata,
         user_config: MarimoConfig,
-        virtual_files_supported: bool,
+        virtual_file_storage: VirtualFileStorageType | None,
         redirect_console_to_browser: bool,
         log_level: int,
     ) -> KernelCreatedResponse:
@@ -264,7 +265,7 @@ class AppHost:
             configs=configs,
             app_metadata=app_metadata,
             user_config=user_config,
-            virtual_files_supported=virtual_files_supported,
+            virtual_file_storage=virtual_file_storage,
             redirect_console_to_browser=redirect_console_to_browser,
             log_level=log_level,
         )

--- a/marimo/_session/app_host/main.py
+++ b/marimo/_session/app_host/main.py
@@ -188,7 +188,7 @@ def _handle_create_kernel(
                     configs=cmd.configs,
                     app_metadata=cmd.app_metadata,
                     user_config=cmd.user_config,
-                    virtual_files_supported=cmd.virtual_files_supported,
+                    virtual_file_storage=cmd.virtual_file_storage,
                     redirect_console_to_browser=cmd.redirect_console_to_browser,
                     interrupt_queue=None,
                     log_level=cmd.log_level,

--- a/marimo/_session/managers/app_host.py
+++ b/marimo/_session/managers/app_host.py
@@ -181,7 +181,10 @@ class AppHostKernelManager(KernelManager):
             configs=self._configs,
             app_metadata=self._app_metadata,
             user_config=self._config_manager.get_config(hide_secrets=False),
-            virtual_files_supported=True,
+            # AppHost runs the kernel in a subprocess, so virtual files
+            # must be stored in shared memory — otherwise the server
+            # process can't serve them on /@file/...
+            virtual_file_storage="shared_memory",
             redirect_console_to_browser=self._redirect_console_to_browser,
             log_level=GLOBAL_SETTINGS.LOG_LEVEL,
         )

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -188,7 +188,6 @@ class IPCKernelManagerImpl(KernelManager):
         configs: dict[CellId_t, CellConfig],
         app_metadata: AppMetadata,
         config_manager: MarimoConfigReader,
-        virtual_files_supported: bool = True,
         redirect_console_to_browser: bool = True,
     ) -> None:
         self.queue_manager = queue_manager
@@ -197,7 +196,6 @@ class IPCKernelManagerImpl(KernelManager):
         self.configs = configs
         self.app_metadata = app_metadata
         self.config_manager = config_manager
-        self.virtual_files_supported = virtual_files_supported
         self.redirect_console_to_browser = redirect_console_to_browser
 
         self._process: subprocess.Popen[bytes] | None = None
@@ -217,7 +215,6 @@ class IPCKernelManagerImpl(KernelManager):
             profile_path=None,
             connection_info=self.connection_info,
             is_run_mode=self.mode == SessionMode.RUN,
-            virtual_files_supported=self.virtual_files_supported,
             redirect_console_to_browser=self.redirect_console_to_browser,
         )
 

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from marimo._ast.cell import CellConfig
     from marimo._config.manager import MarimoConfigReader
     from marimo._runtime.commands import AppMetadata
+    from marimo._runtime.virtual_file import VirtualFileStorageType
     from marimo._types.ids import CellId_t
 
 LOGGER = _loggers.marimo_logger()
@@ -47,7 +48,7 @@ class KernelManagerImpl(KernelManager):
         configs: dict[CellId_t, CellConfig],
         app_metadata: AppMetadata,
         config_manager: MarimoConfigReader,
-        virtual_files_supported: bool,
+        virtual_file_storage: VirtualFileStorageType | None,
         redirect_console_to_browser: bool,
     ) -> None:
         self.kernel_task: ProcessLike | threading.Thread | None = None
@@ -60,7 +61,7 @@ class KernelManagerImpl(KernelManager):
 
         # Only used in edit mode
         self._read_conn: TypedConnection[KernelMessage] | None = None
-        self._virtual_files_supported = virtual_files_supported
+        self._virtual_file_storage = virtual_file_storage
 
     def start_kernel(self) -> None:
         # We use a process in edit mode so that we can interrupt the app
@@ -85,7 +86,7 @@ class KernelManagerImpl(KernelManager):
                     self.configs,
                     self.app_metadata,
                     self.config_manager.get_config(hide_secrets=False),
-                    self._virtual_files_supported,
+                    self._virtual_file_storage,
                     self.redirect_console_to_browser,
                     self.queue_manager.win32_interrupt_queue,
                     self.profile_path,
@@ -137,7 +138,7 @@ class KernelManagerImpl(KernelManager):
                     self.configs,
                     self.app_metadata,
                     self.config_manager.get_config(hide_secrets=False),
-                    self._virtual_files_supported,
+                    self._virtual_file_storage,
                     self.redirect_console_to_browser,
                     # win32 interrupt queue
                     None,

--- a/marimo/_session/session.py
+++ b/marimo/_session/session.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
 
     from marimo._ast.cell_manager import CellManager
+    from marimo._runtime.virtual_file import VirtualFileStorageType
     from marimo._server.models.models import InstantiateNotebookRequest
     from marimo._session.app_host import AppHostContext
 
@@ -116,7 +117,7 @@ class SessionImpl(Session):
         app_metadata: AppMetadata,
         app_file_manager: AppFileManager,
         config_manager: MarimoConfigManager,
-        virtual_files_supported: bool,
+        virtual_file_storage: VirtualFileStorageType | None,
         redirect_console_to_browser: bool,
         auto_instantiate: bool,
         ttl_seconds: int | None,
@@ -183,7 +184,6 @@ class SessionImpl(Session):
                 configs=configs,
                 app_metadata=app_metadata,
                 config_manager=config_manager,
-                virtual_files_supported=virtual_files_supported,
                 redirect_console_to_browser=redirect_console_to_browser,
             )
         else:
@@ -198,7 +198,7 @@ class SessionImpl(Session):
                 configs=configs,
                 app_metadata=app_metadata,
                 config_manager=config_manager,
-                virtual_files_supported=virtual_files_supported,
+                virtual_file_storage=virtual_file_storage,
                 redirect_console_to_browser=redirect_console_to_browser,
             )
 

--- a/marimo/_smoke_tests/process_isolation/README.md
+++ b/marimo/_smoke_tests/process_isolation/README.md
@@ -46,3 +46,20 @@ Open both apps in browser. Each should show a green "PASS" callout.
 - **With `--sandbox`**: Both apps additionally show a green "Sandbox: PASS" callout —
   each app's unique dependency (`humanize` for app1, `pyfiglet` for app2) was installed
   in its own sandbox venv, and the other app's dependency is not present.
+
+---
+
+## Virtual File Smoke Test
+
+Tests that virtual files (images, Arrow data for tables, etc.) created in
+an isolated child process are accessible to the parent server process.
+
+```bash
+marimo run marimo/_smoke_tests/process_isolation/virtual_files.py \
+           marimo/_smoke_tests/process_isolation/app1.py
+```
+
+Multi-file `marimo run` auto-enables process isolation. You should see a
+blue square image, a green HTML heading, and a three-row table. If any of
+those are broken, the cross-process virtual file storage handoff is not
+working.

--- a/marimo/_smoke_tests/process_isolation/virtual_files.py
+++ b/marimo/_smoke_tests/process_isolation/virtual_files.py
@@ -1,0 +1,125 @@
+import marimo
+
+__generated_with = "0.13.0"
+app = marimo.App()
+
+with app.setup:
+    import marimo as mo
+
+
+@app.cell
+def _():
+    mo.md(
+        """
+        # Virtual Files + Process Isolation Smoke Test
+
+        This notebook creates virtual files (HTML, image, JS) to verify they
+        are served correctly when the app runs in an isolated subprocess
+        (`isolate_apps=true`).
+
+        **Bug:** When `isolate_apps` is enabled, the kernel runs in a child
+        process that stores virtual files in process-local `InMemoryStorage`.
+        The server process cannot access them, causing `FileNotFoundError`
+        when the browser requests `/@file/...`.
+
+        **How to test:**
+
+        ```
+        marimo run marimo/_smoke_tests/process_isolation/virtual_files.py \
+                   marimo/_smoke_tests/process_isolation/app1.py
+        ```
+
+        Multi-file `marimo run` auto-enables process isolation. If all three
+        sections below render correctly (not broken images / empty iframes),
+        virtual file serving across process boundaries is working.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    import struct
+    import zlib
+
+    def _make_tiny_png(r: int, g: int, b: int) -> bytes:
+        """Create a minimal valid 1x1 PNG with the given RGB colour."""
+
+        def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+            c = chunk_type + data
+            return (
+                struct.pack(">I", len(data))
+                + c
+                + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+            )
+
+        header = b"\x89PNG\r\n\x1a\n"
+        ihdr = _chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0))
+        raw_row = b"\x00" + bytes([r, g, b])
+        idat = _chunk(b"IDAT", zlib.compress(raw_row))
+        iend = _chunk(b"IEND", b"")
+        return header + ihdr + idat + iend
+
+    png_bytes = _make_tiny_png(0, 128, 255)
+    img_vfile = mo.image(src=png_bytes, width=64, height=64)
+
+    mo.md(
+        f"""
+        ## 1. Image virtual file
+
+        If you see a small blue square below, the image virtual file was
+        served successfully.
+
+        {img_vfile}
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    html_content = "<h3 style='color:green'>Hello from an HTML virtual file!</h3>"
+    html_vfile = mo.Html(
+        f"<iframe srcdoc='{html_content}' "
+        "style='width:100%;height:60px;border:1px solid #ccc'></iframe>"
+    )
+
+    mo.md(
+        f"""
+        ## 2. Inline HTML
+
+        If you see a green heading below, HTML rendering is working.
+
+        {html_vfile}
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    # Use mo.ui.table with a small dataset — tables produce .arrow virtual
+    # files under the hood.
+    table = mo.ui.table(
+        [
+            {"name": "Alice", "score": 95},
+            {"name": "Bob", "score": 87},
+            {"name": "Charlie", "score": 72},
+        ],
+    )
+
+    mo.md(
+        f"""
+        ## 3. Table (Arrow virtual file)
+
+        If the table renders with three rows below, the Arrow virtual file was
+        served successfully.
+
+        {table}
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/process_isolation/virtual_files.py
+++ b/marimo/_smoke_tests/process_isolation/virtual_files.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.13.0"
+__generated_with = "0.23.1"
 app = marimo.App()
 
 with app.setup:
@@ -9,31 +9,29 @@ with app.setup:
 
 @app.cell
 def _():
-    mo.md(
-        """
-        # Virtual Files + Process Isolation Smoke Test
+    mo.md("""
+    # Virtual Files + Process Isolation Smoke Test
 
-        This notebook creates virtual files (HTML, image, JS) to verify they
-        are served correctly when the app runs in an isolated subprocess
-        (`isolate_apps=true`).
+    This notebook creates virtual files (HTML, image, Arrow) to verify they
+    are served correctly when the app runs in an isolated subprocess
+    (`isolate_apps=true`).
 
-        **Bug:** When `isolate_apps` is enabled, the kernel runs in a child
-        process that stores virtual files in process-local `InMemoryStorage`.
-        The server process cannot access them, causing `FileNotFoundError`
-        when the browser requests `/@file/...`.
+    **Bug:** When `isolate_apps` is enabled, the kernel runs in a child
+    process that stores virtual files in process-local `InMemoryStorage`.
+    The server process cannot access them, causing `FileNotFoundError`
+    when the browser requests `/@file/...`.
 
-        **How to test:**
+    **How to test:**
 
-        ```
-        marimo run marimo/_smoke_tests/process_isolation/virtual_files.py \
-                   marimo/_smoke_tests/process_isolation/app1.py
-        ```
+    ```
+    marimo run marimo/_smoke_tests/process_isolation/virtual_files.py \\
+               marimo/_smoke_tests/process_isolation/app1.py
+    ```
 
-        Multi-file `marimo run` auto-enables process isolation. If all three
-        sections below render correctly (not broken images / empty iframes),
-        virtual file serving across process boundaries is working.
-        """
-    )
+    Multi-file `marimo run` auto-enables process isolation. If all three
+    sections below render correctly (not broken images / empty iframes),
+    virtual file serving across process boundaries is working.
+    """)
     return
 
 
@@ -61,38 +59,15 @@ def _():
         return header + ihdr + idat + iend
 
     png_bytes = _make_tiny_png(0, 128, 255)
-    img_vfile = mo.image(src=png_bytes, width=64, height=64)
 
-    mo.md(
-        f"""
-        ## 1. Image virtual file
-
-        If you see a small blue square below, the image virtual file was
-        served successfully.
-
-        {img_vfile}
-        """
-    )
-    return
-
-
-@app.cell
-def _():
-    html_content = "<h3 style='color:green'>Hello from an HTML virtual file!</h3>"
-    html_vfile = mo.Html(
-        f"<iframe srcdoc='{html_content}' "
-        "style='width:100%;height:60px;border:1px solid #ccc'></iframe>"
-    )
-
-    mo.md(
-        f"""
-        ## 2. Inline HTML
-
-        If you see a green heading below, HTML rendering is working.
-
-        {html_vfile}
-        """
-    )
+    mo.vstack([
+        mo.md(
+            "## 1. Image virtual file\n\n"
+            "If you see a small blue square below, the image virtual "
+            "file was served successfully."
+        ),
+        mo.image(src=png_bytes, width=64, height=64),
+    ])
     return
 
 
@@ -108,16 +83,14 @@ def _():
         ],
     )
 
-    mo.md(
-        f"""
-        ## 3. Table (Arrow virtual file)
-
-        If the table renders with three rows below, the Arrow virtual file was
-        served successfully.
-
-        {table}
-        """
-    )
+    mo.vstack([
+        mo.md(
+            "## 2. Table (Arrow virtual file)\n\n"
+            "If the table renders with three rows below, the Arrow "
+            "virtual file was served successfully."
+        ),
+        table,
+    ])
     return
 
 

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -1384,7 +1384,7 @@ except NameError:
                 stream=k.stream,
                 stdout=k.stdout,
                 stderr=k.stderr,
-                virtual_files_supported=True,
+                virtual_file_storage="shared_memory",
                 mode=SessionMode.EDIT,
             )
 
@@ -1550,7 +1550,7 @@ except NameError:
                 stream=k.stream,
                 stdout=k.stdout,
                 stderr=k.stderr,
-                virtual_files_supported=True,
+                virtual_file_storage="shared_memory",
                 mode=SessionMode.EDIT,
             )
 

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -140,7 +140,7 @@ def test_kernel_manager_run_mode() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_file_storage="shared_memory",
+        virtual_file_storage="in_memory",
         redirect_console_to_browser=False,
     )
 
@@ -312,7 +312,7 @@ async def test_session() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_file_storage="shared_memory",
+        virtual_file_storage="in_memory",
         redirect_console_to_browser=False,
     )
 
@@ -416,7 +416,7 @@ def test_session_with_kiosk_consumers() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_file_storage="shared_memory",
+        virtual_file_storage="in_memory",
         redirect_console_to_browser=False,
     )
 
@@ -1039,7 +1039,7 @@ def test_session_with_script_config_overrides(
         app_metadata=app_metadata,
         app_file_manager=app_file_manager,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_file_storage="shared_memory",
+        virtual_file_storage="in_memory",
         redirect_console_to_browser=False,
         ttl_seconds=None,
         auto_instantiate=True,

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -358,7 +358,7 @@ def test_session_disconnect_reconnect() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_file_storage="shared_memory",
+        virtual_file_storage="in_memory",
         redirect_console_to_browser=False,
     )
 
@@ -1093,7 +1093,9 @@ async def test_caching_extension_respects_mode_and_config() -> None:
             app_metadata=app_metadata,
             app_file_manager=AppFileManager.from_app(InternalApp(App())),
             config_manager=config_manager,
-            virtual_file_storage="shared_memory",
+            virtual_file_storage="shared_memory"
+            if mode == SessionMode.EDIT
+            else "in_memory",
             redirect_console_to_browser=False,
             ttl_seconds=None,
             auto_instantiate=auto_instantiate,

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -140,7 +140,7 @@ def test_kernel_manager_run_mode() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_files_supported=True,
+        virtual_file_storage="shared_memory",
         redirect_console_to_browser=False,
     )
 
@@ -174,7 +174,7 @@ def test_kernel_manager_edit_mode() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_files_supported=True,
+        virtual_file_storage="shared_memory",
         redirect_console_to_browser=False,
     )
 
@@ -206,7 +206,7 @@ def test_kernel_manager_interrupt(tmp_path: Path) -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_files_supported=True,
+        virtual_file_storage="shared_memory",
         redirect_console_to_browser=False,
     )
 
@@ -312,7 +312,7 @@ async def test_session() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_files_supported=True,
+        virtual_file_storage="shared_memory",
         redirect_console_to_browser=False,
     )
 
@@ -358,7 +358,7 @@ def test_session_disconnect_reconnect() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_files_supported=True,
+        virtual_file_storage="shared_memory",
         redirect_console_to_browser=False,
     )
 
@@ -416,7 +416,7 @@ def test_session_with_kiosk_consumers() -> None:
         configs={},
         app_metadata=app_metadata,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_files_supported=True,
+        virtual_file_storage="shared_memory",
         redirect_console_to_browser=False,
     )
 
@@ -1039,7 +1039,7 @@ def test_session_with_script_config_overrides(
         app_metadata=app_metadata,
         app_file_manager=app_file_manager,
         config_manager=get_default_config_manager(current_path=None),
-        virtual_files_supported=True,
+        virtual_file_storage="shared_memory",
         redirect_console_to_browser=False,
         ttl_seconds=None,
         auto_instantiate=True,
@@ -1093,7 +1093,7 @@ async def test_caching_extension_respects_mode_and_config() -> None:
             app_metadata=app_metadata,
             app_file_manager=AppFileManager.from_app(InternalApp(App())),
             config_manager=config_manager,
-            virtual_files_supported=True,
+            virtual_file_storage="shared_memory",
             redirect_console_to_browser=False,
             ttl_seconds=None,
             auto_instantiate=auto_instantiate,

--- a/tests/_session/app_host/test_app_host.py
+++ b/tests/_session/app_host/test_app_host.py
@@ -35,7 +35,7 @@ class TestAppHostCommands:
                 configs={},
                 app_metadata=app_metadata,
                 user_config=user_config,
-                virtual_files_supported=True,
+                virtual_file_storage="shared_memory",
                 redirect_console_to_browser=True,
                 log_level=10,
             ),
@@ -455,7 +455,7 @@ class TestAppHostMultipleClients:
                             )
                         )
                     ),
-                    virtual_files_supported=True,
+                    virtual_file_storage="shared_memory",
                     redirect_console_to_browser=False,
                     ttl_seconds=None,
                     auto_instantiate=False,

--- a/tests/_session/app_host/test_main.py
+++ b/tests/_session/app_host/test_main.py
@@ -159,7 +159,7 @@ class TestHandleCreateKernelFailure:
                 app_config={},  # type: ignore[arg-type]
             ),
             user_config=DEFAULT_CONFIG,
-            virtual_files_supported=True,
+            virtual_file_storage="shared_memory",
             redirect_console_to_browser=True,
             log_level=10,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,7 +262,11 @@ class MockedKernel:
             stream=self.stream,  # type: ignore
             stdout=self.stdout,  # type: ignore
             stderr=self.stderr,  # type: ignore
-            virtual_files_supported=True,
+            virtual_file_storage=(
+                "shared_memory"
+                if self.session_mode == SessionMode.EDIT
+                else "in_memory"
+            ),
             mode=self.session_mode,
         )
 


### PR DESCRIPTION
This change updates isolated apps to use shared memory for virtual
file storage.

Isolated apps run in different processes from the main server. This
means they need to place virtual file data in shared memory, but
historically run-mode has run in-process and used in-memory
storage.

The change looks large because we're lifting the choice of storage
out of the kernel context, letting the caller decide what storage
backend to use. This required touching many files. In practice the change is small.

This fixes the issue identified in the following comment: https://github.com/marimo-team/marimo/issues/9127#issuecomment-4225391036