### PR TITLE
docs(ui): clarify UIElement value is read-only

### DIFF
--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -101,7 +101,9 @@ class UIElement(Html, Generic[S, T]):
 
     **Attributes.**
 
-    - value: The value of the `UIElement`.
+    - value: The current value of the `UIElement`. Read-only; it reflects
+      frontend state and can't be assigned directly. If you need to
+      imperatively drive UI state, use `mo.state()`.
 
     **Methods.**
 
@@ -310,7 +312,12 @@ class UIElement(Html, Generic[S, T]):
 
     @property
     def value(self) -> T:
-        """The element's current value."""
+        """The element's current value.
+
+        Read-only; marimo updates it when the UI element changes in the
+        frontend. If you need to imperatively drive UI state, use
+        `mo.state()` instead of assigning to this property.
+        """
         if self._ctx is None:
             return self._value
 


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

The shared `UIElement` docs described `value` without noting that it is read-only, even though the runtime rejects direct assignment with a `RuntimeError` and points users to `mo.state()`.

This updates the `UIElement` class and property docstrings to say that `value` reflects frontend state, cannot be assigned directly, and that `mo.state()` is the supported way to imperatively drive UI state.

Verification:
- reproduced the current runtime behavior in a local venv (`x.value = "hello"` raises `RuntimeError: Setting the value of a UIElement is not allowed...`)
- confirmed the updated docstrings through Python introspection after the edit
- attempted `mkdocs build --strict -q`, but the local docs toolchain failed before rendering due to a mkdocstrings/mkdocs config mismatch in this ad-hoc environment (`PythonConfig.__init__() got an unexpected keyword argument 'import'`)

Fixes #9203
