### PR TITLE
chore: regenerate openapi types for cell_manager TransactionSource

### DIFF
--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -5054,6 +5054,7 @@ components:
           type: array
         source:
           enum:
+          - cell_manager
           - code-mode
           - file-watch
           - frontend

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -6432,7 +6432,12 @@ export interface components {
         | components["schemas"]["SetConfig"]
       )[];
       /** @enum {unknown} */
-      source: "code-mode" | "file-watch" | "frontend" | "kernel";
+      source:
+        | "cell_manager"
+        | "code-mode"
+        | "file-watch"
+        | "frontend"
+        | "kernel";
       /** @default null */
       version?: number | null;
     };


### PR DESCRIPTION
Codegen follow-up to #9457 — regenerates `packages/openapi/api.yaml` and `src/api.ts` to include the `cell_manager` literal in `TransactionSource`.