### PR TITLE
test: xfail a flaky `app` test in CI

### DIFF
--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -1117,6 +1117,12 @@ def test_cli_args(tmp_path: pathlib.Path) -> None:
     assert "value2" in output
 
 
+# TODO(akshayka): Many of the app composition and embedding tests are flaky in
+# CI. This suggests either cross-test state pollution or a bug in the
+# underlying implementation. These bugs are not high priority to fix, so
+# the flaky tests have been marked as xfail. If this ever does become
+# a priority (in particular, if we see GitHub issues about these methods
+# failing in real usage), these failing tests may provide a clue.
 class TestAppComposition:
     async def test_app_embed(self) -> None:
         app = App()
@@ -1784,6 +1790,10 @@ class TestInternalAppOverrides:
         assert not k.errors
         assert k.globals["overrides"] == {"x": 100}
 
+
+    @pytest.mark.xfail(
+        True, reason="Flaky in CI, can't repro locally", strict=False
+    )
     async def test_overrides_returns_multiple_defs(
         self, k: Kernel, exec_req: ExecReqProvider
     ) -> None:
@@ -1825,8 +1835,6 @@ class TestInternalAppOverrides:
         )
         assert not k.errors
         assert k.globals["overrides"] == {"a": 10, "b": 20}
-
-
 
 
 class TestAppKernelRunnerRegistry:


### PR DESCRIPTION
Many of the app composition and embedding tests are flaky in CI. This suggests either cross-test state pollution or a bug in the underlying implementation.

These bugs are not high priority to fix, so the flaky test has been marked as xfail. If this ever does become
a priority (in particular, if we see GitHub issues about these methods failing in real usage), these failing tests may provide a clue.

This test appears to only have started failing somewhat consistently after #9257, but I don't see any relation between the two (it's possible #9257's tests may pollute the test environment, but I haven't been able to see how).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked tests/_ast/test_app.py::TestAppComposition::test_overrides_returns_multiple_defs as xfail to stabilize CI for app composition/embedding. The failure is CI-only and likely due to cross-test state or an underlying bug; we’ll revisit if it affects users.

<sup>Written for commit 3046298905ac6e449728a51a7929ffec9fede0e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

