### PR TITLE
fix: "Download as .py" in WASM run-mode exports

### DIFF
--- a/frontend/src/core/wasm/__tests__/bridge.test.ts
+++ b/frontend/src/core/wasm/__tests__/bridge.test.ts
@@ -1,0 +1,113 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockNotebookReadFile, rpcListeners } = vi.hoisted(() => ({
+  mockNotebookReadFile: vi.fn(),
+  rpcListeners: {} as Record<string, () => void>,
+}));
+
+// Mock browser globals before any imports
+vi.stubGlobal("crossOriginIsolated", false);
+vi.stubGlobal(
+  "Worker",
+  vi.fn(() => ({
+    addEventListener: vi.fn(),
+    postMessage: vi.fn(),
+    terminate: vi.fn(),
+  })),
+);
+
+class MockURL extends URL {
+  static override createObjectURL = vi.fn(() => "blob:mock-url");
+  static override revokeObjectURL = vi.fn();
+}
+vi.stubGlobal("URL", MockURL);
+
+vi.mock("@/core/wasm/rpc", () => ({
+  getWorkerRPC: () => ({
+    proxy: {
+      request: {
+        bridge: vi.fn(),
+        startSession: vi.fn(),
+        readFile: vi.fn(),
+        readNotebook: vi.fn(),
+        saveNotebook: vi.fn(),
+      },
+      send: { consumerReady: vi.fn() },
+    },
+    addMessageListener: (event: string, cb: () => void) => {
+      rpcListeners[event] = cb;
+    },
+  }),
+}));
+
+vi.mock("@/core/meta/globals", () => ({
+  getMarimoVersion: () => "0.0.0-test",
+}));
+
+vi.mock("@/core/wasm/utils", () => ({
+  isWasm: () => true,
+}));
+
+vi.mock("@/core/wasm/store", () => ({
+  fallbackFileStore: { readFile: vi.fn(), saveFile: vi.fn() },
+  notebookFileStore: { readFile: mockNotebookReadFile, saveFile: vi.fn() },
+}));
+
+// Import after all mocks are set up
+import { store } from "@/core/state/jotai";
+import { initialModeAtom } from "@/core/mode";
+import { PyodideBridge } from "../bridge";
+
+// Access INSTANCE once at module level so the constructor runs (and
+// addMessageListener populates rpcListeners) before any test executes.
+void PyodideBridge.INSTANCE;
+
+describe("PyodideBridge.readCode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    store.set(initialModeAtom, undefined);
+  });
+
+  it("reads from notebookFileStore in read mode", async () => {
+    store.set(initialModeAtom, "read");
+    // Trigger getSaveWorker — it reads the current mode and returns a stub
+    // whose readNotebook delegates to notebookFileStore.
+    rpcListeners.initialized();
+    mockNotebookReadFile.mockResolvedValue(
+      "import numpy as np\nprint(np.__version__)",
+    );
+
+    const result = await PyodideBridge.INSTANCE.readCode();
+
+    expect(result).toEqual({
+      contents: "import numpy as np\nprint(np.__version__)",
+    });
+    expect(mockNotebookReadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns empty string when notebookFileStore has no code in read mode", async () => {
+    store.set(initialModeAtom, "read");
+    rpcListeners.initialized();
+    mockNotebookReadFile.mockResolvedValue(null);
+
+    const result = await PyodideBridge.INSTANCE.readCode();
+
+    expect(result).toEqual({ contents: "" });
+  });
+
+  it("does not call notebookFileStore in edit mode", async () => {
+    store.set(initialModeAtom, "edit");
+    // getSaveWorker in edit mode creates a real worker (mocked); readNotebook
+    // goes to the RPC proxy, not notebookFileStore.
+    rpcListeners.initialized();
+
+    await PyodideBridge.INSTANCE.readCode();
+
+    expect(mockNotebookReadFile).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -67,10 +67,10 @@ export class PyodideBridge implements RunRequests, EditRequests {
 
   private getSaveWorker(): SaveWorker {
     if (getInitialAppMode() === "read") {
-      Logger.debug("Skipping SaveWorker in read-mode");
+      Logger.debug("Using partially disabled SaveWorker in read-mode");
       return {
         readFile: throwNotImplemented,
-        readNotebook: throwNotImplemented,
+        readNotebook: async () => (await notebookFileStore.readFile()) ?? "",
         saveNotebook: throwNotImplemented,
       };
     }


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

(I got a lot of help writing the test from Claude.)

When a notebook is exported with `marimo export html-wasm --mode run`, the resulting HTML embeds the notebook source in a `<marimo-code>` element, but the "Download as .py" menu item fails with "Failed to read code / Not implemented".

The reason is that `PyodideBridge.readCode()` calls `this.saveRpc.readNotebook()`.  In read mode, `getSaveWorker()` returns a stub where every method is `throwNotImplemented`, which is what causes that failure.

This PR fixes the problem by checking in `readCode` if the app mode is `"read"`, and if so it just reads the file from `domElementFileStore`.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [X] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (N/A).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [X] Video or media evidence is provided for any visual changes (optional).  (N/A). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [X] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
