### PR TITLE
Scope filter-by-values top-K to exclude the filter being edited

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -227,6 +227,45 @@ _DATATYPE_TO_CATEGORY: dict[str, str] = {
 }
 
 
+def _filters_reference_column(
+    group: FilterGroup, target_column: ColumnName
+) -> bool:
+    """True if any condition in the tree targets `target_column`."""
+    for child in group.children:
+        if isinstance(child, FilterCondition):
+            if child.column_id == target_column:
+                return True
+        elif isinstance(child, FilterGroup):
+            if _filters_reference_column(child, target_column):
+                return True
+    return False
+
+
+def _strip_filters_for_column(
+    group: FilterGroup, target_column: ColumnName
+) -> FilterGroup:
+    """Recursively remove conditions referencing the target column."""
+    valid_children: list[FilterCondition | FilterGroup] = []
+    for child in group.children:
+        if (
+            isinstance(child, FilterCondition)
+            and child.column_id == target_column
+        ):
+            continue
+        elif isinstance(child, FilterGroup):
+            stripped_child = _strip_filters_for_column(child, target_column)
+            if stripped_child.children:
+                valid_children.append(stripped_child)
+        else:
+            valid_children.append(child)
+    return FilterGroup(
+        type="group",
+        operator=group.operator,
+        children=tuple(valid_children),
+        negate=group.negate,
+    )
+
+
 def _filter_valid_columns(
     group: FilterGroup,
     column_dtypes: Mapping[str, str],
@@ -578,6 +617,11 @@ class table(
         else:
             num_rows = self._manager.get_num_rows(force=True)
             total_rows = num_rows if num_rows is not None else "too_many"
+
+        # Most recent filter/query state from the frontend; used to rescope
+        # filter-aware computations like top-K. None until the first _search call.
+        self._current_filters: FilterGroup | None = None
+        self._current_query: str | None = None
 
         # Set the default value for show_column_summaries,
         # if it is not set by the user
@@ -1289,12 +1333,29 @@ class table(
     def _calculate_top_k_rows(
         self, args: CalculateTopKRowsArgs
     ) -> CalculateTopKRowsResponse:
-        """Calculate the top k rows in the table, grouped by column.
-        Returns a table of the top k rows, grouped by column with the count.
+        """Calculate the top k values for a column, with counts.
+
+        If the active filter set targets this column, those conditions are
+        stripped before computing top-K so the picker can surface values the
+        user's current filter would otherwise hide. Filters on other columns
+        and the search query still apply.
         """
         column, k = args.column, args.k
         try:
-            data = self._searched_manager.calculate_top_k_rows(column, k)
+            manager = self._searched_manager
+            current_filters = self._current_filters
+            if (
+                current_filters is not None
+                and current_filters.children
+                and _filters_reference_column(current_filters, column)
+            ):
+                stripped = _strip_filters_for_column(current_filters, column)
+                manager = self._apply_filters_query_sort(
+                    stripped if stripped.children else None,
+                    self._current_query,
+                    None,
+                )
+            data = manager.calculate_top_k_rows(column, k)
             return CalculateTopKRowsResponse(data=data)
         # Some libs will panic like Polars, which are only caught with BaseException
         except BaseException as e:
@@ -1507,6 +1568,9 @@ class table(
         max_columns = args.max_columns
         if max_columns == MAX_COLUMNS_NOT_PROVIDED:
             max_columns = self._max_columns
+
+        self._current_filters = args.filters
+        self._current_query = args.query
 
         def clamp_rows_and_columns(
             manager: TableManager[Any],

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -2313,6 +2313,119 @@ def test_calculate_top_k_rows():
     )
 
 
+_TOP_K_DATA = {
+    "role": ["admin", "admin", "user", "user", "guest"],
+    "country": ["US", "UK", "US", "US", "UK"],
+}
+
+
+def _filter_role_in(values: list[str]) -> FilterGroup:
+    return FilterGroup(
+        type="group",
+        operator="and",
+        children=[
+            FilterCondition(
+                type="condition",
+                column_id="role",
+                operator="in",
+                value=values,
+            )
+        ],
+    )
+
+
+def _filter_country_eq(value: str) -> FilterGroup:
+    return FilterGroup(
+        type="group",
+        operator="and",
+        children=[
+            FilterCondition(
+                type="condition",
+                column_id="country",
+                operator="equals",
+                value=value,
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize("df", create_dataframes(_TOP_K_DATA))
+def test_top_k_ignores_same_column_filter(df: Any) -> None:
+    """Editing a filter on a column must not hide values the filter excludes."""
+    table = ui.table(df)
+    table._search(
+        SearchTableArgs(
+            page_size=10,
+            page_number=0,
+            filters=_filter_role_in(["admin", "user"]),
+        )
+    )
+    result = table._calculate_top_k_rows(
+        CalculateTopKRowsArgs(column="role", k=10)
+    )
+    # `guest` is excluded by the active filter but must still appear,
+    # otherwise users can't broaden the filter back out.
+    assert result == CalculateTopKRowsResponse(
+        data=[("admin", 2), ("user", 2), ("guest", 1)],
+    )
+
+
+@pytest.mark.parametrize("df", create_dataframes(_TOP_K_DATA))
+def test_top_k_respects_other_column_filter(df: Any) -> None:
+    table = ui.table(df)
+    table._search(
+        SearchTableArgs(
+            page_size=10,
+            page_number=0,
+            filters=_filter_country_eq("UK"),
+        )
+    )
+    result = table._calculate_top_k_rows(
+        CalculateTopKRowsArgs(column="role", k=10)
+    )
+    # Only UK rows survive: admin (UK) and guest (UK).
+    assert result == CalculateTopKRowsResponse(
+        data=[("admin", 1), ("guest", 1)],
+    )
+
+
+@pytest.mark.parametrize("df", create_dataframes(_TOP_K_DATA))
+def test_top_k_strips_self_filter_keeps_others(df: Any) -> None:
+    table = ui.table(df)
+    table._search(
+        SearchTableArgs(
+            page_size=10,
+            page_number=0,
+            filters=FilterGroup(
+                type="group",
+                operator="and",
+                children=[
+                    FilterCondition(
+                        type="condition",
+                        column_id="role",
+                        operator="in",
+                        value=["admin", "user"],
+                    ),
+                    FilterCondition(
+                        type="condition",
+                        column_id="country",
+                        operator="equals",
+                        value="UK",
+                    ),
+                ],
+            ),
+        )
+    )
+    result = table._calculate_top_k_rows(
+        CalculateTopKRowsArgs(column="role", k=10)
+    )
+    # `role` filter is stripped, `country == UK` still applies:
+    # UK rows are admin + guest. `guest` reappears because role filter is ignored.
+    assert result == CalculateTopKRowsResponse(
+        data=[("admin", 1), ("guest", 1)],
+    )
+
+
 def _convert_data_bytes_to_pandas_df(
     data: str, data_format: str
 ) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- Re-opening a "filter by values" pill re-computed the picker's top-K list against the already-filtered rows, so values excluded by the current filter vanished from the picker. Narrowing `role` to `[admin, user]` hid `guest` entirely — the user could no longer broaden the filter back out without clearing it.
- `_calculate_top_k_rows` now strips conditions targeting the requested column before computing top-K. Filters on other columns and the active search query still narrow the result, so cross-column filter context is preserved.
- Fast path: when no active filter targets the requested column, the cached `_searched_manager` is reused — zero extra cost for the common case.

### Before
https://github.com/user-attachments/assets/ff33a5f0-d8ae-4332-9870-987f2d99446d

### After
https://github.com/user-attachments/assets/f34d590e-805e-49d3-b26c-d94825b03c4a