### PR TITLE
fix: mo.status.progress_bar correctly handles range step

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -389,7 +389,6 @@ class progress_bar(Generic[S]):
         self.completion_subtitle = completion_subtitle
         self.remove_on_exit = remove_on_exit
         self.disabled = disabled
-        self.step: int = 1
         self.collection = collection
         self._is_async = isinstance(collection, AsyncIterable)
 
@@ -403,9 +402,6 @@ class progress_bar(Generic[S]):
                         "Cannot determine the length of a collection. "
                         "A `total` must be provided."
                     )
-
-            if isinstance(collection, range):
-                self.step = cast(range, collection).step
 
         elif total is None:
             raise ValueError(
@@ -438,7 +434,7 @@ class progress_bar(Generic[S]):
             for item in cast(Iterable[S], self.collection):
                 yield item
                 if not self.disabled:
-                    self.progress.update(increment=self.step)
+                    self.progress.update(increment=1)
         finally:
             self._finish()
 
@@ -458,7 +454,7 @@ class progress_bar(Generic[S]):
             async for item in cast(AsyncIterable[S], self.collection):
                 yield item
                 if not self.disabled:
-                    self.progress.update(increment=self.step)
+                    self.progress.update(increment=1)
         finally:
             self._finish()
 

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -8,8 +8,8 @@ from unittest.mock import patch
 import pytest
 
 from marimo._plugins.stateless.status._progress import (
-    _Progress,
     ProgressBar,
+    _Progress,
     progress_bar,
     spinner,
 )
@@ -333,4 +333,3 @@ def test_progress_bar_range_negative_step(mock_append, mock_flush):
     assert result == [10, 8, 6, 4, 2]
     assert captured[0] is not None
     assert captured[0].current == 5
-

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -9,6 +9,7 @@ import pytest
 
 from marimo._plugins.stateless.status._progress import (
     _Progress,
+    ProgressBar,
     progress_bar,
     spinner,
 )
@@ -247,3 +248,89 @@ async def test_progress_async_for_loop_without_collection_error():
     ):
         async for _ in progress_bar(total=1):
             pass
+
+
+# Bug fix: mo.status.progress_bar should use the step property of 'range'
+# https://github.com/marimo-team/marimo/issues/9575
+
+
+@patch("marimo._runtime.output._output.flush")
+@patch("marimo._runtime.output._output.append")
+def test_progress_bar_range_with_step(mock_append, mock_flush):
+    """progress_bar with range(0, 10, 2) should yield 5 items and increment by 1."""
+    del mock_flush
+
+    captured = [None]
+
+    def capture_progress(obj):
+        if isinstance(obj, ProgressBar):
+            captured[0] = obj
+
+    mock_append.side_effect = capture_progress
+
+    result = list(progress_bar(range(0, 10, 2)))
+    assert result == [0, 2, 4, 6, 8]
+    assert captured[0] is not None
+    # Each iteration should increment by 1, not by the range step
+    assert captured[0].current == 5
+
+
+@patch("marimo._runtime.output._output.flush")
+@patch("marimo._runtime.output._output.append")
+def test_progress_bar_range_no_step(mock_append, mock_flush):
+    """progress_bar with range(10) should still work correctly."""
+    del mock_flush
+
+    captured = [None]
+
+    def capture_progress(obj):
+        if isinstance(obj, ProgressBar):
+            captured[0] = obj
+
+    mock_append.side_effect = capture_progress
+
+    result = list(progress_bar(range(10)))
+    assert result == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert captured[0] is not None
+    assert captured[0].current == 10
+
+
+@patch("marimo._runtime.output._output.flush")
+@patch("marimo._runtime.output._output.append")
+def test_progress_bar_range_custom_step(mock_append, mock_flush):
+    """progress_bar with range(5, 20, 3) should yield 5 items."""
+    del mock_flush
+
+    captured = [None]
+
+    def capture_progress(obj):
+        if isinstance(obj, ProgressBar):
+            captured[0] = obj
+
+    mock_append.side_effect = capture_progress
+
+    result = list(progress_bar(range(5, 20, 3)))
+    assert result == [5, 8, 11, 14, 17]
+    assert captured[0] is not None
+    assert captured[0].current == 5
+
+
+@patch("marimo._runtime.output._output.flush")
+@patch("marimo._runtime.output._output.append")
+def test_progress_bar_range_negative_step(mock_append, mock_flush):
+    """progress_bar with range(10, 0, -2) should yield 5 items."""
+    del mock_flush
+
+    captured = [None]
+
+    def capture_progress(obj):
+        if isinstance(obj, ProgressBar):
+            captured[0] = obj
+
+    mock_append.side_effect = capture_progress
+
+    result = list(progress_bar(range(10, 0, -2)))
+    assert result == [10, 8, 6, 4, 2]
+    assert captured[0] is not None
+    assert captured[0].current == 5
+


### PR DESCRIPTION
**This pull request was authored by a coding agent.**Fixes #9575## Problem`mo.status.progress_bar(range(0, 10, 2))` shows impossible progress states. When a `range` has a non-default step, the progress bar uses the step value as the increment per iteration, causing `current` to exceed `total`.## Root Cause`progress_bar.__init__` extracted `self.step` from `range` objects, then `__iter__`/`__aiter__` used `self.step` as the increment for `ProgressBar.update()`. While `len(range)` correctly computes `total` (5 for `range(0,10,2)`), the increment of 2 per iteration over 5 iterations produces `current=10` — double the actual count.## Fix- Remove `self.step` field entirely- Always increment by 1 per iteration in both `__iter__` and `__aiter__`A progress bar counts **iterations**, not range values. The `range.step` determines what values are yielded, not how many times the loop body executes. Each `yield` = 1 unit of progress, regardless of the range step.## Tests Added- `test_progress_bar_range_with_step` — `range(0, 10, 2)` → 5 items, current=5- `test_progress_bar_range_no_step` — `range(10)` → 10 items, current=10 (regression)- `test_progress_bar_range_custom_step` — `range(5, 20, 3)` → 5 items, current=5- `test_progress_bar_range_negative_step` — `range(10, 0, -2)` → 5 items, current=5All 17 tests pass (13 existing + 4 new). Lint and format checks pass.## Checklist- [x] Code fix is minimal and correct- [x] 4 new tests cover the bug + regression- [x] All existing tests pass- [x] `ruff check` + `ruff format` pass