### PR TITLE
fix: add `_MARIMO_DISABLE_AUTH_ON_VIRTUAL_FILES` env flag

### DIFF
--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -21,6 +21,12 @@ class GlobalSettings:
     IN_SECURE_ENVIRONMENT: bool = os.getenv(
         "MARIMO_IN_SECURE_ENVIRONMENT", "false"
     ) in ("true", "1")
+    # Disable authentication on the virtual file endpoint (`/@file/...`).
+    # Useful in sandboxed/embedded deployments where virtual file URLs need
+    # to be fetched in trusted contexts. Default "false", meaning auth is required.
+    DISABLE_AUTH_ON_VIRTUAL_FILES: bool = os.getenv(
+        "_MARIMO_DISABLE_AUTH_ON_VIRTUAL_FILES", "false"
+    ) in ("true", "1")
 
 
 GLOBAL_SETTINGS = GlobalSettings()

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -22,6 +22,7 @@ from marimo import _loggers
 from marimo._cli.sandbox import SandboxMode
 from marimo._config.manager import get_default_config_manager
 from marimo._config.reader import find_nearest_pyproject_toml
+from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._output.utils import uri_decode_component, uri_encode_component
 from marimo._runtime.virtual_file import (
     EMPTY_VIRTUAL_FILE,
@@ -485,7 +486,6 @@ STATIC_FILES = [
 
 
 @router.get("/@file/{filename_and_length:path}")
-@requires("read")
 def virtual_file(
     request: Request,
 ) -> Response:
@@ -509,6 +509,14 @@ def virtual_file(
         404:
             description: Invalid byte length in virtual file request
     """
+    # Auth is normally required via `@requires("read")`, but can be bypassed
+    # with the `_MARIMO_DISABLE_AUTH_ON_VIRTUAL_FILES` env var for
+    # sandboxed/embedded deployments where virtual file URLs must be
+    # fetched without session auth.
+    if not GLOBAL_SETTINGS.DISABLE_AUTH_ON_VIRTUAL_FILES:
+        if not has_required_scope(request, ["read"]):
+            raise HTTPException(status_code=403)
+
     filename_and_length = request.path_params["filename_and_length"]
 
     LOGGER.debug("Getting virtual file: %s", filename_and_length)

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -240,6 +240,40 @@ def test_vfile(client: TestClient) -> None:
     assert response.json() == {"detail": "Invalid virtual file request"}
 
 
+@patch(
+    "marimo._server.api.endpoints.assets.GLOBAL_SETTINGS.DISABLE_AUTH_ON_VIRTUAL_FILES",
+    True,
+)
+def test_vfile_auth_disabled_allows_unauthenticated(
+    client: TestClient,
+) -> None:
+    # Unauthenticated requests normally return 401, but the env flag
+    # lets them through.
+    response = client.get("/@file/empty.txt")
+    assert response.status_code == 200, response.text
+    assert response.content == b""
+
+    response = client.get("/@file/bad.txt")
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": "Invalid virtual file request"}
+
+
+@patch(
+    "marimo._server.api.endpoints.assets.GLOBAL_SETTINGS.DISABLE_AUTH_ON_VIRTUAL_FILES",
+    False,
+)
+def test_vfile_auth_enabled_rejects_unauthenticated(
+    client: TestClient,
+) -> None:
+    # With the flag off (the default), unauthenticated requests are rejected.
+    response = client.get("/@file/empty.txt")
+    assert response.status_code == 401, response.text
+
+    # Authenticated requests still work.
+    response = client.get("/@file/empty.txt", headers=token_header())
+    assert response.status_code == 200, response.text
+
+
 def test_vfile_large_streaming(client: TestClient) -> None:
     """Regression test: large virtual files must stream without
     Content-Length mismatch (h11 LocalProtocolError).

--- a/tests/_server/api/endpoints/test_requires_decorator.py
+++ b/tests/_server/api/endpoints/test_requires_decorator.py
@@ -18,6 +18,10 @@ EXEMPT_ENDPOINTS: set[tuple[str, str]] = {
     # `/` does its own scope check so it can emit a relative Location on
     # unauthenticated redirects (see #9249).
     ("assets.py", "/"),
+    # Virtual files do their own scope check so the check can be bypassed
+    # via `_MARIMO_DISABLE_AUTH_ON_VIRTUAL_FILES` for sandboxed/embedded
+    # deployments.
+    ("assets.py", "/@file/{filename_and_length:path}"),
 }
 
 ENDPOINTS_DIR = Path(__file__).resolve().parents[4] / (


### PR DESCRIPTION
Allows sandboxed/embedded deployments to serve `/@file/...` without
session auth by setting `_MARIMO_DISABLE_AUTH_ON_VIRTUAL_FILES=true`.
Default is off, so existing deployments remain fully authenticated.
