### PR TITLE
fix: update snapshots and types for altair v6.1.0 / vega-lite v6.4.1

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,8 +65,6 @@
         "!/.*@oxc.*/",
         // react-hook-form is pinned to 7.54.2
         "!/.*react-hook-form.*/",
-        // vega-lite is pinned to 6.3.1
-        "!/.*vega-lite.*/",
         // pyodide needs to be manually updated
         "!/.*pyodide.*/"
       ],

--- a/.github/workflows/test_fe.yaml
+++ b/.github/workflows/test_fe.yaml
@@ -181,10 +181,6 @@ jobs:
             echo "Error: react-hook-form version in package.json must be exactly 7.54.2. As it breaks mo.ui.dataframe"
             exit 1
           fi
-          if ! grep -q '"vega-lite": "6.3.1"' package.json; then
-            echo "Error: vega-lite version in package.json must be exactly 6.3.1. Newer versions break numeric tooltips"
-            exit 1
-          fi
           if ! grep -q '"html-to-image": "1.11.13"' package.json; then
             echo "Error: html-to-image version in package.json must be exactly 1.11.13. Newer versions break matplotlib toolbars"
             exit 1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -155,7 +155,7 @@
     "typescript-memoize": "^1.1.1",
     "use-acp": "0.2.6",
     "use-resize-observer": "^9.1.0",
-    "vega-lite": "6.4.1",
+    "vega-lite": "6.4.2",
     "vega-loader": "^5.1.0",
     "vega-parser": "^7.1.0",
     "vega-tooltip": "^1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -155,7 +155,7 @@
     "typescript-memoize": "^1.1.1",
     "use-acp": "0.2.6",
     "use-resize-observer": "^9.1.0",
-    "vega-lite": "6.3.1",
+    "vega-lite": "6.4.1",
     "vega-loader": "^5.1.0",
     "vega-parser": "^7.1.0",
     "vega-tooltip": "^1.1.0",

--- a/marimo/_data/charts.py
+++ b/marimo/_data/charts.py
@@ -82,7 +82,9 @@ NUMBER_STROKE = "#8e4ec6"  # purple-9
 COMMON_CONFIG = 'properties(width="container").configure_view(stroke=None)'
 
 
-def add_common_config(chart: alt.Chart | alt.LayerChart) -> alt.Chart:
+def add_common_config(
+    chart: alt.Chart | alt.LayerChart | alt.FacetChart,
+) -> alt.Chart:
     return chart.properties(width="container").configure_view(stroke=None)  # type: ignore
 
 

--- a/marimo/_output/formatters/altair_formatters.py
+++ b/marimo/_output/formatters/altair_formatters.py
@@ -196,7 +196,7 @@ def _apply_format_locales(embed_options: dict[str, Any]) -> dict[str, Any]:
             if DependencyManager.vl_convert_python.has():
                 import vl_convert as vlc  # type: ignore
 
-                return dict(vlc.get_time_format_locale(locale))
+                return dict(vlc.get_time_format_locale(locale))  # type: ignore[arg-type]
             else:
                 with urlopen(
                     TIME_FORMAT_LOCALE_URL.format(locale=locale),
@@ -212,7 +212,7 @@ def _apply_format_locales(embed_options: dict[str, Any]) -> dict[str, Any]:
             if DependencyManager.vl_convert_python.has():
                 import vl_convert as vlc  # type: ignore
 
-                return dict(vlc.get_format_locale(locale))
+                return dict(vlc.get_format_locale(locale))  # type: ignore[arg-type]
             else:
                 with urlopen(
                     FORMAT_LOCALE_URL.format(locale=locale),

--- a/marimo/_sql/engines/adbc.py
+++ b/marimo/_sql/engines/adbc.py
@@ -534,7 +534,7 @@ class AdbcDBAPIEngine(SQLConnection[AdbcDbApiConnection]):
                 return pl.from_arrow(arrow_table)
 
             def convert_to_pandas() -> pd.DataFrame:
-                return arrow_table.to_pandas()
+                return cast("pd.DataFrame", arrow_table.to_pandas())
 
             result = convert_to_output(
                 sql_output_format=sql_output_format,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,7 +390,7 @@ importers:
         version: 0.9.6(react@19.2.4)
       react-vega:
         specifier: ^8.0.0
-        version: 8.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vega-embed@7.1.0(vega-lite@6.3.1(vega@6.2.0))(vega@6.2.0))
+        version: 8.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0))
       react-virtuoso:
         specifier: ^4.18.1
         version: 4.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -440,8 +440,8 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vega-lite:
-        specifier: 6.3.1
-        version: 6.3.1(vega@6.2.0)
+        specifier: 6.4.1
+        version: 6.4.1(vega@6.2.0)
       vega-loader:
         specifier: ^5.1.0
         version: 5.1.0
@@ -9368,9 +9368,6 @@ packages:
   vega-expression@2.6.6:
     resolution: {integrity: sha512-zxPzXO33FawU3WQHRmHJaRreyJlyMaNMn1uuCFSouJttPkBBWB5gCrha2f5+pF3t4NMFWTnSrgCkR6mcaubnng==}
 
-  vega-expression@6.0.0:
-    resolution: {integrity: sha512-aw6hGpTSiakAe5KqCsnpXNsBgN823IMq84x2Gg1pJj+H6zxlEfN4FCibPAC0PYWOmSvCRUoXMr7b/wWiwsiPIg==}
-
   vega-expression@6.1.0:
     resolution: {integrity: sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==}
 
@@ -9401,8 +9398,8 @@ packages:
     peerDependencies:
       vega: ^5.4.0
 
-  vega-lite@6.3.1:
-    resolution: {integrity: sha512-k/XPsed82wElz7Rdlzhz3+ctAP3M79Gd+ohnAalozvfjcTjEpYbdJpJVVG+FVwStHnbkLtYlpm2ys9Z+ld9jrQ==}
+  vega-lite@6.4.1:
+    resolution: {integrity: sha512-KO3ybHNouRK4A0al/+2fN9UqgTEfxrd/ntGLY933Hg5UOYotDVQdshR3zn7OfXwQ7uj0W96Vfa5R+QxO8am3IQ==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -9467,9 +9464,6 @@ packages:
 
   vega-util@1.17.4:
     resolution: {integrity: sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==}
-
-  vega-util@2.0.0:
-    resolution: {integrity: sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==}
 
   vega-util@2.1.0:
     resolution: {integrity: sha512-PGfp0m0QCufDmcxKJCWQy4Ov23FoF8DSXmoJwSezi3itQaa2hbxK0+xwsTMP2vy4PR16Pu25HMzgMwXVW1+33w==}
@@ -14520,14 +14514,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@20.19.30)(typescript@5.9.3)
-      vite: rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
+      vite: rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@24.12.2)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
@@ -18914,12 +18908,12 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  react-vega@8.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vega-embed@7.1.0(vega-lite@6.3.1(vega@6.2.0))(vega@6.2.0)):
+  react-vega@8.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)):
     dependencies:
       fast-deep-equal: 3.1.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vega-embed: 7.1.0(vega-lite@6.3.1(vega@6.2.0))(vega@6.2.0)
+      vega-embed: 7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)
 
   react-virtuoso@4.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -20258,7 +20252,7 @@ snapshots:
       vega-loader: 5.1.0
       vega-util: 2.1.0
 
-  vega-embed@7.1.0(vega-lite@6.3.1(vega@6.2.0))(vega@6.2.0):
+  vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0):
     dependencies:
       fast-json-patch: 3.1.1
       json-stringify-pretty-compact: 4.0.0
@@ -20266,9 +20260,9 @@ snapshots:
       tslib: 2.8.1
       vega: 6.2.0
       vega-interpreter: 2.2.1
-      vega-lite: 6.3.1(vega@6.2.0)
+      vega-lite: 6.4.1(vega@6.2.0)
       vega-schema-url-parser: 3.0.2
-      vega-themes: 3.0.0(vega-lite@6.3.1(vega@6.2.0))(vega@6.2.0)
+      vega-themes: 3.0.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)
       vega-tooltip: 1.0.0
 
   vega-encode@5.1.0:
@@ -20286,11 +20280,6 @@ snapshots:
   vega-expression@2.6.6:
     dependencies:
       vega-util: 1.17.4
-
-  vega-expression@6.0.0:
-    dependencies:
-      '@types/estree': 1.0.8
-      vega-util: 2.1.0
 
   vega-expression@6.1.0:
     dependencies:
@@ -20369,14 +20358,14 @@ snapshots:
       vega-util: 1.10.0
       yargs: 13.3.2
 
-  vega-lite@6.3.1(vega@6.2.0):
+  vega-lite@6.4.1(vega@6.2.0):
     dependencies:
       json-stringify-pretty-compact: 4.0.0
       tslib: 2.8.1
       vega: 6.2.0
       vega-event-selector: 4.0.0
-      vega-expression: 6.0.0
-      vega-util: 2.0.0
+      vega-expression: 6.1.0
+      vega-util: 2.1.0
       yargs: 18.0.0
 
   vega-loader@5.1.0:
@@ -20442,10 +20431,10 @@ snapshots:
     dependencies:
       d3-array: 3.2.4
 
-  vega-themes@3.0.0(vega-lite@6.3.1(vega@6.2.0))(vega@6.2.0):
+  vega-themes@3.0.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0):
     dependencies:
       vega: 6.2.0
-      vega-lite: 6.3.1(vega@6.2.0)
+      vega-lite: 6.4.1(vega@6.2.0)
 
   vega-time@3.1.0:
     dependencies:
@@ -20483,8 +20472,6 @@ snapshots:
   vega-util@1.10.0: {}
 
   vega-util@1.17.4: {}
-
-  vega-util@2.0.0: {}
 
   vega-util@2.1.0: {}
 
@@ -20631,7 +20618,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,7 +390,7 @@ importers:
         version: 0.9.6(react@19.2.4)
       react-vega:
         specifier: ^8.0.0
-        version: 8.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0))
+        version: 8.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vega-embed@7.1.0(vega-lite@6.4.2(vega@6.2.0))(vega@6.2.0))
       react-virtuoso:
         specifier: ^4.18.1
         version: 4.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -440,8 +440,8 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vega-lite:
-        specifier: 6.4.1
-        version: 6.4.1(vega@6.2.0)
+        specifier: 6.4.2
+        version: 6.4.2(vega@6.2.0)
       vega-loader:
         specifier: ^5.1.0
         version: 5.1.0
@@ -9398,9 +9398,9 @@ packages:
     peerDependencies:
       vega: ^5.4.0
 
-  vega-lite@6.4.1:
-    resolution: {integrity: sha512-KO3ybHNouRK4A0al/+2fN9UqgTEfxrd/ntGLY933Hg5UOYotDVQdshR3zn7OfXwQ7uj0W96Vfa5R+QxO8am3IQ==}
-    engines: {node: '>=18'}
+  vega-lite@6.4.2:
+    resolution: {integrity: sha512-Mv2PaRIpijz256LM0NdOJd9Md8cqyrXina54xW6Qp865YfY502zlXGUst+W/XznVwISGfatt0yLZuDqCUbBDuw==}
+    engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
       vega: ^6.0.0
@@ -18908,12 +18908,12 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  react-vega@8.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)):
+  react-vega@8.0.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vega-embed@7.1.0(vega-lite@6.4.2(vega@6.2.0))(vega@6.2.0)):
     dependencies:
       fast-deep-equal: 3.1.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vega-embed: 7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)
+      vega-embed: 7.1.0(vega-lite@6.4.2(vega@6.2.0))(vega@6.2.0)
 
   react-virtuoso@4.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -20252,7 +20252,7 @@ snapshots:
       vega-loader: 5.1.0
       vega-util: 2.1.0
 
-  vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0):
+  vega-embed@7.1.0(vega-lite@6.4.2(vega@6.2.0))(vega@6.2.0):
     dependencies:
       fast-json-patch: 3.1.1
       json-stringify-pretty-compact: 4.0.0
@@ -20260,9 +20260,9 @@ snapshots:
       tslib: 2.8.1
       vega: 6.2.0
       vega-interpreter: 2.2.1
-      vega-lite: 6.4.1(vega@6.2.0)
+      vega-lite: 6.4.2(vega@6.2.0)
       vega-schema-url-parser: 3.0.2
-      vega-themes: 3.0.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)
+      vega-themes: 3.0.0(vega-lite@6.4.2(vega@6.2.0))(vega@6.2.0)
       vega-tooltip: 1.0.0
 
   vega-encode@5.1.0:
@@ -20358,7 +20358,7 @@ snapshots:
       vega-util: 1.10.0
       yargs: 13.3.2
 
-  vega-lite@6.4.1(vega@6.2.0):
+  vega-lite@6.4.2(vega@6.2.0):
     dependencies:
       json-stringify-pretty-compact: 4.0.0
       tslib: 2.8.1
@@ -20431,10 +20431,10 @@ snapshots:
     dependencies:
       d3-array: 3.2.4
 
-  vega-themes@3.0.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0):
+  vega-themes@3.0.0(vega-lite@6.4.2(vega@6.2.0))(vega@6.2.0):
     dependencies:
       vega: 6.2.0
-      vega-lite: 6.4.1(vega@6.2.0)
+      vega-lite: 6.4.2(vega@6.2.0)
 
   vega-time@3.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14514,14 +14514,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@20.19.30)(typescript@5.9.3)
-      vite: rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
+      vite: rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@24.12.2)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
@@ -20618,7 +20618,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/tests/_cli/snapshots/export/ipynb/ipynb_with_media_outputs.txt
+++ b/tests/_cli/snapshots/export/ipynb/ipynb_with_media_outputs.txt
@@ -271,7 +271,7 @@
    "outputs": [
     {
      "data": {
-      "application/vnd.vegalite.v6+json": "{\n  \"$schema\": \"https://vega.github.io/schema/vega-lite/v6.1.0.json\",\n  \"config\": {\n    \"view\": {\n      \"continuousHeight\": 300,\n      \"continuousWidth\": 300\n    }\n  },\n  \"data\": {\n    \"name\": \"data-a202e5dd04552c98b78a4bc5fc59f367\"\n  },\n  \"datasets\": {\n    \"data-a202e5dd04552c98b78a4bc5fc59f367\": [\n      {\n        \"x\": 1,\n        \"y\": 1\n      }\n    ]\n  },\n  \"encoding\": {\n    \"x\": {\n      \"field\": \"x\",\n      \"type\": \"ordinal\"\n    },\n    \"y\": {\n      \"field\": \"y\",\n      \"type\": \"quantitative\"\n    }\n  },\n  \"mark\": {\n    \"type\": \"circle\"\n  },\n  \"usermeta\": {\n    \"embedOptions\": {}\n  }\n}"
+      "application/vnd.vegalite.v6+json": "{\n  \"$schema\": \"https://vega.github.io/schema/vega-lite/v6.4.1.json\",\n  \"config\": {\n    \"view\": {\n      \"continuousHeight\": 300,\n      \"continuousWidth\": 300\n    }\n  },\n  \"data\": {\n    \"name\": \"data-a202e5dd04552c98b78a4bc5fc59f367\"\n  },\n  \"datasets\": {\n    \"data-a202e5dd04552c98b78a4bc5fc59f367\": [\n      {\n        \"x\": 1,\n        \"y\": 1\n      }\n    ]\n  },\n  \"encoding\": {\n    \"x\": {\n      \"field\": \"x\",\n      \"type\": \"ordinal\"\n    },\n    \"y\": {\n      \"field\": \"y\",\n      \"type\": \"quantitative\"\n    }\n  },\n  \"mark\": {\n    \"type\": \"circle\"\n  },\n  \"usermeta\": {\n    \"embedOptions\": {}\n  }\n}"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -292,7 +292,7 @@
    "outputs": [
     {
      "data": {
-      "application/vnd.vega.v6+json": "{\n  \"$schema\": \"https://vega.github.io/schema/vega-lite/v6.1.0.json\",\n  \"config\": {\n    \"view\": {\n      \"continuousHeight\": 300,\n      \"continuousWidth\": 300\n    }\n  },\n  \"data\": {\n    \"name\": \"data-a202e5dd04552c98b78a4bc5fc59f367\"\n  },\n  \"datasets\": {\n    \"data-a202e5dd04552c98b78a4bc5fc59f367\": [\n      {\n        \"x\": 1,\n        \"y\": 1\n      }\n    ]\n  },\n  \"encoding\": {\n    \"x\": {\n      \"field\": \"x\",\n      \"type\": \"ordinal\"\n    },\n    \"y\": {\n      \"field\": \"y\",\n      \"type\": \"quantitative\"\n    }\n  },\n  \"mark\": {\n    \"type\": \"circle\"\n  },\n  \"usermeta\": {\n    \"embedOptions\": {}\n  }\n}"
+      "application/vnd.vega.v6+json": "{\n  \"$schema\": \"https://vega.github.io/schema/vega-lite/v6.4.1.json\",\n  \"config\": {\n    \"view\": {\n      \"continuousHeight\": 300,\n      \"continuousWidth\": 300\n    }\n  },\n  \"data\": {\n    \"name\": \"data-a202e5dd04552c98b78a4bc5fc59f367\"\n  },\n  \"datasets\": {\n    \"data-a202e5dd04552c98b78a4bc5fc59f367\": [\n      {\n        \"x\": 1,\n        \"y\": 1\n      }\n    ]\n  },\n  \"encoding\": {\n    \"x\": {\n      \"field\": \"x\",\n      \"type\": \"ordinal\"\n    },\n    \"y\": {\n      \"field\": \"y\",\n      \"type\": \"quantitative\"\n    }\n  },\n  \"mark\": {\n    \"type\": \"circle\"\n  },\n  \"usermeta\": {\n    \"embedOptions\": {}\n  }\n}"
      },
      "metadata": {},
      "output_type": "display_data"

--- a/tests/_data/snapshots/charts_json.txt
+++ b/tests/_data/snapshots/charts_json.txt
@@ -1,6 +1,6 @@
 # boolean
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "view": {
       "continuousHeight": 300,
@@ -160,7 +160,7 @@
 
 # date
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "axis": {
       "grid": false
@@ -327,7 +327,7 @@
         "strokeWidth": 1,
         "type": "rule"
       },
-      "name": "view_08552f810e029e90_2",
+      "name": "view_f88a3e6c17252800_2",
       "transform": [
         {
           "filter": "datum.some_column != null"
@@ -363,7 +363,7 @@
         "type": "point"
       },
       "views": [
-        "view_08552f810e029e90_2"
+        "view_f88a3e6c17252800_2"
       ]
     }
   ],
@@ -372,7 +372,7 @@
 
 # datetime
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "axis": {
       "grid": false
@@ -539,7 +539,7 @@
         "strokeWidth": 1,
         "type": "rule"
       },
-      "name": "view_08552f810e029e90_2",
+      "name": "view_f88a3e6c17252800_2",
       "transform": [
         {
           "filter": "datum.some_column != null"
@@ -575,7 +575,7 @@
         "type": "point"
       },
       "views": [
-        "view_08552f810e029e90_2"
+        "view_f88a3e6c17252800_2"
       ]
     }
   ],
@@ -584,7 +584,7 @@
 
 # time
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "axis": {
       "grid": false
@@ -751,7 +751,7 @@
         "strokeWidth": 1,
         "type": "rule"
       },
-      "name": "view_08552f810e029e90_2",
+      "name": "view_f88a3e6c17252800_2",
       "transform": [
         {
           "filter": "datum.some_column != null"
@@ -787,7 +787,7 @@
         "type": "point"
       },
       "views": [
-        "view_08552f810e029e90_2"
+        "view_f88a3e6c17252800_2"
       ]
     }
   ],
@@ -796,7 +796,7 @@
 
 # integer
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "view": {
       "continuousHeight": 300,
@@ -857,7 +857,7 @@
 
 # number
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "view": {
       "continuousHeight": 300,
@@ -919,7 +919,7 @@
 
 # string
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "axis": {
       "grid": false
@@ -1117,7 +1117,7 @@
 
 # string (limit to 10 items)
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "axis": {
       "grid": false
@@ -1321,7 +1321,7 @@
 
 # unknown
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "view": {
       "continuousHeight": 300,

--- a/tests/_data/snapshots/charts_json_bad_data.txt
+++ b/tests/_data/snapshots/charts_json_bad_data.txt
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "axis": {
       "grid": false

--- a/tests/_data/snapshots/column_preview_bool_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_bool_chart_spec.txt
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "view": {
       "continuousHeight": 300,

--- a/tests/_data/snapshots/column_preview_bool_chart_spec_with_vegafusion.txt
+++ b/tests/_data/snapshots/column_preview_bool_chart_spec_with_vegafusion.txt
@@ -99,7 +99,7 @@
             "scale": "theta"
           },
           "tooltip": {
-            "signal": "{\"bool_col\": isValid(datum[\"bool_col\"]) ? datum[\"bool_col\"] : \"\"+datum[\"bool_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"bool_col\": isValid(datum[\"bool_col\"]) ? isArray(datum[\"bool_col\"]) ? join(datum[\"bool_col\"], '\\n') : datum[\"bool_col\"] : \"\"+datum[\"bool_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "mult": 0.5,
@@ -146,7 +146,7 @@
             "signal": "scale(\"theta\", 0.5 * datum[\"count_start\"] + 0.5 * datum[\"count_end\"])"
           },
           "tooltip": {
-            "signal": "{\"bool_col\": isValid(datum[\"bool_col\"]) ? datum[\"bool_col\"] : \"\"+datum[\"bool_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"bool_col\": isValid(datum[\"bool_col\"]) ? isArray(datum[\"bool_col\"]) ? join(datum[\"bool_col\"], '\\n') : datum[\"bool_col\"] : \"\"+datum[\"bool_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "mult": 0.5,

--- a/tests/_data/snapshots/column_preview_categorical_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_categorical_chart_spec.txt
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "axis": {
       "grid": false

--- a/tests/_data/snapshots/column_preview_categorical_chart_spec_with_vegafusion.txt
+++ b/tests/_data/snapshots/column_preview_categorical_chart_spec_with_vegafusion.txt
@@ -96,7 +96,7 @@
             "signal": "max(0.25, bandwidth('y'))"
           },
           "tooltip": {
-            "signal": "{\"category_col\": isValid(datum[\"category_col\"]) ? datum[\"category_col\"] : \"\"+datum[\"category_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"category_col\": isValid(datum[\"category_col\"]) ? isArray(datum[\"category_col\"]) ? join(datum[\"category_col\"], '\\n') : datum[\"category_col\"] : \"\"+datum[\"category_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "field": "count_end",
@@ -140,7 +140,7 @@
             "signal": "format(datum[\"percentage\"], \".2%\")"
           },
           "tooltip": {
-            "signal": "{\"category_col\": isValid(datum[\"category_col\"]) ? datum[\"category_col\"] : \"\"+datum[\"category_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"category_col\": isValid(datum[\"category_col\"]) ? isArray(datum[\"category_col\"]) ? join(datum[\"category_col\"], '\\n') : datum[\"category_col\"] : \"\"+datum[\"category_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "field": "count",

--- a/tests/_data/snapshots/column_preview_duckdb_bool_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_duckdb_bool_chart_spec.txt
@@ -102,7 +102,7 @@
             "scale": "theta"
           },
           "tooltip": {
-            "signal": "{\"bool_col\": isValid(datum[\"bool_col\"]) ? datum[\"bool_col\"] : \"\"+datum[\"bool_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"bool_col\": isValid(datum[\"bool_col\"]) ? isArray(datum[\"bool_col\"]) ? join(datum[\"bool_col\"], '\\n') : datum[\"bool_col\"] : \"\"+datum[\"bool_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "mult": 0.5,
@@ -149,7 +149,7 @@
             "signal": "scale(\"theta\", 0.5 * datum[\"count_start\"] + 0.5 * datum[\"count_end\"])"
           },
           "tooltip": {
-            "signal": "{\"bool_col\": isValid(datum[\"bool_col\"]) ? datum[\"bool_col\"] : \"\"+datum[\"bool_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"bool_col\": isValid(datum[\"bool_col\"]) ? isArray(datum[\"bool_col\"]) ? join(datum[\"bool_col\"], '\\n') : datum[\"bool_col\"] : \"\"+datum[\"bool_col\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "mult": 0.5,

--- a/tests/_data/snapshots/column_preview_duckdb_categorical_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_duckdb_categorical_chart_spec.txt
@@ -129,7 +129,7 @@
             "signal": "max(0.25, bandwidth('y'))"
           },
           "tooltip": {
-            "signal": "{\"category\": isValid(datum[\"category\"]) ? datum[\"category\"] : \"\"+datum[\"category\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"category\": isValid(datum[\"category\"]) ? isArray(datum[\"category\"]) ? join(datum[\"category\"], '\\n') : datum[\"category\"] : \"\"+datum[\"category\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "field": "count_end",
@@ -173,7 +173,7 @@
             "signal": "format(datum[\"percentage\"], \".2%\")"
           },
           "tooltip": {
-            "signal": "{\"category\": isValid(datum[\"category\"]) ? datum[\"category\"] : \"\"+datum[\"category\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"category\": isValid(datum[\"category\"]) ? isArray(datum[\"category\"]) ? join(datum[\"category\"], '\\n') : datum[\"category\"] : \"\"+datum[\"category\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "field": "count",

--- a/tests/_data/snapshots/column_preview_float_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_float_chart_spec.txt
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "view": {
       "continuousHeight": 300,

--- a/tests/_data/snapshots/column_preview_float_chart_spec_with_vegafusion.txt
+++ b/tests/_data/snapshots/column_preview_float_chart_spec_with_vegafusion.txt
@@ -96,7 +96,7 @@
             "value": "#8e4ec6"
           },
           "tooltip": {
-            "signal": "{\"float_col\": !isValid(datum[\"bin_maxbins_10_float_col\"]) || !isFinite(+datum[\"bin_maxbins_10_float_col\"]) ? \"null\" : format(datum[\"bin_maxbins_10_float_col\"], \",.2f\") + \" \u2013 \" + format(datum[\"bin_maxbins_10_float_col_end\"], \",.2f\"), \"Number of records\": format(datum[\"__count\"], \",.0f\")}"
+            "signal": "{\"float_col\": !isValid(datum[\"bin_maxbins_10_float_col\"]) || !isFinite(+datum[\"bin_maxbins_10_float_col\"]) ? \"null\" : format(datum[\"bin_maxbins_10_float_col\"], \",.2f\") + \" – \" + format(datum[\"bin_maxbins_10_float_col_end\"], \",.2f\"), \"Number of records\": format(datum[\"__count\"], \",.0f\")}"
           },
           "x": {
             "field": "bin_maxbins_10_float_col_end",

--- a/tests/_data/snapshots/column_preview_int_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_int_chart_spec.txt
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "view": {
       "continuousHeight": 300,

--- a/tests/_data/snapshots/column_preview_int_chart_spec_with_vegafusion.txt
+++ b/tests/_data/snapshots/column_preview_int_chart_spec_with_vegafusion.txt
@@ -96,7 +96,7 @@
             "value": "#8e4ec6"
           },
           "tooltip": {
-            "signal": "{\"A\": !isValid(datum[\"bin_maxbins_10_A\"]) || !isFinite(+datum[\"bin_maxbins_10_A\"]) ? \"null\" : format(datum[\"bin_maxbins_10_A\"], \"\") + \" \u2013 \" + format(datum[\"bin_maxbins_10_A_end\"], \"\"), \"Number of records\": format(datum[\"__count\"], \",.0f\")}"
+            "signal": "{\"A\": !isValid(datum[\"bin_maxbins_10_A\"]) || !isFinite(+datum[\"bin_maxbins_10_A\"]) ? \"null\" : format(datum[\"bin_maxbins_10_A\"], \"\") + \" – \" + format(datum[\"bin_maxbins_10_A_end\"], \"\"), \"Number of records\": format(datum[\"__count\"], \",.0f\")}"
           },
           "x": {
             "field": "bin_maxbins_10_A_end",

--- a/tests/_data/snapshots/column_preview_str_chart_spec.txt
+++ b/tests/_data/snapshots/column_preview_str_chart_spec.txt
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "config": {
     "axis": {
       "grid": false

--- a/tests/_data/snapshots/column_preview_str_chart_spec_with_vegafusion.txt
+++ b/tests/_data/snapshots/column_preview_str_chart_spec_with_vegafusion.txt
@@ -81,7 +81,7 @@
             "signal": "max(0.25, bandwidth('y'))"
           },
           "tooltip": {
-            "signal": "{\"B\": isValid(datum[\"B\"]) ? datum[\"B\"] : \"\"+datum[\"B\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"B\": isValid(datum[\"B\"]) ? isArray(datum[\"B\"]) ? join(datum[\"B\"], '\\n') : datum[\"B\"] : \"\"+datum[\"B\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "field": "count_end",
@@ -125,7 +125,7 @@
             "signal": "format(datum[\"percentage\"], \".2%\")"
           },
           "tooltip": {
-            "signal": "{\"B\": isValid(datum[\"B\"]) ? datum[\"B\"] : \"\"+datum[\"B\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
+            "signal": "{\"B\": isValid(datum[\"B\"]) ? isArray(datum[\"B\"]) ? join(datum[\"B\"], '\\n') : datum[\"B\"] : \"\"+datum[\"B\"], \"Number of records\": format(datum[\"count\"], \",.0f\")}"
           },
           "x": {
             "field": "count",

--- a/tests/_plugins/ui/_impl/snapshots/parse_spec_duckdb.txt
+++ b/tests/_plugins/ui/_impl/snapshots/parse_spec_duckdb.txt
@@ -20,5 +20,5 @@
       "type": "quantitative"
     }
   },
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json"
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json"
 }

--- a/tests/_plugins/ui/_impl/snapshots/parse_spec_geopandas.txt
+++ b/tests/_plugins/ui/_impl/snapshots/parse_spec_geopandas.txt
@@ -21,7 +21,7 @@
       "type": "nominal"
     }
   },
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json",
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json",
   "datasets": {
     "data-cc0a8311b413c4168b2c1fac768ce667": [
       {

--- a/tests/_plugins/ui/_impl/snapshots/parse_spec_narwhal.txt
+++ b/tests/_plugins/ui/_impl/snapshots/parse_spec_narwhal.txt
@@ -20,5 +20,5 @@
       "type": "quantitative"
     }
   },
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json"
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json"
 }

--- a/tests/_plugins/ui/_impl/snapshots/parse_spec_pandas.txt
+++ b/tests/_plugins/ui/_impl/snapshots/parse_spec_pandas.txt
@@ -20,5 +20,5 @@
       "type": "quantitative"
     }
   },
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json"
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json"
 }

--- a/tests/_plugins/ui/_impl/snapshots/parse_spec_polars.txt
+++ b/tests/_plugins/ui/_impl/snapshots/parse_spec_polars.txt
@@ -20,5 +20,5 @@
       "type": "quantitative"
     }
   },
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json"
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json"
 }

--- a/tests/_plugins/ui/_impl/snapshots/parse_spec_url.txt
+++ b/tests/_plugins/ui/_impl/snapshots/parse_spec_url.txt
@@ -17,5 +17,5 @@
       "type": "quantitative"
     }
   },
-  "$schema": "https://vega.github.io/schema/vega-lite/v6.1.0.json"
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.4.1.json"
 }


### PR DESCRIPTION
CI was failing on main after the altair upgrade landed:
- snapshots referenced vega-lite v6.1.0 schema and old view-hash names
- alt.layer now returns LayerChart | FacetChart, breaking add_common_config
- vlc.get_*_locale signatures became Literal-typed
