### PR TITLE
test: fix flaky table column-order property tests

### DIFF
--- a/tests/_plugins/ui/_impl/tables/test_default_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_default_table.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
 
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._output.hypertext import Html
@@ -1259,6 +1259,7 @@ _column_name = st.text(
 _column_names = st.lists(_column_name, min_size=1, max_size=10, unique=True)
 
 
+@settings(deadline=1000)
 @given(cols=_column_names, data=st.data())
 def test_drop_columns_preserves_order_row_major(
     cols: list[str], data: st.DataObject
@@ -1277,6 +1278,7 @@ def test_drop_columns_preserves_order_row_major(
     assert mgr.drop_columns(to_drop).get_column_names() == expected
 
 
+@settings(deadline=1000)
 @given(cols=_column_names, data=st.data())
 def test_drop_columns_preserves_order_column_major(
     cols: list[str], data: st.DataObject
@@ -1290,6 +1292,7 @@ def test_drop_columns_preserves_order_column_major(
     assert mgr.drop_columns(to_drop).get_column_names() == expected
 
 
+@settings(deadline=1000)
 @given(cols=_column_names, data=st.data())
 def test_select_columns_preserves_caller_order_row_major(
     cols: list[str], data: st.DataObject
@@ -1308,6 +1311,7 @@ def test_select_columns_preserves_caller_order_row_major(
     assert mgr.select_columns(subset).get_column_names() == subset
 
 
+@settings(deadline=1000)
 @given(cols=_column_names, data=st.data())
 def test_select_columns_preserves_caller_order_column_major(
     cols: list[str], data: st.DataObject


### PR DESCRIPTION
The four column-order property tests in test_default_table.py sometimes trip the default 200ms hypothesis deadline under xdist contention on CI, even though the underlying drop_columns/select_columns operations complete in ~0.002ms. Raise the deadline to 1s, which still catches a pathological regression but tolerates CI noise.