### PR TITLE
fix(terminal): send initial size when WebSocket opens

### DIFF
--- a/frontend/src/components/terminal/terminal.tsx
+++ b/frontend/src/components/terminal/terminal.tsx
@@ -270,9 +270,9 @@ const TerminalComponent: React.FC<TerminalComponentProps> = ({
 
         const handleOpen = () => {
           updateReadyState();
-          // Send initial dimensions to the backend: the mount-time fit() may
-          // have fired before the WS was OPEN, dropping the resize message
-          // and leaving the PTY at its default 0x0 winsize.
+          // Send initial dimensions: the mount-time fit() may have fired
+          // before the WS was OPEN, dropping the resize message and leaving
+          // the PTY at its default 0x0 winsize.
           fitAddon.fit();
           if (terminal.cols > 0 && terminal.rows > 0) {
             socket.send(
@@ -282,6 +282,9 @@ const TerminalComponent: React.FC<TerminalComponentProps> = ({
                 rows: terminal.rows,
               }),
             );
+            // The fit() above may have triggered onResize → scheduled a
+            // debounced send. Cancel it; we just sent the same dims.
+            handleBackendResizeDebounced.cancel();
           }
         };
 

--- a/frontend/src/components/terminal/terminal.tsx
+++ b/frontend/src/components/terminal/terminal.tsx
@@ -270,6 +270,19 @@ const TerminalComponent: React.FC<TerminalComponentProps> = ({
 
         const handleOpen = () => {
           updateReadyState();
+          // Send initial dimensions to the backend: the mount-time fit() may
+          // have fired before the WS was OPEN, dropping the resize message
+          // and leaving the PTY at its default 0x0 winsize.
+          fitAddon.fit();
+          if (terminal.cols > 0 && terminal.rows > 0) {
+            socket.send(
+              JSON.stringify({
+                type: "resize",
+                cols: terminal.cols,
+                rows: terminal.rows,
+              }),
+            );
+          }
         };
 
         const handleDisconnect = () => {

--- a/frontend/src/core/static/static-state.ts
+++ b/frontend/src/core/static/static-state.ts
@@ -43,7 +43,11 @@ function isMarimoStaticState(
 }
 
 function getMarimoStaticState(): Readonly<MarimoStaticState> | undefined {
-  const state = window?.__MARIMO_STATIC__;
+  // `typeof window` guard handles the identifier-undeclared case (e.g.
+  // leaked async work firing after jsdom teardown in tests); `?.` only
+  // short-circuits on null/undefined.
+  const state =
+    typeof window === "undefined" ? undefined : window.__MARIMO_STATIC__;
   return isMarimoStaticState(state) ? state : undefined;
 }
 


### PR DESCRIPTION
The mount-time fitAddon.fit() can fire before the terminal WS reaches
OPEN state (common in iframe + tunneled deployments), in which case the
resize message is silently dropped and the PTY stays at its default 0x0
winsize. bash then falls back to COLUMNS=80, producing horizontal-scroll
input lines and incorrect wrapping.

Send the current dimensions from the open handler so the PTY is always
sized before the user starts typing.
