### PR TITLE
Expand `uv_build` supported versions in build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.8.3,<0.11.0"]
+requires = ["uv_build>=0.8.3,<0.12.0"]
 build-backend = "uv_build"
 
 [project]
@@ -54,11 +54,10 @@ dependencies = [
     "pyzmq>=27.1.0; python_version < '3.15'",
 ]
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 classifiers = [
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: Apache Software License",
     "Environment :: Console",
     "Environment :: Web Environment",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Also migrates/removes deprecated metadata in pyproject.toml

Previously, with uv>=0.11:

```sh
❯ uv sync
Resolved 381 packages in 3ms
   Building marimo @ file:///Users/tmanz/github/marimo-team/marimo
⠙ Preparing packages... (0/1)                       
                                                                                            
warning: `build_system.requires = ["uv-build>=0.8.3,<0.11.0"]` does not contain the current uv version 0.11.7
warning: Found license classifier `License :: OSI Approved :: Apache Software License`. License classifiers are ambiguous and deprecated per PEP     

Built marimo @ file:///Users/tmanz/github/marimo-team/marimo
Prepared 1 package in 6ms
Uninstalled 1 package in 0.89ms
Installed 1 package in 4ms
 ~ marimo==0.23.1 (from file:///Users/tmanz/github/marimo-team/marimo)
```