### PR TITLE
fix: harden trust-bearing window globals and gate script loading

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -72,7 +72,11 @@
     <!-- This is a portal for the data editor to render in -->
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = '{{ mount_config }}';
+      Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
+        value: Object.freeze('{{ mount_config }}'),
+        writable: false,
+        configurable: false,
+      });
     </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/core/static/__tests__/export-context.test.ts
+++ b/frontend/src/core/static/__tests__/export-context.test.ts
@@ -1,0 +1,122 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+// @vitest-environment jsdom
+
+import type { ExtractAtomValue } from "jotai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { hasRunAnyCellAtom } from "@/components/editor/cell/useRunCells";
+import { userConfigAtom } from "@/core/config/config";
+import { parseUserConfig } from "@/core/config/config-schema";
+import { initialModeAtom } from "@/core/mode";
+import { store } from "@/core/state/jotai";
+import {
+  getMarimoExportContext,
+  hasTrustedExportContext,
+  hasTrustedNotebookContext,
+} from "../export-context";
+
+type ExportContextWindow = Window & {
+  __MARIMO_EXPORT_CONTEXT__?: {
+    trusted: boolean;
+    notebookCode?: string;
+  };
+};
+
+function setAutoInstantiate(value: boolean) {
+  const cleared = parseUserConfig({});
+  store.set(userConfigAtom, {
+    ...cleared,
+    runtime: { ...cleared.runtime, auto_instantiate: value },
+  });
+}
+
+describe("hasTrustedNotebookContext", () => {
+  let previousHasRunAnyCell: ExtractAtomValue<typeof hasRunAnyCellAtom>;
+  let previousConfig: ExtractAtomValue<typeof userConfigAtom>;
+  let previousMode: ExtractAtomValue<typeof initialModeAtom>;
+  let w: ExportContextWindow;
+
+  beforeEach(() => {
+    w = window as ExportContextWindow;
+    previousHasRunAnyCell = store.get(hasRunAnyCellAtom);
+    previousConfig = store.get(userConfigAtom);
+    previousMode = store.get(initialModeAtom);
+    store.set(hasRunAnyCellAtom, false);
+    setAutoInstantiate(false);
+    store.set(initialModeAtom, "edit");
+    delete w.__MARIMO_EXPORT_CONTEXT__;
+  });
+
+  afterEach(() => {
+    store.set(hasRunAnyCellAtom, previousHasRunAnyCell);
+    store.set(userConfigAtom, previousConfig);
+    store.set(initialModeAtom, previousMode);
+    delete w.__MARIMO_EXPORT_CONTEXT__;
+  });
+
+  it("returns false in untrusted edit mode before interaction", () => {
+    expect(hasTrustedNotebookContext()).toBe(false);
+  });
+
+  it("returns true once the user has run a cell", () => {
+    store.set(hasRunAnyCellAtom, true);
+    expect(hasTrustedNotebookContext()).toBe(true);
+  });
+
+  it("returns true when a trusted export context is installed", () => {
+    w.__MARIMO_EXPORT_CONTEXT__ = { trusted: true };
+    expect(hasTrustedNotebookContext()).toBe(true);
+  });
+
+  it("returns true when auto_instantiate is enabled", () => {
+    setAutoInstantiate(true);
+    expect(hasTrustedNotebookContext()).toBe(true);
+  });
+
+  it("returns true in read mode", () => {
+    store.set(initialModeAtom, "read");
+    expect(hasTrustedNotebookContext()).toBe(true);
+  });
+
+  it("returns false if initialMode throws (config not yet applied)", () => {
+    store.set(initialModeAtom, undefined);
+    expect(hasTrustedNotebookContext()).toBe(false);
+  });
+});
+
+describe("hasTrustedExportContext / getMarimoExportContext shape validation", () => {
+  let w: ExportContextWindow;
+
+  beforeEach(() => {
+    w = window as ExportContextWindow;
+    delete w.__MARIMO_EXPORT_CONTEXT__;
+  });
+
+  afterEach(() => {
+    delete w.__MARIMO_EXPORT_CONTEXT__;
+  });
+
+  it("accepts a valid context", () => {
+    w.__MARIMO_EXPORT_CONTEXT__ = { trusted: true, notebookCode: "x = 1" };
+    expect(hasTrustedExportContext()).toBe(true);
+    expect(getMarimoExportContext()).toEqual({
+      trusted: true,
+      notebookCode: "x = 1",
+    });
+  });
+
+  it("rejects a context where `trusted` is not exactly true", () => {
+    w.__MARIMO_EXPORT_CONTEXT__ = {
+      trusted: "yes" as unknown as true,
+    };
+    expect(hasTrustedExportContext()).toBe(false);
+    expect(getMarimoExportContext()).toBeUndefined();
+  });
+
+  it("rejects a context with non-string notebookCode", () => {
+    w.__MARIMO_EXPORT_CONTEXT__ = {
+      trusted: true,
+      notebookCode: 42 as unknown as string,
+    };
+    expect(getMarimoExportContext()).toBeUndefined();
+  });
+});

--- a/frontend/src/core/static/__tests__/static-state.test.ts
+++ b/frontend/src/core/static/__tests__/static-state.test.ts
@@ -59,4 +59,22 @@ describe("static-state shape validation", () => {
     setMarimoStatic("pwned");
     expect(isStaticNotebook()).toBe(false);
   });
+
+  it("rejects an array as the state", () => {
+    setMarimoStatic([]);
+    expect(isStaticNotebook()).toBe(false);
+  });
+
+  it("rejects files when it is an array", () => {
+    setMarimoStatic({ files: [], modelNotifications: [] });
+    expect(isStaticNotebook()).toBe(false);
+  });
+
+  it("rejects files that contain non-string values", () => {
+    setMarimoStatic({
+      files: { "/@file/a.txt": 42 },
+      modelNotifications: [],
+    });
+    expect(isStaticNotebook()).toBe(false);
+  });
 });

--- a/frontend/src/core/static/__tests__/static-state.test.ts
+++ b/frontend/src/core/static/__tests__/static-state.test.ts
@@ -1,0 +1,62 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getStaticModelNotifications,
+  getStaticVirtualFiles,
+  isStaticNotebook,
+} from "../static-state";
+
+function setMarimoStatic(value: unknown): void {
+  (window as unknown as { __MARIMO_STATIC__?: unknown }).__MARIMO_STATIC__ =
+    value;
+}
+
+function clearMarimoStatic(): void {
+  delete (window as unknown as { __MARIMO_STATIC__?: unknown })
+    .__MARIMO_STATIC__;
+}
+
+describe("static-state shape validation", () => {
+  beforeEach(() => {
+    clearMarimoStatic();
+  });
+
+  afterEach(() => {
+    clearMarimoStatic();
+  });
+
+  it("treats an absent global as not-a-static-notebook", () => {
+    expect(isStaticNotebook()).toBe(false);
+    expect(getStaticModelNotifications()).toBeUndefined();
+  });
+
+  it("accepts a well-formed state", () => {
+    setMarimoStatic({
+      files: { "/@file/a.txt": "data:text/plain;base64,YQ==" },
+      modelNotifications: [],
+    });
+    expect(isStaticNotebook()).toBe(true);
+    expect(getStaticVirtualFiles()).toEqual({
+      "/@file/a.txt": "data:text/plain;base64,YQ==",
+    });
+    expect(getStaticModelNotifications()).toEqual([]);
+  });
+
+  it("rejects a malformed global (missing files)", () => {
+    setMarimoStatic({ modelNotifications: [] });
+    expect(isStaticNotebook()).toBe(false);
+    expect(getStaticModelNotifications()).toBeUndefined();
+  });
+
+  it("rejects a malformed global (non-array modelNotifications)", () => {
+    setMarimoStatic({ files: {}, modelNotifications: "oops" });
+    expect(isStaticNotebook()).toBe(false);
+  });
+
+  it("rejects a non-object global", () => {
+    setMarimoStatic("pwned");
+    expect(isStaticNotebook()).toBe(false);
+  });
+});

--- a/frontend/src/core/static/export-context.ts
+++ b/frontend/src/core/static/export-context.ts
@@ -1,5 +1,10 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { hasRunAnyCellAtom } from "@/components/editor/cell/useRunCells";
+import { autoInstantiateAtom } from "@/core/config/config";
+import { getInitialAppMode } from "@/core/mode";
+import { store } from "@/core/state/jotai";
+
 export interface MarimoExportContext {
   trusted: true;
   notebookCode?: string;
@@ -40,4 +45,40 @@ export function getMarimoExportContext():
 
 export function hasTrustedExportContext(): boolean {
   return getMarimoExportContext()?.trusted === true;
+}
+
+/**
+ * True when the current page is a context where notebook-authored script
+ * execution is expected, and therefore the user has consented (explicitly or
+ * by the nature of the page) to running arbitrary notebook content:
+ *
+ * - the user has run at least one cell, OR
+ * - a first-party exported notebook page installed a trusted export context
+ *   (islands / static exports / Quarto islands), OR
+ * - `auto_instantiate` is enabled (the notebook runs on page load by user
+ *   configuration), OR
+ * - the page was loaded in `read` / app mode (served by marimo as an app).
+ *
+ * Edit mode before any user interaction is intentionally NOT trusted — that
+ * is the only surface where we must prevent notebook-authored content from
+ * loading scripts or bypassing HTML sanitization.
+ */
+export function hasTrustedNotebookContext(): boolean {
+  if (store.get(hasRunAnyCellAtom)) {
+    return true;
+  }
+  if (hasTrustedExportContext()) {
+    return true;
+  }
+  if (store.get(autoInstantiateAtom)) {
+    return true;
+  }
+  try {
+    if (getInitialAppMode() === "read") {
+      return true;
+    }
+  } catch {
+    // getInitialAppMode throws before mount config is applied; treat as untrusted.
+  }
+  return false;
 }

--- a/frontend/src/core/static/static-state.ts
+++ b/frontend/src/core/static/static-state.ts
@@ -5,20 +5,44 @@ import type { MarimoStaticState, StaticVirtualFiles } from "./types";
 
 declare global {
   interface Window {
-    __MARIMO_STATIC__?: MarimoStaticState;
+    __MARIMO_STATIC__?: Readonly<MarimoStaticState>;
   }
 }
 
+function isMarimoStaticState(
+  value: unknown,
+): value is Readonly<MarimoStaticState> {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as MarimoStaticState;
+  if (typeof candidate.files !== "object" || candidate.files === null) {
+    return false;
+  }
+  if (
+    candidate.modelNotifications !== undefined &&
+    !Array.isArray(candidate.modelNotifications)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function getMarimoStaticState(): Readonly<MarimoStaticState> | undefined {
+  const state = window?.__MARIMO_STATIC__;
+  return isMarimoStaticState(state) ? state : undefined;
+}
+
 export function isStaticNotebook(): boolean {
-  return window?.__MARIMO_STATIC__ !== undefined;
+  return getMarimoStaticState() !== undefined;
 }
 
 export function getStaticVirtualFiles(): StaticVirtualFiles {
-  invariant(window.__MARIMO_STATIC__ !== undefined, "Not a static notebook");
-
-  return window.__MARIMO_STATIC__.files;
+  const state = getMarimoStaticState();
+  invariant(state !== undefined, "Not a static notebook");
+  return state.files;
 }
 
 export function getStaticModelNotifications(): ModelLifecycle[] | undefined {
-  return window?.__MARIMO_STATIC__?.modelNotifications;
+  return getMarimoStaticState()?.modelNotifications;
 }

--- a/frontend/src/core/static/static-state.ts
+++ b/frontend/src/core/static/static-state.ts
@@ -9,14 +9,28 @@ declare global {
   }
 }
 
+function isStringToStringRecord(
+  value: unknown,
+): value is Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  for (const entry of Object.values(value)) {
+    if (typeof entry !== "string") {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isMarimoStaticState(
   value: unknown,
 ): value is Readonly<MarimoStaticState> {
-  if (typeof value !== "object" || value === null) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
   }
   const candidate = value as MarimoStaticState;
-  if (typeof candidate.files !== "object" || candidate.files === null) {
+  if (!isStringToStringRecord(candidate.files)) {
     return false;
   }
   if (

--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -16,6 +16,8 @@ import { CopyClipboardIcon } from "@/components/icons/copy-icon";
 import { QueryParamPreservingLink } from "@/components/ui/query-param-preserving-link";
 import { Tooltip } from "@/components/ui/tooltip";
 import { DocHoverTarget } from "@/core/documentation/DocHoverTarget";
+import { hasTrustedNotebookContext } from "@/core/static/export-context";
+import { Logger } from "@/utils/Logger";
 import { sanitizeHtml, useSanitizeHtml } from "./sanitize";
 
 type ReplacementFn = NonNullable<HTMLReactParserOptions["replace"]>;
@@ -97,6 +99,20 @@ const replaceSrcScripts = (domNode: DOMNode): JSX.Element | undefined => {
     const src = domNode.attribs.src;
     if (!src) {
       return;
+    }
+    // Only append notebook-authored scripts when the page is a trusted
+    // context (the user has run a cell, the page is a trusted export, or
+    // we're running in read/app mode). In untrusted edit mode before any
+    // user interaction, silently drop the script. Outer sanitization will
+    // normally strip <script> tags already; this is defense-in-depth for
+    // flows that reparse children with alwaysSanitizeHtml: false (see
+    // registerReactComponent.getChildren).
+    if (!hasTrustedNotebookContext()) {
+      Logger.warn(
+        `[RenderHTML] refusing <script src> in untrusted context: ${src}`,
+      );
+      // oxlint-disable-next-line react/jsx-no-useless-fragment
+      return <></>;
     }
     // Check if script already exists
     if (!document.querySelector(`script[src="${src}"]`)) {

--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -103,10 +103,10 @@ const replaceSrcScripts = (domNode: DOMNode): JSX.Element | undefined => {
     // Only append notebook-authored scripts when the page is a trusted
     // context (the user has run a cell, the page is a trusted export, or
     // we're running in read/app mode). In untrusted edit mode before any
-    // user interaction, silently drop the script. Outer sanitization will
-    // normally strip <script> tags already; this is defense-in-depth for
-    // flows that reparse children with alwaysSanitizeHtml: false (see
-    // registerReactComponent.getChildren).
+    // user interaction, drop the script and log a warning. Outer
+    // sanitization will normally strip <script> tags already; this is
+    // defense-in-depth for flows that reparse children with
+    // alwaysSanitizeHtml: false (see registerReactComponent.getChildren).
     if (!hasTrustedNotebookContext()) {
       Logger.warn(
         `[RenderHTML] refusing <script src> in untrusted context: ${src}`,
@@ -114,8 +114,13 @@ const replaceSrcScripts = (domNode: DOMNode): JSX.Element | undefined => {
       // oxlint-disable-next-line react/jsx-no-useless-fragment
       return <></>;
     }
-    // Check if script already exists
-    if (!document.querySelector(`script[src="${src}"]`)) {
+    // Check if script already exists. Avoid building a CSS selector from
+    // notebook-provided input, which can throw for valid URLs containing
+    // selector-significant characters (e.g. IPv6 hosts with `[`/`]`).
+    const scriptExists = [...document.querySelectorAll("script[src]")].some(
+      (existingScript) => existingScript.getAttribute("src") === src,
+    );
+    if (!scriptExists) {
       const script = document.createElement("script");
       script.src = src;
       document.head.append(script);

--- a/frontend/src/plugins/core/__test__/RenderHTML.test.ts
+++ b/frontend/src/plugins/core/__test__/RenderHTML.test.ts
@@ -1,5 +1,11 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { describe, expect, test } from "vitest";
+import type { ExtractAtomValue } from "jotai";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { hasRunAnyCellAtom } from "@/components/editor/cell/useRunCells";
+import { userConfigAtom } from "@/core/config/config";
+import { parseUserConfig } from "@/core/config/config-schema";
+import { initialModeAtom } from "@/core/mode";
+import { store } from "@/core/state/jotai";
 import { visibleForTesting } from "../RenderHTML";
 
 const { parseHtml } = visibleForTesting;
@@ -194,6 +200,85 @@ describe("parseHtml", () => {
         </React.Fragment>
       </React.Fragment>
     `);
+  });
+});
+
+describe("replaceSrcScripts trust gate", () => {
+  let previousHasRunAnyCell: ExtractAtomValue<typeof hasRunAnyCellAtom>;
+  let previousConfig: ExtractAtomValue<typeof userConfigAtom>;
+  let previousMode: ExtractAtomValue<typeof initialModeAtom>;
+  const windowWithExport = window as Window & {
+    __MARIMO_EXPORT_CONTEXT__?: unknown;
+  };
+
+  function clearTrustSignals() {
+    const cleared = parseUserConfig({});
+    store.set(hasRunAnyCellAtom, false);
+    store.set(userConfigAtom, {
+      ...cleared,
+      runtime: { ...cleared.runtime, auto_instantiate: false },
+    });
+    store.set(initialModeAtom, "edit");
+    delete windowWithExport.__MARIMO_EXPORT_CONTEXT__;
+  }
+
+  beforeEach(() => {
+    previousHasRunAnyCell = store.get(hasRunAnyCellAtom);
+    previousConfig = store.get(userConfigAtom);
+    previousMode = store.get(initialModeAtom);
+    clearTrustSignals();
+    for (const s of document.head.querySelectorAll(
+      'script[src^="https://cdn.example.com/"]',
+    )) {
+      s.remove();
+    }
+  });
+
+  afterEach(() => {
+    store.set(hasRunAnyCellAtom, previousHasRunAnyCell);
+    store.set(userConfigAtom, previousConfig);
+    store.set(initialModeAtom, previousMode);
+    delete windowWithExport.__MARIMO_EXPORT_CONTEXT__;
+    for (const s of document.head.querySelectorAll(
+      'script[src^="https://cdn.example.com/"]',
+    )) {
+      s.remove();
+    }
+  });
+
+  test("drops <script src> in untrusted edit mode", () => {
+    parseHtml({
+      html: '<script src="https://cdn.example.com/unrun.js"></script>',
+    });
+    expect(
+      document.head.querySelector(
+        'script[src="https://cdn.example.com/unrun.js"]',
+      ),
+    ).toBeNull();
+  });
+
+  test("loads <script src> once a cell has been run", () => {
+    store.set(hasRunAnyCellAtom, true);
+    parseHtml({
+      html: '<script src="https://cdn.example.com/ok.js"></script>',
+    });
+    expect(
+      document.head.querySelector(
+        'script[src="https://cdn.example.com/ok.js"]',
+      ),
+    ).not.toBeNull();
+  });
+
+  test("loads <script src> when a trusted export context is installed", () => {
+    windowWithExport.__MARIMO_EXPORT_CONTEXT__ = { trusted: true };
+    parseHtml({
+      html: '<script src="https://cdn.example.com/export.js"></script>',
+    });
+    expect(
+      document.head.querySelector(
+        'script[src="https://cdn.example.com/export.js"]',
+      ),
+    ).not.toBeNull();
   });
 });
 

--- a/frontend/src/plugins/core/sanitize.ts
+++ b/frontend/src/plugins/core/sanitize.ts
@@ -3,22 +3,28 @@ import { atom, useAtomValue } from "jotai";
 import { hasRunAnyCellAtom } from "@/components/editor/cell/useRunCells";
 import { autoInstantiateAtom } from "@/core/config/config";
 import { getInitialAppMode } from "@/core/mode";
+import { hasTrustedExportContext } from "@/core/static/export-context";
 
 // Re-export so existing consumers don't break.
 export { sanitizeHtml } from "./sanitize-html";
 
 /**
- * Whether to sanitize the html.
- * When running as an app or with auto_instantiate enabled
- * we ignore sanitization because they should be treated as a website.
+ * Whether to sanitize the html. Trust signals match
+ * `hasTrustedNotebookContext` in `@/core/static/export-context`.
+ * Kept as a jotai atom so consumers re-render when `hasRunAnyCellAtom`
+ * flips after the user runs a cell.
  */
 const sanitizeHtmlAtom = atom<boolean>((get) => {
   const hasRunAnyCell = get(hasRunAnyCellAtom);
   const autoInstantiate = get(autoInstantiateAtom);
 
-  // If a user has specifically run at least one cell or auto_instantiate is enabled, we don't need to sanitize.
-  // HTML needs to be rich to allow for interactive widgets and other dynamic content.
   if (hasRunAnyCell || autoInstantiate) {
+    return false;
+  }
+
+  // Trusted export context is installed once at page load by a first-party
+  // script (frozen + non-configurable), so a direct read is safe and stable.
+  if (hasTrustedExportContext()) {
     return false;
   }
 

--- a/frontend/src/plugins/core/trusted-url.ts
+++ b/frontend/src/plugins/core/trusted-url.ts
@@ -37,6 +37,15 @@ export function isTrustedVirtualFileUrl(url: unknown): url is string {
   return false;
 }
 
+/**
+ * Intentionally narrower than `hasTrustedNotebookContext` in
+ * `@/core/static/export-context`: `auto_instantiate` and `read` mode are
+ * deliberately excluded here. Both can be triggered by DOM-observable page
+ * shape, and accepting inline base64 `data:` JS/CSS payloads on their
+ * strength would let a hostile notebook page smuggle attacker-controlled
+ * script into the same origin. Keep this gate tied only to "user actively
+ * ran a cell" or "first-party exporter installed a trusted runtime marker".
+ */
 function hasNotebookTrustedDataUrlContext(): boolean {
   return store.get(hasRunAnyCellAtom) || hasTrustedExportContext();
 }

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -66,6 +66,28 @@ def _export_context_block(*, notebook_code: str) -> str:
     )
 
 
+def _static_state_block(
+    *, files: dict[str, str], model_notifications: list[Any]
+) -> str:
+    """Emit the static-export virtual file table as a frozen, non-configurable
+    global. Locking the shape prevents notebook-authored content from
+    redirecting `@file/...` fetches by mutating the map after emission."""
+    return dedent(
+        f"""
+    <script data-marimo="true">
+        Object.defineProperty(window, "__MARIMO_STATIC__", {{
+            value: Object.freeze({{
+                files: Object.freeze({json_script(files)}),
+                modelNotifications: Object.freeze({json_script(model_notifications)}),
+            }}),
+            writable: false,
+            configurable: false,
+        }});
+    </script>
+    """
+    )
+
+
 def _get_mount_config(
     *,
     filename: str | None,
@@ -407,14 +429,11 @@ def static_notebook_template(
         ),
     )
 
-    static_block = dedent(
-        f"""
-    <script data-marimo="true">
-        window.__MARIMO_STATIC__ = {{}};
-        window.__MARIMO_STATIC__.files = {json_script(files)};
-        window.__MARIMO_STATIC__.modelNotifications = {json_script([n.to_json_serializable() for n in model_notifications or []])};
-    </script>
-    """
+    static_block = _static_state_block(
+        files=files,
+        model_notifications=[
+            n.to_json_serializable() for n in model_notifications or []
+        ],
     )
     static_block += _export_context_block(notebook_code=code)
 

--- a/tests/_server/templates/data/index.html
+++ b/tests/_server/templates/data/index.html
@@ -72,7 +72,11 @@
     <!-- This is a portal for the data editor to render in -->
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = '{{ mount_config }}';
+      Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
+        value: Object.freeze('{{ mount_config }}'),
+        writable: false,
+        configurable: false,
+      });
     </script>
   </body>
 </html>

--- a/tests/_server/templates/snapshots/export1.txt
+++ b/tests/_server/templates/snapshots/export1.txt
@@ -68,9 +68,14 @@
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
   
 <script data-marimo="true">
-    window.__MARIMO_STATIC__ = {};
-    window.__MARIMO_STATIC__.files = {"file1": "File 1 content", "file2": "File 2 content"};
-    window.__MARIMO_STATIC__.modelNotifications = [];
+    Object.defineProperty(window, "__MARIMO_STATIC__", {
+        value: Object.freeze({
+            files: Object.freeze({"file1": "File 1 content", "file2": "File 2 content"}),
+            modelNotifications: Object.freeze([]),
+        }),
+        writable: false,
+        configurable: false,
+    });
 </script>
 
 <script data-marimo="true">
@@ -89,7 +94,8 @@
     <!-- This is a portal for the data editor to render in -->
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = {
+      Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
+        value: Object.freeze({
             "filename": "notebook.py",
             "cwd": "",
             "lspWorkspace": null,
@@ -103,7 +109,10 @@
             "notebook": {"cells": [{"code": "print('Hello, Cell 1')", "code_hash": "6eea77c855e5bfd73f3d851f474ed789", "config": {}, "id": "cell1", "name": "Cell 1"}, {"code": "print('Hello, Cell 2')", "code_hash": "0dce0226aecd5db222f6a3aa3223214b", "config": {}, "id": "cell2", "name": "Cell 2"}], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "session": {"cells": [{"code_hash": "abc123", "console": [{"name": "stdout", "text": "Hello, Cell 1", "type": "stream"}, {"name": "stderr", "text": "Error in Cell 1", "type": "stream"}], "id": "cell1", "outputs": [{"data": {"text/plain": "Hello, Cell 1"}, "type": "data"}]}, {"code_hash": "def456", "console": [], "id": "cell2", "outputs": []}], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "runtimeConfig": null,
-        };
+        }),
+        writable: false,
+        configurable: false,
+      });
     </script>
   
 <marimo-code hidden="">

--- a/tests/_server/templates/snapshots/export2.txt
+++ b/tests/_server/templates/snapshots/export2.txt
@@ -68,9 +68,14 @@
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
   
 <script data-marimo="true">
-    window.__MARIMO_STATIC__ = {};
-    window.__MARIMO_STATIC__.files = {"file1": "File 1 content", "file2": "File 2 content"};
-    window.__MARIMO_STATIC__.modelNotifications = [];
+    Object.defineProperty(window, "__MARIMO_STATIC__", {
+        value: Object.freeze({
+            files: Object.freeze({"file1": "File 1 content", "file2": "File 2 content"}),
+            modelNotifications: Object.freeze([]),
+        }),
+        writable: false,
+        configurable: false,
+    });
 </script>
 
 <script data-marimo="true">
@@ -89,7 +94,8 @@
     <!-- This is a portal for the data editor to render in -->
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = {
+      Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
+        value: Object.freeze({
             "filename": "",
             "cwd": "",
             "lspWorkspace": null,
@@ -103,7 +109,10 @@
             "notebook": {"cells": [{"code": "print('Hello, Cell 1')", "code_hash": "6eea77c855e5bfd73f3d851f474ed789", "config": {}, "id": "cell1", "name": "Cell 1"}, {"code": "print('Hello, Cell 2')", "code_hash": "0dce0226aecd5db222f6a3aa3223214b", "config": {}, "id": "cell2", "name": "Cell 2"}], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "session": {"cells": [{"code_hash": "abc123", "console": [{"name": "stdout", "text": "Hello, Cell 1", "type": "stream"}, {"name": "stderr", "text": "Error in Cell 1", "type": "stream"}], "id": "cell1", "outputs": [{"data": {"text/plain": "Hello, Cell 1"}, "type": "data"}]}, {"code_hash": "def456", "console": [], "id": "cell2", "outputs": []}], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "runtimeConfig": null,
-        };
+        }),
+        writable: false,
+        configurable: false,
+      });
     </script>
   
 <marimo-code hidden="">

--- a/tests/_server/templates/snapshots/export3.txt
+++ b/tests/_server/templates/snapshots/export3.txt
@@ -68,9 +68,14 @@
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
   
 <script data-marimo="true">
-    window.__MARIMO_STATIC__ = {};
-    window.__MARIMO_STATIC__.files = {};
-    window.__MARIMO_STATIC__.modelNotifications = [];
+    Object.defineProperty(window, "__MARIMO_STATIC__", {
+        value: Object.freeze({
+            files: Object.freeze({}),
+            modelNotifications: Object.freeze([]),
+        }),
+        writable: false,
+        configurable: false,
+    });
 </script>
 
 <script data-marimo="true">
@@ -89,7 +94,8 @@
     <!-- This is a portal for the data editor to render in -->
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = {
+      Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
+        value: Object.freeze({
             "filename": "notebook.py",
             "cwd": "",
             "lspWorkspace": null,
@@ -103,7 +109,10 @@
             "notebook": {"cells": [], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "session": {"cells": [], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "runtimeConfig": null,
-        };
+        }),
+        writable: false,
+        configurable: false,
+      });
     </script>
   <marimo-code hidden=""></marimo-code>
 <marimo-code-hash hidden="">07da107bb575cc4e02b0e1d6d99cc204</marimo-code-hash>

--- a/tests/_server/templates/snapshots/export4.txt
+++ b/tests/_server/templates/snapshots/export4.txt
@@ -68,9 +68,14 @@
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
   
 <script data-marimo="true">
-    window.__MARIMO_STATIC__ = {};
-    window.__MARIMO_STATIC__.files = {};
-    window.__MARIMO_STATIC__.modelNotifications = [];
+    Object.defineProperty(window, "__MARIMO_STATIC__", {
+        value: Object.freeze({
+            files: Object.freeze({}),
+            modelNotifications: Object.freeze([]),
+        }),
+        writable: false,
+        configurable: false,
+    });
 </script>
 
 <script data-marimo="true">
@@ -89,7 +94,8 @@
     <!-- This is a portal for the data editor to render in -->
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = {
+      Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
+        value: Object.freeze({
             "filename": "notebook.py",
             "cwd": "",
             "lspWorkspace": null,
@@ -103,7 +109,10 @@
             "notebook": {"cells": [], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "session": {"cells": [], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "runtimeConfig": null,
-        };
+        }),
+        writable: false,
+        configurable: false,
+      });
     </script>
   <marimo-code hidden=""></marimo-code>
 <marimo-code-hash hidden="">07da107bb575cc4e02b0e1d6d99cc204</marimo-code-hash>

--- a/tests/_server/templates/snapshots/export5.txt
+++ b/tests/_server/templates/snapshots/export5.txt
@@ -68,9 +68,14 @@
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
   
 <script data-marimo="true">
-    window.__MARIMO_STATIC__ = {};
-    window.__MARIMO_STATIC__.files = {};
-    window.__MARIMO_STATIC__.modelNotifications = [];
+    Object.defineProperty(window, "__MARIMO_STATIC__", {
+        value: Object.freeze({
+            files: Object.freeze({}),
+            modelNotifications: Object.freeze([]),
+        }),
+        writable: false,
+        configurable: false,
+    });
 </script>
 
 <script data-marimo="true">
@@ -101,7 +106,8 @@
     <!-- This is a portal for the data editor to render in -->
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = {
+      Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
+        value: Object.freeze({
             "filename": "notebook.py",
             "cwd": "",
             "lspWorkspace": null,
@@ -115,7 +121,10 @@
             "notebook": {"cells": [], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "session": {"cells": [], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "runtimeConfig": null,
-        };
+        }),
+        writable: false,
+        configurable: false,
+      });
     </script>
   <marimo-code hidden=""></marimo-code>
 <marimo-code-hash hidden="">07da107bb575cc4e02b0e1d6d99cc204</marimo-code-hash>

--- a/tests/_server/templates/snapshots/export6.txt
+++ b/tests/_server/templates/snapshots/export6.txt
@@ -68,9 +68,14 @@
     <link rel="stylesheet" crossorigin crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@marimo-team/frontend@0.0.0/dist/assets/index.css"">
   
 <script data-marimo="true">
-    window.__MARIMO_STATIC__ = {};
-    window.__MARIMO_STATIC__.files = {};
-    window.__MARIMO_STATIC__.modelNotifications = [];
+    Object.defineProperty(window, "__MARIMO_STATIC__", {
+        value: Object.freeze({
+            files: Object.freeze({}),
+            modelNotifications: Object.freeze([]),
+        }),
+        writable: false,
+        configurable: false,
+    });
 </script>
 
 <script data-marimo="true">
@@ -90,7 +95,8 @@
     <!-- This is a portal for the data editor to render in -->
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
-      window.__MARIMO_MOUNT_CONFIG__ = {
+      Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
+        value: Object.freeze({
             "filename": "notebook.py",
             "cwd": "",
             "lspWorkspace": null,
@@ -104,7 +110,10 @@
             "notebook": {"cells": [], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "session": {"cells": [], "metadata": {"marimo_version": "0.0.0"}, "version": "1"},
             "runtimeConfig": null,
-        };
+        }),
+        writable: false,
+        configurable: false,
+      });
     </script>
   <marimo-code hidden=""></marimo-code>
 <marimo-code-hash hidden="">07da107bb575cc4e02b0e1d6d99cc204</marimo-code-hash>


### PR DESCRIPTION
Follow-up to #9318. Extends the frozen first-party marker pattern to
`__MARIMO_STATIC__` (backs the virtual-file allowlist) and
`__MARIMO_MOUNT_CONFIG__`, and adds a shared `hasTrustedNotebookContext()`
predicate so `RenderHTML.replaceSrcScripts` refuses notebook-authored
`<script src>` in untrusted edit mode before any user interaction.
