### PR TITLE
Mark DuckDb INET type (from inet extension) as unknown type

### DIFF
--- a/marimo/_data/get_datasets.py
+++ b/marimo/_data/get_datasets.py
@@ -522,6 +522,7 @@ _BINARY_TYPES = {"bit", "bitstring", "binary", "varbinary", "bytea"}
 _UNKNOWN_TYPES = {
     "row",
     "geometry",
+    "inet",
     # Null type (can occur when attaching databases or with unknown column types)
     "null",
     '"null"',

--- a/tests/_data/test_get_datasets.py
+++ b/tests/_data/test_get_datasets.py
@@ -660,6 +660,10 @@ def test_db_type_to_data_type_various() -> None:
     assert _db_type_to_data_type("blob") == "string"
     assert _db_type_to_data_type("guid") == "string"
     assert _db_type_to_data_type("nvarchar") == "string"
+    assert _db_type_to_data_type("char") == "string"
+    assert _db_type_to_data_type("bpchar") == "string"
+    assert _db_type_to_data_type("string") == "string"
+    assert _db_type_to_data_type("uuid") == "string"
 
     # Binary types (represented as string)
     assert _db_type_to_data_type("binary") == "string"
@@ -682,6 +686,7 @@ def test_db_type_to_data_type_various() -> None:
     assert _db_type_to_data_type("null") == "unknown"
     assert _db_type_to_data_type("json") == "unknown"
     assert _db_type_to_data_type("row") == "unknown"
+    assert _db_type_to_data_type("inet") == "unknown"
 
 
 @pytest.mark.requires("duckdb")


### PR DESCRIPTION
## 📝 Summary
When using INET extension for DuckDB, I got a warning about inet type:
<img width="493" height="452" alt="image" src="https://github.com/user-attachments/assets/0de1aea9-4c28-4fcd-bf84-e97fd68c853d" />

I marked this type as 'unknown' and updated tests (also for string types)

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.