### PR TITLE
ci: add .venv diagnostic for ubuntu/3.11/core imports

### DIFF
--- a/.github/actions/test-python/action.yaml
+++ b/.github/actions/test-python/action.yaml
@@ -24,56 +24,6 @@ runs:
         python-version: ${{ inputs.python-version }}
         enable-cache: true
 
-    # Diagnostic for the "ModuleNotFoundError: No module named
-    # 'numpy.random' / 'matplotlib.backends.*'" and FileNotFoundError:
-    # '.venv/bin/pytest' failures specific to Ubuntu core-dep runs.
-    # Gated to one representative matrix entry to keep output focused.
-    # Remove once the failures are understood and fixed.
-    - name: Diagnose venv contents
-      if: ${{ inputs.os == 'ubuntu-latest' && inputs.python-version == '3.11' && inputs.dependencies == 'core' }}
-      shell: bash
-      run: |
-        uv sync --python ${{ inputs.python-version }} --group test
-        SP=$(.venv/bin/python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
-
-        echo "=== .venv/bin/ entries ==="
-        ls -la .venv/bin/
-        echo
-        echo "=== .venv/bin/pytest exists? ==="
-        if [ -e .venv/bin/pytest ]; then
-          echo "YES"
-          file .venv/bin/pytest
-          head -3 .venv/bin/pytest || true
-        else
-          echo "NO — this would explain multiprocessing's FileNotFoundError"
-        fi
-        echo
-        echo "=== pytest dist-info RECORD (entry point rows) ==="
-        grep -E '^.venv/bin/pytest|bin/pytest,' "$SP"/pytest-*.dist-info/RECORD 2>/dev/null || echo "(no pytest RECORD entry found)"
-        echo
-        echo "=== direct import probes (.venv/bin/python, NO uv run, NO conftest) ==="
-        .venv/bin/python -c "import numpy.random; print('numpy.random OK')" || echo "numpy.random: FAILED"
-        .venv/bin/python -c "from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; print('webagg OK')" || echo "webagg: FAILED"
-        echo
-        echo "=== import probes AFTER register_formatters (.venv/bin/python, NO uv run) ==="
-        .venv/bin/python -c "
-        from marimo._output.formatters.formatters import register_formatters
-        register_formatters(theme='light')
-        import numpy.random; print('numpy.random OK')
-        from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; print('webagg OK')
-        " || echo "with register_formatters: FAILED"
-        echo
-        echo "=== import probes via uv run (no pytest, no conftest) ==="
-        uv run --python ${{ inputs.python-version }} --group test python -c "
-        import numpy.random; print('numpy.random OK')
-        from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; print('webagg OK')
-        " || echo "uv run python: FAILED"
-        echo
-        echo "=== pytest (isolated, no xdist, no conftest-loaded addopts) ==="
-        uv run --python ${{ inputs.python-version }} --group test pytest \
-          tests/_plugins/stateless/test_mpl.py::test_patch_javascript \
-          -p no:xdist --no-header -q -o addopts= || echo "pytest isolated: FAILED"
-
     # This step is needed since some of our tests rely on the index.html file
     - name: Create assets directory, copy over index.html
       shell: bash
@@ -121,6 +71,8 @@ runs:
     - name: Test changed with base dependencies
       if: ${{ inputs.dependencies == 'core' }}
       shell: bash
+      env:
+        MARIMO_POISON_LOG: /tmp/marimo-poison.log
       run: |
         uv run --python ${{ inputs.python-version }} --group test pytest tests/ \
           -v \
@@ -171,3 +123,16 @@ runs:
           --picked=first \
           --inline-snapshot=disable \
         || { ec=$?; [ $ec -eq 5 ] && exit 0 || exit $ec; }
+
+    # Dump the numpy.random poisoning log from the autouse fixture in
+    # tests/conftest.py. Temporary; remove with the fixture.
+    - name: Dump numpy.random poisoning log
+      if: always()
+      shell: bash
+      run: |
+        if [ -f /tmp/marimo-poison.log ]; then
+          echo "=== numpy.random import state transitions during this run ==="
+          sort -u /tmp/marimo-poison.log
+        else
+          echo "(no poisoning log written — fixture either not loaded or numpy never imported)"
+        fi

--- a/.github/actions/test-python/action.yaml
+++ b/.github/actions/test-python/action.yaml
@@ -132,7 +132,7 @@ runs:
       run: |
         if [ -f /tmp/marimo-poison.log ]; then
           echo "=== numpy.random import state transitions during this run ==="
-          sort -u /tmp/marimo-poison.log
+          cat /tmp/marimo-poison.log
         else
           echo "(no poisoning log written — fixture either not loaded or numpy never imported)"
         fi

--- a/.github/actions/test-python/action.yaml
+++ b/.github/actions/test-python/action.yaml
@@ -25,12 +25,9 @@ runs:
         enable-cache: true
 
     # Diagnostic for the "ModuleNotFoundError: No module named
-    # 'numpy.random' / 'matplotlib.backends.*'" failures specific to Ubuntu
-    # core-dep runs. Gated to one representative matrix entry to keep
-    # output focused. Prints:
-    #   - whether the submodule files are physically present in .venv
-    #   - .venv/bin/python's sys.path
-    #   - whether .venv/bin/python can import them directly (no uv run)
+    # 'numpy.random' / 'matplotlib.backends.*'" and FileNotFoundError:
+    # '.venv/bin/pytest' failures specific to Ubuntu core-dep runs.
+    # Gated to one representative matrix entry to keep output focused.
     # Remove once the failures are understood and fixed.
     - name: Diagnose venv contents
       if: ${{ inputs.os == 'ubuntu-latest' && inputs.python-version == '3.11' && inputs.dependencies == 'core' }}
@@ -38,21 +35,44 @@ runs:
       run: |
         uv sync --python ${{ inputs.python-version }} --group test
         SP=$(.venv/bin/python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
-        echo "=== site-packages: $SP ==="
+
+        echo "=== .venv/bin/ entries ==="
+        ls -la .venv/bin/
         echo
-        echo "=== numpy/random/ (first 20 lines) ==="
-        ls -la "$SP/numpy/random/" 2>&1 | head -20
+        echo "=== .venv/bin/pytest exists? ==="
+        if [ -e .venv/bin/pytest ]; then
+          echo "YES"
+          file .venv/bin/pytest
+          head -3 .venv/bin/pytest || true
+        else
+          echo "NO — this would explain multiprocessing's FileNotFoundError"
+        fi
         echo
-        echo "=== matplotlib/backends/ (webagg|svg files) ==="
-        ls "$SP/matplotlib/backends/" 2>&1 | grep -E 'webagg|svg' || echo "(no matches)"
+        echo "=== pytest dist-info RECORD (entry point rows) ==="
+        grep -E '^.venv/bin/pytest|bin/pytest,' "$SP"/pytest-*.dist-info/RECORD 2>/dev/null || echo "(no pytest RECORD entry found)"
         echo
-        echo "=== .venv/bin/python sys.path ==="
-        .venv/bin/python -c "import sys; print('\n'.join(sys.path))"
+        echo "=== direct import probes (.venv/bin/python, NO uv run, NO conftest) ==="
+        .venv/bin/python -c "import numpy.random; print('numpy.random OK')" || echo "numpy.random: FAILED"
+        .venv/bin/python -c "from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; print('webagg OK')" || echo "webagg: FAILED"
         echo
-        echo "=== direct import probes (.venv/bin/python, no uv run) ==="
-        .venv/bin/python -c "import pytest; print('pytest OK:', pytest.__file__)" || echo "pytest: IMPORT FAILED"
-        .venv/bin/python -c "import numpy.random; print('numpy.random OK:', numpy.random.__file__)" || echo "numpy.random: IMPORT FAILED"
-        .venv/bin/python -c "from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; print('backend_webagg_core OK')" || echo "backend_webagg_core: IMPORT FAILED"
+        echo "=== import probes AFTER register_formatters (.venv/bin/python, NO uv run) ==="
+        .venv/bin/python -c "
+        from marimo._output.formatters.formatters import register_formatters
+        register_formatters(theme='light')
+        import numpy.random; print('numpy.random OK')
+        from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; print('webagg OK')
+        " || echo "with register_formatters: FAILED"
+        echo
+        echo "=== import probes via uv run (no pytest, no conftest) ==="
+        uv run --python ${{ inputs.python-version }} --group test python -c "
+        import numpy.random; print('numpy.random OK')
+        from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; print('webagg OK')
+        " || echo "uv run python: FAILED"
+        echo
+        echo "=== pytest (isolated, no xdist, no conftest-loaded addopts) ==="
+        uv run --python ${{ inputs.python-version }} --group test pytest \
+          tests/_plugins/stateless/test_mpl.py::test_patch_javascript \
+          -p no:xdist --no-header -q -o addopts= || echo "pytest isolated: FAILED"
 
     # This step is needed since some of our tests rely on the index.html file
     - name: Create assets directory, copy over index.html

--- a/.github/actions/test-python/action.yaml
+++ b/.github/actions/test-python/action.yaml
@@ -73,6 +73,7 @@ runs:
       shell: bash
       env:
         MARIMO_POISON_LOG: /tmp/marimo-poison.log
+        MARIMO_SKIP_REGISTER_FORMATTERS: "1"
       run: |
         uv run --python ${{ inputs.python-version }} --group test pytest tests/ \
           -v \

--- a/.github/actions/test-python/action.yaml
+++ b/.github/actions/test-python/action.yaml
@@ -24,6 +24,36 @@ runs:
         python-version: ${{ inputs.python-version }}
         enable-cache: true
 
+    # Diagnostic for the "ModuleNotFoundError: No module named
+    # 'numpy.random' / 'matplotlib.backends.*'" failures specific to Ubuntu
+    # core-dep runs. Gated to one representative matrix entry to keep
+    # output focused. Prints:
+    #   - whether the submodule files are physically present in .venv
+    #   - .venv/bin/python's sys.path
+    #   - whether .venv/bin/python can import them directly (no uv run)
+    # Remove once the failures are understood and fixed.
+    - name: Diagnose venv contents
+      if: ${{ inputs.os == 'ubuntu-latest' && inputs.python-version == '3.11' && inputs.dependencies == 'core' }}
+      shell: bash
+      run: |
+        uv sync --python ${{ inputs.python-version }} --group test
+        SP=$(.venv/bin/python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
+        echo "=== site-packages: $SP ==="
+        echo
+        echo "=== numpy/random/ (first 20 lines) ==="
+        ls -la "$SP/numpy/random/" 2>&1 | head -20
+        echo
+        echo "=== matplotlib/backends/ (webagg|svg files) ==="
+        ls "$SP/matplotlib/backends/" 2>&1 | grep -E 'webagg|svg' || echo "(no matches)"
+        echo
+        echo "=== .venv/bin/python sys.path ==="
+        .venv/bin/python -c "import sys; print('\n'.join(sys.path))"
+        echo
+        echo "=== direct import probes (.venv/bin/python, no uv run) ==="
+        .venv/bin/python -c "import pytest; print('pytest OK:', pytest.__file__)" || echo "pytest: IMPORT FAILED"
+        .venv/bin/python -c "import numpy.random; print('numpy.random OK:', numpy.random.__file__)" || echo "numpy.random: IMPORT FAILED"
+        .venv/bin/python -c "from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg; print('backend_webagg_core OK')" || echo "backend_webagg_core: IMPORT FAILED"
+
     # This step is needed since some of our tests rely on the index.html file
     - name: Create assets directory, copy over index.html
       shell: bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,18 +190,21 @@ def _detect_numpy_random_poisoning(
     yield
     if not _POISON_LOG or "numpy" not in sys.modules:
         return
+    # Passive check: don't call __import__, which would re-cache numpy.random
+    # in sys.modules and mask the very poisoning we're trying to detect.
     global _numpy_random_import_state
-    try:
-        __import__("numpy.random")
-        currently_works = True
-    except ImportError:
-        currently_works = False
-    if _numpy_random_import_state != currently_works:
-        label = "POISONED" if not currently_works else "RECOVERED"
+    in_sys_modules = "numpy.random" in sys.modules
+    if _numpy_random_import_state != in_sys_modules:
+        if _numpy_random_import_state is True and not in_sys_modules:
+            label = "REMOVED_FROM_SYS_MODULES"
+        elif _numpy_random_import_state is False and in_sys_modules:
+            label = "RE_ADDED_TO_SYS_MODULES"
+        else:
+            label = "FIRST_SEEN_PRESENT" if in_sys_modules else "FIRST_SEEN_ABSENT"
         worker = _os.environ.get("PYTEST_XDIST_WORKER", "main")
         with open(_POISON_LOG, "a") as f:
             f.write(f"[{worker}] {label} by: {request.node.nodeid}\n")
-        _numpy_random_import_state = currently_works
+        _numpy_random_import_state = in_sys_modules
 
 
 @dataclasses.dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,18 +202,23 @@ def _probe_numpy_random_state(nodeid: str) -> None:
     try:
         spec = importlib.util.find_spec("numpy.random")
         probe.append(f"find_spec('numpy.random'): {spec!r}")
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         probe.append(f"find_spec raised: {type(e).__name__}: {e}")
     try:
         __import__("numpy.random")
         probe.append("import numpy.random: SUCCESS (this masks the bug below)")
-    except BaseException as e:  # noqa: BLE001
+    except BaseException as e:
         probe.append(f"import numpy.random: {type(e).__name__}: {e}")
         probe.append("TRACEBACK:\n" + traceback.format_exc())
     probe.append(f"sys.path: {sys.path}")
     probe.append(
         "sys.meta_path: "
-        + str([(type(f).__name__, getattr(f, '__module__', '?')) for f in sys.meta_path])
+        + str(
+            [
+                (type(f).__name__, getattr(f, "__module__", "?"))
+                for f in sys.meta_path
+            ]
+        )
     )
     probe.append("=== END PROBE ===")
     worker = _os.environ.get("PYTEST_XDIST_WORKER", "main")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,9 +233,7 @@ def _detect_numpy_random_poisoning(
     # Capture BEFORE the test runs so we can catch tests that mutate
     # sys.modules['numpy.random'] during their body (even if they restore
     # it before teardown).
-    before = (
-        "numpy.random" in sys.modules if "numpy" in sys.modules else None
-    )
+    before = "numpy.random" in sys.modules if "numpy" in sys.modules else None
     yield
     if not _POISON_LOG or "numpy" not in sys.modules:
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,18 @@ if TYPE_CHECKING:
     from types import ModuleType
 
 # register import hooks for third-party module formatters
-register_formatters()
+# TEMP diagnostic: when MARIMO_SKIP_REGISTER_FORMATTERS=1, no-op out
+# register_formatters to test whether its meta_path patching causes the
+# "No module named 'numpy.random'" / submodule-import failures.
+import os as _os_early  # noqa: E402
+
+if _os_early.environ.get("MARIMO_SKIP_REGISTER_FORMATTERS") == "1":
+
+    def register_formatters(theme: str = "light") -> None:  # type: ignore[no-redef]
+        del theme
+
+else:
+    register_formatters()
 
 # Initialize mimetypes for consistent behavior across platforms (especially Windows)
 initialize_mimetypes()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,7 +200,9 @@ def _detect_numpy_random_poisoning(
         elif _numpy_random_import_state is False and in_sys_modules:
             label = "RE_ADDED_TO_SYS_MODULES"
         else:
-            label = "FIRST_SEEN_PRESENT" if in_sys_modules else "FIRST_SEEN_ABSENT"
+            label = (
+                "FIRST_SEEN_PRESENT" if in_sys_modules else "FIRST_SEEN_ABSENT"
+            )
         worker = _os.environ.get("PYTEST_XDIST_WORKER", "main")
         with open(_POISON_LOG, "a") as f:
             f.write(f"[{worker}] {label} by: {request.node.nodeid}\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,37 @@ def patch_random_seed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(UIElement, "_random_seed", random.Random(42))
 
 
+# Temporary diagnostic for CI failure where later tests raise
+# "ModuleNotFoundError: No module named 'numpy.random'" even though a fresh
+# .venv/bin/python can import it fine. Logs the test that flips the import
+# from working to broken (and the inverse), so the poisoning trigger is
+# identifiable from CI output. Remove once the cause is found and fixed.
+_numpy_random_import_state: bool | None = None
+
+
+@pytest.fixture(autouse=True)
+def _detect_numpy_random_poisoning(
+    request: pytest.FixtureRequest,
+) -> Generator[None, None, None]:
+    yield
+    if "numpy" not in sys.modules:
+        return
+    global _numpy_random_import_state
+    try:
+        __import__("numpy.random")
+        currently_works = True
+    except ImportError:
+        currently_works = False
+    if _numpy_random_import_state != currently_works:
+        label = "POISONED" if not currently_works else "RECOVERED"
+        print(
+            f"\n>>> numpy.random {label} by: {request.node.nodeid}",
+            file=sys.stderr,
+            flush=True,
+        )
+        _numpy_random_import_state = currently_works
+
+
 @dataclasses.dataclass
 class _MockStream(ThreadSafeStream):
     """Captures the ops sent through the stream"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,44 @@ import os as _os  # noqa: E402
 
 _POISON_LOG = _os.environ.get("MARIMO_POISON_LOG")
 _numpy_random_import_state: bool | None = None
+_probed_once = False
+
+
+def _probe_numpy_random_state(nodeid: str) -> None:
+    """One-shot: capture why `import numpy.random` fails in this process."""
+    global _probed_once
+    if _probed_once:
+        return
+    _probed_once = True
+    import importlib.util
+    import traceback
+
+    numpy_mod = sys.modules.get("numpy")
+    probe: list[str] = [f"=== PROBE triggered at {nodeid} ==="]
+    probe.append(f"numpy module: {numpy_mod!r}")
+    probe.append(f"numpy.__file__: {getattr(numpy_mod, '__file__', '?')}")
+    probe.append(f"numpy.__path__: {getattr(numpy_mod, '__path__', '?')}")
+    probe.append(f"numpy.__spec__: {getattr(numpy_mod, '__spec__', '?')}")
+    try:
+        spec = importlib.util.find_spec("numpy.random")
+        probe.append(f"find_spec('numpy.random'): {spec!r}")
+    except Exception as e:  # noqa: BLE001
+        probe.append(f"find_spec raised: {type(e).__name__}: {e}")
+    try:
+        __import__("numpy.random")
+        probe.append("import numpy.random: SUCCESS (this masks the bug below)")
+    except BaseException as e:  # noqa: BLE001
+        probe.append(f"import numpy.random: {type(e).__name__}: {e}")
+        probe.append("TRACEBACK:\n" + traceback.format_exc())
+    probe.append(f"sys.path: {sys.path}")
+    probe.append(
+        "sys.meta_path: "
+        + str([(type(f).__name__, getattr(f, '__module__', '?')) for f in sys.meta_path])
+    )
+    probe.append("=== END PROBE ===")
+    worker = _os.environ.get("PYTEST_XDIST_WORKER", "main")
+    with open(_POISON_LOG, "a") as f:
+        f.write(f"[{worker}] " + f"\n[{worker}] ".join(probe) + "\n")
 
 
 @pytest.fixture(autouse=True)
@@ -207,6 +245,12 @@ def _detect_numpy_random_poisoning(
         with open(_POISON_LOG, "a") as f:
             f.write(f"[{worker}] {label} by: {request.node.nodeid}\n")
         _numpy_random_import_state = in_sys_modules
+    # On FIRST_SEEN_ABSENT (numpy is loaded but numpy.random never made it in),
+    # run the one-shot probe to capture the actual failure mode. This call
+    # triggers an import and will cache numpy.random if successful, which
+    # masks further detection — that's acceptable once we have the probe.
+    if not in_sys_modules:
+        _probe_numpy_random_state(request.node.nodeid)
 
 
 @dataclasses.dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,9 +172,14 @@ def patch_random_seed(monkeypatch: pytest.MonkeyPatch) -> None:
 
 # Temporary diagnostic for CI failure where later tests raise
 # "ModuleNotFoundError: No module named 'numpy.random'" even though a fresh
-# .venv/bin/python can import it fine. Logs the test that flips the import
-# from working to broken (and the inverse), so the poisoning trigger is
-# identifiable from CI output. Remove once the cause is found and fixed.
+# .venv/bin/python can import it fine. When MARIMO_POISON_LOG is set, logs
+# tests that flip `import numpy.random` between working and broken into
+# that file so the poisoning trigger is identifiable from CI output.
+# Writes to a file because pytest captures stdout/stderr from fixture
+# teardown and swallows print(). Remove once the cause is found.
+import os as _os  # noqa: E402
+
+_POISON_LOG = _os.environ.get("MARIMO_POISON_LOG")
 _numpy_random_import_state: bool | None = None
 
 
@@ -183,7 +188,7 @@ def _detect_numpy_random_poisoning(
     request: pytest.FixtureRequest,
 ) -> Generator[None, None, None]:
     yield
-    if "numpy" not in sys.modules:
+    if not _POISON_LOG or "numpy" not in sys.modules:
         return
     global _numpy_random_import_state
     try:
@@ -193,11 +198,9 @@ def _detect_numpy_random_poisoning(
         currently_works = False
     if _numpy_random_import_state != currently_works:
         label = "POISONED" if not currently_works else "RECOVERED"
-        print(
-            f"\n>>> numpy.random {label} by: {request.node.nodeid}",
-            file=sys.stderr,
-            flush=True,
-        )
+        worker = _os.environ.get("PYTEST_XDIST_WORKER", "main")
+        with open(_POISON_LOG, "a") as f:
+            f.write(f"[{worker}] {label} by: {request.node.nodeid}\n")
         _numpy_random_import_state = currently_works
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,13 +230,31 @@ def _probe_numpy_random_state(nodeid: str) -> None:
 def _detect_numpy_random_poisoning(
     request: pytest.FixtureRequest,
 ) -> Generator[None, None, None]:
+    # Capture BEFORE the test runs so we can catch tests that mutate
+    # sys.modules['numpy.random'] during their body (even if they restore
+    # it before teardown).
+    before = (
+        "numpy.random" in sys.modules if "numpy" in sys.modules else None
+    )
     yield
     if not _POISON_LOG or "numpy" not in sys.modules:
         return
+    worker = _os.environ.get("PYTEST_XDIST_WORKER", "main")
+    in_sys_modules = "numpy.random" in sys.modules
+    # Log ANY test that flipped numpy.random during its body — this
+    # catches the "remove during test, re-add before teardown" case that
+    # the between-tests check below would miss.
+    if before is not None and before != in_sys_modules:
+        direction = "REMOVED" if before and not in_sys_modules else "RE_ADDED"
+        with open(_POISON_LOG, "a") as f:
+            f.write(
+                f"[{worker}] DURING {request.node.nodeid}: "
+                f"numpy.random {direction} "
+                f"(before={before} after={in_sys_modules})\n"
+            )
     # Passive check: don't call __import__, which would re-cache numpy.random
     # in sys.modules and mask the very poisoning we're trying to detect.
     global _numpy_random_import_state
-    in_sys_modules = "numpy.random" in sys.modules
     if _numpy_random_import_state != in_sys_modules:
         if _numpy_random_import_state is True and not in_sys_modules:
             label = "REMOVED_FROM_SYS_MODULES"
@@ -246,7 +264,6 @@ def _detect_numpy_random_poisoning(
             label = (
                 "FIRST_SEEN_PRESENT" if in_sys_modules else "FIRST_SEEN_ABSENT"
             )
-        worker = _os.environ.get("PYTEST_XDIST_WORKER", "main")
         with open(_POISON_LOG, "a") as f:
             f.write(f"[{worker}] {label} by: {request.node.nodeid}\n")
         _numpy_random_import_state = in_sys_modules

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 # TEMP diagnostic: when MARIMO_SKIP_REGISTER_FORMATTERS=1, no-op out
 # register_formatters to test whether its meta_path patching causes the
 # "No module named 'numpy.random'" / submodule-import failures.
-import os as _os_early  # noqa: E402
+import os as _os_early
 
 if _os_early.environ.get("MARIMO_SKIP_REGISTER_FORMATTERS") == "1":
 


### PR DESCRIPTION
Prints whether numpy.random, matplotlib.backends.*, and pytest are physically present in .venv and whether .venv/bin/python can import them directly. disambiguates "broken wheel install" from "broken sys.path / Python distribution" for the ModuleNotFoundError failures. Gated to one matrix entry to keep output focused.