### PR TITLE
fix: preserve shared-memory virtual files owned by other live sessions

### DIFF
--- a/marimo/_runtime/virtual_file/storage.py
+++ b/marimo/_runtime/virtual_file/storage.py
@@ -176,19 +176,24 @@ class SharedMemoryStorage(VirtualFileStorage):
             del self._storage[key]
 
     def shutdown(self, keys: Iterable[str] | None = None) -> None:
-        del keys  # Always clear all - not shared
         if self._shutting_down:
             return
         try:
             self._shutting_down = True
+            if keys is not None:
+                for key in list(keys):
+                    self.remove(key)
+                return
+
             for shm in self._storage.values():
                 if sys.platform == "win32":
                     shm.close()
                 shm.unlink()
             self._storage.clear()
         finally:
-            self._stale = True
             self._shutting_down = False
+            if keys is None:
+                self._stale = True
 
     def has(self, key: str) -> bool:
         return key in self._storage

--- a/tests/_runtime/test_storage.py
+++ b/tests/_runtime/test_storage.py
@@ -180,6 +180,20 @@ class TestSharedMemoryStorage:
         assert not storage.has("marimo_test_6")
         assert not storage.has("marimo_test_7")
 
+    def test_shutdown_with_keys_only_removes_requested_entries(self) -> None:
+        storage = SharedMemoryStorage()
+        try:
+            storage.store("marimo_test_subset_1", b"data1")
+            storage.store("marimo_test_subset_2", b"data2")
+
+            storage.shutdown(keys=["marimo_test_subset_1"])
+
+            assert not storage.has("marimo_test_subset_1")
+            assert storage.has("marimo_test_subset_2")
+            assert storage.read("marimo_test_subset_2", 5) == b"data2"
+        finally:
+            storage.shutdown()
+
     def test_cross_process_read(self) -> None:
         """Test that shared memory can be read by name from a fresh instance."""
         storage1 = SharedMemoryStorage()

--- a/tests/_runtime/test_virtual_file.py
+++ b/tests/_runtime/test_virtual_file.py
@@ -350,6 +350,7 @@ def test_virtual_file_registry_shared_shared_memory_storage() -> None:
     key2 = f"{uuid.uuid4().hex[:8]}.txt"
     context = type("Context", (), {"virtual_files_supported": True})()
 
+    registry1 = None
     registry2 = None
     try:
         manager.storage = None
@@ -368,6 +369,8 @@ def test_virtual_file_registry_shared_shared_memory_storage() -> None:
         assert read_virtual_file(key2, 3) == b"two"
     finally:
         manager.storage = original_storage
+        if registry1 is not None:
+            registry1.shutdown()
         if registry2 is not None:
             registry2.shutdown()
 

--- a/tests/_runtime/test_virtual_file.py
+++ b/tests/_runtime/test_virtual_file.py
@@ -1,10 +1,16 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import uuid
+
 from marimo._runtime.commands import DeleteCellCommand
 from marimo._runtime.context import get_context
 from marimo._runtime.runtime import Kernel
-from marimo._runtime.virtual_file.storage import InMemoryStorage
+from marimo._runtime.virtual_file.storage import (
+    InMemoryStorage,
+    SharedMemoryStorage,
+    VirtualFileStorageManager,
+)
 from marimo._runtime.virtual_file.virtual_file import (
     VirtualFile,
     VirtualFileLifecycleItem,
@@ -327,6 +333,43 @@ def test_virtual_file_registry_shared_inmemory_storage(
 
     # Ensure old file should still readable
     assert read_virtual_file(vf.filename, 3) == b"abc"
+
+
+def test_virtual_file_registry_shared_shared_memory_storage() -> None:
+    """A shared-memory registry teardown must not clobber another live
+    registry in the same process.
+
+    AppHost-backed run sessions for one notebook share a process but each
+    session gets its own runtime context + VirtualFileRegistry. That is the
+    same multi-registry shape the in-memory regression test above covers;
+    here we assert the shared-memory backend honors the same contract.
+    """
+    manager = VirtualFileStorageManager()
+    original_storage = manager.storage
+    key1 = f"{uuid.uuid4().hex[:8]}.txt"
+    key2 = f"{uuid.uuid4().hex[:8]}.txt"
+    context = type("Context", (), {"virtual_files_supported": True})()
+
+    registry2 = None
+    try:
+        manager.storage = None
+        registry1 = VirtualFileRegistry(storage=SharedMemoryStorage())
+        registry1.add(VirtualFile(filename=key1, buffer=b"one"), context)
+        assert read_virtual_file(key1, 3) == b"one"
+
+        registry2 = VirtualFileRegistry(storage=SharedMemoryStorage())
+        registry2.add(VirtualFile(filename=key2, buffer=b"two"), context)
+        assert read_virtual_file(key2, 3) == b"two"
+
+        registry1.shutdown()
+
+        # A still-live registry must keep serving its files after another
+        # session tears down.
+        assert read_virtual_file(key2, 3) == b"two"
+    finally:
+        manager.storage = original_storage
+        if registry2 is not None:
+            registry2.shutdown()
 
 
 def test_create_and_register_with_context(


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #9226.

This keeps AppHost-backed shared-memory virtual files alive for still-running sessions when another session tears down.

## 🔍 Description of Changes

In the shared-memory backend, `VirtualFileRegistry.shutdown()` currently routes to `SharedMemoryStorage.shutdown(keys=...)`, but `SharedMemoryStorage.shutdown()` ignores `keys` and clears all tracked shared-memory entries.

That means one live session can clear another live session's `@file/...` outputs even though the second session still owns them.

### Root Cause

- AppHost-backed run sessions use `virtual_file_storage="shared_memory"`.
- Multiple live sessions for one notebook can coexist in a single AppHost process.
- Later `VirtualFileRegistry` instances reuse the process-global storage manager.
- Registry teardown passes a key subset, but the shared-memory backend currently treats shutdown as a full clear.

### Changes

- Make `SharedMemoryStorage.shutdown(keys=...)` honor the provided subset instead of clearing all tracked entries.
- Only mark the storage stale on full shutdown.
- Add regression coverage for:
  - shared-memory multi-registry teardown behavior
  - subset shutdown behavior in `SharedMemoryStorage`

### Tests

```bash
uv run --group test pytest tests/_runtime/test_virtual_file.py -k 'shared_inmemory_storage or shared_shared_memory_storage' -q
uv run --group test pytest tests/_runtime/test_storage.py -k 'shutdown_with_keys_only_removes_requested_entries or shutdown_clears_storage' -q
uv run ruff check marimo/_runtime/virtual_file/storage.py tests/_runtime/test_virtual_file.py tests/_runtime/test_storage.py
```

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
