### PR TITLE
Fix: mo.ui.refresh typing and docs

### DIFF
--- a/marimo/_plugins/ui/_impl/refresh.py
+++ b/marimo/_plugins/ui/_impl/refresh.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 @mddoc
-class refresh(UIElement[int, int]):
+class refresh(UIElement[str, str]):
     """A refresh button that will auto-refresh its descendants for a given interval.
 
     Each option value can either be a number (int or float) in seconds or a
@@ -35,7 +35,11 @@ class refresh(UIElement[int, int]):
         ```
 
     Attributes:
-        value (int): The time in seconds since the refresh has been activated.
+        value (str): Before the first refresh, the empty string `""`. After
+            each refresh, a string of the form `"<interval> (<count>)"` —
+            e.g. `"1m (3)"` — where `<interval>` is the selected option and
+            `<count>` increments each tick so that downstream cells re-run
+            on every refresh.
 
     Args:
         options (Optional[list[Union[int, float, str]]], optional): The options for the
@@ -47,8 +51,8 @@ class refresh(UIElement[int, int]):
         default_interval (Optional[Union[int, float, str]], optional): The default value
             of the refresh interval.
         label (str, optional): Markdown label for the element. Defaults to "".
-        on_change (Optional[Callable[[int], None]], optional): Optional callback to run
-            when this element's value changes.
+        on_change (Optional[Callable[[str], None]], optional): Optional callback
+            to run when this element's value changes.
     """
 
     name: Final[str] = "marimo-refresh"
@@ -59,7 +63,7 @@ class refresh(UIElement[int, int]):
         default_interval: float | str | None = None,
         *,
         label: str = "",
-        on_change: Callable[[int], None] | None = None,
+        on_change: Callable[[str], None] | None = None,
     ) -> None:
         if default_interval and not isinstance(
             default_interval, (int, float, str)
@@ -94,7 +98,7 @@ class refresh(UIElement[int, int]):
 
         super().__init__(
             component_name=refresh.name,
-            initial_value=0,
+            initial_value="",
             label=label,
             args={
                 "options": resolved_options,
@@ -103,5 +107,5 @@ class refresh(UIElement[int, int]):
             on_change=on_change,
         )
 
-    def _convert_value(self, value: int) -> int:
+    def _convert_value(self, value: str) -> str:
         return value

--- a/tests/_plugins/ui/_impl/test_refresh.py
+++ b/tests/_plugins/ui/_impl/test_refresh.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from marimo._plugins import ui
+from marimo._runtime.commands import UpdateUIElementCommand
+from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider
+
+
+def test_refresh_initial_value_is_empty_string():
+    refresh = ui.refresh(options=["1s", "5s"], default_interval="1s")
+    assert refresh.value == ""
+
+
+async def test_refresh_value_updates_to_frontend_string(
+    any_kernel: Kernel, exec_req: ExecReqProvider
+):
+    k = any_kernel
+    await k.run(
+        [
+            exec_req.get("import marimo as mo"),
+            exec_req.get("r = mo.ui.refresh(options=['1s', '5s'])"),
+        ]
+    )
+
+    refresh = k.globals["r"]
+    assert refresh.value == ""
+
+    await k.set_ui_element_value(
+        UpdateUIElementCommand([refresh._id], ["1s (0)"])
+    )
+    assert refresh.value == "1s (0)"
+
+
+def test_refresh_on_change_receives_string():
+    seen: list[str] = []
+    refresh = ui.refresh(
+        options=["1s"], default_interval="1s", on_change=seen.append
+    )
+    refresh._update("1s (0)")
+    refresh._update("1s (1)")
+    assert seen == ["1s (0)", "1s (1)"]


### PR DESCRIPTION
The value of ui.refresh is typically a string, but it was documented to be an int.

The value was weird in that it started as an int of 0, then changed to '<interval> (number of refreshes)`.

Rather than keep this initialization behavior, this change updates ui.refresh's initial value to be an empty string. This is a breaking change, but at least they are both false-y.

This change also updates typing and docs to say the value is a str.

Fixes #9213