### PR TITLE
fix: include cell_manager in TransactionSource literal

### DIFF
--- a/marimo/_messaging/notebook/changes.py
+++ b/marimo/_messaging/notebook/changes.py
@@ -98,7 +98,9 @@ DocumentChange = (
 # Transaction
 # ------------------------------------------------------------------
 
-TransactionSource = Literal["frontend", "kernel", "code-mode", "file-watch"]
+TransactionSource = Literal[
+    "frontend", "kernel", "code-mode", "file-watch", "cell_manager"
+]
 
 
 class Transaction(msgspec.Struct, frozen=True, rename="camel"):


### PR DESCRIPTION
Fixes https://github.com/marimo-team/ci-agent/issues/17

Two PRs collided on main:

- #9452 added `Transaction(source="cell_manager")` call sites in `marimo/_ast/app.py` and `marimo/_ast/cell_manager.py` while `Transaction.source` was still typed `str`.
- #9453 then tightened `source` to `TransactionSource = Literal["frontend", "kernel", "code-mode", "file-watch"]` without including `"cell_manager"`.

Each PR was green against its own base, so the mismatch only surfaced on main, where mypy now fails.

Adds `"cell_manager"` to the `TransactionSource` literal.