### PR TITLE
fix: hold references to asyncio tasks

### DIFF
--- a/marimo/_server/api/endpoints/ws/ws_kernel_ready.py
+++ b/marimo/_server/api/endpoints/ws/ws_kernel_ready.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from marimo import _loggers
 from marimo._ast.cell import CellConfig
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
 LOGGER = _loggers.marimo_logger()
 
 LORO_ALLOWED = sys.version_info >= (3, 11)
+
+# Strong refs so fire-and-forget tasks aren't GC'd mid-flight.
+_background_tasks: set[asyncio.Task[Any]] = set()
 
 
 def build_kernel_ready(
@@ -184,4 +187,8 @@ def _try_init_rtc_doc(
             "RTC: Loro is not installed, disabling real-time collaboration"
         )
     else:
-        asyncio.create_task(doc_manager.create_doc(file_key, cell_ids, codes))
+        task = asyncio.create_task(
+            doc_manager.create_doc(file_key, cell_ids, codes)
+        )
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)

--- a/marimo/_server/api/endpoints/ws_endpoint.py
+++ b/marimo/_server/api/endpoints/ws_endpoint.py
@@ -66,6 +66,9 @@ router = APIRouter()
 
 DOC_MANAGER = LoroDocManager()
 
+# Strong refs so fire-and-forget tasks aren't GC'd mid-flight.
+_background_tasks: set[asyncio.Task[None]] = set()
+
 
 @router.websocket("/ws")
 async def websocket_endpoint(
@@ -500,11 +503,13 @@ class WebSocketHandler(SessionConsumer):
             or self.status == ConnectionState.CONNECTING
         ) and self.websocket.application_state is WebSocketState.CONNECTED
         if is_connected:
-            asyncio.create_task(
+            task = asyncio.create_task(
                 self._safe_close(
                     WebSocketCodes.NORMAL_CLOSE, "MARIMO_SHUTDOWN"
                 )
             )
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
 
         if self.ws_future:
             self.ws_future.cancel()

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -695,7 +695,8 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
         self.app_state.timeout_tracker = time.time()
         self.timeout_duration_minutes = timeout_duration_minutes
 
-        asyncio.create_task(self.monitor())
+        # Hold a strong reference so the monitor task isn't GC'd.
+        self._monitor_task = asyncio.create_task(self.monitor())
 
     async def __call__(
         self, scope: Scope, receive: Receive, send: Send

--- a/marimo/_utils/file_watcher.py
+++ b/marimo/_utils/file_watcher.py
@@ -68,10 +68,12 @@ class PollingFileWatcher(FileWatcher):
         self.loop = loop
         self.last_modified: float | None = self._get_modified()
         self._missing_count = 0
+        self._task: asyncio.Task[None] | None = None
 
     def start(self) -> None:
         self._running = True
-        self.loop.create_task(self._poll())
+        # Hold a strong reference so the task isn't GC'd mid-poll.
+        self._task = self.loop.create_task(self._poll())
 
     def stop(self) -> None:
         self._running = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -417,6 +417,7 @@ extend-select = [
     "D419",
     "PGH004", # Use specific rule codes when using noqa
     "PGH005", # Invalid unittest.mock.Mock methods/attributes/properties
+    "RUF006", # Store a reference to the return value of asyncio.create_task
     # "S101", # Checks use `assert` outside the test cases, test cases should be added into the exclusions
     "B004",   # Checks for use of hasattr(x, "__call__") and replaces it with callable(x)
     "B006",   # Checks for uses of mutable objects as function argument defaults.


### PR DESCRIPTION
References to tasks scheduled with `asyncio.create_task()` must be held; if they aren't held, tasks may disappear mid-execution.

https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task

This PR also enables `RUF006` to ensure that this does not happen again.