### PR TITLE
fix(tests): de-flake tracer fallback test and loosen memory thresholds

### DIFF
--- a/tests/_messaging/test_variables.py
+++ b/tests/_messaging/test_variables.py
@@ -176,8 +176,11 @@ def test_get_variable_preview_memory_numpy() -> None:
 
     mem_diff_mb = (mem_after - mem_before) / (1024 * 1024)
 
-    # Memory shouldn't increase significantly during preview
-    assert mem_diff_mb < 1, (
+    # Memory shouldn't increase significantly during preview.
+    # Threshold is well under the 100MB array size so we still catch
+    # full copies, but loose enough to absorb allocator noise on
+    # macOS arm64 runners.
+    assert mem_diff_mb < 5, (
         f"Memory increased by {mem_diff_mb}MB during preview"
     )
     assert preview == "[1. 1. 1. ... 1. 1. 1.]"
@@ -197,8 +200,11 @@ def test_get_variable_preview_bytesarray() -> None:
 
     mem_diff_mb = (mem_after - mem_before) / (1024 * 1024)
 
-    # Memory shouldn't increase significantly during preview
-    assert mem_diff_mb < 1, (
+    # Memory shouldn't increase significantly during preview.
+    # Threshold is well under the 100MB bytearray size so we still catch
+    # full copies, but loose enough to absorb allocator noise on
+    # macOS arm64 runners.
+    assert mem_diff_mb < 5, (
         f"Memory increased by {mem_diff_mb}MB during preview"
     )
     assert (

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -164,6 +164,16 @@ class TestSetTracerProvider:
 
         monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
 
+        # Import these BEFORE entering patch.dict("sys.modules", ...).
+        # On exit, patch.dict clears sys.modules and restores the snapshot
+        # taken at entry, which wipes any modules first loaded inside the
+        # block. If opentelemetry.sdk.trace is only imported inside, the
+        # post-block re-import creates a new TracerProvider class and
+        # isinstance() against the provider built inside the block fails.
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
         with patch.dict(
             "sys.modules",
             {"opentelemetry.exporter.otlp.proto.http.trace_exporter": None},
@@ -171,10 +181,6 @@ class TestSetTracerProvider:
             from marimo._tracer import _set_tracer_provider
 
             _set_tracer_provider()
-
-        from opentelemetry import trace
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
         provider = trace.get_tracer_provider()
         assert isinstance(provider, TracerProvider)


### PR DESCRIPTION
- test_otlp_fallback_to_file_when_selected_exporter_missing: hoist
  opentelemetry imports above patch.dict("sys.modules", ...). On exit
  patch.dict restores its entry-time snapshot, evicting modules first
  imported inside the block; the post-block re-import created a new
  TracerProvider class and broke isinstance().
- test_get_variable_preview_bytesarray / _memory_numpy: bump RSS delta
  threshold from <1MB to <5MB to absorb macOS arm64 allocator noise.
  Still well under the 100MB array size, so a real full copy still fails.
