### PR TITLE
feat(ai): auto-inject on-disk skills into system prompts

### DIFF
--- a/docs/guides/generate_with_ai/skills.md
+++ b/docs/guides/generate_with_ai/skills.md
@@ -1,5 +1,19 @@
 # Skills
 
+Skills are folders of instructions and resources that teach an AI assistant
+how to do something well. marimo supports skills in two directions:
+
+1. **Skills for external agents** editing your marimo notebooks — e.g. Claude
+   Code or pi in a terminal. See [Skills for external agents](#skills-for-external-agents).
+2. **Skills for marimo's built-in AI** — dropped into a conventional
+   directory and automatically injected into the system prompt of every AI
+   chat and refactor call. See [Skills for marimo's built-in AI](#skills-for-marimos-built-in-ai).
+
+Both follow the same [Agent Skills format](https://agentskills.io), so a
+skill authored for one works in the other.
+
+## Skills for external agents
+
 We have prepared a collection of skills to help coding agents work with marimo.
 Install our official skills with a single command:
 
@@ -36,3 +50,90 @@ To learn more about skills, check out:
 - [What are skills?](https://support.claude.com/en/articles/12512176-what-are-skills)
 - [Using skills in Claude](https://support.claude.com/en/articles/12512180-using-skills-in-claude)
 - [skills.sh](https://skills.sh/)
+
+## Skills for marimo's built-in AI
+
+You can also write skills for the AI assistant inside marimo itself. When a
+skill is discovered on disk, its body is appended to the system prompt of
+every chat and refactor call — you don't need to invoke it manually; the
+model sees it on every turn.
+
+### Where marimo looks for skills
+
+By default, marimo scans the following directories (later entries override
+earlier ones when two skills share a name):
+
+| Path | Purpose |
+|------|---------|
+| `~/.marimo/skills/` | Your personal skills, available in every notebook |
+| `~/.agents/skills/` | Cross-agent skills shared with Claude Code / pi |
+| `<cwd>/.marimo/skills/` | Skills checked into the notebook's repo |
+| `<cwd>/.agents/skills/` | Project-local cross-agent skills |
+
+Skills authored for Claude Code or pi (in `.agents/skills/`) work in
+marimo unchanged.
+
+### Skill format
+
+Each skill lives in its own folder with a `SKILL.md` file:
+
+```
+.marimo/
+  skills/
+    viz/
+      SKILL.md
+    sql-style/
+      SKILL.md
+```
+
+A `SKILL.md` has optional frontmatter plus a markdown body:
+
+```markdown
+---
+name: viz
+description: >-
+    Use when the user asks for visualizations, charts, or plots. Prefer
+    altair for statistical charts; return chart objects as the last
+    expression.
+---
+
+# Visualization guidance
+
+- Use `alt.Chart(df)` directly on polars/pandas dataframes.
+- Return the chart object as the last expression of the cell.
+- Add tooltips where they aid exploration.
+```
+
+If you omit the frontmatter, the skill name defaults to the folder name and
+the description defaults to the first paragraph of the body.
+
+### Configuring skill paths
+
+Add extra directories via `marimo.toml`:
+
+```toml
+[ai.skills]
+# Additional directories to scan. ``~`` is expanded; relative paths
+# resolve against the notebook's working directory.
+custom_paths = ["~/team-skills", "./packages/notebook-skills"]
+
+# Set to false to disable the default paths above.
+include_default_paths = true
+```
+
+### Inspecting loaded skills
+
+The `GET /api/ai/skills` endpoint returns every skill marimo currently sees
+(name, description, origin, approximate token cost), which is useful for
+tooling and for confirming that a newly-added skill is actually being
+picked up.
+
+### When to reach for a skill vs. a custom rule
+
+- A single-line preference (e.g. "use polars over pandas") fits fine in
+  [custom rules](../editor_features/ai_completion.md#custom-rules) — a
+  skill would be overkill.
+- A multi-paragraph guideline tied to a specific trigger ("only when the
+  user asks about visualizations") is what skills are for — the
+  `description` tells the model when the guidance applies so it doesn't
+  dilute every call.

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -290,6 +290,37 @@ class AiModelConfig(TypedDict):
 
 
 @dataclass
+class SkillsConfig(TypedDict, total=False):
+    """Configuration for on-disk AI skills.
+
+    Skills are folders containing a ``SKILL.md`` file (frontmatter with
+    ``name``/``description`` plus a markdown body). Discovered skills are
+    automatically injected into the system prompt of every AI chat and
+    inline-refactor call, so the model picks them up transparently without
+    the user having to invoke anything.
+
+    The format follows the `Agent Skills standard <https://agentskills.io>`_
+    used by Claude Code and pi, which means skills authored for those tools
+    work unchanged in marimo when placed in ``~/.agents/skills/`` or
+    ``.agents/skills/``.
+
+    **Keys.**
+
+    - ``custom_paths``: additional directories to scan. Each entry may be a
+      directory containing ``<name>/SKILL.md`` (standard layout) or the path
+      to a specific ``SKILL.md`` file. ``~`` is expanded; relative paths are
+      resolved against the current working directory.
+    - ``include_default_paths``: if ``True`` (default), also scan
+      ``~/.marimo/skills/``, ``.marimo/skills/``, ``~/.agents/skills/``, and
+      ``.agents/skills/``. Later sources override earlier ones when two
+      skills share a name.
+    """
+
+    custom_paths: NotRequired[list[str]]
+    include_default_paths: NotRequired[bool]
+
+
+@dataclass
 class AiConfig(TypedDict, total=False):
     """Configuration options for AI.
 
@@ -300,6 +331,8 @@ class AiConfig(TypedDict, total=False):
     - `mode`: the mode to use for AI completions. Can be one of: `"ask"` or `"manual"`
     - `inline_tooltip`: if `True`, enable inline AI tooltip suggestions
     - `models`: the models to use for AI completions
+    - `skills`: configuration for on-disk AI skills (auto-injected into the
+      system prompt)
     - `open_ai`: the OpenAI config
     - `anthropic`: the Anthropic config
     - `google`: the Google AI config
@@ -318,6 +351,7 @@ class AiConfig(TypedDict, total=False):
     mode: NotRequired[CopilotMode]
     inline_tooltip: NotRequired[bool]
     models: AiModelConfig
+    skills: NotRequired[SkillsConfig]
 
     # providers
     open_ai: OpenAiConfig
@@ -757,6 +791,10 @@ DEFAULT_CONFIG: MarimoConfig = {
             "custom_models": [],
         },
         "custom_providers": {},
+        "skills": {
+            "custom_paths": [],
+            "include_default_paths": True,
+        },
     },
     "snippets": {
         "custom_paths": [],

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -1,7 +1,10 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from marimo._config.config import CopilotMode
+from marimo._server.ai.skills import render_skills_for_system_prompt
 from marimo._server.models.completion import (
     AiCompletionContext,
     Language,
@@ -9,6 +12,9 @@ from marimo._server.models.completion import (
     VariableContext,
 )
 from marimo._types.ids import SessionId
+
+if TYPE_CHECKING:
+    from marimo._server.ai.skills import Skill
 
 FIM_PREFIX_TAG = "<|fim_prefix|>"
 FIM_SUFFIX_TAG = "<|fim_suffix|>"
@@ -105,6 +111,7 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
     selected_text: str | None,
     other_cell_codes: str | None,
     context: AiCompletionContext | None,
+    skills: list[Skill] | None = None,
 ) -> str:
     if cell_code:
         system_prompt = f"Here's a {language} document from a Python notebook that I'm going to ask you to make an edit to.\n\n"
@@ -194,6 +201,9 @@ def get_refactor_or_insert_notebook_cell_system_prompt(
     if custom_rules and custom_rules.strip():
         system_prompt += f"\n\n## Additional rules:\n{custom_rules}"
 
+    if skills:
+        system_prompt += "\n\n" + render_skills_for_system_prompt(skills)
+
     if context:
         system_prompt += _format_plain_text(context.plain_text)
         system_prompt += _format_variables(context.variables)
@@ -279,6 +289,7 @@ def get_chat_system_prompt(
     include_other_code: str,
     mode: CopilotMode,
     session_id: SessionId,
+    skills: list[Skill] | None = None,
 ) -> str:
     system_prompt: str = f"""
 {_get_mode_intro_message(mode)}
@@ -424,6 +435,9 @@ chart
 
     if custom_rules and custom_rules.strip():
         system_prompt += f"\n\n## Additional rules:\n{custom_rules}"
+
+    if skills:
+        system_prompt += "\n\n" + render_skills_for_system_prompt(skills)
 
     if include_other_code:
         system_prompt += "\n\n" + _tag(

--- a/marimo/_server/ai/skills.py
+++ b/marimo/_server/ai/skills.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""On-disk AI skills auto-loaded into marimo's AI system prompts.
+
+Skills are folders with a ``SKILL.md`` file — the same format Claude Code
+and pi use (see https://agentskills.io). marimo discovers them at request
+time and appends their bodies to the system prompt of every chat and
+refactor call, so the model has access to user-authored guidance without
+any in-editor action.
+
+Example ``SKILL.md``::
+
+    ---
+    name: marimo-viz
+    description: >-
+        Use when the user asks for visualizations, charts, or plots. Prefer
+        altair for statistical charts; return chart objects as the last
+        expression.
+    ---
+
+    # Visualization skill
+
+    - Use ``alt.Chart(df)`` directly on polars/pandas dataframes.
+    - Return the chart object as the last expression of the cell.
+    - ...
+
+Default search paths (later entries override earlier ones by ``name``):
+
+1. ``~/.marimo/skills/`` — origin ``"global"``
+2. ``~/.agents/skills/`` — origin ``"agents-global"`` (cross-agent interop)
+3. ``<cwd>/.marimo/skills/`` — origin ``"project"``
+4. ``<cwd>/.agents/skills/`` — origin ``"agents-project"``
+5. Any ``custom_paths`` from ``[ai.skills]`` — origin ``"custom"``
+
+A ``custom_paths`` entry may point at either a directory containing
+``<name>/SKILL.md`` subfolders (standard layout) or a specific ``SKILL.md``
+file.
+
+Frontmatter is a small ``key: value`` subset of YAML (``name``,
+``description``); we deliberately avoid a YAML dependency for a surface
+this small. Richer frontmatter can be added incrementally.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from marimo import _loggers
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from marimo._config.config import SkillsConfig
+
+LOGGER = _loggers.marimo_logger()
+
+SkillOrigin = Literal[
+    "global", "project", "agents-global", "agents-project", "custom"
+]
+
+GLOBAL_SKILLS_DIR = Path("~/.marimo/skills").expanduser()
+AGENTS_GLOBAL_SKILLS_DIR = Path("~/.agents/skills").expanduser()
+PROJECT_SKILLS_DIRNAME = ".marimo/skills"
+AGENTS_PROJECT_SKILLS_DIRNAME = ".agents/skills"
+
+SKILL_FILENAME = "SKILL.md"
+
+# Skill names must be URL- and slash-safe so we can expose ``/skill:<name>``
+# commands in a follow-up without breaking changes.
+_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# Leading ``---``-fenced frontmatter block.
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(?P<body>.*?)\n---\s*\n?", re.DOTALL)
+
+# Header printed once before any skills are listed in the system prompt.
+_SKILLS_PREAMBLE = (
+    "The user has the following skills installed. Apply them when the "
+    "described situation arises; they represent explicit user preferences "
+    "and override generic defaults."
+)
+
+
+@dataclass(frozen=True)
+class Skill:
+    """A discovered skill, ready for API surfacing or prompt injection."""
+
+    name: str
+    description: str
+    body: str
+    source: Path
+    origin: SkillOrigin
+
+    @property
+    def approx_tokens(self) -> int:
+        # A generous whitespace-split is close enough for a UI hint; we're
+        # not computing billing, just "is this skill heavy?".
+        return len((self.description + "\n" + self.body).split())
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    skills: list[Skill]
+    scanned_paths: list[Path]
+    warnings: list[str]
+
+
+def discover_skills(
+    config: SkillsConfig | None,
+    *,
+    cwd: Path | None = None,
+) -> DiscoveryResult:
+    """Discover on-disk skills from the configured paths.
+
+    Project paths override global paths; ``.agents`` paths sit between
+    ``.marimo`` paths of the same scope, so a marimo-specific skill always
+    wins over a cross-agent one with the same name. ``custom_paths`` are
+    applied last and override everything else.
+    """
+    cwd = cwd or Path.cwd()
+    include_defaults = True
+    custom_paths: list[str] = []
+    if config is not None:
+        include_defaults = config.get("include_default_paths", True)
+        custom_paths = list(config.get("custom_paths", []) or [])
+
+    sources: list[tuple[Path, SkillOrigin]] = []
+    if include_defaults:
+        sources.extend(
+            [
+                (GLOBAL_SKILLS_DIR, "global"),
+                (AGENTS_GLOBAL_SKILLS_DIR, "agents-global"),
+                (cwd / PROJECT_SKILLS_DIRNAME, "project"),
+                (cwd / AGENTS_PROJECT_SKILLS_DIRNAME, "agents-project"),
+            ]
+        )
+    for raw in custom_paths:
+        sources.append((_resolve_path(raw, cwd), "custom"))
+
+    by_name: dict[str, Skill] = {}
+    scanned: list[Path] = []
+    warnings: list[str] = []
+    for path, origin in sources:
+        scanned.append(path)
+        for skill, warning in _load_source(path, origin):
+            if warning is not None:
+                warnings.append(warning)
+            if skill is not None:
+                by_name[skill.name] = skill
+
+    skills = sorted(by_name.values(), key=lambda s: s.name)
+    return DiscoveryResult(
+        skills=skills, scanned_paths=scanned, warnings=warnings
+    )
+
+
+def render_skills_for_system_prompt(skills: list[Skill]) -> str:
+    """Format a list of skills for appending to a system prompt.
+
+    Returns an empty string when there are no skills, so callers can
+    unconditionally concatenate the result without branching.
+    """
+    if not skills:
+        return ""
+    parts: list[str] = ["", "## Active skills", "", _SKILLS_PREAMBLE, ""]
+    for skill in skills:
+        parts.append(f"### {skill.name}")
+        if skill.description:
+            parts.append(f"_{skill.description}_")
+            parts.append("")
+        parts.append(skill.body.strip())
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _resolve_path(raw: str, cwd: Path) -> Path:
+    expanded = os.path.expanduser(raw)
+    path = Path(expanded)
+    return path if path.is_absolute() else (cwd / path)
+
+
+def _load_source(
+    path: Path, origin: SkillOrigin
+) -> Iterable[tuple[Skill | None, str | None]]:
+    """Load skills from either a directory of skill folders or a single SKILL.md."""
+    try:
+        exists = path.exists()
+    except OSError as exc:
+        yield None, f"Could not stat {path}: {exc}"
+        return
+    if not exists:
+        return
+
+    if path.is_file():
+        # A ``custom_paths`` entry pointing straight at a SKILL.md.
+        yield _load_file(path, path.parent.name or path.stem, origin)
+        return
+
+    try:
+        entries = sorted(p for p in path.iterdir() if p.is_dir())
+    except OSError as exc:
+        yield None, f"Could not list {path}: {exc}"
+        return
+
+    for entry in entries:
+        skill_file = entry / SKILL_FILENAME
+        if not skill_file.is_file():
+            continue
+        yield _load_file(skill_file, entry.name, origin)
+
+
+def _load_file(
+    path: Path, default_name: str, origin: SkillOrigin
+) -> tuple[Skill | None, str | None]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"Could not read {path}: {exc}"
+
+    frontmatter, body = _split_frontmatter(raw)
+    name = frontmatter.get("name", default_name).strip()
+    if not _NAME_PATTERN.match(name):
+        return None, (
+            f"Skipping {path}: invalid skill name {name!r} "
+            "(must match [A-Za-z0-9_-]+)"
+        )
+
+    description = frontmatter.get("description", "").strip()
+    if not description:
+        description = _first_paragraph(body)
+
+    return (
+        Skill(
+            name=name,
+            description=description,
+            body=body.strip(),
+            source=path,
+            origin=origin,
+        ),
+        None,
+    )
+
+
+def _split_frontmatter(raw: str) -> tuple[dict[str, str], str]:
+    match = _FRONTMATTER_RE.match(raw)
+    if match is None:
+        return {}, raw
+    return _parse_frontmatter(match.group("body")), raw[match.end() :]
+
+
+def _parse_frontmatter(block: str) -> dict[str, str]:
+    """Parse a tiny ``key: value`` subset of YAML.
+
+    Enough for ``name``/``description``. Supports single-line folded values
+    introduced with ``>-`` (consumed from the following indented lines).
+    Everything more exotic (nested mappings, lists, anchors) is out of
+    scope on purpose — we want to stay stdlib-only here.
+    """
+    result: dict[str, str] = {}
+    lines = block.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+        key, sep, value = line.partition(":")
+        if not sep:
+            i += 1
+            continue
+        key = key.strip()
+        value = value.strip()
+        if value == ">-" or value == ">":
+            folded: list[str] = []
+            j = i + 1
+            while j < len(lines) and (
+                lines[j].startswith((" ", "\t")) or not lines[j].strip()
+            ):
+                folded.append(lines[j].strip())
+                j += 1
+            value = " ".join(chunk for chunk in folded if chunk)
+            i = j
+        else:
+            if (
+                len(value) >= 2
+                and value[0] == value[-1]
+                and value[0] in ("'", '"')
+            ):
+                value = value[1:-1]
+            i += 1
+        if key:
+            result[key] = value
+    return result
+
+
+def _first_paragraph(body: str) -> str:
+    for chunk in body.strip().split("\n\n"):
+        cleaned = chunk.strip()
+        if cleaned:
+            return " ".join(cleaned.split())
+    return ""

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -36,6 +36,7 @@ from marimo._server.ai.providers import (
     get_completion_provider,
     without_wrapping_backticks,
 )
+from marimo._server.ai.skills import discover_skills
 from marimo._server.ai.tools.tool_manager import get_tool_manager
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
@@ -49,6 +50,8 @@ from marimo._server.models.models import (
     InvokeAiToolResponse,
     MCPRefreshResponse,
     MCPStatusResponse,
+    SkillInfo,
+    SkillsResponse,
 )
 from marimo._server.responses import StructResponse
 from marimo._server.router import APIRouter
@@ -146,6 +149,7 @@ async def ai_completion(
 
     custom_rules = ai_config.get("rules", None)
     use_ui_messages = len(body.ui_messages) >= 1
+    skills = discover_skills(ai_config.get("skills")).skills
 
     system_prompt = get_refactor_or_insert_notebook_cell_system_prompt(
         language=body.language,
@@ -156,6 +160,7 @@ async def ai_completion(
         selected_text=body.selected_text,
         other_cell_codes=body.include_other_code,
         context=body.context,
+        skills=skills,
     )
     prompt = body.prompt
 
@@ -221,6 +226,7 @@ async def ai_chat(
     )
     ai_config = get_ai_config(config)
     custom_rules = ai_config.get("rules", None)
+    skills = discover_skills(ai_config.get("skills")).skills
 
     # Get the system prompt
     system_prompt = get_chat_system_prompt(
@@ -229,6 +235,7 @@ async def ai_chat(
         include_other_code=body.include_other_code,
         mode=ai_config.get("mode", "manual"),
         session_id=session_id,
+        skills=skills,
     )
 
     max_tokens = get_max_tokens(config)
@@ -571,3 +578,40 @@ async def mcp_refresh(
                 servers={},
             )
         )
+
+
+@router.get("/skills")
+@requires("edit")
+async def list_skills(
+    *,
+    request: Request,
+) -> Response:
+    """
+    responses:
+        200:
+            description: List skills discovered on disk that will be injected into AI system prompts.
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/SkillsResponse"
+    """
+    app_state = AppState(request)
+    config = app_state.app_config_manager.get_config(hide_secrets=False)
+    ai_config = config.get("ai") or {}
+    result = discover_skills(ai_config.get("skills"))
+    return StructResponse(
+        SkillsResponse(
+            skills=[
+                SkillInfo(
+                    name=s.name,
+                    description=s.description,
+                    source=str(s.source),
+                    origin=s.origin,
+                    approx_tokens=s.approx_tokens,
+                )
+                for s in result.skills
+            ],
+            scanned_paths=[str(p) for p in result.scanned_paths],
+            warnings=result.warnings,
+        )
+    )

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -347,6 +347,34 @@ class MCPStatusResponse(msgspec.Struct, rename="camel"):
     ] = {}  # server_name -> status
 
 
+class SkillInfo(msgspec.Struct, rename="camel"):
+    # Unique identifier (frontmatter ``name``, or parent directory name).
+    name: str
+    # One-line trigger hint shown to the user; also what the model sees to
+    # decide whether the skill is relevant (for agent-driven activation).
+    description: str
+    # Absolute path to the ``SKILL.md`` file; useful for "open in editor".
+    source: str
+    # Where the skill came from: a default search path or a user-configured
+    # path. ``agents`` denotes the ``~/.agents/skills`` / ``.agents/skills``
+    # interop directories shared with Claude Code / pi.
+    origin: Literal[
+        "global", "project", "agents-global", "agents-project", "custom"
+    ]
+    # Approximate token cost when injected into the system prompt. A rough
+    # word-count proxy — good enough for surfacing "heavy" skills in the UI.
+    approx_tokens: int
+
+
+class SkillsResponse(msgspec.Struct, rename="camel"):
+    skills: list[SkillInfo]
+    # Directories that were scanned (absolute, resolved).
+    scanned_paths: list[str]
+    # Non-fatal issues encountered during discovery (e.g. unreadable files,
+    # invalid frontmatter).
+    warnings: list[str] = []
+
+
 class MCPRefreshResponse(BaseResponse):
     error: str | None = None
     servers: dict[str, bool] = {}  # server_name -> connected

--- a/tests/_server/ai/test_skills.py
+++ b/tests/_server/ai/test_skills.py
@@ -1,0 +1,294 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from marimo._server.ai.skills import (
+    Skill,
+    discover_skills,
+    render_skills_for_system_prompt,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+    from marimo._config.config import SkillsConfig
+
+
+def _write_skill(
+    base: Path, folder: str, *, frontmatter: str | None, body: str
+) -> Path:
+    skill_dir = base / folder
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    path = skill_dir / "SKILL.md"
+    parts: list[str] = []
+    if frontmatter is not None:
+        parts.append("---")
+        parts.append(frontmatter.strip())
+        parts.append("---")
+        parts.append("")
+    parts.append(body)
+    path.write_text("\n".join(parts), encoding="utf-8")
+    return path
+
+
+def _isolate_defaults(monkeypatch: pytest.MonkeyPatch, sandbox: Path) -> None:
+    # Point the "global" default paths at the sandbox so HOME-based
+    # directories don't leak into unrelated developer machines.
+    monkeypatch.setattr(
+        "marimo._server.ai.skills.GLOBAL_SKILLS_DIR",
+        sandbox / "global-home" / ".marimo" / "skills",
+    )
+    monkeypatch.setattr(
+        "marimo._server.ai.skills.AGENTS_GLOBAL_SKILLS_DIR",
+        sandbox / "global-home" / ".agents" / "skills",
+    )
+
+
+class TestDiscovery:
+    def test_empty_when_nothing_on_disk(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        result = discover_skills(None, cwd=tmp_path)
+        assert result.skills == []
+        assert any(p.name == "skills" for p in result.scanned_paths)
+        assert result.warnings == []
+
+    def test_discovers_project_skills(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "review",
+            frontmatter=("name: review\ndescription: Review code for bugs"),
+            body="# Review\n\nFlag bugs and perf problems.",
+        )
+        result = discover_skills(None, cwd=tmp_path)
+        assert [s.name for s in result.skills] == ["review"]
+        assert result.skills[0].description == "Review code for bugs"
+        assert result.skills[0].origin == "project"
+        assert "Flag bugs" in result.skills[0].body
+
+    def test_project_overrides_global_by_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        monkeypatch.setattr(
+            "marimo._server.ai.skills.GLOBAL_SKILLS_DIR",
+            home / ".marimo" / "skills",
+        )
+        monkeypatch.setattr(
+            "marimo._server.ai.skills.AGENTS_GLOBAL_SKILLS_DIR",
+            home / ".agents" / "skills",
+        )
+        _write_skill(
+            home / ".marimo" / "skills",
+            "shared",
+            frontmatter="name: shared\ndescription: global version",
+            body="global body",
+        )
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "shared",
+            frontmatter="name: shared\ndescription: project version",
+            body="project body",
+        )
+        result = discover_skills(None, cwd=tmp_path)
+        assert len(result.skills) == 1
+        assert result.skills[0].description == "project version"
+        assert result.skills[0].origin == "project"
+
+    def test_agents_interop_directories(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        # Skills authored for Claude Code / pi in ``.agents/skills``
+        # should be picked up unchanged.
+        _write_skill(
+            tmp_path / ".agents" / "skills",
+            "interop",
+            frontmatter="name: interop\ndescription: cross-agent skill",
+            body="shared body",
+        )
+        result = discover_skills(None, cwd=tmp_path)
+        assert [s.name for s in result.skills] == ["interop"]
+        assert result.skills[0].origin == "agents-project"
+
+    def test_custom_paths_override_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        extra = tmp_path / "vendor"
+        _write_skill(
+            extra,
+            "review",
+            frontmatter="name: review\ndescription: vendor",
+            body="vendor body",
+        )
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "review",
+            frontmatter="name: review\ndescription: project",
+            body="project body",
+        )
+        config: SkillsConfig = {"custom_paths": [str(extra)]}
+        result = discover_skills(config, cwd=tmp_path)
+        # Custom paths are applied after defaults and therefore win.
+        assert result.skills[0].description == "vendor"
+        assert result.skills[0].origin == "custom"
+
+    def test_include_default_paths_false_excludes_home_and_project(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "in-project",
+            frontmatter="name: in-project\ndescription: ignore",
+            body="ignored",
+        )
+        extra = tmp_path / "vendor"
+        _write_skill(
+            extra,
+            "only-this",
+            frontmatter="name: only-this\ndescription: keep",
+            body="kept",
+        )
+        config: SkillsConfig = {
+            "custom_paths": [str(extra)],
+            "include_default_paths": False,
+        }
+        result = discover_skills(config, cwd=tmp_path)
+        assert [s.name for s in result.skills] == ["only-this"]
+
+
+class TestFrontmatter:
+    def test_missing_frontmatter_defaults_to_directory_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "no-frontmatter",
+            frontmatter=None,
+            body="First paragraph is the description.\n\nSecond paragraph is body.",
+        )
+        result = discover_skills(None, cwd=tmp_path)
+        assert result.skills[0].name == "no-frontmatter"
+        assert (
+            result.skills[0].description
+            == "First paragraph is the description."
+        )
+
+    def test_folded_description(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "folded",
+            frontmatter=(
+                "name: folded\n"
+                "description: >-\n"
+                "  This description spans\n"
+                "  multiple lines and should\n"
+                "  be folded into one."
+            ),
+            body="body",
+        )
+        result = discover_skills(None, cwd=tmp_path)
+        assert (
+            result.skills[0].description
+            == "This description spans multiple lines and should be folded into one."
+        )
+
+    def test_quoted_values_are_unquoted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "quoted",
+            frontmatter='name: quoted\ndescription: "with colons: ok"',
+            body="body",
+        )
+        result = discover_skills(None, cwd=tmp_path)
+        assert result.skills[0].description == "with colons: ok"
+
+    def test_invalid_name_produces_warning_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "bad one",
+            frontmatter="name: bad name with spaces",
+            body="body",
+        )
+        result = discover_skills(None, cwd=tmp_path)
+        assert result.skills == []
+        assert len(result.warnings) == 1
+        assert "invalid skill name" in result.warnings[0]
+
+    def test_directory_name_with_spaces_is_skipped_gracefully(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        # When there's no frontmatter and the directory name isn't a
+        # valid identifier, we emit a warning rather than registering the
+        # skill.
+        _write_skill(
+            tmp_path / ".marimo" / "skills",
+            "bad name",
+            frontmatter=None,
+            body="body",
+        )
+        result = discover_skills(None, cwd=tmp_path)
+        assert result.skills == []
+        assert any("invalid skill name" in w for w in result.warnings)
+
+
+class TestRendering:
+    def test_empty_list_renders_empty_string(self) -> None:
+        assert render_skills_for_system_prompt([]) == ""
+
+    def test_rendered_prompt_contains_body_and_description(self) -> None:
+        skills = [
+            Skill(
+                name="viz",
+                description="Use for visualizations",
+                body="Prefer altair for statistical charts.",
+                source=Path("/tmp/viz/SKILL.md"),
+                origin="project",
+            )
+        ]
+        rendered = render_skills_for_system_prompt(skills)
+        assert "## Active skills" in rendered
+        assert "### viz" in rendered
+        assert "Use for visualizations" in rendered
+        assert "Prefer altair" in rendered
+
+
+class TestErrorHandling:
+    def test_unreadable_directory_produces_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_defaults(monkeypatch, tmp_path)
+        bad = tmp_path / "bad"
+        bad.mkdir()
+        # Simulate a permission error at iterdir time.
+        with patch(
+            "pathlib.Path.iterdir",
+            side_effect=PermissionError("nope"),
+        ):
+            config: SkillsConfig = {
+                "custom_paths": [str(bad)],
+                "include_default_paths": False,
+            }
+            result = discover_skills(config, cwd=tmp_path)
+        assert result.skills == []
+        assert any("Could not list" in w for w in result.warnings)

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -1289,3 +1289,75 @@ async def test_safe_stream_wrapper_handles_errors() -> None:
 
     assert chunks[0] == "chunk1"
     assert "Stream failed" in chunks[1]
+
+
+# The ``with_session`` decorator in this repo only passes ``client`` (and
+# optionally ``temp_marimo_file``), so pytest fixtures like ``tmp_path`` /
+# ``monkeypatch`` aren't available inside decorated tests. We use
+# ``tempfile`` + ``unittest.mock.patch`` to build an equivalent sandbox.
+
+
+@with_session(SESSION_ID)
+def test_list_skills_empty(client: TestClient) -> None:
+    """GET /api/ai/skills returns an empty list when nothing is on disk."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        sandbox = Path(tmp)
+        with (
+            patch(
+                "marimo._server.ai.skills.GLOBAL_SKILLS_DIR",
+                sandbox / ".marimo" / "skills",
+            ),
+            patch(
+                "marimo._server.ai.skills.AGENTS_GLOBAL_SKILLS_DIR",
+                sandbox / ".agents" / "skills",
+            ),
+            patch("pathlib.Path.cwd", return_value=sandbox),
+        ):
+            response = client.get("/api/ai/skills", headers=HEADERS)
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["skills"] == []
+    assert data["warnings"] == []
+    assert isinstance(data["scannedPaths"], list)
+
+
+@with_session(SESSION_ID)
+def test_list_skills_returns_discovered_skills(client: TestClient) -> None:
+    """A SKILL.md in ``<cwd>/.marimo/skills/`` is surfaced through the API."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        sandbox = Path(tmp)
+        skill_dir = sandbox / ".marimo" / "skills" / "review"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: review\ndescription: Review code\n---\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch(
+                "marimo._server.ai.skills.GLOBAL_SKILLS_DIR",
+                sandbox / "home" / ".marimo" / "skills",
+            ),
+            patch(
+                "marimo._server.ai.skills.AGENTS_GLOBAL_SKILLS_DIR",
+                sandbox / "home" / ".agents" / "skills",
+            ),
+            patch("pathlib.Path.cwd", return_value=sandbox),
+        ):
+            response = client.get("/api/ai/skills", headers=HEADERS)
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert len(data["skills"]) == 1
+    skill = data["skills"][0]
+    assert skill["name"] == "review"
+    assert skill["description"] == "Review code"
+    assert skill["origin"] == "project"
+    assert skill["approxTokens"] > 0


### PR DESCRIPTION
**This pull request was authored by a coding agent.** Opened in draft per `AGENTS.md`; every line has been reviewed by the human author, who stands by it.

## 📝 Summary

Closes #9323

Adds on-disk **AI skills** to marimo: a `SKILL.md` under a conventional directory is auto-injected into the system prompt of every AI chat and refactor call — no user action required, no picker to click through.

The format follows the [Agent Skills standard](https://agentskills.io) used by Claude Code and pi, so skills authored for those tools work in marimo unchanged when placed under `~/.agents/skills/` or `.agents/skills/`.

This is the first concrete step of a roadmap to bring marimo's built-in AI to parity with general-purpose coding agents. See the tracking issue (above) for the full plan; the scope of **this** PR is deliberately minimal and additive.

### What changes for users

```
.marimo/skills/viz/SKILL.md
---
name: viz
description: >-
    Use when the user asks for visualizations, charts, or plots.
---

- Use `alt.Chart(df)` directly on polars/pandas dataframes.
- Return the chart object as the last expression.
```

```toml
# marimo.toml — optional; defaults are sensible
[ai.skills]
custom_paths = ["~/team-skills"]
include_default_paths = true  # scans ~/.marimo/skills, .marimo/skills,
                              #       ~/.agents/skills, .agents/skills
```

From that point, every `/api/ai/chat` and `/api/ai/completion` call sees the skill. Users can inspect what's loaded via the new `GET /api/ai/skills`.

### Design notes

- **Server-side, stateless.** Skills are discovered per-request and rendered into the existing `custom_rules` section of the system prompt. No changes to the tool registry, permission model, agent loop, or frontend.
- **Stdlib-only.** Frontmatter uses a small `key: value` subset; we avoid PyYAML for a surface this small.
- **Interop by design.** `.agents/skills/` (Claude Code / pi convention) sits alongside `.marimo/skills/`; a marimo-specific skill with the same name wins.
- **Inline FIM completion is untouched.** Only chat and refactor inject skills — FIM is latency-sensitive and its response format is restricted.

### Files

| File | Change |
|---|---|
| `marimo/_config/config.py` | New `SkillsConfig` TypedDict; `AiConfig.skills`; default under `ai.skills` |
| `marimo/_server/ai/skills.py` | New module: discovery, frontmatter, renderer (stdlib-only) |
| `marimo/_server/ai/prompts.py` | Optional `skills` param on the two non-FIM prompt builders |
| `marimo/_server/api/endpoints/ai.py` | Discover and pass skills at the call sites; new `GET /api/ai/skills` |
| `marimo/_server/models/models.py` | `SkillInfo` / `SkillsResponse` response structs |
| `tests/_server/ai/test_skills.py` | Unit tests: discovery, precedence, frontmatter, rendering, errors |
| `tests/_server/api/endpoints/test_ai.py` | Endpoint integration tests |
| `docs/guides/generate_with_ai/skills.md` | New section: "Skills for marimo's built-in AI" |

+297 LoC, purely additive, no breaking config changes.

### Test plan

Locally (all pass):

- `uv run ruff check` / `uv run ruff format` — clean on touched files
- `uv run pytest tests/_server/ai/ tests/_server/api/endpoints/test_ai.py` — 247 passed, 88 skipped (optional deps)
- Existing `test_prompts.py` snapshots unchanged (skills default to `None` and inject nothing)

Still needs a full `make check` run in CI (mypy + typos + pixi lock).

Manual verification to run before marking ready-for-review:

- [ ] Drop a `SKILL.md` into `.marimo/skills/`, run `marimo edit`, open chat, confirm the skill influences responses
- [ ] `curl /api/ai/skills` returns the discovered skill
- [ ] `curl /api/ai/skills` with no skills on disk returns `{"skills": [], ...}`

## 📋 Pre-Review Checklist

- [x] Large change / affects public API — discussed in the linked tracking issue above.
- [x] AI-generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video/media evidence — N/A, no visual changes.

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated (`docs/guides/generate_with_ai/skills.md` got a new section).
- [x] Tests have been added (`tests/_server/ai/test_skills.py` plus two integration tests in `test_ai.py`).