### PR TITLE
feat: add Mermaid theme customization options

### DIFF
--- a/docs/api/diagrams.md
+++ b/docs/api/diagrams.md
@@ -14,4 +14,41 @@ def __():
 
 ## Mermaid diagrams
 
+Customize Mermaid styling with `theme` and `theme_variables`:
+
+```python
+mo.mermaid(
+    """
+    graph TD
+        A[Observed] --> B[Latent]
+        B --> C[Posterior]
+    """,
+    theme="base",
+    theme_variables={
+        "primaryColor": "#E8EEF5",
+        "primaryTextColor": "#1F2937",
+        "primaryBorderColor": "#64748B",
+        "lineColor": "#475569",
+        "tertiaryColor": "#F8FAFC",
+    },
+)
+```
+
+`theme` supports `"base"`, `"dark"`, `"default"`, `"forest"`,
+`"neutral"`, and `"null"`.
+
+For supported `theme_variables` keys and defaults, see Mermaid's theming docs:
+
+- [Theme configuration](https://mermaid.js.org/config/theming.html)
+- [Theme variables reference](https://mermaid.js.org/config/theming.html#theme-variables)
+
+Per Mermaid docs, custom `theme_variables` are reliably applied with
+`theme="base"`.
+
+If you pass `theme_variables` with `theme=None`, marimo automatically uses
+`theme="base"`.
+
+If you pass `theme_variables` with any explicit non-`base` theme,
+`mo.mermaid(...)` raises a `ValueError`.
+
 ::: marimo.mermaid

--- a/docs/api/diagrams.md
+++ b/docs/api/diagrams.md
@@ -16,6 +16,15 @@ def __():
 
 Customize Mermaid styling with `theme` and `theme_variables`:
 
+Theme only:
+
+```python
+mo.mermaid(
+    diagram,
+    theme="neutral",
+)
+```
+
 ```python
 mo.mermaid(
     """
@@ -37,6 +46,8 @@ mo.mermaid(
 `theme` supports `"base"`, `"dark"`, `"default"`, `"forest"`,
 `"neutral"`, and `"null"`.
 
+By default, `mo.mermaid(diagram)` follows the app light/dark theme.
+
 For supported `theme_variables` keys and defaults, see Mermaid's theming docs:
 
 - [Theme configuration](https://mermaid.js.org/config/theming.html)
@@ -50,5 +61,8 @@ If you pass `theme_variables` with `theme=None`, marimo automatically uses
 
 If you pass `theme_variables` with any explicit non-`base` theme,
 `mo.mermaid(...)` raises a `ValueError`.
+
+If custom colors are not appearing, make sure you are not combining
+`theme_variables` with a non-`base` theme.
 
 ::: marimo.mermaid

--- a/frontend/src/plugins/core/__test__/sanitize.test.ts
+++ b/frontend/src/plugins/core/__test__/sanitize.test.ts
@@ -145,6 +145,14 @@ describe("sanitizeHtml", () => {
     );
   });
 
+  test("preserves marimo-mermaid with theme attributes", () => {
+    const html =
+      "<marimo-mermaid data-diagram='&quot;graph TD\\nA --&gt; B&quot;' data-theme='&quot;base&quot;' data-theme_variables='{&quot;primaryColor&quot;: &quot;#E8EEF5&quot;, &quot;lineColor&quot;: &quot;#475569&quot;}'></marimo-mermaid>";
+    expect(sanitizeHtml(html)).toMatchInlineSnapshot(
+      `"<marimo-mermaid data-diagram="&quot;graph TD\\nA --> B&quot;" data-theme="&quot;base&quot;" data-theme_variables="{&quot;primaryColor&quot;: &quot;#E8EEF5&quot;, &quot;lineColor&quot;: &quot;#475569&quot;}"></marimo-mermaid>"`,
+    );
+  });
+
   test("keeps style tags with FORCE_BODY", () => {
     const html = "<style>body { color: red; }</style><p>Text</p>";
     expect(sanitizeHtml(html)).toMatchInlineSnapshot(

--- a/frontend/src/plugins/layout/__test__/MermaidPlugin.test.ts
+++ b/frontend/src/plugins/layout/__test__/MermaidPlugin.test.ts
@@ -30,13 +30,21 @@ describe("MermaidPlugin validator", () => {
     });
   });
 
-  test("rejects unsupported theme", () => {
+  test("accepts any string as theme", () => {
     const plugin = new MermaidPlugin();
     const result = plugin.validator.safeParse({
       diagram: "graph TD\nA --> B",
       theme: "invalid",
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.data).toEqual({
+      diagram: "graph TD\nA --> B",
+      theme: "invalid",
+    });
   });
 });

--- a/frontend/src/plugins/layout/__test__/MermaidPlugin.test.ts
+++ b/frontend/src/plugins/layout/__test__/MermaidPlugin.test.ts
@@ -1,0 +1,42 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, test } from "vitest";
+import { MermaidPlugin } from "../mermaid/MermaidPlugin";
+
+describe("MermaidPlugin validator", () => {
+  test("accepts optional theme and theme_variables", () => {
+    const plugin = new MermaidPlugin();
+    const result = plugin.validator.safeParse({
+      diagram: "graph TD\nA --> B",
+      theme: "base",
+      theme_variables: {
+        primaryColor: "#E8EEF5",
+        lineColor: "#475569",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+
+    expect(result.data).toEqual({
+      diagram: "graph TD\nA --> B",
+      theme: "base",
+      theme_variables: {
+        primaryColor: "#E8EEF5",
+        lineColor: "#475569",
+      },
+    });
+  });
+
+  test("rejects unsupported theme", () => {
+    const plugin = new MermaidPlugin();
+    const result = plugin.validator.safeParse({
+      diagram: "graph TD\nA --> B",
+      theme: "invalid",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/src/plugins/layout/mermaid/MermaidPlugin.tsx
+++ b/frontend/src/plugins/layout/mermaid/MermaidPlugin.tsx
@@ -9,6 +9,8 @@ import type {
 
 interface Data {
   diagram: string;
+  theme?: "base" | "dark" | "default" | "forest" | "neutral" | "null";
+  theme_variables?: Record<string, string>;
 }
 
 export class MermaidPlugin implements IStatelessPlugin<Data> {
@@ -16,10 +18,20 @@ export class MermaidPlugin implements IStatelessPlugin<Data> {
 
   validator = z.object({
     diagram: z.string(),
+    theme: z
+      .enum(["base", "dark", "default", "forest", "neutral", "null"])
+      .optional(),
+    theme_variables: z.record(z.string(), z.string()).optional(),
   });
 
   render(props: IStatelessPluginProps<Data>): JSX.Element {
-    return <LazyMermaid diagram={props.data.diagram} />;
+    return (
+      <LazyMermaid
+        diagram={props.data.diagram}
+        theme={props.data.theme}
+        themeVariables={props.data.theme_variables}
+      />
+    );
   }
 }
 

--- a/frontend/src/plugins/layout/mermaid/MermaidPlugin.tsx
+++ b/frontend/src/plugins/layout/mermaid/MermaidPlugin.tsx
@@ -9,7 +9,7 @@ import type {
 
 interface Data {
   diagram: string;
-  theme?: "base" | "dark" | "default" | "forest" | "neutral" | "null";
+  theme?: string;
   theme_variables?: Record<string, string>;
 }
 
@@ -18,9 +18,7 @@ export class MermaidPlugin implements IStatelessPlugin<Data> {
 
   validator = z.object({
     diagram: z.string(),
-    theme: z
-      .enum(["base", "dark", "default", "forest", "neutral", "null"])
-      .optional(),
+    theme: z.string().optional(),
     theme_variables: z.record(z.string(), z.string()).optional(),
   });
 

--- a/frontend/src/plugins/layout/mermaid/mermaid.tsx
+++ b/frontend/src/plugins/layout/mermaid/mermaid.tsx
@@ -10,7 +10,7 @@ import { Logger } from "@/utils/Logger";
 
 interface Props {
   diagram: string;
-  theme?: MermaidConfig["theme"];
+  theme?: string;
   themeVariables?: Record<string, string>;
   config?: MermaidConfig;
 }
@@ -72,7 +72,7 @@ const Mermaid: React.FC<Props> = ({ diagram, theme, themeVariables }) => {
   const resolvedTheme = theme ?? (darkMode ? "dark" : "forest");
   mermaid.initialize({
     ...DEFAULT_CONFIG,
-    theme: resolvedTheme,
+    theme: resolvedTheme as MermaidConfig["theme"],
     themeVariables,
     darkMode: darkMode,
   });

--- a/frontend/src/plugins/layout/mermaid/mermaid.tsx
+++ b/frontend/src/plugins/layout/mermaid/mermaid.tsx
@@ -10,6 +10,8 @@ import { Logger } from "@/utils/Logger";
 
 interface Props {
   diagram: string;
+  theme?: MermaidConfig["theme"];
+  themeVariables?: Record<string, string>;
   config?: MermaidConfig;
 }
 
@@ -62,14 +64,16 @@ function randomAlpha() {
   ).join("");
 }
 
-const Mermaid: React.FC<Props> = ({ diagram }) => {
+const Mermaid: React.FC<Props> = ({ diagram, theme, themeVariables }) => {
   // oxlint-disable-next-line react/hook-use-state
   const [id] = useState(() => randomAlpha());
 
   const darkMode = useTheme().theme === "dark";
+  const resolvedTheme = theme ?? (darkMode ? "dark" : "forest");
   mermaid.initialize({
     ...DEFAULT_CONFIG,
-    theme: darkMode ? "dark" : "forest",
+    theme: resolvedTheme,
+    themeVariables,
     darkMode: darkMode,
   });
 
@@ -86,7 +90,7 @@ const Mermaid: React.FC<Props> = ({ diagram }) => {
       });
 
     return result.svg;
-  }, [trimmedDiagram, id, darkMode]);
+  }, [trimmedDiagram, id, darkMode, resolvedTheme, themeVariables]);
 
   if (error) {
     return <ErrorBanner error={error} />;

--- a/marimo/_plugins/stateless/mermaid.py
+++ b/marimo/_plugins/stateless/mermaid.py
@@ -1,36 +1,16 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Literal
-
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import build_stateless_plugin
 from marimo._utils.dicts import remove_none_values
 
-MermaidTheme = Literal[
-    "base",
-    "dark",
-    "default",
-    "forest",
-    "neutral",
-    "null",
-]
-
-_MERMAID_THEMES: set[MermaidTheme] = {
-    "base",
-    "dark",
-    "default",
-    "forest",
-    "neutral",
-    "null",
-}
-
 
 @mddoc
 def mermaid(
     diagram: str,
-    theme: MermaidTheme | None = None,
+    theme: str | None = None,
     theme_variables: dict[str, str] | None = None,
 ) -> Html:
     """Render a diagram with Mermaid.
@@ -41,8 +21,9 @@ def mermaid(
 
     Args:
         diagram: a string containing a Mermaid diagram
-        theme: optional Mermaid theme (`base`, `dark`, `default`,
-            `forest`, `neutral`, or `null`). If not provided, marimo picks
+        theme: optional Mermaid theme. See
+            https://mermaid.js.org/config/theming.html#available-themes
+            for available themes. If not provided, marimo picks
             a default based on app theme, unless `theme_variables` are
             provided.
         theme_variables: optional Mermaid `themeVariables` overrides.
@@ -78,17 +59,13 @@ def mermaid(
         )
         ```
     """
-    if theme is not None and theme not in _MERMAID_THEMES:
-        raise ValueError(
-            f"theme must be one of {sorted(_MERMAID_THEMES)}, got {theme!r}"
-        )
-
     if theme_variables is not None:
         if theme is None:
             theme = "base"
         elif theme != "base":
             raise ValueError(
-                f"theme_variables require theme='base'. Got theme={theme!r}."
+                f"theme_variables require theme='base'. Got theme={theme!r}. "
+                "See https://mermaid.js.org/config/theming.html"
             )
 
     return Html(

--- a/marimo/_plugins/stateless/mermaid.py
+++ b/marimo/_plugins/stateless/mermaid.py
@@ -1,13 +1,38 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import Literal
+
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import build_stateless_plugin
+from marimo._utils.dicts import remove_none_values
+
+MermaidTheme = Literal[
+    "base",
+    "dark",
+    "default",
+    "forest",
+    "neutral",
+    "null",
+]
+
+_MERMAID_THEMES: set[MermaidTheme] = {
+    "base",
+    "dark",
+    "default",
+    "forest",
+    "neutral",
+    "null",
+}
 
 
 @mddoc
-def mermaid(diagram: str) -> Html:
+def mermaid(
+    diagram: str,
+    theme: MermaidTheme | None = None,
+    theme_variables: dict[str, str] | None = None,
+) -> Html:
     """Render a diagram with Mermaid.
 
     Mermaid is a tool for making diagrams such as flow charts and graphs. See
@@ -16,6 +41,15 @@ def mermaid(diagram: str) -> Html:
 
     Args:
         diagram: a string containing a Mermaid diagram
+        theme: optional Mermaid theme (`base`, `dark`, `default`,
+            `forest`, `neutral`, or `null`). If not provided, marimo picks
+            a default based on app theme, unless `theme_variables` are
+            provided.
+        theme_variables: optional Mermaid `themeVariables` overrides.
+            Mermaid defines supported keys and behavior; see
+            https://mermaid.js.org/config/theming.html#theme-variables.
+            If provided with `theme=None`, marimo automatically sets
+            `theme="base"` so custom colors are applied.
 
     Returns:
         An `Html` object.
@@ -30,11 +64,42 @@ def mermaid(diagram: str) -> Html:
             C --> D
         '''
         mo.mermaid(diagram)
+
+        mo.mermaid(
+            diagram,
+            theme="base",
+            theme_variables={
+                "primaryColor": "#E8EEF5",
+                "primaryTextColor": "#1F2937",
+                "primaryBorderColor": "#64748B",
+                "lineColor": "#475569",
+                "tertiaryColor": "#F8FAFC",
+            },
+        )
         ```
     """
+    if theme is not None and theme not in _MERMAID_THEMES:
+        raise ValueError(
+            f"theme must be one of {sorted(_MERMAID_THEMES)}, got {theme!r}"
+        )
+
+    if theme_variables is not None:
+        if theme is None:
+            theme = "base"
+        elif theme != "base":
+            raise ValueError(
+                f"theme_variables require theme='base'. Got theme={theme!r}."
+            )
+
     return Html(
         build_stateless_plugin(
             component_name="marimo-mermaid",
-            args={"diagram": diagram},
+            args=remove_none_values(
+                {
+                    "diagram": diagram,
+                    "theme": theme,
+                    "theme_variables": theme_variables,
+                }
+            ),
         )
     )

--- a/tests/_plugins/stateless/test_mermaid.py
+++ b/tests/_plugins/stateless/test_mermaid.py
@@ -38,14 +38,6 @@ def test_mo_mermaid_theme_defaults_to_base_with_theme_variables() -> None:
     )
 
 
-def test_mo_mermaid_rejects_invalid_theme() -> None:
-    with pytest.raises(
-        ValueError,
-        match="theme must be one of",
-    ):
-        mermaid("graph TD\nA --> B", theme=cast(Any, "invalid"))
-
-
 def test_mo_mermaid_rejects_theme_variables_with_non_base_theme() -> None:
     with pytest.raises(
         ValueError, match="theme_variables require theme='base'"
@@ -55,3 +47,10 @@ def test_mo_mermaid_rejects_theme_variables_with_non_base_theme() -> None:
             theme="neutral",
             theme_variables={"primaryColor": "#E8EEF5"},
         )
+
+
+def test_mo_mermaid_accepts_any_theme_string() -> None:
+    assert (
+        mermaid("graph TD\nA --> B", theme=cast(Any, "custom-new-theme")).text
+        == "<marimo-mermaid data-diagram='&quot;graph TD&#92;nA --&gt; B&quot;' data-theme='&quot;custom-new-theme&quot;'></marimo-mermaid>"
+    )

--- a/tests/_plugins/stateless/test_mermaid.py
+++ b/tests/_plugins/stateless/test_mermaid.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from typing import Any, cast
+
+import pytest
+
+from marimo._plugins.stateless.mermaid import mermaid
+
+
+def test_mo_mermaid_diagram_only() -> None:
+    assert (
+        mermaid("graph TD\nA --> B").text
+        == "<marimo-mermaid data-diagram='&quot;graph TD&#92;nA --&gt; B&quot;'></marimo-mermaid>"
+    )
+
+
+def test_mo_mermaid_theme_and_theme_variables() -> None:
+    assert (
+        mermaid(
+            "graph TD\nA --> B",
+            theme="base",
+            theme_variables={
+                "primaryColor": "#E8EEF5",
+                "lineColor": "#475569",
+            },
+        ).text
+        == "<marimo-mermaid data-diagram='&quot;graph TD&#92;nA --&gt; B&quot;' data-theme='&quot;base&quot;' data-theme_variables='{&quot;primaryColor&quot;:&quot;#E8EEF5&quot;,&quot;lineColor&quot;:&quot;#475569&quot;}'></marimo-mermaid>"
+    )
+
+
+def test_mo_mermaid_theme_defaults_to_base_with_theme_variables() -> None:
+    assert (
+        mermaid(
+            "graph TD\nA --> B",
+            theme_variables={"primaryColor": "#E8EEF5"},
+        ).text
+        == "<marimo-mermaid data-diagram='&quot;graph TD&#92;nA --&gt; B&quot;' data-theme='&quot;base&quot;' data-theme_variables='{&quot;primaryColor&quot;:&quot;#E8EEF5&quot;}'></marimo-mermaid>"
+    )
+
+
+def test_mo_mermaid_rejects_invalid_theme() -> None:
+    with pytest.raises(
+        ValueError,
+        match="theme must be one of",
+    ):
+        mermaid("graph TD\nA --> B", theme=cast(Any, "invalid"))
+
+
+def test_mo_mermaid_rejects_theme_variables_with_non_base_theme() -> None:
+    with pytest.raises(
+        ValueError, match="theme_variables require theme='base'"
+    ):
+        mermaid(
+            "graph TD\nA --> B",
+            theme="neutral",
+            theme_variables={"primaryColor": "#E8EEF5"},
+        )


### PR DESCRIPTION

This PR adds Mermaid theme customization to `mo.mermaid(...)` so users can style diagrams without manually rewriting Mermaid strings.

## Summary

- Add `theme` and `theme_variables` to `mo.mermaid(...)`
- Wire both through the Mermaid stateless plugin and frontend renderer
- Preserve existing default behavior when no theme is provided
- Re-render Mermaid output when theme/theme variables change
- Add backend/frontend tests and sanitizer coverage
- Update docs with Mermaid reference links and behavior notes

## Behavior

- `theme_variables` + `theme=None` -> marimo automatically uses `theme="base"`
- `theme_variables` + explicit non-`base` theme -> raises `ValueError`

## Examples

Theme only:

```python
mo.mermaid(
    diagram,
    theme="neutral",
)
```

Theme variables (auto-uses `theme="base"` when theme is omitted):

```python
mo.mermaid(
    diagram,
    theme_variables={
        "primaryColor": "#E8EEF5",
        "primaryTextColor": "#1F2937",
        "primaryBorderColor": "#64748B",
        "lineColor": "#475569",
    },
)
```

## Validation

- `uv run --group test pytest tests/_plugins/stateless/test_mermaid.py`
- `pnpm test src/plugins/layout/__test__/MermaidPlugin.test.ts src/plugins/core/__test__/sanitize.test.ts`