### PR TITLE
fix(cache): avoid treating class-like __array__ refs as data primitives

### DIFF
--- a/marimo/_runtime/primitives.py
+++ b/marimo/_runtime/primitives.py
@@ -60,6 +60,9 @@ def is_data_primitive(value: Any) -> bool:
     if is_primitive(value):
         return True
 
+    if inspect.isclass(value):
+        return False
+
     if not (
         hasattr(value, "__array__")
         or hasattr(value, "toarray")

--- a/tests/_runtime/test_primitives.py
+++ b/tests/_runtime/test_primitives.py
@@ -3,7 +3,25 @@
 import functools
 from typing import Any
 
-from marimo._runtime.primitives import is_pure_function
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._runtime.primitives import is_data_primitive, is_pure_function
+
+HAS_NUMPY = DependencyManager.numpy.has()
+
+
+class TestDataPrimitiveClassification:
+    @pytest.mark.skipif(not HAS_NUMPY, reason="numpy is required")
+    def test_rejects_class_like_array_protocol(self) -> None:
+        import numpy as np
+
+        class _ClassLikeArray:
+            @classmethod
+            def __array__(cls, dtype: Any = None) -> Any:
+                return np.array([object()], dtype=object)
+
+        assert is_data_primitive(_ClassLikeArray) is False
 
 
 class TestWrappedFunctionHandling:

--- a/tests/_runtime/test_primitives.py
+++ b/tests/_runtime/test_primitives.py
@@ -14,6 +14,7 @@ HAS_NUMPY = DependencyManager.numpy.has()
 class TestDataPrimitiveClassification:
     @pytest.mark.skipif(not HAS_NUMPY, reason="numpy is required")
     def test_rejects_class_like_array_protocol(self) -> None:
+        """Issue #9563: class-like __array__ refs are not data primitives."""
         import numpy as np
 
         class _ClassLikeArray:


### PR DESCRIPTION
## 📝 Summary
Closes #9563
**This PR fixes a cache-classification edge case in `is_data_primitive`:**
- Root cause: class-like references exposing `__array__` were treated as data primitives.
- Effect: those refs were routed into `data_to_buffer(...).view("uint8")`, which can fail for reference/object arrays with:
  - `TypeError: Cannot change data-type for array of references.`
- Fix: add an early class guard (`inspect.isclass(value) -> False`) in `is_data_primitive`.
- Test: add focused coverage in `tests/_runtime/test_primitives.py` to assert class-like `__array__` refs are not classified as data primitives (issue #9563 case).
**Validation run:**
- `uv run --group test pytest tests/_runtime/test_primitives.py -k class_like_array_protocol` → passed
- `uv run --group test pytest tests -k primitives` → `6 passed, 14 skipped, 8812 deselected`
- `uv run --group test pytest tests -k cache` → `202 passed, 40 skipped, 8590 deselected`
Skips are expected in this environment due to optional dependencies and version/platform-gated tests.

---

## 📋 Pre-Review Checklist
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).  
  - Issue: #9563
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).  
  - Not applicable (no visual changes).

--- 
## ✅ Merge Checklist
- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.  
  - Not applicable: no public API change.
- [x] Tests have been added for the changes made.