### PR TITLE
fix(datasets): avoid exponential blow-up of nested struct sample values

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import datetime
 import functools
 import io
+import json
 import math
+from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -698,17 +700,22 @@ class NarwhalsTableManager(
         # Sample 3 values from the column
         SAMPLE_SIZE = 3
         try:
-            from enum import Enum
+
+            def _json_default(o: Any) -> str:
+                if isinstance(o, Enum):
+                    return o.name
+                return str(o)
 
             def to_primitive(value: Any) -> str | int | float:
-                if isinstance(value, list):
-                    return str([to_primitive(v) for v in value])
-                elif isinstance(value, dict):
-                    return str({k: to_primitive(v) for k, v in value.items()})
-                elif isinstance(value, Enum):
+                if isinstance(value, Enum):
                     return value.name
-                elif isinstance(value, (float, int)):
+                if isinstance(value, (int, float)):
                     return value
+                if isinstance(value, (list, dict)):
+                    try:
+                        return json.dumps(value, default=_json_default)
+                    except (TypeError, ValueError):
+                        return str(value)
                 return str(value)
 
             if self.data[column].dtype == nw.Datetime:

--- a/tests/_plugins/ui/_impl/tables/test_narwhals.py
+++ b/tests/_plugins/ui/_impl/tables/test_narwhals.py
@@ -1535,6 +1535,77 @@ def test_get_sample_values(df: Any) -> None:
     assert sample_values == ["b'bytes1'", "b'bytes2'", "b'bytes3'"]
 
 
+@pytest.mark.skipif(not HAS_DEPS, reason="polars not installed")
+def test_get_sample_values_nested_struct_is_bounded() -> None:
+    import polars as pl
+
+    def build_payload(row_idx: int, depth: int):
+        base = {
+            "kind": chr(65 + (row_idx % 26)),
+            "scores": [row_idx + 1, row_idx + 2, row_idx + 3],
+            "meta": {"city": "Zurich", "active": row_idx % 2 == 0},
+        }
+        if depth == 0:
+            return base
+        return {
+            "level": depth,
+            "items": [
+                base,
+                {
+                    "branch": row_idx,
+                    "child": build_payload(row_idx, depth - 1),
+                },
+            ],
+            "summary": {"row": row_idx, "depth": depth},
+        }
+
+    df = pl.DataFrame({"payload": [build_payload(i, 8) for i in range(3)]})
+    manager = NarwhalsTableManager.from_dataframe(
+        nw.from_native(df, eager_only=True)
+    )
+
+    t0 = time.perf_counter()
+    samples = manager.get_sample_values("payload")
+    elapsed = time.perf_counter() - t0
+
+    assert len(samples) == 3
+    assert elapsed < 1.0, (
+        f"get_sample_values took {elapsed:.2f}s (expected < 1s)"
+    )
+    for s in samples:
+        assert isinstance(s, str)
+        assert len(s) < 1_000_000
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="polars not installed")
+def test_get_sample_values_nested_struct_is_json() -> None:
+    import polars as pl
+
+    df = pl.DataFrame({"x": [{"a": 1, "b": [1, 2, 3]}]})
+    manager = NarwhalsTableManager.from_dataframe(
+        nw.from_native(df, eager_only=True)
+    )
+
+    samples = manager.get_sample_values("x")
+    assert len(samples) == 1
+    assert samples[0].startswith('{"')
+    parsed = json.loads(samples[0])
+    assert parsed == {"a": 1, "b": [1, 2, 3]}
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="polars not installed")
+def test_get_sample_values_nested_struct_with_non_json_leaf() -> None:
+    import polars as pl
+
+    df = pl.DataFrame({"x": [{"when": datetime.datetime(2026, 1, 1), "n": 1}]})
+    manager = NarwhalsTableManager.from_dataframe(
+        nw.from_native(df, eager_only=True)
+    )
+    samples = manager.get_sample_values("x")
+    assert len(samples) == 1
+    assert "2026" in samples[0]
+
+
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 @pytest.mark.parametrize(
     "df",


### PR DESCRIPTION
## Summary

`NarwhalsTableManager.get_sample_values` recursively re-stringified nested list/dict cells, causing each ancestor level to re-escape the children's repr. For deeply nested polars `Struct`/`List` columns this scaled ~8× per depth and produced multi-GB strings that hung the browser when the dataframe was registered as a dataset.

Replace the recursion with one `json.dumps` pass, preserving the `Enum.name`-at-any-depth contract via a `default=` callback. Scalar paths are unchanged.

Fixes #9378.

## Test plan

- [x] New tests in `tests/_plugins/ui/_impl/tables/test_narwhals.py` cover: bounded time/size at nesting depth 8, JSON-shaped output, non-JSON leaf (datetime) embedded in a struct.
- [x] `uv run --group test pytest tests/_plugins/ui/_impl/tables/` — 468 passed.
- [x] `make py-check` clean.
- [x] Manual: register a polars df with depth-8 nested struct via a top-level variable; browser no longer hangs and SQL column hover shows a readable JSON preview.