### PR TITLE
refactor(runtime): narrow callback deps, drop get_context in cache

### DIFF
--- a/marimo/_runtime/callbacks/cache.py
+++ b/marimo/_runtime/callbacks/cache.py
@@ -9,16 +9,15 @@ from marimo._messaging.notification import (
 )
 from marimo._messaging.notification_utils import broadcast_notification
 from marimo._runtime.commands import ClearCacheCommand, GetCacheInfoCommand
-from marimo._runtime.context import get_context
 
 if TYPE_CHECKING:
+    from marimo._runtime.callbacks.protocol import GlobalsView
     from marimo._runtime.request_router import RequestRouter
-    from marimo._runtime.runtime import Kernel
 
 
 class CacheCallbacks:
-    def __init__(self, kernel: Kernel):
-        self._kernel = kernel
+    def __init__(self, scope: GlobalsView):
+        self._scope = scope
 
     def register(self, router: RequestRouter) -> None:
         router.register(ClearCacheCommand, self.clear_cache)
@@ -28,11 +27,9 @@ class CacheCallbacks:
         del request
         from marimo._save.cache import CacheContext
 
-        ctx = get_context()
         saved = 0
-        for obj in ctx.globals.values():
+        for obj in self._scope.globals.values():
             if isinstance(obj, CacheContext):
-                # Loader.clear is a no-op by default; safe on any subclass.
                 obj.loader.clear()
 
         broadcast_notification(CacheClearedNotification(bytes_freed=saved))
@@ -41,14 +38,13 @@ class CacheCallbacks:
         del request
         from marimo._save.cache import CacheContext
 
-        ctx = get_context()
         total_hits = 0
         total_misses = 0
         total_time = 0
         disk_to_free = -1  # TODO: sum up disk usage
         disk_total = -1
 
-        for obj in ctx.globals.values():
+        for obj in self._scope.globals.values():
             if isinstance(obj, CacheContext):
                 hits, misses, _, _, time = obj.cache_info()
                 total_hits += hits

--- a/marimo/_runtime/callbacks/external_storage.py
+++ b/marimo/_runtime/callbacks/external_storage.py
@@ -21,8 +21,8 @@ from marimo._tracer import kernel_tracer
 from marimo._types.ids import VariableName
 
 if TYPE_CHECKING:
+    from marimo._runtime.callbacks.protocol import GlobalsView
     from marimo._runtime.request_router import RequestRouter
-    from marimo._runtime.runtime import Kernel
 
 LOGGER = _loggers.marimo_logger()
 
@@ -31,8 +31,8 @@ class ExternalStorageCallbacks:
     _VFILE_TTL_SECONDS = 60
     _PREVIEW_MAX_BYTES = 1_000_000  # 1 MB
 
-    def __init__(self, kernel: Kernel):
-        self._kernel = kernel
+    def __init__(self, scope: GlobalsView):
+        self._scope = scope
 
     def register(self, router: RequestRouter) -> None:
         router.register(StorageListEntriesCommand, self.list_entries)
@@ -48,10 +48,10 @@ class ExternalStorageCallbacks:
         from marimo._data._external_storage.get_storage import STORAGE_BACKENDS
 
         variable_name = VariableName(namespace)
-        if variable_name not in self._kernel.globals:
+        if variable_name not in self._scope.globals:
             return None, f"Variable '{namespace}' not found"
 
-        var = self._kernel.globals[variable_name]
+        var = self._scope.globals[variable_name]
 
         for backend in STORAGE_BACKENDS:
             if backend.is_compatible(var):

--- a/marimo/_runtime/callbacks/packages.py
+++ b/marimo/_runtime/callbacks/packages.py
@@ -308,7 +308,7 @@ class PackagesCallbacks:
                 cells_to_run.add(cid)
 
         if cells_to_run:
-            await self._kernel._if_autorun_then_run_cells(cells_to_run)
+            await self._kernel.maybe_autorun_cells(cells_to_run)
 
     def _maybe_add_marimo_to_script_metadata(self) -> None:
         if self.should_update_script_metadata():

--- a/marimo/_runtime/callbacks/protocol.py
+++ b/marimo/_runtime/callbacks/protocol.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from marimo._runtime.request_router import RequestRouter
 
 
@@ -18,4 +20,4 @@ class GlobalsView(Protocol):
     """A view onto user-defined variables (kernel globals)."""
 
     @property
-    def globals(self) -> dict[Any, Any]: ...
+    def globals(self) -> Mapping[str, Any]: ...

--- a/marimo/_runtime/callbacks/protocol.py
+++ b/marimo/_runtime/callbacks/protocol.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from marimo._runtime.request_router import RequestRouter
@@ -12,3 +12,10 @@ class KernelCallback(Protocol):
     """A bundle of kernel command handlers that registers itself with a router."""
 
     def register(self, router: RequestRouter) -> None: ...
+
+
+class GlobalsView(Protocol):
+    """A view onto user-defined variables (kernel globals)."""
+
+    @property
+    def globals(self) -> dict[Any, Any]: ...

--- a/marimo/_runtime/callbacks/secrets.py
+++ b/marimo/_runtime/callbacks/secrets.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from marimo._messaging.notification import SecretKeysResultNotification
@@ -19,6 +20,8 @@ if TYPE_CHECKING:
 class SecretsCallbacks:
     def __init__(self, kernel: Kernel):
         self._kernel = kernel
+        # Snapshot at startup so dotenv-loaded keys can later be distinguished from inherited ones.
+        self._original_environ = os.environ.copy()
 
     def register(self, router: RequestRouter) -> None:
         router.register(ListSecretKeysCommand, self.list_secrets)
@@ -26,7 +29,7 @@ class SecretsCallbacks:
 
     async def list_secrets(self, request: ListSecretKeysCommand) -> None:
         secrets = get_secret_keys(
-            self._kernel.user_config, self._kernel._original_environ
+            self._kernel.user_config, self._original_environ
         )
         broadcast_notification(
             SecretKeysResultNotification(

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -510,8 +510,6 @@ class Kernel:
 
         self._hooks = hooks
 
-        self._original_environ = os.environ.copy()
-
         self._globals_lock = threading.RLock()
         self._state_lock = threading.RLock()
         self._completion_worker_started = False
@@ -1393,9 +1391,7 @@ class Kernel:
                             cell_id=cid, status=status
                         )
 
-    async def _if_autorun_then_run_cells(
-        self, cell_ids: set[CellId_t]
-    ) -> None:
+    async def maybe_autorun_cells(self, cell_ids: set[CellId_t]) -> None:
         if self.reactive_execution_mode == "autorun":
             await self._run_cells(cell_ids)
         else:
@@ -1720,7 +1716,7 @@ class Kernel:
         for cell in self.graph.cells.values():
             if "__file__" in cell.refs:
                 roots.add(cell.cell_id)
-        await self._if_autorun_then_run_cells(roots)
+        await self.maybe_autorun_cells(roots)
 
     @kernel_tracer.start_as_current_span("run_scratchpad")
     async def run_scratchpad(self, code: str) -> None:

--- a/tests/_runtime/test_runtime_cache.py
+++ b/tests/_runtime/test_runtime_cache.py
@@ -36,6 +36,7 @@ class TestClearCache:
     async def test_clears_memory_loaders(
         self, mocked_kernel: MockedKernel
     ) -> None:
+        """Regression: clear_cache must purge non-persistence loaders too."""
         k = mocked_kernel.k
         stream = mocked_kernel.stream
 

--- a/tests/_runtime/test_runtime_datasets.py
+++ b/tests/_runtime/test_runtime_datasets.py
@@ -406,12 +406,12 @@ class TestPreviewDatasourceConnection:
         mocked_kernel: MockedKernel,
         connection_requests: list[ExecuteCellCommand],
     ) -> None:
+        """Regression: query-only engines (QueryEngine, not EngineCatalog) must broadcast."""
         k = mocked_kernel.k
         stream = mocked_kernel.stream
 
         await k.run(connection_requests)
 
-        # k.run emits auto-discovery notifications; take a baseline.
         baseline = sum(
             1
             for op in stream.operations

--- a/tests/_runtime/test_runtime_secrets.py
+++ b/tests/_runtime/test_runtime_secrets.py
@@ -27,7 +27,7 @@ async def test_list_secrets_with_values(
     # Set some test secrets
     test_secrets = ["DUMMY_SECRET"]
     os.environ["DUMMY_SECRET"] = "dummy-value"
-    mocked_kernel.k._original_environ = os.environ.copy()
+    secrets_callbacks._original_environ = os.environ.copy()
 
     await secrets_callbacks.list_secrets(
         ListSecretKeysCommand(request_id=RequestId("test"))
@@ -58,7 +58,7 @@ async def test_refresh_secrets(
 ):
     # Set some test secrets
     os.environ["DUMMY_SECRET"] = "dummy-value"
-    mocked_kernel.k._original_environ = os.environ.copy()
+    secrets_callbacks._original_environ = os.environ.copy()
 
     # Spy on load_dotenv method
     original_load_dotenv = mocked_kernel.k.load_dotenv


### PR DESCRIPTION
Introduce a GlobalsView protocol for CacheCallbacks and ExternalStorageCallbacks
so they no longer take the full Kernel; CacheCallbacks now reads globals via
the injected scope instead of get_context(). Move the env snapshot from
Kernel into SecretsCallbacks. Promote _if_autorun_then_run_cells to a public
maybe_autorun_cells on Kernel.
