### PR TITLE
feat(ui): support disabled on dropdown and multiselect

### DIFF
--- a/frontend/src/components/data-table/charts/components/form-fields.tsx
+++ b/frontend/src/components/data-table/charts/components/form-fields.tsx
@@ -789,6 +789,7 @@ export const TooltipSelect = ({
             <FormControl>
               <Multiselect
                 options={fields?.map((field) => field.name) ?? []}
+                disabled={false}
                 value={values}
                 setValue={(values) => {
                   const selectedValues =

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -173,7 +173,7 @@ export const Combobox = <TValue,>({
       <Popover
         open={open}
         onOpenChange={(v) => {
-          if (disabled) {
+          if (disabled && v) {
             return;
           }
           setOpen(v);

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -39,6 +39,7 @@ interface ComboboxCommonProps<TValue> {
   className?: string;
   id?: string;
   keepPopoverOpenOnSelect?: boolean;
+  disabled?: boolean;
 }
 
 type ComboboxFilterProps =
@@ -95,6 +96,7 @@ export const Combobox = <TValue,>({
   chipsClassName,
   keepPopoverOpenOnSelect,
   id,
+  disabled = false,
   ...rest
 }: ComboboxProps<TValue>) => {
   const [open = false, setOpen] = useControllableState({
@@ -168,15 +170,25 @@ export const Combobox = <TValue,>({
 
   return (
     <div className={cn("relative")} {...rest}>
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover
+        open={open}
+        onOpenChange={(v) => {
+          if (disabled) {
+            return;
+          }
+          setOpen(v);
+        }}
+      >
         <PopoverTrigger asChild={true}>
           <div
             id={id}
             className={cn(
-              "flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50",
+              "flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid",
+              disabled && "cursor-not-allowed opacity-50",
               className,
             )}
             aria-expanded={open}
+            aria-disabled={disabled}
           >
             <span className="truncate flex-1 min-w-0">{renderValue()}</span>
             <ChevronDownIcon className="ml-3 w-4 h-4 opacity-50 shrink-0" />
@@ -215,9 +227,15 @@ export const Combobox = <TValue,>({
                   {displayValue?.(val) ?? String(val)}
                   <XCircle
                     onClick={() => {
+                      if (disabled) {
+                        return;
+                      }
                       handleSelect(val);
                     }}
-                    className="w-3 h-3 opacity-50 hover:opacity-100 ml-1 cursor-pointer"
+                    className={cn(
+                      "w-3 h-3 opacity-50 hover:opacity-100 ml-1 cursor-pointer",
+                      disabled && "pointer-events-none",
+                    )}
                   />
                 </Badge>
               );

--- a/frontend/src/plugins/impl/DropdownPlugin.tsx
+++ b/frontend/src/plugins/impl/DropdownPlugin.tsx
@@ -13,6 +13,7 @@ interface Data {
   allowSelectNone: boolean;
   fullWidth: boolean;
   searchable: boolean;
+  disabled: boolean;
 }
 
 export class DropdownPlugin implements IPlugin<string[], Data> {
@@ -25,6 +26,7 @@ export class DropdownPlugin implements IPlugin<string[], Data> {
     allowSelectNone: z.boolean(),
     fullWidth: z.boolean().default(false),
     searchable: z.boolean().default(false),
+    disabled: z.boolean().default(false),
   });
 
   render(props: IPluginProps<string[], Data>): JSX.Element {
@@ -61,7 +63,15 @@ interface DropdownProps extends Data {
 const EMPTY_VALUE = "--";
 
 const Dropdown = (props: DropdownProps): JSX.Element => {
-  const { label, options, value, setValue, allowSelectNone, fullWidth } = props;
+  const {
+    label,
+    options,
+    value,
+    setValue,
+    allowSelectNone,
+    fullWidth,
+    disabled,
+  } = props;
 
   const id = useId();
 
@@ -85,6 +95,7 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
         })}
         value={singleValue}
         id={id}
+        disabled={disabled}
       >
         {allowSelectNone ? (
           <option value={EMPTY_VALUE} selected={value.length === 0}>

--- a/frontend/src/plugins/impl/MultiselectPlugin.tsx
+++ b/frontend/src/plugins/impl/MultiselectPlugin.tsx
@@ -14,6 +14,7 @@ interface Data {
   options: string[];
   fullWidth: boolean;
   maxSelections?: number | undefined;
+  disabled: boolean;
 }
 
 type T = string[];
@@ -27,6 +28,7 @@ export class MultiselectPlugin implements IPlugin<T, Data> {
     options: z.array(z.string()),
     fullWidth: z.boolean().default(false),
     maxSelections: z.number().optional(),
+    disabled: z.boolean().default(false),
   });
 
   render(props: IPluginProps<string[], Data>): JSX.Element {
@@ -63,6 +65,7 @@ export const Multiselect = ({
   setValue,
   fullWidth,
   maxSelections,
+  disabled,
 }: MultiselectProps): JSX.Element => {
   const id = useId();
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -199,6 +202,7 @@ export const Multiselect = ({
         shouldFilter={false}
         search={searchQuery}
         onSearchChange={setSearchQuery}
+        disabled={disabled}
       >
         {renderList()}
       </Combobox>

--- a/frontend/src/plugins/impl/SearchableSelect.tsx
+++ b/frontend/src/plugins/impl/SearchableSelect.tsx
@@ -13,12 +13,21 @@ interface SearchableSelectProps {
   label: string | null;
   allowSelectNone: boolean;
   fullWidth: boolean;
+  disabled: boolean;
 }
 
 const NONE_KEY = "__none__";
 
 export const SearchableSelect = (props: SearchableSelectProps): JSX.Element => {
-  const { options, value, setValue, label, allowSelectNone, fullWidth } = props;
+  const {
+    options,
+    value,
+    setValue,
+    label,
+    allowSelectNone,
+    fullWidth,
+    disabled,
+  } = props;
   const id = useId();
   const [searchQuery, setSearchQuery] = useState<string>("");
 
@@ -113,6 +122,7 @@ export const SearchableSelect = (props: SearchableSelectProps): JSX.Element => {
         shouldFilter={false}
         search={searchQuery}
         onSearchChange={setSearchQuery}
+        disabled={disabled}
         data-testid="marimo-plugin-searchable-dropdown"
       >
         {renderList()}

--- a/frontend/src/plugins/impl/__tests__/DropdownPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/DropdownPlugin.test.tsx
@@ -36,6 +36,7 @@ describe("DropdownPlugin", () => {
           fullWidth: false,
           searchable: true,
           initialValue: [],
+          disabled: false,
         },
         value: [],
         setValue: vi.fn(),
@@ -46,6 +47,58 @@ describe("DropdownPlugin", () => {
       expect(
         screen.getByTestId("marimo-plugin-searchable-dropdown"),
       ).toBeInTheDocument();
+    });
+
+    it("renders disabled native select when disabled is true", () => {
+      const plugin = new DropdownPlugin();
+      const host = document.createElement("div");
+      const props: IPluginProps<
+        string[],
+        z.infer<(typeof plugin)["validator"]>
+      > = {
+        data: {
+          label: "Test Label",
+          options: ["Option 1", "Option 2"],
+          allowSelectNone: false,
+          fullWidth: false,
+          searchable: false,
+          disabled: true,
+          initialValue: [],
+        },
+        value: [],
+        setValue: vi.fn(),
+        host,
+        functions: {},
+      };
+      render(plugin.render(props));
+      expect(screen.getByTestId("marimo-plugin-dropdown")).toBeDisabled();
+    });
+
+    it("renders disabled searchable combobox with aria-disabled", () => {
+      const plugin = new DropdownPlugin();
+      const host = document.createElement("div");
+      const props: IPluginProps<
+        string[],
+        z.infer<(typeof plugin)["validator"]>
+      > = {
+        data: {
+          label: "Test Label",
+          options: ["Option 1", "Option 2"],
+          allowSelectNone: false,
+          fullWidth: false,
+          searchable: true,
+          disabled: true,
+          initialValue: [],
+        },
+        value: [],
+        setValue: vi.fn(),
+        host,
+        functions: {},
+      };
+      render(plugin.render(props));
+      const trigger = screen.getByTestId("marimo-plugin-searchable-dropdown")
+        .firstChild as HTMLElement;
+      expect(trigger).toHaveAttribute("aria-disabled", "true");
     });
 
     it("renders default dropdown when searchable is false", () => {
@@ -62,6 +115,7 @@ describe("DropdownPlugin", () => {
           fullWidth: false,
           searchable: false,
           initialValue: [],
+          disabled: false,
         },
         value: [],
         setValue: vi.fn(),
@@ -87,6 +141,7 @@ describe("DropdownPlugin", () => {
           fullWidth: false,
           searchable: true,
           initialValue: [],
+          disabled: false,
         },
         value: [],
         setValue,
@@ -129,6 +184,7 @@ describe("DropdownPlugin", () => {
           fullWidth: false,
           searchable: true,
           initialValue: [],
+          disabled: false,
         },
         value: ["Apple"],
         setValue,

--- a/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
+++ b/frontend/src/plugins/impl/data-frames/forms/__tests__/__snapshots__/form.test.tsx.snap
@@ -29,9 +29,10 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
         >
           <div
             aria-controls="radix-_r_27_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_26_-form-item"
             type="button"
@@ -84,9 +85,10 @@ exports[`renderZodSchema > should render a form aggregate 1`] = `
         >
           <div
             aria-controls="radix-_r_29_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_28_-form-item"
             type="button"
@@ -401,9 +403,10 @@ exports[`renderZodSchema > should render a form explode_columns 1`] = `
         >
           <div
             aria-controls="radix-_r_2p_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_2o_-form-item"
             type="button"
@@ -598,9 +601,10 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
         >
           <div
             aria-controls="radix-_r_1p_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_1o_-form-item"
             type="button"
@@ -653,9 +657,10 @@ exports[`renderZodSchema > should render a form group_by 1`] = `
         >
           <div
             aria-controls="radix-_r_1r_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_1q_-form-item"
             type="button"
@@ -800,9 +805,10 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
         >
           <div
             aria-controls="radix-_r_3b_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_3a_-form-item"
             type="button"
@@ -855,9 +861,10 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
         >
           <div
             aria-controls="radix-_r_3d_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_3c_-form-item"
             type="button"
@@ -910,9 +917,10 @@ exports[`renderZodSchema > should render a form pivot 1`] = `
         >
           <div
             aria-controls="radix-_r_3f_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_3e_-form-item"
             type="button"
@@ -1300,9 +1308,10 @@ exports[`renderZodSchema > should render a form select_columns 1`] = `
         >
           <div
             aria-controls="radix-_r_4_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_3_-form-item"
             type="button"
@@ -1583,9 +1592,10 @@ exports[`renderZodSchema > should render a form unique 1`] = `
         >
           <div
             aria-controls="radix-_r_32_"
+            aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+            class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
             data-state="closed"
             id="_r_31_-form-item"
             type="button"
@@ -1742,9 +1752,10 @@ exports[`renders custom forms column_id_array 1`] = `
     >
       <div
         aria-controls="radix-_r_41_"
+        aria-disabled="false"
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+        class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
         data-state="closed"
         id="_r_40_-form-item"
         type="button"
@@ -1792,9 +1803,10 @@ exports[`renders custom forms column_id_dot_array 1`] = `
     >
       <div
         aria-controls="radix-_r_43_"
+        aria-disabled="false"
         aria-expanded="false"
         aria-haspopup="dialog"
-        class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid disabled:cursor-not-allowed disabled:opacity-50 min-w-[180px]"
+        class="flex h-6 w-fit mb-1 shadow-xs-solid items-center justify-between rounded-sm border border-input bg-transparent px-2 text-sm font-prose ring-offset-background placeholder:text-muted-foreground hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid min-w-[180px]"
         data-state="closed"
         id="_r_42_-form-item"
         type="button"

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -996,6 +996,7 @@ class dropdown(UIElement[list[str], Any]):
             this element's value changes. Defaults to None.
         full_width (bool, optional): Whether the input should take up the full width
             of its container. Defaults to False.
+        disabled (bool, optional): Whether the dropdown is disabled. Defaults to False.
     """
 
     _FORCE_SEARCHABLE: Final[int] = 1000
@@ -1013,6 +1014,7 @@ class dropdown(UIElement[list[str], Any]):
         label: str = "",
         on_change: Callable[[Any], None] | None = None,
         full_width: bool = False,
+        disabled: bool = False,
     ) -> None:
         # Force searchable if there are too many options
         # This makes the list 'virtualized' on the frontend
@@ -1050,6 +1052,7 @@ class dropdown(UIElement[list[str], Any]):
                 "allow-select-none": allow_select_none,
                 "searchable": searchable,
                 "full-width": full_width,
+                "disabled": disabled,
             },
             on_change=on_change,
         )
@@ -1118,6 +1121,7 @@ class multiselect(UIElement[list[str], list[object]]):
             of its container. Defaults to False.
         max_selections (int, optional): Maximum number of items that can be selected.
             Defaults to None.
+        disabled (bool, optional): Whether the multiselect is disabled. Defaults to False.
     """
 
     _MAX_OPTIONS: Final[int] = 100000
@@ -1132,6 +1136,7 @@ class multiselect(UIElement[list[str], list[object]]):
         on_change: Callable[[list[object]], None] | None = None,
         full_width: bool = False,
         max_selections: int | None = None,
+        disabled: bool = False,
     ) -> None:
         if len(options) > multiselect._MAX_OPTIONS:
             raise ValueError(
@@ -1169,6 +1174,7 @@ class multiselect(UIElement[list[str], list[object]]):
                 "options": list(self.options.keys()),
                 "full-width": full_width,
                 "max-selections": max_selections,
+                "disabled": disabled,
             },
             on_change=on_change,
         )

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -466,6 +466,14 @@ def test_dropdown_lots_of_options() -> None:
     assert dropdown._component_args["searchable"] is True
 
 
+def test_dropdown_disabled() -> None:
+    dd = ui.dropdown(options=["1", "2", "3"])
+    assert dd._component_args["disabled"] is False
+
+    dd = ui.dropdown(options=["1", "2", "3"], disabled=True)
+    assert dd._component_args["disabled"] is True
+
+
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_dropdown_from_dataframe() -> None:
     import pandas as pd
@@ -585,6 +593,14 @@ def test_multiselect_too_many_options() -> None:
         ui.multiselect(options={str(i): i for i in range(200000)})
 
     assert "maximum number" in str(e.value)
+
+
+def test_multiselect_disabled() -> None:
+    ms = ui.multiselect(options=["1", "2", "3"])
+    assert ms._component_args["disabled"] is False
+
+    ms = ui.multiselect(options=["1", "2", "3"], disabled=True)
+    assert ms._component_args["disabled"] is True
 
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")


### PR DESCRIPTION
## Summary

- Adds a `disabled` kwarg to `mo.ui.dropdown` and `mo.ui.multiselect`, matching the pattern already used by other inputs (`text`, `slider`, `checkbox`, `radio`, `button`, etc.).
- Native `<select>` path uses the native `disabled` attribute.
- Searchable dropdown and multiselect (Combobox) block popover toggling and chip removal via `aria-disabled` and pointer-events styling; the trigger remains a `<div>` to avoid changing focus/keyboard semantics for existing combobox usages.

Closes #9579

https://github.com/user-attachments/assets/4ee53d9b-539c-40a9-8fbd-a98c322bcc46


## Test plan

- [x] `make check`
- [x] Python: new `test_dropdown_disabled`, `test_multiselect_disabled`
- [x] Frontend: new tests for disabled native select and disabled searchable combobox; existing tests updated
- [x] Manual: smoke notebook with enabled + disabled variants of dropdown, searchable dropdown, and multiselect