### PR TITLE
allow cell selection on non-interactive marimo elements

### DIFF
--- a/frontend/src/components/data-table/range-focus/__tests__/use-cell-range-selection.test.ts
+++ b/frontend/src/components/data-table/range-focus/__tests__/use-cell-range-selection.test.ts
@@ -1,164 +1,198 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { isInteractiveTarget } from "../use-cell-range-selection";
 
-function createMouseEvent(
-  target: HTMLElement,
-  currentTarget: HTMLElement,
-): React.MouseEvent {
-  return { target, currentTarget } as unknown as React.MouseEvent;
+/**
+ * Dispatch a real `mousedown` from `target` (going through real DOM event
+ * dispatch so `composedPath()` traverses any open shadow roots) and call
+ * `isInteractiveTarget` from inside the listener, where the event's target
+ * and composed path are still live.
+ */
+function isInteractive(target: Element, cell: Element): boolean {
+  let result: boolean | undefined;
+  const handler = (event: Event) => {
+    const path = event.composedPath();
+    result = isInteractiveTarget({
+      target: event.target,
+      currentTarget: cell,
+      nativeEvent: {
+        composedPath: () => path,
+      },
+    } as unknown as React.MouseEvent);
+  };
+  cell.addEventListener("mousedown", handler);
+  target.dispatchEvent(
+    new MouseEvent("mousedown", { bubbles: true, composed: true }),
+  );
+  cell.removeEventListener("mousedown", handler);
+  if (result === undefined) {
+    throw new Error("mousedown did not bubble to the cell");
+  }
+  return result;
 }
+
+let mounted: HTMLElement[] = [];
+
+function makeCell(): HTMLTableCellElement {
+  const table = document.createElement("table");
+  const tbody = document.createElement("tbody");
+  const row = document.createElement("tr");
+  const cell = document.createElement("td");
+  row.append(cell);
+  tbody.append(row);
+  table.append(tbody);
+  document.body.append(table);
+  mounted.push(table);
+  return cell;
+}
+
+afterEach(() => {
+  for (const el of mounted) {
+    el.remove();
+  }
+  mounted = [];
+});
 
 describe("isInteractiveTarget", () => {
   it("returns false when target is the cell itself", () => {
-    const cell = document.createElement("td");
-    expect(isInteractiveTarget(createMouseEvent(cell, cell))).toBe(false);
+    const cell = makeCell();
+    expect(isInteractive(cell, cell)).toBe(false);
   });
 
   it("returns false when clicking plain text inside a cell", () => {
-    const cell = document.createElement("td");
+    const cell = makeCell();
     const span = document.createElement("span");
     cell.append(span);
-    expect(isInteractiveTarget(createMouseEvent(span, cell))).toBe(false);
+    expect(isInteractive(span, cell)).toBe(false);
   });
 
   it.each(["input", "button", "select", "textarea"])(
     "returns true when clicking a <%s>",
     (tag) => {
-      const cell = document.createElement("td");
+      const cell = makeCell();
       const el = document.createElement(tag);
       cell.append(el);
-      expect(isInteractiveTarget(createMouseEvent(el, cell))).toBe(true);
+      expect(isInteractive(el, cell)).toBe(true);
     },
   );
 
   it("returns true when clicking an <a> link", () => {
-    const cell = document.createElement("td");
+    const cell = makeCell();
     const a = document.createElement("a");
     a.href = "#";
     cell.append(a);
-    expect(isInteractiveTarget(createMouseEvent(a, cell))).toBe(true);
+    expect(isInteractive(a, cell)).toBe(true);
   });
 
   it("returns true when clicking a <label>", () => {
-    const cell = document.createElement("td");
+    const cell = makeCell();
     const label = document.createElement("label");
     cell.append(label);
-    expect(isInteractiveTarget(createMouseEvent(label, cell))).toBe(true);
+    expect(isInteractive(label, cell)).toBe(true);
   });
 
-  it('returns true for element with role="checkbox"', () => {
-    const cell = document.createElement("td");
-    const div = document.createElement("div");
-    div.setAttribute("role", "checkbox");
-    cell.append(div);
-    expect(isInteractiveTarget(createMouseEvent(div, cell))).toBe(true);
-  });
-
-  it('returns true for element with role="button"', () => {
-    const cell = document.createElement("td");
-    const div = document.createElement("div");
-    div.setAttribute("role", "button");
-    cell.append(div);
-    expect(isInteractiveTarget(createMouseEvent(div, cell))).toBe(true);
-  });
+  it.each(["checkbox", "button"])(
+    'returns true for element with role="%s"',
+    (role) => {
+      const cell = makeCell();
+      const div = document.createElement("div");
+      div.setAttribute("role", role);
+      cell.append(div);
+      expect(isInteractive(div, cell)).toBe(true);
+    },
+  );
 
   it('returns true for contenteditable="true"', () => {
-    const cell = document.createElement("td");
+    const cell = makeCell();
     const div = document.createElement("div");
     div.setAttribute("contenteditable", "true");
     cell.append(div);
-    expect(isInteractiveTarget(createMouseEvent(div, cell))).toBe(true);
+    expect(isInteractive(div, cell)).toBe(true);
   });
 
   it("returns true when clicking a child nested inside an interactive element", () => {
-    const cell = document.createElement("td");
+    const cell = makeCell();
     const button = document.createElement("button");
     const icon = document.createElement("span");
     button.append(icon);
     cell.append(button);
-    expect(isInteractiveTarget(createMouseEvent(icon, cell))).toBe(true);
+    expect(isInteractive(icon, cell)).toBe(true);
   });
 
-  it("returns true when clicking inside a marimo-ui-element", () => {
-    const cell = document.createElement("td");
+  it("returns true when clicking inside a marimo-ui-element wrapping a real widget", () => {
+    const cell = makeCell();
     const marimoEl = document.createElement("marimo-ui-element");
-    const inner = document.createElement("div");
-    marimoEl.append(inner);
+    const widget = document.createElement("marimo-slider");
+    marimoEl.append(widget);
     cell.append(marimoEl);
-    expect(isInteractiveTarget(createMouseEvent(inner, cell))).toBe(true);
-  });
-
-  it("returns true when clicking the marimo-ui-element itself", () => {
-    const cell = document.createElement("td");
-    const marimoEl = document.createElement("marimo-ui-element");
-    cell.append(marimoEl);
-    expect(isInteractiveTarget(createMouseEvent(marimoEl, cell))).toBe(true);
+    expect(isInteractive(widget, cell)).toBe(true);
+    expect(isInteractive(marimoEl, cell)).toBe(true);
   });
 
   it.each(["marimo-lazy", "marimo-routes"])(
     "returns false when clicking inside a passive content-wrapper UIElement (%s)",
     (tag) => {
-      const cell = document.createElement("td");
+      const cell = makeCell();
       const marimoEl = document.createElement("marimo-ui-element");
       const wrapper = document.createElement(tag);
       const inner = document.createElement("div");
       wrapper.append(inner);
       marimoEl.append(wrapper);
       cell.append(marimoEl);
-      expect(isInteractiveTarget(createMouseEvent(inner, cell))).toBe(false);
-      expect(isInteractiveTarget(createMouseEvent(wrapper, cell))).toBe(false);
+      expect(isInteractive(inner, cell)).toBe(false);
+      expect(isInteractive(wrapper, cell)).toBe(false);
     },
   );
 
-  it.each(["marimo-slider", "marimo-button", "marimo-dropdown"])(
-    "returns true when clicking inside an interactive UIElement (%s)",
-    (tag) => {
-      const cell = document.createElement("td");
-      const marimoEl = document.createElement("marimo-ui-element");
-      const widget = document.createElement(tag);
-      const inner = document.createElement("div");
-      widget.append(inner);
-      marimoEl.append(widget);
-      cell.append(marimoEl);
-      expect(isInteractiveTarget(createMouseEvent(inner, cell))).toBe(true);
-    },
-  );
+  it("returns false when clicking plain content rendered through mo.lazy's shadow DOM (#9189)", () => {
+    // Reproduces the structure marimo creates for mo.lazy(<plain html>):
+    // event.target gets retargeted to <marimo-lazy>, so closest() can't see
+    // into the shadow root. composedPath() must be used to confirm there's
+    // no genuinely interactive descendant.
+    const cell = makeCell();
+    const marimoEl = document.createElement("marimo-ui-element");
+    const lazy = document.createElement("marimo-lazy");
+    marimoEl.append(lazy);
+    cell.append(marimoEl);
 
-  it("returns true when an interactive UIElement is rendered alongside content wrappers", () => {
-    // Genuinely interactive UIElements have their own <marimo-ui-element>
-    // wrapper, so closest() finds it before reaching the outer content
-    // wrapper's <marimo-ui-element>.
-    const cell = document.createElement("td");
+    const shadow = lazy.attachShadow({ mode: "open" });
+    const img = document.createElement("img");
+    shadow.append(img);
+
+    expect(isInteractive(img, cell)).toBe(false);
+  });
+
+  it("returns true when clicking an interactive widget rendered inside a content wrapper's shadow DOM", () => {
+    // mo.lazy(mo.ui.slider(...)): the slider's <marimo-ui-element> lives
+    // inside marimo-lazy's shadow root, so closest() from the retargeted
+    // host couldn't see it. composedPath() does.
+    const cell = makeCell();
     const outerUi = document.createElement("marimo-ui-element");
     const lazy = document.createElement("marimo-lazy");
-    const innerUi = document.createElement("marimo-ui-element");
-    const slider = document.createElement("marimo-slider");
-    const input = document.createElement("input");
-    slider.append(input);
-    innerUi.append(slider);
-    lazy.append(innerUi);
     outerUi.append(lazy);
     cell.append(outerUi);
-    expect(isInteractiveTarget(createMouseEvent(input, cell))).toBe(true);
+
+    const lazyShadow = lazy.attachShadow({ mode: "open" });
+    const innerUi = document.createElement("marimo-ui-element");
+    const slider = document.createElement("marimo-slider");
+    innerUi.append(slider);
+    lazyShadow.append(innerUi);
+
+    const sliderShadow = slider.attachShadow({ mode: "open" });
+    const input = document.createElement("input");
+    input.type = "range";
+    sliderShadow.append(input);
+
+    expect(isInteractive(input, cell)).toBe(true);
   });
 
   it("returns false when clicking a non-interactive div", () => {
-    const cell = document.createElement("td");
+    const cell = makeCell();
     const wrapper = document.createElement("div");
     const text = document.createElement("span");
     wrapper.append(text);
     cell.append(wrapper);
-    expect(isInteractiveTarget(createMouseEvent(text, cell))).toBe(false);
-  });
-
-  it("returns false when target is a non-Element (e.g. Text node)", () => {
-    const cell = document.createElement("td");
-    const textNode = document.createTextNode("hello");
-    cell.append(textNode);
-    expect(isInteractiveTarget(createMouseEvent(textNode as never, cell))).toBe(
-      false,
-    );
+    expect(isInteractive(text, cell)).toBe(false);
   });
 });

--- a/frontend/src/components/data-table/range-focus/__tests__/use-cell-range-selection.test.ts
+++ b/frontend/src/components/data-table/range-focus/__tests__/use-cell-range-selection.test.ts
@@ -97,6 +97,53 @@ describe("isInteractiveTarget", () => {
     expect(isInteractiveTarget(createMouseEvent(marimoEl, cell))).toBe(true);
   });
 
+  it.each(["marimo-lazy", "marimo-routes"])(
+    "returns false when clicking inside a passive content-wrapper UIElement (%s)",
+    (tag) => {
+      const cell = document.createElement("td");
+      const marimoEl = document.createElement("marimo-ui-element");
+      const wrapper = document.createElement(tag);
+      const inner = document.createElement("div");
+      wrapper.append(inner);
+      marimoEl.append(wrapper);
+      cell.append(marimoEl);
+      expect(isInteractiveTarget(createMouseEvent(inner, cell))).toBe(false);
+      expect(isInteractiveTarget(createMouseEvent(wrapper, cell))).toBe(false);
+    },
+  );
+
+  it.each(["marimo-slider", "marimo-button", "marimo-dropdown"])(
+    "returns true when clicking inside an interactive UIElement (%s)",
+    (tag) => {
+      const cell = document.createElement("td");
+      const marimoEl = document.createElement("marimo-ui-element");
+      const widget = document.createElement(tag);
+      const inner = document.createElement("div");
+      widget.append(inner);
+      marimoEl.append(widget);
+      cell.append(marimoEl);
+      expect(isInteractiveTarget(createMouseEvent(inner, cell))).toBe(true);
+    },
+  );
+
+  it("returns true when an interactive UIElement is rendered alongside content wrappers", () => {
+    // Genuinely interactive UIElements have their own <marimo-ui-element>
+    // wrapper, so closest() finds it before reaching the outer content
+    // wrapper's <marimo-ui-element>.
+    const cell = document.createElement("td");
+    const outerUi = document.createElement("marimo-ui-element");
+    const lazy = document.createElement("marimo-lazy");
+    const innerUi = document.createElement("marimo-ui-element");
+    const slider = document.createElement("marimo-slider");
+    const input = document.createElement("input");
+    slider.append(input);
+    innerUi.append(slider);
+    lazy.append(innerUi);
+    outerUi.append(lazy);
+    cell.append(outerUi);
+    expect(isInteractiveTarget(createMouseEvent(input, cell))).toBe(true);
+  });
+
   it("returns false when clicking a non-interactive div", () => {
     const cell = document.createElement("td");
     const wrapper = document.createElement("div");

--- a/frontend/src/components/data-table/range-focus/use-cell-range-selection.ts
+++ b/frontend/src/components/data-table/range-focus/use-cell-range-selection.ts
@@ -130,6 +130,14 @@ export const useCellRangeSelection = <TData>({
 const INTERACTIVE_SELECTOR =
   'input, button, select, textarea, a, label, [role="checkbox"], [role="button"], [contenteditable="true"], marimo-ui-element';
 
+// `<marimo-ui-element>` wraps every stateful UIElement. For content-wrapper
+// UIElements (e.g. `<marimo-lazy>`), the wrapper itself is inert, so we
+// treat the click as non-interactive. See https://github.com/marimo-team/marimo/issues/9189.
+const CONTENT_WRAPPER_MARIMO_TAGS: ReadonlySet<string> = new Set([
+  "marimo-lazy",
+  "marimo-routes",
+]);
+
 /**
  * Skip cell selection when the click target is inside an interactive element
  * (e.g. a checkbox or button rendered as rich cell content).
@@ -139,5 +147,17 @@ export function isInteractiveTarget(e: React.MouseEvent): boolean {
   if (target === e.currentTarget || !(target instanceof Element)) {
     return false;
   }
-  return target.closest(INTERACTIVE_SELECTOR) !== null;
+  const interactiveAncestor = target.closest(INTERACTIVE_SELECTOR);
+  if (!interactiveAncestor) {
+    return false;
+  }
+  // Genuinely interactive children inside a wrapper still have their own
+  // <marimo-ui-element> and are matched by closest() first.
+  if (interactiveAncestor.localName === "marimo-ui-element") {
+    const inner = interactiveAncestor.firstElementChild;
+    if (inner && CONTENT_WRAPPER_MARIMO_TAGS.has(inner.localName)) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/frontend/src/components/data-table/range-focus/use-cell-range-selection.ts
+++ b/frontend/src/components/data-table/range-focus/use-cell-range-selection.ts
@@ -130,9 +130,10 @@ export const useCellRangeSelection = <TData>({
 const INTERACTIVE_SELECTOR =
   'input, button, select, textarea, a, label, [role="checkbox"], [role="button"], [contenteditable="true"], marimo-ui-element';
 
-// `<marimo-ui-element>` wraps every stateful UIElement. For content-wrapper
-// UIElements (e.g. `<marimo-lazy>`), the wrapper itself is inert, so we
-// treat the click as non-interactive. See https://github.com/marimo-team/marimo/issues/9189.
+// `<marimo-ui-element>` wraps every stateful UIElement, but content-wrapper
+// UIElements like `mo.lazy` and `mo.routes` are themselves inert. Clicks on
+// their inner content should still allow cell selection.
+// See https://github.com/marimo-team/marimo/issues/9189.
 const CONTENT_WRAPPER_MARIMO_TAGS: ReadonlySet<string> = new Set([
   "marimo-lazy",
   "marimo-routes",
@@ -141,23 +142,34 @@ const CONTENT_WRAPPER_MARIMO_TAGS: ReadonlySet<string> = new Set([
 /**
  * Skip cell selection when the click target is inside an interactive element
  * (e.g. a checkbox or button rendered as rich cell content).
+ *
+ * Walks `composedPath()` so we can see through Shadow DOM boundaries used by
+ * marimo plugins. Without this, `event.target` is retargeted to the outermost
+ * shadow host (e.g. `<marimo-lazy>`), hiding any genuinely interactive
+ * descendants rendered inside the shadow tree.
  */
 export function isInteractiveTarget(e: React.MouseEvent): boolean {
-  const target = e.target;
-  if (target === e.currentTarget || !(target instanceof Element)) {
-    return false;
-  }
-  const interactiveAncestor = target.closest(INTERACTIVE_SELECTOR);
-  if (!interactiveAncestor) {
-    return false;
-  }
-  // Genuinely interactive children inside a wrapper still have their own
-  // <marimo-ui-element> and are matched by closest() first.
-  if (interactiveAncestor.localName === "marimo-ui-element") {
-    const inner = interactiveAncestor.firstElementChild;
-    if (inner && CONTENT_WRAPPER_MARIMO_TAGS.has(inner.localName)) {
-      return false;
+  const path: readonly EventTarget[] =
+    typeof e.nativeEvent?.composedPath === "function"
+      ? e.nativeEvent.composedPath()
+      : [e.target];
+
+  for (const node of path) {
+    if (node === e.currentTarget) {
+      break;
     }
+    if (!(node instanceof Element) || !node.matches(INTERACTIVE_SELECTOR)) {
+      continue;
+    }
+    // A `<marimo-ui-element>` directly wrapping a passive content-wrapper is
+    // inert; keep walking to find a real interactive ancestor (if any).
+    if (node.localName === "marimo-ui-element") {
+      const inner = node.firstElementChild;
+      if (inner && CONTENT_WRAPPER_MARIMO_TAGS.has(inner.localName)) {
+        continue;
+      }
+    }
+    return true;
   }
-  return true;
+  return false;
 }


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #9189 and #9386.

- isInteractiveTarget used target.closest('…, marimo-ui-element'), which wrongly suppressed selection for mo.lazy (it's a UIElement wrapped in <marimo-ui-element>) and couldn't see inside the plugin's Shadow DOM.
- Walk event.nativeEvent.composedPath() from target to cell instead, piercing shadow roots.
- Skip passive content wrappers (marimo-lazy, marimo-routes) so their inner content is selectable, while still detecting any real interactive widget further along the path.

<img width="813" height="527" alt="image" src="https://github.com/user-attachments/assets/c1d2e26b-4238-4f6a-981b-50a5c735343c" />

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
