### PR TITLE
fix: avoid RecursionError when formatting objects with __getattr__ traps

### DIFF
--- a/marimo/_utils/methods.py
+++ b/marimo/_utils/methods.py
@@ -19,16 +19,19 @@ def is_callable_method(obj: Any, attr: str) -> bool:
     """
     # Use getattr_static first so that we don't trigger __getattr__ traps
     # (e.g. pandas Expression returns a new Expression for any attribute).
+    # Note this is a static lookup that also matches instance attributes —
+    # it just bypasses __getattr__ / __getattribute__.
     try:
         inspect.getattr_static(obj, attr)
     except AttributeError:
         return False
 
-    # The attribute is defined on the class; safely fetch the bound value
-    # so we still resolve properties/descriptors and check callability.
+    # Resolve the actual value so properties/descriptors still work. Swallow
+    # any exception (e.g. property getters that raise) so protocol detection
+    # stays robust and never crashes formatting.
     try:
         method = getattr(obj, attr)
-    except AttributeError:
+    except Exception:
         return False
 
     if inspect.isclass(obj) and not isinstance(method, types.MethodType):

--- a/marimo/_utils/methods.py
+++ b/marimo/_utils/methods.py
@@ -8,12 +8,30 @@ from typing import Any, cast
 
 
 def is_callable_method(obj: Any, attr: str) -> bool:
-    """Check if an attribute is callable on an object."""
-    if not hasattr(obj, attr):
+    """Check if an attribute is a real callable method on an object.
+
+    Uses ``inspect.getattr_static`` so that attributes synthesized by
+    ``__getattr__`` (e.g. ``pandas.api.typing.Expression``, which returns a
+    new ``Expression`` for *any* attribute name) are not treated as protocol
+    methods. Without this, dynamic-attribute objects appear to implement
+    ``_display_`` / ``_mime_`` / ``_repr_*_`` and trigger infinite recursion
+    in the formatter.
+    """
+    # Use getattr_static first so that we don't trigger __getattr__ traps
+    # (e.g. pandas Expression returns a new Expression for any attribute).
+    try:
+        inspect.getattr_static(obj, attr)
+    except AttributeError:
         return False
 
-    method = getattr(obj, attr)
-    if inspect.isclass(obj) and not isinstance(method, (types.MethodType)):
+    # The attribute is defined on the class; safely fetch the bound value
+    # so we still resolve properties/descriptors and check callability.
+    try:
+        method = getattr(obj, attr)
+    except AttributeError:
+        return False
+
+    if inspect.isclass(obj) and not isinstance(method, types.MethodType):
         return False
     return callable(method)
 

--- a/tests/_output/test_try_format.py
+++ b/tests/_output/test_try_format.py
@@ -131,6 +131,28 @@ def test_display_protocol():
     assert result.data == "<p>mime test</p>"
 
 
+def test_getattr_trap_does_not_recurse():
+    """Objects whose __getattr__ returns same-type objects (e.g.
+    pandas.api.typing.Expression) must not trigger infinite recursion in the
+    formatter via the _display_ / _mime_ / _repr_*_ protocols.
+    Regression test for https://github.com/marimo-team/marimo/issues/9494.
+    """
+
+    class GetattrTrap:
+        def __getattr__(self, name: str) -> GetattrTrap:
+            if name.startswith("__"):
+                raise AttributeError(name)
+            return GetattrTrap()
+
+        def __repr__(self) -> str:
+            return "GetattrTrap()"
+
+    result = try_format(GetattrTrap())
+    assert result.exception is None
+    assert result.traceback is None
+    assert "GetattrTrap()" in result.data
+
+
 def test_error_handling():
     """Test error handling during formatting."""
     obj = ErrorObject("test")


### PR DESCRIPTION
`pandas.api.typing.Expression` returns a new `Expression` from
`__getattr__` for any attribute name, so the formatter's `hasattr`-based
protocol detection matched `_display_` and recursed indefinitely.
`is_callable_method` now gates on `inspect.getattr_static` so only
methods truly defined on the class are treated as protocol methods.

Fixes #9494.
