### PR TITLE
Fix UI hang and stabilize tests for unusual tuple/list/dict child classes

### DIFF
--- a/marimo/_utils/flatten.py
+++ b/marimo/_utils/flatten.py
@@ -292,11 +292,14 @@ def contains_instance(value: Any, instance: Any) -> bool:
             return False
         seen.add(id(value))
 
-        if isinstance(value, (tuple, list)):
-            return any(_contains_instance(v) for v in value)
-        elif isinstance(value, dict):
-            return any(_contains_instance(v) for v in value.values())
-        else:
-            return isinstance(value, instance)
+        try:
+            if isinstance(value, (tuple, list)):
+                return any(_contains_instance(v) for v in value)
+            elif isinstance(value, dict):
+                return any(_contains_instance(v) for v in value.values())
+        except Exception:
+            # .__iter__() or .values() raised. Cannot probe container.
+            return False
+        return isinstance(value, instance)
 
     return _contains_instance(value)

--- a/tests/_server/api/endpoints/test_terminal.py
+++ b/tests/_server/api/endpoints/test_terminal.py
@@ -71,8 +71,10 @@ def test_terminal_ws_wrong_token(client: TestClient) -> None:
 
 
 class TestCreateShellEnvironment:
-    def test_create_shell_environment_default_cwd(self) -> None:
+    def test_create_shell_environment_default_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test shell environment creation with default working directory."""
+        monkeypatch.delenv("SHELL", raising=False)
+
         shell, env = _create_shell_environment()
 
         assert shell in ["/bin/bash", "/bin/zsh", "/bin/sh"]
@@ -80,8 +82,10 @@ class TestCreateShellEnvironment:
         assert "LANG" in env
         assert "LC_ALL" in env
 
-    def test_create_shell_environment_custom_cwd(self) -> None:
+    def test_create_shell_environment_custom_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test shell environment creation with custom working directory."""
+        monkeypatch.delenv("SHELL", raising=False)
+
         with tempfile.TemporaryDirectory() as temp_dir:
             shell, env = _create_shell_environment(cwd=temp_dir)
 
@@ -91,9 +95,11 @@ class TestCreateShellEnvironment:
     @patch("os.getcwd")
     @patch("pathlib.Path.home")
     def test_create_shell_environment_fallback_cwd(
-        self, mock_home: Mock, mock_getcwd: Mock
+        self, mock_home: Mock, mock_getcwd: Mock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test shell environment creation when getcwd fails."""
+        monkeypatch.delenv("SHELL", raising=False)
+
         mock_getcwd.side_effect = OSError("No such directory")
         mock_home.return_value = Path("/home/user")
 
@@ -105,9 +111,11 @@ class TestCreateShellEnvironment:
     @patch("os.getcwd")
     @patch("pathlib.Path.home")
     def test_create_shell_environment_ultimate_fallback(
-        self, mock_home: Mock, mock_getcwd: Mock
+        self, mock_home: Mock, mock_getcwd: Mock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test shell environment creation when both getcwd and home fail."""
+        monkeypatch.delenv("SHELL", raising=False)
+
         mock_getcwd.side_effect = OSError("No such directory")
         mock_home.side_effect = Exception("No home directory")
 

--- a/tests/_server/api/endpoints/test_terminal.py
+++ b/tests/_server/api/endpoints/test_terminal.py
@@ -71,7 +71,9 @@ def test_terminal_ws_wrong_token(client: TestClient) -> None:
 
 
 class TestCreateShellEnvironment:
-    def test_create_shell_environment_default_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_create_shell_environment_default_cwd(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test shell environment creation with default working directory."""
         monkeypatch.delenv("SHELL", raising=False)
 
@@ -82,7 +84,9 @@ class TestCreateShellEnvironment:
         assert "LANG" in env
         assert "LC_ALL" in env
 
-    def test_create_shell_environment_custom_cwd(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_create_shell_environment_custom_cwd(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test shell environment creation with custom working directory."""
         monkeypatch.delenv("SHELL", raising=False)
 
@@ -95,7 +99,10 @@ class TestCreateShellEnvironment:
     @patch("os.getcwd")
     @patch("pathlib.Path.home")
     def test_create_shell_environment_fallback_cwd(
-        self, mock_home: Mock, mock_getcwd: Mock, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_home: Mock,
+        mock_getcwd: Mock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test shell environment creation when getcwd fails."""
         monkeypatch.delenv("SHELL", raising=False)
@@ -111,7 +118,10 @@ class TestCreateShellEnvironment:
     @patch("os.getcwd")
     @patch("pathlib.Path.home")
     def test_create_shell_environment_ultimate_fallback(
-        self, mock_home: Mock, mock_getcwd: Mock, monkeypatch: pytest.MonkeyPatch
+        self,
+        mock_home: Mock,
+        mock_getcwd: Mock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test shell environment creation when both getcwd and home fail."""
         monkeypatch.delenv("SHELL", raising=False)

--- a/tests/_utils/test_flatten.py
+++ b/tests/_utils/test_flatten.py
@@ -325,3 +325,42 @@ def test_contains_instance_recursive() -> None:
     for _ in range(5):
         value.append(value)
     assert contains_instance(value, A) is True
+
+
+def test_contains_instance_no_iter_tuple() -> None:
+    class NoIterTuple(tuple):
+        def __iter__(self):
+            raise AttributeError("iter throws")
+
+    collection = NoIterTuple((1, 2, 3))
+    assert contains_instance(collection, NoIterTuple) is False
+    assert contains_instance(collection, tuple) is False
+    assert (
+        contains_instance(collection, int) is False
+    )  # Cannot probe opaque collection
+
+
+def test_contains_instance_no_iter_list() -> None:
+    class NoIterList(list):
+        def __iter__(self):
+            raise AttributeError("iter throws")
+
+    collection = NoIterList([1, 2, 3])
+    assert contains_instance(collection, NoIterList) is False
+    assert contains_instance(collection, list) is False
+    assert (
+        contains_instance(collection, int) is False
+    )  # Cannot probe opaque collection
+
+
+def test_contains_instance_no_iter_dict() -> None:
+    class NoValuesDict(dict):
+        def values(self):
+            raise AttributeError("values() throws")
+
+    collection = NoValuesDict({"a": 1, "b": 2, "c": 3})
+    assert contains_instance(collection, NoValuesDict) is False
+    assert contains_instance(collection, dict) is False
+    assert (
+        contains_instance(collection, int) is False
+    )  # Cannot probe opaque collection


### PR DESCRIPTION
## 📝 Summary

- Closes #9463 and adds tests to `tests/_utils/test_flatten.py`
- Resolves tests in `tests/_server/api/endpoints/test_terminal.py` that flake out on systems where env var `SHELL=/usr/bin/bash`, etc.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [X] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
    _N/A._
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
    _N/A. No AI-generated code_
- [X] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->
    _N/A._

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [X] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Tests have been added for the changes made.
