### PR TITLE
fix: restore cell selection highlight for lazy/image cells in mo.ui.table

### DIFF
--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -164,13 +164,17 @@ export const DataTableBody = <TData,>({
       );
 
       const title = cell.getHoverTitle?.() ?? undefined;
+      const isCellSelected = cell.getIsSelected?.() || false;
       return (
         <TableCell
           tabIndex={0}
           {...getCellDomProps(cell.id)}
           key={cell.id}
           className={cn(
-            "whitespace-pre truncate max-w-[300px] outline-hidden border-r border-r-border/75",
+            "whitespace-pre truncate max-w-[300px] border-r border-r-border/75",
+            isCellSelected
+              ? "outline outline-2 outline-(--blue-7) -outline-offset-2"
+              : "outline-hidden",
             cell.column.getColumnWrapping &&
               cell.column.getColumnWrapping?.() === "wrap" &&
               COLUMN_WRAPPING_STYLES,


### PR DESCRIPTION
Closes #9189

## 📝 Summary

When `mo.ui.table` contains `mo.lazy(mo.image(...))` or `mo.image()` cells with `selection="single-cell"`, the visual highlight does not appear when clicking the image, even though `table.value` updates correctly.

**Root cause:** The existing highlight uses a `::before` pseudo-element with `z-index: -10` on the inner content div. `<img>` elements(both inside shadow DOM (`mo.lazy`) and in light DOM (`mo.image`)), create browser compositing layers that always paint above `z-index: -10` absolutely-positioned elements. This is a fundamental browser rendering constraint, not a CSS specificity issue.

Verified in devtools:
- `td.style.backgroundColor` → invisible behind image ✗
- `td.style.boxShadow = 'inset ...'` → invisible behind image ✗
- `td.style.outline = '2px solid blue'` → visible above image ✓

This also explains why clicking the white gap/padding around the image DID show the highlight — the padding area has no compositing layer.

**Fix:** Apply the selection outline directly on the `<td>` element, which renders in the browser's decoration layer above all content including image compositing layers. One file changed, 4 lines added.

## Screenshots
<img width="671" height="641" alt="Screenshot 2026-04-25 at 6 03 25 PM" src="https://github.com/user-attachments/assets/55d17e57-a2bf-48a8-a0b0-7976d49d3ea1" />
<img width="679" height="665" alt="Screenshot 2026-04-25 at 6 08 54 PM" src="https://github.com/user-attachments/assets/04e8a752-89f7-499d-80e0-eb8fe5197453" />

<img width="696" height="651" alt="Screenshot 2026-04-25 at 6 09 40 PM" src="https://github.com/user-attachments/assets/d6f92da3-16c5-41f7-bc4d-2b883d60daba" />


## Pre-Review Checklist

- [x] All 462 frontend tests pass
- [x] `mo.lazy(mo.image(...))` - blue outline visible on selection
- [x] `mo.image(...)` without lazy - blue outline visible on selection  
- [x] Text cells - blue outline visible on selection
- [x] Dark mode verified (`--blue-7` resolves correctly)