### PR TITLE
feat: status indicator for PDF exports via CLI

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -33,6 +33,7 @@ from marimo._server.export import (
     run_app_then_export_as_ipynb,
     run_app_then_export_as_pdf,
 )
+from marimo._server.export._status import PDFExportStatusEvent
 from marimo._server.export.exporter import Exporter
 from marimo._server.utils import asyncio_run
 from marimo._utils.file_watcher import FileWatcher
@@ -59,6 +60,20 @@ _sandbox_message = (
 )
 def export() -> None:
     pass
+
+
+class _PDFExportCLIReporter:
+    def __call__(self, event: PDFExportStatusEvent) -> None:
+        message = event.message
+        if event.current is not None and event.total is not None:
+            progress = f" [{event.current}/{event.total}]"
+            if message.endswith("..."):
+                message = f"{message[:-3]}{progress}..."
+            elif message.endswith("."):
+                message = f"{message[:-1]}{progress}."
+            else:
+                message = f"{message}{progress}"
+        echo(f"{green('Exporting PDF', bold=True)}: {message}", err=True)
 
 
 def watch_and_export(
@@ -735,6 +750,7 @@ def pdf(
         scale=raster_scale,
         server_mode=raster_server,
     )
+    report_status = _PDFExportCLIReporter()
 
     def export_callback(
         file_path: MarimoPath,
@@ -750,6 +766,7 @@ def pdf(
                     cli_args=cli_args,
                     argv=list(args) if include_outputs else None,
                     rasterization_options=rasterization_options,
+                    status_callback=report_status,
                 )
             )
         except ModuleNotFoundError as e:

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -31,6 +31,7 @@ from marimo._output.hypertext import patch_html_for_non_interactive_output
 from marimo._runtime.commands import AppMetadata, SerializedCLIArgs
 from marimo._runtime.patches import extract_docstring_from_header
 from marimo._schemas.serialization import NotebookSerialization
+from marimo._server.export._status import emit_pdf_export_status
 from marimo._server.export.exporter import Exporter
 from marimo._server.file_router import AppFileRouter
 from marimo._server.models.export import (
@@ -49,6 +50,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from marimo._server.export._pdf_raster import PDFRasterizationOptions
+    from marimo._server.export._status import PDFExportStatusCallback
     from marimo._session.state.session_view import SessionView
     from marimo._session.types import Session
     from marimo._types.ids import CellId_t
@@ -242,6 +244,7 @@ async def run_app_then_export_as_pdf(
     export_as: ExportPDFPreset | None,
     include_inputs: bool = True,
     rasterization_options: PDFRasterizationOptions | None = None,
+    status_callback: PDFExportStatusCallback | None = None,
 ) -> tuple[bytes | None, bool]:
     file_router = AppFileRouter.from_filename(filepath)
     file_key = file_router.get_unique_file_key()
@@ -253,6 +256,11 @@ async def run_app_then_export_as_pdf(
     did_error = False
 
     if include_outputs:
+        emit_pdf_export_status(
+            status_callback,
+            phase="execute",
+            message="executing notebook...",
+        )
         with patch_html_for_non_interactive_output():
             # Using quiet=True to suppress runtime stdout/stderr since outputs
             # are captured in the session_view and will be included in the PDF
@@ -262,6 +270,11 @@ async def run_app_then_export_as_pdf(
                 argv,
                 quiet=True,
             )
+        emit_pdf_export_status(
+            status_callback,
+            phase="execute_complete",
+            message="notebook execution finished.",
+        )
 
         if (
             session_view is not None
@@ -279,7 +292,13 @@ async def run_app_then_export_as_pdf(
                 filepath=filepath.absolute_name,
                 argv=argv,
                 options=rasterization_options,
+                status_callback=status_callback,
             )
+    emit_pdf_export_status(
+        status_callback,
+        phase="prepare",
+        message="serializing notebook for PDF rendering...",
+    )
     exporter = Exporter()
     if export_as == "slides":
         pdf_data = await exporter.export_as_slides_pdf(
@@ -287,6 +306,7 @@ async def run_app_then_export_as_pdf(
             session_view=session_view,
             png_fallbacks=png_fallbacks,
             include_inputs=include_inputs,
+            status_callback=status_callback,
         )
     else:
         pdf_data = exporter.export_as_pdf(
@@ -295,6 +315,13 @@ async def run_app_then_export_as_pdf(
             png_fallbacks=png_fallbacks,
             include_inputs=include_inputs,
             webpdf=webpdf,
+            status_callback=status_callback,
+        )
+    if pdf_data is not None:
+        emit_pdf_export_status(
+            status_callback,
+            phase="complete",
+            message="done.",
         )
     return pdf_data, did_error
 

--- a/marimo/_server/export/_pdf_raster.py
+++ b/marimo/_server/export/_pdf_raster.py
@@ -19,6 +19,7 @@ from marimo._server.export._raster_mime import (
     TEXT_PLAIN,
     VEGA_MIME_TYPES,
 )
+from marimo._server.export._status import emit_pdf_export_status
 from marimo._server.models.export import ExportAsHTMLRequest
 from marimo._types.ids import CellId_t
 from marimo._utils.paths import marimo_package_path
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from marimo._ast.app import InternalApp
+    from marimo._server.export._status import PDFExportStatusCallback
     from marimo._session.state.session_view import SessionView
 
 LOGGER = _loggers.marimo_logger()
@@ -332,6 +334,7 @@ async def _collect_static_captures(
     filepath: str | None,
     options: PDFRasterizationOptions,
     static_targets: list[_RasterTarget],
+    status_callback: PDFExportStatusCallback | None = None,
 ) -> dict[CellId_t, str]:
     """Capture PNG fallbacks from exported static HTML for non-live targets."""
 
@@ -369,6 +372,7 @@ async def _collect_static_captures(
             page_url=server.page_url,
             targets=static_targets,
             scale=options.scale,
+            status_callback=status_callback,
         )
         LOGGER.debug(
             "Raster capture static phase complete: %s/%s captured",
@@ -384,6 +388,7 @@ async def _collect_live_captures(
     argv: list[str] | None,
     options: PDFRasterizationOptions,
     live_targets: list[_RasterTarget],
+    status_callback: PDFExportStatusCallback | None = None,
 ) -> dict[CellId_t, str]:
     """Capture PNG fallbacks from a live notebook runtime when required."""
 
@@ -403,6 +408,7 @@ async def _collect_live_captures(
         targets=live_targets,
         scale=options.scale,
         argv=argv,
+        status_callback=status_callback,
     )
     LOGGER.debug(
         "Raster capture live phase complete: %s/%s captured",
@@ -420,6 +426,7 @@ async def collect_pdf_png_fallbacks(
     filepath: str | None,
     argv: list[str] | None = None,
     options: PDFRasterizationOptions,
+    status_callback: PDFExportStatusCallback | None = None,
 ) -> dict[CellId_t, str]:
     """Collect per-cell PNG fallbacks to inject before nbconvert PDF export."""
 
@@ -454,6 +461,12 @@ async def collect_pdf_png_fallbacks(
         server_mode,
         options.scale,
     )
+    emit_pdf_export_status(
+        status_callback,
+        phase="raster",
+        message="rasterizing interactive outputs...",
+        total=len(targets),
+    )
 
     if server_mode == "live":
         LOGGER.debug("Raster capture strategy: live-only.")
@@ -462,6 +475,7 @@ async def collect_pdf_png_fallbacks(
             argv=argv,
             options=options,
             live_targets=targets,
+            status_callback=status_callback,
         )
     else:
         LOGGER.debug("Raster capture strategy: static-only.")
@@ -472,6 +486,7 @@ async def collect_pdf_png_fallbacks(
             filepath=filepath,
             options=options,
             static_targets=targets,
+            status_callback=status_callback,
         )
 
     LOGGER.debug(
@@ -564,6 +579,7 @@ async def _capture_pngs_from_page(
     page_url: str,
     targets: list[_RasterTarget],
     scale: float,
+    status_callback: PDFExportStatusCallback | None = None,
 ) -> dict[CellId_t, str]:
     """Capture PNG screenshots for target outputs from a single page URL."""
 
@@ -622,6 +638,13 @@ async def _capture_pngs_from_page(
         LOGGER.debug("Page network idle, starting target captures...")
 
         for index, target in enumerate(targets, start=1):
+            emit_pdf_export_status(
+                status_callback,
+                phase="raster",
+                message="rasterizing interactive outputs...",
+                current=index,
+                total=len(targets),
+            )
             LOGGER.info(
                 "Rasterizing [%s/%s] cell=%s (%s)",
                 index,
@@ -693,6 +716,7 @@ async def _capture_pngs_from_live_page(
     targets: list[_RasterTarget],
     scale: float,
     argv: list[str] | None,
+    status_callback: PDFExportStatusCallback | None = None,
 ) -> dict[CellId_t, str]:
     """Capture outputs by running notebook in a live marimo server process."""
 
@@ -701,4 +725,5 @@ async def _capture_pngs_from_live_page(
             page_url=server.page_url,
             targets=targets,
             scale=scale,
+            status_callback=status_callback,
         )

--- a/marimo/_server/export/_status.py
+++ b/marimo/_server/export/_status.py
@@ -5,6 +5,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
+from marimo import _loggers
+
+LOGGER = _loggers.marimo_logger()
+
 PDFExportPhase = Literal[
     "execute",
     "execute_complete",
@@ -38,11 +42,14 @@ def emit_pdf_export_status(
     if status_callback is None:
         return
 
-    status_callback(
-        PDFExportStatusEvent(
-            phase=phase,
-            message=message,
-            current=current,
-            total=total,
+    try:
+        status_callback(
+            PDFExportStatusEvent(
+                phase=phase,
+                message=message,
+                current=current,
+                total=total,
+            )
         )
-    )
+    except Exception as e:
+        LOGGER.debug("PDF export status callback failed: %s", e, exc_info=e)

--- a/marimo/_server/export/_status.py
+++ b/marimo/_server/export/_status.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+PDFExportPhase = Literal[
+    "execute",
+    "execute_complete",
+    "raster",
+    "prepare",
+    "render",
+    "render_fallback",
+    "complete",
+]
+
+
+@dataclass(frozen=True)
+class PDFExportStatusEvent:
+    phase: PDFExportPhase
+    message: str
+    current: int | None = None
+    total: int | None = None
+
+
+PDFExportStatusCallback = Callable[[PDFExportStatusEvent], None]
+
+
+def emit_pdf_export_status(
+    status_callback: PDFExportStatusCallback | None,
+    *,
+    phase: PDFExportPhase,
+    message: str,
+    current: int | None = None,
+    total: int | None = None,
+) -> None:
+    if status_callback is None:
+        return
+
+    status_callback(
+        PDFExportStatusEvent(
+            phase=phase,
+            message=message,
+            current=current,
+            total=total,
+        )
+    )

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -421,6 +421,15 @@ class Exporter:
             PandocMissing,
         )
 
+        def _emit_webpdf_fallback_status() -> None:
+            emit_pdf_export_status(
+                status_callback,
+                phase="render_fallback",
+                message=(
+                    "standard PDF export failed; falling back to WebPDF..."
+                ),
+            )
+
         if not webpdf:
             try:
                 from nbconvert import (  # type: ignore[import-not-found]
@@ -441,37 +450,19 @@ class Exporter:
                 return None
             except OSError as e:
                 # LatexFailed (IOError) or xelatex not on PATH
-                emit_pdf_export_status(
-                    status_callback,
-                    phase="render_fallback",
-                    message=(
-                        "standard PDF export failed; falling back to WebPDF..."
-                    ),
-                )
+                _emit_webpdf_fallback_status()
                 LOGGER.info(
                     "Standard PDF export failed, falling back to webpdf: %s",
                     e,
                 )
             except (PandocMissing, ConversionException) as e:
-                emit_pdf_export_status(
-                    status_callback,
-                    phase="render_fallback",
-                    message=(
-                        "standard PDF export failed; falling back to WebPDF..."
-                    ),
-                )
+                _emit_webpdf_fallback_status()
                 LOGGER.info(
                     "Standard PDF export failed, falling back to webpdf: %s",
                     e,
                 )
             except Exception as e:
-                emit_pdf_export_status(
-                    status_callback,
-                    phase="render_fallback",
-                    message=(
-                        "standard PDF export failed; falling back to WebPDF..."
-                    ),
-                )
+                _emit_webpdf_fallback_status()
                 LOGGER.error(
                     "Standard PDF export failed, falling back to webpdf.",
                     exc_info=e,

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -31,6 +31,7 @@ from marimo._messaging.mimetypes import KnownMimeType
 from marimo._runtime.virtual_file import read_virtual_file
 from marimo._schemas.notebook import NotebookV1
 from marimo._schemas.session import NotebookSessionV1
+from marimo._server.export._status import emit_pdf_export_status
 from marimo._server.models.export import ExportAsHTMLRequest
 from marimo._server.templates.templates import (
     static_notebook_template,
@@ -52,6 +53,8 @@ from marimo._version import __version__
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+    from marimo._server.export._status import PDFExportStatusCallback
 
 LOGGER = _loggers.marimo_logger()
 
@@ -361,6 +364,7 @@ class Exporter:
         png_fallbacks: Mapping[CellId_t, str] | None = None,
         webpdf: bool,
         include_inputs: bool = True,
+        status_callback: PDFExportStatusCallback | None = None,
     ) -> bytes | None:
         """Export notebook as a PDF.
 
@@ -370,6 +374,8 @@ class Exporter:
             png_fallbacks: Optional cell-id keyed image/png fallbacks to
                 inject into notebook outputs before nbconvert.
             include_inputs: Whether to include code cell inputs in the export.
+            status_callback: Optional internal callback for CLI-only PDF
+                export stage updates.
             webpdf: If False, tries standard PDF export (pandoc + TeX) first,
                 falling back to webpdf on failure. If True, uses webpdf
                 directly.
@@ -421,6 +427,11 @@ class Exporter:
                     PDFExporter,
                 )
 
+                emit_pdf_export_status(
+                    status_callback,
+                    phase="render",
+                    message="rendering PDF via standard exporter...",
+                )
                 exporter = PDFExporter()  # type: ignore[no-untyped-call]
                 exporter.exclude_input = not include_inputs
                 pdf_data, _resources = exporter.from_notebook_node(notebook)  # type: ignore[no-untyped-call]
@@ -430,16 +441,37 @@ class Exporter:
                 return None
             except OSError as e:
                 # LatexFailed (IOError) or xelatex not on PATH
+                emit_pdf_export_status(
+                    status_callback,
+                    phase="render_fallback",
+                    message=(
+                        "standard PDF export failed; falling back to WebPDF..."
+                    ),
+                )
                 LOGGER.info(
                     "Standard PDF export failed, falling back to webpdf: %s",
                     e,
                 )
             except (PandocMissing, ConversionException) as e:
+                emit_pdf_export_status(
+                    status_callback,
+                    phase="render_fallback",
+                    message=(
+                        "standard PDF export failed; falling back to WebPDF..."
+                    ),
+                )
                 LOGGER.info(
                     "Standard PDF export failed, falling back to webpdf: %s",
                     e,
                 )
             except Exception as e:
+                emit_pdf_export_status(
+                    status_callback,
+                    phase="render_fallback",
+                    message=(
+                        "standard PDF export failed; falling back to WebPDF..."
+                    ),
+                )
                 LOGGER.error(
                     "Standard PDF export failed, falling back to webpdf.",
                     exc_info=e,
@@ -447,6 +479,11 @@ class Exporter:
 
         from nbconvert import WebPDFExporter
 
+        emit_pdf_export_status(
+            status_callback,
+            phase="render",
+            message="rendering PDF via WebPDF...",
+        )
         web_exporter = WebPDFExporter()  # type: ignore[no-untyped-call]
         web_exporter.exclude_input = not include_inputs
         web_exporter.allow_chromium_download = True
@@ -464,6 +501,7 @@ class Exporter:
         session_view: SessionView | None,
         png_fallbacks: Mapping[CellId_t, str] | None = None,
         include_inputs: bool = True,
+        status_callback: PDFExportStatusCallback | None = None,
     ) -> bytes | None:
         """Export a slides notebook as PDF using reveal.js + Playwright.
 
@@ -481,6 +519,8 @@ class Exporter:
             png_fallbacks: Optional cell-id keyed image/png fallbacks to
                 inject into notebook outputs before conversion.
             include_inputs: Whether to include code cell inputs.
+            status_callback: Optional internal callback for CLI-only PDF
+                export stage updates.
 
         Returns:
             PDF data
@@ -509,6 +549,11 @@ class Exporter:
                 notebook,
                 png_fallbacks=png_fallbacks,
             )
+        emit_pdf_export_status(
+            status_callback,
+            phase="render",
+            message="rendering slides PDF...",
+        )
         return await self._export_slides_as_pdf(notebook, include_inputs)
 
     @staticmethod

--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -1246,6 +1246,97 @@ class TestExportPDF:
         call_kwargs = mock_run_app.await_args.kwargs
         assert call_kwargs["export_as"] is None
 
+    @staticmethod
+    def test_export_pdf_reports_stage_status_updates(
+        temp_marimo_file: str,
+        tmp_path: Path,
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        from marimo._cli.export.commands import pdf as pdf_command
+        from marimo._server.export._status import PDFExportStatusEvent
+
+        output_file = tmp_path / "status.pdf"
+        runner = CliRunner()
+
+        async def fake_run_app(
+            *args: Any, **kwargs: Any
+        ) -> tuple[bytes, bool]:
+            del args
+            status_callback = kwargs["status_callback"]
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="execute",
+                    message="executing notebook...",
+                )
+            )
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="raster",
+                    message="rasterizing interactive outputs...",
+                    current=2,
+                    total=7,
+                )
+            )
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="prepare",
+                    message="serializing notebook for PDF rendering...",
+                )
+            )
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="render",
+                    message="rendering PDF via WebPDF...",
+                )
+            )
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="complete",
+                    message="done.",
+                )
+            )
+            return b"mock_pdf", False
+
+        mock_run_app = AsyncMock(side_effect=fake_run_app)
+
+        with (
+            patch(
+                "marimo._cli.export.commands.DependencyManager.require_many"
+            ),
+            patch(
+                "marimo._cli.export.commands.DependencyManager.playwright.require"
+            ),
+            patch(
+                "marimo._cli.export.commands.run_app_then_export_as_pdf",
+                mock_run_app,
+            ),
+        ):
+            result = runner.invoke(
+                pdf_command,
+                [
+                    "--output",
+                    str(output_file),
+                    "--no-sandbox",
+                    temp_marimo_file,
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert output_file.read_bytes() == b"mock_pdf"
+        assert "Exporting PDF: executing notebook..." in result.output
+        assert (
+            "Exporting PDF: rasterizing interactive outputs [2/7]..."
+            in result.output
+        )
+        assert (
+            "Exporting PDF: serializing notebook for PDF rendering..."
+            in result.output
+        )
+        assert "Exporting PDF: rendering PDF via WebPDF..." in result.output
+        assert "Exporting PDF: done." in result.output
+        assert mock_run_app.await_count == 1
+
 
 @pytest.mark.skipif(
     not DependencyManager.playwright.has(),

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -1237,6 +1237,54 @@ class TestPDFExport:
             ("complete", "done."),
         ]
 
+    @pytest.mark.asyncio
+    async def test_run_app_then_export_as_pdf_ignores_status_callback_failures(
+        self,
+        temp_marimo_file: str,
+    ) -> None:
+        def failing_status_callback(event: PDFExportStatusEvent) -> None:
+            raise RuntimeError(f"boom:{event.phase}")
+
+        def fake_export_as_pdf(
+            self: Exporter, *args: Any, **kwargs: Any
+        ) -> bytes:
+            del self, args, kwargs
+            return b"mock_pdf"
+
+        with (
+            patch(
+                "marimo._server.export.run_app_until_completion",
+                side_effect=AssertionError(
+                    "execution should not run without outputs"
+                ),
+            ),
+            patch(
+                "marimo._server.export._pdf_raster.collect_pdf_png_fallbacks",
+                side_effect=AssertionError(
+                    "rasterization should not run without outputs"
+                ),
+            ),
+            patch.object(
+                Exporter,
+                "export_as_pdf",
+                autospec=True,
+                side_effect=fake_export_as_pdf,
+            ),
+        ):
+            pdf_data, did_error = await run_app_then_export_as_pdf(
+                MarimoPath(temp_marimo_file),
+                include_outputs=False,
+                webpdf=False,
+                cli_args={},
+                argv=None,
+                export_as=None,
+                rasterization_options=MagicMock(enabled=False),
+                status_callback=failing_status_callback,
+            )
+
+        assert pdf_data == b"mock_pdf"
+        assert did_error is False
+
     @pytest.mark.skipif(
         not DependencyManager.nbformat.has()
         or not DependencyManager.nbconvert.has()

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -20,8 +20,10 @@ from marimo._messaging.msgspec_encoder import encode_json_str
 from marimo._messaging.notification import CellNotification
 from marimo._server.export import (
     export_as_wasm,
+    run_app_then_export_as_pdf,
     run_app_until_completion,
 )
+from marimo._server.export._status import PDFExportStatusEvent
 from marimo._server.export.exporter import Exporter
 from marimo._server.models.export import ExportAsHTMLRequest
 from marimo._session.notebook import AppFileManager
@@ -1076,6 +1078,165 @@ class TestPDFExport:
 
             assert "for PDF export" in str(excinfo.value)
 
+    @pytest.mark.asyncio
+    async def test_run_app_then_export_as_pdf_reports_execute_raster_render(
+        self,
+        temp_marimo_file: str,
+        session_view: SessionView,
+    ) -> None:
+        events: list[PDFExportStatusEvent] = []
+
+        async def fake_run_app_until_completion(
+            *args: Any, **kwargs: Any
+        ) -> tuple[SessionView, bool]:
+            del args, kwargs
+            return session_view, False
+
+        async def fake_collect_pdf_png_fallbacks(
+            *args: Any, **kwargs: Any
+        ) -> dict[str, str]:
+            del args
+            status_callback = kwargs["status_callback"]
+            assert status_callback is not None
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="raster",
+                    message="rasterizing interactive outputs...",
+                    total=2,
+                )
+            )
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="raster",
+                    message="rasterizing interactive outputs...",
+                    current=1,
+                    total=2,
+                )
+            )
+            return {"cell-1": "data:image/png;base64,ZmFrZQ=="}
+
+        def fake_export_as_pdf(
+            self: Exporter, *args: Any, **kwargs: Any
+        ) -> bytes:
+            del self, args
+            status_callback = kwargs["status_callback"]
+            assert status_callback is not None
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="render",
+                    message="rendering PDF via WebPDF...",
+                )
+            )
+            return b"mock_pdf"
+
+        with (
+            patch(
+                "marimo._server.export.run_app_until_completion",
+                side_effect=fake_run_app_until_completion,
+            ),
+            patch(
+                "marimo._server.export._pdf_raster.collect_pdf_png_fallbacks",
+                side_effect=fake_collect_pdf_png_fallbacks,
+            ),
+            patch.object(
+                Exporter,
+                "export_as_pdf",
+                autospec=True,
+                side_effect=fake_export_as_pdf,
+            ),
+        ):
+            pdf_data, did_error = await run_app_then_export_as_pdf(
+                MarimoPath(temp_marimo_file),
+                include_outputs=True,
+                webpdf=True,
+                cli_args={},
+                argv=None,
+                export_as=None,
+                rasterization_options=MagicMock(enabled=True),
+                status_callback=events.append,
+            )
+
+        assert pdf_data == b"mock_pdf"
+        assert did_error is False
+        assert [event.phase for event in events] == [
+            "execute",
+            "execute_complete",
+            "raster",
+            "raster",
+            "prepare",
+            "render",
+            "complete",
+        ]
+        assert [event.message for event in events] == [
+            "executing notebook...",
+            "notebook execution finished.",
+            "rasterizing interactive outputs...",
+            "rasterizing interactive outputs...",
+            "serializing notebook for PDF rendering...",
+            "rendering PDF via WebPDF...",
+            "done.",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_run_app_then_export_as_pdf_reports_render_only_without_outputs(
+        self,
+        temp_marimo_file: str,
+    ) -> None:
+        events: list[PDFExportStatusEvent] = []
+
+        def fake_export_as_pdf(
+            self: Exporter, *args: Any, **kwargs: Any
+        ) -> bytes:
+            del self, args
+            status_callback = kwargs["status_callback"]
+            assert status_callback is not None
+            status_callback(
+                PDFExportStatusEvent(
+                    phase="render",
+                    message="rendering PDF via standard exporter...",
+                )
+            )
+            return b"mock_pdf"
+
+        with (
+            patch(
+                "marimo._server.export.run_app_until_completion",
+                side_effect=AssertionError(
+                    "execution should not run without outputs"
+                ),
+            ),
+            patch(
+                "marimo._server.export._pdf_raster.collect_pdf_png_fallbacks",
+                side_effect=AssertionError(
+                    "rasterization should not run without outputs"
+                ),
+            ),
+            patch.object(
+                Exporter,
+                "export_as_pdf",
+                autospec=True,
+                side_effect=fake_export_as_pdf,
+            ),
+        ):
+            pdf_data, did_error = await run_app_then_export_as_pdf(
+                MarimoPath(temp_marimo_file),
+                include_outputs=False,
+                webpdf=False,
+                cli_args={},
+                argv=None,
+                export_as=None,
+                rasterization_options=MagicMock(enabled=False),
+                status_callback=events.append,
+            )
+
+        assert pdf_data == b"mock_pdf"
+        assert did_error is False
+        assert [(event.phase, event.message) for event in events] == [
+            ("prepare", "serializing notebook for PDF rendering..."),
+            ("render", "rendering PDF via standard exporter..."),
+            ("complete", "done."),
+        ]
+
     @pytest.mark.skipif(
         not DependencyManager.nbformat.has()
         or not DependencyManager.nbconvert.has()
@@ -1411,6 +1572,61 @@ class TestPDFExport:
             mock_webpdf_exporter.assert_called_once()
 
     @pytest.mark.skipif(
+        not DependencyManager.nbformat.has()
+        or not DependencyManager.nbconvert.has(),
+        reason="nbformat or nbconvert not installed",
+    )
+    def test_export_as_pdf_reports_status_during_fallback_to_webpdf(
+        self,
+        session_view: SessionView,
+    ) -> None:
+        app = App()
+
+        @app.cell()
+        def test_cell():
+            return "test"
+
+        file_manager = AppFileManager.from_app(InternalApp(app))
+        exporter = Exporter()
+        events: list[PDFExportStatusEvent] = []
+
+        mock_pdf_exporter_instance = MagicMock()
+        mock_pdf_exporter_instance.from_notebook_node.side_effect = OSError(
+            "xelatex not found"
+        )
+
+        mock_webpdf_exporter_instance = MagicMock()
+        mock_webpdf_exporter_instance.from_notebook_node.return_value = (
+            b"fallback_webpdf_data",
+            {},
+        )
+
+        with (
+            patch.object(DependencyManager, "require_many"),
+            patch("nbconvert.PDFExporter") as mock_pdf_exporter,
+            patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
+        ):
+            mock_pdf_exporter.return_value = mock_pdf_exporter_instance
+            mock_webpdf_exporter.return_value = mock_webpdf_exporter_instance
+
+            result = exporter.export_as_pdf(
+                app=file_manager.app,
+                session_view=session_view,
+                webpdf=False,
+                status_callback=events.append,
+            )
+
+        assert result == b"fallback_webpdf_data"
+        assert [(event.phase, event.message) for event in events] == [
+            ("render", "rendering PDF via standard exporter..."),
+            (
+                "render_fallback",
+                "standard PDF export failed; falling back to WebPDF...",
+            ),
+            ("render", "rendering PDF via WebPDF..."),
+        ]
+
+    @pytest.mark.skipif(
         not DependencyManager.nbformat.has(),
         reason="nbformat not installed",
     )
@@ -1472,12 +1688,17 @@ class TestPDFExport:
                     DependencyManager.playwright, "has", return_value=True
                 ),
             ):
+                events: list[PDFExportStatusEvent] = []
                 result = await exporter.export_as_slides_pdf(
                     app=file_manager.app,
                     session_view=session_view,
+                    status_callback=events.append,
                 )
 
             assert result == b"mock_slides_pdf_data"
+            assert [(event.phase, event.message) for event in events] == [
+                ("render", "rendering slides PDF...")
+            ]
             mock_slides_exporter_cls.assert_called_once()
             mock_slides_exporter_instance.from_notebook_node.assert_called_once()
             notebook = (

--- a/tests/_server/export/test_pdf_raster.py
+++ b/tests/_server/export/test_pdf_raster.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+from dataclasses import dataclass
+from types import ModuleType
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -77,6 +80,7 @@ def test_collect_pdf_png_fallbacks_mixed_targets_use_static_by_default() -> (
     None
 ):
     session_view = SessionView()
+    events: list[Any] = []
     original_anywidget = (
         '&lt;marimo-anywidget data-initial-value=\'{"model_id":"m-live"}\''
         "&gt;&lt;/marimo-anywidget&gt;"
@@ -125,7 +129,9 @@ def test_collect_pdf_png_fallbacks_mixed_targets_use_static_by_default() -> (
         page_url: str,
         targets: list[_pdf_raster._RasterTarget],
         scale: float,
+        status_callback: Any = None,
     ) -> dict[str, str]:
+        del status_callback
         assert page_url.endswith("__marimo_pdf_raster__.html")
         assert scale == 4.0
         assert [target.cell_id for target in targets] == ["3", "2", "1"]
@@ -169,6 +175,7 @@ def test_collect_pdf_png_fallbacks_mixed_targets_use_static_by_default() -> (
                 filepath="demo.py",
                 argv=["--arg", "value"],
                 options=_pdf_raster.PDFRasterizationOptions(),
+                status_callback=events.append,
             )
 
     captures = asyncio.run(_run())
@@ -178,6 +185,9 @@ def test_collect_pdf_png_fallbacks_mixed_targets_use_static_by_default() -> (
         "3": "data:image/png;base64,c3RhdGljMw==",
     }
     live_capture_mock.assert_not_awaited()
+    assert [(event.phase, event.message, event.total) for event in events] == [
+        ("raster", "rasterizing interactive outputs...", 3)
+    ]
     output = session_view.cell_notifications["1"].output
     assert output is not None
     assert output.mimetype == "text/plain"
@@ -215,7 +225,9 @@ def test_collect_pdf_png_fallbacks_static_only_uses_static_capture() -> None:
         page_url: str,
         targets: list[_pdf_raster._RasterTarget],
         scale: float,
+        status_callback: Any = None,
     ) -> dict[str, str]:
+        del status_callback
         assert page_url.endswith("__marimo_pdf_raster__.html")
         assert scale == 4.0
         assert [target.cell_id for target in targets] == ["1"]
@@ -297,10 +309,12 @@ def test_collect_pdf_png_fallbacks_live_mode_uses_live_capture() -> None:
         targets: list[_pdf_raster._RasterTarget],
         scale: float,
         argv: list[str] | None,
+        status_callback: Any = None,
     ) -> dict[str, str]:
         del filepath
         del scale
         del argv
+        del status_callback
         assert [target.cell_id for target in targets] == ["2", "1"]
         return {
             "2": "data:image/png;base64,bGl2ZTI=",
@@ -366,3 +380,139 @@ def test_wait_for_target_ready_uses_settle_wait_for_dynamic_targets() -> None:
 
     assert ready is True
     settle_wait.assert_awaited_once()
+
+
+def test_capture_pngs_from_page_reports_progress_in_notebook_order() -> None:
+    class _TimeoutError(Exception):
+        pass
+
+    events: list[Any] = []
+    visited_locators: list[str] = []
+
+    class _FakeLocator:
+        def __init__(self, selector: str) -> None:
+            self.selector = selector
+            self.first = self
+
+        async def wait_for(self, *args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+
+        async def scroll_into_view_if_needed(
+            self, *args: Any, **kwargs: Any
+        ) -> None:
+            del args, kwargs
+
+        async def screenshot(self, *args: Any, **kwargs: Any) -> bytes:
+            del args, kwargs
+            return self.selector.encode("utf-8")
+
+    class _FakePage:
+        async def goto(self, *args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+
+        async def wait_for_load_state(self, *args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+
+        async def wait_for_function(self, *args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+
+        async def evaluate(self, *args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+
+        def locator(self, selector: str) -> _FakeLocator:
+            visited_locators.append(selector)
+            return _FakeLocator(selector)
+
+    class _FakeContext:
+        def __init__(self, page: _FakePage) -> None:
+            self._page = page
+
+        async def new_page(self) -> _FakePage:
+            return self._page
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeBrowser:
+        def __init__(self, context: _FakeContext) -> None:
+            self._context = context
+
+        async def new_context(self, *args: Any, **kwargs: Any) -> _FakeContext:
+            del args, kwargs
+            return self._context
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeChromium:
+        def __init__(self, browser: _FakeBrowser) -> None:
+            self._browser = browser
+
+        async def launch(self) -> _FakeBrowser:
+            return self._browser
+
+    @dataclass
+    class _FakePlaywright:
+        chromium: _FakeChromium
+
+    class _FakePlaywrightContextManager:
+        def __init__(self, playwright: _FakePlaywright) -> None:
+            self._playwright = playwright
+
+        async def __aenter__(self) -> _FakePlaywright:
+            return self._playwright
+
+        async def __aexit__(self, *args: Any) -> bool:
+            del args
+            return False
+
+    page = _FakePage()
+    context = _FakeContext(page)
+    browser = _FakeBrowser(context)
+    playwright = _FakePlaywright(_FakeChromium(browser))
+
+    fake_async_api = ModuleType("playwright.async_api")
+    fake_async_api.TimeoutError = _TimeoutError
+    fake_async_api.async_playwright = lambda: _FakePlaywrightContextManager(
+        playwright
+    )
+    fake_playwright = ModuleType("playwright")
+    fake_playwright.async_api = fake_async_api  # type: ignore[attr-defined]
+
+    targets = [
+        _pdf_raster._RasterTarget(cell_id="2", expects=("vega",)),
+        _pdf_raster._RasterTarget(cell_id="1", expects=("anywidget",)),
+    ]
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "playwright": fake_playwright,
+                "playwright.async_api": fake_async_api,
+            },
+        ),
+        patch.object(
+            _pdf_raster,
+            "_wait_for_target_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        captures = asyncio.run(
+            _pdf_raster._capture_pngs_from_page(
+                page_url="http://127.0.0.1:1234/demo.html",
+                targets=targets,
+                scale=2.0,
+                status_callback=events.append,
+            )
+        )
+
+    assert list(captures) == ["2", "1"]
+    assert [(event.current, event.total) for event in events] == [
+        (1, 2),
+        (2, 2),
+    ]
+    assert visited_locators == [
+        "#output-2 > .output",
+        "#output-1 > .output",
+    ]


### PR DESCRIPTION
## 📝 Summary

Adds status logs about PDF export progress which is especially useful when exporting large PDFs which take minutes.

Motivated by feedback of @mscolnick:

> Currently exporting kitchen_sink.py works but takes on the order of minutes. It would be nice to have some status indication that things are currently churning

### Export on 5x speed with logs

<img width="2000" height="1694" alt="Screen Recording 2026-04-22 at 16 21 51" src="https://github.com/user-attachments/assets/7e6059a6-1245-4175-a93c-68ec7f3699f3" />
