### PR TITLE
Drop dangling @file URLs from the session cache

### DIFF
--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -790,6 +790,7 @@ def preview(file_path: Path, port: int, host: str, headless: bool) -> None:
         session_snapshot = serialize_session_view(
             session_view,
             cell_ids=list(file_manager.app.cell_manager.cell_ids()),
+            drop_virtual_file_outputs=False,
         )
 
         # Get notebook snapshot from file manager

--- a/marimo/_server/export/_session_cache.py
+++ b/marimo/_server/export/_session_cache.py
@@ -65,6 +65,7 @@ def serialize_session_snapshot(
         view,
         cell_ids=cell_ids,
         script_metadata_hash=get_script_metadata_hash(notebook_path),
+        drop_virtual_file_outputs=True,
     )
 
 

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -88,7 +88,9 @@ class Exporter:
 
         # Serialize notebook state
         session_snapshot = serialize_session_view(
-            session_view, cell_ids=app.cell_manager.cell_ids()
+            session_view,
+            cell_ids=app.cell_manager.cell_ids(),
+            drop_virtual_file_outputs=False,
         )
         notebook_snapshot = serialize_notebook(session_view, app.cell_manager)
 

--- a/marimo/_session/state/serialize.py
+++ b/marimo/_session/state/serialize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -52,6 +53,13 @@ if TYPE_CHECKING:
 LOGGER = _loggers.marimo_logger()
 
 
+# Matches the runtime's virtual-file URL shape: `./@file/<bytes>-<name>`
+# (see `marimo/_runtime/virtual_file/virtual_file.py`). Anchored to the
+# byte-length digits so a literal "./@file/" mention in user content
+# doesn't trip the check.
+_VIRTUAL_FILE_URL_RE = re.compile(r"\./@file/\d+-")
+
+
 def _references_virtual_file(data: Any) -> bool:
     """Return True if `data` references a virtual-file URL.
 
@@ -61,7 +69,7 @@ def _references_virtual_file(data: Any) -> bool:
     state — see #9273).
     """
     if isinstance(data, str):
-        return "./@file/" in data
+        return _VIRTUAL_FILE_URL_RE.search(data) is not None
     if isinstance(data, dict):
         return any(_references_virtual_file(v) for v in data.values())
     if isinstance(data, list):

--- a/marimo/_session/state/serialize.py
+++ b/marimo/_session/state/serialize.py
@@ -52,6 +52,23 @@ if TYPE_CHECKING:
 LOGGER = _loggers.marimo_logger()
 
 
+def _references_virtual_file(data: Any) -> bool:
+    """Return True if `data` references a virtual-file URL.
+
+    Virtual files (`./@file/<bytes>-<name>`) are backed by per-process
+    storage that disappears on kernel restart, so any cached output that
+    embeds one would 404 on replay (e.g. anywidget HTML losing its binary
+    state — see #9273).
+    """
+    if isinstance(data, str):
+        return "./@file/" in data
+    if isinstance(data, dict):
+        return any(_references_virtual_file(v) for v in data.values())
+    if isinstance(data, list):
+        return any(_references_virtual_file(v) for v in data)
+    return False
+
+
 def _normalize_error(error: MarimoError | dict[str, Any]) -> ErrorOutput:
     """Normalize error to consistent format."""
     if isinstance(error, dict):
@@ -80,6 +97,8 @@ def _normalize_error(error: MarimoError | dict[str, Any]) -> ErrorOutput:
 def serialize_session_view(
     view: SessionView,
     cell_ids: Iterable[CellId_t],
+    *,
+    drop_virtual_file_outputs: bool,
     script_metadata_hash: str | None = None,
 ) -> NotebookSessionV1:
     """Convert a SessionView to a NotebookSession schema.
@@ -88,6 +107,20 @@ def serialize_session_view(
     the NotebookSession schema (and only these cells will be saved to the
     schema). When not provided, this method attempts to recover the notebook
     order from the SessionView object, but this is not always possible.
+
+    `./@file/...` URLs are backed by per-process buffers, so
+    `drop_virtual_file_outputs` depends on where the snapshot will be
+    consumed:
+
+    - `True` when the snapshot will be replayed in a *different*
+      process from the one that produced it. The buffers are gone, so
+      surviving URLs would 404 on replay (#9273); dropping them leaves
+      the cell un-run until the kernel re-executes it. Used by the
+      on-disk session cache.
+    - `False` when the snapshot will be consumed in the *same* process
+      while buffers are still live, and the caller resolves the URLs
+      itself before they're released — e.g. HTML export inlining them
+      as `data:` URLs.
     """
     cells: list[Cell] = []
 
@@ -110,7 +143,10 @@ def serialize_session_view(
                     cell_notif.output.data,
                 ):
                     outputs.append(_normalize_error(error))
-            else:
+            elif not (
+                drop_virtual_file_outputs
+                and _references_virtual_file(cell_notif.output.data)
+            ):
                 outputs.append(
                     DataOutput(
                         type="data",
@@ -413,6 +449,7 @@ class SessionCacheWriter(AsyncBackgroundTask):
                         script_metadata_hash=_script_metadata_hash(
                             self.notebook_path
                         ),
+                        drop_virtual_file_outputs=True,
                     )
                     if isinstance(self.path, AsyncPath):
                         await self.path.write_text(json.dumps(data, indent=2))

--- a/tests/_session/state/test_serialize_session.py
+++ b/tests/_session/state/test_serialize_session.py
@@ -419,9 +419,93 @@ def test_session_round_trip_drops_dangling_virtual_file_urls(
     code_hash_to_cell_id = _build_code_hash_to_cell_id_mapping(serialized)
     restored = deserialize_session(serialized, code_hash_to_cell_id)
 
+    assert restored.cell_notifications[CELL1].output is None
+
+
+def test_session_round_trip_drops_nested_virtual_file_urls(
+    session_view: SessionView,
+):
+    # `_references_virtual_file` recurses through dicts and lists — a mime
+    # bundle where only one alternative carries the `./@file/` URL must
+    # still trigger the drop.
+    view = session_view
+    view.cell_notifications[CELL1] = _make_cell_notification(
+        CELL1,
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="application/vnd.marimo+mimebundle",
+            data={
+                "text/plain": "widget",
+                "text/html": '<img src="./@file/4-abcd1234.png">',
+            },
+        ),
+    )
+    view.last_executed_code[CELL1] = "widget"
+
+    serialized = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=True
+    )
+    code_hash_to_cell_id = _build_code_hash_to_cell_id_mapping(serialized)
+    restored = deserialize_session(serialized, code_hash_to_cell_id)
+
+    assert restored.cell_notifications[CELL1].output is None
+
+
+def test_drop_virtual_file_outputs_ignores_literal_prefix_in_text(
+    session_view: SessionView,
+):
+    # The check is anchored to the full URL shape (`./@file/<digits>-`),
+    # so plain text that happens to mention the prefix must not trigger
+    # the drop.
+    view = session_view
+    view.cell_notifications[CELL1] = _make_cell_notification(
+        CELL1,
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="text/plain",
+            data="marimo stores virtual files under ./@file/ on the server",
+        ),
+    )
+    view.last_executed_code[CELL1] = "print('docs')"
+
+    serialized = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=True
+    )
+    code_hash_to_cell_id = _build_code_hash_to_cell_id_mapping(serialized)
+    restored = deserialize_session(serialized, code_hash_to_cell_id)
+
     restored_output = restored.cell_notifications[CELL1].output
-    surviving = restored_output.data if restored_output is not None else ""
-    assert "./@file/" not in repr(surviving)
+    assert restored_output is not None
+    assert restored_output.data == (
+        "marimo stores virtual files under ./@file/ on the server"
+    )
+
+
+def test_drop_virtual_file_outputs_preserves_unrelated_outputs(
+    session_view: SessionView,
+):
+    # The drop is targeted: outputs without a virtual-file URL must pass
+    # through even when `drop_virtual_file_outputs=True`.
+    view = session_view
+    view.cell_notifications[CELL1] = _make_cell_notification(
+        CELL1,
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="text/html",
+            data="<b>Hello</b>",
+        ),
+    )
+    view.last_executed_code[CELL1] = "HTML('Hello')"
+
+    serialized = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=True
+    )
+    code_hash_to_cell_id = _build_code_hash_to_cell_id_mapping(serialized)
+    restored = deserialize_session(serialized, code_hash_to_cell_id)
+
+    restored_output = restored.cell_notifications[CELL1].output
+    assert restored_output is not None
+    assert restored_output.data == "<b>Hello</b>"
 
 
 def test_deserialize_basic_session():

--- a/tests/_session/state/test_serialize_session.py
+++ b/tests/_session/state/test_serialize_session.py
@@ -88,7 +88,9 @@ def test_serialize_basic_session(session_view: SessionView):
     )
     view.last_executed_code[CELL1] = "print('Hello, world!')"
 
-    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
+    result = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=False
+    )
     snapshot("basic_session.json", json.dumps(result, indent=2))
 
 
@@ -107,7 +109,9 @@ def test_serialize_session_with_error(session_view: SessionView):
         "raise RuntimeError('Something went wrong')"
     )
 
-    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
+    result = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=False
+    )
     snapshot("error_session.json", json.dumps(result, indent=2))
 
 
@@ -131,7 +135,9 @@ def test_serialize_session_with_console(session_view: SessionView):
     )
     view.last_executed_code[CELL1] = "print('test')"
 
-    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
+    result = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=False
+    )
     snapshot("console_session.json", json.dumps(result, indent=2))
 
 
@@ -151,7 +157,9 @@ def test_serialize_session_with_mime_bundle(session_view: SessionView):
     )
     view.last_executed_code[CELL1] = "HTML('Hello')"
 
-    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
+    result = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=False
+    )
     snapshot("mime_bundle_session.json", json.dumps(result, indent=2))
 
 
@@ -412,10 +420,10 @@ def test_session_round_trip_drops_dangling_virtual_file_urls(
     restored = deserialize_session(serialized, code_hash_to_cell_id)
 
     restored_output = restored.cell_notifications[CELL1].output
-    surviving = (
-        restored_output.data if restored_output is not None else ""
-    )
+    surviving = restored_output.data if restored_output is not None else ""
     assert "./@file/" not in repr(surviving)
+
+
 def test_deserialize_basic_session():
     """Test deserialization of a basic session"""
     session = NotebookSessionV1(
@@ -796,7 +804,9 @@ def test_serialize_session_with_dict_error():
         "raise RuntimeError('Something went wrong')"
     )
 
-    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
+    result = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=False
+    )
     assert len(result["cells"]) == 1
     assert len(result["cells"][0]["outputs"]) == 1
     assert result["cells"][0]["outputs"][0]["type"] == "error"
@@ -832,7 +842,9 @@ def test_serialize_session_with_mixed_error_formats(session_view: SessionView):
     )
     view.last_executed_code[CELL1] = "# code that causes mixed errors"
 
-    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
+    result = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=False
+    )
 
     # Verify the error normalization worked correctly
     assert len(result["cells"]) == 1
@@ -934,7 +946,9 @@ class TestSessionCacheManager:
             cache_file.parent.mkdir(parents=True)
 
             # Write cache file
-            data = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
+            data = serialize_session_view(
+                view, cell_ids=[CELL1], drop_virtual_file_outputs=False
+            )
             cache_file.write_text(json.dumps(data))
 
             # Read back
@@ -972,7 +986,9 @@ class TestSessionCacheManager:
             cache_file.parent.mkdir(parents=True)
 
             # Write cache file
-            data = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
+            data = serialize_session_view(
+                view, cell_ids=[CELL1], drop_virtual_file_outputs=False
+            )
             cache_file.write_text(json.dumps(data))
 
             # Read back

--- a/tests/_session/state/test_serialize_session.py
+++ b/tests/_session/state/test_serialize_session.py
@@ -88,7 +88,7 @@ def test_serialize_basic_session(session_view: SessionView):
     )
     view.last_executed_code[CELL1] = "print('Hello, world!')"
 
-    result = serialize_session_view(view, cell_ids=[CELL1])
+    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
     snapshot("basic_session.json", json.dumps(result, indent=2))
 
 
@@ -107,7 +107,7 @@ def test_serialize_session_with_error(session_view: SessionView):
         "raise RuntimeError('Something went wrong')"
     )
 
-    result = serialize_session_view(view, cell_ids=[CELL1])
+    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
     snapshot("error_session.json", json.dumps(result, indent=2))
 
 
@@ -131,7 +131,7 @@ def test_serialize_session_with_console(session_view: SessionView):
     )
     view.last_executed_code[CELL1] = "print('test')"
 
-    result = serialize_session_view(view, cell_ids=[CELL1])
+    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
     snapshot("console_session.json", json.dumps(result, indent=2))
 
 
@@ -151,7 +151,7 @@ def test_serialize_session_with_mime_bundle(session_view: SessionView):
     )
     view.last_executed_code[CELL1] = "HTML('Hello')"
 
-    result = serialize_session_view(view, cell_ids=[CELL1])
+    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
     snapshot("mime_bundle_session.json", json.dumps(result, indent=2))
 
 
@@ -382,20 +382,13 @@ def test_serialize_notebook_missing_cell_data(session_view: SessionView):
     assert cell["config"]["hide_code"] is None
 
 
-def test_session_round_trip_does_not_preserve_dangling_virtual_file_urls(
+def test_session_round_trip_drops_dangling_virtual_file_urls(
     session_view: SessionView,
 ):
-    """Cell-output HTML referencing `./@file/...` virtual files must not
-    survive a session-cache round-trip verbatim. After kernel restart the
-    backing buffers are gone, so any URL replayed into the frontend will
-    404 — anywidget initialization then fails for the restored cell.
-
-    Regression: https://github.com/marimo-team/marimo/issues/9273.
-
-    The fix may strip these references, replace them with data URLs, or
-    persist + re-register the buffers. Whichever approach lands, the
-    verbatim URL must not survive.
-    """
+    # Regression: https://github.com/marimo-team/marimo/issues/9273.
+    # A `./@file/...` URL in cached HTML output points at a per-process
+    # buffer that won't exist on the next kernel; the URL must not
+    # survive the on-disk cache round-trip.
     html = (
         '<marimo-anywidget data-name="Counter">'
         '<img src="./@file/4-abcd1234.png">'
@@ -412,19 +405,17 @@ def test_session_round_trip_does_not_preserve_dangling_virtual_file_urls(
     )
     view.last_executed_code[CELL1] = "widget"
 
-    serialized = serialize_session_view(view, cell_ids=[CELL1])
+    serialized = serialize_session_view(
+        view, cell_ids=[CELL1], drop_virtual_file_outputs=True
+    )
     code_hash_to_cell_id = _build_code_hash_to_cell_id_mapping(serialized)
     restored = deserialize_session(serialized, code_hash_to_cell_id)
 
     restored_output = restored.cell_notifications[CELL1].output
-    assert restored_output is not None
-    assert isinstance(restored_output.data, str)
-    assert "./@file/" not in restored_output.data, (
-        "Restored cell output preserved a virtual-file URL whose backing "
-        "buffer no longer exists after kernel restart."
+    surviving = (
+        restored_output.data if restored_output is not None else ""
     )
-
-
+    assert "./@file/" not in repr(surviving)
 def test_deserialize_basic_session():
     """Test deserialization of a basic session"""
     session = NotebookSessionV1(
@@ -805,7 +796,7 @@ def test_serialize_session_with_dict_error():
         "raise RuntimeError('Something went wrong')"
     )
 
-    result = serialize_session_view(view, cell_ids=[CELL1])
+    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
     assert len(result["cells"]) == 1
     assert len(result["cells"][0]["outputs"]) == 1
     assert result["cells"][0]["outputs"][0]["type"] == "error"
@@ -841,7 +832,7 @@ def test_serialize_session_with_mixed_error_formats(session_view: SessionView):
     )
     view.last_executed_code[CELL1] = "# code that causes mixed errors"
 
-    result = serialize_session_view(view, cell_ids=[CELL1])
+    result = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
 
     # Verify the error normalization worked correctly
     assert len(result["cells"]) == 1
@@ -943,7 +934,7 @@ class TestSessionCacheManager:
             cache_file.parent.mkdir(parents=True)
 
             # Write cache file
-            data = serialize_session_view(view, cell_ids=[CELL1])
+            data = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
             cache_file.write_text(json.dumps(data))
 
             # Read back
@@ -981,7 +972,7 @@ class TestSessionCacheManager:
             cache_file.parent.mkdir(parents=True)
 
             # Write cache file
-            data = serialize_session_view(view, cell_ids=[CELL1])
+            data = serialize_session_view(view, cell_ids=[CELL1], drop_virtual_file_outputs=False)
             cache_file.write_text(json.dumps(data))
 
             # Read back
@@ -1013,7 +1004,9 @@ class TestSessionCacheManager:
             cache_file.parent.mkdir(parents=True)
 
             # Write cache file
-            data = serialize_session_view(view, cell_ids=[id1, id2])
+            data = serialize_session_view(
+                view, cell_ids=[id1, id2], drop_virtual_file_outputs=False
+            )
             cache_file.write_text(json.dumps(data))
 
             # Read back
@@ -1047,7 +1040,10 @@ class TestSessionCacheManager:
             cache_file.parent.mkdir(parents=True)
 
             data = serialize_session_view(
-                view, cell_ids=[id1, id2], script_metadata_hash="old"
+                view,
+                cell_ids=[id1, id2],
+                script_metadata_hash="old",
+                drop_virtual_file_outputs=False,
             )
             cache_file.write_text(json.dumps(data))
 
@@ -1093,7 +1089,9 @@ class TestSessionCacheManager:
             cache_file.parent.mkdir(parents=True)
 
             # Write cache file
-            data = serialize_session_view(view, cell_ids=[CELL1, CELL2])
+            data = serialize_session_view(
+                view, cell_ids=[CELL1, CELL2], drop_virtual_file_outputs=False
+            )
             cache_file.write_text(json.dumps(data))
 
             # Read back

--- a/tests/_session/state/test_serialize_session.py
+++ b/tests/_session/state/test_serialize_session.py
@@ -382,6 +382,49 @@ def test_serialize_notebook_missing_cell_data(session_view: SessionView):
     assert cell["config"]["hide_code"] is None
 
 
+def test_session_round_trip_does_not_preserve_dangling_virtual_file_urls(
+    session_view: SessionView,
+):
+    """Cell-output HTML referencing `./@file/...` virtual files must not
+    survive a session-cache round-trip verbatim. After kernel restart the
+    backing buffers are gone, so any URL replayed into the frontend will
+    404 — anywidget initialization then fails for the restored cell.
+
+    Regression: https://github.com/marimo-team/marimo/issues/9273.
+
+    The fix may strip these references, replace them with data URLs, or
+    persist + re-register the buffers. Whichever approach lands, the
+    verbatim URL must not survive.
+    """
+    html = (
+        '<marimo-anywidget data-name="Counter">'
+        '<img src="./@file/4-abcd1234.png">'
+        "</marimo-anywidget>"
+    )
+    view = session_view
+    view.cell_notifications[CELL1] = _make_cell_notification(
+        CELL1,
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="text/html",
+            data=html,
+        ),
+    )
+    view.last_executed_code[CELL1] = "widget"
+
+    serialized = serialize_session_view(view, cell_ids=[CELL1])
+    code_hash_to_cell_id = _build_code_hash_to_cell_id_mapping(serialized)
+    restored = deserialize_session(serialized, code_hash_to_cell_id)
+
+    restored_output = restored.cell_notifications[CELL1].output
+    assert restored_output is not None
+    assert isinstance(restored_output.data, str)
+    assert "./@file/" not in restored_output.data, (
+        "Restored cell output preserved a virtual-file URL whose backing "
+        "buffer no longer exists after kernel restart."
+    )
+
+
 def test_deserialize_basic_session():
     """Test deserialization of a basic session"""
     session = NotebookSessionV1(

--- a/tests/_session/state/test_serialize_session_missing_type.py
+++ b/tests/_session/state/test_serialize_session_missing_type.py
@@ -29,7 +29,9 @@ def test_serialize_session_with_dict_error_missing_type():
         "raise RuntimeError('Something went wrong')"
     )
 
-    result = serialize_session_view(view, cell_ids=[CELL_ID])
+    result = serialize_session_view(
+        view, cell_ids=[CELL_ID], drop_virtual_file_outputs=False
+    )
     assert len(result["cells"]) == 1
     assert len(result["cells"][0]["outputs"]) == 1
     assert result["cells"][0]["outputs"][0]["type"] == "error"


### PR DESCRIPTION
Fixes #9273

The `./@file/...` URLs are backed by per-process buffers, so a cached snapshot replayed after kernel restart points at storage that no longer exists and the asset endpoint 404s (anywidget initialization for the restored cell then fails).

`serialize_session_view` now takes a required `drop_virtual_file_outputs` keyword so each consumer picks deliberately based on whether the snapshot will be replayed in the same process as the producer. The on-disk cache passes `True` (cell appears un-run on restore, kernel re-emits a fresh output); HTML export and the static preview pass `False` and inline the buffers themselves while they're still live.
