### PR TITLE
fix: update CsvViewer layout to use flex column.

### DIFF
--- a/frontend/src/components/editor/file-tree/renderers.tsx
+++ b/frontend/src/components/editor/file-tree/renderers.tsx
@@ -88,7 +88,7 @@ export const CsvViewer: React.FC<{ contents: string }> = ({ contents }) => {
       setPaginationState={setPagination}
       wrapperClassName="h-full justify-between pb-1 px-1"
       pagination={true}
-      className="rounded-none border-b flex overflow-hidden"
+      className="rounded-none border-b flex flex-col overflow-hidden"
       rowSelection={Objects.EMPTY}
     />
   );


### PR DESCRIPTION
Flex (default to flex row) doesn't show the contents.

## 📝 Summary

Change flex to flex-col so table shows even when sidebar is small.

Closes #9335

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [X] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
