### PR TITLE
test: verify test_import_multiprocessing on main (do not merge)

### DIFF
--- a/tests/_messaging/test_streams.py
+++ b/tests/_messaging/test_streams.py
@@ -189,3 +189,4 @@ async def test_import_multiprocessing(
         ]
     )
     assert mocked_kernel.stdout.messages == ["hello", "\n"]
+    # Trigger CI: throwaway edit to force pytest_changed to pick up this file.


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Throwaway draft PR to verify that `tests/_messaging/test_streams.py::test_import_multiprocessing` still passes on Windows CI when built from `main` (no changes beyond a whitespace/comment nudge to get `pytest_changed` to pick up the test).

Context: on PR #9248 (`aka/fix-kill-process-group`) this test hangs and hits the 2-minute pytest-timeout on Windows. We need to confirm whether this is a regression introduced by that branch or a latent issue on `main`.

**Do not merge — will be closed once CI reports.**