### PR TITLE
docs: attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,13 @@ a greater movement toward reactive dataflow programming. From
 declarative, and reactive programming are transforming a broad range of tools
 for the better.
 
+Finally, we would like to acknowledge [Bennet
+Meyers](https://bmeyers.github.io/about/) and [David
+Chassin](https://www.chassin.org/about/) for believing in marimo from the very
+beginning: this work was supported in part by U.S. DOE Office of Critical
+Minerals and Energy Innovation (CMEI) Integrated Energy Systems Office (IESO),
+Agreement 34368.
+
 <p align="right">
   <img src="https://raw.githubusercontent.com/marimo-team/marimo/main/docs/_static/marimo-logotype-horizontal.png" height="200px">
 </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -395,6 +395,13 @@ a greater movement toward reactive dataflow programming. From
 declarative, and reactive programming are transforming a broad range of tools
 for the better.
 
+Finally, we would like to acknowledge [Bennet
+Meyers](https://bmeyers.github.io/about/) and [David
+Chassin](https://www.chassin.org/about/) for believing in marimo from the very
+beginning: this work was supported in part by U.S. DOE Office of Critical
+Minerals and Energy Innovation (CMEI) Integrated Energy Systems Office (IESO),
+Agreement 34368.
+
 <p align="right">
   <img src="https://raw.githubusercontent.com/marimo-team/marimo/main/docs/_static/marimo-logotype-horizontal.png" style="height:200px" alt="marimo logo">
 </p>


### PR DESCRIPTION
This PR adds attribution for Bennet and David's roles, via the DOE, in supporting marimo.