### PR TITLE
refactor(session): remove unused flush_messages plumbing

### DIFF
--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -594,13 +594,6 @@ async def run_app_until_completion(
         http_request=None,
     )
     await instantiated_event.wait()
-    # Process console messages
-    #
-    # TODO(akshayka): A timing issue with the console output worker
-    # might still exist; the better thing to do would be to flush
-    # the worker, then ask it to quit and join on it. If we have an
-    # issue with some outputs being missed, that's what we should do.
-    session.flush_messages()
     # Hack: yield to give the session view a chance to process the incoming
     # console operations.
     await asyncio.sleep(0.1)

--- a/marimo/_session/extensions/extensions.py
+++ b/marimo/_session/extensions/extensions.py
@@ -408,11 +408,6 @@ class NotificationListenerExtension(SessionExtension):
         # Don't block session close on disk I/O; kernel still holds state.
         self._autosave_runner.shutdown(wait=False)
 
-    def flush(self) -> None:
-        """Flush any pending messages from the distributor."""
-        if self.distributor is not None:
-            self.distributor.flush()
-
 
 class LoggingExtension(EventAwareExtension):
     """Extension for logging session events."""

--- a/marimo/_session/session.py
+++ b/marimo/_session/session.py
@@ -312,12 +312,6 @@ class SessionImpl(Session):
         """Get the consumers in the session."""
         return self.room.consumers
 
-    def flush_messages(self) -> None:
-        """Flush any pending messages."""
-        ext = self.extensions.get(NotificationListenerExtension)
-        if ext is not None:
-            ext.flush()
-
     async def rename_path(self, new_path: str) -> None:
         """Rename the path of the session."""
         old_path = self.app_file_manager.path

--- a/marimo/_session/types.py
+++ b/marimo/_session/types.py
@@ -163,10 +163,6 @@ class Session(Protocol):
         """Try to interrupt the kernel."""
         ...
 
-    def flush_messages(self) -> None:
-        """Flush any pending messages."""
-        ...
-
     async def rename_path(self, new_path: str) -> None:
         """Rename the path of the session."""
         ...

--- a/marimo/_utils/distributor.py
+++ b/marimo/_utils/distributor.py
@@ -35,10 +35,6 @@ class Distributor(Protocol, Generic[T]):
         """Stop the distributor."""
         ...
 
-    def flush(self) -> None:
-        """Flush the distributor."""
-        ...
-
 
 class ConnectionDistributor(Distributor[T]):
     """
@@ -112,14 +108,6 @@ class ConnectionDistributor(Distributor[T]):
             self.input_connection.close()
         self.consumers.clear()
 
-    def flush(self) -> None:
-        """Flush the distributor."""
-        while self.input_connection.poll():
-            try:
-                self.input_connection.recv()
-            except EOFError:
-                break
-
 
 class QueueDistributor(Distributor[T]):
     def __init__(self, queue: QueueType[T | None]) -> None:
@@ -160,6 +148,3 @@ class QueueDistributor(Distributor[T]):
 
     def stop(self) -> None:
         self.queue.put_nowait(None)
-
-    def flush(self) -> None:
-        """Flush the distributor."""

--- a/tests/_session/extensions/test_extensions.py
+++ b/tests/_session/extensions/test_extensions.py
@@ -570,21 +570,6 @@ class TestEventAwareExtension:
         ext.on_detach()  # should not raise
 
 
-class TestNotificationListenerFlush:
-    """Tests for NotificationListenerExtension.flush()."""
-
-    def test_flush_delegates_to_distributor(self) -> None:
-        ext = NotificationListenerExtension(Mock(), Mock())
-        ext.distributor = Mock()
-        ext.flush()
-        ext.distributor.flush.assert_called_once()
-
-    def test_flush_noop_without_distributor(self) -> None:
-        ext = NotificationListenerExtension(Mock(), Mock())
-        ext.distributor = None
-        ext.flush()  # should not raise
-
-
 class TestExtensionRegistry:
     """Tests for ExtensionRegistry."""
 


### PR DESCRIPTION
Console output ordering is now handled by FlushMarker in the buffered
console writer (#9164). The Session.flush_messages chain only reached
QueueDistributor.flush, which was a no-op.
