### PR TITLE
fix(files): show .git and .venv in file browser

### DIFF
--- a/frontend/src/components/editor/file-tree/file-explorer.tsx
+++ b/frontend/src/components/editor/file-tree/file-explorer.tsx
@@ -9,6 +9,7 @@ import {
   CopyMinusIcon,
   DownloadIcon,
   ExternalLinkIcon,
+  EyeIcon,
   EyeOffIcon,
   FilePlus2Icon,
   FolderPlusIcon,
@@ -198,6 +199,7 @@ export const FileExplorer: React.FC<{
       <Toolbar
         onRefresh={handleRefresh}
         onHidden={handleHiddenFilesToggle}
+        showHiddenFiles={showHiddenFiles}
         onCreateFile={handleCreateFile}
         onCreateNotebook={handleCreateNotebook}
         onCreateFolder={handleCreateFolder}
@@ -265,6 +267,7 @@ const INDENT_STEP = 15;
 interface ToolbarProps {
   onRefresh: () => void;
   onHidden: () => void;
+  showHiddenFiles: boolean;
   onCreateFile: () => void;
   onCreateNotebook: () => void;
   onCreateFolder: () => void;
@@ -275,6 +278,7 @@ interface ToolbarProps {
 const Toolbar = ({
   onRefresh,
   onHidden,
+  showHiddenFiles,
   onCreateFile,
   onCreateNotebook,
   onCreateFolder,
@@ -334,14 +338,20 @@ const Toolbar = ({
         data-testid="file-explorer-refresh-button"
         onClick={onRefresh}
       />
-      <Tooltip content="Toggle hidden files">
+      <Tooltip
+        content={showHiddenFiles ? "Hide hidden files" : "Show hidden files"}
+      >
         <Button
           data-testid="file-explorer-hidden-files-button"
           onClick={onHidden}
           variant="text"
           size="xs"
         >
-          <EyeOffIcon size={16} />
+          {showHiddenFiles ? (
+            <EyeIcon size={16} className="text-primary" />
+          ) : (
+            <EyeOffIcon size={16} />
+          )}
         </Button>
       </Tooltip>
       <Tooltip content="Collapse all folders">

--- a/marimo/_server/files/os_file_system.py
+++ b/marimo/_server/files/os_file_system.py
@@ -21,10 +21,14 @@ from marimo._utils.files import natural_sort
 
 LOGGER = _loggers.marimo_logger()
 
-IGNORE_LIST = [
+LIST_IGNORE_LIST = [
     ".",
     "..",
     ".DS_Store",
+]
+
+SEARCH_IGNORE_LIST = [
+    *LIST_IGNORE_LIST,
     "__pycache__",
     "node_modules",
     ".git",
@@ -71,7 +75,7 @@ class OSFileSystem(FileSystem):
         try:
             with os.scandir(path) as it:
                 for entry in it:
-                    if entry.name in IGNORE_LIST:
+                    if entry.name in LIST_IGNORE_LIST:
                         continue
                     try:
                         is_directory = entry.is_dir()
@@ -356,7 +360,7 @@ class OSFileSystem(FileSystem):
                             break
 
                         # Skip ignored files/directories
-                        if entry.name in IGNORE_LIST:
+                        if entry.name in SEARCH_IGNORE_LIST:
                             continue
 
                         # Check if name matches query

--- a/tests/_server/files/test_os_file_system.py
+++ b/tests/_server/files/test_os_file_system.py
@@ -741,6 +741,8 @@ def test_search_respects_ignore_list(test_dir: Path, fs: OSFileSystem) -> None:
     (test_dir / ".DS_Store").write_text("content")
     (test_dir / "__pycache__").mkdir()
     (test_dir / "node_modules").mkdir()
+    (test_dir / ".git").mkdir()
+    (test_dir / ".venv").mkdir()
     (test_dir / "regular_file.txt").write_text("content")
 
     # Search for anything - should not find ignored items
@@ -756,6 +758,29 @@ def test_search_respects_ignore_list(test_dir: Path, fs: OSFileSystem) -> None:
     assert ".DS_Store" not in file_names
     assert "__pycache__" not in file_names
     assert "node_modules" not in file_names
+
+    # .git and .venv must also be skipped by search to avoid traversing
+    # large object stores / site-packages trees.
+    results = fs.search(query=".", path=str(test_dir))
+    file_names = {f.name for f in results}
+    assert ".git" not in file_names
+    assert ".venv" not in file_names
+
+
+def test_list_files_includes_git_and_venv(
+    test_dir: Path, fs: OSFileSystem
+) -> None:
+    """list_files surfaces .git/.venv so the frontend toggle can reveal them."""
+    (test_dir / ".git").mkdir()
+    (test_dir / ".venv").mkdir()
+    (test_dir / ".DS_Store").write_text("content")
+
+    files = fs.list_files(str(test_dir))
+    file_names = {f.name for f in files}
+    assert ".git" in file_names
+    assert ".venv" in file_names
+    # .DS_Store remains filtered at the API layer.
+    assert ".DS_Store" not in file_names
 
 
 def test_search_directory_and_file_filters(


### PR DESCRIPTION
## Summary

- list_files unconditionally stripped `.git` and `.venv`, so the file tree's "Show hidden files" toggle could never reveal them. Split the ignore list: listing only filters `.`, `..`, `.DS_Store`; recursive search still skips `.git`, `.venv`, `node_modules`, `__pycache__`, and `site-packages` to avoid traversing pack files and site-packages.
- File-explorer toggle button now swaps to an open-eye icon in the accent color when hidden files are visible.

https://github.com/user-attachments/assets/6026a7d4-1584-4989-9ed6-66e8b7b6b40a

## Test plan

- [x] `uv run --group test pytest tests/_server/files/test_os_file_system.py`
- [x] `make py-check`
- [x] `make fe-check`
- [x] Manual: dotfiles hidden by default, visible after toggle; file search does not return entries from `.git`/`.venv`.