### PR TITLE
fix markdown .center, .right, .left not respecting new lines

### DIFF
--- a/examples/ui/layout.py
+++ b/examples/ui/layout.py
@@ -7,7 +7,7 @@
 
 import marimo
 
-__generated_with = "0.19.7"
+__generated_with = "0.23.2"
 app = marimo.App()
 
 

--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -204,7 +204,7 @@ class Html(MIME):
         """
         from marimo._plugins.stateless import flex
 
-        return flex.hstack([self], justify="center")
+        return flex.vstack([_BlockWrapped(self)], align="center", gap=0)
 
     @mddoc
     def right(self) -> Html:
@@ -220,7 +220,7 @@ class Html(MIME):
         """
         from marimo._plugins.stateless import flex
 
-        return flex.hstack([self], justify="end")
+        return flex.vstack([_BlockWrapped(self)], align="end", gap=0)
 
     @mddoc
     def left(self) -> Html:
@@ -236,7 +236,7 @@ class Html(MIME):
         """
         from marimo._plugins.stateless import flex
 
-        return flex.hstack([self], justify="start")
+        return flex.vstack([_BlockWrapped(self)], align="start", gap=0)
 
     @mddoc
     def callout(
@@ -287,6 +287,33 @@ class Html(MIME):
 
     def _repr_html_(self) -> str:
         return self.text
+
+
+class _BlockWrapped(Html):
+    """Wraps another Html in a plain block ``<div>``.
+
+    Used by :meth:`Html.center`, :meth:`Html.left`, and :meth:`Html.right`
+    so that the wrapped content renders inside a single block container
+    (preserving normal block flow and margin collapsing between inner
+    elements) rather than becoming multiple flex-column siblings when the
+    inner wrapper uses ``display: contents`` (as ``mo.md`` does).
+
+    The inner Html is re-rendered on every ``text`` access so mutable
+    children (e.g. ``mo.status.spinner``) keep updating live.
+    """
+
+    def __init__(self, inner: Html) -> None:
+        self._inner = inner
+        super().__init__(self._build_text())
+
+    def _build_text(self) -> str:
+        from marimo._output.builder import h
+
+        return h.div(self._inner.text)
+
+    @property
+    def text(self) -> str:
+        return self._build_text()
 
 
 MARIMO_NO_JS_KEY = "MARIMO_NO_JS"

--- a/marimo/_smoke_tests/justify.py
+++ b/marimo/_smoke_tests/justify.py
@@ -1,0 +1,388 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # `.center()` / `.left()` / `.right()` smoke tests
+
+    This notebook exercises the Html alignment helpers across a variety
+    of content types. Scroll through the cells to visually confirm each
+    scenario.
+
+    **Expected behavior**
+
+    - `.center()` horizontally centers the content as a block unit.
+    - `.left()` and `.right()` align the content to the respective edge
+      at its natural (content) width.
+    - **Newlines / multi-block markdown must be preserved** (this was
+      the original bug: headings + paragraphs were being flattened
+      into a horizontal row).
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 1. Single-line markdown
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("This markdown is **centered**.").center()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("This markdown is **left**-justified.").left()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("This markdown is **right**-justified.").right()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 2. Multi-block markdown (the original bug)
+
+    The heading and paragraph must stack **vertically**, each
+    horizontally aligned according to the method called.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Centered title
+
+        A deck exercising slides, sub-slides (stacks), fragments, and skip cells.
+        """
+    ).center()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Left-aligned title
+
+        A description that should appear on its own line, left-aligned.
+        """
+    ).left()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Left-aligned title
+
+        A description that should appear on its own line, left-aligned.
+        """
+    ).left().style({"height": "80px", "overflow": "auto", "background": "lightgray"})
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Right-aligned title
+
+        A description that should appear on its own line, right-aligned.
+        """
+    ).right()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## Heading
+
+        First paragraph of several lines of prose that should
+        wrap naturally and stay as its own block.
+
+        Second paragraph, also on its own block-level line.
+
+        - A list item
+        - Another list item
+        """
+    ).center()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 3. Single UI element
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.ui.button(label="Centered button").center()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.ui.button(label="Left button").left()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.ui.button(label="Right button").right()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 4. Inline UI inside markdown
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    _button = mo.ui.button(label="Click me")
+    mo.md(f"{_button} _inline button with text, centered as a line._").center()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 5. Images
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.image(
+        src="https://marimo.io/logo.png",
+        width=120,
+    ).center()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        "![marimo](https://marimo.io/logo.png)\n\n*A caption below the image.*"
+    ).center()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 6. Alignment applied to an `hstack`
+
+    `.left()` / `.center()` / `.right()` group the hstack at the
+    requested edge at its content width.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.hstack(
+        [
+            mo.ui.checkbox(label="A"),
+            mo.ui.checkbox(label="B"),
+            mo.ui.checkbox(label="C"),
+        ],
+        gap=1,
+    ).left()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.hstack(
+        [
+            mo.ui.checkbox(label="A"),
+            mo.ui.checkbox(label="B"),
+            mo.ui.checkbox(label="C"),
+        ],
+        gap=1,
+    ).center()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.hstack(
+        [
+            mo.ui.checkbox(label="A"),
+            mo.ui.checkbox(label="B"),
+            mo.ui.checkbox(label="C"),
+        ],
+        gap=1,
+    ).right()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 7. Alignment applied to a `vstack`
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.vstack(
+        [
+            mo.md("**Title**"),
+            mo.md("A short paragraph below the title."),
+            mo.ui.button(label="Action"),
+        ],
+        gap=0.5,
+    ).center()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.vstack(
+        [
+            mo.md("**Title**"),
+            mo.md("A short paragraph below the title."),
+            mo.ui.button(label="Action"),
+        ],
+        gap=0.5,
+    ).right()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 8. Chained with `.callout()`
+
+    Newlines inside the markdown must be preserved inside the callout.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Important notice
+
+        The callout body should render with this heading on its own line
+        and this paragraph on the following line.
+        """
+    ).center().callout(kind="info")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Warning
+
+        Multiple paragraphs.
+
+        All left-aligned and stacked vertically.
+        """
+    ).left().callout(kind="warn")
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 9. Module-level helpers
+
+    `mo.center(x)`, `mo.left(x)`, `mo.right(x)` should behave
+    identically to the `.center()` / `.left()` / `.right()` methods.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.center(
+        mo.md(
+            """
+            # Module-level center
+
+            Heading + paragraph, still stacked vertically.
+            """
+        )
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.left(mo.ui.button(label="mo.left(button)"))
+    return
+
+
+@app.cell
+def _(mo):
+    mo.right(mo.ui.button(label="mo.right(button)"))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 10. Double-chained alignment
+
+    Last call wins; newlines still preserved.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Double-chain
+
+        First centered, then left-aligned -- should end up left-aligned
+        with block flow intact.
+        """
+    ).center().left()
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_output/test_hypertext.py
+++ b/tests/_output/test_hypertext.py
@@ -93,19 +93,62 @@ def test_html_batch():
 def test_html_center():
     html = Html("<p>Centered</p>")
     centered = html.center()
-    assert "justify-content: center" in centered.text
+    # center/left/right use a column-direction stack with cross-axis
+    # alignment so multi-block content retains its block flow.
+    assert "flex-direction: column" in centered.text
+    assert "align-items: center" in centered.text
 
 
 def test_html_right():
     html = Html("<p>Right</p>")
     right_aligned = html.right()
-    assert "justify-content: flex-end" in right_aligned.text
+    assert "flex-direction: column" in right_aligned.text
+    assert "align-items: flex-end" in right_aligned.text
 
 
 def test_html_left():
     html = Html("<p>Left</p>")
     left_aligned = html.left()
-    assert "justify-content: flex-start" in left_aligned.text
+    assert "flex-direction: column" in left_aligned.text
+    assert "align-items: flex-start" in left_aligned.text
+
+
+def test_html_center_preserves_multi_block_markdown():
+    # Regression: markdown with multiple top-level blocks (e.g. heading +
+    # paragraph) must not be flattened into a horizontal row when centered,
+    # and must keep normal block-flow spacing (margin collapsing) rather
+    # than gaining extra space from flex-column gaps.
+    html = Html(
+        '<span class="markdown contents"><h1>Title</h1>'
+        '<span class="paragraph">Description</span></span>'
+    )
+    centered = html.center()
+    # Column-direction flex so the wrapper, not individual blocks, gets
+    # aligned; paragraph and heading must not be flex-row siblings.
+    assert "flex-direction: column" in centered.text
+    assert "flex-direction: row" not in centered.text
+    # gap=0 so the alignment wrapper doesn't add extra spacing.
+    assert "gap: 0rem" in centered.text
+    # The content is wrapped in a plain block <div> so inner blocks use
+    # normal block flow (margins collapse, no flex-item semantics leaked
+    # via `display: contents`).
+    assert (
+        '<div><span class="markdown contents"><h1>Title</h1>'
+        '<span class="paragraph">Description</span></span></div>'
+    ) in centered.text
+    # Heading precedes paragraph (document order preserved).
+    assert centered.text.index("<h1>") < centered.text.index("paragraph")
+
+
+def test_html_center_live_updates_propagate():
+    # The block wrapper must re-render on every text access so mutable
+    # children (e.g. spinners) keep updating live.
+    inner = Html("<div>initial</div>")
+    centered = inner.center()
+    assert "initial" in centered.text
+    inner._text = "<div>updated</div>"
+    assert "updated" in centered.text
+    assert "initial" not in centered.text
 
 
 def test_html_callout():


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

Wraps in a div with vstack instead of hstack. Use _BlockWrapped because plain vstacks were causing additional spacing to be added between divs.

Before:
<img width="1144" height="582" alt="image" src="https://github.com/user-attachments/assets/481661d4-135a-4d44-a2ac-0177ae5a8621" />

After:
<img width="1147" height="675" alt="image" src="https://github.com/user-attachments/assets/4aa8ede4-0d0d-471a-a0fd-3803a039918c" />

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
