### PR TITLE
feat: editable filter pills

### DIFF
--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -22,7 +22,10 @@ import React, { memo } from "react";
 import { useLocale } from "react-aria";
 
 import { Table } from "@/components/ui/table";
-import type { GetRowIds } from "@/plugins/impl/DataTablePlugin";
+import type {
+  CalculateTopKRows,
+  GetRowIds,
+} from "@/plugins/impl/DataTablePlugin";
 import { cn } from "@/utils/cn";
 import {
   PANEL_TYPES,
@@ -89,6 +92,7 @@ interface DataTableProps<TData> extends Partial<ExportActionProps> {
   showFilters?: boolean;
   filters?: ColumnFiltersState;
   onFiltersChange?: OnChangeFn<ColumnFiltersState>;
+  calculateTopKRows?: CalculateTopKRows;
   reloading?: boolean;
   // Columns
   freezeColumnsLeft?: string[];
@@ -139,6 +143,7 @@ const DataTableInternal = <TData,>({
   showFilters = false,
   filters,
   onFiltersChange,
+  calculateTopKRows,
   reloading,
   freezeColumnsLeft,
   freezeColumnsRight,
@@ -282,7 +287,11 @@ const DataTableInternal = <TData,>({
 
   return (
     <div className={cn(wrapperClassName, "flex flex-col space-y-1")}>
-      <FilterPills filters={filters} table={table} />
+      <FilterPills
+        filters={filters}
+        table={table}
+        calculateTopKRows={calculateTopKRows}
+      />
       <CellSelectionProvider>
         <div
           part="table-wrapper"

--- a/frontend/src/components/data-table/filter-by-values-picker.tsx
+++ b/frontend/src/components/data-table/filter-by-values-picker.tsx
@@ -1,0 +1,225 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+"use no memo";
+
+import type { Column } from "@tanstack/react-table";
+import { ChevronDownIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useAsyncData } from "@/hooks/useAsyncData";
+import { ErrorBanner } from "@/plugins/impl/common/error-banner";
+import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
+import { cn } from "@/utils/cn";
+import { Logger } from "@/utils/Logger";
+import { Spinner } from "../icons/spinner";
+import { Button } from "../ui/button";
+import { Checkbox } from "../ui/checkbox";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "../ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { SentinelCell } from "./sentinel-cell";
+import { detectSentinel, stringifyUnknownValue } from "./utils";
+
+const TOP_K_ROWS = 30;
+
+interface Props<TData, TValue> {
+  column: Column<TData, TValue>;
+  calculateTopKRows?: CalculateTopKRows;
+  chosenValues: unknown[];
+  onChange: (values: unknown[]) => void;
+}
+
+export const FilterByValuesPicker = <TData, TValue>({
+  column,
+  calculateTopKRows,
+  chosenValues,
+  onChange,
+}: Props<TData, TValue>) => {
+  const [open, setOpen] = useState(false);
+
+  const chosenValuesSet = useMemo(
+    () => new Set(chosenValues),
+    [chosenValues],
+  );
+
+  const selectedValuesStr = useMemo(() => {
+    if (chosenValuesSet.size === 0) {
+      return "Select values…";
+    }
+    const items = [...chosenValuesSet].map((v) =>
+      stringifyUnknownValue({ value: v }),
+    );
+    return `[${items.join(", ")}]`;
+  }, [chosenValuesSet]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild={true}>
+        <Button
+          variant="outline"
+          size="xs"
+          className="h-6 mb-1 w-full justify-between font-normal"
+        >
+          <span
+            className={cn(
+              "truncate",
+              chosenValuesSet.size === 0 && "text-muted-foreground",
+            )}
+          >
+            {selectedValuesStr}
+          </span>
+          <ChevronDownIcon className="h-4 w-4 opacity-50 shrink-0" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0">
+        <PickerBody
+          column={column}
+          calculateTopKRows={calculateTopKRows}
+          chosenValues={chosenValuesSet}
+          onChange={onChange}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+interface PickerBodyProps<TData, TValue> {
+  column: Column<TData, TValue>;
+  calculateTopKRows?: CalculateTopKRows;
+  chosenValues: Set<unknown>;
+  onChange: (values: unknown[]) => void;
+}
+
+const PickerBody = <TData, TValue>({
+  column,
+  calculateTopKRows,
+  chosenValues,
+  onChange,
+}: PickerBodyProps<TData, TValue>) => {
+  const [query, setQuery] = useState<string>("");
+
+  const { data, isPending, error } = useAsyncData(async () => {
+    if (!calculateTopKRows) {
+      return null;
+    }
+    const res = await calculateTopKRows({ column: column.id, k: TOP_K_ROWS });
+    return res.data;
+  }, []);
+
+  const filteredData = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    try {
+      return data.filter(([value, _count]) =>
+        value === undefined
+          ? false
+          : String(value).toLowerCase().includes(query.toLowerCase()),
+      );
+    } catch (error_) {
+      Logger.error("Error filtering data", error_);
+      return [];
+    }
+  }, [data, query]);
+
+  const handleToggle = (value: unknown) => {
+    const next = new Set(chosenValues);
+    if (next.has(value)) {
+      next.delete(value);
+    } else {
+      next.add(value);
+    }
+    onChange([...next]);
+  };
+
+  const allChecked = chosenValues.size === filteredData.length;
+
+  const handleToggleAll = () => {
+    if (!data) {
+      return;
+    }
+    onChange(allChecked ? [] : filteredData.map(([value]) => value));
+  };
+
+  if (isPending) {
+    return <Spinner size="medium" className="mx-auto mt-12 mb-10" />;
+  }
+
+  if (error) {
+    return <ErrorBanner error={error} className="my-10 mx-4" />;
+  }
+
+  if (!data) {
+    return (
+      <div className="py-6 px-4 text-sm text-muted-foreground text-center">
+        No values available
+      </div>
+    );
+  }
+
+  return (
+    <Command className="text-sm outline-hidden" shouldFilter={false}>
+      <CommandInput
+        placeholder={`Search among the top ${data.length} values`}
+        autoFocus={true}
+        onValueChange={(value) => setQuery(value.trim())}
+      />
+      <CommandEmpty>No results found.</CommandEmpty>
+      <CommandList>
+        {filteredData.length > 0 && (
+          <CommandItem
+            value="__select-all__"
+            className="border-b rounded-none px-3"
+            onSelect={handleToggleAll}
+          >
+            <Checkbox
+              checked={allChecked}
+              aria-label="Select all"
+              className="mr-3 h-3.5 w-3.5"
+            />
+            <span className="font-bold flex-1">{column.id}</span>
+            <span className="font-bold">Count</span>
+          </CommandItem>
+        )}
+        {filteredData.map(([value, count], rowIndex) => {
+          const isSelected = chosenValues.has(value);
+          const valueString = stringifyUnknownValue({ value });
+          const sentinel = detectSentinel(
+            value,
+            column.columnDef.meta?.dataType,
+          );
+          return (
+            <CommandItem
+              key={rowIndex}
+              value={valueString}
+              className="not-last:border-b rounded-none px-3"
+              onSelect={() => handleToggle(value)}
+            >
+              <Checkbox
+                checked={isSelected}
+                aria-label="Select row"
+                className="mr-3 h-3.5 w-3.5"
+              />
+              <span className="flex-1 overflow-hidden max-h-20 line-clamp-3">
+                {sentinel ? (
+                  <SentinelCell sentinel={sentinel} />
+                ) : (
+                  valueString
+                )}
+              </span>
+              <span className="ml-3">{count}</span>
+            </CommandItem>
+          );
+        })}
+      </CommandList>
+      {filteredData.length === TOP_K_ROWS && (
+        <span className="text-xs text-muted-foreground py-1.5 text-center">
+          Only showing the top {TOP_K_ROWS} values
+        </span>
+      )}
+    </Command>
+  );
+};

--- a/frontend/src/components/data-table/filter-by-values-picker.tsx
+++ b/frontend/src/components/data-table/filter-by-values-picker.tsx
@@ -9,6 +9,8 @@ import { ErrorBanner } from "@/plugins/impl/common/error-banner";
 import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
 import { cn } from "@/utils/cn";
 import { Logger } from "@/utils/Logger";
+import { Sets } from "@/utils/sets";
+import { smartMatch } from "@/utils/smartMatch";
 import { Spinner } from "../icons/spinner";
 import { Button } from "../ui/button";
 import { Checkbox } from "../ui/checkbox";
@@ -104,18 +106,24 @@ const PickerBody = <TData, TValue>({
     }
     const res = await calculateTopKRows({ column: column.id, k: TOP_K_ROWS });
     return res.data;
-  }, []);
+  }, [calculateTopKRows, column.id]);
 
   const filteredData = useMemo(() => {
     if (!data) {
       return [];
     }
     try {
-      return data.filter(([value, _count]) =>
-        value === undefined
-          ? false
-          : String(value).toLowerCase().includes(query.toLowerCase()),
-      );
+      // try to do includes and also smart match for prefixes
+      return data.filter(([value, _count]) => {
+        if (value === undefined) {
+          return false;
+        }
+        const str = String(value);
+        return (
+          smartMatch(query, str) ||
+          str.toLowerCase().includes(query.toLowerCase())
+        );
+      });
     } catch (error_) {
       Logger.error("Error filtering data", error_);
       return [];
@@ -123,22 +131,34 @@ const PickerBody = <TData, TValue>({
   }, [data, query]);
 
   const handleToggle = (value: unknown) => {
-    const next = new Set(chosenValues);
-    if (next.has(value)) {
-      next.delete(value);
-    } else {
-      next.add(value);
-    }
-    onChange([...next]);
+    onChange([...Sets.toggle(chosenValues, value)]);
   };
 
-  const allChecked = chosenValues.size === filteredData.length;
+  const allVisibleChecked =
+    filteredData.length > 0 &&
+    filteredData.every(([value]) => chosenValues.has(value));
+
+  const selectAllState: boolean | "indeterminate" = allVisibleChecked
+    ? true
+    : chosenValues.size > 0
+      ? "indeterminate"
+      : false;
 
   const handleToggleAll = () => {
     if (!data) {
       return;
     }
-    onChange(allChecked ? [] : filteredData.map(([value]) => value));
+    const next = new Set(chosenValues);
+    if (allVisibleChecked) {
+      for (const [value] of filteredData) {
+        next.delete(value);
+      }
+    } else {
+      for (const [value] of filteredData) {
+        next.add(value);
+      }
+    }
+    onChange([...next]);
   };
 
   if (isPending) {
@@ -173,7 +193,7 @@ const PickerBody = <TData, TValue>({
             onSelect={handleToggleAll}
           >
             <Checkbox
-              checked={allChecked}
+              checked={selectAllState}
               aria-label="Select all"
               className="mr-3 h-3.5 w-3.5"
             />
@@ -181,7 +201,7 @@ const PickerBody = <TData, TValue>({
             <span className="font-bold">Count</span>
           </CommandItem>
         )}
-        {filteredData.map(([value, count], rowIndex) => {
+        {filteredData.map(([value, count]) => {
           const isSelected = chosenValues.has(value);
           const valueString = stringifyUnknownValue({ value });
           const sentinel = detectSentinel(
@@ -190,7 +210,7 @@ const PickerBody = <TData, TValue>({
           );
           return (
             <CommandItem
-              key={rowIndex}
+              key={valueString}
               value={valueString}
               className="not-last:border-b rounded-none px-3"
               onSelect={() => handleToggle(value)}
@@ -208,7 +228,7 @@ const PickerBody = <TData, TValue>({
           );
         })}
       </CommandList>
-      {filteredData.length === TOP_K_ROWS && (
+      {data.length === TOP_K_ROWS && (
         <span className="text-xs text-muted-foreground py-1.5 text-center">
           Only showing the top {TOP_K_ROWS} values
         </span>

--- a/frontend/src/components/data-table/filter-by-values-picker.tsx
+++ b/frontend/src/components/data-table/filter-by-values-picker.tsx
@@ -40,10 +40,7 @@ export const FilterByValuesPicker = <TData, TValue>({
 }: Props<TData, TValue>) => {
   const [open, setOpen] = useState(false);
 
-  const chosenValuesSet = useMemo(
-    () => new Set(chosenValues),
-    [chosenValues],
-  );
+  const chosenValuesSet = useMemo(() => new Set(chosenValues), [chosenValues]);
 
   const selectedValuesStr = useMemo(() => {
     if (chosenValuesSet.size === 0) {
@@ -204,11 +201,7 @@ const PickerBody = <TData, TValue>({
                 className="mr-3 h-3.5 w-3.5"
               />
               <span className="flex-1 overflow-hidden max-h-20 line-clamp-3">
-                {sentinel ? (
-                  <SentinelCell sentinel={sentinel} />
-                ) : (
-                  valueString
-                )}
+                {sentinel ? <SentinelCell sentinel={sentinel} /> : valueString}
               </span>
               <span className="ml-3">{count}</span>
             </CommandItem>

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -5,7 +5,6 @@ import type { Column, Table } from "@tanstack/react-table";
 import { CheckIcon, MinusIcon, Trash2Icon, XIcon } from "lucide-react";
 import { useId, useState } from "react";
 import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
-import type { OperatorType } from "@/plugins/impl/data-frames/utils/operators";
 import { Combobox, ComboboxItem } from "../ui/combobox";
 import { Input } from "../ui/input";
 import { NumberField } from "../ui/number-field";
@@ -419,7 +418,7 @@ function buildFilterValue({
   draft: DraftValue;
 }): ColumnFilterValue | undefined {
   if (operator === "is_null" || operator === "is_not_null") {
-    const op = operator as OperatorType;
+    const op = operator;
     if (type === "number") {
       return Filter.number({ operator: op });
     }
@@ -440,20 +439,20 @@ function buildFilterValue({
     }
     return Filter.text({
       text: draft.text,
-      operator: "contains" as OperatorType,
+      operator: "contains",
     });
   }
   if (type === "boolean") {
     if (operator === "is_true") {
       return Filter.boolean({
         value: true,
-        operator: "is_true" as OperatorType,
+        operator: "is_true",
       });
     }
     if (operator === "is_false") {
       return Filter.boolean({
         value: false,
-        operator: "is_false" as OperatorType,
+        operator: "is_false",
       });
     }
     return undefined;
@@ -464,7 +463,7 @@ function buildFilterValue({
     }
     return Filter.select({
       options: draft.options,
-      operator: (operator === "not_in" ? "not_in" : "in") as OperatorType,
+      operator: operator === "not_in" ? "not_in" : "in",
     });
   }
   return undefined;

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -1,0 +1,464 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+"use no memo";
+
+import type { Column, Table } from "@tanstack/react-table";
+import { CheckIcon, MinusIcon, Trash2Icon, XIcon } from "lucide-react";
+import { useId, useState } from "react";
+import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
+import type { OperatorType } from "@/plugins/impl/data-frames/utils/operators";
+import { Combobox, ComboboxItem } from "../ui/combobox";
+import { Input } from "../ui/input";
+import { NumberField } from "../ui/number-field";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { Button } from "../ui/button";
+import { FilterByValuesPicker } from "./filter-by-values-picker";
+import { type ColumnFilterValue, Filter } from "./filters";
+import { Tooltip } from "../ui/tooltip";
+
+// Editable filter types in this editor — date/datetime/time are read-only
+// Will add support for rest in next PR
+type EditableFilterType = "number" | "text" | "boolean" | "select";
+
+// UI-level operator for the operator dropdown. Today the committed filter
+// value does not carry this operator for number ranges — ranges are
+// converted to `>=` / `<=` condition pairs at the RPC boundary
+// (`filterToFilterCondition`). The follow-up PR splits UI operators into
+// distinct `<`, `>`, `between` variants and routes them through as-is.
+type UiOperator =
+  | "between"
+  | "contains"
+  | "is_true"
+  | "is_false"
+  | "is_null"
+  | "is_not_null"
+  | "in"
+  | "not_in";
+
+// will be expanded by a follow up PR
+const OPERATORS_BY_TYPE: Record<EditableFilterType, UiOperator[]> = {
+  number: ["between", "is_null", "is_not_null"],
+  text: ["contains", "is_null", "is_not_null"],
+  boolean: ["is_true", "is_false", "is_null", "is_not_null"],
+  select: ["in", "not_in"],
+};
+
+const DEFAULT_OPERATOR: Record<EditableFilterType, UiOperator> = {
+  number: "between",
+  text: "contains",
+  boolean: "is_true",
+  select: "in",
+};
+
+const OPERATOR_LABELS: Record<UiOperator, string> = {
+  between: "Between",
+  contains: "Contains",
+  is_true: "Is true",
+  is_false: "Is false",
+  is_null: "Is null",
+  is_not_null: "Is not null",
+  in: "Is in",
+  not_in: "Not in",
+};
+
+const OPERATORS_WITHOUT_VALUE = new Set<UiOperator>([
+  "is_true",
+  "is_false",
+  "is_null",
+  "is_not_null",
+]);
+
+interface DraftValue {
+  min?: number;
+  max?: number;
+  text?: string;
+  options?: unknown[];
+}
+
+interface Snapshot {
+  columnId: string;
+  value: ColumnFilterValue;
+}
+
+interface FilterPillEditorProps<TData> {
+  snapshot: Snapshot;
+  table: Table<TData>;
+  calculateTopKRows?: CalculateTopKRows;
+  onClose: () => void;
+}
+
+export const FilterPillEditor = <TData,>({
+  snapshot, // current state of filter pre-edit
+  table,
+  calculateTopKRows,
+  onClose,
+}: FilterPillEditorProps<TData>) => {
+  const columnId = useId();
+  const operatorId = useId();
+  const valueId = useId();
+
+  const snapshotType = getEditableType(snapshot.value);
+  const snapshotOperator = getUiOperator(snapshot.value);
+  const snapshotDraft = toDraftValue(snapshot.value);
+
+  const [draftColumnId, setDraftColumnId] = useState<string>(snapshot.columnId);
+  const [draftType, setDraftType] = useState<EditableFilterType>(snapshotType);
+  const [draftOperator, setDraftOperator] =
+    useState<UiOperator>(snapshotOperator);
+  const [draftValue, setDraftValue] = useState<DraftValue>(snapshotDraft);
+
+  const editableColumns = table.getAllColumns().filter((c) => {
+    const ft = c.columnDef.meta?.filterType;
+    return (
+      ft === "number" || ft === "text" || ft === "boolean" || ft === "select"
+    );
+  });
+
+  // if we switch back to pre-edit column+operator
+  // restore the original value as well
+  const rehydrateIfMatchesSnapshot = (args: {
+    id: string;
+    type: EditableFilterType;
+    operator: UiOperator;
+  }) => {
+    if (
+      args.id === snapshot.columnId &&
+      args.type === snapshotType &&
+      args.operator === snapshotOperator
+    ) {
+      setDraftValue(snapshotDraft);
+    }
+  };
+
+  const handleColumnChange = (nextColumnId: string | null) => {
+    if (!nextColumnId) {
+      return;
+    }
+    const nextColumn = table.getColumn(nextColumnId);
+    const nextColumnType = (nextColumn?.columnDef.meta?.filterType ??
+      "text") as EditableFilterType;
+
+    let nextOperator = draftOperator;
+    if (nextColumnType !== draftType) {
+      nextOperator = DEFAULT_OPERATOR[nextColumnType];
+      setDraftType(nextColumnType);
+      setDraftOperator(nextOperator);
+      setDraftValue({});
+    }
+    setDraftColumnId(nextColumnId);
+    rehydrateIfMatchesSnapshot({
+      id: nextColumnId,
+      type: nextColumnType,
+      operator: nextOperator,
+    });
+  };
+
+  const handleOperatorChange = (nextOp: UiOperator) => {
+    setDraftOperator(nextOp);
+    rehydrateIfMatchesSnapshot({
+      id: draftColumnId,
+      type: draftType,
+      operator: nextOp,
+    });
+  };
+
+  const handleApply = () => {
+    const value = buildFilterValue({
+      type: draftType,
+      operator: draftOperator,
+      draft: draftValue,
+    });
+    if (!value) {
+      return;
+    }
+    table.setColumnFilters((filters) => {
+      const dropIds = new Set([snapshot.columnId, draftColumnId]);
+      const filtered = filters.filter((f) => !dropIds.has(f.id));
+      return [...filtered, { id: draftColumnId, value }];
+    });
+    onClose();
+  };
+
+  const handleClear = () => {
+    table.setColumnFilters((filters) =>
+      filters.filter((f) => f.id !== snapshot.columnId),
+    );
+    onClose();
+  };
+
+  const showValueSlot = !OPERATORS_WITHOUT_VALUE.has(draftOperator);
+
+  return (
+    <div className="flex flex-row gap-4 items-end p-3">
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground" htmlFor={columnId}>
+          Column
+        </label>
+        <Combobox<string>
+          id={columnId}
+          value={draftColumnId}
+          onValueChange={handleColumnChange}
+          multiple={false}
+          placeholder="Select column…"
+          displayValue={(id) => id}
+        >
+          {editableColumns.map((c) => (
+            <ComboboxItem key={c.id} value={c.id}>
+              {c.id}
+            </ComboboxItem>
+          ))}
+        </Combobox>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label htmlFor={operatorId} className="text-xs text-muted-foreground">
+          Operator
+        </label>
+        <Select
+          value={draftOperator}
+          onValueChange={(v) => handleOperatorChange(v as UiOperator)}
+        >
+          <SelectTrigger id={operatorId} className="h-6 mb-1 bg-transparent">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {OPERATORS_BY_TYPE[draftType].map((op) => (
+              <SelectItem key={op} value={op}>
+                {OPERATOR_LABELS[op]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {showValueSlot && (
+        <div className="flex flex-col gap-1">
+          <label htmlFor={valueId} className="text-xs text-muted-foreground">
+            Value
+          </label>
+          <ValueSlot
+            id={valueId}
+            type={draftType}
+            value={draftValue}
+            onChange={setDraftValue}
+            column={table.getColumn(draftColumnId) ?? null}
+            calculateTopKRows={calculateTopKRows}
+          />
+        </div>
+      )}
+      <div className="flex gap-1 mb-1">
+        <Tooltip content="Apply filter">
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="rounded-full text-primary hover:text-primary hover:bg-primary/10"
+            onClick={handleApply}
+            aria-label="Apply filter"
+          >
+            <CheckIcon className="h-3.5 w-3.5" aria-hidden={true} />
+          </Button>
+        </Tooltip>
+        <Tooltip content="Close without saving">
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="rounded-full text-muted-foreground hover:text-foreground hover:bg-muted"
+            onClick={onClose}
+            aria-label="Close without saving"
+          >
+            <XIcon className="h-3.5 w-3.5" aria-hidden={true} />
+          </Button>
+        </Tooltip>
+        <Tooltip content="Remove filter">
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="rounded-full text-destructive hover:text-destructive hover:bg-destructive/10"
+            onClick={handleClear}
+            aria-label="Remove filter"
+          >
+            <Trash2Icon className="h-3.5 w-3.5" aria-hidden={true} />
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+interface ValueSlotProps<TData, TValue> {
+  id?: string;
+  type: EditableFilterType;
+  value: DraftValue;
+  onChange: (next: DraftValue) => void;
+  column: Column<TData, TValue> | null;
+  calculateTopKRows?: CalculateTopKRows;
+}
+
+const ValueSlot = <TData, TValue>({
+  id,
+  type,
+  value,
+  onChange,
+  column,
+  calculateTopKRows,
+}: ValueSlotProps<TData, TValue>) => {
+  if (type === "number") {
+    return (
+      <div className="flex gap-1 items-center w-48">
+        <NumberField
+          id={id}
+          value={value.min}
+          onChange={(v) => onChange({ ...value, min: v })}
+          aria-label="min"
+          placeholder="min"
+          className="border-input flex-1 min-w-0"
+        />
+        <MinusIcon className="h-5 w-5 text-muted-foreground shrink-0" />
+        <NumberField
+          value={value.max}
+          onChange={(v) => onChange({ ...value, max: v })}
+          aria-label="max"
+          placeholder="max"
+          className="border-input flex-1 min-w-0"
+        />
+      </div>
+    );
+  }
+  if (type === "text") {
+    return (
+      <Input
+        id={id}
+        type="text"
+        value={value.text ?? ""}
+        onChange={(e) => onChange({ ...value, text: e.target.value })}
+        placeholder="Text…"
+        className="border-input min-w-0"
+      />
+    );
+  }
+  if (type === "select" && column) {
+    return (
+      <div className="flex w-48">
+        <FilterByValuesPicker
+          column={column}
+          calculateTopKRows={calculateTopKRows}
+          chosenValues={value.options ?? []}
+          onChange={(values) => onChange({ ...value, options: values })}
+        />
+      </div>
+    );
+  }
+  return null;
+};
+
+function getEditableType(value: ColumnFilterValue): EditableFilterType {
+  if (value.type === "number") {
+    return "number";
+  }
+  if (value.type === "text") {
+    return "text";
+  }
+  if (value.type === "boolean") {
+    return "boolean";
+  }
+  if (value.type === "select") {
+    return "select";
+  }
+  // date/datetime/time fall back to text; callers should guard. supported in future
+  return "text";
+}
+
+function getUiOperator(value: ColumnFilterValue): UiOperator {
+  if (value.operator === "is_null") {
+    return "is_null";
+  }
+  if (value.operator === "is_not_null") {
+    return "is_not_null";
+  }
+  if (value.type === "number") {
+    return "between";
+  }
+  if (value.type === "text") {
+    return "contains";
+  }
+  if (value.type === "boolean") {
+    return value.value ? "is_true" : "is_false";
+  }
+  if (value.type === "select") {
+    return value.operator === "not_in" ? "not_in" : "in";
+  }
+  return "contains";
+}
+
+function toDraftValue(value: ColumnFilterValue): DraftValue {
+  if (value.type === "number") {
+    return { min: value.min, max: value.max };
+  }
+  if (value.type === "text") {
+    return { text: value.text };
+  }
+  if (value.type === "select") {
+    return { options: [...value.options] };
+  }
+  return {};
+}
+
+function buildFilterValue({
+  type,
+  operator,
+  draft,
+}: {
+  type: EditableFilterType;
+  operator: UiOperator;
+  draft: DraftValue;
+}): ColumnFilterValue | undefined {
+  if (operator === "is_null" || operator === "is_not_null") {
+    return Filter.text({ operator: operator as OperatorType });
+  }
+  if (type === "number") {
+    if (draft.min === undefined && draft.max === undefined) {
+      return undefined;
+    }
+    return Filter.number({ min: draft.min, max: draft.max });
+  }
+  if (type === "text") {
+    if (!draft.text) {
+      return undefined;
+    }
+    return Filter.text({
+      text: draft.text,
+      operator: "contains" as OperatorType,
+    });
+  }
+  if (type === "boolean") {
+    if (operator === "is_true") {
+      return Filter.boolean({
+        value: true,
+        operator: "is_true" as OperatorType,
+      });
+    }
+    if (operator === "is_false") {
+      return Filter.boolean({
+        value: false,
+        operator: "is_false" as OperatorType,
+      });
+    }
+    return undefined;
+  }
+  if (type === "select") {
+    if (!draft.options || draft.options.length === 0) {
+      return undefined;
+    }
+    return Filter.select({
+      options: draft.options,
+      operator: (operator === "not_in" ? "not_in" : "in") as OperatorType,
+    });
+  }
+  return undefined;
+}

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -419,7 +419,14 @@ function buildFilterValue({
   draft: DraftValue;
 }): ColumnFilterValue | undefined {
   if (operator === "is_null" || operator === "is_not_null") {
-    return Filter.text({ operator: operator as OperatorType });
+    const op = operator as OperatorType;
+    if (type === "number") {
+      return Filter.number({ operator: op });
+    }
+    if (type === "boolean") {
+      return Filter.boolean({ operator: op });
+    }
+    return Filter.text({ operator: op });
   }
   if (type === "number") {
     if (draft.min === undefined && draft.max === undefined) {

--- a/frontend/src/components/data-table/filter-pills.tsx
+++ b/frontend/src/components/data-table/filter-pills.tsx
@@ -37,7 +37,7 @@ export const FilterPills = <TData,>({
   }
 
   return (
-    <div className="flex flex-wrap gap-2 px-1 py-2">
+    <div part="filter-pills" className="flex flex-wrap gap-2 px-1 py-2">
       {filters.map((filter) => (
         <FilterPill
           key={filter.id}
@@ -121,7 +121,7 @@ const FilterPill = <TData,>({
       type="button"
       size="icon"
       variant="ghost"
-      className="ml-1 rounded-full text-destructive hover:text-destructive hover:bg-destructive/10"
+      className="ml-1 rounded-full text-destructive/60 hover:text-destructive hover:shadow-none hover:bg-transparent"
       onClick={handleRemove}
       aria-label="Remove filter"
     >

--- a/frontend/src/components/data-table/filter-pills.tsx
+++ b/frontend/src/components/data-table/filter-pills.tsx
@@ -1,24 +1,31 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 "use no memo";
 
-import type {
-  ColumnFilter,
-  ColumnFiltersState,
-  Table,
-} from "@tanstack/react-table";
+import type { ColumnFiltersState, Table } from "@tanstack/react-table";
 import { XIcon } from "lucide-react";
+import { useState } from "react";
 import { type DateFormatter, useDateFormatter } from "react-aria";
+import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
 import { logNever } from "@/utils/assertNever";
+import { cn } from "@/utils/cn";
 import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { FilterPillEditor } from "./filter-pill-editor";
 import type { ColumnFilterValue } from "./filters";
 import { stringifyUnknownValue } from "./utils";
 
 interface Props<TData> {
   filters: ColumnFiltersState | undefined;
   table: Table<TData>;
+  calculateTopKRows?: CalculateTopKRows;
 }
 
-export const FilterPills = <TData,>({ filters, table }: Props<TData>) => {
+export const FilterPills = <TData,>({
+  filters,
+  table,
+  calculateTopKRows,
+}: Props<TData>) => {
   const timeFormatter = useDateFormatter({
     hour: "2-digit",
     minute: "2-digit",
@@ -29,49 +36,176 @@ export const FilterPills = <TData,>({ filters, table }: Props<TData>) => {
     return null;
   }
 
-  function renderFilterPill(filter: ColumnFilter) {
-    const formattedValue = formatValue(
-      filter.value as ColumnFilterValue,
-      timeFormatter,
-    );
-    if (!formattedValue) {
-      return null;
-    }
-
-    return (
-      <Badge key={filter.id} variant="secondary" className="dark:invert">
-        {filter.id} {formattedValue}{" "}
-        <span
-          className="cursor-pointer opacity-60 hover:opacity-100 pl-1 py-[2px]"
-          onClick={() => {
+  return (
+    <div className="flex flex-wrap gap-2 px-1 py-2">
+      {filters.map((filter) => (
+        <FilterPill
+          key={filter.id}
+          columnId={filter.id}
+          value={filter.value as ColumnFilterValue}
+          timeFormatter={timeFormatter}
+          table={table}
+          calculateTopKRows={calculateTopKRows}
+          onRemove={() =>
             table.setColumnFilters((filters) =>
               filters.filter((f) => f.id !== filter.id),
-            );
-          }}
-        >
-          <XIcon className="w-3.5 h-3.5" />
-        </span>
+            )
+          }
+        />
+      ))}
+    </div>
+  );
+};
+
+interface FilterPillProps<TData> {
+  columnId: string;
+  value: ColumnFilterValue;
+  timeFormatter: DateFormatter;
+  table: Table<TData>;
+  calculateTopKRows?: CalculateTopKRows;
+  onRemove: () => void;
+}
+
+const FilterPill = <TData,>({
+  columnId,
+  value,
+  timeFormatter,
+  table,
+  calculateTopKRows,
+  onRemove,
+}: FilterPillProps<TData>) => {
+  const [open, setOpen] = useState(false);
+
+  const formatted = formatValue(value, timeFormatter);
+  if (!formatted) {
+    return null;
+  }
+
+  // this is temporary, with more operator & datatype support this goes away
+  const isReadOnly =
+    "type" in value &&
+    (value.type === "date" ||
+      value.type === "datetime" ||
+      value.type === "time");
+
+  const twoSegment = formatted.value === undefined;
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRemove();
+  };
+
+  const segments = (
+    <>
+      <span className="text-foreground">{columnId}</span>
+      <Separator />
+      <span
+        className={cn(
+          "font-normal",
+          twoSegment ? "text-foreground" : "text-foreground/70",
+        )}
+      >
+        {formatted.operator}
+      </span>
+      {!twoSegment && (
+        <>
+          <Separator />
+          <span className="text-foreground">{formatted.value}</span>
+        </>
+      )}
+    </>
+  );
+
+  const removeButton = (
+    <Button
+      type="button"
+      size="icon"
+      variant="ghost"
+      className="ml-1 rounded-full text-destructive hover:text-destructive hover:bg-destructive/10"
+      onClick={handleRemove}
+      aria-label="Remove filter"
+    >
+      <XIcon className="h-3.5 w-3.5" aria-hidden={true} />
+    </Button>
+  );
+
+  if (isReadOnly) {
+    return (
+      <Badge
+        variant="outline"
+        className="bg-background border-border text-foreground"
+      >
+        {segments}
+        {removeButton}
       </Badge>
     );
   }
 
   return (
-    <div className="flex flex-wrap gap-2 px-1">
-      {filters.map(renderFilterPill)}
-    </div>
+    <Popover open={open} onOpenChange={setOpen} modal={true}>
+      <Badge
+        variant="outline"
+        className={cn(
+          "bg-background border-border text-foreground",
+          "hover:bg-accent hover:text-accent-foreground",
+          "has-data-[state=open]:bg-accent has-data-[state=open]:text-accent-foreground",
+          "transition-colors",
+        )}
+      >
+        <PopoverTrigger asChild={true}>
+          <button
+            type="button"
+            className="inline-flex items-center cursor-pointer bg-transparent border-0 p-0 [font:inherit] text-inherit"
+            aria-label={`Edit filter on ${columnId}`}
+          >
+            {segments}
+          </button>
+        </PopoverTrigger>
+        {removeButton}
+      </Badge>
+      <PopoverContent
+        className="w-auto p-0"
+        align="start"
+        alignOffset={-10}
+        sideOffset={10}
+        avoidCollisions={true}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <FilterPillEditor
+          snapshot={{ columnId, value }}
+          table={table}
+          calculateTopKRows={calculateTopKRows}
+          onClose={() => setOpen(false)}
+        />
+      </PopoverContent>
+    </Popover>
   );
 };
 
-function formatValue(value: ColumnFilterValue, timeFormatter: DateFormatter) {
+function Separator() {
+  return (
+    <span aria-hidden={true} className="mx-1.5 w-px h-3 bg-foreground/30" />
+  );
+}
+
+interface FormattedFilter {
+  operator: string;
+  value?: string;
+}
+
+function formatValue(
+  value: ColumnFilterValue,
+  timeFormatter: DateFormatter,
+): FormattedFilter | undefined {
   if (!("type" in value)) {
     return;
   }
 
   if (value.operator === "is_null") {
-    return "is null";
+    return { operator: "is null" };
   }
   if (value.operator === "is_not_null") {
-    return "is not null";
+    return { operator: "is not null" };
   }
 
   if (value.type === "number") {
@@ -90,17 +224,19 @@ function formatValue(value: ColumnFilterValue, timeFormatter: DateFormatter) {
     return formatMinMax(value.min?.toISOString(), value.max?.toISOString());
   }
   if (value.type === "boolean") {
-    return `is ${value.value ? "True" : "False"}`;
+    return { operator: `is ${value.value ? "True" : "False"}` };
   }
   if (value.type === "select") {
     const stringifiedOptions = value.options.map((o) =>
       stringifyUnknownValue({ value: o }),
     );
-    const operator = value.operator === "in" ? "is in" : "not in";
-    return `${operator} [${stringifiedOptions.join(", ")}]`;
+    return {
+      operator: value.operator === "in" ? "is in" : "not in",
+      value: `[${stringifiedOptions.join(", ")}]`,
+    };
   }
   if (value.type === "text") {
-    return `contains "${value.text}"`;
+    return { operator: "contains", value: `"${value.text}"` };
   }
   logNever(value);
   return undefined;
@@ -109,18 +245,18 @@ function formatValue(value: ColumnFilterValue, timeFormatter: DateFormatter) {
 function formatMinMax(
   min: string | number | undefined,
   max: string | number | undefined,
-) {
+): FormattedFilter | undefined {
   if (min === undefined && max === undefined) {
     return;
   }
   if (min === max) {
-    return `== ${min}`;
+    return { operator: "==", value: String(min) };
   }
   if (min === undefined) {
-    return `<= ${max}`;
+    return { operator: "<=", value: String(max) };
   }
   if (max === undefined) {
-    return `>= ${min}`;
+    return { operator: ">=", value: String(min) };
   }
-  return `${min} - ${max}`;
+  return { operator: "between", value: `${min} - ${max}` };
 }

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { Check } from "lucide-react";
+import { Check, Minus } from "lucide-react";
 import { Checkbox as CheckboxPrimitive } from "radix-ui";
 import * as React from "react";
 
@@ -13,18 +13,22 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "flex items-center justify-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "flex items-center justify-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
       className,
     )}
     {...props}
   >
     <CheckboxPrimitive.Indicator
-      // `max-h-[14px] overflow-hidden` are for the checkmark icon to not resize the checkbox
+      // `max-h-[14px] overflow-hidden` are for the icon to not resize the checkbox
       className={cn(
         "flex items-center justify-center text-current max-h-[14px] overflow-hidden",
       )}
     >
-      <Check className="h-4 w-4" />
+      {props.checked === "indeterminate" ? (
+        <Minus className="h-4 w-4" />
+      ) : (
+        <Check className="h-4 w-4" />
+      )}
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -37,6 +37,7 @@ interface ComboboxCommonProps<TValue> {
   onSearchChange?: (search: string) => void;
   emptyState?: React.ReactNode;
   className?: string;
+  id?: string;
   keepPopoverOpenOnSelect?: boolean;
 }
 
@@ -93,6 +94,7 @@ export const Combobox = <TValue,>({
   chips = false,
   chipsClassName,
   keepPopoverOpenOnSelect,
+  id,
   ...rest
 }: ComboboxProps<TValue>) => {
   const [open = false, setOpen] = useControllableState({
@@ -169,6 +171,7 @@ export const Combobox = <TValue,>({
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild={true}>
           <div
+            id={id}
             className={cn(
               "flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50",
               className,

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -124,6 +124,10 @@
       marimo-table::part(table-footer) {
         padding-inline: 0.25rem;
       }
+
+      marimo-table::part(filter-pills) {
+        padding-bottom: 0;
+      }
     }
 
     & > :first-child {

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -1073,6 +1073,7 @@ const DataTableComponent = ({
             showFilters={showFilters}
             filters={filters}
             onFiltersChange={setFilters}
+            calculateTopKRows={calculate_top_k_rows}
             reloading={reloading}
             onRowSelectionChange={handleRowSelectionChange}
             freezeColumnsLeft={freezeColumnsLeft}

--- a/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
+++ b/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
           aria-describedby="_r_26_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_26_-form-item"
         >
           <div
             aria-controls="radix-_r_27_"
@@ -34,6 +33,7 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_26_-form-item"
             type="button"
           >
             <span
@@ -81,7 +81,6 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
           aria-describedby="_r_28_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_28_-form-item"
         >
           <div
             aria-controls="radix-_r_29_"
@@ -89,6 +88,7 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_28_-form-item"
             type="button"
           >
             <span
@@ -398,7 +398,6 @@ exports[`renderZodSchema > should render a form explode_columns 1`] = `
           aria-describedby="_r_2o_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_2o_-form-item"
         >
           <div
             aria-controls="radix-_r_2p_"
@@ -406,6 +405,7 @@ exports[`renderZodSchema > should render a form explode_columns 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_2o_-form-item"
             type="button"
           >
             <span
@@ -595,7 +595,6 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
           aria-describedby="_r_1o_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_1o_-form-item"
         >
           <div
             aria-controls="radix-_r_1p_"
@@ -603,6 +602,7 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_1o_-form-item"
             type="button"
           >
             <span
@@ -650,7 +650,6 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
           aria-describedby="_r_1q_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_1q_-form-item"
         >
           <div
             aria-controls="radix-_r_1r_"
@@ -658,6 +657,7 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_1q_-form-item"
             type="button"
           >
             <span
@@ -756,7 +756,7 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
             aria-checked="false"
             aria-describedby="_r_1u_-form-item-description"
             aria-invalid="false"
-            class="flex items-center justify-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+            class="flex items-center justify-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground"
             data-state="unchecked"
             data-testid="marimo-plugin-data-frames-boolean-checkbox"
             id="_r_1u_-form-item"
@@ -797,7 +797,6 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
           aria-describedby="_r_3a_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_3a_-form-item"
         >
           <div
             aria-controls="radix-_r_3b_"
@@ -805,6 +804,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_3a_-form-item"
             type="button"
           >
             <span
@@ -852,7 +852,6 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
           aria-describedby="_r_3c_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_3c_-form-item"
         >
           <div
             aria-controls="radix-_r_3d_"
@@ -860,6 +859,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_3c_-form-item"
             type="button"
           >
             <span
@@ -907,7 +907,6 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
           aria-describedby="_r_3e_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_3e_-form-item"
         >
           <div
             aria-controls="radix-_r_3f_"
@@ -915,6 +914,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_3e_-form-item"
             type="button"
           >
             <span
@@ -1256,7 +1256,7 @@ exports[`renderZodSchema > should render a form sample_rows 1`] = `
             aria-checked="false"
             aria-describedby="_r_2n_-form-item-description"
             aria-invalid="false"
-            class="flex items-center justify-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+            class="flex items-center justify-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground"
             data-state="unchecked"
             data-testid="marimo-plugin-data-frames-boolean-checkbox"
             id="_r_2n_-form-item"
@@ -1297,7 +1297,6 @@ exports[`renderZodSchema > should render a form select_columns 1`] = `
           aria-describedby="_r_3_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_3_-form-item"
         >
           <div
             aria-controls="radix-_r_4_"
@@ -1305,6 +1304,7 @@ exports[`renderZodSchema > should render a form select_columns 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_3_-form-item"
             type="button"
           >
             <span
@@ -1471,7 +1471,7 @@ exports[`renderZodSchema > should render a form sort_column 1`] = `
             aria-checked="false"
             aria-describedby="_r_1f_-form-item-description"
             aria-invalid="false"
-            class="flex items-center justify-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+            class="flex items-center justify-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground"
             data-state="unchecked"
             data-testid="marimo-plugin-data-frames-boolean-checkbox"
             id="_r_1f_-form-item"
@@ -1580,7 +1580,6 @@ exports[`renderZodSchema > should render a form unique 1`] = `
           aria-describedby="_r_31_-form-item-description"
           aria-invalid="false"
           class="relative"
-          id="_r_31_-form-item"
         >
           <div
             aria-controls="radix-_r_32_"
@@ -1588,6 +1587,7 @@ exports[`renderZodSchema > should render a form unique 1`] = `
             aria-haspopup="dialog"
             class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
             data-state="closed"
+            id="_r_31_-form-item"
             type="button"
           >
             <span
@@ -1739,7 +1739,6 @@ exports[`renders custom forms column_id_array 1`] = `
       aria-describedby="_r_40_-form-item-description"
       aria-invalid="false"
       class="relative"
-      id="_r_40_-form-item"
     >
       <div
         aria-controls="radix-_r_41_"
@@ -1747,6 +1746,7 @@ exports[`renders custom forms column_id_array 1`] = `
         aria-haspopup="dialog"
         class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
         data-state="closed"
+        id="_r_40_-form-item"
         type="button"
       >
         <span
@@ -1789,7 +1789,6 @@ exports[`renders custom forms column_id_dot_array 1`] = `
       aria-describedby="_r_42_-form-item-description"
       aria-invalid="false"
       class="relative"
-      id="_r_42_-form-item"
     >
       <div
         aria-controls="radix-_r_43_"
@@ -1797,6 +1796,7 @@ exports[`renders custom forms column_id_dot_array 1`] = `
         aria-haspopup="dialog"
         class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
         data-state="closed"
+        id="_r_42_-form-item"
         type="button"
       >
         <span

--- a/frontend/src/utils/sets.ts
+++ b/frontend/src/utils/sets.ts
@@ -27,4 +27,17 @@ export const Sets = {
     }
     return true;
   },
+
+  /**
+   * Return a new set with `item` toggled — removed if present, added if not.
+   */
+  toggle<T>(set: Set<T>, item: T): Set<T> {
+    const result = new Set(set);
+    if (result.has(item)) {
+      result.delete(item);
+    } else {
+      result.add(item);
+    }
+    return result;
+  },
 };


### PR DESCRIPTION
## 📝 Summary

- Click a column-filter pill in a data-table to open an inline
  editor: pick column, operator, and value; Apply / Close / Remove.
- Editable types: number / text / boolean / select. Date/datetime/time
  remain read-only — separate PR.
- Also: new `FilterByValuesPicker` (controlled top-K dropdown, used in
  the select value slot); `Combobox` forwards `id` onto its trigger so
  `<label htmlFor>` works.

## Scope

- `filter-pill-editor.tsx` (new): popover with Combobox / Select /
  value slot. Snapshot-based rehydration restores the pre-edit values
  when the user navigates back to the same column + operator.
- `filter-by-values-picker.tsx` (new): fully-controlled, emits on
  every toggle. Intended to replace the column-header popover in a
  follow-up.
- `filter-pills.tsx`: three-segment pill (col | op | val),
  focusable button trigger, `calculateTopKRows` threaded through to
  the select value slot.
- `combobox.tsx`: new optional `id` prop forwarded to the trigger.


https://github.com/user-attachments/assets/5722c3d9-5023-4c40-838e-ccc0cb9912eb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make filter pills editable via an inline popover editor. Users can change column, operator, and value directly from the pill; date/datetime/time pills remain read‑only.

- **New Features**
  - Inline editor on pill click with Apply, Close, and Remove actions.
  - Supported types: number, text, boolean, select; others render read‑only.
  - Three-segment pills show column | operator | value for quick scanning.
  - New `FilterByValuesPicker`: controlled top‑K values dropdown for select filters, powered by `calculateTopKRows`.
  - `DataTable` accepts `calculateTopKRows` and passes it to pills; `DataTablePlugin` wires `calculate_top_k_rows`.
  - `Combobox` forwards `id` to its trigger to enable `<label htmlFor>` association.

- **Bug Fixes**
  - `FilterByValuesPicker`: fixed async deps; smarter search (smartMatch + includes); Select All affects only visible items with indeterminate state; correct truncation notice; stable keys.
  - `FilterPillEditor`: `is_null`/`is_not_null` preserve column type across round‑trips; `Checkbox` now supports an indeterminate state (minus icon) used by Select All.

<sup>Written for commit 7f2a1f241b3e3ea7bd301af16807d99508683698. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

