### PR TITLE
refactor: `SetConfig` is now full-replacement instead of partial-update

### DIFF
--- a/frontend/src/core/cells/__tests__/apply-transaction.test.ts
+++ b/frontend/src/core/cells/__tests__/apply-transaction.test.ts
@@ -469,10 +469,10 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0 },
-      { type: "set-config", cellId: b, column: 1 },
-      { type: "set-config", cellId: c, column: 0 },
-      { type: "set-config", cellId: d, column: 1 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: b, column: 1, disabled: false, hideCode: false },
+      { type: "set-config", cellId: c, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: d, column: 1, disabled: false, hideCode: false },
     ]);
     // a and c in col0; b and d in col1. Order within each column follows
     // the reorder-cells order.
@@ -487,7 +487,7 @@ describe("applyTransactionChanges column rebuild", () => {
   it("set-config without reorder-cells moves the cell to the new column", () => {
     setup("a", "b", "c");
     const [, b] = state.cellIds.inOrderIds;
-    apply([{ type: "set-config", cellId: b, column: 1 }]);
+    apply([{ type: "set-config", cellId: b, column: 1, disabled: false, hideCode: false }]);
     // Without reorder-cells, the flat order comes from the current tree.
     // b gets explicit col=1; a and c stay with default null → follow the
     // previous cell's column (a → col0 because prev=0; c → col1 because
@@ -503,7 +503,15 @@ describe("applyTransactionChanges column rebuild", () => {
   it("no column change: set-config only touching other fields does not repartition", () => {
     setup("a", "b", "c");
     const [, b] = state.cellIds.inOrderIds;
-    apply([{ type: "set-config", cellId: b, hideCode: true }]);
+    apply([
+      {
+        type: "set-config",
+        cellId: b,
+        column: null,
+        disabled: false,
+        hideCode: true,
+      },
+    ]);
     // All three cells remain in a single column. No rebuild triggered.
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -525,8 +533,8 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b] },
-      { type: "set-config", cellId: a, column: 0 },
-      { type: "set-config", cellId: b, column: 1 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: b, column: 1, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -550,8 +558,8 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0 },
-      { type: "set-config", cellId: c, column: 1 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -562,8 +570,8 @@ describe("applyTransactionChanges column rebuild", () => {
     // Now merge everything back to col 0.
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: c, column: 0 },
-      { type: "set-config", cellId: d, column: 0 },
+      { type: "set-config", cellId: c, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: d, column: 0, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -609,8 +617,8 @@ describe("applyTransactionChanges column rebuild", () => {
       { type: "reorder-cells", cellIds: [a, b, c] },
       { type: "set-code", cellId: a, code: "x = 1" },
       { type: "set-name", cellId: b, name: "middle" },
-      { type: "set-config", cellId: a, column: 0 },
-      { type: "set-config", cellId: b, column: 1 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: b, column: 1, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -658,8 +666,8 @@ describe("applyTransactionChanges column rebuild", () => {
     // Split into two columns. Only a and c are anchors.
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0 },
-      { type: "set-config", cellId: c, column: 1 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -670,7 +678,7 @@ describe("applyTransactionChanges column rebuild", () => {
     // Move the c anchor to col 0. d has no explicit column so it follows c.
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: c, column: 0 },
+      { type: "set-config", cellId: c, column: 0, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -686,9 +694,9 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0 },
-      { type: "set-config", cellId: c, column: 1 },
-      { type: "set-config", cellId: d, column: 1 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
+      { type: "set-config", cellId: d, column: 1, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -700,7 +708,7 @@ describe("applyTransactionChanges column rebuild", () => {
     // does NOT follow c.
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: c, column: 0 },
+      { type: "set-config", cellId: c, column: 0, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -719,8 +727,8 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       // set-config appears FIRST in the transaction.
-      { type: "set-config", cellId: a, column: 0 },
-      { type: "set-config", cellId: c, column: 1 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
       // reorder-cells comes afterwards.
       { type: "reorder-cells", cellIds: [a, b, c, d] },
     ]);
@@ -741,9 +749,9 @@ describe("applyTransactionChanges column rebuild", () => {
     setup("a", "b", "c", "d");
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
-      { type: "set-config", cellId: a, column: 0 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
       { type: "set-code", cellId: a, code: "x = 1" },
-      { type: "set-config", cellId: c, column: 1 },
+      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
       { type: "reorder-cells", cellIds: [a, b, c, d] },
       { type: "set-name", cellId: d, name: "last" },
     ]);
@@ -769,8 +777,8 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0 },
-      { type: "set-config", cellId: c, column: 1 },
+      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "

--- a/frontend/src/core/cells/__tests__/apply-transaction.test.ts
+++ b/frontend/src/core/cells/__tests__/apply-transaction.test.ts
@@ -469,10 +469,34 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: b, column: 1, disabled: false, hideCode: false },
-      { type: "set-config", cellId: c, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: d, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: b,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: d,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     // a and c in col0; b and d in col1. Order within each column follows
     // the reorder-cells order.
@@ -487,7 +511,15 @@ describe("applyTransactionChanges column rebuild", () => {
   it("set-config without reorder-cells moves the cell to the new column", () => {
     setup("a", "b", "c");
     const [, b] = state.cellIds.inOrderIds;
-    apply([{ type: "set-config", cellId: b, column: 1, disabled: false, hideCode: false }]);
+    apply([
+      {
+        type: "set-config",
+        cellId: b,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
+    ]);
     // Without reorder-cells, the flat order comes from the current tree.
     // b gets explicit col=1; a and c stay with default null → follow the
     // previous cell's column (a → col0 because prev=0; c → col1 because
@@ -533,8 +565,20 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b] },
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: b, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: b,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -558,8 +602,20 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -570,8 +626,20 @@ describe("applyTransactionChanges column rebuild", () => {
     // Now merge everything back to col 0.
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: c, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: d, column: 0, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: d,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -617,8 +685,20 @@ describe("applyTransactionChanges column rebuild", () => {
       { type: "reorder-cells", cellIds: [a, b, c] },
       { type: "set-code", cellId: a, code: "x = 1" },
       { type: "set-name", cellId: b, name: "middle" },
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: b, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: b,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -666,8 +746,20 @@ describe("applyTransactionChanges column rebuild", () => {
     // Split into two columns. Only a and c are anchors.
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -678,7 +770,13 @@ describe("applyTransactionChanges column rebuild", () => {
     // Move the c anchor to col 0. d has no explicit column so it follows c.
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: c, column: 0, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -694,9 +792,27 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
-      { type: "set-config", cellId: d, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: d,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -708,7 +824,13 @@ describe("applyTransactionChanges column rebuild", () => {
     // does NOT follow c.
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: c, column: 0, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "
@@ -727,8 +849,20 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       // set-config appears FIRST in the transaction.
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
       // reorder-cells comes afterwards.
       { type: "reorder-cells", cellIds: [a, b, c, d] },
     ]);
@@ -749,9 +883,21 @@ describe("applyTransactionChanges column rebuild", () => {
     setup("a", "b", "c", "d");
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
       { type: "set-code", cellId: a, code: "x = 1" },
-      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
       { type: "reorder-cells", cellIds: [a, b, c, d] },
       { type: "set-name", cellId: d, name: "last" },
     ]);
@@ -777,8 +923,20 @@ describe("applyTransactionChanges column rebuild", () => {
     const [a, b, c, d] = state.cellIds.inOrderIds;
     apply([
       { type: "reorder-cells", cellIds: [a, b, c, d] },
-      { type: "set-config", cellId: a, column: 0, disabled: false, hideCode: false },
-      { type: "set-config", cellId: c, column: 1, disabled: false, hideCode: false },
+      {
+        type: "set-config",
+        cellId: a,
+        column: 0,
+        disabled: false,
+        hideCode: false,
+      },
+      {
+        type: "set-config",
+        cellId: c,
+        column: 1,
+        disabled: false,
+        hideCode: false,
+      },
     ]);
     expect(prettyColumns(state)).toMatchInlineSnapshot(`
       "

--- a/frontend/src/core/cells/__tests__/document-changes.test.ts
+++ b/frontend/src/core/cells/__tests__/document-changes.test.ts
@@ -203,6 +203,8 @@ describe("toDocumentChanges", () => {
         [
           {
             "cellId": "0",
+            "column": null,
+            "disabled": false,
             "hideCode": true,
             "type": "set-config",
           },
@@ -246,6 +248,8 @@ describe("toDocumentChanges", () => {
           {
             "cellId": "1",
             "column": 1,
+            "disabled": false,
+            "hideCode": false,
             "type": "set-config",
           },
           {
@@ -273,11 +277,15 @@ describe("toDocumentChanges", () => {
           {
             "cellId": "1",
             "column": 1,
+            "disabled": false,
+            "hideCode": false,
             "type": "set-config",
           },
           {
             "cellId": "2",
             "column": 1,
+            "disabled": false,
+            "hideCode": false,
             "type": "set-config",
           },
           {
@@ -310,11 +318,15 @@ describe("toDocumentChanges", () => {
           {
             "cellId": "1",
             "column": 0,
+            "disabled": false,
+            "hideCode": false,
             "type": "set-config",
           },
           {
             "cellId": "2",
             "column": 0,
+            "disabled": false,
+            "hideCode": false,
             "type": "set-config",
           },
           {
@@ -358,6 +370,8 @@ describe("toDocumentChanges", () => {
           {
             "cellId": "1",
             "column": 1,
+            "disabled": false,
+            "hideCode": false,
             "type": "set-config",
           },
           {

--- a/frontend/src/core/cells/document-changes.ts
+++ b/frontend/src/core/cells/document-changes.ts
@@ -156,10 +156,13 @@ function columnChanges(
   for (const [cellId, newCol] of newColumns) {
     const prevCol = prevColumns.get(cellId);
     if (prevCol !== newCol) {
+      const cell = getCell(cellId, newState);
       changes.push({
         type: "set-config",
         cellId: cellId,
         column: newCol,
+        disabled: cell?.config.disabled ?? false,
+        hideCode: cell?.config.hide_code ?? false,
       });
     }
   }
@@ -257,18 +260,21 @@ export function toDocumentChanges(
     }
 
     // updateCellConfig → set-config
-    // Maps CellConfig's snake_case hide_code to the change's camelCase hideCode.
-    // Only includes fields that were actually specified in the partial config
-    // (from the action payload, not the full cell config).
+    // SetConfig is full-replacement: emit the cell's complete config from
+    // newState (which already merged the action's partial payload).
     case "updateCellConfig": {
-      const { cellId, config } = action.payload;
+      const { cellId } = action.payload;
+      const cell = getCell(cellId, newState);
+      if (!cell) {
+        return [];
+      }
       return [
         {
           type: "set-config",
           cellId: cellId,
-          ...(config.hide_code != null && { hideCode: config.hide_code }),
-          ...(config.disabled != null && { disabled: config.disabled }),
-          ...(config.column != null && { column: config.column }),
+          column: cell.config.column ?? null,
+          disabled: cell.config.disabled ?? false,
+          hideCode: cell.config.hide_code ?? false,
         },
       ];
     }
@@ -538,18 +544,15 @@ export function fromDocumentChanges(
         break;
 
       // set-config → updateCellConfig
-      // Maps the change's camelCase hideCode back to CellConfig's snake_case
-      // hide_code. Only includes fields that are non-null (null means
-      // "not specified" on the wire, not "clear the value").
       case "set-config":
         actions.push({
           type: "updateCellConfig",
           payload: {
             cellId: change.cellId,
             config: {
-              ...(change.hideCode != null && { hide_code: change.hideCode }),
-              ...(change.disabled != null && { disabled: change.disabled }),
-              ...(change.column != null && { column: change.column }),
+              column: change.column,
+              disabled: change.disabled,
+              hide_code: change.hideCode,
             },
           },
         });
@@ -650,7 +653,7 @@ export function applyTransactionChanges(
     ) {
       continue;
     }
-    if (change.type === "set-config" && change.column != null) {
+    if (change.type === "set-config") {
       hasColumnChange = true;
     }
     if (change.type === "create-cell" && change.config?.column != null) {

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -180,10 +180,16 @@ class _SetupContext:
         place rather than re-registering.
         """
         cm = self._app._cell_manager
+        existing_cfg = cm.document.get_cell(cm.setup_cell_id).config
         cm.document.apply(
             Transaction(
                 changes=(
-                    SetConfig(cell_id=cm.setup_cell_id, hide_code=hide_code),
+                    SetConfig(
+                        cell_id=cm.setup_cell_id,
+                        column=existing_cfg.column,
+                        disabled=existing_cfg.disabled,
+                        hide_code=hide_code,
+                    ),
                 ),
                 source="cell_manager",
             )

--- a/marimo/_messaging/notebook/changes.py
+++ b/marimo/_messaging/notebook/changes.py
@@ -76,12 +76,12 @@ class SetName(msgspec.Struct, frozen=True, tag="set-name", rename="camel"):
 
 
 class SetConfig(msgspec.Struct, frozen=True, tag="set-config", rename="camel"):
-    """Partially update a cell's config. None fields are unchanged."""
+    """Replace a cell's config."""
 
     cell_id: CellId_t
-    column: int | None = None
-    disabled: bool | None = None
-    hide_code: bool | None = None
+    column: int | None
+    disabled: bool
+    hide_code: bool
 
 
 DocumentChange = (

--- a/marimo/_messaging/notebook/document.py
+++ b/marimo/_messaging/notebook/document.py
@@ -211,15 +211,9 @@ class NotebookDocument:
         elif isinstance(change, SetConfig):
             cell = self._find_cell(change.cell_id)
             cell.config = CellConfig(
-                column=change.column
-                if change.column is not None
-                else cell.config.column,
-                disabled=change.disabled
-                if change.disabled is not None
-                else cell.config.disabled,
-                hide_code=change.hide_code
-                if change.hide_code is not None
-                else cell.config.hide_code,
+                column=change.column,
+                disabled=change.disabled,
+                hide_code=change.hide_code,
             )
         else:
             assert_never(change)

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -4454,7 +4454,7 @@ components:
       title: SetCode
       type: object
     SetConfig:
-      description: Partially update a cell's config. None fields are unchanged.
+      description: Replace a cell's config.
       properties:
         cellId:
           $ref: '#/components/schemas/CellId'
@@ -4462,23 +4462,19 @@ components:
           anyOf:
           - type: integer
           - type: 'null'
-          default: null
         disabled:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          default: null
+          type: boolean
         hideCode:
-          anyOf:
-          - type: boolean
-          - type: 'null'
-          default: null
+          type: boolean
         type:
           enum:
           - set-config
       required:
       - type
       - cellId
+      - column
+      - disabled
+      - hideCode
       title: SetConfig
       type: object
     SetName:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -6056,16 +6056,13 @@ export interface components {
     };
     /**
      * SetConfig
-     * @description Partially update a cell's config. None fields are unchanged.
+     * @description Replace a cell's config.
      */
     SetConfig: {
       cellId: components["schemas"]["CellId"];
-      /** @default null */
-      column?: number | null;
-      /** @default null */
-      disabled?: boolean | null;
-      /** @default null */
-      hideCode?: boolean | null;
+      column: number | null;
+      disabled: boolean;
+      hideCode: boolean;
       /** @enum {unknown} */
       type: "set-config";
     };

--- a/tests/_messaging/notebook/test_changes.py
+++ b/tests/_messaging/notebook/test_changes.py
@@ -49,7 +49,12 @@ class TestChangesFrozen:
             op.name = "bar"  # type: ignore[misc]
 
     def test_set_config_frozen(self) -> None:
-        op = SetConfig(cell_id=CellId_t("a"), hide_code=True)
+        op = SetConfig(
+            cell_id=CellId_t("a"),
+            column=None,
+            disabled=False,
+            hide_code=True,
+        )
         with pytest.raises(AttributeError):
             op.hide_code = False  # type: ignore[misc]
 

--- a/tests/_messaging/notebook/test_document.py
+++ b/tests/_messaging/notebook/test_document.py
@@ -277,54 +277,85 @@ class TestSetName:
 
 
 class TestSetConfig:
-    def test_partial_hide_code(self) -> None:
-        doc = _doc("a")
-        doc.apply(_tx(SetConfig(cell_id=CellId_t("a"), hide_code=True)))
-        cfg = doc.get_cell(CellId_t("a")).config
-        assert cfg.hide_code is True
-        assert cfg.disabled is False  # unchanged default
-
-    def test_partial_disabled(self) -> None:
-        doc = _doc("a")
-        doc.apply(_tx(SetConfig(cell_id=CellId_t("a"), disabled=True)))
-        cfg = doc.get_cell(CellId_t("a")).config
-        assert cfg.disabled is True
-        assert cfg.hide_code is False  # unchanged default
-
-    def test_multiple_fields(self) -> None:
+    def test_sets_hide_code(self) -> None:
         doc = _doc("a")
         doc.apply(
             _tx(
-                SetConfig(cell_id=CellId_t("a"), hide_code=True, disabled=True)
+                SetConfig(
+                    cell_id=CellId_t("a"),
+                    column=None,
+                    disabled=False,
+                    hide_code=True,
+                )
             )
         )
         cfg = doc.get_cell(CellId_t("a")).config
-        assert cfg.hide_code is True
-        assert cfg.disabled is True
+        assert cfg == CellConfig(column=None, disabled=False, hide_code=True)
 
-    def test_all_none_is_noop(self) -> None:
+    def test_sets_disabled(self) -> None:
         doc = _doc("a")
-        doc.apply(_tx(SetConfig(cell_id=CellId_t("a"))))
+        doc.apply(
+            _tx(
+                SetConfig(
+                    cell_id=CellId_t("a"),
+                    column=None,
+                    disabled=True,
+                    hide_code=False,
+                )
+            )
+        )
         cfg = doc.get_cell(CellId_t("a")).config
-        assert cfg == CellConfig()
+        assert cfg == CellConfig(column=None, disabled=True, hide_code=False)
 
-    def test_preserves_existing(self) -> None:
-        """Setting one field preserves other non-default fields."""
+    def test_replaces_existing(self) -> None:
+        # SetConfig is a full replacement: prior fields are overwritten,
+        # not merged. This is what makes ``column=None`` a meaningful reset
+        # rather than a sentinel for "leave unchanged".
         doc = NotebookDocument(
             [
                 NotebookCell(
                     id=CellId_t("a"),
                     code="",
                     name="__",
-                    config=CellConfig(hide_code=True, column=2),
+                    config=CellConfig(column=2, disabled=True, hide_code=True),
                 )
             ]
         )
-        doc.apply(_tx(SetConfig(cell_id=CellId_t("a"), disabled=True)))
+        doc.apply(
+            _tx(
+                SetConfig(
+                    cell_id=CellId_t("a"),
+                    column=0,
+                    disabled=False,
+                    hide_code=False,
+                )
+            )
+        )
         cfg = doc.get_cell(CellId_t("a")).config
-        assert cfg.disabled is True
-        assert cfg.hide_code is True  # preserved
-        assert cfg.column == 2  # preserved
+        assert cfg == CellConfig(column=0, disabled=False, hide_code=False)
+
+    def test_column_reset_to_none(self) -> None:
+        doc = NotebookDocument(
+            [
+                NotebookCell(
+                    id=CellId_t("a"),
+                    code="",
+                    name="__",
+                    config=CellConfig(column=1),
+                )
+            ]
+        )
+        doc.apply(
+            _tx(
+                SetConfig(
+                    cell_id=CellId_t("a"),
+                    column=None,
+                    disabled=False,
+                    hide_code=False,
+                )
+            )
+        )
+        assert doc.get_cell(CellId_t("a")).config.column is None
 
 
 # ------------------------------------------------------------------

--- a/tests/_session/extensions/test_notification_listener_autosave.py
+++ b/tests/_session/extensions/test_notification_listener_autosave.py
@@ -174,7 +174,14 @@ class TestKernelSourcedAutoSave:
     ) -> None:
         ext._on_kernel_message(
             session,
-            _serialize_tx(SetConfig(cell_id=existing_cell_id, hide_code=True)),
+            _serialize_tx(
+                SetConfig(
+                    cell_id=existing_cell_id,
+                    column=None,
+                    disabled=False,
+                    hide_code=True,
+                )
+            ),
         )
         contents = notebook_path.read_text()
         assert "hide_code=True" in contents or "hide_code: true" in contents


### PR DESCRIPTION
## Summary

- `SetConfig` was a partial update where `None` meant "leave unchanged", which collided with the legitimate `column=None` value (cell outside any column layout). Any diff producer that emitted `SetConfig(column=None, ...)` to reset a cell's column was silently dropped on apply.
- Made `SetConfig` a full replacement: `column`/`disabled`/`hide_code` are required and overwrite the cell's config directly. Producers that already emitted full triples (file-watch reload, code-mode plan) need no changes; the `app.setup` setup-cell producer now reads existing config first. Frontend producers (`columnChanges`, `updateCellConfig`) and the apply consumer mirror the full-replacement semantic.