### PR TITLE
docs: clarify that marimo run does not send code to the client

### DIFF
--- a/docs/guides/deploying/index.md
+++ b/docs/guides/deploying/index.md
@@ -55,7 +55,12 @@ marimo run app.py --base-url /subpath
 
 ### Including code in your application
 
-You can include code in your application by using the `--include-code` flag when running your application.
+By default, `marimo run` hides the notebook source code from the app and does
+not send it to the client, so the code is not retrievable via browser dev
+tools. This is useful when the notebook source is confidential.
+
+If you would like to expose the source code in the app, you can include it by
+using the `--include-code` flag when running your application.
 
 ```bash
 marimo run app.py --include-code

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -997,7 +997,10 @@ Example:
     is_flag=True,
     default=False,
     type=bool,
-    help="Include notebook code in the app.",
+    help=(
+        "Include notebook code in the app. By default, code is hidden and "
+        "is not sent to the client."
+    ),
 )
 @click.option(
     "--session-ttl",


### PR DESCRIPTION
## 📝 Summary

Closes #9489

The previous wording in the deploying guide and the `--include-code` CLI help could be read as "the code is hidden by default, but maybe still sent to the browser and accessible via dev tools." That ambiguity matters when the notebook source is confidential.

Without `--include-code`, `marimo run` blanks the cell source before sending the `kernel-ready` message over the WebSocket (see [`tests/_server/api/endpoints/test_ws.py::test_kernel_ready_sends_names_but_not_code_when_include_code_false`](https://github.com/marimo-team/marimo/blob/main/tests/_server/api/endpoints/test_ws.py#L252)), so the source is not retrievable from the client. This PR makes that explicit in two places:

- `docs/guides/deploying/index.md` — expand the "Including code in your application" section to state that by default the source is hidden and not sent to the client.
- `marimo/_cli/cli.py` — update the `--include-code` help text (which feeds the auto-generated CLI reference at `docs/cli.md` via `mkdocs-click`) with the same clarification.

No behavior change; docs only.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions (Please provide a link if applicable). — Linked to #9489.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made. — Existing test `test_kernel_ready_sends_names_but_not_code_when_include_code_false` already covers the underlying behavior.