### PR TITLE
feat: enhance homepage with Workspace file management

### DIFF
--- a/frontend/src/components/editor/file-tree/file-explorer.tsx
+++ b/frontend/src/components/editor/file-tree/file-explorer.tsx
@@ -392,7 +392,7 @@ const Show = ({
   );
 };
 
-const Edit = ({ node }: { node: NodeApi<FileInfo> }) => {
+export const Edit = ({ node }: { node: NodeApi<FileInfo> }) => {
   const ref = useRef<HTMLInputElement>(null);
   useEffect(() => {
     ref.current?.focus();

--- a/frontend/src/components/home/state.ts
+++ b/frontend/src/components/home/state.ts
@@ -15,7 +15,13 @@ export const RunningNotebooksContext = React.createContext<{
   runningNotebooks: new Map(),
   setRunningNotebooks: Functions.NOOP,
 });
-export const WorkspaceRootContext = React.createContext<string>("");
+export const WorkspaceContext = React.createContext<{
+  root: string;
+  refreshAll: () => void;
+}>({
+  root: "",
+  refreshAll: Functions.NOOP,
+});
 
 export const includeMarkdownAtom = atomWithStorage<boolean>(
   "marimo:home:include-markdown",

--- a/frontend/src/components/pages/home-page.tsx
+++ b/frontend/src/components/pages/home-page.tsx
@@ -7,14 +7,16 @@ import {
   ChevronRightIcon,
   ChevronsDownUpIcon,
   ClockIcon,
+  CopyIcon,
+  Edit3Icon,
   ExternalLinkIcon,
   PlayCircleIcon,
   PowerOffIcon,
   RefreshCcwIcon,
   SearchIcon,
+  Trash2Icon,
 } from "lucide-react";
-import type React from "react";
-import { Suspense, use, useEffect, useRef, useState } from "react";
+import React, { Suspense, use, useEffect, useRef, useState } from "react";
 import {
   type NodeApi,
   type NodeRendererProps,
@@ -22,22 +24,38 @@ import {
   type TreeApi,
 } from "react-arborist";
 import { useLocale } from "react-aria";
+import useEvent from "react-use-event-hook";
 import { MarkdownIcon } from "@/components/editor/cell/code/icons";
 import {
   FILE_ICON as FILE_TYPE_ICONS,
   type FileIconType as FileType,
   guessFileIconType as guessFileType,
 } from "@/components/editor/file-tree/file-icons";
+import {
+  MoreActionsButton,
+  MENU_ITEM_ICON_CLASS,
+} from "@/components/editor/file-tree/tree-actions";
 import { useImperativeModal } from "@/components/modal/ImperativeModal";
 import { AlertDialogDestructiveAction } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Label } from "@/components/ui/label";
 import { Tooltip } from "@/components/ui/tooltip";
 import { toast } from "@/components/ui/use-toast";
 import { getSessionId, isSessionId } from "@/core/kernel/session";
 import { useRequestClient } from "@/core/network/requests";
-import type { FileInfo, MarimoFile } from "@/core/network/types";
+import type {
+  FileInfo,
+  MarimoFile,
+  FileUpdateResponse,
+} from "@/core/network/types";
 import { combineAsyncData, useAsyncData } from "@/hooks/useAsyncData";
 import { useInterval } from "@/hooks/useInterval";
 import { Banner } from "@/plugins/impl/common/error-banner";
@@ -47,11 +65,13 @@ import { timeAgo } from "@/utils/dates";
 import { prettyError } from "@/utils/errors";
 import { Maps } from "@/utils/maps";
 import { Paths } from "@/utils/paths";
+import { fileSplit, resolvePaths } from "@/utils/pathUtils";
 import { asURL } from "@/utils/url";
 import { newNotebookURL } from "@/utils/urls";
 import { ConfigButton } from "../app-config/app-config-button";
 import { ErrorBoundary } from "../editor/boundary/ErrorBoundary";
 import { ShutdownButton } from "../editor/controls/shutdown-button";
+import { Edit } from "../editor/file-tree/file-explorer";
 import {
   Header,
   OpenTutorialDropDown,
@@ -61,7 +81,7 @@ import {
   expandedFoldersAtom,
   includeMarkdownAtom,
   RunningNotebooksContext,
-  WorkspaceRootContext,
+  WorkspaceContext,
 } from "../home/state";
 import { Spinner } from "../icons/spinner";
 import { Input } from "../ui/input";
@@ -131,7 +151,7 @@ const HomePage: React.FC = () => {
             files={recents.files}
           />
           <ErrorBoundary>
-            <WorkspaceNotebooks />
+            <WorkspaceNotebooks onRefresh={recentsResponse.refetch} />
           </ErrorBoundary>
         </div>
       </RunningNotebooksContext>
@@ -139,7 +159,9 @@ const HomePage: React.FC = () => {
   );
 };
 
-const WorkspaceNotebooks: React.FC = () => {
+const WorkspaceNotebooks: React.FC<{ onRefresh: () => void }> = ({
+  onRefresh,
+}) => {
   const { getWorkspaceFiles } = useRequestClient();
   const [includeMarkdown, setIncludeMarkdown] = useAtom(includeMarkdownAtom);
   const [searchText, setSearchText] = useState("");
@@ -153,6 +175,10 @@ const WorkspaceNotebooks: React.FC = () => {
     () => getWorkspaceFiles({ includeMarkdown }),
     [includeMarkdown],
   );
+  const refreshAll = useEvent(() => {
+    refetch();
+    onRefresh();
+  });
 
   if (isPending) {
     return <Spinner centered={true} size="xlarge" className="mt-6" />;
@@ -167,7 +193,7 @@ const WorkspaceNotebooks: React.FC = () => {
   }
 
   return (
-    <WorkspaceRootContext value={workspace.root}>
+    <WorkspaceContext value={{ root: workspace.root, refreshAll }}>
       <div className="flex flex-col gap-2">
         {workspace.hasMore && (
           <Banner kind="warn" className="rounded p-4">
@@ -216,7 +242,7 @@ const WorkspaceNotebooks: React.FC = () => {
           <NotebookFileTree searchText={searchText} files={workspace.files} />
         </div>
       </div>
-    </WorkspaceRootContext>
+    </WorkspaceContext>
   );
 };
 
@@ -244,6 +270,8 @@ const NotebookFileTree: React.FC<{
   const [openState, setOpenState] = useAtom(expandedFoldersAtom);
   const openStateIsEmpty = Object.keys(openState).length === 0;
   const ref = useRef<TreeApi<FileInfo>>(undefined);
+  const { sendRenameFileOrFolder } = useRequestClient();
+  const { root, refreshAll } = use(WorkspaceContext);
 
   useEffect(() => {
     // If empty, collapse all
@@ -251,6 +279,21 @@ const NotebookFileTree: React.FC<{
       ref.current?.closeAll();
     }
   }, [openStateIsEmpty]);
+
+  const handleRename = useEvent(async (id: string, name: string) => {
+    const node = ref.current?.get(id);
+    if (!node) {
+      toast({
+        title: "Failed",
+        description: `Node with id ${id} not found in the tree`,
+      });
+      return;
+    }
+    const paths = { path: node.data.path, name, root };
+    const { path, newPath } = resolvePaths(paths);
+    await sendRenameFileOrFolder({ path, newPath }).then(handleResponse);
+    refreshAll();
+  });
 
   if (files.length === 0) {
     return (
@@ -277,6 +320,9 @@ const NotebookFileTree: React.FC<{
         const prevOpen = openState[id] ?? false;
         setOpenState({ ...openState, [id]: !prevOpen });
       }}
+      onRename={async ({ id, name }) => {
+        await handleRename(id, name);
+      }}
       padding={5}
       rowHeight={35}
       indent={15}
@@ -286,7 +332,6 @@ const NotebookFileTree: React.FC<{
       // Disable interactions
       disableDrop={true}
       disableDrag={true}
-      disableEdit={true}
       disableMultiSelection={true}
     >
       {Node}
@@ -301,11 +346,22 @@ const Node = ({ node, style }: NodeRendererProps<FileInfo>) => {
 
   const Icon = FILE_TYPE_ICONS[fileType];
   const iconEl = <Icon className="w-5 h-5 shrink-0" strokeWidth={1.5} />;
-  const root = use(WorkspaceRootContext);
+  const { root } = use(WorkspaceContext);
+  const { runningNotebooks } = use(RunningNotebooksContext);
 
   const renderItem = () => {
     const itemClassName =
       "flex items-center pl-1 cursor-pointer hover:bg-accent/50 hover:text-accent-foreground rounded-l flex-1 overflow-hidden h-full pr-3 gap-2";
+
+    if (node.isEditing) {
+      return (
+        <div className={itemClassName}>
+          {iconEl}
+          <Edit node={node} />
+        </div>
+      );
+    }
+
     if (node.data.isDirectory) {
       return (
         <span className={itemClassName}>
@@ -323,6 +379,10 @@ const Node = ({ node, style }: NodeRendererProps<FileInfo>) => {
     const isMarkdown =
       relativePath.endsWith(".md") || relativePath.endsWith(".qmd");
 
+    const isRunning = runningNotebooks.has(relativePath);
+    const needsSessionShutdownButtonSpace =
+      runningNotebooks.size > 0 && !isRunning;
+
     return (
       <a
         className={itemClassName}
@@ -334,7 +394,13 @@ const Node = ({ node, style }: NodeRendererProps<FileInfo>) => {
           {node.data.name}
           {isMarkdown && <MarkdownIcon className="ml-2 inline opacity-80" />}
         </span>
+        <FileActions node={node} isRunning={isRunning} />
         <SessionShutdownButton filePath={relativePath} />
+        {needsSessionShutdownButtonSpace && (
+          <div className="invisible pointer-events-none">
+            <Button size={"icon"} variant="outline" />
+          </div>
+        )}
         <ExternalLinkIcon
           size={20}
           className="group-hover:opacity-100 opacity-0 text-primary"
@@ -526,5 +592,106 @@ const CreateNewNotebook: React.FC = () => {
     </a>
   );
 };
+
+const FileActions = ({
+  node,
+  isRunning = false,
+}: {
+  node: NodeApi<FileInfo>;
+  isRunning?: boolean;
+}) => {
+  const { root, refreshAll } = use(WorkspaceContext);
+  const { sendCopyFileOrFolder, sendDeleteFileOrFolder } = useRequestClient();
+  const { openConfirm } = useImperativeModal();
+
+  const handleDuplicate = useEvent(async () => {
+    const [name, extension] = fileSplit(node.data.name);
+    const duplicateName = `${name}_copy${extension}`;
+    const paths = { path: node.data.path, name: duplicateName, root };
+    const { path, newPath } = resolvePaths(paths);
+    await sendCopyFileOrFolder({ path, newPath }).then(handleResponse);
+    refreshAll();
+  });
+
+  const handleDelete = useEvent(async () => {
+    const paths = { path: node.data.path, name: "", root };
+    const { path } = resolvePaths(paths);
+    openConfirm({
+      title: "Delete notebook",
+      description: `Are you sure you want to delete ${node.data.name}?`,
+      confirmAction: (
+        <AlertDialogDestructiveAction
+          onClick={async () => {
+            await sendDeleteFileOrFolder({ path }).then(handleResponse);
+            refreshAll();
+          }}
+          aria-label="Confirm"
+        >
+          Delete
+        </AlertDialogDestructiveAction>
+      ),
+    });
+  });
+
+  const ic = MENU_ITEM_ICON_CLASS;
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger
+        asChild={true}
+        tabIndex={-1}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
+      >
+        <MoreActionsButton
+          data-testid="workspace-more-button"
+          className="w-4 h-6 p-0"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="print:hidden w-fit min-w-[120px]"
+        onClick={(e) => e.stopPropagation()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        {!isRunning && (
+          <DropdownMenuItem onSelect={() => node.edit()}>
+            <Edit3Icon className={ic} />
+            Rename
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem onSelect={handleDuplicate}>
+          <CopyIcon className={ic} />
+          Duplicate
+        </DropdownMenuItem>
+        {!isRunning && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={handleDelete} variant="danger">
+              <Trash2Icon className={ic} />
+              Delete
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+// frontend/src/components/editor/file-tree/requesting-tree.tsx
+function handleResponse(
+  response: FileUpdateResponse,
+): FileUpdateResponse | null {
+  if (!response.success) {
+    toast({
+      title: "Failed",
+      description: response.message,
+    });
+    return null;
+  }
+
+  return response;
+}
 
 export default HomePage;

--- a/frontend/src/components/pages/home-page.tsx
+++ b/frontend/src/components/pages/home-page.tsx
@@ -16,7 +16,8 @@ import {
   SearchIcon,
   Trash2Icon,
 } from "lucide-react";
-import React, { Suspense, use, useEffect, useRef, useState } from "react";
+import type React from "react";
+import { Suspense, use, useEffect, useRef, useState } from "react";
 import {
   type NodeApi,
   type NodeRendererProps,
@@ -53,8 +54,8 @@ import { getSessionId, isSessionId } from "@/core/kernel/session";
 import { useRequestClient } from "@/core/network/requests";
 import type {
   FileInfo,
-  MarimoFile,
   FileUpdateResponse,
+  MarimoFile,
 } from "@/core/network/types";
 import { combineAsyncData, useAsyncData } from "@/hooks/useAsyncData";
 import { useInterval } from "@/hooks/useInterval";

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -260,7 +260,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponseReturnNull);
     },
     openFile: async (request) => {
-      await waitForConnectionOpen();
       await getClient()
         .POST("/api/files/open", {
           body: request,
@@ -281,7 +280,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponseReturnNull);
     },
     sendListFiles: async (request) => {
-      await waitForConnectionOpen();
       return getClient()
         .POST("/api/files/list_files", {
           body: request,
@@ -289,7 +287,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     sendSearchFiles: async (request) => {
-      await waitForConnectionOpen();
       return getClient()
         .POST("/api/files/search", {
           body: request,
@@ -297,7 +294,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     sendCreateFileOrFolder: async (request) => {
-      await waitForConnectionOpen();
       return getClient()
         .POST("/api/files/create", {
           body: request,
@@ -305,7 +301,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     sendDeleteFileOrFolder: async (request) => {
-      await waitForConnectionOpen();
       return getClient()
         .POST("/api/files/delete", {
           body: request,
@@ -313,7 +308,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     sendCopyFileOrFolder: async (request) => {
-      await waitForConnectionOpen();
       return getClient()
         .POST("/api/files/copy", {
           body: request,
@@ -321,7 +315,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     sendRenameFileOrFolder: async (request) => {
-      await waitForConnectionOpen();
       return getClient()
         .POST("/api/files/move", {
           body: request,
@@ -329,7 +322,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     sendUpdateFile: async (request) => {
-      await waitForConnectionOpen();
       return getClient()
         .POST("/api/files/update", {
           body: request,
@@ -337,7 +329,6 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     sendFileDetails: async (request) => {
-      await waitForConnectionOpen();
       return getClient()
         .POST("/api/files/file_details", {
           body: request,

--- a/frontend/src/utils/pathUtils.test.ts
+++ b/frontend/src/utils/pathUtils.test.ts
@@ -1,6 +1,10 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { describe, expect, it } from "vitest";
-import { fileSplit, getProtocolAndParentDirectories } from "./pathUtils";
+import {
+  fileSplit,
+  getProtocolAndParentDirectories,
+  resolvePaths,
+} from "./pathUtils";
 
 describe("getProtocolAndParentDirectories", () => {
   it("should extract protocol and list parent directories correctly", () => {
@@ -109,5 +113,43 @@ describe("fileSplit", () => {
       "path/to/file.txt",
       ".md",
     ]);
+  });
+});
+
+describe("resolvePaths", () => {
+  it("should resolve paths relative to root", () => {
+    const result = resolvePaths({
+      path: "notebooks/notebook.py",
+      name: "notebook_copy.py",
+      root: "/workspaces/marimo",
+    });
+    expect(result).toEqual({
+      path: "/workspaces/marimo/notebooks/notebook.py",
+      newPath: "/workspaces/marimo/notebooks/notebook_copy.py",
+    });
+  });
+
+  it("should handle absolute paths", () => {
+    const result = resolvePaths({
+      path: "/abs/path/notebook.py",
+      name: "notebook_copy.py",
+      root: "/workspaces/marimo",
+    });
+    expect(result).toEqual({
+      path: "/abs/path/notebook.py",
+      newPath: "/abs/path/notebook_copy.py",
+    });
+  });
+
+  it("should handle Windows paths", () => {
+    const result = resolvePaths({
+      path: "notebook.py",
+      name: "notebook_copy.py",
+      root: "C:\\Users\\marimo",
+    });
+    expect(result).toEqual({
+      path: "C:\\Users\\marimo\\notebook.py",
+      newPath: "C:\\Users\\marimo\\notebook_copy.py",
+    });
   });
 });

--- a/frontend/src/utils/pathUtils.ts
+++ b/frontend/src/utils/pathUtils.ts
@@ -1,5 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { type FilePath, Paths, PathBuilder } from "./paths";
+
 /**
  * Get the protocol and parent directories of a path.
  */
@@ -73,4 +75,33 @@ export function fileSplit(path: string): [name: string, extension: string] {
   const name = lastDotIndex > 0 ? path.slice(0, lastDotIndex) : path;
   const extension = lastDotIndex > 0 ? path.slice(lastDotIndex) : "";
   return [name, extension];
+}
+
+/**
+ * Resolves the absolute paths for a file operation (like rename or copy).
+ * Takes a current node path, a new name without directory, and the workspace
+ * root to return the absolute current path and the absolute new path.
+ */
+export function resolvePaths({
+  path,
+  name,
+  root,
+}: {
+  path: string;
+  name: string;
+  root: string;
+}) {
+  const pathBuilder = PathBuilder.guessDeliminator(root);
+  const currentPath = path as FilePath;
+  const parentPath = pathBuilder.dirname(currentPath);
+  const newPath = pathBuilder.join(parentPath, name);
+
+  const absoluteCurrentPath = Paths.isAbsolute(path)
+    ? path
+    : pathBuilder.join(root, currentPath);
+  const absoluteNewPath = Paths.isAbsolute(newPath)
+    ? newPath
+    : pathBuilder.join(root, newPath);
+
+  return { path: absoluteCurrentPath, newPath: absoluteNewPath };
 }


### PR DESCRIPTION
## 📝 Summary

Closes #6877 

This PR introduces direct notebook management capabilities (Rename, Duplicate, Delete) to the homepage file tree. Users can now manage their workspace files without opening the editor.

<img width="400" src="https://github.com/user-attachments/assets/68ccecb3-55bb-4731-84a5-81741f0b371e" />

https://github.com/user-attachments/assets/63a9bbee-ff61-43cc-87ed-500e27b3e2b3

## Changes

### 1. File Management Actions
- **Rename**: Inline renaming support.
- **Duplicate**: One-click notebook duplication (e.g., `notebook.py` -> `notebook_copy.py`).
- **Delete**: Deletion flow with a confirmation dialog.
- **Consistency**: All actions follow the same patterns as the existing file explorer.

### 2. UI/UX Improvements
- **Action Menus**: Introduced `FileActions` dropdown menus for each notebook node.
- **Safety Guards**: Implemented logic to disable destructive actions (Rename/Delete) for currently running notebooks.
- **Synchronized Updates**: Operations now trigger a simultaneous refresh of both the "Workspace" tree and the "Recent Notebooks" section.

### 3. Infrastructure & Utilities
- **Connection Handling**: Removed `waitForConnectionOpen` (WebSocket connection wait) from HTTP-based file API requests. This was necessary to prevent homepage file operations from being blocked when a kernel connection is not yet established.
- **Path Utilities**: Enhanced `pathUtils.ts` with `resolvePaths` for robust path resolution.
- **Testing**: Added unit tests for `resolvePaths`, including various path formats (Windows, absolute, relative).


## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
