### PR TITLE
test: clean up DuckDB tables leaked by test_sql_error_handling

### DIFF
--- a/tests/_sql/test_sql_error_handling.py
+++ b/tests/_sql/test_sql_error_handling.py
@@ -20,6 +20,31 @@ HAS_PANDAS = DependencyManager.pandas.has()
 HAS_POLARS = DependencyManager.polars.has()
 
 
+# Tables created on DuckDB's default in-memory connection by tests below.
+# Both `sql()` without an engine and bare `duckdb.sql(...)` share this
+# singleton, so anything left behind leaks to other tests on the same xdist
+# worker (e.g. tests/_data/test_get_datasets.py::test_get_databases).
+_LEAKED_DUCKDB_TABLES = (
+    "test_error_table",
+    "test_type_table",
+    "test_hints_table",
+    "test_columns",
+    "hint_test_table",
+    "hint_multiline_table",
+)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_duckdb_default_connection():
+    yield
+    if not HAS_DUCKDB:
+        return
+    import duckdb
+
+    for table in _LEAKED_DUCKDB_TABLES:
+        duckdb.sql(f"DROP TABLE IF EXISTS {table}")
+
+
 class TestDuckDBRuntimeErrors:
     """Test DuckDB errors that occur during SQL execution."""
 


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Fixes flaky Windows CI failures in `tests/_data/test_get_datasets.py::test_get_databases` and `::test_get_databases_with_no_tables`.

## Root cause

`marimo._sql.sql.sql()` called without an `engine=` argument (and bare `duckdb.sql(...)`) both target DuckDB's process-wide default in-memory connection. `get_databases_from_duckdb(connection=None)` reads from that same singleton. Tests in `tests/_sql/test_sql_error_handling.py` create tables (`test_error_table`, `test_type_table`, `test_hints_table`, `test_columns`, `hint_test_table`, `hint_multiline_table`) with `CREATE OR REPLACE TABLE` and never drop them. Whenever pytest-xdist happens to schedule them before `test_get_databases*` on the same worker, the leaked tables appear in the `main` schema and the assertion fails.

CI evidence (run [24859690600](https://github.com/marimo-team/marimo/actions/runs/24859690600)):
- Windows gw0 ran error-handling tests at ~75%, then `test_get_databases` at ~94% — FAILED.
- macOS gw2 ran `test_get_databases` at ~11% (before any error-handling tests landed on that worker) — PASSED.

Reproduced locally by running `tests/_sql/test_sql_error_handling.py` followed by the two target tests in the same process:

- Without this change: 2 failed with the exact CI traceback.
- With this change: 32 passed.

## Fix

Add a single module-level autouse fixture that drops the known set of leaked tables after each test. Scoped narrowly to this file since it owns the pollution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up DuckDB tables created by error-handling tests to stop cross-test leakage on the default in-memory connection. This removes flaky CI failures in database discovery tests.

- **Bug Fixes**
  - Add an autouse `pytest` fixture in `tests/_sql/test_sql_error_handling.py` to drop known tables after each test on the default `duckdb` connection.
  - Prevents leaked tables from appearing in the `main` schema when `pytest-xdist` reuses a worker.
  - Covers: `test_error_table`, `test_type_table`, `test_hints_table`, `test_columns`, `hint_test_table`, `hint_multiline_table`.

<sup>Written for commit a540a0b381fb6564b47bdf4c04848b07c2ca6d54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

