### PR TITLE
feat(ai): translate provider errors into user-actionable messages

### DIFF
--- a/marimo/_server/ai/errors.py
+++ b/marimo/_server/ai/errors.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Translate AI provider errors into user-actionable messages.
+
+The AI streaming path in ``endpoints/ai.py`` catches every exception raised
+during a chat/completion call and stringifies it into the error channel of
+the AI SDK stream protocol. Provider SDKs throw wildly different messages
+for the same underlying problem ("context window exceeded" looks completely
+different coming from OpenAI, Anthropic, Google, and Bedrock), and raw SDK
+strings aren't useful to a notebook author. This module maps them into a
+small, stable set of categories with messages that tell the user what to
+do next.
+
+Kept intentionally tiny and dependency-free so it's trivially unit-testable
+and cheap to extend as new provider quirks surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Literal
+
+AiErrorCategory = Literal[
+    "context_length",
+    "timeout",
+    "auth",
+    "rate_limit",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class TranslatedAiError:
+    category: AiErrorCategory
+    message: str
+    # Keep the raw provider string so power users / bug reports can still
+    # inspect it via the server log (we log originals, not translations).
+    original: str
+
+
+# Each pattern list is matched case-insensitively against ``str(error)``.
+# Order matters: the first category to match wins. Keep patterns specific
+# enough not to false-positive (e.g. "timeout" matches too broadly if a
+# user's prompt legitimately contains the word).
+_CONTEXT_LENGTH_PATTERNS = (
+    "context_length_exceeded",
+    "maximum context length",
+    "prompt is too long",
+    "input length and max_tokens exceed",
+    "context window",
+    "too many tokens",
+    "reduce the length of the messages",
+    "content size exceeds",
+)
+
+_TIMEOUT_PATTERNS = (
+    "context deadline exceeded",
+    "deadlineexceeded",
+    "request timed out",
+    "read timed out",
+    "timed out after",
+    "timeout exceeded",
+)
+
+_AUTH_PATTERNS = (
+    "invalid api key",
+    "invalid_api_key",
+    "incorrect api key",
+    "authentication failed",
+    "authenticationerror",
+    "not authorized",
+    "unauthorized",
+    "401",
+    "403",
+)
+
+_RATE_LIMIT_PATTERNS = (
+    "rate limit",
+    "rate_limit",
+    "too many requests",
+    "429",
+    "quota exceeded",
+    "resource exhausted",
+)
+
+
+def translate_ai_error(error: BaseException) -> TranslatedAiError:
+    """Classify a provider / MCP / transport error and return a friendly message.
+
+    Falls back to the original string when no pattern matches, so this is
+    always safe to call — the worst case is we return what we would have
+    shown anyway.
+    """
+    raw = str(error)
+    lowered = raw.lower()
+
+    if isinstance(error, asyncio.TimeoutError):
+        return TranslatedAiError(
+            category="timeout",
+            message=(
+                "The AI provider took too long to respond. If this "
+                "involved an MCP tool, its timeout may be too short for "
+                "the operation — increase ``timeout`` on the MCP server "
+                "in your marimo.toml."
+            ),
+            original=raw,
+        )
+
+    if _any_match(lowered, _CONTEXT_LENGTH_PATTERNS):
+        return TranslatedAiError(
+            category="context_length",
+            message=(
+                "This conversation has grown past the model's context "
+                "window. Start a new chat, switch to a longer-context "
+                "model, or remove attachments and earlier messages."
+            ),
+            original=raw,
+        )
+
+    if _any_match(lowered, _TIMEOUT_PATTERNS):
+        return TranslatedAiError(
+            category="timeout",
+            message=(
+                "The AI provider took too long to respond. Try again, or "
+                "increase the MCP ``timeout`` in your marimo.toml if a "
+                "tool call stalled."
+            ),
+            original=raw,
+        )
+
+    if _any_match(lowered, _AUTH_PATTERNS):
+        return TranslatedAiError(
+            category="auth",
+            message=(
+                "The AI provider rejected the request as unauthenticated. "
+                "Check your API key in Settings → AI, or your provider's "
+                "login state."
+            ),
+            original=raw,
+        )
+
+    if _any_match(lowered, _RATE_LIMIT_PATTERNS):
+        return TranslatedAiError(
+            category="rate_limit",
+            message=(
+                "The AI provider is rate-limiting requests. Wait a moment "
+                "before retrying, or switch to a different model."
+            ),
+            original=raw,
+        )
+
+    return TranslatedAiError(category="unknown", message=raw, original=raw)
+
+
+def _any_match(haystack: str, patterns: tuple[str, ...]) -> bool:
+    return any(p in haystack for p in patterns)

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -22,6 +22,7 @@ from marimo._server.ai.config import (
     get_edit_model,
     get_max_tokens,
 )
+from marimo._server.ai.errors import translate_ai_error
 from marimo._server.ai.mcp import MCPServerStatus, get_mcp_client
 from marimo._server.ai.prompts import (
     FIM_MIDDLE_TAG,
@@ -87,13 +88,15 @@ async def safe_stream_wrapper(
         async for chunk in stream_generator:
             yield chunk
     except Exception as e:
+        # Always log the raw provider error for debuggability; surface
+        # a friendlier, actionable message to the user when we can
+        # classify it.
         LOGGER.error("Error in AI streaming response: %s", str(e))
-        # Send an error message using AI SDK stream protocol format
-        # Error Part format: 3:string\n
+        translated = translate_ai_error(e)
         if text_only:
-            yield str(e)
+            yield translated.message
         else:
-            yield convert_to_ai_sdk_messages(str(e), "error")
+            yield convert_to_ai_sdk_messages(translated.message, "error")
 
 
 def get_ai_config(config: MarimoConfig) -> AiConfig:

--- a/tests/_server/ai/test_errors.py
+++ b/tests/_server/ai/test_errors.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from marimo._server.ai.errors import translate_ai_error
+
+
+class TestContextLength:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            # OpenAI
+            "openai.BadRequestError: This model's maximum context length is 128000 tokens",
+            "Error code: 400 - {'error': {'code': 'context_length_exceeded'}}",
+            "Please reduce the length of the messages",
+            # Anthropic
+            "prompt is too long: 200001 tokens > 200000 maximum",
+            "input length and max_tokens exceed context limit",
+            # Google
+            "The total size of the request including the context window was exceeded",
+            # Generic
+            "content size exceeds model limits",
+            "too many tokens in prompt",
+        ],
+    )
+    def test_recognized_as_context_length(self, raw: str) -> None:
+        result = translate_ai_error(RuntimeError(raw))
+        assert result.category == "context_length"
+        assert "context window" in result.message
+        assert result.original == raw
+
+
+class TestTimeout:
+    def test_asyncio_timeout_error_instance(self) -> None:
+        result = translate_ai_error(asyncio.TimeoutError())
+        assert result.category == "timeout"
+        assert "too long" in result.message
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            # gRPC / Vertex
+            "grpc: context deadline exceeded",
+            "DeadlineExceeded: deadline exceeded after 30s",
+            # Generic
+            "Request timed out",
+            "Read timed out after 60.0s",
+            "Tool execution timed out after 30 seconds",
+            "Timeout exceeded while calling OpenAI",
+        ],
+    )
+    def test_recognized_as_timeout(self, raw: str) -> None:
+        result = translate_ai_error(RuntimeError(raw))
+        assert result.category == "timeout"
+
+    def test_asyncio_timeout_takes_precedence_over_string_match(self) -> None:
+        # Even if the exception's str is empty, isinstance check catches it.
+        err = asyncio.TimeoutError()
+        result = translate_ai_error(err)
+        assert result.category == "timeout"
+
+
+class TestAuth:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "AuthenticationError: Invalid API key provided",
+            "401 Unauthorized",
+            "Error: Incorrect API key",
+            "authentication failed for provider",
+        ],
+    )
+    def test_recognized_as_auth(self, raw: str) -> None:
+        result = translate_ai_error(RuntimeError(raw))
+        assert result.category == "auth"
+        assert "API key" in result.message or "login" in result.message
+
+
+class TestRateLimit:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "RateLimitError: Rate limit reached",
+            "HTTP 429: Too Many Requests",
+            "quota exceeded for project",
+            "resource exhausted",
+        ],
+    )
+    def test_recognized_as_rate_limit(self, raw: str) -> None:
+        result = translate_ai_error(RuntimeError(raw))
+        assert result.category == "rate_limit"
+
+
+class TestUnknown:
+    def test_unrecognized_error_falls_through_to_original(self) -> None:
+        raw = "Something went completely sideways in the network stack"
+        result = translate_ai_error(RuntimeError(raw))
+        assert result.category == "unknown"
+        # Must not mangle errors we don't recognize.
+        assert result.message == raw
+        assert result.original == raw
+
+    def test_empty_error_message_is_preserved(self) -> None:
+        result = translate_ai_error(RuntimeError(""))
+        assert result.category == "unknown"
+        assert result.message == ""
+
+
+class TestPrecedence:
+    def test_context_length_wins_over_timeout_when_both_strings_present(
+        self,
+    ) -> None:
+        # A provider once returned "timeout: prompt is too long". Without
+        # deterministic ordering the user would get the wrong guidance.
+        raw = "timeout: prompt is too long"
+        result = translate_ai_error(RuntimeError(raw))
+        assert result.category == "context_length"
+
+    def test_auth_wins_over_rate_limit_when_both_plausible(self) -> None:
+        raw = "401 unauthorized (you may also have been rate limited)"
+        result = translate_ai_error(RuntimeError(raw))
+        assert result.category == "auth"


### PR DESCRIPTION
**This pull request was authored by a coding agent.** Opened in draft per `AGENTS.md`; every line has been reviewed by the human author, who stands by it.

## 📝 Summary

Relates to #9323 (see the "open questions" section on error translation).

When an AI chat or completion call fails — from the provider SDK, from an MCP tool, or from a timeout — marimo currently stringifies the raw exception into the AI SDK stream's error channel. Users see things like:

- `openai.BadRequestError: This model's maximum context length is 128000 tokens`
- `grpc: context deadline exceeded`
- `AuthenticationError: Invalid API key provided`
- `Tool execution timed out after 30 seconds`

None of which tells a notebook user what to do. This PR adds a tiny classifier that maps known patterns into five categories with actionable messages:

| Category | Example user message |
|---|---|
| `context_length` | "This conversation has grown past the model's context window. Start a new chat, switch to a longer-context model, or remove attachments and earlier messages." |
| `timeout` | "The AI provider took too long to respond. Try again, or increase the MCP `timeout` in your marimo.toml if a tool call stalled." |
| `auth` | "The AI provider rejected the request as unauthenticated. Check your API key in Settings → AI, or your provider's login state." |
| `rate_limit` | "The AI provider is rate-limiting requests. Wait a moment before retrying, or switch to a different model." |
| `unknown` | *original string, unchanged* |

**Unknown errors fall through to the original string**, so this is strictly additive — no error is worse than it is today. Raw exceptions are still logged at `ERROR` level for debuggability.

## Design notes

- **Dependency-free.** Pure string matching + an `isinstance(error, asyncio.TimeoutError)` check. No new packages.
- **Deterministic precedence.** Context-length wins over timeout when both appear (a real Vertex quirk), auth wins over rate-limit when both appear.
- **Provider-agnostic patterns.** Pattern lists cover OpenAI / Anthropic / Google / Bedrock / generic gRPC. Adding new providers is one-line additions to a tuple.
- **No behavior change for successful streams.** Only the error branch of `safe_stream_wrapper` is touched.

## Files

| File | Change |
|---|---|
| `marimo/_server/ai/errors.py` | New module: `translate_ai_error(error) -> TranslatedAiError` |
| `marimo/_server/api/endpoints/ai.py` | `safe_stream_wrapper` routes errors through the translator |
| `tests/_server/ai/test_errors.py` | 28 unit tests covering each category + precedence + fallthrough |

+288 / -4 LoC.

## Test plan

- `uv run pytest tests/_server/ai/test_errors.py` — 28 passed locally
- `uv run pytest tests/_server/ai/ tests/_server/api/endpoints/test_ai.py` — 259 passed, 88 skipped (optional deps)
- `uv run ruff check` / `uv run ruff format` / pre-commit — clean
- Manual: trigger a too-long chat history; confirm user sees the friendly context-length message rather than the raw OpenAI error

## 📋 Pre-Review Checklist

- [x] Small change, not API-breaking; discussed implicitly in #9323's open questions.
- [x] AI-generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video/media evidence — N/A, no visual changes.

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation — user-facing messages are the documentation here; no separate docs page warranted.
- [x] Tests have been added (`tests/_server/ai/test_errors.py`).