### PR TITLE
fix: allow for data-uris in mpl-interactive and marimo-panel after a cell has run

### DIFF
--- a/frontend/src/plugins/core/__test__/trusted-url.test.ts
+++ b/frontend/src/plugins/core/__test__/trusted-url.test.ts
@@ -49,12 +49,15 @@ describe("isTrustedVirtualFileUrl", () => {
   });
 
   describe("data URL exemption", () => {
+    let previousHasRunAnyCell: boolean;
+
     beforeEach(() => {
+      previousHasRunAnyCell = store.get(hasRunAnyCellAtom);
       store.set(hasRunAnyCellAtom, true);
     });
 
     afterEach(() => {
-      store.set(hasRunAnyCellAtom, false);
+      store.set(hasRunAnyCellAtom, previousHasRunAnyCell);
     });
 
     it.each([

--- a/frontend/src/plugins/core/__test__/trusted-url.test.ts
+++ b/frontend/src/plugins/core/__test__/trusted-url.test.ts
@@ -1,5 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hasRunAnyCellAtom } from "@/components/editor/cell/useRunCells";
+import { store } from "@/core/state/jotai";
 import { isTrustedVirtualFileUrl } from "../trusted-url";
 
 describe("isTrustedVirtualFileUrl", () => {
@@ -44,5 +46,44 @@ describe("isTrustedVirtualFileUrl", () => {
     expect(isTrustedVirtualFileUrl(undefined)).toBe(false);
     expect(isTrustedVirtualFileUrl(42)).toBe(false);
     expect(isTrustedVirtualFileUrl({})).toBe(false);
+  });
+
+  describe("data URL exemption", () => {
+    beforeEach(() => {
+      store.set(hasRunAnyCellAtom, true);
+    });
+
+    afterEach(() => {
+      store.set(hasRunAnyCellAtom, false);
+    });
+
+    it.each([
+      "data:text/javascript;base64,ZXhwb3J0IGRlZmF1bHQge30=",
+      "data:application/javascript;base64,ZXhwb3J0IGRlZmF1bHQge30=",
+      "data:text/css;base64,Ym9keXt9",
+    ])("accepts safe data URL %s after a cell has run", (url) => {
+      expect(isTrustedVirtualFileUrl(url)).toBe(true);
+    });
+
+    it.each([
+      // Non-base64 data URLs are refused
+      "data:text/javascript,alert(1)",
+      "data:text/javascript;charset=utf-8,alert(1)",
+      // HTML / SVG / arbitrary types are refused
+      "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+      "data:image/svg+xml;base64,PHN2Zy8+",
+      "data:application/octet-stream;base64,AAA=",
+    ])("still rejects unsafe data URL %s", (url) => {
+      expect(isTrustedVirtualFileUrl(url)).toBe(false);
+    });
+
+    it("rejects data URL when no cell has been run", () => {
+      store.set(hasRunAnyCellAtom, false);
+      expect(
+        isTrustedVirtualFileUrl(
+          "data:text/javascript;base64,ZXhwb3J0IGRlZmF1bHQge30=",
+        ),
+      ).toBe(false);
+    });
   });
 });

--- a/frontend/src/plugins/core/trusted-url.ts
+++ b/frontend/src/plugins/core/trusted-url.ts
@@ -1,20 +1,45 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { hasRunAnyCellAtom } from "@/components/editor/cell/useRunCells";
+import { store } from "@/core/state/jotai";
+
 /**
  * Whether a URL can be trusted to point at a marimo-served virtual file.
  *
  * Plugins that load remote scripts or stylesheets (e.g. MplInteractive, Panel)
  * must call this before turning a plugin-supplied URL into a `<script src>` or
- * `<link href>`. The backend always serializes these URLs as virtual file
+ * `<link href>`. The backend normally serializes these URLs as virtual file
  * paths of the form `./@file/<byte_length>-<filename>` (see
  * `VirtualFile.create_and_register`). Accepting anything else would let a
  * maliciously crafted `<marimo-*>` element embedded in markdown load
  * attacker-controlled JavaScript at same origin, since the HTML sanitizer
  * lets arbitrary marimo custom elements and attributes through.
+ *
+ * Some runtimes (WASM, VS Code) have no backend to serve virtual files, so
+ * `VirtualFile` falls back to inline base64 data URLs (see `virtual_file.py`).
+ * We accept those only once the user has explicitly run a cell in the current
+ * notebook — the same trust signal `sanitize.ts` uses to lift HTML
+ * sanitization. Running a cell requires deliberate user action and already
+ * executes arbitrary Python, so a data URL script loaded afterwards is not a
+ * new attack surface.
  */
 export function isTrustedVirtualFileUrl(url: unknown): url is string {
   if (typeof url !== "string" || url.length === 0) {
     return false;
   }
-  return /^(\.?\/)?@file\/[^?#]+$/.test(url);
+  if (/^(\.?\/)?@file\/[^?#]+$/.test(url)) {
+    return true;
+  }
+  if (isSafeDataUrl(url) && store.get(hasRunAnyCellAtom)) {
+    return true;
+  }
+  return false;
+}
+
+function isSafeDataUrl(url: string): boolean {
+  return (
+    url.startsWith("data:text/javascript;base64,") ||
+    url.startsWith("data:application/javascript;base64,") ||
+    url.startsWith("data:text/css;base64,")
+  );
 }


### PR DESCRIPTION
This PR updates the logic for trusting virtual file URLs in marimo plugins, allowing data uri after some cell has been run that use inline base64 data URLs (WASM and VS Code runtimes)