### PR TITLE
chore: bump engines.node to >=22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ _Note: We recommend that Windows developers use [WSL](https://learn.microsoft.co
 ### Prerequisites
 
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) (Python package manager)
-- [Node.js](https://nodejs.org/) 20+
+- [Node.js](https://nodejs.org/) 22+
 - [pnpm](https://pnpm.io/installation) 9+
 
 ### Getting started

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "pnpm": ">=9.15.9"
   },
   "packageManager": "pnpm@10.28.2",


### PR DESCRIPTION
## Summary

- Bumps `engines.node` from `>=20` to `>=22` to align with the runtime we actually test in CI (Node 24)
- Node 20 entered maintenance LTS on 2025-10-21 and ends 2026-04-30 — keeping `>=22` still supports the current LTS line without forcing users onto Node 24

## Test plan

- [x] CI passes (already runs on Node 24)