### PR TITLE
ci: don't cancel in-flight docs and release runs on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -69,8 +69,25 @@ jobs:
       - name: 📚 CLAUDE.md
         run: cp docs/_static/CLAUDE.md .vercel/output/static/CLAUDE.md
 
-      - name: 🚀 Deploy to Vercel
+      # Skip deploy if a newer commit has landed on main while this run was building,
+      # so an older run can't overwrite a newer deploy. The run still completes green.
+      - name: 🔍 Check if still tip of main
+        id: latest
         if: github.ref == 'refs/heads/main'
+        env:
+          GH_SHA: ${{ github.sha }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          LATEST_SHA=$(git ls-remote "https://github.com/${GH_REPO}.git" refs/heads/main | awk '{print $1}')
+          if [ "$LATEST_SHA" = "$GH_SHA" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping deploy — superseded by a newer commit on main ($LATEST_SHA)."
+          fi
+
+      - name: 🚀 Deploy to Vercel
+        if: github.ref == 'refs/heads/main' && steps.latest.outputs.is_latest == 'true'
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -127,9 +127,39 @@ jobs:
           path: frontend/
           retention-days: 1
 
+  # Recheck after the build completes before publishing to npm. The `dev` dist-tag is
+  # mutable — if a stale older run publishes after a newer one, `@dev` gets pointed at
+  # older artifacts. Always runs; returns is_latest=true for non-main callers so this
+  # reusable workflow stays safe outside the push-to-main path.
+  recheck_tip_of_main:
+    name: 🔍 Still tip of main?
+    needs: publish_dev_release
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - id: check
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ "$GH_REF" != "refs/heads/main" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          LATEST_SHA=$(git ls-remote "https://github.com/${GH_REPO}.git" refs/heads/main | awk '{print $1}')
+          if [ "$LATEST_SHA" = "$GH_SHA" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping npm publish — superseded by a newer commit on main ($LATEST_SHA) during build."
+          fi
+
   publish_wasm_dev:
     name: 📤 Publish @marimo-team/frontend to npm
-    needs: publish_dev_release
+    needs: [publish_dev_release, recheck_tip_of_main]
+    if: needs.recheck_tip_of_main.outputs.is_latest == 'true'
     uses: ./.github/workflows/publish-npm.yml
     with:
       package-artifact-name: frontend-dev
@@ -141,7 +171,8 @@ jobs:
 
   publish_islands_dev:
     name: 📤 Publish @marimo-team/islands to npm
-    needs: publish_dev_release
+    needs: [publish_dev_release, recheck_tip_of_main]
+    if: needs.recheck_tip_of_main.outputs.is_latest == 'true'
     uses: ./.github/workflows/publish-npm.yml
     with:
       package-artifact-name: frontend-islands-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,11 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # On main: unique group per run so nothing is cancelled (avoids a red X on the commit
+  # when a newer push supersedes this one). On tags: per-ref group with cancel-in-progress,
+  # preserving the original production-release behavior.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # ── Production Release (tag push) ──────────────────────────────
@@ -72,19 +75,67 @@ jobs:
 
   # ── Development Release (push to main) ─────────────────────────
 
+  # Skip the dev release chain if a newer commit has landed on main while this run was
+  # queued, so we don't burn a TestPyPI version on a superseded SHA. Downstream dev jobs
+  # (build_dev + publish_dev_*) skip automatically via their `needs:` chain.
+  check_dev_latest:
+    name: 🔍 Still tip of main?
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - id: check
+        env:
+          GH_SHA: ${{ github.sha }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          LATEST_SHA=$(git ls-remote "https://github.com/${GH_REPO}.git" refs/heads/main | awk '{print $1}')
+          if [ "$LATEST_SHA" = "$GH_SHA" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping dev release — superseded by a newer commit on main ($LATEST_SHA)."
+          fi
+
   build_dev:
     name: 🔧 Development Release
-    if: github.ref == 'refs/heads/main'
+    needs: check_dev_latest
+    if: github.ref == 'refs/heads/main' && needs.check_dev_latest.outputs.is_latest == 'true'
     uses: ./.github/workflows/release-dev.yml
     secrets: inherit
     permissions:
       contents: read # Required for checkout
       id-token: write # Required for nodejs OIDC
 
+  # Recheck after the build completes: the build takes several minutes, long enough that
+  # a newer commit may have landed during that window. Skipping here prevents a stale
+  # older run from publishing to TestPyPI after the newer run has already published.
+  recheck_dev_latest:
+    name: 🔍 Recheck still tip of main?
+    needs: build_dev
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - id: check
+        env:
+          GH_SHA: ${{ github.sha }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          LATEST_SHA=$(git ls-remote "https://github.com/${GH_REPO}.git" refs/heads/main | awk '{print $1}')
+          if [ "$LATEST_SHA" = "$GH_SHA" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping TestPyPI publish — superseded by a newer commit on main ($LATEST_SHA) during build."
+          fi
+
   publish_dev_pypi_marimo:
     name: 📤 Publish marimo to TestPyPI
-    if: github.ref == 'refs/heads/main'
-    needs: build_dev
+    if: github.ref == 'refs/heads/main' && needs.recheck_dev_latest.outputs.is_latest == 'true'
+    needs: [build_dev, recheck_dev_latest]
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -104,8 +155,8 @@ jobs:
 
   publish_dev_pypi_marimo_base:
     name: 📤 Publish marimo-base to TestPyPI
-    if: github.ref == 'refs/heads/main'
-    needs: build_dev
+    if: github.ref == 'refs/heads/main' && needs.recheck_dev_latest.outputs.is_latest == 'true'
+    needs: [build_dev, recheck_dev_latest]
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:


### PR DESCRIPTION
Match the behavior from #9312: on pushes to main, use a per-run concurrency group so a newer push never cancels an older one. Cancelled workflows show as a red X on the commit in the GitHub UI, which makes the UI not useful. For docs we also want to guarantee the build actually completes.

To keep this safe without cancellation, each workflow re-checks that its SHA is still the tip of main before shipping artifacts and skips the final step if it's been superseded, so a stale older run can't clobber a newer deploy/publish. This keeps the workflow status green.

- docs.yml: per-run group, gate the Vercel deploy on tip-of-main
- release.yml: per-run group on main only (tags keep cancel-in-progress), gate TestPyPI publishes before and after build_dev
- release-dev.yml: recheck tip-of-main before the npm publishes