### PR TITLE
fix(output): render Enum members as str in JSON serializer

### DIFF
--- a/marimo/_messaging/msgspec_encoder.py
+++ b/marimo/_messaging/msgspec_encoder.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import collections
 import datetime
 import decimal
+import enum
 import fractions
 import uuid
 from math import isnan
@@ -181,6 +182,12 @@ def enc_hook(obj: Any) -> Any:
                 "Error converting matplotlib figures to HTML",
                 exc_info=True,
             )
+
+    # Encode Enum members as their str form (e.g. "TestEnum.ONE"). Without
+    # this, plain Enum members reach the __dict__ fallback and leak internals
+    # (_value_, _name_, ...).
+    if isinstance(obj, enum.Enum):
+        return str(obj)
 
     # Handle objects with __slots__
     # Check on type(obj) to avoid triggering __getattr__ on objects that

--- a/tests/_plugins/core/test_json_encoder.py
+++ b/tests/_plugins/core/test_json_encoder.py
@@ -441,6 +441,26 @@ def test_enum_encoding() -> None:
     assert encoded == "2"
 
 
+def test_enum_via_sanitize_json_bigint() -> None:
+    """The stdlib-json path used by table serializers must render Enum
+    members as their str form, not leak __dict__ internals."""
+    from enum import Enum, auto
+
+    from marimo._output.data.data import sanitize_json_bigint
+
+    class TestEnum(Enum):
+        ONE = auto()
+        TWO = auto()
+
+    encoded = sanitize_json_bigint(
+        [{"col": TestEnum.ONE}, {"col": TestEnum.TWO}]
+    )
+    assert encoded == ('[{"col":"TestEnum.ONE"},{"col":"TestEnum.TWO"}]')
+    assert "_value_" not in encoded
+    assert "_name_" not in encoded
+    assert "__objclass__" not in encoded
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 11), reason="StrEnum not supported in Python 3.10"
 )


### PR DESCRIPTION
## Summary

Plain `enum.Enum` members displayed in `mo.ui.table` or as a pandas DataFrame rendered their `__dict__` internals (`_value_`, `_name_`, `__objclass__`, `_sort_order_`) instead of a readable label.

The table/DataFrame path serializes cells through `sanitize_json_bigint`, which uses stdlib `json.dumps`. stdlib json has no native `Enum` support, so members reached the generic `__dict__` fallback in `enc_hook` and leaked their internals. The msgspec-native `encode_json_str` path was unaffected because msgspec encodes `Enum` natively (as `.value`).

This adds an explicit `enum.Enum` branch in `enc_hook` ahead of the `__dict__`/`__slots__` fallbacks that returns `str(obj)` (e.g. `"TestEnum.ONE"`). `IntEnum` and `StrEnum` still match their `int`/`str` isinstance branches first, so the existing test (`encode_json_str(Color.RED) == "1"`) is preserved.

Fixes https://github.com/marimo-team/marimo/issues/9576

## Test plan

- [x] `make py-check`
- [x] `pytest tests/_plugins/core/test_json_encoder.py -k enum` (3 passed, including new `test_enum_via_sanitize_json_bigint`)
- [x] Manual repro from the bug report — `mo.ui.table` and `pd.DataFrame` views show `TestEnum.ONE` / `TestEnum.TWO` in the Enum column