### PR TITLE
Rename ctx.notify to broadcast_raw_notification

### DIFF
--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -1694,36 +1694,13 @@ class AsyncCodeModeContext:
     def broadcast_raw_notification(self, notification: Notification) -> None:
         """Low-level: broadcast a fully-constructed ``Notification`` to the frontend.
 
-        This is an escape hatch for emitting notification payloads that
-        don't yet have a higher-level helper on ``ctx``. You construct the
-        typed ``Notification`` yourself and this method puts it on the
-        kernel's outbound stream. There is no validation, batching, or
-        debouncing — the payload is delivered as-is.
+        Escape hatch for emitting notification payloads directly; the
+        payload is delivered as-is, with no validation, batching, or
+        debouncing. Prefer a higher-level helper on ``ctx`` when one exists.
 
-        The ``Notification`` type is a discriminated union. Browse the
-        full list at ``marimo._messaging.notification`` (or look at the
-        re-exports in ``marimo._internal.notifications``).
-        Representative subtypes include:
-
-        - ``AlertNotification`` — modal alert dialog.
-        - ``BannerNotification`` — persistent banner across the top of the notebook.
-        - ``InstallingPackageAlertNotification`` — package install progress.
-        - ``MissingPackageAlertNotification`` — prompt to install a missing package.
-        - ``ReloadNotification`` — ask the frontend to reload.
-        - ``NotebookDocumentTransactionNotification`` — apply a document transaction.
-
-        Examples:
-            ```python
-            from marimo._messaging.notification import BannerNotification
-
-            ctx.broadcast_raw_notification(
-                BannerNotification(title="Heads up", description="…")
-            )
-            ```
-
-        Args:
-            notification: A typed ``Notification`` instance. See module
-                docstring above for the available subtypes.
+        See ``marimo._messaging.notification`` for the full discriminated
+        union. Agent-facing subtypes include ``BannerNotification`` (persistent
+        banner) and ``AlertNotification`` (modal dialog).
         """
         broadcast_notification(notification, stream=self._kernel.stream)  # type: ignore[arg-type]
 

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -1691,9 +1691,7 @@ class AsyncCodeModeContext:
                 type(command).__name__,
             )
 
-    def broadcast_raw_notification(
-        self, notification: Notification
-    ) -> None:
+    def broadcast_raw_notification(self, notification: Notification) -> None:
         """Low-level: broadcast a fully-constructed ``Notification`` to the frontend.
 
         This is an escape hatch for emitting notification payloads that

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -1590,7 +1590,7 @@ class AsyncCodeModeContext:
             tx = Transaction(changes=tuple(doc_ops), source="code-mode")
             # Apply to local snapshot so _cell_label can read names.
             self._document.apply(tx)
-            self.notify(
+            self.broadcast_raw_notification(
                 NotebookDocumentTransactionNotification(transaction=tx)
             )
 
@@ -1691,8 +1691,42 @@ class AsyncCodeModeContext:
                 type(command).__name__,
             )
 
-    def notify(self, notification: Notification) -> None:
-        """Send a notification to the frontend."""
+    def broadcast_raw_notification(
+        self, notification: Notification
+    ) -> None:
+        """Low-level: broadcast a fully-constructed ``Notification`` to the frontend.
+
+        This is an escape hatch for emitting notification payloads that
+        don't yet have a higher-level helper on ``ctx``. You construct the
+        typed ``Notification`` yourself and this method puts it on the
+        kernel's outbound stream. There is no validation, batching, or
+        debouncing — the payload is delivered as-is.
+
+        The ``Notification`` type is a discriminated union. Browse the
+        full list at ``marimo._messaging.notification`` (or look at the
+        re-exports in ``marimo._internal.notifications``).
+        Representative subtypes include:
+
+        - ``AlertNotification`` — modal alert dialog.
+        - ``BannerNotification`` — persistent banner across the top of the notebook.
+        - ``InstallingPackageAlertNotification`` — package install progress.
+        - ``MissingPackageAlertNotification`` — prompt to install a missing package.
+        - ``ReloadNotification`` — ask the frontend to reload.
+        - ``NotebookDocumentTransactionNotification`` — apply a document transaction.
+
+        Examples:
+            ```python
+            from marimo._messaging.notification import BannerNotification
+
+            ctx.broadcast_raw_notification(
+                BannerNotification(title="Heads up", description="…")
+            )
+            ```
+
+        Args:
+            notification: A typed ``Notification`` instance. See module
+                docstring above for the available subtypes.
+        """
         broadcast_notification(notification, stream=self._kernel.stream)  # type: ignore[arg-type]
 
 


### PR DESCRIPTION
The old name read like a toast helper, but the method is a low-level escape hatch that takes a fully-constructed `Notification` payload and puts it on the kernel's outbound stream.
