### PR TITLE
fix: avoid double-mangling names inside walrus comprehension

### DIFF
--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -910,7 +910,10 @@ class ScopedVisitor(ast.NodeVisitor):
                     )
                     break
         else:
-            self.generic_visit(node)
+            # NB: only visit the target — value was already visited above.
+            # Calling generic_visit here would re-visit value, causing names
+            # inside it to be mangled twice (issue #9274).
+            self.visit(node.target)
         return node
 
     def visit_Name(self, node: ast.Name) -> ast.Name:

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -460,6 +460,28 @@ def test_walrus_with_comp_value_does_not_double_mangle() -> None:
     assert v.refs == {"items"}
 
 
+@pytest.mark.parametrize(
+    "code",
+    [
+        "if _x := [_y for _y in _things]: pass",
+        "print(_r := sum(n for n in _things))",
+        "if _x := {k: v for k, v in _things.items()}: pass",
+        "if _x := (lambda: _things): pass",
+    ],
+    ids=["listcomp", "genexp", "dictcomp", "lambda"],
+)
+def test_walrus_does_not_double_mangle_across_nested_scopes(
+    code: str,
+) -> None:
+    # The double-visit in visit_NamedExpr (issue #9274) affects any nested
+    # scope inside the walrus value, not only set comprehensions.
+    v = visitor.ScopedVisitor(mangle_prefix="cell_MJUe")
+    mod = ast.parse(code)
+    v.visit(mod)
+    unparsed = ast.unparse(mod)
+    assert "_cell_MJUe_cell_MJUe_" not in unparsed, unparsed
+
+
 def test_assignments_in_multiple_scopes() -> None:
     code = (
         "a = 0\ndef foo():\n  b = 0\n  c = 0\n  def bar():\n    d = 0\ne = 0"

--- a/tests/_ast/test_visitor.py
+++ b/tests/_ast/test_visitor.py
@@ -435,6 +435,31 @@ def test_walrus_in_comp_in_fn_block_does_not_leak_to_global() -> None:
     }
 
 
+def test_walrus_with_comp_value_does_not_double_mangle() -> None:
+    """Regression test for issue #9274.
+
+    When a walrus expression at module scope holds a comprehension as its
+    value, names inside the comprehension must be mangled once, not twice.
+    """
+    code = (
+        "for _key, _values in items.items():\n"
+        "    if _matches := {k for k, v in _values.items() if v > 1}:\n"
+        "        pass\n"
+    )
+    v = visitor.ScopedVisitor(mangle_prefix="cell_MJUe")
+    mod = ast.parse(code)
+    v.visit(mod)
+    unparsed = ast.unparse(mod)
+    assert "_cell_MJUe_cell_MJUe_values" not in unparsed
+    assert "_cell_MJUe_values.items()" in unparsed
+    assert v.defs == {
+        "_cell_MJUe_key",
+        "_cell_MJUe_values",
+        "_cell_MJUe_matches",
+    }
+    assert v.refs == {"items"}
+
+
 def test_assignments_in_multiple_scopes() -> None:
     code = (
         "a = 0\ndef foo():\n  b = 0\n  c = 0\n  def bar():\n    d = 0\ne = 0"


### PR DESCRIPTION
## 📝 Summary

Closes #9274

Walrus expressions at module scope that hold a comprehension as their value were having names inside the comprehension mangled twice, producing errors like:

```
NameError: name '_cell_MJUe_cell_MJUe_values' is not defined
```

### Root cause

In `visit_NamedExpr` (`marimo/_ast/visitor.py`), `node.value` was visited explicitly, and then — when the walrus was not inside a comprehension — `self.generic_visit(node)` was called, which visits **all** children of the node and therefore re-visited `node.value`. For a walrus whose value is a comprehension (e.g. `_matches := {k for k, v in _values.items() if v > 1}`), this entered the comprehension's scope twice. After #8762 extended private-name mangling to nested-scope lookups, the second visit re-mangled the already-mangled private name, producing the double prefix.

### Fix

In the non-comprehension branch of `visit_NamedExpr`, only visit `node.target` — the value was already visited earlier in the method.

### Reproduction (from the issue)

```python
items = {"a": {"x": 1, "y": 2}, "b": {"x": 3, "y": 4}}
for _key, _values in items.items():
    if _matches := {k for k, v in _values.items() if v > 1}:
        pass
```

Before: `NameError: name '_cell_XXX_cell_XXX_values' is not defined`. After: runs successfully.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
