### PR TITLE
Update dataflow.md.txt snapshot

### DIFF
--- a/tests/_convert/markdown/snapshots/dataflow.md.txt
+++ b/tests/_convert/markdown/snapshots/dataflow.md.txt
@@ -38,7 +38,7 @@ A marimo notebook is a directed acyclic graph in which nodes represent
 cells and edges represent data dependencies. marimo creates this graph by
 analyzing each cell (without running it) to determine its
 
-- references ("refs*), the global variables it reads but doesn't define;
+- references ("refs"), the global variables it reads but doesn't define;
 - definitions ("defs"), the global variables it defines.
 
 There is an edge from one cell to another if the latter cell references any


### PR DESCRIPTION
#9173 fixed a typo in `marimo/_tutorials/dataflow.py` (refs* → refs") but didn't regenerate the snapshot.
