### PR TITLE
fix: msgspec encoding for starlette user

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, Protocol, overload
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, overload
 
 from marimo import _loggers
 from marimo._ast.cell import (
@@ -1274,15 +1274,17 @@ class AsyncCodeModeContext:
             )
         # Read trusted server URL and auth token injected by the
         # /execute endpoint (from server config, not request headers).
-        server_url: str | None = request.meta.get("screenshot_server_url")
+        server_url = cast(
+            "str | None", request.meta.get("screenshot_server_url")
+        )
         if server_url is None:
             raise ScreenshotError(
                 "Cannot take screenshots: screenshot_server_url not "
                 "found in request.meta.  This endpoint may not "
                 "support screenshots."
             )
-        screenshot_auth_token: str | None = request.meta.get(
-            "screenshot_auth_token"
+        screenshot_auth_token = cast(
+            "str | None", request.meta.get("screenshot_auth_token")
         )
 
         # Lazy-init the screenshot session (browser reuse).

--- a/marimo/_messaging/context.py
+++ b/marimo/_messaging/context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import uuid
 from contextvars import ContextVar
 from dataclasses import dataclass
+from typing import cast
 
 from marimo._runtime.commands import HTTPRequest
 
@@ -50,5 +51,5 @@ def is_code_mode_request() -> bool:
     request = HTTP_REQUEST_CTX.get(None)
     if request is None:
         return False
-    path: str = request.url.get("path", "")
+    path = cast("str", request.url.get("path", ""))
     return path.endswith("/api/kernel/execute")

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -70,6 +70,26 @@ Primitive = str | bool | int | float
 SerializedCLIArgs = dict[str, ListOrValue[Primitive]]
 
 
+def _user_to_dict(user: Any) -> dict[str, Any]:
+    """Normalize an auth user into a serializable dict.
+
+    Starlette's authentication middleware sets ``request.scope["user"]`` to a
+    ``BaseUser`` instance (commonly ``SimpleUser``). Storing the raw object on
+    ``HTTPRequest.user`` breaks msgspec serialization on the IPC path. Convert
+    to a dict matching the documented contract: "info from authentication
+    middleware (e.g., is_authenticated, username)".
+    """
+    if user is None:
+        return {}
+    if isinstance(user, dict):
+        return user
+    return {
+        "username": getattr(user, "username", ""),
+        "is_authenticated": getattr(user, "is_authenticated", False),
+        "display_name": getattr(user, "display_name", ""),
+    }
+
+
 @dataclass
 class HTTPRequest(Mapping[str, Any]):
     """Serializable HTTP request representation.
@@ -159,7 +179,7 @@ class HTTPRequest(Mapping[str, Any]):
             query_params=query_params,
             path_params=request.path_params,
             cookies=request.cookies,
-            user=request.get("user", {}),
+            user=_user_to_dict(request.get("user")),
             meta=request.get("meta", {}),
             # Left out for now. This may contain information that the app author
             # does not want to expose.

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -12,6 +12,7 @@ from typing import (
     Literal,
     TypeVar,
     Union,
+    cast,
 )
 from uuid import uuid4
 
@@ -22,6 +23,7 @@ from marimo._ast.app_config import _AppConfig
 from marimo._config.config import MarimoConfig
 from marimo._data.models import DataTableSource
 from marimo._messaging.notebook.document import NotebookCell
+from marimo._types.encodable import Encodable
 from marimo._types.ids import CellId_t, RequestId, UIElementId, WidgetModelId
 
 LOGGER = _loggers.marimo_logger()
@@ -70,7 +72,7 @@ Primitive = str | bool | int | float
 SerializedCLIArgs = dict[str, ListOrValue[Primitive]]
 
 
-def _user_to_dict(user: Any) -> dict[str, Any]:
+def _user_to_dict(user: Any) -> dict[str, Encodable]:
     """Normalize an auth user into a serializable dict.
 
     Starlette's authentication middleware sets ``request.scope["user"]`` to a
@@ -88,6 +90,18 @@ def _user_to_dict(user: Any) -> dict[str, Any]:
         "is_authenticated": getattr(user, "is_authenticated", False),
         "display_name": getattr(user, "display_name", ""),
     }
+
+
+def _meta_to_dict(meta: Any) -> dict[str, Encodable]:
+    """Normalize user-defined ``request.scope["meta"]`` at the boundary.
+
+    Trusted shape per the public contract (``mo.app_meta().request``); we
+    just enforce dict-ness at the seam. Non-``Encodable`` values inside will
+    surface at IPC encode time rather than being silently coerced.
+    """
+    if meta is None or not isinstance(meta, dict):
+        return {}
+    return cast("dict[str, Encodable]", meta)
 
 
 @dataclass
@@ -108,14 +122,14 @@ class HTTPRequest(Mapping[str, Any]):
         user: User info from authentication middleware (e.g., is_authenticated, username).
     """
 
-    url: dict[str, Any]  # Serialized URL
-    base_url: dict[str, Any]  # Serialized URL
+    url: dict[str, Encodable]  # Serialized URL
+    base_url: dict[str, Encodable]  # Serialized URL
     headers: dict[str, str]  # Raw headers
     query_params: dict[str, list[str]]  # Raw query params
-    path_params: dict[str, Any]
+    path_params: dict[str, Encodable]
     cookies: dict[str, str]
-    meta: dict[str, Any]  # User-defined storage
-    user: Any
+    meta: dict[str, Encodable]  # User-defined storage
+    user: dict[str, Encodable]
 
     # We don't include session or auth because they may contain
     # information that the app author does not want to expose.
@@ -141,11 +155,11 @@ class HTTPRequest(Mapping[str, Any]):
             return self.__dict__
 
     def __repr__(self) -> str:
-        return f"HTTPRequest(path={self.url['path']}, params={len(self.query_params)})"
+        return f"HTTPRequest(path={self.url['path']!r}, params={len(self.query_params)})"
 
     @staticmethod
     def from_request(request: HTTPConnection) -> HTTPRequest:
-        def _url_to_dict(url: URL) -> dict[str, Any]:
+        def _url_to_dict(url: URL) -> dict[str, Encodable]:
             return {
                 "path": url.path,
                 "port": url.port,
@@ -180,7 +194,7 @@ class HTTPRequest(Mapping[str, Any]):
             path_params=request.path_params,
             cookies=request.cookies,
             user=_user_to_dict(request.get("user")),
-            meta=request.get("meta", {}),
+            meta=_meta_to_dict(request.get("meta")),
             # Left out for now. This may contain information that the app author
             # does not want to expose.
             # session=request.session if "session" in request else {},
@@ -778,7 +792,7 @@ class ModelUpdateMessage(
         buffer_paths: Paths within state dict pointing to binary buffers.
     """
 
-    state: dict[str, Any]
+    state: dict[str, Encodable]
     buffer_paths: list[list[str | int]]
 
     def into_comm_payload_content(self) -> dict[str, Any]:
@@ -800,7 +814,7 @@ class ModelCustomMessage(
         content: Arbitrary content for the custom message.
     """
 
-    content: Any
+    content: Encodable
 
     def into_comm_payload_content(self) -> dict[str, Any]:
         return {

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -129,7 +129,7 @@ class HTTPRequest(Mapping[str, Any]):
     path_params: dict[str, Encodable]
     cookies: dict[str, str]
     meta: dict[str, Encodable]  # User-defined storage
-    user: dict[str, Encodable]
+    user: Encodable
 
     # We don't include session or auth because they may contain
     # information that the app author does not want to expose.

--- a/marimo/_types/encodable.py
+++ b/marimo/_types/encodable.py
@@ -1,20 +1,25 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Union
-
-import msgspec
+from typing import TYPE_CHECKING, Any, Union
 
 # Values that round-trip through the IPC msgspec encoder.
-Encodable = Union[
-    None,
-    bool,
-    int,
-    float,
-    str,
-    bytes,
-    list["Encodable"],
-    tuple["Encodable", ...],
-    dict[str, "Encodable"],
-    msgspec.Struct,
-]
+# The recursive type defintion breaks msgspec, but mypy is able to handle it and
+# give us some garuntees.
+if TYPE_CHECKING:
+    import msgspec
+
+    Encodable = Union[
+        None,
+        bool,
+        int,
+        float,
+        str,
+        bytes,
+        list["Encodable"],
+        tuple["Encodable", ...],
+        dict[str, "Encodable"],
+        msgspec.Struct,
+    ]
+else:
+    Encodable = Any

--- a/marimo/_types/encodable.py
+++ b/marimo/_types/encodable.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import Union
+
+import msgspec
+
+# Values that round-trip through the IPC msgspec encoder.
+Encodable = Union[
+    None,
+    bool,
+    int,
+    float,
+    str,
+    bytes,
+    list["Encodable"],
+    tuple["Encodable", ...],
+    dict[str, "Encodable"],
+    msgspec.Struct,
+]

--- a/marimo/_types/encodable.py
+++ b/marimo/_types/encodable.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Union
 
 # Values that round-trip through the IPC msgspec encoder.
-# The recursive type defintion breaks msgspec, but mypy is able to handle it and
+# The recursive type definition breaks msgspec, but mypy is able to handle it and
 # give us some garuntees.
 if TYPE_CHECKING:
     import msgspec

--- a/tests/_runtime/test_requests.py
+++ b/tests/_runtime/test_requests.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
+import msgspec
+from starlette.authentication import SimpleUser
 from starlette.datastructures import URL, Headers, QueryParams
 from starlette.requests import HTTPConnection
 
@@ -15,17 +17,20 @@ class MockHTTPConnection(HTTPConnection):
         url: str = "http://localhost:8000/test?param1=value1&param2=value2",
         headers: dict[str, str] | None = None,
         path_params: dict[str, Any] | None = None,
+        user: Any = None,
     ):
         url_obj = URL(url)
         # Convert headers to list of tuples as expected by Starlette
         raw_headers = [(k.lower(), v) for k, v in (headers or {}).items()]
-        scope = {
+        scope: dict[str, Any] = {
             "type": "http",
             "method": "GET",
             "headers": dict(raw_headers),
             "path": url_obj.path,
             "path_params": path_params or {},
         }
+        if user is not None:
+            scope["user"] = user
         super().__init__(scope)
         self._url = url_obj
         self._base_url = URL("http://localhost:8000")
@@ -145,3 +150,34 @@ def test_display():
     display_dict = request._display_()
     assert isinstance(display_dict, dict)
     assert "url" in display_dict
+
+
+def test_from_request_normalizes_starlette_user():
+    """Starlette BaseUser instances must be flattened to a dict so that
+    HTTPRequest can be msgspec-encoded across the IPC queue boundary."""
+    mock_request = MockHTTPConnection(user=SimpleUser("alice"))
+    request_like = HTTPRequest.from_request(mock_request)
+    assert request_like["user"] == {
+        "username": "alice",
+        "is_authenticated": True,
+        "display_name": "alice",
+    }
+    # Regression for the IPC msgspec path: encoding must not raise.
+    msgspec.msgpack.encode(request_like["user"])
+
+
+def test_from_request_user_missing_returns_empty_dict():
+    mock_request = MockHTTPConnection()
+    request_like = HTTPRequest.from_request(mock_request)
+    assert request_like["user"] == {}
+
+
+def test_from_request_user_already_dict_passthrough():
+    mock_request = MockHTTPConnection(
+        user={"username": "bob", "is_authenticated": True}
+    )
+    request_like = HTTPRequest.from_request(mock_request)
+    assert request_like["user"] == {
+        "username": "bob",
+        "is_authenticated": True,
+    }

--- a/tests/_runtime/test_requests.py
+++ b/tests/_runtime/test_requests.py
@@ -181,3 +181,29 @@ def test_from_request_user_already_dict_passthrough():
         "username": "bob",
         "is_authenticated": True,
     }
+
+
+def test_command_msgspec_json_decode_command_with_http_request():
+    """Regression for the Pyodide path: ``parse_dataclass`` builds a
+    ``msgspec.json`` decoder for any Command containing an ``HTTPRequest``
+    field. msgspec.json rejects unions with two array-like members, so
+    ``Encodable`` must avoid e.g. ``list | tuple`` simultaneously.
+    """
+    from marimo._runtime.commands import ExecuteCellCommand
+
+    # NB: ``Command`` uses ``rename="camel"``, but ``HTTPRequest`` is a
+    # plain ``@dataclass`` whose fields stay snake_case on the wire.
+    payload = (
+        b'{"type":"execute-cell","cellId":"c1","code":"x=1","request":'
+        b'{"url":{"path":"/x"},"base_url":{},"headers":{},'
+        b'"query_params":{},"path_params":{},"cookies":{},"meta":{},'
+        b'"user":{"username":"u","is_authenticated":true,"display_name":"u"}}}'
+    )
+    cmd = msgspec.json.decode(payload, type=ExecuteCellCommand)
+    assert cmd.cell_id == "c1"
+    assert cmd.request is not None
+    assert cmd.request["user"] == {
+        "username": "u",
+        "is_authenticated": True,
+        "display_name": "u",
+    }


### PR DESCRIPTION
## 📝 Summary

This PR fixes a bug introduced in 0.23.3 where msgspec encoding fails on a starlette object, breaking `sandbox home` mode. This PR also adds typing to help mitigate these issues in the future.