### PR TITLE
﻿fix(frontend): fix new notebook URL using wrong file query param

### DIFF
--- a/frontend/src/utils/urls.ts
+++ b/frontend/src/utils/urls.ts
@@ -23,8 +23,9 @@ export function hasQueryParam(key: string, value?: string): boolean {
 
 export function newNotebookURL() {
   const sessionId = generateSessionId();
-  const initializationId = `__new__${sessionId}`;
-  return asURL(`?file=${encodeURIComponent(initializationId)}`).toString();
+  return asURL(
+    `?file=__new__&session_id=${encodeURIComponent(sessionId)}`,
+  ).toString();
 }
 
 const urlRegex = /^(https?:\/\/\S+)$/;


### PR DESCRIPTION
newNotebookURL() was building ?file=__new__<sessionId>, but the backend's parse_file_key only recognises the exact sentinel __new__. The suffixed value was treated as a file path, causing a 404 on every new notebook open.

Fix by separating the two concerns: pass file=__new__ as the notebook key and session_id=<id> as the session identifier, consistent with how existing (unsaved) notebooks are linked from the home page.

## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
I have read the CLA Document and I hereby sign the CLA