### PR TITLE
feat: visually distinguish null, empty, whitespace, NaN, and Infinity in table cells

### DIFF
--- a/frontend/src/components/data-table/__tests__/sentinel-cell.test.tsx
+++ b/frontend/src/components/data-table/__tests__/sentinel-cell.test.tsx
@@ -1,0 +1,77 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SentinelCell } from "../sentinel-cell";
+import type { CellValueSentinel } from "../types";
+
+function renderSentinel(sentinel: CellValueSentinel) {
+  const { container } = render(<SentinelCell sentinel={sentinel} />);
+  return container.querySelector("span")!;
+}
+
+describe("SentinelCell", () => {
+  it("renders null as None", () => {
+    const span = renderSentinel({ type: "null", value: null });
+    expect(span.textContent).toBe("None");
+    expect(span.getAttribute("aria-label")).toBe("None");
+    expect(span.className).toContain("italic");
+    expect(span.className).toContain("bg-muted");
+  });
+
+  it("renders empty string as <empty>", () => {
+    const span = renderSentinel({ type: "empty-string", value: "" });
+    expect(span.textContent).toBe("<empty>");
+    expect(span.getAttribute("aria-label")).toBe("empty string");
+  });
+
+  it("renders single space", () => {
+    const span = renderSentinel({ type: "whitespace", value: " " });
+    expect(span.textContent).toBe("\u2423");
+    expect(span.getAttribute("aria-label")).toBe("1 space");
+  });
+
+  it("renders multiple spaces", () => {
+    const span = renderSentinel({ type: "whitespace", value: "   " });
+    expect(span.textContent).toBe("\u2423\u2423\u2423");
+    expect(span.getAttribute("aria-label")).toBe("3 spaces");
+  });
+
+  it("renders tab", () => {
+    const span = renderSentinel({ type: "whitespace", value: "\t" });
+    expect(span.textContent).toBe("\u2192");
+    expect(span.getAttribute("aria-label")).toBe("1 tab");
+  });
+
+  it("renders newline", () => {
+    const span = renderSentinel({ type: "whitespace", value: "\n" });
+    expect(span.textContent).toBe("\u21B5");
+    expect(span.getAttribute("aria-label")).toBe("1 newline");
+  });
+
+  it("renders mixed whitespace", () => {
+    const span = renderSentinel({ type: "whitespace", value: "\t \n" });
+    expect(span.textContent).toBe("\u2192\u2423\u21B5");
+    expect(span.getAttribute("aria-label")).toBe("1 tab, 1 space, 1 newline");
+  });
+
+  it("renders NaN", () => {
+    const span = renderSentinel({ type: "nan", value: Number.NaN });
+    expect(span.textContent).toBe("NaN");
+  });
+
+  it("renders inf", () => {
+    const span = renderSentinel({ type: "positive-infinity", value: Infinity });
+    expect(span.textContent).toBe("inf");
+    expect(span.getAttribute("title")).toBe("Infinity");
+  });
+
+  it("renders -inf", () => {
+    const span = renderSentinel({
+      type: "negative-infinity",
+      value: -Infinity,
+    });
+    expect(span.textContent).toBe("-inf");
+    expect(span.getAttribute("title")).toBe("-Infinity");
+  });
+});

--- a/frontend/src/components/data-table/__tests__/sentinel-cell.test.tsx
+++ b/frontend/src/components/data-table/__tests__/sentinel-cell.test.tsx
@@ -39,19 +39,19 @@ describe("SentinelCell", () => {
 
   it("renders tab", () => {
     const span = renderSentinel({ type: "whitespace", value: "\t" });
-    expect(span.textContent).toBe("\u2192");
+    expect(span.textContent).toBe("\\t");
     expect(span.getAttribute("aria-label")).toBe("1 tab");
   });
 
   it("renders newline", () => {
     const span = renderSentinel({ type: "whitespace", value: "\n" });
-    expect(span.textContent).toBe("\u21B5");
+    expect(span.textContent).toBe("\\n");
     expect(span.getAttribute("aria-label")).toBe("1 newline");
   });
 
   it("renders mixed whitespace", () => {
     const span = renderSentinel({ type: "whitespace", value: "\t \n" });
-    expect(span.textContent).toBe("\u2192\u2423\u21B5");
+    expect(span.textContent).toBe("\\t\u2423\\n");
     expect(span.getAttribute("aria-label")).toBe("1 tab, 1 space, 1 newline");
   });
 
@@ -73,5 +73,11 @@ describe("SentinelCell", () => {
     });
     expect(span.textContent).toBe("-inf");
     expect(span.getAttribute("title")).toBe("-Infinity");
+  });
+
+  it("renders NaT", () => {
+    const span = renderSentinel({ type: "nat", value: "NaT" });
+    expect(span.textContent).toBe("NaT");
+    expect(span.getAttribute("title")).toBe("NaT (Not a Time)");
   });
 });

--- a/frontend/src/components/data-table/__tests__/utils.test.ts
+++ b/frontend/src/components/data-table/__tests__/utils.test.ts
@@ -3,6 +3,7 @@
 import type { Table } from "@tanstack/react-table";
 import { describe, expect, it } from "vitest";
 import {
+  detectSentinel,
   getClipboardContent,
   getPageIndexForRow,
   getRawValue,
@@ -183,6 +184,102 @@ describe("getClipboardContent", () => {
     const result = getClipboardContent(null, displayed);
     expect(result.text).toBe("null");
     expect(result.html).toBe("<i>N/A</i>");
+  });
+});
+
+describe("detectSentinel", () => {
+  it("should detect null and undefined", () => {
+    expect(detectSentinel(null)).toEqual({ type: "null", value: null });
+    expect(detectSentinel(undefined)).toEqual({
+      type: "null",
+      value: undefined,
+    });
+  });
+
+  it("should detect empty string", () => {
+    expect(detectSentinel("")).toEqual({ type: "empty-string", value: "" });
+  });
+
+  it("should detect whitespace-only strings", () => {
+    expect(detectSentinel(" ")).toEqual({ type: "whitespace", value: " " });
+    expect(detectSentinel("   ")).toEqual({ type: "whitespace", value: "   " });
+    expect(detectSentinel("\t")).toEqual({ type: "whitespace", value: "\t" });
+    expect(detectSentinel("\n")).toEqual({ type: "whitespace", value: "\n" });
+    expect(detectSentinel("\t \n")).toEqual({
+      type: "whitespace",
+      value: "\t \n",
+    });
+  });
+
+  it("should detect NaN", () => {
+    expect(detectSentinel(Number.NaN)).toEqual({
+      type: "nan",
+      value: Number.NaN,
+    });
+  });
+
+  it("should detect Infinity", () => {
+    expect(detectSentinel(Number.POSITIVE_INFINITY)).toEqual({
+      type: "positive-infinity",
+      value: Number.POSITIVE_INFINITY,
+    });
+    expect(detectSentinel(Number.NEGATIVE_INFINITY)).toEqual({
+      type: "negative-infinity",
+      value: Number.NEGATIVE_INFINITY,
+    });
+  });
+
+  it("should return null for normal values", () => {
+    expect(detectSentinel("hello")).toBeNull();
+    expect(detectSentinel(42)).toBeNull();
+    expect(detectSentinel(0)).toBeNull();
+    expect(detectSentinel(-1.5)).toBeNull();
+    expect(detectSentinel(true)).toBeNull();
+    expect(detectSentinel(false)).toBeNull();
+    expect(detectSentinel({})).toBeNull();
+    expect(detectSentinel([])).toBeNull();
+  });
+
+  it("should not match literal null-like strings", () => {
+    expect(detectSentinel("null")).toBeNull();
+    expect(detectSentinel("NULL")).toBeNull();
+    expect(detectSentinel("None")).toBeNull();
+  });
+
+  it("should not match string NaN/Infinity in non-numeric columns", () => {
+    expect(detectSentinel("NaN")).toBeNull();
+    expect(detectSentinel("Infinity")).toBeNull();
+    expect(detectSentinel("-Infinity")).toBeNull();
+  });
+
+  it("should match string NaN/Infinity in numeric columns", () => {
+    const opts = { isNumericColumn: true };
+    expect(detectSentinel("NaN", opts)).toEqual({
+      type: "nan",
+      value: "NaN",
+    });
+    expect(detectSentinel("Infinity", opts)).toEqual({
+      type: "positive-infinity",
+      value: "Infinity",
+    });
+    expect(detectSentinel("-Infinity", opts)).toEqual({
+      type: "negative-infinity",
+      value: "-Infinity",
+    });
+    expect(detectSentinel("inf", opts)).toEqual({
+      type: "positive-infinity",
+      value: "inf",
+    });
+    expect(detectSentinel("-inf", opts)).toEqual({
+      type: "negative-infinity",
+      value: "-inf",
+    });
+  });
+
+  it("should still not match normal strings in numeric columns", () => {
+    const opts = { isNumericColumn: true };
+    expect(detectSentinel("hello", opts)).toBeNull();
+    expect(detectSentinel("42", opts)).toBeNull();
   });
 });
 

--- a/frontend/src/components/data-table/__tests__/utils.test.ts
+++ b/frontend/src/components/data-table/__tests__/utils.test.ts
@@ -189,97 +189,128 @@ describe("getClipboardContent", () => {
 
 describe("detectSentinel", () => {
   it("should detect null and undefined", () => {
-    expect(detectSentinel(null)).toEqual({ type: "null", value: null });
-    expect(detectSentinel(undefined)).toEqual({
+    expect(detectSentinel(null, undefined)).toEqual({
+      type: "null",
+      value: null,
+    });
+    expect(detectSentinel(undefined, undefined)).toEqual({
       type: "null",
       value: undefined,
     });
   });
 
   it("should detect empty string", () => {
-    expect(detectSentinel("")).toEqual({ type: "empty-string", value: "" });
+    expect(detectSentinel("", "string")).toEqual({
+      type: "empty-string",
+      value: "",
+    });
   });
 
   it("should detect whitespace-only strings", () => {
-    expect(detectSentinel(" ")).toEqual({ type: "whitespace", value: " " });
-    expect(detectSentinel("   ")).toEqual({ type: "whitespace", value: "   " });
-    expect(detectSentinel("\t")).toEqual({ type: "whitespace", value: "\t" });
-    expect(detectSentinel("\n")).toEqual({ type: "whitespace", value: "\n" });
-    expect(detectSentinel("\t \n")).toEqual({
+    expect(detectSentinel(" ", "string")).toEqual({
+      type: "whitespace",
+      value: " ",
+    });
+    expect(detectSentinel("   ", "string")).toEqual({
+      type: "whitespace",
+      value: "   ",
+    });
+    expect(detectSentinel("\t", "string")).toEqual({
+      type: "whitespace",
+      value: "\t",
+    });
+    expect(detectSentinel("\n", "string")).toEqual({
+      type: "whitespace",
+      value: "\n",
+    });
+    expect(detectSentinel("\t \n", "string")).toEqual({
       type: "whitespace",
       value: "\t \n",
     });
   });
 
   it("should detect NaN", () => {
-    expect(detectSentinel(Number.NaN)).toEqual({
+    expect(detectSentinel(Number.NaN, "number")).toEqual({
       type: "nan",
       value: Number.NaN,
     });
   });
 
   it("should detect Infinity", () => {
-    expect(detectSentinel(Number.POSITIVE_INFINITY)).toEqual({
+    expect(detectSentinel(Number.POSITIVE_INFINITY, "number")).toEqual({
       type: "positive-infinity",
       value: Number.POSITIVE_INFINITY,
     });
-    expect(detectSentinel(Number.NEGATIVE_INFINITY)).toEqual({
+    expect(detectSentinel(Number.NEGATIVE_INFINITY, "number")).toEqual({
       type: "negative-infinity",
       value: Number.NEGATIVE_INFINITY,
     });
   });
 
   it("should return null for normal values", () => {
-    expect(detectSentinel("hello")).toBeNull();
-    expect(detectSentinel(42)).toBeNull();
-    expect(detectSentinel(0)).toBeNull();
-    expect(detectSentinel(-1.5)).toBeNull();
-    expect(detectSentinel(true)).toBeNull();
-    expect(detectSentinel(false)).toBeNull();
-    expect(detectSentinel({})).toBeNull();
-    expect(detectSentinel([])).toBeNull();
+    expect(detectSentinel("hello", "string")).toBeNull();
+    expect(detectSentinel(42, "number")).toBeNull();
+    expect(detectSentinel(0, "number")).toBeNull();
+    expect(detectSentinel(-1.5, "number")).toBeNull();
+    expect(detectSentinel(true, "boolean")).toBeNull();
+    expect(detectSentinel(false, "boolean")).toBeNull();
+    expect(detectSentinel({}, "unknown")).toBeNull();
+    expect(detectSentinel([], "unknown")).toBeNull();
   });
 
   it("should not match literal null-like strings", () => {
-    expect(detectSentinel("null")).toBeNull();
-    expect(detectSentinel("NULL")).toBeNull();
-    expect(detectSentinel("None")).toBeNull();
+    expect(detectSentinel("null", "string")).toBeNull();
+    expect(detectSentinel("NULL", "string")).toBeNull();
+    expect(detectSentinel("None", "string")).toBeNull();
   });
 
   it("should not match string NaN/Infinity in non-numeric columns", () => {
-    expect(detectSentinel("NaN")).toBeNull();
-    expect(detectSentinel("Infinity")).toBeNull();
-    expect(detectSentinel("-Infinity")).toBeNull();
+    expect(detectSentinel("NaN", "string")).toBeNull();
+    expect(detectSentinel("Infinity", "string")).toBeNull();
+    expect(detectSentinel("-Infinity", "string")).toBeNull();
   });
 
   it("should match string NaN/Infinity in numeric columns", () => {
-    const opts = { isNumericColumn: true };
-    expect(detectSentinel("NaN", opts)).toEqual({
+    expect(detectSentinel("NaN", "number")).toEqual({
       type: "nan",
       value: "NaN",
     });
-    expect(detectSentinel("Infinity", opts)).toEqual({
+    expect(detectSentinel("Infinity", "number")).toEqual({
       type: "positive-infinity",
       value: "Infinity",
     });
-    expect(detectSentinel("-Infinity", opts)).toEqual({
+    expect(detectSentinel("-Infinity", "number")).toEqual({
       type: "negative-infinity",
       value: "-Infinity",
     });
-    expect(detectSentinel("inf", opts)).toEqual({
+    expect(detectSentinel("inf", "number")).toEqual({
       type: "positive-infinity",
       value: "inf",
     });
-    expect(detectSentinel("-inf", opts)).toEqual({
+    expect(detectSentinel("-inf", "number")).toEqual({
       type: "negative-infinity",
       value: "-inf",
     });
   });
 
   it("should still not match normal strings in numeric columns", () => {
-    const opts = { isNumericColumn: true };
-    expect(detectSentinel("hello", opts)).toBeNull();
-    expect(detectSentinel("42", opts)).toBeNull();
+    expect(detectSentinel("hello", "number")).toBeNull();
+    expect(detectSentinel("42", "number")).toBeNull();
+  });
+
+  it("should not match NaT in non-temporal columns", () => {
+    expect(detectSentinel("NaT", "string")).toBeNull();
+  });
+
+  it("should match NaT in temporal columns", () => {
+    expect(detectSentinel("NaT", "datetime")).toEqual({
+      type: "nat",
+      value: "NaT",
+    });
+    expect(detectSentinel("NaT", "date")).toEqual({
+      type: "nat",
+      value: "NaT",
+    });
   });
 });
 

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -66,7 +66,6 @@ import {
   renderSortFilterIcon,
   renderSorts,
 } from "./header-items";
-import { isNumericType } from "./types";
 import { detectSentinel, stringifyUnknownValue } from "./utils";
 
 const TOP_K_ROWS = 30;
@@ -649,12 +648,10 @@ const PopoverFilterByValues = <TData, TValue>({
             {filteredData.map(([value, count], rowIndex) => {
               const isSelected = chosenValues.has(value);
               const valueString = stringifyUnknownValue({ value });
-              const isNumericColumn = isNumericType(
+              const sentinel = detectSentinel(
+                value,
                 column.columnDef.meta?.dataType,
               );
-              const sentinel = detectSentinel(value, {
-                isNumericColumn,
-              });
 
               return (
                 <CommandItem

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -53,6 +53,8 @@ import {
   SelectValue,
 } from "../ui/select";
 import { type ColumnFilterForType, Filter } from "./filters";
+import { SentinelCell } from "./sentinel-cell";
+import { detectSentinel } from "./utils";
 import {
   ClearFilterMenuItem,
   FilterButtons,
@@ -65,6 +67,7 @@ import {
   renderSortFilterIcon,
   renderSorts,
 } from "./header-items";
+import { isNumericType } from "./types";
 import { stringifyUnknownValue } from "./utils";
 
 const TOP_K_ROWS = 30;
@@ -647,6 +650,12 @@ const PopoverFilterByValues = <TData, TValue>({
             {filteredData.map(([value, count], rowIndex) => {
               const isSelected = chosenValues.has(value);
               const valueString = stringifyUnknownValue({ value });
+              const isNumericColumn = isNumericType(
+                column.columnDef.meta?.dataType,
+              );
+              const sentinel = detectSentinel(value, {
+                isNumericColumn,
+              });
 
               return (
                 <CommandItem
@@ -661,7 +670,11 @@ const PopoverFilterByValues = <TData, TValue>({
                     className="mr-3 h-3.5 w-3.5"
                   />
                   <span className="flex-1 overflow-hidden max-h-20 line-clamp-3">
-                    {valueString}
+                    {sentinel ? (
+                      <SentinelCell sentinel={sentinel} />
+                    ) : (
+                      valueString
+                    )}
                   </span>
                   <span className="ml-3">{count}</span>
                 </CommandItem>

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -54,7 +54,6 @@ import {
 } from "../ui/select";
 import { type ColumnFilterForType, Filter } from "./filters";
 import { SentinelCell } from "./sentinel-cell";
-import { detectSentinel } from "./utils";
 import {
   ClearFilterMenuItem,
   FilterButtons,
@@ -68,7 +67,7 @@ import {
   renderSorts,
 } from "./header-items";
 import { isNumericType } from "./types";
-import { stringifyUnknownValue } from "./utils";
+import { detectSentinel, stringifyUnknownValue } from "./utils";
 
 const TOP_K_ROWS = 30;
 

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -525,11 +525,9 @@ export function renderCellValue<TData, TValue>({
 
   const isWrapped = column.getColumnWrapping?.() === "wrap";
 
-  // Sentinel values (null, whitespace, NaN, Infinity) rendered specially.
+  // Sentinel values (null, whitespace, NaN, Infinity, NaT) rendered specially.
   // Empty strings are left as-is
-  const sentinel = detectSentinel(value, {
-    isNumericColumn: isNumericType(dataType),
-  });
+  const sentinel = detectSentinel(value, dataType);
   if (sentinel && sentinel.type !== "empty-string") {
     return (
       <div onClick={selectCell} className={cellStyles}>

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -37,7 +37,10 @@ import {
   extractTimezone,
   type FieldTypesWithExternalType,
   INDEX_COLUMN_NAME,
+  isNumericType,
 } from "./types";
+import { SentinelCell } from "./sentinel-cell";
+import { detectSentinel } from "./utils";
 import { uniformSample } from "./uniformSample";
 import { MarkdownUrlDetector, UrlDetector } from "./url-detector";
 
@@ -163,7 +166,7 @@ export function generateColumns<T>({
     }
     // Auto right-align numeric columns
     const dataType = getMeta(key).dataType;
-    if (dataType === "number" || dataType === "integer") {
+    if (isNumericType(dataType)) {
       return "right";
     }
     return undefined;
@@ -269,7 +272,7 @@ export function generateColumns<T>({
           !isCellSelected;
 
         const dataType = column.columnDef.meta?.dataType;
-        const isNumeric = dataType === "number" || dataType === "integer";
+        const isNumeric = isNumericType(dataType);
         const cellStyles = getCellStyleClass({
           justify,
           wrapped,
@@ -521,6 +524,17 @@ export function renderCellValue<TData, TValue>({
   const dtype = column.columnDef.meta?.dtype;
 
   const isWrapped = column.getColumnWrapping?.() === "wrap";
+
+  // Sentinel values (null, whitespace, NaN, Infinity) rendered specially.
+  // Empty strings are left as-is
+  const sentinel = detectSentinel(value);
+  if (sentinel && sentinel.type !== "empty-string") {
+    return (
+      <div onClick={selectCell} className={cellStyles}>
+        <SentinelCell sentinel={sentinel} />
+      </div>
+    );
+  }
 
   if (dataType === "datetime" && typeof value === "string") {
     try {

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -527,7 +527,9 @@ export function renderCellValue<TData, TValue>({
 
   // Sentinel values (null, whitespace, NaN, Infinity) rendered specially.
   // Empty strings are left as-is
-  const sentinel = detectSentinel(value);
+  const sentinel = detectSentinel(value, {
+    isNumericColumn: isNumericType(dataType),
+  });
   if (sentinel && sentinel.type !== "empty-string") {
     return (
       <div onClick={selectCell} className={cellStyles}>

--- a/frontend/src/components/data-table/sentinel-cell.tsx
+++ b/frontend/src/components/data-table/sentinel-cell.tsx
@@ -1,0 +1,91 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { CellValueSentinel, CellValueSentinelType } from "./types";
+
+const WHITESPACE_MARKERS: Record<string, string> = {
+  " ": "\u2423", // open box (space symbol)
+  "\t": "\u2192", // right arrow
+  "\n": "\u21B5", // return symbol
+  "\r": "\u21B5", // return symbol (treat same as \n)
+};
+
+function renderWhitespaceMarkers(str: string): string {
+  return [...str].map((ch) => WHITESPACE_MARKERS[ch] ?? ch).join("");
+}
+
+function describeWhitespace(str: string): string {
+  const CHAR_NAMES: Record<string, string> = {
+    " ": "space",
+    "\t": "tab",
+    "\n": "newline",
+    "\r": "newline",
+  };
+  const counts: Record<string, number> = {};
+  for (const ch of str) {
+    const name = CHAR_NAMES[ch] ?? "character";
+    counts[name] = (counts[name] ?? 0) + 1;
+  }
+  return Object.entries(counts)
+    .map(([name, count]) => `${count} ${name}${count > 1 ? "s" : ""}`)
+    .join(", ");
+}
+
+interface SentinelConfig {
+  label: (value: CellValueSentinel["value"]) => string;
+  tooltip: (value: CellValueSentinel["value"]) => string;
+  ariaLabel: (value: CellValueSentinel["value"]) => string;
+}
+
+const SENTINEL_CONFIG: Record<CellValueSentinelType, SentinelConfig> = {
+  null: {
+    label: () => "None",
+    tooltip: () => "None",
+    ariaLabel: () => "None",
+  },
+  "empty-string": {
+    label: () => "<empty>",
+    tooltip: () => "<empty>",
+    ariaLabel: () => "empty string",
+  },
+  whitespace: {
+    label: (value) => renderWhitespaceMarkers(value as string),
+    tooltip: (value) => describeWhitespace(value as string),
+    ariaLabel: (value) => describeWhitespace(value as string),
+  },
+  nan: {
+    label: () => "NaN",
+    tooltip: () => "NaN",
+    ariaLabel: () => "NaN",
+  },
+  "positive-infinity": {
+    label: () => "inf",
+    tooltip: () => "Infinity",
+    ariaLabel: () => "infinity",
+  },
+  "negative-infinity": {
+    label: () => "-inf",
+    tooltip: () => "-Infinity",
+    ariaLabel: () => "negative infinity",
+  },
+};
+
+export function SentinelCell({
+  sentinel,
+}: {
+  sentinel: CellValueSentinel;
+}): React.ReactElement {
+  const config = SENTINEL_CONFIG[sentinel.type];
+  const label = config.label(sentinel.value);
+  const tooltip = config.tooltip(sentinel.value);
+  const ariaLabel = config.ariaLabel(sentinel.value);
+
+  return (
+    <span
+      className="italic text-muted-foreground bg-muted rounded px-1"
+      aria-label={ariaLabel}
+      title={tooltip}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/data-table/sentinel-cell.tsx
+++ b/frontend/src/components/data-table/sentinel-cell.tsx
@@ -2,27 +2,21 @@
 
 import type { CellValueSentinel, CellValueSentinelType } from "./types";
 
-const WHITESPACE_MARKERS: Record<string, string> = {
-  " ": "\u2423", // open box (space symbol)
-  "\t": "\u2192", // right arrow
-  "\n": "\u21B5", // return symbol
-  "\r": "\u21B5", // return symbol (treat same as \n)
+const WHITESPACE_CHARS: Record<string, { marker: string; name: string }> = {
+  " ": { marker: "\u2423", name: "space" }, // open box (space symbol)
+  "\t": { marker: "\\t", name: "tab" },
+  "\n": { marker: "\\n", name: "newline" },
+  "\r": { marker: "\\r", name: "newline" },
 };
 
 function renderWhitespaceMarkers(str: string): string {
-  return [...str].map((ch) => WHITESPACE_MARKERS[ch] ?? ch).join("");
+  return [...str].map((ch) => WHITESPACE_CHARS[ch]?.marker ?? ch).join("");
 }
 
 function describeWhitespace(str: string): string {
-  const CHAR_NAMES: Record<string, string> = {
-    " ": "space",
-    "\t": "tab",
-    "\n": "newline",
-    "\r": "newline",
-  };
   const counts: Record<string, number> = {};
   for (const ch of str) {
-    const name = CHAR_NAMES[ch] ?? "character";
+    const name = WHITESPACE_CHARS[ch]?.name ?? "character";
     counts[name] = (counts[name] ?? 0) + 1;
   }
   return Object.entries(counts)
@@ -48,9 +42,9 @@ const SENTINEL_CONFIG: Record<CellValueSentinelType, SentinelConfig> = {
     ariaLabel: () => "empty string",
   },
   whitespace: {
-    label: (value) => renderWhitespaceMarkers(value as string),
-    tooltip: (value) => describeWhitespace(value as string),
-    ariaLabel: (value) => describeWhitespace(value as string),
+    label: (value) => renderWhitespaceMarkers(String(value)),
+    tooltip: (value) => describeWhitespace(String(value)),
+    ariaLabel: (value) => describeWhitespace(String(value)),
   },
   nan: {
     label: () => "NaN",
@@ -66,6 +60,11 @@ const SENTINEL_CONFIG: Record<CellValueSentinelType, SentinelConfig> = {
     label: () => "-inf",
     tooltip: () => "-Infinity",
     ariaLabel: () => "negative infinity",
+  },
+  nat: {
+    label: () => "NaT",
+    tooltip: () => "NaT (Not a Time)",
+    ariaLabel: () => "Not a Time",
   },
 };
 
@@ -85,7 +84,7 @@ export function SentinelCell({
       aria-label={ariaLabel}
       title={tooltip}
     >
-      {label}
+      <span className="opacity-70">{label}</span>
     </span>
   );
 }

--- a/frontend/src/components/data-table/types.ts
+++ b/frontend/src/components/data-table/types.ts
@@ -95,6 +95,22 @@ export type DataTableSelection =
   | "multi-cell"
   | null;
 
+export type CellValueSentinel =
+  | { type: "null"; value: null | undefined }
+  | { type: "empty-string"; value: string }
+  | { type: "whitespace"; value: string }
+  | { type: "nan"; value: number | string }
+  | { type: "positive-infinity"; value: number | string }
+  | { type: "negative-infinity"; value: number | string };
+
+export type CellValueSentinelType = CellValueSentinel["type"];
+
+export function isNumericType(
+  dataType: DataType | undefined,
+): dataType is "number" | "integer" {
+  return dataType === "number" || dataType === "integer";
+}
+
 export function extractTimezone(dtype: string | undefined): string | undefined {
   if (!dtype) {
     return undefined;

--- a/frontend/src/components/data-table/types.ts
+++ b/frontend/src/components/data-table/types.ts
@@ -101,7 +101,8 @@ export type CellValueSentinel =
   | { type: "whitespace"; value: string }
   | { type: "nan"; value: number | string }
   | { type: "positive-infinity"; value: number | string }
-  | { type: "negative-infinity"; value: number | string };
+  | { type: "negative-infinity"; value: number | string }
+  | { type: "nat"; value: string };
 
 export type CellValueSentinelType = CellValueSentinel["type"];
 
@@ -109,6 +110,12 @@ export function isNumericType(
   dataType: DataType | undefined,
 ): dataType is "number" | "integer" {
   return dataType === "number" || dataType === "integer";
+}
+
+export function isTemporalType(
+  dataType: DataType | undefined,
+): dataType is "date" | "datetime" | "time" {
+  return dataType === "date" || dataType === "datetime" || dataType === "time";
 }
 
 export function extractTimezone(dtype: string | undefined): string | undefined {

--- a/frontend/src/components/data-table/utils.ts
+++ b/frontend/src/components/data-table/utils.ts
@@ -5,11 +5,7 @@ import type { TableData } from "@/plugins/impl/DataTablePlugin";
 import { vegaLoadData } from "@/plugins/impl/vega/loader";
 import { jsonParseWithSpecialChar } from "@/utils/json/json-parser";
 import { getMimeValues } from "./mime-cell";
-import {
-  INDEX_COLUMN_NAME,
-  type CellValueSentinelType,
-  type CellValueSentinel,
-} from "./types";
+import { INDEX_COLUMN_NAME, type CellValueSentinel } from "./types";
 
 const WHITESPACE_ONLY_RE = /^[\s]+$/;
 
@@ -93,7 +89,12 @@ export function getPageIndexForRow(
 
 // String representations of numeric special values.
 // Only matched when the caller indicates the column is numeric.
-const NUMERIC_STRING_SPECIALS: Record<string, CellValueSentinelType> = {
+type StringValueSentinelType = Extract<
+  CellValueSentinel,
+  { value: number | string }
+>["type"];
+
+const NUMERIC_STRING_SPECIALS: Record<string, StringValueSentinelType> = {
   NaN: "nan",
   Infinity: "positive-infinity",
   "-Infinity": "negative-infinity",

--- a/frontend/src/components/data-table/utils.ts
+++ b/frontend/src/components/data-table/utils.ts
@@ -5,7 +5,13 @@ import type { TableData } from "@/plugins/impl/DataTablePlugin";
 import { vegaLoadData } from "@/plugins/impl/vega/loader";
 import { jsonParseWithSpecialChar } from "@/utils/json/json-parser";
 import { getMimeValues } from "./mime-cell";
-import { INDEX_COLUMN_NAME } from "./types";
+import {
+  INDEX_COLUMN_NAME,
+  type CellValueSentinelType,
+  type CellValueSentinel,
+} from "./types";
+
+const WHITESPACE_ONLY_RE = /^[\s]+$/;
 
 /**
  * Convenience function to load table data.
@@ -80,6 +86,66 @@ export function getPageIndexForRow(
 
   if (rowIdx < currentPageStart || rowIdx > currentPageEnd) {
     return Math.floor(rowIdx / pageSize);
+  }
+
+  return null;
+}
+
+// String representations of numeric special values.
+// Only matched when the caller indicates the column is numeric.
+const NUMERIC_STRING_SPECIALS: Record<string, CellValueSentinelType> = {
+  NaN: "nan",
+  Infinity: "positive-infinity",
+  "-Infinity": "negative-infinity",
+  inf: "positive-infinity",
+  "-inf": "negative-infinity",
+};
+
+/**
+ * Detect if a cell value is a sentinel (null, empty string, whitespace,
+ * NaN, infinity). String representations like "NaN" are only matched when
+ * `opts.isNumericColumn` is true.
+ *
+ * @param value - value to detect
+ * @param opts.isNumericColumn - flag if the column is of a numeric type
+ * @returns
+ */
+export function detectSentinel(
+  value: unknown,
+  opts?: { isNumericColumn?: boolean },
+): CellValueSentinel | null {
+  if (value == null) {
+    return { type: "null", value };
+  }
+
+  if (typeof value === "string") {
+    if (value === "") {
+      return { type: "empty-string", value };
+    }
+    if (WHITESPACE_ONLY_RE.test(value)) {
+      return { type: "whitespace", value };
+    }
+    // String "NaN"/"Infinity" in a numeric column = actual special float value
+    if (opts?.isNumericColumn) {
+      const type = NUMERIC_STRING_SPECIALS[value];
+      if (type) {
+        return { type, value };
+      }
+    }
+    return null;
+  }
+
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) {
+      return { type: "nan", value };
+    }
+    if (value === Number.POSITIVE_INFINITY) {
+      return { type: "positive-infinity", value };
+    }
+    if (value === Number.NEGATIVE_INFINITY) {
+      return { type: "negative-infinity", value };
+    }
+    return null;
   }
 
   return null;

--- a/frontend/src/components/data-table/utils.ts
+++ b/frontend/src/components/data-table/utils.ts
@@ -5,7 +5,13 @@ import type { TableData } from "@/plugins/impl/DataTablePlugin";
 import { vegaLoadData } from "@/plugins/impl/vega/loader";
 import { jsonParseWithSpecialChar } from "@/utils/json/json-parser";
 import { getMimeValues } from "./mime-cell";
-import { INDEX_COLUMN_NAME, type CellValueSentinel } from "./types";
+import type { DataType } from "@/core/kernel/messages";
+import {
+  type CellValueSentinel,
+  INDEX_COLUMN_NAME,
+  isNumericType,
+  isTemporalType,
+} from "./types";
 
 const WHITESPACE_ONLY_RE = /^[\s]+$/;
 
@@ -104,16 +110,12 @@ const NUMERIC_STRING_SPECIALS: Record<string, StringValueSentinelType> = {
 
 /**
  * Detect if a cell value is a sentinel (null, empty string, whitespace,
- * NaN, infinity). String representations like "NaN" are only matched when
- * `opts.isNumericColumn` is true.
- *
- * @param value - value to detect
- * @param opts.isNumericColumn - flag if the column is of a numeric type
- * @returns
+ * NaN, infinity, NaT). Column-type-dependent sentinels (string "NaN",
+ * "NaT", etc.) are matched based on `dataType`.
  */
 export function detectSentinel(
   value: unknown,
-  opts?: { isNumericColumn?: boolean },
+  dataType: DataType | undefined,
 ): CellValueSentinel | null {
   if (value == null) {
     return { type: "null", value };
@@ -127,11 +129,15 @@ export function detectSentinel(
       return { type: "whitespace", value };
     }
     // String "NaN"/"Infinity" in a numeric column = actual special float value
-    if (opts?.isNumericColumn) {
+    if (isNumericType(dataType)) {
       const type = NUMERIC_STRING_SPECIALS[value];
       if (type) {
         return { type, value };
       }
+    }
+    // String "NaT" in a temporal column = pandas Not-a-Time sentinel
+    if (isTemporalType(dataType) && value === "NaT") {
+      return { type: "nat", value };
     }
     return null;
   }

--- a/marimo/_smoke_tests/tables/sentinel_values.py
+++ b/marimo/_smoke_tests/tables/sentinel_values.py
@@ -1,0 +1,299 @@
+import marimo
+
+__generated_with = "0.23.1"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # Sentinel Values in Tables
+
+    Tables should visually distinguish sentinel values (null, empty string,
+    whitespace-only strings, NaN, ±Infinity, NaT) from normal data.
+
+    Each framework has its own semantics — this notebook exercises the
+    rendering across Polars, Pandas (object dtype), and Pandas nullable
+    dtypes.
+
+    ## Expected rendering
+    - `None` / null → muted italic pill labeled `None`
+    - Empty string `"\"` → blank in cell, `<empty>` pill in filter dropdown
+    - Whitespace (` `, `\t`, `\n`) → visible markers in a pill
+    - `NaN` / `inf` / `-inf` → muted pills
+    - `NaT` (pandas) → muted pill labeled `NaT` in datetime columns
+    - Literal string `"null"`, `"NaN"`, etc. → rendered as normal text
+    """)
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import polars as pl
+    import pandas as pd
+
+    return mo, pd, pl
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Polars
+
+    Polars cleanly separates `null` (missing) from `NaN` (a real float value).
+    `is_null()` returns `False` for `NaN` — it's a value, not missing.
+    Expect `NaN` to render with a pill (it's a special float), distinct from `null`.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, pl):
+    import datetime as _dt
+
+    df = pl.DataFrame(
+        {
+            "string_value": [
+                "",
+                None,
+                "NULL",
+                "null",
+                " ",
+                "   ",
+                "\t",
+                "\n",
+                "\t \n",
+            ],
+            "str_description": [
+                "empty string",
+                "None",
+                "string 'NULL'",
+                "string 'null'",
+                "single space",
+                "three spaces",
+                "tab",
+                "newline",
+                "tab + space + newline",
+            ],
+            "numeric_value": [
+                1.0,
+                None,
+                float("nan"),
+                float("inf"),
+                float("-inf"),
+                0.0,
+                42.0,
+                -1.5,
+                100.0,
+            ],
+            "num_description": [
+                "1.0",
+                "None (null)",
+                "NaN (value in polars)",
+                "inf",
+                "-inf",
+                "0.0",
+                "42.0",
+                "-1.5",
+                "100.0",
+            ],
+            "datetime_value": [
+                _dt.datetime(2024, 1, 1),
+                None,
+                None,
+                _dt.datetime(2024, 3, 15),
+                _dt.datetime(2024, 4, 20),
+                _dt.datetime(2024, 5, 10),
+                _dt.datetime(2024, 6, 1),
+                _dt.datetime(2024, 7, 4),
+                _dt.datetime(2024, 8, 15),
+            ],
+            "dt_description": [
+                "normal",
+                "None \u2192 null",
+                "None \u2192 null",
+                "normal",
+                "normal",
+                "normal",
+                "normal",
+                "normal",
+                "normal",
+            ],
+        }
+    )
+    mo.vstack([mo.md("### Polars"), mo.ui.table(selection=None, data=df)])
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Pandas (classic, object dtype)
+
+    **Caveats:**
+    - `None` in a float column is coerced to `NaN`
+    - `NaN` is pandas' sentinel for missing in float columns — no way to
+      distinguish "missing" from "computational NaN"
+    - Missing datetime values are `NaT` (Not a Time), a separate sentinel
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, pd):
+    pdf_classic = pd.DataFrame(
+        {
+            "string_value": [
+                "",
+                None,
+                "NULL",
+                "null",
+                " ",
+                "   ",
+                "\t",
+                "\n",
+                "\t \n",
+            ],
+            "str_description": [
+                "empty string",
+                "None (becomes NaN)",
+                "string 'NULL'",
+                "string 'null'",
+                "single space",
+                "three spaces",
+                "tab",
+                "newline",
+                "tab + space + newline",
+            ],
+            "numeric_value": [
+                1.0,
+                None,
+                float("nan"),
+                float("inf"),
+                float("-inf"),
+                0.0,
+                42.0,
+                -1.5,
+                100.0,
+            ],
+            "num_description": [
+                "1.0",
+                "None (becomes NaN)",
+                "NaN (missing in pandas)",
+                "inf",
+                "-inf",
+                "0.0",
+                "42.0",
+                "-1.5",
+                "100.0",
+            ],
+            "datetime_value": pd.to_datetime(
+                [
+                    "2024-01-01",
+                    None,
+                    pd.NaT,
+                    "2024-03-15",
+                    "2024-04-20",
+                    "2024-05-10",
+                    "2024-06-01",
+                    "2024-07-04",
+                    "2024-08-15",
+                ]
+            ),
+            "dt_description": [
+                "normal date",
+                "None \u2192 NaT",
+                "pd.NaT",
+                "normal",
+                "normal",
+                "normal",
+                "normal",
+                "normal",
+                "normal",
+            ],
+        }
+    )
+    mo.vstack(
+        [
+            mo.md("### Pandas classic (object dtype)"),
+            mo.ui.table(selection=None, data=pdf_classic),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Pandas (nullable dtypes)
+
+    `StringDtype` and `Float64` use `pd.NA` as the missing sentinel.
+
+    **Caveat:** pandas converts `float("nan")` to `pd.NA` at storage time in
+    nullable `Float64` columns — so NaN and NA are indistinguishable on
+    the wire. Both render as `None`.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, pd):
+    pdf_nullable = pd.DataFrame(
+        {
+            "string_value": pd.array(
+                ["", None, pd.NA, "NULL", "null", " ", "   ", "\t", "\n", "\t \n"],
+                dtype="string",
+            ),
+            "str_description": [
+                "empty string",
+                "None \u2192 pd.NA",
+                "pd.NA",
+                "string 'NULL'",
+                "string 'null'",
+                "single space",
+                "three spaces",
+                "tab",
+                "newline",
+                "tab + space + newline",
+            ],
+            "numeric_value": pd.array(
+                [
+                    1.0,
+                    None,
+                    pd.NA,
+                    float("nan"),
+                    float("inf"),
+                    float("-inf"),
+                    0.0,
+                    42.0,
+                    -1.5,
+                    100.0,
+                ],
+                dtype="Float64",
+            ),
+            "num_description": [
+                "1.0",
+                "None \u2192 pd.NA",
+                "pd.NA",
+                "NaN \u2192 pd.NA by pandas",
+                "inf",
+                "-inf",
+                "0.0",
+                "42.0",
+                "-1.5",
+                "100.0",
+            ],
+        }
+    )
+    mo.vstack(
+        [
+            mo.md("### Pandas nullable (StringDtype / Float64)"),
+            mo.ui.table(selection=None, data=pdf_nullable),
+        ]
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Closes #9155

## Summary
- Null values render as `None` in an italic muted pill
- Empty strings render as blank in cells, `<empty>` in filter dropdown
- Whitespace-only strings show visible markers: `␣` (space), `→` (tab), `↵` (newline)
- NaN renders as `NaN`, Infinity as `inf`/`-inf` — all in italic muted pills
- String "NaN"/"Infinity" in numeric columns detected correctly via column type context
- Filter-by-values dropdown uses the same sentinel rendering

<img width="1349" height="527" alt="Screenshot 2026-04-16 at 11 37 50 AM" src="https://github.com/user-attachments/assets/19877163-9b9d-4350-994a-abfdb4a1e73f" />

<img width="1349" height="527" alt="Screenshot 2026-04-16 at 11 38 05 AM" src="https://github.com/user-attachments/assets/129b22a8-447c-47fd-ad0e-b47adcac49d8" />

<img width="413" height="522" alt="Screenshot 2026-04-16 at 11 38 25 AM" src="https://github.com/user-attachments/assets/f0bfb9d8-7c9a-428d-9a8d-08eefabd978b" />