### PR TITLE
fix: flush console output worker before broadcasting run completion

### DIFF
--- a/marimo/_messaging/console_output_worker.py
+++ b/marimo/_messaging/console_output_worker.py
@@ -10,6 +10,7 @@ from marimo._messaging.mimetypes import ConsoleMimeType
 from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
+    import threading
     from collections import deque
     from threading import Condition
 
@@ -27,6 +28,19 @@ class ConsoleMsg:
     cell_id: CellId_t
     data: str
     mimetype: ConsoleMimeType
+
+
+@dataclass
+class FlushRequest:
+    """Signal the buffered writer to flush pending outputs immediately.
+
+    When the worker pops this off its queue, it drains whatever it has
+    buffered to the underlying stream before setting ``done``. Callers can
+    then be certain that every console message enqueued before this request
+    has been written to the pipe.
+    """
+
+    done: threading.Event
 
 
 def _write_console_output(
@@ -71,7 +85,7 @@ def _add_output_to_buffer(
 
 
 def buffered_writer(
-    msg_queue: deque[ConsoleMsg | None],
+    msg_queue: deque[ConsoleMsg | FlushRequest | None],
     stream: Stream,
     cv: Condition,
 ) -> None:
@@ -84,6 +98,13 @@ def buffered_writer(
     was noticeably faster than the builtin queue.Queue in testing.)
 
     A `None` passed to `msg_queue` signals the writer should terminate.
+    Any still-buffered outputs are dropped, matching the non-blocking
+    shutdown semantics of ``ThreadSafeStream.stop()``; callers that care
+    about delivery must flush before stopping the stream.
+
+    A `FlushRequest` passed to `msg_queue` forces an immediate flush of
+    whatever is currently buffered, and signals the request's `done` event
+    once the outputs have been written to the stream.
     """
 
     # only have a non-None timer when there's at least one output buffered
@@ -92,9 +113,12 @@ def buffered_writer(
     timer: float | None = None
 
     outputs_buffered_per_cell: dict[CellId_t, list[ConsoleMsg]] = {}
+    pending_flush_requests: list[FlushRequest] = []
+    terminating = False
     while True:
         with cv:
-            # We wait for messages until the timer (if any) expires
+            # We wait for messages until the timer (if any) expires, or until
+            # a flush/termination request forces us out of the wait loop.
             while timer is None or timer > 0:
                 time_started_waiting = time.time()
                 # if the timer is set or if the message queue is empty, wait;
@@ -105,8 +129,13 @@ def buffered_writer(
                 while msg_queue:
                     msg = msg_queue.popleft()
                     if msg is None:
-                        return
-                    _add_output_to_buffer(msg, outputs_buffered_per_cell)
+                        terminating = True
+                    elif isinstance(msg, FlushRequest):
+                        pending_flush_requests.append(msg)
+                    else:
+                        _add_output_to_buffer(msg, outputs_buffered_per_cell)
+                if terminating or pending_flush_requests:
+                    break
                 if outputs_buffered_per_cell and timer is None:
                     # start the timeout timer
                     timer = TIMEOUT_S
@@ -114,7 +143,17 @@ def buffered_writer(
                     time_waited = time.time() - time_started_waiting
                     timer -= time_waited
 
-        # the timer has expired: flush the outputs
+        if terminating:
+            # Preserve the non-blocking shutdown contract: drop any
+            # buffered outputs rather than writing them, but wake up any
+            # flush waiters so they don't hang forever if stop() raced a
+            # concurrent flush_console().
+            for req in pending_flush_requests:
+                req.done.set()
+            return
+
+        # the timer expired or a flush was requested: write all buffered
+        # outputs to the stream
         for cell_id, buffer in outputs_buffered_per_cell.items():
             for output in buffer:
                 _write_console_output(
@@ -126,3 +165,9 @@ def buffered_writer(
                 )
         outputs_buffered_per_cell = {}
         timer = None
+
+        # Signal any flush waiters only after writes have completed, so they
+        # can rely on the invariant "pending outputs are on the pipe."
+        for req in pending_flush_requests:
+            req.done.set()
+        pending_flush_requests = []

--- a/marimo/_messaging/notification_utils.py
+++ b/marimo/_messaging/notification_utils.py
@@ -62,6 +62,31 @@ def broadcast_notification(
         return
 
 
+def broadcast_run_completion(stream: Stream | None = None) -> None:
+    """Broadcast a ``CompletedRunNotification`` after flushing console output.
+
+    Flushing first upgrades the semantics of the completion signal from
+    "cells are done running" to "every output for this run is on the wire."
+    Consumers that snapshot the session state on completion (e.g. the
+    ipynb/PDF exporters) can then rely on stdout/stderr produced during
+    the run being visible in the session view; without the flush, the
+    console worker's 10 ms buffering timer can make them race the signal.
+    """
+    from marimo._messaging.notification import CompletedRunNotification
+
+    if stream is None:
+        try:
+            ctx = get_context()
+        except ContextNotInitializedError:
+            LOGGER.debug("No context initialized.")
+            return
+        else:
+            stream = ctx.stream
+
+    stream.flush_console()
+    broadcast_notification(CompletedRunNotification(), stream)
+
+
 class CellNotificationUtils:
     """Utilities for broadcasting cell notifications."""
 

--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -14,7 +14,11 @@ from typing import (
 
 from marimo import _loggers
 from marimo._messaging.cell_output import CellChannel
-from marimo._messaging.console_output_worker import ConsoleMsg, buffered_writer
+from marimo._messaging.console_output_worker import (
+    ConsoleMsg,
+    FlushRequest,
+    buffered_writer,
+)
 from marimo._messaging.mimetypes import ConsoleMimeType
 from marimo._messaging.types import (
     KernelMessage,
@@ -106,7 +110,9 @@ class ThreadSafeStream(Stream):
         if self.redirect_console:
             # Console outputs are buffered
             self.console_msg_cv = threading.Condition(threading.Lock())
-            self.console_msg_queue: deque[ConsoleMsg | None] = deque()
+            self.console_msg_queue: deque[ConsoleMsg | FlushRequest | None] = (
+                deque()
+            )
             self.buffered_console_thread = threading.Thread(
                 target=buffered_writer,
                 args=(self.console_msg_queue, self, self.console_msg_cv),
@@ -132,6 +138,25 @@ class ThreadSafeStream(Stream):
                     deserialize_kernel_notification_name(data),
                     e,
                 )
+
+    def flush_console(self) -> None:
+        """Synchronously drain pending buffered console output.
+
+        Blocks until the buffered-writer thread has written every
+        console message enqueued before this call out to the underlying
+        pipe. Used to guarantee ordering against broadcasts from the main
+        kernel thread (e.g. ``CompletedRunNotification``) — without it,
+        stdout/stderr from the tail end of a run can race the completion
+        signal and arrive at the server after consumers have already
+        snapshotted the session.
+        """
+        if not self.redirect_console:
+            return
+        done = threading.Event()
+        with self.console_msg_cv:
+            self.console_msg_queue.append(FlushRequest(done=done))
+            self.console_msg_cv.notify()
+        done.wait()
 
     def stop(self) -> None:
         """Teardown resources created by the stream."""

--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -29,6 +29,15 @@ class Stream(abc.ABC):
         """Tear down resources, if any."""
         return
 
+    def flush_console(self) -> None:
+        """Synchronously drain any pending buffered console output.
+
+        Blocks until every stdout/stderr message enqueued on this stream has
+        been written through to the underlying pipe/queue. The default
+        implementation is a no-op, for streams that don't buffer.
+        """
+        return
+
 
 class NoopStream(Stream):
     def write(self, data: KernelMessage) -> None:

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -68,7 +68,6 @@ from marimo._messaging.notebook.document import (
 from marimo._messaging.notification import (
     CacheClearedNotification,
     CacheInfoNotification,
-    CompletedRunNotification,
     DataColumnPreviewNotification,
     DataSourceConnectionsNotification,
     FunctionCallResultNotification,
@@ -96,6 +95,7 @@ from marimo._messaging.notification import (
 from marimo._messaging.notification_utils import (
     CellNotificationUtils,
     broadcast_notification,
+    broadcast_run_completion,
 )
 from marimo._messaging.print_override import print_override
 from marimo._messaging.streams import (
@@ -2341,14 +2341,14 @@ class Kernel:
         async def handle_instantiate(request: CreateNotebookCommand) -> None:
             with http_request_context(request.request):
                 await self.instantiate(request)
-            broadcast_notification(CompletedRunNotification())
+            broadcast_run_completion()
 
         async def handle_execute_multiple(
             request: ExecuteCellsCommand,
         ) -> None:
             with http_request_context(request.request):
                 await self.run(request.execution_requests)
-            broadcast_notification(CompletedRunNotification())
+            broadcast_run_completion()
 
         async def handle_sync_graph(
             request: SyncGraphCommand,
@@ -2357,7 +2357,7 @@ class Kernel:
                 await self.sync_graph(
                     request.cells, request.run_ids, request.delete_ids
                 )
-            broadcast_notification(CompletedRunNotification())
+            broadcast_run_completion()
 
         async def handle_execute_scratchpad(
             request: ExecuteScratchpadCommand,
@@ -2372,21 +2372,21 @@ class Kernel:
                 http_request_context(request.request),
             ):
                 await self.run_scratchpad(request.code)
-            broadcast_notification(CompletedRunNotification())
+            broadcast_run_completion()
 
         async def handle_execute_stale(
             request: ExecuteStaleCellsCommand,
         ) -> None:
             with http_request_context(request.request):
                 await self.run_stale_cells()
-            broadcast_notification(CompletedRunNotification())
+            broadcast_run_completion()
 
         async def handle_set_ui_element_value(
             request: UpdateUIElementCommand,
         ) -> None:
             with http_request_context(request.request):
                 await self.set_ui_element_value(request, notify_frontend=False)
-            broadcast_notification(CompletedRunNotification())
+            broadcast_run_completion()
 
         async def handle_pdb_request(request: DebugCellCommand) -> None:
             await self.pdb_request(request.cell_id)
@@ -2413,13 +2413,13 @@ class Kernel:
                     ),
                     notify_frontend=False,
                 )
-                broadcast_notification(CompletedRunNotification())
+                broadcast_run_completion()
             elif self.state_updates:
                 # Callbacks during message processing (e.g. widget observe
                 # handlers) may have called mo.state setters. Process
                 # those pending state updates now.
                 await self._run_cells(set())
-                broadcast_notification(CompletedRunNotification())
+                broadcast_run_completion()
 
         async def handle_function_call(request: InvokeFunctionCommand) -> None:
             status, ret, _ = await self.function_call_request(request)
@@ -2441,7 +2441,7 @@ class Kernel:
             request: InstallPackagesCommand,
         ) -> None:
             await self.packages_callbacks.install_missing_packages(request)
-            broadcast_notification(CompletedRunNotification())
+            broadcast_run_completion()
 
         async def handle_stop(request: StopKernelCommand) -> None:
             del request

--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -557,16 +557,13 @@ async def run_app_until_completion(
         http_request=None,
     )
     await instantiated_event.wait()
-    # Process console messages
-    #
-    # TODO(akshayka): A timing issue with the console output worker
-    # might still exist; the better thing to do would be to flush
-    # the worker, then ask it to quit and join on it. If we have an
-    # issue with some outputs being missed, that's what we should do.
-    session.flush_messages()
-    # Hack: yield to give the session view a chance to process the incoming
-    # console operations.
-    await asyncio.sleep(0.1)
+    # CompletedRunNotification is broadcast only after the kernel flushes
+    # its buffered console-output worker (see ``broadcast_run_completion``),
+    # so stdout/stderr for the run reaches the distributor ahead of the
+    # completion signal. The distributor processes messages in FIFO order
+    # and updates ``session_view`` synchronously from ``session.notify``,
+    # so by the time this await resumes every console message is already
+    # reflected in the view.
 
     if persist_session:
         from marimo._server.export._session_cache import (

--- a/tests/_messaging/test_console_output_worker.py
+++ b/tests/_messaging/test_console_output_worker.py
@@ -9,6 +9,7 @@ from marimo._messaging.cell_output import CellChannel
 from marimo._messaging.console_output_worker import (
     TIMEOUT_S,
     ConsoleMsg,
+    FlushRequest,
     _add_output_to_buffer,
     _can_merge_outputs,
     _write_console_output,
@@ -247,6 +248,190 @@ class TestConsoleOutputWorker:
 
         finally:
             # Signal the writer to terminate
+            with cv:
+                msg_queue.append(None)
+                cv.notify()
+            thread.join(timeout=1.0)
+
+    def test_flush_request_drains_buffer_synchronously(self) -> None:
+        # A FlushRequest must force the worker to write buffered outputs
+        # before its ``done`` event fires, without waiting for the 10ms
+        # timer.
+        stream = MockStream()
+        msg_queue: deque[ConsoleMsg | FlushRequest | None] = deque()
+        cv = threading.Condition()
+
+        thread = threading.Thread(
+            target=buffered_writer, args=(msg_queue, stream, cv)
+        )
+        thread.daemon = True
+        thread.start()
+
+        try:
+            done = threading.Event()
+            with cv:
+                msg_queue.append(
+                    ConsoleMsg(
+                        stream=CellChannel.STDOUT,
+                        cell_id="cell1",
+                        data="buffered",
+                        mimetype="text/plain",
+                    )
+                )
+                msg_queue.append(FlushRequest(done=done))
+                cv.notify()
+
+            # The event should be set well inside the 10ms timer window
+            # if the flush really is synchronous.
+            assert done.wait(timeout=1.0), "FlushRequest.done never fired"
+            assert len(stream.operations) == 1
+            assert stream.operations[0]["console"]["data"] == "buffered"
+
+        finally:
+            with cv:
+                msg_queue.append(None)
+                cv.notify()
+            thread.join(timeout=1.0)
+
+    def test_flush_request_on_empty_buffer_signals_done(self) -> None:
+        # Flushing when nothing is buffered must still return promptly.
+        stream = MockStream()
+        msg_queue: deque[ConsoleMsg | FlushRequest | None] = deque()
+        cv = threading.Condition()
+
+        thread = threading.Thread(
+            target=buffered_writer, args=(msg_queue, stream, cv)
+        )
+        thread.daemon = True
+        thread.start()
+
+        try:
+            done = threading.Event()
+            with cv:
+                msg_queue.append(FlushRequest(done=done))
+                cv.notify()
+
+            assert done.wait(timeout=1.0)
+            assert len(stream.operations) == 0
+
+        finally:
+            with cv:
+                msg_queue.append(None)
+                cv.notify()
+            thread.join(timeout=1.0)
+
+    def test_termination_drops_buffered_outputs(self) -> None:
+        # The non-blocking shutdown contract: a None sentinel causes the
+        # worker to return without writing whatever it still has buffered.
+        # Callers that care about delivery must flush first.
+        stream = MockStream()
+        msg_queue: deque[ConsoleMsg | FlushRequest | None] = deque()
+        cv = threading.Condition()
+
+        thread = threading.Thread(
+            target=buffered_writer, args=(msg_queue, stream, cv)
+        )
+        thread.daemon = True
+        thread.start()
+
+        with cv:
+            msg_queue.append(
+                ConsoleMsg(
+                    stream=CellChannel.STDOUT,
+                    cell_id="cell1",
+                    data="dropped",
+                    mimetype="text/plain",
+                )
+            )
+            msg_queue.append(None)
+            cv.notify()
+
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+        assert stream.operations == []
+
+    def test_termination_wakes_pending_flush_request(self) -> None:
+        # If stop() races a concurrent flush_console(), the worker must
+        # still set the flush request's done event before returning,
+        # otherwise the flusher hangs forever.
+        stream = MockStream()
+        msg_queue: deque[ConsoleMsg | FlushRequest | None] = deque()
+        cv = threading.Condition()
+
+        thread = threading.Thread(
+            target=buffered_writer, args=(msg_queue, stream, cv)
+        )
+        thread.daemon = True
+        thread.start()
+
+        done = threading.Event()
+        with cv:
+            msg_queue.append(FlushRequest(done=done))
+            msg_queue.append(None)
+            cv.notify()
+
+        assert done.wait(timeout=1.0), (
+            "FlushRequest.done must fire even on termination"
+        )
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+
+    def test_flush_happens_before_subsequent_enqueues(self) -> None:
+        # Writes enqueued *before* a FlushRequest must all be flushed by the
+        # time done fires; writes enqueued *after* the flush must not have
+        # leaked into the batch.
+        stream = MockStream()
+        msg_queue: deque[ConsoleMsg | FlushRequest | None] = deque()
+        cv = threading.Condition()
+
+        thread = threading.Thread(
+            target=buffered_writer, args=(msg_queue, stream, cv)
+        )
+        thread.daemon = True
+        thread.start()
+
+        try:
+            done = threading.Event()
+            with cv:
+                msg_queue.append(
+                    ConsoleMsg(
+                        stream=CellChannel.STDOUT,
+                        cell_id="cell1",
+                        data="pre",
+                        mimetype="text/plain",
+                    )
+                )
+                msg_queue.append(FlushRequest(done=done))
+                cv.notify()
+
+            assert done.wait(timeout=1.0)
+            # At this point only "pre" should be on the wire.
+            assert [op["console"]["data"] for op in stream.operations] == [
+                "pre"
+            ]
+
+            # Subsequent writes go through the normal 10ms path.
+            with cv:
+                msg_queue.append(
+                    ConsoleMsg(
+                        stream=CellChannel.STDOUT,
+                        cell_id="cell1",
+                        data="post",
+                        mimetype="text/plain",
+                    )
+                )
+                cv.notify()
+
+            for _ in range(20):
+                time.sleep(TIMEOUT_S * 2)
+                if len(stream.operations) == 2:
+                    break
+            assert [op["console"]["data"] for op in stream.operations] == [
+                "pre",
+                "post",
+            ]
+
+        finally:
             with cv:
                 msg_queue.append(None)
                 cv.notify()

--- a/tests/_server/export/fixtures/apps/with_console_output.py
+++ b/tests/_server/export/fixtures/apps/with_console_output.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.19.2"
+__generated_with = "0.23.2"
 app = marimo.App()
 
 


### PR DESCRIPTION
CompletedRunNotification was broadcast by the main kernel thread as soon as cells finished, independently of the buffered console-output worker, which holds writes for up to 10ms before flushing. Under CI load the buffered stdout/stderr could arrive at the parent process after the completion signal, so consumers that snapshot session state on completion (the ipynb/PDF exporters) saw incomplete output. The export path papered over this with a 100ms asyncio.sleep, which wasn't always enough.

Fix the underlying race: give ThreadSafeStream a synchronous flush_console() that drives a new FlushRequest sentinel through the buffered writer and blocks until pending outputs have been written to the pipe. Route every CompletedRunNotification through a new broadcast_run_completion() helper that flushes first, so the completion signal now means "every output for this run is on the wire," not just "cells are done running." Every consumer benefits from the stronger guarantee, not just export.

Also drop the export path's asyncio.sleep(0.1) hack along with a misleading session.flush_messages() call whose distributor-level implementation actively discards pending messages instead of forwarding them. With the kernel-side ordering guarantee, neither is needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure run completion is broadcast only after all buffered console output is flushed. Fixes a race that sometimes dropped tail stdout/stderr in exports and removes the export sleep hack.

- **Bug Fixes**
  - Added `FlushRequest` to the console-output worker and a synchronous `flush_console()` on the stream to drain buffered logs.
  - Introduced `broadcast_run_completion()` that flushes then emits `CompletedRunNotification`; used across runtime handlers.
  - Kept non-blocking shutdown (pending logs are dropped on stop) but ensure pending flush waiters are signaled.
  - Removed export path’s `asyncio.sleep(0.1)` and `session.flush_messages()` since ordering is now guaranteed.
  - Added tests for flush behavior, ordering, and termination edge cases.

<sup>Written for commit d007a1427f2068ecf3866c05e33afc826e1d3505. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

