### PR TITLE
feat: prompt user to build fe at first run

### DIFF
--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -67,6 +67,16 @@ assets_dir = root / "assets"
 follow_symlinks = server_config.get("follow_symlink", False)
 
 
+def _missing_index_html_detail() -> str:
+    repo_root = marimo_package_path().parent
+    if (repo_root / "frontend").exists() and (repo_root / "pyproject.toml").exists():
+        return (
+            "index.html not found. Frontend assets do not appear to be built "
+            "for this source checkout; run `make fe` and restart marimo."
+        )
+    return "index.html not found and no asset_url configured"
+
+
 def _has_symlinks(directory: Path) -> bool:
     """Check if a directory is a symlink or contains symlinked files."""
     if directory.is_symlink():
@@ -316,7 +326,7 @@ async def index(request: Request) -> Response:
     else:
         raise HTTPException(
             status_code=500,
-            detail="index.html not found and no asset_url configured",
+            detail=_missing_index_html_detail(),
         )
 
     if not file_key:

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -69,7 +69,9 @@ follow_symlinks = server_config.get("follow_symlink", False)
 
 def _missing_index_html_detail() -> str:
     repo_root = marimo_package_path().parent
-    if (repo_root / "frontend").exists() and (repo_root / "pyproject.toml").exists():
+    if (repo_root / "frontend").exists() and (
+        repo_root / "pyproject.toml"
+    ).exists():
         return (
             "index.html not found. Frontend assets do not appear to be built "
             "for this source checkout; run `make fe` and restart marimo."

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -73,8 +73,8 @@ def _missing_index_html_detail() -> str:
         repo_root / "pyproject.toml"
     ).exists():
         return (
-            "index.html not found. Frontend assets do not appear to be built "
-            "for this source checkout; run `make fe` and restart marimo."
+            "index.html not found. Did you run `make fe`? "
+            "Restart marimo after building."
         )
     return "index.html not found and no asset_url configured"
 

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -104,7 +104,9 @@ def test_index_missing_assets_in_source_checkout_shows_build_hint(
         response = client.get("/", headers=token_header())
 
     assert response.status_code == 500
-    assert "run `make fe` and restart marimo" in response.json()["detail"]
+    detail = response.json()["detail"]
+    assert "Did you run `make fe`?" in detail
+    assert "Restart marimo after building." in detail
 
 
 def test_index_strips_access_token_query_param(client: TestClient) -> None:

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -83,6 +83,30 @@ def test_index_when_new_file(client: TestClient) -> None:
     assert "<title>marimo</title>" in content
 
 
+def test_index_missing_assets_in_source_checkout_shows_build_hint(
+    client: TestClient, tmp_path: Path
+) -> None:
+    source_root = tmp_path / "repo"
+    source_root.mkdir()
+    (source_root / "frontend").mkdir()
+    (source_root / "pyproject.toml").write_text("")
+
+    missing_static_root = tmp_path / "missing_static"
+    missing_static_root.mkdir()
+
+    with (
+        patch("marimo._server.api.endpoints.assets.root", missing_static_root),
+        patch(
+            "marimo._server.api.endpoints.assets.marimo_package_path",
+            return_value=source_root / "marimo",
+        ),
+    ):
+        response = client.get("/", headers=token_header())
+
+    assert response.status_code == 500
+    assert "run `make fe` and restart marimo" in response.json()["detail"]
+
+
 def test_index_strips_access_token_query_param(client: TestClient) -> None:
     # A valid `?access_token=` in the URL should 303 to the same path with
     # the token removed, carrying a session cookie so the follow-up request


### PR DESCRIPTION
When `marimo edit` is run from a repo checkout without built frontend assets, the current error is `index.html not found and no asset_url configured`, which is confusing for contributors. This changes that path to return a more actionable message telling the user to run `make fe` and restart marimo.