### PR TITLE
Add a CLI tip for marimo pair

### DIFF
--- a/marimo/_cli/tips.py
+++ b/marimo/_cli/tips.py
@@ -52,6 +52,10 @@ CLI_STARTUP_TIPS: Final[tuple[CliTip, ...]] = (
         command="marimo export thumbnail folder/",
     ),
     CliTip(
+        text="Pair-program with AI agents on running notebooks",
+        link="https://links.marimo.app/marimo-pair",
+    ),
+    CliTip(
         text="Coming from Jupyter?",
         link="https://docs.marimo.io/guides/coming_from/jupyter/",
     ),


### PR DESCRIPTION
Tell users about marimo pair from our CLI tips.

Docs link, instead of `marimo pair prompt ...` since we don't know what port the user is running on, nor which agent they would like to use. The docs also educate users on what pair is.