### PR TITLE
feat(plotly): Escape to clear selection and sync greyout across traces

### DIFF
--- a/frontend/src/plugins/impl/plotly/Plot.tsx
+++ b/frontend/src/plugins/impl/plotly/Plot.tsx
@@ -162,6 +162,26 @@ export const Plot = (props: PlotProps) => {
       if (e.key !== "Escape" || e.defaultPrevented) {
         return;
       }
+      // Don't hijack Escape from text editors elsewhere on the page
+      // (e.g. CodeMirror notebook cells, inputs, search boxes).
+      const active = document.activeElement;
+      if (active instanceof HTMLElement) {
+        const tag = active.tagName;
+        if (
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          active.isContentEditable
+        ) {
+          return;
+        }
+        // With multiple plots on the page, only clear the one whose
+        // container holds focus. A bare-body activeElement means nothing
+        // in particular is focused, in which case it's fine to clear.
+        if (active !== document.body && !el.contains(active)) {
+          return;
+        }
+      }
       Plotly.restyle(el, "selectedpoints", null).catch(() => {});
       Plotly.relayout(el, "selections", null).catch(() => {});
       onDeselect();
@@ -181,6 +201,11 @@ export const Plot = (props: PlotProps) => {
   // only updates the clicked trace, so we explicitly set [] on all others to
   // grey them out. `layout.selections` is cleared whenever the plugin has no
   // active overlay, otherwise the box/lasso outline sticks around.
+  //
+  // When the plugin is not managing selection state at all (both props
+  // undefined) we leave Plotly alone — the figure may carry persistent
+  // `layout.selections` or per-trace `selectedpoints` that belong to the
+  // user, and wiping them would contradict the figure they passed in.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) {
@@ -189,9 +214,14 @@ export const Plot = (props: PlotProps) => {
     if (!data.length) {
       return;
     }
+    if (selectedPoints === undefined && layoutSelections === undefined) {
+      return;
+    }
 
-    const byTrace = new Map<number, number[]>();
-    if (selectedPoints) {
+    const traceIndices = data.map((_, i) => i);
+    const traceUpdate: Partial<PlotlyTypes.Data> = {};
+    if (selectedPoints !== undefined) {
+      const byTrace = new Map<number, number[]>();
       for (const point of selectedPoints) {
         const curve =
           typeof point.curveNumber === "number" ? point.curveNumber : undefined;
@@ -211,28 +241,23 @@ export const Plot = (props: PlotProps) => {
         indices.push(pointIdx);
         byTrace.set(curve, indices);
       }
+      const anySelection = byTrace.size > 0;
+      const emptyFill: number[] | null = anySelection ? [] : null;
+      (traceUpdate as { selectedpoints: (number[] | null)[] }).selectedpoints =
+        traceIndices.map((i) => byTrace.get(i) ?? emptyFill);
     }
 
-    const traceIndices = data.map((_, i) => i);
-    const anySelection = byTrace.size > 0;
-    const emptyFill: number[] | null = anySelection ? [] : null;
-    const nextSelectedpoints: (number[] | null)[] = traceIndices.map(
-      (i) => byTrace.get(i) ?? emptyFill,
-    );
+    const layoutUpdate: Partial<PlotlyTypes.Layout> = {};
+    if (layoutSelections !== undefined) {
+      const hasActiveOverlay =
+        Array.isArray(layoutSelections) && layoutSelections.length > 0;
+      if (!hasActiveOverlay) {
+        // `null` removes the attribute; cast because Layout's type omits it.
+        (layoutUpdate as { selections: null }).selections = null;
+      }
+    }
 
-    const hasActiveOverlay =
-      Array.isArray(layoutSelections) && layoutSelections.length > 0;
-    const layoutUpdate: Partial<PlotlyTypes.Layout> = hasActiveOverlay
-      ? {}
-      : // `null` removes the attribute; cast because Layout's type omits it.
-        ({ selections: null } as Partial<PlotlyTypes.Layout>);
-
-    Plotly.update(
-      el,
-      { selectedpoints: nextSelectedpoints },
-      layoutUpdate,
-      traceIndices,
-    ).catch(() => {});
+    Plotly.update(el, traceUpdate, layoutUpdate, traceIndices).catch(() => {});
   }, [selectedPoints, layoutSelections, data]);
 
   // Window resize handler

--- a/frontend/src/plugins/impl/plotly/Plot.tsx
+++ b/frontend/src/plugins/impl/plotly/Plot.tsx
@@ -22,6 +22,12 @@ export interface Figure {
   frames: PlotlyTypes.Frame[] | null;
 }
 
+export interface SelectedPoint {
+  curveNumber?: unknown;
+  pointIndex?: unknown;
+  pointNumber?: unknown;
+}
+
 export interface PlotProps {
   data: PlotlyTypes.Data[];
   layout: Partial<PlotlyTypes.Layout>;
@@ -31,6 +37,9 @@ export interface PlotProps {
   style?: React.CSSProperties;
   useResizeHandler?: boolean;
   divId?: string;
+  hasSelection?: boolean;
+  selectedPoints?: ReadonlyArray<SelectedPoint>;
+  layoutSelections?: ReadonlyArray<unknown>;
   onRelayout?: (event: PlotlyTypes.PlotRelayoutEvent) => void;
   onRelayouting?: (event: PlotlyTypes.PlotRelayoutEvent) => void;
   onSelected?: (event: PlotlyTypes.PlotSelectionEvent) => void;
@@ -135,6 +144,96 @@ export const Plot = (props: PlotProps) => {
     },
     EVENT_NAMES.map((name) => props[propName(name)]),
   );
+
+  // Escape = clear selection. Plotly only supports double-click, so we wire up
+  // the keyboard shortcut: clear per-point highlights, remove box/lasso
+  // overlays, then notify the plugin to reset state.
+  const { hasSelection, selectedPoints, layoutSelections, onDeselect } = props;
+  useEffect(() => {
+    if (!hasSelection || !onDeselect) {
+      return;
+    }
+    const el = containerRef.current;
+    if (!el) {
+      return;
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) {
+        return;
+      }
+      Plotly.restyle(el, "selectedpoints", null).catch(() => {});
+      Plotly.relayout(el, "selections", null).catch(() => {});
+      onDeselect();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [hasSelection, onDeselect]);
+
+  // Sync selection visuals to Plotly in one atomic `Plotly.update` pass, so
+  // we don't race Plotly's own click animation.
+  //
+  // `selectedpoints` per trace: null = normal render, [] = all greyed,
+  // [i…] = those highlighted, rest greyed. Plotly's default click handling
+  // only updates the clicked trace, so we explicitly set [] on all others to
+  // grey them out. `layout.selections` is cleared whenever the plugin has no
+  // active overlay, otherwise the box/lasso outline sticks around.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) {
+      return;
+    }
+    if (!data.length) {
+      return;
+    }
+
+    const byTrace = new Map<number, number[]>();
+    if (selectedPoints) {
+      for (const point of selectedPoints) {
+        const curve =
+          typeof point.curveNumber === "number" ? point.curveNumber : undefined;
+        if (curve === undefined) {
+          continue;
+        }
+        const pointIdx =
+          typeof point.pointIndex === "number"
+            ? point.pointIndex
+            : typeof point.pointNumber === "number"
+              ? point.pointNumber
+              : undefined;
+        if (pointIdx === undefined) {
+          continue;
+        }
+        const indices = byTrace.get(curve) ?? [];
+        indices.push(pointIdx);
+        byTrace.set(curve, indices);
+      }
+    }
+
+    const traceIndices = data.map((_, i) => i);
+    const anySelection = byTrace.size > 0;
+    const emptyFill: number[] | null = anySelection ? [] : null;
+    const nextSelectedpoints: (number[] | null)[] = traceIndices.map(
+      (i) => byTrace.get(i) ?? emptyFill,
+    );
+
+    const hasActiveOverlay =
+      Array.isArray(layoutSelections) && layoutSelections.length > 0;
+    const layoutUpdate: Partial<PlotlyTypes.Layout> = hasActiveOverlay
+      ? {}
+      : // `null` removes the attribute; cast because Layout's type omits it.
+        ({ selections: null } as Partial<PlotlyTypes.Layout>);
+
+    Plotly.update(
+      el,
+      { selectedpoints: nextSelectedpoints },
+      layoutUpdate,
+      traceIndices,
+    ).catch(() => {});
+  }, [selectedPoints, layoutSelections, data]);
 
   // Window resize handler
   useEffect(() => {

--- a/frontend/src/plugins/impl/plotly/PlotlyPlugin.tsx
+++ b/frontend/src/plugins/impl/plotly/PlotlyPlugin.tsx
@@ -111,6 +111,32 @@ export const PlotlyComponent = memo(
         setValue((prev) => ({ ...prev, dragmode }));
       },
     );
+    const handleClearSelection = useEvent(() => {
+      setValue((prev) => ({
+        ...prev,
+        selections: Arrays.EMPTY,
+        points: Arrays.EMPTY,
+        indices: Arrays.EMPTY,
+        range: undefined,
+        lasso: undefined,
+      }));
+    });
+
+    const hasSelection = useMemo(() => {
+      if (!value) {
+        return false;
+      }
+      const points = value.points;
+      const indices = value.indices;
+      const selections = value.selections;
+      return (
+        (Array.isArray(points) && points.length > 0) ||
+        (Array.isArray(indices) && indices.length > 0) ||
+        (Array.isArray(selections) && selections.length > 0) ||
+        value.range !== undefined ||
+        value.lasso !== undefined
+      );
+    }, [value]);
 
     const configMemo = useDeepCompareMemoize(config);
     const plotlyConfig = useMemo((): Partial<Plotly.Config> => {
@@ -153,6 +179,9 @@ export const PlotlyComponent = memo(
       <LazyPlot
         {...figure}
         layout={layout}
+        hasSelection={hasSelection}
+        selectedPoints={value?.points}
+        layoutSelections={value?.selections}
         onRelayout={(layoutUpdate) => {
           // Persist dragmode in the state to keep it across re-renders
           if ("dragmode" in layoutUpdate) {
@@ -174,18 +203,7 @@ export const PlotlyComponent = memo(
             setValue((prev) => ({ ...prev, ...obj }));
           }
         }}
-        onDeselect={useEvent(() => {
-          setValue((prev) => {
-            return {
-              ...prev,
-              selections: Arrays.EMPTY,
-              points: Arrays.EMPTY,
-              indices: Arrays.EMPTY,
-              range: undefined,
-              lasso: undefined,
-            };
-          });
-        })}
+        onDeselect={handleClearSelection}
         onTreemapClick={useEvent((evt: Readonly<Plotly.PlotMouseEvent>) => {
           if (!evt) {
             return;
@@ -232,17 +250,31 @@ export const PlotlyComponent = memo(
             return;
           }
 
+          // plotly_selected also fires for plain clicks under
+          // clickmode="event+select". Those events have no range/lassoPoints
+          // but may still carry a stale overlay in evt.selections — detect
+          // the click case and clear the overlay so only the click sticks.
+          const hasRange = evt.range !== undefined;
+          const rawLasso =
+            "lassoPoints" in evt
+              ? (evt.lassoPoints as
+                  | { x?: unknown[]; y?: unknown[] }
+                  | undefined)
+              : undefined;
+          const hasLasso = rawLasso !== undefined;
+          const isClickSelection = !hasRange && !hasLasso;
+
           setValue((prev) => ({
             ...prev,
-            selections:
-              "selections" in evt ? (evt.selections as unknown[]) : [],
+            selections: isClickSelection
+              ? Arrays.EMPTY
+              : "selections" in evt
+                ? (evt.selections as unknown[])
+                : [],
             points: extractPoints(evt.points),
             indices: extractIndices(evt.points),
-            range: evt.range,
-            lasso:
-              "lassoPoints" in evt
-                ? (evt.lassoPoints as { x?: unknown[]; y?: unknown[] })
-                : undefined,
+            range: hasRange ? evt.range : undefined,
+            lasso: hasLasso ? rawLasso : undefined,
           }));
         })}
         className="w-full"

--- a/frontend/src/plugins/impl/plotly/__tests__/PlotlyPlugin.test.tsx
+++ b/frontend/src/plugins/impl/plotly/__tests__/PlotlyPlugin.test.tsx
@@ -10,6 +10,13 @@ import { PlotlyComponent } from "../PlotlyPlugin";
 SetupMocks.resizeObserver();
 
 type CapturedPlotProps = {
+  hasSelection?: boolean;
+  selectedPoints?: ReadonlyArray<{
+    curveNumber?: unknown;
+    pointIndex?: unknown;
+    pointNumber?: unknown;
+  }>;
+  layoutSelections?: ReadonlyArray<unknown>;
   onClick?: (event: {
     points: {
       data?: { type?: string };
@@ -19,6 +26,20 @@ type CapturedPlotProps = {
       pointNumber?: number;
       curveNumber?: number;
     }[];
+  }) => void;
+  onDeselect?: () => void;
+  onSelected?: (event: {
+    points: {
+      data?: { type?: string };
+      x?: string | number;
+      y?: string | number;
+      pointIndex?: number;
+      pointNumber?: number;
+      curveNumber?: number;
+    }[];
+    range?: { x?: number[]; y?: number[] };
+    lassoPoints?: { x?: unknown[]; y?: unknown[] };
+    selections?: unknown[];
   }) => void;
 } | null;
 
@@ -159,6 +180,319 @@ describe("PlotlyPlugin", () => {
       ],
       indices: [0],
       range: undefined,
+    });
+  });
+
+  it("selectedPoints is forwarded to Plot so greyout stays in sync", async () => {
+    const setValue = vi.fn<Setter<unknown>>();
+
+    const points = [
+      { x: "Feb", y: 18, curveNumber: 0, pointIndex: 1, pointNumber: 1 },
+    ];
+
+    render(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "bar" }], layout: {}, frames: null }}
+          value={{ points, indices: [1] }}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(capturedPlotProps).not.toBeNull();
+    });
+    expect(capturedPlotProps?.selectedPoints).toEqual(points);
+  });
+
+  it("click handler empties layoutSelections so Plot can clear the box/lasso overlay", async () => {
+    const setValue = vi.fn<Setter<unknown>>();
+
+    render(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "bar" }], layout: {}, frames: null }}
+          value={{
+            selections: [{ type: "rect", x0: 0, x1: 1, y0: 0, y1: 1 }],
+            range: { x: [0, 1], y: [0, 1] },
+          }}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(capturedPlotProps).not.toBeNull();
+    });
+
+    act(() => {
+      capturedPlotProps?.onClick?.({
+        points: [
+          {
+            data: { type: "bar" },
+            x: "Feb",
+            y: 18,
+            pointIndex: 1,
+            pointNumber: 1,
+            curveNumber: 0,
+          },
+        ],
+      });
+    });
+
+    expect(setValue).toHaveBeenCalledTimes(1);
+    const updater = setValue.mock.calls[0][0] as (
+      value: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    const next = updater({
+      selections: [{ type: "rect", x0: 0, x1: 1, y0: 0, y1: 1 }],
+      range: { x: [0, 1], y: [0, 1] },
+    });
+    expect(next.selections).toEqual([]);
+    expect(next.range).toBeUndefined();
+    expect(next.lasso).toBeUndefined();
+    expect(next.points).toEqual([
+      { x: "Feb", y: 18, curveNumber: 0, pointNumber: 1, pointIndex: 1 },
+    ]);
+  });
+
+  it("onSelected treats a single-point event with no range/lasso as a click replacement", async () => {
+    const setValue = vi.fn<Setter<unknown>>();
+
+    render(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "scatter" }], layout: {}, frames: null }}
+          value={{
+            selections: [{ type: "rect", x0: 0, x1: 1, y0: 0, y1: 1 }],
+            range: { x: [0, 1], y: [0, 1] },
+            points: [{ x: 0.5, y: 0.5, curveNumber: 0, pointIndex: 42 }],
+            indices: [42],
+          }}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(capturedPlotProps).not.toBeNull();
+    });
+
+    // Single click on a scatter point after a box selection: plotly_selected
+    // still echoes evt.selections from the old box, but no range/lassoPoints.
+    act(() => {
+      capturedPlotProps?.onSelected?.({
+        points: [
+          {
+            data: { type: "scatter" },
+            x: 2.6,
+            y: 7.7,
+            pointIndex: 108,
+            pointNumber: 108,
+            curveNumber: 2,
+          },
+        ],
+        selections: [{ type: "rect", x0: 0, x1: 1, y0: 0, y1: 1 }],
+      });
+    });
+
+    expect(setValue).toHaveBeenCalledTimes(1);
+    const updater = setValue.mock.calls[0][0] as (
+      value: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    const next = updater({});
+    expect(next.selections).toEqual([]);
+    expect(next.range).toBeUndefined();
+    expect(next.lasso).toBeUndefined();
+    expect(next.indices).toEqual([108]);
+    expect((next.points as Array<Record<string, unknown>>)[0]).toMatchObject({
+      x: 2.6,
+      y: 7.7,
+      curveNumber: 2,
+      pointIndex: 108,
+    });
+  });
+
+  it("onSelected preserves range/selections for a box selection", async () => {
+    const setValue = vi.fn<Setter<unknown>>();
+
+    render(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "scatter" }], layout: {}, frames: null }}
+          value={undefined}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(capturedPlotProps).not.toBeNull();
+    });
+
+    const boxSelections = [{ type: "rect", x0: 3, x1: 4, y0: 5, y1: 8 }];
+    const boxRange = { x: [3, 4], y: [5, 8] };
+    act(() => {
+      capturedPlotProps?.onSelected?.({
+        points: [
+          {
+            data: { type: "scatter" },
+            x: 3.5,
+            y: 6,
+            pointIndex: 0,
+            pointNumber: 0,
+            curveNumber: 0,
+          },
+          {
+            data: { type: "scatter" },
+            x: 3.8,
+            y: 7,
+            pointIndex: 1,
+            pointNumber: 1,
+            curveNumber: 0,
+          },
+        ],
+        range: boxRange,
+        selections: boxSelections,
+      });
+    });
+
+    expect(setValue).toHaveBeenCalledTimes(1);
+    const updater = setValue.mock.calls[0][0] as (
+      value: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    const next = updater({});
+    expect(next.selections).toEqual(boxSelections);
+    expect(next.range).toEqual(boxRange);
+    expect(next.lasso).toBeUndefined();
+    expect(next.indices).toEqual([0, 1]);
+  });
+
+  it("hasSelection reflects current selection state", async () => {
+    const setValue = vi.fn<Setter<unknown>>();
+
+    const { rerender } = render(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "scatter" }], layout: {}, frames: null }}
+          value={undefined}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(capturedPlotProps).not.toBeNull();
+    });
+    expect(capturedPlotProps?.hasSelection).toBe(false);
+
+    rerender(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "scatter" }], layout: {}, frames: null }}
+          value={{ points: [{ x: 1, y: 2 }], indices: [0] }}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+    await waitFor(() => {
+      expect(capturedPlotProps?.hasSelection).toBe(true);
+    });
+
+    rerender(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "scatter" }], layout: {}, frames: null }}
+          value={{ range: { x: [0, 1], y: [0, 1] } }}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+    await waitFor(() => {
+      expect(capturedPlotProps?.hasSelection).toBe(true);
+    });
+
+    rerender(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "scatter" }], layout: {}, frames: null }}
+          value={{ lasso: { x: [0], y: [0] } }}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+    await waitFor(() => {
+      expect(capturedPlotProps?.hasSelection).toBe(true);
+    });
+  });
+
+  it("onDeselect clears all selection state (shared by double-click and Escape)", async () => {
+    const setValue = vi.fn<Setter<unknown>>();
+
+    render(
+      <Suspense fallback={null}>
+        <PlotlyComponent
+          figure={{ data: [{ type: "scatter" }], layout: {}, frames: null }}
+          value={{
+            points: [{ x: 1, y: 2 }],
+            indices: [0],
+            range: { x: [0, 1], y: [0, 1] },
+            lasso: { x: [0], y: [0] },
+            selections: [{ type: "rect" }],
+            dragmode: "select",
+          }}
+          setValue={setValue}
+          host={document.createElement("div")}
+          config={{}}
+        />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(capturedPlotProps).not.toBeNull();
+    });
+
+    act(() => {
+      capturedPlotProps?.onDeselect?.();
+    });
+
+    expect(setValue).toHaveBeenCalledTimes(1);
+    const updater = setValue.mock.calls[0][0] as (
+      value: Record<string, unknown>,
+    ) => unknown;
+    expect(
+      updater({
+        points: [{ x: 1, y: 2 }],
+        indices: [0],
+        range: { x: [0, 1], y: [0, 1] },
+        lasso: { x: [0], y: [0] },
+        selections: [{ type: "rect" }],
+        dragmode: "select",
+      }),
+    ).toEqual({
+      points: [],
+      indices: [],
+      selections: [],
+      range: undefined,
+      lasso: undefined,
+      dragmode: "select",
     });
   });
 

--- a/frontend/src/plugins/impl/plotly/__tests__/PlotlyPlugin.test.tsx
+++ b/frontend/src/plugins/impl/plotly/__tests__/PlotlyPlugin.test.tsx
@@ -5,17 +5,14 @@ import { Suspense } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { SetupMocks } from "@/__mocks__/common";
 import type { Setter } from "@/plugins/types";
+import type { SelectedPoint } from "../Plot";
 import { PlotlyComponent } from "../PlotlyPlugin";
 
 SetupMocks.resizeObserver();
 
 type CapturedPlotProps = {
   hasSelection?: boolean;
-  selectedPoints?: ReadonlyArray<{
-    curveNumber?: unknown;
-    pointIndex?: unknown;
-    pointNumber?: unknown;
-  }>;
+  selectedPoints?: ReadonlyArray<SelectedPoint>;
   layoutSelections?: ReadonlyArray<unknown>;
   onClick?: (event: {
     points: {


### PR DESCRIPTION
## 📝 Summary

Followup (https://github.com/marimo-team/marimo/pull/9011#pullrequestreview-4074315873)

- Press `Escape` with a chart focused to clear any box, lasso, or click selection (complements Plotly's double-click).
- Every trace is now reconciled on each selection update, so non-selected points are greyed out consistently instead of staying at full color.
- A single click with `clickmode="event+select"` now clears any previous box/lasso overlay instead of leaving a stale shape behind.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

CC: @Light2Dark @mscolnick