### PR TITLE
fix: skip wasm controller dynamic import unless host opts in

### DIFF
--- a/frontend/src/core/wasm/__tests__/bridge.test.ts
+++ b/frontend/src/core/wasm/__tests__/bridge.test.ts
@@ -58,7 +58,7 @@ vi.mock("@/core/wasm/store", () => ({
 // Import after all mocks are set up
 import { store } from "@/core/state/jotai";
 import { initialModeAtom } from "@/core/mode";
-import { PyodideBridge } from "../bridge";
+import { getWasmWorkerName, PyodideBridge } from "../bridge";
 
 // Access INSTANCE once at module level so the constructor runs (and
 // addMessageListener populates rpcListeners) before any test executes.
@@ -109,5 +109,30 @@ describe("PyodideBridge.readCode", () => {
     await PyodideBridge.INSTANCE.readCode();
 
     expect(mockNotebookReadFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("getWasmWorkerName", () => {
+  afterEach(() => {
+    delete (window as unknown as { __MARIMO_HAS_WASM_CONTROLLER__?: boolean })
+      .__MARIMO_HAS_WASM_CONTROLLER__;
+  });
+
+  it("returns the version without suffix by default", () => {
+    expect(getWasmWorkerName()).toBe("0.0.0-test");
+  });
+
+  it("appends ::controller when the host opts in", () => {
+    (
+      window as unknown as { __MARIMO_HAS_WASM_CONTROLLER__?: boolean }
+    ).__MARIMO_HAS_WASM_CONTROLLER__ = true;
+    expect(getWasmWorkerName()).toBe("0.0.0-test::controller");
+  });
+
+  it("does not append the suffix for non-true values", () => {
+    (
+      window as unknown as { __MARIMO_HAS_WASM_CONTROLLER__?: unknown }
+    ).__MARIMO_HAS_WASM_CONTROLLER__ = "true";
+    expect(getWasmWorkerName()).toBe("0.0.0-test");
   });
 });

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -81,9 +81,9 @@ export class PyodideBridge implements RunRequests, EditRequests {
       new URL("./worker/save-worker.ts", import.meta.url),
       {
         type: "module",
-        // Pass the version to the worker
+        // Pass the version (and optional capability suffix) to the worker
         /* @vite-ignore */
-        name: getMarimoVersion(),
+        name: getWasmWorkerName(),
       },
     );
 
@@ -101,9 +101,9 @@ export class PyodideBridge implements RunRequests, EditRequests {
       new URL("./worker/worker.ts", import.meta.url),
       {
         type: "module",
-        // Pass the version to the worker
+        // Pass the version (and optional capability suffix) to the worker
         /* @vite-ignore */
-        name: getMarimoVersion(),
+        name: getWasmWorkerName(),
       },
     );
 
@@ -633,4 +633,17 @@ export function createPyodideConnection(): IConnectionTransport {
   return BasicTransport.withProducerCallback((callback) => {
     PyodideBridge.INSTANCE.attachMessageConsumer(callback);
   });
+}
+
+// Compose the worker name. The version prefix is read by getMarimoVersion()
+// in the worker; the optional "::controller" suffix tells getController.ts
+// that the host page provides a custom /wasm/controller.js and that the
+// dynamic import should be attempted. Hosts opt in by setting
+// `window.__MARIMO_HAS_WASM_CONTROLLER__ = true` before this module loads.
+function getWasmWorkerName(): string {
+  const hasCustomController =
+    typeof window !== "undefined" &&
+    (window as unknown as { __MARIMO_HAS_WASM_CONTROLLER__?: boolean })
+      .__MARIMO_HAS_WASM_CONTROLLER__ === true;
+  return getMarimoVersion() + (hasCustomController ? "::controller" : "");
 }

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -639,8 +639,9 @@ export function createPyodideConnection(): IConnectionTransport {
 // in the worker; the optional "::controller" suffix tells getController.ts
 // that the host page provides a custom /wasm/controller.js and that the
 // dynamic import should be attempted. Hosts opt in by setting
-// `window.__MARIMO_HAS_WASM_CONTROLLER__ = true` before this module loads.
-function getWasmWorkerName(): string {
+// `window.__MARIMO_HAS_WASM_CONTROLLER__ = true` before
+// PyodideBridge/worker initialization.
+export function getWasmWorkerName(): string {
   const hasCustomController =
     typeof window !== "undefined" &&
     (window as unknown as { __MARIMO_HAS_WASM_CONTROLLER__?: boolean })

--- a/frontend/src/core/wasm/worker/getController.ts
+++ b/frontend/src/core/wasm/worker/getController.ts
@@ -5,6 +5,13 @@ import type { WasmController } from "./types";
 // Load the controller
 // Falls back to the default controller
 export async function getController(version: string): Promise<WasmController> {
+  // Hosts that provide a custom /wasm/controller.js opt in via the worker
+  // name (see bridge.ts). Default: skip the dynamic import to avoid a
+  // guaranteed-404 round trip on the standard build.
+  const hasCustomController = self.name?.includes("::controller") ?? false;
+  if (!hasCustomController) {
+    return new DefaultWasmController();
+  }
   try {
     const controller = await import(
       /* @vite-ignore */ `/wasm/controller.js?version=${version}`

--- a/frontend/src/core/wasm/worker/save-worker.ts
+++ b/frontend/src/core/wasm/worker/save-worker.ts
@@ -103,5 +103,6 @@ const rpc = createRPC<SaveWorkerSchema, ParentSchema>({
 rpc.send("ready", {});
 
 function getMarimoVersion() {
-  return self.name; // We store the version in the worker name
+  // Worker name is "<version>" or "<version>::<capability>" — see bridge.ts.
+  return self.name.split("::")[0];
 }

--- a/frontend/src/core/wasm/worker/worker.ts
+++ b/frontend/src/core/wasm/worker/worker.ts
@@ -375,7 +375,8 @@ const namesThatRequireSync = new Set<keyof RawBridge>([
 ]);
 
 function getMarimoVersion() {
-  return self.name; // We store the version in the worker name
+  // Worker name is "<version>" or "<version>::<capability>" — see bridge.ts.
+  return self.name.split("::")[0];
 }
 
 const pyodideReadyPromise = t.wrapAsync(loadPyodideAndPackages)();


### PR DESCRIPTION
Avoids a guaranteed-404 fetch for /wasm/controller.js on standard builds.
Hosts opt in by setting `window.__MARIMO_HAS_WASM_CONTROLLER__ = true`,
which appends a "::controller" suffix to the worker name so getController
attempts the dynamic import.

