### PR TITLE
fix: only toast cell logs in app mode

### DIFF
--- a/frontend/src/core/cells/__tests__/apply-transaction.test.ts
+++ b/frontend/src/core/cells/__tests__/apply-transaction.test.ts
@@ -305,4 +305,46 @@ describe("applyTransactionChanges edge cases", () => {
       "
     `);
   });
+
+  it("set-code updates the mounted editor view's document", () => {
+    // Existing tests only check cellData.code — this covers the editor
+    // view side, so regressions in the reducer's imperative sync (or in
+    // the CellEditor useEffect that backs it up) don't go unnoticed.
+    setup('x = "BEFORE"');
+    const [a] = state.cellIds.inOrderIds;
+    const editorView = state.cellHandles[a].current?.editorViewOrNull;
+    expect(editorView?.state.doc.toString()).toBe('x = "BEFORE"');
+
+    apply([{ type: "set-code", cellId: a, code: 'x = "AFTER"' }]);
+
+    expect(state.cellData[a].code).toBe('x = "AFTER"');
+    expect(editorView?.state.doc.toString()).toBe('x = "AFTER"');
+  });
+
+  it("create-cell then set-code on same cell updates editor", () => {
+    // Mirrors the code_mode flow that exposed marimo-pair#27: create_cell
+    // in one batch, edit_cell in a second batch, each arriving as a
+    // separate transaction.
+    setup();
+    apply([
+      {
+        type: "create-cell",
+        cellId: cellId("repro"),
+        code: 'x = "BEFORE"',
+        name: "repro_bug",
+        config: {},
+      },
+    ]);
+    const editorView =
+      state.cellHandles[cellId("repro")].current?.editorViewOrNull;
+    expect(editorView?.state.doc.toString()).toBe('x = "BEFORE"');
+
+    apply([
+      { type: "set-code", cellId: cellId("repro"), code: 'x = "AFTER"' },
+      { type: "reorder-cells", cellIds: [cellId("repro")] },
+    ]);
+
+    expect(state.cellData[cellId("repro")].code).toBe('x = "AFTER"');
+    expect(editorView?.state.doc.toString()).toBe('x = "AFTER"');
+  });
 });

--- a/frontend/src/core/cells/__tests__/logs.test.ts
+++ b/frontend/src/core/cells/__tests__/logs.test.ts
@@ -5,6 +5,11 @@ import { cellId } from "@/__tests__/branded";
 import type { CellMessage } from "../../kernel/messages";
 import { formatLogTimestamp, getCellLogsForMessage } from "../logs";
 
+// Stable mock reference so every (re)import of use-toast sees the same spy,
+// even after vi.resetModules() clears the module cache between tests.
+const { toastMock } = vi.hoisted(() => ({ toastMock: vi.fn() }));
+vi.mock("@/components/ui/use-toast", () => ({ toast: toastMock }));
+
 describe("getCellLogsForMessage", () => {
   beforeEach(() => {
     // Mock console.log to avoid cluttering test output
@@ -321,6 +326,102 @@ describe("getCellLogsForMessage", () => {
 
     expect(logs).toHaveLength(1);
     expect(logs[0].level).toBe("stderr");
+  });
+});
+
+describe("getCellLogsForMessage - internal error toast", () => {
+  // Re-imported per test after vi.resetModules() so the module-level
+  // `didAlreadyToastError` flag starts fresh and all jotai atom references
+  // (initialModeAtom, etc.) match the versions used by the reset logs.ts.
+  let getLogs: typeof import("../logs").getCellLogsForMessage;
+  let store: typeof import("@/core/state/jotai").store;
+  let initialModeAtom: typeof import("@/core/mode").initialModeAtom;
+
+  beforeEach(async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {
+      // no-op
+    });
+    vi.resetModules();
+    ({ getCellLogsForMessage: getLogs } = await import("../logs"));
+    ({ store } = await import("@/core/state/jotai"));
+    ({ initialModeAtom } = await import("@/core/mode"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  const makeErrorCellMessage = (id: CellMessage["cell_id"]): CellMessage => ({
+    cell_id: id,
+    console: [],
+    output: {
+      mimetype: "application/vnd.marimo+error",
+      data: [
+        {
+          type: "exception",
+          exception_type: "ValueError",
+          msg: "something exploded",
+          traceback: ["File foo.py, line 1", "ValueError: something exploded"],
+        },
+      ],
+      channel: "marimo-error",
+      timestamp: 0,
+    } as unknown as CellMessage["output"],
+    status: "idle",
+    stale_inputs: null,
+    timestamp: 0,
+  });
+
+  test("shows toast for internal errors in app (read) mode", () => {
+    store.set(initialModeAtom, "read");
+
+    getLogs(makeErrorCellMessage(cellId("cell-err-1")));
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "An internal error occurred",
+        variant: "danger",
+      }),
+    );
+  });
+
+  test("does not show toast for internal errors in edit mode", () => {
+    store.set(initialModeAtom, "edit");
+
+    getLogs(makeErrorCellMessage(cellId("cell-err-2")));
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  test("edit-mode errors do not consume the once-per-session toast slot", () => {
+    // Errors received while in edit mode should be silently skipped...
+    store.set(initialModeAtom, "edit");
+    getLogs(makeErrorCellMessage(cellId("cell-err-3")));
+    expect(toastMock).not.toHaveBeenCalled();
+
+    // ...and a subsequent error in app mode should still toast.
+    store.set(initialModeAtom, "read");
+    getLogs(makeErrorCellMessage(cellId("cell-err-4")));
+    expect(toastMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("toast only fires once across multiple app-mode errors", () => {
+    store.set(initialModeAtom, "read");
+
+    getLogs(makeErrorCellMessage(cellId("cell-err-5")));
+    getLogs(makeErrorCellMessage(cellId("cell-err-6")));
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("suppresses toast when initial mode has not been set", () => {
+    // Leave initialModeAtom at its default (undefined); getInitialAppMode
+    // will throw and the logic should swallow it without toasting.
+    getLogs(makeErrorCellMessage(cellId("cell-err-7")));
+
+    expect(toastMock).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/core/cells/logs.ts
+++ b/frontend/src/core/cells/logs.ts
@@ -7,7 +7,7 @@ import { Strings } from "@/utils/strings";
 import type { CellMessage, OutputMessage } from "../kernel/messages";
 import { isErrorMime } from "../mime";
 import type { CellId } from "./ids";
-import { getInitialAppMode } from "../mode";
+import { initialModeAtom } from "../mode";
 import { store } from "../state/jotai";
 import { tracebackModalAtom } from "../errors/traceback-atom";
 import React from "react";
@@ -85,13 +85,10 @@ export function getCellLogsForMessage(cell: CellMessage): CellLog[] {
     );
 
     // Only show the toast in app mode: edit mode already surfaces errors in
-    // the cell UI, so toasting there would be noisy and duplicative.
-    let isAppMode = false;
-    try {
-      isAppMode = getInitialAppMode() === "read";
-    } catch {
-      // Initial mode not set yet (e.g. in tests/islands) — suppress the toast.
-    }
+    // the cell UI, so toasting there would be noisy and duplicative. Read the
+    // atom directly so an unset initial mode (e.g. in tests/islands) simply
+    // returns undefined instead of throwing and masking real errors.
+    const isAppMode = store.get(initialModeAtom) === "read";
 
     // Only show toast once, and only in app mode
     if (exceptionErrors.length > 0 && !didAlreadyToastError && isAppMode) {

--- a/frontend/src/core/cells/logs.ts
+++ b/frontend/src/core/cells/logs.ts
@@ -7,6 +7,7 @@ import { Strings } from "@/utils/strings";
 import type { CellMessage, OutputMessage } from "../kernel/messages";
 import { isErrorMime } from "../mime";
 import type { CellId } from "./ids";
+import { getInitialAppMode } from "../mode";
 import { store } from "../state/jotai";
 import { tracebackModalAtom } from "../errors/traceback-atom";
 import React from "react";
@@ -83,7 +84,17 @@ export function getCellLogsForMessage(cell: CellMessage): CellLog[] {
         error.type === "internal",
     );
 
-    if (exceptionErrors.length > 0 && !didAlreadyToastError) {
+    // Only show the toast in app mode: edit mode already surfaces errors in
+    // the cell UI, so toasting there would be noisy and duplicative.
+    let isAppMode = false;
+    try {
+      isAppMode = getInitialAppMode() === "read";
+    } catch {
+      // Initial mode not set yet (e.g. in tests/islands) — suppress the toast.
+    }
+
+    // Only show toast once, and only in app mode
+    if (exceptionErrors.length > 0 && !didAlreadyToastError && isAppMode) {
       didAlreadyToastError = true;
 
       // Find first error with a traceback


### PR DESCRIPTION
Previously we were toasting on all internal errors. When only this should be happening in run mode. Also this skips it for the scratch pad (which i saw when used by code_mode)