### PR TITLE
docs: specify html is only in app mode

### DIFF
--- a/docs/guides/configuration/html_head.md
+++ b/docs/guides/configuration/html_head.md
@@ -4,7 +4,7 @@ You can include a custom HTML head file to add additional functionality to your 
 
 !!! note "App mode only"
 
-    Custom HTML head content is only injected in **app mode** (`marimo run`). It is not applied in edit mode. If you need custom styling in edit mode, use [`css_file`](theming.md) instead since CSS works in both modes.
+    Custom HTML head content is only injected in **app mode** (`marimo run`). It is not applied in edit mode. If you need custom styling in edit mode use [`css_file`](theming.md).
 
 To include a custom HTML head file, specify the relative file path in your app configuration. This can be done through the marimo editor UI in the notebook settings (top-right corner).
 

--- a/docs/guides/configuration/html_head.md
+++ b/docs/guides/configuration/html_head.md
@@ -2,6 +2,10 @@
 
 You can include a custom HTML head file to add additional functionality to your notebook, such as analytics, custom fonts, meta tags, or external scripts. The contents of this file will be injected into the `<head>` section of your notebook.
 
+!!! note "App mode only"
+
+    Custom HTML head content is only injected in **app mode** (`marimo run`). It is not applied in edit mode. If you need custom styling in edit mode, use [`css_file`](theming.md) instead since CSS works in both modes.
+
 To include a custom HTML head file, specify the relative file path in your app configuration. This can be done through the marimo editor UI in the notebook settings (top-right corner).
 
 This will be reflected in your notebook file:

--- a/docs/guides/configuration/html_head.md
+++ b/docs/guides/configuration/html_head.md
@@ -2,9 +2,9 @@
 
 You can include a custom HTML head file to add additional functionality to your notebook, such as analytics, custom fonts, meta tags, or external scripts. The contents of this file will be injected into the `<head>` section of your notebook.
 
-!!! note "App mode only"
+!!! note "Run mode only"
 
-    Custom HTML head content is only injected in **app mode** (`marimo run`). It is not applied in edit mode. If you need custom styling in edit mode use [`css_file`](theming.md).
+    Custom HTML head content is only injected in **run mode** (`marimo run`). It is not applied in edit mode. If you need custom styling in edit mode, use [`css_file`](theming.md).
 
 To include a custom HTML head file, specify the relative file path in your app configuration. This can be done through the marimo editor UI in the notebook settings (top-right corner).
 


### PR DESCRIPTION
## 📝 Summary

related #9298

In #9137 and part of our security sprint we disabled `html_head` in edit mode as we determined it violated our policy of **no unapproved python or javascript should run without explicit user approval**.

This PR clarifies that `html_head` (at the moment) is only supported in run mode since our current docs do not make this distinction.