### PR TITLE
fix: guard `_references_virtual_file` against cyclic data

### DIFF
--- a/marimo/_session/state/serialize.py
+++ b/marimo/_session/state/serialize.py
@@ -68,12 +68,25 @@ def _references_virtual_file(data: Any) -> bool:
     embeds one would 404 on replay (e.g. anywidget HTML losing its binary
     state — see #9273).
     """
+    return _references_virtual_file_inner(data, set())
+
+
+def _references_virtual_file_inner(data: Any, seen: set[int]) -> bool:
     if isinstance(data, str):
         return _VIRTUAL_FILE_URL_RE.search(data) is not None
-    if isinstance(data, dict):
-        return any(_references_virtual_file(v) for v in data.values())
-    if isinstance(data, list):
-        return any(_references_virtual_file(v) for v in data)
+    if isinstance(data, (dict, list)):
+        # Guard against cycles: session outputs shouldn't contain them in
+        # practice, but a self-referencing structure should return False
+        # cleanly rather than blow the stack.
+        container_id = id(data)
+        if container_id in seen:
+            return False
+        seen.add(container_id)
+        if isinstance(data, dict):
+            return any(
+                _references_virtual_file_inner(v, seen) for v in data.values()
+            )
+        return any(_references_virtual_file_inner(v, seen) for v in data)
     return False
 
 

--- a/tests/_session/state/test_serialize_session.py
+++ b/tests/_session/state/test_serialize_session.py
@@ -22,6 +22,7 @@ from marimo._session.state.serialize import (
     SessionCacheManager,
     SessionCacheWriter,
     _hash_code,
+    _references_virtual_file,
     deserialize_session,
     get_session_cache_file,
     serialize_notebook,
@@ -479,6 +480,25 @@ def test_drop_virtual_file_outputs_ignores_literal_prefix_in_text(
     assert restored_output.data == (
         "marimo stores virtual files under ./@file/ on the server"
     )
+
+
+def test_references_virtual_file_handles_cyclic_data():
+    # A self-referencing dict or list must return False cleanly rather
+    # than raising RecursionError — the check is purely defensive, but
+    # a serializer that blows the stack is a poor failure mode for code
+    # that just decides whether to drop URLs.
+    cyclic_dict: dict[str, object] = {}
+    cyclic_dict["self"] = cyclic_dict
+    assert _references_virtual_file(cyclic_dict) is False
+
+    cyclic_list: list[object] = []
+    cyclic_list.append(cyclic_list)
+    assert _references_virtual_file(cyclic_list) is False
+
+    # Cycle through a nested structure still detects the URL when present.
+    leaf: dict[str, object] = {"html": '<img src="./@file/4-abcd1234.png">'}
+    leaf["self"] = leaf
+    assert _references_virtual_file(leaf) is True
 
 
 def test_drop_virtual_file_outputs_preserves_unrelated_outputs(


### PR DESCRIPTION
A self-referencing dict or list would blow the stack with `RecursionError` instead of returning cleanly — a poor failure mode for code that just decides whether to drop a cached output.

Track visited container ids in a seen-set so the walk terminates on cycles. Session outputs shouldn't contain them in practice; this is purely defensive.
