### PR TITLE
fix: use urlparse instead of regex for proxy determination

### DIFF
--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 import threading
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlparse
 
 import uvicorn
 
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
     from marimo._cli.tips import CliTip
 
 DEFAULT_PORT = 2718
-PROXY_REGEX = re.compile(r"^(.*):(\d+)$")
 
 
 def _execute_startup_command(
@@ -140,21 +139,29 @@ def _resolve_proxy(port: int, host: str, proxy: str | None) -> tuple[int, str]:
        (uvicorn)  -----------------
 
 
-    If the proxy is provided, it will default to port 80. Otherwise if the
-    proxy has a port specified, it will use that port.
-    e.g. `example.com:8080`
+    If the proxy is provided, it will default to port 80 (443 for https://).
+    Supports bare hostnames, host:port, and full URLs with a scheme.
+    e.g. `example.com:8080`, `https://example.com`, `https://example.com:8443`
     """
     if not proxy:
         return port, host
 
-    match = PROXY_REGEX.match(proxy)
-    # Our proxy has an explicit port defined, so return that.
-    if match:
-        external_host, external_port = match.groups()
-        return int(external_port), external_host
+    # Prefix with "//" so urlparse treats the value as a netloc rather than a
+    # path when no scheme is present — handles "host", "host:port", and full
+    # "scheme://host:port" forms uniformly.
+    parse_target = proxy if "://" in proxy else f"//{proxy}"
+    parsed = urlparse(parse_target)
 
-    # A default to 80 is reasonable if a proxy is provided.
-    return 80, proxy
+    # parsed.hostname strips brackets from IPv6 addresses (e.g. [::1] → ::1)
+    external_host = parsed.hostname or proxy
+    if parsed.port is not None:
+        external_port = parsed.port
+    elif parsed.scheme == "https":
+        external_port = 443
+    else:
+        external_port = 80
+
+    return external_port, external_host
 
 
 def start(

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -150,12 +150,25 @@ def _resolve_proxy(port: int, host: str, proxy: str | None) -> tuple[int, str]:
     # path when no scheme is present — handles "host", "host:port", and full
     # "scheme://host:port" forms uniformly.
     parse_target = proxy if "://" in proxy else f"//{proxy}"
-    parsed = urlparse(parse_target)
 
-    # parsed.hostname strips brackets from IPv6 addresses (e.g. [::1] → ::1)
-    external_host = parsed.hostname or proxy
-    if parsed.port is not None:
-        external_port = parsed.port
+    try:
+        parsed = urlparse(parse_target)
+
+        # parsed.hostname strips brackets from IPv6 addresses
+        # (e.g. [::1] → ::1)
+        external_host = parsed.hostname or proxy
+        parsed_port = parsed.port
+    except ValueError:
+        LOGGER.warning(
+            "Ignoring invalid proxy value %r; falling back to host=%r, port=%r",
+            proxy,
+            host,
+            port,
+        )
+        return port, host
+
+    if parsed_port is not None:
+        external_port = parsed_port
     elif parsed.scheme == "https":
         external_port = 443
     else:

--- a/tests/_server/test_startup_url.py
+++ b/tests/_server/test_startup_url.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from marimo._server.api.lifespans import _startup_url
+from marimo._server.start import _resolve_proxy
 from marimo._server.tokens import AuthToken
 
 
@@ -44,6 +45,39 @@ def _make_state(host: str, port: int = 2718, base_url: str = "/") -> MagicMock:
 def test_startup_url_ipv6(host: str, expected: str) -> None:
     state = _make_state(host)
     assert _startup_url(state) == expected
+
+
+@pytest.mark.parametrize(
+    ("proxy", "in_port", "in_host", "expected_port", "expected_host"),
+    [
+        # No proxy: port and host pass through unchanged
+        (None, 2972, "127.0.0.1", 2972, "127.0.0.1"),
+        # Bare hostname: default to port 80
+        ("example.com", 2972, "127.0.0.1", 80, "example.com"),
+        # host:port
+        ("example.com:8080", 2972, "127.0.0.1", 8080, "example.com"),
+        # http:// schema: default port 80
+        ("http://example.com", 2972, "127.0.0.1", 80, "example.com"),
+        # https:// schema: default port 443
+        ("https://example.com", 2972, "127.0.0.1", 443, "example.com"),
+        # https:// schema with explicit port
+        ("https://example.com:8443", 2972, "127.0.0.1", 8443, "example.com"),
+        # http:// with explicit port
+        ("http://example.com:8080", 2972, "127.0.0.1", 8080, "example.com"),
+        # IPv6 with brackets and port
+        ("[2001:db8::1]:8080", 2972, "127.0.0.1", 8080, "2001:db8::1"),
+    ],
+)
+def test_resolve_proxy(
+    proxy: str | None,
+    in_port: int,
+    in_host: str,
+    expected_port: int,
+    expected_host: str,
+) -> None:
+    port, host = _resolve_proxy(in_port, in_host, proxy)
+    assert port == expected_port
+    assert host == expected_host
 
 
 def test_startup_url_getnameinfo_failure() -> None:


### PR DESCRIPTION
## 📝 Summary

closes #9250

Replaces brittle regex for proxy determination with `urlparse`