### PR TITLE
Return html encoded matplotlib Figure from msgspec encoder hook

### DIFF
--- a/marimo/_messaging/msgspec_encoder.py
+++ b/marimo/_messaging/msgspec_encoder.py
@@ -170,6 +170,7 @@ def enc_hook(obj: Any) -> Any:
             if isinstance(obj, matplotlib.figure.Figure):
                 html = as_html(vstack([str(obj), obj]))
                 mimetype, data = html._mime_()
+                return {"mimetype": mimetype, "data": data}
 
             if isinstance(obj, Axes):
                 html = as_html(vstack([str(obj), obj]))


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
This fix changes the msgspec encoder hook to actually return encoded matplotlib Figure objects – like it's already done for matplotlib Axes objects.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `msgspec` encoder hook to return HTML-encoded data for `matplotlib.figure.Figure` objects. This matches the existing `Axes` handling so figures render correctly and serialize without errors.

<sup>Written for commit 21fa169a3610e61217153d0f65f2bb7c25614ea9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

