### PR TITLE
fix variants for toast

### DIFF
--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -24,32 +24,41 @@ const ToastViewport = React.forwardRef<
 ));
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
+const VARIANT_CLASSES = {
+  default: "bg-background border",
+  danger:
+    "group destructive text-error border-destructive bg-(--red-1) shadow-md-solid shadow-error",
+} as const satisfies Record<string, string>;
+
+type ToastVariant = keyof typeof VARIANT_CLASSES;
+
 const toastVariants = cva(
   "data-[swipe=move]:transition-none group relative pointer-events-auto flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=move]:translate-x-(--radix-toast-swipe-move-x) data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-(--radix-toast-swipe-end-x) data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full sm:data-[state=open]:slide-in-from-bottom-full data-[state=closed]:slide-out-to-right-full",
   {
     variants: {
-      variant: {
-        default: "bg-background border",
-        danger:
-          "group destructive text-error border-destructive bg-(--red-1) shadow-md-solid shadow-error",
-      },
+      variant: VARIANT_CLASSES,
     },
     defaultVariants: {
-      variant: "default",
+      variant: "default" satisfies ToastVariant,
     },
   },
 );
+
+function isToastVariant(value: unknown): value is ToastVariant {
+  return typeof value === "string" && value in VARIANT_CLASSES;
+}
 
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
     VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
+  const resolvedVariant = isToastVariant(variant) ? variant : "default";
   return (
     <ToastPrimitives.Root
       ref={ref}
       className={cn(
-        toastVariants({ variant: variant || "default" }),
+        toastVariants({ variant: resolvedVariant }),
         "print:hidden",
         className,
       )}


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Code_mode would call toast with `success` kind, which is not supported at the moment. So, it would choose the wrong styles.
```python
mo.status.toast(
    title="Claude reporting for duty! 🧑‍🍳",
    description="Ready to pair on the kitchen sink ✨ — what shall we cook up?",
    kind="success",  # <---- Not supported
)
```

This resolves to choose the `default` style and adds some better typing.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
