### PR TITLE
feat(table): expand column filter operators and pill-editor UX

### DIFF
--- a/frontend/src/components/data-table/__tests__/column-header.test.ts
+++ b/frontend/src/components/data-table/__tests__/column-header.test.ts
@@ -49,7 +49,9 @@ describe("seedFromFilter", () => {
       values: [],
       operator: "in",
     });
-    expect(seedFromFilter(Filter.number({ min: 0, max: 10 }))).toEqual({
+    expect(
+      seedFromFilter(Filter.number({ operator: "between", min: 0, max: 10 })),
+    ).toEqual({
       values: [],
       operator: "in",
     });

--- a/frontend/src/components/data-table/__tests__/column-header.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-header.test.tsx
@@ -20,9 +20,10 @@ beforeAll(() => {
   }
 });
 
-function mockColumn(
-  initial?: ReturnType<typeof Filter.number>,
-): Column<unknown, unknown> & {
+function mockColumn(initial?: ReturnType<typeof Filter.number>): Column<
+  unknown,
+  unknown
+> & {
   setFilterValue: ReturnType<typeof vi.fn>;
 } {
   let filterValue = initial;
@@ -107,9 +108,10 @@ describe("NumberFilterMenu", () => {
   });
 });
 
-function mockTextColumn(
-  initial?: ReturnType<typeof Filter.text>,
-): Column<unknown, unknown> & {
+function mockTextColumn(initial?: ReturnType<typeof Filter.text>): Column<
+  unknown,
+  unknown
+> & {
   setFilterValue: ReturnType<typeof vi.fn>;
 } {
   let filterValue = initial;
@@ -168,10 +170,7 @@ describe("TextFilterMenu", () => {
       data: [["a", 1] as [unknown, number]],
     }));
     render(
-      <TextFilterMenu
-        column={column}
-        calculateTopKRows={calculateTopKRows}
-      />,
+      <TextFilterMenu column={column} calculateTopKRows={calculateTopKRows} />,
     );
     expect(
       await screen.findByPlaceholderText(/Search or add a value/i),

--- a/frontend/src/components/data-table/__tests__/column-header.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-header.test.tsx
@@ -2,9 +2,7 @@
 import type { Column } from "@tanstack/react-table";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-// NumberFilterMenu does not exist yet — Task 5 introduces it.
-// These tests are expected to fail until that change lands.
-import { NumberFilterMenu } from "../column-header";
+import { NumberFilterMenu, TextFilterMenu } from "../column-header";
 import { Filter } from "../filters";
 
 beforeAll(() => {
@@ -106,5 +104,103 @@ describe("NumberFilterMenu", () => {
     expect(
       screen.queryByRole("button", { name: /apply/i }),
     ).not.toBeInTheDocument();
+  });
+});
+
+function mockTextColumn(
+  initial?: ReturnType<typeof Filter.text>,
+): Column<unknown, unknown> & {
+  setFilterValue: ReturnType<typeof vi.fn>;
+} {
+  let filterValue = initial;
+  const setFilterValue = vi.fn((next) => {
+    filterValue = next;
+  });
+  return {
+    id: "name",
+    columnDef: { meta: { dataType: "string", filterType: "text" } },
+    getFilterValue: () => filterValue,
+    setFilterValue,
+  } as unknown as Column<unknown, unknown> & {
+    setFilterValue: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("TextFilterMenu", () => {
+  it("shows all 11 text operators in the dropdown", () => {
+    const column = mockTextColumn();
+    render(<TextFilterMenu column={column} />);
+    fireEvent.click(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    const labels = within(listbox)
+      .getAllByRole("option")
+      .map((o) => o.textContent);
+    expect(labels).toEqual([
+      "Contains",
+      "Equals",
+      "Doesn't equal",
+      "Matches regex",
+      "Starts with",
+      "Ends with",
+      "Is in",
+      "Not in",
+      "Is empty",
+      "Is null",
+      "Is not null",
+    ]);
+  });
+
+  it("single-string operator renders a text input seeded from current filter", () => {
+    const column = mockTextColumn(
+      Filter.text({ operator: "equals", text: "alice" }),
+    );
+    render(<TextFilterMenu column={column} />);
+    const input = screen.getByPlaceholderText("Text...") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe("alice");
+  });
+
+  it("'in' operator renders the creatable values picker", async () => {
+    const column = mockTextColumn(
+      Filter.text({ operator: "in", values: ["a", "b"] }),
+    );
+    const calculateTopKRows = vi.fn(async () => ({
+      data: [["a", 1] as [unknown, number]],
+    }));
+    render(
+      <TextFilterMenu
+        column={column}
+        calculateTopKRows={calculateTopKRows}
+      />,
+    );
+    expect(
+      await screen.findByPlaceholderText(/Search or add a value/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Text...")).not.toBeInTheDocument();
+  });
+
+  it("selecting is_empty commits immediately and hides the value UI", () => {
+    const column = mockTextColumn();
+    render(<TextFilterMenu column={column} />);
+    fireEvent.click(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    fireEvent.click(within(listbox).getByText("Is empty"));
+    expect(column.setFilterValue).toHaveBeenCalledWith(
+      Filter.text({ operator: "is_empty" }),
+    );
+    expect(screen.queryByPlaceholderText("Text...")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /apply/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("apply is disabled when scalar text is empty", () => {
+    const column = mockTextColumn();
+    render(<TextFilterMenu column={column} />);
+    expect(screen.getByRole("button", { name: /apply/i })).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText("Text..."), {
+      target: { value: "x" },
+    });
+    expect(screen.getByRole("button", { name: /apply/i })).not.toBeDisabled();
   });
 });

--- a/frontend/src/components/data-table/__tests__/column-header.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-header.test.tsx
@@ -90,21 +90,20 @@ describe("NumberFilterMenu", () => {
     expect(screen.queryByLabelText("max")).not.toBeInTheDocument();
   });
 
-  it("selecting a nullish operator commits immediately and hides value inputs", () => {
+  it("selecting a nullish operator hides value inputs and commits on Apply", () => {
     const column = mockColumn();
     render(<NumberFilterMenu column={column} />);
     fireEvent.click(screen.getByRole("combobox"));
     const listbox = screen.getByRole("listbox");
     fireEvent.click(within(listbox).getByText("Is null"));
-    expect(column.setFilterValue).toHaveBeenCalledWith(
-      Filter.number({ operator: "is_null" }),
-    );
+    expect(column.setFilterValue).not.toHaveBeenCalled();
     expect(screen.queryByLabelText("min")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("max")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("value")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /apply/i }),
-    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(column.setFilterValue).toHaveBeenCalledWith(
+      Filter.number({ operator: "is_null" }),
+    );
   });
 });
 
@@ -178,19 +177,18 @@ describe("TextFilterMenu", () => {
     expect(screen.queryByPlaceholderText("Text...")).not.toBeInTheDocument();
   });
 
-  it("selecting is_empty commits immediately and hides the value UI", () => {
+  it("selecting is_empty hides the value UI and commits on Apply", () => {
     const column = mockTextColumn();
     render(<TextFilterMenu column={column} />);
     fireEvent.click(screen.getByRole("combobox"));
     const listbox = screen.getByRole("listbox");
     fireEvent.click(within(listbox).getByText("Is empty"));
+    expect(column.setFilterValue).not.toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText("Text...")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
     expect(column.setFilterValue).toHaveBeenCalledWith(
       Filter.text({ operator: "is_empty" }),
     );
-    expect(screen.queryByPlaceholderText("Text...")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /apply/i }),
-    ).not.toBeInTheDocument();
   });
 
   it("apply is disabled when scalar text is empty", () => {

--- a/frontend/src/components/data-table/__tests__/column-header.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-header.test.tsx
@@ -1,0 +1,110 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import type { Column } from "@tanstack/react-table";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+// NumberFilterMenu does not exist yet — Task 5 introduces it.
+// These tests are expected to fail until that change lands.
+import { NumberFilterMenu } from "../column-header";
+import { Filter } from "../filters";
+
+beforeAll(() => {
+  global.HTMLElement.prototype.scrollIntoView = () => {
+    // jsdom does not implement scrollIntoView; Radix calls it on open.
+  };
+  // Radix Select gates pointer interactions on hasPointerCapture; jsdom omits it.
+  if (!global.HTMLElement.prototype.hasPointerCapture) {
+    global.HTMLElement.prototype.hasPointerCapture = () => false;
+  }
+  if (!global.HTMLElement.prototype.releasePointerCapture) {
+    global.HTMLElement.prototype.releasePointerCapture = () => {
+      // no-op
+    };
+  }
+});
+
+function mockColumn(
+  initial?: ReturnType<typeof Filter.number>,
+): Column<unknown, unknown> & {
+  setFilterValue: ReturnType<typeof vi.fn>;
+} {
+  let filterValue = initial;
+  const setFilterValue = vi.fn((next) => {
+    filterValue = next;
+  });
+  return {
+    id: "age",
+    columnDef: { meta: { dataType: "number", filterType: "number" } },
+    getFilterValue: () => filterValue,
+    setFilterValue,
+  } as unknown as Column<unknown, unknown> & {
+    setFilterValue: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("NumberFilterMenu", () => {
+  it("shows all expected operators in the dropdown", () => {
+    const column = mockColumn();
+    render(<NumberFilterMenu column={column} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+    const listbox = screen.getByRole("listbox");
+    const labels = within(listbox)
+      .getAllByRole("option")
+      .map((o) => o.textContent);
+    expect(labels).toEqual([
+      "Between",
+      "Equals",
+      "Doesn't equal",
+      "Greater than",
+      "Greater than or equal",
+      "Less than",
+      "Less than or equal",
+      "Is null",
+      "Is not null",
+    ]);
+  });
+
+  it("between mode disables Apply until both min and max are defined", () => {
+    const column = mockColumn();
+    render(<NumberFilterMenu column={column} />);
+    const apply = screen.getByRole("button", { name: /apply/i });
+    expect(apply).toBeDisabled();
+
+    const min = screen.getByLabelText("min");
+    fireEvent.change(min, { target: { value: "1" } });
+    fireEvent.blur(min);
+    expect(apply).toBeDisabled();
+
+    const max = screen.getByLabelText("max");
+    fireEvent.change(max, { target: { value: "10" } });
+    fireEvent.blur(max);
+    expect(apply).not.toBeDisabled();
+  });
+
+  it("comparison mode shows a single value field seeded from current filter", () => {
+    const column = mockColumn(Filter.number({ operator: ">", value: 18 }));
+    render(<NumberFilterMenu column={column} />);
+    const value = screen.getByLabelText("value") as HTMLInputElement;
+    expect(value).toBeInTheDocument();
+    expect(value.value).toBe("18");
+    expect(screen.queryByLabelText("min")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("max")).not.toBeInTheDocument();
+  });
+
+  it("selecting a nullish operator commits immediately and hides value inputs", () => {
+    const column = mockColumn();
+    render(<NumberFilterMenu column={column} />);
+    fireEvent.click(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    fireEvent.click(within(listbox).getByText("Is null"));
+    expect(column.setFilterValue).toHaveBeenCalledWith(
+      Filter.number({ operator: "is_null" }),
+    );
+    expect(screen.queryByLabelText("min")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("max")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("value")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /apply/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/data-table/__tests__/filter-by-values-picker.test.tsx
+++ b/frontend/src/components/data-table/__tests__/filter-by-values-picker.test.tsx
@@ -1,0 +1,112 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import type { Column } from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { FilterByValuesList } from "../filter-by-values-picker";
+
+beforeAll(() => {
+  global.HTMLElement.prototype.scrollIntoView = () => {
+    // jsdom does not implement scrollIntoView; cmdk calls it on selection.
+  };
+});
+
+function mockColumn(): Column<unknown, unknown> {
+  return {
+    id: "name",
+    columnDef: { meta: { dataType: "string" } },
+  } as unknown as Column<unknown, unknown>;
+}
+
+async function calculateTopK() {
+  return {
+    data: [
+      ["alice", 3],
+      ["bob", 1],
+    ] as Array<[string, number]>,
+  };
+}
+
+describe("FilterByValuesList — creatable", () => {
+  it("shows '+ Add \"X\"' item when creatable and query is non-empty", async () => {
+    const onChange = vi.fn();
+    render(
+      <FilterByValuesList
+        column={mockColumn()}
+        calculateTopKRows={calculateTopK}
+        chosenValues={new Set()}
+        onChange={onChange}
+        creatable={true}
+      />,
+    );
+    await screen.findByText("alice");
+    const input = screen.getByPlaceholderText(/Search or add/i);
+    fireEvent.change(input, { target: { value: "carol" } });
+    expect(await screen.findByText(/\+ Add "carol"/)).toBeInTheDocument();
+  });
+
+  it("commits the literal when '+ Add' is selected", async () => {
+    const onChange = vi.fn();
+    render(
+      <FilterByValuesList
+        column={mockColumn()}
+        calculateTopKRows={calculateTopK}
+        chosenValues={new Set()}
+        onChange={onChange}
+        creatable={true}
+      />,
+    );
+    await screen.findByText("alice");
+    const input = screen.getByPlaceholderText(/Search or add/i);
+    fireEvent.change(input, { target: { value: "carol" } });
+    fireEvent.click(await screen.findByText(/\+ Add "carol"/));
+    expect(onChange).toHaveBeenCalledWith(["carol"]);
+  });
+
+  it("Enter key in creatable mode commits the query as a value", async () => {
+    const onChange = vi.fn();
+    render(
+      <FilterByValuesList
+        column={mockColumn()}
+        calculateTopKRows={calculateTopK}
+        chosenValues={new Set()}
+        onChange={onChange}
+        creatable={true}
+      />,
+    );
+    await screen.findByText("alice");
+    const input = screen.getByPlaceholderText(/Search or add/i);
+    fireEvent.change(input, { target: { value: "dave" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith(["dave"]);
+  });
+
+  it("does NOT show '+ Add' when creatable is false", async () => {
+    render(
+      <FilterByValuesList
+        column={mockColumn()}
+        calculateTopKRows={calculateTopK}
+        chosenValues={new Set()}
+        onChange={vi.fn()}
+        creatable={false}
+      />,
+    );
+    await screen.findByText("alice");
+    const input = screen.getByPlaceholderText(/Search among/i);
+    fireEvent.change(input, { target: { value: "carol" } });
+    expect(screen.queryByText(/\+ Add/)).not.toBeInTheDocument();
+  });
+
+  it("renders chosen values that are not in top-K with — count", async () => {
+    render(
+      <FilterByValuesList
+        column={mockColumn()}
+        calculateTopKRows={calculateTopK}
+        chosenValues={new Set(["zara"])}
+        onChange={vi.fn()}
+      />,
+    );
+    await screen.findByText("alice");
+    expect(screen.getByText("zara")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/data-table/__tests__/filter-pill-editor.test.tsx
+++ b/frontend/src/components/data-table/__tests__/filter-pill-editor.test.tsx
@@ -35,10 +35,7 @@ function makeColumn(
 }
 
 function mockTable(): Table<unknown> {
-  const columns = [
-    makeColumn("name", "text"),
-    makeColumn("age", "number"),
-  ];
+  const columns = [makeColumn("name", "text"), makeColumn("age", "number")];
   return {
     getAllColumns: () => columns,
     getColumn: (id: string) => columns.find((c) => c.id === id),

--- a/frontend/src/components/data-table/__tests__/filter-pill-editor.test.tsx
+++ b/frontend/src/components/data-table/__tests__/filter-pill-editor.test.tsx
@@ -98,8 +98,7 @@ describe("FilterPillEditor — snapshot rehydration", () => {
         onClose={vi.fn()}
       />,
     );
-    expect(await screen.findByText("a")).toBeInTheDocument();
-    expect(await screen.findByText("b")).toBeInTheDocument();
+    expect(await screen.findByText("[a, b]")).toBeInTheDocument();
   });
 
   it("rehydrates a text contains snapshot with seeded text", () => {

--- a/frontend/src/components/data-table/__tests__/filter-pill-editor.test.tsx
+++ b/frontend/src/components/data-table/__tests__/filter-pill-editor.test.tsx
@@ -1,0 +1,179 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import type { Column, Table } from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { FilterPillEditor } from "../filter-pill-editor";
+import { Filter } from "../filters";
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(<TooltipProvider>{ui}</TooltipProvider>);
+
+beforeAll(() => {
+  global.HTMLElement.prototype.scrollIntoView = () => {
+    // jsdom does not implement scrollIntoView; cmdk calls it on selection.
+  };
+  // jsdom lacks hasPointerCapture used by radix Select
+  if (!global.HTMLElement.prototype.hasPointerCapture) {
+    global.HTMLElement.prototype.hasPointerCapture = () => false;
+  }
+  if (!global.HTMLElement.prototype.scrollTo) {
+    global.HTMLElement.prototype.scrollTo = () => {
+      // noop for jsdom
+    };
+  }
+});
+
+function makeColumn(
+  id: string,
+  filterType: "text" | "number" | "boolean" | "select",
+): Column<unknown, unknown> {
+  return {
+    id,
+    columnDef: { meta: { filterType, dataType: "string" } },
+  } as unknown as Column<unknown, unknown>;
+}
+
+function mockTable(): Table<unknown> {
+  const columns = [
+    makeColumn("name", "text"),
+    makeColumn("age", "number"),
+  ];
+  return {
+    getAllColumns: () => columns,
+    getColumn: (id: string) => columns.find((c) => c.id === id),
+    setColumnFilters: vi.fn(),
+  } as unknown as Table<unknown>;
+}
+
+async function calculateTopK() {
+  return {
+    data: [
+      ["alice", 3],
+      ["bob", 1],
+    ] as Array<[string, number]>,
+  };
+}
+
+describe("FilterPillEditor — snapshot rehydration", () => {
+  it("rehydrates a number > snapshot with seeded value", () => {
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "age",
+          value: Filter.number({ operator: ">", value: 18 }),
+        }}
+        table={mockTable()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByDisplayValue("18")).toBeInTheDocument();
+    expect(screen.getByLabelText("value")).toBeInTheDocument();
+    // No min/max range fields rendered for comparison operator.
+    expect(screen.queryByLabelText("min")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("max")).not.toBeInTheDocument();
+  });
+
+  it("rehydrates a number between snapshot with seeded min/max", () => {
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "age",
+          value: Filter.number({ operator: "between", min: 1, max: 9 }),
+        }}
+        table={mockTable()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByDisplayValue("1")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("9")).toBeInTheDocument();
+  });
+
+  it("rehydrates a text in snapshot seeding the creatable picker", async () => {
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "name",
+          value: Filter.text({ operator: "in", values: ["a", "b"] }),
+        }}
+        table={mockTable()}
+        calculateTopKRows={calculateTopK}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(await screen.findByText("a")).toBeInTheDocument();
+    expect(await screen.findByText("b")).toBeInTheDocument();
+  });
+
+  it("rehydrates a text contains snapshot with seeded text", () => {
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "name",
+          value: Filter.text({ operator: "contains", text: "hello" }),
+        }}
+        table={mockTable()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByDisplayValue("hello")).toBeInTheDocument();
+  });
+
+  it("hides the value slot for is_null/is_not_null/is_empty", () => {
+    const { rerender } = renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "name",
+          value: Filter.text({ operator: "is_null" }),
+        }}
+        table={mockTable()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Value")).not.toBeInTheDocument();
+
+    rerender(
+      <TooltipProvider>
+        <FilterPillEditor
+          snapshot={{
+            columnId: "name",
+            value: Filter.text({ operator: "is_empty" }),
+          }}
+          table={mockTable()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+    expect(screen.queryByText("Value")).not.toBeInTheDocument();
+  });
+});
+
+describe("FilterPillEditor — apply", () => {
+  it("commits a number > filter via setColumnFilters", () => {
+    const table = mockTable();
+    const onClose = vi.fn();
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "age",
+          value: Filter.number({ operator: ">", value: 18 }),
+        }}
+        table={table}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Apply filter"));
+    expect(table.setColumnFilters).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const updater = (table.setColumnFilters as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    const next = updater([]);
+    expect(next).toEqual([
+      {
+        id: "age",
+        value: { type: "number", operator: ">", value: 18 },
+      },
+    ]);
+  });
+});

--- a/frontend/src/components/data-table/__tests__/filters.test.ts
+++ b/frontend/src/components/data-table/__tests__/filters.test.ts
@@ -24,7 +24,6 @@ describe("filterToFilterCondition", () => {
       {
         column_id: "col",
         operator: "is_null",
-        value: undefined,
         type: "condition",
         negate: false,
       },
@@ -40,45 +39,53 @@ describe("filterToFilterCondition", () => {
       {
         column_id: "col",
         operator: "is_not_null",
-        value: undefined,
         type: "condition",
         negate: false,
       },
     ]);
   });
 
-  it("handles number filter with min only", () => {
-    const result = filterToFilterCondition("age", Filter.number({ min: 18 }));
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      column_id: "age",
-      operator: ">=",
-      value: 18,
-      type: "condition",
-      negate: false,
-    });
-  });
-
-  it("handles number filter with max only", () => {
-    const result = filterToFilterCondition("age", Filter.number({ max: 65 }));
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      column_id: "age",
-      operator: "<=",
-      value: 65,
-      type: "condition",
-      negate: false,
-    });
-  });
-
-  it("handles number filter with min and max", () => {
+  it("handles number filter with == operator", () => {
     const result = filterToFilterCondition(
       "age",
-      Filter.number({ min: 18, max: 65 }),
+      Filter.number({ operator: "==", value: 42 }),
     );
-    expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ operator: ">=", value: 18 });
-    expect(result[1]).toMatchObject({ operator: "<=", value: 65 });
+    expect(result).toEqual([
+      {
+        column_id: "age",
+        operator: "==",
+        value: 42,
+        type: "condition",
+        negate: false,
+      },
+    ]);
+  });
+
+  it("handles number filter with all comparison operators", () => {
+    for (const op of ["==", "!=", ">", ">=", "<", "<="] as const) {
+      const result = filterToFilterCondition(
+        "x",
+        Filter.number({ operator: op, value: 5 }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ operator: op, value: 5 });
+    }
+  });
+
+  it("number / between emits a single between condition", () => {
+    const result = filterToFilterCondition(
+      "age",
+      Filter.number({ operator: "between", min: 18, max: 65 }),
+    );
+    expect(result).toEqual([
+      {
+        column_id: "age",
+        operator: "between",
+        value: { min: 18, max: 65 },
+        type: "condition",
+        negate: false,
+      },
+    ]);
   });
 
   it("handles text filter", () => {
@@ -97,6 +104,71 @@ describe("filterToFilterCondition", () => {
     ]);
   });
 
+  it("handles text filter with all single-string operators", () => {
+    for (const op of [
+      "contains",
+      "equals",
+      "does_not_equal",
+      "regex",
+      "starts_with",
+      "ends_with",
+    ] as const) {
+      const result = filterToFilterCondition(
+        "col",
+        Filter.text({ operator: op, text: "x" }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ operator: op, value: "x" });
+    }
+  });
+
+  it("handles text filter with in operator", () => {
+    const result = filterToFilterCondition(
+      "name",
+      Filter.text({ operator: "in", values: ["alice", "bob"] }),
+    );
+    expect(result).toEqual([
+      {
+        column_id: "name",
+        operator: "in",
+        value: ["alice", "bob"],
+        type: "condition",
+        negate: false,
+      },
+    ]);
+  });
+
+  it("handles text filter with not_in operator", () => {
+    const result = filterToFilterCondition(
+      "name",
+      Filter.text({ operator: "not_in", values: ["alice"] }),
+    );
+    expect(result).toEqual([
+      {
+        column_id: "name",
+        operator: "not_in",
+        value: ["alice"],
+        type: "condition",
+        negate: false,
+      },
+    ]);
+  });
+
+  it("handles text filter with is_empty operator", () => {
+    const result = filterToFilterCondition(
+      "name",
+      Filter.text({ operator: "is_empty" }),
+    );
+    expect(result).toEqual([
+      {
+        column_id: "name",
+        operator: "is_empty",
+        type: "condition",
+        negate: false,
+      },
+    ]);
+  });
+
   it("handles boolean true filter", () => {
     const result = filterToFilterCondition(
       "active",
@@ -106,7 +178,6 @@ describe("filterToFilterCondition", () => {
       {
         column_id: "active",
         operator: "is_true",
-        value: undefined,
         type: "condition",
         negate: false,
       },
@@ -122,7 +193,6 @@ describe("filterToFilterCondition", () => {
       {
         column_id: "active",
         operator: "is_false",
-        value: undefined,
         type: "condition",
         negate: false,
       },
@@ -166,7 +236,7 @@ describe("filterToFilterCondition", () => {
   it("every condition has type and negate fields", () => {
     const result = filterToFilterCondition(
       "col",
-      Filter.number({ min: 1, max: 10 }),
+      Filter.number({ operator: "between", min: 1, max: 10 }),
     );
     for (const condition of result) {
       expect(condition).toHaveProperty("type", "condition");
@@ -188,7 +258,7 @@ describe("filtersToFilterGroup", () => {
 
   it("wraps single filter in AND group", () => {
     const result = filtersToFilterGroup([
-      { id: "age", value: Filter.number({ min: 18 }) },
+      { id: "age", value: Filter.number({ operator: ">=", value: 18 }) },
     ]);
     expect(result.type).toBe("group");
     expect(result.operator).toBe("and");
@@ -198,19 +268,25 @@ describe("filtersToFilterGroup", () => {
 
   it("wraps multiple filters in AND group", () => {
     const result = filtersToFilterGroup([
-      { id: "age", value: Filter.number({ min: 18 }) },
+      { id: "age", value: Filter.number({ operator: ">=", value: 18 }) },
       { id: "name", value: Filter.text({ text: "foo", operator: "contains" }) },
     ]);
     expect(result.children).toHaveLength(2);
     expect(result.operator).toBe("and");
   });
 
-  it("flattens multi-condition filters", () => {
+  it("between filter emits a single between condition", () => {
     const result = filtersToFilterGroup([
-      { id: "age", value: Filter.number({ min: 18, max: 65 }) },
+      {
+        id: "age",
+        value: Filter.number({ operator: "between", min: 18, max: 65 }),
+      },
     ]);
-    // min + max = 2 conditions
-    expect(result.children).toHaveLength(2);
+    expect(result.children).toHaveLength(1);
+    expect(result.children[0]).toMatchObject({
+      operator: "between",
+      value: { min: 18, max: 65 },
+    });
   });
 });
 

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -438,9 +438,6 @@ export const NumberFilterMenu = <TData, TValue>({
 
   const handleOperatorChange = (next: OperatorType) => {
     setOperator(next);
-    if (next === "is_null" || next === "is_not_null") {
-      column.setFilterValue(Filter.number({ operator: next }));
-    }
   };
 
   return (
@@ -478,14 +475,12 @@ export const NumberFilterMenu = <TData, TValue>({
           className="shadow-none! border-border hover:shadow-none!"
         />
       )}
-      {!isNullish && (
-        <FilterButtons
-          onApply={handleApply}
-          onClear={handleClear}
-          clearButtonDisabled={!hasFilter}
-          applyButtonDisabled={applyDisabled}
-        />
-      )}
+      <FilterButtons
+        onApply={handleApply}
+        onClear={handleClear}
+        clearButtonDisabled={!hasFilter}
+        applyButtonDisabled={applyDisabled}
+      />
     </div>
   );
 };
@@ -548,9 +543,6 @@ export const TextFilterMenu = <TData, TValue>({
 
   const handleOperatorChange = (next: OperatorType) => {
     setOperator(next);
-    if (next === "is_null" || next === "is_not_null" || next === "is_empty") {
-      column.setFilterValue(Filter.text({ operator: next }));
-    }
   };
 
   return (
@@ -597,14 +589,12 @@ export const TextFilterMenu = <TData, TValue>({
           creatable={true}
         />
       )}
-      {!isNullish && (
-        <FilterButtons
-          onApply={handleApply}
-          onClear={handleClear}
-          clearButtonDisabled={!hasFilter}
-          applyButtonDisabled={applyDisabled}
-        />
-      )}
+      <FilterButtons
+        onApply={handleApply}
+        onClear={handleClear}
+        clearButtonDisabled={!hasFilter}
+        applyButtonDisabled={applyDisabled}
+      />
     </div>
   );
 };

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -311,10 +311,7 @@ const OperatorSelect = ({
   options: readonly OperatorType[];
   onChange: (next: OperatorType) => void;
 }) => (
-  <Select
-    value={operator}
-    onValueChange={(v) => onChange(v as OperatorType)}
-  >
+  <Select value={operator} onValueChange={(v) => onChange(v as OperatorType)}>
     <SelectTrigger className="border-border shadow-none! ring-0! w-full mb-0.5">
       <SelectValue />
     </SelectTrigger>
@@ -551,11 +548,7 @@ export const TextFilterMenu = <TData, TValue>({
 
   const handleOperatorChange = (next: OperatorType) => {
     setOperator(next);
-    if (
-      next === "is_null" ||
-      next === "is_not_null" ||
-      next === "is_empty"
-    ) {
+    if (next === "is_null" || next === "is_not_null" || next === "is_empty") {
       column.setFilterValue(Filter.text({ operator: next }));
     }
   };

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -574,6 +574,7 @@ export const TextFilterMenu = <TData, TValue>({
           onChange={(e) => setText(e.target.value)}
           placeholder="Text..."
           onKeyDown={(e) => {
+            e.stopPropagation();
             if (e.key === "Enter") {
               handleApply();
             }

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -9,7 +9,7 @@ import {
   TextIcon,
   XIcon,
 } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useLocale } from "react-aria";
 import {
   DropdownMenu,
@@ -26,7 +26,6 @@ import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
 import type { OperatorType } from "@/plugins/impl/data-frames/utils/operators";
 import { logNever } from "@/utils/assertNever";
 import { cn } from "@/utils/cn";
-import { capitalize } from "@/utils/strings";
 import { Button } from "../ui/button";
 import { DraggablePopover } from "../ui/draggable-popover";
 import { Input } from "../ui/input";
@@ -36,15 +35,18 @@ import {
   Select,
   SelectContent,
   SelectItem,
-  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
 import { FilterByValuesList } from "./filter-by-values-picker";
+import { OPERATOR_LABELS } from "./operator-labels";
 import {
   type ColumnFilterForType,
   type ColumnFilterValue,
   Filter,
+  NUMBER_COMPARISON_OPS,
+  type NumberComparisonOp,
+  NUMBER_OPS,
 } from "./filters";
 import {
   ClearFilterMenuItem,
@@ -261,7 +263,7 @@ export function renderMenuItemFilter<TData, TValue>(
         {filterMenuItem}
         <DropdownMenuPortal>
           <DropdownMenuSubContent>
-            <NumberRangeFilter column={column} />
+            <NumberFilterMenu column={column} />
           </DropdownMenuSubContent>
         </DropdownMenuPortal>
       </DropdownMenuSub>
@@ -292,58 +294,31 @@ export function renderMenuItemFilter<TData, TValue>(
   return null;
 }
 
-// Type-safe constants for null filter operators
-const NULL_FILTER_OPERATORS = {
-  is_null: "is_null",
-  is_not_null: "is_not_null",
-} satisfies Record<string, OperatorType>;
-
-const NullFilter = <TData, TValue>({
-  column,
-  defaultItem,
+const OperatorSelect = ({
   operator,
-  setOperator,
+  options,
+  onChange,
 }: {
-  column: Column<TData, TValue>;
-  defaultItem?: OperatorType | "between";
-  operator: OperatorType | "between";
-  setOperator: (operator: OperatorType) => void;
-}) => {
-  const handleValueChange = (value: OperatorType) => {
-    setOperator(value);
-    if (value === "is_null" || value === "is_not_null") {
-      column.setFilterValue(Filter.text({ operator: value }));
-    }
-  };
-
-  const isNullOrNotNull = operator === "is_null" || operator === "is_not_null";
-
-  return (
-    <Select
-      value={operator}
-      onValueChange={(value) => handleValueChange(value as OperatorType)}
-    >
-      <SelectTrigger
-        className={cn(
-          "border-border shadow-none! ring-0! w-full mb-0.5",
-          isNullOrNotNull && "mb-2",
-        )}
-      >
-        <SelectValue defaultValue={operator} />
-      </SelectTrigger>
-      <SelectContent>
-        {defaultItem && (
-          <SelectItem value={defaultItem}>{capitalize(defaultItem)}</SelectItem>
-        )}
-        <SelectSeparator />
-        <SelectItem value={NULL_FILTER_OPERATORS.is_null}>Is null</SelectItem>
-        <SelectItem value={NULL_FILTER_OPERATORS.is_not_null}>
-          Is not null
+  operator: OperatorType;
+  options: readonly OperatorType[];
+  onChange: (next: OperatorType) => void;
+}) => (
+  <Select
+    value={operator}
+    onValueChange={(v) => onChange(v as OperatorType)}
+  >
+    <SelectTrigger className="border-border shadow-none! ring-0! w-full mb-0.5">
+      <SelectValue />
+    </SelectTrigger>
+    <SelectContent>
+      {options.map((op) => (
+        <SelectItem key={op} value={op}>
+          {OPERATOR_LABELS[op]}
         </SelectItem>
-      </SelectContent>
-    </Select>
-  );
-};
+      ))}
+    </SelectContent>
+  </Select>
+);
 
 const BooleanFilter = <TData, TValue>({
   column,
@@ -389,7 +364,21 @@ const BooleanFilter = <TData, TValue>({
   );
 };
 
-const NumberRangeFilter = <TData, TValue>({
+const NUMBER_COMPARISON_SET: ReadonlySet<OperatorType> = new Set(
+  NUMBER_COMPARISON_OPS,
+);
+const isNumberComparisonOp = (op: OperatorType): op is NumberComparisonOp =>
+  NUMBER_COMPARISON_SET.has(op);
+
+type NumberComparisonFilter = Extract<
+  ColumnFilterForType<"number">,
+  { value: number }
+>;
+const isNumberComparisonFilter = (
+  filter: ColumnFilterForType<"number">,
+): filter is NumberComparisonFilter => isNumberComparisonOp(filter.operator);
+
+export const NumberFilterMenu = <TData, TValue>({
   column,
 }: {
   column: Column<TData, TValue>;
@@ -399,83 +388,98 @@ const NumberRangeFilter = <TData, TValue>({
     | undefined;
   const hasFilter = currentFilter !== undefined;
 
-  const [operator, setOperator] = useState<OperatorType | "between">(
+  const [operator, setOperator] = useState<OperatorType>(
     currentFilter?.operator ?? "between",
   );
-  const [min, setMin] = useState<number | undefined>(currentFilter?.min);
-  const [max, setMax] = useState<number | undefined>(currentFilter?.max);
-  const minRef = useRef<HTMLInputElement>(null);
-  const maxRef = useRef<HTMLInputElement>(null);
+  const [min, setMin] = useState<number | undefined>(
+    currentFilter?.operator === "between" ? currentFilter.min : undefined,
+  );
+  const [max, setMax] = useState<number | undefined>(
+    currentFilter?.operator === "between" ? currentFilter.max : undefined,
+  );
+  const [value, setValue] = useState<number | undefined>(
+    currentFilter !== undefined && isNumberComparisonFilter(currentFilter)
+      ? currentFilter.value
+      : undefined,
+  );
 
-  const handleApply = (opts: { min?: number; max?: number } = {}) => {
-    column.setFilterValue(
-      Filter.number({
-        min: opts.min ?? min,
-        max: opts.max ?? max,
-        operator: operator === "between" ? undefined : operator,
-      }),
-    );
+  const isComparison = isNumberComparisonOp(operator);
+  const isNullish = operator === "is_null" || operator === "is_not_null";
+
+  const applyDisabled =
+    (operator === "between" && (min === undefined || max === undefined)) ||
+    (isComparison && value === undefined);
+
+  const handleApply = () => {
+    if (isNullish) {
+      column.setFilterValue(Filter.number({ operator }));
+      return;
+    }
+    if (operator === "between" && min !== undefined && max !== undefined) {
+      column.setFilterValue(Filter.number({ operator: "between", min, max }));
+      return;
+    }
+    if (isComparison && value !== undefined) {
+      column.setFilterValue(Filter.number({ operator, value }));
+    }
+  };
+
+  const handleClear = () => {
+    setMin(undefined);
+    setMax(undefined);
+    setValue(undefined);
+    column.setFilterValue(undefined);
+  };
+
+  const handleOperatorChange = (next: OperatorType) => {
+    setOperator(next);
+    if (next === "is_null" || next === "is_not_null") {
+      column.setFilterValue(Filter.number({ operator: next }));
+    }
   };
 
   return (
     <div className="flex flex-col gap-1 pt-3 px-2">
-      <NullFilter
-        column={column}
-        defaultItem="between"
+      <OperatorSelect
         operator={operator}
-        setOperator={setOperator}
+        options={NUMBER_OPS}
+        onChange={handleOperatorChange}
       />
       {operator === "between" && (
-        <>
-          <div className="flex gap-1 items-center">
-            <NumberField
-              ref={minRef}
-              value={min}
-              onChange={(value) => setMin(value)}
-              aria-label="min"
-              placeholder="min"
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleApply({
-                    min: Number.parseFloat(e.currentTarget.value),
-                  });
-                }
-                if (e.key === "Tab") {
-                  maxRef.current?.focus();
-                }
-              }}
-              className="shadow-none! border-border hover:shadow-none!"
-            />
-            <MinusIcon className="h-5 w-5 text-muted-foreground" />
-            <NumberField
-              ref={maxRef}
-              value={max}
-              onChange={(value) => setMax(value)}
-              aria-label="max"
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleApply({
-                    max: Number.parseFloat(e.currentTarget.value),
-                  });
-                }
-                if (e.key === "Tab") {
-                  minRef.current?.focus();
-                }
-              }}
-              placeholder="max"
-              className="shadow-none! border-border hover:shadow-none!"
-            />
-          </div>
-          <FilterButtons
-            onApply={handleApply}
-            onClear={() => {
-              setMin(undefined);
-              setMax(undefined);
-              column.setFilterValue(undefined);
-            }}
-            clearButtonDisabled={!hasFilter}
+        <div className="flex gap-1 items-center">
+          <NumberField
+            value={min}
+            onChange={setMin}
+            aria-label="min"
+            placeholder="min"
+            className="shadow-none! border-border hover:shadow-none!"
           />
-        </>
+          <MinusIcon className="h-5 w-5 text-muted-foreground" />
+          <NumberField
+            value={max}
+            onChange={setMax}
+            aria-label="max"
+            placeholder="max"
+            className="shadow-none! border-border hover:shadow-none!"
+          />
+        </div>
+      )}
+      {isComparison && (
+        <NumberField
+          value={value}
+          onChange={setValue}
+          aria-label="value"
+          placeholder="value"
+          className="shadow-none! border-border hover:shadow-none!"
+        />
+      )}
+      {!isNullish && (
+        <FilterButtons
+          onApply={handleApply}
+          onClear={handleClear}
+          clearButtonDisabled={!hasFilter}
+          applyButtonDisabled={applyDisabled}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -47,6 +47,9 @@ import {
   NUMBER_COMPARISON_OPS,
   type NumberComparisonOp,
   NUMBER_OPS,
+  TEXT_OPS,
+  TEXT_SCALAR_OPS,
+  type TextScalarOp,
 } from "./filters";
 import {
   ClearFilterMenuItem,
@@ -150,7 +153,7 @@ export const DataTableColumnHeader = <TData, TValue>({
               {renderColumnWrapping(column)}
               {renderFormatOptions(column, locale)}
               <DropdownMenuSeparator />
-              {renderMenuItemFilter(column)}
+              {renderMenuItemFilter(column, calculateTopKRows)}
               {renderFilterByValues(column, setIsFilterValueOpen)}
               {hasFilter && <ClearFilterMenuItem column={column} />}
             </DropdownMenuContent>
@@ -213,6 +216,7 @@ const SortButton = <TData, TValue>({
 
 export function renderMenuItemFilter<TData, TValue>(
   column: Column<TData, TValue>,
+  calculateTopKRows?: CalculateTopKRows,
 ) {
   const canFilter = column.getCanFilter();
   if (!canFilter) {
@@ -250,7 +254,10 @@ export function renderMenuItemFilter<TData, TValue>(
         {filterMenuItem}
         <DropdownMenuPortal>
           <DropdownMenuSubContent>
-            <TextFilter column={column} />
+            <TextFilterMenu
+              column={column}
+              calculateTopKRows={calculateTopKRows}
+            />
           </DropdownMenuSubContent>
         </DropdownMenuPortal>
       </DropdownMenuSub>
@@ -485,66 +492,111 @@ export const NumberFilterMenu = <TData, TValue>({
   );
 };
 
-const TextFilter = <TData, TValue>({
+const TEXT_SCALAR_SET: ReadonlySet<OperatorType> = new Set(TEXT_SCALAR_OPS);
+const isTextScalarOp = (op: OperatorType): op is TextScalarOp =>
+  TEXT_SCALAR_SET.has(op);
+
+export const TextFilterMenu = <TData, TValue>({
   column,
+  calculateTopKRows,
 }: {
   column: Column<TData, TValue>;
+  calculateTopKRows?: CalculateTopKRows;
 }) => {
   const currentFilter = column.getFilterValue() as
     | ColumnFilterForType<"text">
     | undefined;
   const hasFilter = currentFilter !== undefined;
-  const [value, setValue] = useState<string>(currentFilter?.text ?? "");
+
   const [operator, setOperator] = useState<OperatorType>(
     currentFilter?.operator ?? "contains",
   );
+  const [text, setText] = useState<string>(
+    currentFilter && "text" in currentFilter ? currentFilter.text : "",
+  );
+  const [values, setValues] = useState<string[]>(
+    currentFilter && "values" in currentFilter ? [...currentFilter.values] : [],
+  );
+
+  const isScalar = isTextScalarOp(operator);
+  const isMulti = operator === "in" || operator === "not_in";
+  const isNullish =
+    operator === "is_null" ||
+    operator === "is_not_null" ||
+    operator === "is_empty";
+
+  const applyDisabled =
+    (isScalar && text === "") || (isMulti && values.length === 0);
 
   const handleApply = () => {
-    if (operator !== "contains") {
+    if (isNullish) {
       column.setFilterValue(Filter.text({ operator }));
       return;
     }
-
-    if (value === "") {
-      column.setFilterValue(undefined);
+    if (isScalar && text !== "") {
+      column.setFilterValue(Filter.text({ operator, text }));
       return;
     }
+    if (isMulti && values.length > 0) {
+      column.setFilterValue(Filter.text({ operator, values }));
+    }
+  };
 
-    column.setFilterValue(Filter.text({ text: value, operator }));
+  const handleClear = () => {
+    setText("");
+    setValues([]);
+    column.setFilterValue(undefined);
+  };
+
+  const handleOperatorChange = (next: OperatorType) => {
+    setOperator(next);
+    if (
+      next === "is_null" ||
+      next === "is_not_null" ||
+      next === "is_empty"
+    ) {
+      column.setFilterValue(Filter.text({ operator: next }));
+    }
   };
 
   return (
     <div className="flex flex-col gap-1 pt-3 px-2">
-      <NullFilter
-        column={column}
-        defaultItem="contains"
+      <OperatorSelect
         operator={operator}
-        setOperator={setOperator}
+        options={TEXT_OPS}
+        onChange={handleOperatorChange}
       />
-      {operator === "contains" && (
-        <>
-          <Input
-            type="text"
-            icon={<TextIcon className="h-3 w-3 text-muted-foreground mb-1" />}
-            value={value ?? ""}
-            onChange={(e) => setValue(e.target.value)}
-            placeholder="Text..."
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                handleApply();
-              }
-            }}
-            className="shadow-none! border-border hover:shadow-none!"
-          />
-          <FilterButtons
-            onApply={handleApply}
-            onClear={() => {
-              setValue("");
-              column.setFilterValue(undefined);
-            }}
-            clearButtonDisabled={!hasFilter}
-          />
-        </>
+      {isScalar && (
+        <Input
+          type="text"
+          icon={<TextIcon className="h-3 w-3 text-muted-foreground mb-1" />}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Text..."
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              handleApply();
+            }
+          }}
+          className="shadow-none! border-border hover:shadow-none!"
+        />
+      )}
+      {isMulti && (
+        <FilterByValuesList
+          column={column}
+          calculateTopKRows={calculateTopKRows}
+          chosenValues={new Set(values)}
+          onChange={(next) => setValues(next.map(String))}
+          creatable={true}
+        />
+      )}
+      {!isNullish && (
+        <FilterButtons
+          onApply={handleApply}
+          onClear={handleClear}
+          clearButtonDisabled={!hasFilter}
+          applyButtonDisabled={applyDisabled}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -29,6 +29,7 @@ import { cn } from "@/utils/cn";
 import { Button } from "../ui/button";
 import { DraggablePopover } from "../ui/draggable-popover";
 import { Input } from "../ui/input";
+import { RegexInput } from "./regex-input";
 import { NumberField } from "../ui/number-field";
 import { PopoverClose } from "../ui/popover";
 import {
@@ -566,7 +567,19 @@ export const TextFilterMenu = <TData, TValue>({
         options={TEXT_OPS}
         onChange={handleOperatorChange}
       />
-      {isScalar && (
+      {isScalar && operator === "regex" && (
+        <RegexInput
+          value={text}
+          onChange={setText}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") {
+              handleApply();
+            }
+          }}
+        />
+      )}
+      {isScalar && operator !== "regex" && (
         <Input
           type="text"
           icon={<TextIcon className="h-3 w-3 text-muted-foreground mb-1" />}

--- a/frontend/src/components/data-table/filter-by-values-picker.tsx
+++ b/frontend/src/components/data-table/filter-by-values-picker.tsx
@@ -60,6 +60,7 @@ export const FilterByValuesPicker = <TData, TValue>({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild={true}>
         <Button
+          type="button"
           variant="outline"
           size="xs"
           className="h-6 mb-1 w-full justify-between font-normal"

--- a/frontend/src/components/data-table/filter-by-values-picker.tsx
+++ b/frontend/src/components/data-table/filter-by-values-picker.tsx
@@ -32,6 +32,7 @@ interface Props<TData, TValue> {
   calculateTopKRows?: CalculateTopKRows;
   chosenValues: unknown[];
   onChange: (values: unknown[]) => void;
+  creatable?: boolean;
 }
 
 export const FilterByValuesPicker = <TData, TValue>({
@@ -39,6 +40,7 @@ export const FilterByValuesPicker = <TData, TValue>({
   calculateTopKRows,
   chosenValues,
   onChange,
+  creatable = false,
 }: Props<TData, TValue>) => {
   const [open, setOpen] = useState(false);
 
@@ -79,6 +81,7 @@ export const FilterByValuesPicker = <TData, TValue>({
           calculateTopKRows={calculateTopKRows}
           chosenValues={chosenValuesSet}
           onChange={onChange}
+          creatable={creatable}
         />
       </PopoverContent>
     </Popover>

--- a/frontend/src/components/data-table/filter-by-values-picker.tsx
+++ b/frontend/src/components/data-table/filter-by-values-picker.tsx
@@ -229,7 +229,8 @@ export const FilterByValuesList = <TData, TValue>({
             : `Search among the top ${data.length} values`
         }
         autoFocus={true}
-        onValueChange={(value) => setQuery(value.trim())}
+        value={query}
+        onValueChange={setQuery}
         onKeyDown={(e) => {
           if (e.key === "Enter" && canCreate) {
             e.preventDefault();

--- a/frontend/src/components/data-table/filter-by-values-picker.tsx
+++ b/frontend/src/components/data-table/filter-by-values-picker.tsx
@@ -90,6 +90,7 @@ interface FilterByValuesListProps<TData, TValue> {
   calculateTopKRows?: CalculateTopKRows;
   chosenValues: Set<unknown>;
   onChange: (values: unknown[]) => void;
+  creatable?: boolean;
 }
 
 /**
@@ -100,6 +101,7 @@ export const FilterByValuesList = <TData, TValue>({
   calculateTopKRows,
   chosenValues,
   onChange,
+  creatable = false,
 }: FilterByValuesListProps<TData, TValue>) => {
   const [query, setQuery] = useState<string>("");
 
@@ -133,13 +135,48 @@ export const FilterByValuesList = <TData, TValue>({
     }
   }, [data, query]);
 
+  // Surface chosen values that aren't in the top-K so they stay visible/uncheckable.
+  // Count is undefined for these rows; the cell renders an em-dash.
+  const mergedData = useMemo<Array<[unknown, number | undefined]>>(() => {
+    const seen = new Set(filteredData.map(([v]) => v));
+    const extras: Array<[unknown, number | undefined]> = [];
+    for (const chosen of chosenValues) {
+      if (seen.has(chosen)) {
+        continue;
+      }
+      const str = String(chosen);
+      const matches =
+        query.length === 0 ||
+        smartMatch(query, str) ||
+        str.toLowerCase().includes(query.toLowerCase());
+      if (matches) {
+        extras.push([chosen, undefined]);
+      }
+    }
+    return [...filteredData, ...extras];
+  }, [filteredData, chosenValues, query]);
+
   const handleToggle = (value: unknown) => {
     onChange([...Sets.toggle(chosenValues, value)]);
   };
 
+  const trimmedQuery = query.trim();
+  const canCreate =
+    creatable &&
+    trimmedQuery !== "" &&
+    !mergedData.some(([v]) => String(v) === trimmedQuery);
+
+  const commitCreate = () => {
+    if (!canCreate) {
+      return;
+    }
+    onChange([...chosenValues, trimmedQuery]);
+    setQuery("");
+  };
+
   const allVisibleChecked =
-    filteredData.length > 0 &&
-    filteredData.every(([value]) => chosenValues.has(value));
+    mergedData.length > 0 &&
+    mergedData.every(([value]) => chosenValues.has(value));
 
   const selectAllState: boolean | "indeterminate" = allVisibleChecked
     ? true
@@ -153,11 +190,11 @@ export const FilterByValuesList = <TData, TValue>({
     }
     const next = new Set(chosenValues);
     if (allVisibleChecked) {
-      for (const [value] of filteredData) {
+      for (const [value] of mergedData) {
         next.delete(value);
       }
     } else {
-      for (const [value] of filteredData) {
+      for (const [value] of mergedData) {
         next.add(value);
       }
     }
@@ -183,13 +220,23 @@ export const FilterByValuesList = <TData, TValue>({
   return (
     <Command className="text-sm outline-hidden" shouldFilter={false}>
       <CommandInput
-        placeholder={`Search among the top ${data.length} values`}
+        placeholder={
+          creatable
+            ? "Search or add a value…"
+            : `Search among the top ${data.length} values`
+        }
         autoFocus={true}
         onValueChange={(value) => setQuery(value.trim())}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && canCreate) {
+            e.preventDefault();
+            commitCreate();
+          }
+        }}
       />
       <CommandEmpty>No results found.</CommandEmpty>
       <CommandList>
-        {filteredData.length > 0 && (
+        {mergedData.length > 0 && (
           <CommandItem
             value="__select-all__"
             className="border-b rounded-none px-3"
@@ -204,7 +251,7 @@ export const FilterByValuesList = <TData, TValue>({
             <span className="font-bold">Count</span>
           </CommandItem>
         )}
-        {filteredData.map(([value, count]) => {
+        {mergedData.map(([value, count]) => {
           const isSelected = chosenValues.has(value);
           const valueString = stringifyUnknownValue({ value });
           const sentinel = detectSentinel(
@@ -226,10 +273,19 @@ export const FilterByValuesList = <TData, TValue>({
               <span className="flex-1 overflow-hidden max-h-20 line-clamp-3">
                 {sentinel ? <SentinelCell sentinel={sentinel} /> : valueString}
               </span>
-              <span className="ml-3">{count}</span>
+              <span className="ml-3">{count === undefined ? "—" : count}</span>
             </CommandItem>
           );
         })}
+        {canCreate && (
+          <CommandItem
+            value={`__create__:${trimmedQuery}`}
+            className="border-t rounded-none px-3 italic"
+            onSelect={commitCreate}
+          >
+            + Add "{trimmedQuery}"
+          </CommandItem>
+        )}
       </CommandList>
       {data.length === TOP_K_ROWS && (
         <span className="text-xs text-muted-foreground py-1.5 text-center">

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -3,7 +3,7 @@
 
 import type { Column, Table } from "@tanstack/react-table";
 import { CheckIcon, MinusIcon, Trash2Icon, XIcon } from "lucide-react";
-import { useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
 import type { OperatorType } from "@/plugins/impl/data-frames/utils/operators";
 import { Combobox, ComboboxItem } from "../ui/combobox";
@@ -17,10 +17,7 @@ import {
   SelectValue,
 } from "../ui/select";
 import { Button } from "../ui/button";
-import {
-  FilterByValuesList,
-  FilterByValuesPicker,
-} from "./filter-by-values-picker";
+import { FilterByValuesPicker } from "./filter-by-values-picker";
 import {
   type ColumnFilterValue,
   Filter,
@@ -126,10 +123,7 @@ export const FilterPillEditor = <TData,>({
     id: string;
     operator: OperatorType;
   }) => {
-    if (
-      args.id === snapshot.columnId &&
-      args.operator === snapshotOperator
-    ) {
+    if (args.id === snapshot.columnId && args.operator === snapshotOperator) {
       setDraftValue(snapshotDraft);
     }
   };
@@ -158,22 +152,31 @@ export const FilterPillEditor = <TData,>({
 
   const handleOperatorChange = (nextOp: OperatorType) => {
     setDraftOperator(nextOp);
-    setDraftValue(emptyDraftFor(draftType, nextOp));
+    const nextEmpty = emptyDraftFor(draftType, nextOp);
+    if (nextEmpty.kind !== draftValue.kind) {
+      setDraftValue(nextEmpty);
+    }
     rehydrateIfMatchesSnapshot({
       id: draftColumnId,
       operator: nextOp,
     });
   };
 
+  const pendingValue = buildFilterValue({
+    type: draftType,
+    operator: draftOperator,
+    draft: draftValue,
+  });
+  const applyDisabled = pendingValue === undefined;
+  const applyTooltip = applyDisabled
+    ? getMissingValueMessage(draftType, draftOperator)
+    : "Apply filter";
+
   const handleApply = () => {
-    const value = buildFilterValue({
-      type: draftType,
-      operator: draftOperator,
-      draft: draftValue,
-    });
-    if (!value) {
+    if (!pendingValue) {
       return;
     }
+    const value = pendingValue;
     table.setColumnFilters((filters) => {
       const dropIds = new Set([snapshot.columnId, draftColumnId]);
       const filtered = filters.filter((f) => !dropIds.has(f.id));
@@ -192,8 +195,27 @@ export const FilterPillEditor = <TData,>({
   const showValueSlot = !OPERATORS_WITHOUT_VALUE.has(draftOperator);
   const operatorOptions = OPERATORS_BY_TYPE[draftType];
 
+  const valueSlotRef = useRef<HTMLDivElement>(null);
+  const operatorTriggerRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    const firstInput = valueSlotRef.current?.querySelector<HTMLElement>(
+      'input, [role="combobox"]',
+    );
+    if (firstInput) {
+      firstInput.focus();
+    } else {
+      operatorTriggerRef.current?.focus();
+    }
+  }, [draftType, draftOperator]);
+
   return (
-    <div className="flex flex-row gap-4 items-end p-3">
+    <form
+      className="flex flex-row gap-4 items-end p-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleApply();
+      }}
+    >
       <div className="flex flex-col gap-1">
         <label className="text-xs text-muted-foreground" htmlFor={columnId}>
           Column
@@ -218,10 +240,15 @@ export const FilterPillEditor = <TData,>({
           Operator
         </label>
         <Select
+          key={draftType}
           value={draftOperator}
           onValueChange={(v) => handleOperatorChange(v as OperatorType)}
         >
-          <SelectTrigger id={operatorId} className="h-6 mb-1 bg-transparent">
+          <SelectTrigger
+            ref={operatorTriggerRef}
+            id={operatorId}
+            className="h-6 mb-1 bg-transparent"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -234,7 +261,7 @@ export const FilterPillEditor = <TData,>({
         </Select>
       </div>
       {showValueSlot && (
-        <div className="flex flex-col gap-1">
+        <div ref={valueSlotRef} className="flex flex-col gap-1">
           <label htmlFor={valueId} className="text-xs text-muted-foreground">
             Value
           </label>
@@ -250,17 +277,19 @@ export const FilterPillEditor = <TData,>({
         </div>
       )}
       <div className="flex gap-1 mb-1">
-        <Tooltip content="Apply filter">
-          <Button
-            type="button"
-            size="icon"
-            variant="ghost"
-            className="rounded-full text-primary hover:text-primary hover:bg-primary/10"
-            onClick={handleApply}
-            aria-label="Apply filter"
-          >
-            <CheckIcon className="h-3.5 w-3.5" aria-hidden={true} />
-          </Button>
+        <Tooltip content={applyTooltip}>
+          <span className="inline-flex">
+            <Button
+              type="submit"
+              size="icon"
+              variant="ghost"
+              disabled={applyDisabled}
+              className="rounded-full text-primary hover:text-primary hover:bg-primary/10"
+              aria-label="Apply filter"
+            >
+              <CheckIcon className="h-3.5 w-3.5" aria-hidden={true} />
+            </Button>
+          </span>
         </Tooltip>
         <Tooltip content="Close without saving">
           <Button
@@ -287,7 +316,7 @@ export const FilterPillEditor = <TData,>({
           </Button>
         </Tooltip>
       </div>
-    </div>
+    </form>
   );
 };
 
@@ -313,7 +342,7 @@ const ValueSlot = <TData, TValue>({
   if (type === "number" && operator === "between") {
     const v = value.kind === "between" ? value : { kind: "between" as const };
     return (
-      <div className="flex gap-1 items-center w-48">
+      <div className="flex gap-1 items-center w-44">
         <NumberField
           id={id}
           value={v.min}
@@ -335,7 +364,9 @@ const ValueSlot = <TData, TValue>({
   }
   if (type === "number" && isNumberComparisonOp(operator)) {
     const v =
-      value.kind === "single-number" ? value : { kind: "single-number" as const };
+      value.kind === "single-number"
+        ? value
+        : { kind: "single-number" as const };
     return (
       <NumberField
         id={id}
@@ -343,7 +374,7 @@ const ValueSlot = <TData, TValue>({
         onChange={(n) => onChange({ kind: "single-number", value: n })}
         aria-label="value"
         placeholder="value"
-        className="border-input min-w-0"
+        className="border-input w-24 min-w-0"
       />
     );
   }
@@ -356,10 +387,10 @@ const ValueSlot = <TData, TValue>({
       value.kind === "multi-text" ? value : { kind: "multi-text" as const };
     return (
       <div className="w-48">
-        <FilterByValuesList
+        <FilterByValuesPicker
           column={column}
           calculateTopKRows={calculateTopKRows}
-          chosenValues={new Set(v.values ?? [])}
+          chosenValues={v.values ?? []}
           onChange={(next) =>
             onChange({ kind: "multi-text", values: next.map(String) })
           }
@@ -376,9 +407,11 @@ const ValueSlot = <TData, TValue>({
         id={id}
         type="text"
         value={v.text ?? ""}
-        onChange={(e) => onChange({ kind: "single-text", text: e.target.value })}
+        onChange={(e) =>
+          onChange({ kind: "single-text", text: e.target.value })
+        }
         placeholder="Text…"
-        className="border-input min-w-0"
+        className="border-input w-40 min-w-0"
       />
     );
   }
@@ -466,6 +499,19 @@ function emptyDraftFor(
     return { kind: "options", options: [] };
   }
   return { kind: "none" };
+}
+
+function getMissingValueMessage(
+  type: EditableFilterType,
+  operator: OperatorType,
+): string {
+  if (type === "number" && operator === "between") {
+    return "Min and max are required";
+  }
+  if (type === "text" && (operator === "in" || operator === "not_in")) {
+    return "Pick at least one value";
+  }
+  return "Value is required";
 }
 
 function buildFilterValue({

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -5,6 +5,7 @@ import type { Column, Table } from "@tanstack/react-table";
 import { CheckIcon, MinusIcon, Trash2Icon, XIcon } from "lucide-react";
 import { useId, useState } from "react";
 import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
+import type { OperatorType } from "@/plugins/impl/data-frames/utils/operators";
 import { Combobox, ComboboxItem } from "../ui/combobox";
 import { Input } from "../ui/input";
 import { NumberField } from "../ui/number-field";
@@ -16,58 +17,71 @@ import {
   SelectValue,
 } from "../ui/select";
 import { Button } from "../ui/button";
-import { FilterByValuesPicker } from "./filter-by-values-picker";
-import { type ColumnFilterValue, Filter } from "./filters";
+import {
+  FilterByValuesList,
+  FilterByValuesPicker,
+} from "./filter-by-values-picker";
+import {
+  type ColumnFilterValue,
+  Filter,
+  MEMBERSHIP_OPS,
+  NUMBER_COMPARISON_OPS,
+  type NumberComparisonOp,
+  NUMBER_OPS,
+  TEXT_OPS,
+  TEXT_SCALAR_OPS,
+  type TextScalarOp,
+} from "./filters";
 import { OPERATOR_LABELS } from "./operator-labels";
 import { Tooltip } from "../ui/tooltip";
 
-// Editable filter types in this editor — date/datetime/time are read-only
-// Will add support for rest in next PR
 type EditableFilterType = "number" | "text" | "boolean" | "select";
 
-// UI-level operator for the operator dropdown. Today the committed filter
-// value does not carry this operator for number ranges — ranges are
-// converted to `>=` / `<=` condition pairs at the RPC boundary
-// (`filterToFilterCondition`). The follow-up PR splits UI operators into
-// distinct `<`, `>`, `between` variants and routes them through as-is.
-type UiOperator =
-  | "between"
-  | "contains"
-  | "is_true"
-  | "is_false"
-  | "is_null"
-  | "is_not_null"
-  | "in"
-  | "not_in";
+const BOOLEAN_OPS = ["is_true", "is_false", "is_null", "is_not_null"] as const;
+const SELECT_OPS = MEMBERSHIP_OPS;
 
-// will be expanded by a follow up PR
-const OPERATORS_BY_TYPE: Record<EditableFilterType, UiOperator[]> = {
-  number: ["between", "is_null", "is_not_null"],
-  text: ["contains", "is_null", "is_not_null"],
-  boolean: ["is_true", "is_false", "is_null", "is_not_null"],
-  select: ["in", "not_in"],
+const OPERATORS_BY_TYPE: Record<
+  EditableFilterType,
+  ReadonlyArray<OperatorType>
+> = {
+  number: NUMBER_OPS,
+  text: TEXT_OPS,
+  boolean: BOOLEAN_OPS,
+  select: SELECT_OPS,
 };
 
-const DEFAULT_OPERATOR: Record<EditableFilterType, UiOperator> = {
+const DEFAULT_OPERATOR: Record<EditableFilterType, OperatorType> = {
   number: "between",
   text: "contains",
   boolean: "is_true",
   select: "in",
 };
 
-const OPERATORS_WITHOUT_VALUE = new Set<UiOperator>([
+const OPERATORS_WITHOUT_VALUE = new Set<OperatorType>([
   "is_true",
   "is_false",
   "is_null",
   "is_not_null",
+  "is_empty",
 ]);
 
-interface DraftValue {
-  min?: number;
-  max?: number;
-  text?: string;
-  options?: unknown[];
-}
+const NUMBER_COMPARISON_SET: ReadonlySet<OperatorType> = new Set(
+  NUMBER_COMPARISON_OPS,
+);
+const TEXT_SCALAR_SET: ReadonlySet<OperatorType> = new Set(TEXT_SCALAR_OPS);
+
+const isNumberComparisonOp = (op: OperatorType): op is NumberComparisonOp =>
+  NUMBER_COMPARISON_SET.has(op);
+const isTextScalarOp = (op: OperatorType): op is TextScalarOp =>
+  TEXT_SCALAR_SET.has(op);
+
+type DraftValue =
+  | { kind: "between"; min?: number; max?: number }
+  | { kind: "single-number"; value?: number }
+  | { kind: "single-text"; text?: string }
+  | { kind: "multi-text"; values?: string[] }
+  | { kind: "options"; options?: unknown[] }
+  | { kind: "none" };
 
 interface Snapshot {
   columnId: string;
@@ -82,7 +96,7 @@ interface FilterPillEditorProps<TData> {
 }
 
 export const FilterPillEditor = <TData,>({
-  snapshot, // current state of filter pre-edit
+  snapshot,
   table,
   calculateTopKRows,
   onClose,
@@ -92,13 +106,13 @@ export const FilterPillEditor = <TData,>({
   const valueId = useId();
 
   const snapshotType = getEditableType(snapshot.value);
-  const snapshotOperator = getUiOperator(snapshot.value);
+  const snapshotOperator = snapshot.value.operator as OperatorType;
   const snapshotDraft = toDraftValue(snapshot.value);
 
   const [draftColumnId, setDraftColumnId] = useState<string>(snapshot.columnId);
   const [draftType, setDraftType] = useState<EditableFilterType>(snapshotType);
   const [draftOperator, setDraftOperator] =
-    useState<UiOperator>(snapshotOperator);
+    useState<OperatorType>(snapshotOperator);
   const [draftValue, setDraftValue] = useState<DraftValue>(snapshotDraft);
 
   const editableColumns = table.getAllColumns().filter((c) => {
@@ -108,16 +122,12 @@ export const FilterPillEditor = <TData,>({
     );
   });
 
-  // if we switch back to pre-edit column+operator
-  // restore the original value as well
   const rehydrateIfMatchesSnapshot = (args: {
     id: string;
-    type: EditableFilterType;
-    operator: UiOperator;
+    operator: OperatorType;
   }) => {
     if (
       args.id === snapshot.columnId &&
-      args.type === snapshotType &&
       args.operator === snapshotOperator
     ) {
       setDraftValue(snapshotDraft);
@@ -137,21 +147,20 @@ export const FilterPillEditor = <TData,>({
       nextOperator = DEFAULT_OPERATOR[nextColumnType];
       setDraftType(nextColumnType);
       setDraftOperator(nextOperator);
-      setDraftValue({});
+      setDraftValue(emptyDraftFor(nextColumnType, nextOperator));
     }
     setDraftColumnId(nextColumnId);
     rehydrateIfMatchesSnapshot({
       id: nextColumnId,
-      type: nextColumnType,
       operator: nextOperator,
     });
   };
 
-  const handleOperatorChange = (nextOp: UiOperator) => {
+  const handleOperatorChange = (nextOp: OperatorType) => {
     setDraftOperator(nextOp);
+    setDraftValue(emptyDraftFor(draftType, nextOp));
     rehydrateIfMatchesSnapshot({
       id: draftColumnId,
-      type: draftType,
       operator: nextOp,
     });
   };
@@ -181,6 +190,7 @@ export const FilterPillEditor = <TData,>({
   };
 
   const showValueSlot = !OPERATORS_WITHOUT_VALUE.has(draftOperator);
+  const operatorOptions = OPERATORS_BY_TYPE[draftType];
 
   return (
     <div className="flex flex-row gap-4 items-end p-3">
@@ -209,13 +219,13 @@ export const FilterPillEditor = <TData,>({
         </label>
         <Select
           value={draftOperator}
-          onValueChange={(v) => handleOperatorChange(v as UiOperator)}
+          onValueChange={(v) => handleOperatorChange(v as OperatorType)}
         >
           <SelectTrigger id={operatorId} className="h-6 mb-1 bg-transparent">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {OPERATORS_BY_TYPE[draftType].map((op) => (
+            {operatorOptions.map((op) => (
               <SelectItem key={op} value={op}>
                 {OPERATOR_LABELS[op]}
               </SelectItem>
@@ -231,6 +241,7 @@ export const FilterPillEditor = <TData,>({
           <ValueSlot
             id={valueId}
             type={draftType}
+            operator={draftOperator}
             value={draftValue}
             onChange={setDraftValue}
             column={table.getColumn(draftColumnId) ?? null}
@@ -283,6 +294,7 @@ export const FilterPillEditor = <TData,>({
 interface ValueSlotProps<TData, TValue> {
   id?: string;
   type: EditableFilterType;
+  operator: OperatorType;
   value: DraftValue;
   onChange: (next: DraftValue) => void;
   column: Column<TData, TValue> | null;
@@ -292,26 +304,28 @@ interface ValueSlotProps<TData, TValue> {
 const ValueSlot = <TData, TValue>({
   id,
   type,
+  operator,
   value,
   onChange,
   column,
   calculateTopKRows,
 }: ValueSlotProps<TData, TValue>) => {
-  if (type === "number") {
+  if (type === "number" && operator === "between") {
+    const v = value.kind === "between" ? value : { kind: "between" as const };
     return (
       <div className="flex gap-1 items-center w-48">
         <NumberField
           id={id}
-          value={value.min}
-          onChange={(v) => onChange({ ...value, min: v })}
+          value={v.min}
+          onChange={(n) => onChange({ kind: "between", min: n, max: v.max })}
           aria-label="min"
           placeholder="min"
           className="border-input flex-1 min-w-0"
         />
         <MinusIcon className="h-5 w-5 text-muted-foreground shrink-0" />
         <NumberField
-          value={value.max}
-          onChange={(v) => onChange({ ...value, max: v })}
+          value={v.max}
+          onChange={(n) => onChange({ kind: "between", min: v.min, max: n })}
           aria-label="max"
           placeholder="max"
           className="border-input flex-1 min-w-0"
@@ -319,26 +333,64 @@ const ValueSlot = <TData, TValue>({
       </div>
     );
   }
-  if (type === "text") {
+  if (type === "number" && isNumberComparisonOp(operator)) {
+    const v =
+      value.kind === "single-number" ? value : { kind: "single-number" as const };
+    return (
+      <NumberField
+        id={id}
+        value={v.value}
+        onChange={(n) => onChange({ kind: "single-number", value: n })}
+        aria-label="value"
+        placeholder="value"
+        className="border-input min-w-0"
+      />
+    );
+  }
+  if (
+    type === "text" &&
+    (operator === "in" || operator === "not_in") &&
+    column
+  ) {
+    const v =
+      value.kind === "multi-text" ? value : { kind: "multi-text" as const };
+    return (
+      <div className="w-48">
+        <FilterByValuesList
+          column={column}
+          calculateTopKRows={calculateTopKRows}
+          chosenValues={new Set(v.values ?? [])}
+          onChange={(next) =>
+            onChange({ kind: "multi-text", values: next.map(String) })
+          }
+          creatable={true}
+        />
+      </div>
+    );
+  }
+  if (type === "text" && isTextScalarOp(operator)) {
+    const v =
+      value.kind === "single-text" ? value : { kind: "single-text" as const };
     return (
       <Input
         id={id}
         type="text"
-        value={value.text ?? ""}
-        onChange={(e) => onChange({ ...value, text: e.target.value })}
+        value={v.text ?? ""}
+        onChange={(e) => onChange({ kind: "single-text", text: e.target.value })}
         placeholder="Text…"
         className="border-input min-w-0"
       />
     );
   }
   if (type === "select" && column) {
+    const v = value.kind === "options" ? value : { kind: "options" as const };
     return (
       <div className="flex w-48">
         <FilterByValuesPicker
           column={column}
           calculateTopKRows={calculateTopKRows}
-          chosenValues={value.options ?? []}
-          onChange={(values) => onChange({ ...value, options: values })}
+          chosenValues={v.options ?? []}
+          onChange={(values) => onChange({ kind: "options", options: values })}
         />
       </div>
     );
@@ -359,43 +411,61 @@ function getEditableType(value: ColumnFilterValue): EditableFilterType {
   if (value.type === "select") {
     return "select";
   }
-  // date/datetime/time fall back to text; callers should guard. supported in future
   return "text";
-}
-
-function getUiOperator(value: ColumnFilterValue): UiOperator {
-  if (value.operator === "is_null") {
-    return "is_null";
-  }
-  if (value.operator === "is_not_null") {
-    return "is_not_null";
-  }
-  if (value.type === "number") {
-    return "between";
-  }
-  if (value.type === "text") {
-    return "contains";
-  }
-  if (value.type === "boolean") {
-    return value.value ? "is_true" : "is_false";
-  }
-  if (value.type === "select") {
-    return value.operator === "not_in" ? "not_in" : "in";
-  }
-  return "contains";
 }
 
 function toDraftValue(value: ColumnFilterValue): DraftValue {
   if (value.type === "number") {
-    return { min: value.min, max: value.max };
+    switch (value.operator) {
+      case "between":
+        return { kind: "between", min: value.min, max: value.max };
+      case "is_null":
+      case "is_not_null":
+        return { kind: "none" };
+      default:
+        return { kind: "single-number", value: value.value };
+    }
   }
   if (value.type === "text") {
-    return { text: value.text };
+    switch (value.operator) {
+      case "in":
+      case "not_in":
+        return { kind: "multi-text", values: [...value.values] };
+      case "is_null":
+      case "is_not_null":
+      case "is_empty":
+        return { kind: "none" };
+      default:
+        return { kind: "single-text", text: value.text };
+    }
   }
   if (value.type === "select") {
-    return { options: [...value.options] };
+    return { kind: "options", options: [...value.options] };
   }
-  return {};
+  return { kind: "none" };
+}
+
+function emptyDraftFor(
+  type: EditableFilterType,
+  operator: OperatorType,
+): DraftValue {
+  if (OPERATORS_WITHOUT_VALUE.has(operator)) {
+    return { kind: "none" };
+  }
+  if (type === "number") {
+    return operator === "between"
+      ? { kind: "between" }
+      : { kind: "single-number" };
+  }
+  if (type === "text") {
+    return operator === "in" || operator === "not_in"
+      ? { kind: "multi-text", values: [] }
+      : { kind: "single-text" };
+  }
+  if (type === "select") {
+    return { kind: "options", options: [] };
+  }
+  return { kind: "none" };
 }
 
 function buildFilterValue({
@@ -404,51 +474,79 @@ function buildFilterValue({
   draft,
 }: {
   type: EditableFilterType;
-  operator: UiOperator;
+  operator: OperatorType;
   draft: DraftValue;
 }): ColumnFilterValue | undefined {
-  if (operator === "is_null" || operator === "is_not_null") {
-    const op = operator;
-    if (type === "number") {
-      return Filter.number({ operator: op });
-    }
-    if (type === "boolean") {
-      return Filter.boolean({ operator: op });
-    }
-    return Filter.text({ operator: op });
-  }
   if (type === "number") {
-    if (draft.min === undefined && draft.max === undefined) {
+    if (operator === "is_null" || operator === "is_not_null") {
+      return Filter.number({ operator });
+    }
+    if (operator === "between") {
+      if (
+        draft.kind !== "between" ||
+        draft.min === undefined ||
+        draft.max === undefined
+      ) {
+        return undefined;
+      }
+      return Filter.number({
+        operator: "between",
+        min: draft.min,
+        max: draft.max,
+      });
+    }
+    if (!isNumberComparisonOp(operator)) {
       return undefined;
     }
-    return Filter.number({ min: draft.min, max: draft.max });
+    if (draft.kind !== "single-number" || draft.value === undefined) {
+      return undefined;
+    }
+    return Filter.number({ operator, value: draft.value });
   }
   if (type === "text") {
-    if (!draft.text) {
+    if (
+      operator === "is_null" ||
+      operator === "is_not_null" ||
+      operator === "is_empty"
+    ) {
+      return Filter.text({ operator });
+    }
+    if (operator === "in" || operator === "not_in") {
+      if (
+        draft.kind !== "multi-text" ||
+        !draft.values ||
+        draft.values.length === 0
+      ) {
+        return undefined;
+      }
+      return Filter.text({ operator, values: draft.values });
+    }
+    if (!isTextScalarOp(operator)) {
       return undefined;
     }
-    return Filter.text({
-      text: draft.text,
-      operator: "contains",
-    });
+    if (draft.kind !== "single-text" || !draft.text) {
+      return undefined;
+    }
+    return Filter.text({ operator, text: draft.text });
   }
   if (type === "boolean") {
     if (operator === "is_true") {
-      return Filter.boolean({
-        value: true,
-        operator: "is_true",
-      });
+      return Filter.boolean({ value: true, operator: "is_true" });
     }
     if (operator === "is_false") {
-      return Filter.boolean({
-        value: false,
-        operator: "is_false",
-      });
+      return Filter.boolean({ value: false, operator: "is_false" });
+    }
+    if (operator === "is_null" || operator === "is_not_null") {
+      return Filter.boolean({ operator });
     }
     return undefined;
   }
   if (type === "select") {
-    if (!draft.options || draft.options.length === 0) {
+    if (
+      draft.kind !== "options" ||
+      !draft.options ||
+      draft.options.length === 0
+    ) {
       return undefined;
     }
     return Filter.select({

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -200,7 +200,7 @@ export const FilterPillEditor = <TData,>({
   const operatorTriggerRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     const firstInput = valueSlotRef.current?.querySelector<HTMLElement>(
-      'input, [role="combobox"]',
+      'input, [role="combobox"], button',
     );
     if (firstInput) {
       firstInput.focus();

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -18,6 +18,7 @@ import {
 } from "../ui/select";
 import { Button } from "../ui/button";
 import { FilterByValuesPicker } from "./filter-by-values-picker";
+import { RegexInput } from "./regex-input";
 import {
   type ColumnFilterValue,
   Filter,
@@ -402,6 +403,16 @@ const ValueSlot = <TData, TValue>({
   if (type === "text" && isTextScalarOp(operator)) {
     const v =
       value.kind === "single-text" ? value : { kind: "single-text" as const };
+    if (operator === "regex") {
+      return (
+        <RegexInput
+          id={id}
+          value={v.text ?? ""}
+          onChange={(text) => onChange({ kind: "single-text", text })}
+          className="w-40"
+        />
+      );
+    }
     return (
       <Input
         id={id}

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from "../ui/button";
 import { FilterByValuesPicker } from "./filter-by-values-picker";
 import { type ColumnFilterValue, Filter } from "./filters";
+import { OPERATOR_LABELS } from "./operator-labels";
 import { Tooltip } from "../ui/tooltip";
 
 // Editable filter types in this editor — date/datetime/time are read-only
@@ -52,17 +53,6 @@ const DEFAULT_OPERATOR: Record<EditableFilterType, UiOperator> = {
   text: "contains",
   boolean: "is_true",
   select: "in",
-};
-
-const OPERATOR_LABELS: Record<UiOperator, string> = {
-  between: "Between",
-  contains: "Contains",
-  is_true: "Is true",
-  is_false: "Is false",
-  is_null: "Is null",
-  is_not_null: "Is not null",
-  in: "Is in",
-  not_in: "Not in",
 };
 
 const OPERATORS_WITHOUT_VALUE = new Set<UiOperator>([

--- a/frontend/src/components/data-table/filter-pills.tsx
+++ b/frontend/src/components/data-table/filter-pills.tsx
@@ -13,6 +13,7 @@ import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { FilterPillEditor } from "./filter-pill-editor";
 import type { ColumnFilterValue } from "./filters";
+import { OPERATOR_LABELS } from "./operator-labels";
 import { stringifyUnknownValue } from "./utils";
 
 interface Props<TData> {
@@ -209,19 +210,62 @@ function formatValue(
   }
 
   if (value.type === "number") {
-    return formatMinMax(value.min, value.max);
+    switch (value.operator) {
+      case "between":
+        return {
+          operator: OPERATOR_LABELS.between.toLowerCase(),
+          value: `${value.min} - ${value.max}`,
+        };
+      case "==":
+      case "!=":
+      case ">":
+      case ">=":
+      case "<":
+      case "<=":
+        return { operator: value.operator, value: String(value.value) };
+    }
+  }
+  if (value.type === "text") {
+    switch (value.operator) {
+      case "in":
+      case "not_in": {
+        const items = value.values.map((v) => `"${v}"`);
+        return {
+          operator: value.operator === "in" ? "is in" : "not in",
+          value: `[${items.join(", ")}]`,
+        };
+      }
+      case "is_empty":
+        return { operator: "is empty" };
+      case "contains":
+      case "equals":
+      case "does_not_equal":
+      case "regex":
+      case "starts_with":
+      case "ends_with":
+        return {
+          operator: OPERATOR_LABELS[value.operator].toLowerCase(),
+          value: `"${value.text}"`,
+        };
+    }
   }
   if (value.type === "date") {
-    return formatMinMax(value.min?.toISOString(), value.max?.toISOString());
+    return formatMinMaxLegacy(
+      value.min?.toISOString(),
+      value.max?.toISOString(),
+    );
   }
   if (value.type === "time") {
-    return formatMinMax(
+    return formatMinMaxLegacy(
       value.min ? timeFormatter.format(value.min) : undefined,
       value.max ? timeFormatter.format(value.max) : undefined,
     );
   }
   if (value.type === "datetime") {
-    return formatMinMax(value.min?.toISOString(), value.max?.toISOString());
+    return formatMinMaxLegacy(
+      value.min?.toISOString(),
+      value.max?.toISOString(),
+    );
   }
   if (value.type === "boolean") {
     return { operator: `is ${value.value ? "True" : "False"}` };
@@ -235,14 +279,11 @@ function formatValue(
       value: `[${stringifiedOptions.join(", ")}]`,
     };
   }
-  if (value.type === "text") {
-    return { operator: "contains", value: `"${value.text}"` };
-  }
   logNever(value);
   return undefined;
 }
 
-function formatMinMax(
+function formatMinMaxLegacy(
   min: string | number | undefined,
   max: string | number | undefined,
 ): FormattedFilter | undefined {

--- a/frontend/src/components/data-table/filters.ts
+++ b/frontend/src/components/data-table/filters.ts
@@ -32,15 +32,42 @@ export type FilterType =
   | "select"
   | "boolean";
 
+interface NullishOpts {
+  operator: "is_null" | "is_not_null";
+}
+
+type NumberFilterOpts =
+  | { operator: "between"; min: number; max: number }
+  | {
+      operator: "==" | "!=" | ">" | ">=" | "<" | "<=";
+      value: number;
+    }
+  | NullishOpts;
+
+type TextFilterOpts =
+  | {
+      operator:
+        | "contains"
+        | "equals"
+        | "does_not_equal"
+        | "regex"
+        | "starts_with"
+        | "ends_with";
+      text: string;
+    }
+  | { operator: "in" | "not_in"; values: string[] }
+  | { operator: "is_empty" }
+  | NullishOpts;
+
 // Filter is a factory function that creates a filter object
 export const Filter = {
-  number(opts: { min?: number; max?: number; operator?: OperatorType }) {
+  number(opts: NumberFilterOpts) {
     return {
       type: "number",
       ...opts,
     } as const;
   },
-  text(opts: { text?: string; operator: OperatorType }) {
+  text(opts: TextFilterOpts) {
     return {
       type: "text",
       ...opts,
@@ -84,6 +111,15 @@ export type ColumnFilterForType<T extends FilterType> = T extends FilterType
   ? Extract<ColumnFilterValue, { type: T }>
   : never;
 
+function isNullishFilter(
+  filter: ColumnFilterValue,
+): filter is Extract<
+  ColumnFilterValue,
+  { operator: "is_null" | "is_not_null" }
+> {
+  return filter.operator === "is_null" || filter.operator === "is_not_null";
+}
+
 export function filterToFilterCondition(
   columnIdString: string,
   filter: ColumnFilterValue | undefined,
@@ -93,12 +129,11 @@ export function filterToFilterCondition(
   }
   const columnId = columnIdString as ColumnId;
 
-  if (filter.operator === "is_null" || filter.operator === "is_not_null") {
+  if (isNullishFilter(filter)) {
     return [
       {
         column_id: columnId,
         operator: filter.operator,
-        value: undefined,
         type: "condition",
         negate: false,
       },
@@ -106,38 +141,76 @@ export function filterToFilterCondition(
   }
 
   switch (filter.type) {
-    case "number": {
-      const conditions: FilterConditionType[] = [];
-      if (filter.min !== undefined) {
-        conditions.push({
-          column_id: columnId,
-          operator: ">=",
-          value: filter.min,
-          type: "condition",
-          negate: false,
-        });
+    case "number":
+      switch (filter.operator) {
+        case "between":
+          return [
+            {
+              column_id: columnId,
+              operator: "between",
+              value: { min: filter.min, max: filter.max },
+              type: "condition",
+              negate: false,
+            },
+          ];
+        case "==":
+        case "!=":
+        case ">":
+        case ">=":
+        case "<":
+        case "<=":
+          return [
+            {
+              column_id: columnId,
+              operator: filter.operator,
+              value: filter.value,
+              type: "condition",
+              negate: false,
+            },
+          ];
+        default:
+          assertNever(filter);
       }
-      if (filter.max !== undefined) {
-        conditions.push({
-          column_id: columnId,
-          operator: "<=",
-          value: filter.max,
-          type: "condition",
-          negate: false,
-        });
-      }
-      return conditions;
-    }
     case "text":
-      return [
-        {
-          column_id: columnId,
-          operator: filter.operator,
-          value: filter.text,
-          type: "condition",
-          negate: false,
-        },
-      ];
+      switch (filter.operator) {
+        case "contains":
+        case "equals":
+        case "does_not_equal":
+        case "regex":
+        case "starts_with":
+        case "ends_with":
+          return [
+            {
+              column_id: columnId,
+              operator: filter.operator,
+              value: filter.text,
+              type: "condition",
+              negate: false,
+            },
+          ];
+        case "in":
+        case "not_in":
+          return [
+            {
+              column_id: columnId,
+              operator: filter.operator,
+              value: filter.values,
+              type: "condition",
+              negate: false,
+            },
+          ];
+        case "is_empty":
+          return [
+            {
+              column_id: columnId,
+              operator: "is_empty",
+              type: "condition",
+              negate: false,
+            },
+          ];
+        default:
+          assertNever(filter);
+      }
     case "datetime": {
       const conditions: FilterConditionType[] = [];
       if (filter.min !== undefined) {
@@ -210,7 +283,6 @@ export function filterToFilterCondition(
           {
             column_id: columnId,
             operator: "is_true",
-            value: undefined,
             type: "condition",
             negate: false,
           },
@@ -221,7 +293,6 @@ export function filterToFilterCondition(
           {
             column_id: columnId,
             operator: "is_false",
-            value: undefined,
             type: "condition",
             negate: false,
           },

--- a/frontend/src/components/data-table/filters.ts
+++ b/frontend/src/components/data-table/filters.ts
@@ -32,30 +32,54 @@ export type FilterType =
   | "select"
   | "boolean";
 
+export const NULLISH_OPS = ["is_null", "is_not_null"] as const;
+export const MEMBERSHIP_OPS = ["in", "not_in"] as const;
+export const NUMBER_COMPARISON_OPS = [
+  "==",
+  "!=",
+  ">",
+  ">=",
+  "<",
+  "<=",
+] as const;
+export const TEXT_SCALAR_OPS = [
+  "contains",
+  "equals",
+  "does_not_equal",
+  "regex",
+  "starts_with",
+  "ends_with",
+] as const;
+
+export const NUMBER_OPS = [
+  "between",
+  ...NUMBER_COMPARISON_OPS,
+  ...NULLISH_OPS,
+] as const;
+export const TEXT_OPS = [
+  ...TEXT_SCALAR_OPS,
+  ...MEMBERSHIP_OPS,
+  "is_empty",
+  ...NULLISH_OPS,
+] as const;
+
+export type NullishOp = (typeof NULLISH_OPS)[number];
+export type MembershipOp = (typeof MEMBERSHIP_OPS)[number];
+export type NumberComparisonOp = (typeof NUMBER_COMPARISON_OPS)[number];
+export type TextScalarOp = (typeof TEXT_SCALAR_OPS)[number];
+
 interface NullishOpts {
-  operator: "is_null" | "is_not_null";
+  operator: NullishOp;
 }
 
 type NumberFilterOpts =
   | { operator: "between"; min: number; max: number }
-  | {
-      operator: "==" | "!=" | ">" | ">=" | "<" | "<=";
-      value: number;
-    }
+  | { operator: NumberComparisonOp; value: number }
   | NullishOpts;
 
 type TextFilterOpts =
-  | {
-      operator:
-        | "contains"
-        | "equals"
-        | "does_not_equal"
-        | "regex"
-        | "starts_with"
-        | "ends_with";
-      text: string;
-    }
-  | { operator: "in" | "not_in"; values: string[] }
+  | { operator: TextScalarOp; text: string }
+  | { operator: MembershipOp; values: string[] }
   | { operator: "is_empty" }
   | NullishOpts;
 

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -328,14 +328,21 @@ export const FilterButtons = ({
   onApply,
   onClear,
   clearButtonDisabled,
+  applyButtonDisabled,
 }: {
   onApply: () => void;
   onClear: () => void;
   clearButtonDisabled?: boolean;
+  applyButtonDisabled?: boolean;
 }) => {
   return (
     <div className="flex gap-2 px-2 justify-between">
-      <Button variant="link" size="sm" onClick={onApply}>
+      <Button
+        variant="link"
+        size="sm"
+        onClick={onApply}
+        disabled={applyButtonDisabled}
+      >
         Apply
       </Button>
       <Button

--- a/frontend/src/components/data-table/operator-labels.ts
+++ b/frontend/src/components/data-table/operator-labels.ts
@@ -1,0 +1,25 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import type { OperatorType } from "@/plugins/impl/data-frames/utils/operators";
+
+export const OPERATOR_LABELS: Record<OperatorType | "between", string> = {
+  "==": "Equals",
+  "!=": "Doesn't equal",
+  ">": "Greater than",
+  ">=": "Greater than or equal",
+  "<": "Less than",
+  "<=": "Less than or equal",
+  between: "Between",
+  contains: "Contains",
+  equals: "Equals",
+  does_not_equal: "Doesn't equal",
+  starts_with: "Starts with",
+  ends_with: "Ends with",
+  regex: "Matches regex",
+  in: "Is in",
+  not_in: "Not in",
+  is_empty: "Is empty",
+  is_true: "Is true",
+  is_false: "Is false",
+  is_null: "Is null",
+  is_not_null: "Is not null",
+};

--- a/frontend/src/components/data-table/regex-input.tsx
+++ b/frontend/src/components/data-table/regex-input.tsx
@@ -1,0 +1,61 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import React from "react";
+import { cn } from "@/utils/cn";
+import { Input } from "../ui/input";
+
+export interface RegexInputProps {
+  id?: string;
+  value: string;
+  onChange: (next: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  className?: string;
+  autoFocus?: boolean;
+  "aria-label"?: string;
+}
+
+export const RegexInput = React.forwardRef<HTMLInputElement, RegexInputProps>(
+  (
+    {
+      id,
+      value,
+      onChange,
+      onKeyDown,
+      placeholder = "pattern",
+      className,
+      autoFocus,
+      "aria-label": ariaLabel,
+    },
+    ref,
+  ) => (
+    <div
+      className={cn(
+        "flex items-stretch h-6 mb-1 rounded-sm border border-input bg-background shadow-xs-solid focus-within:shadow-md-solid focus-within:ring-1 focus-within:ring-ring focus-within:border-primary",
+        className,
+      )}
+    >
+      <Slash />
+      <Input
+        ref={ref}
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        aria-label={ariaLabel}
+        rootClassName="flex-1 min-w-0"
+        className="border-0 mb-0 h-full shadow-none! hover:shadow-none! focus-visible:shadow-none! focus-visible:ring-0 focus-visible:border-0 rounded-none bg-transparent"
+      />
+      <Slash />
+    </div>
+  ),
+);
+RegexInput.displayName = "RegexInput";
+
+const Slash = () => (
+  <span className="px-1.5 flex items-center text-muted-foreground font-code text-sm select-none">
+    /
+  </span>
+);

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -170,10 +170,9 @@ export const Combobox = <TValue,>({
     <div className={cn("relative")} {...rest}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild={true}>
-          <div
+          <button
             id={id}
-            role="button"
-            tabIndex={0}
+            type="button"
             className={cn(
               "flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50",
               className,
@@ -182,7 +181,7 @@ export const Combobox = <TValue,>({
           >
             <span className="truncate flex-1 min-w-0">{renderValue()}</span>
             <ChevronDownIcon className="ml-3 w-4 h-4 opacity-50 shrink-0" />
-          </div>
+          </button>
         </PopoverTrigger>
         <PopoverContent
           className="w-full min-w-(--radix-popover-trigger-width) p-0"

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -172,6 +172,8 @@ export const Combobox = <TValue,>({
         <PopoverTrigger asChild={true}>
           <div
             id={id}
+            role="button"
+            tabIndex={0}
             className={cn(
               "flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50",
               className,

--- a/frontend/src/components/ui/number-field.tsx
+++ b/frontend/src/components/ui/number-field.tsx
@@ -62,6 +62,7 @@ export const NumberField = React.forwardRef<HTMLInputElement, NumberFieldProps>(
               slot="increment"
               isDisabled={props.isDisabled}
               variant={variant}
+              excludeFromTabOrder={true}
             >
               <ChevronUp
                 aria-hidden={true}
@@ -73,6 +74,7 @@ export const NumberField = React.forwardRef<HTMLInputElement, NumberFieldProps>(
               slot="decrement"
               isDisabled={props.isDisabled}
               variant={variant}
+              excludeFromTabOrder={true}
             >
               <ChevronDown
                 aria-hidden={true}

--- a/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
+++ b/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_27_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -58,7 +58,7 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -82,7 +82,7 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_29_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -113,7 +113,7 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -399,7 +399,7 @@ exports[`renderZodSchema > should render a form explode_columns 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_2p_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -430,7 +430,7 @@ exports[`renderZodSchema > should render a form explode_columns 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -596,7 +596,7 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_1p_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -627,7 +627,7 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -651,7 +651,7 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_1r_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -682,7 +682,7 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -798,7 +798,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_3b_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -829,7 +829,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -853,7 +853,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_3d_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -884,7 +884,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -908,7 +908,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_3f_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -939,7 +939,7 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -1298,7 +1298,7 @@ exports[`renderZodSchema > should render a form select_columns 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_4_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -1329,7 +1329,7 @@ exports[`renderZodSchema > should render a form select_columns 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -1581,7 +1581,7 @@ exports[`renderZodSchema > should render a form unique 1`] = `
           aria-invalid="false"
           class="relative"
         >
-          <div
+          <button
             aria-controls="radix-_r_32_"
             aria-expanded="false"
             aria-haspopup="dialog"
@@ -1612,7 +1612,7 @@ exports[`renderZodSchema > should render a form unique 1`] = `
                 d="m6 9 6 6 6-6"
               />
             </svg>
-          </div>
+          </button>
           <div
             class="flex flex-col gap-1 items-start"
           />
@@ -1740,7 +1740,7 @@ exports[`renders custom forms column_id_array 1`] = `
       aria-invalid="false"
       class="relative"
     >
-      <div
+      <button
         aria-controls="radix-_r_41_"
         aria-expanded="false"
         aria-haspopup="dialog"
@@ -1771,7 +1771,7 @@ exports[`renders custom forms column_id_array 1`] = `
             d="m6 9 6 6 6-6"
           />
         </svg>
-      </div>
+      </button>
       <div
         class="flex flex-col gap-1 items-start"
       />
@@ -1790,7 +1790,7 @@ exports[`renders custom forms column_id_dot_array 1`] = `
       aria-invalid="false"
       class="relative"
     >
-      <div
+      <button
         aria-controls="radix-_r_43_"
         aria-expanded="false"
         aria-haspopup="dialog"
@@ -1821,7 +1821,7 @@ exports[`renders custom forms column_id_dot_array 1`] = `
             d="m6 9 6 6 6-6"
           />
         </svg>
-      </div>
+      </button>
       <div
         class="flex flex-col gap-1 items-start"
       />

--- a/frontend/src/plugins/impl/data-frames/schema.ts
+++ b/frontend/src/plugins/impl/data-frames/schema.ts
@@ -80,7 +80,7 @@ export const FilterConditionSchema = z
       .enum(Object.keys(ALL_OPERATORS) as [OperatorType, ...OperatorType[]])
       .describe(FieldOptions.of({ label: " " })),
     type: z.literal("condition").default("condition"),
-    value: z.any().describe(FieldOptions.of({ label: "Value" })),
+    value: z.any().optional().describe(FieldOptions.of({ label: "Value" })),
     negate: z.boolean().default(false),
   })
   .describe(FieldOptions.of({ direction: "row", special: "column_filter" }));

--- a/frontend/src/plugins/impl/data-frames/schema.ts
+++ b/frontend/src/plugins/impl/data-frames/schema.ts
@@ -80,7 +80,10 @@ export const FilterConditionSchema = z
       .enum(Object.keys(ALL_OPERATORS) as [OperatorType, ...OperatorType[]])
       .describe(FieldOptions.of({ label: " " })),
     type: z.literal("condition").default("condition"),
-    value: z.any().optional().describe(FieldOptions.of({ label: "Value" })),
+    value: z
+      .any()
+      .optional()
+      .describe(FieldOptions.of({ label: "Value" })),
     negate: z.boolean().default(false),
   })
   .describe(FieldOptions.of({ direction: "row", special: "column_filter" }));


### PR DESCRIPTION
> **Reviewer note**: please review **commit by commit**.

## Summary

Expands the table's column-filter capabilities and overhauls the filter-pill editor.

- **Filter models**: typed text/number filter models, shared operators module, native between for numbers, value-drop for unary text ops.
- **Column header**: full operator pickers for text and number columns. `FilterByValuesList` gains creatable mode and fixes the chosen-outside-top-K case.
- **Pill editor**: full per-dtype operator support, operator-aware label/value formatting, plus UX polish (Apply gated by form submit + tooltip, draft preserved across compatible operator changes, keyboard focus flow, values picker as popover, right-sized value slots).
- **Regex filter**: slash-bracketed input for the new `regex` text operator.
- **Bug fix**: column-header text filter no longer eats special characters via key-propagation.
- **Creatable values picker:** the `in` / `not_in` value picker now supports typing values that aren't in the top-K — they appear as a "+ Add" item and, once selected, render at the bottom of the picker with no count so they stay visible and removable.

## Screenshots/Videos
### Column Header Filtering

https://github.com/user-attachments/assets/435052c5-3365-4b81-a8f0-1b6fcddbca46


### Values picker

https://github.com/user-attachments/assets/4f400f6e-7b91-48b1-9030-4036fc80c0bd




## Test plan

- [x] Filter a text column with every operator (contains, starts/ends with, equals, regex, is_empty, is_not_empty, ...)
- [x] Filter a number column with every operator (between, eq, lt, gt, ...)
- [x] Open the pill editor, switch operators: draft value preserved where compatible, cleared otherwise
- [x] Tab through column, operator, value, Apply
- [x] Apply button disabled with tooltip until value is valid; form submit also applies
- [x] FilterByValuesList: type to create a new value, confirm values outside top-K still display
- [x] Regex input accepts `/pattern/flags`
- [x] Special chars (`/`, `[`, `]`, etc.) typed into the column-header text filter reach the input