### PR TITLE
fix: kill kernel's process group on shutdown

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -444,24 +444,37 @@ def run_in_sandbox(
 
     env = os.environ.copy()
     env["MARIMO_MANAGE_SCRIPT_METADATA"] = "true"
+    # Let the inner marimo server poll for our PID so it can shut down if we
+    # get SIGKILLed (signal handlers below can't catch uncatchable signals).
+    env["MARIMO_ANCESTOR_PID"] = str(os.getpid())
     if extra_env:
         env.update(extra_env)
 
-    process = subprocess.Popen(uv_cmd, env=env)
+    # On Unix, run `uv` in its own session so that (a) the tty no longer
+    # delivers SIGINT/SIGTERM to it directly and (b) we can signal the whole
+    # subtree with a single killpg. The signal handlers below are then the
+    # sole path for forwarding signals from the CLI down to uv, the inner
+    # marimo server, and the kernel.
+    if sys.platform == "win32":
+        process = subprocess.Popen(uv_cmd, env=env)
+    else:
+        process = subprocess.Popen(uv_cmd, env=env, start_new_session=True)
 
     def handler(sig: int, frame: object) -> None:
-        del sig
         del frame
         try:
             if sys.platform == "win32":
                 os.kill(process.pid, signal.CTRL_C_EVENT)
             else:
-                os.kill(process.pid, signal.SIGINT)
+                os.killpg(process.pid, sig)
         except ProcessLookupError:
             # Process may have already been terminated.
             pass
 
     signal.signal(signal.SIGINT, handler)
+    if sys.platform != "win32":
+        signal.signal(signal.SIGTERM, handler)
+        signal.signal(signal.SIGHUP, handler)
 
     return process.wait()
 

--- a/marimo/_ipc/launch_kernel.py
+++ b/marimo/_ipc/launch_kernel.py
@@ -52,6 +52,7 @@ def main() -> None:
         is_edit_mode=not args.is_run_mode,
         is_ipc=True,
         redirect_console_to_browser=args.redirect_console_to_browser,
+        parent_pid=args.parent_pid,
     )
 
 

--- a/marimo/_ipc/types.py
+++ b/marimo/_ipc/types.py
@@ -38,6 +38,7 @@ class KernelArgs(msgspec.Struct):
     # virtual_files_supported is ignored, but kept for backward compatibility
     virtual_files_supported: bool = True
     redirect_console_to_browser: bool = True
+    parent_pid: int | None = None
 
     def encode_json(self) -> bytes:
         return encode_json_bytes(self)

--- a/marimo/_runtime/parent_poller.py
+++ b/marimo/_runtime/parent_poller.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Poll another process and exist when that process exits.
+
+Ported from ipykernel.parentpoller (BSD-licensed) to avoid orphaned kernel
+processes when the marimo server is killed ungracefully (e.g. SIGKILL, OOM).
+Without this, a crashed server can leave the kernel and its children running
+forever.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import time
+from dataclasses import dataclass
+from threading import Event, Thread
+from typing import TYPE_CHECKING, Final
+
+from marimo import _loggers
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+LOGGER = _loggers.marimo_logger()
+
+_PARENT_POLL_INTERVAL_SECONDS: Final[float] = 1.0
+_PARENT_SHUTDOWN_WAIT_SECONDS: Final[float] = 1.0
+
+
+def kill_own_process_group() -> None:
+    """Force-kill this process and all peers in its process group."""
+    try:
+        os.killpg(os.getpgrp(), signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except OSError:
+        LOGGER.debug(
+            "Failed to kill kernel process group; exiting current process.",
+            exc_info=True,
+        )
+    os._exit(1)
+
+
+@dataclass(frozen=True)
+class ParentPollerHandle:
+    """State shared between a parent poller and its owner."""
+
+    exit_detected: Event
+    cleanup_complete: Event
+
+    def mark_cleanup_complete(self) -> None:
+        """For the caller to signal to the poller it can exit."""
+        self.cleanup_complete.set()
+
+    def finalize_if_parent_died(self) -> None:
+        if not self.exit_detected.is_set():
+            return
+
+        self.mark_cleanup_complete()
+        kill_own_process_group()
+
+
+class ParentPollerUnix(Thread):
+    """Daemon thread that exits the process when the parent has died."""
+
+    def __init__(
+        self,
+        parent_pid: int,
+        *,
+        request_graceful_shutdown: Callable[[], None],
+        parent_exit_detected: Event,
+        cleanup_complete: Event,
+        target_name: str = "kernel",
+    ) -> None:
+        super().__init__(daemon=True)
+        self.parent_pid = parent_pid
+        self.request_graceful_shutdown = request_graceful_shutdown
+        self.parent_exit_detected = parent_exit_detected
+        self.cleanup_complete = cleanup_complete
+        self.target_name = target_name
+
+    def _request_shutdown(self) -> None:
+        try:
+            self.request_graceful_shutdown()
+        except Exception:
+            LOGGER.debug(
+                "Failed to request graceful shutdown during parent-death "
+                "shutdown; force-kill fallback may be required.",
+                exc_info=True,
+            )
+
+    def _handle_parent_death(self) -> None:
+        LOGGER.warning(
+            "Parent server appears to have exited, shutting down %s.",
+            self.target_name,
+        )
+        self.parent_exit_detected.set()
+        self._request_shutdown()
+
+        if self.cleanup_complete.wait(timeout=_PARENT_SHUTDOWN_WAIT_SECONDS):
+            return
+
+        LOGGER.warning(
+            "%s cleanup did not finish before timeout; force-killing its "
+            "process group.",
+            self.target_name.capitalize(),
+        )
+        kill_own_process_group()
+
+    def run(self) -> None:
+        from errno import EINTR
+
+        # If the passed-in parent pid doesn't match our actual ppid,
+        # fall back to detecting reparenting to init (ppid == 1).
+        if os.getppid() != self.parent_pid:
+            self.parent_pid = 0
+
+        while True:
+            try:
+                ppid = os.getppid()
+                parent_is_init = not self.parent_pid and ppid == 1
+                parent_has_changed = (
+                    self.parent_pid and ppid != self.parent_pid
+                )
+                if parent_is_init or parent_has_changed:
+                    self._handle_parent_death()
+                    return
+                time.sleep(_PARENT_POLL_INTERVAL_SECONDS)
+            except OSError as e:
+                if e.errno == EINTR:
+                    continue
+                raise
+
+
+def start_parent_poller(
+    parent_pid: int | None,
+    *,
+    request_graceful_shutdown: Callable[[], None],
+    target_name: str,
+) -> ParentPollerHandle | None:
+    """Start a parent poller when the current Unix subprocess has a parent.
+
+    Returns `None` when parent polling is not applicable, such as when
+    running on Windows or when reparenting to PID 1 is expected.
+    """
+    if sys.platform == "win32" or parent_pid in (None, 1):
+        return None
+
+    assert parent_pid is not None
+    parent_pid_int = parent_pid
+    handle = ParentPollerHandle(
+        exit_detected=Event(),
+        cleanup_complete=Event(),
+    )
+    ParentPollerUnix(
+        parent_pid=parent_pid_int,
+        request_graceful_shutdown=request_graceful_shutdown,
+        parent_exit_detected=handle.exit_detected,
+        cleanup_complete=handle.cleanup_complete,
+        target_name=target_name,
+    ).start()
+    return handle

--- a/marimo/_runtime/parent_poller.py
+++ b/marimo/_runtime/parent_poller.py
@@ -21,11 +21,25 @@ LOGGER = _loggers.marimo_logger()
 
 
 class ParentPollerUnix(Thread):
-    """Daemon thread that kills the process group when the parent has died."""
+    """Daemon thread that kills the process group when the parent has died.
 
-    def __init__(self, parent_pid: int) -> None:
+    Two independent death-detection mechanisms:
+
+    - `parent_pid`: watches the *direct* parent. When the direct parent exits,
+      the OS reparents us (getppid becomes 1 or some other PID), which we can
+      observe.
+
+    - `ancestor_pid`: watches a non-parent PID.
+    """
+
+    def __init__(
+        self,
+        parent_pid: int,
+        ancestor_pid: int | None = None,
+    ) -> None:
         super().__init__(daemon=True)
         self.parent_pid = parent_pid
+        self.ancestor_pid = ancestor_pid
 
     def _handle_parent_death(self) -> None:
         LOGGER.warning("Parent server appears to have exited, shutting down.")
@@ -40,6 +54,19 @@ class ParentPollerUnix(Thread):
                 exc_info=True,
             )
         os._exit(1)
+
+    def _ancestor_is_gone(self) -> bool:
+        if self.ancestor_pid is None or self.ancestor_pid <= 1:
+            return False
+        try:
+            os.kill(self.ancestor_pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            # Ancestor exists but we no longer have permission to signal it
+            # (e.g. PID reused by an unrelated user's process). Treat as gone.
+            return True
+        return False
 
     def run(self) -> None:
         from errno import EINTR
@@ -56,7 +83,11 @@ class ParentPollerUnix(Thread):
                 parent_has_changed = (
                     self.parent_pid and ppid != self.parent_pid
                 )
-                if parent_is_init or parent_has_changed:
+                if (
+                    parent_is_init
+                    or parent_has_changed
+                    or self._ancestor_is_gone()
+                ):
                     self._handle_parent_death()
                     return
                 time.sleep(1.0)
@@ -66,7 +97,10 @@ class ParentPollerUnix(Thread):
                 raise
 
 
-def start_parent_poller(parent_pid: int | None) -> None:
+def start_parent_poller(
+    parent_pid: int | None,
+    ancestor_pid: int | None = None,
+) -> None:
     """Start a parent poller when the current Unix subprocess has a parent.
 
     Returns `None` when parent polling is not applicable, such as when
@@ -75,4 +109,4 @@ def start_parent_poller(parent_pid: int | None) -> None:
     if sys.platform == "win32" or parent_pid is None or parent_pid == 1:
         return
 
-    ParentPollerUnix(parent_pid=parent_pid).start()
+    ParentPollerUnix(parent_pid=parent_pid, ancestor_pid=ancestor_pid).start()

--- a/marimo/_runtime/parent_poller.py
+++ b/marimo/_runtime/parent_poller.py
@@ -13,7 +13,6 @@ import os
 import signal
 import sys
 import time
-from dataclasses import dataclass
 from threading import Event, Thread
 from typing import TYPE_CHECKING, Final
 
@@ -42,25 +41,6 @@ def kill_own_process_group() -> None:
     os._exit(1)
 
 
-@dataclass(frozen=True)
-class ParentPollerHandle:
-    """State shared between a parent poller and its owner."""
-
-    exit_detected: Event
-    cleanup_complete: Event
-
-    def mark_cleanup_complete(self) -> None:
-        """For the caller to signal to the poller it can exit."""
-        self.cleanup_complete.set()
-
-    def finalize_if_parent_died(self) -> None:
-        if not self.exit_detected.is_set():
-            return
-
-        self.mark_cleanup_complete()
-        kill_own_process_group()
-
-
 class ParentPollerUnix(Thread):
     """Daemon thread that exits the process when the parent has died."""
 
@@ -69,16 +49,25 @@ class ParentPollerUnix(Thread):
         parent_pid: int,
         *,
         request_graceful_shutdown: Callable[[], None],
-        parent_exit_detected: Event,
-        cleanup_complete: Event,
         target_name: str = "kernel",
     ) -> None:
         super().__init__(daemon=True)
         self.parent_pid = parent_pid
         self.request_graceful_shutdown = request_graceful_shutdown
-        self.parent_exit_detected = parent_exit_detected
-        self.cleanup_complete = cleanup_complete
         self.target_name = target_name
+        self.parent_exit_detected = Event()
+        self.cleanup_complete = Event()
+
+    def mark_cleanup_complete(self) -> None:
+        """For the caller to signal to the poller it can exit."""
+        self.cleanup_complete.set()
+
+    def finalize_if_parent_died(self) -> None:
+        if not self.parent_exit_detected.is_set():
+            return
+
+        self.mark_cleanup_complete()
+        kill_own_process_group()
 
     def _request_shutdown(self) -> None:
         try:
@@ -138,26 +127,19 @@ def start_parent_poller(
     *,
     request_graceful_shutdown: Callable[[], None],
     target_name: str,
-) -> ParentPollerHandle | None:
+) -> ParentPollerUnix | None:
     """Start a parent poller when the current Unix subprocess has a parent.
 
     Returns `None` when parent polling is not applicable, such as when
     running on Windows or when reparenting to PID 1 is expected.
     """
-    if sys.platform == "win32" or parent_pid in (None, 1):
+    if sys.platform == "win32" or parent_pid is None or parent_pid == 1:
         return None
 
-    assert parent_pid is not None
-    parent_pid_int = parent_pid
-    handle = ParentPollerHandle(
-        exit_detected=Event(),
-        cleanup_complete=Event(),
-    )
-    ParentPollerUnix(
-        parent_pid=parent_pid_int,
+    poller = ParentPollerUnix(
+        parent_pid=parent_pid,
         request_graceful_shutdown=request_graceful_shutdown,
-        parent_exit_detected=handle.exit_detected,
-        cleanup_complete=handle.cleanup_complete,
         target_name=target_name,
-    ).start()
-    return handle
+    )
+    poller.start()
+    return poller

--- a/marimo/_runtime/parent_poller.py
+++ b/marimo/_runtime/parent_poller.py
@@ -13,13 +13,9 @@ import os
 import signal
 import sys
 import time
-from threading import Event, Thread
-from typing import TYPE_CHECKING, Final
+from threading import Thread
 
 from marimo import _loggers
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 LOGGER = _loggers.marimo_logger()
 
@@ -32,9 +28,7 @@ class ParentPollerUnix(Thread):
         self.parent_pid = parent_pid
 
     def _handle_parent_death(self) -> None:
-        LOGGER.warning(
-            "Parent server appears to have exited, shutting down."
-        )
+        LOGGER.warning("Parent server appears to have exited, shutting down.")
 
         try:
             os.killpg(os.getpgrp(), signal.SIGKILL)
@@ -72,7 +66,7 @@ class ParentPollerUnix(Thread):
                 raise
 
 
-def start_parent_poller(parent_pid: int | None):
+def start_parent_poller(parent_pid: int | None) -> None:
     """Start a parent poller when the current Unix subprocess has a parent.
 
     Returns `None` when parent polling is not applicable, such as when

--- a/marimo/_runtime/parent_poller.py
+++ b/marimo/_runtime/parent_poller.py
@@ -23,79 +23,29 @@ if TYPE_CHECKING:
 
 LOGGER = _loggers.marimo_logger()
 
-_PARENT_POLL_INTERVAL_SECONDS: Final[float] = 1.0
-_PARENT_SHUTDOWN_WAIT_SECONDS: Final[float] = 1.0
-
-
-def kill_own_process_group() -> None:
-    """Force-kill this process and all peers in its process group."""
-    try:
-        os.killpg(os.getpgrp(), signal.SIGKILL)
-    except ProcessLookupError:
-        pass
-    except OSError:
-        LOGGER.debug(
-            "Failed to kill kernel process group; exiting current process.",
-            exc_info=True,
-        )
-    os._exit(1)
-
 
 class ParentPollerUnix(Thread):
-    """Daemon thread that exits the process when the parent has died."""
+    """Daemon thread that kills the process group when the parent has died."""
 
-    def __init__(
-        self,
-        parent_pid: int,
-        *,
-        request_graceful_shutdown: Callable[[], None],
-        target_name: str = "kernel",
-    ) -> None:
+    def __init__(self, parent_pid: int) -> None:
         super().__init__(daemon=True)
         self.parent_pid = parent_pid
-        self.request_graceful_shutdown = request_graceful_shutdown
-        self.target_name = target_name
-        self.parent_exit_detected = Event()
-        self.cleanup_complete = Event()
-
-    def mark_cleanup_complete(self) -> None:
-        """For the caller to signal to the poller it can exit."""
-        self.cleanup_complete.set()
-
-    def finalize_if_parent_died(self) -> None:
-        if not self.parent_exit_detected.is_set():
-            return
-
-        self.mark_cleanup_complete()
-        kill_own_process_group()
-
-    def _request_shutdown(self) -> None:
-        try:
-            self.request_graceful_shutdown()
-        except Exception:
-            LOGGER.debug(
-                "Failed to request graceful shutdown during parent-death "
-                "shutdown; force-kill fallback may be required.",
-                exc_info=True,
-            )
 
     def _handle_parent_death(self) -> None:
         LOGGER.warning(
-            "Parent server appears to have exited, shutting down %s.",
-            self.target_name,
+            "Parent server appears to have exited, shutting down."
         )
-        self.parent_exit_detected.set()
-        self._request_shutdown()
 
-        if self.cleanup_complete.wait(timeout=_PARENT_SHUTDOWN_WAIT_SECONDS):
-            return
-
-        LOGGER.warning(
-            "%s cleanup did not finish before timeout; force-killing its "
-            "process group.",
-            self.target_name.capitalize(),
-        )
-        kill_own_process_group()
+        try:
+            os.killpg(os.getpgrp(), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        except OSError:
+            LOGGER.debug(
+                "Failed to kill kernel process group; exiting current process.",
+                exc_info=True,
+            )
+        os._exit(1)
 
     def run(self) -> None:
         from errno import EINTR
@@ -115,31 +65,20 @@ class ParentPollerUnix(Thread):
                 if parent_is_init or parent_has_changed:
                     self._handle_parent_death()
                     return
-                time.sleep(_PARENT_POLL_INTERVAL_SECONDS)
+                time.sleep(1.0)
             except OSError as e:
                 if e.errno == EINTR:
                     continue
                 raise
 
 
-def start_parent_poller(
-    parent_pid: int | None,
-    *,
-    request_graceful_shutdown: Callable[[], None],
-    target_name: str,
-) -> ParentPollerUnix | None:
+def start_parent_poller(parent_pid: int | None):
     """Start a parent poller when the current Unix subprocess has a parent.
 
     Returns `None` when parent polling is not applicable, such as when
     running on Windows or when reparenting to PID 1 is expected.
     """
     if sys.platform == "win32" or parent_pid is None or parent_pid == 1:
-        return None
+        return
 
-    poller = ParentPollerUnix(
-        parent_pid=parent_pid,
-        request_graceful_shutdown=request_graceful_shutdown,
-        target_name=target_name,
-    )
-    poller.start()
-    return poller
+    ParentPollerUnix(parent_pid=parent_pid).start()

--- a/marimo/_runtime/parent_poller.py
+++ b/marimo/_runtime/parent_poller.py
@@ -1,5 +1,5 @@
 # Copyright 2026 Marimo. All rights reserved.
-"""Poll another process and exist when that process exits.
+"""Poll another process and exit when that process exits.
 
 Ported from ipykernel.parentpoller (BSD-licensed) to avoid orphaned kernel
 processes when the marimo server is killed ungracefully (e.g. SIGKILL, OOM).

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3563,16 +3563,19 @@ def launch_kernel(
         _loggers.set_level(log_level)
     LOGGER.debug("Launching kernel")
 
-    # Determine behavior:
-    # - is_subprocess: edit mode uses Process, IPC uses subprocess - both can receive signals
-    # - Run mode (not edit) uses autorun config regardless of IPC
     is_subprocess = is_edit_mode or is_ipc
-
     loop_factory: Callable[[], asyncio.AbstractEventLoop] | None = None
     if is_subprocess:
         restore_signals()
 
-        # The runtime process inherits the server's loop policy, on Windows, we
+        # Become the leader of a new session/process group before connecting
+        # back to the parent, to avoid race conditions with the parent
+        # process (which assumes its child is in another process group).
+        if sys.platform != "win32":
+            os.setsid()
+            start_parent_poller(parent_pid)
+
+        # The runtime process inherits the server's loop policy. On Windows, we
         # restore the event loop policy to the default ProactorEventLoop, so
         # user code can use asyncio.create_subprocess_exec and other APIs that
         # the SelectorEventLoop does not implement.
@@ -3729,15 +3732,6 @@ def launch_kernel(
         from marimo._output.formatters.formatters import register_formatters
 
         register_formatters(theme=user_config["display"]["theme"])
-
-        # TODO: Windows workaround -- find a way to make the process
-        # its group leader
-        if sys.platform != "win32":
-            # Make this process group leader to prevent it from receiving
-            # signals intended for the parent (server) process,
-            # Ctrl+C in particular.
-            os.setsid()
-            start_parent_poller(parent_pid)
 
         signal.signal(signal.SIGINT, handlers.construct_interrupt_handler(ctx))
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3720,7 +3720,6 @@ def launch_kernel(
         # completions only provided in edit mode
         kernel.start_completion_worker(completion_queue)
 
-    parent_poller = None
     if is_subprocess:
         # Subprocess kernels (EDIT and IPC_RUN) can receive signals and need
         # their own formatter registration since they don't share state with
@@ -3738,14 +3737,7 @@ def launch_kernel(
             # signals intended for the parent (server) process,
             # Ctrl+C in particular.
             os.setsid()
-
-            parent_poller = start_parent_poller(
-                parent_pid,
-                request_graceful_shutdown=lambda: control_queue.put_nowait(
-                    StopKernelCommand()
-                ),
-                target_name="kernel",
-            )
+            start_parent_poller(parent_pid)
 
         signal.signal(signal.SIGINT, handlers.construct_interrupt_handler(ctx))
 
@@ -3836,9 +3828,3 @@ def launch_kernel(
     kernel.teardown()
     if isinstance(pipe, connection.Connection):
         pipe.close()
-
-    if parent_poller is not None:
-        # The server kills the process group for edit-mode sessions and app
-        # host sessions. This is a last resort to clean up the kernel's
-        # children if the server isn't around to do so.
-        parent_poller.finalize_if_parent_died()

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3720,6 +3720,7 @@ def launch_kernel(
         # completions only provided in edit mode
         kernel.start_completion_worker(completion_queue)
 
+    parent_poller = None
     if is_subprocess:
         # Subprocess kernels (EDIT and IPC_RUN) can receive signals and need
         # their own formatter registration since they don't share state with
@@ -3732,7 +3733,6 @@ def launch_kernel(
 
         # TODO: Windows workaround -- find a way to make the process
         # its group leader
-        parent_poller = None
         if sys.platform != "win32":
             # Make this process group leader to prevent it from receiving
             # signals intended for the parent (server) process,

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -182,6 +182,9 @@ from marimo._runtime.packages.utils import (
     is_python_isolated,
 )
 from marimo._runtime.params import CLIArgs, QueryParams
+from marimo._runtime.parent_poller import (
+    start_parent_poller,
+)
 from marimo._runtime.redirect_streams import redirect_streams
 from marimo._runtime.reload.autoreload import ModuleReloader
 from marimo._runtime.reload.module_watcher import ModuleWatcher
@@ -3554,6 +3557,7 @@ def launch_kernel(
     profile_path: str | None = None,
     log_level: int | None = None,
     is_ipc: bool = False,
+    parent_pid: int | None = None,
 ) -> None:
     if log_level is not None:
         _loggers.set_level(log_level)
@@ -3720,18 +3724,28 @@ def launch_kernel(
         # Subprocess kernels (EDIT and IPC_RUN) can receive signals and need
         # their own formatter registration since they don't share state with
         # the host process.
+        #
+        # Each subprocess kernel needs to install the formatter import hooks
         from marimo._output.formatters.formatters import register_formatters
+
+        register_formatters(theme=user_config["display"]["theme"])
 
         # TODO: Windows workaround -- find a way to make the process
         # its group leader
+        parent_poller = None
         if sys.platform != "win32":
             # Make this process group leader to prevent it from receiving
             # signals intended for the parent (server) process,
             # Ctrl+C in particular.
             os.setsid()
 
-        # Each subprocess kernel needs to install the formatter import hooks
-        register_formatters(theme=user_config["display"]["theme"])
+            parent_poller = start_parent_poller(
+                parent_pid,
+                request_graceful_shutdown=lambda: control_queue.put_nowait(
+                    StopKernelCommand()
+                ),
+                target_name="kernel",
+            )
 
         signal.signal(signal.SIGINT, handlers.construct_interrupt_handler(ctx))
 
@@ -3822,3 +3836,9 @@ def launch_kernel(
     kernel.teardown()
     if isinstance(pipe, connection.Connection):
         pipe.close()
+
+    if parent_poller is not None:
+        # The server kills the process group for edit-mode sessions and app
+        # host sessions. This is a last resort to clean up the kernel's
+        # children if the server isn't around to do so.
+        parent_poller.finalize_if_parent_died()

--- a/marimo/_server/api/lifespans.py
+++ b/marimo/_server/api/lifespans.py
@@ -27,6 +27,7 @@ from marimo._server.tokens import AuthToken
 from marimo._server.utils import initialize_mimetypes
 from marimo._server.uvicorn_utils import close_uvicorn
 from marimo._session.model import SessionMode
+from marimo._utils.subprocess import cancel_pending_reaps
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -257,6 +258,13 @@ async def etc(app: Starlette) -> AsyncIterator[None]:
     # Mimetypes
     initialize_mimetypes()
     yield
+
+
+@contextlib.asynccontextmanager
+async def reap_subprocesses(app: Starlette) -> AsyncIterator[None]:
+    del app
+    yield
+    await cancel_pending_reaps()
 
 
 def _pretty_host(host: str, port: int) -> str:

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -17,6 +17,7 @@ from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._mcp.setup import McpType, setup_mcp_server
 from marimo._messaging.notification import StartupLogsNotification
 from marimo._runtime.commands import SerializedCLIArgs
+from marimo._runtime.parent_poller import start_parent_poller
 from marimo._server.api import lifespans
 from marimo._server.config import (
     StarletteServerStateInit,
@@ -211,6 +212,20 @@ def start(
     Start the server.
     """
     import packaging.version
+
+    # In single-file sandbox mode, uv becomes our direct parent. So we
+    # watch the outer CLI's PID, terminating if the CLI terminates.
+    ancestor_pid_env = os.environ.get("MARIMO_ANCESTOR_PID")
+    if ancestor_pid_env:
+        try:
+            start_parent_poller(
+                parent_pid=os.getppid(),
+                ancestor_pid=int(ancestor_pid_env),
+            )
+        except ValueError:
+            LOGGER.warning(
+                "Ignoring invalid MARIMO_ANCESTOR_PID=%r", ancestor_pid_env
+            )
 
     # Defaults when mcp is enabled
     if mcp:

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -313,6 +313,7 @@ def start(
         lifespans.open_browser,
         lifespans.tool_manager,
         lifespans.server_registry,
+        lifespans.reap_subprocesses,
         *LIFESPAN_REGISTRY.get_all(),
     ]
 

--- a/marimo/_session/app_host/commands.py
+++ b/marimo/_session/app_host/commands.py
@@ -93,6 +93,7 @@ class AppHostArgs(msgspec.Struct):
     # Notebook file path, for debug logs
     file_path: str
     log_level: int
+    parent_pid: int | None
 
     def encode_json(self) -> bytes:
         return msgspec.json.encode(self)

--- a/marimo/_session/app_host/connection.py
+++ b/marimo/_session/app_host/connection.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
+import os
 from typing import TYPE_CHECKING
 
 from marimo._config.settings import GLOBAL_SETTINGS
@@ -74,6 +75,7 @@ class AppHostConnection:
             stream_addr=f"{_BIND_ADDR}:{stream_port}",
             file_path=file_path,
             log_level=log_level,
+            parent_pid=os.getpid(),
         )
 
         return conn, args

--- a/marimo/_session/app_host/host.py
+++ b/marimo/_session/app_host/host.py
@@ -7,7 +7,7 @@ import pickle
 import subprocess
 import sys
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from marimo import _loggers
 from marimo._messaging.types import KernelMessage
@@ -23,6 +23,8 @@ from marimo._session.app_host.commands import (
     encode_mgmt_command,
 )
 from marimo._session.app_host.connection import AppHostConnection
+from marimo._session.queue import ProcessLike
+from marimo._utils.subprocess import try_kill_process_and_group
 
 if TYPE_CHECKING:
     import queue
@@ -357,14 +359,7 @@ class AppHost:
                 pass
 
         if self._process is not None:
-            try:
-                self._process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                self._process.terminate()
-                try:
-                    self._process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    self._process.kill()
+            try_kill_process_and_group(cast(ProcessLike, self._process))
 
         # Close all sockets (with linger=0).  This interrupts any
         # pending poll()/recv() in _stream_receiver_loop with ETERM,

--- a/marimo/_session/app_host/host.py
+++ b/marimo/_session/app_host/host.py
@@ -359,7 +359,10 @@ class AppHost:
                 pass
 
         if self._process is not None:
-            try_kill_process_and_group(cast(ProcessLike, self._process))
+            try:
+                try_kill_process_and_group(cast(ProcessLike, self._process))
+            except Exception as e:
+                LOGGER.warning(e)
 
         # Close all sockets (with linger=0).  This interrupts any
         # pending poll()/recv() in _stream_receiver_loop with ETERM,

--- a/marimo/_session/app_host/host.py
+++ b/marimo/_session/app_host/host.py
@@ -361,6 +361,8 @@ class AppHost:
         if self._process is not None:
             try:
                 try_kill_process_and_group(cast(ProcessLike, self._process))
+            except ProcessLookupError:
+                pass
             except Exception as e:
                 LOGGER.warning(e)
 

--- a/marimo/_session/app_host/main.py
+++ b/marimo/_session/app_host/main.py
@@ -21,6 +21,7 @@ from marimo._messaging.thread_local_streams import install_thread_local_proxies
 from marimo._output.formatters.formatters import register_formatters
 from marimo._runtime import runtime
 from marimo._runtime.commands import StopKernelCommand
+from marimo._runtime.parent_poller import start_parent_poller
 from marimo._session.app_host.commands import (
     AppHostArgs,
     AppHostReadyResponse,
@@ -246,6 +247,10 @@ def app_host_main(args: AppHostArgs) -> None:
     # Ignore SIGINT in app host processes. The main process handles Ctrl-C
     # and sends ShutdownAppHostCmd via the management channel.
     signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    if sys.platform != "win32":
+        os.setsid()
+        start_parent_poller(args.parent_pid)
 
     _loggers.set_level(args.log_level)
     LOGGER.debug(

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -397,7 +397,7 @@ class IPCKernelManagerImpl(KernelManager):
                 commands.StopKernelCommand()
             )
             self.queue_manager.close_queues()
-            if self._process.poll() is None:
+            if self._process.poll() is None and self.kernel_task is not None:
                 try:
                     try_kill_process_and_group(self.kernel_task)
                 except Exception as e:

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -398,7 +398,10 @@ class IPCKernelManagerImpl(KernelManager):
             )
             self.queue_manager.close_queues()
             if self._process.poll() is None:
-                try_kill_process_and_group(cast(ProcessLike, self._process))
+                try:
+                    try_kill_process_and_group(cast(ProcessLike, self._process))
+                except Exception as e:
+                    LOGGER.warning(e)
 
         # Always attempt cleanup, even if _process is None
         cleanup_sandbox_dir(self._sandbox_dir)

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -35,6 +35,7 @@ from marimo._session._venv import (
 from marimo._session.model import SessionMode
 from marimo._session.queue import ProcessLike, QueueType, route_control_request
 from marimo._session.types import KernelManager, QueueManager
+from marimo._utils.subprocess import try_kill_process_and_group
 from marimo._utils.typed_connection import TypedConnection
 
 if TYPE_CHECKING:
@@ -396,14 +397,8 @@ class IPCKernelManagerImpl(KernelManager):
                 commands.StopKernelCommand()
             )
             self.queue_manager.close_queues()
-
-            # Terminate process if still alive
             if self._process.poll() is None:
-                self._process.terminate()
-                try:
-                    self._process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    self._process.kill()
+                try_kill_process_and_group(cast(ProcessLike, self._process))
 
         # Always attempt cleanup, even if _process is None
         cleanup_sandbox_dir(self._sandbox_dir)

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -216,6 +216,7 @@ class IPCKernelManagerImpl(KernelManager):
             connection_info=self.connection_info,
             is_run_mode=self.mode == SessionMode.RUN,
             redirect_console_to_browser=self.redirect_console_to_browser,
+            parent_pid=os.getpid(),
         )
 
         venv_config = _get_venv_config(self.config_manager)

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -400,6 +400,8 @@ class IPCKernelManagerImpl(KernelManager):
             if self._process.poll() is None and self.kernel_task is not None:
                 try:
                     try_kill_process_and_group(self.kernel_task)
+                except ProcessLookupError:
+                    pass
                 except Exception as e:
                     LOGGER.warning(e)
 

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -399,7 +399,7 @@ class IPCKernelManagerImpl(KernelManager):
             self.queue_manager.close_queues()
             if self._process.poll() is None:
                 try:
-                    try_kill_process_and_group(cast(ProcessLike, self._process))
+                    try_kill_process_and_group(self.kernel_task)
                 except Exception as e:
                     LOGGER.warning(e)
 

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -20,6 +20,7 @@ from marimo._runtime import commands, runtime
 from marimo._session.model import SessionMode
 from marimo._session.queue import ProcessLike
 from marimo._session.types import KernelManager, QueueManager
+from marimo._utils.platform import is_windows
 from marimo._utils.print import print_
 from marimo._utils.typed_connection import TypedConnection
 
@@ -253,28 +254,41 @@ class KernelManagerImpl(KernelManager):
                 self.queue_manager.put_control_request(
                     commands.StopKernelCommand()
                 )
-        else:
-            # otherwise we have something that is `ProcessLike`
-            if self.profile_path is not None and self.kernel_task.is_alive():
-                self.queue_manager.put_control_request(
-                    commands.StopKernelCommand()
-                )
-                # Hack: Wait for kernel to exit and write out profile;
-                # joining the process hangs, but not sure why.
-                print_(
-                    "\tWriting profile statistics to",
-                    self.profile_path,
-                    " ...",
-                )
-                while not os.path.exists(self.profile_path):
-                    time.sleep(0.1)
-                time.sleep(1)
+            return
 
-            self.queue_manager.close_queues()
-            if self.kernel_task.is_alive():
+        # Otherwise, we have something that is `ProcessLike`
+        if self.profile_path is not None and self.kernel_task.is_alive():
+            self.queue_manager.put_control_request(
+                commands.StopKernelCommand()
+            )
+            # Hack: Wait for kernel to exit and write out profile;
+            # joining the process hangs, but not sure why.
+            print_(
+                "\tWriting profile statistics to",
+                self.profile_path,
+                " ...",
+            )
+            while not os.path.exists(self.profile_path):
+                time.sleep(0.1)
+            time.sleep(1)
+
+        self.queue_manager.close_queues()
+        if self.kernel_task.is_alive() and is_windows():
+            # TODO(akshayka): Investigate whether we need to kill an entire
+            # process group on Windows, and if so how
+            self.kernel_task.terminate()
+        elif self.kernel_task.is_alive():
+            kernel_pgid = os.getpgid(self.kernel_task.pid)  # type: ignore
+            if kernel_pgid == os.getpgrp():
+                # This should never happen. The child's kernel
+                LOGGER.warning(
+                    "The kernel's pgid matches the server's (%d)", kernel_pgid
+                )
                 self.kernel_task.terminate()
-            if self._read_conn is not None:
-                self._read_conn.close()
+            else:
+                os.killpg(kernel_pgid, signal.SIGTERM)
+        if self._read_conn is not None:
+            self._read_conn.close()
 
     @property
     def kernel_connection(self) -> TypedConnection[KernelMessage]:

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -20,8 +20,8 @@ from marimo._runtime import commands, runtime
 from marimo._session.model import SessionMode
 from marimo._session.queue import ProcessLike
 from marimo._session.types import KernelManager, QueueManager
-from marimo._utils.platform import is_windows
 from marimo._utils.print import print_
+from marimo._utils.subprocess import try_kill_process_and_group
 from marimo._utils.typed_connection import TypedConnection
 
 if TYPE_CHECKING:
@@ -273,20 +273,7 @@ class KernelManagerImpl(KernelManager):
             time.sleep(1)
 
         self.queue_manager.close_queues()
-        if self.kernel_task.is_alive() and is_windows():
-            # TODO(akshayka): Investigate whether we need to kill an entire
-            # process group on Windows, and if so how
-            self.kernel_task.terminate()
-        elif self.kernel_task.is_alive():
-            kernel_pgid = os.getpgid(self.kernel_task.pid)  # type: ignore
-            if kernel_pgid == os.getpgrp():
-                # This should never happen. The child's kernel
-                LOGGER.warning(
-                    "The kernel's pgid matches the server's (%d)", kernel_pgid
-                )
-                self.kernel_task.terminate()
-            else:
-                os.killpg(kernel_pgid, signal.SIGTERM)
+        try_kill_process_and_group(self.kernel_task)
         if self._read_conn is not None:
             self._read_conn.close()
 

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -275,6 +275,8 @@ class KernelManagerImpl(KernelManager):
         self.queue_manager.close_queues()
         try:
             try_kill_process_and_group(self.kernel_task)
+        except ProcessLookupError:
+            pass
         except Exception as e:
             LOGGER.warning(e)
         if self._read_conn is not None:

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -273,7 +273,10 @@ class KernelManagerImpl(KernelManager):
             time.sleep(1)
 
         self.queue_manager.close_queues()
-        try_kill_process_and_group(self.kernel_task)
+        try:
+            try_kill_process_and_group(self.kernel_task)
+        except Exception as e:
+            LOGGER.warning(e)
         if self._read_conn is not None:
             self._read_conn.close()
 

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -91,6 +91,10 @@ class KernelManagerImpl(KernelManager):
                     self.queue_manager.win32_interrupt_queue,
                     self.profile_path,
                     GLOBAL_SETTINGS.LOG_LEVEL,
+                    # is_ipc
+                    False,
+                    # PID
+                    os.getpid(),
                 ),
                 # The process can't be a daemon, because daemonic processes
                 # can't create children

--- a/marimo/_smoke_tests/process_group.py
+++ b/marimo/_smoke_tests/process_group.py
@@ -1,0 +1,24 @@
+import marimo
+
+__generated_with = "0.23.1"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import subprocess
+
+    subprocess.Popen(["sleep", "1000"])
+    return
+
+
+@app.cell
+def _():
+    import os
+
+    os.system('ps -ef | grep sleep')
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -314,10 +314,13 @@ async def _reap_process_unix(process: ProcessLike, pgid: int | None) -> None:
     LOGGER.warning(
         "Process %s did not respond to SIGTERM. Force killing.", pid
     )
-    if pgid is not None:
-        os.killpg(pgid, signal.SIGKILL)
-    elif pid is not None:
-        os.kill(pid, signal.SIGKILL)
+    try:
+        if pgid is not None:
+            os.killpg(pgid, signal.SIGKILL)
+        elif pid is not None:
+            os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
 
     wait_for_s = 10
     waited_s = 0

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import os
+import signal
 import subprocess
 from collections.abc import Callable, Mapping, Sequence
 from typing import (
@@ -11,6 +13,8 @@ from typing import (
 )
 
 from marimo import _loggers
+from marimo._session.queue import ProcessLike
+from marimo._utils.platform import is_windows
 
 LOGGER = _loggers.marimo_logger()
 
@@ -271,3 +275,33 @@ def safe_popen(
     except Exception as e:
         LOGGER.error("Failed to create subprocess for command %s: %s", args, e)
         return None
+
+
+def try_kill_process_and_group(process: ProcessLike) -> None:
+    """Attempt to kill the process group to which process belongs.
+
+    Refuses to kill the group if its the same group as the calling process.
+
+    Regardless, tries to kill the process.
+    """
+    try:
+        pid = process.pid
+        if pid is None:
+            return
+
+        if is_windows():
+            # TODO(akshayka): Investigate whether we need to kill an entire
+            # process group on Windows, and if so how ...
+            process.terminate()
+        else:
+            target_pgid = os.getpgid(pid)
+            if target_pgid == os.getpgrp():
+                # This should never happen. The child's target
+                LOGGER.warning(
+                    "The target's pgid matches the server's (%d)", target_pgid
+                )
+                process.terminate()
+            else:
+                os.killpg(target_pgid, signal.SIGTERM)
+    except Exception as e:
+        LOGGER.warning(e)

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -308,7 +308,9 @@ async def _reap_pid_unix(pgid: int | None, pid: int) -> None:
     if _non_blocking_process_finished(pid):
         return
 
-    LOGGER.warning("Process %d did not respond to SIGTERM. Force killing.", pid)
+    LOGGER.warning(
+        "Process %d did not respond to SIGTERM. Force killing.", pid
+    )
     if pgid is not None:
         os.killpg(pgid, signal.SIGKILL)
     else:
@@ -316,12 +318,17 @@ async def _reap_pid_unix(pgid: int | None, pid: int) -> None:
 
     wait_for_s = 10
     waited_s = 0
-    while not (process_finished := _non_blocking_process_finished(pid)) and waited_s < wait_for_s:
+    while (
+        not (process_finished := _non_blocking_process_finished(pid))
+        and waited_s < wait_for_s
+    ):
         await asyncio.sleep(1.0)
         waited_s += 1
 
     if not process_finished:
-        LOGGER.warning("Waited for 10s, but process %d has still not quit ...", pid)
+        LOGGER.warning(
+            "Waited for 10s, but process %d has still not quit ...", pid
+        )
         return
 
 

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import asyncio
 import os
 import signal
 import subprocess
@@ -277,32 +278,93 @@ def safe_popen(
         return None
 
 
+_REAP_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _non_blocking_process_finished(pid: int) -> bool:
+    """Returns True if the process has finished."""
+    try:
+        ret, _ = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        return True
+    return ret != 0
+
+
+async def cancel_pending_reaps() -> None:
+    """Cancel and await any in-flight reap tasks.
+
+    Call from a server shutdown hook so asyncio doesn't emit
+    "Task was destroyed but it is pending" when the loop closes.
+    """
+    tasks = list(_REAP_TASKS)
+    for t in tasks:
+        t.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _reap_pid_unix(pgid: int | None, pid: int) -> None:
+    await asyncio.sleep(5.0)
+    if _non_blocking_process_finished(pid):
+        return
+
+    LOGGER.warning("Process %d did not respond to SIGTERM. Force killing.", pid)
+    if pgid is not None:
+        os.killpg(pgid, signal.SIGKILL)
+    else:
+        os.kill(pid, signal.SIGKILL)
+
+    wait_for_s = 10
+    waited_s = 0
+    while not (process_finished := _non_blocking_process_finished(pid)) and waited_s < wait_for_s:
+        await asyncio.sleep(1.0)
+        waited_s += 1
+
+    if not process_finished:
+        LOGGER.warning("Waited for 10s, but process %d has still not quit ...", pid)
+        return
+
+
 def try_kill_process_and_group(process: ProcessLike) -> None:
     """Attempt to kill the process group to which process belongs.
 
     Refuses to kill the group if its the same group as the calling process.
 
     Regardless, tries to kill the process.
-    """
-    try:
-        pid = process.pid
-        if pid is None:
-            return
 
-        if is_windows():
-            # TODO(akshayka): Investigate whether we need to kill an entire
-            # process group on Windows, and if so how ...
-            process.terminate()
-        else:
-            target_pgid = os.getpgid(pid)
-            if target_pgid == os.getpgrp():
-                # This should never happen ... the kernel process makes sure to
-                # call setsid and become the group leader
-                LOGGER.warning(
-                    "The target's pgid matches the server's (%d)", target_pgid
-                )
-                process.terminate()
-            else:
-                os.killpg(target_pgid, signal.SIGTERM)
-    except Exception as e:
-        LOGGER.warning(e)
+    If running in an event loop, starts a task to reap the process on Unix-like
+    systems. If not running in an event loop, it is the caller's responsibility
+    to reap the process.
+    """
+    pid = process.pid
+    if pid is None:
+        return
+
+    if is_windows():
+        # TODO(akshayka): Investigate whether we need to kill an entire
+        # process group on Windows, and if so how ...
+        process.terminate()
+        return
+
+    target_pgid = os.getpgid(pid)
+    if target_pgid == os.getpgrp():
+        # This should never happen ... the kernel process makes sure to
+        # call setsid and become the group leader
+        LOGGER.warning(
+            "The target's pgid matches the server's (%d)", target_pgid
+        )
+        target_pgid = None
+        process.terminate()
+    else:
+        os.killpg(target_pgid, signal.SIGTERM)
+
+    if _non_blocking_process_finished(pid):
+        return
+
+    try:
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(_reap_pid_unix(target_pgid, pid))
+        _REAP_TASKS.add(task)
+        task.add_done_callback(_REAP_TASKS.discard)
+    except RuntimeError:
+        pass

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -296,7 +296,8 @@ def try_kill_process_and_group(process: ProcessLike) -> None:
         else:
             target_pgid = os.getpgid(pid)
             if target_pgid == os.getpgrp():
-                # This should never happen. The child's target
+                # This should never happen ... the kernel process makes sure to
+                # call setsid and become the group leader
                 LOGGER.warning(
                     "The target's pgid matches the server's (%d)", target_pgid
                 )

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -281,13 +281,15 @@ def safe_popen(
 _REAP_TASKS: set[asyncio.Task[None]] = set()
 
 
-def _non_blocking_process_finished(pid: int) -> bool:
-    """Returns True if the process has finished."""
-    try:
-        ret, _ = os.waitpid(pid, os.WNOHANG)
-    except ChildProcessError:
-        return True
-    return ret != 0
+def _process_finished(process: ProcessLike) -> bool:
+    """Return whether the process has finished without blocking."""
+    # NB: It is not safe to call os.waitpid() directly because
+    # apparently Popen.poll() and multiprcoessing.Process.is_alive()
+    # assume that they are the ones that reap zombie processes.
+    poll = getattr(process, "poll", None)
+    if poll is not None:
+        return poll() is not None
+    return not process.is_alive()
 
 
 async def cancel_pending_reaps() -> None:
@@ -303,23 +305,24 @@ async def cancel_pending_reaps() -> None:
         await asyncio.gather(*tasks, return_exceptions=True)
 
 
-async def _reap_pid_unix(pgid: int | None, pid: int) -> None:
+async def _reap_process_unix(process: ProcessLike, pgid: int | None) -> None:
+    pid = process.pid
     await asyncio.sleep(5.0)
-    if _non_blocking_process_finished(pid):
+    if _process_finished(process):
         return
 
     LOGGER.warning(
-        "Process %d did not respond to SIGTERM. Force killing.", pid
+        "Process %s did not respond to SIGTERM. Force killing.", pid
     )
     if pgid is not None:
         os.killpg(pgid, signal.SIGKILL)
-    else:
+    elif pid is not None:
         os.kill(pid, signal.SIGKILL)
 
     wait_for_s = 10
     waited_s = 0
     while (
-        not (process_finished := _non_blocking_process_finished(pid))
+        not (process_finished := _process_finished(process))
         and waited_s < wait_for_s
     ):
         await asyncio.sleep(1.0)
@@ -327,7 +330,7 @@ async def _reap_pid_unix(pgid: int | None, pid: int) -> None:
 
     if not process_finished:
         LOGGER.warning(
-            "Waited for 10s, but process %d has still not quit ...", pid
+            "Waited for 10s, but process %s has still not quit ...", pid
         )
         return
 
@@ -353,24 +356,24 @@ def try_kill_process_and_group(process: ProcessLike) -> None:
         process.terminate()
         return
 
-    target_pgid: int = os.getpgid(pid)
-    if target_pgid == os.getpgrp():
+    pgid = os.getpgid(pid)
+    target_pgid: int | None
+    if pgid == os.getpgrp():
         # This should never happen ... the kernel process makes sure to
         # call setsid and become the group leader
-        LOGGER.warning(
-            "The target's pgid matches the server's (%d)", target_pgid
-        )
-        target_pgid = None  # type: ignore
+        LOGGER.warning("The target's pgid matches the server's (%d)", pgid)
+        target_pgid = None
         process.terminate()
     else:
-        os.killpg(target_pgid, signal.SIGTERM)
+        target_pgid = pgid
+        os.killpg(pgid, signal.SIGTERM)
 
-    if _non_blocking_process_finished(pid):
+    if _process_finished(process):
         return
 
     try:
         loop = asyncio.get_running_loop()
-        task = loop.create_task(_reap_pid_unix(target_pgid, pid))
+        task = loop.create_task(_reap_process_unix(process, target_pgid))
         _REAP_TASKS.add(task)
         task.add_done_callback(_REAP_TASKS.discard)
     except RuntimeError:

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -335,7 +335,7 @@ async def _reap_pid_unix(pgid: int | None, pid: int) -> None:
 def try_kill_process_and_group(process: ProcessLike) -> None:
     """Attempt to kill the process group to which process belongs.
 
-    Refuses to kill the group if its the same group as the calling process.
+    Refuses to kill the group if it the current process belongs to it.
 
     Regardless, tries to kill the process.
 

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -353,14 +353,14 @@ def try_kill_process_and_group(process: ProcessLike) -> None:
         process.terminate()
         return
 
-    target_pgid = os.getpgid(pid)
+    target_pgid: int = os.getpgid(pid)
     if target_pgid == os.getpgrp():
         # This should never happen ... the kernel process makes sure to
         # call setsid and become the group leader
         LOGGER.warning(
             "The target's pgid matches the server's (%d)", target_pgid
         )
-        target_pgid = None
+        target_pgid = None  # type: ignore
         process.terminate()
     else:
         os.killpg(target_pgid, signal.SIGTERM)

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -938,8 +938,13 @@ def test_cli_server_exits_when_ancestor_pid_dies(
     # start_new_session so the poller's killpg doesn't touch pytest.
     p = subprocess.Popen(
         [
-            "marimo", "edit", temp_marimo_file,
-            "-p", str(port), "--headless", "--no-token",
+            "marimo",
+            "edit",
+            temp_marimo_file,
+            "-p",
+            str(port),
+            "--headless",
+            "--no-token",
         ],
         env=env,
         start_new_session=True,

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -868,6 +868,52 @@ def test_cli_new() -> None:
     _check_contents(p, b'"serverToken": ', contents)
 
 
+@pytest.mark.skipif(
+    _is_win32(),
+    reason="Parent polling is Unix-only (relies on getppid/killpg)",
+)
+def test_cli_kernel_killed_when_server_killed() -> None:
+    """Orphaned kernels should self-terminate via the parent poller."""
+    import psutil
+    from websockets.sync.client import connect
+
+    port = _get_port()
+    p = subprocess.Popen(
+        ["marimo", "new", "-p", str(port), "--headless", "--no-token"]
+    )
+    try:
+        assert _try_fetch(port) is not None
+        # Opening a WebSocket causes the server to spawn a kernel process.
+        with connect(f"ws://localhost:{port}/ws?session_id=s1"):
+            server = psutil.Process(p.pid)
+            deadline = time.time() + 10
+            kernel_pids: list[int] = []
+            while time.time() < deadline:
+                kernel_pids = [c.pid for c in server.children()]
+                if kernel_pids:
+                    break
+                time.sleep(0.2)
+            assert kernel_pids, "expected kernel child process to be spawned"
+
+        # Kill only the server; the kernel's parent poller should notice.
+        p.kill()
+        p.wait(timeout=5)
+
+        deadline = time.time() + 10
+        while time.time() < deadline and any(
+            psutil.pid_exists(pid) for pid in kernel_pids
+        ):
+            time.sleep(0.2)
+
+        still_alive = [pid for pid in kernel_pids if psutil.pid_exists(pid)]
+        assert not still_alive, (
+            f"kernel pids {still_alive} still alive after server killed"
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            p.kill()
+
+
 def test_cli_run(temp_marimo_file: str) -> None:
     port = _get_port()
     p = subprocess.Popen(

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -940,13 +940,13 @@ def test_cli_sandbox_descendants_killed_when_cli_killed(
             "--sandbox",
         ]
     )
-    descendants: list[int] = []
+    descendants = []
     try:
         assert _try_fetch(port) is not None
         cli = psutil.Process(p.pid)
         deadline = time.time() + 10
         while time.time() < deadline:
-            descendants = [c.pid for c in cli.children(recursive=True)]
+            descendants = cli.children(recursive=True)
             if len(descendants) >= 2:  # uv + inner marimo server at minimum
                 break
             time.sleep(0.2)
@@ -955,22 +955,29 @@ def test_cli_sandbox_descendants_killed_when_cli_killed(
         p.kill()
         p.wait(timeout=5)
 
+        def _alive(proc: psutil.Process) -> bool:
+            # Treat zombies (exited but unreaped by their parent) as dead —
+            # the ancestor poller signalled them; only the reaper hasn't
+            # gotten around to them yet.
+            try:
+                return proc.status() != psutil.STATUS_ZOMBIE
+            except psutil.NoSuchProcess:
+                return False
+
         deadline = time.time() + 15
-        while time.time() < deadline and any(
-            psutil.pid_exists(pid) for pid in descendants
-        ):
+        while time.time() < deadline and any(_alive(c) for c in descendants):
             time.sleep(0.2)
 
-        still_alive = [pid for pid in descendants if psutil.pid_exists(pid)]
+        still_alive = [c for c in descendants if _alive(c)]
         assert not still_alive, (
-            f"sandbox descendants {still_alive} still alive after CLI killed"
+            f"sandbox descendants still alive after CLI killed: {still_alive}"
         )
     finally:
         with contextlib.suppress(Exception):
             p.kill()
-        for pid in descendants:
+        for c in descendants:
             with contextlib.suppress(Exception):
-                os.kill(pid, signal.SIGKILL)
+                os.kill(c.pid, signal.SIGKILL)
 
 
 def test_cli_run(temp_marimo_file: str) -> None:

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -918,66 +918,48 @@ def test_cli_kernel_killed_when_server_killed() -> None:
     _is_win32(),
     reason="Parent polling is Unix-only (relies on getppid/killpg)",
 )
-@pytest.mark.skipif(not HAS_UV, reason="uv is required for sandbox tests")
-def test_cli_sandbox_descendants_killed_when_cli_killed(
+def test_cli_server_exits_when_ancestor_pid_dies(
     temp_marimo_file: str,
 ) -> None:
-    """Single-file sandbox: killing the outer marimo CLI (here via SIGKILL,
-    which signal handlers can't catch) must still reap the `uv run` child,
-    the inner marimo server, and the kernel — via the ancestor poller."""
-    import psutil
+    """When MARIMO_ANCESTOR_PID points at a process that dies, the server's
+    ancestor poller should shut the server down.
+
+    This is the mechanism the single-file sandbox relies on to clean up the
+    inner marimo (and its kernel) when the outer CLI is SIGKILLed — we can't
+    exercise that end-to-end here because the sandbox's inner marimo is
+    installed fresh by uv from PyPI (not the PR's source), so any changes
+    under test wouldn't be present in the inner process. Testing the
+    mechanism directly avoids that."""
+    fake_ancestor = subprocess.Popen(["sleep", "60"])
+    env = os.environ.copy()
+    env["MARIMO_ANCESTOR_PID"] = str(fake_ancestor.pid)
 
     port = _get_port()
+    # start_new_session so the poller's killpg doesn't touch pytest.
     p = subprocess.Popen(
         [
-            "marimo",
-            "edit",
-            temp_marimo_file,
-            "-p",
-            str(port),
-            "--headless",
-            "--no-token",
-            "--sandbox",
-        ]
+            "marimo", "edit", temp_marimo_file,
+            "-p", str(port), "--headless", "--no-token",
+        ],
+        env=env,
+        start_new_session=True,
     )
-    descendants = []
     try:
         assert _try_fetch(port) is not None
-        cli = psutil.Process(p.pid)
-        deadline = time.time() + 10
-        while time.time() < deadline:
-            descendants = cli.children(recursive=True)
-            if len(descendants) >= 2:  # uv + inner marimo server at minimum
-                break
-            time.sleep(0.2)
-        assert descendants, "expected descendant processes"
 
-        p.kill()
-        p.wait(timeout=5)
+        fake_ancestor.kill()
+        fake_ancestor.wait(timeout=5)
 
-        def _alive(proc: psutil.Process) -> bool:
-            # Treat zombies (exited but unreaped by their parent) as dead —
-            # the ancestor poller signalled them; only the reaper hasn't
-            # gotten around to them yet.
-            try:
-                return proc.status() != psutil.STATUS_ZOMBIE
-            except psutil.NoSuchProcess:
-                return False
-
-        deadline = time.time() + 15
-        while time.time() < deadline and any(_alive(c) for c in descendants):
-            time.sleep(0.2)
-
-        still_alive = [c for c in descendants if _alive(c)]
-        assert not still_alive, (
-            f"sandbox descendants still alive after CLI killed: {still_alive}"
-        )
+        # Poller ticks every 1s; give it a generous window.
+        try:
+            p.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pytest.fail("server did not exit after ancestor died")
     finally:
         with contextlib.suppress(Exception):
-            p.kill()
-        for c in descendants:
-            with contextlib.suppress(Exception):
-                os.kill(c.pid, signal.SIGKILL)
+            fake_ancestor.kill()
+        with contextlib.suppress(Exception):
+            os.killpg(os.getpgid(p.pid), signal.SIGKILL)
 
 
 def test_cli_run(temp_marimo_file: str) -> None:

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -914,6 +914,65 @@ def test_cli_kernel_killed_when_server_killed() -> None:
             p.kill()
 
 
+@pytest.mark.skipif(
+    _is_win32(),
+    reason="Parent polling is Unix-only (relies on getppid/killpg)",
+)
+@pytest.mark.skipif(not HAS_UV, reason="uv is required for sandbox tests")
+def test_cli_sandbox_descendants_killed_when_cli_killed(
+    temp_marimo_file: str,
+) -> None:
+    """Single-file sandbox: killing the outer marimo CLI (here via SIGKILL,
+    which signal handlers can't catch) must still reap the `uv run` child,
+    the inner marimo server, and the kernel — via the ancestor poller."""
+    import psutil
+
+    port = _get_port()
+    p = subprocess.Popen(
+        [
+            "marimo",
+            "edit",
+            temp_marimo_file,
+            "-p",
+            str(port),
+            "--headless",
+            "--no-token",
+            "--sandbox",
+        ]
+    )
+    descendants: list[int] = []
+    try:
+        assert _try_fetch(port) is not None
+        cli = psutil.Process(p.pid)
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            descendants = [c.pid for c in cli.children(recursive=True)]
+            if len(descendants) >= 2:  # uv + inner marimo server at minimum
+                break
+            time.sleep(0.2)
+        assert descendants, "expected descendant processes"
+
+        p.kill()
+        p.wait(timeout=5)
+
+        deadline = time.time() + 15
+        while time.time() < deadline and any(
+            psutil.pid_exists(pid) for pid in descendants
+        ):
+            time.sleep(0.2)
+
+        still_alive = [pid for pid in descendants if psutil.pid_exists(pid)]
+        assert not still_alive, (
+            f"sandbox descendants {still_alive} still alive after CLI killed"
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            p.kill()
+        for pid in descendants:
+            with contextlib.suppress(Exception):
+                os.kill(pid, signal.SIGKILL)
+
+
 def test_cli_run(temp_marimo_file: str) -> None:
     port = _get_port()
     p = subprocess.Popen(

--- a/tests/_runtime/test_parent_poller.py
+++ b/tests/_runtime/test_parent_poller.py
@@ -45,3 +45,20 @@ def test_parent_poller_unix_propagates_getppid_error():
         pytest.raises(ValueError, match="boom"),
     ):
         poller.run()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="only works on posix")
+def test_parent_poller_unix_ancestor_gone():
+    # Direct parent alive, but ancestor is gone: ppid-based check can't
+    # detect this, so the ancestor_pid probe must trigger shutdown.
+    ppid = os.getppid()
+    poller = ParentPollerUnix(parent_pid=ppid, ancestor_pid=4242)
+
+    with (
+        mock.patch("os.getppid", return_value=ppid),
+        mock.patch("os.kill", side_effect=ProcessLookupError),
+        mock.patch("os.killpg"),
+        mock.patch("os._exit", side_effect=SystemExit(1)),
+        pytest.raises(SystemExit),
+    ):
+        poller.run()

--- a/tests/_runtime/test_parent_poller.py
+++ b/tests/_runtime/test_parent_poller.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from marimo._runtime.parent_poller import ParentPollerUnix
+
+
+@pytest.mark.skipif(os.name == "nt", reason="only works on posix")
+def test_parent_poller_unix_reparent_to_pid1():
+    poller = ParentPollerUnix(parent_pid=221)
+
+    with (
+        mock.patch("os.getppid", return_value=1),
+        mock.patch("os.killpg"),
+        mock.patch("os._exit", side_effect=SystemExit(1)),
+        pytest.raises(SystemExit),
+    ):
+        poller.run()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="only works on posix")
+def test_parent_poller_unix_reparent_not_pid1():
+    parent_pid = 221
+    poller = ParentPollerUnix(parent_pid=parent_pid)
+
+    with (
+        mock.patch("os.getppid", side_effect=[parent_pid, parent_pid - 1]),
+        mock.patch("os.killpg"),
+        mock.patch("os._exit", side_effect=SystemExit(1)),
+        pytest.raises(SystemExit),
+    ):
+        poller.run()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="only works on posix")
+def test_parent_poller_unix_propagates_getppid_error():
+    poller = ParentPollerUnix(parent_pid=221)
+
+    with (
+        mock.patch("os.getppid", side_effect=ValueError("boom")),
+        pytest.raises(ValueError, match="boom"),
+    ):
+        poller.run()

--- a/tests/_session/app_host/test_app_host.py
+++ b/tests/_session/app_host/test_app_host.py
@@ -214,6 +214,8 @@ class TestAppHostPool:
 class TestAppHost:
     def test_start_and_shutdown(self) -> None:
         """App host starts and shuts down cleanly."""
+        import time
+
         from marimo._session.app_host.host import AppHost
 
         app_host = AppHost("/tmp/test_app.py")
@@ -222,6 +224,11 @@ class TestAppHost:
         assert app_host.pid is not None
 
         app_host.shutdown()
+        # shutdown() signals the subprocess but doesn't synchronously
+        # wait for it to exit, so poll briefly for the process to die.
+        deadline = time.monotonic() + 5.0
+        while app_host.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.05)
         assert not app_host.is_alive()
 
 

--- a/tests/_session/managers/test_kernel.py
+++ b/tests/_session/managers/test_kernel.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from marimo._ast.app_config import _AppConfig
+from marimo._config.manager import get_default_config_manager
+from marimo._runtime.commands import (
+    AppMetadata,
+    CreateNotebookCommand,
+    ExecuteCellCommand,
+    UpdateUIElementCommand,
+)
+from marimo._session.managers import KernelManagerImpl, QueueManagerImpl
+from marimo._session.model import SessionMode
+
+
+def _is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+def test_close_kernel_kills_user_spawned_subprocess(tmp_path: Path) -> None:
+    """A subprocess spawned by kernel-executed user code must be killed when
+    the kernel is closed."""
+    pid_file = tmp_path / "child.pid"
+
+    queue_manager = QueueManagerImpl(use_multiprocessing=True)
+    kernel_manager = KernelManagerImpl(
+        queue_manager=queue_manager,
+        mode=SessionMode.EDIT,
+        configs={},
+        app_metadata=AppMetadata(
+            query_params={},
+            filename="test.py",
+            cli_args={},
+            argv=None,
+            app_config=_AppConfig(),
+        ),
+        config_manager=get_default_config_manager(current_path=None),
+        virtual_file_storage="shared_memory",
+        redirect_console_to_browser=False,
+    )
+
+    kernel_manager.start_kernel()
+    try:
+        assert kernel_manager.is_alive()
+
+        queue_manager.control_queue.put(
+            CreateNotebookCommand(
+                execution_requests=(
+                    ExecuteCellCommand(
+                        cell_id="1",
+                        code=inspect.cleandoc(
+                            f"""
+                            import subprocess
+                            _proc = subprocess.Popen(["sleep", "60"])
+                            with open("{pid_file}", "w") as _f:
+                                _f.write(str(_proc.pid))
+                            """
+                        ),
+                    ),
+                ),
+                cell_ids=("1",),
+                set_ui_element_value_request=UpdateUIElementCommand(
+                    object_ids=[], values=[]
+                ),
+                auto_run=True,
+            )
+        )
+
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and not pid_file.exists():
+            time.sleep(0.05)
+        assert pid_file.exists(), "kernel never spawned the subprocess"
+        child_pid = int(pid_file.read_text())
+        assert _is_alive(child_pid)
+    finally:
+        kernel_manager.close_kernel()
+
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and _is_alive(child_pid):
+        time.sleep(0.05)
+    try:
+        assert not _is_alive(child_pid)
+    finally:
+        if _is_alive(child_pid):
+            try:
+                os.kill(child_pid, 9)
+            except ProcessLookupError:
+                pass

--- a/tests/_utils/test_subprocess.py
+++ b/tests/_utils/test_subprocess.py
@@ -1,7 +1,10 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -11,7 +14,11 @@ from unittest.mock import patch
 import pytest
 
 from marimo._session.queue import ProcessLike
-from marimo._utils.subprocess import safe_popen, try_kill_process_and_group
+from marimo._utils.subprocess import (
+    _REAP_TASKS,
+    safe_popen,
+    try_kill_process_and_group,
+)
 
 
 class TestSafePopen:
@@ -136,3 +143,38 @@ def test_try_kill_process_and_group_kills_pgroup_spares_new_session() -> None:
                 except ProcessLookupError:
                     pass
         leader.wait(timeout=5)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+async def test_try_kill_process_and_group_sigkills_stubborn_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """try_kill_process_and_group schedules a reap task that escalates to
+    SIGKILL when the child ignores SIGTERM.
+    """
+    # Skip the reaper's real 5s/1s waits so the test is fast.
+    real_sleep = asyncio.sleep
+
+    async def no_wait(_delay: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", no_wait)
+
+    script = (
+        "import signal, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "while True: time.sleep(1)\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script], start_new_session=True
+    )
+    pgid = os.getpgid(proc.pid)
+    try:
+        try_kill_process_and_group(cast(ProcessLike, proc))
+        # Drain the reap task(s) scheduled on the current loop.
+        await asyncio.gather(*list(_REAP_TASKS), return_exceptions=True)
+        assert not _is_alive(proc.pid)
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(pgid, signal.SIGKILL)

--- a/tests/_utils/test_subprocess.py
+++ b/tests/_utils/test_subprocess.py
@@ -166,7 +166,7 @@ async def test_try_kill_process_and_group_sigkills_stubborn_child(
         "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
         "while True: time.sleep(1)\n"
     )
-    proc = subprocess.Popen(
+    proc = subprocess.Popen(  # noqa: ASYNC220
         [sys.executable, "-c", script], start_new_session=True
     )
     pgid = os.getpgid(proc.pid)

--- a/tests/_utils/test_subprocess.py
+++ b/tests/_utils/test_subprocess.py
@@ -1,10 +1,17 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
+import time
+from typing import cast
 from unittest.mock import patch
 
-from marimo._utils.subprocess import safe_popen
+import pytest
+
+from marimo._session.queue import ProcessLike
+from marimo._utils.subprocess import safe_popen, try_kill_process_and_group
 
 
 class TestSafePopen:
@@ -64,3 +71,68 @@ class TestSafePopen:
             cwd="/nonexistent/directory/abc123",
         )
         assert result is None
+
+
+# Script mimics a marimo kernel / app host: calls setsid (like
+# runtime.launch_kernel and app_host_main) to become its own process group
+# leader, spawns two children — one in the same process group, one in a new
+# session — prints their PIDs, then sleeps.
+_PGROUP_LEADER_SCRIPT = """
+import os, subprocess, sys, time
+os.setsid()
+child_pg = subprocess.Popen(
+    [sys.executable, '-c', 'import time; time.sleep(15)']
+)
+child_newpg = subprocess.Popen(
+    [sys.executable, '-c', 'import time; time.sleep(15)'],
+    start_new_session=True,
+)
+print(child_pg.pid, child_newpg.pid, flush=True)
+time.sleep(15)
+"""
+
+
+def _is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
+def test_try_kill_process_and_group_kills_pgroup_spares_new_session() -> None:
+    """Covers the shutdown path used by KernelManagerImpl, IPCKernelManagerImpl,
+    and AppHost — all three delegate to try_kill_process_and_group.
+    """
+    leader = subprocess.Popen(
+        [sys.executable, "-c", _PGROUP_LEADER_SCRIPT],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    child_pg_pid = child_newpg_pid = 0
+    try:
+        assert leader.stdout is not None
+        child_pg_pid, child_newpg_pid = (
+            int(x) for x in leader.stdout.readline().split()
+        )
+
+        try_kill_process_and_group(cast(ProcessLike, leader))
+
+        # wait() reaps the child so it doesn't linger as a zombie.
+        assert leader.wait(timeout=5) is not None
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and _is_alive(child_pg_pid):
+            time.sleep(0.05)
+
+        assert not _is_alive(child_pg_pid)
+        assert _is_alive(child_newpg_pid)
+    finally:
+        for pid in (leader.pid, child_pg_pid, child_newpg_pid):
+            if pid:
+                try:
+                    os.kill(pid, 9)
+                except ProcessLookupError:
+                    pass
+        leader.wait(timeout=5)


### PR DESCRIPTION
This change updates the server to kill the entire kernel process group in Unix-like systems, not just the kernel process. It also adds clean-up logic in the event that the parent process dies.

**User-spawned processes.** Before this change, processes started by user-code in the kernel (such as `sleep 100`) weren't shut down on kernel shutdown, leading to leaks. With this change, the entire process group is killed. There are a few unit tests that exercise this, as well as a smoke test.

**Zombie processes.** This change adds background tasks that reap zombie kernel processes while the server is running. This will only make a difference for long-lived servers, as on server shutdown zombies should be reaped by the operating system.

**Orphaned kernels.** Additionally, on Unix-like systems, this change adds a poller to the kernel process that checks whether the server that started it is still alive. If the server dies, the poller causes the kernel process to terminate. For example, if you start a marimo edit session, then manually kill just the server, the kernel and its associated processes (which usually have `multiprocessing` in their command, you the reviewer may have seen such processes hanging around) will now also be cleaned up:

```
[W 260418 07:40:14 parent_poller:31] Parent server appears to have exited, shutting down.
```

**Single-file sandbox sessions.** A parent poller is started to clean up uv and marimo if the CLI process is terminated.

These cleanup mechanisms are applied to edit-mode sessions, IPC (sandbox) sessions, and AppHost sessions.

These changes are modeled after similar logic in `ipykernel`.