### PR TITLE
fix: deflake file watcher function reload detection

### DIFF
--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -82,8 +82,12 @@ async def test_reload_function(
     while retries < 10:
         await asyncio.sleep(INTERVAL)
         retries += 1
-        if k.graph.cells[er_1.cell_id].stale:
+        if (
+            k.graph.cells[er_1.cell_id].stale
+            and k.graph.cells[er_2.cell_id].stale
+        ):
             break
+
     assert k.graph.cells[er_1.cell_id].stale
     assert k.graph.cells[er_2.cell_id].stale
     assert not k.graph.cells[er_3.cell_id].stale

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -39,6 +39,7 @@ def _setup_test_sleep():
 
 # these tests use random filenames for modules because they share
 # the same sys.modules object, and each test needs fresh modules
+@pytest.mark.flaky(reruns=3)
 async def test_reload_function(
     tmp_path: pathlib.Path,
     py_modname: str,
@@ -77,7 +78,12 @@ async def test_reload_function(
     )
 
     # wait for the watcher to pick up the change
-    await asyncio.sleep(INTERVAL * 3)
+    retries = 0
+    while retries < 10:
+        await asyncio.sleep(INTERVAL)
+        retries += 1
+        if k.graph.cells[er_1.cell_id].stale:
+            break
     assert k.graph.cells[er_1.cell_id].stale
     assert k.graph.cells[er_2.cell_id].stale
     assert not k.graph.cells[er_3.cell_id].stale


### PR DESCRIPTION
Poll with max retries in a flaky test that depends on detecting filesystem modification.