### PR TITLE
fix: improve parameter validation error messages for list[NewType] fields

### DIFF
--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -152,12 +152,12 @@ class _DataclassParser:
                     f"Value '{value}' does not fit any type of the literal"
                 )
             return value  # type: ignore[no-any-return]
-        elif type(cls) is type(Enum) and issubclass(cls, Enum):
+        elif isinstance(cls, type) and issubclass(cls, Enum):
             return cls(value)  # type: ignore[return-value]
         elif dataclasses.is_dataclass(cls):
             return self.build_dataclass(value, cls)  # type: ignore[return-value]
 
-        if issubclass(cls, msgspec.Struct):
+        if isinstance(cls, type) and issubclass(cls, msgspec.Struct):
             return _parse_msgspec(
                 value, strict=not self.allow_unknown_keys, cls=cls
             )  # type: ignore[return-value]

--- a/tests/_utils/test_parse_dataclass.py
+++ b/tests/_utils/test_parse_dataclass.py
@@ -944,3 +944,30 @@ def test_dataclass_with_nested_msgspec_struct() -> None:
     # Test as dict
     parsed = parse_raw(data, Nested, allow_unknown_keys=True)
     assert parsed == Nested(config=StructClass(limit=10))
+
+
+def test_wrong_container_type_error_message() -> None:
+    """Test that wrong container types produce clear error messages, not TypeError."""
+
+    @dataclass
+    class ArgsWithList:
+        session_id: CellId_t
+        cell_ids: list[CellId_t]
+
+    # Test wrong type for list field (string instead of list)
+    with pytest.raises(ValueError) as exc_info:
+        parse_raw(
+            {"session_id": "test", "cell_ids": "not_a_list"}, ArgsWithList
+        )
+    assert "does not fit" in str(exc_info.value)
+
+    # Test wrong type for list field (dict instead of list)
+    with pytest.raises(ValueError) as exc_info:
+        parse_raw({"session_id": "test", "cell_ids": {"a": 1}}, ArgsWithList)
+    assert "does not fit" in str(exc_info.value)
+
+    # Test valid list
+    result = parse_raw(
+        {"session_id": "test", "cell_ids": ["c1", "c2"]}, ArgsWithList
+    )
+    assert result.cell_ids == ["c1", "c2"]


### PR DESCRIPTION
## Summary
Closes #9430

Fixes `TypeError: issubclass() arg 1 must be a class` when tools receive wrong parameter types. Tools like `get_cell_runtime_data`, `get_cell_outputs`, and `get_tables_and_variables` now return clear validation errors instead of cryptic exceptions.

**Before vs After:**
| Scenario | Before | After |
|--------|--------|--------|
| `cell_ids: "wrong"` | `TypeError: issubclass() arg 1 must be a class` | `ValueError: Value 'wrong' does not fit 'list[...]'` | 

## Root Cause
In `marimo/_utils/parse_dataclass.py`, `issubclass()` was called without checking if `cls` is an actual class. When `cls` was a generic type like `list[CellId_t]`, `issubclass()` raised `TypeError`.

## Changes
- `marimo/_utils/parse_dataclass.py`: Added `isinstance(cls, type)` guard before `issubclass()` calls on lines 155 and 160
- `tests/_utils/test_parse_dataclass.py`: Added regression test `test_wrong_container_type_error_message`

## Tests
- [x] `make py-check`
- [x] `pytest tests/_utils/test_parse_dataclass.py`
- [x] `pytest tests/_ai/tools/`
- [x] `pytest tests/_server/ai/tools/test_tool_manager.py`