### PR TITLE
test: deflake subprocess kill test 

### DIFF
--- a/tests/_utils/test_subprocess.py
+++ b/tests/_utils/test_subprocess.py
@@ -107,6 +107,19 @@ def _is_alive(pid: int) -> bool:
     return True
 
 
+def _wait_until_dead(pid: int, timeout_s: float = 5.0) -> None:
+    """Poll until the kernel has reaped `pid`, then assert.
+
+    Tolerates the latency between SIGKILL delivery and the kernel actually
+    tearing the process down — a bare `assert not _is_alive(pid)` immediately
+    after a kill is racy.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline and _is_alive(pid):
+        time.sleep(0.05)
+    assert not _is_alive(pid)
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX only")
 def test_try_kill_process_and_group_kills_pgroup_spares_new_session() -> None:
     """Covers the shutdown path used by KernelManagerImpl, IPCKernelManagerImpl,
@@ -129,11 +142,7 @@ def test_try_kill_process_and_group_kills_pgroup_spares_new_session() -> None:
         # wait() reaps the child so it doesn't linger as a zombie.
         assert leader.wait(timeout=5) is not None
 
-        deadline = time.monotonic() + 5.0
-        while time.monotonic() < deadline and _is_alive(child_pg_pid):
-            time.sleep(0.05)
-
-        assert not _is_alive(child_pg_pid)
+        _wait_until_dead(child_pg_pid)
         assert _is_alive(child_newpg_pid)
     finally:
         for pid in (leader.pid, child_pg_pid, child_newpg_pid):
@@ -174,7 +183,7 @@ async def test_try_kill_process_and_group_sigkills_stubborn_child(
         try_kill_process_and_group(cast(ProcessLike, proc))
         # Drain the reap task(s) scheduled on the current loop.
         await asyncio.gather(*list(_REAP_TASKS), return_exceptions=True)
-        assert not _is_alive(proc.pid)
+        _wait_until_dead(proc.pid)
     finally:
         with contextlib.suppress(ProcessLookupError):
             os.killpg(pgid, signal.SIGKILL)

--- a/tests/_utils/test_subprocess.py
+++ b/tests/_utils/test_subprocess.py
@@ -162,13 +162,17 @@ async def test_try_kill_process_and_group_sigkills_stubborn_child(
     """try_kill_process_and_group schedules a reap task that escalates to
     SIGKILL when the child ignores SIGTERM.
     """
-    # Skip the reaper's real 5s/1s waits so the test is fast.
+    # Cap the reaper's real 5s/1s waits to 50ms so the test is fast, but
+    # leave enough wall-clock time for the kernel to deliver SIGKILL and
+    # for the reaper's own `poll()` to reap the zombie. Zeroing the delay
+    # entirely lets the reaper exit before the child is reaped, after which
+    # `_is_alive` (which sees zombies as alive) would spin to timeout.
     real_sleep = asyncio.sleep
 
-    async def no_wait(_delay: float) -> None:
-        await real_sleep(0)
+    async def short_sleep(_delay: float) -> None:
+        await real_sleep(0.05)
 
-    monkeypatch.setattr(asyncio, "sleep", no_wait)
+    monkeypatch.setattr(asyncio, "sleep", short_sleep)
 
     script = (
         "import signal, time\n"


### PR DESCRIPTION
The async reap test patched asyncio.sleep to a no-op to skip the reaper's own waits, but that left no time for the kernel to tear down the SIGKILL'd child before the test asserted it was dead. Replace the bare liveness assertions with a bounded poll.