### PR TITLE
chore(ci): add --ignore-scripts to global npm installs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: 3.12
 
       - name: ⚡ Install Vercel CLI
-        run: npm install --ignore-scripts --global vercel@latest
+        run: npm install --ignore-scripts --global vercel@50.44.0
 
       - name: ⬇️ Pull Vercel Environment Information
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: 3.12
 
       - name: ⚡ Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --ignore-scripts --global vercel@latest
 
       - name: ⬇️ Pull Vercel Environment Information
         env:

--- a/.github/workflows/test_cli.yaml
+++ b/.github/workflows/test_cli.yaml
@@ -129,7 +129,7 @@ jobs:
           # Get version from package.json
           pyodide_version=$(cat frontend/package.json | jq -r '.dependencies["pyodide"]')
           echo "Pyodide version: $pyodide_version"
-          npm install pyodide@$pyodide_version
+          npm install --ignore-scripts pyodide@$pyodide_version
           wheel_file=$(ls dist/*.whl)
           echo "Testing wheel: $wheel_file"
           node tests/_pyodide/test_pyodide_acceptance.mjs "$wheel_file"


### PR DESCRIPTION
Defense-in-depth motivated by the TanStack npm supply-chain compromise (May 2026).

- `test_cli.yaml` (test_pyodide): `npm install pyodide`
- `docs.yml` (deploy): `npm install --global vercel`

Note: the `docs.yml` install still runs in a job with `id-token: write` for Doppler OIDC, so the OIDC-fused supply-chain audit finding remains — fully resolving it requires a job split (separate Doppler-fetch and deploy jobs), which is a larger restructure.