### PR TITLE
fix(css): theme-aware styling for rename popup in dark mode

### DIFF
--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -108,6 +108,25 @@
   background: var(--gray-3);
 }
 
+/* -- Variable rename popup -- */
+
+/*
+ * The rename popup created by @marimo-team/codemirror-languageserver uses
+ * hardcoded inline styles (background: white, border: 1px solid #ddd).
+ * Override those here so the popup matches the editor theme in both light
+ * and dark mode.
+ */
+.cm-rename-popup {
+  background: var(--popover) !important;
+  border-color: var(--border) !important;
+}
+
+.cm-rename-popup input {
+  background: var(--background);
+  color: var(--foreground);
+  border-color: var(--border) !important;
+}
+
 /* -- Codeium -- */
 
 .cm-codeium-cycle {


### PR DESCRIPTION
## 📝 Summary

Closes #9197

When pressing F2 to rename a variable in dark mode, the rename input popup has insufficient contrast — the text is nearly invisible because the popup uses a hardcoded `background: white` inline style regardless of theme.

The popup is rendered by `@marimo-team/codemirror-languageserver` with these inline styles:
```js
popup.style.cssText = "... background: white; border: 1px solid #ddd; ..."
input.style.cssText = "... border: 1px solid #ddd;"
```

**Fix:** Override the popup's background, border, and input text colour in `codemirror.css` using marimo's existing CSS custom properties (`--popover`, `--background`, `--foreground`, `--border`), which already use `light-dark()` and adapt correctly to both themes.

**Before (dark mode):** white background on the popup, text is invisible against it  
**After (dark mode):** popup uses `var(--popover)` — matches the editor's dark background  
**Light mode:** unaffected — `var(--popover)` resolves to white, same as before

## 📋 Pre-Review Checklist

- [x] This change addresses an existing filed issue (#9197) and was explicitly invited by a marimo collaborator in that issue thread.
- [x] The code change has been reviewed line-by-line.
- [ ] Video or media evidence — I'm not able to run the UI to record a screenshot, but the fix is a pure CSS override and the before/after is described above. Happy to update if a maintainer can confirm visually.

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation is not applicable for this CSS-only fix.
- [x] No tests added — this is a visual CSS fix; the change is two CSS rules totalling 8 lines.