### PR TITLE
Fix lru_cache(...) resetting when cell is rerun

### DIFF
--- a/marimo/_save/save.py
+++ b/marimo/_save/save.py
@@ -1157,7 +1157,7 @@ def lru_cache(  # type: ignore[misc]
             *args,
             pin_modules=pin_modules,
             loader=MemoryLoader.partial(max_size=maxsize),
-            _frame_offset=2,
+            _frame_offset=2 if callable(arg) else 1,
             **kwargs,
         ),
     )

--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -1081,6 +1081,36 @@ class TestCacheDecorator:
         )
         assert k.globals["b"] == 55
 
+    async def test_lru_cache_with_maxsize_persists_across_cell_reruns(
+        self, k: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        cached_cell = exec_req.get(
+            """
+            @lru_cache(maxsize=128)
+            def foo():
+                print("ran")
+
+            foo()
+            foo()
+            """
+        )
+
+        await k.run(
+            [
+                exec_req.get(
+                    """
+                    from marimo._save.save import lru_cache
+                    """
+                ),
+                cached_cell,
+            ]
+        )
+        await k.run([cached_cell])
+
+        assert not k.stderr.messages, k.stderr
+        assert k.stdout.messages.count("ran") == 1
+        assert k.globals["foo"].hits == 3
+
     async def test_persistent_cache(
         self, k: Kernel, exec_req: ExecReqProvider
     ) -> None:


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Previously `@mo.lru_cache(maxsize=128)` (or similar) would reset after the cell is rerun because the extra wrapping call caused the frame offset to point one frame too high, causing the `_cache_call._set_context` to think the function isn't global.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). **Not a large change**
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it. **The unit test is AI-written, I stand by it**
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made --> **no visual changes**

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

I have read the CLA Document and I hereby sign the CLA
