### PR TITLE
refactor: register cells via NotebookDocument transactions

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -188,7 +188,7 @@ class _SetupContext:
                 source="cell_manager",
             )
         )
-        self._cell._cell.configure(CellConfig(hide_code=hide_code))
+        self._cell._cell.configure({"hide_code": hide_code})
         self._hide_code = hide_code
         return self
 

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -42,6 +42,7 @@ from marimo._ast.parse import ast_parse
 from marimo._ast.variables import BUILTINS
 from marimo._convert.converters import MarimoConvert
 from marimo._messaging.mimetypes import KnownMimeType
+from marimo._messaging.notebook.changes import SetConfig, Transaction
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._runtime import dataflow
@@ -172,16 +173,24 @@ class _SetupContext:
         hide_code: bool = False,
         **kwargs: Any,  # noqa: ARG002
     ) -> _SetupContext:
-        """When called with parameters, create a new context with those parameters."""
-        cell = self._app._cell_manager.cell_context(
-            app=InternalApp(self._app),
-            frame=inspect.stack()[1].frame,
-            config=CellConfig(hide_code=hide_code),
+        """When called with parameters, update the setup cell config.
+
+        The setup cell was already registered when ``app.setup`` ran
+        (the property getter); this call updates that cell's config in
+        place rather than re-registering.
+        """
+        cm = self._app._cell_manager
+        cm.document.apply(
+            Transaction(
+                changes=(
+                    SetConfig(cell_id=cm.setup_cell_id, hide_code=hide_code),
+                ),
+                source="cell_manager",
+            )
         )
-        self._app._setup = _SetupContext(
-            app=self._app, cell=cell, hide_code=hide_code
-        )
-        return self._app._setup
+        self._cell._cell.configure(CellConfig(hide_code=hide_code))
+        self._hide_code = hide_code
+        return self
 
 
 @dataclass

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -10,8 +10,6 @@ from typing import (
     TypeVar,
 )
 
-from msgspec.structs import replace as structs_replace
-
 from marimo import _loggers
 from marimo._ast.cell import Cell, CellConfig
 from marimo._ast.cell_id import CellIdGenerator
@@ -25,6 +23,7 @@ from marimo._ast.models import CellData
 from marimo._ast.names import DEFAULT_CELL_NAME, SETUP_CELL_NAME
 from marimo._ast.parse import fixed_dedent
 from marimo._ast.pytest import process_for_pytest
+from marimo._messaging.notebook.changes import CreateCell, Transaction
 from marimo._messaging.notebook.document import NotebookCell, NotebookDocument
 from marimo._schemas.serialization import (
     CellDef,
@@ -220,20 +219,19 @@ class CellManager:
             self._cell_id_generator.seen_ids.add(cell_id)
 
         resolved_config = config or CellConfig()
-        existing = self._document.get(cell_id)
-        if existing is not None:
-            existing.code = code
-            existing.name = name
-            existing.config = resolved_config
-        else:
-            self._document._cells.append(
-                NotebookCell(
-                    id=cell_id,
-                    code=code,
-                    name=name,
-                    config=resolved_config,
-                )
+        self._document.apply(
+            Transaction(
+                changes=(
+                    CreateCell(
+                        cell_id=cell_id,
+                        code=code,
+                        name=name,
+                        config=resolved_config,
+                    ),
+                ),
+                source="cell_manager",
             )
+        )
         self._compiled_cells[cell_id] = cell
 
     def register_ir_cell(
@@ -556,26 +554,19 @@ class CellManager:
         """
         prev_codes = prev_cell_manager.code_lookup()
         current_codes = self.code_lookup()
-        # Create mapping from new to old ids
+        # match_cell_ids_by_similarity returns {new_id: old_id};
+        # _rekey expects {old_id: new_id}.
         id_mapping = match_cell_ids_by_similarity(prev_codes, current_codes)
+        rekey = {old_id: new_id for new_id, old_id in id_mapping.items()}
 
-        # Rebuild the document and compiled-cell sidecar with rekeyed entries.
-        # structs_replace produces a fresh NotebookCell per remap rather than
-        # mutating the existing instance's id, keeping each instance's
-        # primary key stable from construction to disposal.
-        new_cells: list[NotebookCell] = []
-        new_compiled: dict[CellId_t, Cell | None] = {}
-        for new_id, old_id in id_mapping.items():
-            old_cell = self._document._find_cell(old_id)
-            new_cells.append(structs_replace(old_cell, id=new_id))
-            new_compiled[new_id] = self._compiled_cells.get(old_id)
+        self._document._rekey(rekey)
+        self._compiled_cells = {
+            rekey.get(old_id, old_id): cell
+            for old_id, cell in self._compiled_cells.items()
+        }
 
-        self._document._cells = new_cells
-        self._compiled_cells = new_compiled
-
-        # Add the new ids to the set, so we don't reuse them in the future
-        for _id in id_mapping:
-            self._cell_id_generator.seen_ids.add(_id)
+        for new_id in id_mapping:
+            self._cell_id_generator.seen_ids.add(new_id)
 
     @property
     def seen_ids(self) -> set[CellId_t]:

--- a/marimo/_messaging/notebook/document.py
+++ b/marimo/_messaging/notebook/document.py
@@ -242,6 +242,20 @@ class NotebookDocument:
         self._cells = cells
         self._version += 1
 
+    def _rekey(self, mapping: dict[CellId_t, CellId_t]) -> None:
+        """Rekey cells by an old-id to new-id mapping, preserving order.
+
+        Cells whose id is not in ``mapping`` keep their existing id.
+        Each rekeyed cell is replaced by a fresh ``NotebookCell`` so its
+        primary key is stable from construction to disposal. Bumps
+        ``version`` so observers see the rekey as a state change.
+        """
+        self._cells = [
+            structs_replace(c, id=mapping[c.id]) if c.id in mapping else c
+            for c in self._cells
+        ]
+        self._version += 1
+
     def _find_index(self, cell_id: CellId_t) -> int:
         for i, cell in enumerate(self._cells):
             if cell.id == cell_id:

--- a/marimo/_messaging/notebook/document.py
+++ b/marimo/_messaging/notebook/document.py
@@ -249,7 +249,18 @@ class NotebookDocument:
         Each rekeyed cell is replaced by a fresh ``NotebookCell`` so its
         primary key is stable from construction to disposal. Bumps
         ``version`` so observers see the rekey as a state change.
+
+        Raises ``ValueError`` if the rekey would produce duplicate ids.
         """
+        final_ids: set[CellId_t] = set()
+        for c in self._cells:
+            new_id = mapping.get(c.id, c.id)
+            if new_id in final_ids:
+                raise ValueError(
+                    f"Rekey would produce duplicate cell id {new_id!r}"
+                )
+            final_ids.add(new_id)
+
         self._cells = [
             structs_replace(c, id=mapping[c.id]) if c.id in mapping else c
             for c in self._cells

--- a/marimo/_sql/engines/adbc.py
+++ b/marimo/_sql/engines/adbc.py
@@ -534,7 +534,8 @@ class AdbcDBAPIEngine(SQLConnection[AdbcDbApiConnection]):
                 return pl.from_arrow(arrow_table)
 
             def convert_to_pandas() -> pd.DataFrame:
-                return cast("pd.DataFrame", arrow_table.to_pandas())
+                df: pd.DataFrame = arrow_table.to_pandas()
+                return df
 
             result = convert_to_output(
                 sql_output_format=sql_output_format,

--- a/tests/_ast/test_cell.py
+++ b/tests/_ast/test_cell.py
@@ -491,3 +491,19 @@ def test_is_different_from_default():
 
     config = CellConfig(hide_code=False)
     assert not config.is_different_from_default()
+
+
+def test_cell_config_configure_dict_is_partial():
+    config = CellConfig(disabled=True, column=2)
+    config.configure({"hide_code": True})
+    assert config.hide_code is True
+    assert config.disabled is True
+    assert config.column == 2
+
+
+def test_cell_config_configure_struct_writes_all_fields():
+    config = CellConfig(disabled=True, column=2)
+    config.configure(CellConfig(hide_code=True))
+    assert config.hide_code is True
+    assert config.disabled is False
+    assert config.column is None

--- a/tests/_ast/test_cell_manager.py
+++ b/tests/_ast/test_cell_manager.py
@@ -99,6 +99,22 @@ class TestCellManager:
         for _ in range(50):
             assert cell_manager.create_cell_id() != explicit_id
 
+    def test_register_cell_rejects_duplicate_id(
+        self, cell_manager: CellManager
+    ) -> None:
+        cell_manager.register_cell(TEST_CELL1, "x = 1", CellConfig())
+        with pytest.raises(ValueError, match="already exists"):
+            cell_manager.register_cell(TEST_CELL1, "x = 2", CellConfig())
+
+    def test_register_cell_bumps_document_version(
+        self, cell_manager: CellManager
+    ) -> None:
+        assert cell_manager.document.version == 0
+        cell_manager.register_cell(TEST_CELL1, "x = 1", CellConfig())
+        assert cell_manager.document.version == 1
+        cell_manager.register_cell(TEST_CELL2, "y = 2", CellConfig())
+        assert cell_manager.document.version == 2
+
     def test_ensure_one_cell(self, cell_manager: CellManager) -> None:
         assert len(list(cell_manager.cell_ids())) == 0
         cell_manager.ensure_one_cell()
@@ -790,6 +806,17 @@ class TestSortCellIdsByCompiledCells:
         assert list(curr.cell_ids()) == [CELL_A]
         assert curr._compiled_cells.get(CELL_A) is compiled_cell
         assert CELL_X not in curr._compiled_cells
+
+    def test_sort_bumps_document_version(self) -> None:
+        prev = CellManager()
+        prev.register_cell(CELL_A, "x = 1", CellConfig())
+
+        curr = CellManager()
+        curr.register_cell(CELL_X, "x = 1", CellConfig())
+
+        version_before = curr.document.version
+        curr.sort_cell_ids_by_similarity(prev)
+        assert curr.document.version > version_before
 
     @pytest.mark.xfail(
         reason=(

--- a/tests/_messaging/notebook/test_document.py
+++ b/tests/_messaging/notebook/test_document.py
@@ -435,6 +435,47 @@ class TestVersion:
         # pre-rebuild state for comparison.
         assert doc._cells is new_cells
 
+    def test_rekey_bumps_version(self) -> None:
+        doc = _doc("a", "b")
+        starting = doc.version
+        doc._rekey({CellId_t("a"): CellId_t("x")})
+        assert doc.version == starting + 1
+        assert _ids(doc) == ["x", "b"]
+
+
+class TestRekey:
+    def test_renames_mapped_cells(self) -> None:
+        doc = _doc("a", "b", "c")
+        doc._rekey(
+            {CellId_t("a"): CellId_t("x"), CellId_t("c"): CellId_t("z")}
+        )
+        assert _ids(doc) == ["x", "b", "z"]
+
+    def test_preserves_unmapped_cells(self) -> None:
+        doc = _doc("a", "b")
+        doc._rekey({CellId_t("a"): CellId_t("x")})
+        assert _ids(doc) == ["x", "b"]
+
+    def test_rejects_duplicate_target_ids(self) -> None:
+        doc = _doc("a", "b")
+        with pytest.raises(ValueError, match="duplicate"):
+            doc._rekey(
+                {CellId_t("a"): CellId_t("x"), CellId_t("b"): CellId_t("x")}
+            )
+
+    def test_rejects_target_colliding_with_unmapped(self) -> None:
+        doc = _doc("a", "b")
+        with pytest.raises(ValueError, match="duplicate"):
+            doc._rekey({CellId_t("a"): CellId_t("b")})
+
+    def test_failed_validation_does_not_mutate(self) -> None:
+        doc = _doc("a", "b")
+        starting = doc.version
+        with pytest.raises(ValueError):
+            doc._rekey({CellId_t("a"): CellId_t("b")})
+        assert _ids(doc) == ["a", "b"]
+        assert doc.version == starting
+
 
 # ------------------------------------------------------------------
 # Combined ops

--- a/tests/_session/notebook/test_loader.py
+++ b/tests/_session/notebook/test_loader.py
@@ -72,8 +72,19 @@ def test_load_notebook_loads_cells(tmp_path: Path) -> None:
     assert "x = 1" in cells[0].code
 
 
+def test_load_notebook_advances_document_version(tmp_path: Path) -> None:
+    nb = _write_notebook(tmp_path / "nb.py")
+    fm = load_notebook(nb)
+    assert fm.app.cell_manager.document.version > 0
+
+
 def test_new_notebook_returns_unbacked_manager() -> None:
     fm = new_notebook()
     assert isinstance(fm, AppFileManager)
     assert fm.path is None
     assert fm.filename is None
+
+
+def test_new_notebook_advances_document_version() -> None:
+    fm = new_notebook()
+    assert fm.app.cell_manager.document.version > 0


### PR DESCRIPTION
Follow-up to #9405 

## Summary
- `register_cell` now applies a `CreateCell` transaction and rejects duplicate ids
  - earlier we were silently overriding
- New `NotebookDocument._rekey(mapping)` helper; `sort_cell_ids_by_similarity` switches to it.
- `_SetupContext.__call__` (the `app.setup(hide_code=...)` path) updates the setup cell config via `SetConfig` instead of re-registering. The two calls to registrations worked previously because of silent override in register_cell.
- `document.version` now reflects every cell-state change, including initial load and rekey.

## Why
After #9405's wrap-and-delegate refactor, two doors still mutated cell state — `_document.apply(Transaction)` and `_document._cells.append(...)`. This PR closes the second door so the document state machine is the single mutation API. Drift between `cell_manager` and `session.document` becomes structurally impossible, and any future transaction subscriber (e.g. RTC) sees initial-load mutations instead of starting from a `version == 0` snapshot of an already-populated doc.