### PR TITLE
fix: guard `_resolve_proxy` against bare-port inputs

### DIFF
--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -157,7 +157,7 @@ def _resolve_proxy(port: int, host: str, proxy: str | None) -> tuple[int, str]:
 
         # parsed.hostname strips brackets from IPv6 addresses
         # (e.g. [::1] → ::1)
-        external_host = parsed.hostname or proxy
+        external_host = parsed.hostname
         parsed_port = parsed.port
     except ValueError:
         LOGGER.warning(
@@ -167,6 +167,13 @@ def _resolve_proxy(port: int, host: str, proxy: str | None) -> tuple[int, str]:
             port,
         )
         return port, host
+
+    # Bare-port inputs like ":8080" leave parsed.hostname empty (urlparse
+    # sees an empty netloc with an explicit port); fall back to the
+    # original `host` arg rather than using the literal proxy string —
+    # which otherwise becomes the nonsense public hostname ":8080".
+    if not external_host:
+        external_host = host
 
     if parsed_port is not None:
         external_port = parsed_port

--- a/tests/_server/test_startup_url.py
+++ b/tests/_server/test_startup_url.py
@@ -66,6 +66,11 @@ def test_startup_url_ipv6(host: str, expected: str) -> None:
         ("http://example.com:8080", 2972, "127.0.0.1", 8080, "example.com"),
         # IPv6 with brackets and port
         ("[2001:db8::1]:8080", 2972, "127.0.0.1", 8080, "2001:db8::1"),
+        # Bare-port proxy (no host): port applies, host falls back to
+        # the inbound host arg rather than the literal ":8080" string.
+        (":8080", 2972, "0.0.0.0", 8080, "0.0.0.0"),
+        # Empty string proxy is treated as "no proxy".
+        ("", 2972, "127.0.0.1", 2972, "127.0.0.1"),
     ],
 )
 def test_resolve_proxy(


### PR DESCRIPTION
`_resolve_proxy(..., ":8080")` previously returned `(8080, ":8080")` because `parsed.hostname` is empty for a bare-port netloc and we fell back to the raw proxy string — so `":8080"` became the public host.

Fall back to the inbound `host` arg when `parsed.hostname` is empty.
