### PR TITLE
fix(table): preserve column order in DefaultTableManager select/drop

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/default_table.py
+++ b/marimo/_plugins/ui/_impl/tables/default_table.py
@@ -141,19 +141,16 @@ class DefaultTableManager(TableManager[JsonTableData]):
         return DefaultTableManager([self.data[i] for i in indices])
 
     def select_columns(self, columns: list[str]) -> DefaultTableManager:
-        column_set = set(columns)
         # Column major data
         if isinstance(self.data, dict):
             new_data: dict[str, Any] = {
-                key: value
-                for key, value in self.data.items()
-                if key in column_set
+                key: self.data[key] for key in columns if key in self.data
             }
             return DefaultTableManager(new_data)
         # Row major data
         return DefaultTableManager(
             [
-                {key: row[key] for key in column_set}
+                {key: row[key] for key in columns}
                 for row in self._normalize_data(self.data)
             ]
         )
@@ -213,9 +210,10 @@ class DefaultTableManager(TableManager[JsonTableData]):
         return selected_cells
 
     def drop_columns(self, columns: list[str]) -> DefaultTableManager:
-        return self.select_columns(
-            list(set(self.get_column_names()) - set(columns))
-        )
+        new_cols = [
+            col for col in self.get_column_names() if col not in columns
+        ]
+        return self.select_columns(new_cols)
 
     def take(self, count: int, offset: int) -> DefaultTableManager:
         if count < 0:

--- a/marimo/_plugins/ui/_impl/tables/default_table.py
+++ b/marimo/_plugins/ui/_impl/tables/default_table.py
@@ -210,8 +210,9 @@ class DefaultTableManager(TableManager[JsonTableData]):
         return selected_cells
 
     def drop_columns(self, columns: list[str]) -> DefaultTableManager:
+        to_drop = set(columns)
         new_cols = [
-            col for col in self.get_column_names() if col not in columns
+            col for col in self.get_column_names() if col not in to_drop
         ]
         return self.select_columns(new_cols)
 

--- a/tests/_plugins/ui/_impl/tables/test_default_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_default_table.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import datetime
 import json
+import string
 import unittest
 from datetime import date
 from pathlib import Path
 from typing import Any
 
 import pytest
+from hypothesis import given, strategies as st
 
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.hypertext import Html
@@ -1179,3 +1181,71 @@ def test_validate_header_tooltip_invalid() -> None:
     mapping = {"does_not_exist": "oops"}
     with pytest.raises(ValueError):
         _validate_header_tooltip(mapping, columns)
+
+
+_column_name = st.text(
+    alphabet=string.ascii_letters + string.digits + "_",
+    min_size=1,
+    max_size=10,
+)
+_column_names = st.lists(_column_name, min_size=1, max_size=10, unique=True)
+
+
+@given(cols=_column_names, data=st.data())
+def test_drop_columns_preserves_order_row_major(
+    cols: list[str], data: st.DataObject
+) -> None:
+    to_drop = data.draw(
+        st.lists(st.sampled_from(cols), unique=True, max_size=len(cols))
+    )
+    mgr = DefaultTableManager(
+        [
+            {c: i for i, c in enumerate(cols)},
+            {c: i + 1 for i, c in enumerate(cols)},
+        ]
+    )
+    expected = [c for c in cols if c not in set(to_drop)]
+    assert mgr.drop_columns(to_drop).get_column_names() == expected
+
+
+@given(cols=_column_names, data=st.data())
+def test_drop_columns_preserves_order_column_major(
+    cols: list[str], data: st.DataObject
+) -> None:
+    to_drop = data.draw(
+        st.lists(st.sampled_from(cols), unique=True, max_size=len(cols))
+    )
+    mgr = DefaultTableManager({c: [i, i + 1] for i, c in enumerate(cols)})
+    expected = [c for c in cols if c not in set(to_drop)]
+    assert mgr.drop_columns(to_drop).get_column_names() == expected
+
+
+@given(cols=_column_names, data=st.data())
+def test_select_columns_preserves_caller_order_row_major(
+    cols: list[str], data: st.DataObject
+) -> None:
+    subset = data.draw(
+        st.lists(
+            st.sampled_from(cols), unique=True, min_size=1, max_size=len(cols)
+        )
+    )
+    mgr = DefaultTableManager(
+        [
+            {c: i for i, c in enumerate(cols)},
+            {c: i + 1 for i, c in enumerate(cols)},
+        ]
+    )
+    assert mgr.select_columns(subset).get_column_names() == subset
+
+
+@given(cols=_column_names, data=st.data())
+def test_select_columns_preserves_caller_order_column_major(
+    cols: list[str], data: st.DataObject
+) -> None:
+    subset = data.draw(
+        st.lists(
+            st.sampled_from(cols), unique=True, min_size=1, max_size=len(cols)
+        )
+    )
+    mgr = DefaultTableManager({c: [i, i + 1] for i, c in enumerate(cols)})
+    assert mgr.select_columns(subset).get_column_names() == subset

--- a/tests/_plugins/ui/_impl/tables/test_default_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_default_table.py
@@ -1204,7 +1204,8 @@ def test_drop_columns_preserves_order_row_major(
             {c: i + 1 for i, c in enumerate(cols)},
         ]
     )
-    expected = [c for c in cols if c not in set(to_drop)]
+    to_drop_set = set(to_drop)
+    expected = [c for c in cols if c not in to_drop_set]
     assert mgr.drop_columns(to_drop).get_column_names() == expected
 
 
@@ -1216,7 +1217,8 @@ def test_drop_columns_preserves_order_column_major(
         st.lists(st.sampled_from(cols), unique=True, max_size=len(cols))
     )
     mgr = DefaultTableManager({c: [i, i + 1] for i, c in enumerate(cols)})
-    expected = [c for c in cols if c not in set(to_drop)]
+    to_drop_set = set(to_drop)
+    expected = [c for c in cols if c not in to_drop_set]
     assert mgr.drop_columns(to_drop).get_column_names() == expected
 
 


### PR DESCRIPTION
Closes #9219.

## Summary

`mo.ui.table` with plain Python data (`list[dict]` / `dict[str, list]`) was scrambling column order on every export. The fix makes `select_columns` and `drop_columns` keep the caller's column order on both the row-major and column-major paths.

**Cause**
`drop_columns` did a set-difference, and the row-major `select_columns` iterated a set. Set order depends on `PYTHONHASHSEED`, so it was random.
Pandas/polars DataFrames weren't affected — they go through `NarwhalsTableManager.drop_columns` which defers to the DataFrame's own `drop()`.

## Tests
Four hypothesis property tests in `test_default_table.py` pin the invariant: for any column list and any drop/select subset, output order matches the original.