### PR TITLE
fix(md): normalize Windows backslashes in inserted image URLs

### DIFF
--- a/frontend/src/core/codemirror/markdown/__tests__/commands.test.ts
+++ b/frontend/src/core/codemirror/markdown/__tests__/commands.test.ts
@@ -385,6 +385,42 @@ describe("insertImage", () => {
     );
   });
 
+  test("normalizes Windows backslash paths to forward slashes in image URL", async () => {
+    view = createEditor("Hello, world!");
+    view.dispatch({
+      selection: { anchor: 7, head: 7 },
+    });
+
+    vi.spyOn(store, "get").mockImplementation((atom) => {
+      if (atom === filenameAtom) {
+        return "C:\\Users\\user\\project\\notebook.py";
+      }
+      if (atom === requestClientAtom) {
+        return mockRequestClient;
+      }
+    });
+
+    mockRequestClient.sendCreateFileOrFolder.mockResolvedValueOnce({
+      success: true,
+      message: null,
+      info: {
+        path: "C:\\Users\\user\\project\\public\\hello.png",
+        name: "hello.png",
+        children: [],
+        id: "",
+        isDirectory: false,
+        isMarimoFile: false,
+        lastModified: null,
+      },
+    });
+
+    await insertImage(view, mockPngFile());
+
+    expect(view.state.doc.toString()).toMatchInlineSnapshot(
+      `"Hello, ![alt](public/hello.png)world!"`,
+    );
+  });
+
   test("saves image as file different extension", async () => {
     view = createEditor("Hello, world!");
     view.dispatch({

--- a/frontend/src/core/codemirror/markdown/commands.ts
+++ b/frontend/src/core/codemirror/markdown/commands.ts
@@ -360,7 +360,10 @@ export async function insertImage(view: EditorView, file: File) {
             notebookDir &&
             savedFilePath.startsWith(notebookDir)
           ) {
-            savedFilePath = Paths.rest(savedFilePath, notebookDir);
+            savedFilePath = Paths.rest(savedFilePath, notebookDir).replaceAll(
+              "\\",
+              "/",
+            );
           }
 
           toast({


### PR DESCRIPTION
## Summary

Closes #9159.

Pasting an image into a markdown cell on Windows produced an inserted URL like `![alt](public\image.png)`. Backslash is not a URL separator, so the browser couldn't resolve the path and the image rendered broken. `mo.image("public/image.png")` worked around it.

Root cause: after creating the file under `public/`, the relative path was computed with `Paths.rest` which preserves whatever separator the server returned — `\` on Windows. The result was inserted verbatim into the markdown URL.

Fix: normalize to `/` at the insert site (one line, `frontend/src/core/codemirror/markdown/commands.ts`).