### PR TITLE
perf(complete): bail out of type inference when completion budget expires

### DIFF
--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -278,15 +278,24 @@ def _get_completion_option(
     completion: jedi.api.classes.Completion,
     script: jedi.Script,
     compute_completion_info: bool,
+    compute_type: bool = True,
 ) -> CompletionOption:
     name = completion.name
+    # `completion.type` triggers jedi inference and can be surprisingly
+    # expensive on cold caches for heavy libraries (pandas, numpy, torch).
+    # When callers are already over budget they pass `compute_type=False`, in
+    # which case we also skip docstring computation — it re-triggers the same
+    # inference we just declined to pay for.
+    if not compute_type:
+        return CompletionOption(name=name, type="", completion_info="")
+
     kind = completion.type
 
     if compute_completion_info:
         # Choose whether the completion info should be from the name
         # or the enclosing function's signature, if any
         symbol_to_lookup = completion
-        if completion.type == "param":
+        if kind == "param":
             # Show the function/class docstring if available
             signatures = script.get_signatures()
             if len(signatures) == 1:
@@ -307,26 +316,25 @@ def _get_completion_options(
     limit: int,
     timeout: float,
 ) -> list[CompletionOption]:
-    if len(completions) > limit:
-        return [
-            _get_completion_option(
-                completion, script, compute_completion_info=False
-            )
-            for completion in completions
-            if _should_include_name(completion.name, prefix)
-        ]
+    # For large completion sets (e.g. `pd.`, ~140 attrs), building per-item
+    # docstrings costs seconds of jedi inference that the user will never read.
+    # Skip docstrings globally past `limit` and rely on the time budget to bail
+    # out of further type inference if we're already slow.
+    compute_docstrings = len(completions) <= limit
 
     completion_options: list[CompletionOption] = []
     start_time = time.time()
     for completion in completions:
         if not _should_include_name(completion.name, prefix):
             continue
-        elapsed_time = time.time() - start_time
+        under_time_budget = (time.time() - start_time) < timeout
         completion_options.append(
             _get_completion_option(
                 completion,
                 script,
-                compute_completion_info=elapsed_time < timeout,
+                compute_completion_info=compute_docstrings
+                and under_time_budget,
+                compute_type=under_time_budget,
             )
         )
     return completion_options

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -323,11 +323,11 @@ def _get_completion_options(
     compute_docstrings = len(completions) <= limit
 
     completion_options: list[CompletionOption] = []
-    start_time = time.time()
+    deadline = time.monotonic() + timeout
     for completion in completions:
         if not _should_include_name(completion.name, prefix):
             continue
-        under_time_budget = (time.time() - start_time) < timeout
+        under_time_budget = time.monotonic() < deadline
         completion_options.append(
             _get_completion_option(
                 completion,

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import random
 import threading
+import time
 from collections.abc import Mapping
 from inspect import signature
 from types import ModuleType
@@ -19,6 +20,8 @@ from marimo._messaging.types import KernelMessage, Stream
 from marimo._runtime.commands import CodeCompletionCommand
 from marimo._runtime.complete import (
     _build_docstring_cached,
+    _get_completion_option,
+    _get_completion_options,
     _get_docstring,
     _maybe_get_key_options,
     _resolve_chained_key_path,
@@ -709,3 +712,160 @@ def test_resolve_chained_key_path(
 ) -> None:
     key_path = _resolve_chained_key_path("obj", trigger_code)
     assert key_path == expected_key_path
+
+
+class _FakeCompletion:
+    """Stand-in for jedi.api.classes.Completion.
+
+    Tracks whether `type` was accessed so we can assert we didn't pay the
+    (expensive) jedi inference cost in the fast path.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        completion_type: str = "function",
+        raise_on_type: bool = False,
+    ) -> None:
+        self.name = name
+        self._type = completion_type
+        self._raise_on_type = raise_on_type
+        self.type_access_count = 0
+        self.docstring_called = False
+
+    @property
+    def type(self) -> str:
+        self.type_access_count += 1
+        if self._raise_on_type:
+            raise AssertionError(
+                "completion.type accessed when it should have been skipped"
+            )
+        return self._type
+
+    def docstring(self, *_args: Any, **_kwargs: Any) -> str:
+        self.docstring_called = True
+        return ""
+
+
+def test_get_completion_option_skips_type_when_compute_type_false() -> None:
+    completion = _FakeCompletion("foo", raise_on_type=True)
+    script = mock.MagicMock()
+
+    option = _get_completion_option(
+        completion,
+        script,
+        compute_completion_info=False,
+        compute_type=False,
+    )
+
+    assert option.name == "foo"
+    assert option.type == ""
+    assert option.completion_info == ""
+    assert completion.type_access_count == 0
+
+
+def test_get_completion_option_computes_type_by_default() -> None:
+    completion = _FakeCompletion("foo", completion_type="class")
+    script = mock.MagicMock()
+
+    option = _get_completion_option(
+        completion,
+        script,
+        compute_completion_info=False,
+    )
+
+    assert option.type == "class"
+    assert completion.type_access_count == 1
+
+
+def test_get_completion_option_skips_all_inference_when_type_skipped() -> None:
+    """When `compute_type=False`, we also skip docstrings and signatures.
+    The whole point of `compute_type=False` is "we're out of budget", so
+    further jedi inference (docstring, signature) would defeat the purpose.
+    """
+    completion = _FakeCompletion("foo", raise_on_type=True)
+    script = mock.MagicMock()
+
+    option = _get_completion_option(
+        completion,
+        script,
+        compute_completion_info=True,
+        compute_type=False,
+    )
+
+    assert option.name == "foo"
+    assert option.type == ""
+    assert option.completion_info == ""
+    assert completion.type_access_count == 0
+    assert not completion.docstring_called
+    script.get_signatures.assert_not_called()
+
+
+def test_get_completion_options_skips_docstrings_past_limit() -> None:
+    completions = [_FakeCompletion(f"attr_{i}") for i in range(10)]
+    script = mock.MagicMock()
+
+    options = _get_completion_options(
+        completions, script, prefix="", limit=5, timeout=5.0
+    )
+
+    assert len(options) == 10
+    assert all(opt.completion_info == "" for opt in options)
+    # Types are still computed since we're well under the timeout
+    assert all(c.type_access_count == 1 for c in completions)
+
+
+def test_get_completion_options_keeps_docstrings_under_limit() -> None:
+    completions = [_FakeCompletion(f"attr_{i}") for i in range(3)]
+    script = mock.MagicMock()
+
+    _get_completion_options(
+        completions, script, prefix="", limit=10, timeout=5.0
+    )
+
+    # All three completions should have had docstring() invoked
+    assert all(c.docstring_called for c in completions)
+
+
+def test_get_completion_options_bails_out_when_timeout_elapsed() -> None:
+    """Once the time budget is blown, subsequent completions skip both type
+    inference and docstring lookup — this is the key knob that keeps cold
+    completions from taking 10+ seconds on heavy libraries.
+    """
+    completions = [_FakeCompletion(f"attr_{i}") for i in range(4)]
+    script = mock.MagicMock()
+
+    # Burn time on the first call so the rest see an expired budget.
+    original_time = time.time
+    times = iter([0.0, 0.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0])
+
+    with mock.patch(
+        "marimo._runtime.complete.time.time",
+        side_effect=lambda: next(times, original_time()),
+    ):
+        options = _get_completion_options(
+            completions, script, prefix="", limit=100, timeout=1.0
+        )
+
+    # First one completes normally, the rest should have no info or type
+    assert options[0].completion_info != "" or completions[0].docstring_called
+    assert options[0].type == "function"
+    for opt in options[1:]:
+        assert opt.type == ""
+        assert opt.completion_info == ""
+
+
+def test_get_completion_options_respects_prefix_filter() -> None:
+    """Underscore names are filtered out by `_should_include_name`."""
+    completions = [
+        _FakeCompletion("public"),
+        _FakeCompletion("_private"),
+        _FakeCompletion("__dunder__"),
+    ]
+    script = mock.MagicMock()
+
+    options = _get_completion_options(
+        completions, script, prefix="", limit=100, timeout=5.0
+    )
+
+    assert [opt.name for opt in options] == ["public"]


### PR DESCRIPTION
Completing against heavy libraries (`pandas`, `numpy`, `torch`, `aiohttp`, ...) on a cold jedi cache was paying the full per-item inference cost for every completion, even when the list is large enough that we already skip docstrings. On molab this made the first `pd.` tab take ~11s; on a local Mac with a cleared cache, ~5.5s.

- Add `compute_type=True` kwarg to `_get_completion_option`; when False, skip the `completion.type` access (and the docstring/signature path, which re-triggers the same inference).
- Collapse the split oversize/normal branches of `_get_completion_options` into one loop that tracks a time budget. Once the budget expires, remaining completions are returned with name only.

Per-completion options cost: 29.6 ms (OLD) -> 19.0 ms (NEW), ~36% across the suite. Worst-case savings for heavy libs bigger:
  - `aiohttp` (169 attrs): ~9.6s projected -> 2.8s measured (~71%)
  - `pandas` cold (141 attrs): ~11.3s pre-patch -> ~2.0s capped (~82%)

```
  Projected savings, same-lib cold

  ┌────────────────────────────────────────────┬────────┬───────────┬─────────────────┬───────────────┐
  │                    lib                     │ #comps │    OLD    │       NEW       │     saved     │
  ├────────────────────────────────────────────┼────────┼───────────┼─────────────────┼───────────────┤
  │ pandas (molab, measured pre-patch)         │    141 │ 11,300 ms │ ~2,000 ms (cap) │ ~9.3 s (82 %) │
  ├────────────────────────────────────────────┼────────┼───────────┼─────────────────┼───────────────┤
  │ aiohttp (projected OLD = 169 × 57 ms/comp) │    169 │ ~9,600 ms │        2,839 ms │ ~6.8 s (71 %) │
  ├────────────────────────────────────────────┼────────┼───────────┼─────────────────┼───────────────┤
  │ rich (measured OLD, projected NEW cap)     │     98 │  5,547 ms │ ~2,000 ms (cap) │ ~3.5 s (64 %) │
  └────────────────────────────────────────────┴────────┴───────────┴─────────────────┴───────────────┘

  Local cold cache, same scenarios before vs after

  ┌──────────────────────────────────────┬──────────┬──────────┬──────────────────────────────────┐
  │               scenario               │  before  │  after   │                Δ                 │
  ├──────────────────────────────────────┼──────────┼──────────┼──────────────────────────────────┤
  │ import pandas as pd; pd. (141 attrs) │ 5,506 ms │ 2,520 ms │                            −54 % │
  ├──────────────────────────────────────┼──────────┼──────────┼──────────────────────────────────┤
  │ import numpy as np; np.lin (2 attrs) │ 1,002 ms │   902 ms │                            −10 % │
  ├──────────────────────────────────────┼──────────┼──────────┼──────────────────────────────────┤
  │ import os; os.path.join(             │   109 ms │   399 ms │ noise (jedi.Script, not options) │
  ├──────────────────────────────────────┼──────────┼──────────┼──────────────────────────────────┤
  │ d[" key completion                   │   1.0 ms │   0.7 ms │                            noise │
  ├──────────────────────────────────────┼──────────┼──────────┼──────────────────────────────────┤
  │ import sys; sys                      │  12.8 ms │  10.9 ms │                            noise │
  └──────────────────────────────────────┴──────────┴──────────┴──────────────────────────────────┘
```

**Tradeoff**: on cold heavy libs, only the first ~50-80 completions get type icons; the rest go out blank and fill in on subsequent requests as jedi's internal cache populates. Warm completions are unchanged.