### PR TITLE
chore: rename cell_manager TransactionSource to cell-manager

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -185,7 +185,7 @@ class _SetupContext:
                 changes=(
                     SetConfig(cell_id=cm.setup_cell_id, hide_code=hide_code),
                 ),
-                source="cell_manager",
+                source="cell-manager",
             )
         )
         self._cell._cell.configure({"hide_code": hide_code})

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -229,7 +229,7 @@ class CellManager:
                         config=resolved_config,
                     ),
                 ),
-                source="cell_manager",
+                source="cell-manager",
             )
         )
         self._compiled_cells[cell_id] = cell

--- a/marimo/_messaging/notebook/changes.py
+++ b/marimo/_messaging/notebook/changes.py
@@ -99,7 +99,7 @@ DocumentChange = (
 # ------------------------------------------------------------------
 
 TransactionSource = Literal[
-    "frontend", "kernel", "code-mode", "file-watch", "cell_manager"
+    "frontend", "kernel", "code-mode", "file-watch", "cell-manager"
 ]
 
 

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -5054,7 +5054,7 @@ components:
           type: array
         source:
           enum:
-          - cell_manager
+          - cell-manager
           - code-mode
           - file-watch
           - frontend

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -6433,7 +6433,7 @@ export interface components {
       )[];
       /** @enum {unknown} */
       source:
-        | "cell_manager"
+        | "cell-manager"
         | "code-mode"
         | "file-watch"
         | "frontend"


### PR DESCRIPTION
Use kebab-case for the `cell-manager` transaction source, matching the other sources (`frontend`, `kernel`, `code-mode`, `file-watch`).

Follow-up to #9457 and #9458.

## Test plan
- [x] `make check` passes