### PR TITLE
Suppress `marimo-ui-value-update` echo for user-initiated changes

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -782,7 +782,7 @@ class App:
         self,
         request: UpdateUIElementCommand,
         *,
-        notify_frontend: bool = False,
+        notify_frontend: bool,
     ) -> bool:
         app_kernel_runner = self._get_kernel_runner()
         return await app_kernel_runner.set_ui_element_value(
@@ -1047,7 +1047,7 @@ class InternalApp:
         self,
         request: UpdateUIElementCommand,
         *,
-        notify_frontend: bool = False,
+        notify_frontend: bool,
     ) -> bool:
         return await self._app._set_ui_element_value(
             request, notify_frontend=notify_frontend

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -779,10 +779,15 @@ class App:
         return output, _Namespace(defs, owner=self)
 
     async def _set_ui_element_value(
-        self, request: UpdateUIElementCommand
+        self,
+        request: UpdateUIElementCommand,
+        *,
+        notify_frontend: bool = False,
     ) -> bool:
         app_kernel_runner = self._get_kernel_runner()
-        return await app_kernel_runner.set_ui_element_value(request)
+        return await app_kernel_runner.set_ui_element_value(
+            request, notify_frontend=notify_frontend
+        )
 
     async def _function_call(
         self, request: InvokeFunctionCommand
@@ -1039,9 +1044,14 @@ class InternalApp:
         return self._app._run_cell_sync(cell, kwargs)
 
     async def set_ui_element_value(
-        self, request: UpdateUIElementCommand
+        self,
+        request: UpdateUIElementCommand,
+        *,
+        notify_frontend: bool = False,
     ) -> bool:
-        return await self._app._set_ui_element_value(request)
+        return await self._app._set_ui_element_value(
+            request, notify_frontend=notify_frontend
+        )
 
     async def function_call(
         self, request: InvokeFunctionCommand

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -703,7 +703,8 @@ class AsyncCodeModeContext:
                 UpdateUIElementCommand(
                     object_ids=list(object_ids),
                     values=list(values),
-                )
+                ),
+                notify_frontend=True,
             )
 
         # Print a summary of what was applied.

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -202,7 +202,7 @@ class AppKernelRunner:
         self,
         request: UpdateUIElementCommand,
         *,
-        notify_frontend: bool = False,
+        notify_frontend: bool,
     ) -> bool:
         with self._runtime_context.install():
             return await self._kernel.set_ui_element_value(

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -199,10 +199,15 @@ class AppKernelRunner:
         return self.outputs, self._kernel.globals
 
     async def set_ui_element_value(
-        self, request: UpdateUIElementCommand
+        self,
+        request: UpdateUIElementCommand,
+        *,
+        notify_frontend: bool = False,
     ) -> bool:
         with self._runtime_context.install():
-            return await self._kernel.set_ui_element_value(request)
+            return await self._kernel.set_ui_element_value(
+                request, notify_frontend=notify_frontend
+            )
 
     async def function_call(
         self, request: InvokeFunctionCommand

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1876,11 +1876,28 @@ class Kernel:
 
     @kernel_tracer.start_as_current_span("set_ui_element_value")
     async def set_ui_element_value(
-        self, request: UpdateUIElementCommand
+        self,
+        request: UpdateUIElementCommand,
+        *,
+        notify_frontend: bool = False,
     ) -> bool:
         """Set the value of a UI element bound to a global variable.
 
         Runs cells that reference the UI element by name.
+
+        Args:
+            request: The UI element update command.
+            notify_frontend: Whether to broadcast the new value back to
+                the frontend via a ``marimo-ui-value-update`` message.
+                Default ``False`` — the usual case (user-initiated
+                updates from the frontend) already has the value
+                locally; re-broadcasting it causes redundant traffic
+                and, on transports with non-negligible round-trip
+                latency (LSP, remote kernels), can visibly snap the
+                rendered widget backward to a stale value. Set
+                ``True`` for genuinely kernel-initiated changes
+                (e.g. code_mode's ``set_ui_value``) where the
+                frontend has no other way to learn about the update.
 
         Returns True if any ui elements were set, False otherwise
         """
@@ -1909,7 +1926,8 @@ class Kernel:
                                 object_ids=[object_id],
                                 values=[value],
                                 request=request.request,
-                            )
+                            ),
+                            notify_frontend=notify_frontend,
                         )
                     ):
                         bindings = [
@@ -1981,19 +1999,17 @@ class Kernel:
                     write_traceback(tmpio.read())
                 else:
                     updated_components.append(component)
-                    # Broadcast the new value to the frontend so the
-                    # rendered widget reflects kernel-initiated changes
-                    # (e.g. from code_mode's set_ui_value).
-                    broadcast_notification(
-                        UIElementMessageNotification(
-                            ui_element=object_id,
-                            message={
-                                "type": "marimo-ui-value-update",
-                                "value": value,
-                            },
-                        ),
-                        self.stream,
-                    )
+                    if notify_frontend:
+                        broadcast_notification(
+                            UIElementMessageNotification(
+                                ui_element=object_id,
+                                message={
+                                    "type": "marimo-ui-value-update",
+                                    "value": value,
+                                },
+                            ),
+                            self.stream,
+                        )
 
             bound_names = {
                 name

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1879,7 +1879,7 @@ class Kernel:
         self,
         request: UpdateUIElementCommand,
         *,
-        notify_frontend: bool = False,
+        notify_frontend: bool,
     ) -> bool:
         """Set the value of a UI element bound to a global variable.
 
@@ -1889,15 +1889,15 @@ class Kernel:
             request: The UI element update command.
             notify_frontend: Whether to broadcast the new value back to
                 the frontend via a ``marimo-ui-value-update`` message.
-                Default ``False`` — the usual case (user-initiated
-                updates from the frontend) already has the value
-                locally; re-broadcasting it causes redundant traffic
-                and, on transports with non-negligible round-trip
-                latency (LSP, remote kernels), can visibly snap the
-                rendered widget backward to a stale value. Set
-                ``True`` for genuinely kernel-initiated changes
-                (e.g. code_mode's ``set_ui_value``) where the
-                frontend has no other way to learn about the update.
+                Set ``False`` for user-initiated updates from the frontend
+                (the frontend already has the value locally;
+                re-broadcasting causes redundant traffic and, on transports
+                with non-negligible round-trip latency (LSP, remote
+                kernels), can visibly snap the rendered widget backward to
+                a stale value). Set ``True`` for genuinely
+                kernel-initiated changes (e.g. code_mode's
+                ``set_ui_value``) where the frontend has no other way to
+                learn about the update.
 
         Returns True if any ui elements were set, False otherwise
         """
@@ -2382,7 +2382,7 @@ class Kernel:
             request: UpdateUIElementCommand,
         ) -> None:
             with http_request_context(request.request):
-                await self.set_ui_element_value(request)
+                await self.set_ui_element_value(request, notify_frontend=False)
             broadcast_notification(CompletedRunNotification())
 
         async def handle_pdb_request(request: DebugCellCommand) -> None:
@@ -2407,7 +2407,8 @@ class Kernel:
                 await self.set_ui_element_value(
                     UpdateUIElementCommand.from_ids_and_values(
                         [(UIElementId(ui_element_id), state)]
-                    )
+                    ),
+                    notify_frontend=False,
                 )
                 broadcast_notification(CompletedRunNotification())
             elif self.state_updates:

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -1447,7 +1447,8 @@ class TestAppComposition:
         assert await k.set_ui_element_value(
             UpdateUIElementCommand.from_ids_and_values(
                 [(dropdown_element._id, ["second"])]
-            )
+            ),
+            notify_frontend=False,
         )
         assert token[0] == 2
 
@@ -1499,7 +1500,8 @@ class TestAppComposition:
         # testing that only descendants of the updated UI elements run,
         # and that the other UI element is not reset
         assert await k.set_ui_element_value(
-            UpdateUIElementCommand.from_ids_and_values([(x._id, 2)])
+            UpdateUIElementCommand.from_ids_and_values([(x._id, 2)]),
+            notify_frontend=False,
         )
 
         assert app_kernel_runner == app._get_kernel_runner()
@@ -1508,7 +1510,8 @@ class TestAppComposition:
         assert y.value == 1
 
         assert await k.set_ui_element_value(
-            UpdateUIElementCommand.from_ids_and_values([(y._id, 3)])
+            UpdateUIElementCommand.from_ids_and_values([(y._id, 3)]),
+            notify_frontend=False,
         )
 
         assert x.value == 2

--- a/tests/_plugins/ui/_impl/test_anywidget.py
+++ b/tests/_plugins/ui/_impl/test_anywidget.py
@@ -143,7 +143,8 @@ x = as_marimo_element.count
         await k.set_ui_element_value(
             UpdateUIElementCommand.from_ids_and_values(
                 [(ui_element._id, {"count": 5})]
-            )
+            ),
+            notify_frontend=False,
         )
 
         assert k.globals["w_value"]["count"] == 5
@@ -292,7 +293,8 @@ x = as_marimo_element.count
         await k.set_ui_element_value(
             UpdateUIElementCommand.from_ids_and_values(
                 [(ui_element._id, {"value": 42})]
-            )
+            ),
+            notify_frontend=False,
         )
 
         assert ui_element.value == {"value": 42}

--- a/tests/_plugins/ui/_impl/test_refresh.py
+++ b/tests/_plugins/ui/_impl/test_refresh.py
@@ -26,7 +26,8 @@ async def test_refresh_value_updates_to_frontend_string(
     assert refresh.value == ""
 
     await k.set_ui_element_value(
-        UpdateUIElementCommand([refresh._id], ["1s (0)"])
+        UpdateUIElementCommand([refresh._id], ["1s (0)"]),
+        notify_frontend=False,
     )
     assert refresh.value == "1s (0)"
 

--- a/tests/_plugins/ui/_impl/test_run_button.py
+++ b/tests/_plugins/ui/_impl/test_run_button.py
@@ -33,7 +33,10 @@ async def test_run_button_set_to_true_on_click(
     run_button = k.globals["b"]
     assert not run_button.value
 
-    await k.set_ui_element_value(UpdateUIElementCommand([run_button._id], [1]))
+    await k.set_ui_element_value(
+        UpdateUIElementCommand([run_button._id], [1]),
+        notify_frontend=False,
+    )
 
     if not k.lazy():
         assert k.globals["x"] == 1
@@ -80,13 +83,19 @@ async def test_run_buttons_in_array(
     assert count[0] == 0
 
     # Just one button pushed
-    await k.set_ui_element_value(UpdateUIElementCommand([arr[0]._id], [1]))
+    await k.set_ui_element_value(
+        UpdateUIElementCommand([arr[0]._id], [1]),
+        notify_frontend=False,
+    )
     assert count[0] == 1
     assert not arr.value[0]
     assert not arr.value[1]
     # Push another button, first button's value should be false, so just an
     # increment by 1
-    await k.set_ui_element_value(UpdateUIElementCommand([arr[1]._id], [1]))
+    await k.set_ui_element_value(
+        UpdateUIElementCommand([arr[1]._id], [1]),
+        notify_frontend=False,
+    )
     assert count[0] == 2
     assert not arr.value[0]
     assert not arr.value[1]
@@ -124,13 +133,19 @@ async def test_run_buttons_in_dict(
     assert count[0] == 0
 
     # Just one button pushed
-    await k.set_ui_element_value(UpdateUIElementCommand([hoc["0"]._id], [1]))
+    await k.set_ui_element_value(
+        UpdateUIElementCommand([hoc["0"]._id], [1]),
+        notify_frontend=False,
+    )
     assert count[0] == 1
     assert not hoc.value["0"]
     assert not hoc.value["1"]
     # Push another button, first button's value should be false, so just an
     # increment by 1
-    await k.set_ui_element_value(UpdateUIElementCommand([hoc["1"]._id], [1]))
+    await k.set_ui_element_value(
+        UpdateUIElementCommand([hoc["1"]._id], [1]),
+        notify_frontend=False,
+    )
     assert count[0] == 2
     assert not hoc.value["0"]
     assert not hoc.value["1"]

--- a/tests/_runtime/runner/test_cell_runner.py
+++ b/tests/_runtime/runner/test_cell_runner.py
@@ -199,7 +199,8 @@ async def test_ui_element_update_skips_overridden_cells(
     # because x is overridden
     slider_element = k.globals["slider_element"]
     assert await k.set_ui_element_value(
-        UpdateUIElementCommand.from_ids_and_values([(slider_element._id, 8)])
+        UpdateUIElementCommand.from_ids_and_values([(slider_element._id, 8)]),
+        notify_frontend=False,
     )
 
     # After UI update, result should still be 200 because x is still overridden

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -212,9 +212,9 @@ class TestExecution:
 
         element_id = k.globals["s"]._id
         await k.set_ui_element_value(
-            UpdateUIElementCommand.from_ids_and_values([(element_id, 5)])
+            UpdateUIElementCommand.from_ids_and_values([(element_id, 5)]),
+            notify_frontend=False,
         )
-        assert k.globals["s"].value == 5
 
         if k.reactive_execution_mode == "lazy":
             assert k.graph.cells["2"].stale
@@ -255,7 +255,8 @@ class TestExecution:
         # Set a child of the array to 5 ...
         child_id = k.globals["array"][0]._id
         await k.set_ui_element_value(
-            UpdateUIElementCommand.from_ids_and_values([(child_id, 5)])
+            UpdateUIElementCommand.from_ids_and_values([(child_id, 5)]),
+            notify_frontend=False,
         )
 
         # Make sure the array and its child are updated
@@ -293,7 +294,8 @@ class TestExecution:
 
         array_id = k.globals["array"]._id
         await k.set_ui_element_value(
-            UpdateUIElementCommand.from_ids_and_values([(array_id, {"0": 5})])
+            UpdateUIElementCommand.from_ids_and_values([(array_id, {"0": 5})]),
+            notify_frontend=False,
         )
         assert k.globals["array"].value == [5]
         if k.lazy():
@@ -324,7 +326,8 @@ class TestExecution:
         # called
         child_id = k.globals["array"][0]._id
         await k.set_ui_element_value(
-            UpdateUIElementCommand.from_ids_and_values([(child_id, 5)])
+            UpdateUIElementCommand.from_ids_and_values([(child_id, 5)]),
+            notify_frontend=False,
         )
         if k.lazy():
             assert k.graph.cells[er.cell_id].stale
@@ -348,7 +351,8 @@ class TestExecution:
         # This shouldn't crash the kernel, and s's value should still be
         # updated
         await k.set_ui_element_value(
-            UpdateUIElementCommand.from_ids_and_values([(element_id, 5)])
+            UpdateUIElementCommand.from_ids_and_values([(element_id, 5)]),
+            notify_frontend=False,
         )
         assert k.globals["_cell_1_s"].value == 5
 
@@ -1205,7 +1209,8 @@ except NameError:
         element_id = k.globals["defs"]["slider"]._id
 
         await k.set_ui_element_value(
-            UpdateUIElementCommand.from_ids_and_values([(element_id, 5)])
+            UpdateUIElementCommand.from_ids_and_values([(element_id, 5)]),
+            notify_frontend=False,
         )
         assert k.globals["defs"]["slider"].value == 5
         if k.lazy():
@@ -1226,7 +1231,8 @@ except NameError:
         await k.set_ui_element_value(
             UpdateUIElementCommand.from_ids_and_values(
                 [("does not exist", None)]
-            )
+            ),
+            notify_frontend=False,
         )
 
     async def test_interrupt(


### PR DESCRIPTION
The kernel broadcasts a `marimo-ui-value-update` after every UI element value change, including user-initiated ones where the frontend already has the value. The echo is invisible over WebSocket but lands stale on high-latency transports, where `broadcastMessage` applies it and visibly snaps widgets backward mid-drag (the slider lag in marimo-team/marimo-lsp#515).

These changes gate the broadcast behind a `notify_frontend` kwarg that defaults off to scope the feature for code-mode only.
