### PR TITLE
fix: do not mutate the test environment during tests

### DIFF
--- a/tests/_code_mode/test_context.py
+++ b/tests/_code_mode/test_context.py
@@ -753,18 +753,35 @@ class TestPackages:
     async def test_list_errors_after_add(self, k: Kernel) -> None:
         """list() raises after add() has been called in the same batch."""
         with _ctx(k) as ctx:
-            async with ctx as nb:
-                nb.packages.add("pandas")
-                with pytest.raises(RuntimeError):
-                    nb.packages.list()
+            pm = k.packages_callbacks.package_manager
+            assert pm is not None
+
+            # Mock install: queued ops still run on context exit and would
+            # otherwise invoke `uv add pandas` against the test venv.
+            with patch.object(
+                pm, "install", new_callable=AsyncMock, return_value=True
+            ):
+                async with ctx as nb:
+                    nb.packages.add("pandas")
+                    with pytest.raises(RuntimeError):
+                        nb.packages.list()
 
     async def test_list_errors_after_remove(self, k: Kernel) -> None:
         """list() raises after remove() has been called in the same batch."""
         with _ctx(k) as ctx:
-            async with ctx as nb:
-                nb.packages.remove("pandas")
-                with pytest.raises(RuntimeError):
-                    nb.packages.list()
+            pm = k.packages_callbacks.package_manager
+            assert pm is not None
+
+            # Mock uninstall: queued ops still run on context exit and would
+            # otherwise invoke `uv remove pandas` against the test venv,
+            # triggering a `uv sync` that wipes every test-group package.
+            with patch.object(
+                pm, "uninstall", new_callable=AsyncMock, return_value=True
+            ):
+                async with ctx as nb:
+                    nb.packages.remove("pandas")
+                    with pytest.raises(RuntimeError):
+                        nb.packages.list()
 
     async def test_add_and_remove_in_same_batch(self, k: Kernel) -> None:
         """add and remove can coexist in the same batch, executed in order."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,16 @@ def _assert_venv_not_wiped(
     Checking the canary before and after each test pinpoints the exact
     offender: see `tests/_code_mode/test_context.py::TestPackages` for
     the required mocking pattern.
+
+    Under pytest-xdist, other workers run concurrently; the post-check
+    can fire on a worker whose current test did not cause the mutation.
+    We soften the post-check message in that case and recommend
+    rerunning with `-p no:xdist` to identify the culprit.
     """
+    import os
+
+    under_xdist = "PYTEST_XDIST_WORKER" in os.environ
+
     if _venv_canary_path is None:
         # Could not establish a canary (e.g. hypothesis not installed on
         # disk); nothing to protect.
@@ -144,14 +153,25 @@ def _assert_venv_not_wiped(
         )
     yield
     if not _venv_canary_path.exists():
-        pytest.fail(
-            f"Test {request.node.nodeid!r} mutated the shared venv: "
-            f"canary {_venv_canary_path} no longer exists. This test "
-            f"(or a fixture it uses) invoked the real package manager. "
-            f"Mock pm.install/pm.uninstall — see "
-            f"tests/_code_mode/test_context.py::TestPackages for the "
-            f"required pattern."
-        )
+        if under_xdist:
+            pytest.fail(
+                f"Test venv was mutated during or concurrent with "
+                f"{request.node.nodeid!r}: canary {_venv_canary_path} "
+                f"no longer exists. Under xdist the mutator may be a "
+                f"different worker's test. Rerun with `-p no:xdist` "
+                f"to identify the culprit. See "
+                f"tests/_code_mode/test_context.py::TestPackages for "
+                f"the required mocking pattern."
+            )
+        else:
+            pytest.fail(
+                f"Test {request.node.nodeid!r} mutated the shared venv: "
+                f"canary {_venv_canary_path} no longer exists. This test "
+                f"(or a fixture it uses) invoked the real package manager. "
+                f"Mock pm.install/pm.uninstall — see "
+                f"tests/_code_mode/test_context.py::TestPackages for the "
+                f"required pattern."
+            )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,74 @@ def pytest_collection_modifyitems(
 
 
 @pytest.fixture(scope="session")
+def _venv_canary_path() -> Path | None:
+    """Resolve an on-disk file whose existence signals the test venv is intact.
+
+    We use `hypothesis`: it's in the `test` dependency group but not in
+    `[project.dependencies]`, so if a test calls through to the real
+    `UvPackageManager.install`/`uninstall` (which shells out to
+    `uv add`/`uv remove` → `uv sync`), the sync resolves against
+    `[project.dependencies]` only and deletes every test-group package
+    from `.venv`. Watching `hypothesis/__init__.py` catches that
+    mutation with a single stat call.
+    """
+    import importlib.util
+
+    spec = importlib.util.find_spec("hypothesis")
+    if spec is None or spec.origin is None:
+        return None
+    path = Path(spec.origin)
+    return path if path.exists() else None
+
+
+@pytest.fixture(autouse=True)
+def _assert_venv_not_wiped(
+    _venv_canary_path: Path | None, request: pytest.FixtureRequest
+) -> Generator[None, None, None]:
+    """Fail fast if a test mutates the shared test venv.
+
+    The historical failure this guards against: an unmocked call to
+    `UvPackageManager.install`/`uninstall` (e.g. via
+    `ctx.packages.add`/`remove` in code-mode tests) runs
+    `uv add`/`uv remove` against the project's `pyproject.toml`,
+    then `uv sync` resolves only `[project.dependencies]` and deletes
+    every `[dependency-groups].test` package — pytest, hypothesis,
+    numpy, matplotlib, execnet, the `.venv/bin/pytest` shim — from the
+    venv. Subsequent tests cascade into obscure
+    `ModuleNotFoundError`/`FileNotFoundError` failures.
+
+    Checking the canary before and after each test pinpoints the exact
+    offender: see `tests/_code_mode/test_context.py::TestPackages` for
+    the required mocking pattern.
+    """
+    if _venv_canary_path is None:
+        # Could not establish a canary (e.g. hypothesis not installed on
+        # disk); nothing to protect.
+        yield
+        return
+
+    if not _venv_canary_path.exists():
+        pytest.fail(
+            f"Test venv was mutated before {request.node.nodeid!r}: "
+            f"canary {_venv_canary_path} is missing. A previous test "
+            f"invoked the real package manager (likely via "
+            f"ctx.packages.add/remove without mocking pm.install/"
+            f"pm.uninstall). See tests/_code_mode/test_context.py::"
+            f"TestPackages for the required pattern."
+        )
+    yield
+    if not _venv_canary_path.exists():
+        pytest.fail(
+            f"Test {request.node.nodeid!r} mutated the shared venv: "
+            f"canary {_venv_canary_path} no longer exists. This test "
+            f"(or a fixture it uses) invoked the real package manager. "
+            f"Mock pm.install/pm.uninstall — see "
+            f"tests/_code_mode/test_context.py::TestPackages for the "
+            f"required pattern."
+        )
+
+
+@pytest.fixture(scope="session")
 def _fake_main_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """A benign empty .py file to assign as __main__.__file__ in tests.
 


### PR DESCRIPTION
This PR fixes a test regression caused by tests that mutated the test virtual environment.

A few code mode tests were calling `uv add` and `uv remove`. This synced the environment to marimo's dependencies and deleted all the test dependencies. This led to many errors that looked different (multiprocessing.spawn failing to start, various packages failing to import) but that were all symptoms of the same issue .

In this change, we mock the package manager. We also add a test fixture that detects venv environment corruption and fails fast to prevent this from happening again.

Before this change, 45+ tests were failing. With the following four tests are failing on Ubuntu, macOS, and Windows. These tests are unrelated to the root cause addressed in this PR.

```
FAILED tests/_plugins/ui/_impl/test_table.py::test_download_as[df0] - AssertionError
FAILED tests/_plugins/ui/_impl/test_table.py::test_get_data_url_no_deps - AssertionError: assert False
 +  where False = <built-in method startswith of str object at 0x7f8e887c9390>('data:application/json;base64,')
 +    where <built-in method startswith of str object at 0x7f8e887c9390> = 'data:text/csv;base64,dmFsdWUKMQoyCjMK'.startswith
 +      where 'data:text/csv;base64,dmFsdWUKMQoyCjMK' = GetDataUrlResponse(data_url='data:text/csv;base64,dmFsdWUKMQoyCjMK', format='csv').data_url
FAILED tests/_server/api/endpoints/test_assets.py::test_serve_static_allowed_files - RuntimeError: File at path /home/runner/work/marimo/marimo/marimo/_static/manifest.json does not exist.
FAILED tests/_runtime/test_complete.py::test_get_completion_options_bails_out_when_timeout_elapsed - AssertionError: assert 'function' == ''
```