### PR TITLE
update default duckdb mo.sql deps

### DIFF
--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -130,7 +130,8 @@ class QueryEngine(BaseEngine[CONN], ABC):
         """Execute a SQL query and return a dataframe."""
 
     def sql_output_format(self) -> SqlOutputType:
-        return _validate_sql_output_format(get_configured_sql_output_format())
+        configured_output_format = get_configured_sql_output_format()
+        return _validate_sql_output_format(configured_output_format)
 
     def execute_in_explain_mode(
         self, query: str, globals_dict: dict[str, Any] | None = None

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -8,16 +8,12 @@ from typing import Any, Generic, Literal, TypeVar
 from marimo._config.config import SqlOutputType
 from marimo._data.models import Database, DataTable, Schema
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._runtime.context.types import (
-    ContextNotInitializedError,
-    get_context,
-    runtime_context_installed,
-)
 from marimo._sql.parse import (
     format_query_with_globals,
     replace_brackets_with_quotes,
 )
 from marimo._sql.utils import (
+    get_configured_sql_output_format,
     is_query_empty,
     strip_explain_from_error_message,
     wrap_query_with_explain,
@@ -134,13 +130,7 @@ class QueryEngine(BaseEngine[CONN], ABC):
         """Execute a SQL query and return a dataframe."""
 
     def sql_output_format(self) -> SqlOutputType:
-        if runtime_context_installed():
-            try:
-                ctx = get_context()
-                return _validate_sql_output_format(ctx.app_config.sql_output)
-            except ContextNotInitializedError:
-                return "auto"
-        return "auto"
+        return _validate_sql_output_format(get_configured_sql_output_format())
 
     def execute_in_explain_mode(
         self, query: str, globals_dict: dict[str, Any] | None = None

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from typing import Any, Literal, cast
 
-from marimo._dependencies.dependencies import DependencyManager
+from marimo._dependencies.dependencies import Dependency, DependencyManager
 from marimo._output.rich_help import mddoc
 from marimo._runtime.output import replace
 from marimo._sql.engines.dbapi import DBAPIConnection, DBAPIEngine
@@ -15,6 +15,7 @@ from marimo._sql.error_utils import MarimoSQLException, is_sql_parse_error
 from marimo._sql.get_engines import SUPPORTED_ENGINES
 from marimo._sql.utils import (
     extract_explain_content,
+    get_configured_sql_output_format,
     is_explain_query,
     raise_df_import_error,
 )
@@ -25,6 +26,46 @@ from marimo._utils.narwhals_utils import can_narwhalify_lazyframe
 def get_default_result_limit() -> int | None:
     limit = os.environ.get("MARIMO_SQL_DEFAULT_LIMIT")
     return int(limit) if limit is not None else None
+
+
+def _default_duckdb_deps() -> list[Dependency]:
+    """Return all deps required to run `mo.sql(query)` with the default DuckDB
+    engine, including the dataframe library used for the configured output
+    format.
+
+    Resolving the dataframe library upfront lets the kernel prompt the user to
+    install everything in a single step, instead of prompting first for
+    duckdb/sqlglot and then again for polars/pandas after the query is parsed.
+    """
+    deps: list[Dependency] = [
+        DependencyManager.duckdb,
+        DependencyManager.sqlglot,
+    ]
+
+    # Mirrors `raise_df_import_error("polars[pyarrow]")` in `marimo/_sql/utils.py`:
+    # polars conversion is much faster when pyarrow is available, so we eagerly
+    # request the extras.
+    polars_with_pyarrow = Dependency(
+        "polars", pkg_name_to_install="polars[pyarrow]"
+    )
+
+    sql_output = get_configured_sql_output_format()
+    if sql_output in ("polars", "lazy-polars"):
+        deps.append(polars_with_pyarrow)
+    elif sql_output == "pandas":
+        deps.append(DependencyManager.pandas)
+    elif sql_output == "auto":
+        # In auto mode either polars or pandas is acceptable; only bundle an
+        # install when neither is already present. Prefer polars[pyarrow] to
+        # mirror the fallback error raised by `convert_to_output`.
+        if (
+            not DependencyManager.polars.has()
+            and not DependencyManager.pandas.has()
+        ):
+            deps.append(polars_with_pyarrow)
+
+    # "native" returns the underlying DuckDB relation and needs no df lib.
+    return deps
 
 
 @mddoc
@@ -63,8 +104,7 @@ def sql(
     if engine is None:
         DependencyManager.require_many(
             "to execute sql",
-            DependencyManager.duckdb,
-            DependencyManager.sqlglot,
+            *_default_duckdb_deps(),
             source="kernel",
         )
         sql_engine = DuckDBEngine(connection=None)

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -2,8 +2,12 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from marimo._config.config import SqlOutputType
 from marimo._dependencies.dependencies import Dependency, DependencyManager
 from marimo._output.rich_help import mddoc
 from marimo._runtime.output import replace
@@ -29,39 +33,47 @@ def get_default_result_limit() -> int | None:
     return int(limit) if limit is not None else None
 
 
+def _resolve_default_duckdb_deps(
+    sql_output: SqlOutputType,
+    *,
+    polars_installed: Callable[[], bool],
+    pandas_installed: Callable[[], bool],
+) -> list[Dependency]:
+    deps: list[Dependency] = [
+        DependencyManager.duckdb,
+        DependencyManager.sqlglot,
+    ]
+    polars_with_pyarrow = Dependency(
+        "polars", pkg_name_to_install="polars[pyarrow]"
+    )
+
+    if sql_output == "polars" or sql_output == "lazy-polars":
+        deps.append(polars_with_pyarrow)
+    elif sql_output == "pandas":
+        deps.append(DependencyManager.pandas)
+    elif sql_output == "auto":
+        if not polars_installed() and not pandas_installed():
+            deps.append(polars_with_pyarrow)
+    elif sql_output == "native":
+        # "native" returns the underlying DuckDB relation and needs no df lib.
+        pass
+    else:
+        log_never(sql_output)
+
+    return deps
+
+
 def _default_duckdb_deps() -> list[Dependency]:
     """
     Return all deps required to run `mo.sql(query)` with the default DuckDB
     engine, including the dataframe library used for the configured output
     format.
     """
-    deps: list[Dependency] = [
-        DependencyManager.duckdb,
-        DependencyManager.sqlglot,
-    ]
-
-    polars_with_pyarrow = Dependency(
-        "polars", pkg_name_to_install="polars[pyarrow]"
+    return _resolve_default_duckdb_deps(
+        get_configured_sql_output_format(),
+        polars_installed=DependencyManager.polars.has,
+        pandas_installed=DependencyManager.pandas.has,
     )
-
-    sql_output = get_configured_sql_output_format()
-    if sql_output == "polars" or sql_output == "lazy-polars":
-        deps.append(polars_with_pyarrow)
-    elif sql_output == "pandas":
-        deps.append(DependencyManager.pandas)
-    elif sql_output == "auto":
-        if (
-            not DependencyManager.polars.has()
-            and not DependencyManager.pandas.has()
-        ):
-            deps.append(polars_with_pyarrow)
-    elif sql_output == "native":
-        # "native" returns the underlying DuckDB relation and needs no df lib.
-        return deps
-    else:
-        log_never(sql_output)
-
-    return deps
 
 
 @mddoc

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -20,6 +20,7 @@ from marimo._sql.utils import (
     raise_df_import_error,
 )
 from marimo._types.ids import VariableName
+from marimo._utils.assert_never import log_never
 from marimo._utils.narwhals_utils import can_narwhalify_lazyframe
 
 
@@ -54,8 +55,12 @@ def _default_duckdb_deps() -> list[Dependency]:
             and not DependencyManager.pandas.has()
         ):
             deps.append(polars_with_pyarrow)
+    elif sql_output == "native":
+        # "native" returns the underlying DuckDB relation and needs no df lib.
+        return deps
+    else:
+        log_never(sql_output)
 
-    # "native" returns the underlying DuckDB relation and needs no df lib.
     return deps
 
 

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -29,22 +29,16 @@ def get_default_result_limit() -> int | None:
 
 
 def _default_duckdb_deps() -> list[Dependency]:
-    """Return all deps required to run `mo.sql(query)` with the default DuckDB
+    """
+    Return all deps required to run `mo.sql(query)` with the default DuckDB
     engine, including the dataframe library used for the configured output
     format.
-
-    Resolving the dataframe library upfront lets the kernel prompt the user to
-    install everything in a single step, instead of prompting first for
-    duckdb/sqlglot and then again for polars/pandas after the query is parsed.
     """
     deps: list[Dependency] = [
         DependencyManager.duckdb,
         DependencyManager.sqlglot,
     ]
 
-    # Mirrors `raise_df_import_error("polars[pyarrow]")` in `marimo/_sql/utils.py`:
-    # polars conversion is much faster when pyarrow is available, so we eagerly
-    # request the extras.
     polars_with_pyarrow = Dependency(
         "polars", pkg_name_to_install="polars[pyarrow]"
     )
@@ -55,9 +49,6 @@ def _default_duckdb_deps() -> list[Dependency]:
     elif sql_output == "pandas":
         deps.append(DependencyManager.pandas)
     elif sql_output == "auto":
-        # In auto mode either polars or pandas is acceptable; only bundle an
-        # install when neither is already present. Prefer polars[pyarrow] to
-        # mirror the fallback error raised by `convert_to_output`.
         if (
             not DependencyManager.polars.has()
             and not DependencyManager.pandas.has()

--- a/marimo/_sql/sql.py
+++ b/marimo/_sql/sql.py
@@ -45,7 +45,7 @@ def _default_duckdb_deps() -> list[Dependency]:
     )
 
     sql_output = get_configured_sql_output_format()
-    if sql_output in ("polars", "lazy-polars"):
+    if sql_output == "polars" or sql_output == "lazy-polars":
         deps.append(polars_with_pyarrow)
     elif sql_output == "pandas":
         deps.append(DependencyManager.pandas)

--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -37,10 +37,6 @@ def get_configured_sql_output_format() -> SqlOutputType:
 
     Returns "auto" when no runtime context is available (e.g. when `mo.sql(...)`
     is called outside of a marimo app).
-
-    This is a pure config read with no side effects. Callers that also need to
-    require the corresponding dataframe library should layer validation on top
-    (see `_validate_sql_output_format` in `marimo._sql.engines.types`).
     """
     if not runtime_context_installed():
         return "auto"

--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -14,6 +14,7 @@ from marimo._runtime._wasm._duckdb import (
 from marimo._runtime.context.types import (
     ContextNotInitializedError,
     get_context,
+    runtime_context_installed,
 )
 
 if TYPE_CHECKING:
@@ -29,6 +30,24 @@ LOGGER = _loggers.marimo_logger()
 CHEAP_DISCOVERY_DATABASES = ["duckdb", "sqlite", "mysql", "postgresql"]
 # DuckDB SQL can return None for DDL, so keep "patch did not apply" distinct.
 _NO_WASM_DUCKDB_RESULT = object()
+
+
+def get_configured_sql_output_format() -> SqlOutputType:
+    """Read the configured SQL output format from the runtime context.
+
+    Returns "auto" when no runtime context is available (e.g. when `mo.sql(...)`
+    is called outside of a marimo app).
+
+    This is a pure config read with no side effects. Callers that also need to
+    require the corresponding dataframe library should layer validation on top
+    (see `_validate_sql_output_format` in `marimo._sql.engines.types`).
+    """
+    if not runtime_context_installed():
+        return "auto"
+    try:
+        return get_context().app_config.sql_output
+    except ContextNotInitializedError:
+        return "auto"
 
 
 def _try_wasm_duckdb(

--- a/tests/_sql/test_get_engines.py
+++ b/tests/_sql/test_get_engines.py
@@ -346,7 +346,11 @@ def test_get_engines_duckdb_databases() -> None:
     assert connection.default_database == "memory"
     assert connection.default_schema == "main"
 
-    sql("CREATE TABLE test_table (id INTEGER);")
+    with patch(
+        "marimo._sql.sql.get_configured_sql_output_format",
+        return_value="native",
+    ):
+        sql("CREATE TABLE test_table (id INTEGER);")
 
     # Reload the connection to get the new table
     connection = engine_to_data_source_connection(
@@ -370,7 +374,11 @@ def test_get_engines_duckdb_databases() -> None:
             sample_values=[],
         )
     ]
-    sql("DROP TABLE test_table;")
+    with patch(
+        "marimo._sql.sql.get_configured_sql_output_format",
+        return_value="native",
+    ):
+        sql("DROP TABLE test_table;")
 
 
 @pytest.mark.skipif(not HAS_SQLALCHEMY, reason="SQLAlchemy not installed")

--- a/tests/_sql/test_sql.py
+++ b/tests/_sql/test_sql.py
@@ -9,13 +9,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 from inline_snapshot import snapshot
 
-from marimo._dependencies.dependencies import DependencyManager
+from marimo._config.config import SqlOutputType
+from marimo._dependencies.dependencies import Dependency, DependencyManager
 from marimo._dependencies.errors import ManyModulesNotFoundError
 from marimo._output.formatting import Plain
 from marimo._plugins import ui
 from marimo._sql.engines.ibis import IbisEngine
 from marimo._sql.engines.sqlalchemy import SQLAlchemyEngine
-from marimo._sql.sql import _default_duckdb_deps, _query_includes_limit, sql
+from marimo._sql.sql import (
+    _query_includes_limit,
+    _resolve_default_duckdb_deps,
+    sql,
+)
 from marimo._sql.utils import (
     extract_explain_content,
     is_explain_query,
@@ -25,7 +30,7 @@ from marimo._sql.utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     import duckdb
     import sqlalchemy as sa
@@ -135,8 +140,6 @@ def fake_dependency_has(monkeypatch: pytest.MonkeyPatch) -> set[str]:
     The returned set acts as the "installed packages" registry — add a pkg name
     to it to make `Dependency(pkg).has()` return True.
     """
-    from marimo._dependencies.dependencies import Dependency
-
     installed: set[str] = set()
 
     def fake(self: Dependency, quiet: bool = False) -> bool:
@@ -144,6 +147,9 @@ def fake_dependency_has(monkeypatch: pytest.MonkeyPatch) -> set[str]:
         return self.pkg in installed
 
     monkeypatch.setattr(Dependency, "has", fake)
+    for dep in vars(DependencyManager).values():
+        if isinstance(dep, Dependency) and "has" in dep.__dict__:
+            monkeypatch.delattr(dep, "has")
     return installed
 
 
@@ -169,85 +175,123 @@ def fake_sql_output(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
     return current
 
 
-@pytest.mark.usefixtures("fake_dependency_has")
 class TestDefaultDuckDBDeps:
-    """Tests that the default-DuckDB path bundles all required installs into a
-    single ManyModulesNotFoundError, so the user only gets prompted once."""
+    """Tests for the pure `_resolve_default_duckdb_deps` helper. These are
+    side-effect free: they don't touch global runtime state or the real
+    `DependencyManager`, so they're immune to test-ordering issues.
+    """
 
     @staticmethod
-    def _pkg_names(deps: list) -> list[str]:
-        return [dep.pkg_name_to_install for dep in deps]
+    def _pkg_names(deps: list[Dependency]) -> list[str]:
+        return [dep.pkg_name_to_install or dep.pkg for dep in deps]
 
-    def test_auto_bundles_polars_when_no_df_lib_present(
-        self, fake_sql_output: dict[str, str]
-    ) -> None:
-        fake_sql_output["value"] = "auto"
-        assert self._pkg_names(_default_duckdb_deps()) == [
+    @staticmethod
+    def _const(value: bool) -> Callable[[], bool]:
+        return lambda: value
+
+    def test_auto_bundles_polars_when_no_df_lib_present(self) -> None:
+        deps = _resolve_default_duckdb_deps(
+            "auto",
+            polars_installed=self._const(False),
+            pandas_installed=self._const(False),
+        )
+        assert self._pkg_names(deps) == [
             "duckdb",
             "sqlglot",
             "polars[pyarrow]",
         ]
 
-    def test_auto_skips_df_lib_when_pandas_already_installed(
-        self,
-        fake_dependency_has: set[str],
-        fake_sql_output: dict[str, str],
-    ) -> None:
-        fake_sql_output["value"] = "auto"
-        fake_dependency_has.add("pandas")
-        assert self._pkg_names(_default_duckdb_deps()) == [
-            "duckdb",
-            "sqlglot",
-        ]
+    def test_auto_skips_df_lib_when_pandas_already_installed(self) -> None:
+        deps = _resolve_default_duckdb_deps(
+            "auto",
+            polars_installed=self._const(False),
+            pandas_installed=self._const(True),
+        )
+        assert self._pkg_names(deps) == ["duckdb", "sqlglot"]
 
-    def test_auto_skips_df_lib_when_polars_already_installed(
-        self,
-        fake_dependency_has: set[str],
-        fake_sql_output: dict[str, str],
-    ) -> None:
-        fake_sql_output["value"] = "auto"
-        fake_dependency_has.add("polars")
-        assert self._pkg_names(_default_duckdb_deps()) == [
-            "duckdb",
-            "sqlglot",
-        ]
+    def test_auto_skips_df_lib_when_polars_already_installed(self) -> None:
+        deps = _resolve_default_duckdb_deps(
+            "auto",
+            polars_installed=self._const(True),
+            pandas_installed=self._const(False),
+        )
+        assert self._pkg_names(deps) == ["duckdb", "sqlglot"]
 
-    def test_pandas_output_requires_pandas(
-        self, fake_sql_output: dict[str, str]
+    def test_auto_short_circuits_pandas_check_when_polars_present(
+        self,
     ) -> None:
-        fake_sql_output["value"] = "pandas"
-        assert self._pkg_names(_default_duckdb_deps()) == [
-            "duckdb",
-            "sqlglot",
+        """If polars is already installed, pandas.has() must not be invoked."""
+        pandas_calls = 0
+
+        def pandas_installed() -> bool:
+            nonlocal pandas_calls
+            pandas_calls += 1
+            return False
+
+        _resolve_default_duckdb_deps(
+            "auto",
+            polars_installed=self._const(True),
+            pandas_installed=pandas_installed,
+        )
+        assert pandas_calls == 0
+
+    def test_pandas_output_requires_pandas(self) -> None:
+        deps = _resolve_default_duckdb_deps(
             "pandas",
-        ]
+            polars_installed=self._const(False),
+            pandas_installed=self._const(False),
+        )
+        assert self._pkg_names(deps) == ["duckdb", "sqlglot", "pandas"]
 
     @pytest.mark.parametrize("output", ["polars", "lazy-polars"])
     def test_polars_outputs_require_polars_pyarrow(
-        self, fake_sql_output: dict[str, str], output: str
+        self, output: SqlOutputType
     ) -> None:
-        fake_sql_output["value"] = output
-        assert self._pkg_names(_default_duckdb_deps()) == [
+        deps = _resolve_default_duckdb_deps(
+            output,
+            polars_installed=self._const(False),
+            pandas_installed=self._const(False),
+        )
+        assert self._pkg_names(deps) == [
             "duckdb",
             "sqlglot",
             "polars[pyarrow]",
         ]
 
-    def test_native_output_skips_df_lib(
-        self, fake_sql_output: dict[str, str]
+    def test_native_output_skips_df_lib(self) -> None:
+        deps = _resolve_default_duckdb_deps(
+            "native",
+            polars_installed=self._const(False),
+            pandas_installed=self._const(False),
+        )
+        assert self._pkg_names(deps) == ["duckdb", "sqlglot"]
+
+    @pytest.mark.parametrize(
+        "output", ["polars", "lazy-polars", "pandas", "native"]
+    )
+    def test_non_auto_outputs_skip_has_checks(
+        self, output: SqlOutputType
     ) -> None:
-        fake_sql_output["value"] = "native"
-        assert self._pkg_names(_default_duckdb_deps()) == [
-            "duckdb",
-            "sqlglot",
-        ]
+        """Non-auto branches must not invoke `.has()` callables at all."""
+
+        def boom() -> bool:
+            raise AssertionError(
+                "has() should not be called for non-auto sql_output"
+            )
+
+        _resolve_default_duckdb_deps(
+            output, polars_installed=boom, pandas_installed=boom
+        )
+
+
+@pytest.mark.usefixtures("fake_dependency_has")
+class TestDefaultDuckDBDepsEndToEnd:
+    """End-to-end: verify `mo.sql(...)` bundles all missing installs into a
+    single ManyModulesNotFoundError, so the user only gets prompted once."""
 
     def test_sql_raises_single_bundled_error_when_all_missing(
         self, fake_sql_output: dict[str, str]
     ) -> None:
-        """End-to-end check: with no deps installed and auto output, calling
-        `mo.sql(...)` raises one ManyModulesNotFoundError listing all of
-        duckdb, sqlglot, and polars[pyarrow] at once."""
         fake_sql_output["value"] = "auto"
         with pytest.raises(ManyModulesNotFoundError) as excinfo:
             sql("SELECT 1")

--- a/tests/_sql/test_sql.py
+++ b/tests/_sql/test_sql.py
@@ -10,11 +10,12 @@ import pytest
 from inline_snapshot import snapshot
 
 from marimo._dependencies.dependencies import DependencyManager
+from marimo._dependencies.errors import ManyModulesNotFoundError
 from marimo._output.formatting import Plain
 from marimo._plugins import ui
 from marimo._sql.engines.ibis import IbisEngine
 from marimo._sql.engines.sqlalchemy import SQLAlchemyEngine
-from marimo._sql.sql import _query_includes_limit, sql
+from marimo._sql.sql import _default_duckdb_deps, _query_includes_limit, sql
 from marimo._sql.utils import (
     extract_explain_content,
     is_explain_query,
@@ -124,6 +125,146 @@ def test_sql_with_invalid_engine() -> None:
     """Test sql function with invalid engine."""
     with pytest.raises(ValueError, match="Unsupported engine"):
         sql("SELECT 1", engine="invalid")
+
+
+@pytest.fixture
+def fake_dependency_has(monkeypatch: pytest.MonkeyPatch) -> set[str]:
+    """Stub `Dependency.has` so the bundled-deps logic doesn't depend on the
+    test environment having (or not having) duckdb/polars/etc. installed.
+
+    The returned set acts as the "installed packages" registry — add a pkg name
+    to it to make `Dependency(pkg).has()` return True.
+    """
+    from marimo._dependencies.dependencies import Dependency
+
+    installed: set[str] = set()
+
+    def fake(self: Dependency, quiet: bool = False) -> bool:
+        del quiet
+        return self.pkg in installed
+
+    monkeypatch.setattr(Dependency, "has", fake)
+    return installed
+
+
+@pytest.fixture
+def fake_sql_output(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Stub the runtime-context lookup so we can drive `sql_output` without
+    spinning up a kernel.
+
+    We patch the shared util at its definition site so the same fixture
+    transparently controls every call site (the bundled-deps logic in
+    `sql.py`, the engine-level validation in `engines/types.py`, etc.).
+    """
+    current = {"value": "auto"}
+
+    def fake_format() -> str:
+        return current["value"]
+
+    monkeypatch.setattr(
+        "marimo._sql.utils.get_configured_sql_output_format", fake_format
+    )
+    # `sql.py` and `engines/types.py` import the symbol directly, so we also
+    # need to patch the re-bound references they hold.
+    monkeypatch.setattr(
+        "marimo._sql.sql.get_configured_sql_output_format", fake_format
+    )
+    monkeypatch.setattr(
+        "marimo._sql.engines.types.get_configured_sql_output_format",
+        fake_format,
+    )
+    return current
+
+
+@pytest.mark.usefixtures("fake_dependency_has")
+class TestDefaultDuckDBDeps:
+    """Tests that the default-DuckDB path bundles all required installs into a
+    single ManyModulesNotFoundError, so the user only gets prompted once."""
+
+    @staticmethod
+    def _pkg_names(deps: list) -> list[str]:
+        return [dep.pkg_name_to_install for dep in deps]
+
+    def test_auto_bundles_polars_when_no_df_lib_present(
+        self, fake_sql_output: dict[str, str]
+    ) -> None:
+        fake_sql_output["value"] = "auto"
+        assert self._pkg_names(_default_duckdb_deps()) == [
+            "duckdb",
+            "sqlglot",
+            "polars[pyarrow]",
+        ]
+
+    def test_auto_skips_df_lib_when_pandas_already_installed(
+        self,
+        fake_dependency_has: set[str],
+        fake_sql_output: dict[str, str],
+    ) -> None:
+        fake_sql_output["value"] = "auto"
+        fake_dependency_has.add("pandas")
+        assert self._pkg_names(_default_duckdb_deps()) == [
+            "duckdb",
+            "sqlglot",
+        ]
+
+    def test_auto_skips_df_lib_when_polars_already_installed(
+        self,
+        fake_dependency_has: set[str],
+        fake_sql_output: dict[str, str],
+    ) -> None:
+        fake_sql_output["value"] = "auto"
+        fake_dependency_has.add("polars")
+        assert self._pkg_names(_default_duckdb_deps()) == [
+            "duckdb",
+            "sqlglot",
+        ]
+
+    def test_pandas_output_requires_pandas(
+        self, fake_sql_output: dict[str, str]
+    ) -> None:
+        fake_sql_output["value"] = "pandas"
+        assert self._pkg_names(_default_duckdb_deps()) == [
+            "duckdb",
+            "sqlglot",
+            "pandas",
+        ]
+
+    @pytest.mark.parametrize("output", ["polars", "lazy-polars"])
+    def test_polars_outputs_require_polars_pyarrow(
+        self, fake_sql_output: dict[str, str], output: str
+    ) -> None:
+        fake_sql_output["value"] = output
+        assert self._pkg_names(_default_duckdb_deps()) == [
+            "duckdb",
+            "sqlglot",
+            "polars[pyarrow]",
+        ]
+
+    def test_native_output_skips_df_lib(
+        self, fake_sql_output: dict[str, str]
+    ) -> None:
+        fake_sql_output["value"] = "native"
+        assert self._pkg_names(_default_duckdb_deps()) == [
+            "duckdb",
+            "sqlglot",
+        ]
+
+    def test_sql_raises_single_bundled_error_when_all_missing(
+        self, fake_sql_output: dict[str, str]
+    ) -> None:
+        """End-to-end check: with no deps installed and auto output, calling
+        `mo.sql(...)` raises one ManyModulesNotFoundError listing all of
+        duckdb, sqlglot, and polars[pyarrow] at once."""
+        fake_sql_output["value"] = "auto"
+        with pytest.raises(ManyModulesNotFoundError) as excinfo:
+            sql("SELECT 1")
+
+        assert excinfo.value.package_names == [
+            "duckdb",
+            "sqlglot",
+            "polars[pyarrow]",
+        ]
+        assert excinfo.value.source == "kernel"
 
 
 @pytest.mark.skipif(not HAS_SQLALCHEMY, reason="SQLAlchemy not installed")

--- a/tests/_sql/test_sql.py
+++ b/tests/_sql/test_sql.py
@@ -152,27 +152,20 @@ def fake_sql_output(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
     """Stub the runtime-context lookup so we can drive `sql_output` without
     spinning up a kernel.
 
-    We patch the shared util at its definition site so the same fixture
-    transparently controls every call site (the bundled-deps logic in
-    `sql.py`, the engine-level validation in `engines/types.py`, etc.).
+    `sql.py` and `engines/types.py` import `get_configured_sql_output_format`
+    directly, so each consumer module holds its own binding and must be
+    patched independently.
     """
     current = {"value": "auto"}
 
     def fake_format() -> str:
         return current["value"]
 
-    monkeypatch.setattr(
-        "marimo._sql.utils.get_configured_sql_output_format", fake_format
-    )
-    # `sql.py` and `engines/types.py` import the symbol directly, so we also
-    # need to patch the re-bound references they hold.
-    monkeypatch.setattr(
-        "marimo._sql.sql.get_configured_sql_output_format", fake_format
-    )
-    monkeypatch.setattr(
+    for target in (
+        "marimo._sql.sql.get_configured_sql_output_format",
         "marimo._sql.engines.types.get_configured_sql_output_format",
-        fake_format,
-    )
+    ):
+        monkeypatch.setattr(target, fake_format)
     return current
 
 


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
When you run mo.sql with duckdb from a fresh engine, it prompts you to install `duckdb`, and `sqlglot`, and then after running, prompts to install polars/pandas.

This now gets you to install all 3 packages from the start.
<img width="1466" height="428" alt="image" src="https://github.com/user-attachments/assets/d5497301-0bb7-41aa-a0a3-baa2d16b5c28" />

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
