### PR TITLE
fix: stdin handling for empty submissions

### DIFF
--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -740,6 +740,7 @@ const EditableCellComponent = ({
             <ConsoleOutput
               consoleOutputs={cellRuntime.consoleOutputs}
               stale={consoleOutputStale}
+              interrupted={cellRuntime.interrupted}
               // Empty name if serialization triggered
               cellName={cellRuntime.serialization ? "_" : cellData.name}
               onRefactorWithAI={handleRefactorWithAI}
@@ -1204,6 +1205,7 @@ const SetupCellComponent = ({
             <ConsoleOutput
               consoleOutputs={cellRuntime.consoleOutputs}
               stale={consoleOutputStale}
+              interrupted={cellRuntime.interrupted}
               // Don't show name
               cellName={"_"}
               onRefactorWithAI={handleRefactorWithAI}

--- a/frontend/src/components/editor/output/console/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/console/ConsoleOutput.tsx
@@ -359,9 +359,9 @@ const StdInput = (props: {
           if (e.key === "Enter" && !e.shiftKey) {
             if (value) {
               addToHistory(value);
-              onSubmit(value);
-              setValue("");
             }
+            onSubmit(value);
+            setValue("");
             e.preventDefault();
             e.stopPropagation();
           }
@@ -383,11 +383,23 @@ const StdInputWithResponse = (props: {
   response?: string;
   isPassword?: boolean;
 }) => {
+  const { output, response, isPassword } = props;
+  const hasResponse = response != null && response !== "";
   return (
     <div className="flex gap-2 items-center">
-      {renderText(props.output)}
-      {!props.isPassword && (
-        <span className="text-(--sky-11)">{props.response}</span>
+      {renderText(output)}
+      {!isPassword && (
+        <span
+          className="inline-flex items-center gap-1 text-(--sky-11)"
+          aria-label="stdin response"
+        >
+          <ChevronRightIcon className="w-4 h-4 shrink-0 opacity-70" />
+          {hasResponse ? (
+            response
+          ) : (
+            <span className="italic opacity-70">(empty)</span>
+          )}
+        </span>
       )}
     </div>
   );

--- a/frontend/src/components/editor/output/console/ConsoleOutput.tsx
+++ b/frontend/src/components/editor/output/console/ConsoleOutput.tsx
@@ -85,6 +85,7 @@ interface Props {
   className?: string;
   consoleOutputs: WithResponse<OutputMessage>[];
   stale: boolean;
+  interrupted: boolean;
   debuggerActive: boolean;
   onRefactorWithAI?: OnRefactorWithAI;
   onClear?: () => void;
@@ -111,6 +112,7 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
   const {
     consoleOutputs: rawConsoleOutputs,
     stale,
+    interrupted,
     cellName,
     cellId,
     onSubmitDebugger,
@@ -280,6 +282,7 @@ const ConsoleOutputInternal = (props: Props): React.ReactNode => {
                 output={output.data}
                 response={output.response}
                 isPassword={isPassword}
+                interrupted={interrupted}
               />
             );
           }
@@ -382,13 +385,16 @@ const StdInputWithResponse = (props: {
   output: string;
   response?: string;
   isPassword?: boolean;
+  interrupted?: boolean;
 }) => {
-  const { output, response, isPassword } = props;
+  const { output, response, isPassword, interrupted } = props;
   const hasResponse = response != null && response !== "";
+  const wasInterruptedWithoutResponse = interrupted && !hasResponse;
+
   return (
     <div className="flex gap-2 items-center">
       {renderText(output)}
-      {!isPassword && (
+      {!isPassword && !wasInterruptedWithoutResponse && (
         <span
           className="inline-flex items-center gap-1 text-(--sky-11)"
           aria-label="stdin response"

--- a/frontend/src/components/editor/output/console/__tests__/ConsoleOutput.test.tsx
+++ b/frontend/src/components/editor/output/console/__tests__/ConsoleOutput.test.tsx
@@ -118,6 +118,82 @@ describe("ConsoleOutput pdb history", () => {
     expect(newInput).toHaveValue("next");
   });
 
+  it("should submit an empty string when Enter is pressed with no input", () => {
+    // Many CLIs prompt "Press Enter to continue" and expect "" back.
+    const onSubmitDebugger = vi.fn();
+    const outputs: WithResponse<OutputMessage>[] = [
+      stdinPrompt("Press Enter to continue: "),
+    ];
+
+    renderWithProvider(
+      <ConsoleOutput
+        {...defaultProps}
+        consoleOutputs={outputs}
+        onSubmitDebugger={onSubmitDebugger}
+      />,
+    );
+
+    const input = screen.getByTestId("console-input");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSubmitDebugger).toHaveBeenCalledWith("", 0);
+  });
+
+  it("should not record empty submissions in input history", () => {
+    const onSubmitDebugger = vi.fn();
+    const outputs1: WithResponse<OutputMessage>[] = [stdinPrompt("(Pdb) ")];
+
+    const { rerender } = renderWithProvider(
+      <ConsoleOutput
+        {...defaultProps}
+        consoleOutputs={outputs1}
+        onSubmitDebugger={onSubmitDebugger}
+      />,
+    );
+
+    let input = screen.getByTestId("console-input");
+    fireEvent.change(input, { target: { value: "step" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const outputs2: WithResponse<OutputMessage>[] = [
+      stdinPrompt("(Pdb) ", "step"),
+      stdinPrompt("(Pdb) "),
+    ];
+    rerender(
+      <TooltipProvider>
+        <ConsoleOutput
+          {...defaultProps}
+          consoleOutputs={outputs2}
+          onSubmitDebugger={onSubmitDebugger}
+        />
+      </TooltipProvider>,
+    );
+
+    // Submit an empty value; this should NOT enter the history stack.
+    input = screen.getByTestId("console-input");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const outputs3: WithResponse<OutputMessage>[] = [
+      stdinPrompt("(Pdb) ", "step"),
+      stdinPrompt("(Pdb) ", ""),
+      stdinPrompt("(Pdb) "),
+    ];
+    rerender(
+      <TooltipProvider>
+        <ConsoleOutput
+          {...defaultProps}
+          consoleOutputs={outputs3}
+          onSubmitDebugger={onSubmitDebugger}
+        />
+      </TooltipProvider>,
+    );
+
+    // ArrowUp should jump back to "step", skipping the empty submission.
+    input = screen.getByTestId("console-input");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input).toHaveValue("step");
+  });
+
   it("should navigate through multiple history entries across remounts", () => {
     const onSubmitDebugger = vi.fn();
 

--- a/frontend/src/components/editor/output/console/__tests__/ConsoleOutput.test.tsx
+++ b/frontend/src/components/editor/output/console/__tests__/ConsoleOutput.test.tsx
@@ -28,6 +28,7 @@ describe("ConsoleOutput integration", () => {
     cellName: "test_cell",
     consoleOutputs: [] as WithResponse<OutputMessage>[],
     stale: false,
+    interrupted: false,
     debuggerActive: false,
     onSubmitDebugger: () => {
       // noop
@@ -59,6 +60,7 @@ describe("ConsoleOutput pdb history", () => {
     cellName: "test_cell",
     consoleOutputs: [] as WithResponse<OutputMessage>[],
     stale: false,
+    interrupted: false,
     debuggerActive: false,
     onSubmitDebugger: vi.fn(),
   };
@@ -268,6 +270,41 @@ describe("ConsoleOutput pdb history", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" });
     expect(input).toHaveValue("");
   });
+
+  it("should distinguish an interrupted prompt from a bare-Enter submission", () => {
+    // After interrupt, cell.ts coerces pending stdin prompts to response: "".
+    // We must render that case differently from a real bare-Enter response,
+    // so the user isn't told they "submitted" a blank value.
+    const interruptedOutputs: WithResponse<OutputMessage>[] = [
+      stdinPrompt("Press Enter to continue: ", ""),
+    ];
+
+    const { rerender } = renderWithProvider(
+      <ConsoleOutput
+        {...defaultProps}
+        consoleOutputs={interruptedOutputs}
+        interrupted={true}
+      />,
+    );
+
+    // No response chunk should be rendered for an interrupted pending prompt.
+    expect(screen.queryByLabelText("stdin response")).not.toBeInTheDocument();
+
+    // Same outputs, but the cell isn't interrupted -- this is a real
+    // bare-Enter submission, so we should render the (empty) placeholder.
+    rerender(
+      <TooltipProvider>
+        <ConsoleOutput
+          {...defaultProps}
+          consoleOutputs={interruptedOutputs}
+          interrupted={false}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByLabelText("stdin response")).toBeInTheDocument();
+    expect(screen.getByText("(empty)")).toBeInTheDocument();
+  });
 });
 
 describe("ConsoleOutput debounced clearing", () => {
@@ -295,6 +332,7 @@ describe("ConsoleOutput debounced clearing", () => {
     cellName: "test_cell",
     consoleOutputs: [] as WithResponse<OutputMessage>[],
     stale: false,
+    interrupted: false,
     debuggerActive: false,
     onSubmitDebugger: vi.fn(),
   };

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -405,7 +405,7 @@ const VerticalCell = memo(
           <ConsoleOutput
             consoleOutputs={consoleOutputs}
             stale={outputStale}
-            interrupted={false}
+            interrupted={interrupted}
             cellName={name}
             onSubmitDebugger={() => null}
             cellId={cellId}

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -405,6 +405,7 @@ const VerticalCell = memo(
           <ConsoleOutput
             consoleOutputs={consoleOutputs}
             stale={outputStale}
+            interrupted={false}
             cellName={name}
             onSubmitDebugger={() => null}
             cellId={cellId}

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -289,6 +289,7 @@ export const ScratchPad: React.FC = () => {
                 consoleOutputs={consoleOutputs}
                 className="overflow-auto"
                 stale={false}
+                interrupted={false}
                 cellName={DEFAULT_CELL_NAME}
                 onSubmitDebugger={Functions.NOOP}
                 cellId={cellId}

--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -466,20 +466,6 @@ class ThreadSafeStdin(Stdin):
 
         return self._stream.input_queue.get()
 
-    def readline(self, size: int | None = -1) -> str:  # type: ignore[override]
-        # size only included for compatibility with sys.stdin.readline API;
-        # we don't support it.
-        del size
-        return self._readline_with_prompt(prompt="")
-
-    def readlines(self, hint: int | None = -1) -> list[str]:  # type: ignore[override]
-        # Just an alias for readline.
-        #
-        # hint only included for compatibility with sys.stdin.readlines API;
-        # we don't support it.
-        del hint
-        return self._readline_with_prompt(prompt="").split("\n")
-
 
 @contextlib.contextmanager
 def redirect(standard_stream: Stdout | Stderr) -> Iterator[None]:

--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -102,19 +102,7 @@ class Stderr(io.TextIOBase):
 class Stdin(io.TextIOBase):
     name = "stdin"
 
-    def _stop(self) -> None:
-        """Tear down resources, if any."""
-
-
-@dataclasses.dataclass(kw_only=True)
-class KernelStreams:
-    """The four I/O channels the kernel uses to communicate with the host."""
-
-    stream: Stream
-    stdout: Stdout | None
-    stderr: Stderr | None
-    stdin: Stdin | None
-
+    @abc.abstractmethod
     def _readline_with_prompt(
         self, prompt: str = "", password: bool = False
     ) -> str:
@@ -123,8 +111,6 @@ class KernelStreams:
         Subclasses implement the transport. Returns the user-typed text
         without a trailing newline (matches Python's input() contract).
         """
-        del prompt, password
-        raise NotImplementedError
 
     # `size` and `hint` are accepted for sys.stdin API compatibility but
     # ignored: marimo's stdin is a single-prompt pseudofile.
@@ -138,3 +124,16 @@ class KernelStreams:
     def readlines(self, hint: int | None = -1) -> list[str]:  # type: ignore[override]
         del hint
         return [self.readline()]
+
+    def _stop(self) -> None:
+        """Tear down resources, if any."""
+
+
+@dataclasses.dataclass(kw_only=True)
+class KernelStreams:
+    """The four I/O channels the kernel uses to communicate with the host."""
+
+    stream: Stream
+    stdout: Stdout | None
+    stderr: Stderr | None
+    stdin: Stdin | None

--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -63,7 +63,7 @@ def _ensure_plain_str(s: str) -> str:
 
 
 # These streams are not stoppable by users (we don't implement stop).
-class Stdout(io.TextIOBase):
+class Stdout(io.TextIOBase, abc.ABC):
     name = "stdout"
 
     @abc.abstractmethod
@@ -81,7 +81,7 @@ class Stdout(io.TextIOBase):
         """Tear down resources, if any."""
 
 
-class Stderr(io.TextIOBase):
+class Stderr(io.TextIOBase, abc.ABC):
     name = "stderr"
 
     @abc.abstractmethod
@@ -99,7 +99,7 @@ class Stderr(io.TextIOBase):
         """Tear down resources, if any."""
 
 
-class Stdin(io.TextIOBase):
+class Stdin(io.TextIOBase, abc.ABC):
     name = "stdin"
 
     @abc.abstractmethod

--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -114,3 +114,27 @@ class KernelStreams:
     stdout: Stdout | None
     stderr: Stderr | None
     stdin: Stdin | None
+
+    def _readline_with_prompt(
+        self, prompt: str = "", password: bool = False
+    ) -> str:
+        """Send a prompt to the frontend and return the user's bare response.
+
+        Subclasses implement the transport. Returns the user-typed text
+        without a trailing newline (matches Python's input() contract).
+        """
+        del prompt, password
+        raise NotImplementedError
+
+    # `size` and `hint` are accepted for sys.stdin API compatibility but
+    # ignored: marimo's stdin is a single-prompt pseudofile.
+
+    def readline(self, size: int | None = -1) -> str:  # type: ignore[override]
+        del size
+        # Trailing "\n" is required so a blank submission doesn't look like
+        # EOF to builtin input() (used by rich, click, getpass, pdb, etc.).
+        return self._readline_with_prompt(prompt="") + "\n"
+
+    def readlines(self, hint: int | None = -1) -> list[str]:  # type: ignore[override]
+        del hint
+        return [self.readline()]

--- a/marimo/_pyodide/streams.py
+++ b/marimo/_pyodide/streams.py
@@ -179,17 +179,3 @@ class PyodideStdin(Stdin):
     def _get_response(self) -> str:
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(self.stream.input_queue.get())
-
-    def readline(self, size: int | None = -1) -> str:  # type: ignore[override]
-        # size only included for compatibility with sys.stdin.readline API;
-        # we don't support it.
-        del size
-        return self._readline_with_prompt(prompt="")
-
-    def readlines(self, hint: int | None = -1) -> list[str]:  # type: ignore[override]
-        # Just an alias for readline.
-        #
-        # hint only included for compatibility with sys.stdin.readlines API;
-        # we don't support it.
-        del hint
-        return self._readline_with_prompt(prompt="").split("\n")

--- a/tests/_messaging/test_streams.py
+++ b/tests/_messaging/test_streams.py
@@ -25,7 +25,7 @@ class TestStdin:
         await k.run(
             [exec_req.get("import sys; output = sys.stdin.readline()")]
         )
-        assert k.globals["output"] == ""
+        assert k.globals["output"] == "\n"
 
     @staticmethod
     async def test_readlines_installed(
@@ -34,7 +34,19 @@ class TestStdin:
         await k.run(
             [exec_req.get("import sys; output = sys.stdin.readlines()")]
         )
-        assert k.globals["output"] == [""]
+        assert k.globals["output"] == ["\n"]
+
+    @staticmethod
+    async def test_builtin_input_with_empty_response(
+        k: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        # Bypasses the cell-scoped input override, exercising the same
+        # readline()-based path that rich/click/getpass/pdb hit. Must not
+        # raise EOFError on an empty submission.
+        await k.run(
+            [exec_req.get("import builtins; output = builtins.input()")]
+        )
+        assert k.globals["output"] == ""
 
     @staticmethod
     async def test_getpass_installed(

--- a/tests/_messaging/test_types.py
+++ b/tests/_messaging/test_types.py
@@ -1,8 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import override
-
 import pytest
 
 from marimo._messaging.mimetypes import KnownMimeType
@@ -149,7 +147,6 @@ class TestStdoutStderr:
 
 class TestStdin:
     class MockStdin(Stdin):
-        @override
         def _readline_with_prompt(
             self, prompt: str = "", password: bool = False
         ) -> str:

--- a/tests/_messaging/test_types.py
+++ b/tests/_messaging/test_types.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import override
+
 import pytest
 
 from marimo._messaging.mimetypes import KnownMimeType
@@ -146,12 +148,20 @@ class TestStdoutStderr:
 
 
 class TestStdin:
+    class MockStdin(Stdin):
+        @override
+        def _readline_with_prompt(
+            self, prompt: str = "", password: bool = False
+        ) -> str:
+            del prompt, password
+            return ""
+
     def test_stdin_name(self) -> None:
-        stdin = Stdin()
+        stdin = self.MockStdin()
         assert stdin.name == "stdin"
 
     def test_not_stoppable(self) -> None:
-        stdin = Stdin()
+        stdin = self.MockStdin()
         assert not hasattr(stdin, "stop")
 
 

--- a/tests/_pyodide/test_pyodide_streams.py
+++ b/tests/_pyodide/test_pyodide_streams.py
@@ -45,8 +45,9 @@ def pyodide_stderr(pyodide_: PyodideStream) -> PyodideStderr:
 
 @pytest.fixture
 def pyodide_stdin(pyodide_: PyodideStream) -> PyodideStdin:
+    # bridge.ts -> put_input sends raw user text; readline() adds the "\n".
     stdin = PyodideStdin(pyodide_)
-    stdin._get_response = lambda: "test input\n"
+    stdin._get_response = lambda: "test input"
     return stdin
 
 
@@ -132,12 +133,9 @@ class TestPyodideStdin:
         pyodide_pipe: Mock,
         pyodide_input_queue: asyncio.Queue[str],
     ) -> None:
-        # Queue up a response
-        await pyodide_input_queue.put("test input\n")
-        # Read the line
+        await pyodide_input_queue.put("test input")
         result = pyodide_stdin.readline()
         assert result == "test input\n"
-        # Verify prompt was sent
         assert pyodide_pipe.call_count == 1
         msg_bytes = pyodide_pipe.call_args[0][0]
         msg = json.loads(msg_bytes)
@@ -152,12 +150,11 @@ class TestPyodideStdin:
         pyodide_pipe: Mock,
         pyodide_input_queue: asyncio.Queue[str],
     ) -> None:
-        # Queue up a response
-        await pyodide_input_queue.put("test input\n")
-        # Read the line with prompt
+        await pyodide_input_queue.put("test input")
+        # The _readline_with_prompt primitive returns bare text; the "\n"
+        # is only added by readline() for file-protocol consumers.
         result = pyodide_stdin._readline_with_prompt("Enter: ")
-        assert result == "test input\n"
-        # Verify prompt was sent
+        assert result == "test input"
         assert pyodide_pipe.call_count == 1
         msg_bytes = pyodide_pipe.call_args[0][0]
         msg = json.loads(msg_bytes)
@@ -172,16 +169,11 @@ class TestPyodideStdin:
         pyodide_pipe: Mock,
         pyodide_input_queue: asyncio.Queue[str],
     ) -> None:
-        pyodide_stdin._get_response = Mock(
-            return_value="line1\nline2\nline3\n"
-        )
+        pyodide_stdin._get_response = Mock(return_value="hello")
 
-        # Queue up a response
-        await pyodide_input_queue.put("line1\nline2\nline3\n")
-        # Read the lines
+        await pyodide_input_queue.put("hello")
         result = pyodide_stdin.readlines()
-        assert result == ["line1", "line2", "line3", ""]
-        # Verify prompt was sent
+        assert result == ["hello\n"]
         assert pyodide_pipe.call_count == 1
         msg_bytes = pyodide_pipe.call_args[0][0]
         msg = json.loads(msg_bytes)
@@ -189,3 +181,13 @@ class TestPyodideStdin:
         assert msg["cell_id"] == pyodide_stdin.stream.cell_id
         assert msg["console"]["mimetype"] == "text/plain"
         assert msg["console"]["data"] == ""
+
+    async def test_readline_empty_submission(
+        self,
+        pyodide_stdin: PyodideStdin,
+        pyodide_input_queue: asyncio.Queue[str],
+    ) -> None:
+        # Empty submission must be a blank line ("\n"), not "" (= EOF).
+        pyodide_stdin._get_response = lambda: ""
+        await pyodide_input_queue.put("")
+        assert pyodide_stdin.readline() == "\n"


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
- Pressing Enter with no input in marimo's stdin box was silently swallowed by the frontend, so any CLI calling `input("Press Enter to continue:")` (e.g. `logfire`, `click.prompt`, `rich.prompt`, `pdb`) would hang forever. 
- Once unblocked, a second bug surfaced: `builtins.input()` raised `EOFError` on blank submissions because `ThreadSafeStdin.readline()` returned `""` — which CPython's `input()` interprets as EOF rather than a blank line.

### Fix

**Frontend** (`ConsoleOutput.tsx`)
- `StdInput` now submits on Enter even when empty (history skip preserved).
- `StdInputWithResponse` renders past responses with a `>` chevron, sky-11 color, and an `(empty)` placeholder so user-typed responses are visually distinct from stdout — even when the prompt half is empty (which happens when CLIs `print()` the prompt themselves before calling `input()`).

<img width="501" height="191" alt="image" src="https://github.com/user-attachments/assets/59999aad-09fe-4174-9408-b009981130be" />

**Backend** (`marimo/_messaging/types.py`, `streams.py`, `_pyodide/streams.py`)
- `Stdin.readline()` now appends `"\n"` so blank submissions surface as `"\n"` rather than `""`. `readlines()` simplified to `[readline()]`.
- Lifted `readline`/`readlines` to the `Stdin` base class — both subclasses had identical implementations.
- `_readline_with_prompt` unchanged: still returns the bare response, so `input_override` continues to satisfy Python's `input()` contract.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
