### PR TITLE
ci: try enabling xdist on windows

### DIFF
--- a/.github/actions/test-python/action.yaml
+++ b/.github/actions/test-python/action.yaml
@@ -2,9 +2,6 @@ name: Test Python
 description: Run the marimo Python test suite for a given Python version and dependency set. Assumes the repo has already been checked out.
 
 inputs:
-  os:
-    description: Runner OS (ubuntu-latest, macos-latest, or windows-latest). Used to disable pytest-xdist on Windows.
-    required: true
   python-version:
     description: Python version to test against.
     required: true
@@ -57,27 +54,15 @@ runs:
     # Exit code 5 = no tests collected (e.g. only CLI test files changed);
     # treat that as success since CLI tests run in a separate workflow.
     #
-    # xdist is also disabled when the `test-serial` label is applied to a PR,
+    # xdist is disabled when the `test-serial` label is applied to a PR,
     # as an escape hatch when parallelism causes flakes that block a merge.
-    #
-    # TODO: xdist is disabled on Windows because several tests
-    # crash workers. Fix and re-enable. Failing tests:
-    #   - tests/_islands/test_island_generator.py::test_build
-    #   - tests/_islands/test_island_generator.py::test_render
-    #   - tests/_islands/test_island_generator.py::test_render_multiline_markdown
-    #   - tests/_messaging/test_streams.py::test_import_multiprocessing
-    #   - tests/_server/api/endpoints/test_ai.py::TestOpenAiEndpoints::test_completion_without_token
-    #   - tests/_server/test_session_manager.py::test_create_session_new
-    #   - tests/_server/test_session_manager.py::test_create_session_absolute_url
-    #   - tests/_server/test_session_manager.py::test_create_session_with_script_config_overrides
-    #   - tests/_server/test_session_manager.py::test_recents_touch_called_on_session_create
     - name: Test changed with base dependencies
       if: ${{ inputs.dependencies == 'core' }}
       shell: bash
       run: |
         uv run --python ${{ inputs.python-version }} --group test pytest tests/ \
           -v \
-          ${{ (inputs.os != 'windows-latest' && !contains(github.event.pull_request.labels.*.name, 'test-serial')) && '-n auto' || '-p no:xdist' }} \
+          ${{ !contains(github.event.pull_request.labels.*.name, 'test-serial') && '-n auto' || '-p no:xdist' }} \
           -k "not test_cli" \
           --durations=10 \
           -p packages.pytest_changed \
@@ -94,7 +79,7 @@ runs:
       run: |
         uv run --python ${{ inputs.python-version }} --group test-optional pytest tests/ \
           -v \
-          ${{ (inputs.os != 'windows-latest' && !contains(github.event.pull_request.labels.*.name, 'test-serial')) && '-n auto' || '-p no:xdist' }} \
+          ${{ !contains(github.event.pull_request.labels.*.name, 'test-serial') && '-n auto' || '-p no:xdist' }} \
           -k "not test_cli" \
           --durations=10 \
           -p packages.pytest_changed \
@@ -115,7 +100,7 @@ runs:
       run: |
         uv run --python ${{ inputs.python-version }} --group test pytest tests/ \
           -v \
-          ${{ (inputs.os != 'windows-latest' && !contains(github.event.pull_request.labels.*.name, 'test-serial')) && '-n auto' || '-p no:xdist' }} \
+          ${{ !contains(github.event.pull_request.labels.*.name, 'test-serial') && '-n auto' || '-p no:xdist' }} \
           -k "not test_cli" \
           --durations=10 \
           -p packages.pytest_changed \

--- a/.github/workflows/test_be.yaml
+++ b/.github/workflows/test_be.yaml
@@ -138,7 +138,6 @@ jobs:
           fetch-depth: 0 # Fetch all history for git diff
       - uses: ./.github/actions/test-python
         with:
-          os: ubuntu-latest
           python-version: ${{ matrix.python-version }}
           dependencies: ${{ matrix.dependencies }}
 
@@ -158,7 +157,6 @@ jobs:
           fetch-depth: 0 # Fetch all history for git diff
       - uses: ./.github/actions/test-python
         with:
-          os: macos-latest
           python-version: ${{ matrix.python-version }}
           dependencies: ${{ matrix.dependencies }}
 
@@ -178,7 +176,6 @@ jobs:
           fetch-depth: 0 # Fetch all history for git diff
       - uses: ./.github/actions/test-python
         with:
-          os: windows-latest
           python-version: ${{ matrix.python-version }}
           dependencies: ${{ matrix.dependencies }}
 


### PR DESCRIPTION
Recent changes to CI appear to have fixed Windows under xdist. Perhaps the global save-and-restore-main fixture.