### PR TITLE
fix: consistent mangling for private imports

### DIFF
--- a/marimo/_ast/transformers.py
+++ b/marimo/_ast/transformers.py
@@ -458,6 +458,11 @@ class DeprivateVisitor(ast.NodeTransformer):
         node.id = unmangle_local(node.id).name
         return node
 
+    def visit_alias(self, node: ast.alias) -> ast.alias:
+        if node.asname:
+            node.asname = unmangle_local(node.asname).name
+        return node
+
     def generic_visit(self, node: ast.AST) -> ast.AST:
         if hasattr(node, "name") and node.name:
             node.name = unmangle_local(node.name).name

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -280,9 +280,6 @@ class ScopedVisitor(ast.NodeVisitor):
             #   import [a.b.c] - we define a
             #   from foo import [a] - we define a
             #   from foo import [*] - we don't define anything
-            #
-            # Note:
-            # Don't mangle - user has no control over package name
             basename = node.name.split(".")[0]
             if basename == "*":
                 # Use the ImportFrom node's line number for consistency
@@ -298,7 +295,13 @@ class ScopedVisitor(ast.NodeVisitor):
                     f"{line} SyntaxError: Importing symbols with `import *` "
                     "is not allowed in marimo."
                 )
-            return basename
+            # Previously we did not mangle. So this is technically breaking
+            # from 0.22.0 (#8762) but now consistent with private naming
+            # conventions.
+            mangled = self._if_local_then_mangle(basename)
+            if mangled != basename:
+                node.asname = mangled
+            return mangled
         else:
             node.asname = self._if_local_then_mangle(node.asname)
             return node.asname

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -298,22 +298,34 @@ class ScopedVisitor(ast.NodeVisitor):
             # Mangle _-prefixed imports consistently with other
             # private naming conventions. We set asname (not name)
             # because name is the actual module path to import —
-            # changing it would alter what gets imported. asname
+            # changing it would alter what gets imported. `asname`
             # only controls the local binding:
             #   from my_module import _private
             # becomes:
             #   from my_module import _private as _mangled
             mangled = self._if_local_then_mangle(basename)
             if mangled != basename:
+                # An alternative would be rewriting
+                #   import _pkg.submodule
+                #   _pkg.submodule.attr
+                # as
+                #   import _pkg.submodule as _mangled
+                #   _mangled.attr
+                # but this would increase the complexity of
+                # visitor a fair amount.
+                # TODO(dmadisetti): Consider revising.
                 if "." in node.name:
                     rest = node.name[len(basename) + 1 :]
-                    raise SyntaxError(
-                        f"Dotted import `import {node.name}` binds a "
-                        f"private top-level name `{basename}` which "
-                        f"cannot be safely used. Use "
-                        f"`from {basename} import {rest}` or add an "
-                        f"explicit alias instead."
+                    import warnings
+
+                    warnings.warn(
+                        f"`import {node.name}` binds private name "
+                        f"`{basename}` and cannot be safely used. "
+                        f"Try `from {basename} import {rest}` or "
+                        f"`import {node.name} as my_submodule`.",
+                        stacklevel=2,
                     )
+                    return basename
                 node.asname = mangled
             return mangled
         else:

--- a/marimo/_ast/visitor.py
+++ b/marimo/_ast/visitor.py
@@ -295,11 +295,25 @@ class ScopedVisitor(ast.NodeVisitor):
                     f"{line} SyntaxError: Importing symbols with `import *` "
                     "is not allowed in marimo."
                 )
-            # Previously we did not mangle. So this is technically breaking
-            # from 0.22.0 (#8762) but now consistent with private naming
-            # conventions.
+            # Mangle _-prefixed imports consistently with other
+            # private naming conventions. We set asname (not name)
+            # because name is the actual module path to import —
+            # changing it would alter what gets imported. asname
+            # only controls the local binding:
+            #   from my_module import _private
+            # becomes:
+            #   from my_module import _private as _mangled
             mangled = self._if_local_then_mangle(basename)
             if mangled != basename:
+                if "." in node.name:
+                    rest = node.name[len(basename) + 1 :]
+                    raise SyntaxError(
+                        f"Dotted import `import {node.name}` binds a "
+                        f"private top-level name `{basename}` which "
+                        f"cannot be safely used. Use "
+                        f"`from {basename} import {rest}` or add an "
+                        f"explicit alias instead."
+                    )
                 node.asname = mangled
             return mangled
         else:

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -73,6 +73,30 @@ class TestParseCell:
         assert cell.refs == set()
         assert not cell.imported_namespaces
 
+    @staticmethod
+    def test_private_import_mangling() -> None:
+        # from mod import _private — mangled via asname
+        cell = compile_cell("from marimo import _output")
+        assert "_output" not in cell.defs
+        assert cell.refs == set()
+
+        # from mod import _private as public — public alias, no mangling
+        cell = compile_cell("from marimo import _output as output")
+        assert "output" in cell.defs
+
+        # from mod import public as _private — alias is mangled
+        cell = compile_cell("from marimo import output as _out")
+        assert "_out" not in cell.defs
+        assert cell.refs == set()
+
+        # import _pkg (no dots) — mangled
+        cell = compile_cell("import _mypkg")
+        assert "_mypkg" not in cell.defs
+
+        # import _pkg.sub (dotted) — error, can't safely mangle
+        with pytest.raises(SyntaxError, match="cannot be safely used"):
+            compile_cell("import _pkg.submodule")
+
 
 class TestCompilerFlags:
     @staticmethod

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -110,15 +110,10 @@ class TestParseCell:
 
         from marimo._ast.visitor import ScopedVisitor
 
-        code = (
-            "def foo():\n"
-            "    _pkg.sub.attr()\n"
-            "\n"
-            "import _pkg.sub"
-        )
+        code = "def foo():\n    _pkg.sub.attr()\n\nimport _pkg.sub"
         tree = ast.parse(code)
+        v = ScopedVisitor(mangle_prefix="test")
         with pytest.warns(match="cannot be safely used"):
-            v = ScopedVisitor(mangle_prefix="test")
             v.visit(tree)
         # The function body should reference _pkg (unmangled) to
         # match the import, but the visitor mangles it on first pass.

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -93,9 +93,11 @@ class TestParseCell:
         cell = compile_cell("import _mypkg")
         assert "_mypkg" not in cell.defs
 
-        # import _pkg.sub (dotted) — error, can't safely mangle
-        with pytest.raises(SyntaxError, match="cannot be safely used"):
-            compile_cell("import _pkg.submodule")
+        # import _pkg.sub (dotted) — warns and skips mangling
+        with pytest.warns(match="cannot be safely used"):
+            cell = compile_cell("import _pkg.submodule")
+        # _pkg stays unmangled — lands in temporaries, not defs
+        assert "_pkg" in cell.temporaries
 
 
 class TestCompilerFlags:

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -99,6 +99,33 @@ class TestParseCell:
         # _pkg stays unmangled — lands in temporaries, not defs
         assert "_pkg" in cell.temporaries
 
+    @staticmethod
+    @pytest.mark.xfail(
+        reason="Dotted _-prefixed imports skip mangling but deferred "
+        "references in function bodies are mangled before the import "
+        "is visited, causing a name mismatch."
+    )
+    def test_dotted_private_import_deferred_ref() -> None:
+        import ast
+
+        from marimo._ast.visitor import ScopedVisitor
+
+        code = (
+            "def foo():\n"
+            "    _pkg.sub.attr()\n"
+            "\n"
+            "import _pkg.sub"
+        )
+        tree = ast.parse(code)
+        with pytest.warns(match="cannot be safely used"):
+            v = ScopedVisitor(mangle_prefix="test")
+            v.visit(tree)
+        # The function body should reference _pkg (unmangled) to
+        # match the import, but the visitor mangles it on first pass.
+        func_body = ast.unparse(tree.body[0].body[0])
+        assert "_pkg" in func_body
+        assert "_test" not in func_body
+
 
 class TestCompilerFlags:
     @staticmethod

--- a/tests/_ast/test_transformers.py
+++ b/tests/_ast/test_transformers.py
@@ -362,6 +362,18 @@ def test_deprivate_visitor() -> None:
     assert "_cell_123_private_var" not in code_result
 
 
+def test_deprivate_visitor_strips_alias_asname() -> None:
+    """Synthetic asname from import mangling must be stripped for hashing."""
+    code = "from marimo import _output as _cell_abc_output"
+    tree = ast.parse(code)
+
+    result = DeprivateVisitor().visit(tree)
+
+    alias = result.body[0].names[0]
+    assert alias.asname == "_output"
+    assert "_cell_abc" not in ast.unparse(result)
+
+
 def test_remove_returns() -> None:
     """Test the RemoveReturns transformer."""
     code = """

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -2214,7 +2214,6 @@ class TestStrictExecution:
         assert "f" in k.globals
         assert k.globals["V"] == 5
 
-
     @staticmethod
     async def test_cell_private_imports(
         execution_kernel: Kernel, exec_req: ExecReqProvider
@@ -2246,6 +2245,55 @@ class TestStrictExecution:
         assert "Hello" in k.globals["L"].text
         assert "NameError" in k.stderr.messages[0]
 
+    @staticmethod
+    async def test_cell_private_import_as_public(
+        execution_kernel: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        """from mod import _private as public — public name, no mangling."""
+        k = execution_kernel
+        await k.run(
+            [
+                exec_req.get(
+                    """
+                    from marimo import _output as output
+                    def f(x):
+                       return output.md.md(x)
+                    """
+                ),
+                exec_req.get("L = f('Hello')"),
+            ]
+        )
+        assert not k.errors
+        assert not k.stderr.messages, k.stderr.messages
+        assert "output" in k.globals
+        assert "L" in k.globals
+        assert "Hello" in k.globals["L"].text
+
+    @staticmethod
+    async def test_cell_public_import_as_private(
+        execution_kernel: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        """from mod import public as _private — mangled, cell-private."""
+        k = execution_kernel
+        await k.run(
+            [
+                exec_req.get(
+                    """
+                    from marimo._output import md as _md
+                    def f(x):
+                       return _md.md(x)
+                    """
+                ),
+                exec_req.get("L = f('Hello')"),
+                exec_req.get("_md"),
+            ]
+        )
+        assert not k.errors
+        assert "_md" not in k.globals
+        assert "L" in k.globals
+        assert "Hello" in k.globals["L"].text
+        # Cell 3 gets NameError: _md is cell-private
+        assert "NameError" in k.stderr.messages[0]
 
     @staticmethod
     async def test_cell_copy_works(

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -2214,6 +2214,39 @@ class TestStrictExecution:
         assert "f" in k.globals
         assert k.globals["V"] == 5
 
+
+    @staticmethod
+    async def test_cell_private_imports(
+        execution_kernel: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        k = execution_kernel
+        await k.run(
+            [
+                exec_req.get(
+                    """
+                    from marimo import _output
+                    from marimo import _sql
+                    def f(x):
+                       return _output.md.md(x)
+                    """
+                ),
+                exec_req.get(
+                    """
+                  L = f("Hello")
+                  """
+                ),
+                exec_req.get("L; never_assigned = _sql"),
+            ]
+        )
+        assert not k.errors
+        assert "_output" not in k.globals
+        assert "_sql" not in k.globals
+        assert "L" in k.globals
+        assert "never_assigned" not in k.globals
+        assert "Hello" in k.globals["L"].text
+        assert "NameError" in k.stderr.messages[0]
+
+
     @staticmethod
     async def test_cell_copy_works(
         strict_kernel: Kernel, exec_req: ExecReqProvider

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -2214,7 +2214,6 @@ class TestStrictExecution:
         assert "f" in k.globals
         assert k.globals["V"] == 5
 
-
     @staticmethod
     async def test_cell_private_imports(
         execution_kernel: Kernel, exec_req: ExecReqProvider
@@ -2245,7 +2244,6 @@ class TestStrictExecution:
         assert "never_assigned" not in k.globals
         assert "Hello" in k.globals["L"].text
         assert "NameError" in k.stderr.messages[0]
-
 
     @staticmethod
     async def test_cell_copy_works(


### PR DESCRIPTION
## 📝 Summary

A scoping change introduced in #8762 changed `_` prefixed imports by turning then into privates.
While this is consistent with the remainder of marimo's private pattern, it is technically a breaking change as of 0.22.0, and the edge case was not correctly handled. The change lead to a bug where imports referenced in scope were not correctly addressed. This PR handles the mangling behavior for these import cases.

An alternative PR, for retaining the behavior, is here: https://github.com/marimo-team/marimo/pull/9308 but this requires ref tracking a little differently such that the `_` pattern is properly placed into globals.

closes #9151