### PR TITLE
fix(islands): propagate notebook filename through MarimoIslandGenerator.from_file

### DIFF
--- a/marimo/_islands/_island_generator.py
+++ b/marimo/_islands/_island_generator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 from textwrap import dedent
 from typing import TYPE_CHECKING, cast
@@ -271,7 +272,10 @@ class MarimoIslandGenerator:
         file_manager = load_notebook(filename)
 
         generator = MarimoIslandGenerator()
-        generator._source_filename = filename
+        # Resolve at capture time so a chdir between ``from_file`` and
+        # ``build`` doesn't change which absolute path cells see for
+        # ``__file__`` / ``mo.notebook_dir()``.
+        generator._source_filename = os.path.abspath(filename)
         stubs = []
         for cell_data in file_manager.app.cell_manager.cell_data():
             stubs.append(

--- a/marimo/_islands/_island_generator.py
+++ b/marimo/_islands/_island_generator.py
@@ -249,6 +249,10 @@ class MarimoIslandGenerator:
         self._app = InternalApp(App())
         self._stubs: list[MarimoIslandStub] = []
         self._config = _AppConfig()
+        # When constructed via ``from_file``, this records the notebook
+        # source path so cells see ``__file__`` / ``mo.notebook_dir()``
+        # resolve to the notebook rather than to the host process.
+        self._source_filename: str | None = None
 
     @staticmethod
     def from_file(
@@ -267,6 +271,7 @@ class MarimoIslandGenerator:
         file_manager = load_notebook(filename)
 
         generator = MarimoIslandGenerator()
+        generator._source_filename = filename
         stubs = []
         for cell_data in file_manager.app.cell_manager.cell_data():
             stubs.append(
@@ -338,7 +343,9 @@ class MarimoIslandGenerator:
             raise ValueError("You can only call build() once")
 
         (session, did_error) = await run_app_until_completion(
-            file_manager=AppFileManager.from_app(self._app),
+            file_manager=AppFileManager.from_app(
+                self._app, filename=self._source_filename
+            ),
             cli_args={},
             argv=None,
         )

--- a/marimo/_session/notebook/file_manager.py
+++ b/marimo/_session/notebook/file_manager.py
@@ -105,16 +105,24 @@ class AppFileManager:
         self._filename = _maybe_path(value)
 
     @staticmethod
-    def from_app(app: InternalApp) -> AppFileManager:
+    def from_app(
+        app: InternalApp,
+        filename: str | Path | None = None,
+    ) -> AppFileManager:
         """Create AppFileManager from an existing InternalApp.
 
         Args:
             app: The internal app to wrap
+            filename: Optional source path for the notebook. When set,
+                ``AppMetadata.filename`` (and therefore ``__file__`` /
+                ``mo.notebook_dir()`` inside cells) resolves to the source
+                file rather than the host process's ``__main__``.
 
         Returns:
             AppFileManager instance
         """
         manager = AppFileManager(None)
+        manager._filename = _maybe_path(filename)
         manager.app = app
         return manager
 

--- a/marimo/_session/notebook/file_manager.py
+++ b/marimo/_session/notebook/file_manager.py
@@ -122,7 +122,11 @@ class AppFileManager:
             AppFileManager instance
         """
         manager = AppFileManager(None)
-        manager._filename = _maybe_path(filename)
+        # Snapshot to an absolute path at assignment time so a later
+        # ``chdir`` cannot change which file ``self.path`` resolves to.
+        manager.filename = (
+            os.path.abspath(str(filename)) if filename is not None else None
+        )
         manager.app = app
         return manager
 

--- a/tests/_islands/test_island_generator.py
+++ b/tests/_islands/test_island_generator.py
@@ -190,6 +190,59 @@ def __(mo):
     )
 
 
+async def test_from_file_resolves_relative_path_at_capture_time(
+    tmp_path: Path,
+) -> None:
+    # Companion to ``test_from_file_propagates_filename_to_cells``:
+    # passing a relative path to ``from_file`` should snapshot the
+    # absolute path immediately, so a ``chdir`` between ``from_file``
+    # and ``build`` cannot change which file cells see.
+    import os
+
+    nb_dir = tmp_path / "notebooks"
+    nb_dir.mkdir()
+    marimo_file = nb_dir / "nb.py"
+    marimo_file.write_text(
+        """
+import marimo
+
+app = marimo.App()
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+@app.cell
+def __(mo):
+    mo.md(f"FILE={__file__}")
+    return ()
+        """
+    )
+
+    other_dir = tmp_path / "elsewhere"
+    other_dir.mkdir()
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(nb_dir)
+        generator = MarimoIslandGenerator.from_file("nb.py")
+        # Move to an unrelated directory before ``build`` runs.
+        os.chdir(other_dir)
+        await generator.build()
+    finally:
+        os.chdir(original_cwd)
+
+    captured = generator._stubs[1].output
+    assert captured is not None
+    data = captured.data
+    assert str(marimo_file) in data, (
+        f"expected __file__ to resolve to {marimo_file}, got: {data}"
+    )
+    # And the path shouldn't accidentally resolve under ``other_dir``.
+    assert str(other_dir / "nb.py") not in data
+
+
 def test_render_head():
     generator = MarimoIslandGenerator()
     head_html = generator.render_head()

--- a/tests/_islands/test_island_generator.py
+++ b/tests/_islands/test_island_generator.py
@@ -151,6 +151,45 @@ def __(mo):
     assert "The answer is 42" in stub2.output.data
 
 
+async def test_from_file_propagates_filename_to_cells(tmp_path: Path):
+    # Regression test for #9391: cells rendered through
+    # ``MarimoIslandGenerator.from_file()`` must see ``__file__`` and
+    # ``mo.notebook_dir()`` resolve to the notebook source, not to the
+    # host process's ``__main__`` (which under installed CLIs is a
+    # launcher shim).
+    marimo_file = tmp_path / "nb.py"
+    marimo_file.write_text(
+        """
+import marimo
+
+app = marimo.App()
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+@app.cell
+def __(mo):
+    mo.md(f"FILE={__file__} | DIR={mo.notebook_dir()}")
+    return ()
+        """
+    )
+
+    generator = MarimoIslandGenerator.from_file(str(marimo_file))
+    await generator.build()
+
+    captured = generator._stubs[1].output
+    assert captured is not None
+    data = captured.data
+    assert str(marimo_file) in data, (
+        f"expected __file__ to resolve to {marimo_file}, got: {data}"
+    )
+    assert str(marimo_file.parent) in data, (
+        f"expected notebook_dir() to resolve to {marimo_file.parent}, got: {data}"
+    )
+
+
 def test_render_head():
     generator = MarimoIslandGenerator()
     head_html = generator.render_head()

--- a/tests/_server/test_file_manager_filename.py
+++ b/tests/_server/test_file_manager_filename.py
@@ -59,3 +59,29 @@ class TestAppFileManagerFilenames:
             file_manager.rename(str(target_path))
 
         assert "already exists" in str(exc_info.value.detail)
+
+    def test_from_app_snapshots_relative_filename_to_absolute(
+        self, tmp_path: Path
+    ) -> None:
+        # ``AppFileManager.from_app(..., filename=...)`` must snapshot a
+        # relative ``filename`` to an absolute path at call time so a
+        # later ``chdir`` cannot shift which file ``self.path`` resolves
+        # to (which is what ``AppMetadata.filename`` / ``__file__`` are
+        # built from).
+        import os
+
+        from marimo._ast.app import App, InternalApp
+
+        nb_dir = tmp_path / "notebooks"
+        nb_dir.mkdir()
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(nb_dir)
+            manager = AppFileManager.from_app(
+                InternalApp(App()), filename="nb.py"
+            )
+            expected = str(nb_dir / "nb.py")
+            os.chdir(tmp_path)
+            assert manager.path == expected
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
## Summary

Closes #9391

`MarimoIslandGenerator.from_file(path)` previously discarded the source path. `build()` then constructed `AppFileManager` with `filename=None`, the kernel inherited `app_metadata.filename = None`, and `create_main_module(file=None)` fell through to `sys.modules['__main__'].__file__` — i.e. the host process's launcher script. Cells inside notebooks rendered through islands therefore saw `__file__` (and `mo.notebook_dir()`) resolve to the calling script (or to the installed CLI's `.venv/bin/<entry>` shim) rather than to the notebook source. `marimo edit` and `marimo export` were unaffected; only the islands code path was broken.

The fix threads the source path through:

- `MarimoIslandGenerator.__init__` gains a `_source_filename` field (defaults to `None`, so manual `MarimoIslandGenerator() + add_code()` flows are unchanged).
- `from_file()` records the path on the instance.
- `build()` passes it to `AppFileManager.from_app(self._app, filename=…)`.
- `AppFileManager.from_app` accepts a new optional `filename` kwarg and assigns `_filename` directly. All existing single-arg callers (29 in tests + 1 here) continue to work.

`run_app_until_completion` already populates `AppMetadata(filename=file_manager.path, …)`, so once the file manager knows the path the existing kernel / `patch_main_module` plumbing delivers the correct `__file__` — no further changes in `_runtime/`.

### Before / after (issue's exact repro)

`/tmp/repro/notebooks/nb.py` prints `__file__` and `mo.notebook_dir()` from a cell. `/tmp/repro/scripts/render.py` calls `MarimoIslandGenerator.from_file(...)`.

Before:
```
__file__ = '/tmp/repro/scripts/render.py'
notebook_dir() = PosixPath('/tmp/repro/scripts')
```

After:
```
__file__ = '/tmp/repro/notebooks/nb.py'
notebook_dir() = PosixPath('/tmp/repro/notebooks')
```

### Note on backward compatibility

This restores the documented / expected semantics, but it **is** a behavior change for any island user who relied on `__file__` resolving to the host process. @mscolnick noted in [#9391](https://github.com/marimo-team/marimo/issues/9391#issuecomment-) that this may warrant a breaking-change classification — happy to take labeling / release-note guidance.

## Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue — see @mscolnick's comment on #9391: *"this does look like a real issue. we'd gladly accept the contribution to fix this."*
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). — N/A, no visual change.

## Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes. — `AppFileManager.from_app` docstring updated to document the new `filename` parameter.
- [x] Tests have been added for the changes made. — `tests/_islands/test_island_generator.py::test_from_file_propagates_filename_to_cells`.

## Verification

- `pytest tests/_islands/` — 11 passed (10 existing + 1 new regression test)
- `pytest tests/_server/test_file_manager.py tests/_server/test_sessions.py tests/_server/export/test_exporter.py` — 81 passed (the 15 deselected `test_export_html*` failures are pre-existing on `main` due to no `make fe` artifact and unrelated to this change)
- `ruff check` / `ruff format --check` — clean on changed files
- `mypy marimo --exclude=marimo/_tutorials/` — same 14 pre-existing errors as `main`; zero new errors introduced