### PR TITLE
Add slide config form in sidebar, and reveal slide types

### DIFF
--- a/frontend/src/components/editor/renderers/slides-layout/__tests__/compute-slide-cells.test.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/__tests__/compute-slide-cells.test.ts
@@ -28,6 +28,37 @@ describe("computeSlideCellsInfo", () => {
     expect(result.cellsWithOutput).toEqual([]);
     expect(result.skippedIds.size).toBe(0);
     expect(result.slideTypes.size).toBe(0);
+    expect(result.startCellIndex).toBe(0);
+  });
+
+  it("computes firstNonSkippedIndex as the first non-skipped cell", () => {
+    const result = computeSlideCellsInfo(
+      [cell("a"), cell("b"), cell("c")],
+      layoutOf([
+        ["a", { type: "skip" }],
+        ["b", { type: "skip" }],
+        ["c", { type: "slide" }],
+      ]),
+    );
+    expect(result.startCellIndex).toBe(2);
+  });
+
+  it("falls back to 0 when every cell is skipped", () => {
+    // If the user marked everything as skip we still have to land somewhere;
+    // the renderer treats 0 as a safe default rather than rendering nothing.
+    const result = computeSlideCellsInfo(
+      [cell("a"), cell("b")],
+      layoutOf([
+        ["a", { type: "skip" }],
+        ["b", { type: "skip" }],
+      ]),
+    );
+    expect(result.startCellIndex).toBe(0);
+  });
+
+  it("uses index 0 when no cells are skipped", () => {
+    const result = computeSlideCellsInfo([cell("a"), cell("b")], layoutOf([]));
+    expect(result.startCellIndex).toBe(0);
   });
 
   it("filters out cells with no output", () => {

--- a/frontend/src/components/editor/renderers/slides-layout/__tests__/compute-slide-cells.test.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/__tests__/compute-slide-cells.test.ts
@@ -1,0 +1,119 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, it, expect } from "vitest";
+import { computeSlideCellsInfo } from "../compute-slide-cells";
+import type { SlideConfig, SlidesLayout } from "../types";
+import type { CellId } from "@/core/cells/ids";
+
+interface TestCell {
+  id: CellId;
+  output: { data: unknown } | null;
+}
+
+const DEFAULT_OUTPUT: TestCell["output"] = { data: "ok" };
+
+const cell = (
+  id: string,
+  output: TestCell["output"] = DEFAULT_OUTPUT,
+): TestCell => ({ id: id as CellId, output });
+
+const layoutOf = (entries: Array<[string, SlideConfig]>): SlidesLayout => ({
+  cells: new Map(entries.map(([id, cfg]) => [id as CellId, cfg])),
+  deck: {},
+});
+
+describe("computeSlideCellsInfo", () => {
+  it("returns empty results for empty input", () => {
+    const result = computeSlideCellsInfo([], layoutOf([]));
+    expect(result.cellsWithOutput).toEqual([]);
+    expect(result.skippedIds.size).toBe(0);
+    expect(result.slideTypes.size).toBe(0);
+  });
+
+  it("filters out cells with no output", () => {
+    const result = computeSlideCellsInfo(
+      [cell("a"), cell("b", null), cell("c")],
+      layoutOf([]),
+    );
+    expect(result.cellsWithOutput.map((c) => c.id)).toEqual(["a", "c"]);
+  });
+
+  it("filters out cells whose output data is empty string", () => {
+    // Mirrors the editor contract: an explicit empty-string payload means the
+    // cell rendered nothing, so it should not occupy a slide.
+    const result = computeSlideCellsInfo(
+      [cell("a"), cell("b", { data: "" }), cell("c")],
+      layoutOf([]),
+    );
+    expect(result.cellsWithOutput.map((c) => c.id)).toEqual(["a", "c"]);
+  });
+
+  it("keeps cells whose output data is a non-empty value (including falsy ones)", () => {
+    // Only "" is treated as empty — 0 / false / null-shaped payloads still
+    // represent rendered output and should stay in the deck.
+    const result = computeSlideCellsInfo(
+      [
+        cell("a", { data: 0 }),
+        cell("b", { data: false }),
+        cell("c", { data: null }),
+      ],
+      layoutOf([]),
+    );
+    expect(result.cellsWithOutput.map((c) => c.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("populates slideTypes only for cells with an explicit type", () => {
+    const result = computeSlideCellsInfo(
+      [cell("a"), cell("b"), cell("c")],
+      layoutOf([
+        ["a", { type: "slide" }],
+        ["b", {}],
+        ["c", { type: "fragment" }],
+      ]),
+    );
+    expect(Object.fromEntries(result.slideTypes)).toEqual({
+      a: "slide",
+      c: "fragment",
+    });
+  });
+
+  it("tracks skipped cells in skippedIds", () => {
+    const result = computeSlideCellsInfo(
+      [cell("a"), cell("b"), cell("c")],
+      layoutOf([
+        ["a", { type: "slide" }],
+        ["b", { type: "skip" }],
+        ["c", { type: "skip" }],
+      ]),
+    );
+    expect([...result.skippedIds]).toEqual(["b", "c"]);
+    // Skipped cells are still "visible" deck cells — they just aren't rendered
+    // in reveal. The minimap relies on the full list plus skippedIds.
+    expect(result.cellsWithOutput.map((c) => c.id)).toEqual(["a", "b", "c"]);
+    expect(result.slideTypes.get("b" as CellId)).toBe("skip");
+  });
+
+  it("ignores layout entries for cells that have no output", () => {
+    // If a cell was skipped in the layout but no longer produces output (e.g.
+    // the user deleted its code), it should drop out of both maps — otherwise
+    // the skip set would reference ghosts.
+    const result = computeSlideCellsInfo(
+      [cell("a"), cell("b", null)],
+      layoutOf([
+        ["a", { type: "slide" }],
+        ["b", { type: "skip" }],
+      ]),
+    );
+    expect(result.cellsWithOutput.map((c) => c.id)).toEqual(["a"]);
+    expect(result.skippedIds.size).toBe(0);
+    expect(result.slideTypes.has("b" as CellId)).toBe(false);
+  });
+
+  it("preserves the input order of cells in cellsWithOutput", () => {
+    const result = computeSlideCellsInfo(
+      [cell("c"), cell("a"), cell("b")],
+      layoutOf([]),
+    );
+    expect(result.cellsWithOutput.map((c) => c.id)).toEqual(["c", "a", "b"]);
+  });
+});

--- a/frontend/src/components/editor/renderers/slides-layout/__tests__/plugin.test.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/__tests__/plugin.test.ts
@@ -28,7 +28,7 @@ describe("SlidesLayoutPlugin validator", () => {
   it("accepts a fully populated layout", () => {
     expect(
       SlidesLayoutPlugin.validator.safeParse({
-        cells: [{ type: "slide", codeSnippet: "foo" }, {}],
+        cells: [{ type: "slide" }, {}],
         deck: { transition: "fade" },
       }).success,
     ).toBe(true);
@@ -63,26 +63,28 @@ describe("SlidesLayoutPlugin deserializeLayout", () => {
 
   it("passes through every serialized entry by position (thin passthrough)", () => {
     const layout = SlidesLayoutPlugin.deserializeLayout(
-      { cells: [{}, { type: "fragment" }, { codeSnippet: "x" }] },
+      // Third entry carries an unknown key to prove the deserializer does not
+      // strip fields it does not recognize (forward-compat).
+      // oxlint-disable-next-line typescript/no-explicit-any
+      { cells: [{}, { type: "fragment" }, { notes: "x" } as any] },
       [makeCell("a"), makeCell("b"), makeCell("c")],
     );
     expect([...layout.cells.keys()]).toEqual(["a", "b", "c"]);
     expect(layout.cells.get("a" as CellId)).toEqual({});
     expect(layout.cells.get("b" as CellId)).toEqual({ type: "fragment" });
-    expect(layout.cells.get("c" as CellId)).toEqual({ codeSnippet: "x" });
+    expect(layout.cells.get("c" as CellId)).toEqual({ notes: "x" });
   });
 });
 
 describe("SlidesLayoutPlugin serializeLayout", () => {
-  it("emits a full cells array with a codeSnippet preview for every cell", () => {
+  it("emits one entry per notebook cell (dense, positional)", () => {
+    // Even with no per-cell config, the output array must have one slot per
+    // notebook cell so positional alignment is preserved on reload.
     const serialized = SlidesLayoutPlugin.serializeLayout(
       { cells: new Map(), deck: {} },
       [makeCell("a"), makeCell("b", "print(42)")],
     );
-    expect(serialized.cells).toEqual([
-      { codeSnippet: "print('hi')..." },
-      { codeSnippet: "print(42)..." },
-    ]);
+    expect(serialized.cells).toEqual([{}, {}]);
     expect(serialized.deck).toEqual({});
   });
 
@@ -105,24 +107,6 @@ describe("SlidesLayoutPlugin serializeLayout", () => {
       [makeCell("a")],
     );
     expect(serialized.deck).toEqual({ transition: "fade" });
-  });
-
-  it("regenerates codeSnippet from the current cell code on every save", () => {
-    const cells = [makeCell("a", "print('fresh code here')")];
-    const serialized = SlidesLayoutPlugin.serializeLayout(
-      // Stale snippet in the in-memory map must be overwritten.
-      {
-        cells: new Map([
-          ["a" as CellId, { type: "slide", codeSnippet: "stale..." }],
-        ]),
-        deck: {},
-      },
-      cells,
-    );
-    expect(serialized.cells?.[0]).toEqual({
-      type: "slide",
-      codeSnippet: "print('fresh code here')...",
-    });
   });
 
   it("passes through unknown SlideConfig fields (forward compat)", () => {
@@ -198,13 +182,9 @@ const BACKWARDS_COMPAT_SNAPSHOTS: BackwardsCompatCase[] = [
     // Current serializer output as of this commit. If you change the
     // serializer, add the new shape as an additional snapshot — don't edit
     // this one.
-    label: "current: cells + deck + codeSnippet",
+    label: "current: cells + deck",
     input: {
-      cells: [
-        { type: "slide", codeSnippet: "print('hi')..." },
-        { codeSnippet: "print('hi')..." },
-        { type: "fragment", codeSnippet: "print('hi')..." },
-      ],
+      cells: [{ type: "slide" }, {}, { type: "fragment" }],
       deck: { transition: "slide" },
     },
     expected: {
@@ -303,11 +283,9 @@ describe("SlidesLayoutPlugin backwards compatibility", () => {
       {
         "cells": [
           {
-            "codeSnippet": "print('hello')...",
             "type": "slide",
           },
           {
-            "codeSnippet": "x = 1...",
             "type": "fragment",
           },
         ],

--- a/frontend/src/components/editor/renderers/slides-layout/__tests__/plugin.test.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/__tests__/plugin.test.ts
@@ -1,0 +1,320 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, it, expect } from "vitest";
+import { SlidesLayoutPlugin } from "../plugin";
+import type { CellData } from "@/core/cells/types";
+import type { CellId } from "@/core/cells/ids";
+
+function makeCell(id: string, code = "print('hi')"): CellData {
+  return {
+    id: id as CellId,
+    name: id,
+    code,
+    edited: false,
+    lastCodeRun: null,
+    lastExecutionTime: null,
+    config: { hide_code: false, disabled: false, column: null },
+    serializedEditorState: null,
+  };
+}
+
+describe("SlidesLayoutPlugin validator", () => {
+  it("accepts the legacy empty-object shape written by older marimo versions", () => {
+    // Backwards compat: any slides file saved before we introduced `cells` /
+    // `deck` looks like `{}` on disk. It must still validate.
+    expect(SlidesLayoutPlugin.validator.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts a fully populated layout", () => {
+    expect(
+      SlidesLayoutPlugin.validator.safeParse({
+        cells: [{ type: "slide", codeSnippet: "foo" }, {}],
+        deck: { transition: "fade" },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects unknown slide types", () => {
+    expect(
+      SlidesLayoutPlugin.validator.safeParse({
+        cells: [{ type: "bogus" }],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("SlidesLayoutPlugin deserializeLayout", () => {
+  it("returns an empty map when serialized.cells is missing", () => {
+    // Regression: previously accessed `serialized.cells.length` on undefined
+    // and threw, preventing the app from initializing.
+    const layout = SlidesLayoutPlugin.deserializeLayout({}, [makeCell("a")]);
+    expect(layout.cells.size).toBe(0);
+    expect(layout.deck).toEqual({});
+  });
+
+  it("tolerates missing deck", () => {
+    const layout = SlidesLayoutPlugin.deserializeLayout(
+      { cells: [{ type: "slide" }] },
+      [makeCell("a")],
+    );
+    expect(layout.deck).toEqual({});
+    expect(layout.cells.get("a" as CellId)).toEqual({ type: "slide" });
+  });
+
+  it("passes through every serialized entry by position (thin passthrough)", () => {
+    const layout = SlidesLayoutPlugin.deserializeLayout(
+      { cells: [{}, { type: "fragment" }, { codeSnippet: "x" }] },
+      [makeCell("a"), makeCell("b"), makeCell("c")],
+    );
+    expect([...layout.cells.keys()]).toEqual(["a", "b", "c"]);
+    expect(layout.cells.get("a" as CellId)).toEqual({});
+    expect(layout.cells.get("b" as CellId)).toEqual({ type: "fragment" });
+    expect(layout.cells.get("c" as CellId)).toEqual({ codeSnippet: "x" });
+  });
+});
+
+describe("SlidesLayoutPlugin serializeLayout", () => {
+  it("emits a full cells array with a codeSnippet preview for every cell", () => {
+    const serialized = SlidesLayoutPlugin.serializeLayout(
+      { cells: new Map(), deck: {} },
+      [makeCell("a"), makeCell("b", "print(42)")],
+    );
+    expect(serialized.cells).toEqual([
+      { codeSnippet: "print('hi')..." },
+      { codeSnippet: "print(42)..." },
+    ]);
+    expect(serialized.deck).toEqual({});
+  });
+
+  it("passes user-set SlideConfig fields through unchanged", () => {
+    const cells = [makeCell("a"), makeCell("b"), makeCell("c")];
+    const serialized = SlidesLayoutPlugin.serializeLayout(
+      {
+        cells: new Map([["b" as CellId, { type: "fragment" }]]),
+        deck: {},
+      },
+      cells,
+    );
+    expect(serialized.cells).toHaveLength(3);
+    expect(serialized.cells?.[1]).toMatchObject({ type: "fragment" });
+  });
+
+  it("serializes deck config verbatim", () => {
+    const serialized = SlidesLayoutPlugin.serializeLayout(
+      { cells: new Map(), deck: { transition: "fade" } },
+      [makeCell("a")],
+    );
+    expect(serialized.deck).toEqual({ transition: "fade" });
+  });
+
+  it("regenerates codeSnippet from the current cell code on every save", () => {
+    const cells = [makeCell("a", "print('fresh code here')")];
+    const serialized = SlidesLayoutPlugin.serializeLayout(
+      // Stale snippet in the in-memory map must be overwritten.
+      {
+        cells: new Map([
+          ["a" as CellId, { type: "slide", codeSnippet: "stale..." }],
+        ]),
+        deck: {},
+      },
+      cells,
+    );
+    expect(serialized.cells?.[0]).toEqual({
+      type: "slide",
+      codeSnippet: "print('fresh code here')...",
+    });
+  });
+
+  it("passes through unknown SlideConfig fields (forward compat)", () => {
+    // When a future version adds a new SlideConfig field, serialize should
+    // not need updating. Exercise that by stuffing an arbitrary property
+    // into the in-memory config and checking it survives.
+    const cells = [makeCell("a")];
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const futureConfig = { type: "slide", notes: "speaker notes" } as any;
+    const serialized = SlidesLayoutPlugin.serializeLayout(
+      { cells: new Map([["a" as CellId, futureConfig]]), deck: {} },
+      cells,
+    );
+    expect(serialized.cells?.[0]).toMatchObject({
+      type: "slide",
+      notes: "speaker notes",
+    });
+  });
+
+  it("round-trips user-set config through serialize + deserialize", () => {
+    const cells = [makeCell("a"), makeCell("b")];
+    const before = {
+      cells: new Map([["b" as CellId, { type: "fragment" as const }]]),
+      deck: { transition: "fade" as const },
+    };
+    const serialized = SlidesLayoutPlugin.serializeLayout(before, cells);
+    const after = SlidesLayoutPlugin.deserializeLayout(serialized, cells);
+    expect(after.deck).toEqual({ transition: "fade" });
+    expect(after.cells.get("b" as CellId)).toMatchObject({ type: "fragment" });
+  });
+});
+
+/**
+ * Frozen snapshots of every on-disk shape this plugin has ever had to parse.
+ *
+ * RULES FOR THIS BLOCK:
+ * - Never delete or modify an existing snapshot — users have `.slides.json`
+ *   files in these exact shapes sitting on their disks.
+ * - When the on-disk shape evolves, add a new snapshot here (with the release
+ *   / commit that introduced it) so we keep proving we can load the old ones.
+ * - If you need to change the serializer's output, add a snapshot of the new
+ *   shape to `serializedSnapshot` so a diff will surface the change in review.
+ *
+ * Every snapshot is required to:
+ *   1. pass the zod validator (today it is defined but not applied on load;
+ *      this guards against regressions once it is),
+ *   2. deserialize without throwing,
+ *   3. survive a deserialize → serialize → deserialize round trip without
+ *      throwing or losing any user-set field carried in the expectations.
+ */
+interface BackwardsCompatCase {
+  label: string;
+  input: unknown;
+  /**
+   * Expected state after deserializing `input` against `cells`. Only asserted
+   * properties need to be listed — extra properties are ignored.
+   */
+  expected: {
+    deck?: unknown;
+    cellIds: string[];
+    cellEntries?: Array<[string, unknown]>;
+  };
+}
+
+const BACKWARDS_COMPAT_SNAPSHOTS: BackwardsCompatCase[] = [
+  {
+    // Shape written by every marimo version before we added per-slide config.
+    label: "legacy bare {} (pre-slide-config)",
+    input: {},
+    expected: { deck: {}, cellIds: [] },
+  },
+  {
+    // Current serializer output as of this commit. If you change the
+    // serializer, add the new shape as an additional snapshot — don't edit
+    // this one.
+    label: "current: cells + deck + codeSnippet",
+    input: {
+      cells: [
+        { type: "slide", codeSnippet: "print('hi')..." },
+        { codeSnippet: "print('hi')..." },
+        { type: "fragment", codeSnippet: "print('hi')..." },
+      ],
+      deck: { transition: "slide" },
+    },
+    expected: {
+      deck: { transition: "slide" },
+      cellIds: ["a", "b", "c"],
+      cellEntries: [
+        ["a", { type: "slide" }],
+        ["c", { type: "fragment" }],
+      ],
+    },
+  },
+  {
+    // Defensive: if a future version adds a new SlideConfig field and a user
+    // downgrades, we must not crash on unknown keys.
+    label: "forward-compat: unknown SlideConfig fields present",
+    input: {
+      cells: [{ type: "slide", notes: "x", background: "#000" }],
+    },
+    expected: {
+      deck: {},
+      cellIds: ["a"],
+      cellEntries: [["a", { type: "slide" }]],
+    },
+  },
+];
+
+describe("SlidesLayoutPlugin backwards compatibility", () => {
+  it.each(BACKWARDS_COMPAT_SNAPSHOTS)(
+    "loads snapshot: $label",
+    ({ input, expected }) => {
+      const cells = expected.cellIds.map((id) => makeCell(id));
+
+      // 1. Validator must accept the shape.
+      const parsed = SlidesLayoutPlugin.validator.safeParse(input);
+      expect(
+        parsed.success,
+        `validator rejected: ${JSON.stringify(input)}`,
+      ).toBe(true);
+
+      // 2. Deserialize must succeed and reflect the user-set fields.
+      const layout = SlidesLayoutPlugin.deserializeLayout(
+        // Use the raw input (not the validator output) because that is what
+        // `deserializeLayout` actually receives in production today.
+        // oxlint-disable-next-line typescript/no-explicit-any
+        input as any,
+        cells,
+      );
+      if (expected.deck !== undefined) {
+        expect(layout.deck).toEqual(expected.deck);
+      }
+      for (const [cellId, expectedConfig] of expected.cellEntries ?? []) {
+        expect(layout.cells.get(cellId as CellId)).toMatchObject(
+          expectedConfig as object,
+        );
+      }
+
+      // 3. Round trip must not throw and must preserve the same user fields.
+      const reserialized = SlidesLayoutPlugin.serializeLayout(layout, cells);
+      expect(
+        SlidesLayoutPlugin.validator.safeParse(reserialized).success,
+        `serializer produced a shape that no longer validates: ${JSON.stringify(reserialized)}`,
+      ).toBe(true);
+      const redeserialized = SlidesLayoutPlugin.deserializeLayout(
+        reserialized,
+        cells,
+      );
+      for (const [cellId, expectedConfig] of expected.cellEntries ?? []) {
+        expect(redeserialized.cells.get(cellId as CellId)).toMatchObject(
+          expectedConfig as object,
+        );
+      }
+      if (expected.deck !== undefined) {
+        expect(redeserialized.deck).toEqual(expected.deck);
+      }
+    },
+  );
+
+  it("current serializer output is captured by an inline snapshot", () => {
+    // If this snapshot changes you are changing the on-disk shape. That is
+    // allowed, but:
+    //   1. Add the previous shape to BACKWARDS_COMPAT_SNAPSHOTS above so we
+    //      keep proving we can still load it.
+    //   2. Update this inline snapshot.
+    const cells = [makeCell("a", "print('hello')"), makeCell("b", "x = 1")];
+    const serialized = SlidesLayoutPlugin.serializeLayout(
+      {
+        cells: new Map([
+          ["a" as CellId, { type: "slide" }],
+          ["b" as CellId, { type: "fragment" }],
+        ]),
+        deck: { transition: "fade" },
+      },
+      cells,
+    );
+    expect(serialized).toMatchInlineSnapshot(`
+      {
+        "cells": [
+          {
+            "codeSnippet": "print('hello')...",
+            "type": "slide",
+          },
+          {
+            "codeSnippet": "x = 1...",
+            "type": "fragment",
+          },
+        ],
+        "deck": {
+          "transition": "fade",
+        },
+      }
+    `);
+  });
+});

--- a/frontend/src/components/editor/renderers/slides-layout/compute-slide-cells.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/compute-slide-cells.ts
@@ -1,0 +1,36 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { CellId } from "@/core/cells/ids";
+import type { SlideType, SlidesLayout } from "./types";
+
+export interface SlideCellLike {
+  id: CellId;
+  output: { data: unknown } | null;
+}
+
+export interface SlideCellsInfo<T extends SlideCellLike> {
+  cellsWithOutput: T[];
+  skippedIds: Set<CellId>;
+  slideTypes: Map<CellId, SlideType>;
+}
+
+export function computeSlideCellsInfo<T extends SlideCellLike>(
+  cells: readonly T[],
+  layout: Pick<SlidesLayout, "cells">,
+): SlideCellsInfo<T> {
+  const cellsWithOutput = cells.filter(
+    (cell) => cell.output != null && cell.output.data !== "",
+  );
+  const skippedIds = new Set<CellId>();
+  const slideTypes = new Map<CellId, SlideType>();
+  for (const cell of cellsWithOutput) {
+    const type = layout.cells.get(cell.id)?.type;
+    if (type) {
+      slideTypes.set(cell.id, type);
+    }
+    if (type === "skip") {
+      skippedIds.add(cell.id);
+    }
+  }
+  return { cellsWithOutput, skippedIds, slideTypes };
+}

--- a/frontend/src/components/editor/renderers/slides-layout/compute-slide-cells.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/compute-slide-cells.ts
@@ -12,6 +12,8 @@ export interface SlideCellsInfo<T extends SlideCellLike> {
   cellsWithOutput: T[];
   skippedIds: Set<CellId>;
   slideTypes: Map<CellId, SlideType>;
+  // Index of the first cell in `cellsWithOutput` that is not skipped
+  startCellIndex: number;
 }
 
 export function computeSlideCellsInfo<T extends SlideCellLike>(
@@ -23,14 +25,26 @@ export function computeSlideCellsInfo<T extends SlideCellLike>(
   );
   const skippedIds = new Set<CellId>();
   const slideTypes = new Map<CellId, SlideType>();
-  for (const cell of cellsWithOutput) {
+
+  let startCell: T | null = null;
+  let startCellIndex = 0;
+
+  for (const [index, cell] of cellsWithOutput.entries()) {
     const type = layout.cells.get(cell.id)?.type;
     if (type) {
       slideTypes.set(cell.id, type);
     }
     if (type === "skip") {
       skippedIds.add(cell.id);
+    } else if (startCell === null) {
+      startCell = cell;
+      startCellIndex = index;
     }
   }
-  return { cellsWithOutput, skippedIds, slideTypes };
+  return {
+    cellsWithOutput,
+    skippedIds,
+    slideTypes,
+    startCellIndex,
+  };
 }

--- a/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
@@ -52,7 +52,7 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
     const slideCells = new Map<CellId, SlideConfig>();
     for (const [idx, cell] of cells.entries()) {
       const slideConfig = serialized.cells?.at(idx);
-      if (slideConfig) {
+      if (slideConfig?.type) {
         slideCells.set(cell.id, slideConfig);
       }
     }

--- a/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
@@ -22,20 +22,24 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
   name: "Slides",
 
   validator: z.object({
-    cells: z
-      .array(
-        z.object({
-          type: z.enum(["slide", "sub-slide", "fragment", "skip"]).optional(),
-          codeSnippet: z.string().optional(),
-        }),
-      )
-      .optional(),
+    cells: z.array(
+      z.object({
+        type: z.enum(["slide", "sub-slide", "fragment", "skip"]).optional(),
+        codeSnippet: z.string().optional(),
+      }),
+    ),
+    deck: z.object({
+      transition: z
+        .enum(["none", "fade", "slide", "convex", "concave", "zoom"])
+        .optional(),
+    }),
   }),
 
   deserializeLayout: (serialized, cells): SlidesLayout => {
-    if (serialized.cells?.length === 0) {
+    if (serialized.cells.length === 0) {
       return {
         cells: new Map(),
+        deck: {},
       };
     }
 
@@ -55,6 +59,7 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
 
     return {
       cells: slideCells,
+      deck: serialized.deck,
     };
   },
 
@@ -78,6 +83,7 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
 
     return {
       cells: serializedCells,
+      deck: layout.deck,
     };
   },
 
@@ -85,5 +91,6 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
 
   getInitialLayout: () => ({
     cells: new Map(),
+    deck: {},
   }),
 };

--- a/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
@@ -21,29 +21,30 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
   type: "slides",
   name: "Slides",
 
+  // All fields are optional so layouts saved by older marimo versions will work
   validator: z.object({
-    cells: z.array(
-      z.object({
-        type: z.enum(["slide", "sub-slide", "fragment", "skip"]).optional(),
-        codeSnippet: z.string().optional(),
-      }),
-    ),
-    deck: z.object({
-      transition: z
-        .enum(["none", "fade", "slide", "convex", "concave", "zoom"])
-        .optional(),
-    }),
+    cells: z
+      .array(
+        z.object({
+          type: z.enum(["slide", "sub-slide", "fragment", "skip"]).optional(),
+          codeSnippet: z.string().optional(),
+        }),
+      )
+      .optional(),
+    deck: z
+      .object({
+        transition: z
+          .enum(["none", "fade", "slide", "convex", "concave", "zoom"])
+          .optional(),
+      })
+      .optional(),
   }),
 
   deserializeLayout: (serialized, cells): SlidesLayout => {
-    if (serialized.cells.length === 0) {
-      return {
-        cells: new Map(),
-        deck: {},
-      };
-    }
+    const serializedCells = serialized.cells ?? [];
+    const deck = serialized.deck ?? {};
 
-    if (serialized.cells?.length !== cells.length) {
+    if (serializedCells.length > 0 && serializedCells.length !== cells.length) {
       Logger.warn(
         "Number of cells in layout does not match number of cells in notebook",
       );
@@ -51,41 +52,23 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
 
     const slideCells = new Map<CellId, SlideConfig>();
     for (const [idx, cell] of cells.entries()) {
-      const slideConfig = serialized.cells?.at(idx);
-      if (slideConfig?.type) {
+      const slideConfig = serializedCells.at(idx);
+      if (slideConfig) {
         slideCells.set(cell.id, slideConfig);
       }
     }
 
-    return {
-      cells: slideCells,
-      deck: serialized.deck,
-    };
+    return { cells: slideCells, deck };
   },
 
-  serializeLayout: (layout, cells): SerializedSlidesLayout => {
-    const serializedCells: SlideConfig[] = cells.map((cell) => {
-      const slideConfig = layout.cells.get(cell.id);
-      if (!slideConfig) {
-        return {};
-      }
-
-      const serialized: SlideConfig = {
-        // A code snippet is added to help the user / AI understand the cell.
-        codeSnippet: `${cell.code.slice(0, 100)}...`,
-      };
-      // We don't want to save undefined
-      if (slideConfig.type) {
-        serialized.type = slideConfig.type;
-      }
-      return serialized;
-    });
-
-    return {
-      cells: serializedCells,
-      deck: layout.deck,
-    };
-  },
+  serializeLayout: (layout, cells): SerializedSlidesLayout => ({
+    cells: cells.map((cell) => ({
+      ...layout.cells.get(cell.id),
+      // Let's user or an AI understand the layout.json better
+      codeSnippet: `${cell.code.slice(0, 100)}...`,
+    })),
+    deck: layout.deck,
+  }),
 
   Component: SlidesLayoutRenderer,
 

--- a/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
@@ -27,7 +27,6 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
       .array(
         z.object({
           type: z.enum(["slide", "sub-slide", "fragment", "skip"]).optional(),
-          codeSnippet: z.string().optional(),
         }),
       )
       .optional(),
@@ -64,8 +63,6 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
   serializeLayout: (layout, cells): SerializedSlidesLayout => ({
     cells: cells.map((cell) => ({
       ...layout.cells.get(cell.id),
-      // Lets a user or an AI understand the layout.json better
-      codeSnippet: `${cell.code.slice(0, 100)}...`,
     })),
     deck: layout.deck,
   }),

--- a/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
@@ -65,11 +65,15 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
         return {};
       }
 
-      return {
-        type: slideConfig.type,
+      const serialized: SlideConfig = {
         // A code snippet is added to help the user / AI understand the cell.
         codeSnippet: `${cell.code.slice(0, 100)}...`,
       };
+      // We don't want to save undefined
+      if (slideConfig.type) {
+        serialized.type = slideConfig.type;
+      }
+      return serialized;
     });
 
     return {

--- a/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
@@ -64,7 +64,7 @@ export const SlidesLayoutPlugin: ICellRendererPlugin<
   serializeLayout: (layout, cells): SerializedSlidesLayout => ({
     cells: cells.map((cell) => ({
       ...layout.cells.get(cell.id),
-      // Let's user or an AI understand the layout.json better
+      // Lets a user or an AI understand the layout.json better
       codeSnippet: `${cell.code.slice(0, 100)}...`,
     })),
     deck: layout.deck,

--- a/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/plugin.tsx
@@ -3,29 +3,83 @@
 import { z } from "zod";
 import type { ICellRendererPlugin } from "../types";
 import { SlidesLayoutRenderer } from "./slides-layout";
-import type { SlidesLayout } from "./types";
+import type {
+  SerializedSlidesLayout,
+  SlideConfig,
+  SlidesLayout,
+} from "./types";
+import { Logger } from "@/utils/Logger";
+import type { CellId } from "@/core/cells/ids";
 
 /**
  * Plugin definition for the slides layout.
  */
 export const SlidesLayoutPlugin: ICellRendererPlugin<
-  SlidesLayout,
+  SerializedSlidesLayout,
   SlidesLayout
 > = {
   type: "slides",
   name: "Slides",
 
-  validator: z.object({}),
+  validator: z.object({
+    cells: z
+      .array(
+        z.object({
+          type: z.enum(["slide", "sub-slide", "fragment", "skip"]).optional(),
+          codeSnippet: z.string().optional(),
+        }),
+      )
+      .optional(),
+  }),
 
-  deserializeLayout: (_serialized, _cells): SlidesLayout => {
-    return {};
+  deserializeLayout: (serialized, cells): SlidesLayout => {
+    if (serialized.cells?.length === 0) {
+      return {
+        cells: new Map(),
+      };
+    }
+
+    if (serialized.cells?.length !== cells.length) {
+      Logger.warn(
+        "Number of cells in layout does not match number of cells in notebook",
+      );
+    }
+
+    const slideCells = new Map<CellId, SlideConfig>();
+    for (const [idx, cell] of cells.entries()) {
+      const slideConfig = serialized.cells?.at(idx);
+      if (slideConfig) {
+        slideCells.set(cell.id, slideConfig);
+      }
+    }
+
+    return {
+      cells: slideCells,
+    };
   },
 
-  serializeLayout: (_layout, _cells): SlidesLayout => {
-    return {};
+  serializeLayout: (layout, cells): SerializedSlidesLayout => {
+    const serializedCells: SlideConfig[] = cells.map((cell) => {
+      const slideConfig = layout.cells.get(cell.id);
+      if (!slideConfig) {
+        return {};
+      }
+
+      return {
+        type: slideConfig.type,
+        // A code snippet is added to help the user / AI understand the cell.
+        codeSnippet: `${cell.code.slice(0, 100)}...`,
+      };
+    });
+
+    return {
+      cells: serializedCells,
+    };
   },
 
   Component: SlidesLayoutRenderer,
 
-  getInitialLayout: () => ({}),
+  getInitialLayout: () => ({
+    cells: new Map(),
+  }),
 };

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import React, { useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { useAtomValue } from "jotai";
 import { numColumnsAtom } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
@@ -27,23 +27,28 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   const [activeCellId, setActiveCellId] = useState<CellId | null>(null);
   const deckRef = useRef<RevealApi | null>(null);
 
-  const cellsWithOutput = cells.filter(
-    (cell) => cell.output != null && cell.output.data !== "",
-  );
-
-  const skippedIds = new Set<CellId>();
-  for (const c of cellsWithOutput) {
-    if (layout.cells.get(c.id)?.type === "skip") {
-      skippedIds.add(c.id);
+  const { cellsWithOutput, skippedIds, defaultIndex } = useMemo(() => {
+    const withOutput = cells.filter(
+      (cell) => cell.output != null && cell.output.data !== "",
+    );
+    const skipped = new Set<CellId>();
+    for (const c of withOutput) {
+      if (layout.cells.get(c.id)?.type === "skip") {
+        skipped.add(c.id);
+      }
     }
-  }
-
-  // Prefer a non-skipped cell on initial load so the deck lands on a real
-  // slide instead of the skip-preview overlay.
-  const firstNonSkippedIndex = cellsWithOutput.findIndex(
-    (c) => !skippedIds.has(c.id),
-  );
-  const defaultIndex = firstNonSkippedIndex === -1 ? 0 : firstNonSkippedIndex;
+    // Prefer a non-skipped cell on initial load so the deck lands on a real
+    // slide instead of the skip-preview overlay.
+    const firstNonSkippedIndex = withOutput.findIndex(
+      (c) => !skipped.has(c.id),
+    );
+    const defaultIdx = firstNonSkippedIndex === -1 ? 0 : firstNonSkippedIndex;
+    return {
+      cellsWithOutput: withOutput,
+      skippedIds: skipped,
+      defaultIndex: defaultIdx,
+    };
+  }, [cells, layout.cells]);
 
   const activeSlideIndex = activeCellId
     ? cellsWithOutput.findIndex((c) => c.id === activeCellId)

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -31,10 +31,25 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
     (cell) => cell.output != null && cell.output.data !== "",
   );
 
+  const skippedIds = new Set<CellId>();
+  for (const c of cellsWithOutput) {
+    if (layout.cells.get(c.id)?.type === "skip") {
+      skippedIds.add(c.id);
+    }
+  }
+
+  // Prefer a non-skipped cell on initial load so the deck lands on a real
+  // slide instead of the skip-preview overlay.
+  const firstNonSkippedIndex = cellsWithOutput.findIndex(
+    (c) => !skippedIds.has(c.id),
+  );
+  const defaultIndex = firstNonSkippedIndex === -1 ? 0 : firstNonSkippedIndex;
+
   const activeSlideIndex = activeCellId
     ? cellsWithOutput.findIndex((c) => c.id === activeCellId)
-    : 0;
-  const resolvedIndex = activeSlideIndex === -1 ? 0 : activeSlideIndex;
+    : defaultIndex;
+  const resolvedIndex =
+    activeSlideIndex === -1 ? defaultIndex : activeSlideIndex;
 
   const handleSlideChange = useEvent((index: number) => {
     const cell = cellsWithOutput[index];
@@ -66,7 +81,8 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
         cells={cellsWithOutput}
         thumbnailWidth={220}
         canReorder={!isMultiColumn}
-        activeCellId={activeCellId ?? cellsWithOutput[0]?.id ?? null}
+        activeCellId={activeCellId ?? cellsWithOutput[defaultIndex]?.id ?? null}
+        skippedIds={skippedIds}
         onSlideClick={handleSlideChange}
       />
       {slides}

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -16,9 +16,8 @@ const LazySlidesComponent = React.lazy(
 );
 
 export const SlidesLayoutRenderer: React.FC<Props> = ({
-  // Currently we don't have layout config
-  // layout,
-  // setLayout,
+  layout,
+  setLayout,
   cells,
   mode,
 }) => {
@@ -47,9 +46,12 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   const slides = (
     <LazySlidesComponent
       cellsWithOutput={cellsWithOutput}
+      layout={layout}
+      setLayout={setLayout}
       activeIndex={resolvedIndex}
       onSlideChange={handleSlideChange}
       deckRef={deckRef}
+      configWidth={250}
     />
   );
 
@@ -62,6 +64,7 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
     <div className="pr-18 pb-5 flex-1 flex flex-row max-h-11/12 gap-2">
       <SlidesMinimap
         cells={cellsWithOutput}
+        thumbnailWidth={220}
         canReorder={!isMultiColumn}
         activeCellId={activeCellId ?? cellsWithOutput[0]?.id ?? null}
         onSlideClick={handleSlideChange}

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -79,16 +79,24 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
       onSlideChange={handleSlideChange}
       deckRef={deckRef}
       configWidth={250}
+      mode={mode}
     />
   );
 
   if (isReading) {
-    return <div className="p-4 flex flex-1 max-h-[95%]">{slides}</div>;
+    // Cap the deck height and derive width from height via aspect-video so it stays 16:9 without
+    // ballooning to the full viewport on wide screens.
+    return (
+      <div className="p-4 flex flex-1 items-center justify-center min-h-0">
+        <div className="h-full max-h-[95vh] aspect-video max-w-full flex">
+          {slides}
+        </div>
+      </div>
+    );
   }
 
   return (
-    // Use 11/12 to ensure all content fits on the page (no overflow, scrolling required)
-    <div className="pr-18 pb-5 flex-1 flex flex-row max-h-11/12 gap-2">
+    <div className="pr-18 pb-2 flex flex-row gap-2 min-h-0">
       <SlidesMinimap
         cells={cellsWithOutput}
         thumbnailWidth={220}

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -28,15 +28,16 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   const [activeCellId, setActiveCellId] = useState<CellId | null>(null);
   const deckRef = useRef<RevealApi | null>(null);
 
-  const { cellsWithOutput, skippedIds, slideTypes } = useMemo(
+  const { cellsWithOutput, skippedIds, slideTypes, startCellIndex } = useMemo(
     () => computeSlideCellsInfo(cells, layout),
     [cells, layout],
   );
 
   const activeSlideIndex = activeCellId
     ? cellsWithOutput.findIndex((c) => c.id === activeCellId)
-    : 0;
-  const resolvedIndex = activeSlideIndex === -1 ? 0 : activeSlideIndex;
+    : startCellIndex;
+  const resolvedIndex =
+    activeSlideIndex === -1 ? startCellIndex : activeSlideIndex;
 
   const handleSlideChange = useEvent((index: number) => {
     const cell = cellsWithOutput[index];
@@ -76,7 +77,9 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
         cells={cellsWithOutput}
         thumbnailWidth={220}
         canReorder={!isMultiColumn}
-        activeCellId={activeCellId ?? cellsWithOutput[0]?.id ?? null}
+        activeCellId={
+          activeCellId ?? cellsWithOutput[startCellIndex]?.id ?? null
+        }
         skippedIds={skippedIds}
         slideTypes={slideTypes}
         onSlideClick={handleSlideChange}

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -27,41 +27,32 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   const [activeCellId, setActiveCellId] = useState<CellId | null>(null);
   const deckRef = useRef<RevealApi | null>(null);
 
-  const { cellsWithOutput, skippedIds, slideTypes, defaultIndex } =
-    useMemo(() => {
-      const withOutput = cells.filter(
-        (cell) => cell.output != null && cell.output.data !== "",
-      );
-      const skipped = new Set<CellId>();
-      const types = new Map<CellId, SlideType>();
-      for (const c of withOutput) {
-        const type = layout.cells.get(c.id)?.type;
-        if (type) {
-          types.set(c.id, type);
-        }
-        if (type === "skip") {
-          skipped.add(c.id);
-        }
+  const { cellsWithOutput, skippedIds, slideTypes } = useMemo(() => {
+    const withOutput = cells.filter(
+      (cell) => cell.output != null && cell.output.data !== "",
+    );
+    const skipped = new Set<CellId>();
+    const types = new Map<CellId, SlideType>();
+    for (const c of withOutput) {
+      const type = layout.cells.get(c.id)?.type;
+      if (type) {
+        types.set(c.id, type);
       }
-      // Prefer a non-skipped cell on initial load so the deck lands on a real
-      // slide instead of the skip-preview overlay.
-      const firstNonSkippedIndex = withOutput.findIndex(
-        (c) => !skipped.has(c.id),
-      );
-      const defaultIdx = firstNonSkippedIndex === -1 ? 0 : firstNonSkippedIndex;
-      return {
-        cellsWithOutput: withOutput,
-        skippedIds: skipped,
-        slideTypes: types,
-        defaultIndex: defaultIdx,
-      };
-    }, [cells, layout.cells]);
+      if (type === "skip") {
+        skipped.add(c.id);
+      }
+    }
+    return {
+      cellsWithOutput: withOutput,
+      skippedIds: skipped,
+      slideTypes: types,
+    };
+  }, [cells, layout.cells]);
 
   const activeSlideIndex = activeCellId
     ? cellsWithOutput.findIndex((c) => c.id === activeCellId)
-    : defaultIndex;
-  const resolvedIndex =
-    activeSlideIndex === -1 ? defaultIndex : activeSlideIndex;
+    : 0;
+  const resolvedIndex = activeSlideIndex === -1 ? 0 : activeSlideIndex;
 
   const handleSlideChange = useEvent((index: number) => {
     const cell = cellsWithOutput[index];
@@ -101,7 +92,7 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
         cells={cellsWithOutput}
         thumbnailWidth={220}
         canReorder={!isMultiColumn}
-        activeCellId={activeCellId ?? cellsWithOutput[defaultIndex]?.id ?? null}
+        activeCellId={activeCellId ?? cellsWithOutput[0]?.id ?? null}
         skippedIds={skippedIds}
         slideTypes={slideTypes}
         onSlideClick={handleSlideChange}

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -4,7 +4,7 @@ import { useAtomValue } from "jotai";
 import { numColumnsAtom } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
 import type { ICellRendererProps } from "../types";
-import type { SlidesLayout } from "./types";
+import type { SlideType, SlidesLayout } from "./types";
 import { SlidesMinimap } from "@/components/slides/minimap";
 import useEvent from "react-use-event-hook";
 import type { RevealApi } from "reveal.js";
@@ -27,28 +27,35 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   const [activeCellId, setActiveCellId] = useState<CellId | null>(null);
   const deckRef = useRef<RevealApi | null>(null);
 
-  const { cellsWithOutput, skippedIds, defaultIndex } = useMemo(() => {
-    const withOutput = cells.filter(
-      (cell) => cell.output != null && cell.output.data !== "",
-    );
-    const skipped = new Set<CellId>();
-    for (const c of withOutput) {
-      if (layout.cells.get(c.id)?.type === "skip") {
-        skipped.add(c.id);
+  const { cellsWithOutput, skippedIds, slideTypes, defaultIndex } =
+    useMemo(() => {
+      const withOutput = cells.filter(
+        (cell) => cell.output != null && cell.output.data !== "",
+      );
+      const skipped = new Set<CellId>();
+      const types = new Map<CellId, SlideType>();
+      for (const c of withOutput) {
+        const type = layout.cells.get(c.id)?.type;
+        if (type) {
+          types.set(c.id, type);
+        }
+        if (type === "skip") {
+          skipped.add(c.id);
+        }
       }
-    }
-    // Prefer a non-skipped cell on initial load so the deck lands on a real
-    // slide instead of the skip-preview overlay.
-    const firstNonSkippedIndex = withOutput.findIndex(
-      (c) => !skipped.has(c.id),
-    );
-    const defaultIdx = firstNonSkippedIndex === -1 ? 0 : firstNonSkippedIndex;
-    return {
-      cellsWithOutput: withOutput,
-      skippedIds: skipped,
-      defaultIndex: defaultIdx,
-    };
-  }, [cells, layout.cells]);
+      // Prefer a non-skipped cell on initial load so the deck lands on a real
+      // slide instead of the skip-preview overlay.
+      const firstNonSkippedIndex = withOutput.findIndex(
+        (c) => !skipped.has(c.id),
+      );
+      const defaultIdx = firstNonSkippedIndex === -1 ? 0 : firstNonSkippedIndex;
+      return {
+        cellsWithOutput: withOutput,
+        skippedIds: skipped,
+        slideTypes: types,
+        defaultIndex: defaultIdx,
+      };
+    }, [cells, layout.cells]);
 
   const activeSlideIndex = activeCellId
     ? cellsWithOutput.findIndex((c) => c.id === activeCellId)
@@ -88,6 +95,7 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
         canReorder={!isMultiColumn}
         activeCellId={activeCellId ?? cellsWithOutput[defaultIndex]?.id ?? null}
         skippedIds={skippedIds}
+        slideTypes={slideTypes}
         onSlideClick={handleSlideChange}
       />
       {slides}

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -4,7 +4,8 @@ import { useAtomValue } from "jotai";
 import { numColumnsAtom } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
 import type { ICellRendererProps } from "../types";
-import type { SlideType, SlidesLayout } from "./types";
+import type { SlidesLayout } from "./types";
+import { computeSlideCellsInfo } from "./compute-slide-cells";
 import { SlidesMinimap } from "@/components/slides/minimap";
 import useEvent from "react-use-event-hook";
 import type { RevealApi } from "reveal.js";
@@ -27,27 +28,10 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   const [activeCellId, setActiveCellId] = useState<CellId | null>(null);
   const deckRef = useRef<RevealApi | null>(null);
 
-  const { cellsWithOutput, skippedIds, slideTypes } = useMemo(() => {
-    const withOutput = cells.filter(
-      (cell) => cell.output != null && cell.output.data !== "",
-    );
-    const skipped = new Set<CellId>();
-    const types = new Map<CellId, SlideType>();
-    for (const c of withOutput) {
-      const type = layout.cells.get(c.id)?.type;
-      if (type) {
-        types.set(c.id, type);
-      }
-      if (type === "skip") {
-        skipped.add(c.id);
-      }
-    }
-    return {
-      cellsWithOutput: withOutput,
-      skippedIds: skipped,
-      slideTypes: types,
-    };
-  }, [cells, layout.cells]);
+  const { cellsWithOutput, skippedIds, slideTypes } = useMemo(
+    () => computeSlideCellsInfo(cells, layout),
+    [cells, layout],
+  );
 
   const activeSlideIndex = activeCellId
     ? cellsWithOutput.findIndex((c) => c.id === activeCellId)

--- a/frontend/src/components/editor/renderers/slides-layout/types.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/types.ts
@@ -27,7 +27,6 @@ export interface SlidesLayout extends Omit<
 export type SlideType = "slide" | "sub-slide" | "fragment" | "skip";
 export interface SlideConfig {
   type?: SlideType;
-  codeSnippet?: string;
 }
 
 export type DeckTransition =

--- a/frontend/src/components/editor/renderers/slides-layout/types.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/types.ts
@@ -1,13 +1,24 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 /* oxlint-disable typescript/no-empty-object-type */
 
+import type { CellId } from "@/core/cells/ids";
+
 /**
  * The serialized form of a slides layout.
  * This must be backwards-compatible as it is stored on the user's disk.
  */
 // oxlint-disable-next-line typescript/consistent-type-definitions
-export type SerializedSlidesLayout = {};
+export type SerializedSlidesLayout = {
+  cells?: SlideConfig[];
+};
 
-export interface SlidesLayout extends SerializedSlidesLayout {
-  // No additional properties for now
+export interface SlidesLayout extends Omit<SerializedSlidesLayout, "cells"> {
+  // We map the cells to their IDs so that we can track them as they move around.
+  cells: Map<CellId, SlideConfig>;
+}
+
+export type SlideType = "slide" | "sub-slide" | "fragment" | "skip";
+export interface SlideConfig {
+  type?: SlideType;
+  codeSnippet?: string;
 }

--- a/frontend/src/components/editor/renderers/slides-layout/types.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/types.ts
@@ -9,7 +9,8 @@ import type { CellId } from "@/core/cells/ids";
  */
 // oxlint-disable-next-line typescript/consistent-type-definitions
 export type SerializedSlidesLayout = {
-  cells?: SlideConfig[];
+  deck: DeckConfig;
+  cells: SlideConfig[];
 };
 
 export interface SlidesLayout extends Omit<SerializedSlidesLayout, "cells"> {
@@ -21,4 +22,15 @@ export type SlideType = "slide" | "sub-slide" | "fragment" | "skip";
 export interface SlideConfig {
   type?: SlideType;
   codeSnippet?: string;
+}
+
+export type DeckTransition =
+  | "none"
+  | "fade"
+  | "slide"
+  | "convex"
+  | "concave"
+  | "zoom";
+export interface DeckConfig {
+  transition?: DeckTransition;
 }

--- a/frontend/src/components/editor/renderers/slides-layout/types.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/types.ts
@@ -9,13 +9,19 @@ import type { CellId } from "@/core/cells/ids";
  */
 // oxlint-disable-next-line typescript/consistent-type-definitions
 export type SerializedSlidesLayout = {
-  deck: DeckConfig;
-  cells: SlideConfig[];
+  // Both fields are optional so files saved before these existed (e.g. the
+  // bare `{}` emitted by earlier marimo versions) still deserialize cleanly.
+  deck?: DeckConfig;
+  cells?: SlideConfig[];
 };
 
-export interface SlidesLayout extends Omit<SerializedSlidesLayout, "cells"> {
+export interface SlidesLayout extends Omit<
+  SerializedSlidesLayout,
+  "cells" | "deck"
+> {
   // We map the cells to their IDs so that we can track them as they move around.
   cells: Map<CellId, SlideConfig>;
+  deck: DeckConfig;
 }
 
 export type SlideType = "slide" | "sub-slide" | "fragment" | "skip";

--- a/frontend/src/components/editor/renderers/types.ts
+++ b/frontend/src/components/editor/renderers/types.ts
@@ -66,7 +66,9 @@ export interface ICellRendererPlugin<S, L> {
    */
   validator: ZodType<S>;
 
+  // Take a serialized layout and a list of cells, and return a layout object.
   deserializeLayout: (layout: S, cells: CellData[]) => L;
+  // Take the in-memory layout object and a list of cells, and return a serialized layout.
   serializeLayout: (layout: L, cells: CellData[]) => S;
 
   Component: React.FC<ICellRendererProps<L>>;

--- a/frontend/src/components/slides/__tests__/compose-slides.test.ts
+++ b/frontend/src/components/slides/__tests__/compose-slides.test.ts
@@ -6,7 +6,6 @@ import {
   composeSlides,
   computeDeckNavigation,
   resolveActiveCellIndex,
-  type ComposeOptions,
 } from "../compose-slides";
 import type { SlideType } from "@/components/editor/renderers/slides-layout/types";
 
@@ -20,16 +19,19 @@ interface Cell {
   type?: SlideType;
 }
 
-const compose = (cells: Cell[], opts: ComposeOptions = {}) =>
-  composeSlides(cells, (c) => c.type ?? "slide", opts);
+const compose = (cells: Cell[]) =>
+  composeSlides({
+    cells,
+    getType: (c) => c.type ?? "slide",
+  });
 
 /**
  * Collapse the tree to a readable shape so failures produce tiny, obvious
  * diffs:
  *   stacks -> subslides -> blocks -> { f: isFragment, ids: [...] }
  */
-const shape = (cells: Cell[], opts: ComposeOptions = {}) =>
-  compose(cells, opts).stacks.map((s) =>
+const shape = (cells: Cell[]) =>
+  compose(cells).stacks.map((s) =>
     s.subslides.map((sub) =>
       sub.blocks.map((b) => ({
         f: b.isFragment,
@@ -128,7 +130,7 @@ describe("composeSlides", () => {
     ).toEqual([[[{ f: false, ids: ["a"] }], [{ f: false, ids: ["b"] }]]]);
   });
 
-  it("drops 'skip' cells by default", () => {
+  it("drops 'skip' cells from the deck", () => {
     expect(
       shape([
         { id: "a", type: "slide" },
@@ -139,26 +141,6 @@ describe("composeSlides", () => {
       [
         [
           { f: false, ids: ["a"] },
-          { f: true, ids: ["c"] },
-        ],
-      ],
-    ]);
-  });
-
-  it("keeps 'skip' cells in the current block when dropSkipped=false", () => {
-    expect(
-      shape(
-        [
-          { id: "a", type: "slide" },
-          { id: "b", type: "skip" },
-          { id: "c", type: "fragment" },
-        ],
-        { dropSkipped: false },
-      ),
-    ).toEqual([
-      [
-        [
-          { f: false, ids: ["a", "b"] },
           { f: true, ids: ["c"] },
         ],
       ],
@@ -244,7 +226,7 @@ describe("composeSlides", () => {
   it("is generic over cell shape (preserves object identity)", () => {
     const a = { id: "a", type: "slide" as const, extra: 42 };
     const b = { id: "b", type: "fragment" as const, extra: 7 };
-    const result = composeSlides([a, b], (c) => c.type);
+    const result = composeSlides({ cells: [a, b], getType: (c) => c.type });
     expect(result.stacks[0].subslides[0].blocks[0].cells[0]).toBe(a);
     expect(result.stacks[0].subslides[0].blocks[1].cells[0]).toBe(b);
   });
@@ -252,8 +234,11 @@ describe("composeSlides", () => {
 
 describe("buildSlideIndices", () => {
   const build = (cells: Cell[]) => {
-    const composition = composeSlides(cells, (c) => c.type ?? "slide");
-    return buildSlideIndices(composition, cells, (c) => c.id);
+    const composition = composeSlides({
+      cells,
+      getType: (c) => c.type ?? "slide",
+    });
+    return buildSlideIndices({ composition, cells, getId: (c) => c.id });
   };
 
   it("maps each cell to its {h, v, f} location", () => {

--- a/frontend/src/components/slides/__tests__/compose-slides.test.ts
+++ b/frontend/src/components/slides/__tests__/compose-slides.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildSlideIndices,
   composeSlides,
+  computeDeckNavigation,
   resolveActiveCellIndex,
   type ComposeOptions,
 } from "../compose-slides";
@@ -325,5 +326,64 @@ describe("resolveActiveCellIndex", () => {
 
   it("returns undefined for unknown stacks", () => {
     expect(resolveActiveCellIndex(map, { h: 9, v: 0, f: 0 })).toBeUndefined();
+  });
+});
+
+describe("computeDeckNavigation", () => {
+  it("returns null when the deck is already on a non-fragment target", () => {
+    expect(
+      computeDeckNavigation({ h: 0, v: 0, f: -1 }, { h: 0, v: 0, f: -1 }),
+    ).toBeNull();
+  });
+
+  it("returns null when the deck is already on the target fragment", () => {
+    expect(
+      computeDeckNavigation({ h: 0, v: 0, f: 1 }, { h: 0, v: 0, f: 1 }),
+    ).toBeNull();
+  });
+
+  it("navigates to a different stack", () => {
+    expect(
+      computeDeckNavigation({ h: 0, v: 0, f: -1 }, { h: 2, v: 0, f: -1 }),
+    ).toEqual({ h: 2, v: 0, f: -1 });
+  });
+
+  it("navigates to a different subslide within the same stack", () => {
+    expect(
+      computeDeckNavigation({ h: 1, v: 0, f: -1 }, { h: 1, v: 2, f: -1 }),
+    ).toEqual({ h: 1, v: 2, f: -1 });
+  });
+
+  it("collapses revealed fragments when jumping to the parent slide", () => {
+    // Regression: previously left `f` unchanged, so the deck would stay on
+    // the last-revealed fragment when the user clicked the parent slide in
+    // the minimap.
+    expect(
+      computeDeckNavigation({ h: 0, v: 0, f: 2 }, { h: 0, v: 0, f: -1 }),
+    ).toEqual({ h: 0, v: 0, f: -1 });
+  });
+
+  it("collapses fragments when jumping to a parent slide in a different stack", () => {
+    expect(
+      computeDeckNavigation({ h: 1, v: 0, f: 3 }, { h: 0, v: 0, f: -1 }),
+    ).toEqual({ h: 0, v: 0, f: -1 });
+  });
+
+  it("advances to a specific fragment on the same slide", () => {
+    expect(
+      computeDeckNavigation({ h: 0, v: 0, f: -1 }, { h: 0, v: 0, f: 2 }),
+    ).toEqual({ h: 0, v: 0, f: 2 });
+  });
+
+  it("rewinds to an earlier fragment on the same slide", () => {
+    expect(
+      computeDeckNavigation({ h: 0, v: 0, f: 3 }, { h: 0, v: 0, f: 1 }),
+    ).toEqual({ h: 0, v: 0, f: 1 });
+  });
+
+  it("jumps across stacks directly to a fragment", () => {
+    expect(
+      computeDeckNavigation({ h: 0, v: 0, f: -1 }, { h: 2, v: 1, f: 0 }),
+    ).toEqual({ h: 2, v: 1, f: 0 });
   });
 });

--- a/frontend/src/components/slides/__tests__/compose-slides.test.ts
+++ b/frontend/src/components/slides/__tests__/compose-slides.test.ts
@@ -1,0 +1,334 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildSlideIndices,
+  composeSlides,
+  resolveActiveCellIndex,
+  type ComposeCellType,
+  type ComposeOptions,
+} from "../compose-slides";
+
+interface Cell {
+  id: string;
+  type?: ComposeCellType;
+}
+
+const compose = (cells: Cell[], opts: ComposeOptions = {}) =>
+  composeSlides(cells, (c) => c.type, opts);
+
+/**
+ * Collapse the tree to a readable shape so failures produce tiny, obvious
+ * diffs:
+ *   stacks -> subslides -> blocks -> { f: isFragment, ids: [...] }
+ */
+const shape = (cells: Cell[], opts: ComposeOptions = {}) =>
+  compose(cells, opts).stacks.map((s) =>
+    s.subslides.map((sub) =>
+      sub.blocks.map((b) => ({
+        f: b.isFragment,
+        ids: b.cells.map((x) => x.id),
+      })),
+    ),
+  );
+
+describe("composeSlides", () => {
+  it("returns an empty composition for empty input", () => {
+    expect(compose([])).toEqual({ stacks: [] });
+  });
+
+  it("treats each 'slide' cell as its own stack", () => {
+    expect(
+      shape([
+        { id: "a", type: "slide" },
+        { id: "b", type: "slide" },
+        { id: "c", type: "slide" },
+      ]),
+    ).toEqual([
+      [[{ f: false, ids: ["a"] }]],
+      [[{ f: false, ids: ["b"] }]],
+      [[{ f: false, ids: ["c"] }]],
+    ]);
+  });
+
+  it("nests 'sub-slide' cells under the current slide (vertical stack)", () => {
+    expect(
+      shape([
+        { id: "a", type: "slide" },
+        { id: "b", type: "sub-slide" },
+        { id: "c", type: "sub-slide" },
+        { id: "d", type: "slide" },
+      ]),
+    ).toEqual([
+      [
+        [{ f: false, ids: ["a"] }],
+        [{ f: false, ids: ["b"] }],
+        [{ f: false, ids: ["c"] }],
+      ],
+      [[{ f: false, ids: ["d"] }]],
+    ]);
+  });
+
+  it("wraps fragments in their own block on the current subslide", () => {
+    expect(
+      shape([
+        { id: "a", type: "slide" },
+        { id: "b", type: "fragment" },
+        { id: "c", type: "fragment" },
+      ]),
+    ).toEqual([
+      [
+        [
+          { f: false, ids: ["a"] },
+          { f: true, ids: ["b"] },
+          { f: true, ids: ["c"] },
+        ],
+      ],
+    ]);
+  });
+
+  it("treats undefined (continuation) as appending to the current block", () => {
+    expect(
+      shape([
+        { id: "a", type: "slide" },
+        { id: "b" },
+        { id: "c", type: "fragment" },
+        { id: "d" },
+      ]),
+    ).toEqual([
+      [
+        [
+          { f: false, ids: ["a", "b"] },
+          { f: true, ids: ["c", "d"] },
+        ],
+      ],
+    ]);
+  });
+
+  it("creates an implicit initial subslide when the first cell is a fragment", () => {
+    expect(shape([{ id: "a", type: "fragment" }])).toEqual([
+      [[{ f: true, ids: ["a"] }]],
+    ]);
+  });
+
+  it("creates an implicit initial stack when the first cell is a sub-slide", () => {
+    expect(
+      shape([
+        { id: "a", type: "sub-slide" },
+        { id: "b", type: "sub-slide" },
+      ]),
+    ).toEqual([[[{ f: false, ids: ["a"] }], [{ f: false, ids: ["b"] }]]]);
+  });
+
+  it("creates an implicit initial block when the first cell is a continuation", () => {
+    expect(shape([{ id: "a" }, { id: "b" }])).toEqual([
+      [[{ f: false, ids: ["a", "b"] }]],
+    ]);
+  });
+
+  it("drops 'skip' cells by default", () => {
+    expect(
+      shape([
+        { id: "a", type: "slide" },
+        { id: "b", type: "skip" },
+        { id: "c", type: "fragment" },
+      ]),
+    ).toEqual([
+      [
+        [
+          { f: false, ids: ["a"] },
+          { f: true, ids: ["c"] },
+        ],
+      ],
+    ]);
+  });
+
+  it("keeps 'skip' cells in the current block when dropSkipped=false", () => {
+    expect(
+      shape(
+        [
+          { id: "a", type: "slide" },
+          { id: "b", type: "skip" },
+          { id: "c", type: "fragment" },
+        ],
+        { dropSkipped: false },
+      ),
+    ).toEqual([
+      [
+        [
+          { f: false, ids: ["a", "b"] },
+          { f: true, ids: ["c"] },
+        ],
+      ],
+    ]);
+  });
+
+  it("skip at the very start does not create an empty leading stack", () => {
+    expect(
+      shape([
+        { id: "a", type: "skip" },
+        { id: "b", type: "slide" },
+      ]),
+    ).toEqual([[[{ f: false, ids: ["b"] }]]]);
+  });
+
+  it("supports multiple fragments interleaved with continuations", () => {
+    expect(
+      shape([
+        { id: "a", type: "slide" },
+        { id: "b", type: "fragment" },
+        { id: "c" },
+        { id: "d", type: "fragment" },
+      ]),
+    ).toEqual([
+      [
+        [
+          { f: false, ids: ["a"] },
+          { f: true, ids: ["b", "c"] },
+          { f: true, ids: ["d"] },
+        ],
+      ],
+    ]);
+  });
+
+  it("resets fragment context when a new subslide opens", () => {
+    expect(
+      shape([
+        { id: "a", type: "slide" },
+        { id: "b", type: "fragment" },
+        { id: "c", type: "sub-slide" },
+        { id: "d" },
+      ]),
+    ).toEqual([
+      [
+        [
+          { f: false, ids: ["a"] },
+          { f: true, ids: ["b"] },
+        ],
+        [{ f: false, ids: ["c", "d"] }],
+      ],
+    ]);
+  });
+
+  it("handles a realistic mixed sequence", () => {
+    expect(
+      shape([
+        { id: "title", type: "slide" },
+        { id: "intro1" },
+        { id: "intro2", type: "fragment" },
+        { id: "deep", type: "sub-slide" },
+        { id: "deep-body" },
+        { id: "debug", type: "skip" },
+        { id: "outro", type: "slide" },
+      ]),
+    ).toEqual([
+      [
+        [
+          { f: false, ids: ["title", "intro1"] },
+          { f: true, ids: ["intro2"] },
+        ],
+        [{ f: false, ids: ["deep", "deep-body"] }],
+      ],
+      [[{ f: false, ids: ["outro"] }]],
+    ]);
+  });
+
+  it("is generic over cell shape (preserves object identity)", () => {
+    const a = { id: "a", type: "slide" as const, extra: 42 };
+    const b = { id: "b", type: "fragment" as const, extra: 7 };
+    const result = composeSlides([a, b], (c) => c.type);
+    expect(result.stacks[0].subslides[0].blocks[0].cells[0]).toBe(a);
+    expect(result.stacks[0].subslides[0].blocks[1].cells[0]).toBe(b);
+  });
+});
+
+describe("buildSlideIndices", () => {
+  const build = (cells: Cell[]) => {
+    const composition = composeSlides(cells, (c) => c.type);
+    return buildSlideIndices(composition, cells, (c) => c.id);
+  };
+
+  it("maps each cell to its {h, v, f} location", () => {
+    const cells: Cell[] = [
+      { id: "a", type: "slide" },
+      { id: "b", type: "fragment" },
+      { id: "c", type: "sub-slide" },
+      { id: "d", type: "slide" },
+      { id: "e", type: "fragment" },
+      { id: "f", type: "fragment" },
+    ];
+    const { cellToTarget } = build(cells);
+    expect(cellToTarget.get("a")).toEqual({ h: 0, v: 0, f: -1 });
+    expect(cellToTarget.get("b")).toEqual({ h: 0, v: 0, f: 0 });
+    expect(cellToTarget.get("c")).toEqual({ h: 0, v: 1, f: -1 });
+    expect(cellToTarget.get("d")).toEqual({ h: 1, v: 0, f: -1 });
+    expect(cellToTarget.get("e")).toEqual({ h: 1, v: 0, f: 0 });
+    expect(cellToTarget.get("f")).toEqual({ h: 1, v: 0, f: 1 });
+  });
+
+  it("maps {h, v, f} back to the flat index of the last visible cell", () => {
+    const cells: Cell[] = [
+      { id: "a", type: "slide" },
+      { id: "b", type: "fragment" },
+      { id: "c", type: "fragment" },
+    ];
+    const { targetToCellIndex } = build(cells);
+    // Before any fragment is revealed, the active cell is the last pre-fragment cell.
+    expect(targetToCellIndex.get("0,0,-1")).toBe(0); // "a"
+    // After fragment 0 is shown, active advances to "b".
+    expect(targetToCellIndex.get("0,0,0")).toBe(1); // "b"
+    // After fragment 1 is shown, active advances to "c".
+    expect(targetToCellIndex.get("0,0,1")).toBe(2); // "c"
+  });
+
+  it("populates f=-1 with the first cell when the subslide starts with a fragment", () => {
+    const cells: Cell[] = [{ id: "a", type: "fragment" }];
+    const { targetToCellIndex } = build(cells);
+    expect(targetToCellIndex.get("0,0,-1")).toBe(0);
+    expect(targetToCellIndex.get("0,0,0")).toBe(0);
+  });
+
+  it("records continuation cells under their containing fragment's f index", () => {
+    const cells: Cell[] = [
+      { id: "a", type: "slide" },
+      { id: "b", type: "fragment" },
+      { id: "c" }, // continuation -> same fragment as b
+    ];
+    const { cellToTarget, targetToCellIndex } = build(cells);
+    expect(cellToTarget.get("c")).toEqual({ h: 0, v: 0, f: 0 });
+    // Active cell for that fragment is the last cell in the block -> "c"
+    expect(targetToCellIndex.get("0,0,0")).toBe(2);
+  });
+
+  it("drops skipped cells from the index entirely", () => {
+    const cells: Cell[] = [
+      { id: "a", type: "slide" },
+      { id: "b", type: "skip" },
+    ];
+    const { cellToTarget } = build(cells);
+    expect(cellToTarget.has("a")).toBe(true);
+    expect(cellToTarget.has("b")).toBe(false);
+  });
+});
+
+describe("resolveActiveCellIndex", () => {
+  const map = new Map<string, number>([
+    ["0,0,-1", 0],
+    ["0,0,0", 1],
+    ["0,0,1", 2],
+    ["1,0,-1", 3],
+  ]);
+
+  it("returns the exact match when one exists", () => {
+    expect(resolveActiveCellIndex(map, { h: 0, v: 0, f: 1 })).toBe(2);
+  });
+
+  it("falls back to f=-1 when there is no fragment-specific entry", () => {
+    // reveal may report f=0 for slides without any fragments
+    expect(resolveActiveCellIndex(map, { h: 1, v: 0, f: 0 })).toBe(3);
+  });
+
+  it("returns undefined for unknown stacks", () => {
+    expect(resolveActiveCellIndex(map, { h: 9, v: 0, f: 0 })).toBeUndefined();
+  });
+});

--- a/frontend/src/components/slides/__tests__/compose-slides.test.ts
+++ b/frontend/src/components/slides/__tests__/compose-slides.test.ts
@@ -5,6 +5,7 @@ import {
   buildSlideIndices,
   composeSlides,
   computeDeckNavigation,
+  resolveDeckNavigationTarget,
   resolveActiveCellIndex,
 } from "../compose-slides";
 import type { SlideType } from "@/components/editor/renderers/slides-layout/types";
@@ -311,6 +312,64 @@ describe("resolveActiveCellIndex", () => {
 
   it("returns undefined for unknown stacks", () => {
     expect(resolveActiveCellIndex(map, { h: 9, v: 0, f: 0 })).toBeUndefined();
+  });
+});
+
+describe("resolveDeckNavigationTarget", () => {
+  const resolve = (cells: Cell[], activeIndex: number | undefined) => {
+    const composition = compose(cells);
+    const { cellToTarget } = buildSlideIndices({
+      composition,
+      cells,
+      getId: (cell) => cell.id,
+    });
+    return resolveDeckNavigationTarget({
+      activeIndex,
+      cells,
+      cellToTarget,
+      getId: (cell) => cell.id,
+    });
+  };
+
+  it("returns the selected cell target when the cell is part of the deck", () => {
+    expect(
+      resolve(
+        [
+          { id: "a", type: "slide" },
+          { id: "b", type: "fragment" },
+        ],
+        1,
+      ),
+    ).toEqual({ h: 0, v: 0, f: 0 });
+  });
+
+  it("parks a skipped cell on the closest earlier deck cell", () => {
+    expect(
+      resolve(
+        [
+          { id: "a", type: "slide" },
+          { id: "skip", type: "skip" },
+          { id: "b", type: "slide" },
+        ],
+        1,
+      ),
+    ).toEqual({ h: 0, v: 0, f: -1 });
+  });
+
+  it("falls forward when a skipped cell appears before any real slide", () => {
+    expect(
+      resolve(
+        [
+          { id: "skip", type: "skip" },
+          { id: "a", type: "slide" },
+        ],
+        0,
+      ),
+    ).toEqual({ h: 0, v: 0, f: -1 });
+  });
+
+  it("returns undefined when there is no real slide to park on", () => {
+    expect(resolve([{ id: "skip", type: "skip" }], 0)).toBeUndefined();
   });
 });
 

--- a/frontend/src/components/slides/__tests__/compose-slides.test.ts
+++ b/frontend/src/components/slides/__tests__/compose-slides.test.ts
@@ -5,17 +5,22 @@ import {
   buildSlideIndices,
   composeSlides,
   resolveActiveCellIndex,
-  type ComposeCellType,
   type ComposeOptions,
 } from "../compose-slides";
+import type { SlideType } from "@/components/editor/renderers/slides-layout/types";
 
 interface Cell {
   id: string;
-  type?: ComposeCellType;
+  /**
+   * Optional for ergonomics; mirrors the on-disk shape where a missing
+   * `type` means "use the default slide type". The `compose` helper below
+   * normalizes this to `"slide"` before passing through.
+   */
+  type?: SlideType;
 }
 
 const compose = (cells: Cell[], opts: ComposeOptions = {}) =>
-  composeSlides(cells, (c) => c.type, opts);
+  composeSlides(cells, (c) => c.type ?? "slide", opts);
 
 /**
  * Collapse the tree to a readable shape so failures produce tiny, obvious
@@ -87,7 +92,7 @@ describe("composeSlides", () => {
     ]);
   });
 
-  it("treats undefined (continuation) as appending to the current block", () => {
+  it("treats cells with no type as their own new slide (the default)", () => {
     expect(
       shape([
         { id: "a", type: "slide" },
@@ -96,12 +101,14 @@ describe("composeSlides", () => {
         { id: "d" },
       ]),
     ).toEqual([
+      [[{ f: false, ids: ["a"] }]],
       [
         [
-          { f: false, ids: ["a", "b"] },
-          { f: true, ids: ["c", "d"] },
+          { f: false, ids: ["b"] },
+          { f: true, ids: ["c"] },
         ],
       ],
+      [[{ f: false, ids: ["d"] }]],
     ]);
   });
 
@@ -118,12 +125,6 @@ describe("composeSlides", () => {
         { id: "b", type: "sub-slide" },
       ]),
     ).toEqual([[[{ f: false, ids: ["a"] }], [{ f: false, ids: ["b"] }]]]);
-  });
-
-  it("creates an implicit initial block when the first cell is a continuation", () => {
-    expect(shape([{ id: "a" }, { id: "b" }])).toEqual([
-      [[{ f: false, ids: ["a", "b"] }]],
-    ]);
   });
 
   it("drops 'skip' cells by default", () => {
@@ -172,19 +173,20 @@ describe("composeSlides", () => {
     ).toEqual([[[{ f: false, ids: ["b"] }]]]);
   });
 
-  it("supports multiple fragments interleaved with continuations", () => {
+  it("opens a fresh fragment block for each consecutive fragment cell", () => {
     expect(
       shape([
         { id: "a", type: "slide" },
         { id: "b", type: "fragment" },
-        { id: "c" },
+        { id: "c", type: "fragment" },
         { id: "d", type: "fragment" },
       ]),
     ).toEqual([
       [
         [
           { f: false, ids: ["a"] },
-          { f: true, ids: ["b", "c"] },
+          { f: true, ids: ["b"] },
+          { f: true, ids: ["c"] },
           { f: true, ids: ["d"] },
         ],
       ],
@@ -197,7 +199,7 @@ describe("composeSlides", () => {
         { id: "a", type: "slide" },
         { id: "b", type: "fragment" },
         { id: "c", type: "sub-slide" },
-        { id: "d" },
+        { id: "d", type: "fragment" },
       ]),
     ).toEqual([
       [
@@ -205,7 +207,10 @@ describe("composeSlides", () => {
           { f: false, ids: ["a"] },
           { f: true, ids: ["b"] },
         ],
-        [{ f: false, ids: ["c", "d"] }],
+        [
+          { f: false, ids: ["c"] },
+          { f: true, ids: ["d"] },
+        ],
       ],
     ]);
   });
@@ -214,20 +219,22 @@ describe("composeSlides", () => {
     expect(
       shape([
         { id: "title", type: "slide" },
-        { id: "intro1" },
-        { id: "intro2", type: "fragment" },
+        { id: "intro", type: "fragment" },
         { id: "deep", type: "sub-slide" },
-        { id: "deep-body" },
+        { id: "deep-body", type: "fragment" },
         { id: "debug", type: "skip" },
         { id: "outro", type: "slide" },
       ]),
     ).toEqual([
       [
         [
-          { f: false, ids: ["title", "intro1"] },
-          { f: true, ids: ["intro2"] },
+          { f: false, ids: ["title"] },
+          { f: true, ids: ["intro"] },
         ],
-        [{ f: false, ids: ["deep", "deep-body"] }],
+        [
+          { f: false, ids: ["deep"] },
+          { f: true, ids: ["deep-body"] },
+        ],
       ],
       [[{ f: false, ids: ["outro"] }]],
     ]);
@@ -244,7 +251,7 @@ describe("composeSlides", () => {
 
 describe("buildSlideIndices", () => {
   const build = (cells: Cell[]) => {
-    const composition = composeSlides(cells, (c) => c.type);
+    const composition = composeSlides(cells, (c) => c.type ?? "slide");
     return buildSlideIndices(composition, cells, (c) => c.id);
   };
 
@@ -286,18 +293,6 @@ describe("buildSlideIndices", () => {
     const { targetToCellIndex } = build(cells);
     expect(targetToCellIndex.get("0,0,-1")).toBe(0);
     expect(targetToCellIndex.get("0,0,0")).toBe(0);
-  });
-
-  it("records continuation cells under their containing fragment's f index", () => {
-    const cells: Cell[] = [
-      { id: "a", type: "slide" },
-      { id: "b", type: "fragment" },
-      { id: "c" }, // continuation -> same fragment as b
-    ];
-    const { cellToTarget, targetToCellIndex } = build(cells);
-    expect(cellToTarget.get("c")).toEqual({ h: 0, v: 0, f: 0 });
-    // Active cell for that fragment is the last cell in the block -> "c"
-    expect(targetToCellIndex.get("0,0,0")).toBe(2);
   });
 
   it("drops skipped cells from the index entirely", () => {

--- a/frontend/src/components/slides/compose-slides.ts
+++ b/frontend/src/components/slides/compose-slides.ts
@@ -35,11 +35,6 @@ export interface Composition<T> {
   stacks: ComposedStack<T>[];
 }
 
-export interface ComposeOptions {
-  /** Drop `skip` cells entirely. Defaults to true. */
-  dropSkipped?: boolean;
-}
-
 /**
  * Groups a flat list of cells into a tree of stacks / subslides / blocks based
  * on each cell's {@link SlideType}.
@@ -56,43 +51,42 @@ export interface ComposeOptions {
  * - `"slide"`     -> open a new stack + subslide, cell goes in a plain block.
  * - `"sub-slide"` -> open a new subslide inside the current stack.
  * - `"fragment"`  -> open a new fragment block inside the current subslide.
- * - `"skip"`      -> dropped by default; kept (in the current block) when
- *                    `dropSkipped: false`.
+ * - `"skip"`      -> dropped entirely. If a caller wants to preserve these,
+ *                    they can remap the type in `getType`.
  *
  * If the very first cell is a `fragment` or `sub-slide`, a containing stack /
  * subslide is created implicitly.
  */
-export function composeSlides<T>(
-  cells: readonly T[],
-  getType: (cell: T) => SlideType,
-  opts: ComposeOptions = {},
-): Composition<T> {
-  const dropSkipped = opts.dropSkipped ?? true;
+export function composeSlides<T>({
+  cells,
+  getType,
+}: {
+  cells: readonly T[];
+  getType: (cell: T) => SlideType;
+}): Composition<T> {
   const stacks: ComposedStack<T>[] = [];
   let stack: ComposedStack<T> | null = null;
   let subslide: ComposedSubslide<T> | null = null;
-  let block: ComposedBlock<T> | null = null;
 
-  const openStack = () => {
-    stack = { subslides: [] };
-    stacks.push(stack);
+  const openStack = (): ComposedStack<T> => {
+    const next: ComposedStack<T> = { subslides: [] };
+    stacks.push(next);
+    stack = next;
     subslide = null;
-    block = null;
+    return next;
   };
-  const openSubslide = () => {
-    if (!stack) {
-      openStack();
-    }
-    subslide = { blocks: [] };
-    stack!.subslides.push(subslide);
-    block = null;
+  const openSubslide = (): ComposedSubslide<T> => {
+    const parent = stack ?? openStack();
+    const next: ComposedSubslide<T> = { blocks: [] };
+    parent.subslides.push(next);
+    subslide = next;
+    return next;
   };
-  const openBlock = (isFragment: boolean) => {
-    if (!subslide) {
-      openSubslide();
-    }
-    block = { isFragment, cells: [] };
-    subslide!.blocks.push(block);
+  const openBlock = (isFragment: boolean): ComposedBlock<T> => {
+    const parent = subslide ?? openSubslide();
+    const next: ComposedBlock<T> = { isFragment, cells: [] };
+    parent.blocks.push(next);
+    return next;
   };
 
   for (const cell of cells) {
@@ -100,30 +94,18 @@ export function composeSlides<T>(
 
     switch (type) {
       case "skip":
-        if (dropSkipped) {
-          break;
-        }
-        // Keep skipped cells in the current block if one is open, otherwise
-        // open a plain block on the current (or implicit) subslide.
-        if (!block) {
-          openBlock(false);
-        }
-        block!.cells.push(cell);
         break;
       case "slide":
         openStack();
         openSubslide();
-        openBlock(false);
-        block!.cells.push(cell);
+        openBlock(false).cells.push(cell);
         break;
       case "sub-slide":
         openSubslide();
-        openBlock(false);
-        block!.cells.push(cell);
+        openBlock(false).cells.push(cell);
         break;
       case "fragment":
-        openBlock(true);
-        block!.cells.push(cell);
+        openBlock(true).cells.push(cell);
         break;
     }
   }
@@ -166,11 +148,15 @@ export interface SlideIndices<Id> {
  * Build {@link SlideIndices} for a composition so callers can translate
  * between a flat cell list and reveal.js's `{h, v, f}` indices.
  */
-export function buildSlideIndices<T, Id>(
-  composition: Composition<T>,
-  cells: readonly T[],
-  getId: (cell: T) => Id,
-): SlideIndices<Id> {
+export function buildSlideIndices<T, Id>({
+  composition,
+  cells,
+  getId,
+}: {
+  composition: Composition<T>;
+  cells: readonly T[];
+  getId: (cell: T) => Id;
+}): SlideIndices<Id> {
   const cellToTarget = new Map<Id, SlideTarget>();
   const targetToCellIndex = new Map<string, number>();
   const cellIndexById = new Map<Id, number>();

--- a/frontend/src/components/slides/compose-slides.ts
+++ b/frontend/src/components/slides/compose-slides.ts
@@ -1,0 +1,254 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { SlideType } from "../editor/renderers/slides-layout/types";
+
+/**
+ * A contiguous run of cells that render together on a single subslide.
+ *
+ * - `isFragment=false`: cells are emitted inline in the <Slide>.
+ * - `isFragment=true`:  cells are wrapped in a single <Fragment> so they reveal
+ *   as one step.
+ */
+export interface ComposedBlock<T> {
+  isFragment: boolean;
+  cells: T[];
+}
+
+/**
+ * One <Slide>. Vertical stacking is expressed at the Stack level.
+ */
+export interface ComposedSubslide<T> {
+  blocks: ComposedBlock<T>[];
+}
+
+/**
+ * One horizontal position in the deck.
+ *
+ * - `subslides.length === 1` -> render as a single <Slide>.
+ * - `subslides.length > 1`  -> render as <Stack><Slide/>...</Stack>.
+ */
+export interface ComposedStack<T> {
+  subslides: ComposedSubslide<T>[];
+}
+
+export interface Composition<T> {
+  stacks: ComposedStack<T>[];
+}
+
+/**
+ * The per-cell slide-type. `undefined` means "continuation" — the cell sticks
+ * to whatever container the previous cell opened (slide / subslide / fragment).
+ * This matches RISE's behavior for cells with no `slide_type` metadata.
+ */
+export type ComposeCellType = SlideType | undefined;
+
+export interface ComposeOptions {
+  /** Drop `skip` cells entirely. Defaults to true. */
+  dropSkipped?: boolean;
+}
+
+/**
+ * Groups a flat list of cells into a tree of stacks / subslides / blocks based
+ * on each cell's {@link SlideType}.
+ *
+ * Inspired by the RISE JupyterLab extension's `markupSlides`, but adapted for a
+ * declarative React renderer: instead of mutating DOM during the walk, we
+ * produce a tree the caller can render however they like.
+ *
+ * Rules (per cell):
+ * - `"slide"`     -> open a new stack + subslide, cell goes in a plain block.
+ * - `"sub-slide"` -> open a new subslide inside the current stack.
+ * - `"fragment"`  -> open a new fragment block inside the current subslide.
+ * - `"skip"`      -> dropped by default; kept (in the current block) when
+ *                    `dropSkipped: false`.
+ * - `undefined`   -> append to whatever block is currently open (continuation).
+ *
+ * If the very first cell is a `fragment` or `sub-slide`, a containing stack /
+ * subslide is created implicitly.
+ */
+export function composeSlides<T>(
+  cells: readonly T[],
+  getType: (cell: T) => ComposeCellType,
+  opts: ComposeOptions = {},
+): Composition<T> {
+  const dropSkipped = opts.dropSkipped ?? true;
+  const stacks: ComposedStack<T>[] = [];
+  let stack: ComposedStack<T> | null = null;
+  let subslide: ComposedSubslide<T> | null = null;
+  let block: ComposedBlock<T> | null = null;
+
+  const openStack = () => {
+    stack = { subslides: [] };
+    stacks.push(stack);
+    subslide = null;
+    block = null;
+  };
+  const openSubslide = () => {
+    if (!stack) {
+      openStack();
+    }
+    subslide = { blocks: [] };
+    stack!.subslides.push(subslide);
+    block = null;
+  };
+  const openBlock = (isFragment: boolean) => {
+    if (!subslide) {
+      openSubslide();
+    }
+    block = { isFragment, cells: [] };
+    subslide!.blocks.push(block);
+  };
+  const appendToCurrent = (cell: T) => {
+    if (!block) {
+      openBlock(false);
+    }
+    block!.cells.push(cell);
+  };
+
+  for (const cell of cells) {
+    const type = getType(cell);
+
+    if (type === "skip") {
+      if (dropSkipped) {
+        continue;
+      }
+      appendToCurrent(cell);
+      continue;
+    }
+
+    if (type === "slide") {
+      openStack();
+      openSubslide();
+      openBlock(false);
+      block!.cells.push(cell);
+    } else if (type === "sub-slide") {
+      openSubslide();
+      openBlock(false);
+      block!.cells.push(cell);
+    } else if (type === "fragment") {
+      openBlock(true);
+      block!.cells.push(cell);
+    } else {
+      appendToCurrent(cell);
+    }
+  }
+
+  return { stacks };
+}
+
+/**
+ * A location within the composed tree. Mirrors reveal.js's `{h, v, f}` indices
+ * so callers can feed it directly to `Reveal.slide(h, v, f?)`.
+ *
+ * - `h`: stack index
+ * - `v`: subslide index within that stack
+ * - `f`: fragment block index within the subslide, or `-1` for non-fragment
+ *   cells (i.e. content that's visible before any fragment is revealed).
+ */
+export interface SlideTarget {
+  h: number;
+  v: number;
+  f: number;
+}
+
+export interface SlideIndices<Id> {
+  /** Where each cell lives in the deck. */
+  cellToTarget: Map<Id, SlideTarget>;
+  /**
+   * `"h,v,f"` -> flat index into the original cell list. The value is the
+   * "active" cell for that position — i.e. the last cell currently visible
+   * on screen, so the active cell advances as the user steps through
+   * fragments.
+   *
+   * `f === -1` represents "nothing revealed yet" and is always populated when
+   * a subslide exists, so it doubles as a fallback for subslides that have
+   * no fragments at all (reveal reports `f === 0` in that case).
+   */
+  targetToCellIndex: Map<string, number>;
+}
+
+/**
+ * Build {@link SlideIndices} for a composition so callers can translate
+ * between a flat cell list and reveal.js's `{h, v, f}` indices.
+ */
+export function buildSlideIndices<T, Id>(
+  composition: Composition<T>,
+  cells: readonly T[],
+  getId: (cell: T) => Id,
+): SlideIndices<Id> {
+  const cellToTarget = new Map<Id, SlideTarget>();
+  const targetToCellIndex = new Map<string, number>();
+  const cellIndexById = new Map<Id, number>();
+  for (const [i, cell] of cells.entries()) {
+    cellIndexById.set(getId(cell), i);
+  }
+
+  composition.stacks.forEach((stack, h) => {
+    stack.subslides.forEach((sub, v) => {
+      // f = -1: "nothing revealed yet" state. Active cell = last cell that
+      // appears before the first fragment block. If the subslide starts with
+      // a fragment block, fall back to its first cell so we still have an
+      // anchor when nothing is visible yet.
+      let preFragmentActiveId: Id | undefined;
+      for (const block of sub.blocks) {
+        if (block.isFragment) {
+          break;
+        }
+        const last = block.cells.at(-1);
+        if (last) {
+          preFragmentActiveId = getId(last);
+        }
+      }
+      if (preFragmentActiveId === undefined) {
+        const fallback = sub.blocks[0]?.cells[0];
+        if (fallback) {
+          preFragmentActiveId = getId(fallback);
+        }
+      }
+      if (preFragmentActiveId !== undefined) {
+        const idx = cellIndexById.get(preFragmentActiveId);
+        if (idx != null) {
+          targetToCellIndex.set(`${h},${v},-1`, idx);
+        }
+      }
+
+      let fragmentCounter = -1;
+      for (const block of sub.blocks) {
+        if (block.isFragment) {
+          fragmentCounter++;
+          for (const cell of block.cells) {
+            cellToTarget.set(getId(cell), { h, v, f: fragmentCounter });
+          }
+          const last = block.cells.at(-1);
+          if (last) {
+            const idx = cellIndexById.get(getId(last));
+            if (idx != null) {
+              targetToCellIndex.set(`${h},${v},${fragmentCounter}`, idx);
+            }
+          }
+        } else {
+          for (const cell of block.cells) {
+            cellToTarget.set(getId(cell), { h, v, f: -1 });
+          }
+        }
+      }
+    });
+  });
+  return { cellToTarget, targetToCellIndex };
+}
+
+/**
+ * Resolve the flat cell index for the current reveal indices. For slides
+ * without fragments reveal may report `f = 0`, so we fall back to the `-1`
+ * entry (which is always populated when a subslide exists).
+ */
+export function resolveActiveCellIndex(
+  targetToCellIndex: ReadonlyMap<string, number>,
+  indices: { h: number; v: number; f: number },
+): number | undefined {
+  const { h, v, f } = indices;
+  return (
+    targetToCellIndex.get(`${h},${v},${f}`) ??
+    targetToCellIndex.get(`${h},${v},-1`)
+  );
+}

--- a/frontend/src/components/slides/compose-slides.ts
+++ b/frontend/src/components/slides/compose-slides.ts
@@ -234,10 +234,88 @@ export function resolveActiveCellIndex(
   );
 }
 
+function findDeckTarget<T, Id>({
+  start,
+  stop,
+  step,
+  cells,
+  cellToTarget,
+  getId,
+}: {
+  start: number;
+  stop: number;
+  step: 1 | -1;
+  cells: readonly T[];
+  cellToTarget: ReadonlyMap<Id, SlideTarget>;
+  getId: (cell: T) => Id;
+}): SlideTarget | undefined {
+  for (let i = start; i !== stop; i += step) {
+    const target = cellToTarget.get(getId(cells[i]));
+    if (target) {
+      return target;
+    }
+  }
+  return undefined;
+}
+
 /**
- * Decide where the deck should navigate to given the user's current target
- * cell. Returns `null` when the deck is already in the right place so the
- * caller can skip the imperative `deck.slide()` call.
+ * Resolve the deck location that should back the currently selected minimap
+ * entry.
+ *
+ * Cells marked `"skip"` are not part of the composed deck; for those we
+ * "park" on the closest real slide in notebook order (preferring the
+ * predecessor). Handling the UI consequences of parking — ignoring reveal.js
+ * echo events and intercepting keyboard nav — is the caller's job.
+ */
+export function resolveDeckNavigationTarget<T, Id>({
+  activeIndex,
+  cells,
+  cellToTarget,
+  getId,
+}: {
+  activeIndex: number | undefined;
+  cells: readonly T[];
+  cellToTarget: ReadonlyMap<Id, SlideTarget>;
+  getId: (cell: T) => Id;
+}): SlideTarget | undefined {
+  if (activeIndex == null) {
+    return undefined;
+  }
+
+  const activeCell = cells[activeIndex];
+  if (!activeCell) {
+    return undefined;
+  }
+
+  const directTarget = cellToTarget.get(getId(activeCell));
+  if (directTarget) {
+    return directTarget;
+  }
+
+  return (
+    findDeckTarget({
+      start: activeIndex - 1,
+      stop: -1,
+      step: -1,
+      cells,
+      cellToTarget,
+      getId,
+    }) ??
+    findDeckTarget({
+      start: activeIndex + 1,
+      stop: cells.length,
+      step: 1,
+      cells,
+      cellToTarget,
+      getId,
+    })
+  );
+}
+
+/**
+ * Decide where the deck should navigate to given the user's target cell, or
+ * `null` if the deck is already there (so the caller can skip the imperative
+ * `deck.slide()` call).
  *
  * Each minimap entry is a distinct navigation target, so the fragment index
  * is always pinned:
@@ -251,13 +329,9 @@ export function computeDeckNavigation(
   current: { h: number; v: number; f: number },
   target: SlideTarget,
 ): SlideTarget | null {
-  const targetF = target.f >= 0 ? target.f : -1;
-  if (
-    current.h === target.h &&
-    current.v === target.v &&
-    current.f === targetF
-  ) {
+  const next = { h: target.h, v: target.v, f: target.f >= 0 ? target.f : -1 };
+  if (current.h === next.h && current.v === next.v && current.f === next.f) {
     return null;
   }
-  return { h: target.h, v: target.v, f: targetF };
+  return next;
 }

--- a/frontend/src/components/slides/compose-slides.ts
+++ b/frontend/src/components/slides/compose-slides.ts
@@ -35,13 +35,6 @@ export interface Composition<T> {
   stacks: ComposedStack<T>[];
 }
 
-/**
- * The per-cell slide-type. `undefined` means "continuation" — the cell sticks
- * to whatever container the previous cell opened (slide / subslide / fragment).
- * This matches RISE's behavior for cells with no `slide_type` metadata.
- */
-export type ComposeCellType = SlideType | undefined;
-
 export interface ComposeOptions {
   /** Drop `skip` cells entirely. Defaults to true. */
   dropSkipped?: boolean;
@@ -55,20 +48,23 @@ export interface ComposeOptions {
  * declarative React renderer: instead of mutating DOM during the walk, we
  * produce a tree the caller can render however they like.
  *
+ * Callers are responsible for normalizing "no type set" to a concrete
+ * {@link SlideType} before getting here — the convention in this codebase is
+ * that a cell with no configured type is a `"slide"`.
+ *
  * Rules (per cell):
  * - `"slide"`     -> open a new stack + subslide, cell goes in a plain block.
  * - `"sub-slide"` -> open a new subslide inside the current stack.
  * - `"fragment"`  -> open a new fragment block inside the current subslide.
  * - `"skip"`      -> dropped by default; kept (in the current block) when
  *                    `dropSkipped: false`.
- * - `undefined`   -> append to whatever block is currently open (continuation).
  *
  * If the very first cell is a `fragment` or `sub-slide`, a containing stack /
  * subslide is created implicitly.
  */
 export function composeSlides<T>(
   cells: readonly T[],
-  getType: (cell: T) => ComposeCellType,
+  getType: (cell: T) => SlideType,
   opts: ComposeOptions = {},
 ): Composition<T> {
   const dropSkipped = opts.dropSkipped ?? true;
@@ -98,38 +94,37 @@ export function composeSlides<T>(
     block = { isFragment, cells: [] };
     subslide!.blocks.push(block);
   };
-  const appendToCurrent = (cell: T) => {
-    if (!block) {
-      openBlock(false);
-    }
-    block!.cells.push(cell);
-  };
 
   for (const cell of cells) {
     const type = getType(cell);
 
-    if (type === "skip") {
-      if (dropSkipped) {
-        continue;
-      }
-      appendToCurrent(cell);
-      continue;
-    }
-
-    if (type === "slide") {
-      openStack();
-      openSubslide();
-      openBlock(false);
-      block!.cells.push(cell);
-    } else if (type === "sub-slide") {
-      openSubslide();
-      openBlock(false);
-      block!.cells.push(cell);
-    } else if (type === "fragment") {
-      openBlock(true);
-      block!.cells.push(cell);
-    } else {
-      appendToCurrent(cell);
+    switch (type) {
+      case "skip":
+        if (dropSkipped) {
+          break;
+        }
+        // Keep skipped cells in the current block if one is open, otherwise
+        // open a plain block on the current (or implicit) subslide.
+        if (!block) {
+          openBlock(false);
+        }
+        block!.cells.push(cell);
+        break;
+      case "slide":
+        openStack();
+        openSubslide();
+        openBlock(false);
+        block!.cells.push(cell);
+        break;
+      case "sub-slide":
+        openSubslide();
+        openBlock(false);
+        block!.cells.push(cell);
+        break;
+      case "fragment":
+        openBlock(true);
+        block!.cells.push(cell);
+        break;
     }
   }
 

--- a/frontend/src/components/slides/compose-slides.ts
+++ b/frontend/src/components/slides/compose-slides.ts
@@ -247,3 +247,31 @@ export function resolveActiveCellIndex(
     targetToCellIndex.get(`${h},${v},-1`)
   );
 }
+
+/**
+ * Decide where the deck should navigate to given the user's current target
+ * cell. Returns `null` when the deck is already in the right place so the
+ * caller can skip the imperative `deck.slide()` call.
+ *
+ * Each minimap entry is a distinct navigation target, so the fragment index
+ * is always pinned:
+ *   - fragment cells (`target.f >= 0`) advance to that fragment
+ *   - non-fragment cells reset to `f = -1` so any revealed fragments on the
+ *     destination slide collapse — otherwise jumping to the parent slide
+ *     from elsewhere in the deck leaves fragments looking "completed"
+ *     instead of clean.
+ */
+export function computeDeckNavigation(
+  current: { h: number; v: number; f: number },
+  target: SlideTarget,
+): SlideTarget | null {
+  const targetF = target.f >= 0 ? target.f : -1;
+  if (
+    current.h === target.h &&
+    current.v === target.v &&
+    current.f === targetF
+  ) {
+    return null;
+  }
+  return { h: target.h, v: target.v, f: targetF };
+}

--- a/frontend/src/components/slides/minimap.tsx
+++ b/frontend/src/components/slides/minimap.tsx
@@ -48,8 +48,15 @@ interface ResolvedDropTarget {
   index: number;
 }
 
+interface ThumbnailDimensions {
+  width: number;
+  height: number;
+  scale: number;
+}
+
 interface SlideThumbnailCardProps extends React.HTMLAttributes<HTMLDivElement> {
   cell: SlideCell;
+  dimensions: ThumbnailDimensions;
   isActiveSlide?: boolean;
   isActiveDragSource?: boolean;
   isOverlay?: boolean;
@@ -59,6 +66,7 @@ interface SlideThumbnailCardProps extends React.HTMLAttributes<HTMLDivElement> {
 
 interface SlideThumbnailRowProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   cell: SlideCell;
+  dimensions: ThumbnailDimensions;
   isActiveSlide?: boolean;
   dropIndicator?: DropPosition | null;
   isActiveDragSource?: boolean;
@@ -68,14 +76,22 @@ interface SlideThumbnailRowProps extends React.ButtonHTMLAttributes<HTMLButtonEl
 
 interface SlidesMinimapProps {
   cells: SlideCell[];
+  thumbnailWidth: number;
   canReorder: boolean;
   activeCellId: CellId | null;
   onSlideClick: (index: number) => void;
 }
 
-const THUMBNAIL_WIDTH = 256;
-const THUMBNAIL_HEIGHT = 144;
-const THUMBNAIL_SCALE = 0.3;
+const SLIDE_ASPECT_RATIO = 16 / 9;
+const SLIDE_BASE_WIDTH = 960;
+
+function computeThumbnailDimensions(width: number): ThumbnailDimensions {
+  return {
+    width,
+    height: width / SLIDE_ASPECT_RATIO,
+    scale: width / SLIDE_BASE_WIDTH,
+  };
+}
 const MINIMAP_AUTO_SCROLL = {
   threshold: { x: 0, y: 0.1 },
 };
@@ -156,6 +172,7 @@ function useVisibleCellIds(
 
 export const SlidesMinimap = ({
   cells,
+  thumbnailWidth,
   canReorder,
   activeCellId,
   onSlideClick,
@@ -168,6 +185,7 @@ export const SlidesMinimap = ({
   const [dropTarget, setDropTarget] = useState<ProjectedDropTarget | null>(
     null,
   );
+  const dimensions = computeThumbnailDimensions(thumbnailWidth);
 
   useEffect(() => {
     if (!activeCellId || !containerRef.current) {
@@ -245,6 +263,7 @@ export const SlidesMinimap = ({
           <SlideThumbnailRow
             key={cell.id}
             cell={cell}
+            dimensions={dimensions}
             isActiveSlide={cell.id === activeCellId}
             isVisible={visibleIds.has(cell.id)}
             onClick={() => onSlideClick(index)}
@@ -275,6 +294,7 @@ export const SlidesMinimap = ({
             <SortableSlideThumbnail
               key={cell.id}
               cell={cell}
+              dimensions={dimensions}
               isActive={activeId === cell.id}
               isActiveSlide={cell.id === activeCellId}
               isVisible={visibleIds.has(cell.id)}
@@ -292,6 +312,7 @@ export const SlidesMinimap = ({
         {activeCell && (
           <SlideThumbnailCard
             cell={activeCell}
+            dimensions={dimensions}
             isOverlay={true}
             isActiveDragSource={true}
           />
@@ -320,6 +341,7 @@ const SlideThumbnailsContainer = ({
 
 interface SortableSlideThumbnailProps {
   cell: SlideCell;
+  dimensions: ThumbnailDimensions;
   dropIndicator?: DropPosition | null;
   isActive: boolean;
   isActiveSlide?: boolean;
@@ -329,6 +351,7 @@ interface SortableSlideThumbnailProps {
 
 const SortableSlideThumbnail = ({
   cell,
+  dimensions,
   dropIndicator,
   isActive,
   isActiveSlide,
@@ -343,6 +366,7 @@ const SortableSlideThumbnail = ({
     <SlideThumbnailRow
       ref={setNodeRef}
       cell={cell}
+      dimensions={dimensions}
       dropIndicator={dropIndicator}
       isActiveDragSource={isActive}
       isActiveSlide={isActiveSlide}
@@ -356,6 +380,7 @@ const SortableSlideThumbnail = ({
 
 const SlideThumbnailRow = ({
   cell,
+  dimensions,
   className,
   style,
   dropIndicator,
@@ -397,6 +422,7 @@ const SlideThumbnailRow = ({
       )}
       <SlideThumbnailCard
         cell={cell}
+        dimensions={dimensions}
         isActiveSlide={isActiveSlide}
         isActiveDragSource={isActiveDragSource}
         isVisible={isVisible}
@@ -407,6 +433,7 @@ const SlideThumbnailRow = ({
 
 const SlideThumbnailCard = ({
   cell,
+  dimensions,
   className,
   style,
   isActiveSlide = false,
@@ -416,15 +443,17 @@ const SlideThumbnailCard = ({
   ref,
   ...props
 }: SlideThumbnailCardProps) => {
+  const { width, height, scale } = dimensions;
+
   const outerStyle: React.CSSProperties = {
-    width: THUMBNAIL_WIDTH,
-    height: THUMBNAIL_HEIGHT,
+    width,
+    height,
     contain: "strict",
     ...(isOverlay
       ? null
       : {
           contentVisibility: "auto",
-          containIntrinsicSize: `${THUMBNAIL_WIDTH}px ${THUMBNAIL_HEIGHT}px`,
+          containIntrinsicSize: `${width}px ${height}px`,
         }),
     ...style,
   };
@@ -450,10 +479,10 @@ const SlideThumbnailCard = ({
         <div
           className="flex p-6 box-border pointer-events-none mo-slide-content overflow-hidden"
           style={{
-            transform: `scale(${THUMBNAIL_SCALE})`,
+            transform: `scale(${scale})`,
             transformOrigin: "top left",
-            width: THUMBNAIL_WIDTH / THUMBNAIL_SCALE,
-            height: THUMBNAIL_HEIGHT / THUMBNAIL_SCALE,
+            width: width / scale,
+            height: height / scale,
           }}
         >
           <Slide cellId={cell.id} status={cell.status} output={cell.output} />

--- a/frontend/src/components/slides/minimap.tsx
+++ b/frontend/src/components/slides/minimap.tsx
@@ -5,7 +5,10 @@ import type { CellId } from "@/core/cells/ids";
 import type { CellColumnId } from "@/utils/id-tree";
 import { useEffect, useRef, useState } from "react";
 import type { ICellRendererProps } from "../editor/renderers/types";
-import type { SlidesLayout } from "../editor/renderers/slides-layout/types";
+import type {
+  SlideType,
+  SlidesLayout,
+} from "../editor/renderers/slides-layout/types";
 import {
   DndContext,
   DragOverlay,
@@ -29,9 +32,10 @@ import {
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { cn } from "@/utils/cn";
 import { Slide } from "./slide";
-import { EyeOffIcon, InfoIcon } from "lucide-react";
+import { InfoIcon, type LucideIcon } from "lucide-react";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Logger } from "@/utils/Logger";
+import { SLIDE_TYPE_OPTIONS_BY_VALUE } from "./slide-form";
 
 type Props = ICellRendererProps<SlidesLayout>;
 type SlideCell = Props["cells"][number];
@@ -62,7 +66,7 @@ interface SlideThumbnailCardProps extends React.HTMLAttributes<HTMLDivElement> {
   isActiveDragSource?: boolean;
   isOverlay?: boolean;
   isVisible?: boolean;
-  isSkipped?: boolean;
+  slideType?: SlideType;
   ref?: React.Ref<HTMLDivElement>;
 }
 
@@ -73,7 +77,7 @@ interface SlideThumbnailRowProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   dropIndicator?: DropPosition | null;
   isActiveDragSource?: boolean;
   isVisible?: boolean;
-  isSkipped?: boolean;
+  slideType?: SlideType;
   ref?: React.Ref<HTMLButtonElement>;
 }
 
@@ -82,13 +86,20 @@ interface SlidesMinimapProps {
   thumbnailWidth: number;
   canReorder: boolean;
   activeCellId: CellId | null;
-  /**
-   * Set of cell ids that are marked `skip` in the slides layout. These are
-   * still rendered in the minimap but visually deemphasized to signal they
-   * won't appear in fullscreen presentation mode.
-   */
+  // Set of cell ids that are marked `skip` in the slides layout.
   skippedIds?: ReadonlySet<CellId>;
+  slideTypes?: ReadonlyMap<CellId, SlideType>;
   onSlideClick: (index: number) => void;
+}
+
+function getSlideTypeVisual(
+  slideType: SlideType | undefined,
+): { label: string; description: string; Icon: LucideIcon } | null {
+  if (!slideType || slideType === "slide") {
+    return null;
+  }
+  const { label, description, Icon } = SLIDE_TYPE_OPTIONS_BY_VALUE[slideType];
+  return { label, description, Icon };
 }
 
 const SLIDE_ASPECT_RATIO = 16 / 9;
@@ -185,6 +196,7 @@ export const SlidesMinimap = ({
   canReorder,
   activeCellId,
   skippedIds,
+  slideTypes,
   onSlideClick,
 }: SlidesMinimapProps) => {
   const cellIds = useCellIds();
@@ -276,7 +288,11 @@ export const SlidesMinimap = ({
             dimensions={dimensions}
             isActiveSlide={cell.id === activeCellId}
             isVisible={visibleIds.has(cell.id)}
-            isSkipped={skippedIds?.has(cell.id)}
+            slideType={resolveSlideType({
+              cellId: cell.id,
+              slideTypes,
+              skippedIds,
+            })}
             onClick={() => onSlideClick(index)}
           />
         ))}
@@ -309,7 +325,11 @@ export const SlidesMinimap = ({
               isActive={activeId === cell.id}
               isActiveSlide={cell.id === activeCellId}
               isVisible={visibleIds.has(cell.id)}
-              isSkipped={skippedIds?.has(cell.id)}
+              slideType={resolveSlideType({
+                cellId: cell.id,
+                slideTypes,
+                skippedIds,
+              })}
               dropIndicator={
                 dropTarget?.overId === cell.id && activeId !== cell.id
                   ? dropTarget.position
@@ -358,7 +378,7 @@ interface SortableSlideThumbnailProps {
   isActive: boolean;
   isActiveSlide?: boolean;
   isVisible?: boolean;
-  isSkipped?: boolean;
+  slideType?: SlideType;
   onClick?: () => void;
 }
 
@@ -369,7 +389,7 @@ const SortableSlideThumbnail = ({
   isActive,
   isActiveSlide,
   isVisible,
-  isSkipped,
+  slideType,
   onClick,
 }: SortableSlideThumbnailProps) => {
   const { attributes, listeners, setNodeRef } = useSortable({
@@ -385,7 +405,7 @@ const SortableSlideThumbnail = ({
       isActiveDragSource={isActive}
       isActiveSlide={isActiveSlide}
       isVisible={isVisible}
-      isSkipped={isSkipped}
+      slideType={slideType}
       onClick={onClick}
       {...attributes}
       {...listeners}
@@ -402,7 +422,7 @@ const SlideThumbnailRow = ({
   isActiveSlide = false,
   isActiveDragSource = false,
   isVisible,
-  isSkipped = false,
+  slideType,
   onClick,
   ref,
   ...props
@@ -413,7 +433,7 @@ const SlideThumbnailRow = ({
     ...style,
   };
 
-  const button = (
+  return (
     <button
       ref={ref}
       type="button"
@@ -442,19 +462,10 @@ const SlideThumbnailRow = ({
         isActiveSlide={isActiveSlide}
         isActiveDragSource={isActiveDragSource}
         isVisible={isVisible}
-        isSkipped={isSkipped}
+        slideType={slideType}
       />
     </button>
   );
-
-  if (isSkipped) {
-    return (
-      <Tooltip content="Skipped in presentation" delayDuration={300}>
-        {button}
-      </Tooltip>
-    );
-  }
-  return button;
 };
 
 const SlideThumbnailCard = ({
@@ -466,11 +477,13 @@ const SlideThumbnailCard = ({
   isActiveDragSource = false,
   isOverlay = false,
   isVisible = false,
-  isSkipped = false,
+  slideType,
   ref,
   ...props
 }: SlideThumbnailCardProps) => {
   const { width, height, scale } = dimensions;
+  const visual = getSlideTypeVisual(slideType);
+  const isSkipped = slideType === "skip";
 
   const outerStyle: React.CSSProperties = {
     width,
@@ -516,18 +529,30 @@ const SlideThumbnailCard = ({
         </div>
       )}
       {isSkipped && (
-        <>
-          <div
-            className="absolute inset-0 bg-muted/60 pointer-events-none"
-            aria-hidden={true}
-          />
-          <div
-            className="absolute top-1 right-1 rounded-full bg-background/90 border border-border p-1 shadow-sm pointer-events-none"
-            aria-label="Skipped in presentation"
+        <div
+          className="absolute inset-0 bg-muted/60 pointer-events-none"
+          aria-hidden={true}
+        />
+      )}
+      {visual && (
+        <Tooltip
+          content={
+            <span className="text-xs opacity-80">{visual.description}</span>
+          }
+        >
+          <span
+            className={cn(
+              "absolute top-1 right-1 flex items-center gap-1 rounded-full border p-0.5 font-medium leading-none shadow-xs cursor-help",
+              isSkipped
+                ? "bg-background/90 border-border text-muted-foreground"
+                : "bg-background/95 border-border text-foreground/80",
+            )}
+            aria-label={visual.label}
           >
-            <EyeOffIcon className="h-3 w-3 text-muted-foreground" />
-          </div>
-        </>
+            <visual.Icon className="h-3.5 w-3.5" />
+            {/* <span>{visual.label}</span> */}
+          </span>
+        </Tooltip>
       )}
     </div>
   );
@@ -595,6 +620,32 @@ function resolveDropTarget({
  */
 function asCellId(id: UniqueIdentifier): CellId | null {
   return typeof id === "string" ? (id as CellId) : null;
+}
+
+/**
+ * Resolves the effective slide type for a cell. Falls back to `"skip"` if the
+ * caller-supplied `skippedIds` set marks the cell as skipped, which keeps this
+ * component working when only the legacy `skippedIds` prop is provided.
+ * Returns `undefined` for the default `"slide"` type so callers can skip
+ * rendering any badge.
+ */
+function resolveSlideType({
+  cellId,
+  slideTypes,
+  skippedIds,
+}: {
+  cellId: CellId;
+  slideTypes: ReadonlyMap<CellId, SlideType> | undefined;
+  skippedIds: ReadonlySet<CellId> | undefined;
+}): SlideType | undefined {
+  const type = slideTypes?.get(cellId);
+  if (type && type !== "slide") {
+    return type;
+  }
+  if (skippedIds?.has(cellId)) {
+    return "skip";
+  }
+  return undefined;
 }
 
 export const exportedForTesting = {

--- a/frontend/src/components/slides/minimap.tsx
+++ b/frontend/src/components/slides/minimap.tsx
@@ -29,7 +29,8 @@ import {
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { cn } from "@/utils/cn";
 import { Slide } from "./slide";
-import { InfoIcon } from "lucide-react";
+import { EyeOffIcon, InfoIcon } from "lucide-react";
+import { Tooltip } from "@/components/ui/tooltip";
 import { Logger } from "@/utils/Logger";
 
 type Props = ICellRendererProps<SlidesLayout>;
@@ -61,6 +62,7 @@ interface SlideThumbnailCardProps extends React.HTMLAttributes<HTMLDivElement> {
   isActiveDragSource?: boolean;
   isOverlay?: boolean;
   isVisible?: boolean;
+  isSkipped?: boolean;
   ref?: React.Ref<HTMLDivElement>;
 }
 
@@ -71,6 +73,7 @@ interface SlideThumbnailRowProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   dropIndicator?: DropPosition | null;
   isActiveDragSource?: boolean;
   isVisible?: boolean;
+  isSkipped?: boolean;
   ref?: React.Ref<HTMLButtonElement>;
 }
 
@@ -79,6 +82,12 @@ interface SlidesMinimapProps {
   thumbnailWidth: number;
   canReorder: boolean;
   activeCellId: CellId | null;
+  /**
+   * Set of cell ids that are marked `skip` in the slides layout. These are
+   * still rendered in the minimap but visually deemphasized to signal they
+   * won't appear in fullscreen presentation mode.
+   */
+  skippedIds?: ReadonlySet<CellId>;
   onSlideClick: (index: number) => void;
 }
 
@@ -175,6 +184,7 @@ export const SlidesMinimap = ({
   thumbnailWidth,
   canReorder,
   activeCellId,
+  skippedIds,
   onSlideClick,
 }: SlidesMinimapProps) => {
   const cellIds = useCellIds();
@@ -266,6 +276,7 @@ export const SlidesMinimap = ({
             dimensions={dimensions}
             isActiveSlide={cell.id === activeCellId}
             isVisible={visibleIds.has(cell.id)}
+            isSkipped={skippedIds?.has(cell.id)}
             onClick={() => onSlideClick(index)}
           />
         ))}
@@ -298,6 +309,7 @@ export const SlidesMinimap = ({
               isActive={activeId === cell.id}
               isActiveSlide={cell.id === activeCellId}
               isVisible={visibleIds.has(cell.id)}
+              isSkipped={skippedIds?.has(cell.id)}
               dropIndicator={
                 dropTarget?.overId === cell.id && activeId !== cell.id
                   ? dropTarget.position
@@ -346,6 +358,7 @@ interface SortableSlideThumbnailProps {
   isActive: boolean;
   isActiveSlide?: boolean;
   isVisible?: boolean;
+  isSkipped?: boolean;
   onClick?: () => void;
 }
 
@@ -356,6 +369,7 @@ const SortableSlideThumbnail = ({
   isActive,
   isActiveSlide,
   isVisible,
+  isSkipped,
   onClick,
 }: SortableSlideThumbnailProps) => {
   const { attributes, listeners, setNodeRef } = useSortable({
@@ -371,6 +385,7 @@ const SortableSlideThumbnail = ({
       isActiveDragSource={isActive}
       isActiveSlide={isActiveSlide}
       isVisible={isVisible}
+      isSkipped={isSkipped}
       onClick={onClick}
       {...attributes}
       {...listeners}
@@ -387,6 +402,7 @@ const SlideThumbnailRow = ({
   isActiveSlide = false,
   isActiveDragSource = false,
   isVisible,
+  isSkipped = false,
   onClick,
   ref,
   ...props
@@ -397,7 +413,7 @@ const SlideThumbnailRow = ({
     ...style,
   };
 
-  return (
+  const button = (
     <button
       ref={ref}
       type="button"
@@ -426,9 +442,19 @@ const SlideThumbnailRow = ({
         isActiveSlide={isActiveSlide}
         isActiveDragSource={isActiveDragSource}
         isVisible={isVisible}
+        isSkipped={isSkipped}
       />
     </button>
   );
+
+  if (isSkipped) {
+    return (
+      <Tooltip content="Skipped in presentation" delayDuration={300}>
+        {button}
+      </Tooltip>
+    );
+  }
+  return button;
 };
 
 const SlideThumbnailCard = ({
@@ -440,6 +466,7 @@ const SlideThumbnailCard = ({
   isActiveDragSource = false,
   isOverlay = false,
   isVisible = false,
+  isSkipped = false,
   ref,
   ...props
 }: SlideThumbnailCardProps) => {
@@ -464,7 +491,7 @@ const SlideThumbnailCard = ({
     <div
       ref={ref}
       className={cn(
-        "border-2 shrink-0 rounded-md relative select-none bg-background cursor-pointer active:cursor-grabbing",
+        "border-2 shrink-0 rounded-md relative select-none bg-background cursor-pointer active:cursor-grabbing overflow-hidden",
         isActiveSlide || isActiveDragSource || isOverlay
           ? "border-blue-500"
           : "border-border",
@@ -487,6 +514,20 @@ const SlideThumbnailCard = ({
         >
           <Slide cellId={cell.id} status={cell.status} output={cell.output} />
         </div>
+      )}
+      {isSkipped && (
+        <>
+          <div
+            className="absolute inset-0 bg-muted/60 pointer-events-none"
+            aria-hidden={true}
+          />
+          <div
+            className="absolute top-1 right-1 rounded-full bg-background/90 border border-border p-1 shadow-sm pointer-events-none"
+            aria-label="Skipped in presentation"
+          >
+            <EyeOffIcon className="h-3 w-3 text-muted-foreground" />
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -1,6 +1,12 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { useEffect, useRef, useState, Fragment as ReactFragment } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  Fragment as ReactFragment,
+} from "react";
 import useEvent from "react-use-event-hook";
 import {
   ExpandIcon,
@@ -14,7 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/utils/cn";
 import type { CellData, CellRuntimeState } from "@/core/cells/types";
-import type { RevealApi } from "reveal.js";
+import type { RevealApi, RevealConfig } from "reveal.js";
 import { Events } from "@/utils/events";
 import { Logger } from "@/utils/Logger";
 import "./slides.css";
@@ -124,9 +130,13 @@ const RevealSlidesComponent = ({
   // `undefined` when the deck is empty; that case is handled below.
   const activeConfigCell = activeCell ?? cellsWithOutput[0];
 
-  const composition = composeSlides(
-    cellsWithOutput,
-    (cell) => layout.cells.get(cell.id)?.type ?? DEFAULT_SLIDE_TYPE,
+  const composition = useMemo(
+    () =>
+      composeSlides(
+        cellsWithOutput,
+        (cell) => layout.cells.get(cell.id)?.type ?? DEFAULT_SLIDE_TYPE,
+      ),
+    [cellsWithOutput, layout.cells],
   );
 
   // Skip cells are dropped from the composed deck to match reveal.js
@@ -137,10 +147,24 @@ const RevealSlidesComponent = ({
       ? activeCell
       : null;
 
-  const { cellToTarget, targetToCellIndex } = buildSlideIndices(
-    composition,
-    cellsWithOutput,
-    (c) => c.id,
+  const { cellToTarget, targetToCellIndex } = useMemo(
+    () => buildSlideIndices(composition, cellsWithOutput, (c) => c.id),
+    [composition, cellsWithOutput],
+  );
+
+  const deckTransition = layout.deck?.transition ?? DEFAULT_DECK_TRANSITION;
+  const revealConfig: RevealConfig = useMemo(
+    () => ({
+      embedded: true,
+      width,
+      height,
+      center: false,
+      minScale: 0.2,
+      maxScale: 2,
+      transition: deckTransition,
+      keyboardCondition: (event: KeyboardEvent) => !Events.fromInput(event),
+    }),
+    [width, height, deckTransition],
   );
 
   useEffect(() => {
@@ -190,17 +214,7 @@ const RevealSlidesComponent = ({
         <Deck
           deckRef={deckRef}
           className="aspect-video overflow-hidden h-full border rounded bg-background mo-slides-theme prose-slides"
-          config={{
-            embedded: true,
-            width,
-            height,
-            center: false,
-            minScale: 0.2,
-            maxScale: 2,
-            transition: layout.deck?.transition ?? DEFAULT_DECK_TRANSITION,
-            keyboardCondition: (event: KeyboardEvent) =>
-              !Events.fromInput(event),
-          }}
+          config={revealConfig}
           onSlideChange={() => {
             reportCurrentCell();
             const deck = deckRef.current;

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -168,7 +168,6 @@ const RevealSlidesComponent = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { width, height } = useSlideDimensions(containerRef);
-  const [isConfigOpen, setIsConfigOpen] = useState(false);
   const activeCell =
     activeIndex != null ? cellsWithOutput[activeIndex] : undefined;
   // Fall back to the first cell while the deck settles on an initial slide.

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -1,33 +1,39 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { useEffect, useRef, useState } from "react";
-import { ChevronRightIcon, ExpandIcon, SettingsIcon } from "lucide-react";
-import { Deck, Slide } from "@revealjs/react";
+import { useEffect, useRef, useState, Fragment as ReactFragment } from "react";
+import useEvent from "react-use-event-hook";
+import {
+  ExpandIcon,
+  EyeOffIcon,
+  PanelRightCloseIcon,
+  PanelRightOpenIcon,
+} from "lucide-react";
+import { Deck, Fragment, Slide, Stack } from "@revealjs/react";
 import { Slide as CellOutputSlide } from "@/components/slides/slide";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { cn } from "@/utils/cn";
 import type { CellData, CellRuntimeState } from "@/core/cells/types";
 import type { RevealApi } from "reveal.js";
 import { Events } from "@/utils/events";
 import { Logger } from "@/utils/Logger";
-import {
-  Select,
-  SelectItem,
-  SelectContent,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
 import "./slides.css";
 import "./reveal-slides.css";
-import type {
-  SlideType,
-  SlidesLayout,
-} from "../editor/renderers/slides-layout/types";
-import type { CellId } from "@/core/cells/ids";
+import type { SlidesLayout } from "../editor/renderers/slides-layout/types";
+import {
+  buildSlideIndices,
+  composeSlides,
+  resolveActiveCellIndex,
+  type ComposedSubslide,
+} from "./compose-slides";
+import { DEFAULT_SLIDE_TYPE, SlidesForm } from "./slide-form";
 
 const ASPECT_RATIO = 16 / 9;
-const COLLAPSED_CONFIG_WIDTH = 32;
-const DEFAULT_SLIDE_TYPE: SlideType = "slide";
+const COLLAPSED_CONFIG_WIDTH = 36;
+const CONFIG_OPEN_STORAGE_KEY = "marimo:slides:configOpen";
+
+type RuntimeCell = CellRuntimeState & CellData;
 
 function useSlideDimensions(ref: React.RefObject<HTMLDivElement | null>) {
   const [dims, setDims] = useState({ width: 960, height: 540 });
@@ -58,6 +64,37 @@ function useSlideDimensions(ref: React.RefObject<HTMLDivElement | null>) {
   return dims;
 }
 
+const SubslideView = ({
+  subslide,
+}: {
+  subslide: ComposedSubslide<RuntimeCell>;
+}) => (
+  <Slide>
+    <div className="h-full w-full overflow-auto flex">
+      <div className="mo-slide-content" style={{ margin: "auto 20px" }}>
+        {subslide.blocks.map((block, i) => {
+          const rendered = block.cells.map((cell) => (
+            <CellOutputSlide
+              key={cell.id}
+              cellId={cell.id}
+              status={cell.status}
+              output={cell.output}
+            />
+          ));
+          if (block.isFragment) {
+            return (
+              <Fragment key={i} as="div">
+                {rendered}
+              </Fragment>
+            );
+          }
+          return <ReactFragment key={i}>{rendered}</ReactFragment>;
+        })}
+      </div>
+    </div>
+  </Slide>
+);
+
 const RevealSlidesComponent = ({
   cellsWithOutput,
   layout,
@@ -67,7 +104,7 @@ const RevealSlidesComponent = ({
   deckRef,
   configWidth = 300, // px
 }: {
-  cellsWithOutput: (CellRuntimeState & CellData)[];
+  cellsWithOutput: RuntimeCell[];
   layout: SlidesLayout;
   setLayout: (layout: SlidesLayout) => void;
   activeIndex?: number;
@@ -77,26 +114,77 @@ const RevealSlidesComponent = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { width, height } = useSlideDimensions(containerRef);
-  const [isConfigOpen, setIsConfigOpen] = useState(true);
-  const activeCellId = cellsWithOutput[activeIndex ?? 0]?.id;
+  const [isConfigOpen, setIsConfigOpen] = useLocalStorage<boolean>(
+    CONFIG_OPEN_STORAGE_KEY,
+    true,
+  );
+  const activeCell =
+    activeIndex != null ? cellsWithOutput[activeIndex] : undefined;
+  const activeCellId = activeCell?.id ?? cellsWithOutput[0]?.id;
+
+  const composition = composeSlides(
+    cellsWithOutput,
+    (cell) => layout.cells.get(cell.id)?.type ?? DEFAULT_SLIDE_TYPE,
+  );
+
+  // Skip cells are dropped from the composed deck to match reveal.js
+  // semantics. When the user selects a skip cell in the minimap we render an
+  // editor-only preview on top of the deck; the deck itself stays put.
+  const skippedPreviewCell =
+    activeCell && layout.cells.get(activeCell.id)?.type === "skip"
+      ? activeCell
+      : null;
+
+  const { cellToTarget, targetToCellIndex } = buildSlideIndices(
+    composition,
+    cellsWithOutput,
+    (c) => c.id,
+  );
 
   useEffect(() => {
     const deck = deckRef.current;
-    if (deck == null || activeIndex == null) {
+    if (deck == null || activeCell == null) {
       return;
     }
-    const { h } = deck.getIndices();
-    if (h !== activeIndex) {
-      deck.slide(activeIndex);
+    const target = cellToTarget.get(activeCell.id);
+    if (!target) {
+      return;
     }
-  }, [activeIndex, deckRef]);
+    const { h, v, f } = deck.getIndices();
+    // For fragment cells, advance to that fragment so it's visible.
+    // For non-fragment cells (target.f === -1), leave f unchanged so we don't
+    // collapse already-revealed fragments on the destination slide.
+    const targetF = target.f >= 0 ? target.f : undefined;
+    if (
+      h !== target.h ||
+      v !== target.v ||
+      (targetF != null && f !== targetF)
+    ) {
+      deck.slide(target.h, target.v, targetF);
+    }
+  }, [activeCell, cellToTarget, deckRef]);
+
+  // Report the current cell index to the parent component
+  const reportCurrentCell = useEvent(() => {
+    const deck = deckRef.current;
+    if (!deck) {
+      return;
+    }
+    const flatIndex = resolveActiveCellIndex(
+      targetToCellIndex,
+      deck.getIndices(),
+    );
+    if (flatIndex != null) {
+      onSlideChange?.(flatIndex);
+    }
+  });
 
   return (
     <div
       ref={containerRef}
-      className="relative h-full w-full flex-1 flex flex-row gap-3 items-center"
+      className="relative h-full w-full flex-1 flex flex-row gap-3 items-stretch"
     >
-      <div className="group relative flex-1">
+      <div className="group relative flex-1 flex items-center">
         <Deck
           deckRef={deckRef}
           className="aspect-video overflow-hidden h-full border rounded bg-background mo-slides-theme prose-slides"
@@ -107,44 +195,57 @@ const RevealSlidesComponent = ({
             center: false,
             minScale: 0.2,
             maxScale: 2,
-            keyboardCondition: (event: KeyboardEvent) => {
-              return !Events.fromInput(event);
-            },
+            keyboardCondition: (event: KeyboardEvent) =>
+              !Events.fromInput(event),
           }}
           onSlideChange={() => {
+            reportCurrentCell();
             const deck = deckRef.current;
-            if (deck) {
-              onSlideChange?.(deck.getIndices().h);
-              // Trigger resize so vega-embed re-measures container width
-              if (
-                deck
-                  .getCurrentSlide()
-                  ?.querySelector(".vega-embed, marimo-vega")
-              ) {
-                requestAnimationFrame(() => {
-                  window.dispatchEvent(new Event("resize"));
-                });
-              }
+            // Trigger resize so vega-embed re-measures container width
+            if (
+              deck?.getCurrentSlide()?.querySelector(".vega-embed, marimo-vega")
+            ) {
+              requestAnimationFrame(() => {
+                window.dispatchEvent(new Event("resize"));
+              });
             }
           }}
+          onFragmentShown={reportCurrentCell}
+          onFragmentHidden={reportCurrentCell}
         >
-          {cellsWithOutput.map((cell) => (
-            <Slide key={cell.id}>
-              <div className="h-full w-full overflow-auto flex">
-                <div
-                  className="mo-slide-content"
-                  style={{ margin: "auto 20px" }}
-                >
-                  <CellOutputSlide
-                    cellId={cell.id}
-                    status={cell.status}
-                    output={cell.output}
-                  />
-                </div>
-              </div>
-            </Slide>
-          ))}
+          {composition.stacks.map((stack, i) => {
+            if (stack.subslides.length === 1) {
+              return <SubslideView key={i} subslide={stack.subslides[0]} />;
+            }
+            return (
+              <Stack key={i}>
+                {stack.subslides.map((sub, j) => (
+                  <SubslideView key={j} subslide={sub} />
+                ))}
+              </Stack>
+            );
+          })}
         </Deck>
+        {skippedPreviewCell && (
+          <div
+            className="absolute inset-y-0 left-0 aspect-video h-full w-full z-10 border rounded bg-background flex flex-col overflow-hidden"
+            aria-label="Skipped in presentation"
+          >
+            <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground border-b bg-muted/40">
+              <EyeOffIcon className="h-3.5 w-3.5" />
+              <span>Skipped in presentation</span>
+            </div>
+            <div className="flex-1 overflow-auto flex">
+              <div className="mo-slide-content" style={{ margin: "auto 20px" }}>
+                <CellOutputSlide
+                  cellId={skippedPreviewCell.id}
+                  status={skippedPreviewCell.status}
+                  output={skippedPreviewCell.output}
+                />
+              </div>
+            </div>
+          </div>
+        )}
         <Tooltip content="Fullscreen (F)">
           <Button
             data-testid="marimo-plugin-slides-fullscreen"
@@ -165,90 +266,55 @@ const RevealSlidesComponent = ({
         </Tooltip>
       </div>
 
-      <div
-        className="h-full flex flex-col transition-[width] duration-200 ease-out overflow-hidden -mr-5"
+      <aside
+        className="h-full flex flex-col border-l border-border/60 bg-muted/20 transition-[width] duration-200 ease-out overflow-hidden"
         style={{
           width: isConfigOpen ? configWidth : COLLAPSED_CONFIG_WIDTH,
         }}
+        aria-label="Slide configuration"
       >
-        <div className="flex items-center gap-1">
-          <Tooltip content={isConfigOpen ? "Collapse" : "Expand"}>
+        <header
+          className={cn(
+            "flex items-center h-9 shrink-0 border-b border-border/60",
+            isConfigOpen ? "justify-between px-2" : "justify-center px-0",
+          )}
+        >
+          {isConfigOpen && (
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground pl-1">
+              Slide
+            </span>
+          )}
+          <Tooltip content={isConfigOpen ? "Collapse panel" : "Expand panel"}>
             <Button
               variant="ghost"
               size="icon"
-              className="h-6 w-6 text-muted-foreground"
-              onClick={() => setIsConfigOpen((v) => !v)}
+              className="h-7 w-7 text-muted-foreground hover:text-foreground"
+              onClick={() => setIsConfigOpen(!isConfigOpen)}
               aria-expanded={isConfigOpen}
               aria-controls="slide-config-panel"
             >
               {isConfigOpen ? (
-                <ChevronRightIcon className="h-4 w-4" />
+                <PanelRightCloseIcon className="h-4 w-4" />
               ) : (
-                <SettingsIcon className="h-4 w-4" />
+                <PanelRightOpenIcon className="h-4 w-4" />
               )}
             </Button>
           </Tooltip>
-          {isConfigOpen && (
-            <h2 className="text-md font-semibold flex-1 text-center">
-              Slide Configuration
-            </h2>
-          )}
-        </div>
+        </header>
 
         {isConfigOpen && (
-          <SlidesForm
-            layout={layout}
-            setLayout={setLayout}
-            cellId={activeCellId}
-          />
+          <div
+            id="slide-config-panel"
+            className="flex-1 overflow-y-auto overflow-x-hidden"
+          >
+            <SlidesForm
+              layout={layout}
+              setLayout={setLayout}
+              cellId={activeCellId}
+            />
+          </div>
         )}
-      </div>
-    </div>
-  );
-};
-
-const SlidesForm = ({
-  layout,
-  setLayout,
-  cellId,
-}: {
-  layout: SlidesLayout;
-  setLayout: (layout: SlidesLayout) => void;
-  cellId: CellId;
-}) => {
-  const currentSlideType: SlideType =
-    layout.cells.get(cellId)?.type ?? DEFAULT_SLIDE_TYPE;
-
-  const handleSlideTypeChange = (value: SlideType) => {
-    const existingConfig = layout.cells.get(cellId);
-    const newCells = new Map(layout.cells);
-    newCells.set(cellId, { ...existingConfig, type: value });
-    setLayout({
-      ...layout,
-      cells: newCells,
-    });
-  };
-
-  return (
-    <div id="slide-config-panel" className="p-3 mt-5">
-      <div className="flex flex-row gap-2 items-center">
-        <Select
-          value={currentSlideType}
-          onValueChange={(value) => {
-            handleSlideTypeChange(value as SlideType);
-          }}
-        >
-          <SelectTrigger className="w-32">
-            <SelectValue placeholder="Slide Type" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="slide">Slide</SelectItem>
-            <SelectItem value="sub-slide">Sub-slide</SelectItem>
-            <SelectItem value="fragment">Fragment</SelectItem>
-            <SelectItem value="skip">Skip</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+      </aside>
     </div>
   );
 };

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -1,7 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { useEffect } from "react";
-import { ExpandIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { ChevronRightIcon, ExpandIcon, SettingsIcon } from "lucide-react";
 import { Deck, Slide } from "@revealjs/react";
 import { Slide as CellOutputSlide } from "@/components/slides/slide";
 import { Button } from "@/components/ui/button";
@@ -10,21 +10,76 @@ import type { CellData, CellRuntimeState } from "@/core/cells/types";
 import type { RevealApi } from "reveal.js";
 import { Events } from "@/utils/events";
 import { Logger } from "@/utils/Logger";
-
+import {
+  Select,
+  SelectItem,
+  SelectContent,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import "./slides.css";
 import "./reveal-slides.css";
+import type {
+  SlideType,
+  SlidesLayout,
+} from "../editor/renderers/slides-layout/types";
+import type { CellId } from "@/core/cells/ids";
+
+const ASPECT_RATIO = 16 / 9;
+const COLLAPSED_CONFIG_WIDTH = 32;
+const DEFAULT_SLIDE_TYPE: SlideType = "slide";
+
+function useSlideDimensions(ref: React.RefObject<HTMLDivElement | null>) {
+  const [dims, setDims] = useState({ width: 960, height: 540 });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width <= 0 || height <= 0) {
+        return;
+      }
+      const fitWidth = Math.min(width, height * ASPECT_RATIO);
+      const fitHeight = fitWidth / ASPECT_RATIO;
+      setDims({
+        width: Math.round(fitWidth),
+        height: Math.round(fitHeight),
+      });
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return dims;
+}
 
 const RevealSlidesComponent = ({
   cellsWithOutput,
+  layout,
+  setLayout,
   activeIndex,
   onSlideChange,
   deckRef,
+  configWidth = 300, // px
 }: {
   cellsWithOutput: (CellRuntimeState & CellData)[];
+  layout: SlidesLayout;
+  setLayout: (layout: SlidesLayout) => void;
   activeIndex?: number;
   onSlideChange?: (index: number) => void;
   deckRef: React.RefObject<RevealApi | null>;
+  configWidth?: number;
 }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { width, height } = useSlideDimensions(containerRef);
+  const [isConfigOpen, setIsConfigOpen] = useState(true);
+  const activeCellId = cellsWithOutput[activeIndex ?? 0]?.id;
+
   useEffect(() => {
     const deck = deckRef.current;
     if (deck == null || activeIndex == null) {
@@ -37,71 +92,163 @@ const RevealSlidesComponent = ({
   }, [activeIndex, deckRef]);
 
   return (
-    <div className="group relative h-full w-full flex-1">
-      <Deck
-        deckRef={deckRef}
-        className="relative w-full h-full border rounded bg-background mo-slides-theme prose-slides"
-        style={{ height: "100%" }}
-        config={{
-          embedded: true, // Avoid styles leaking out
-          overview: false,
-          width: "100%",
-          height: "100%", // Both style and config height are needed to ensure the deck is full height
-          center: false, // We are handling this manually
-          minScale: 1,
-          maxScale: 1,
-          // Only enable keyboard controls when not focused on an input
-          keyboardCondition: (event: KeyboardEvent) => {
-            return !Events.fromInput(event);
-          },
-        }}
-        onSlideChange={() => {
-          const deck = deckRef.current;
-          if (deck) {
-            onSlideChange?.(deck.getIndices().h);
-            // Trigger resize so vega-embed re-measures container width
-            if (
-              deck.getCurrentSlide()?.querySelector(".vega-embed, marimo-vega")
-            ) {
-              requestAnimationFrame(() => {
-                window.dispatchEvent(new Event("resize"));
-              });
+    <div
+      ref={containerRef}
+      className="relative h-full w-full flex-1 flex flex-row gap-3 items-center"
+    >
+      <div className="group relative flex-1">
+        <Deck
+          deckRef={deckRef}
+          className="aspect-video overflow-hidden h-full border rounded bg-background mo-slides-theme prose-slides"
+          config={{
+            embedded: true,
+            width,
+            height,
+            center: false,
+            minScale: 0.2,
+            maxScale: 2,
+            keyboardCondition: (event: KeyboardEvent) => {
+              return !Events.fromInput(event);
+            },
+          }}
+          onSlideChange={() => {
+            const deck = deckRef.current;
+            if (deck) {
+              onSlideChange?.(deck.getIndices().h);
+              // Trigger resize so vega-embed re-measures container width
+              if (
+                deck
+                  .getCurrentSlide()
+                  ?.querySelector(".vega-embed, marimo-vega")
+              ) {
+                requestAnimationFrame(() => {
+                  window.dispatchEvent(new Event("resize"));
+                });
+              }
             }
-          }
-        }}
-      >
-        {cellsWithOutput.map((cell) => (
-          <Slide key={cell.id}>
-            <div className="h-full w-full overflow-auto flex">
-              <div className="mo-slide-content" style={{ margin: "auto 0" }}>
-                <CellOutputSlide
-                  cellId={cell.id}
-                  status={cell.status}
-                  output={cell.output}
-                />
-              </div>
-            </div>
-          </Slide>
-        ))}
-      </Deck>
-      <Tooltip content="Fullscreen (F)">
-        <Button
-          data-testid="marimo-plugin-slides-fullscreen"
-          variant="ghost"
-          size="icon"
-          className="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-70 text-muted-foreground transition-opacity h-7 w-7"
-          onClick={() => {
-            deckRef.current
-              ?.getViewportElement()
-              ?.requestFullscreen()
-              .catch((error) => {
-                Logger.error("Failed to request fullscreen", error);
-              });
           }}
         >
-          <ExpandIcon className="h-4 w-4" />
-        </Button>
-      </Tooltip>
+          {cellsWithOutput.map((cell) => (
+            <Slide key={cell.id}>
+              <div className="h-full w-full overflow-auto flex">
+                <div
+                  className="mo-slide-content"
+                  style={{ margin: "auto 20px" }}
+                >
+                  <CellOutputSlide
+                    cellId={cell.id}
+                    status={cell.status}
+                    output={cell.output}
+                  />
+                </div>
+              </div>
+            </Slide>
+          ))}
+        </Deck>
+        <Tooltip content="Fullscreen (F)">
+          <Button
+            data-testid="marimo-plugin-slides-fullscreen"
+            variant="ghost"
+            size="icon"
+            className="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-70 text-muted-foreground transition-opacity h-7 w-7"
+            onClick={() => {
+              deckRef.current
+                ?.getViewportElement()
+                ?.requestFullscreen()
+                .catch((error) => {
+                  Logger.error("Failed to request fullscreen", error);
+                });
+            }}
+          >
+            <ExpandIcon className="h-4 w-4" />
+          </Button>
+        </Tooltip>
+      </div>
+
+      <div
+        className="h-full flex flex-col transition-[width] duration-200 ease-out overflow-hidden -mr-5"
+        style={{
+          width: isConfigOpen ? configWidth : COLLAPSED_CONFIG_WIDTH,
+        }}
+      >
+        <div className="flex items-center gap-1">
+          <Tooltip content={isConfigOpen ? "Collapse" : "Expand"}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 text-muted-foreground"
+              onClick={() => setIsConfigOpen((v) => !v)}
+              aria-expanded={isConfigOpen}
+              aria-controls="slide-config-panel"
+            >
+              {isConfigOpen ? (
+                <ChevronRightIcon className="h-4 w-4" />
+              ) : (
+                <SettingsIcon className="h-4 w-4" />
+              )}
+            </Button>
+          </Tooltip>
+          {isConfigOpen && (
+            <h2 className="text-md font-semibold flex-1 text-center">
+              Slide Configuration
+            </h2>
+          )}
+        </div>
+
+        {isConfigOpen && (
+          <SlidesForm
+            layout={layout}
+            setLayout={setLayout}
+            cellId={activeCellId}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const SlidesForm = ({
+  layout,
+  setLayout,
+  cellId,
+}: {
+  layout: SlidesLayout;
+  setLayout: (layout: SlidesLayout) => void;
+  cellId: CellId;
+}) => {
+  const currentSlideType: SlideType =
+    layout.cells.get(cellId)?.type ?? DEFAULT_SLIDE_TYPE;
+
+  const handleSlideTypeChange = (value: SlideType) => {
+    const existingConfig = layout.cells.get(cellId);
+    const newCells = new Map(layout.cells);
+    newCells.set(cellId, { ...existingConfig, type: value });
+    setLayout({
+      ...layout,
+      cells: newCells,
+    });
+  };
+
+  return (
+    <div id="slide-config-panel" className="p-3 mt-5">
+      <div className="flex flex-row gap-2 items-center">
+        <Select
+          value={currentSlideType}
+          onValueChange={(value) => {
+            handleSlideTypeChange(value as SlideType);
+          }}
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="Slide Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="slide">Slide</SelectItem>
+            <SelectItem value="sub-slide">Sub-slide</SelectItem>
+            <SelectItem value="fragment">Fragment</SelectItem>
+            <SelectItem value="skip">Skip</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -172,7 +172,7 @@ const RevealSlidesComponent = ({
     activeIndex != null ? cellsWithOutput[activeIndex] : undefined;
   // Fall back to the first cell while the deck settles on an initial slide.
   // Still `undefined` when the deck is empty (handled below).
-  const activeConfigCell = activeCell ?? cellsWithOutput[0];
+  const activeConfigCell = activeCell ?? cellsWithOutput.at(0);
 
   const composition = useMemo(
     () =>

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -12,7 +12,6 @@ import { Deck, Fragment, Slide, Stack } from "@revealjs/react";
 import { Slide as CellOutputSlide } from "@/components/slides/slide";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
-import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { cn } from "@/utils/cn";
 import type { CellData, CellRuntimeState } from "@/core/cells/types";
 import type { RevealApi } from "reveal.js";
@@ -31,7 +30,6 @@ import { DEFAULT_SLIDE_TYPE, SlidesForm } from "./slide-form";
 
 const ASPECT_RATIO = 16 / 9;
 const COLLAPSED_CONFIG_WIDTH = 36;
-const CONFIG_OPEN_STORAGE_KEY = "marimo:slides:configOpen";
 
 type RuntimeCell = CellRuntimeState & CellData;
 
@@ -114,10 +112,7 @@ const RevealSlidesComponent = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { width, height } = useSlideDimensions(containerRef);
-  const [isConfigOpen, setIsConfigOpen] = useLocalStorage<boolean>(
-    CONFIG_OPEN_STORAGE_KEY,
-    true,
-  );
+  const [isConfigOpen, setIsConfigOpen] = useState(false);
   const activeCell =
     activeIndex != null ? cellsWithOutput[activeIndex] : undefined;
   // Fall back to the first cell so the config panel has something to edit

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -26,7 +26,11 @@ import {
   resolveActiveCellIndex,
   type ComposedSubslide,
 } from "./compose-slides";
-import { DEFAULT_SLIDE_TYPE, SlidesForm } from "./slide-form";
+import {
+  DEFAULT_DECK_TRANSITION,
+  DEFAULT_SLIDE_TYPE,
+  SlidesForm,
+} from "./slide-form";
 
 const ASPECT_RATIO = 16 / 9;
 const COLLAPSED_CONFIG_WIDTH = 36;
@@ -193,6 +197,7 @@ const RevealSlidesComponent = ({
             center: false,
             minScale: 0.2,
             maxScale: 2,
+            transition: layout.deck?.transition ?? DEFAULT_DECK_TRANSITION,
             keyboardCondition: (event: KeyboardEvent) =>
               !Events.fromInput(event),
           }}
@@ -279,7 +284,7 @@ const RevealSlidesComponent = ({
         >
           {isConfigOpen && (
             <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground pl-1">
-              Slide
+              Configuration
             </span>
           )}
           <Tooltip content={isConfigOpen ? "Collapse panel" : "Expand panel"}>

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -133,10 +133,11 @@ const RevealSlidesComponent = ({
 
   const composition = useMemo(
     () =>
-      composeSlides(
-        cellsWithOutput,
-        (cell) => layout.cells.get(cell.id)?.type ?? DEFAULT_SLIDE_TYPE,
-      ),
+      composeSlides({
+        cells: cellsWithOutput,
+        getType: (cell) =>
+          layout.cells.get(cell.id)?.type ?? DEFAULT_SLIDE_TYPE,
+      }),
     [cellsWithOutput, layout.cells],
   );
 
@@ -149,7 +150,12 @@ const RevealSlidesComponent = ({
       : null;
 
   const { cellToTarget, targetToCellIndex } = useMemo(
-    () => buildSlideIndices(composition, cellsWithOutput, (c) => c.id),
+    () =>
+      buildSlideIndices({
+        composition,
+        cells: cellsWithOutput,
+        getId: (c) => c.id,
+      }),
     [composition, cellsWithOutput],
   );
 

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -38,6 +38,7 @@ import {
   DEFAULT_SLIDE_TYPE,
   SlidesForm,
 } from "./slide-form";
+import type { AppMode } from "@/core/mode";
 
 const ASPECT_RATIO = 16 / 9;
 const COLLAPSED_CONFIG_WIDTH = 36;
@@ -111,6 +112,7 @@ const RevealSlidesComponent = ({
   activeIndex,
   onSlideChange,
   deckRef,
+  mode,
   configWidth = 300, // px
 }: {
   cellsWithOutput: RuntimeCell[];
@@ -119,6 +121,7 @@ const RevealSlidesComponent = ({
   activeIndex?: number;
   onSlideChange?: (index: number) => void;
   deckRef: React.RefObject<RevealApi | null>;
+  mode: AppMode;
   configWidth?: number;
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -205,144 +208,153 @@ const RevealSlidesComponent = ({
   });
 
   return (
-    <div
-      ref={containerRef}
-      className="relative h-full w-full flex-1 flex flex-row gap-3 items-stretch"
-    >
-      <div className="group relative flex-1 flex items-center">
-        <Deck
-          deckRef={deckRef}
-          className="aspect-video overflow-hidden h-full border rounded bg-background mo-slides-theme prose-slides"
-          config={revealConfig}
-          onSlideChange={() => {
-            reportCurrentCell();
-            const deck = deckRef.current;
-            // Trigger resize so vega-embed re-measures container width
-            if (
-              deck?.getCurrentSlide()?.querySelector(".vega-embed, marimo-vega")
-            ) {
-              requestAnimationFrame(() => {
-                window.dispatchEvent(new Event("resize"));
-              });
-            }
-          }}
-          onFragmentShown={reportCurrentCell}
-          onFragmentHidden={reportCurrentCell}
-        >
-          {composition.stacks.map((stack, i) => {
-            if (stack.subslides.length === 1) {
-              return <SubslideView key={i} subslide={stack.subslides[0]} />;
-            }
-            return (
-              <Stack key={i}>
-                {stack.subslides.map((sub, j) => (
-                  <SubslideView key={j} subslide={sub} />
-                ))}
-              </Stack>
-            );
-          })}
-        </Deck>
-        {skippedPreviewCell && (
-          <div
-            className="absolute inset-y-0 left-0 aspect-video h-full w-full z-10 border rounded bg-background flex flex-col overflow-hidden"
-            aria-label="Skipped in presentation"
+    <div className="flex-1 min-w-0 flex flex-row gap-3">
+      <div
+        ref={containerRef}
+        className="flex-1 min-w-0 flex items-center justify-center overflow-hidden"
+      >
+        <div className="group relative" style={{ width, height }}>
+          <Deck
+            deckRef={deckRef}
+            className="aspect-video w-full overflow-hidden border rounded bg-background mo-slides-theme prose-slides"
+            config={revealConfig}
+            onSlideChange={() => {
+              reportCurrentCell();
+              const deck = deckRef.current;
+              // Trigger resize so vega-embed re-measures container width
+              if (
+                deck
+                  ?.getCurrentSlide()
+                  ?.querySelector(".vega-embed, marimo-vega")
+              ) {
+                requestAnimationFrame(() => {
+                  window.dispatchEvent(new Event("resize"));
+                });
+              }
+            }}
+            onFragmentShown={reportCurrentCell}
+            onFragmentHidden={reportCurrentCell}
           >
-            <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground border-b bg-muted/40">
-              <EyeOffIcon className="h-3.5 w-3.5" />
-              <span>Skipped in presentation</span>
-            </div>
-            <div className="flex-1 overflow-auto flex">
-              <div className="mo-slide-content" style={{ margin: "auto 20px" }}>
-                <CellOutputSlide
-                  cellId={skippedPreviewCell.id}
-                  status={skippedPreviewCell.status}
-                  output={skippedPreviewCell.output}
-                />
+            {composition.stacks.map((stack, i) => {
+              if (stack.subslides.length === 1) {
+                return <SubslideView key={i} subslide={stack.subslides[0]} />;
+              }
+              return (
+                <Stack key={i}>
+                  {stack.subslides.map((sub, j) => (
+                    <SubslideView key={j} subslide={sub} />
+                  ))}
+                </Stack>
+              );
+            })}
+          </Deck>
+          {skippedPreviewCell && (
+            <div
+              className="absolute inset-0 z-10 border rounded bg-background flex flex-col overflow-hidden"
+              aria-label="Skipped in presentation"
+            >
+              <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground border-b bg-muted/40">
+                <EyeOffIcon className="h-3.5 w-3.5" />
+                <span>Skipped in presentation</span>
+              </div>
+              <div className="flex-1 overflow-auto flex">
+                <div
+                  className="mo-slide-content"
+                  style={{ margin: "auto 20px" }}
+                >
+                  <CellOutputSlide
+                    cellId={skippedPreviewCell.id}
+                    status={skippedPreviewCell.status}
+                    output={skippedPreviewCell.output}
+                  />
+                </div>
               </div>
             </div>
-          </div>
-        )}
-        <Tooltip content="Fullscreen (F)">
-          <Button
-            data-testid="marimo-plugin-slides-fullscreen"
-            variant="ghost"
-            size="icon"
-            className="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-70 text-muted-foreground transition-opacity h-7 w-7"
-            onClick={() => {
-              deckRef.current
-                ?.getViewportElement()
-                ?.requestFullscreen()
-                .catch((error) => {
-                  Logger.error("Failed to request fullscreen", error);
-                });
-            }}
-          >
-            <ExpandIcon className="h-4 w-4" />
-          </Button>
-        </Tooltip>
-      </div>
-
-      <aside
-        className="h-full flex flex-col border-l border-border/60 bg-muted/20 transition-[width] duration-200 ease-out overflow-hidden"
-        style={{
-          width: isConfigOpen ? configWidth : COLLAPSED_CONFIG_WIDTH,
-        }}
-        aria-label="Slide configuration"
-      >
-        <header
-          className={cn(
-            "flex items-center h-9 shrink-0 border-b border-border/60",
-            isConfigOpen ? "justify-between px-2" : "justify-center px-0",
           )}
-        >
-          {isConfigOpen && (
-            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground pl-1">
-              Configuration
-            </span>
-          )}
-          <Tooltip content={isConfigOpen ? "Collapse panel" : "Expand panel"}>
+          <Tooltip content="Fullscreen (F)">
             <Button
+              data-testid="marimo-plugin-slides-fullscreen"
               variant="ghost"
               size="icon"
-              className="h-7 w-7 text-muted-foreground hover:text-foreground"
-              onClick={() => setIsConfigOpen(!isConfigOpen)}
-              aria-expanded={isConfigOpen}
-              aria-controls="slide-config-panel"
+              className="absolute top-2 right-2 z-20 opacity-0 group-hover:opacity-70 text-muted-foreground transition-opacity h-7 w-7"
+              onClick={() => {
+                deckRef.current
+                  ?.getViewportElement()
+                  ?.requestFullscreen()
+                  .catch((error) => {
+                    Logger.error("Failed to request fullscreen", error);
+                  });
+              }}
             >
-              {isConfigOpen ? (
-                <PanelRightCloseIcon className="h-4 w-4" />
-              ) : (
-                <PanelRightOpenIcon className="h-4 w-4" />
-              )}
+              <ExpandIcon className="h-4 w-4" />
             </Button>
           </Tooltip>
-        </header>
+        </div>
+      </div>
 
-        {isConfigOpen && (
-          <div
-            id="slide-config-panel"
-            className="flex-1 overflow-y-auto overflow-x-hidden"
-          >
-            {activeConfigCell ? (
-              <SlidesForm
-                layout={layout}
-                setLayout={setLayout}
-                cellId={activeConfigCell.id}
-              />
-            ) : (
-              <div className="flex flex-col gap-1.5 p-3 text-xs text-muted-foreground">
-                <span className="font-semibold text-sm text-foreground">
-                  No slides yet
-                </span>
-                <p>
-                  Run a cell that produces output to add it to the deck. Slide
-                  settings will appear here once a slide is selected.
-                </p>
-              </div>
+      {mode !== "read" && (
+        <aside
+          className="h-full flex flex-col border-l border-border/60 bg-muted/20 transition-[width] duration-200 ease-out overflow-hidden"
+          style={{
+            width: isConfigOpen ? configWidth : COLLAPSED_CONFIG_WIDTH,
+          }}
+          aria-label="Slide configuration"
+        >
+          <header
+            className={cn(
+              "flex items-center h-9 shrink-0 border-b border-border/60",
+              isConfigOpen ? "justify-between px-2" : "justify-center px-0",
             )}
-          </div>
-        )}
-      </aside>
+          >
+            {isConfigOpen && (
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground pl-1">
+                Configuration
+              </span>
+            )}
+            <Tooltip content={isConfigOpen ? "Collapse panel" : "Expand panel"}>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                onClick={() => setIsConfigOpen(!isConfigOpen)}
+                aria-expanded={isConfigOpen}
+                aria-controls="slide-config-panel"
+              >
+                {isConfigOpen ? (
+                  <PanelRightCloseIcon className="h-4 w-4" />
+                ) : (
+                  <PanelRightOpenIcon className="h-4 w-4" />
+                )}
+              </Button>
+            </Tooltip>
+          </header>
+
+          {isConfigOpen && (
+            <div
+              id="slide-config-panel"
+              className="flex-1 overflow-y-auto overflow-x-hidden"
+            >
+              {activeConfigCell ? (
+                <SlidesForm
+                  layout={layout}
+                  setLayout={setLayout}
+                  cellId={activeConfigCell.id}
+                />
+              ) : (
+                <div className="flex flex-col gap-1.5 p-3 text-xs text-muted-foreground">
+                  <span className="font-semibold text-sm text-foreground">
+                    No slides yet
+                  </span>
+                  <p>
+                    Run a cell that produces output to add it to the deck. Slide
+                    settings will appear here once a slide is selected.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </aside>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -29,6 +29,7 @@ import type { SlidesLayout } from "../editor/renderers/slides-layout/types";
 import {
   buildSlideIndices,
   composeSlides,
+  computeDeckNavigation,
   resolveActiveCellIndex,
   type ComposedSubslide,
 } from "./compose-slides";
@@ -176,17 +177,9 @@ const RevealSlidesComponent = ({
     if (!target) {
       return;
     }
-    const { h, v, f } = deck.getIndices();
-    // For fragment cells, advance to that fragment so it's visible.
-    // For non-fragment cells (target.f === -1), leave f unchanged so we don't
-    // collapse already-revealed fragments on the destination slide.
-    const targetF = target.f >= 0 ? target.f : undefined;
-    if (
-      h !== target.h ||
-      v !== target.v ||
-      (targetF != null && f !== targetF)
-    ) {
-      deck.slide(target.h, target.v, targetF);
+    const next = computeDeckNavigation(deck.getIndices(), target);
+    if (next) {
+      deck.slide(next.h, next.v, next.f);
     }
   }, [activeCell, cellToTarget, deckRef]);
 

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -120,7 +120,10 @@ const RevealSlidesComponent = ({
   );
   const activeCell =
     activeIndex != null ? cellsWithOutput[activeIndex] : undefined;
-  const activeCellId = activeCell?.id ?? cellsWithOutput[0]?.id;
+  // Fall back to the first cell so the config panel has something to edit
+  // while the deck is still settling on an initial slide. This can still be
+  // `undefined` when the deck is empty; that case is handled below.
+  const activeConfigCell = activeCell ?? cellsWithOutput[0];
 
   const composition = composeSlides(
     cellsWithOutput,
@@ -307,11 +310,23 @@ const RevealSlidesComponent = ({
             id="slide-config-panel"
             className="flex-1 overflow-y-auto overflow-x-hidden"
           >
-            <SlidesForm
-              layout={layout}
-              setLayout={setLayout}
-              cellId={activeCellId}
-            />
+            {activeConfigCell ? (
+              <SlidesForm
+                layout={layout}
+                setLayout={setLayout}
+                cellId={activeConfigCell.id}
+              />
+            ) : (
+              <div className="flex flex-col gap-1.5 p-3 text-xs text-muted-foreground">
+                <span className="font-semibold text-sm text-foreground">
+                  No slides yet
+                </span>
+                <p>
+                  Run a cell that produces output to add it to the deck. Slide
+                  settings will appear here once a slide is selected.
+                </p>
+              </div>
+            )}
           </div>
         )}
       </aside>

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -31,6 +31,7 @@ import {
   composeSlides,
   computeDeckNavigation,
   resolveActiveCellIndex,
+  resolveDeckNavigationTarget,
   type ComposedSubslide,
 } from "./compose-slides";
 import {
@@ -44,6 +45,43 @@ const ASPECT_RATIO = 16 / 9;
 const COLLAPSED_CONFIG_WIDTH = 36;
 
 type RuntimeCell = CellRuntimeState & CellData;
+
+/**
+ * reveal.js caches the last visited vertical index on each stack and can
+ * resume there on later horizontal navigation. After minimap-driven jumps we
+ * want stacks to re-enter from the top instead of reusing stale stack state.
+ */
+function clearPreviousVerticalIndices(deck: RevealApi) {
+  const slidesEl = deck.getSlidesElement();
+  if (!slidesEl) {
+    return;
+  }
+
+  for (const stack of slidesEl.querySelectorAll(
+    "section.stack[data-previous-indexv]",
+  )) {
+    stack.removeAttribute("data-previous-indexv");
+  }
+}
+
+const FORWARD_NAV_KEYS = new Set([
+  " ",
+  "Spacebar",
+  "ArrowRight",
+  "ArrowDown",
+  "PageDown",
+]);
+const BACK_NAV_KEYS = new Set(["ArrowLeft", "ArrowUp", "PageUp"]);
+
+function classifyNavKey(event: KeyboardEvent): 1 | -1 | 0 {
+  if (FORWARD_NAV_KEYS.has(event.key)) {
+    return 1;
+  }
+  if (BACK_NAV_KEYS.has(event.key)) {
+    return -1;
+  }
+  return 0;
+}
 
 function useSlideDimensions(ref: React.RefObject<HTMLDivElement | null>) {
   const [dims, setDims] = useState({ width: 960, height: 540 });
@@ -129,9 +167,8 @@ const RevealSlidesComponent = ({
   const [isConfigOpen, setIsConfigOpen] = useState(false);
   const activeCell =
     activeIndex != null ? cellsWithOutput[activeIndex] : undefined;
-  // Fall back to the first cell so the config panel has something to edit
-  // while the deck is still settling on an initial slide. This can still be
-  // `undefined` when the deck is empty; that case is handled below.
+  // Fall back to the first cell while the deck settles on an initial slide.
+  // Still `undefined` when the deck is empty (handled below).
   const activeConfigCell = activeCell ?? cellsWithOutput[0];
 
   const composition = useMemo(
@@ -144,9 +181,9 @@ const RevealSlidesComponent = ({
     [cellsWithOutput, layout.cells],
   );
 
-  // Skip cells are dropped from the composed deck to match reveal.js
-  // semantics. When the user selects a skip cell in the minimap we render an
-  // editor-only preview on top of the deck; the deck itself stays put.
+  // Skip cells aren't part of the composed deck. When one is selected in the
+  // minimap we render a preview over the deck and park reveal on a neighboring
+  // real slide; keyboard nav while parked is handled below.
   const skippedPreviewCell =
     activeCell && layout.cells.get(activeCell.id)?.type === "skip"
       ? activeCell
@@ -179,21 +216,31 @@ const RevealSlidesComponent = ({
 
   useEffect(() => {
     const deck = deckRef.current;
-    if (deck == null || activeCell == null) {
+    if (deck == null) {
       return;
     }
-    const target = cellToTarget.get(activeCell.id);
-    if (!target) {
+    const target = resolveDeckNavigationTarget({
+      activeIndex,
+      cells: cellsWithOutput,
+      cellToTarget,
+      getId: (cell) => cell.id,
+    });
+    const next = target && computeDeckNavigation(deck.getIndices(), target);
+    if (!next) {
       return;
     }
-    const next = computeDeckNavigation(deck.getIndices(), target);
-    if (next) {
-      deck.slide(next.h, next.v, next.f);
-    }
-  }, [activeCell, cellToTarget, deckRef]);
+    deck.slide(next.h, next.v, next.f);
+    clearPreviousVerticalIndices(deck);
+  }, [activeIndex, cellToTarget, cellsWithOutput, deckRef]);
 
-  // Report the current cell index to the parent component
+  // Forward the deck's current cell to the parent, except while a skipped
+  // preview is parked: every reveal.js event during that window is an echo
+  // of the programmatic park (possibly with transient indices), so ignoring
+  // them keeps `activeCellId` pinned on the skipped cell.
   const reportCurrentCell = useEvent(() => {
+    if (skippedPreviewCell != null) {
+      return;
+    }
     const deck = deckRef.current;
     if (!deck) {
       return;
@@ -206,6 +253,37 @@ const RevealSlidesComponent = ({
       onSlideChange?.(flatIndex);
     }
   });
+
+  // While parked on a skipped preview, step through minimap order instead of
+  // letting reveal.js advance from the parked slide the user can't see.
+  const handleParkedNavKey = useEvent((event: KeyboardEvent) => {
+    if (!skippedPreviewCell || activeIndex == null) {
+      return;
+    }
+    if (Events.fromInput(event)) {
+      return;
+    }
+    const direction = classifyNavKey(event);
+    if (direction === 0) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    const nextIndex = activeIndex + direction;
+    if (nextIndex < 0 || nextIndex >= cellsWithOutput.length) {
+      return;
+    }
+    onSlideChange?.(nextIndex);
+  });
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleParkedNavKey, { capture: true });
+    return () => {
+      document.removeEventListener("keydown", handleParkedNavKey, {
+        capture: true,
+      });
+    };
+  }, [handleParkedNavKey]);
 
   return (
     <div className="flex-1 min-w-0 flex flex-row gap-3">

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -8,19 +8,14 @@ import {
   Fragment as ReactFragment,
 } from "react";
 import useEvent from "react-use-event-hook";
-import {
-  ExpandIcon,
-  EyeOffIcon,
-  PanelRightCloseIcon,
-  PanelRightOpenIcon,
-} from "lucide-react";
+import { ExpandIcon, EyeOffIcon } from "lucide-react";
 import { Deck, Fragment, Slide, Stack } from "@revealjs/react";
 import { Slide as CellOutputSlide } from "@/components/slides/slide";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
-import { cn } from "@/utils/cn";
-import type { CellData, CellRuntimeState } from "@/core/cells/types";
+import type { RuntimeCell } from "@/core/cells/types";
 import type { RevealApi, RevealConfig } from "reveal.js";
+import { useEventListener } from "@/hooks/useEventListener";
 import { Events } from "@/utils/events";
 import { Logger } from "@/utils/Logger";
 import "./slides.css";
@@ -37,14 +32,11 @@ import {
 import {
   DEFAULT_DECK_TRANSITION,
   DEFAULT_SLIDE_TYPE,
-  SlidesForm,
+  SlideSidebar,
 } from "./slide-form";
 import type { AppMode } from "@/core/mode";
 
 const ASPECT_RATIO = 16 / 9;
-const COLLAPSED_CONFIG_WIDTH = 36;
-
-type RuntimeCell = CellRuntimeState & CellData;
 
 /**
  * reveal.js caches the last visited vertical index on each stack and can
@@ -110,6 +102,18 @@ function useSlideDimensions(ref: React.RefObject<HTMLDivElement | null>) {
   }, [ref]);
 
   return dims;
+}
+
+/**
+ * Trigger a resize event on the window
+ * Vega elements need to be re-measured when the container width changes.
+ */
+function triggerResize(deck: RevealApi | null) {
+  if (deck?.getCurrentSlide()?.querySelector(".vega-embed, marimo-vega")) {
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+  }
 }
 
 const SubslideView = ({
@@ -276,14 +280,7 @@ const RevealSlidesComponent = ({
     onSlideChange?.(nextIndex);
   });
 
-  useEffect(() => {
-    document.addEventListener("keydown", handleParkedNavKey, { capture: true });
-    return () => {
-      document.removeEventListener("keydown", handleParkedNavKey, {
-        capture: true,
-      });
-    };
-  }, [handleParkedNavKey]);
+  useEventListener(document, "keydown", handleParkedNavKey, { capture: true });
 
   return (
     <div className="flex-1 min-w-0 flex flex-row gap-3">
@@ -299,16 +296,7 @@ const RevealSlidesComponent = ({
             onSlideChange={() => {
               reportCurrentCell();
               const deck = deckRef.current;
-              // Trigger resize so vega-embed re-measures container width
-              if (
-                deck
-                  ?.getCurrentSlide()
-                  ?.querySelector(".vega-embed, marimo-vega")
-              ) {
-                requestAnimationFrame(() => {
-                  window.dispatchEvent(new Event("resize"));
-                });
-              }
+              triggerResize(deck);
             }}
             onFragmentShown={reportCurrentCell}
             onFragmentHidden={reportCurrentCell}
@@ -371,67 +359,12 @@ const RevealSlidesComponent = ({
       </div>
 
       {mode !== "read" && (
-        <aside
-          className="h-full flex flex-col border-l border-border/60 bg-muted/20 transition-[width] duration-200 ease-out overflow-hidden"
-          style={{
-            width: isConfigOpen ? configWidth : COLLAPSED_CONFIG_WIDTH,
-          }}
-          aria-label="Slide configuration"
-        >
-          <header
-            className={cn(
-              "flex items-center h-9 shrink-0 border-b border-border/60",
-              isConfigOpen ? "justify-between px-2" : "justify-center px-0",
-            )}
-          >
-            {isConfigOpen && (
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground pl-1">
-                Configuration
-              </span>
-            )}
-            <Tooltip content={isConfigOpen ? "Collapse panel" : "Expand panel"}>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                onClick={() => setIsConfigOpen(!isConfigOpen)}
-                aria-expanded={isConfigOpen}
-                aria-controls="slide-config-panel"
-              >
-                {isConfigOpen ? (
-                  <PanelRightCloseIcon className="h-4 w-4" />
-                ) : (
-                  <PanelRightOpenIcon className="h-4 w-4" />
-                )}
-              </Button>
-            </Tooltip>
-          </header>
-
-          {isConfigOpen && (
-            <div
-              id="slide-config-panel"
-              className="flex-1 overflow-y-auto overflow-x-hidden"
-            >
-              {activeConfigCell ? (
-                <SlidesForm
-                  layout={layout}
-                  setLayout={setLayout}
-                  cellId={activeConfigCell.id}
-                />
-              ) : (
-                <div className="flex flex-col gap-1.5 p-3 text-xs text-muted-foreground">
-                  <span className="font-semibold text-sm text-foreground">
-                    No slides yet
-                  </span>
-                  <p>
-                    Run a cell that produces output to add it to the deck. Slide
-                    settings will appear here once a slide is selected.
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
-        </aside>
+        <SlideSidebar
+          configWidth={configWidth}
+          layout={layout}
+          setLayout={setLayout}
+          activeConfigCell={activeConfigCell}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/slides/reveal-slides.css
+++ b/frontend/src/components/slides/reveal-slides.css
@@ -42,6 +42,25 @@
   height: 100%;
 }
 
+/* Reveal.js animates slides by rendering past/future neighbors in the layout
+   and translating them offscreen. Tailwind v4's preflight forces `[hidden]`
+   elements to `display: none !important`, which collapses those neighbors
+   and kills the transition. Reasserting `display: block` inside the same
+   `@layer base` lets selector specificity beat preflight's `[hidden]` rule. */
+@layer base {
+  .reveal .slides > section.past,
+  .reveal .slides > section.future,
+  .reveal .slides > section > section.past,
+  .reveal .slides > section > section.future {
+    display: block !important;
+  }
+}
+
+/* Without this, the slides will animate as if from the edge of the screen. We hide this unless fullscreen */
+.reveal-viewport:not(:fullscreen) {
+  overflow: hidden;
+}
+
 /* Reveal slides can contain multiple blocks on a single subslide (the root
    cell plus one or more fragments), so we stack vertically and stretch each
    block to full width so its content stays left-aligned like a single cell

--- a/frontend/src/components/slides/reveal-slides.css
+++ b/frontend/src/components/slides/reveal-slides.css
@@ -37,6 +37,19 @@
   text-align: unset;
 }
 
-.reveal .slides > section {
+.reveal .slides > section,
+.reveal .slides > section > section {
   height: 100%;
+}
+
+/* Reveal slides can contain multiple blocks on a single subslide (the root
+   cell plus one or more fragments), so we stack vertically and stretch each
+   block to full width so its content stays left-aligned like a single cell
+   would. The base `.mo-slide-content` stays a horizontal shrink-wrap flex for
+   swiper/minimap, which only ever render one child. */
+.reveal .mo-slide-content {
+  flex-direction: column;
+}
+.reveal .mo-slide-content .output {
+  margin: 0;
 }

--- a/frontend/src/components/slides/slide-form.tsx
+++ b/frontend/src/components/slides/slide-form.tsx
@@ -5,7 +5,7 @@ import {
   LayoutTemplateIcon,
   type LucideIcon,
   Rows2Icon,
-  SparklesIcon,
+  CookieIcon,
 } from "lucide-react";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
@@ -26,14 +26,15 @@ import type {
 
 export const DEFAULT_SLIDE_TYPE: SlideType = "slide";
 export const DEFAULT_DECK_TRANSITION: DeckTransition = "slide";
-interface SlideTypeOption {
+
+export interface SlideTypeOption {
   value: SlideType;
   label: string;
   description: string;
   Icon: LucideIcon;
 }
 
-const SLIDE_TYPE_OPTIONS: SlideTypeOption[] = [
+export const SLIDE_TYPE_OPTIONS: readonly SlideTypeOption[] = [
   {
     value: "slide",
     label: "Slide",
@@ -52,7 +53,7 @@ const SLIDE_TYPE_OPTIONS: SlideTypeOption[] = [
     value: "fragment",
     label: "Fragment",
     description: "Reveals step-by-step on the current slide without advancing.",
-    Icon: SparklesIcon,
+    Icon: CookieIcon,
   },
   {
     value: "skip",
@@ -62,6 +63,15 @@ const SLIDE_TYPE_OPTIONS: SlideTypeOption[] = [
     Icon: EyeOffIcon,
   },
 ];
+
+/**
+ * Lookup form of {@link SLIDE_TYPE_OPTIONS} for O(1) access by `SlideType`.
+ */
+export const SLIDE_TYPE_OPTIONS_BY_VALUE: Readonly<
+  Record<SlideType, SlideTypeOption>
+> = Object.fromEntries(
+  SLIDE_TYPE_OPTIONS.map((option) => [option.value, option]),
+) as Record<SlideType, SlideTypeOption>;
 
 interface DeckTransitionOption {
   value: DeckTransition;

--- a/frontend/src/components/slides/slide-form.tsx
+++ b/frontend/src/components/slides/slide-form.tsx
@@ -8,15 +8,24 @@ import {
   SparklesIcon,
 } from "lucide-react";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { CellId } from "@/core/cells/ids";
 import { cn } from "@/utils/cn";
 import type {
+  DeckTransition,
   SlidesLayout,
   SlideType,
 } from "../editor/renderers/slides-layout/types";
 
 export const DEFAULT_SLIDE_TYPE: SlideType = "slide";
-
+export const DEFAULT_DECK_TRANSITION: DeckTransition = "slide";
 interface SlideTypeOption {
   value: SlideType;
   label: string;
@@ -54,7 +63,63 @@ const SLIDE_TYPE_OPTIONS: SlideTypeOption[] = [
   },
 ];
 
+interface DeckTransitionOption {
+  value: DeckTransition;
+  label: string;
+  description: string;
+}
+
+const DECK_TRANSITION_OPTIONS: DeckTransitionOption[] = [
+  { value: "none", label: "None", description: "No animation between slides." },
+  { value: "fade", label: "Fade", description: "Cross-fade between slides." },
+  {
+    value: "slide",
+    label: "Slide",
+    description: "Slides move horizontally / vertically.",
+  },
+  {
+    value: "convex",
+    label: "Convex",
+    description: "Rotate with a convex curve.",
+  },
+  {
+    value: "concave",
+    label: "Concave",
+    description: "Rotate with a concave curve.",
+  },
+  { value: "zoom", label: "Zoom", description: "Zoom into the next slide." },
+];
+
 export const SlidesForm = ({
+  layout,
+  setLayout,
+  cellId,
+}: {
+  layout: SlidesLayout;
+  setLayout: (layout: SlidesLayout) => void;
+  cellId: CellId;
+}) => {
+  return (
+    <Tabs defaultValue="slide" className="flex flex-col flex-1 p-3 gap-3">
+      <TabsList className="grid grid-cols-2">
+        <TabsTrigger value="slide">Slide</TabsTrigger>
+        <TabsTrigger value="deck">Deck</TabsTrigger>
+      </TabsList>
+      <TabsContent value="slide" className="mt-0 flex-1">
+        <SlideConfigForm
+          layout={layout}
+          setLayout={setLayout}
+          cellId={cellId}
+        />
+      </TabsContent>
+      <TabsContent value="deck" className="mt-0 flex-1">
+        <DeckConfigForm layout={layout} setLayout={setLayout} />
+      </TabsContent>
+    </Tabs>
+  );
+};
+
+const SlideConfigForm = ({
   layout,
   setLayout,
   cellId,
@@ -77,7 +142,7 @@ export const SlidesForm = ({
   };
 
   return (
-    <div className="flex flex-col gap-3 p-3">
+    <div className="flex flex-col gap-3">
       <span className="font-semibold text-sm">Slide type</span>
       <RadioGroup
         aria-label="Slide type"
@@ -128,6 +193,60 @@ export const SlidesForm = ({
           );
         })}
       </RadioGroup>
+    </div>
+  );
+};
+
+const DeckConfigForm = ({
+  layout,
+  setLayout,
+}: {
+  layout: SlidesLayout;
+  setLayout: (layout: SlidesLayout) => void;
+}) => {
+  const currentTransition: DeckTransition =
+    layout.deck?.transition ?? DEFAULT_DECK_TRANSITION;
+  const activeDescription = DECK_TRANSITION_OPTIONS.find(
+    (opt) => opt.value === currentTransition,
+  )?.description;
+
+  const handleTransitionChange = (value: DeckTransition) => {
+    setLayout({
+      ...layout,
+      deck: { ...layout.deck, transition: value },
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor="deck-transition"
+          className="font-semibold text-sm text-foreground"
+        >
+          Transition
+        </label>
+        <Select
+          value={currentTransition}
+          onValueChange={(value) =>
+            handleTransitionChange(value as DeckTransition)
+          }
+        >
+          <SelectTrigger id="deck-transition" aria-label="Slide transition">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {DECK_TRANSITION_OPTIONS.map(({ value, label }) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {activeDescription && (
+          <p className="text-xs text-foreground/70">{activeDescription}</p>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/slides/slide-form.tsx
+++ b/frontend/src/components/slides/slide-form.tsx
@@ -1,0 +1,126 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import {
+  EyeOffIcon,
+  LayoutTemplateIcon,
+  type LucideIcon,
+  Rows2Icon,
+  SparklesIcon,
+} from "lucide-react";
+import type { CellId } from "@/core/cells/ids";
+import { cn } from "@/utils/cn";
+import type {
+  SlidesLayout,
+  SlideType,
+} from "../editor/renderers/slides-layout/types";
+
+export const DEFAULT_SLIDE_TYPE: SlideType = "slide";
+
+interface SlideTypeOption {
+  value: SlideType;
+  label: string;
+  description: string;
+  Icon: LucideIcon;
+}
+
+const SLIDE_TYPE_OPTIONS: SlideTypeOption[] = [
+  {
+    value: "slide",
+    label: "Slide",
+    description:
+      "A new top-level slide. Advances horizontally with the right arrow.",
+    Icon: LayoutTemplateIcon,
+  },
+  {
+    value: "sub-slide",
+    label: "Sub-slide",
+    description:
+      "Stacks vertically under the previous slide. Reached with the down arrow.",
+    Icon: Rows2Icon,
+  },
+  {
+    value: "fragment",
+    label: "Fragment",
+    description: "Reveals step-by-step on the current slide without advancing.",
+    Icon: SparklesIcon,
+  },
+  {
+    value: "skip",
+    label: "Skip",
+    description:
+      "Hidden from the presentation. Still visible here in the editor.",
+    Icon: EyeOffIcon,
+  },
+];
+
+export const SlidesForm = ({
+  layout,
+  setLayout,
+  cellId,
+}: {
+  layout: SlidesLayout;
+  setLayout: (layout: SlidesLayout) => void;
+  cellId: CellId;
+}) => {
+  const currentSlideType: SlideType =
+    layout.cells.get(cellId)?.type ?? DEFAULT_SLIDE_TYPE;
+
+  const handleSlideTypeChange = (value: SlideType) => {
+    const existingConfig = layout.cells.get(cellId);
+    const newCells = new Map(layout.cells);
+    newCells.set(cellId, { ...existingConfig, type: value });
+    setLayout({
+      ...layout,
+      cells: newCells,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <span className="font-semibold text-sm">Slide type</span>
+      <div
+        role="radiogroup"
+        aria-label="Slide type"
+        className="flex flex-col gap-1.5"
+      >
+        {SLIDE_TYPE_OPTIONS.map(({ value, label, description, Icon }) => {
+          const isSelected = currentSlideType === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              onClick={() => handleSlideTypeChange(value)}
+              className={cn(
+                "group text-left rounded-md border p-2.5 transition-colors",
+                isSelected
+                  ? "border-primary bg-primary/5"
+                  : "border-border/60 bg-background hover:bg-accent/50 hover:border-border",
+              )}
+            >
+              <div className="flex items-start gap-2.5">
+                <span
+                  className={cn(
+                    "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded",
+                    isSelected
+                      ? "bg-primary/10 text-primary"
+                      : "bg-muted text-muted-foreground group-hover:text-foreground",
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                </span>
+                <div>
+                  <p className="text-sm leading-tight">{label}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {description}
+                  </p>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/slides/slide-form.tsx
+++ b/frontend/src/components/slides/slide-form.tsx
@@ -6,6 +6,8 @@ import {
   type LucideIcon,
   Rows2Icon,
   CookieIcon,
+  PanelRightCloseIcon,
+  PanelRightOpenIcon,
 } from "lucide-react";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
@@ -23,9 +25,14 @@ import type {
   SlidesLayout,
   SlideType,
 } from "../editor/renderers/slides-layout/types";
+import { useState } from "react";
+import { Tooltip } from "../ui/tooltip";
+import { Button } from "../ui/button";
+import type { RuntimeCell } from "@/core/cells/types";
 
 export const DEFAULT_SLIDE_TYPE: SlideType = "slide";
 export const DEFAULT_DECK_TRANSITION: DeckTransition = "slide";
+const COLLAPSED_CONFIG_WIDTH = 36;
 
 export interface SlideTypeOption {
   value: SlideType;
@@ -100,7 +107,7 @@ const DECK_TRANSITION_OPTIONS: DeckTransitionOption[] = [
   { value: "zoom", label: "Zoom", description: "Zoom into the next slide." },
 ];
 
-export const SlidesForm = ({
+const SlidesForm = ({
   layout,
   setLayout,
   cellId,
@@ -258,5 +265,83 @@ const DeckConfigForm = ({
         )}
       </div>
     </div>
+  );
+};
+
+export const SlideSidebar = ({
+  configWidth,
+  layout,
+  setLayout,
+  activeConfigCell,
+}: {
+  configWidth: number;
+  layout: SlidesLayout;
+  setLayout: (layout: SlidesLayout) => void;
+  activeConfigCell: RuntimeCell;
+}) => {
+  const [isConfigOpen, setIsConfigOpen] = useState(false);
+
+  return (
+    <aside
+      className="h-full flex flex-col border-l border-border/60 bg-muted/20 transition-[width] duration-200 ease-out overflow-hidden"
+      style={{
+        width: isConfigOpen ? configWidth : COLLAPSED_CONFIG_WIDTH,
+      }}
+      aria-label="Slide configuration"
+    >
+      <header
+        className={cn(
+          "flex items-center h-9 shrink-0 border-b border-border/60",
+          isConfigOpen ? "justify-between px-2" : "justify-center px-0",
+        )}
+      >
+        {isConfigOpen && (
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground pl-1">
+            Configuration
+          </span>
+        )}
+        <Tooltip content={isConfigOpen ? "Collapse panel" : "Expand panel"}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-foreground"
+            onClick={() => setIsConfigOpen(!isConfigOpen)}
+            aria-expanded={isConfigOpen}
+            aria-controls="slide-config-panel"
+          >
+            {isConfigOpen ? (
+              <PanelRightCloseIcon className="h-4 w-4" />
+            ) : (
+              <PanelRightOpenIcon className="h-4 w-4" />
+            )}
+          </Button>
+        </Tooltip>
+      </header>
+
+      {isConfigOpen && (
+        <div
+          id="slide-config-panel"
+          className="flex-1 overflow-y-auto overflow-x-hidden"
+        >
+          {activeConfigCell ? (
+            <SlidesForm
+              layout={layout}
+              setLayout={setLayout}
+              cellId={activeConfigCell.id}
+            />
+          ) : (
+            <div className="flex flex-col gap-1.5 p-3 text-xs text-muted-foreground">
+              <span className="font-semibold text-sm text-foreground">
+                No slides yet
+              </span>
+              <p>
+                Run a cell that produces output to add it to the deck. Slide
+                settings will appear here once a slide is selected.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </aside>
   );
 };

--- a/frontend/src/components/slides/slide-form.tsx
+++ b/frontend/src/components/slides/slide-form.tsx
@@ -7,6 +7,7 @@ import {
   Rows2Icon,
   SparklesIcon,
 } from "lucide-react";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import type { CellId } from "@/core/cells/ids";
 import { cn } from "@/utils/cn";
 import type {
@@ -78,25 +79,24 @@ export const SlidesForm = ({
   return (
     <div className="flex flex-col gap-3 p-3">
       <span className="font-semibold text-sm">Slide type</span>
-      <div
-        role="radiogroup"
+      <RadioGroup
         aria-label="Slide type"
+        value={currentSlideType}
+        onValueChange={(value) => handleSlideTypeChange(value as SlideType)}
         className="flex flex-col gap-1.5"
       >
         {SLIDE_TYPE_OPTIONS.map(({ value, label, description, Icon }) => {
           const isSelected = currentSlideType === value;
           return (
-            <button
+            <RadioGroupItem
               key={value}
-              type="button"
-              role="radio"
-              aria-checked={isSelected}
-              onClick={() => handleSlideTypeChange(value)}
+              value={value}
               className={cn(
-                "group text-left rounded-md border p-2.5 transition-colors",
+                "group h-auto w-full text-left rounded-md p-2.5 transition-colors shadow-none! border",
+                "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 isSelected
                   ? "border-primary bg-primary/5"
-                  : "border-border/60 bg-background hover:bg-accent/50 hover:border-border",
+                  : "border-border bg-background hover:bg-accent/50 hover:border-foreground/30",
               )}
             >
               <div className="flex items-start gap-2.5">
@@ -111,16 +111,23 @@ export const SlidesForm = ({
                   <Icon className="h-3.5 w-3.5" />
                 </span>
                 <div>
-                  <p className="text-sm leading-tight">{label}</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
+                  <p
+                    className={cn(
+                      "text-sm font-medium leading-tight",
+                      isSelected ? "text-primary" : "text-foreground",
+                    )}
+                  >
+                    {label}
+                  </p>
+                  <p className="mt-0.5 text-xs text-foreground/70">
                     {description}
                   </p>
                 </div>
               </div>
-            </button>
+            </RadioGroupItem>
           );
         })}
-      </div>
+      </RadioGroup>
     </div>
   );
 };

--- a/frontend/src/components/slides/slide-form.tsx
+++ b/frontend/src/components/slides/slide-form.tsx
@@ -277,7 +277,7 @@ export const SlideSidebar = ({
   configWidth: number;
   layout: SlidesLayout;
   setLayout: (layout: SlidesLayout) => void;
-  activeConfigCell: RuntimeCell;
+  activeConfigCell?: RuntimeCell;
 }) => {
   const [isConfigOpen, setIsConfigOpen] = useState(false);
 

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -33,9 +33,11 @@ const RadioGroupItem = React.forwardRef<
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <Circle className="h-[10px] w-[10px] fill-primary text-current" />
-      </RadioGroupPrimitive.Indicator>
+      {children ?? (
+        <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+          <Circle className="h-[10px] w-[10px] fill-primary text-current" />
+        </RadioGroupPrimitive.Indicator>
+      )}
     </RadioGroupPrimitive.Item>
   );
 });

--- a/frontend/src/core/cells/types.ts
+++ b/frontend/src/core/cells/types.ts
@@ -119,6 +119,8 @@ export interface CellRuntimeState {
   serialization?: string | null;
 }
 
+export type RuntimeCell = CellRuntimeState & CellData;
+
 export type WithResponse<T> = T & {
   /**
    * This is not saved to the server, but we update this field

--- a/frontend/src/core/layout/layout.ts
+++ b/frontend/src/core/layout/layout.ts
@@ -84,7 +84,6 @@ export function getSerializedLayout() {
     return null;
   }
 
-  const data = layoutData[selectedLayout];
   const plugin = cellRendererPlugins.find(
     (plugin) => plugin.type === selectedLayout,
   );
@@ -92,8 +91,13 @@ export function getSerializedLayout() {
     Logger.error(`Unknown layout type: ${selectedLayout}`);
     return null;
   }
+  const cells = notebookCells(notebook);
+  // Fall back to the plugin's initial layout when the user has not yet
+  // interacted with this layout — otherwise serializers that expect a
+  // structured layout object crash on `undefined`.
+  const data = layoutData[selectedLayout] ?? plugin.getInitialLayout(cells);
   return {
     type: selectedLayout,
-    data: plugin.serializeLayout(data, notebookCells(notebook)),
+    data: plugin.serializeLayout(data, cells),
   };
 }

--- a/marimo/_smoke_tests/slides_examples/layouts/nested_slides.slides.json
+++ b/marimo/_smoke_tests/slides_examples/layouts/nested_slides.slides.json
@@ -15,7 +15,7 @@
         "codeSnippet": "# Cell 3 (fragment) \u2014 first reveal on the title slide.\nmo.md(\"\"\"\n- Built with `@revealjs/react`\n\"\"\")..."
       },
       {
-        "type": "slide",
+        "type": "fragment",
         "codeSnippet": "# Cell 4 (fragment) \u2014 second reveal on the title slide.\nmo.md(\"\"\"\n- Composed from flat marimo cells\n..."
       },
       {

--- a/marimo/_smoke_tests/slides_examples/layouts/nested_slides.slides.json
+++ b/marimo/_smoke_tests/slides_examples/layouts/nested_slides.slides.json
@@ -3,92 +3,70 @@
   "data": {
     "cells": [
       {
-        "codeSnippet": "# Cell 1 (skip) \u2014 has visible output in the notebook, but dropped from the presentation.\nimport mari...",
         "type": "skip"
       },
       {
-        "codeSnippet": "# Cell 2 (slide) \u2014 title slide.\nmo.md(\"\"\"\n# Nested Slides Smoke Test\n\nA deck exercising slides, sub-...",
         "type": "slide"
       },
       {
-        "codeSnippet": "# Cell 3 (fragment) \u2014 first reveal on the title slide.\nmo.md(\"\"\"\n- Built with `@revealjs/react`\n\"\"\")...",
         "type": "fragment"
       },
       {
-        "codeSnippet": "# Cell 4 (fragment) \u2014 second reveal on the title slide.\nmo.md(\"\"\"\n- Composed from flat marimo cells\n...",
         "type": "fragment"
       },
       {
-        "codeSnippet": "# Cell 5 (slide) \u2014 agenda.\nmo.md(\"\"\"\n## Agenda\n\n1. Section A \u2014 sub-slides & fragments\n2. Section B \u2014...",
         "type": "slide"
       },
       {
-        "codeSnippet": "# Cell 6 (slide) \u2014 start of Section A stack.\nmo.md(\"# Section A\").center()...",
         "type": "slide"
       },
       {
-        "codeSnippet": "# Cell 7 (sub-slide) \u2014 A.1 vertical subslide.\nmo.md(\"\"\"\n## A.1 \u2014 Plain text\n\"\"\")...",
         "type": "sub-slide"
       },
       {
-        "codeSnippet": "# Cell 8 (fragment) \u2014 A.1 first bullet.\nmo.md(\"\"\"\n- Fragments reveal incrementally\n\"\"\")...",
         "type": "fragment"
       },
       {
-        "codeSnippet": "# Cell 9 (fragment) \u2014 A.1 second bullet.\nmo.md(\"\"\"\n- Each `fragment` cell is one reveal step\n\"\"\")...",
         "type": "fragment"
       },
       {
-        "codeSnippet": "# Cell 10 (sub-slide) \u2014 A.2 vertical subslide.\nmo.md(\"\"\"\n## A.2 \u2014 Continuation cells\n\"\"\")...",
+        "type": "sub-slide"
+      },
+      {},
+      {
         "type": "sub-slide"
       },
       {
-        "codeSnippet": "# Cell 11 (no slide type) \u2014 treated as a slide.\nmo.md(\"\"\"\nCells with no slide type are treated as sl..."
-      },
-      {
-        "codeSnippet": "# Cell 12 (sub-slide) \u2014 A.3 chart subslide.\nimport numpy as np\n\nx = np.linspace(0, 2 * np.pi, 100)\nm...",
-        "type": "sub-slide"
-      },
-      {
-        "codeSnippet": "# Cell 13 (slide) \u2014 start of Section B stack.\nmo.md(\"# Section B\").center()...",
         "type": "slide"
       },
       {
-        "codeSnippet": "# Cell 14 (sub-slide) \u2014 B.1 hstack.\nmo.vstack(\n    [\n        mo.md(\"## B.1 \u2014 hstack\"),\n        mo.hs...",
         "type": "sub-slide"
       },
       {
-        "codeSnippet": "# Cell 15 (fragment) \u2014 reveals under B.1.\nmo.md(\"\"\"\n_hstack items sized equally_\n\"\"\")...",
         "type": "fragment"
       },
       {
-        "codeSnippet": "# Cell 16 (sub-slide) \u2014 B.2 nested grid.\nmo.vstack(\n    [\n        mo.md(\"## B.2 \u2014 Nested grid\"),\n   ...",
         "type": "sub-slide"
       },
       {
-        "codeSnippet": "# Cell 17 (skip) \u2014 renders visibly in the notebook but is dropped from the presentation.\nsecret = 42...",
         "type": "skip"
       },
       {
-        "codeSnippet": "# Cell 18 (slide) \u2014 Section C title.\nmo.md(\"# Section C \u2014 Fragments\").center()...",
         "type": "slide"
       },
       {
-        "codeSnippet": "# Cell 19 (fragment).\nmo.md(\"\"\"\n### First reveal\n\"\"\")...",
         "type": "fragment"
       },
       {
-        "codeSnippet": "# Cell 20 (fragment).\nmo.md(\"\"\"\n### Second reveal\n\"\"\")...",
         "type": "fragment"
       },
       {
-        "codeSnippet": "# Cell 21 (fragment) \u2014 pulls in the skipped cell's value.\nmo.md(f\"### Third reveal \u2014 secret is **{se...",
         "type": "fragment"
       },
       {
-        "codeSnippet": "# Cell 22 (slide) \u2014 closing slide.\nmo.md(\n    \"\"\"\n    # Thanks!\n\n    Questions?\n    \"\"\"\n).center()...",
         "type": "slide"
       }
-    ]
+    ],
+    "deck": {}
   }
 }

--- a/marimo/_smoke_tests/slides_examples/layouts/nested_slides.slides.json
+++ b/marimo/_smoke_tests/slides_examples/layouts/nested_slides.slides.json
@@ -1,0 +1,94 @@
+{
+  "type": "slides",
+  "data": {
+    "cells": [
+      {
+        "type": "skip",
+        "codeSnippet": "# Cell 1 (skip) \u2014 has visible output in the notebook, but dropped from the presentation.\nimport mari..."
+      },
+      {
+        "type": "slide",
+        "codeSnippet": "# Cell 2 (slide) \u2014 title slide.\nmo.md(\"\"\"\n# Nested Slides Smoke Test\n\nA deck exercising slides, sub-..."
+      },
+      {
+        "type": "fragment",
+        "codeSnippet": "# Cell 3 (fragment) \u2014 first reveal on the title slide.\nmo.md(\"\"\"\n- Built with `@revealjs/react`\n\"\"\")..."
+      },
+      {
+        "type": "slide",
+        "codeSnippet": "# Cell 4 (fragment) \u2014 second reveal on the title slide.\nmo.md(\"\"\"\n- Composed from flat marimo cells\n..."
+      },
+      {
+        "type": "slide",
+        "codeSnippet": "# Cell 5 (slide) \u2014 agenda.\nmo.md(\"\"\"\n## Agenda\n\n1. Section A \u2014 sub-slides & fragments\n2. Section B \u2014..."
+      },
+      {
+        "type": "slide",
+        "codeSnippet": "# Cell 6 (slide) \u2014 start of Section A stack.\nmo.md(\"# Section A\").center()..."
+      },
+      {
+        "type": "sub-slide",
+        "codeSnippet": "# Cell 7 (sub-slide) \u2014 A.1 vertical subslide.\nmo.md(\"\"\"\n## A.1 \u2014 Plain text\n\"\"\")..."
+      },
+      {
+        "type": "fragment",
+        "codeSnippet": "# Cell 8 (fragment) \u2014 A.1 first bullet.\nmo.md(\"\"\"\n- Fragments reveal incrementally\n\"\"\")..."
+      },
+      {
+        "type": "fragment",
+        "codeSnippet": "# Cell 9 (fragment) \u2014 A.1 second bullet.\nmo.md(\"\"\"\n- Each `fragment` cell is one reveal step\n\"\"\")..."
+      },
+      {
+        "type": "sub-slide",
+        "codeSnippet": "# Cell 10 (sub-slide) \u2014 A.2 vertical subslide.\nmo.md(\"\"\"\n## A.2 \u2014 Continuation cells\n\"\"\")..."
+      },
+      {
+        "codeSnippet": "# Cell 11 (continuation \u2014 no slide type) \u2014 flows into the previous block.\nmo.md(\"\"\"\nCells with no sl..."
+      },
+      {
+        "type": "sub-slide",
+        "codeSnippet": "# Cell 12 (sub-slide) \u2014 A.3 chart subslide.\nimport numpy as np\n\nx = np.linspace(0, 2 * np.pi, 100)\nm..."
+      },
+      {
+        "type": "slide",
+        "codeSnippet": "# Cell 13 (slide) \u2014 start of Section B stack.\nmo.md(\"# Section B\").center()..."
+      },
+      {
+        "type": "sub-slide",
+        "codeSnippet": "# Cell 14 (sub-slide) \u2014 B.1 hstack.\nmo.vstack(\n    [\n        mo.md(\"## B.1 \u2014 hstack\"),\n        mo.hs..."
+      },
+      {
+        "type": "fragment",
+        "codeSnippet": "# Cell 15 (fragment) \u2014 reveals under B.1.\nmo.md(\"\"\"\n_hstack items sized equally_\n\"\"\")..."
+      },
+      {
+        "type": "sub-slide",
+        "codeSnippet": "# Cell 16 (sub-slide) \u2014 B.2 nested grid.\nmo.vstack(\n    [\n        mo.md(\"## B.2 \u2014 Nested grid\"),\n   ..."
+      },
+      {
+        "type": "skip",
+        "codeSnippet": "# Cell 17 (skip) \u2014 renders visibly in the notebook but is dropped from the presentation.\nsecret = 42..."
+      },
+      {
+        "type": "slide",
+        "codeSnippet": "# Cell 18 (slide) \u2014 Section C title.\nmo.md(\"# Section C \u2014 Fragments\").center()..."
+      },
+      {
+        "type": "fragment",
+        "codeSnippet": "# Cell 19 (fragment).\nmo.md(\"\"\"\n### First reveal\n\"\"\")..."
+      },
+      {
+        "type": "fragment",
+        "codeSnippet": "# Cell 20 (fragment).\nmo.md(\"\"\"\n### Second reveal\n\"\"\")..."
+      },
+      {
+        "type": "fragment",
+        "codeSnippet": "# Cell 21 (fragment) \u2014 pulls in the skipped cell's value.\nmo.md(f\"### Third reveal \u2014 secret is **{se..."
+      },
+      {
+        "type": "slide",
+        "codeSnippet": "# Cell 22 (slide) \u2014 closing slide.\nmo.md(\n    \"\"\"\n    # Thanks!\n\n    Questions?\n    \"\"\"\n).center()..."
+      }
+    ]
+  }
+}

--- a/marimo/_smoke_tests/slides_examples/layouts/nested_slides.slides.json
+++ b/marimo/_smoke_tests/slides_examples/layouts/nested_slides.slides.json
@@ -3,91 +3,91 @@
   "data": {
     "cells": [
       {
-        "type": "skip",
-        "codeSnippet": "# Cell 1 (skip) \u2014 has visible output in the notebook, but dropped from the presentation.\nimport mari..."
+        "codeSnippet": "# Cell 1 (skip) \u2014 has visible output in the notebook, but dropped from the presentation.\nimport mari...",
+        "type": "skip"
       },
       {
-        "type": "slide",
-        "codeSnippet": "# Cell 2 (slide) \u2014 title slide.\nmo.md(\"\"\"\n# Nested Slides Smoke Test\n\nA deck exercising slides, sub-..."
+        "codeSnippet": "# Cell 2 (slide) \u2014 title slide.\nmo.md(\"\"\"\n# Nested Slides Smoke Test\n\nA deck exercising slides, sub-...",
+        "type": "slide"
       },
       {
-        "type": "fragment",
-        "codeSnippet": "# Cell 3 (fragment) \u2014 first reveal on the title slide.\nmo.md(\"\"\"\n- Built with `@revealjs/react`\n\"\"\")..."
+        "codeSnippet": "# Cell 3 (fragment) \u2014 first reveal on the title slide.\nmo.md(\"\"\"\n- Built with `@revealjs/react`\n\"\"\")...",
+        "type": "fragment"
       },
       {
-        "type": "fragment",
-        "codeSnippet": "# Cell 4 (fragment) \u2014 second reveal on the title slide.\nmo.md(\"\"\"\n- Composed from flat marimo cells\n..."
+        "codeSnippet": "# Cell 4 (fragment) \u2014 second reveal on the title slide.\nmo.md(\"\"\"\n- Composed from flat marimo cells\n...",
+        "type": "fragment"
       },
       {
-        "type": "slide",
-        "codeSnippet": "# Cell 5 (slide) \u2014 agenda.\nmo.md(\"\"\"\n## Agenda\n\n1. Section A \u2014 sub-slides & fragments\n2. Section B \u2014..."
+        "codeSnippet": "# Cell 5 (slide) \u2014 agenda.\nmo.md(\"\"\"\n## Agenda\n\n1. Section A \u2014 sub-slides & fragments\n2. Section B \u2014...",
+        "type": "slide"
       },
       {
-        "type": "slide",
-        "codeSnippet": "# Cell 6 (slide) \u2014 start of Section A stack.\nmo.md(\"# Section A\").center()..."
+        "codeSnippet": "# Cell 6 (slide) \u2014 start of Section A stack.\nmo.md(\"# Section A\").center()...",
+        "type": "slide"
       },
       {
-        "type": "sub-slide",
-        "codeSnippet": "# Cell 7 (sub-slide) \u2014 A.1 vertical subslide.\nmo.md(\"\"\"\n## A.1 \u2014 Plain text\n\"\"\")..."
+        "codeSnippet": "# Cell 7 (sub-slide) \u2014 A.1 vertical subslide.\nmo.md(\"\"\"\n## A.1 \u2014 Plain text\n\"\"\")...",
+        "type": "sub-slide"
       },
       {
-        "type": "fragment",
-        "codeSnippet": "# Cell 8 (fragment) \u2014 A.1 first bullet.\nmo.md(\"\"\"\n- Fragments reveal incrementally\n\"\"\")..."
+        "codeSnippet": "# Cell 8 (fragment) \u2014 A.1 first bullet.\nmo.md(\"\"\"\n- Fragments reveal incrementally\n\"\"\")...",
+        "type": "fragment"
       },
       {
-        "type": "fragment",
-        "codeSnippet": "# Cell 9 (fragment) \u2014 A.1 second bullet.\nmo.md(\"\"\"\n- Each `fragment` cell is one reveal step\n\"\"\")..."
+        "codeSnippet": "# Cell 9 (fragment) \u2014 A.1 second bullet.\nmo.md(\"\"\"\n- Each `fragment` cell is one reveal step\n\"\"\")...",
+        "type": "fragment"
       },
       {
-        "type": "sub-slide",
-        "codeSnippet": "# Cell 10 (sub-slide) \u2014 A.2 vertical subslide.\nmo.md(\"\"\"\n## A.2 \u2014 Continuation cells\n\"\"\")..."
+        "codeSnippet": "# Cell 10 (sub-slide) \u2014 A.2 vertical subslide.\nmo.md(\"\"\"\n## A.2 \u2014 Continuation cells\n\"\"\")...",
+        "type": "sub-slide"
       },
       {
-        "codeSnippet": "# Cell 11 (continuation \u2014 no slide type) \u2014 flows into the previous block.\nmo.md(\"\"\"\nCells with no sl..."
+        "codeSnippet": "# Cell 11 (no slide type) \u2014 treated as a slide.\nmo.md(\"\"\"\nCells with no slide type are treated as sl..."
       },
       {
-        "type": "sub-slide",
-        "codeSnippet": "# Cell 12 (sub-slide) \u2014 A.3 chart subslide.\nimport numpy as np\n\nx = np.linspace(0, 2 * np.pi, 100)\nm..."
+        "codeSnippet": "# Cell 12 (sub-slide) \u2014 A.3 chart subslide.\nimport numpy as np\n\nx = np.linspace(0, 2 * np.pi, 100)\nm...",
+        "type": "sub-slide"
       },
       {
-        "type": "slide",
-        "codeSnippet": "# Cell 13 (slide) \u2014 start of Section B stack.\nmo.md(\"# Section B\").center()..."
+        "codeSnippet": "# Cell 13 (slide) \u2014 start of Section B stack.\nmo.md(\"# Section B\").center()...",
+        "type": "slide"
       },
       {
-        "type": "sub-slide",
-        "codeSnippet": "# Cell 14 (sub-slide) \u2014 B.1 hstack.\nmo.vstack(\n    [\n        mo.md(\"## B.1 \u2014 hstack\"),\n        mo.hs..."
+        "codeSnippet": "# Cell 14 (sub-slide) \u2014 B.1 hstack.\nmo.vstack(\n    [\n        mo.md(\"## B.1 \u2014 hstack\"),\n        mo.hs...",
+        "type": "sub-slide"
       },
       {
-        "type": "fragment",
-        "codeSnippet": "# Cell 15 (fragment) \u2014 reveals under B.1.\nmo.md(\"\"\"\n_hstack items sized equally_\n\"\"\")..."
+        "codeSnippet": "# Cell 15 (fragment) \u2014 reveals under B.1.\nmo.md(\"\"\"\n_hstack items sized equally_\n\"\"\")...",
+        "type": "fragment"
       },
       {
-        "type": "sub-slide",
-        "codeSnippet": "# Cell 16 (sub-slide) \u2014 B.2 nested grid.\nmo.vstack(\n    [\n        mo.md(\"## B.2 \u2014 Nested grid\"),\n   ..."
+        "codeSnippet": "# Cell 16 (sub-slide) \u2014 B.2 nested grid.\nmo.vstack(\n    [\n        mo.md(\"## B.2 \u2014 Nested grid\"),\n   ...",
+        "type": "sub-slide"
       },
       {
-        "type": "skip",
-        "codeSnippet": "# Cell 17 (skip) \u2014 renders visibly in the notebook but is dropped from the presentation.\nsecret = 42..."
+        "codeSnippet": "# Cell 17 (skip) \u2014 renders visibly in the notebook but is dropped from the presentation.\nsecret = 42...",
+        "type": "skip"
       },
       {
-        "type": "slide",
-        "codeSnippet": "# Cell 18 (slide) \u2014 Section C title.\nmo.md(\"# Section C \u2014 Fragments\").center()..."
+        "codeSnippet": "# Cell 18 (slide) \u2014 Section C title.\nmo.md(\"# Section C \u2014 Fragments\").center()...",
+        "type": "slide"
       },
       {
-        "type": "fragment",
-        "codeSnippet": "# Cell 19 (fragment).\nmo.md(\"\"\"\n### First reveal\n\"\"\")..."
+        "codeSnippet": "# Cell 19 (fragment).\nmo.md(\"\"\"\n### First reveal\n\"\"\")...",
+        "type": "fragment"
       },
       {
-        "type": "fragment",
-        "codeSnippet": "# Cell 20 (fragment).\nmo.md(\"\"\"\n### Second reveal\n\"\"\")..."
+        "codeSnippet": "# Cell 20 (fragment).\nmo.md(\"\"\"\n### Second reveal\n\"\"\")...",
+        "type": "fragment"
       },
       {
-        "type": "fragment",
-        "codeSnippet": "# Cell 21 (fragment) \u2014 pulls in the skipped cell's value.\nmo.md(f\"### Third reveal \u2014 secret is **{se..."
+        "codeSnippet": "# Cell 21 (fragment) \u2014 pulls in the skipped cell's value.\nmo.md(f\"### Third reveal \u2014 secret is **{se...",
+        "type": "fragment"
       },
       {
-        "type": "slide",
-        "codeSnippet": "# Cell 22 (slide) \u2014 closing slide.\nmo.md(\n    \"\"\"\n    # Thanks!\n\n    Questions?\n    \"\"\"\n).center()..."
+        "codeSnippet": "# Cell 22 (slide) \u2014 closing slide.\nmo.md(\n    \"\"\"\n    # Thanks!\n\n    Questions?\n    \"\"\"\n).center()...",
+        "type": "slide"
       }
     ]
   }

--- a/marimo/_smoke_tests/slides_examples/nested_slides.py
+++ b/marimo/_smoke_tests/slides_examples/nested_slides.py
@@ -108,9 +108,9 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(mo):
-    # Cell 11 (continuation — no slide type) — flows into the previous block.
+    # Cell 11 (no slide type) — treated as a slide.
     mo.md("""
-    Cells with no slide type stick to whatever container the previous cell opened.
+    Cells with no slide type are treated as slides.
     """)
     return
 

--- a/marimo/_smoke_tests/slides_examples/nested_slides.py
+++ b/marimo/_smoke_tests/slides_examples/nested_slides.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.1"
+__generated_with = "0.23.2"
 app = marimo.App(
     width="medium",
     layout_file="layouts/nested_slides.slides.json",

--- a/marimo/_smoke_tests/slides_examples/nested_slides.py
+++ b/marimo/_smoke_tests/slides_examples/nested_slides.py
@@ -1,0 +1,244 @@
+import marimo
+
+__generated_with = "0.23.1"
+app = marimo.App(
+    width="medium",
+    layout_file="layouts/nested_slides.slides.json",
+)
+
+
+@app.cell
+def _():
+    # Cell 1 (skip) — has visible output in the notebook, but dropped from the presentation.
+    import marimo as mo
+
+    mo.callout(
+        mo.md(
+            "**Debug (skip):** imports loaded — you should NOT see this in the presentation."
+        ),
+        kind="info",
+    )
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 2 (slide) — title slide.
+    mo.md("""
+    # Nested Slides Smoke Test
+
+    A deck exercising slides, sub-slides (stacks), fragments, and skip cells.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 3 (fragment) — first reveal on the title slide.
+    mo.md("""
+    - Built with `@revealjs/react`
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 4 (fragment) — second reveal on the title slide.
+    mo.md("""
+    - Composed from flat marimo cells
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 5 (slide) — agenda.
+    mo.md("""
+    ## Agenda
+
+    1. Section A — sub-slides & fragments
+    2. Section B — layouts across a stack
+    3. Section C — fragments only
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 6 (slide) — start of Section A stack.
+    mo.md("# Section A").center()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 7 (sub-slide) — A.1 vertical subslide.
+    mo.md("""
+    ## A.1 — Plain text
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 8 (fragment) — A.1 first bullet.
+    mo.md("""
+    - Fragments reveal incrementally
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 9 (fragment) — A.1 second bullet.
+    mo.md("""
+    - Each `fragment` cell is one reveal step
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 10 (sub-slide) — A.2 vertical subslide.
+    mo.md("""
+    ## A.2 — Continuation cells
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 11 (continuation — no slide type) — flows into the previous block.
+    mo.md("""
+    Cells with no slide type stick to whatever container the previous cell opened.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 12 (sub-slide) — A.3 chart subslide.
+    import numpy as np
+
+    x = np.linspace(0, 2 * np.pi, 100)
+    mo.vstack(
+        [
+            mo.md("## A.3 — A chart"),
+            mo.plain_text(f"sin(x) sampled at {len(x)} points"),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 13 (slide) — start of Section B stack.
+    mo.md("# Section B").center()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 14 (sub-slide) — B.1 hstack.
+    mo.vstack(
+        [
+            mo.md("## B.1 — hstack"),
+            mo.hstack(
+                [mo.md("Left"), mo.md("Middle"), mo.md("Right")], widths="equal"
+            ),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 15 (fragment) — reveals under B.1.
+    mo.md("""
+    _hstack items sized equally_
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 16 (sub-slide) — B.2 nested grid.
+    mo.vstack(
+        [
+            mo.md("## B.2 — Nested grid"),
+            mo.vstack(
+                [
+                    mo.hstack(
+                        [mo.md("A"), mo.md("B"), mo.md("C")], widths="equal"
+                    ),
+                    mo.hstack(
+                        [mo.md("D"), mo.md("E"), mo.md("F")], widths="equal"
+                    ),
+                ]
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    # Cell 17 (skip) — renders visibly in the notebook but is dropped from the presentation.
+    secret = 42
+
+    mo.callout(
+        mo.md(
+            f"**Debug (skip):** computed `secret = {secret}` — you should NOT see this in the presentation."
+        ),
+        kind="warn",
+    )
+    return (secret,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 18 (slide) — Section C title.
+    mo.md("# Section C — Fragments").center()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 19 (fragment).
+    mo.md("""
+    ### First reveal
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 20 (fragment).
+    mo.md("""
+    ### Second reveal
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, secret):
+    # Cell 21 (fragment) — pulls in the skipped cell's value.
+    mo.md(f"### Third reveal — secret is **{secret}**")
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    # Cell 22 (slide) — closing slide.
+    mo.md(
+        """
+        # Thanks!
+
+        Questions?
+        """
+    ).center()
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
https://github.com/user-attachments/assets/05cc64ce-fbc7-4fdd-9301-0945f81cdd28

in read mode
<img width="3024" height="1812" alt="image" src="https://github.com/user-attachments/assets/a1d5cf56-6836-4c24-bbe0-9364480a219c" />

- SerializedSlidesLayout now carries optional cells: SlideConfig[] and deck: DeckConfig; both are optional so existing .slides.json files (including bare {}) still deserialize cleanly.
- SlideConfig supports type: "slide" | "sub-slide" | "fragment" | "skip" 
- DeckConfig supports transition: "none" | "fade" | "slide" | "convex" | "concave" | "zoom".

- New compose-slides.ts groups the flat cell list into stacks → subslides → blocks, mirroring reveal.js's {h, v, f} indices, with helpers buildSlideIndices and resolveActiveCellIndex.

- New tabbed SlidesForm (Slide | Deck):

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
