### PR TITLE
fix: use the proactor event loop policy on Windows in edit-mode runtimes

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3519,18 +3519,22 @@ def launch_kernel(
     # - Run mode (not edit) uses autorun config regardless of IPC
     is_subprocess = is_edit_mode or is_ipc
 
+    loop_factory: Callable[[], asyncio.AbstractEventLoop] | None = None
     if is_subprocess:
         restore_signals()
 
-        # The kernel subprocess does not use add_reader() (the server side
-        # does, via ConnectionDistributor), so it can run on the Proactor
-        # loop on Windows. Force the Proactor policy here so user code can
-        # use asyncio.create_subprocess_exec and other APIs that the
-        # SelectorEventLoop on Windows does not implement.
+        # The runtime process inherits the server's loop policy, on Windows, we
+        # restore the event loop policy to the default ProactorEventLoop, so
+        # user code can use asyncio.create_subprocess_exec and other APIs that
+        # the SelectorEventLoop does not implement.
         if sys.platform == "win32":
-            asyncio.set_event_loop_policy(
-                asyncio.WindowsProactorEventLoopPolicy()
-            )
+            if sys.version_info >= (3, 14):
+                # Event loop policies are deprecated in Python 3.14
+                loop_factory = asyncio.ProactorEventLoop
+            else:
+                asyncio.set_event_loop_policy(
+                    asyncio.WindowsProactorEventLoopPolicy()
+                )
 
     profiler = None
     if profile_path is not None:
@@ -3733,7 +3737,10 @@ def launch_kernel(
     # queue.get().  The queue read is offloaded to a thread via
     # run_in_executor; avoid adding further async primitives elsewhere in the
     # runtime unless there is a very good reason.
-    asyncio.run(control_loop(kernel))
+    if loop_factory is not None:
+        asyncio.run(control_loop(kernel), loop_factory=loop_factory)
+    else:
+        asyncio.run(control_loop(kernel))
 
     if not use_fd_redirect:
         from marimo._messaging.thread_local_streams import (

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3522,6 +3522,16 @@ def launch_kernel(
     if is_subprocess:
         restore_signals()
 
+        # The kernel subprocess does not use add_reader() (the server side
+        # does, via ConnectionDistributor), so it can run on the Proactor
+        # loop on Windows. Force the Proactor policy here so user code can
+        # use asyncio.create_subprocess_exec and other APIs that the
+        # SelectorEventLoop on Windows does not implement.
+        if sys.platform == "win32":
+            asyncio.set_event_loop_policy(
+                asyncio.WindowsProactorEventLoopPolicy()
+            )
+
     profiler = None
     if profile_path is not None:
         import cProfile

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -6,8 +6,9 @@ import copy
 import pathlib
 import sys
 import textwrap
-from typing import TYPE_CHECKING, cast
-from unittest.mock import Mock, patch
+from contextlib import ExitStack
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -45,7 +46,12 @@ from marimo._runtime.context.types import teardown_context
 from marimo._runtime.dataflow import EdgeWithVar
 from marimo._runtime.patches import create_main_module
 from marimo._runtime.runner.hooks import create_default_hooks
-from marimo._runtime.runtime import Kernel, notebook_dir, notebook_location
+from marimo._runtime.runtime import (
+    Kernel,
+    launch_kernel,
+    notebook_dir,
+    notebook_location,
+)
 from marimo._runtime.scratch import SCRATCH_CELL_ID
 from marimo._session.model import SessionMode
 from marimo._utils.parse_dataclass import parse_raw
@@ -53,7 +59,7 @@ from tests._messaging.mocks import MockStderr, MockStream
 from tests.conftest import ExecReqProvider, MockedKernel
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Coroutine, Sequence
 
 
 def _check_edges(error: Error, expected_edges: Sequence[EdgeWithVar]) -> None:
@@ -4175,3 +4181,148 @@ class TestRequestHandler:
         assert handler1 is handler2
         assert handler2 is handler3
         assert handler1 is handler3
+
+
+class TestLaunchKernelEventLoop:
+    """Event-loop policy / factory selection in launch_kernel.
+
+    The kernel subprocess must run on the Windows ProactorEventLoop so
+    user code can use asyncio.create_subprocess_exec() and other APIs
+    the SelectorEventLoop does not implement. The server keeps the
+    SelectorEventLoop because ConnectionDistributor relies on
+    loop.add_reader().
+
+    These tests stub out everything after the event-loop setup so only
+    the policy / loop_factory decision is exercised.
+    """
+
+    _HEAVY_DEPENDENCY_TARGETS = [
+        "marimo._runtime.runtime.restore_signals",
+        "marimo._runtime.runtime.ThreadSafeStream",
+        "marimo._runtime.runtime.ThreadSafeStdout",
+        "marimo._runtime.runtime.ThreadSafeStderr",
+        "marimo._runtime.runtime.ThreadSafeStdin",
+        "marimo._runtime.runtime.marimo_pdb.MarimoPdb",
+        "marimo._runtime.runtime.Kernel",
+        "marimo._runtime.runtime.initialize_kernel_context",
+        "marimo._runtime.runtime.patches.patch_main_module",
+        "marimo._output.formatters.formatters.register_formatters",
+    ]
+
+    class _StopAfterAsyncioRun(Exception):
+        """Sentinel raised from the mocked asyncio.run so we skip the
+        post-run teardown path (which touches a runtime context we
+        haven't initialized)."""
+
+    @classmethod
+    def _fake_asyncio_run(
+        cls, coro: Coroutine[Any, Any, Any], **_kwargs: Any
+    ) -> None:
+        # Close the never-awaited coroutine to suppress the
+        # RuntimeWarning, then bail so we don't execute the post-run
+        # teardown.
+        coro.close()
+        raise cls._StopAfterAsyncioRun
+
+    @classmethod
+    def _call_launch_kernel(cls, *, is_edit_mode: bool) -> None:
+        with pytest.raises(cls._StopAfterAsyncioRun):
+            launch_kernel(
+                control_queue=MagicMock(),
+                set_ui_element_queue=MagicMock(),
+                completion_queue=MagicMock(),
+                input_queue=MagicMock(),
+                stream_queue=MagicMock(),
+                socket_addr=None,
+                is_edit_mode=is_edit_mode,
+                configs={},
+                app_metadata=AppMetadata(
+                    query_params={}, cli_args={}, app_config=_AppConfig()
+                ),
+                user_config=DEFAULT_CONFIG,
+                virtual_file_storage=None,
+                redirect_console_to_browser=False,
+            )
+
+    @pytest.fixture
+    def harness(self):
+        """Neutralize launch_kernel's heavy dependencies so the test
+        only observes the event-loop policy / loop_factory decision."""
+        with ExitStack() as stack:
+            for target in self._HEAVY_DEPENDENCY_TARGETS:
+                stack.enter_context(patch(target))
+            # `signal` is used as `signal.signal(...)` and references
+            # `signal.SIGBREAK`, which only exists on Windows — swap
+            # the whole module ref so non-Windows hosts don't blow up.
+            stack.enter_context(
+                patch("marimo._runtime.runtime.signal", new=MagicMock())
+            )
+            run_mock = MagicMock(side_effect=self._fake_asyncio_run)
+            stack.enter_context(patch("asyncio.run", run_mock))
+            yield run_mock
+
+    def test_non_windows_does_not_change_event_loop_policy(self, harness):
+        with (
+            patch("sys.platform", "linux"),
+            patch.object(asyncio, "set_event_loop_policy") as set_policy,
+        ):
+            self._call_launch_kernel(is_edit_mode=True)
+
+        set_policy.assert_not_called()
+        assert harness.call_count == 1
+        assert "loop_factory" not in harness.call_args.kwargs
+
+    def test_windows_pre_314_installs_proactor_event_loop_policy(
+        self, harness
+    ):
+        with (
+            patch("sys.platform", "win32"),
+            patch("sys.version_info", (3, 12, 0, "final", 0)),
+            patch.object(
+                asyncio, "WindowsProactorEventLoopPolicy", create=True
+            ) as policy_cls,
+            patch.object(asyncio, "set_event_loop_policy") as set_policy,
+        ):
+            self._call_launch_kernel(is_edit_mode=True)
+
+        policy_cls.assert_called_once_with()
+        set_policy.assert_called_once_with(policy_cls.return_value)
+        # Pre-3.14 uses the policy API, not loop_factory.
+        assert "loop_factory" not in harness.call_args.kwargs
+
+    def test_windows_314_plus_uses_proactor_loop_factory(self, harness):
+        # Event loop policies are deprecated in 3.14; launch_kernel must
+        # pass ProactorEventLoop as the loop_factory to asyncio.run
+        # instead of mutating the global policy.
+        with (
+            patch("sys.platform", "win32"),
+            patch("sys.version_info", (3, 14, 0, "final", 0)),
+            patch.object(
+                asyncio, "ProactorEventLoop", create=True
+            ) as proactor_cls,
+            patch.object(asyncio, "set_event_loop_policy") as set_policy,
+        ):
+            self._call_launch_kernel(is_edit_mode=True)
+
+        set_policy.assert_not_called()
+        assert harness.call_args.kwargs.get("loop_factory") is proactor_cls
+
+    def test_run_mode_on_windows_does_not_touch_event_loop_policy(
+        self, harness
+    ):
+        # Run mode (not edit, not IPC) runs in-process on the server's
+        # loop and must NOT mutate the event loop policy — the server
+        # uses the Selector loop for ConnectionDistributor.add_reader().
+        with (
+            patch("sys.platform", "win32"),
+            patch("sys.version_info", (3, 12, 0, "final", 0)),
+            patch.object(
+                asyncio, "WindowsProactorEventLoopPolicy", create=True
+            ) as policy_cls,
+            patch.object(asyncio, "set_event_loop_policy") as set_policy,
+        ):
+            self._call_launch_kernel(is_edit_mode=False)
+
+        policy_cls.assert_not_called()
+        set_policy.assert_not_called()
+        assert "loop_factory" not in harness.call_args.kwargs

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -4192,8 +4192,9 @@ class TestLaunchKernelEventLoop:
     SelectorEventLoop because ConnectionDistributor relies on
     loop.add_reader().
 
-    These tests stub out everything after the event-loop setup so only
-    the policy / loop_factory decision is exercised.
+    Each test exercises a single (platform, python-version) branch and
+    skips when the current runner doesn't match it. CI runs across all
+    major operating systems, so every branch is covered somewhere.
     """
 
     _HEAVY_DEPENDENCY_TARGETS = [
@@ -4251,9 +4252,8 @@ class TestLaunchKernelEventLoop:
         with ExitStack() as stack:
             for target in self._HEAVY_DEPENDENCY_TARGETS:
                 stack.enter_context(patch(target))
-            # `signal` is used as `signal.signal(...)` and references
-            # `signal.SIGBREAK`, which only exists on Windows — swap
-            # the whole module ref so non-Windows hosts don't blow up.
+            # Swap the whole signal module ref to avoid registering real
+            # SIGINT/SIGTERM/SIGBREAK handlers in the test process.
             stack.enter_context(
                 patch("marimo._runtime.runtime.signal", new=MagicMock())
             )
@@ -4261,25 +4261,28 @@ class TestLaunchKernelEventLoop:
             stack.enter_context(patch("asyncio.run", run_mock))
             yield run_mock
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="exercises the non-Windows branch",
+    )
     def test_non_windows_does_not_change_event_loop_policy(self, harness):
-        with (
-            patch("sys.platform", "linux"),
-            patch.object(asyncio, "set_event_loop_policy") as set_policy,
-        ):
+        with patch.object(asyncio, "set_event_loop_policy") as set_policy:
             self._call_launch_kernel(is_edit_mode=True)
 
         set_policy.assert_not_called()
         assert harness.call_count == 1
         assert "loop_factory" not in harness.call_args.kwargs
 
+    @pytest.mark.skipif(
+        sys.platform != "win32" or sys.version_info >= (3, 14),
+        reason="exercises the Windows pre-3.14 branch",
+    )
     def test_windows_pre_314_installs_proactor_event_loop_policy(
         self, harness
     ):
         with (
-            patch("sys.platform", "win32"),
-            patch("sys.version_info", (3, 12, 0, "final", 0)),
             patch.object(
-                asyncio, "WindowsProactorEventLoopPolicy", create=True
+                asyncio, "WindowsProactorEventLoopPolicy"
             ) as policy_cls,
             patch.object(asyncio, "set_event_loop_policy") as set_policy,
         ):
@@ -4290,16 +4293,16 @@ class TestLaunchKernelEventLoop:
         # Pre-3.14 uses the policy API, not loop_factory.
         assert "loop_factory" not in harness.call_args.kwargs
 
+    @pytest.mark.skipif(
+        sys.platform != "win32" or sys.version_info < (3, 14),
+        reason="exercises the Windows 3.14+ branch",
+    )
     def test_windows_314_plus_uses_proactor_loop_factory(self, harness):
         # Event loop policies are deprecated in 3.14; launch_kernel must
         # pass ProactorEventLoop as the loop_factory to asyncio.run
         # instead of mutating the global policy.
         with (
-            patch("sys.platform", "win32"),
-            patch("sys.version_info", (3, 14, 0, "final", 0)),
-            patch.object(
-                asyncio, "ProactorEventLoop", create=True
-            ) as proactor_cls,
+            patch.object(asyncio, "ProactorEventLoop") as proactor_cls,
             patch.object(asyncio, "set_event_loop_policy") as set_policy,
         ):
             self._call_launch_kernel(is_edit_mode=True)
@@ -4307,22 +4310,18 @@ class TestLaunchKernelEventLoop:
         set_policy.assert_not_called()
         assert harness.call_args.kwargs.get("loop_factory") is proactor_cls
 
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="run-mode guard is only meaningful on Windows",
+    )
     def test_run_mode_on_windows_does_not_touch_event_loop_policy(
         self, harness
     ):
         # Run mode (not edit, not IPC) runs in-process on the server's
         # loop and must NOT mutate the event loop policy — the server
         # uses the Selector loop for ConnectionDistributor.add_reader().
-        with (
-            patch("sys.platform", "win32"),
-            patch("sys.version_info", (3, 12, 0, "final", 0)),
-            patch.object(
-                asyncio, "WindowsProactorEventLoopPolicy", create=True
-            ) as policy_cls,
-            patch.object(asyncio, "set_event_loop_policy") as set_policy,
-        ):
+        with patch.object(asyncio, "set_event_loop_policy") as set_policy:
             self._call_launch_kernel(is_edit_mode=False)
 
-        policy_cls.assert_not_called()
         set_policy.assert_not_called()
         assert "loop_factory" not in harness.call_args.kwargs


### PR DESCRIPTION
This change updates the kernel to use the Proactor event loop in Windows in edit mode, partially fixing #9182.

Before this change, the kernel process inherited the event loop policy of the server process (which is the selector policy, because we use the `add_reader` API). 

This is only a partial fix because it doesn't address when the kernel runs in-process (`marimo run notebook.py`). We could maybe change the event loop policy even in the in-process situation, but we would have to double check that doing so wouldn't break the server as a side-effect.