### PR TITLE
fix: pass theme to register_formatters in pyodide and script runner

### DIFF
--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -444,7 +444,7 @@ def _launch_pyodide_kernel(
         teardown_kernel,
     )
 
-    register_formatters()
+    register_formatters(theme=user_config["display"]["theme"])
     LOGGER.debug("Launching pyodide kernel")
 
     # Patches for pyodide compatibility

--- a/marimo/_runtime/app/script_runner.py
+++ b/marimo/_runtime/app/script_runner.py
@@ -207,7 +207,11 @@ class AppScriptRunner:
             from marimo._output.formatting import FORMATTERS
 
             if not FORMATTERS.is_empty():
-                register_formatters()
+                from marimo._runtime.context import get_context
+
+                register_formatters(
+                    theme=get_context().marimo_config["display"]["theme"]
+                )
 
             post_execute_hooks = []
             if DependencyManager.matplotlib.has():


### PR DESCRIPTION
Both call sites had user config in scope (or via context) but were
defaulting formatters to the light theme.
