### PR TITLE
fix: provide upper bound on jedi pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ description = "A library for making reactive notebooks and apps"
 dependencies = [
     # For maintainable cli
     "click>=8.0,<9",
-    # code completion
-    "jedi>=0.18.0",
+    # code completion (upper bound applied temporarily for resolution)
+    "jedi>=0.18.0,<0.20.0",
     # compile markdown to html
     "markdown>=3.6,<4",
     # add features to markdown

--- a/tests/snapshots/dependencies.txt
+++ b/tests/snapshots/dependencies.txt
@@ -1,7 +1,7 @@
 click>=8.0,<9
 docutils>=0.16.0
 itsdangerous>=2.0.0
-jedi>=0.18.0
+jedi>=0.18.0,<0.20.0
 loro>=1.10.0
 markdown>=3.6,<4
 msgspec>=0.20.0


### PR DESCRIPTION
## 📝 Summary

closes #9446
closes #9447

Currently `jedi==0.20.0` is incompatible with `python-lsp` (`jedi<0.20.0` is hardcoded). As such, limit `jedi` for now, until we can properly solve