### PR TITLE
fix: keep stepped range progress totals aligned

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -392,7 +392,6 @@ class progress_bar(Generic[S]):
         self.step: int = 1
         self.collection = collection
         self._is_async = isinstance(collection, AsyncIterable)
-        total_was_provided = total is not None
 
         if collection is not None:
             if total is None:
@@ -405,7 +404,7 @@ class progress_bar(Generic[S]):
                         "A `total` must be provided."
                     )
 
-            elif total_was_provided and isinstance(collection, range):
+            elif isinstance(collection, range):
                 self.step = cast(range, collection).step
 
         elif total is None:

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -405,7 +405,7 @@ class progress_bar(Generic[S]):
                         "A `total` must be provided."
                     )
 
-            if total_was_provided and isinstance(collection, range):
+            elif total_was_provided and isinstance(collection, range):
                 self.step = cast(range, collection).step
 
         elif total is None:

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -392,6 +392,7 @@ class progress_bar(Generic[S]):
         self.step: int = 1
         self.collection = collection
         self._is_async = isinstance(collection, AsyncIterable)
+        total_was_provided = total is not None
 
         if collection is not None:
             if total is None:
@@ -404,7 +405,7 @@ class progress_bar(Generic[S]):
                         "A `total` must be provided."
                     )
 
-            if isinstance(collection, range):
+            if total_was_provided and isinstance(collection, range):
                 self.step = cast(range, collection).step
 
         elif total is None:

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -167,6 +167,22 @@ def test_progress_without_context():
             pass
 
 
+def test_progress_with_stepped_range_without_total() -> None:
+    assert runtime_context_installed() is False
+
+    progress = progress_bar(range(0, 10, 2))
+    assert list(progress) == [0, 2, 4, 6, 8]
+    assert (progress.progress.current, progress.progress.total) == (5, 5)
+
+
+def test_progress_with_stepped_range_and_total() -> None:
+    assert runtime_context_installed() is False
+
+    progress = progress_bar(range(0, 10, 2), total=10)
+    assert list(progress) == [0, 2, 4, 6, 8]
+    assert (progress.progress.current, progress.progress.total) == (10, 10)
+
+
 async def sleep(seconds):
     import asyncio
 


### PR DESCRIPTION
This pull request was authored by a coding agent.

## Summary

- Fix `mo.status.progress_bar(range(...))` when `total` is inferred, so stepped ranges track the number of yielded items instead of advancing past the inferred total.
- Preserve existing explicit-total behavior for stepped ranges, where `range.step` is used with the caller-provided total.
- Add regressions for both inferred and explicit totals on `range(0, 10, 2)`.

Closes #9575.

## Validation

- `uv run --group test pytest tests/_plugins/stateless/status/test_progress.py -q` (`15 passed`)
- `uv run ruff check marimo/_plugins/stateless/status/_progress.py tests/_plugins/stateless/status/test_progress.py`
- `uv run ruff format --check marimo/_plugins/stateless/status/_progress.py tests/_plugins/stateless/status/test_progress.py`
- `uv run --only-group typecheck mypy marimo/_plugins/stateless/status/_progress.py`
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact --timeout 30`

## Limitations

- I ran focused Python/status validation only; I did not run the full test suite or a browser UI smoke.
- I did not take any account/legal action for the CLA beyond reading the contribution guidance.
