### PR TITLE
fix: add Path to cookie

### DIFF
--- a/marimo/_server/api/auth.py
+++ b/marimo/_server/api/auth.py
@@ -167,7 +167,7 @@ class CookieSession:
 class CustomSessionMiddleware(SessionMiddleware):
     """
     Wrapper around starlette's SessionMiddleware to:
-     - customize the session cookie based on the the port
+     - customize the session cookie based on the port and base URL
      - only run in Edit mode
     """
 
@@ -188,6 +188,7 @@ class CustomSessionMiddleware(SessionMiddleware):
         # we don't have access to the app state
 
         self.original_session_cookie = session_cookie
+        self.original_path = path
 
         if version.parse(starlette.__version__) >= version.parse("0.32.0"):
             # Domain was added in 0.32.0; we currently don't use it.
@@ -223,11 +224,21 @@ class CustomSessionMiddleware(SessionMiddleware):
 
         # We key the token cookie by port to avoid conflicts
         # with multiple marimo instances running on the same host
+        cookie_name = self.original_session_cookie
         maybe_port = state.maybe_port
         if maybe_port is not None:
-            self.session_cookie = (
-                f"{self.original_session_cookie}_{maybe_port}"
-            )
+            cookie_name = f"{cookie_name}_{maybe_port}"
+
+        base_url = getattr(state.state, "base_url", "")
+        if base_url:
+            slug = base_url.lstrip("/").replace("/", "_")
+            if slug:
+                cookie_name = f"{cookie_name}_{slug}"
+            self.path = base_url
+        else:
+            self.path = self.original_path
+
+        self.session_cookie = cookie_name
 
         return await super().__call__(scope, receive, send)
 

--- a/tests/_server/api/test_auth.py
+++ b/tests/_server/api/test_auth.py
@@ -41,6 +41,7 @@ async def test_custom_session_middleware_call(app: Starlette):
 
     await middleware(scope, mock_receive, mock_send)
     assert middleware.session_cookie == "session_1234"
+    assert middleware.path == "/"
 
 
 async def test_custom_session_middleware_call_with_port():
@@ -50,6 +51,32 @@ async def test_custom_session_middleware_call_with_port():
 
     await middleware(scope, mock_receive, mock_send)
     assert middleware.session_cookie == "session"
+
+
+def _app_with_base_url(base_url: str) -> Starlette:
+    app = create_starlette_app(base_url=base_url, enable_auth=True)
+    get_starlette_server_state_init(base_url=base_url).apply(app.state)
+    return app
+
+
+async def test_custom_session_middleware_scopes_cookie_to_base_url():
+    app = _app_with_base_url("/marimo1")
+    middleware = CustomSessionMiddleware(app, "secret_key")
+    scope = create_connection(app).scope
+
+    await middleware(scope, mock_receive, mock_send)
+    assert middleware.session_cookie == "session_1234_marimo1"
+    assert middleware.path == "/marimo1"
+
+
+async def test_custom_session_middleware_scopes_cookie_to_nested_base_url():
+    app = _app_with_base_url("/apps/ml/notebook")
+    middleware = CustomSessionMiddleware(app, "secret_key")
+    scope = create_connection(app).scope
+
+    await middleware(scope, mock_receive, mock_send)
+    assert middleware.session_cookie == "session_1234_apps_ml_notebook"
+    assert middleware.path == "/apps/ml/notebook"
 
 
 @pytest.fixture


### PR DESCRIPTION

Closes #9363

Scopes the name of the cookie to the path, as well as adds a `Path` attribute to the cookie

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
