### PR TITLE
perf(frontend): parallelize file uploads with bounded concurrency

### DIFF
--- a/frontend/src/components/editor/file-tree/requesting-tree.tsx
+++ b/frontend/src/components/editor/file-tree/requesting-tree.tsx
@@ -11,6 +11,9 @@ import { prettyError } from "@/utils/errors";
 import { Functions } from "@/utils/functions";
 import { type FilePath, PathBuilder } from "@/utils/paths";
 import { resolvePaths } from "@/utils/pathUtils";
+import { mapWithConcurrency } from "@/utils/semaphore";
+
+const FILE_OP_CONCURRENCY = 5;
 
 /**
  * Normalized result of a file mutation: the server response when successful,
@@ -159,28 +162,26 @@ export class RequestingTree {
       ? (this.delegate.find(parentId)?.data.path ?? parentId)
       : this.rootPath;
 
-    await Promise.all(
-      fromIds.map(async (id) => {
-        const node = this.delegate.find(id);
-        if (!node) {
-          return;
-        }
-        const originalPath = node.data.path;
-        const newPath = this.path.join(
-          parentPath,
-          this.path.basename(originalPath as FilePath),
-        );
-        const result = await this.callbacks
-          .renameFileOrFolder({ path: originalPath, newPath })
-          .then(handleFileResponse);
-        if (!result) {
-          return;
-        }
+    await mapWithConcurrency(fromIds, FILE_OP_CONCURRENCY, async (id) => {
+      const node = this.delegate.find(id);
+      if (!node) {
+        return;
+      }
+      const originalPath = node.data.path;
+      const newPath = this.path.join(
+        parentPath,
+        this.path.basename(originalPath as FilePath),
+      );
+      const result = await this.callbacks
+        .renameFileOrFolder({ path: originalPath, newPath })
+        .then(handleFileResponse);
+      if (!result) {
+        return;
+      }
 
-        this.delegate.move({ id, parentId, index: 0 });
-        this.delegate.update({ id, changes: { path: newPath } });
-      }),
-    );
+      this.delegate.move({ id, parentId, index: 0 });
+      this.delegate.update({ id, changes: { path: newPath } });
+    });
 
     this.onChange(this.delegate.data);
 
@@ -262,11 +263,12 @@ export class RequestingTree {
       this.rootPath,
       ...ids.map((id) => this.delegate.find(id)?.data.path),
     ].filter(Boolean);
-    // Request all folders in parallel, and catch any errors
-    const data = await Promise.all(
-      openFolders.map((path) =>
+    // Request open folders with bounded concurrency; swallow per-folder errors.
+    const data = await mapWithConcurrency(
+      openFolders,
+      FILE_OP_CONCURRENCY,
+      (path) =>
         this.callbacks.listFiles({ path: path }).catch(() => ({ files: [] })),
-      ),
     );
 
     for (const [idx, openFolder] of openFolders.entries()) {

--- a/frontend/src/components/editor/file-tree/upload.tsx
+++ b/frontend/src/components/editor/file-tree/upload.tsx
@@ -6,9 +6,11 @@ import { useRequestClient } from "@/core/network/requests";
 import { withLoadingToast } from "@/utils/download";
 import { Logger } from "@/utils/Logger";
 import { type FilePath, PathBuilder } from "@/utils/paths";
+import { mapWithConcurrency } from "@/utils/semaphore";
 import { refreshRoot } from "./state";
 
 const MAX_SIZE = 1024 * 1024 * 100; // 100MB
+const UPLOAD_CONCURRENCY = 5;
 
 export function useFileExplorerUpload(options: DropzoneOptions = {}) {
   const { sendCreateFileOrFolder } = useRequestClient();
@@ -58,24 +60,28 @@ export function useFileExplorerUpload(options: DropzoneOptions = {}) {
         loadingTitle,
         async (progress) => {
           progress.addTotal(acceptedFiles.length);
-          for (const file of acceptedFiles) {
-            // We strip the leading slash since File.path can return
-            // `/path/to/file`.
-            const filePath = stripLeadingSlash(getPath(file));
-            let directoryPath = "" as FilePath;
-            if (filePath) {
-              directoryPath =
-                PathBuilder.guessDeliminator(filePath).dirname(filePath);
-            }
+          await mapWithConcurrency(
+            acceptedFiles,
+            UPLOAD_CONCURRENCY,
+            async (file) => {
+              // We strip the leading slash since File.path can return
+              // `/path/to/file`.
+              const filePath = stripLeadingSlash(getPath(file));
+              let directoryPath = "" as FilePath;
+              if (filePath) {
+                directoryPath =
+                  PathBuilder.guessDeliminator(filePath).dirname(filePath);
+              }
 
-            await sendCreateFileOrFolder({
-              path: directoryPath,
-              type: "file",
-              name: file.name,
-              file,
-            });
-            progress.increment(1);
-          }
+              await sendCreateFileOrFolder({
+                path: directoryPath,
+                type: "file",
+                name: file.name,
+                file,
+              });
+              progress.increment(1);
+            },
+          );
           await refreshRoot();
         },
         onFinish,

--- a/frontend/src/plugins/impl/vega/resolve-data.ts
+++ b/frontend/src/plugins/impl/vega/resolve-data.ts
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { asRemoteURL } from "@/core/runtime/config";
+import { Semaphore } from "@/utils/semaphore";
 import { vegaLoadData } from "./loader";
 import type {
   FacetedUnitSpec,
@@ -17,6 +18,8 @@ type AnySpec =
   | UnitSpec<Field>
   | GenericFacetSpec<FacetedUnitSpec<Field>, LayerSpec<Field>, Field>;
 
+const VEGA_DATA_FETCH_CONCURRENCY = 5;
+
 /**
  * Given a VegaLite spec with URL data, resolve the data and return a new spec with the resolved data.
  *
@@ -30,6 +33,9 @@ export async function resolveVegaSpecData(
   }
 
   const datasets = "datasets" in spec ? { ...spec.datasets } : {};
+  // Single semaphore shared across the whole spec so total in-flight fetches
+  // (across all nested layers/hconcat/vconcat) stay bounded.
+  const fetchSem = new Semaphore(VEGA_DATA_FETCH_CONCURRENCY);
 
   const traverse = async <T extends AnySpec>(spec: T): Promise<T> => {
     if (!spec) {
@@ -80,7 +86,8 @@ export async function resolveVegaSpecData(
     } catch {
       return spec;
     }
-    const data = await vegaLoadData(url.href, spec.data.format);
+    const format = spec.data.format;
+    const data = await fetchSem.run(() => vegaLoadData(url.href, format));
 
     datasets[url.pathname] = data;
 

--- a/frontend/src/utils/__tests__/semaphore.test.ts
+++ b/frontend/src/utils/__tests__/semaphore.test.ts
@@ -1,0 +1,212 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { describe, expect, it } from "vitest";
+import { Deferred } from "../Deferred";
+import { mapWithConcurrency, Semaphore } from "../semaphore";
+
+describe("Semaphore", () => {
+  it("rejects invalid permit counts", () => {
+    expect(() => new Semaphore(0)).toThrow();
+    expect(() => new Semaphore(-1)).toThrow();
+    expect(() => new Semaphore(1.5)).toThrow();
+  });
+
+  it("resolves run() with the function's value", async () => {
+    const sem = new Semaphore(1);
+    await expect(sem.run(async () => 42)).resolves.toBe(42);
+    expect(sem.available).toBe(1);
+    expect(sem.pending).toBe(0);
+  });
+
+  it("releases the permit when run() rejects", async () => {
+    const sem = new Semaphore(1);
+    await expect(
+      sem.run(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(sem.available).toBe(1);
+  });
+
+  it("caps concurrent in-flight tasks at `permits`", async () => {
+    const sem = new Semaphore(3);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const gates = Array.from({ length: 10 }, () => new Deferred<void>());
+
+    const tasks = gates.map((gate) =>
+      sem.run(async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await gate.promise;
+        inFlight--;
+      }),
+    );
+
+    // Let microtasks run so the first batch is scheduled.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(maxInFlight).toBe(3);
+    expect(sem.available).toBe(0);
+    expect(sem.pending).toBe(7);
+
+    // Release them all and confirm everyone finishes.
+    for (const gate of gates) {
+      gate.resolve();
+    }
+    await Promise.all(tasks);
+    expect(maxInFlight).toBe(3);
+    expect(sem.available).toBe(3);
+    expect(sem.pending).toBe(0);
+  });
+
+  it("releases waiters in FIFO order", async () => {
+    const sem = new Semaphore(1);
+    const order: number[] = [];
+    const hold = new Deferred<void>();
+
+    // First holder takes the only permit and parks on `hold`.
+    const first = sem.run(async () => {
+      order.push(0);
+      await hold.promise;
+    });
+
+    // Queue three more in known order.
+    const rest = [1, 2, 3].map((i) =>
+      sem.run(async () => {
+        order.push(i);
+      }),
+    );
+
+    await Promise.resolve();
+    expect(order).toEqual([0]);
+    expect(sem.pending).toBe(3);
+
+    hold.resolve();
+    await Promise.all([first, ...rest]);
+    expect(order).toEqual([0, 1, 2, 3]);
+  });
+
+  it("supports manual acquire/release", async () => {
+    const sem = new Semaphore(2);
+    await sem.acquire();
+    await sem.acquire();
+    expect(sem.available).toBe(0);
+
+    let resolved = false;
+    const waiter = sem.acquire().then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    sem.release();
+    await waiter;
+    expect(resolved).toBe(true);
+
+    sem.release();
+    sem.release();
+    expect(sem.available).toBe(2);
+  });
+});
+
+describe("mapWithConcurrency", () => {
+  it("returns [] for empty input without invoking fn", async () => {
+    let called = 0;
+    const result = await mapWithConcurrency([], 5, async () => {
+      called++;
+      return 1;
+    });
+    expect(result).toEqual([]);
+    expect(called).toBe(0);
+  });
+
+  it("preserves input order in the result", async () => {
+    const input = [10, 20, 30, 40, 50];
+    const result = await mapWithConcurrency(input, 2, async (n) => {
+      // Reverse the natural completion order so we'd notice if order broke.
+      await new Promise((r) => setTimeout(r, input.length - input.indexOf(n)));
+      return n * 2;
+    });
+    expect(result).toEqual([20, 40, 60, 80, 100]);
+  });
+
+  it("respects the concurrency cap", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    const gates = items.map(() => new Deferred<void>());
+
+    const result = mapWithConcurrency(items, 4, async (i) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await gates[i].promise;
+      inFlight--;
+      return i;
+    });
+
+    // Flush microtasks so the first batch enters fn().
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(maxInFlight).toBe(4);
+
+    // Releasing one gate should let exactly one queued task enter fn().
+    for (const gate of gates) {
+      gate.resolve();
+    }
+    await result;
+    expect(maxInFlight).toBe(4);
+  });
+
+  it("lets in-flight tasks complete after the first rejection", async () => {
+    const completed: number[] = [];
+    const gates = [0, 1, 2, 3, 4].map(() => new Deferred<void>());
+
+    const result = mapWithConcurrency([0, 1, 2, 3, 4], 5, async (i) => {
+      await gates[i].promise;
+      if (i === 0) {
+        throw new Error("first failed");
+      }
+      completed.push(i);
+      return i;
+    });
+
+    // Reject the first one; the other 4 are still gated.
+    gates[0].resolve();
+    // Drain the rejection (catch so it doesn't escape the test).
+    await expect(result).rejects.toThrow("first failed");
+
+    // The other tasks were already in-flight when the rejection happened;
+    // they should still resolve when their gates open.
+    for (let i = 1; i < gates.length; i++) {
+      gates[i].resolve();
+    }
+    // Yield so the remaining sem.run() finallys run.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(completed.toSorted()).toEqual([1, 2, 3, 4]);
+  });
+
+  it("rejects on the first error", async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (n) => {
+        if (n === 2) {
+          throw new Error("nope");
+        }
+        return n;
+      }),
+    ).rejects.toThrow("nope");
+  });
+
+  it("throws on invalid concurrency", () => {
+    expect(() => mapWithConcurrency([1, 2, 3], 0, async (n) => n)).toThrow();
+  });
+
+  it("passes the index to fn", async () => {
+    const result = await mapWithConcurrency(
+      ["a", "b", "c"],
+      2,
+      async (item, index) => `${index}:${item}`,
+    );
+    expect(result).toEqual(["0:a", "1:b", "2:c"]);
+  });
+});

--- a/frontend/src/utils/__tests__/semaphore.test.ts
+++ b/frontend/src/utils/__tests__/semaphore.test.ts
@@ -87,6 +87,11 @@ describe("Semaphore", () => {
     expect(order).toEqual([0, 1, 2, 3]);
   });
 
+  it("throws on release() beyond initial permit count", () => {
+    const sem = new Semaphore(2);
+    expect(() => sem.release()).toThrow(/more times than acquire/);
+  });
+
   it("supports manual acquire/release", async () => {
     const sem = new Semaphore(2);
     await sem.acquire();
@@ -197,8 +202,9 @@ describe("mapWithConcurrency", () => {
     ).rejects.toThrow("nope");
   });
 
-  it("throws on invalid concurrency", () => {
+  it("throws on invalid concurrency, even for empty input", () => {
     expect(() => mapWithConcurrency([1, 2, 3], 0, async (n) => n)).toThrow();
+    expect(() => mapWithConcurrency([], 0, async (n: number) => n)).toThrow();
   });
 
   it("passes the index to fn", async () => {

--- a/frontend/src/utils/fileToBase64.ts
+++ b/frontend/src/utils/fileToBase64.ts
@@ -1,5 +1,9 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { mapWithConcurrency } from "./semaphore";
+
+const FILE_READ_CONCURRENCY = 5;
+
 /**
  * Converts a Blob or File to either a base64-encoded string or a data URL.
  *
@@ -35,11 +39,8 @@ export function blobToString(
  * Returns a promised array of tuples [file name, file contents].
  */
 export function filesToBase64(files: File[]): Promise<[string, string][]> {
-  return Promise.all(
-    files.map((file) =>
-      blobToString(file, "base64").then(
-        (contents) => [file.name, contents] as [string, string],
-      ),
-    ),
-  );
+  return mapWithConcurrency(files, FILE_READ_CONCURRENCY, async (file) => {
+    const contents = await blobToString(file, "base64");
+    return [file.name, contents] as [string, string];
+  });
 }

--- a/frontend/src/utils/semaphore.ts
+++ b/frontend/src/utils/semaphore.ts
@@ -5,6 +5,7 @@
  * tasks. Waiters are released in FIFO order.
  */
 export class Semaphore {
+  private readonly maxPermits: number;
   private permits: number;
   private waiters: Array<() => void> = [];
 
@@ -14,6 +15,7 @@ export class Semaphore {
         `Semaphore permits must be a positive integer, got ${permits}`,
       );
     }
+    this.maxPermits = permits;
     this.permits = permits;
   }
 
@@ -43,6 +45,11 @@ export class Semaphore {
       next();
       return;
     }
+    if (this.permits >= this.maxPermits) {
+      throw new Error(
+        "Semaphore.release() called more times than acquire() — refusing to exceed initial permit count",
+      );
+    }
     this.permits++;
   }
 
@@ -59,8 +66,9 @@ export class Semaphore {
 
 /**
  * Map over `items` with bounded parallelism. Preserves input order in the
- * result. Rejects with the first error encountered (like `Promise.all`); other
- * in-flight tasks are awaited but their results are discarded.
+ * result. Rejects as soon as the first task rejects (like `Promise.all`);
+ * already-started tasks keep running to completion in the background but
+ * their results are dropped.
  */
 // oxlint-disable-next-line marimo/prefer-object-params -- map-style helper, mirrors Array.prototype.map
 export function mapWithConcurrency<T, R>(
@@ -68,10 +76,12 @@ export function mapWithConcurrency<T, R>(
   concurrency: number,
   fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
+  // Validate concurrency before the empty-input fast path so misconfiguration
+  // is never silently accepted.
+  const sem = new Semaphore(concurrency);
   if (items.length === 0) {
     return Promise.resolve([]);
   }
-  const sem = new Semaphore(concurrency);
   return Promise.all(
     items.map((item, index) => sem.run(() => fn(item, index))),
   );

--- a/frontend/src/utils/semaphore.ts
+++ b/frontend/src/utils/semaphore.ts
@@ -1,0 +1,78 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+/**
+ * Counting semaphore that gates async work to at most `permits` in-flight
+ * tasks. Waiters are released in FIFO order.
+ */
+export class Semaphore {
+  private permits: number;
+  private waiters: Array<() => void> = [];
+
+  constructor(permits: number) {
+    if (!Number.isInteger(permits) || permits < 1) {
+      throw new Error(
+        `Semaphore permits must be a positive integer, got ${permits}`,
+      );
+    }
+    this.permits = permits;
+  }
+
+  /** Permits currently available. */
+  get available(): number {
+    return this.permits;
+  }
+
+  /** Number of waiters queued for a permit. */
+  get pending(): number {
+    return this.waiters.length;
+  }
+
+  acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+      return;
+    }
+    this.permits++;
+  }
+
+  /** Acquire a permit, run `fn`, then release the permit. */
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+}
+
+/**
+ * Map over `items` with bounded parallelism. Preserves input order in the
+ * result. Rejects with the first error encountered (like `Promise.all`); other
+ * in-flight tasks are awaited but their results are discarded.
+ */
+// oxlint-disable-next-line marimo/prefer-object-params -- map-style helper, mirrors Array.prototype.map
+export function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return Promise.resolve([]);
+  }
+  const sem = new Semaphore(concurrency);
+  return Promise.all(
+    items.map((item, index) => sem.run(() => fn(item, index))),
+  );
+}


### PR DESCRIPTION
Add Semaphore + mapWithConcurrency utility (cap N concurrent promises)
and apply it with N=5 to: file-tree uploads (previously sequential),
file-tree move/refreshAll, filesToBase64, and vega data resolution
(single shared semaphore across the recursive spec traversal).
