### PR TITLE
log error on kernel failure to connect

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3598,18 +3598,29 @@ def launch_kernel(
     pipe: TypedConnection[KernelMessage] | None = None
     if socket_addr is not None:
         n_tries = 0
+        last_error: BaseException | None = None
         while n_tries < 100:
             try:
                 pipe = TypedConnection[KernelMessage].of(
                     connection.Client(socket_addr)
                 )
                 break
-            except Exception:
+            except Exception as e:
+                last_error = e
                 n_tries += 1
                 time.sleep(0.01)
 
         if n_tries == 100 or pipe is None:
-            LOGGER.debug("Failed to connect to socket.")
+            # Parent is blocked in listener.accept() with no timeout; if we
+            # return silently the parent hangs forever. Log the cause so the
+            # next failure is diagnosable instead of opaque.
+            LOGGER.error(
+                "marimo kernel subprocess failed to connect to %s "
+                "after %d attempts",
+                socket_addr,
+                n_tries,
+                exc_info=last_error,
+            )
             return
 
         stream = ThreadSafeStream(

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -3611,9 +3611,10 @@ def launch_kernel(
                 time.sleep(0.01)
 
         if n_tries == 100 or pipe is None:
-            # Parent is blocked in listener.accept() with no timeout; if we
-            # return silently the parent hangs forever. Log the cause so the
-            # next failure is diagnosable instead of opaque.
+            # The parent may still be waiting for this subprocess to connect,
+            # but startup now watches kernel liveness and will abort if the
+            # kernel exits. Log the cause so the failure is diagnosable
+            # instead of opaque.
             LOGGER.error(
                 "marimo kernel subprocess failed to connect to %s "
                 "after %d attempts",

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -154,11 +154,39 @@ class KernelManagerImpl(KernelManager):
 
         self.kernel_task.start()  # type: ignore
         if listener is not None:
-            # First thing kernel does is connect to the socket, so it's safe to
-            # call accept
-            self._read_conn = TypedConnection[KernelMessage].of(
-                listener.accept()
+            # Listener.accept() has no timeout. Run it on a helper thread so
+            # the main path can watchdog kernel_task liveness; otherwise a
+            # child that dies before connecting leaves us blocked forever.
+            result: dict[str, Any] = {}
+
+            def _accept() -> None:
+                try:
+                    result["conn"] = listener.accept()
+                except BaseException as e:
+                    result["error"] = e
+
+            accept_thread = threading.Thread(
+                target=_accept, name="kernel-accept", daemon=True
             )
+            accept_thread.start()
+            while True:
+                accept_thread.join(timeout=0.5)
+                if not accept_thread.is_alive():
+                    break
+                if not self.kernel_task.is_alive():  # type: ignore[attr-defined]
+                    # Closing the listener unblocks accept() in the helper
+                    # thread so it can exit cleanly instead of leaking.
+                    listener.close()
+                    accept_thread.join(timeout=1.0)
+                    raise RuntimeError(
+                        "marimo kernel subprocess exited before "
+                        "connecting (exitcode="
+                        f"{getattr(self.kernel_task, 'exitcode', None)})"
+                        "; check subprocess stderr for the cause"
+                    )
+            if "error" in result:
+                raise result["error"]
+            self._read_conn = TypedConnection[KernelMessage].of(result["conn"])
 
     @property
     def pid(self) -> int | None:

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -162,7 +162,7 @@ class KernelManagerImpl(KernelManager):
             def _accept() -> None:
                 try:
                     result["conn"] = listener.accept()
-                except BaseException as e:
+                except Exception as e:
                     result["error"] = e
 
             accept_thread = threading.Thread(


### PR DESCRIPTION
In the kernel, when we fail to connect to the server, emit an error log. In the server, add liveness checks to kernel connection, and bail out if we detect the kernel process died. 