### PR TITLE
docs: clarify that marimo run hides source code by default

### DIFF
--- a/docs/guides/deploying/index.md
+++ b/docs/guides/deploying/index.md
@@ -55,10 +55,9 @@ marimo run app.py --base-url /subpath
 
 ### Including code in your application
 
-By default, `marimo run` does not send your notebook's source code to the
-client, so viewers cannot read it from the browser (including through the
-browser dev tools). This makes `marimo run` suitable for deploying
-notebooks whose source code is confidential.
+By default, `marimo run` does not send your notebook's source code to
+browser clients, so viewers cannot read it from the browser (including
+through dev tools).
 
 If you want to expose the code to viewers, pass the `--include-code` flag:
 

--- a/docs/guides/deploying/index.md
+++ b/docs/guides/deploying/index.md
@@ -55,7 +55,12 @@ marimo run app.py --base-url /subpath
 
 ### Including code in your application
 
-You can include code in your application by using the `--include-code` flag when running your application.
+By default, `marimo run` does not send your notebook's source code to the
+client, so viewers cannot read it from the browser (including through the
+browser dev tools). This makes `marimo run` suitable for deploying
+notebooks whose source code is confidential.
+
+If you want to expose the code to viewers, pass the `--include-code` flag:
 
 ```bash
 marimo run app.py --include-code

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,8 +211,8 @@ Create or edit notebooks with
 marimo edit
 ```
 
-**Run apps.** Run your notebook as a web app, with Python
-code hidden and uneditable:
+**Run apps.** Run your notebook as a web app. By default, the Python
+source code is not sent to the browser, so it stays hidden and uneditable:
 
 ```bash
 marimo run your_notebook.py

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -997,7 +997,10 @@ Example:
     is_flag=True,
     default=False,
     type=bool,
-    help="Include notebook code in the app.",
+    help=(
+        "Send notebook source code to the client. "
+        "By default, code is not sent to the client and cannot be viewed in the browser."
+    ),
 )
 @click.option(
     "--session-ttl",


### PR DESCRIPTION
## 📝 Summary

Closes #9489.

Clarifies in three places that `marimo run` does not send notebook source code to the browser by default:

- `docs/guides/deploying/index.md`: expands the "Including code in your application" section to state that the default makes `marimo run` suitable for deploying notebooks with confidential source code, and that viewers cannot read it via browser dev tools.
- `docs/index.md`: rewords the landing page so "hidden and uneditable" is explained by the source not being sent to the browser, rather than implying a UI-only restriction.
- `marimo/_cli/cli.py`: updates the `--include-code` flag help text to describe both the effect of the flag and the default behavior.

No behavior change; documentation/help-text only.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.