### PR TITLE
Restore LICENSE in sdist via PEP 639 license-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
 ]
 readme = "README.md"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Operating System :: OS Independent",


### PR DESCRIPTION
Fixes #9339

#9231 moved to the SPDX `license = "Apache-2.0"` expression but didn't add `license-files`, and uv_build doesn't glob `LICENSE*` by default, so the 0.23.2 sdist shipped without one.
