### PR TITLE
fix: force Content-Disposition on table export downloads

### DIFF
--- a/frontend/src/components/data-table/export-actions.tsx
+++ b/frontend/src/components/data-table/export-actions.tsx
@@ -154,16 +154,18 @@ export const ExportMenu: React.FC<ExportActionProps> = (props) => {
     const downloadName = `${baseName}.${format}`;
     // Append ?download=1 so the server returns Content-Disposition: attachment.
     // This forces a save even when <a download> is ignored — e.g., inside
-    // sandboxed iframes that lack `allow-downloads`.
-    const separator = result.url.includes("?") ? "&" : "?";
-    const params = new URLSearchParams({
-      download: "1",
-      filename: downloadName,
-    });
-    downloadByURL(
-      `${result.url}${separator}${params.toString()}`,
-      downloadName,
-    );
+    // sandboxed iframes that lack `allow-downloads`. Skip for data: URLs
+    // (used in pyodide/wasm) since query params would corrupt the payload.
+    let downloadUrl = result.url;
+    if (!downloadUrl.startsWith("data:")) {
+      const separator = downloadUrl.includes("?") ? "&" : "?";
+      const params = new URLSearchParams({
+        download: "1",
+        filename: downloadName,
+      });
+      downloadUrl = `${downloadUrl}${separator}${params.toString()}`;
+    }
+    downloadByURL(downloadUrl, downloadName);
   };
 
   const handleClipboardCopy = async (

--- a/frontend/src/components/data-table/export-actions.tsx
+++ b/frontend/src/components/data-table/export-actions.tsx
@@ -151,7 +151,19 @@ export const ExportMenu: React.FC<ExportActionProps> = (props) => {
     }
     const rawName = (result.filename ?? "").trim();
     const baseName = Filenames.withoutExtension(rawName) || "download";
-    downloadByURL(result.url, `${baseName}.${format}`);
+    const downloadName = `${baseName}.${format}`;
+    // Append ?download=1 so the server returns Content-Disposition: attachment.
+    // This forces a save even when <a download> is ignored — e.g., inside
+    // sandboxed iframes that lack `allow-downloads`.
+    const separator = result.url.includes("?") ? "&" : "?";
+    const params = new URLSearchParams({
+      download: "1",
+      filename: downloadName,
+    });
+    downloadByURL(
+      `${result.url}${separator}${params.toString()}`,
+      downloadName,
+    );
   };
 
   const handleClipboardCopy = async (

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -549,6 +549,17 @@ def virtual_file(
 
     chunks = read_virtual_file_chunked(filename, int(byte_length))
     mimetype, _ = mimetypes.guess_type(filename)
+    headers = {
+        "Cache-Control": "max-age=86400",
+    }
+    # When ?download=1 is set, force a save dialog. This bypasses cases
+    # where <a download> is ignored (e.g., sandboxed iframes without
+    # allow-downloads, or some Permissions-Policy configurations).
+    if request.query_params.get("download") == "1":
+        from marimo._convert.common.filename import make_download_headers
+
+        download_filename = request.query_params.get("filename") or filename
+        headers.update(make_download_headers(download_filename))
     # Do NOT set Content-Length here. StreamingResponse with an explicit
     # Content-Length causes h11 LocalProtocolError ("Too little data for
     # declared Content-Length") for large files. Omitting it lets h11 use
@@ -556,9 +567,7 @@ def virtual_file(
     return StreamingResponse(
         content=chunks,
         media_type=mimetype,
-        headers={
-            "Cache-Control": "max-age=86400",
-        },
+        headers=headers,
     )
 
 

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -340,6 +340,61 @@ def test_vfile_large_streaming(client: TestClient) -> None:
         manager.storage = original_storage
 
 
+def test_vfile_download_query_param_sets_content_disposition(
+    client: TestClient,
+) -> None:
+    """`?download=1` forces Content-Disposition: attachment so the browser
+    saves the response instead of rendering it inline. This covers iframed
+    deployments where <a download> is silently ignored."""
+    from marimo._runtime.virtual_file.storage import (
+        InMemoryStorage,
+        VirtualFileStorageManager,
+    )
+
+    manager = VirtualFileStorageManager()
+    original_storage = manager.storage
+    storage = InMemoryStorage()
+    manager.storage = storage
+
+    try:
+        data = b'[{"a": 1}]'
+        filename = "data.json"
+        storage.store(filename, data)
+        byte_length = len(data)
+
+        # Without ?download=1 — no Content-Disposition.
+        response = client.get(
+            f"/@file/{byte_length}-{filename}",
+            headers=token_header(),
+        )
+        assert response.status_code == 200
+        assert "content-disposition" not in response.headers
+
+        # With ?download=1 — attachment header is set.
+        response = client.get(
+            f"/@file/{byte_length}-{filename}?download=1",
+            headers=token_header(),
+        )
+        assert response.status_code == 200
+        assert response.content == data
+        cd = response.headers.get("content-disposition", "")
+        assert cd.startswith("attachment")
+        assert "data.json" in cd
+
+        # Custom download filename via ?filename=...
+        response = client.get(
+            f"/@file/{byte_length}-{filename}"
+            "?download=1&filename=my-export.json",
+            headers=token_header(),
+        )
+        assert response.status_code == 200
+        cd = response.headers.get("content-disposition", "")
+        assert cd.startswith("attachment")
+        assert "my-export.json" in cd
+    finally:
+        manager.storage = original_storage
+
+
 def test_public_file_serving(client: TestClient) -> None:
     # Setup app state with a mock notebook
     app_state = AppState.from_app(cast(Any, client.app))


### PR DESCRIPTION
Pass `?download=1` from the data-table export menu so the virtual-file
endpoint returns `Content-Disposition: attachment`. Without this, iframed
deployments where `<a download>` is ignored (sandboxed iframes, restrictive
Permissions-Policy) navigated to the JSON instead of saving it.
