### PR TITLE
split test_be into multiple jobs, one per OS

### DIFF
--- a/.github/actions/test-python/action.yaml
+++ b/.github/actions/test-python/action.yaml
@@ -1,0 +1,123 @@
+name: Test Python
+description: Run the marimo Python test suite for a given Python version and dependency set. Assumes the repo has already been checked out.
+
+inputs:
+  os:
+    description: Runner OS (ubuntu-latest, macos-latest, or windows-latest). Used to disable pytest-xdist on Windows.
+    required: true
+  python-version:
+    description: Python version to test against.
+    required: true
+  dependencies:
+    description: Dependency group — "core", "core,optional", or "minimal".
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Use uv's managed Python rather than the hostedtoolcache build from
+    # actions/setup-python: the hostedtoolcache interpreter has ABI quirks
+    # that caused numpy/matplotlib lazy submodule imports to fail on CI.
+    - name: 🐍 Setup uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      with:
+        python-version: ${{ inputs.python-version }}
+        enable-cache: true
+
+    # This step is needed since some of our tests rely on the index.html file
+    - name: Create assets directory, copy over index.html
+      shell: bash
+      run: |
+        mkdir -p marimo/_static/assets
+        cp frontend/index.html marimo/_static/index.html
+        cp frontend/public/favicon.ico marimo/_static/favicon.ico
+
+    # Setup test flags based on conditions
+    - name: Setup test flags
+      id: setup-flags
+      shell: bash
+      run: |
+        # Set CHANGED_FROM: On PRs, compare against base branch; on main, compare against HEAD~1
+        CHANGED_FROM="${{ github.base_ref && format('origin/{0}', github.base_ref) || 'HEAD~1' }}"
+        echo "changed_from=$CHANGED_FROM"
+        echo "changed_from=$CHANGED_FROM" >> $GITHUB_OUTPUT
+
+        # Set INCLUDE_UNCHANGED: true if test-all label, python 3.13 + optional deps, or main branch
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'test-all') }}" == "true" ]] || \
+           [[ "${{ inputs.python-version }}" == "3.13" && "${{ inputs.dependencies }}" == "core,optional" ]] || \
+           [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          echo "include_unchanged=true"
+          echo "include_unchanged=true" >> $GITHUB_OUTPUT
+        else
+          echo "include_unchanged=false"
+          echo "include_unchanged=false" >> $GITHUB_OUTPUT
+        fi
+
+    # Test with base dependencies
+    # Exit code 5 = no tests collected (e.g. only CLI test files changed);
+    # treat that as success since CLI tests run in a separate workflow.
+    #
+    # TODO: xdist is disabled on Windows because several tests
+    # crash workers. Fix and re-enable. Failing tests:
+    #   - tests/_islands/test_island_generator.py::test_build
+    #   - tests/_islands/test_island_generator.py::test_render
+    #   - tests/_islands/test_island_generator.py::test_render_multiline_markdown
+    #   - tests/_messaging/test_streams.py::test_import_multiprocessing
+    #   - tests/_server/api/endpoints/test_ai.py::TestOpenAiEndpoints::test_completion_without_token
+    #   - tests/_server/test_session_manager.py::test_create_session_new
+    #   - tests/_server/test_session_manager.py::test_create_session_absolute_url
+    #   - tests/_server/test_session_manager.py::test_create_session_with_script_config_overrides
+    #   - tests/_server/test_session_manager.py::test_recents_touch_called_on_session_create
+    - name: Test changed with base dependencies
+      if: ${{ inputs.dependencies == 'core' }}
+      shell: bash
+      run: |
+        uv run --python ${{ inputs.python-version }} --group test pytest tests/ \
+          -v \
+          ${{ inputs.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
+          -k "not test_cli" \
+          --durations=10 \
+          -p packages.pytest_changed \
+          --changed-from=${{ steps.setup-flags.outputs.changed_from }} \
+          --include-unchanged=${{ steps.setup-flags.outputs.include_unchanged }} \
+          --picked=first \
+          --inline-snapshot=disable \
+        || { ec=$?; [ $ec -eq 5 ] && exit 0 || exit $ec; }
+
+    # Test with optional dependencies
+    - name: Test changed with optional dependencies
+      if: ${{ inputs.dependencies == 'core,optional' }}
+      shell: bash
+      run: |
+        uv run --python ${{ inputs.python-version }} --group test-optional pytest tests/ \
+          -v \
+          ${{ inputs.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
+          -k "not test_cli" \
+          --durations=10 \
+          -p packages.pytest_changed \
+          --changed-from=${{ steps.setup-flags.outputs.changed_from }} \
+          --include-unchanged=${{ steps.setup-flags.outputs.include_unchanged }} \
+          --picked=first \
+          --inline-snapshot=disable \
+        || { ec=$?; [ $ec -eq 5 ] && exit 0 || exit $ec; }
+
+    # Test with minimal dependencies using lowest resolution
+    # https://docs.astral.sh/uv/concepts/resolution/#lowest-resolution
+    # https://docs.astral.sh/uv/reference/environment/#uv_resolution
+    - name: Test with minimal dependencies (lowest resolution)
+      if: ${{ inputs.dependencies == 'minimal' }}
+      shell: bash
+      env:
+        UV_RESOLUTION: lowest-direct
+      run: |
+        uv run --python ${{ inputs.python-version }} --group test pytest tests/ \
+          -v \
+          ${{ inputs.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
+          -k "not test_cli" \
+          --durations=10 \
+          -p packages.pytest_changed \
+          --changed-from=${{ steps.setup-flags.outputs.changed_from }} \
+          --include-unchanged=${{ steps.setup-flags.outputs.include_unchanged }} \
+          --picked=first \
+          --inline-snapshot=disable \
+        || { ec=$?; [ $ec -eq 5 ] && exit 0 || exit $ec; }

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -100,156 +100,87 @@ jobs:
 
   # For PRs, we only run the tests for the changed files.
   # If there is a `test-all` label, we run the tests across unchanged files as well.
-  test_python:
+  #
+  # Split by OS so that a failure on one runner does not cancel sibling jobs on
+  # other runners (each job has its own matrix and therefore its own fail-fast
+  # scope). Within a single OS, the default fail-fast behavior is preserved.
+  test_python_ubuntu:
     needs: changes
     if: ${{ needs.changes.outputs.backend == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test-all')) }}
-    name: ${{ matrix.os }} / Py ${{ matrix.python-version }} / ${{ matrix.dependencies }} deps
-    runs-on: ${{ matrix.os }}
+    name: ubuntu-latest / Py ${{ matrix.python-version }} / ${{ matrix.dependencies }} deps
+    runs-on: ubuntu-latest
     timeout-minutes: 25
-    defaults:
-      run:
-        shell: bash
-
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        dependencies: ["core", "core,optional"]
         python-version: ["3.10"]
+        dependencies: ["core", "core,optional"]
         include:
-          - os: ubuntu-latest
-            python-version: "3.10"
+          - python-version: "3.10"
             dependencies: "minimal"
-          - os: ubuntu-latest
-            python-version: "3.11"
+          - python-version: "3.11"
             dependencies: "core"
-          - os: ubuntu-latest
-            python-version: "3.12"
+          - python-version: "3.12"
             dependencies: "core"
-          - os: ubuntu-latest
-            python-version: "3.13"
+          - python-version: "3.13"
             dependencies: "core"
-          - os: ubuntu-latest
-            python-version: "3.14"
+          - python-version: "3.14"
             dependencies: "core"
-          - os: ubuntu-latest
-            python-version: "3.10"
+          - python-version: "3.11"
             dependencies: "core,optional"
-          - os: ubuntu-latest
-            python-version: "3.11"
+          - python-version: "3.12"
             dependencies: "core,optional"
-          - os: ubuntu-latest
-            python-version: "3.12"
-            dependencies: "core,optional"
-          - os: ubuntu-latest
-            python-version: "3.13"
+          - python-version: "3.13"
             dependencies: "core,optional"
           # TODO: Add in 3.14 optional once there is broader wheel support
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # Fetch all history for git diff
-
-      # Use uv's managed Python rather than the hostedtoolcache build from
-      # actions/setup-python: the hostedtoolcache interpreter has ABI quirks
-      # that caused numpy/matplotlib lazy submodule imports to fail on CI.
-      - name: 🐍 Setup uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: ./.github/actions/test-python
         with:
+          os: ubuntu-latest
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
+          dependencies: ${{ matrix.dependencies }}
 
-      # This step is needed since some of our tests rely on the index.html file
-      - name: Create assets directory, copy over index.html
-        run: |
-          mkdir -p marimo/_static/assets
-          cp frontend/index.html marimo/_static/index.html
-          cp frontend/public/favicon.ico marimo/_static/favicon.ico
+  test_python_macos:
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test-all')) }}
+    name: macos-latest / Py ${{ matrix.python-version }} / ${{ matrix.dependencies }} deps
+    runs-on: macos-latest
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+        dependencies: ["core", "core,optional"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # Fetch all history for git diff
+      - uses: ./.github/actions/test-python
+        with:
+          os: macos-latest
+          python-version: ${{ matrix.python-version }}
+          dependencies: ${{ matrix.dependencies }}
 
-      # Setup test flags based on conditions
-      - name: Setup test flags
-        id: setup-flags
-        run: |
-          # Set CHANGED_FROM: On PRs, compare against base branch; on main, compare against HEAD~1
-          CHANGED_FROM="${{ github.base_ref && format('origin/{0}', github.base_ref) || 'HEAD~1' }}"
-          echo "changed_from=$CHANGED_FROM"
-          echo "changed_from=$CHANGED_FROM" >> $GITHUB_OUTPUT
-
-          # Set INCLUDE_UNCHANGED: true if test-all label, python 3.13 + optional deps, or main branch
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'test-all') }}" == "true" ]] || \
-             [[ "${{ matrix.python-version }}" == "3.13" && "${{ matrix.dependencies }}" == "core,optional" ]] || \
-             [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "include_unchanged=true"
-            echo "include_unchanged=true" >> $GITHUB_OUTPUT
-          else
-            echo "include_unchanged=false"
-            echo "include_unchanged=false" >> $GITHUB_OUTPUT
-          fi
-
-      # Test with base dependencies
-      # Exit code 5 = no tests collected (e.g. only CLI test files changed);
-      # treat that as success since CLI tests run in a separate workflow.
-      #
-      # TODO: xdist is disabled on Windows because several tests
-      # crash workers. Fix and re-enable. Failing tests:
-      #   - tests/_islands/test_island_generator.py::test_build
-      #   - tests/_islands/test_island_generator.py::test_render
-      #   - tests/_islands/test_island_generator.py::test_render_multiline_markdown
-      #   - tests/_messaging/test_streams.py::test_import_multiprocessing
-      #   - tests/_server/api/endpoints/test_ai.py::TestOpenAiEndpoints::test_completion_without_token
-      #   - tests/_server/test_session_manager.py::test_create_session_new
-      #   - tests/_server/test_session_manager.py::test_create_session_absolute_url
-      #   - tests/_server/test_session_manager.py::test_create_session_with_script_config_overrides
-      #   - tests/_server/test_session_manager.py::test_recents_touch_called_on_session_create
-      - name: Test changed with base dependencies
-        if: ${{ matrix.dependencies == 'core' }}
-        run: |
-          uv run --python ${{ matrix.python-version }} --group test pytest tests/ \
-            -v \
-            ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
-            -k "not test_cli" \
-            --durations=10 \
-            -p packages.pytest_changed \
-            --changed-from=${{ steps.setup-flags.outputs.changed_from }} \
-            --include-unchanged=${{ steps.setup-flags.outputs.include_unchanged }} \
-            --picked=first \
-            --inline-snapshot=disable \
-          || { ec=$?; [ $ec -eq 5 ] && exit 0 || exit $ec; }
-
-      # Test with optional dependencies
-      - name: Test changed with optional dependencies
-        if: ${{ matrix.dependencies == 'core,optional' }}
-        run: |
-          uv run --python ${{ matrix.python-version }} --group test-optional pytest tests/ \
-            -v \
-            ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
-            -k "not test_cli" \
-            --durations=10 \
-            -p packages.pytest_changed \
-            --changed-from=${{ steps.setup-flags.outputs.changed_from }} \
-            --include-unchanged=${{ steps.setup-flags.outputs.include_unchanged }} \
-            --picked=first \
-            --inline-snapshot=disable \
-          || { ec=$?; [ $ec -eq 5 ] && exit 0 || exit $ec; }
-
-      # Test with minimal dependencies using lowest resolution
-      # https://docs.astral.sh/uv/concepts/resolution/#lowest-resolution
-      # https://docs.astral.sh/uv/reference/environment/#uv_resolution
-      - name: Test with minimal dependencies (lowest resolution)
-        if: ${{ matrix.dependencies == 'minimal' }}
-        run: |
-          uv run --python ${{ matrix.python-version }} --group test pytest tests/ \
-            -v \
-            ${{ matrix.os != 'windows-latest' && '-n auto' || '-p no:xdist' }} \
-            -k "not test_cli" \
-            --durations=10 \
-            -p packages.pytest_changed \
-            --changed-from=${{ steps.setup-flags.outputs.changed_from }} \
-            --include-unchanged=${{ steps.setup-flags.outputs.include_unchanged }} \
-            --picked=first \
-            --inline-snapshot=disable \
-          || { ec=$?; [ $ec -eq 5 ] && exit 0 || exit $ec; }
-        env:
-          UV_RESOLUTION: lowest-direct
+  test_python_windows:
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'test-all')) }}
+    name: windows-latest / Py ${{ matrix.python-version }} / ${{ matrix.dependencies }} deps
+    runs-on: windows-latest
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+        dependencies: ["core", "core,optional"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # Fetch all history for git diff
+      - uses: ./.github/actions/test-python
+        with:
+          os: windows-latest
+          python-version: ${{ matrix.python-version }}
+          dependencies: ${{ matrix.dependencies }}
 
   # Only run coverage on `main` so it is not blocking
   test_coverage:


### PR DESCRIPTION
Today's test_python job uses a single matrix across ubuntu, macos, and windows with GitHub's default fail-fast: true. A single test failure on any runner cancels every other matrix entry, so a flaky Windows test wipes out in-flight Ubuntu and macOS runs that have nothing to do with the failure, forcing a full re-run.

Split test_python into test_python_ubuntu, test_python_macos, and test_python_windows, each with its own matrix. fail-fast now scopes per OS: sibling entries on the same OS still cancel (preserving the cost-saving behavior), but other OSes continue independently.

The per-entry steps (setup-uv, assets, flag-computation, pytest invocations) are factored into a new composite action at .github/actions/test-python to avoid duplicating ~100 lines of yaml across the three jobs. Matches the existing composite-action pattern used by install, build-frontend, and pr-comment-on-failure.

The workflow-level concurrency block is unchanged and continues to cancel stale runs on fresh pushes as before.