### PR TITLE
fix: prevent mpl figure DPI from compounding on cell rerun (#9466)

### DIFF
--- a/marimo/_plugins/ui/_impl/from_mpl_interactive.py
+++ b/marimo/_plugins/ui/_impl/from_mpl_interactive.py
@@ -163,6 +163,17 @@ class mpl_interactive(UIElement[ModelIdRef, dict[str, Any]]):
     def __init__(self, figure: Figure | SubFigure) -> None:
         self._figure = figure
 
+        # Restore the figure's DPI to its pre-scaling value before creating a
+        # new canvas. matplotlib's FigureCanvasBase.__init__ unconditionally
+        # sets ``figure._original_dpi = figure.dpi``; if a previous WebAgg
+        # canvas already scaled ``figure.dpi`` up by the device pixel ratio
+        # (e.g., 100 -> 200 on a HiDPI display), the new canvas would treat
+        # the scaled value as "original" and scale it again on the next
+        # ``set_device_pixel_ratio`` event, compounding on every cell rerun.
+        original_dpi = getattr(figure, "_original_dpi", None)
+        if original_dpi is not None and figure.dpi != original_dpi:
+            figure.dpi = original_dpi
+
         # Create FigureManagerWebAgg
         self._figure_manager = new_figure_manager_given_figure(
             id(figure), figure

--- a/tests/_plugins/ui/_impl/test_from_mpl_interactive.py
+++ b/tests/_plugins/ui/_impl/test_from_mpl_interactive.py
@@ -243,6 +243,44 @@ class TestMplCleanupHandle:
 
 
 @pytest.mark.requires("matplotlib")
+class TestDpiPreservationOnRerun:
+    """Re-running a cell that wraps the same figure should not compound DPI.
+
+    matplotlib's ``FigureCanvasBase.__init__`` unconditionally captures
+    ``figure._original_dpi = figure.dpi``. After a HiDPI client connects
+    and scales ``figure.dpi`` up by the device pixel ratio, a subsequent
+    canvas creation on the same figure would treat that scaled value as
+    "original" and scale it again — making the resolution compound on
+    every rerun (see issue #9466).
+    """
+
+    def test_dpi_does_not_compound_across_reruns(self) -> None:
+        import matplotlib.pyplot as plt
+
+        from marimo._plugins.ui._impl.from_mpl_interactive import (
+            mpl_interactive,
+        )
+
+        fig, ax = plt.subplots(figsize=(5, 5), dpi=100)
+        ax.plot([1, 2, 3])
+
+        for _ in range(3):
+            with patch("marimo._plugins.ui._impl.comm.broadcast_notification"):
+                element = mpl_interactive(fig)
+            # Simulate the HiDPI handshake from the frontend.
+            element._figure_manager.handle_json(
+                {"type": "set_device_pixel_ratio", "device_pixel_ratio": 2}
+            )
+            element._figure_manager.handle_json(
+                {"type": "resize", "width": 500, "height": 500}
+            )
+            assert fig.dpi == 200
+            assert tuple(fig.get_size_inches()) == (5.0, 5.0)
+
+        plt.close(fig)
+
+
+@pytest.mark.requires("matplotlib")
 class TestMplInteractiveArgs:
     """Test that mpl_interactive passes correct args to the UIElement."""
 


### PR DESCRIPTION
matplotlib's FigureCanvasBase.__init__ unconditionally captures
figure._original_dpi = figure.dpi. After a HiDPI client scales the
figure DPI up by the device pixel ratio, subsequent canvas creations
treat the scaled value as the new "original" and scale it again,
compounding on every rerun. Restore the figure's DPI before creating
the new canvas.
