### PR TITLE
ci(test_be): use uv-managed Python instead of setup-python

### DIFF
--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -149,8 +149,14 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for git diff
 
+      # Use uv's managed Python rather than the hostedtoolcache build from
+      # actions/setup-python: the hostedtoolcache interpreter has ABI quirks
+      # that caused numpy/matplotlib lazy submodule imports to fail on CI.
       - name: 🐍 Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
 
       # This step is needed since some of our tests rely on the index.html file
       - name: Create assets directory, copy over index.html
@@ -158,11 +164,6 @@ jobs:
           mkdir -p marimo/_static/assets
           cp frontend/index.html marimo/_static/index.html
           cp frontend/public/favicon.ico marimo/_static/favicon.ico
-
-      # Required since python3.14 not pulled automatically for now.
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: ${{ matrix.python-version }}
 
       # Setup test flags based on conditions
       - name: Setup test flags
@@ -202,6 +203,7 @@ jobs:
       - name: Test changed with base dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |
+          uv sync --python ${{ matrix.python-version }} --group test
           uv run --python ${{ matrix.python-version }} --group test pytest tests/ \
             -v \
             ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
@@ -218,6 +220,7 @@ jobs:
       - name: Test changed with optional dependencies
         if: ${{ matrix.dependencies == 'core,optional' }}
         run: |
+          uv sync --python ${{ matrix.python-version }} --group test-optional
           uv run --python ${{ matrix.python-version }} --group test-optional pytest tests/ \
             -v \
             ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
@@ -236,6 +239,7 @@ jobs:
       - name: Test with minimal dependencies (lowest resolution)
         if: ${{ matrix.dependencies == 'minimal' }}
         run: |
+          uv sync --python ${{ matrix.python-version }} --group test
           uv run --python ${{ matrix.python-version }} --group test pytest tests/ \
             -v \
             ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -203,7 +203,6 @@ jobs:
       - name: Test changed with base dependencies
         if: ${{ matrix.dependencies == 'core' }}
         run: |
-          uv sync --python ${{ matrix.python-version }} --group test
           uv run --python ${{ matrix.python-version }} --group test pytest tests/ \
             -v \
             ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
@@ -220,7 +219,6 @@ jobs:
       - name: Test changed with optional dependencies
         if: ${{ matrix.dependencies == 'core,optional' }}
         run: |
-          uv sync --python ${{ matrix.python-version }} --group test-optional
           uv run --python ${{ matrix.python-version }} --group test-optional pytest tests/ \
             -v \
             ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
@@ -239,7 +237,6 @@ jobs:
       - name: Test with minimal dependencies (lowest resolution)
         if: ${{ matrix.dependencies == 'minimal' }}
         run: |
-          uv sync --python ${{ matrix.python-version }} --group test
           uv run --python ${{ matrix.python-version }} --group test pytest tests/ \
             -v \
             ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \

--- a/packages/pytest_changed/__init__.py
+++ b/packages/pytest_changed/__init__.py
@@ -272,7 +272,11 @@ def pytest_configure(config: pytest.Config) -> None:
 
     if not changed_files:
         print_(f"No Python files changed from {changed_from}")
-        config.option.changed_test_files = set()
+        if config.getoption("include_unchanged"):
+            print_("--include-unchanged set - running all tests")
+            config.option.changed_test_files = None
+        else:
+            config.option.changed_test_files = set()
         return
 
     print_(

--- a/packages/pytest_changed/__init__.py
+++ b/packages/pytest_changed/__init__.py
@@ -253,6 +253,13 @@ def pytest_configure(config: pytest.Config) -> None:
         pytest.exit("Not in a git repository", returncode=1)
         raise UnreachableError("Not in a git repository") from e
 
+    # When --include-unchanged is set, we always run all tests, so skip the
+    # (expensive) changed-file detection and dependency-graph analysis.
+    if config.getoption("include_unchanged"):
+        print_("--include-unchanged set - running all tests")
+        config.option.changed_test_files = None
+        return
+
     # Get test base directory from args or fall back to repo root
     test_base = get_test_base(config, repo_root)
 
@@ -272,11 +279,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
     if not changed_files:
         print_(f"No Python files changed from {changed_from}")
-        if config.getoption("include_unchanged"):
-            print_("--include-unchanged set - running all tests")
-            config.option.changed_test_files = None
-        else:
-            config.option.changed_test_files = set()
+        config.option.changed_test_files = set()
         return
 
     print_(


### PR DESCRIPTION
The hostedtoolcache interpreter from actions/setup-python has ABI quirks that caused lazy submodule imports (numpy.random, numpy.testing, matplotlib.backends.backend_svg/backend_webagg_core) to raise ModuleNotFoundError on CI despite loading fine locally. It also caused test_acts_as_test to fail with "No module named pytest" because sys.executable pointed outside the project venv.

Switch to `uv python install` so the matrix interpreter comes from uv's managed builds (python-build-standalone), and add an explicit `uv sync --group <group>` before each pytest run so the project venv is the source of truth for subprocesses.

3.14 is now in uv's managed Python catalog, so we no longer have to use the hostedtoolcache interpreter.

This PR also fixes a bug in the pytest-changed plugin which was preventing the `test-all` label from doing its job.