### PR TITLE
fix(mpl): contain comm callback errors in mpl_interactive

### DIFF
--- a/marimo/_plugins/ui/_impl/from_mpl_interactive.py
+++ b/marimo/_plugins/ui/_impl/from_mpl_interactive.py
@@ -274,23 +274,37 @@ class mpl_interactive(UIElement[ModelIdRef, dict[str, Any]]):
             self._handle_download(fmt)
             return
         else:
-            # Forward to figure manager (mouse events, toolbar actions, etc.)
-            self._figure_manager.handle_json(event)  # type: ignore[no-untyped-call]
+            # Forward to figure manager (mouse events, toolbar actions, etc.).
+            # Swallow callback exceptions so a buggy handler can't kill the
+            # kernel subprocess; the exception propagates up through the comm
+            # manager and terminates asyncio.run otherwise.
+            try:
+                self._figure_manager.handle_json(event)  # type: ignore[no-untyped-call]
+            except Exception:
+                LOGGER.exception(
+                    "mpl_interactive handle_json failed for event type %s",
+                    msg_type,
+                )
 
     def _handle_download(self, fmt: str) -> None:
         """Render figure to the requested format and send back via comm."""
-        buf = io.BytesIO()
-        self._figure_manager.canvas.figure.savefig(
-            buf, format=fmt, bbox_inches="tight"
-        )
-        blob = buf.getvalue()
-        self._comm.send(
-            data={
-                "method": "custom",
-                "content": {"type": "download", "format": fmt},
-            },
-            buffers=[blob],
-        )
+        try:
+            buf = io.BytesIO()
+            self._figure_manager.canvas.figure.savefig(
+                buf, format=fmt, bbox_inches="tight"
+            )
+            blob = buf.getvalue()
+            self._comm.send(
+                data={
+                    "method": "custom",
+                    "content": {"type": "download", "format": fmt},
+                },
+                buffers=[blob],
+            )
+        except Exception:
+            LOGGER.exception(
+                "mpl_interactive download failed (fmt=%s)", fmt
+            )
 
     def _convert_value(
         self, value: ModelIdRef | dict[str, Any]

--- a/marimo/_plugins/ui/_impl/from_mpl_interactive.py
+++ b/marimo/_plugins/ui/_impl/from_mpl_interactive.py
@@ -302,9 +302,7 @@ class mpl_interactive(UIElement[ModelIdRef, dict[str, Any]]):
                 buffers=[blob],
             )
         except Exception:
-            LOGGER.exception(
-                "mpl_interactive download failed (fmt=%s)", fmt
-            )
+            LOGGER.exception("mpl_interactive download failed (fmt=%s)", fmt)
 
     def _convert_value(
         self, value: ModelIdRef | dict[str, Any]


### PR DESCRIPTION
## Summary

A raising callback inside `mpl_interactive._handle_comm_msg` (e.g. matplotlib's `AttributeError: 'Axes' object has no attribute '_pan_start'` from `end_pan` without a prior `start_pan`) was propagating up through `MarimoComm.handle_msg` → `WIDGET_COMM_MANAGER.receive_comm_message` → the kernel's request handler, terminating `asyncio.run` and killing the kernel subprocess. The uvicorn parent kept serving so the UI just reported "stopped responding".

This wraps the `handle_json` and `_handle_download` calls in `try/except Exception` and logs via `LOGGER.exception` so a buggy callback is contained while the traceback still surfaces for diagnosis. `BaseException` is intentionally not caught.

Fixes the kernel-crash half of the matplotlib pan/zoom issue (see linked Linear issue). The underlying matplotlib `_pan_start` bug is tracked separately.

## Test plan

- [x] Manual repro via the linked Linear repro (pan → re-run cell → zoom → pan): exception logged, kernel stays alive, figure remains responsive.
- [x] Direct programmatic injection: `_handle_comm_msg` with a raising `handle_json` returns cleanly and a follow-up message is processed.