### PR TITLE
Autosave only during code-mode

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -1587,7 +1587,7 @@ class AsyncCodeModeContext:
             internal_ops=ops,
         )
         if doc_ops:
-            tx = Transaction(changes=tuple(doc_ops), source="kernel")
+            tx = Transaction(changes=tuple(doc_ops), source="code-mode")
             # Apply to local snapshot so _cell_label can read names.
             self._document.apply(tx)
             self.notify(

--- a/marimo/_messaging/notebook/changes.py
+++ b/marimo/_messaging/notebook/changes.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import msgspec
 
 from marimo._ast.cell import CellConfig
@@ -96,6 +98,8 @@ DocumentChange = (
 # Transaction
 # ------------------------------------------------------------------
 
+TransactionSource = Literal["frontend", "kernel", "code-mode", "file-watch"]
+
 
 class Transaction(msgspec.Struct, frozen=True, rename="camel"):
     """An atomic batch of changes applied to a NotebookDocument.
@@ -106,5 +110,5 @@ class Transaction(msgspec.Struct, frozen=True, rename="camel"):
     """
 
     changes: tuple[DocumentChange, ...]
-    source: str
+    source: TransactionSource
     version: int | None = None

--- a/marimo/_session/extensions/extensions.py
+++ b/marimo/_session/extensions/extensions.py
@@ -18,6 +18,7 @@ import msgspec
 
 from marimo import _loggers
 from marimo._cli.print import red
+from marimo._messaging.notebook.changes import TransactionSource
 from marimo._messaging.notebook.document import NotebookCell
 from marimo._messaging.notification import (
     AlertNotification,
@@ -260,7 +261,7 @@ class NotificationListenerExtension(SessionExtension):
         consider a middleware chain instead of inline dispatch.
         """
         notif: KernelMessage | NotificationMessage = msg
-        kernel_transaction_applied = False
+        applied_source: TransactionSource | None = None
 
         name = try_deserialize_kernel_notification_name(msg)
         if name == NotebookDocumentTransactionNotification.name:
@@ -273,7 +274,7 @@ class NotificationListenerExtension(SessionExtension):
                 notif = NotebookDocumentTransactionNotification(
                     transaction=applied
                 )
-                kernel_transaction_applied = applied.source == "kernel"
+                applied_source = applied.source
             except Exception:
                 LOGGER.warning(
                     "Failed to decode/apply kernel document transaction"
@@ -281,16 +282,23 @@ class NotificationListenerExtension(SessionExtension):
 
         session.notify(notif, from_consumer_id=None)
 
-        if kernel_transaction_applied:
-            self._maybe_autosave(session)
+        if applied_source is not None:
+            self._maybe_autosave(session, applied_source)
 
-    def _maybe_autosave(self, session: Session) -> None:
-        """Best-effort persistence of kernel-driven mutations to disk.
+    def _maybe_autosave(
+        self, session: Session, source: TransactionSource
+    ) -> None:
+        """Best-effort persistence of code-mode mutations to disk.
 
+        Only ``source="code-mode"`` transactions persist; ``"kernel"``
+        bookkeeping (e.g. instantiation cell-order broadcasts) is skipped
+        so opening or running a notebook never rewrites it on disk.
         Skipped in run mode and for unnamed notebooks. Failures surface as
         an ``AlertNotification`` toast; they never raise out of the
         interceptor.
         """
+        if source != "code-mode":
+            return
         if self.kernel_manager.mode != SessionMode.EDIT:
             return
 

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -5053,7 +5053,11 @@ components:
               propertyName: type
           type: array
         source:
-          type: string
+          enum:
+          - code-mode
+          - file-watch
+          - frontend
+          - kernel
         version:
           anyOf:
           - type: integer

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -6431,7 +6431,8 @@ export interface components {
         | components["schemas"]["SetName"]
         | components["schemas"]["SetConfig"]
       )[];
-      source: string;
+      /** @enum {unknown} */
+      source: "code-mode" | "file-watch" | "frontend" | "kernel";
       /** @default null */
       version?: number | null;
     };

--- a/tests/_session/extensions/test_notification_listener_autosave.py
+++ b/tests/_session/extensions/test_notification_listener_autosave.py
@@ -18,6 +18,7 @@ from marimo._messaging.notebook.changes import (
     SetConfig,
     SetName,
     Transaction,
+    TransactionSource,
 )
 from marimo._messaging.notebook.document import NotebookCell, NotebookDocument
 from marimo._messaging.notification import (
@@ -71,7 +72,7 @@ def _document_from(app_file_manager: AppFileManager) -> NotebookDocument:
 
 
 def _serialize_tx(
-    *changes: DocumentChange, source: str = "kernel"
+    *changes: DocumentChange, source: TransactionSource = "code-mode"
 ) -> KernelMessage:
     return serialize_kernel_message(
         NotebookDocumentTransactionNotification(


### PR DESCRIPTION
## Summary

- Tighten `Transaction.source` to `Literal["frontend", "kernel", "code-mode", "file-watch"]` so the closed set is type-checked.
- Rename code-mode's transaction emission from `source="kernel"` to `source="code-mode"`, and gate `_maybe_autosave` on it.


## Why
`run_app_then_export_as_ipynb` (and any other path using `run_app_until_completion` in EDIT mode) was rewriting source `.py` files as a side effect.

The fix flips the autosave default from "all kernel-sourced transactions persist" to "only code-mode transactions persist."