### PR TITLE
fix: fix file deletion race in file watcher

### DIFF
--- a/marimo/_utils/file_watcher.py
+++ b/marimo/_utils/file_watcher.py
@@ -109,9 +109,10 @@ class PollingFileWatcher(FileWatcher):
             self._missing_count = 0
 
             # Check for file changes. Note: the file may be removed between
-            # the exists() check above and getmtime() here (common on Windows,
-            # where deletion is asynchronous). In that case getmtime returns
-            # None; skip this cycle so we don't fire a spurious callback.
+            # the exists() check above and the _get_modified() call here
+            # (common on Windows, where deletion is asynchronous). In that
+            # case _get_modified() returns None; skip this cycle so we don't
+            # fire a spurious callback.
             modified = self._get_modified()
             if modified is not None:
                 if self.last_modified is None:

--- a/marimo/_utils/file_watcher.py
+++ b/marimo/_utils/file_watcher.py
@@ -108,13 +108,17 @@ class PollingFileWatcher(FileWatcher):
             # File exists again; reset the missing counter
             self._missing_count = 0
 
-            # Check for file changes
+            # Check for file changes. Note: the file may be removed between
+            # the exists() check above and getmtime() here (common on Windows,
+            # where deletion is asynchronous). In that case getmtime returns
+            # None; skip this cycle so we don't fire a spurious callback.
             modified = self._get_modified()
-            if self.last_modified is None:
-                self.last_modified = modified
-            elif modified != self.last_modified:
-                self.last_modified = modified
-                await self.on_file_changed()
+            if modified is not None:
+                if self.last_modified is None:
+                    self.last_modified = modified
+                elif modified != self.last_modified:
+                    self.last_modified = modified
+                    await self.on_file_changed()
             await asyncio.sleep(self.POLL_SECONDS)
 
 


### PR DESCRIPTION
This fixes a race condition in the file watcher in which the file was deleted after an existence check.