### PR TITLE
feat: Cache text and version files to avoid read/import costs on all …

### DIFF
--- a/marimo/_server/templates/api.py
+++ b/marimo/_server/templates/api.py
@@ -7,6 +7,7 @@ to HTML without needing to use internal template functions directly.
 
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -25,6 +26,7 @@ from marimo._session.model import SessionMode
 from marimo._utils.code import hash_code
 
 
+@functools.lru_cache(maxsize=1)
 def _get_html_template() -> str:
     """Get the base HTML template."""
     from marimo._utils.paths import marimo_package_path

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import functools
 import html
 import json
 import os
@@ -619,7 +620,11 @@ def _del_none_or_empty(d: Any) -> Any:
     }
 
 
+@functools.lru_cache(maxsize=1)
 def get_version() -> str:
+    # Invariant for the lifetime of the process; cache so the three
+    # render-path call sites (mount_config + two .replace passes) don't
+    # each pay the importlib.metadata lookup.
     return (
         f"{__version__} (editable)" if is_editable("marimo") else __version__
     )

--- a/marimo/_utils/versions.py
+++ b/marimo/_utils/versions.py
@@ -3,11 +3,19 @@ from __future__ import annotations
 
 import json
 import re
+from functools import cache
 from importlib.metadata import Distribution
 
 
+@cache
 def is_editable(pkg_name: str) -> bool:
-    """Check if a package is an editable install"""
+    """Check if a package is an editable install.
+
+    Result is invariant within a process — a package can't become editable
+    while we're running — so we cache to avoid the importlib.metadata +
+    direct_url.json file read on every call. Render-path hot spot before
+    caching: ~10 posix.stat calls per render via templates.get_version.
+    """
 
     try:
         direct_url = Distribution.from_name(pkg_name).read_text(


### PR DESCRIPTION
…calls.

## 📝 Summary

index.html wasn't cached so we paid a load cost every time we hit it. In molab this means that rendering had some overhead.

Closes #9512

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
