### PR TITLE
Documentation Bugfix: Polars cannot read json from URL

### DIFF
--- a/docs/guides/working_with_data/dataframes.md
+++ b/docs/guides/working_with_data/dataframes.md
@@ -47,10 +47,12 @@ df
 
 ```python
 import polars as pl
+import urllib.request
 
-df = pl.read_json(
-"https://raw.githubusercontent.com/vega/vega-datasets/master/data/cars.json"
-)
+url = "https://raw.githubusercontent.com/vega/vega-datasets/master/data/cars.json"
+
+with urllib.request.urlopen(url) as response:
+    df = pl.read_json(response.read())
 df
 ```
 


### PR DESCRIPTION
Affected documentation: https://docs.marimo.io/guides/working_with_data/dataframes/#__tabbed_1_2

Polars read_json() cannot read from a URL. Documentation: https://docs.pola.rs/api/python/dev/reference/api/polars.read_json.html

## 📝 Summary

The current implementation throws the following error:

```
FileNotFoundError
No such file or directory (os error 2): https://raw.githubusercontent.com/vega/vega-datasets/master/data/cars.json
```

The fix does not introduce new dependencies.

Screenshot:
<img width="933" height="835" alt="image" src="https://github.com/user-attachments/assets/461473da-7327-442b-9353-3932d44629d8" />


## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
