### PR TITLE
tests: save and restore main for islands tests

### DIFF
--- a/tests/_islands/test_island_generator.py
+++ b/tests/_islands/test_island_generator.py
@@ -10,6 +10,7 @@ from marimo._islands._island_generator import (
     MarimoIslandGenerator,
 )
 from tests.mocks import snapshotter
+from tests.utils import save_and_restore_main
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -25,6 +26,7 @@ def test_add_code():
     assert len(list(generator._app.cell_manager.cells())) == 1
 
 
+@save_and_restore_main
 async def test_build():
     generator = MarimoIslandGenerator()
     generator.add_code("print('Hello, World!')")
@@ -39,6 +41,7 @@ async def test_build():
         await generator.build()
 
 
+@save_and_restore_main
 async def test_render():
     generator = MarimoIslandGenerator()
     block1 = generator.add_code("import marimo as mo")
@@ -77,6 +80,7 @@ async def test_render():
     )
 
 
+@save_and_restore_main
 async def test_render_multiline_markdown():
     generator = MarimoIslandGenerator()
     stub = generator.add_code(
@@ -105,6 +109,7 @@ async def test_render_multiline_markdown():
     snapshot("markdown.txt", stub.render())
 
 
+@save_and_restore_main
 async def test_from_file(tmp_path: Path):
     # Create a temporary marimo file
     marimo_file = tmp_path / "temp_marimo_file.py"

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -2,19 +2,17 @@
 from __future__ import annotations
 
 import asyncio
-import functools
 import inspect
 import os
 import queue
 import sys
 import threading
 import time
-from collections.abc import Callable
 from multiprocessing.queues import Queue as MPQueue
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
-from typing import Any, TypeVar
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -55,10 +53,9 @@ from marimo._session.session import (
 from marimo._session.state.session_view import SessionView
 from marimo._types.ids import ConsumerId, SessionId
 from marimo._utils.marimo_path import MarimoPath
+from tests.utils import save_and_restore_main
 
 initialize_asyncio()
-
-F = TypeVar("F", bound=Callable[..., Any])
 
 app_metadata = AppMetadata(
     query_params={"some_param": "some_value"},
@@ -88,25 +85,6 @@ class MockSessionConsumer(SessionConsumer):
 
     def notify(self, notification: KernelMessage) -> None:
         self.notify_calls.append(deserialize_kernel_message(notification))
-
-
-# TODO(akshayka): automatically do this for every test in our test suite
-def save_and_restore_main(f: F) -> F:
-    """Kernels swap out the main module; restore it after running tests"""
-
-    @functools.wraps(f)
-    def wrapper(*args: Any, **kwargs: Any) -> None:
-        main = sys.modules["__main__"]
-        try:
-            res = f(*args, **kwargs)
-            if asyncio.iscoroutine(res):
-                asyncio.run(res)
-            else:
-                pass
-        finally:
-            sys.modules["__main__"] = main
-
-    return wrapper  # type: ignore
 
 
 session_id = SessionId("test")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+import functools
 import inspect
+import sys
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from marimo._messaging.msgspec_encoder import (
     asdict,
@@ -14,6 +17,25 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     import msgspec
+
+F = TypeVar("F", bound="Callable[..., Any]")
+
+
+# TODO(akshayka): automatically do this for every test in our test suite
+def save_and_restore_main(f: F) -> F:
+    """Kernels swap out the main module; restore it after running tests."""
+
+    @functools.wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> None:
+        main = sys.modules["__main__"]
+        try:
+            res = f(*args, **kwargs)
+            if asyncio.iscoroutine(res):
+                asyncio.run(res)
+        finally:
+            sys.modules["__main__"] = main
+
+    return wrapper  # type: ignore
 
 
 def try_assert_n_times(n: int, assert_fn: Callable[[], None]) -> None:


### PR DESCRIPTION
Unit tests that exercise multiprocessing typically need to save and restore main. This change applies our save-and-restore-main utility to islands tests to fix CI (`test_build` and `test_render` are failing without this change.)

In a follow-up change I will attempt applying the utility globally.