### PR TITLE
fix: strip executor frame from cell tracebacks on Windows

### DIFF
--- a/marimo/_messaging/tracebacks.py
+++ b/marimo/_messaging/tracebacks.py
@@ -92,7 +92,10 @@ def _trim_traceback(traceback: str) -> str:
     if (
         len(lines) > 2
         and lines[0] == "Traceback (most recent call last):"
-        and '/marimo/_runtime/executor.py", line ' in lines[1]
+        and (
+            '/marimo/_runtime/executor.py", line ' in lines[1]
+            or '\\marimo\\_runtime\\executor.py", line ' in lines[1]
+        )
         and lines[1].endswith(", in execute_cell")
     ):
         for i in range(2, len(lines)):


### PR DESCRIPTION
_trim_traceback only matched forward-slash paths, so on Windows the
internal execute_cell frame leaked into the rendered traceback and
broke the scratchpad integration snapshots.
