### PR TITLE
ci: resolve marimo from local wheel in sandbox tests

### DIFF
--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -166,8 +166,15 @@ jobs:
       # xdist is disabled for CLI tests because they test process-level
       # behavior (spawning marimo processes, port binding) that conflicts
       # with parallel execution.
+      #
+      # UV_FIND_LINKS points sandbox subprocesses at the locally-built wheel,
+      # so `marimo[lsp]==<current version>` resolves to it instead of PyPI.
+      # Without this, a marimo release published less than UV_EXCLUDE_NEWER ago
+      # falls outside the cutoff and sandbox resolution fails.
       - name: Test CLI
         shell: bash
+        env:
+          UV_FIND_LINKS: ${{ github.workspace }}
         run: |
           uv venv
           uv pip install --group=test-optional --group=dev marimo*.whl


### PR DESCRIPTION
UV_EXCLUDE_NEWER=7 days could reject a freshly-published marimo when
sandbox subprocesses tried to install marimo[lsp]==<version> from PyPI.
Point UV_FIND_LINKS at the wheel artifact so sandbox tests use the wheel
under test instead of PyPI.
