### PR TITLE
style: hide marimo-pair in wasm, fix opencode prompt

### DIFF
--- a/frontend/src/components/editor/actions/pair-with-agent-modal.tsx
+++ b/frontend/src/components/editor/actions/pair-with-agent-modal.tsx
@@ -37,7 +37,7 @@ function getPromptCommand(
     case "codex":
       return `codex "$(${base} --codex)"`;
     case "opencode":
-      return `opencode "$(${base} --opencode)"`;
+      return `opencode --prompt "$(${base} --opencode)"`;
     default:
       assertNever(agent);
   }

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -348,6 +348,7 @@ export function useNotebookActions() {
     {
       icon: <SparklesIcon size={14} strokeWidth={1.5} />,
       label: "Pair with an agent",
+      hidden: isWasm(),
       handle: async () => {
         openModal(<PairWithAgentModal onClose={closeModal} />);
       },


### PR DESCRIPTION
* hide marimo-pair in wasm
* fix the `opencode` copy command