### PR TITLE
feat(table): allow hosts to size-gate downloads

### DIFF
--- a/frontend/src/components/data-table/TableTopBar.tsx
+++ b/frontend/src/components/data-table/TableTopBar.tsx
@@ -34,6 +34,7 @@ interface TableTopBarProps extends Partial<ExportActionProps> {
   showTableExplorer?: boolean;
   togglePanel?: (panelType: PanelType) => void;
   isAnyPanelOpen?: boolean;
+  sizeBytes?: number | null;
 }
 
 export const TableTopBar: React.FC<TableTopBarProps> = ({
@@ -48,6 +49,7 @@ export const TableTopBar: React.FC<TableTopBarProps> = ({
   togglePanel,
   isAnyPanelOpen,
   downloadAs,
+  sizeBytes,
 }) => {
   const [internalValue, setInternalValue] = useState(searchQuery || "");
   const debouncedSearch = useDebounce(internalValue, 500);
@@ -130,7 +132,9 @@ export const TableTopBar: React.FC<TableTopBarProps> = ({
             Explore
           </Button>
         )}
-        {downloadAs && <ExportMenu downloadAs={downloadAs} />}
+        {downloadAs && (
+          <ExportMenu downloadAs={downloadAs} sizeBytes={sizeBytes} />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -70,6 +70,9 @@ interface DataTableProps<TData> extends Partial<ExportActionProps> {
   setSorting?: OnChangeFn<SortingState>; // controlled sorting
   // Pagination
   totalRows: number | TooManyRows;
+  // JSON-serialized size of the currently-rendered data. Forwarded to
+  // ExportMenu so hosts can size-gate the Export button via downloadSizeLimitAtom.
+  sizeBytes?: number | null;
   totalColumns: number;
   pagination?: boolean;
   manualPagination?: boolean; // server-side pagination
@@ -121,6 +124,7 @@ const DataTableInternal = <TData,>({
   selection,
   totalColumns,
   totalRows,
+  sizeBytes,
   manualSorting = false,
   sorting,
   setSorting,
@@ -309,6 +313,7 @@ const DataTableInternal = <TData,>({
             togglePanel={togglePanel}
             isAnyPanelOpen={isAnyPanelOpen}
             downloadAs={downloadAs}
+            sizeBytes={sizeBytes}
           />
           <Table
             className={cn(

--- a/frontend/src/components/data-table/download-policy/atoms.ts
+++ b/frontend/src/components/data-table/download-policy/atoms.ts
@@ -1,0 +1,10 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { atom } from "jotai";
+
+export interface DownloadSizeLimit {
+  limitBytes: number;
+  unavailableMessage: string;
+}
+
+export const downloadSizeLimitAtom = atom<DownloadSizeLimit | null>(null);

--- a/frontend/src/components/data-table/export-actions.tsx
+++ b/frontend/src/components/data-table/export-actions.tsx
@@ -113,11 +113,10 @@ export const ExportMenu: React.FC<ExportActionProps> = (props) => {
       data-testid="export-button"
       size="xs"
       variant="text"
-      aria-disabled={disabled}
+      disabled={disabled}
       className={cn(
         "print:hidden text-xs gap-1",
         open ? "text-primary" : "text-muted-foreground",
-        disabled && "opacity-50 cursor-not-allowed",
       )}
     >
       <DownloadIcon className="w-3.5 h-3.5" />
@@ -249,16 +248,16 @@ export const ExportMenu: React.FC<ExportActionProps> = (props) => {
   };
 
   return (
-    <DropdownMenu
-      modal={false}
-      open={open}
-      onOpenChange={(next) => setOpen(next && !disabled)}
-    >
+    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
       <Tooltip
         content={disabled ? policy?.unavailableMessage : "Export"}
         open={open ? false : undefined}
       >
-        <DropdownMenuTrigger asChild={true}>{button}</DropdownMenuTrigger>
+        <DropdownMenuTrigger asChild={true} disabled={disabled}>
+          <span tabIndex={disabled ? 0 : -1} className="inline-flex">
+            {button}
+          </span>
+        </DropdownMenuTrigger>
       </Tooltip>
       <DropdownMenuContent side="bottom" className="print:hidden">
         <DropdownMenuLabel className="text-xs text-muted-foreground">

--- a/frontend/src/components/data-table/export-actions.tsx
+++ b/frontend/src/components/data-table/export-actions.tsx
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { useAtomValue } from "jotai";
 import {
   BracesIcon,
   BrickWallIcon,
@@ -9,6 +10,7 @@ import {
 } from "lucide-react";
 import React from "react";
 import { useLocale } from "react-aria";
+import { downloadSizeLimitAtom } from "./download-policy/atoms";
 import { logNever } from "@/utils/assertNever";
 import { cn } from "@/utils/cn";
 import { copyToClipboard } from "@/utils/copy";
@@ -84,6 +86,11 @@ export interface ExportActionProps {
     error?: string | null;
     missing_packages?: string[] | null;
   }>;
+  // JSON-serialized size of the currently-rendered data. Used together with
+  // downloadSizeLimitAtom to disable the Export button when a host (e.g.,
+  // marimo-lsp inside VS Code) declares a download size cap. Null/undefined
+  // means "no info" and the gate stays disabled (fail-open).
+  sizeBytes?: number | null;
 }
 
 const labelForDownloadFormat = (format: DownloadFormat): string =>
@@ -94,15 +101,23 @@ const labelForCopyFormat = (format: CopyFormat): string =>
 export const ExportMenu: React.FC<ExportActionProps> = (props) => {
   const { locale } = useLocale();
   const [open, setOpen] = React.useState(false);
+  const policy = useAtomValue(downloadSizeLimitAtom);
+  const disabled = !!(
+    policy &&
+    props.sizeBytes != null &&
+    props.sizeBytes > policy.limitBytes
+  );
 
   const button = (
     <Button
       data-testid="export-button"
       size="xs"
       variant="text"
+      aria-disabled={disabled}
       className={cn(
         "print:hidden text-xs gap-1",
         open ? "text-primary" : "text-muted-foreground",
+        disabled && "opacity-50 cursor-not-allowed",
       )}
     >
       <DownloadIcon className="w-3.5 h-3.5" />
@@ -113,7 +128,10 @@ export const ExportMenu: React.FC<ExportActionProps> = (props) => {
   const resolveDownloadUrl = async (
     format: DownloadFormat,
     onRetry: () => void,
-  ): Promise<{ url: string; filename: string } | null> => {
+  ): Promise<{
+    url: string;
+    filename: string;
+  } | null> => {
     let response: Awaited<ReturnType<typeof props.downloadAs>>;
     try {
       response = await props.downloadAs({ format });
@@ -143,7 +161,10 @@ export const ExportMenu: React.FC<ExportActionProps> = (props) => {
       return null;
     }
 
-    return { url: response.url, filename: response.filename };
+    return {
+      url: response.url,
+      filename: response.filename,
+    };
   };
 
   const handleDownload = async (format: DownloadFormat) => {
@@ -228,8 +249,15 @@ export const ExportMenu: React.FC<ExportActionProps> = (props) => {
   };
 
   return (
-    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
-      <Tooltip content="Export" open={open ? false : undefined}>
+    <DropdownMenu
+      modal={false}
+      open={open}
+      onOpenChange={(next) => setOpen(next && !disabled)}
+    >
+      <Tooltip
+        content={disabled ? policy?.unavailableMessage : "Export"}
+        open={open ? false : undefined}
+      >
         <DropdownMenuTrigger asChild={true}>{button}</DropdownMenuTrigger>
       </Tooltip>
       <DropdownMenuContent side="bottom" className="print:hidden">

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -622,6 +622,7 @@ export const LoadingDataTableComponent = memo(
       useDeepCompareMemoize(props.fieldTypes),
       props.data,
       props.totalRows,
+      props.sizeBytes,
       props.lazy,
       props.cellHoverTexts,
       props.cellStyles,

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -194,6 +194,7 @@ interface Data<T> {
   wrappedColumns?: string[];
   headerTooltip?: Record<string, string>;
   totalColumns: number;
+  sizeBytes?: number | null;
   maxColumns: number | "all";
   hasStableRowId: boolean;
   lazy: boolean;
@@ -220,6 +221,7 @@ type DataTableFunctions = {
     cell_styles?: CellStyleState | null;
     cell_hover_texts?: Record<string, Record<string, string | null>> | null;
     raw_data?: TableData<T> | null;
+    size_bytes?: number | null;
   }>;
   get_data_url?: GetDataUrl;
   get_row_ids?: GetRowIds;
@@ -270,6 +272,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
       headerTooltip: z.record(z.string(), z.string()).optional(),
       fieldTypes: columnToFieldTypesSchema.nullish(),
       totalColumns: z.number(),
+      sizeBytes: z.number().nullish(),
       maxColumns: z.union([z.number(), z.literal("all")]).default("all"),
       hasStableRowId: z.boolean().default(false),
       maxHeight: z.number().optional(),
@@ -327,6 +330,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
             .nullable(),
           cell_hover_texts: cellHoverTextSchema.nullable(),
           raw_data: z.union([z.string(), z.array(z.looseObject({}))]).nullish(),
+          size_bytes: z.number().nullish(),
         }),
       ),
     get_row_ids: rpc.input(z.object({}).passthrough()).output(
@@ -532,6 +536,7 @@ export const LoadingDataTableComponent = memo(
       rows: T[];
       rawRows?: T[];
       totalRows: number | TooManyRows;
+      sizeBytes?: number | null;
       cellStyles: CellStyleState | undefined | null;
       cellHoverTexts?: Record<string, Record<string, string | null>> | null;
     }>(async () => {
@@ -548,6 +553,7 @@ export const LoadingDataTableComponent = memo(
       let tableData = props.data;
       let rawTableData: TableData<T> | undefined | null = props.rawData;
       let totalRows = props.totalRows;
+      let sizeBytes = props.sizeBytes ?? null;
       let cellStyles = props.cellStyles;
       let cellHoverTexts = props.cellHoverTexts;
 
@@ -591,6 +597,7 @@ export const LoadingDataTableComponent = memo(
         tableData = searchResults.data;
         rawTableData = searchResults.raw_data;
         totalRows = searchResults.total_rows;
+        sizeBytes = searchResults.size_bytes ?? null;
         cellStyles = searchResults.cell_styles || {};
         cellHoverTexts = searchResults.cell_hover_texts || {};
       }
@@ -603,6 +610,7 @@ export const LoadingDataTableComponent = memo(
         rows: tableData,
         rawRows: rawData,
         totalRows: totalRows,
+        sizeBytes,
         cellStyles,
         cellHoverTexts,
       };
@@ -728,6 +736,7 @@ export const LoadingDataTableComponent = memo(
         setFilters={setFilters}
         reloading={isFetching && !isPending}
         totalRows={data?.totalRows ?? props.totalRows}
+        sizeBytes={data?.sizeBytes ?? props.sizeBytes ?? null}
         paginationState={paginationState}
         setPaginationState={setPaginationState}
         cellStyles={data?.cellStyles ?? props.cellStyles}
@@ -774,6 +783,7 @@ const DataTableComponent = ({
   data,
   rawData,
   totalRows,
+  sizeBytes,
   maxColumns,
   pagination,
   selection,
@@ -1053,6 +1063,7 @@ const DataTableComponent = ({
             maxHeight={maxHeight}
             sorting={sorting}
             totalRows={totalRows}
+            sizeBytes={sizeBytes}
             totalColumns={totalColumns}
             manualSorting={true}
             setSorting={setSorting}

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -64,6 +64,7 @@ type PluginFunctions = {
     column_types_per_step: FieldTypesWithExternalType[];
     python_code?: string | null;
     sql_code?: string | null;
+    size_bytes?: number | null;
   }>;
   get_column_values: (req: { column: string }) => Promise<{
     values: unknown[];
@@ -81,6 +82,7 @@ type PluginFunctions = {
   }) => Promise<{
     data: TableData<T>;
     total_rows: number;
+    size_bytes?: number | null;
   }>;
   download_as: DownloadAsArgs;
 };
@@ -118,6 +120,7 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
         column_types_per_step: z.array(columnToFieldTypesSchema),
         python_code: z.string().nullish(),
         sql_code: z.string().nullish(),
+        size_bytes: z.number().nullish(),
       }),
     ),
     get_column_values: rpc.input(z.object({ column: z.string() })).output(
@@ -147,6 +150,7 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
         z.object({
           data: z.union([z.string(), z.array(z.object({}).passthrough())]),
           total_rows: z.number(),
+          size_bytes: z.number().nullish(),
         }),
       ),
     download_as: DownloadAsSchema,
@@ -203,6 +207,7 @@ export const DataFrameComponent = memo(
       column_types_per_step,
       python_code,
       sql_code,
+      size_bytes,
     } = data || {};
 
     const totalColumns = field_types?.length;
@@ -322,6 +327,7 @@ export const DataFrameComponent = memo(
           data={url || ""}
           hasStableRowId={false}
           totalRows={total_rows ?? 0}
+          sizeBytes={size_bytes ?? null}
           totalColumns={totalColumns ?? 0}
           maxColumns="all"
           pageSize={pageSize}

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -72,6 +72,9 @@ class GetDataFrameResponse:
     column_types_per_step: list[FieldTypes]
     python_code: str | None = None
     sql_code: str | None = None
+    # JSON-serialized size of the current (post-transform) data; see
+    # ``SearchTableResponse.size_bytes`` for usage.
+    size_bytes: int | None = None
 
 
 @dataclass
@@ -196,6 +199,7 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
                 "columns": self._get_column_types(),
                 "dataframe-name": dataframe_name,
                 "total": rows,
+                "size-bytes": self._get_json_size_bytes(self._manager),
                 "page-size": page_size,
                 "show-download": show_download,
                 "download-csv-encoding": download_csv_encoding,
@@ -267,6 +271,7 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
             sql_code=self._handler.as_sql_code(
                 self._transform_container._snapshot_df
             ),
+            size_bytes=response.size_bytes,
         )
 
     def _get_column_values(
@@ -333,6 +338,7 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
         return SearchTableResponse(
             data=data,
             total_rows=result.get_num_rows(force=True) or 0,
+            size_bytes=self._get_json_size_bytes(result),
         )
 
     def _download_as(self, args: DownloadAsArgs) -> DownloadAsResponse:
@@ -391,3 +397,11 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
         if limit is not None:
             tm = tm.take(limit, 0)
         return tm
+
+    @memoize_last_value
+    def _get_json_size_bytes(self, manager: TableManager[Any]) -> int | None:
+        """JSON-serialized size of ``manager``; see table._get_json_size_bytes."""
+        try:
+            return len(manager.to_json(strict_json=True))
+        except Exception:
+            return None

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -797,7 +797,11 @@ class table(
                 "data": search_result_data,
                 "raw-data": search_result_raw_data,
                 "total-rows": total_rows,
-                "size-bytes": self._get_json_size_bytes(self._manager),
+                "size-bytes": (
+                    self._get_json_size_bytes(self._manager)
+                    if not _internal_lazy
+                    else None
+                ),
                 "total-columns": num_columns,
                 "max-columns": max_columns_arg,
                 "banner-text": self._get_banner_text(),

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -71,6 +71,7 @@ from marimo._runtime.context.types import (
 from marimo._runtime.context.utils import get_mode
 from marimo._runtime.functions import EmptyArgs, Function
 from marimo._utils.hashable import is_hashable
+from marimo._utils.memoize import memoize_last_value
 from marimo._utils.methods import getcallable
 from marimo._utils.narwhals_utils import (
     can_narwhalify_lazyframe,
@@ -165,6 +166,8 @@ class SearchTableResponse:
     # Unformatted data mirroring the same shape/page as `data`,
     # provided when format_mapping is applied.
     raw_data: str | None = None
+    # JSON-serialized size of the currently-rendered (searched/filtered) data.
+    size_bytes: int | None = None
 
 
 @dataclass
@@ -794,6 +797,7 @@ class table(
                 "data": search_result_data,
                 "raw-data": search_result_raw_data,
                 "total-rows": total_rows,
+                "size-bytes": self._get_json_size_bytes(self._manager),
                 "total-columns": num_columns,
                 "max-columns": max_columns_arg,
                 "banner-text": self._get_banner_text(),
@@ -915,6 +919,20 @@ class table(
                     indices
                 )
             return unwrap_narwhals_dataframe(self._selected_manager.data)  # type: ignore[no-any-return]
+
+    @memoize_last_value
+    def _get_json_size_bytes(self, manager: TableManager[Any]) -> int | None:
+        """Size in bytes of the manager's JSON serialization.
+
+        JSON is the largest format we export, so this is a conservative size estimate:
+        if the JSON fits under a host's download limit, CSV and Parquet will
+        too. Memoized on manager identity — recomputed when filters/search
+        produce a new ``_searched_manager``.
+        """
+        try:
+            return len(manager.to_json(strict_json=True))
+        except Exception:
+            return None
 
     def _download_as(self, args: DownloadAsArgs) -> DownloadAsResponse:
         """Download the table data in the specified format.
@@ -1619,6 +1637,7 @@ class table(
                     offset, args.page_size, total_rows
                 ),
                 raw_data=raw_data,
+                size_bytes=self._get_json_size_bytes(self._manager),
             )
 
         filter_function = (
@@ -1649,6 +1668,7 @@ class table(
                 offset, args.page_size, total_rows
             ),
             raw_data=raw_data,
+            size_bytes=self._get_json_size_bytes(result),
         )
 
     def _get_row_ids(self, args: EmptyArgs) -> GetRowIdsResponse:

--- a/marimo/_plugins/ui/_impl/utils/dataframe.py
+++ b/marimo/_plugins/ui/_impl/utils/dataframe.py
@@ -116,18 +116,17 @@ def download_as(
             if csv_encoding is not None
             else get_default_csv_encoding()
         )
-        vfile = mo_data.csv(
-            manager.to_csv(encoding=encoding, separator=csv_separator)
-        )
+        payload = manager.to_csv(encoding=encoding, separator=csv_separator)
+        vfile = mo_data.csv(payload)
     elif ext == "json":
         # Use strict JSON to ensure compliance with JSON spec
-        vfile = mo_data.json(
-            manager.to_json(
-                encoding=None, ensure_ascii=json_ensure_ascii, strict_json=True
-            )
+        payload = manager.to_json(
+            encoding=None, ensure_ascii=json_ensure_ascii, strict_json=True
         )
+        vfile = mo_data.json(payload)
     elif ext == "parquet":
-        vfile = mo_data.parquet(manager.to_parquet())
+        payload = manager.to_parquet()
+        vfile = mo_data.parquet(payload)
     else:
         raise ValueError("format must be one of 'csv', 'json', or 'parquet'.")
 

--- a/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
@@ -883,3 +883,40 @@ def test_base_exception_handling():
     assert "to json panic" in str(exc_info.value)
     assert exc_info.value.error == str(exc_info.value)
     assert type(table.value) is type(df)
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_dataframe_render_args_carry_size_bytes() -> None:
+    import pandas as pd
+
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    subject = ui.dataframe(df)
+    args = subject._component_args  # type: ignore[attr-defined]
+    assert args["size-bytes"] == len(
+        subject._manager.to_json(strict_json=True)
+    )
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_dataframe_get_dataframe_response_carries_size_bytes() -> None:
+    import pandas as pd
+
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    subject = ui.dataframe(df)
+    response = subject._get_dataframe(EmptyArgs())
+    assert response.size_bytes == len(
+        subject._manager.to_json(strict_json=True)
+    )
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_dataframe_get_json_size_bytes_fails_open() -> None:
+    import pandas as pd
+
+    subject = ui.dataframe(pd.DataFrame({"a": [1]}))
+
+    class _Boom:
+        def to_json(self, **_: object) -> str:
+            raise RuntimeError("boom")
+
+    assert subject._get_json_size_bytes(_Boom()) is None  # type: ignore[arg-type]

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1370,6 +1370,78 @@ def test_download_as(df: Any) -> None:
         assert selected_nw["cities"][0] == "New York"
 
 
+def test_json_size_bytes_matches_payload() -> None:
+    data = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+    table = ui.table(data)
+    expected = len(table._manager.to_json(strict_json=True))
+    assert table._get_json_size_bytes(table._manager) == expected
+    assert expected > 0
+
+
+def test_json_size_bytes_cached_per_manager_identity() -> None:
+    table = ui.table([{"a": 1}, {"a": 2}])
+    # The constructor already primed the cache with table._manager; verify
+    # that asking again does not re-serialize, while a fresh manager does.
+    call_count = 0
+    original_to_json = type(table._manager).to_json
+
+    def counting_to_json(self: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        return original_to_json(self, **kwargs)
+
+    other_manager = ui.table([{"a": 3, "b": 4}])._manager
+    # other_manager's construction primed the cache with a different key,
+    # so the next call on table._manager will be a fresh miss.
+    with patch.object(type(table._manager), "to_json", counting_to_json):
+        table._get_json_size_bytes(table._manager)
+        table._get_json_size_bytes(table._manager)
+        assert call_count == 1, (
+            "second call with same manager identity should hit cache"
+        )
+        table._get_json_size_bytes(other_manager)
+        assert call_count == 2, (
+            "different manager identity should recompute"
+        )
+
+
+def test_json_size_bytes_fails_open() -> None:
+    table = ui.table([{"a": 1}])
+
+    class _Boom:
+        def to_json(self, **_: Any) -> str:
+            raise RuntimeError("boom")
+
+    assert table._get_json_size_bytes(_Boom()) is None  # type: ignore[arg-type]
+
+
+def test_render_args_carry_size_bytes() -> None:
+    table = ui.table([{"a": 1}, {"a": 2}])
+    args = table._component_args  # type: ignore[attr-defined]
+    assert args["size-bytes"] == len(
+        table._manager.to_json(strict_json=True)
+    )
+
+
+def test_search_response_carries_size_bytes() -> None:
+    data = [{"a": i} for i in range(10)]
+    table = ui.table(data)
+    # Unfiltered branch — should report _manager's size.
+    unfiltered = table._search(
+        SearchTableArgs(page_size=5, page_number=0)
+    )
+    assert unfiltered.size_bytes == len(
+        table._manager.to_json(strict_json=True)
+    )
+    # Filtered branch — should report the searched manager's size, which
+    # differs from the full manager.
+    filtered = table._search(
+        SearchTableArgs(query="1", page_size=5, page_number=0)
+    )
+    assert filtered.size_bytes is not None
+    assert filtered.size_bytes < unfiltered.size_bytes
+
+
 def test_download_as_ignores_cell_selection() -> None:
     # Download should ignore selection when in cell selection modes
     data = {"a": [1, 2, 3]}

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1400,9 +1400,7 @@ def test_json_size_bytes_cached_per_manager_identity() -> None:
             "second call with same manager identity should hit cache"
         )
         table._get_json_size_bytes(other_manager)
-        assert call_count == 2, (
-            "different manager identity should recompute"
-        )
+        assert call_count == 2, "different manager identity should recompute"
 
 
 def test_json_size_bytes_fails_open() -> None:
@@ -1418,18 +1416,14 @@ def test_json_size_bytes_fails_open() -> None:
 def test_render_args_carry_size_bytes() -> None:
     table = ui.table([{"a": 1}, {"a": 2}])
     args = table._component_args  # type: ignore[attr-defined]
-    assert args["size-bytes"] == len(
-        table._manager.to_json(strict_json=True)
-    )
+    assert args["size-bytes"] == len(table._manager.to_json(strict_json=True))
 
 
 def test_search_response_carries_size_bytes() -> None:
     data = [{"a": i} for i in range(10)]
     table = ui.table(data)
     # Unfiltered branch — should report _manager's size.
-    unfiltered = table._search(
-        SearchTableArgs(page_size=5, page_number=0)
-    )
+    unfiltered = table._search(SearchTableArgs(page_size=5, page_number=0))
     assert unfiltered.size_bytes == len(
         table._manager.to_json(strict_json=True)
     )


### PR DESCRIPTION
This is step 1 toward fixing [marimo-team/marimo-lsp#542](https://github.com/marimo-team/marimo-lsp/issues/542); the companion change will live in marimo-lsp, which will set the atom to a concrete VS Code–appropriate limit at renderer init.

## Summary

Adds `size_bytes` to `DownloadAsResponse` and a new `downloadSizeLimitAtom` (jotai) that gates `mo.ui.table` exports and clipboard copies when the serialized payload exceeds a host-supplied limit. The default policy is `null` (gate dormant); hosts opt in by setting the atom at init time.

This is a bandaid until streaming exports lands — the goal is to give VS Code's NotebookRenderer iframe (and any other sandboxed host) a way to refuse downloads it can't fulfill, rather than failing silently.

- Backend: `download_as` now returns `(url, filename, size_bytes)`; the size is computed once from the already-serialized bytes per format (csv/json/parquet). Threaded through both `ui.table._download_as` and `ui.dataframe._download_as`.
- Frontend: `ExportMenu` reads `downloadSizeLimitAtom`; when set and \`size_bytes > limitBytes\`, a danger toast fires and the download/copy is skipped. Fail-open when \`size_bytes\` is absent (older backend) or the atom is unset.
- Schema: `DownloadAsSchema` zod output mirrors the new optional field.

This is blocking https://github.com/marimo-team/marimo-lsp/pull/554

## Test plan

- [x] \`make py-check\` clean
- [x] \`make fe-check\` clean
- [x] Backend tests for \`download_as\` size correctness (csv/json/parquet) and \`_download_as\` populating \`size_bytes\`
- [x] Manual: in browser, with atom unset, big-table export still works (no regression)
- [x] Manual: with the atom temporarily defaulted to \`{ limitBytes: 1, ... }\`, any non-empty table export and clipboard copy triggers the toast and skips the action